### PR TITLE
fix: roll back block metadata when SSD cache save fails

### DIFF
--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -497,6 +497,12 @@ class BlockAwarePrefixCache(CacheManager):
                         logger.warning(
                             f"Failed to save block {block.block_id} to tiered cache"
                         )
+                        # Persistence failed: roll back metadata so we don't
+                        # retain a block that cannot be reconstructed later.
+                        self.paged_cache.free_block(block.block_id)
+                        block_table.block_ids.pop()
+                        block_table.num_tokens -= len(block_tokens)
+                        break
                 else:
                     # Failed to extract tensor data - free block and stop
                     logger.debug(

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -984,6 +984,43 @@ class TestArraysCacheLastBlockOnly:
         assert saved_keys.tolist() == expected_keys.tolist()
         assert saved_values.tolist() == expected_values.tolist()
 
+    def test_store_cache_rolls_back_when_ssd_save_fails(self, mx):
+        """Failed SSD save should not retain block metadata in paged cache."""
+        block_size = 4
+        paged_cache = PagedCacheManager(
+            block_size=block_size,
+            max_blocks=100,
+            model_name="test-model",
+            initial_blocks=100,
+        )
+        mock_ssd = MagicMock()
+        mock_ssd.save_block.return_value = False
+
+        model = MockModel(num_layers=1)
+        cache = BlockAwarePrefixCache(
+            model=model,
+            paged_cache_manager=paged_cache,
+            paged_ssd_cache_manager=mock_ssd,
+        )
+
+        tokens = [1, 2, 3, 4]  # exactly one full block
+        keys = mx.ones((1, 8, 4, 64))
+        values = mx.ones((1, 8, 4, 64))
+        cache_data = [
+            {"state": (keys, values), "cache_type": "KVCache", "class_name": "KVCache"}
+        ]
+
+        result = cache.store_cache("req-rollback", tokens, cache_data)
+
+        assert result is not None
+        # If persistence fails, block should be rolled back (not indexed/retained).
+        assert len(result.block_ids) == 0
+        assert result.num_tokens == 0
+        assert paged_cache.stats.allocated_blocks == 1  # null block only
+
+        failed_hash = compute_block_hash(None, tokens, model_name="test-model")
+        assert paged_cache.cached_block_hash_to_block.get_block(failed_hash) is None
+
 
 class TestPrefixCacheCacheList:
     """Tests for CacheList support in BlockAwarePrefixCache."""


### PR DESCRIPTION
 ## Summary

  Fix a rollback bug in `BlockAwarePrefixCache.store_cache` when SSD persistence fails for a newly allocated block.

  Previously, if `paged_ssd_cache.save_block(...)` returned `False`, we logged a warning but still kept that block in the request’s block table/hash metadata. That could leave a block that cannot be reconstructed
  later.

  This change rolls back that block immediately on save failure.

  ## Root Cause

  In the `store_cache` loop, a new block was:
  1. allocated,
  2. added to `block_table`,
  3. hash-registered,

  before SSD persistence completed.

  If SSD save failed, metadata was not reverted, so the request could retain an invalid tail block.

  ## Fix

  In the `save_block == False` branch:
  - `free_block(block.block_id)`
  - `block_table.block_ids.pop()`
  - `block_table.num_tokens -= len(block_tokens)`
  - `break` the allocation loop

  This mirrors existing rollback behavior used for other block-extraction/continuity failure paths.

  ## Tests

  Added regression test:
  - `tests/test_prefix_cache.py::test_store_cache_rolls_back_when_ssd_save_fails`

  What it validates:
  - failed save does not retain block IDs in the result table
  - `num_tokens` is rolled back to `0`
  - allocated-block accounting returns to null-block-only state
  - failed block hash is not present in `cached_block_hash_to_block`

  ## Validation

  Ran:
  `uv run --extra dev pytest tests/test_prefix_cache.py -k "rolls_back_when_ssd_save_fails" -q`

  Result:
  - `1 passed, 65 deselected`

  ## Scope

  - Small, focused fix
  - Files changed:
    - `omlx/cache/prefix_cache.py`
    - `tests/test_prefix_cache.py`
  - No API or dependency changes