### PR TITLE
fix(menubar): reuse admin session across stats fetches

### DIFF
--- a/packaging/omlx_app/admin_client.py
+++ b/packaging/omlx_app/admin_client.py
@@ -72,6 +72,10 @@ class AdminStatsClient:
             return resp.json()
         return None
 
+    def matches(self, base_url: str, api_key: str) -> bool:
+        """Return True if this client was created with the given credentials."""
+        return self._base_url == base_url and self._api_key == api_key
+
     def invalidate(self) -> None:
         """Discard the current session (e.g. server restarted)."""
         self._session = None

--- a/packaging/omlx_app/app.py
+++ b/packaging/omlx_app/app.py
@@ -739,15 +739,20 @@ class OMLXAppDelegate(NSObject):
     def _fetch_stats(self):
         """Fetch serving stats from the admin API."""
         api_key = self.config.get_server_api_key()
+        current_base_url = f"http://127.0.0.1:{self.config.port}"
+
         if not api_key:
             self._cached_stats = None
             self._cached_alltime_stats = None
             return
 
+        if self._stats_client is not None and not self._stats_client.matches(
+            current_base_url, api_key
+        ):
+            self._stats_client = None
+
         if self._stats_client is None:
-            self._stats_client = AdminStatsClient(
-                f"http://127.0.0.1:{self.config.port}", api_key
-            )
+            self._stats_client = AdminStatsClient(current_base_url, api_key)
 
         self._cached_stats = self._stats_client.fetch_stats()
         self._cached_alltime_stats = self._stats_client.fetch_stats(scope="alltime")

--- a/tests/test_omlx_app.py
+++ b/tests/test_omlx_app.py
@@ -295,7 +295,7 @@ class TestServerConfig:
         config.set_server_api_key("roundtrip-key")
         assert config.get_server_api_key() == "roundtrip-key"
 
-    @patch("omlx_app.admin_client.requests.Session")
+    @patch("omlx_app.config.requests.Session")
     def test_update_server_api_key_runtime_success(self, mock_session_cls, tmp_path):
         """Test runtime API key update on running server."""
         config = ServerConfig(base_path=str(tmp_path))
@@ -313,7 +313,7 @@ class TestServerConfig:
         assert result is True
         assert mock_session.post.call_count == 2
 
-    @patch("omlx_app.admin_client.requests.Session")
+    @patch("omlx_app.config.requests.Session")
     def test_update_server_api_key_runtime_server_down(self, mock_session_cls, tmp_path):
         """Test runtime update returns False when server unreachable."""
         import requests as req
@@ -1026,3 +1026,12 @@ class TestAdminStatsClient:
         client._session = Mock()
         client.invalidate()
         assert client._session is None
+
+    def test_matches_same_credentials(self, client):
+        assert client.matches("http://127.0.0.1:8000", "test-key")
+
+    def test_matches_different_api_key(self, client):
+        assert not client.matches("http://127.0.0.1:8000", "other-key")
+
+    def test_matches_different_port(self, client):
+        assert not client.matches("http://127.0.0.1:9999", "test-key")


### PR DESCRIPTION
## What

Currently `_fetch_stats()` in the menubar app creates a new
`requests.Session()` on every call, which means `POST /admin/api/login`
is fired every 5 seconds — one login request per stats cycle, indefinitely.

## Why it matters

- Produces unnecessary noise in the server access log (login appears
  alongside every stats request)
- Sends the API key over the wire more frequently than needed
- Creates and discards a session object on every cycle with no benefit

## Fix

Introduce `AdminStatsClient` (`packaging/omlx_app/admin_client.py`) that
persists the session cookie across `_fetch_stats()` calls:

- Logs in only when no session exists (first call, or after invalidation)
- On `401` (e.g. server restart changes the secret key), invalidates and
  retries login once automatically
- On `RequestException`, clears the session so the next cycle retries cleanly
- `invalidate()` is called explicitly when the server enters ERROR or
  UNRESPONSIVE state

`AdminStatsClient` is placed in its own module (`admin_client.py`) so it
can be unit-tested without the PyObjC dependency that makes `app.py`
untestable in a standard pytest environment.

## Tests

Added `TestAdminStatsClient` in `tests/test_omlx_app.py` (6 cases covering
first-login, session reuse, auto-relogin on `401`, login failure, connection
error session cleanup, and explicit `invalidate()`).

### Running the tests

> **Note:** `pytest -m "not slow"` currently fails with
> `ModuleNotFoundError: No module named 'omlx_app.admin_client'; 'omlx_app' is not a package`
> due to a conflict between the editable install's path hook and the
> `packaging/` source root. Use the explicit paths below instead:

```bash
# Run only the new AdminStatsClient unit tests
pytest tests/test_omlx_app.py -v

# Run all fast omlx_app tests (skip slow model-loading tests)
pytest tests/test_omlx_app.py tests/test_updater.py -v
