### PR TITLE
fix: detect text-only quants of VLM model families as LLM

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -175,12 +175,19 @@ def detect_model_type(model_path: Path) -> ModelType:
         if arch in VLM_ARCHITECTURES:
             return "vlm"
 
-    # Check for VLM: model_type field
+    # Check for VLM: model_type field (only if vision capabilities are present)
+    # Some model families (e.g., qwen3_5_moe) have both VLM and text-only variants.
+    # Text-only quants won't have vision_config in their config.json.
     if normalized_type in VLM_MODEL_TYPES:
-        return "vlm"
+        if "vision_config" in config:
+            return "vlm"
+        logger.info(
+            f"Model type '{model_type}' is in VLM_MODEL_TYPES but no vision_config found — "
+            "treating as LLM (text-only quant)"
+        )
 
     # Check for VLM: presence of vision_config (fallback heuristic)
-    # Some VLMs have both vision_config + text_config, others only vision_config.
+    # Catch-all for VLMs that aren't yet listed in VLM_MODEL_TYPES.
     if "vision_config" in config:
         return "vlm"
 

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -144,6 +144,25 @@ class TestDetectModelType:
         (tmp_path / "config.json").write_text(json.dumps(config))
         assert detect_model_type(tmp_path) == "vlm"
 
+    def test_detect_text_only_qwen3_5_moe_as_llm(self, tmp_path):
+        """Text-only quant of qwen3_5_moe (no vision_config) should be LLM."""
+        config = {
+            "model_type": "qwen3_5_moe",
+            "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "llm"
+
+    def test_detect_vlm_model_type_requires_vision_config(self, tmp_path):
+        """VLM_MODEL_TYPES match without vision_config should fall back to LLM."""
+        config = {
+            "model_type": "gemma3",
+            # No VLM architecture, no vision_config — text-only derivative
+            "architectures": ["SomeTextOnlyArch"],
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "llm"
+
 
 class TestEstimateModelSize:
     """Tests for estimate_model_size function."""


### PR DESCRIPTION
## Description

Text-only quantizations of natively multimodal models (e.g., Qwen 3.5 122B-A10B quantized via `mlx_lm.convert`) are misdetected as `type: vlm`, causing the VLM engine to load, fail, and fall back to LLM on every server restart.

### Root Cause

`mlx_lm.convert` only converts text weights — the vision tower and `vision_config` are stripped during quantization. However, `config.json` retains `model_type: "qwen3_5_moe"` from the source model. Since `qwen3_5_moe` is in `VLM_MODEL_TYPES`, `detect_model_type()` returns `"vlm"` based on model_type alone, without checking for actual vision capabilities.

The VLM-to-LLM fallback (#72) catches this at runtime, but the failed VLM engine load is wasted work on every restart.

### Fix

For model_type-based VLM detection, also require `vision_config` in `config.json`. If a model's type is in `VLM_MODEL_TYPES` but has no `vision_config`, it's a text-only quant — classify as LLM directly.

Architecture-based detection (`VLM_ARCHITECTURES`) is unchanged since those are definitively VLM classes.

This affects any model family where both VLM and text-only variants share a `model_type` — currently `qwen3_5_moe`, but likely more as natively multimodal architectures become common.

*Independent of #82 and #83.*

### Testing

- 2 new tests: text-only qwen3_5_moe → LLM, with vision_config → VLM
- All 2,165 existing tests pass
- Verified on qwen3.5-122b-8bit: now detected as `type: llm, engine: batched` at discovery (no VLM fallback)

### Files Changed

| File | Changes |
|------|---------|
| `omlx/model_discovery.py` | +10/−3 — require vision_config for model_type VLM match |
| `tests/test_model_discovery.py` | +19 — 2 new detection tests |
