### PR TITLE
feat: add partial mode for assistant message prefill

### DIFF
--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -65,6 +65,10 @@ class Message(BaseModel):
     tool_calls: Optional[List[dict]] = None
     # For tool response messages (role="tool")
     tool_call_id: Optional[str] = None
+    # Participant name, rendered into chat template (e.g. Kimi K2/K2.5 named assistants)
+    name: Optional[str] = None
+    # Continue from this message instead of starting a new turn (prefill / partial mode)
+    partial: bool = False
 
 
 # =============================================================================

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -12,6 +12,35 @@ from .openai_models import Message
 
 
 # =============================================================================
+# Partial Mode Detection
+# =============================================================================
+
+
+def detect_and_strip_partial(messages: list[dict]) -> bool:
+    """Check if the final assistant message has partial=True; strip the field from all messages.
+
+    Partial mode signals that the model should continue from the final assistant
+    message rather than starting a new turn.  The ``partial`` key is not part of
+    the chat-template contract, so it is always removed before the messages are
+    passed to ``apply_chat_template``.
+
+    Args:
+        messages: List of message dicts (mutated in-place).
+
+    Returns:
+        True if the final message is an assistant message with ``partial=True``.
+    """
+    is_partial = (
+        bool(messages)
+        and messages[-1].get("role") == "assistant"
+        and messages[-1].get("partial", False)
+    )
+    for msg in messages:
+        msg.pop("partial", None)
+    return is_partial
+
+
+# =============================================================================
 # Special Token Patterns
 # =============================================================================
 
