### PR TITLE
fix: rebuild menubar menu after update check

### DIFF
--- a/packaging/omlx_app/app.py
+++ b/packaging/omlx_app/app.py
@@ -267,6 +267,7 @@ class OMLXAppDelegate(NSObject):
                         "notes": data.get("body", ""),
                     }
                     logger.info(f"Update available: {latest}")
+                    self._build_menu()
                 else:
                     self._update_info = None
             else:


### PR DESCRIPTION
## Summary

* Menubar app could detect a newer GitHub release (logs show `Update available: x.y.z`) but the menu wouldn’t show the “Update Available” item until the menu happened to rebuild later.
* Rebuild the menubar menu immediately after setting `_update_info`, so the update item appears right away.

## Files changed

| File                         | Change |
| ---------------------------- | ------ |
| `packaging/omlx_app/app.py`  | Rebuild menu right after update detection to surface “Update Available” |

## Test plan

* `uv run pytest -m "not slow"` — passed
* `uv run pytest tests/test_updater.py -v` — 20 passed
* Manual: run an older `.app` (e.g. 0.2.8) and verify the menubar menu immediately shows **Update Available (0.2.9)** after launch.