### PR TITLE
Fix compile-on crash for embeddings/reranker by compiling primitive-output paths

### DIFF
--- a/omlx/models/embedding.py
+++ b/omlx/models/embedding.py
@@ -7,30 +7,12 @@ text embeddings using Apple's MLX framework.
 """
 
 import logging
-from dataclasses import dataclass, field
-from typing import Any, List, Optional
+from dataclasses import dataclass
+from typing import List, Optional
 
 import mlx.core as mx
 
 logger = logging.getLogger(__name__)
-
-
-class _CompiledForward:
-    """Wraps an MLX module to route __call__ through mx.compile.
-
-    Keeps compiled Metal pipeline states alive in memory, preventing
-    kernel eviction after idle periods (~3s on macOS).
-    """
-
-    def __init__(self, module):
-        self._module = module
-        self._compiled = mx.compile(module.__call__, shapeless=True)
-
-    def __call__(self, *args, **kwargs):
-        return self._compiled(*args, **kwargs)
-
-    def __getattr__(self, name):
-        return getattr(self._module, name)
 
 
 @dataclass
@@ -73,6 +55,8 @@ class MLXEmbeddingModel:
         self.processor = None
         self._loaded = False
         self._hidden_size: Optional[int] = None
+        self._is_compiled = False
+        self._compiled_embed = None
 
     def load(self) -> None:
         """Load the model and processor/tokenizer."""
@@ -86,18 +70,14 @@ class MLXEmbeddingModel:
 
             self.model, self.processor = load(self.model_name)
 
-            # Get hidden size from model config (before wrapping)
+            # Get hidden size from model config
             if hasattr(self.model, "config"):
                 config = self.model.config
                 self._hidden_size = getattr(config, "hidden_size", None)
-                if self._hidden_size is None:
-                    # Try text_config for vision-language models
-                    if hasattr(config, "text_config"):
-                        self._hidden_size = getattr(
-                            config.text_config, "hidden_size", None
-                        )
+                if self._hidden_size is None and hasattr(config, "text_config"):
+                    self._hidden_size = getattr(config.text_config, "hidden_size", None)
 
-            # Try mx.compile for persistent Metal kernel caching
+            # Compile a primitive-only embedding forward path
             self._is_compiled = self._try_compile()
 
             self._loaded = True
@@ -122,25 +102,46 @@ class MLXEmbeddingModel:
             logger.error(f"Failed to load embedding model: {e}")
             raise
 
-    def _try_compile(self) -> bool:
-        """Try to compile the model's forward pass with mx.compile.
+    def _extract_embeddings_array(self, outputs):
+        """Extract embedding tensor from model outputs."""
+        if hasattr(outputs, "text_embeds") and outputs.text_embeds is not None:
+            return outputs.text_embeds
+        if hasattr(outputs, "pooler_output") and outputs.pooler_output is not None:
+            return outputs.pooler_output
+        if hasattr(outputs, "last_hidden_state") and outputs.last_hidden_state is not None:
+            return mx.mean(outputs.last_hidden_state, axis=1)
+        raise ValueError(
+            "Model output does not contain expected embedding fields "
+            "(text_embeds, pooler_output, or last_hidden_state)"
+        )
 
-        Returns True if compilation succeeded, False otherwise.
-        On failure, self.model is reverted to the original uncompiled model.
+    def _try_compile(self) -> bool:
         """
-        original_model = self.model
+        Compile a primitive-output embedding forward function.
+
+        Root-cause fix:
+        - Compiling model.__call__ directly can return arrays without primitives
+          for some embedding/reranker models, causing eval() runtime errors.
+        - We compile a narrower function that returns only the final embedding array.
+        """
+        base_model = self.model
+
         try:
-            self.model = _CompiledForward(original_model)
-            # Trigger compilation with a dummy forward pass
-            test_ids = mx.zeros((1, 4), dtype=mx.int32)
-            _ = self.model(test_ids)
-            logger.info(f"mx.compile enabled for {self.model_name}")
+            def _compiled_embed(inputs):
+                outputs = base_model(**inputs)
+                return self._extract_embeddings_array(outputs)
+
+            # NOTE: shapeless=True can fail output shape inference for AddMM
+            # in some embedding models; use default compile mode.
+            self._compiled_embed = mx.compile(_compiled_embed)
+            logger.info(
+                f"mx.compile enabled for {self.model_name} "
+                f"(primitive embedding path)"
+            )
             return True
         except Exception as e:
