### PR TITLE
fix: persist dashboard tabs in query params

### DIFF
--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -2,6 +2,9 @@
     const OCR_CONFIG_MODEL_TYPES = new Set([
         'deepseekocr', 'deepseekocr_2', 'dots_ocr', 'glm_ocr',
     ]);
+    const DASHBOARD_MAIN_TABS = new Set(['status', 'settings', 'models', 'logs', 'bench']);
+    const DASHBOARD_SETTINGS_TABS = new Set(['global', 'models']);
+    const DASHBOARD_MODELS_TABS = new Set(['manager', 'downloader']);
 
     function dashboard() {
         return {
@@ -190,6 +193,7 @@
             async init() {
                 // Apply theme
                 this.applyTheme();
+                this.applyTabStateFromUrl();
 
                 await Promise.all([
                     this.loadGlobalSettings(),
@@ -199,43 +203,98 @@
                     lucide.createIcons();
                 });
 
-                // Load stats and start polling if starting on status tab
-                if (this.mainTab === 'status') {
-                    await this.loadStats();
-                    this.startStatsRefresh();
-                }
+                await this.handleMainTabChange(this.mainTab);
 
                 // Watch for main tab changes to manage refresh timers
                 this.$watch('mainTab', (value) => {
-                    if (value === 'status') {
-                        this.loadStats();
-                        this.startStatsRefresh();
-                    } else {
-                        this.stopStatsRefresh();
-                    }
-                    if (value === 'logs') {
-                        this.loadLogs();
-                        this.startLogRefresh();
-                    } else {
-                        this.stopLogRefresh();
-                    }
-                    if (value === 'models') {
-                        this.loadHFModels();
-                        this.loadHFTasks();
-                        if (this.modelsTab === 'downloader') {
-                            if (!this.hfRecommendedLoaded) this.loadRecommendedModels();
-                        }
-                        const hasActive = this.hfTasks.some(t =>
-                            t.status === 'pending' || t.status === 'downloading');
-                        if (hasActive) this.startHFRefresh();
-                    } else {
-                        this.stopHFRefresh();
-                    }
-                    if (value === 'bench') {
-                        if (!this.benchDeviceInfo) this.loadBenchDeviceInfo();
-                    }
-                    this.$nextTick(() => lucide.createIcons());
+                    this.handleMainTabChange(value);
                 });
+
+                window.addEventListener('popstate', () => {
+                    this.applyTabStateFromUrl();
+                    this.handleMainTabChange(this.mainTab);
+                });
+            },
+
+            async handleMainTabChange(value) {
+                if (value === 'status') {
+                    await this.loadStats();
+                    this.startStatsRefresh();
+                } else {
+                    this.stopStatsRefresh();
+                }
+                if (value === 'logs') {
+                    await this.loadLogs();
+                    this.startLogRefresh();
+                } else {
+                    this.stopLogRefresh();
+                }
+                if (value === 'models') {
+                    await this.loadHFModels();
+                    await this.loadHFTasks();
+                    if (this.modelsTab === 'downloader' && !this.hfRecommendedLoaded) {
+                        await this.loadRecommendedModels();
+                    }
+                    const hasActive = this.hfTasks.some(t =>
+                        t.status === 'pending' || t.status === 'downloading');
+                    if (hasActive) this.startHFRefresh();
+                } else {
+                    this.stopHFRefresh();
+                }
+                if (value === 'bench' && !this.benchDeviceInfo) {
+                    await this.loadBenchDeviceInfo();
+                }
+                this.$nextTick(() => lucide.createIcons());
+            },
+
+            applyTabStateFromUrl() {
+                const params = new URLSearchParams(window.location.search);
+                const mainTab = params.get('tab');
+                const settingsTab = params.get('settingsTab');
+                const modelsTab = params.get('modelsTab');
+
+                this.mainTab = DASHBOARD_MAIN_TABS.has(mainTab) ? mainTab : 'status';
+                this.activeTab = DASHBOARD_SETTINGS_TABS.has(settingsTab) ? settingsTab : 'global';
+                this.modelsTab = DASHBOARD_MODELS_TABS.has(modelsTab) ? modelsTab : 'manager';
+            },
+
+            syncTabStateToUrl() {
+                const url = new URL(window.location.href);
+                url.searchParams.set('tab', this.mainTab);
+
+                if (this.mainTab === 'settings') {
+                    url.searchParams.set('settingsTab', this.activeTab);
+                } else {
+                    url.searchParams.delete('settingsTab');
+                }
+
+                if (this.mainTab === 'models') {
+                    url.searchParams.set('modelsTab', this.modelsTab);
+                } else {
+                    url.searchParams.delete('modelsTab');
+                }
+
+                window.history.replaceState({}, '', url);
+            },
+
+            setMainTab(tab) {
+                if (!DASHBOARD_MAIN_TABS.has(tab)) return;
+                this.mainTab = tab;
+                this.syncTabStateToUrl();
+            },
+
+            setSettingsTab(tab) {
+                if (!DASHBOARD_SETTINGS_TABS.has(tab)) return;
+                this.activeTab = tab;
+                this.mainTab = 'settings';
+                this.syncTabStateToUrl();
+            },
+
+            setModelsTab(tab) {
+                if (!DASHBOARD_MODELS_TABS.has(tab)) return;
+                this.modelsTab = tab;
+                this.mainTab = 'models';
+                this.syncTabStateToUrl();
             },
 
             async loadGlobalSettings() {

--- a/omlx/admin/templates/dashboard/_models.html
+++ b/omlx/admin/templates/dashboard/_models.html
@@ -3,7 +3,7 @@
                     <!-- Sub-tab navigation (Manager / Downloader) -->
                     <div class="flex items-center gap-2 mb-10 animate-fade-in-up">
                         <button
-                            @click="modelsTab = 'manager'; loadHFModels();"
+                            @click="setModelsTab('manager'); loadHFModels();"
                             :class="modelsTab === 'manager'
                                 ? 'bg-neutral-900 text-white'
                                 : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"
@@ -11,7 +11,7 @@
                             {{ t('models.tab.manager') }}
                         </button>
                         <button
-                            @click="modelsTab = 'downloader'; if (!hfRecommendedLoaded) loadRecommendedModels(); loadHFTasks();"
+                            @click="setModelsTab('downloader'); if (!hfRecommendedLoaded) loadRecommendedModels(); loadHFTasks();"
                             :class="modelsTab === 'downloader'
                                 ? 'bg-neutral-900 text-white'
                                 : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"

--- a/omlx/admin/templates/dashboard/_navbar.html
+++ b/omlx/admin/templates/dashboard/_navbar.html
@@ -20,7 +20,7 @@
             <!-- Center Navigation -->
             <div class="flex items-center gap-1 bg-neutral-100 rounded-full p-1">
                 <button
-                    @click="mainTab = 'status'"
+                    @click="setMainTab('status')"
                     :class="mainTab === 'status'
                         ? 'bg-white text-neutral-900 shadow-sm'
                         : 'text-neutral-600 hover:text-neutral-900'"
@@ -31,7 +31,7 @@
                 </button>
                 <div class="relative" @mouseenter="modelsDropdown = true" @mouseleave="modelsDropdown = false">
                     <button
-                        @click="mainTab = 'models'"
+                        @click="setMainTab('models')"
                         :class="mainTab === 'models'
                             ? 'bg-white text-neutral-900 shadow-sm'
                             : 'text-neutral-600 hover:text-neutral-900'"
@@ -58,7 +58,7 @@
                         x-cloak
                     >
                         <button
-                            @click="mainTab = 'models'; modelsTab = 'manager'; modelsDropdown = false; loadHFModels();"
+                            @click="setModelsTab('manager'); modelsDropdown = false; loadHFModels();"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'models' && modelsTab === 'manager'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -68,7 +68,7 @@
                             {{ t('navbar.dropdown.manager') }}
                         </button>
                         <button
-                            @click="mainTab = 'models'; modelsTab = 'downloader'; modelsDropdown = false; loadHFModels(); loadHFTasks(); if (!hfRecommendedLoaded) loadRecommendedModels();"
+                            @click="setModelsTab('downloader'); modelsDropdown = false; loadHFModels(); loadHFTasks(); if (!hfRecommendedLoaded) loadRecommendedModels();"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'models' && modelsTab === 'downloader'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -81,7 +81,7 @@
                 </div>
                 <div class="relative" @mouseenter="settingsDropdown = true" @mouseleave="settingsDropdown = false">
                     <button
-                        @click="mainTab = 'settings'"
+                        @click="setMainTab('settings')"
                         :class="mainTab === 'settings'
                             ? 'bg-white text-neutral-900 shadow-sm'
                             : 'text-neutral-600 hover:text-neutral-900'"
@@ -103,7 +103,7 @@
                         x-cloak
                     >
                         <button
-                            @click="mainTab = 'settings'; activeTab = 'global'; settingsDropdown = false"
+                            @click="setSettingsTab('global'); settingsDropdown = false"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'settings' && activeTab === 'global'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -113,7 +113,7 @@
                             {{ t('navbar.dropdown.global_settings') }}
                         </button>
                         <button
-                            @click="mainTab = 'settings'; activeTab = 'models'; settingsDropdown = false"
+                            @click="setSettingsTab('models'); settingsDropdown = false"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'settings' && activeTab === 'models'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -125,7 +125,7 @@
                     </div>
                 </div>
                 <button
-                    @click="mainTab = 'logs'; if (!logContent) loadLogs()"
+                    @click="setMainTab('logs'); if (!logContent) loadLogs()"
                     :class="mainTab === 'logs'
                         ? 'bg-white text-neutral-900 shadow-sm'
                         : 'text-neutral-600 hover:text-neutral-900'"
@@ -135,7 +135,7 @@
                     {{ t('navbar.tab.logs') }}
                 </button>
                 <button
-                    @click="mainTab = 'bench'"
+                    @click="setMainTab('bench')"
                     :class="mainTab === 'bench'
                         ? 'bg-white text-neutral-900 shadow-sm'
                         : 'text-neutral-600 hover:text-neutral-900'"

--- a/omlx/admin/templates/dashboard/_settings.html
+++ b/omlx/admin/templates/dashboard/_settings.html
@@ -2,7 +2,7 @@
             <!-- Tab Navigation -->
             <div class="flex items-center gap-2 mb-10 animate-fade-in-up">
                 <button
-                    @click="activeTab = 'global'"
+                    @click="setSettingsTab('global')"
                     :class="activeTab === 'global'
                         ? 'bg-neutral-900 text-white'
                         : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"
@@ -11,7 +11,7 @@
                     {{ t('settings.tab.global') }}
                 </button>
                 <button
-                    @click="activeTab = 'models'"
+                    @click="setSettingsTab('models')"
                     :class="activeTab === 'models'
                         ? 'bg-neutral-900 text-white'
                         : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"


### PR DESCRIPTION

  ## Summary
  - persist the selected admin dashboard tab in URL query parameters
  - restore nested `settings` and `models` subtabs on reload and browser navigation
  - route dashboard tab clicks through shared Alpine helpers instead of raw state assignment

  ## Testing
  - `node -e "new Function(require('fs').readFileSync('omlx/admin/static/js/dashboard.js',
  'utf8'))"`
  - started `omlx serve --model-dir /tmp/omlx-models --port 8000` outside the sandbox and
  verified the admin dashboard loads locally
  - `python3 -m pytest tests/test_admin_auth.py -vv -s` currently aborts in this environment
  because importing `mlx` triggers a native Metal initialization crash (`NSRangeException`)
  before test execution

  ## Why
  Reloading `/admin/dashboard` reset the UI to the default home/status tab even after the
  user selected a different dashboard section. This change keeps the current tab selection in
  the URL so refreshes and direct links preserve the same view.
