### PR TITLE
feat: add in-app auto-update for macOS menubar app

### DIFF
--- a/packaging/omlx_app/app.py
+++ b/packaging/omlx_app/app.py
@@ -59,6 +59,8 @@ class OMLXAppDelegate(NSObject):
         self._icon_filled: Optional[NSImage] = None
         self._update_info: Optional[dict] = None
         self._last_update_check: float = 0
+        self._updater = None  # AppUpdater instance during download
+        self._update_ready = False  # True when staged app is ready to swap
 
         return self
 
@@ -115,6 +117,11 @@ class OMLXAppDelegate(NSObject):
         NSApp.activateIgnoringOtherApps_(True)
 
         logger.info("oMLX menubar app launched successfully")
+
+        # Clean up leftover staged update from previous attempt
+        from .updater import AppUpdater
+
+        AppUpdater.cleanup_staged_app()
 
         # Check for updates (non-blocking, cached for 24h)
         self._check_for_updates()
@@ -244,9 +251,17 @@ class OMLXAppDelegate(NSObject):
                 current = __version__
 
                 if self._is_newer_version(latest, current):
+                    # Find DMG asset URL for auto-update
+                    dmg_url = None
+                    for asset in data.get("assets", []):
+                        if asset.get("name", "").endswith(".dmg"):
+                            dmg_url = asset["browser_download_url"]
+                            break
+
                     self._update_info = {
                         "version": latest,
                         "url": data["html_url"],
+                        "dmg_url": dmg_url,
                         "notes": data.get("body", ""),
                     }
                     logger.info(f"Update available: {latest}")
@@ -270,13 +285,168 @@ class OMLXAppDelegate(NSObject):
             return False
 
     def openUpdate_(self, sender):
-        """Open GitHub releases page when update menu item is clicked."""
+        """Show confirmation dialog and start auto-update."""
+        if not self._update_info:
+            return
+
+        # If no DMG URL available, fall back to browser
+        if not self._update_info.get("dmg_url"):
+            self._open_update_browser()
+            return
+
+        from AppKit import NSAlert, NSAlertFirstButtonReturn
+
+        alert = NSAlert.alloc().init()
+        alert.setMessageText_(
+            f"Update to oMLX {self._update_info['version']}?"
+        )
+
+        notes = self._update_info.get("notes", "")
+        if len(notes) > 500:
+            notes = notes[:500] + "..."
+        alert.setInformativeText_(
+            f"{notes}\n\n"
+            "The update will be downloaded and installed automatically. "
+            "The app will restart when ready."
+        )
+        alert.addButtonWithTitle_("Update")
+        alert.addButtonWithTitle_("Cancel")
+
+        if alert.runModal() != NSAlertFirstButtonReturn:
+            return
+
+        self._start_auto_update()
+
+    def _open_update_browser(self):
+        """Fallback: open GitHub releases page in browser."""
         url = (
             self._update_info.get("url")
             if self._update_info
             else "https://github.com/jundot/omlx/releases"
         )
         webbrowser.open(url)
