### PR TITLE
fix(embedding): support custom processor input preparation

### DIFF
--- a/omlx/models/embedding.py
+++ b/omlx/models/embedding.py
@@ -209,6 +209,48 @@ class MLXEmbeddingModel:
             "(text_embeds, pooler_output, or last_hidden_state)"
         )
 
+    def _uses_custom_embedding_inputs(self, processor) -> bool:
+        """Return True when processor exposes a custom embedding input API."""
+        return hasattr(processor, "prepare_embedding_inputs") or hasattr(
+            processor, "prepare_model_inputs"
+        )
+
+    def _prepare_embedding_inputs(
+        self,
+        processor,
+        texts: List[str],
+        max_length: int,
+        padding: bool,
+        truncation: bool,
+    ):
+        """
+        Prepare inputs for embedding inference.
+
+        Some embedding processors, such as qwen3_vl in mlx-embeddings, expose
+        a higher-level embedding API instead of the tokenizer-style
+        ``processor(texts, ...)`` path. Reuse that official extension point
+        when available to avoid positional-argument mismatches.
+        """
+        if self._uses_custom_embedding_inputs(processor):
+            items = [{"text": text} for text in texts]
+            if hasattr(processor, "prepare_embedding_inputs"):
+                return processor.prepare_embedding_inputs(
+                    items, return_tensors="mlx"
+                )
+            return processor.prepare_model_inputs(items, return_tensors="mlx")
+
+        from mlx_embeddings.utils import prepare_inputs
+
+        return prepare_inputs(
+            processor,
+            None,
+            texts,
+            max_length,
+            padding,
+            truncation,
+            None,
+        )
+
     def _try_compile(self) -> bool:
         """
         Compile a primitive-output embedding forward function.
@@ -266,7 +308,9 @@ class MLXEmbeddingModel:
             texts = [texts]
 
         processor = self.processor
-        if hasattr(processor, "_tokenizer"):
+        if hasattr(processor, "_tokenizer") and not self._uses_custom_embedding_inputs(
+            processor
+        ):
             processor = processor._tokenizer
 
         embeddings_array = None
@@ -301,19 +345,14 @@ class MLXEmbeddingModel:
             outputs = self.model(input_ids=input_ids, attention_mask=attention_mask)
             embeddings_array = self._extract_embeddings_array(outputs)
         else:
-            from mlx_embeddings import generate
-            from mlx_embeddings.utils import prepare_inputs
-
             if self._is_compiled and self._compiled_embed is not None:
                 try:
-                    inputs = prepare_inputs(
+                    inputs = self._prepare_embedding_inputs(
                         processor,
-                        None,
                         texts,
                         max_length,
                         padding,
                         truncation,
-                        None,
                     )
                     if not isinstance(inputs, dict):
                         inputs = dict(inputs)
@@ -327,14 +366,28 @@ class MLXEmbeddingModel:
                     self._compiled_embed = None
 
             if embeddings_array is None:
-                outputs = generate(
-                    self.model,
-                    processor,
-                    texts,
-                    max_length=max_length,
-                    padding=padding,
-                    truncation=truncation,
-                )
+                if self._uses_custom_embedding_inputs(processor):
+                    inputs = self._prepare_embedding_inputs(
+                        processor,
+                        texts,
+                        max_length,
+                        padding,
+                        truncation,
+                    )
+                    if not isinstance(inputs, dict):
+                        inputs = dict(inputs)
+                    outputs = self.model(**inputs)
+                else:
+                    from mlx_embeddings import generate
+
+                    outputs = generate(
+                        self.model,
+                        processor,
+                        texts,
+                        max_length=max_length,
+                        padding=padding,
+                        truncation=truncation,
+                    )
                 embeddings_array = self._extract_embeddings_array(outputs)
 
         mx.eval(embeddings_array)

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -361,16 +361,24 @@ class TestEmbeddingCompileFallback:
         import mlx.core as mx
         from omlx.models.embedding import MLXEmbeddingModel
 
+        class StandardTokenizer:
+            def encode(self, text, add_special_tokens=True):
+                del text, add_special_tokens
+                return [1, 2, 3]
+
+        class StandardProcessor:
+            def __init__(self):
+                self._tokenizer = StandardTokenizer()
+
         model = MLXEmbeddingModel("test-model")
         model._loaded = True
         model._is_compiled = True
         model._compiled_embed = MagicMock(side_effect=RuntimeError("compile fail"))
         model.model = MagicMock()
-        model.processor = MagicMock(spec=[])
-        model.processor._tokenizer = MagicMock()
+        model.processor = StandardProcessor()
 
         # Mock generate to return outputs with text_embeds
-        mock_outputs = MagicMock(spec=[])
+        mock_outputs = MagicMock()
         mock_outputs.text_embeds = mx.array([[0.1, 0.2, 0.3]])
         mock_outputs.pooler_output = None
         mock_outputs.last_hidden_state = None
@@ -403,6 +411,70 @@ class TestEmbeddingCompileFallback:
             result = model.embed(["test"])
 
         assert len(result.embeddings) == 1
+
+    def test_custom_processor_compiled_path_uses_prepare_embedding_inputs(self):
+        """Custom embedding processors should use their own prepare API."""
+        import mlx.core as mx
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel("test-model")
+        model._loaded = True
+        model._is_compiled = True
+        model._compiled_embed = MagicMock(return_value=mx.array([[0.1, 0.2]]))
+        model.model = MagicMock()
+
+        processor = MagicMock(spec=[])
+        processor.prepare_embedding_inputs = MagicMock(
+            return_value={
+                "input_ids": mx.array([[1, 2, 3]]),
+                "attention_mask": mx.array([[1, 1, 1]]),
+            }
+        )
+        model.processor = processor
+
+        with patch("mlx_embeddings.generate") as mock_generate:
+            result = model.embed(["hello world"])
+
+        processor.prepare_embedding_inputs.assert_called_once_with(
+            [{"text": "hello world"}], return_tensors="mlx"
+        )
+        mock_generate.assert_not_called()
+        assert result.embeddings[0] == pytest.approx([0.1, 0.2], abs=1e-5)
+
+    def test_custom_processor_eager_path_bypasses_generate(self):
+        """Custom embedding processors should bypass mlx_embeddings.generate()."""
+        import mlx.core as mx
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel("test-model")
+        model._loaded = True
+        model._is_compiled = False
+        model._compiled_embed = None
+
+        mock_outputs = MagicMock(spec=[])
+        mock_outputs.text_embeds = mx.array([[0.3, 0.4, 0.5]])
+        mock_outputs.pooler_output = None
+        mock_outputs.last_hidden_state = None
+        model.model = MagicMock(return_value=mock_outputs)
+
+        processor = MagicMock(spec=[])
+        processor.prepare_embedding_inputs = MagicMock(
+            return_value={
+                "input_ids": mx.array([[4, 5, 6]]),
+                "attention_mask": mx.array([[1, 1, 1]]),
+            }
+        )
+        model.processor = processor
+
+        with patch("mlx_embeddings.generate") as mock_generate:
+            result = model.embed(["hello world"])
+
+        processor.prepare_embedding_inputs.assert_called_once_with(
+            [{"text": "hello world"}], return_tensors="mlx"
+        )
+        mock_generate.assert_not_called()
+        model.model.assert_called_once()
+        assert result.embeddings[0] == pytest.approx([0.3, 0.4, 0.5], abs=1e-5)
 
 
 class TestEmbeddingEngine:


### PR DESCRIPTION
## Summary
  - route embedding requests through custom processor hooks when available
  - keep the existing generic tokenizer path for standard text embedding models
  - add regression coverage for both compiled and eager embedding execution

## Why
  Qwen3-VL embedding models can be loaded through `mlx-embeddings`, but oMLX always used the generic `processor(texts, ...)` path for embedding requests. For custom processors such as `qwen3_vl`, that positional call is interpreted as image input, which breaks `/v1/embeddings` even when the model is explicitly treated as an embedding model.

## Testing
  - `uv run pytest tests/test_embedding.py -k "custom_processor or compiled_path_fallback_on_failure or is_compiled_false_uses_eager_path"`
  - started oMLX with `Qwen3-VL-Embedding-2B-mxfp8` forced to `embedding` and verified `/v1/embeddings` returns vectors for single and batch text inputs