### PR TITLE
feat: per-model KV cache quantization support

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -1007,6 +1007,8 @@ async def list_models(is_admin: bool = Depends(require_admin)):
                 "chat_template_kwargs": settings.chat_template_kwargs,
                 "forced_ct_kwargs": settings.forced_ct_kwargs,
                 "ttl_seconds": settings.ttl_seconds,
+                "kv_cache_bits": settings.kv_cache_bits,
+                "kv_cache_group_size": settings.kv_cache_group_size,
                 "is_pinned": settings.is_pinned,
                 "is_default": settings.is_default,
                 "display_name": settings.display_name,

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -74,6 +74,7 @@ class EnginePool:
         self,
         max_model_memory: int,
         scheduler_config: SchedulerConfig | None = None,
+        settings_manager: "ModelSettingsManager | None" = None,
     ):
         """
         Initialize the engine pool.
@@ -81,12 +82,14 @@ class EnginePool:
         Args:
             max_model_memory: Maximum memory for loaded models in bytes
             scheduler_config: Configuration for BatchedEngine schedulers
+            settings_manager: Optional ModelSettingsManager for model-specific KV cache settings
         """
         self._entries: dict[str, EngineEntry] = {}
         self._lock = asyncio.Lock()
         self._max_model_memory = max_model_memory
         self._current_model_memory = 0
         self._scheduler_config = scheduler_config or SchedulerConfig()
+        self._settings_manager = settings_manager
         self._process_memory_enforcer: object | None = None  # Set by server
 
     @property
