### PR TITLE
fix: extract reasoning content in non-streaming responses (#82)

### DIFF
--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -26,6 +26,16 @@ _THINKING_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
 _THINKING_TAIL_PATTERN = re.compile(r'^(.*?)</think>', re.DOTALL)
 
 
+def _strip_thinking_blocks(text: str) -> str:
+    """Strip <think> blocks (and partial tail blocks) from text."""
+    if not text:
+        return ""
+    stripped = _THINKING_PATTERN.sub("", text)
+    if '</think>' in stripped and '<think>' not in stripped:
+        stripped = _THINKING_TAIL_PATTERN.sub("", stripped, count=1)
+    return stripped.strip()
+
+
 def extract_thinking(text: str) -> Tuple[str, str]:
     """Extract thinking and content from complete text.
 
@@ -45,20 +55,10 @@ def extract_thinking(text: str) -> Tuple[str, str]:
     if not text:
         return ("", "")
 
-    thinking_parts = []
-    remaining = text
-
-    # Extract all <think>...</think> blocks
-    while True:
-        match = _THINKING_PATTERN.search(remaining)
-        if not match:
-            break
-        thinking_parts.append(match.group(1))
-        remaining = remaining[:match.start()] + remaining[match.end():]
-
+    thinking_parts = [m.group(1) for m in _THINKING_PATTERN.finditer(text)]
     if thinking_parts:
         thinking = "\n".join(thinking_parts).strip()
-        return (thinking, remaining.strip())
+        return (thinking, _strip_thinking_blocks(text))
 
     # Handle partial: content before </think> without <think> tag
     if '</think>' in text and '<think>' not in text:

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -52,6 +52,12 @@ from typing import Optional, Union
 
 import secrets
 
+try:
+    import jinja2
+    _TEMPLATE_ERRORS = (TypeError, ValueError, jinja2.TemplateError)
+except ImportError:
+    _TEMPLATE_ERRORS = (TypeError, ValueError)
+
 from fastapi import Depends, FastAPI, HTTPException, Request as FastAPIRequest
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.exceptions import RequestValidationError
@@ -213,6 +219,41 @@ def get_engine_pool() -> EnginePool:
 def get_mcp_manager():
     """Get the MCP manager instance (may be None)."""
     return _server_state.mcp_manager
+
+
+def maybe_prepend_think_prefix(engine: BaseEngine, raw_text: str) -> str:
+    """Prepend <think> prefix for reasoning templates when output is missing open tag."""
+    if not raw_text or "<think>" in raw_text or "</think>" not in raw_text:
+        return raw_text
+
+    cached = getattr(engine, "_needs_think_prefix_nonstream", None)
+    if cached is None:
+        cached = False
+        tokenizer = getattr(engine, "tokenizer", None)
+        if tokenizer is None:
+            logger.warning("Cannot detect think-prefix behavior: tokenizer missing")
+        elif not hasattr(tokenizer, "apply_chat_template"):
+            logger.warning("Cannot detect think-prefix behavior: no apply_chat_template")
+        else:
+            try:
+                probe_messages = [{"role": "user", "content": "ping"}]
+                prompt = tokenizer.apply_chat_template(
+                    probe_messages,
+                    tokenize=False,
+                    add_generation_prompt=True,
+                    chat_template_kwargs={"enable_thinking": True},
+                )
+                think_tag = getattr(tokenizer, "think_start", "<think>")
+                if isinstance(prompt, str):
+                    cached = prompt.rstrip().endswith(think_tag)
+            except _TEMPLATE_ERRORS as e:
+                logger.warning("Failed reasoning think-prefix detection: %s", e)
+        setattr(engine, "_needs_think_prefix_nonstream", cached)
+
+    if not cached:
+        return raw_text
+    think_tag = getattr(getattr(engine, "tokenizer", None), "think_start", "<think>")
+    return f"{think_tag}\n{raw_text}"
 
 
 async def verify_api_key(
@@ -1540,6 +1581,7 @@ async def create_chat_completion(
 
     # Separate thinking from content
     raw_text = clean_special_tokens(output.text) if output.text else ""
+    raw_text = maybe_prepend_think_prefix(engine, raw_text)
     thinking_content, regular_content = extract_thinking(raw_text)
 
     # For Harmony (gpt-oss) models, tool_calls are already extracted by the parser
@@ -1860,6 +1902,7 @@ async def stream_chat_completion(
         cleaned_text = ""
     elif has_tools and accumulated_text:
         # Separate thinking from content, then parse tool calls from content
+        accumulated_text = maybe_prepend_think_prefix(engine, accumulated_text)
         thinking_content, regular_content = extract_thinking(accumulated_text)
         cleaned_text, tool_calls = parse_tool_calls(
             regular_content,
@@ -2133,6 +2176,7 @@ async def stream_anthropic_messages(
         ]
     elif kwargs.get("tools"):
         # Non-Harmony: separate thinking, then parse tool calls from content
+        accumulated_text = maybe_prepend_think_prefix(engine, accumulated_text)
         _, regular_content = extract_thinking(accumulated_text)
         cleaned_text, tool_calls = parse_tool_calls(
             regular_content,
@@ -2374,6 +2418,7 @@ async def create_anthropic_message(
 
     # Separate thinking from content
     raw_text = clean_special_tokens(output.text) if output.text else ""
+    raw_text = maybe_prepend_think_prefix(engine, raw_text)
     thinking_content, regular_content = extract_thinking(raw_text)
 
     # For Harmony (gpt-oss) models, tool_calls are already extracted by the parser

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -3,7 +3,8 @@
 
 import pytest
 
-from omlx.api.thinking import ThinkingParser, extract_thinking
+from omlx.api.thinking import ThinkingParser, extract_thinking, _strip_thinking_blocks
+from omlx.server import maybe_prepend_think_prefix
 
 
 class TestExtractThinking:
@@ -37,6 +38,12 @@ class TestExtractThinking:
         """Only thinking content, no answer."""
         thinking, content = extract_thinking("<think>reasoning</think>")
         assert thinking == "reasoning"
+        assert content == ""
+
+    def test_all_thinking_returns_empty_content(self):
+        """All-thinking output should not leak think tags into answer."""
+        thinking, content = extract_thinking("<think>internal reasoning only</think>")
+        assert thinking == "internal reasoning only"
         assert content == ""
 
     def test_multiline_thinking(self):
@@ -79,6 +86,47 @@ class TestExtractThinking:
         )
         assert "Let me reason..." in thinking
         assert "Final answer." in content
+
+
+class TestStripThinkingBlocks:
+    def test_strip_complete(self):
+        assert _strip_thinking_blocks("<think>a</think>b") == "b"
+
+    def test_strip_partial_tail(self):
+        assert _strip_thinking_blocks("reasoning</think>answer") == "answer"
+
+    def test_strip_all_thinking(self):
+        assert _strip_thinking_blocks("<think>only</think>") == ""
+
+    def test_empty(self):
+        assert _strip_thinking_blocks("") == ""
+
+
+class TestMaybePrependThinkPrefix:
+    def test_noop_already_has_open_tag(self):
+        engine = type("Engine", (), {"tokenizer": None})()
+        raw = "<think>reason</think>answer"
+        assert maybe_prepend_think_prefix(engine, raw) == raw
+
+    def test_noop_no_close_tag(self):
+        engine = type("Engine", (), {"tokenizer": None})()
+        raw = "just answer"
+        assert maybe_prepend_think_prefix(engine, raw) == raw
+
+    def test_noop_empty(self):
+        engine = type("Engine", (), {"tokenizer": None})()
+        assert maybe_prepend_think_prefix(engine, "") == ""
+
+    def test_prepends_when_needed(self):
+        class DummyTokenizer:
+            think_start = "<think>"
+
+            def apply_chat_template(self, *args, **kwargs):
+                return "prompt...<think>"
+
+        engine = type("Engine", (), {"tokenizer": DummyTokenizer()})()
+        raw = "reasoning</think>answer"
+        assert maybe_prepend_think_prefix(engine, raw) == "<think>\n" + raw
 
 
 class TestThinkingParser:


### PR DESCRIPTION
Went back and re-reviewed and cleaned up.  I -think- this one should be cleaner.