### PR TITLE
fix: launch command ignores settings.json host/port config

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -214,9 +214,11 @@ def serve_command(args):
 
 def launch_command(args):
     """Launch an external tool integrated with oMLX."""
+    import os
     import requests
 
     from .integrations import get_integration, list_integrations
+    from .settings import GlobalSettings
 
     tool_name = args.tool
 
@@ -233,9 +235,13 @@ def launch_command(args):
         print("Available: " + ", ".join(i.name for i in list_integrations()))
         sys.exit(1)
 
+    # Resolve host/port: CLI args > env vars > settings.json > defaults
+    settings = GlobalSettings.load()
+    host = args.host or os.environ.get("OMLX_HOST") or settings.server.host
+    port = args.port or int(os.environ.get("OMLX_PORT", 0)) or settings.server.port
+
     # Check if oMLX server is running
-    port = args.port or 8000
-    base_url = f"http://127.0.0.1:{port}"
+    base_url = f"http://{host}:{port}"
     try:
         resp = requests.get(f"{base_url}/health", timeout=3)
         resp.raise_for_status()
@@ -300,7 +306,7 @@ def launch_command(args):
     print(f"Launching {integration.display_name} with model {model}...")
     tools_profile = getattr(args, "tools_profile", "coding")
     integration.launch(
-        port=port, api_key=api_key, model=model, tools_profile=tools_profile
+        port=port, api_key=api_key, model=model, host=host, tools_profile=tools_profile
     )
 
 
