### PR TITLE
fix(test): restore sys.modules polluted by test_find_matching_dmg

### DIFF
--- a/tests/test_find_matching_dmg.py
+++ b/tests/test_find_matching_dmg.py
@@ -51,6 +51,11 @@ def _get_find_matching_dmg():
     sys.modules["omlx._version"] = version_mod
 
     try:
+        # Save omlx_app modules before replacing them so the finally block
+        # can restore the original state (prevents polluting later tests).
+        for mod in ("omlx_app.app", "omlx_app", "omlx_app.config", "omlx_app.server_manager"):
+            saved[mod] = sys.modules.get(mod)
+
         # Remove cached omlx_app.app module to force reimport
         sys.modules.pop("omlx_app.app", None)
         sys.modules.pop("omlx_app", None)


### PR DESCRIPTION
_get_find_matching_dmg() (introduced in 090cfea) replaces omlx_app, omlx_app.config, and omlx_app.server_manager in sys.modules with MagicMock objects but never saves their original values for the finally block to restore. This leaks MagicMock modules into every subsequent test, causing 76 failures in test_omlx_app.py when run after test_find_matching_dmg.

Save the omlx_app.* module references before popping them so the existing finally-block restoration logic covers them.