-            logger.info(
-                f"mx.compile unavailable for {self.model_name}: {e}"
-            )
-            self.model = original_model
+            logger.info(f"mx.compile unavailable for {self.model_name}: {e}")
+            self._compiled_embed = None
             return False
 
     def embed(
@@ -166,45 +167,51 @@ class MLXEmbeddingModel:
             self.load()
 
         from mlx_embeddings import generate
+        from mlx_embeddings.utils import prepare_inputs
 
         # Normalize input
         if isinstance(texts, str):
             texts = [texts]
 
         # Get the underlying tokenizer from TokenizerWrapper
-        # TokenizerWrapper uses __getattr__ to forward attribute access,
-        # but __call__ is a special method that isn't forwarded.
-        # Pass _tokenizer directly to mlx-embeddings generate().
         processor = self.processor
         if hasattr(processor, "_tokenizer"):
             processor = processor._tokenizer
 
-        # Use mlx-embeddings generate() for batch processing and future optimizations
-        outputs = generate(
-            self.model,
-            processor,
-            texts,
-            max_length=max_length,
-            padding=padding,
-            truncation=truncation,
-        )
+        embeddings_array = None
 
-        # Extract embeddings from output
-        # mlx-embeddings returns BaseModelOutput with text_embeds (normalized)
-        if hasattr(outputs, "text_embeds") and outputs.text_embeds is not None:
-            embeddings_array = outputs.text_embeds
-        elif hasattr(outputs, "pooler_output") and outputs.pooler_output is not None:
-            embeddings_array = outputs.pooler_output
-        elif (
-            hasattr(outputs, "last_hidden_state") and outputs.last_hidden_state is not None
-        ):
-            # Fallback: mean pooling over last_hidden_state
-            embeddings_array = mx.mean(outputs.last_hidden_state, axis=1)
-        else:
-            raise ValueError(
-                "Model output does not contain expected embedding fields "
-                "(text_embeds, pooler_output, or last_hidden_state)"
+        # Compile path: run primitive-output compiled function
+        if self._is_compiled and self._compiled_embed is not None:
+            try:
+                inputs = prepare_inputs(
+                    processor,
+                    None,
+                    texts,
+                    max_length,
+                    padding,
+                    truncation,
+                    None,
+                )
+                if not isinstance(inputs, dict):
+                    inputs = dict(inputs)
+                embeddings_array = self._compiled_embed(inputs)
+            except Exception as e:
+                logger.warning(
+                    f"compiled embedding path failed for {self.model_name}: {e}; "
+                    f"falling back to eager generate()"
+                )
+
+        # Eager path fallback
+        if embeddings_array is None:
+            outputs = generate(
+                self.model,
+                processor,
+                texts,
+                max_length=max_length,
+                padding=padding,
+                truncation=truncation,
             )
+            embeddings_array = self._extract_embeddings_array(outputs)
 
         # Ensure computation is done
         mx.eval(embeddings_array)

--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -108,6 +108,8 @@ class MLXRerankerModel:
         self._token_false_id: int | None = None
         self._prefix_tokens: list[int] | None = None
         self._suffix_tokens: list[int] | None = None
+        self._is_compiled = False
+        self._compiled_seq_logits = None
 
     def _get_architecture(self) -> str | None:
         """Get the model architecture from config.json."""
@@ -278,24 +280,46 @@ class MLXRerankerModel:
             raise
 
     def _try_compile(self) -> bool:
-        """Try to compile the model's forward pass with mx.compile.
+        """Compile reranker scoring path to return primitive logits arrays.
 
-        Returns True if compilation succeeded, False otherwise.
-        On failure, self.model is reverted to the original uncompiled model.
+        Root-cause fix:
+        - Compiling model.__call__ directly can yield arrays without primitives
+          in some MLX output containers.
+        - Compile a narrow function that returns logits only.
         """
-        original_model = self.model
+        if self._is_causal_lm:
+            # CausalLM reranker path uses generation/logit selection logic;
+            # keep eager path until a dedicated compiled scorer is added.
+            logger.info(
+                f"mx.compile skipped for causal-lm reranker {self.model_name}"
+            )
+            self._compiled_seq_logits = None
+            return False
+
+        base_model = self.model
         try:
-            self.model = _CompiledForward(original_model)
-            # Trigger compilation with a dummy forward pass
-            test_ids = mx.zeros((1, 4), dtype=mx.int32)
-            _ = self.model(test_ids)
-            logger.info(f"mx.compile enabled for {self.model_name}")
+            def _compiled_seq_logits(inputs):
+                outputs = base_model(**inputs)
+                if hasattr(outputs, "pooler_output") and outputs.pooler_output is not None:
+                    return outputs.pooler_output
+                raise ValueError(
+                    "Model output does not contain pooler_output. "
+                    "Ensure the model is a SequenceClassification model."
+                )
+
+            # NOTE: use default compile mode. shapeless=True can fail shape
+            # inference for some linear ops in embedding/reranker stacks.
+            self._compiled_seq_logits = mx.compile(_compiled_seq_logits)
+            logger.info(
+                f"mx.compile enabled for {self.model_name} "
+                f"(primitive reranker logits path)"
+            )
             return True
         except Exception as e:
             logger.info(
                 f"mx.compile unavailable for {self.model_name}: {e}"
             )
-            self.model = original_model
+            self._compiled_seq_logits = None
             return False
 
     # Default max_length per model type
@@ -458,21 +482,29 @@ class MLXRerankerModel:
         input_ids = mx.array(inputs["input_ids"])
         attention_mask = mx.array(inputs["attention_mask"])
 
-        # Forward pass
-        outputs = self.model(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-        )
-
-        # Extract scores from pooler_output
-        # pooler_output shape: (batch_size, num_labels)
-        if hasattr(outputs, "pooler_output") and outputs.pooler_output is not None:
-            logits = outputs.pooler_output
+        # Forward pass (compiled primitive logits path when available)
+        if self._is_compiled and self._compiled_seq_logits is not None:
+            model_inputs = {
+                "input_ids": input_ids,
+                "attention_mask": attention_mask,
+            }
+            logits = self._compiled_seq_logits(model_inputs)
         else:
-            raise ValueError(
-                "Model output does not contain pooler_output. "
-                "Ensure the model is a SequenceClassification model."
+            outputs = self.model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
             )
+
+            # Extract scores from pooler_output
+            # pooler_output shape: (batch_size, num_labels)
+            if hasattr(outputs, "pooler_output") and outputs.pooler_output is not None:
+                logits = outputs.pooler_output
+            else:
+                raise ValueError(
+                    "Model output does not contain pooler_output. "
+                    "Ensure the model is a SequenceClassification model."
+                )
+
 
         # Ensure computation is done
         mx.eval(logits)


### PR DESCRIPTION
# PR Title
Fix compile-on crash for embeddings/reranker by compiling primitive-output paths

## Problem
`/v1/embeddings` and `/v1/rerank` can fail with:

```
RuntimeError: [eval] Attempting to eval an array without a primitive.
```

The crash appears when `mx.compile` wraps `model.__call__` directly and the output is a container object (e.g., `BaseModelOutput`).

## Root Cause
Current compile wrapping point is too broad:
- compiled target: `model.__call__`
- downstream eval target: fields extracted from output containers

For embedding/reranker flows this can produce arrays that fail `mx.eval(...)` in runtime.

## Fix
Compile narrower functions that return primitive tensors directly.

### Embedding (`omlx/models/embedding.py`)
- compile path changed from direct `model.__call__` wrapper
- new compiled function returns final embedding tensor only
  - `text_embeds` / `pooler_output` / mean pooled `last_hidden_state`
- use default `mx.compile(...)` mode (no `shapeless=True`)
- keep eager fallback if compile path fails

### Reranker (`omlx/models/reranker.py`)
- for SequenceClassification rerankers:
  - compile function returns `pooler_output` logits directly
  - `_rerank_seq_classification()` uses compiled logits path
- causal-lm reranker path unchanged

## Why this works
By compiling at the primitive-output stage, we avoid carrying output-container semantics through the compiled boundary and remove the `array without primitive` eval failure.

## Validation
- `/v1/embeddings` returns 200 (tested with `mxbai-embed-large-v1`, `bge-small-en-v1.5`)
- `/v1/rerank` returns 200 (tested with `bge-reranker-v2-m3`)
- OpenClaw `memory_search` recovered (depends on embeddings route)

## Notes
This PR preserves compile optimization intent (no global compile disable) while fixing runtime stability.

## Test Plan
1. Start server on Apple Silicon (same config as report).
2. Call `/v1/embeddings` repeatedly and after idle.
3. Call `/v1/rerank` repeatedly and after idle.
4. Confirm no 500 and no `array without primitive` stack trace in logs.

Fixes #282