@@ -256,6 +285,8 @@ def extract_text_content(
             if isinstance(content, list):
                 content = _extract_text_from_content_list(content)
             msg_dict = {"role": role, "content": content if content else ""}
+            if getattr(msg, 'name', None):
+                msg_dict["name"] = msg.name
 
             # Preserve structured tool_calls for models with native tool calling
             # so the chat template renders them in the model's native format.
@@ -309,21 +340,28 @@ def extract_text_content(
             processed_messages.append(msg_dict)
             continue
 
+        # Build optional extra fields from the source message
+        _extra: dict = {}
+        if getattr(msg, 'name', None):
+            _extra["name"] = msg.name
+        if getattr(msg, 'partial', False):
+            _extra["partial"] = True
+
         # Handle None content
         if content is None:
-            processed_messages.append({"role": role, "content": ""})
+            processed_messages.append({"role": role, "content": "", **_extra})
             continue
 
         if isinstance(content, str):
             # Simple text message
-            processed_messages.append({"role": role, "content": content})
+            processed_messages.append({"role": role, "content": content, **_extra})
         elif isinstance(content, list):
             # Content array - extract text parts only
             combined_text = _extract_text_from_content_list(content)
-            processed_messages.append({"role": role, "content": combined_text})
+            processed_messages.append({"role": role, "content": combined_text, **_extra})
         else:
             # Unknown format, try to convert
-            processed_messages.append({"role": role, "content": str(content)})
+            processed_messages.append({"role": role, "content": str(content), **_extra})
 
     return _merge_consecutive_roles(
         _consolidate_system_messages(processed_messages)
@@ -386,6 +424,8 @@ def extract_multimodal_content(
             if isinstance(content, list):
                 content = _extract_text_from_content_list(content)
             msg_dict = {"role": role, "content": content if content else ""}
+            if getattr(msg, 'name', None):
+                msg_dict["name"] = msg.name
 
             if getattr(tokenizer, 'has_tool_calling', False):
                 tool_calls_list = []
@@ -434,12 +474,19 @@ def extract_multimodal_content(
             processed_messages.append(msg_dict)
             continue
 
+        # Build optional extra fields from the source message
+        _extra: dict = {}
+        if getattr(msg, 'name', None):
+            _extra["name"] = msg.name
+        if getattr(msg, 'partial', False):
+            _extra["partial"] = True
+
         if content is None:
-            processed_messages.append({"role": role, "content": ""})
+            processed_messages.append({"role": role, "content": "", **_extra})
             continue
 
         if isinstance(content, str):
-            processed_messages.append({"role": role, "content": content})
+            processed_messages.append({"role": role, "content": content, **_extra})
         elif isinstance(content, list):
             # Preserve image_url parts for VLM processing
             multimodal_parts = _extract_multimodal_content_list(content)
@@ -448,13 +495,13 @@ def extract_multimodal_content(
             )
             if has_images:
                 # Keep as content list for VLM engine
-                processed_messages.append({"role": role, "content": multimodal_parts})
+                processed_messages.append({"role": role, "content": multimodal_parts, **_extra})
             else:
                 # Text-only, flatten to string
                 combined_text = _extract_text_from_content_list(content)
-                processed_messages.append({"role": role, "content": combined_text})
+                processed_messages.append({"role": role, "content": combined_text, **_extra})
         else:
-            processed_messages.append({"role": role, "content": str(content)})
+            processed_messages.append({"role": role, "content": str(content), **_extra})
 
     return _consolidate_system_messages(processed_messages)
 

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -12,7 +12,7 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 from ..api.tool_calling import convert_tools_for_template
-from ..api.utils import clean_special_tokens
+from ..api.utils import clean_special_tokens, detect_and_strip_partial
 from ..utils.tokenizer import get_tokenizer_config
 from .base import BaseEngine, GenerationOutput
 
@@ -206,10 +206,13 @@ class BatchedEngine(BaseEngine):
                 (e.g. enable_thinking, reasoning_effort). Overrides global _enable_thinking.
         """
         if hasattr(self._tokenizer, 'apply_chat_template'):
+            is_partial = detect_and_strip_partial(messages)
             template_kwargs = {
                 "tokenize": False,
-                "add_generation_prompt": True,
+                "add_generation_prompt": not is_partial,
             }
+            if is_partial:
+                template_kwargs["continue_final_message"] = True
             if tools:
                 template_kwargs["tools"] = tools
             # Global fallback

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -32,7 +32,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import mlx.core as mx
 
 from ..api.tool_calling import convert_tools_for_template
-from ..api.utils import clean_special_tokens
+from ..api.utils import clean_special_tokens, detect_and_strip_partial
 from ..models.vlm import VLMModelAdapter
 from ..utils.image import (
     compute_image_hash,
@@ -471,6 +471,8 @@ class VLMBatchedEngine(BaseEngine):
                 return_messages=True,
             )
 
+        # Strip partial field from messages (VLM always uses add_generation_prompt=True)
+        detect_and_strip_partial(formatted_messages)
         template_kwargs = {
             "tokenize": False,
             "add_generation_prompt": True,
@@ -559,6 +561,8 @@ class VLMBatchedEngine(BaseEngine):
     ) -> str:
         """Apply chat template for text-only messages (no images)."""
         if hasattr(self._tokenizer, "apply_chat_template"):
+            # Strip partial field (VLM always uses add_generation_prompt=True)
+            detect_and_strip_partial(messages)
             template_kwargs = {
                 "tokenize": False,
                 "add_generation_prompt": True,

--- a/omlx/models/llm.py
+++ b/omlx/models/llm.py
@@ -10,6 +10,7 @@ import logging
 from dataclasses import dataclass
 from typing import Iterator
 
+from ..api.utils import detect_and_strip_partial
 from ..utils.tokenizer import get_tokenizer_config
 
 logger = logging.getLogger(__name__)
@@ -265,11 +266,14 @@ class MLXLanguageModel:
 
         # Apply chat template
         if hasattr(self.tokenizer, 'apply_chat_template'):
+            is_partial = detect_and_strip_partial(messages)
             # Build kwargs for apply_chat_template
             template_kwargs = {
                 "tokenize": False,
-                "add_generation_prompt": True,
+                "add_generation_prompt": not is_partial,
             }
+            if is_partial:
+                template_kwargs["continue_final_message"] = True
 
             # Add tools if provided and supported
             if tools:

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -11,6 +11,7 @@ from omlx.api.utils import (
     _consolidate_system_messages,
     _merge_consecutive_roles,
     clean_output_text,
+    detect_and_strip_partial,
     extract_harmony_messages,
     extract_multimodal_content,
     extract_text_content,
@@ -1225,3 +1226,201 @@ class TestExtractMultimodalContent:
         content = result[0]["content"]
         assert content[1]["type"] == "image_url"
         assert content[1]["image_url"]["url"] == "https://example.com/a.png"
+
+
+# =============================================================================
+# Partial Mode & Name Preservation
+# =============================================================================
+
+
+class TestDetectAndStripPartial:
+    """Tests for detect_and_strip_partial() helper."""
+
+    def test_detects_partial_assistant(self):
+        """Detects partial=True on final assistant message."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "{", "partial": True},
+        ]
+        assert detect_and_strip_partial(messages) is True
+
+    def test_ignores_partial_non_assistant(self):
+        """partial=True on non-assistant final message returns False."""
+        messages = [
+            {"role": "user", "content": "Hello", "partial": True},
+        ]
+        assert detect_and_strip_partial(messages) is False
+
+    def test_strips_partial_from_all_messages(self):
+        """partial field is removed from every message."""
+        messages = [
+            {"role": "user", "content": "Hello", "partial": False},
+            {"role": "assistant", "content": "{", "partial": True},
+        ]
+        detect_and_strip_partial(messages)
+        for msg in messages:
+            assert "partial" not in msg
+
+    def test_empty_messages(self):
+        """Empty message list returns False without error."""
+        assert detect_and_strip_partial([]) is False
+
+    def test_no_partial_field(self):
+        """Messages without partial field return False."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi"},
+        ]
+        assert detect_and_strip_partial(messages) is False
+
+
+class TestExtractTextContentPreservesNamePartial:
+    """Tests that extract_text_content preserves name and partial fields."""
+
+    def test_preserves_name_on_text_message(self):
+        """name field survives extraction for text messages."""
+        messages = [
+            Message(role="assistant", content="Hello", name="Kimi"),
+        ]
+        result = extract_text_content(messages)
+        assert result[0]["name"] == "Kimi"
+
+    def test_preserves_partial_on_assistant(self):
+        """partial field survives extraction for assistant messages."""
+        messages = [
+            Message(role="assistant", content="{", partial=True),
+        ]
+        result = extract_text_content(messages)
+        assert result[0].get("partial") is True
+
+    def test_no_name_when_absent(self):
+        """name key is absent when not set on source message."""
+        messages = [
+            Message(role="user", content="Hello"),
+        ]
+        result = extract_text_content(messages)
+        assert "name" not in result[0]
+
+    def test_no_partial_when_false(self):
+        """partial key is absent when False on source message."""
+        messages = [
+            Message(role="user", content="Hello"),
+        ]
+        result = extract_text_content(messages)
+        assert "partial" not in result[0]
+
+    def test_preserves_name_on_tool_call_message(self):
+        """name field preserved on assistant message with tool_calls."""
+        messages = [
+            Message(
+                role="assistant",
+                content="Let me call a tool",
+                name="Kimi",
+                tool_calls=[{"id": "1", "function": {"name": "search", "arguments": "{}"}}],
+            ),
+        ]
+        result = extract_text_content(messages)
+        assert result[0].get("name") == "Kimi"
+
+    def test_preserves_name_in_multimodal_extraction(self):
+        """name field survives multimodal extraction."""
+        messages = [
+            Message(role="assistant", content="Hello", name="Kimi"),
+        ]
+        result = extract_multimodal_content(messages)
+        assert result[0]["name"] == "Kimi"
+
+
+class TestNameFieldSchemaAcceptance:
+    """Tests that the `name` field is accepted by the Message schema.
+
+    The `name` field is part of the OpenAI chat completion spec and used by
+    models like Kimi K2/K2.5 for named-assistant persona rendering.  Many
+    templates silently ignore it, so we cannot reliably assert on template
+    output — but we CAN verify that the schema accepts it without error
+    and that it survives message extraction for templates that do use it.
+
+    On models that support it, the assistant `name` field acts as a
+    probability space constraint — the same prompt produces distinctly
+    different character voices depending on the name.  Models that ignore
+    it simply drop the field harmlessly.
+
+    Validated on Kimi-K2-Instruct-0905-mlx-3bit with a HHGTTG roleplay
+    scenario (system: turn-based RP, user: Arthur banging on bathroom
+    door, assistant: partial prefill "*" with name set).  Same prompt,
+    three names, three distinct voices:
+
+        name="Marvin the Paranoid Android":
+            *door creaks open* ... "A damp towel is flung over the
+            shower rail like a limp flag of surrender."
+
+        name="Ford Prefect":
+            *door slides open* ... "I seem to have mistaken this door
+            for the entry to the relaxation chamber of the Starship
+            Heart of Gold."
+
+        name="Zaphod Beeblebrox":
+            "Yes, yes, an hour is precisely how long it takes to
+            negotiate a cease-fire between the fungal colonies behind
+            the soap dish and the mildew syndicate under the sink."
+    """
+
+    def test_name_field_accepted_on_all_roles(self):
+        """Message schema accepts name on user, assistant, and system roles."""
+        msgs = [
+            Message(
+                role="system",
+                content="This is a turn-based roleplaying session set in the "
+                "Hitchhiker's Guide to the Galaxy universe.",
+            ),
+            Message(
+                role="user",
+                content="*bangs on the bathroom door* Oi! It's been an hour! "
+                "Some of us need to use the facilities too, you know!",
+                name="Arthur Dent",
+            ),
+            Message(
+                role="assistant",
+                content="*",
+                name="Marvin the Paranoid Android",
+                partial=True,
+            ),
+        ]
+        # No ValidationError raised — schema accepts name on all roles
+        assert msgs[1].name == "Arthur Dent"
+        assert msgs[2].name == "Marvin the Paranoid Android"
+
+    def test_name_field_survives_extraction_for_template(self):
+        """name is carried through extract_text_content so templates can render it."""
+        msgs = [
+            Message(
+                role="system",
+                content="This is a turn-based roleplaying session set in the "
+                "Hitchhiker's Guide to the Galaxy universe.",
+            ),
+            Message(
+                role="user",
+                content="*bangs on the bathroom door* Oi! It's been an hour! "
+                "Some of us need to use the facilities too, you know!",
+                name="Arthur Dent",
+            ),
+            Message(
+                role="assistant",
+                content="*",
+                name="Marvin the Paranoid Android",
+                partial=True,
+            ),
+        ]
+        result = extract_text_content(msgs)
+
+        # system message is consolidated to front; user and assistant follow
+        assert result[1]["name"] == "Arthur Dent"
+        assert result[2]["name"] == "Marvin the Paranoid Android"
+        # partial also survives for the engine to consume
+        assert result[2]["partial"] is True
+
+    def test_name_absent_when_not_provided(self):
+        """name key does not leak into message dicts when not set."""
+        msgs = [Message(role="user", content="Hello")]
+        result = extract_text_content(msgs)
+        assert "name" not in result[0]

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -528,3 +528,147 @@ class TestBatchedEngineModelType:
         engine._model = mock_model
 
         assert engine.model_type is None
+
+
+class TestApplyChatTemplatePartialMode:
+    """Tests for partial mode support in _apply_chat_template()."""
+
+    def test_partial_mode_sets_continue_final_message(self):
+        """Final assistant message with partial=True sets continue_final_message."""
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "<formatted>"
+        engine._tokenizer = mock_tokenizer
+
+        messages = [
+            {"role": "user", "content": "Generate JSON"},
+            {"role": "assistant", "content": "{", "partial": True},
+        ]
+
+        engine._apply_chat_template(messages)
+
+        call_kwargs = mock_tokenizer.apply_chat_template.call_args[1]
+        assert call_kwargs["add_generation_prompt"] is False
+        assert call_kwargs["continue_final_message"] is True
+
+    def test_partial_non_assistant_ignored(self):
+        """partial=True on a non-assistant message does not trigger partial mode."""
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "<formatted>"
+        engine._tokenizer = mock_tokenizer
+
+        messages = [
+            {"role": "user", "content": "Hello", "partial": True},
+        ]
+
+        engine._apply_chat_template(messages)
+
+        call_kwargs = mock_tokenizer.apply_chat_template.call_args[1]
+        assert call_kwargs["add_generation_prompt"] is True
+        assert "continue_final_message" not in call_kwargs
+
+    def test_partial_field_stripped_before_template(self):
+        """partial field is removed from messages before calling apply_chat_template."""
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "<formatted>"
+        engine._tokenizer = mock_tokenizer
+
+        messages = [
+            {"role": "user", "content": "Hello", "partial": False},
+            {"role": "assistant", "content": "{", "partial": True},
+        ]
+
+        engine._apply_chat_template(messages)
+
+        # Check the messages passed to apply_chat_template
+        call_args = mock_tokenizer.apply_chat_template.call_args[0][0]
+        for msg in call_args:
+            assert "partial" not in msg
+
+    def test_partial_true_continues_vs_new_turn(self):
+        """Verify the core partial toggle: partial=True continues, absent starts new turn.
+
+        With partial=True on the final assistant message, the engine must pass
+        add_generation_prompt=False and continue_final_message=True so the
+        model continues from the assistant's content rather than starting a
+        new turn.  Without partial, the default add_generation_prompt=True
+        appends the generation prompt (e.g. <|im_start|>assistant) for a
+        fresh response.
+
+        NOTE: The `name` field is not tested here because its rendering is
+        model-template-specific — many templates silently ignore it, so
+        assertions on template output would be fragile and model-dependent.
+        """
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+
+        mock_tokenizer = MagicMock()
+        engine._tokenizer = mock_tokenizer
+
+        base_messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Return JSON with keys: name, age"},
+        ]
+
+        # --- partial=True: continue from prefill ---
+        mock_tokenizer.apply_chat_template.return_value = "...assistant\n{"
+        partial_messages = base_messages + [
+            {"role": "assistant", "content": "{", "partial": True},
+        ]
+        engine._apply_chat_template(partial_messages)
+
+        partial_kwargs = mock_tokenizer.apply_chat_template.call_args[1]
+        assert partial_kwargs["add_generation_prompt"] is False
+        assert partial_kwargs["continue_final_message"] is True
+
+        # --- no partial: new turn ---
+        mock_tokenizer.apply_chat_template.reset_mock()
+        mock_tokenizer.apply_chat_template.return_value = "...<|im_start|>assistant\n"
+        normal_messages = list(base_messages)  # no trailing assistant
+        engine._apply_chat_template(normal_messages)
+
+        normal_kwargs = mock_tokenizer.apply_chat_template.call_args[1]
+        assert normal_kwargs["add_generation_prompt"] is True
+        assert "continue_final_message" not in normal_kwargs
+
+    def test_partial_with_streaming(self):
+        """partial mode kwargs are the same regardless of downstream streaming.
+
+        The engine's _apply_chat_template is called identically for streaming
+        and non-streaming — the partial toggle affects template kwargs only,
+        not the generation path.  This test confirms the kwargs are set
+        correctly when the messages would be used in a streaming context.
+        """
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "...1."
+        engine._tokenizer = mock_tokenizer
+
+        messages = [
+            {"role": "user", "content": "List 3 colors"},
+            {"role": "assistant", "content": "1.", "partial": True},
+        ]
+
+        engine._apply_chat_template(messages)
+
+        call_kwargs = mock_tokenizer.apply_chat_template.call_args[1]
+        assert call_kwargs["add_generation_prompt"] is False
+        assert call_kwargs["continue_final_message"] is True
+        # partial stripped from message dicts
+        call_msgs = mock_tokenizer.apply_chat_template.call_args[0][0]
+        assert "partial" not in call_msgs[-1]

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -724,6 +724,36 @@ class TestCountChatTokens:
 
 
 # ---------------------------------------------------------------------------
+# TestPartialModeVLM
+# ---------------------------------------------------------------------------
+
+class TestPartialModeVLM:
+    """Tests for partial mode in VLM engine — always ignored."""
+
+    def test_apply_chat_template_partial_ignored(self):
+        """VLM _apply_chat_template strips partial but always uses add_generation_prompt=True."""
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "<formatted>"
+        engine = _make_loaded_engine(tokenizer=mock_tokenizer)
+
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "{", "partial": True},
+        ]
+
+        engine._apply_chat_template(messages)
+
+        call_kwargs = mock_tokenizer.apply_chat_template.call_args[1]
+        assert call_kwargs["add_generation_prompt"] is True
+        assert "continue_final_message" not in call_kwargs
+
+        # partial field should be stripped from messages
+        call_msgs = mock_tokenizer.apply_chat_template.call_args[0][0]
+        for msg in call_msgs:
+            assert "partial" not in msg
+
+
+# ---------------------------------------------------------------------------
 # TestGetStats
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR implements support for Moonshot's "partial mode", an extension to the OpenAI chat completion API that enables message prefills and renaming of role anchors. This enables prefill patterns (JSON mode via `"content": "{"`) and named-assistant persona consistency (Kimi K2/K2.5 `name` field rendering).

Full disclosure: Moonshot has not publicly documented how "partial mode" is implemented on their API backend, but when you compare [their documentation](https://platform.moonshot.ai/docs/api/partial) to the model templates for [K2](https://huggingface.co/moonshotai/Kimi-K2-Instruct/blob/main/chat_template.jinja) and [K2.5](https://huggingface.co/moonshotai/Kimi-K2.5/blob/main/chat_template.jinja), it becomes pretty obvious what they're doing here.

The underlying infrastructure is already present in mlx_lm and the chat templates of Kimi K2 and K2.5. This change allows the `name` field to be passed through to the backend (in all circumstances), and reserves the `partial` field as a boolean toggle for switching between `continue_final_message=True` and `add_generation_prompt=True` in apply_chat_template. `partial` is consumed by the API server and not passed to the model template, unlike `name`.

For more information on Partial Mode, refer to the following:
- Moonshot's Partial Mode documentation: https://platform.moonshot.ai/docs/api/partial
- My PR previously submitted to mlx-openai-server: https://github.com/cubist38/mlx-openai-server/pull/213

---

Schema changes:
- Add `name` and `partial` fields to Message model
- Add `detect_and_strip_partial()` helper in api/utils.py
- Preserve `name`/`partial` through extract_text_content() and extract_multimodal_content() message extraction

Engine changes:
- BatchedEngine._apply_chat_template(): conditional generation prompt based on partial mode detection
- VLMBatchedEngine: strip `partial` field in both template methods but always use `add_generation_prompt=True` (vision models do not support continuation)
- MLXLanguageModel.chat(): same partial mode logic as BatchedEngine

