### PR TITLE
admin: clarify sub-block cache (<block_size) in runtime cache observability

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -17,9 +17,10 @@ import shutil
 import sys
 import time
 from collections import deque
+from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, Optional, List, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
@@ -151,7 +152,7 @@ class GlobalSettingsRequest(BaseModel):
     integrations_codex_model: Optional[str] = None
     integrations_opencode_model: Optional[str] = None
     integrations_openclaw_model: Optional[str] = None
-    integrations_openclaw_tools_profile: Optional[str] = None
+    integrations_openclaw_tools_profile: Optional[Literal["minimal", "coding", "messaging", "full"]] = None
 
     # UI settings
     ui_language: Optional[str] = None
@@ -2259,6 +2260,145 @@ def _parse_commits_from_pyproject(
     return commits
 
 
+def _build_runtime_cache_observability(
+    global_settings,
+    model_filter: str = "",
+) -> dict:
+    """Build runtime cache observability payload for dashboard.
+
+    Includes the effective runtime paths and per-model SSD cache runtime stats
+    from loaded schedulers, so users can verify real cache state without manual
+    process inspection.
+    """
+    if global_settings is None:
+        return {
+            "base_path": "",
+            "ssd_cache_dir": "",
+            "response_state_dir": "",
+            "models": [],
+            "total_num_files": 0,
+            "total_size_bytes": 0,
+            "effective_block_sizes": [],
+        }
+
+    cache_dir = global_settings.cache.get_ssd_cache_dir(global_settings.base_path)
+    payload = {
+        "base_path": str(global_settings.base_path),
+        "ssd_cache_dir": str(cache_dir),
+        "response_state_dir": str(cache_dir / "response-state"),
+        "models": [],
+        "total_num_files": 0,
+        "total_size_bytes": 0,
+        "effective_block_sizes": [],
+    }
+
+    engine_pool = _get_engine_pool()
+    if engine_pool is None:
+        return payload
+
+    block_sizes = set()
+
+    for model_info in engine_pool.get_status().get("models", []):
+        model_id = model_info.get("id")
+        if not model_id:
+            continue
+        if model_filter and model_id != model_filter:
+            continue
+        if not model_info.get("loaded"):
+            continue
+
+        entry = engine_pool._entries.get(model_id)
+        if entry is None or entry.engine is None:
+            continue
+
+        async_core = getattr(entry.engine, "_engine", None)
+        core = getattr(async_core, "engine", None) if async_core is not None else None
+        scheduler = getattr(core, "scheduler", None) if core is not None else None
+
+        runtime_stats = None
+        if scheduler is not None and hasattr(scheduler, "get_ssd_cache_stats"):
+            try:
+                runtime_stats = scheduler.get_ssd_cache_stats()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to collect runtime cache stats for model '%s': %s",
+                    model_id,
+                    exc,
+                )
+                continue
+
+        if not runtime_stats:
+            continue
+
+        block_size = runtime_stats.get("block_size")
+        indexed_blocks = runtime_stats.get("indexed_blocks")
+
+        ssd_stats = runtime_stats.get("ssd_cache")
+        if is_dataclass(ssd_stats):
+            ssd_stats = asdict(ssd_stats)
+        elif hasattr(ssd_stats, "to_dict"):
+            ssd_stats = ssd_stats.to_dict()
+        elif not isinstance(ssd_stats, dict):
+            ssd_stats = {}
+
+        prefix_stats = runtime_stats.get("prefix_cache")
+        if is_dataclass(prefix_stats):
+            prefix_stats = asdict(prefix_stats)
+        elif hasattr(prefix_stats, "to_dict"):
+            prefix_stats = prefix_stats.to_dict()
+        elif not isinstance(prefix_stats, dict):
+            prefix_stats = {}
+
+        indexed_blocks_value = indexed_blocks if isinstance(indexed_blocks, int) else 0
+        if not isinstance(block_size, int) or block_size <= 0:
+            block_size = int(prefix_stats.get("block_size", 0) or 0)
+
+        partial_block_skips = int(prefix_stats.get("partial_block_skips", 0) or 0)
+        partial_tokens_skipped = int(prefix_stats.get("partial_tokens_skipped", 0) or 0)
+        last_partial_tokens_skipped = int(
+            prefix_stats.get("last_partial_tokens_skipped", 0) or 0
+        )
+        last_tokens_to_next_block = int(
+            prefix_stats.get("last_tokens_to_next_block", 0) or 0
+        )
+
+        has_sub_block_cache = (
+            indexed_blocks_value == 0
+            and isinstance(block_size, int)
+            and block_size > 0
+            and partial_block_skips > 0
+        )
+
+        model_payload = {
+            "id": model_id,
+            "block_size": block_size,
+            "indexed_blocks": indexed_blocks_value,
+            "indexed_blocks_display": (
+                f"<{block_size}" if has_sub_block_cache else str(indexed_blocks_value)
+            ),
+            "has_sub_block_cache": has_sub_block_cache,
+            "partial_block_skips": partial_block_skips,
+            "partial_tokens_skipped": partial_tokens_skipped,
+            "last_partial_tokens_skipped": last_partial_tokens_skipped,
+            "last_tokens_to_next_block": last_tokens_to_next_block,
+            "num_files": int(ssd_stats.get("num_files", 0) or 0),
+            "total_size_bytes": int(ssd_stats.get("total_size_bytes", 0) or 0),
+            "hot_cache_max_bytes": int(ssd_stats.get("hot_cache_max_bytes", 0) or 0),
+            "hot_cache_size_bytes": int(ssd_stats.get("hot_cache_size_bytes", 0) or 0),
+            "hot_cache_entries": int(ssd_stats.get("hot_cache_entries", 0) or 0),
+        }
+
+        payload["models"].append(model_payload)
+        payload["total_num_files"] += model_payload["num_files"]
+        payload["total_size_bytes"] += model_payload["total_size_bytes"]
+
+        if isinstance(block_size, int) and block_size > 0:
+            block_sizes.add(block_size)
+
+    payload["effective_block_sizes"] = sorted(block_sizes)
+    return payload
+
+
 @router.get("/api/stats")
 async def get_server_stats(
     model: str = "",
@@ -2279,7 +2419,6 @@ async def get_server_stats(
     global_settings = _get_global_settings()
     host = global_settings.server.host if global_settings else "127.0.0.1"
     port = global_settings.server.port if global_settings else 8000
-    api_key = global_settings.auth.api_key if global_settings else ""
 
     from ..model_discovery import format_size
     from ..prefill_progress import get_prefill_tracker
@@ -2287,12 +2426,15 @@ async def get_server_stats(
 
     # Build active_models data for the dashboard card.
     active_models_data = _build_active_models_data()
+    runtime_cache_data = _build_runtime_cache_observability(
+        global_settings,
+        model_filter=model,
+    )
 
     return {
         **snapshot,
         "host": host,
         "port": port,
-        "api_key": api_key or "",
         "cli_prefix": get_cli_prefix(),
         "claude_code_context_scaling_enabled": (
             global_settings.claude_code.context_scaling_enabled
@@ -2306,6 +2448,7 @@ async def get_server_stats(
         ),
         "engines": _get_engine_info(),
         "active_models": active_models_data,
+        "runtime_cache": runtime_cache_data,
     }
 
 

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -109,7 +109,6 @@
                 total_requests: 0,
                 host: '127.0.0.1',
                 port: 8000,
-                api_key: '',
                 engines: {},
                 active_models: {
                     models: [],
@@ -117,6 +116,15 @@
                     model_memory_max: 0,
                     total_active_requests: 0,
                     total_waiting_requests: 0,
+                },
+                runtime_cache: {
+                    base_path: '',
+                    ssd_cache_dir: '',
+                    response_state_dir: '',
+                    models: [],
+                    total_num_files: 0,
+                    total_size_bytes: 0,
+                    effective_block_sizes: [],
                 },
             },
             alltimeStats: {
@@ -915,24 +923,31 @@
                 return this.models.filter(m => m.model_type === 'llm' || m.model_type === 'vlm' || !m.model_type);
             },
 
+            shellQuote(value) {
+                const s = String(value ?? '');
+                if (!s) return "''";
+                return `'${s.replace(/'/g, `'"'"'`)}'`;
+            },
+
+            shellEnvAssign(name, value) {
+                return `${name}=${this.shellQuote(value)}`;
+            },
+
             get claudeCodeCommand() {
                 const mode = this.globalSettings.claude_code.mode;
                 if (mode === 'cloud') {
                     return 'env -u ANTHROPIC_BASE_URL -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_DEFAULT_OPUS_MODEL -u ANTHROPIC_DEFAULT_SONNET_MODEL -u ANTHROPIC_DEFAULT_HAIKU_MODEL -u API_TIMEOUT_MS -u CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC claude';
                 }
-                // Local mode
+                // Local mode (intentionally keyless; provide API key separately if needed)
                 const port = this.stats.port || 8000;
                 const opusModel = this.globalSettings.claude_code.opus_model || 'select-a-model';
                 const sonnetModel = this.globalSettings.claude_code.sonnet_model || 'select-a-model';
                 const haikuModel = this.globalSettings.claude_code.haiku_model || 'select-a-model';
                 const parts = [];
-                parts.push(`ANTHROPIC_BASE_URL=http://${this.displayHost}:${port}`);
-                if (this.stats.api_key) {
-                    parts.push(`ANTHROPIC_AUTH_TOKEN=${this.stats.api_key}`);
-                }
-                parts.push(`ANTHROPIC_DEFAULT_OPUS_MODEL=${opusModel}`);
-                parts.push(`ANTHROPIC_DEFAULT_SONNET_MODEL=${sonnetModel}`);
-                parts.push(`ANTHROPIC_DEFAULT_HAIKU_MODEL=${haikuModel}`);
+                parts.push(this.shellEnvAssign('ANTHROPIC_BASE_URL', `http://${this.displayHost}:${port}`));
+                parts.push(this.shellEnvAssign('ANTHROPIC_DEFAULT_OPUS_MODEL', opusModel));
+                parts.push(this.shellEnvAssign('ANTHROPIC_DEFAULT_SONNET_MODEL', sonnetModel));
+                parts.push(this.shellEnvAssign('ANTHROPIC_DEFAULT_HAIKU_MODEL', haikuModel));
                 parts.push('API_TIMEOUT_MS=3000000');
                 parts.push('CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1');
                 parts.push('claude');
@@ -964,33 +979,20 @@
             get codexCommand() {
                 const cli = this.stats.cli_prefix || 'omlx';
                 const model = this.globalSettings.integrations.codex_model || 'select-a-model';
-                const parts = [`${cli} launch codex --model ${model}`];
-                if (this.stats.api_key) {
-                    parts.push(`--api-key ${this.stats.api_key}`);
-                }
-                return parts.join(' ');
+                return `${this.shellQuote(cli)} launch codex --model ${this.shellQuote(model)}`;
             },
 
             get opencodeCommand() {
                 const cli = this.stats.cli_prefix || 'omlx';
                 const model = this.globalSettings.integrations.opencode_model || 'select-a-model';
-                const parts = [`${cli} launch opencode --model ${model}`];
-                if (this.stats.api_key) {
-                    parts.push(`--api-key ${this.stats.api_key}`);
-                }
-                return parts.join(' ');
+                return `${this.shellQuote(cli)} launch opencode --model ${this.shellQuote(model)}`;
             },
 
             get openclawCommand() {
                 const cli = this.stats.cli_prefix || 'omlx';
                 const model = this.globalSettings.integrations.openclaw_model || 'select-a-model';
                 const profile = this.globalSettings.integrations.openclaw_tools_profile || 'full';
-                const parts = [`${cli} launch openclaw --model ${model}`];
-                if (this.stats.api_key) {
-                    parts.push(`--api-key ${this.stats.api_key}`);
-                }
-                parts.push(`--tools-profile ${profile}`);
-                return parts.join(' ');
+                return `${this.shellQuote(cli)} launch openclaw --model ${this.shellQuote(model)} --tools-profile ${this.shellQuote(profile)}`;
             },
 
             async saveIntegrationSettings() {

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -100,6 +100,86 @@
                         </div>
                     </div>
 
+                    <!-- Runtime Cache Observability -->
+                    <div class="bg-white rounded-2xl border border-neutral-200 overflow-hidden mb-8">
+                        <div class="flex items-center justify-between px-6 py-4 bg-neutral-100 border-b border-neutral-200">
+                            <div class="flex items-center gap-3">
+                                <i data-lucide="database" class="w-4 h-4 text-neutral-500"></i>
+                                <span class="text-xs font-bold uppercase tracking-wider text-neutral-600">Runtime Cache Observability</span>
+                            </div>
+                            <div class="text-xs text-neutral-500"
+                                 x-text="formatNumber((stats.runtime_cache?.total_num_files || 0)) + ' files · ' + formatSizeBytes((stats.runtime_cache?.total_size_bytes || 0))"></div>
+                        </div>
+                        <div class="px-6 py-4 space-y-3">
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs">
+                                <div>
+                                    <div class="text-neutral-400 mb-1">Active base_path</div>
+                                    <code class="block px-2 py-1 rounded bg-neutral-50 text-neutral-700 break-all"
+                                          x-text="stats.runtime_cache?.base_path || '-' "></code>
+                                </div>
+                                <div>
+                                    <div class="text-neutral-400 mb-1">Effective ssd_cache_dir</div>
+                                    <code class="block px-2 py-1 rounded bg-neutral-50 text-neutral-700 break-all"
+                                          x-text="stats.runtime_cache?.ssd_cache_dir || '-' "></code>
+                                </div>
+                            </div>
+
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs">
+                                <div>
+                                    <div class="text-neutral-400 mb-1">response-state directory</div>
+                                    <code class="block px-2 py-1 rounded bg-neutral-50 text-neutral-700 break-all"
+                                          x-text="stats.runtime_cache?.response_state_dir || '-' "></code>
+                                </div>
+                                <div>
+                                    <div class="text-neutral-400 mb-1">Effective block size(s)</div>
+                                    <code class="block px-2 py-1 rounded bg-neutral-50 text-neutral-700"
+                                          x-text="(stats.runtime_cache?.effective_block_sizes || []).length ? (stats.runtime_cache.effective_block_sizes.join(', ') + ' tokens') : '-' "></code>
+                                </div>
+                            </div>
+
+                            <div x-show="stats.runtime_cache?.models && stats.runtime_cache.models.length > 0" x-cloak
+                                 class="overflow-x-auto border border-neutral-100 rounded-lg">
+                                <table class="min-w-full text-xs">
+                                    <thead class="bg-neutral-50 text-neutral-500 uppercase tracking-wider">
+                                        <tr>
+                                            <th class="px-3 py-2 text-left">Model</th>
+                                            <th class="px-3 py-2 text-right">Block Size</th>
+                                            <th class="px-3 py-2 text-right">Indexed Blocks</th>
+                                            <th class="px-3 py-2 text-right">Sub-block Cache</th>
+                                            <th class="px-3 py-2 text-right">Cache Files</th>
+                                            <th class="px-3 py-2 text-right">Cache Size</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="divide-y divide-neutral-100 text-neutral-700">
+                                        <template x-for="m in stats.runtime_cache.models" :key="m.id">
+                                            <tr>
+                                                <td class="px-3 py-2 font-medium" x-text="m.id"></td>
+                                                <td class="px-3 py-2 text-right" x-text="m.block_size || '-' "></td>
+                                                <td class="px-3 py-2 text-right">
+                                                    <span x-show="!m.has_sub_block_cache" x-text="formatNumber(m.indexed_blocks || 0)"></span>
+                                                    <span x-show="m.has_sub_block_cache" class="font-medium text-amber-600" x-text="m.indexed_blocks_display"></span>
+                                                </td>
+                                                <td class="px-3 py-2 text-right">
+                                                    <span x-show="m.has_sub_block_cache"
+                                                          class="text-amber-600"
+                                                          x-text="'cached (' + (m.last_partial_tokens_skipped || m.indexed_blocks_display || ('<' + (m.block_size || '?'))) + ' tokens)'">
+                                                    </span>
+                                                    <span x-show="!m.has_sub_block_cache" class="text-neutral-400">-</span>
+                                                </td>
+                                                <td class="px-3 py-2 text-right" x-text="formatNumber(m.num_files || 0)"></td>
+                                                <td class="px-3 py-2 text-right" x-text="formatSizeBytes(m.total_size_bytes || 0)"></td>
+                                            </tr>
+                                        </template>
+                                    </tbody>
+                                </table>
+                            </div>
+
+                            <div class="text-[11px] text-neutral-500">
+                                Note: <span class="font-medium text-amber-600">Sub-block Cache</span> means requests below one full block (for example &lt;1024 tokens on some models) are cached in memory/paged cache but are not counted as indexed SSD blocks.
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Active Models -->
                     <div class="bg-white rounded-2xl border border-neutral-200 overflow-hidden mb-8">
                         <div class="flex items-center justify-between px-6 py-4 bg-neutral-100 border-b border-neutral-200">

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -111,6 +111,10 @@ class BlockAwarePrefixCache(CacheManager):
         self._hits = 0
         self._misses = 0
         self._tokens_saved = 0
+        self._partial_block_skips = 0
+        self._partial_tokens_skipped = 0
+        self._last_partial_tokens_skipped = 0
+        self._last_tokens_to_next_block = 0
 
     def _get_model_num_layers(self, model: Any) -> int:
         """
@@ -376,6 +380,8 @@ class BlockAwarePrefixCache(CacheManager):
 
         if not new_tokens:
             # All tokens already cached
+            self._last_partial_tokens_skipped = 0
+            self._last_tokens_to_next_block = 0
             return block_table
 
         # Allocate only full blocks (skip partial trailing block).
@@ -385,6 +391,25 @@ class BlockAwarePrefixCache(CacheManager):
         # the last full block, which is critical for non-sliceable caches
         # (ArraysCache/RotatingKVCache) that use last-block-only storage.
         num_new_blocks = len(new_tokens) // self.block_size
+        trailing_partial_tokens = len(new_tokens) % self.block_size
+        self._last_partial_tokens_skipped = trailing_partial_tokens
+        self._last_tokens_to_next_block = (
+            self.block_size - trailing_partial_tokens
+            if trailing_partial_tokens > 0
+            else 0
+        )
+        if trailing_partial_tokens > 0:
+            self._partial_block_skips += 1
+            self._partial_tokens_skipped += trailing_partial_tokens
+            logger.debug(
+                "Skipping trailing partial block for %s: %s token(s) not persisted "
+                "(block_size=%s, needs +%s token(s) to fill next block)",
+                request_id,
+                trailing_partial_tokens,
+                self.block_size,
+                self._last_tokens_to_next_block,
+            )
+
         blocks_saved_to_ssd = 0
 
         for i in range(num_new_blocks):
@@ -1898,6 +1923,11 @@ class BlockAwarePrefixCache(CacheManager):
             misses=self._misses,
             evictions=self.paged_cache.stats.evictions,
             tokens_saved=self._tokens_saved,
+            partial_block_skips=self._partial_block_skips,
+            partial_tokens_skipped=self._partial_tokens_skipped,
+            block_size=self.block_size,
+            last_partial_tokens_skipped=self._last_partial_tokens_skipped,
+            last_tokens_to_next_block=self._last_tokens_to_next_block,
         )
 
     def get_stats_dict(self) -> Dict[str, Any]:
@@ -1915,6 +1945,11 @@ class BlockAwarePrefixCache(CacheManager):
             "misses": self._misses,
             "hit_rate": self._hits / (self._hits + self._misses) if (self._hits + self._misses) > 0 else 0,
             "tokens_saved": self._tokens_saved,
+            "partial_block_skips": self._partial_block_skips,
+            "partial_tokens_skipped": self._partial_tokens_skipped,
+            "block_size": self.block_size,
+            "last_partial_tokens_skipped": self._last_partial_tokens_skipped,
+            "last_tokens_to_next_block": self._last_tokens_to_next_block,
             "active_requests": len(self._request_tables),
             **paged_stats,
         }
@@ -1924,6 +1959,10 @@ class BlockAwarePrefixCache(CacheManager):
         self._hits = 0
         self._misses = 0
         self._tokens_saved = 0
+        self._partial_block_skips = 0
+        self._partial_tokens_skipped = 0
+        self._last_partial_tokens_skipped = 0
+        self._last_tokens_to_next_block = 0
         self.paged_cache.reset_stats()
 
     def clear(self) -> int:

--- a/omlx/cache/stats.py
+++ b/omlx/cache/stats.py
@@ -78,10 +78,16 @@ class PrefixCacheStats(BaseCacheStats):
     """
     Statistics for prefix cache performance.
 
-    Extends base stats with tokens_saved to track efficiency.
+    Extends base stats with tokens_saved to track efficiency and
+    partial-block skip metrics for observability.
     """
 
     tokens_saved: int = 0
+    partial_block_skips: int = 0
+    partial_tokens_skipped: int = 0
+    block_size: int = 0
+    last_partial_tokens_skipped: int = 0
+    last_tokens_to_next_block: int = 0
     _total_queries: int = field(default=0, repr=False)
 
     @property
@@ -101,6 +107,10 @@ class PrefixCacheStats(BaseCacheStats):
         """Reset all statistics to zero."""
         super().reset()
         self.tokens_saved = 0
+        self.partial_block_skips = 0
+        self.partial_tokens_skipped = 0
+        self.last_partial_tokens_skipped = 0
+        self.last_tokens_to_next_block = 0
         self._total_queries = 0
 
 

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3775,7 +3775,7 @@ class Scheduler:
         return verified
 
     def get_ssd_cache_stats(self) -> Optional[Dict[str, Any]]:
-        """Get paged SSD cache statistics."""
+        """Get paged SSD + prefix cache observability statistics."""
         stats = {}
 
         if self.paged_ssd_cache_manager is not None:
@@ -3785,6 +3785,11 @@ class Scheduler:
             # In paged SSD-only mode, all cache data is on paged SSD
             stats["indexed_blocks"] = self.paged_cache_manager.cold_block_count
             stats["block_size"] = self.config.paged_cache_block_size
+
+        if self.block_aware_cache is not None:
+            # Expose prefix-cache observability so UI can distinguish
+            # "0 indexed blocks" from "sub-block cached (<block_size)".
+            stats["prefix_cache"] = self.block_aware_cache.get_stats_dict()
 
         return stats if stats else None
 

--- a/tests/test_admin_api_key.py
+++ b/tests/test_admin_api_key.py
@@ -3,9 +3,12 @@
 
 import asyncio
 from dataclasses import fields as dataclass_fields
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from omlx.admin.auth import validate_api_key, verify_any_api_key, verify_api_key
 from omlx.model_settings import ModelSettings
@@ -537,3 +540,164 @@ class TestLoginEndpoint:
             mock_response.set_cookie.assert_called_once()
         finally:
             _restore_getter(original)
+
+
+class TestStatsSecurity:
+    """Tests for /admin/api/stats response hardening."""
+
+    def test_stats_response_does_not_include_raw_api_key(self):
+        """The stats payload must not leak auth.api_key."""
+        mock_settings = MagicMock()
+        mock_settings.server.host = "127.0.0.1"
+        mock_settings.server.port = 9981
+        mock_settings.auth.api_key = "super-secret-key"
+        mock_settings.claude_code.context_scaling_enabled = True
+        mock_settings.claude_code.target_context_size = 200000
+
+        mock_metrics = MagicMock()
+        mock_metrics.get_snapshot.return_value = {
+            "total_prompt_tokens": 0,
+            "total_cached_tokens": 0,
+            "cache_efficiency": 0,
+            "avg_prefill_tps": 0,
+            "avg_generation_tps": 0,
+            "total_requests": 0,
+        }
+
+        with (
+            patch.object(admin_routes, "_get_global_settings", return_value=mock_settings),
+            patch("omlx.server_metrics.get_server_metrics", return_value=mock_metrics),
+            patch.object(admin_routes, "_get_engine_info", return_value={}),
+            patch.object(admin_routes, "_build_active_models_data", return_value={"models": []}),
+            patch.object(admin_routes, "_build_runtime_cache_observability", return_value={"models": []}),
+        ):
+            result = asyncio.run(admin_routes.get_server_stats(is_admin=True))
+
+        assert "api_key" not in result
+
+
+class TestRuntimeCacheObservability:
+    """Tests for runtime cache observability robustness."""
+
+    def test_runtime_cache_ignores_single_model_stats_failure(self):
+        """One model failing stats collection should not break the whole payload."""
+        cache_dir = Path("/tmp/omlx-cache")
+
+        mock_settings = MagicMock()
+        mock_settings.base_path = Path("/tmp/omlx-base")
+        mock_settings.cache.get_ssd_cache_dir.return_value = cache_dir
+
+        bad_scheduler = MagicMock()
+        bad_scheduler.get_ssd_cache_stats.side_effect = RuntimeError("boom")
+        good_scheduler = MagicMock()
+        good_scheduler.get_ssd_cache_stats.return_value = {
+            "block_size": 1024,
+            "indexed_blocks": 12,
+            "ssd_cache": {
+                "num_files": 3,
+                "total_size_bytes": 4096,
+                "hot_cache_max_bytes": 0,
+                "hot_cache_size_bytes": 0,
+                "hot_cache_entries": 0,
+            },
+        }
+
+        bad_entry = SimpleNamespace(
+            engine=SimpleNamespace(
+                _engine=SimpleNamespace(
+                    engine=SimpleNamespace(scheduler=bad_scheduler)
+                )
+            )
+        )
+        good_entry = SimpleNamespace(
+            engine=SimpleNamespace(
+                _engine=SimpleNamespace(
+                    engine=SimpleNamespace(scheduler=good_scheduler)
+                )
+            )
+        )
+
+        engine_pool = MagicMock()
+        engine_pool.get_status.return_value = {
+            "models": [
+                {"id": "bad-model", "loaded": True},
+                {"id": "good-model", "loaded": True},
+            ]
+        }
+        engine_pool._entries = {
+            "bad-model": bad_entry,
+            "good-model": good_entry,
+        }
+
+        with patch.object(admin_routes, "_get_engine_pool", return_value=engine_pool):
+            payload = admin_routes._build_runtime_cache_observability(mock_settings)
+
+        assert [m["id"] for m in payload["models"]] == ["good-model"]
+        assert payload["total_num_files"] == 3
+        assert payload["total_size_bytes"] == 4096
+        assert payload["effective_block_sizes"] == [1024]
+
+    def test_runtime_cache_marks_sub_block_cached_when_indexed_blocks_zero(self):
+        """Show <block_size indicator only when sub-block cache evidence exists."""
+        cache_dir = Path("/tmp/omlx-cache")
+
+        mock_settings = MagicMock()
+        mock_settings.base_path = Path("/tmp/omlx-base")
+        mock_settings.cache.get_ssd_cache_dir.return_value = cache_dir
+
+        scheduler = MagicMock()
+        scheduler.get_ssd_cache_stats.return_value = {
+            "block_size": 1024,
+            "indexed_blocks": 0,
+            "ssd_cache": {
+                "num_files": 0,
+                "total_size_bytes": 0,
+            },
+            "prefix_cache": {
+                "partial_block_skips": 2,
+                "partial_tokens_skipped": 1200,
+                "last_partial_tokens_skipped": 577,
+                "last_tokens_to_next_block": 447,
+            },
+        }
+
+        entry = SimpleNamespace(
+            engine=SimpleNamespace(
+                _engine=SimpleNamespace(
+                    engine=SimpleNamespace(scheduler=scheduler)
+                )
+            )
+        )
+
+        engine_pool = MagicMock()
+        engine_pool.get_status.return_value = {
+            "models": [
+                {"id": "qwen-a3b", "loaded": True},
+            ]
+        }
+        engine_pool._entries = {"qwen-a3b": entry}
+
+        with patch.object(admin_routes, "_get_engine_pool", return_value=engine_pool):
+            payload = admin_routes._build_runtime_cache_observability(mock_settings)
+
+        model_payload = payload["models"][0]
+        assert model_payload["indexed_blocks"] == 0
+        assert model_payload["has_sub_block_cache"] is True
+        assert model_payload["indexed_blocks_display"] == "<1024"
+        assert model_payload["last_partial_tokens_skipped"] == 577
+
+
+class TestGlobalSettingsValidation:
+    """Tests for stricter GlobalSettingsRequest validation."""
+
+    def test_integrations_openclaw_tools_profile_rejects_invalid_value(self):
+        with pytest.raises(ValidationError):
+            admin_routes.GlobalSettingsRequest(
+                integrations_openclaw_tools_profile="invalid-profile"
+            )
+
+    def test_integrations_openclaw_tools_profile_accepts_valid_values(self):
+        req = admin_routes.GlobalSettingsRequest(
+            integrations_openclaw_tools_profile="coding"
+        )
+        assert req.integrations_openclaw_tools_profile == "coding"

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -249,6 +249,9 @@ class TestBlockAwarePrefixCache:
         assert stats.hits == 5
         assert stats.misses == 3
         assert stats.tokens_saved == 100
+        assert stats.partial_block_skips == 0
+        assert stats.partial_tokens_skipped == 0
+        assert stats.block_size == prefix_cache.block_size
 
     def test_get_stats_dict(self, prefix_cache):
         """Test getting statistics as dictionary."""
@@ -260,6 +263,9 @@ class TestBlockAwarePrefixCache:
         assert "hits" in stats_dict
         assert "misses" in stats_dict
         assert "hit_rate" in stats_dict
+        assert "partial_block_skips" in stats_dict
+        assert "partial_tokens_skipped" in stats_dict
+        assert "last_tokens_to_next_block" in stats_dict
         assert stats_dict["hit_rate"] == pytest.approx(10 / 15)
 
     def test_reset_stats(self, prefix_cache):
@@ -267,12 +273,20 @@ class TestBlockAwarePrefixCache:
         prefix_cache._hits = 10
         prefix_cache._misses = 5
         prefix_cache._tokens_saved = 500
+        prefix_cache._partial_block_skips = 3
+        prefix_cache._partial_tokens_skipped = 42
+        prefix_cache._last_partial_tokens_skipped = 2
+        prefix_cache._last_tokens_to_next_block = 254
 
         prefix_cache.reset_stats()
 
         assert prefix_cache._hits == 0
         assert prefix_cache._misses == 0
         assert prefix_cache._tokens_saved == 0
+        assert prefix_cache._partial_block_skips == 0
+        assert prefix_cache._partial_tokens_skipped == 0
+        assert prefix_cache._last_partial_tokens_skipped == 0
+        assert prefix_cache._last_tokens_to_next_block == 0
 
     def test_clear(self, prefix_cache, paged_cache):
         """Test clearing all cache data."""
@@ -854,6 +868,12 @@ class TestArraysCacheLastBlockOnly:
         # num_tokens should reflect only full blocks
         assert result.num_tokens == 8  # 2 blocks * 4 tokens
 
+        stats = cache.get_stats()
+        assert stats.partial_block_skips == 1
+        assert stats.partial_tokens_skipped == 2
+        assert stats.last_partial_tokens_skipped == 2
+        assert stats.last_tokens_to_next_block == 2
+
     def test_store_cache_arrayscache_partial_trailing_uses_last_full_block_state(self, mx):
         """ArraysCache with trailing partial tokens stores only full blocks safely."""
         from omlx.cache.hybrid_cache import ModelCacheConfig
@@ -934,6 +954,12 @@ class TestArraysCacheLastBlockOnly:
         assert result is not None
         assert len(result.block_ids) == 0
         assert result.num_tokens == 0
+
+        stats = cache.get_stats()
+        assert stats.partial_block_skips == 1
+        assert stats.partial_tokens_skipped == 3
+        assert stats.last_partial_tokens_skipped == 3
+        assert stats.last_tokens_to_next_block == 1
 
     def test_store_cache_exact_multiple_creates_all_blocks(self, mx):
         """Tokens exactly divisible by block_size should create all blocks."""


### PR DESCRIPTION
## Summary
This PR addresses the follow-up confusion in #246 where requests below one full block (for example `<1024` on ArraysCache models) appear as `0 indexed blocks` and look like cache is not working.

### What changed
- Expose prefix-cache observability from scheduler runtime stats (`partial_block_skips`, `last_partial_tokens_skipped`, etc.).
- Extend admin runtime cache payload with:
  - `has_sub_block_cache`
  - `indexed_blocks_display` (shows `<block_size` only when sub-block cache evidence exists)
  - partial block diagnostics fields
- Update dashboard Runtime Cache table:
  - `Indexed Blocks` shows `<block_size` instead of `0` when applicable
  - add `Sub-block Cache` column to indicate cached-but-not-SSD-indexed cases
  - add explanatory note to avoid interpreting this as no-cache

### Why
For models using larger effective block size (e.g. 1024), short requests can be cached in memory/paged cache but cannot form full SSD index blocks. Showing raw `0` is technically true for SSD indexed blocks but misleading for users.

### Behavior
- If `indexed_blocks == 0` **and** prefix-cache metrics indicate trailing partial blocks, dashboard shows `<block_size`.
- Otherwise dashboard keeps showing the numeric indexed block count.

## Tests
Ran targeted tests:
- `tests/test_admin_api_key.py::TestRuntimeCacheObservability::test_runtime_cache_ignores_single_model_stats_failure`
- `tests/test_admin_api_key.py::TestRuntimeCacheObservability::test_runtime_cache_marks_sub_block_cached_when_indexed_blocks_zero`
- `tests/test_admin_api_key.py::TestStatsSecurity::test_stats_response_does_not_include_raw_api_key`
- `tests/test_prefix_cache.py::TestArraysCacheLastBlockOnly::test_store_cache_arrayscache_partial_trailing_uses_last_full_block_state`
- `tests/test_prefix_cache.py::TestArraysCacheLastBlockOnly::test_store_cache_all_partial_creates_no_blocks`

All passed locally.