@@ -399,6 +402,8 @@ class EnginePool:
         Raises:
             ModelLoadingError: If model is already being loaded
         """
+        import copy
+
         entry = self._entries[model_id]
         if entry.is_loading:
             raise ModelLoadingError(model_id)
@@ -407,6 +412,20 @@ class EnginePool:
         entry.abort_loading = False
         try:
             logger.info(f"Loading model: {model_id}")
+
+            # Read model settings for KV cache quantization
+            engine_scheduler_config = self._scheduler_config
+            if self._settings_manager is not None:
+                model_settings = self._settings_manager.get_settings(model_id)
+                if model_settings.kv_cache_bits is not None or model_settings.kv_cache_group_size != 64:
+                    # Create a copy with model-specific KV cache settings
+                    engine_scheduler_config = copy.copy(self._scheduler_config)
+                    engine_scheduler_config.kv_cache_bits = model_settings.kv_cache_bits
+                    engine_scheduler_config.kv_cache_group_size = model_settings.kv_cache_group_size
+                    logger.info(
+                        f"Model {model_id}: KV cache quantization "
+                        f"{model_settings.kv_cache_bits}-bit, group_size={model_settings.kv_cache_group_size}"
+                    )
 
             # Create engine based on engine type
             if entry.engine_type == "embedding":
@@ -419,13 +438,13 @@ class EnginePool:
                 # VLMBatchedEngine for vision-language models
                 engine = VLMBatchedEngine(
                     model_name=entry.model_path,
-                    scheduler_config=self._scheduler_config,
+                    scheduler_config=engine_scheduler_config,
                 )
             else:
                 # BatchedEngine with continuous batching (default)
                 engine = BatchedEngine(
                     model_name=entry.model_path,
-                    scheduler_config=self._scheduler_config,
+                    scheduler_config=engine_scheduler_config,
                 )
 
             try:

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -30,6 +30,8 @@ class ModelSettings:
         top_k: Top-k sampling parameter (None = use global default).
         repetition_penalty: Repetition penalty (None = use default 1.0, i.e. disabled).
         force_sampling: Force sampling even with temperature=0.
+        kv_cache_bits: KV cache quantization bits (None=fp16, 8, or 4).
+        kv_cache_group_size: KV cache quantization group size.
         is_pinned: Keep model loaded in memory.
         is_default: Use this model when no model is specified.
         display_name: Human-readable name for UI display.
@@ -49,6 +51,10 @@ class ModelSettings:
     forced_ct_kwargs: Optional[list[str]] = None  # Keys that cannot be overridden by API requests
     ttl_seconds: Optional[int] = None  # Auto-unload after idle seconds (None = no TTL)
     model_type_override: Optional[str] = None  # "llm", "vlm", "embedding", "reranker", or None (auto-detect)
+
+    # KV cache quantization settings
+    kv_cache_bits: Optional[int] = None  # KV cache quantization: None=fp16, 8, or 4
+    kv_cache_group_size: int = 64  # Quantization group size
 
     # Model management flags
     is_pinned: bool = False

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -98,18 +98,25 @@ class _PrefillAbortedError(Exception):
 class _BoundarySnapshotBatchGenerator(BatchGenerator):
     """BatchGenerator with boundary-aligned prefill snapshot callbacks."""
 
+    # KV cache quantization state
+    _kv_quantization_logged: bool = False
+
     def __init__(
         self,
         *args: Any,
         boundary_block_size: int = 0,
         prefill_boundary_callback: Optional[Callable[[int, List[Any], int], None]] = None,
         abort_check_callback: Optional[Callable[[List[int]], List[int]]] = None,
+        kv_cache_bits: Optional[int] = None,
+        kv_cache_group_size: int = 64,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
         self._boundary_block_size = max(0, int(boundary_block_size))
         self._prefill_boundary_callback = prefill_boundary_callback
         self._abort_check_callback = abort_check_callback
+        self.kv_cache_bits: Optional[int] = kv_cache_bits
+        self.kv_cache_group_size: int = kv_cache_group_size
         # Memory limits for inline prefill checking (set by Scheduler).
         # mx.get_active_memory() is ~20ns, negligible vs ~5s prefill chunks.
         self._memory_limit_bytes: int = 0  # soft limit, 0 = disabled
@@ -117,6 +124,27 @@ class _BoundarySnapshotBatchGenerator(BatchGenerator):
         # Per-UID VLM embeddings for batched prefill.
         # uid → (inputs_embeds, extra_kwargs, start_offset)
         self._vlm_pending: Dict[int, Tuple[mx.array, Dict[str, Any], int]] = {}
+
+    def _quantize_cache(self, prompt_cache: List[Any]) -> List[Any]:
+        """Quantize KV cache layers that support it."""
+        if not self._kv_quantization_logged:
+            logger.info(f"KV cache: quantized {self.kv_cache_bits}-bit, group_size={self.kv_cache_group_size}")
+            _BoundarySnapshotBatchGenerator._kv_quantization_logged = True
+
+        quantized = []
+        for i, cache_obj in enumerate(prompt_cache):
+            if hasattr(cache_obj, 'to_quantized'):
+                try:
+                    quantized.append(cache_obj.to_quantized(
+                        group_size=self.kv_cache_group_size,
+                        bits=self.kv_cache_bits
+                    ))
+                except Exception as e:
+                    logger.warning(f"KV cache quantization failed for layer {i}: {e}, using fp16")
+                    quantized.append(cache_obj)
+            else:
+                quantized.append(cache_obj)
+        return quantized
 
     # Cache class names known to be sliceable (no boundary snapshots needed).
     _KNOWN_SLICEABLE = frozenset({"KVCache", "BatchKVCache", "QuantizedKVCache"})
@@ -376,6 +404,10 @@ class _BoundarySnapshotBatchGenerator(BatchGenerator):
             inputs = _left_pad_prompts(inputs, max_length=max_length)
             prompt_cache = _make_cache(self.model, padding, self.max_kv_size)
 
+            # Apply KV cache quantization if enabled
+            if self.kv_cache_bits is not None:
+                prompt_cache = self._quantize_cache(prompt_cache)
+
             # Build left-padded VLM embeddings batch (matching token padding).
             batched_embeds, batched_extra = self._build_left_padded_vlm_batch(
                 vlm_embeds_map, list(uids), lengths, max_length
@@ -485,6 +517,10 @@ class _BoundarySnapshotBatchGenerator(BatchGenerator):
             last_inputs = mx.array([p[-1:] for p in inputs])
             inputs = _right_pad_prompts(inputs, max_length=max_length)
             prompt_cache = _merge_caches(caches)
+
+            # Apply KV cache quantization if enabled
+            if self.kv_cache_bits is not None:
+                prompt_cache = self._quantize_cache(prompt_cache)
 
             # Build right-padded VLM embeddings batch (matching token padding).
             batched_embeds, batched_extra = self._build_right_padded_vlm_batch(
@@ -824,6 +860,10 @@ class SchedulerConfig:
     # GC/cleanup settings (memory optimization)
     gc_cleanup_interval: int = 0  # Steps between gc.collect() calls (0=disabled)
     mlx_cache_cleanup_interval: int = 32  # Steps between mx.clear_cache() calls
+
+    # KV cache quantization settings
+    kv_cache_bits: Optional[int] = None  # None=fp16, 8, or 4
+    kv_cache_group_size: int = 64  # Quantization group size
 
 
 @dataclass
@@ -1419,6 +1459,8 @@ class Scheduler:
                 else None
             ),
             abort_check_callback=self._check_pending_aborts_for_uids,
+            kv_cache_bits=self.config.kv_cache_bits,
+            kv_cache_group_size=self.config.kv_cache_group_size,
         )
         bg._memory_limit_bytes = self._memory_limit_bytes
         bg._memory_hard_limit_bytes = self._memory_hard_limit_bytes

--- a/tests/test_admin_api_key.py
+++ b/tests/test_admin_api_key.py
@@ -43,6 +43,8 @@ class TestListModelsSettings:
             is_default=False,
             display_name="Test Model",
             description="A test model",
+            kv_cache_bits=8,
+            kv_cache_group_size=64,
         )
 
         mock_settings_manager = MagicMock()


### PR DESCRIPTION
Add kv_cache_bits and kv_cache_group_size as per-model settings to enable quantized KV caches via mlx-lm's QuantizedKVCache. This reduces KV cache memory footprint by 50% (8-bit) or 75% (4-bit), helping larger model quantizations fit in memory on constrained systems.

Changes:
- model_settings.py: Add kv_cache_bits (None/4/8) and kv_cache_group_size fields
- scheduler.py: Add _quantize_cache() to _BoundarySnapshotBatchGenerator, apply at both cache creation sites (left-pad and right-pad paths), thread config through SchedulerConfig
- engine_pool.py: Read per-model KV cache settings and create model-specific SchedulerConfig copies with KV cache config before engine creation
- admin/routes.py: Expose new fields in list_models API response

Configuration via ~/.omlx/model_settings.json:
  {"models": {"MyModel": {"kv_cache_bits": 8, "kv_cache_group_size": 64}}}

Graceful fallback: if to_quantized() fails on any cache layer, logs a warning and keeps fp16 for that layer. Models without the setting are unaffected (fp16 default).