### PR TITLE
fix: stream content token-by-token when tools are present

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -290,6 +290,65 @@ def parse_tool_calls(
     return cleaned_text, None
 
 
+class ToolCallStreamFilter:
+    """Streaming filter that suppresses tool-call markup from content deltas.
+
+    Buffers a small window of tokens to detect the tool-call start marker
+    from the model's tokenizer.  Content before the marker is emitted
+    normally; once the marker is found, all subsequent content is suppressed
+    (tool calls are parsed from accumulated text after generation).
+
+    Args:
+        tokenizer: The model's tokenizer — uses ``tool_call_start`` to
+            determine what to look for.
+    """
+
+    def __init__(self, tokenizer: Any):
+        self._marker: str = getattr(tokenizer, "tool_call_start", "")
+        self._max_len = len(self._marker) if self._marker else 0
+        self._buffer = ""
+        self._suppressing = False
+
+    @property
+    def active(self) -> bool:
+        """Whether this filter has a marker to look for."""
+        return self._max_len > 0
+
+    def feed(self, text: str) -> str:
+        """Feed a content delta, return the portion safe to emit."""
+        if self._suppressing or not text:
+            return ""
+        if not self.active:
+            return text
+
+        self._buffer += text
+
+        idx = self._buffer.find(self._marker)
+        if idx >= 0:
+            self._suppressing = True
+            safe = self._buffer[:idx]
+            self._buffer = ""
+            return safe
+
+        # Emit content that can't possibly be a partial marker start.
+        # Keep the last (marker_len - 1) chars buffered.
+        safe_len = len(self._buffer) - self._max_len + 1
+        if safe_len > 0:
+            safe = self._buffer[:safe_len]
+            self._buffer = self._buffer[safe_len:]
+            return safe
+
+        return ""
+
+    def finish(self) -> str:
+        """Flush remaining buffer (only if we never found a marker)."""
+        if self._suppressing:
+            return ""
+        buf = self._buffer
+        self._buffer = ""
+        return buf
+
+
 def convert_tools_for_template(
     tools: Optional[List]
 ) -> Optional[List[dict]]:

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -118,6 +118,7 @@ from .api.rerank_models import (
     RerankUsage,
 )
 from .api.tool_calling import (
+    ToolCallStreamFilter,
     build_json_system_prompt,
     convert_tools_for_template,
     parse_json_output,
@@ -1765,9 +1766,11 @@ async def stream_chat_completion(
     )
     yield f"data: {first_chunk.model_dump_json(exclude_none=True)}\n\n"
 
-    # Stream content — buffer when tools are present so we can strip
-    # tool call markup before emitting (prevents clients from seeing
-    # tool calls in both content and structured tool_calls chunks).
+    # Stream content token-by-token.  When tools are present, a
+    # ToolCallStreamFilter suppresses tool-call markup so clients
+    # don't see raw XML/tags — tool calls are parsed from accumulated
+    # text after generation and emitted as structured chunks.
+    tool_filter = ToolCallStreamFilter(engine.tokenizer) if has_tools else None
     try:
         async for output in engine.stream_chat(messages=messages, **kwargs):
             if first_token_time is None and output.new_text:
@@ -1776,7 +1779,7 @@ async def stream_chat_completion(
             if output.new_text:
                 accumulated_text += output.new_text
 
-            if not has_tools and output.new_text:
+            if output.new_text:
                 thinking_delta, content_delta = thinking_parser.feed(output.new_text)
 
                 # Emit reasoning_content delta
@@ -1791,17 +1794,21 @@ async def stream_chat_completion(
                     )
                     yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
 
-                # Emit content delta
+                # Emit content delta — filter out tool-call markup when
+                # tools are present so clients see clean streamed text.
                 if content_delta:
-                    chunk = ChatCompletionChunk(
-                        id=response_id,
-                        model=request.model,
-                        choices=[ChatCompletionChunkChoice(
-                            delta=ChatCompletionChunkDelta(content=content_delta),
-                            finish_reason=None,
-                        )],
-                    )
-                    yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
+                    if tool_filter:
+                        content_delta = tool_filter.feed(content_delta)
+                    if content_delta:
+                        chunk = ChatCompletionChunk(
+                            id=response_id,
+                            model=request.model,
+                            choices=[ChatCompletionChunkChoice(
+                                delta=ChatCompletionChunkDelta(content=content_delta),
+                                finish_reason=None,
+                            )],
+                        )
+                        yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
     except Exception as e:
         logger.error(f"Error during chat streaming: {e}")
         error_chunk = ChatCompletionChunk(
@@ -1817,24 +1824,40 @@ async def stream_chat_completion(
         return
 
     # Flush remaining buffered content from thinking parser
-    if not has_tools:
-        thinking_delta, content_delta = thinking_parser.finish()
-        if thinking_delta:
-            chunk = ChatCompletionChunk(
-                id=response_id,
-                model=request.model,
-                choices=[ChatCompletionChunkChoice(
-                    delta=ChatCompletionChunkDelta(reasoning_content=thinking_delta),
-                    finish_reason=None,
-                )],
-            )
-            yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
+    thinking_delta, content_delta = thinking_parser.finish()
+    if thinking_delta:
+        chunk = ChatCompletionChunk(
+            id=response_id,
+            model=request.model,
+            choices=[ChatCompletionChunkChoice(
+                delta=ChatCompletionChunkDelta(reasoning_content=thinking_delta),
+                finish_reason=None,
+            )],
+        )
+        yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
+    if content_delta:
+        if tool_filter:
+            content_delta = tool_filter.feed(content_delta)
         if content_delta:
             chunk = ChatCompletionChunk(
                 id=response_id,
                 model=request.model,
                 choices=[ChatCompletionChunkChoice(
                     delta=ChatCompletionChunkDelta(content=content_delta),
+                    finish_reason=None,
+                )],
+            )
+            yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
+
+    # Flush any remaining buffered content from the tool-call filter
+    if tool_filter:
+        remaining = tool_filter.finish()
+        if remaining:
+            chunk = ChatCompletionChunk(
+                id=response_id,
+                model=request.model,
+                choices=[ChatCompletionChunkChoice(
+                    delta=ChatCompletionChunkDelta(content=remaining),
                     finish_reason=None,
                 )],
             )
@@ -1866,30 +1889,6 @@ async def stream_chat_completion(
             tokenizer=engine.tokenizer,
             tools=kwargs.get("tools"),
         )
-
-        # Emit reasoning_content if present (buffered mode)
-        if thinking_content:
-            rc_chunk = ChatCompletionChunk(
-                id=response_id,
-                model=request.model,
-                choices=[ChatCompletionChunkChoice(
-                    delta=ChatCompletionChunkDelta(reasoning_content=thinking_content),
-                    finish_reason=None,
-                )],
-            )
-            yield f"data: {rc_chunk.model_dump_json(exclude_none=True)}\n\n"
-
-    # When tools were requested, emit buffered content now (cleaned of markup)
-    if has_tools and cleaned_text:
-        content_chunk = ChatCompletionChunk(
-            id=response_id,
-            model=request.model,
-            choices=[ChatCompletionChunkChoice(
-                delta=ChatCompletionChunkDelta(content=cleaned_text),
-                finish_reason=None,
-            )],
-        )
-        yield f"data: {content_chunk.model_dump_json(exclude_none=True)}\n\n"
 
     # Emit tool call chunks if found
     if tool_calls:


### PR DESCRIPTION
## Summary

- Remove the `if not has_tools` gate that prevented token-by-token streaming
  when `tools` was present in the request
- Add `ToolCallStreamFilter` that uses the tokenizer's `tool_call_start`
  marker to suppress tool-call markup from the content stream in real time
- Remove the now-redundant buffered content/reasoning re-emit after generation
- Tool call parsing from accumulated text is unchanged

Fixes #102

## How it works

Previously, when `has_tools` was True, all content deltas were skipped during
generation and the entire response was emitted as one chunk at the end. This
broke visual streaming in every client that sends `tools` in the request
(Open WebUI, LibreChat, etc.).

Now, content streams normally regardless of tools. A lightweight
`ToolCallStreamFilter` buffers a small window of tokens (equal to the
tokenizer's `tool_call_start` marker length) to detect when tool-call markup
begins. Content before the marker streams normally; once the marker is found,
subsequent content is suppressed. Tool calls are still parsed from the full
accumulated text after generation and emitted as structured `tool_calls` chunks.

## Test plan

- [x] Regular chat (no tools in request): streams token-by-token as before
- [x] Chat with tools present, no tool call invoked: streams token-by-token,
      no markup visible
- [x] Chat with tools present, tool call invoked: content before tool call
      streams, tool-call markup suppressed, tool calls parsed and emitted
      correctly
- [x] Tested with Open WebUI — visual streaming now works