### PR TITLE
feat(admin): filter HF model search to MLX library only

### DIFF
--- a/omlx/admin/hf_downloader.py
+++ b/omlx/admin/hf_downloader.py
@@ -244,6 +244,9 @@ class HFDownloader:
     ) -> dict:
         """Search HuggingFace models by query string.
 
+        Results are restricted to the MLX library so that only MLX-compatible
+        models are returned (same as https://huggingface.co/models?library=mlx).
+
         Args:
             query: Search query string.
             sort: Sort order (trending/downloads/created/updated/most_params/least_params).
@@ -261,6 +264,7 @@ class HFDownloader:
                 search=query,
                 sort=sort_key,
                 limit=limit,
+                filter="mlx",
                 expand=["safetensors", "downloads", "likes", "trendingScore"],
             ),
             timeout=_HF_API_TIMEOUT,


### PR DESCRIPTION
## Summary

* Admin model search called the HuggingFace API without a library filter, so results could include non–MLX models.
* Search now passes `filter="mlx"` so only MLX-compatible models are returned (aligned with [huggingface.co/models?library=mlx](https://huggingface.co/models?library=mlx)).
* Docstring updated to describe this behavior.

## Files changed

| File | Change |
|------|--------|
| `omlx/admin/hf_downloader.py` | Add `filter="mlx"` to search request; document MLX-only results in docstring |

## Test plan

* `uv run pytest tests/test_hf_downloader.py -v` — 74 passed
* Manual: open Admin → Models, run a search and confirm results are MLX models only.