### PR TITLE
fix: pass top_k through to SamplingParams in BatchedEngine

### DIFF
--- a/omlx/engine/base.py
+++ b/omlx/engine/base.py
@@ -66,6 +66,7 @@ class BaseEngine(ABC):
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
+        top_k: int = 0,
         stop: Optional[List[str]] = None,
         **kwargs,
     ) -> GenerationOutput:
@@ -77,6 +78,7 @@ class BaseEngine(ABC):
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
             top_p: Top-p sampling
+            top_k: Top-k sampling (0 = disabled)
             stop: Stop sequences
             **kwargs: Additional model-specific parameters
 
@@ -92,6 +94,7 @@ class BaseEngine(ABC):
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
+        top_k: int = 0,
         stop: Optional[List[str]] = None,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
@@ -103,6 +106,7 @@ class BaseEngine(ABC):
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
             top_p: Top-p sampling
+            top_k: Top-k sampling (0 = disabled)
             stop: Stop sequences
             **kwargs: Additional model-specific parameters
 
@@ -118,6 +122,7 @@ class BaseEngine(ABC):
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
+        top_k: int = 0,
         tools: Optional[List[dict]] = None,
         **kwargs,
     ) -> GenerationOutput:
@@ -129,6 +134,7 @@ class BaseEngine(ABC):
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
             top_p: Top-p sampling
+            top_k: Top-k sampling (0 = disabled)
             tools: Optional tool definitions
             **kwargs: Additional model-specific parameters
 
@@ -144,6 +150,7 @@ class BaseEngine(ABC):
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
+        top_k: int = 0,
         tools: Optional[List[dict]] = None,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
@@ -155,6 +162,7 @@ class BaseEngine(ABC):
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
             top_p: Top-p sampling
+            top_k: Top-k sampling (0 = disabled)
             tools: Optional tool definitions
             **kwargs: Additional model-specific parameters
 

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -228,6 +228,7 @@ class BatchedEngine(BaseEngine):
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
+        top_k: int = 0,
         stop: list[str] | None = None,
         **kwargs,
     ) -> GenerationOutput:
@@ -239,6 +240,7 @@ class BatchedEngine(BaseEngine):
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
             top_p: Top-p sampling
+            top_k: Top-k sampling (0 = disabled)
             stop: Stop sequences
             **kwargs: Additional model-specific parameters
 
@@ -254,6 +256,7 @@ class BatchedEngine(BaseEngine):
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
+            top_k=top_k,
             stop=stop or [],
         )
 
@@ -279,6 +282,7 @@ class BatchedEngine(BaseEngine):
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
+        top_k: int = 0,
         stop: list[str] | None = None,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
@@ -290,6 +294,7 @@ class BatchedEngine(BaseEngine):
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
             top_p: Top-p sampling
+            top_k: Top-k sampling (0 = disabled)
             stop: Stop sequences
             **kwargs: Additional model-specific parameters
 
@@ -305,6 +310,7 @@ class BatchedEngine(BaseEngine):
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
+            top_k=top_k,
             stop=stop or [],
         )
 
@@ -352,6 +358,7 @@ class BatchedEngine(BaseEngine):
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
+        top_k: int = 0,
         tools: list[dict] | None = None,
         **kwargs,
     ) -> GenerationOutput:
@@ -363,6 +370,7 @@ class BatchedEngine(BaseEngine):
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
             top_p: Top-p sampling
+            top_k: Top-k sampling (0 = disabled)
             tools: Optional tool definitions
             **kwargs: Additional model-specific parameters
 
@@ -386,6 +394,7 @@ class BatchedEngine(BaseEngine):
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
+            top_k=top_k,
             **kwargs,
         )
 
@@ -395,6 +404,7 @@ class BatchedEngine(BaseEngine):
         max_tokens: int = 256,
         temperature: float = 0.7,
         top_p: float = 0.9,
+        top_k: int = 0,
         tools: list[dict] | None = None,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
@@ -406,6 +416,7 @@ class BatchedEngine(BaseEngine):
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
             top_p: Top-p sampling
+            top_k: Top-k sampling (0 = disabled)
             tools: Optional tool definitions
             **kwargs: Additional model-specific parameters
 
@@ -429,6 +440,7 @@ class BatchedEngine(BaseEngine):
             max_tokens=max_tokens,
             temperature=temperature,
             top_p=top_p,
+            top_k=top_k,
             **kwargs,
         ):
             yield output


### PR DESCRIPTION
## Summary
- `top_k` was passed by `server.py` to all engine methods but silently dropped — it landed in `**kwargs` and was never forwarded to `SamplingParams`
- Per-model `top_k` from the admin UI, global `top_k` from settings, and request-level `top_k` all had no effect on sampling
- Added `top_k` as an explicit parameter to `generate()`, `stream_generate()`, `chat()`, and `stream_chat()` in both `BaseEngine` and `BatchedEngine`

## Test plan
- [x] All 1712 unit tests pass (5 pre-existing failures unrelated)
- [ ] Set per-model `top_k` via admin UI → verify debug logs show it reaching the sampler
- [ ] Confirm global `top_k=40` from settings now actually applies