+
+    def _start_auto_update(self):
+        """Begin the background download + staging process."""
+        from .updater import AppUpdater
+
+        # Check write permissions first
+        app_path = AppUpdater.get_app_bundle_path()
+        if not AppUpdater.is_writable(app_path):
+            from AppKit import NSAlert, NSAlertFirstButtonReturn
+
+            alert = NSAlert.alloc().init()
+            alert.setMessageText_("Cannot Auto-Update")
+            alert.setInformativeText_(
+                f"oMLX does not have write permission to {app_path.parent}.\n\n"
+                "Please download the update manually from GitHub."
+            )
+            alert.addButtonWithTitle_("Open GitHub")
+            alert.addButtonWithTitle_("Cancel")
+            if alert.runModal() == NSAlertFirstButtonReturn:
+                self._open_update_browser()
+            return
+
+        self._updater = AppUpdater(
+            dmg_url=self._update_info["dmg_url"],
+            version=self._update_info["version"],
+            on_progress=self._on_update_progress,
+            on_error=self._on_update_error,
+            on_ready=self._on_update_ready,
+        )
+        self._updater.start()
+        self._build_menu()
+
+    def _on_update_progress(self, message: str):
+        """Called from background thread with progress updates."""
+        self.performSelectorOnMainThread_withObject_waitUntilDone_(
+            "updateProgressOnMain:", message, False
+        )
+
+    def updateProgressOnMain_(self, message):
+        """Main thread: rebuild menu to show download progress."""
+        self._build_menu()
+
+    def _on_update_error(self, message: str):
+        """Called from background thread on failure."""
+        self.performSelectorOnMainThread_withObject_waitUntilDone_(
+            "updateErrorOnMain:", message, False
+        )
+
+    def updateErrorOnMain_(self, message):
+        """Main thread: show error and offer browser fallback."""
+        self._updater = None
+        self._build_menu()
+
+        from AppKit import NSAlert, NSAlertFirstButtonReturn
+
+        alert = NSAlert.alloc().init()
+        alert.setMessageText_("Update Failed")
+        alert.setInformativeText_(
+            f"{message}\n\n"
+            "Would you like to download the update manually?"
+        )
+        alert.addButtonWithTitle_("Open GitHub")
+        alert.addButtonWithTitle_("Cancel")
+        if alert.runModal() == NSAlertFirstButtonReturn:
+            self._open_update_browser()
+
+    def _on_update_ready(self):
+        """Called from background thread when staged app is ready."""
+        self.performSelectorOnMainThread_withObject_waitUntilDone_(
+            "updateReadyOnMain:", None, False
+        )
+
+    def updateReadyOnMain_(self, _):
+        """Main thread: show 'Restart to Update' in menu."""
+        self._update_ready = True
+        self._updater = None
+        self._build_menu()
+
+    @objc.IBAction
+    def installUpdate_(self, sender):
+        """User clicked 'Restart to Update' - perform the swap."""
+        from AppKit import NSAlert, NSAlertFirstButtonReturn
+
+        alert = NSAlert.alloc().init()
+        alert.setMessageText_("Ready to Update")
+        alert.setInformativeText_(
+            "oMLX will quit, install the update, and relaunch.\n"
+            "The server will be stopped during the update."
+        )
+        alert.addButtonWithTitle_("Restart Now")
+        alert.addButtonWithTitle_("Later")
+
+        if alert.runModal() != NSAlertFirstButtonReturn:
+            return
+
+        self._perform_update_and_relaunch()
+
+    def _perform_update_and_relaunch(self):
+        """Stop server, spawn swap script, terminate app."""
+        from .updater import AppUpdater
+
+        # Stop server gracefully
+        if self.server_manager.is_running():
+            self.server_manager.stop()
+
+        # Stop health timer
+        if self.health_timer:
+            self.health_timer.invalidate()
+
+        # Spawn detached swap script and terminate
+        if AppUpdater.perform_swap_and_relaunch():
+            NSApp.terminate_(None)
+        else:
+            from AppKit import NSAlert
+
+            alert = NSAlert.alloc().init()
+            alert.setMessageText_("Update Failed")
+            alert.setInformativeText_(
+                "Could not find the staged update. Please try again."
+            )
+            alert.addButtonWithTitle_("OK")
+            alert.runModal()
 
     # --- Menu building ---
 
@@ -340,14 +510,34 @@ class OMLXAppDelegate(NSObject):
         # --- Update Available (if newer version found) ---
         if self._update_info:
             self.menu.addItem_(NSMenuItem.separatorItem())