@@ -463,10 +469,16 @@ Example directory structure:
         help="Model to use (interactive selection if not specified)",
     )
     launch_parser.add_argument(
+        "--host",
+        type=str,
+        default=None,
+        help="oMLX server host (default: from settings or 127.0.0.1)",
+    )
+    launch_parser.add_argument(
         "--port",
         type=int,
         default=None,
-        help="oMLX server port (default: 8000)",
+        help="oMLX server port (default: from settings or 8000)",
     )
     launch_parser.add_argument(
         "--api-key",

--- a/omlx/integrations/base.py
+++ b/omlx/integrations/base.py
@@ -28,11 +28,11 @@ class Integration:
         """Generate the command string for clipboard/display."""
         raise NotImplementedError
 
-    def configure(self, port: int, api_key: str, model: str) -> None:
+    def configure(self, port: int, api_key: str, model: str, host: str = "127.0.0.1") -> None:
         """Configure the tool (write config files, etc.)."""
         pass
 
-    def launch(self, port: int, api_key: str, model: str, **kwargs) -> None:
+    def launch(self, port: int, api_key: str, model: str, host: str = "127.0.0.1", **kwargs) -> None:
         """Configure and launch the tool."""
         raise NotImplementedError
 

--- a/omlx/integrations/codex.py
+++ b/omlx/integrations/codex.py
@@ -16,7 +16,7 @@ model_provider = "omlx"
 
 [model_providers.omlx]
 name = "oMLX"
-base_url = "http://127.0.0.1:{port}/v1"
+base_url = "http://{host}:{port}/v1"
 env_key = "OMLX_API_KEY"
 """
 
@@ -43,7 +43,7 @@ class CodexIntegration(Integration):
             f"launch codex --model {model or 'select-a-model'}"
         )
 
-    def configure(self, port: int, api_key: str, model: str) -> None:
+    def configure(self, port: int, api_key: str, model: str, host: str = "127.0.0.1") -> None:
         config_path = self.CONFIG_PATH
         config_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -59,13 +59,14 @@ class CodexIntegration(Integration):
 
         content = _CONFIG_TEMPLATE.format(
             model=model or "select-a-model",
+            host=host,
             port=port,
         )
         config_path.write_text(content, encoding="utf-8")
         print(f"Config written: {config_path}")
 
-    def launch(self, port: int, api_key: str, model: str, **kwargs) -> None:
-        self.configure(port, api_key, model)
+    def launch(self, port: int, api_key: str, model: str, host: str = "127.0.0.1", **kwargs) -> None:
+        self.configure(port, api_key, model, host=host)
 
         env = os.environ.copy()
         env["OMLX_API_KEY"] = api_key or "omlx"

--- a/omlx/integrations/openclaw.py
+++ b/omlx/integrations/openclaw.py
@@ -42,12 +42,13 @@ class OpenClawIntegration(Integration):
         port: int,
         api_key: str,
         model: str,
+        host: str = "127.0.0.1",
         tools_profile: str = "coding",
     ) -> None:
         def updater(config: dict) -> None:
             config.setdefault("models", {}).setdefault("providers", {})
             provider_config = {
-                "baseUrl": f"http://127.0.0.1:{port}/v1",
+                "baseUrl": f"http://{host}:{port}/v1",
                 "apiKey": api_key or "omlx",
                 "api": "openai-completions",
             }
@@ -155,10 +156,11 @@ class OpenClawIntegration(Integration):
         port: int,
         api_key: str,
         model: str,
+        host: str = "127.0.0.1",
         tools_profile: str = "coding",
         **kwargs,
     ) -> None:
-        self.configure(port, api_key, model, tools_profile=tools_profile)
+        self.configure(port, api_key, model, host=host, tools_profile=tools_profile)
         self.configure_exec_approvals(tools_profile)
 
         env = os.environ.copy()
@@ -185,7 +187,7 @@ class OpenClawIntegration(Integration):
                 env=env,
             )
             # Onboarding overwrites config, re-apply
-            self.configure(port, api_key, model, tools_profile=tools_profile)
+            self.configure(port, api_key, model, host=host, tools_profile=tools_profile)
             self.configure_exec_approvals(tools_profile)
 
         _, gw_port = self._gateway_info()

--- a/omlx/integrations/opencode.py
+++ b/omlx/integrations/opencode.py
@@ -30,14 +30,14 @@ class OpenCodeIntegration(Integration):
             f"launch opencode --model {model or 'select-a-model'}"
         )
 
-    def configure(self, port: int, api_key: str, model: str) -> None:
+    def configure(self, port: int, api_key: str, model: str, host: str = "127.0.0.1") -> None:
         def updater(config: dict) -> None:
             config.setdefault("provider", {})
             provider_config = {
                 "npm": "@ai-sdk/openai-compatible",
                 "name": "oMLX",
                 "options": {
-                    "baseURL": f"http://127.0.0.1:{port}/v1",
+                    "baseURL": f"http://{host}:{port}/v1",
                 },
             }
             if api_key:
@@ -56,8 +56,8 @@ class OpenCodeIntegration(Integration):
 
         self._write_json_config(self.CONFIG_PATH, updater)
 
-    def launch(self, port: int, api_key: str, model: str, **kwargs) -> None:
-        self.configure(port, api_key, model)
+    def launch(self, port: int, api_key: str, model: str, host: str = "127.0.0.1", **kwargs) -> None:
+        self.configure(port, api_key, model, host=host)
 
         env = os.environ.copy()
         args = ["opencode"]


### PR DESCRIPTION
## Summary

- `omlx-cli launch` hardcoded `http://127.0.0.1:8000`, ignoring `~/.omlx/settings.json` host/port and `OMLX_HOST`/`OMLX_PORT` environment variables
- Users who changed the port in the oMLX GUI would get: `oMLX server is not running at http://127.0.0.1:8000`
- Now resolves host/port with proper priority: **CLI args > env vars > settings.json > defaults**
- Passes resolved host through to all integration `configure()`/`launch()` methods so generated config files use the correct server address

## Files changed

| File | Change |
|------|--------|
| `omlx/cli.py` | Read host/port from `GlobalSettings.load()`, add `--host` arg to launch subcommand |
| `omlx/integrations/base.py` | Add `host` parameter to `configure()` and `launch()` signatures |
| `omlx/integrations/opencode.py` | Use dynamic `host` in `baseURL` |
| `omlx/integrations/codex.py` | Use dynamic `host` in config template |
| `omlx/integrations/openclaw.py` | Use dynamic `host` in `baseUrl`, including post-onboarding re-configure |

## Test plan

- [x] `pytest tests/test_cli.py` — 20 passed
- [x] `pytest tests/test_integrations.py` — 25 passed
- [x] `pytest tests/test_settings.py` — 159 passed
- [ ] Manual: change port in oMLX GUI settings, verify `omlx-cli launch opencode` connects to correct port
- [ ] Manual: set `OMLX_PORT=2026`, verify launch uses port 2026
- [ ] Manual: `omlx-cli launch opencode --host 0.0.0.0 --port 9000`, verify CLI args take priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)