### PR TITLE
fix(build): add PEP 735 dependency-groups for uv sync --dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,19 @@ dev = [
     "mypy>=1.0.0",
     "mcp>=1.0.0",
 ]
+# PEP 735 dependency groups — consumed by `uv sync --dev`.
+# Keep in sync with [project.optional-dependencies] dev above
+# (pip/legacy toolchains use that section instead).
+[dependency-groups]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "black>=23.0.0",
+    "ruff>=0.1.0",
+    "mypy>=1.0.0",
+    "mcp>=1.0.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/jundot/omlx"
 Documentation = "https://github.com/jundot/omlx#readme"


### PR DESCRIPTION
Dev dependencies (pytest, pytest-asyncio, etc.) were only defined under [project.optional-dependencies] which requires `uv sync --extra dev` or `uv pip install -e ".[dev]"`. The modern uv convention uses [dependency-groups] (PEP 735) so that `uv sync --dev` will install them. Without this, `uv sync` actively uninstalls pytest and pytest-asyncio, causing all async tests to fail with "async def functions are not natively supported". 

The existing definition is preserved under [project.optional-dependencies] for backward compatibility, but will need to be separately maintained.