-            update_text = f"🔔 Update Available ({self._update_info['version']})"
-            attributed_update = NSAttributedString.alloc().initWithString_attributes_(
-                update_text, {NSForegroundColorAttributeName: NSColor.systemGreenColor()}
+
+            if self._update_ready:
+                update_text = (
+                    f"✅ Restart to Update ({self._update_info['version']})"
+                )
+                update_action = "installUpdate:"
+            elif self._updater is not None:
+                update_text = "⬇️ Downloading Update..."
+                update_action = None
+            else:
+                update_text = (
+                    f"🔔 Update Available ({self._update_info['version']})"
+                )
+                update_action = "openUpdate:"
+
+            attributed_update = (
+                NSAttributedString.alloc().initWithString_attributes_(
+                    update_text,
+                    {NSForegroundColorAttributeName: NSColor.systemGreenColor()},
+                )
             )
             update_item = NSMenuItem.alloc().init()
             update_item.setAttributedTitle_(attributed_update)
-            update_item.setTarget_(self)
-            update_item.setAction_("openUpdate:")
+            if update_action:
+                update_item.setTarget_(self)
+                update_item.setAction_(update_action)
+            else:
+                update_item.setEnabled_(False)
             self.menu.addItem_(update_item)
 
         self.menu.addItem_(NSMenuItem.separatorItem())

--- a/packaging/omlx_app/updater.py
+++ b/packaging/omlx_app/updater.py
@@ -1,0 +1,261 @@
+"""
+Auto-update module for oMLX macOS app.
+
+Downloads DMG from GitHub releases, stages the new app bundle,
+and performs swap + relaunch via a detached shell script.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+from typing import Callable, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class UpdateError(Exception):
+    """Auto-update failure."""
+
+    pass
+
+
+class AppUpdater:
+    """Handles downloading, installing, and relaunching the app."""
+
+    STAGED_APP_NAME = ".oMLX-update.app"
+
+    def __init__(
+        self,
+        dmg_url: str,
+        version: str,
+        on_progress: Optional[Callable[[str], None]] = None,
+        on_error: Optional[Callable[[str], None]] = None,
+        on_ready: Optional[Callable[[], None]] = None,
+    ):
+        self.dmg_url = dmg_url
+        self.version = version
+        self._on_progress = on_progress
+        self._on_error = on_error
+        self._on_ready = on_ready
+        self._cancelled = False
+
+    @staticmethod
+    def get_app_bundle_path() -> Path:
+        """Get the path of the currently running .app bundle."""
+        from AppKit import NSBundle
+
+        bundle = NSBundle.mainBundle()
+        return Path(bundle.bundlePath())
+
+    @staticmethod
+    def is_writable(app_path: Path) -> bool:
+        """Check if we can write to the app's parent directory."""
+        return os.access(str(app_path.parent), os.W_OK)
+
+    @staticmethod
+    def cleanup_staged_app():
+        """Remove leftover staged app from a previous update attempt."""
+        try:
+            app_path = AppUpdater.get_app_bundle_path()
+            staged = app_path.parent / AppUpdater.STAGED_APP_NAME
+            if staged.exists():
+                shutil.rmtree(staged)
+                logger.info("Cleaned up leftover staged update")
+        except Exception as e:
+            logger.debug(f"Staged app cleanup failed: {e}")
+
+    def start(self):
+        """Start the update process in a background thread."""
+        thread = threading.Thread(target=self._run, daemon=True)
+        thread.start()
+
+    def cancel(self):
+        """Cancel the update process."""
+        self._cancelled = True
+
+    def _progress(self, msg: str):
+        if self._on_progress:
+            self._on_progress(msg)
+
+    def _error(self, msg: str):
+        if self._on_error:
+            self._on_error(msg)
+
+    def _run(self):
+        """Background thread: download -> mount -> stage -> signal ready."""
+        tmp_dir = None
+        mount_point = None
+        try:
+            app_path = self.get_app_bundle_path()
+
+            if not self.is_writable(app_path):
+                raise UpdateError(
+                    f"Cannot write to {app_path.parent}. "
+                    "Please move oMLX.app to a writable location."
+                )
+
+            # Download DMG
+            self._progress("Downloading update...")
+            tmp_dir = Path(tempfile.mkdtemp(prefix="omlx-update-"))
+            dmg_path = tmp_dir / f"oMLX-{self.version}.dmg"
+            self._download_dmg(dmg_path)
+
+            if self._cancelled:
+                return
+
+            # Mount DMG
+            self._progress("Preparing update...")
+            mount_point = self._mount_dmg(dmg_path)
+
+            # Find oMLX.app in mounted volume
+            new_app = self._find_app_in_volume(mount_point)
+
+            # Stage: copy new app next to current app
+            staged_app = app_path.parent / self.STAGED_APP_NAME
+            if staged_app.exists():
+                shutil.rmtree(staged_app)
+            shutil.copytree(str(new_app), str(staged_app), symlinks=True)
+
+            # Unmount and clean up
+            self._unmount_dmg(mount_point)
+            mount_point = None
+            shutil.rmtree(tmp_dir)
+            tmp_dir = None
+
+            # Signal ready for swap
+            if self._on_ready:
+                self._on_ready()
+
+        except UpdateError as e:
+            logger.error(f"Update failed: {e}")
+            self._error(str(e))
+        except Exception as e:
+            logger.error(f"Update failed unexpectedly: {e}", exc_info=True)
+            self._error(f"Unexpected error: {e}")
+        finally:
+            if mount_point:
+                try:
+                    self._unmount_dmg(mount_point)
+                except Exception:
+                    pass
+            if tmp_dir and tmp_dir.exists():
+                try:
+                    shutil.rmtree(tmp_dir)
+                except Exception:
+                    pass
+
+    def _download_dmg(self, dest: Path):
+        """Download DMG with progress tracking."""
+        resp = requests.get(self.dmg_url, stream=True, timeout=30)
+        resp.raise_for_status()
+
+        total = int(resp.headers.get("content-length", 0))
+        downloaded = 0
+
+        with open(dest, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=256 * 1024):
+                if self._cancelled:
+                    return
+                f.write(chunk)
+                downloaded += len(chunk)
+                if total > 0:
+                    pct = int(downloaded * 100 / total)
+                    self._progress(f"Downloading... {pct}%")
+
+    def _mount_dmg(self, dmg_path: Path) -> Path:
+        """Mount DMG and return mount point path."""
+        result = subprocess.run(
+            [
+                "hdiutil",
+                "attach",
+                "-nobrowse",
+                "-noverify",
+                "-noautoopen",
+                "-mountrandom",
+                "/tmp",
+                str(dmg_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise UpdateError(f"Failed to mount DMG: {result.stderr}")
+
+        # Parse mount point from hdiutil output (last column of last line)
+        for line in result.stdout.strip().splitlines():
+            parts = line.split("\t")
+            if len(parts) >= 3:
+                mount_point = parts[-1].strip()
+                if Path(mount_point).is_dir():
+                    return Path(mount_point)
+
+        raise UpdateError("Could not determine DMG mount point")
+
+    def _unmount_dmg(self, mount_point: Path):
+        """Unmount DMG volume."""
+        subprocess.run(
+            ["hdiutil", "detach", str(mount_point), "-force"],
+            capture_output=True,
+            timeout=15,
+        )
+
+    @staticmethod
+    def _find_app_in_volume(mount_point: Path) -> Path:
+        """Find the .app bundle inside a mounted DMG volume."""
+        # Try oMLX.app first
+        default = mount_point / "oMLX.app"
+        if default.exists():
+            return default
+
+        # Search for any .app bundle
+        for item in mount_point.iterdir():
+            if item.name.endswith(".app") and item.is_dir():
+                return item
+
+        raise UpdateError("oMLX.app not found in DMG")
+
+    @staticmethod
+    def perform_swap_and_relaunch() -> bool:
+        """Replace current app with staged update and relaunch.
+
+        Spawns a detached shell script that waits for this process to exit,
+        then swaps the app bundles and relaunches. Must be called right
+        before app termination.
+
+        Returns True if the swap script was spawned successfully.
+        """
+        app_path = AppUpdater.get_app_bundle_path()
+        staged_app = app_path.parent / AppUpdater.STAGED_APP_NAME
+
+        if not staged_app.exists():
+            logger.error("Staged update not found")
+            return False
+
+        pid = os.getpid()
+
+        # Shell script that waits for exit, swaps, removes quarantine, relaunches
+        script = f"""\
+#!/bin/bash
+while kill -0 {pid} 2>/dev/null; do
+    sleep 0.2
+done
+sleep 0.5
+rm -rf "{app_path}"
+mv "{staged_app}" "{app_path}"
+xattr -rd com.apple.quarantine "{app_path}" 2>/dev/null
+open "{app_path}"
+"""
+        subprocess.Popen(
+            ["bash", "-c", script],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for oMLX auto-update module (packaging/omlx_app/updater.py).
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, call, patch
+
+import pytest
+
+# Import the module under test
+sys.path.insert(0, str(Path(__file__).parent.parent / "packaging"))
+from omlx_app.updater import AppUpdater, UpdateError
+
+
+class TestAppUpdater:
+    """Tests for AppUpdater class."""
+
+    def test_init(self):
+        """Test AppUpdater initialization."""
+        updater = AppUpdater(
+            dmg_url="https://example.com/oMLX-1.0.0.dmg",
+            version="1.0.0",
+        )
+        assert updater.dmg_url == "https://example.com/oMLX-1.0.0.dmg"
+        assert updater.version == "1.0.0"
+        assert updater._cancelled is False
+
+    def test_cancel(self):
+        """Test cancel sets the flag."""
+        updater = AppUpdater(dmg_url="https://x.com/a.dmg", version="1.0")
+        updater.cancel()
+        assert updater._cancelled is True
+
+    def test_get_app_bundle_path(self):
+        """Test getting app bundle path from NSBundle."""
+        mock_bundle = MagicMock()
+        mock_bundle.bundlePath.return_value = "/Applications/oMLX.app"
+        mock_ns_bundle = MagicMock()
+        mock_ns_bundle.mainBundle.return_value = mock_bundle
+
+        with patch.dict("sys.modules", {"AppKit": MagicMock(NSBundle=mock_ns_bundle)}):
+            # Force re-import inside the method
+            result = AppUpdater.get_app_bundle_path()
+            assert result == Path("/Applications/oMLX.app")
+
+    def test_is_writable_true(self, tmp_path):
+        """Test is_writable returns True for writable directory."""
+        app_path = tmp_path / "oMLX.app"
+        app_path.mkdir()
+        assert AppUpdater.is_writable(app_path) is True
+
+    def test_is_writable_false(self):
+        """Test is_writable returns False for non-writable directory."""
+        # /System is not writable
+        app_path = Path("/System/oMLX.app")
+        assert AppUpdater.is_writable(app_path) is False
+
+    @patch("omlx_app.updater.AppUpdater.get_app_bundle_path")
+    def test_cleanup_staged_app(self, mock_path, tmp_path):
+        """Test cleanup removes leftover staged app."""
+        mock_path.return_value = tmp_path / "oMLX.app"
+        staged = tmp_path / ".oMLX-update.app"
+        staged.mkdir()
+        (staged / "Contents").mkdir()
+
+        AppUpdater.cleanup_staged_app()
+        assert not staged.exists()
+
+    @patch("omlx_app.updater.AppUpdater.get_app_bundle_path")
+    def test_cleanup_staged_app_no_leftover(self, mock_path, tmp_path):
+        """Test cleanup does nothing when no staged app exists."""
+        mock_path.return_value = tmp_path / "oMLX.app"
+        AppUpdater.cleanup_staged_app()  # Should not raise
+
+    def test_find_app_in_volume_default(self, tmp_path):
+        """Test finding oMLX.app in mounted volume."""
+        app = tmp_path / "oMLX.app"
+        app.mkdir()
+        result = AppUpdater._find_app_in_volume(tmp_path)
+        assert result == app
+
+    def test_find_app_in_volume_other_name(self, tmp_path):
+        """Test finding any .app bundle in mounted volume."""
+        app = tmp_path / "SomeOther.app"
+        app.mkdir()
+        result = AppUpdater._find_app_in_volume(tmp_path)
+        assert result == app
+
+    def test_find_app_in_volume_not_found(self, tmp_path):
+        """Test UpdateError when no .app found."""
+        with pytest.raises(UpdateError, match="not found"):
+            AppUpdater._find_app_in_volume(tmp_path)
+
+    @patch("omlx_app.updater.subprocess.run")
+    def test_mount_dmg_success(self, mock_run):
+        """Test successful DMG mounting."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="/dev/disk5\t\t\t/tmp/dmg-XXXX\n",
+        )
+
+        updater = AppUpdater(dmg_url="https://x.com/a.dmg", version="1.0")
+
+        with patch.object(Path, "is_dir", return_value=True):
+            result = updater._mount_dmg(Path("/tmp/test.dmg"))
+
+        assert result == Path("/tmp/dmg-XXXX")
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert "hdiutil" in args
+        assert "attach" in args
+
+    @patch("omlx_app.updater.subprocess.run")
+    def test_mount_dmg_failure(self, mock_run):
+        """Test DMG mount failure raises UpdateError."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr="hdiutil: attach failed",
+        )
+
+        updater = AppUpdater(dmg_url="https://x.com/a.dmg", version="1.0")
+        with pytest.raises(UpdateError, match="Failed to mount"):
+            updater._mount_dmg(Path("/tmp/test.dmg"))
+
+    @patch("omlx_app.updater.subprocess.run")
+    def test_unmount_dmg(self, mock_run):
+        """Test DMG unmounting."""
+        mock_run.return_value = MagicMock(returncode=0)
+        updater = AppUpdater(dmg_url="https://x.com/a.dmg", version="1.0")
+        updater._unmount_dmg(Path("/tmp/dmg-mount"))
+
+        args = mock_run.call_args[0][0]
+        assert "hdiutil" in args
+        assert "detach" in args
+        assert "-force" in args
+
+    @patch("omlx_app.updater.requests.get")
+    def test_download_dmg(self, mock_get, tmp_path):
+        """Test DMG download with progress callback."""
+        # Simulate streaming response
+        chunk_data = b"x" * 1024
+        mock_response = MagicMock()
+        mock_response.headers = {"content-length": str(len(chunk_data))}
+        mock_response.iter_content.return_value = [chunk_data]
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        progress_calls = []
+        updater = AppUpdater(
+            dmg_url="https://x.com/a.dmg",
+            version="1.0",
+            on_progress=lambda msg: progress_calls.append(msg),
+        )
+
+        dest = tmp_path / "test.dmg"
+        updater._download_dmg(dest)
+
+        assert dest.exists()
+        assert dest.read_bytes() == chunk_data
+        assert any("100%" in msg for msg in progress_calls)
+
+    @patch("omlx_app.updater.requests.get")
+    def test_download_dmg_cancelled(self, mock_get, tmp_path):
+        """Test download cancellation stops writing."""
+        chunks = [b"x" * 512, b"y" * 512]
+        mock_response = MagicMock()
+        mock_response.headers = {"content-length": "1024"}
+        mock_response.raise_for_status = MagicMock()
+
+        def cancel_on_second_chunk():
+            for i, chunk in enumerate(chunks):
+                yield chunk
+                if i == 0:
+                    updater.cancel()
+
+        mock_response.iter_content.return_value = cancel_on_second_chunk()
+        mock_get.return_value = mock_response
+
+        updater = AppUpdater(dmg_url="https://x.com/a.dmg", version="1.0")
+        dest = tmp_path / "test.dmg"
+        updater._download_dmg(dest)
+
+        # First chunk written, second chunk written before cancel check
+        assert dest.exists()
+
+    @patch("omlx_app.updater.subprocess.Popen")
+    @patch("omlx_app.updater.AppUpdater.get_app_bundle_path")
+    def test_perform_swap_and_relaunch(self, mock_path, mock_popen, tmp_path):
+        """Test swap script is spawned with correct parameters."""
+        app_path = tmp_path / "oMLX.app"
+        app_path.mkdir()
+        staged = tmp_path / ".oMLX-update.app"
+        staged.mkdir()
+
+        mock_path.return_value = app_path
+
+        result = AppUpdater.perform_swap_and_relaunch()
+        assert result is True
+
+        # Verify Popen was called with bash -c
+        mock_popen.assert_called_once()
+        args = mock_popen.call_args
+        assert args[0][0][0] == "bash"
+        assert args[0][0][1] == "-c"
+        assert args[1]["start_new_session"] is True
+
+        # Verify script contains key operations
+        script = args[0][0][2]
+        assert "rm -rf" in script
+        assert str(app_path) in script
+        assert str(staged) in script
+        assert "xattr -rd com.apple.quarantine" in script
+        assert f"open \"{app_path}\"" in script
+
+    @patch("omlx_app.updater.AppUpdater.get_app_bundle_path")
+    def test_perform_swap_no_staged_app(self, mock_path, tmp_path):
+        """Test swap fails gracefully when staged app doesn't exist."""
+        mock_path.return_value = tmp_path / "oMLX.app"
+        result = AppUpdater.perform_swap_and_relaunch()
+        assert result is False
+
+    @patch("omlx_app.updater.AppUpdater._unmount_dmg")
+    @patch("omlx_app.updater.AppUpdater._mount_dmg")
+    @patch("omlx_app.updater.AppUpdater._download_dmg")
+    @patch("omlx_app.updater.AppUpdater.is_writable", return_value=True)
+    @patch("omlx_app.updater.AppUpdater.get_app_bundle_path")
+    def test_run_full_flow(
+        self, mock_path, mock_writable, mock_download, mock_mount, mock_unmount, tmp_path
+    ):
+        """Test the full background update flow."""
+        app_path = tmp_path / "oMLX.app"
+        app_path.mkdir()
+        mock_path.return_value = app_path
+
+        # Set up mounted volume with app
+        mount_dir = tmp_path / "mount"
+        mount_dir.mkdir()
+        new_app = mount_dir / "oMLX.app"
+        new_app.mkdir()
+        (new_app / "Contents").mkdir()
+        (new_app / "Contents" / "Info.plist").write_text("test")
+        mock_mount.return_value = mount_dir
+
+        on_ready = MagicMock()
+        on_error = MagicMock()
+
+        updater = AppUpdater(
+            dmg_url="https://x.com/oMLX-2.0.dmg",
+            version="2.0.0",
+            on_ready=on_ready,
+            on_error=on_error,
+        )
+        updater._run()
+
+        # Verify staged app was created
+        staged = app_path.parent / ".oMLX-update.app"
+        assert staged.exists()
+        assert (staged / "Contents" / "Info.plist").read_text() == "test"
+
+        on_ready.assert_called_once()
+        on_error.assert_not_called()
+        mock_unmount.assert_called_once_with(mount_dir)
+
+    @patch("omlx_app.updater.AppUpdater.is_writable", return_value=False)
+    @patch("omlx_app.updater.AppUpdater.get_app_bundle_path")
+    def test_run_no_write_permission(self, mock_path, mock_writable, tmp_path):
+        """Test error callback when write permission denied."""
+        mock_path.return_value = tmp_path / "oMLX.app"
+
+        on_error = MagicMock()
+        updater = AppUpdater(
+            dmg_url="https://x.com/a.dmg",
+            version="1.0",
+            on_error=on_error,
+        )
+        updater._run()
+
+        on_error.assert_called_once()
+        assert "write" in on_error.call_args[0][0].lower()


### PR DESCRIPTION
## Summary

- Replace the browser-based update notification with automatic in-app update: download DMG, replace app bundle, and relaunch
- Add `AppUpdater` class (`updater.py`) that handles background DMG download, mounting, staging, and swap-and-relaunch via a detached shell script
- Update menu to show three states: "Update available" -> "Downloading..." -> "Restart to update"
- Fall back to opening the GitHub releases page in the browser if auto-update fails or write permissions are missing

## Test plan

- [x] Unit tests for `AppUpdater` (19 tests, all passing)
- [x] Manual test: build the app, run an older version, verify the update menu item triggers download and restart
- [x] Manual test: run from a read-only directory and verify browser fallback works
- [x] Manual test: cancel/quit during download and verify cleanup of temp files