### PR TITLE
fix: support pointing model directory directly at a model folder

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -368,6 +368,12 @@ def discover_models(model_dir: Path) -> dict[str, DiscoveredModel]:
                     f"(not a model or organization folder)"
                 )
 
+    # Fallback: if no models found and the directory itself is a model, register it.
+    # This supports pointing directly at a single model folder, e.g.:
+    #   /Models/Qwen3.5-9B-MLX-4bit/  (contains config.json and weight files)
+    if not models and _is_model_dir(model_dir):
+        _register_model(models, model_dir, model_dir.name)
+
     return models
 
 

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -286,6 +286,19 @@ class TestDiscoverModels:
         assert models["llama-3b"].model_type == "llm"
         assert models["llama-3b"].engine_type == "batched"
 
+    def test_discover_model_dir_is_itself_a_model(self, tmp_path):
+        """Test that pointing directly at a model directory works."""
+        model_dir = tmp_path / "Qwen3-5-9B-MLX-4bit"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "qwen2"}))
+        (model_dir / "model.safetensors").write_bytes(b"0" * 1000)
+
+        models = discover_models(model_dir)
+        assert len(models) == 1
+        assert "Qwen3-5-9B-MLX-4bit" in models
+        assert models["Qwen3-5-9B-MLX-4bit"].model_type == "llm"
+        assert models["Qwen3-5-9B-MLX-4bit"].engine_type == "batched"
+
     def test_discover_multiple_models(self, tmp_path):
         """Test discovery of multiple models."""
         # Create first LLM model


### PR DESCRIPTION
## Summary  

- `discover_models()` now detects when the given path is itself a model directory (has `config.json`) and registers it directly, rather than scanning its children
- Previously, pointing to a specific model folder (e.g. `/Models/Qwen3.5-9B-MLX-4bit/`) would find nothing since it would look for model subdirectories inside the weight files
- Adds a test covering the direct model directory case

Closes #149  
 
## Test plan  
 
- [ ] Add a model dir pointing directly at a single model folder (e.g. LM Studio's `~/.lmstudio/models/mlx-community/Qwen3.5-9B-MLX-4bit/`)
— model should appear in the models list 
- [ ] Add a model dir pointing at a parent folder containing multiple models — existing behavior unchanged
- [ ] Run `pytest tests/test_model_discovery.py`
