### PR TITLE
feat(embedding): add multimodal embedding items

### DIFF
--- a/omlx/api/embedding_models.py
+++ b/omlx/api/embedding_models.py
@@ -10,7 +10,23 @@ import time
 import uuid
 from typing import List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+
+class EmbeddingInputItem(BaseModel):
+    """Structured input item for multimodal embeddings."""
+
+    text: Optional[str] = None
+    image: Optional[str] = None
+
+    model_config = {"extra": "forbid"}
+
+    @model_validator(mode="after")
+    def validate_fields(self) -> "EmbeddingInputItem":
+        """Require at least one supported field."""
+        if self.text is None and self.image is None:
+            raise ValueError("Embedding input item must include text or image")
+        return self
 
 
 class EmbeddingRequest(BaseModel):
@@ -20,8 +36,11 @@ class EmbeddingRequest(BaseModel):
     OpenAI-compatible request format for the /v1/embeddings endpoint.
     """
 
-    input: Union[str, List[str]]
+    input: Optional[Union[str, List[str]]] = None
     """Input text(s) to embed. Can be a single string or list of strings."""
+
+    items: Optional[List[EmbeddingInputItem]] = None
+    """Structured embedding items for multimodal inputs."""
 
     model: str
     """ID of the model to use."""
@@ -38,6 +57,17 @@ class EmbeddingRequest(BaseModel):
     The number of dimensions the output embeddings should have.
     Only supported by some models. If not supported, returns full dimensions.
     """
+
+    @model_validator(mode="after")
+    def validate_input_source(self) -> "EmbeddingRequest":
+        """Require exactly one input source."""
+        if self.input is None and self.items is None:
+            raise ValueError("Either input or items must be provided")
+        if self.input is not None and self.items is not None:
+            raise ValueError("input and items cannot be provided together")
+        if self.items is not None and len(self.items) == 0:
+            raise ValueError("items cannot be empty")
+        return self
 
 
 class EmbeddingData(BaseModel):

--- a/omlx/api/embedding_utils.py
+++ b/omlx/api/embedding_utils.py
@@ -10,8 +10,11 @@ Provides:
 
 import base64
 import math
+import os
 import struct
-from typing import Any, List, Union
+from typing import Any, Dict, List, Union
+
+from .embedding_models import EmbeddingInputItem
 
 
 def encode_embedding_base64(embedding: List[float]) -> str:
@@ -112,3 +115,46 @@ def normalize_input(input_data: Union[str, List[str]]) -> List[str]:
     if isinstance(input_data, str):
         return [input_data]
     return list(input_data)
+
+
+def normalize_embedding_items(
+    items: List[Union[EmbeddingInputItem, Dict[str, Any]]]
+) -> List[Dict[str, str]]:
+    """
+    Normalize structured embedding items into plain dicts.
+
+    Args:
+        items: Structured embedding input items
+
+    Returns:
+        List of normalized item dicts with only supported keys
+    """
+    normalized: List[Dict[str, str]] = []
+
+    for item in items:
+        if hasattr(item, "model_dump"):
+            payload = item.model_dump(exclude_none=True)
+        else:
+            payload = {
+                key: value for key, value in dict(item).items() if value is not None
+            }
+
+        text = payload.get("text")
+        image = payload.get("image")
+
+        normalized_item: Dict[str, str] = {}
+        if text is not None:
+            normalized_item["text"] = text
+        if image is not None:
+            normalized_item["image"] = image
+
+        normalized.append(normalized_item)
+
+    return normalized
+
+
+def is_likely_local_image_path(image: str) -> bool:
+    """Return True when the image string looks like a local filesystem path."""
+    if image.startswith(("http://", "https://", "data:")):
+        return False
+    return os.path.exists(image)

--- a/omlx/engine/embedding.py
+++ b/omlx/engine/embedding.py
@@ -10,7 +10,7 @@ streaming or chat completion.
 import asyncio
 import gc
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import mlx.core as mx
 
@@ -89,7 +89,7 @@ class EmbeddingEngine(BaseNonStreamingEngine):
 
     async def embed(
         self,
-        texts: List[str],
+        texts: Union[List[str], List[Dict[str, str]]],
         max_length: int = 512,
         padding: bool = True,
         truncation: bool = True,
@@ -113,7 +113,7 @@ class EmbeddingEngine(BaseNonStreamingEngine):
 
         def _embed_sync():
             return model.embed(
-                texts=texts,
+                inputs=texts,
                 max_length=max_length,
                 padding=padding,
                 truncation=truncation,

--- a/omlx/models/embedding.py
+++ b/omlx/models/embedding.py
@@ -8,12 +8,14 @@ for XLMRoBERTa and BERT embedding models.
 """
 
 import json
+import inspect
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import mlx.core as mx
+from mlx.utils import tree_flatten
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +126,8 @@ class MLXEmbeddingModel:
                         weights[key] = f.get_tensor(key)
 
             weights = model_instance.sanitize(weights)
-            model_instance.load_weights(list(weights.items()))
+            self._validate_native_weights(model_instance, weights)
+            model_instance.load_weights(list(weights.items()), strict=False)
             mx.eval(model_instance.parameters())
 
             try:
@@ -209,16 +212,77 @@ class MLXEmbeddingModel:
             "(text_embeds, pooler_output, or last_hidden_state)"
         )
 
+    def _validate_native_weights(
+        self, model_instance, weights: Dict[str, Any]
+    ) -> None:
+        """Reject native checkpoints with missing or shape-incompatible core weights."""
+        expected_weights = dict(tree_flatten(model_instance.parameters()))
+        expected_weight_names = set(expected_weights.keys())
+        provided_weight_names = set(weights.keys())
+        missing_weight_names = expected_weight_names - provided_weight_names
+
+        optional_missing_prefixes = ("pooler.",)
+        required_missing = sorted(
+            name
+            for name in missing_weight_names
+            if not name.startswith(optional_missing_prefixes)
+        )
+        if required_missing:
+            preview = ", ".join(required_missing[:10])
+            suffix = "..." if len(required_missing) > 10 else ""
+            raise ValueError(
+                "Native embedding checkpoint is missing required weights: "
+                f"{preview}{suffix}"
+            )
+
+        shape_mismatches = []
+        for name in expected_weight_names & provided_weight_names:
+            expected_shape = tuple(expected_weights[name].shape)
+            provided_shape = tuple(weights[name].shape)
+            if expected_shape != provided_shape:
+                shape_mismatches.append((name, expected_shape, provided_shape))
+
+        if shape_mismatches:
+            preview = ", ".join(
+                f"{name}: expected {expected_shape}, got {provided_shape}"
+                for name, expected_shape, provided_shape in shape_mismatches[:5]
+            )
+            suffix = "..." if len(shape_mismatches) > 5 else ""
+            raise ValueError(
+                "Native embedding checkpoint has incompatible weight shapes: "
+                f"{preview}{suffix}"
+            )
+
     def _uses_custom_embedding_inputs(self, processor) -> bool:
         """Return True when processor exposes a custom embedding input API."""
-        return hasattr(processor, "prepare_embedding_inputs") or hasattr(
-            processor, "prepare_model_inputs"
-        )
+        for attr_name in ("prepare_embedding_inputs", "prepare_model_inputs"):
+            try:
+                inspect.getattr_static(processor, attr_name)
+                return True
+            except AttributeError:
+                continue
+        return False
+
+    def _normalize_embedding_inputs(
+        self,
+        inputs: Union[str, Dict[str, str], List[str], List[Dict[str, str]]],
+    ) -> List[Dict[str, str]]:
+        """Normalize embedding inputs into item dicts."""
+        if not inputs:
+            return []
+        if isinstance(inputs, str):
+            return [{"text": inputs}]
+        if isinstance(inputs, dict):
+            return [dict(inputs)]
+        first = inputs[0]
+        if isinstance(first, str):
+            return [{"text": text} for text in inputs]
+        return [dict(item) for item in inputs]
 
     def _prepare_embedding_inputs(
         self,
         processor,
-        texts: List[str],
+        inputs: Union[List[str], List[Dict[str, str]]],
         max_length: int,
         padding: bool,
         truncation: bool,
@@ -231,20 +295,28 @@ class MLXEmbeddingModel:
         ``processor(texts, ...)`` path. Reuse that official extension point
         when available to avoid positional-argument mismatches.
         """
+        normalized_inputs = self._normalize_embedding_inputs(inputs)
+
         if self._uses_custom_embedding_inputs(processor):
-            items = [{"text": text} for text in texts]
             if hasattr(processor, "prepare_embedding_inputs"):
                 return processor.prepare_embedding_inputs(
-                    items, return_tensors="mlx"
+                    normalized_inputs, return_tensors="mlx"
                 )
-            return processor.prepare_model_inputs(items, return_tensors="mlx")
+            return processor.prepare_model_inputs(
+                normalized_inputs, return_tensors="mlx"
+            )
+
+        if any("image" in item for item in normalized_inputs):
+            raise ValueError(
+                f"Embedding model '{self.model_name}' does not support image inputs"
+            )
 
         from mlx_embeddings.utils import prepare_inputs
 
         return prepare_inputs(
             processor,
             None,
-            texts,
+            [item.get("text", "") for item in normalized_inputs],
             max_length,
             padding,
             truncation,
@@ -284,7 +356,7 @@ class MLXEmbeddingModel:
 
     def embed(
         self,
-        texts: List[str],
+        inputs: Union[str, List[str], List[Dict[str, str]]],
         max_length: int = 512,
         padding: bool = True,
         truncation: bool = True,
@@ -304,21 +376,27 @@ class MLXEmbeddingModel:
         if not self._loaded:
             self.load()
 
-        if isinstance(texts, str):
-            texts = [texts]
+        normalized_inputs = self._normalize_embedding_inputs(inputs)
+        input_texts = [item["text"] for item in normalized_inputs if "text" in item]
+        has_image_inputs = any("image" in item for item in normalized_inputs)
 
         processor = self.processor
-        if hasattr(processor, "_tokenizer") and not self._uses_custom_embedding_inputs(
-            processor
-        ):
+        uses_custom_embedding_inputs = self._uses_custom_embedding_inputs(processor)
+        if hasattr(processor, "_tokenizer") and not uses_custom_embedding_inputs:
             processor = processor._tokenizer
 
+        if has_image_inputs and (self._using_native or not uses_custom_embedding_inputs):
+            raise ValueError(
+                f"Embedding model '{self.model_name}' does not support image inputs"
+            )
+
         embeddings_array = None
+        total_tokens: Optional[int] = None
 
         if self._using_native:
             if hasattr(processor, "__call__"):
                 encoded = processor(
-                    texts,
+                    input_texts,
                     padding=padding,
                     truncation=truncation,
                     max_length=max_length,
@@ -329,7 +407,7 @@ class MLXEmbeddingModel:
             else:
                 encoded_ids = []
                 masks = []
-                for text in texts:
+                for text in input_texts:
                     enc = processor.encode(text, add_special_tokens=True)
                     ids = list(enc.ids)[:max_length]
                     encoded_ids.append(ids)
@@ -344,18 +422,22 @@ class MLXEmbeddingModel:
 
             outputs = self.model(input_ids=input_ids, attention_mask=attention_mask)
             embeddings_array = self._extract_embeddings_array(outputs)
+            total_tokens = self._count_prepared_tokens(
+                {"attention_mask": attention_mask, "input_ids": input_ids}
+            )
         else:
             if self._is_compiled and self._compiled_embed is not None:
                 try:
                     inputs = self._prepare_embedding_inputs(
                         processor,
-                        texts,
+                        normalized_inputs,
                         max_length,
                         padding,
                         truncation,
                     )
                     if not isinstance(inputs, dict):
                         inputs = dict(inputs)
+                    total_tokens = self._count_prepared_tokens(inputs)
                     embeddings_array = self._compiled_embed(inputs)
                 except Exception as e:
                     logger.warning(
@@ -366,10 +448,10 @@ class MLXEmbeddingModel:
                     self._compiled_embed = None
 
             if embeddings_array is None:
-                if self._uses_custom_embedding_inputs(processor):
+                if uses_custom_embedding_inputs:
                     inputs = self._prepare_embedding_inputs(
                         processor,
-                        texts,
+                        normalized_inputs,
                         max_length,
                         padding,
                         truncation,
@@ -377,13 +459,14 @@ class MLXEmbeddingModel:
                     if not isinstance(inputs, dict):
                         inputs = dict(inputs)
                     outputs = self.model(**inputs)
+                    total_tokens = self._count_prepared_tokens(inputs)
                 else:
                     from mlx_embeddings import generate
 
                     outputs = generate(
                         self.model,
                         processor,
-                        texts,
+                        input_texts,
                         max_length=max_length,
                         padding=padding,
                         truncation=truncation,
@@ -392,7 +475,8 @@ class MLXEmbeddingModel:
 
         mx.eval(embeddings_array)
         embeddings = embeddings_array.tolist()
-        total_tokens = self._count_tokens(texts)
+        if total_tokens is None:
+            total_tokens = self._count_tokens(normalized_inputs)
         dimensions = len(embeddings[0]) if embeddings else 0
 
         return EmbeddingOutput(
@@ -401,12 +485,17 @@ class MLXEmbeddingModel:
             dimensions=dimensions,
         )
 
-    def _count_tokens(self, texts: List[str]) -> int:
+    def _count_tokens(
+        self, inputs: Union[List[str], List[Dict[str, str]]]
+    ) -> int:
         """Count total tokens in input texts."""
         total = 0
         processor = self.processor
 
-        for text in texts:
+        for item in self._normalize_embedding_inputs(inputs):
+            text = item.get("text")
+            if not text:
+                continue
             if hasattr(processor, "encode"):
                 tokens = processor.encode(text, add_special_tokens=True)
                 if isinstance(tokens, list):
@@ -427,6 +516,37 @@ class MLXEmbeddingModel:
                 total += len(text.split()) + 2
 
         return total
+
+    def _count_prepared_tokens(self, prepared_inputs: Dict[str, Any]) -> int:
+        """Count tokens from prepared model inputs, including multimodal tokens."""
+        attention_mask = prepared_inputs.get("attention_mask")
+        if attention_mask is not None:
+            try:
+                return int(mx.sum(attention_mask).item())
+            except Exception:
+                pass
+            if isinstance(attention_mask, list):
+                return int(sum(sum(row) if isinstance(row, list) else row for row in attention_mask))
+            if hasattr(attention_mask, "tolist"):
+                values = attention_mask.tolist()
+                if values and isinstance(values[0], list):
+                    return int(sum(sum(row) for row in values))
+                return int(sum(values))
+
+        input_ids = prepared_inputs.get("input_ids")
+        if input_ids is None:
+            return 0
+        if hasattr(input_ids, "shape"):
+            if len(input_ids.shape) == 0:
+                return 1
+            if len(input_ids.shape) == 1:
+                return int(input_ids.shape[0])
+            return int(input_ids.shape[0] * input_ids.shape[1])
+        if isinstance(input_ids, list):
+            if input_ids and isinstance(input_ids[0], list):
+                return int(sum(len(row) for row in input_ids))
+            return int(len(input_ids))
+        return 0
 
     @property
     def hidden_size(self) -> Optional[int]:

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -107,6 +107,7 @@ from .api.embedding_models import (
 )
 from .api.embedding_utils import (
     encode_embedding_base64,
+    normalize_embedding_items,
     truncate_embedding,
     normalize_input,
 )
@@ -1517,7 +1518,8 @@ async def create_embeddings(
     - float or base64 encoding format
     - Optional dimension reduction (with renormalization)
     """
-    if _server_state.oq_manager and _server_state.oq_manager.is_quantizing:
+    oq_manager = getattr(_server_state, "oq_manager", None)
+    if oq_manager and oq_manager.is_quantizing:
         raise HTTPException(
             status_code=503,
             detail="Server is busy with oQ quantization. Please try again after quantization completes.",
@@ -1525,20 +1527,28 @@ async def create_embeddings(
 
     engine = await get_embedding_engine(request.model)
 
-    # Normalize input to list
-    texts = normalize_input(request.input)
+    if request.items is not None:
+        embedding_inputs = normalize_embedding_items(request.items)
+    elif request.input is not None:
+        embedding_inputs = normalize_input(request.input)
+    else:
+        embedding_inputs = []
 
-    if not texts:
+    if not embedding_inputs:
         raise HTTPException(status_code=400, detail="Input cannot be empty")
 
     # Generate embeddings
     start_time = time.perf_counter()
-
-    output = await engine.embed(texts)
+    try:
+        output = await engine.embed(embedding_inputs)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except TypeError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
     elapsed = time.perf_counter() - start_time
     logger.info(
-        f"Embedding: {len(texts)} texts, {output.dimensions} dims, "
+        f"Embedding: {len(embedding_inputs)} inputs, {output.dimensions} dims, "
         f"{output.total_tokens} tokens in {elapsed:.3f}s"
     )
 

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -72,7 +72,7 @@ class MockEmbeddingEngineImpl(EmbeddingEngine):
     async def stop(self) -> None:
         pass
 
-    async def embed(self, texts: List[str], **kwargs) -> MockEmbeddingOutput:
+    async def embed(self, texts, **kwargs) -> MockEmbeddingOutput:
         return MockEmbeddingOutput(
             embeddings=[[0.1, 0.2, 0.3] for _ in texts],
             total_tokens=len(texts) * 5,
@@ -868,6 +868,48 @@ class TestEmbeddingsEndpoint:
         assert "total_tokens" in data["usage"]
         assert "embedding" in data["data"][0]
         assert isinstance(data["data"][0]["embedding"], list)
+
+    def test_embeddings_structured_items_input(self, client, mock_engine_pool):
+        """Test embeddings with structured multimodal items."""
+        mock_engine_pool._models.append(
+            {"id": "test-embed-model", "loaded": True, "pinned": False, "size": 500000}
+        )
+
+        response = client.post(
+            "/v1/embeddings",
+            json={
+                "model": "test-embed-model",
+                "items": [
+                    {"text": "hello"},
+                    {"image": "https://example.com/image.jpg"},
+                    {
+                        "text": "hello",
+                        "image": "https://example.com/image.jpg",
+                    },
+                ],
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 3
+
+    def test_embeddings_rejects_mixed_input_sources(self, client, mock_engine_pool):
+        """Test embeddings rejects input and items together."""
+        mock_engine_pool._models.append(
+            {"id": "test-embed-model", "loaded": True, "pinned": False, "size": 500000}
+        )
+
+        response = client.post(
+            "/v1/embeddings",
+            json={
+                "model": "test-embed-model",
+                "input": "hello",
+                "items": [{"text": "hello"}],
+            },
+        )
+
+        assert response.status_code == 422
 
 
 class TestRerankEndpoint:

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -4,6 +4,7 @@
 import base64
 import json
 import math
+import numpy as np
 import struct
 import tempfile
 from pathlib import Path
@@ -13,6 +14,7 @@ import pytest
 
 from omlx.api.embedding_models import (
     EmbeddingData,
+    EmbeddingInputItem,
     EmbeddingRequest,
     EmbeddingResponse,
     EmbeddingUsage,
@@ -20,6 +22,7 @@ from omlx.api.embedding_models import (
 from omlx.api.embedding_utils import (
     count_tokens,
     encode_embedding_base64,
+    normalize_embedding_items,
     normalize_input,
     truncate_embedding,
 )
@@ -51,6 +54,38 @@ class TestEmbeddingModels:
         assert request.input == ["Hello", "World"]
         assert request.encoding_format == "base64"
         assert request.dimensions == 256
+
+    def test_embedding_request_items_input(self):
+        """Test EmbeddingRequest with structured items."""
+        request = EmbeddingRequest(
+            items=[
+                EmbeddingInputItem(text="hello"),
+                EmbeddingInputItem(image="https://example.com/image.jpg"),
+            ],
+            model="test-model",
+        )
+        assert request.input is None
+        assert len(request.items) == 2
+
+    def test_embedding_request_rejects_both_input_and_items(self):
+        """Test EmbeddingRequest rejects mixed input sources."""
+        with pytest.raises(ValueError, match="cannot be provided together"):
+            EmbeddingRequest(
+                input="hello",
+                items=[EmbeddingInputItem(text="world")],
+                model="test-model",
+            )
+
+    def test_embedding_input_item_requires_text_or_image(self):
+        """Test EmbeddingInputItem rejects empty payloads."""
+        with pytest.raises(ValueError, match="text or image"):
+            EmbeddingInputItem()
+
+    def test_embedding_input_item_allows_empty_string_text(self):
+        """Test EmbeddingInputItem preserves empty-string text items."""
+        item = EmbeddingInputItem(text="")
+        assert item.text == ""
+        assert item.image is None
 
     def test_embedding_data(self):
         """Test EmbeddingData model."""
@@ -174,6 +209,27 @@ class TestEmbeddingUtils:
         """Test normalizing list input."""
         result = normalize_input(["Hello", "World"])
         assert result == ["Hello", "World"]
+
+    def test_normalize_embedding_items(self):
+        """Test structured embedding items normalization."""
+        result = normalize_embedding_items(
+            [
+                EmbeddingInputItem(text="hello"),
+                EmbeddingInputItem(image="https://example.com/image.jpg"),
+                EmbeddingInputItem(
+                    text="hello",
+                    image="https://example.com/image.jpg",
+                ),
+            ]
+        )
+        assert result == [
+            {"text": "hello"},
+            {"image": "https://example.com/image.jpg"},
+            {
+                "text": "hello",
+                "image": "https://example.com/image.jpg",
+            },
+        ]
 
     def test_count_tokens_with_encode(self):
         """Test token counting with tokenizer that has encode method."""
@@ -476,6 +532,89 @@ class TestEmbeddingCompileFallback:
         model.model.assert_called_once()
         assert result.embeddings[0] == pytest.approx([0.3, 0.4, 0.5], abs=1e-5)
 
+    def test_custom_processor_receives_image_items_unchanged(self):
+        """Custom processors should receive raw image strings unchanged."""
+        import mlx.core as mx
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel("test-model")
+        model._loaded = True
+        model._is_compiled = False
+        model._compiled_embed = None
+
+        mock_outputs = MagicMock(spec=[])
+        mock_outputs.text_embeds = mx.array([[0.3, 0.4, 0.5]])
+        mock_outputs.pooler_output = None
+        mock_outputs.last_hidden_state = None
+        model.model = MagicMock(return_value=mock_outputs)
+
+        processor = MagicMock(spec=[])
+        processor.prepare_embedding_inputs = MagicMock(
+            return_value={
+                "input_ids": mx.array([[4, 5, 6]]),
+                "attention_mask": mx.array([[1, 1, 1]]),
+            }
+        )
+        model.processor = processor
+
+        inputs = [
+            {"text": "hello"},
+            {"image": "https://example.com/image.jpg"},
+            {
+                "text": "hello",
+                "image": "https://example.com/image.jpg",
+            },
+        ]
+        result = model.embed(inputs)
+
+        processor.prepare_embedding_inputs.assert_called_once_with(
+            inputs, return_tensors="mlx"
+        )
+        assert result.embeddings[0] == pytest.approx([0.3, 0.4, 0.5], abs=1e-5)
+
+    def test_custom_processor_counts_image_only_tokens_from_prepared_inputs(self):
+        """Image-only custom processor inputs should contribute to usage stats."""
+        import mlx.core as mx
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel("test-model")
+        model._loaded = True
+        model._is_compiled = False
+        model._compiled_embed = None
+
+        mock_outputs = MagicMock(spec=[])
+        mock_outputs.text_embeds = mx.array([[0.3, 0.4, 0.5]])
+        mock_outputs.pooler_output = None
+        mock_outputs.last_hidden_state = None
+        model.model = MagicMock(return_value=mock_outputs)
+
+        processor = MagicMock(spec=[])
+        processor.prepare_embedding_inputs = MagicMock(
+            return_value={
+                "input_ids": mx.array([[11, 12, 13, 14]]),
+                "attention_mask": mx.array([[1, 1, 1, 1]]),
+            }
+        )
+        model.processor = processor
+
+        result = model.embed([{"image": "https://example.com/image.jpg"}])
+
+        assert result.total_tokens == 4
+
+    def test_standard_processor_rejects_image_inputs(self):
+        """Standard text embedding processors should reject image items."""
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel("test-model")
+        model._loaded = True
+        model._is_compiled = False
+        model._compiled_embed = None
+        model.model = MagicMock()
+        model.processor = MagicMock()
+
+        with pytest.raises(ValueError, match="does not support image inputs"):
+            model.embed([{"image": "https://example.com/image.jpg"}])
+
 
 class TestEmbeddingEngine:
     """Tests for EmbeddingEngine."""
@@ -624,6 +763,11 @@ class TestEmbeddingModelsPydantic:
         request = EmbeddingRequest(input=["a", "b"], model="model")
         assert request.input == ["a", "b"]
 
+        request = EmbeddingRequest(
+            items=[EmbeddingInputItem(text="test")], model="model"
+        )
+        assert request.items[0].text == "test"
+
     def test_embedding_data_accepts_string_embedding(self):
         """Test EmbeddingData accepts string (base64) embedding."""
         data = EmbeddingData(index=0, embedding="base64string")
@@ -677,10 +821,54 @@ class TestEmbeddingIntegration:
 class TestNativeEmbeddingLoading:
     """Tests for native embedding model loading (without mlx-embeddings)."""
 
+    class MockNativeTokenizer:
+        """Minimal tokenizer used only by native-loading tests."""
+
+        def __init__(self, vocab_size: int = 30522):
+            self.vocab_size = max(vocab_size, 16)
+
+        def encode(self, text: str, add_special_tokens: bool = True):
+            tokens = [abs(hash(token)) % (self.vocab_size - 3) + 3 for token in text.split()]
+            if add_special_tokens:
+                return [101, *tokens, 102]
+            return tokens
+
+        def __call__(
+            self,
+            texts,
+            *,
+            padding=True,
+            truncation=True,
+            max_length=512,
+            return_tensors="np",
+        ):
+            del truncation, return_tensors
+            encoded = [self.encode(text, add_special_tokens=True)[:max_length] for text in texts]
+            target_len = max(len(ids) for ids in encoded) if padding and encoded else 0
+            input_ids = []
+            attention_mask = []
+            for ids in encoded:
+                pad_len = max(target_len - len(ids), 0)
+                input_ids.append(ids + [0] * pad_len)
+                attention_mask.append([1] * len(ids) + [0] * pad_len)
+            return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+    def _write_full_native_checkpoint(self, tmp_path, config):
+        """Write a complete native checkpoint for a small embedding model."""
+        from mlx.utils import tree_flatten
+        from omlx.models.xlm_roberta import Model, ModelArgs
+        from safetensors.numpy import save_file
+
+        model_config = ModelArgs(**config)
+        model = Model(model_config)
+        weights = {name: np.array(value) for name, value in tree_flatten(model.parameters())}
+        save_file(weights, str(tmp_path / "model.safetensors"))
+
     def test_load_native_bert_model(self, tmp_path):
         """Test native loading of BERT embedding model."""
         import sys
         sys.path.insert(0, str(Path(__file__).parent.parent))
+        from safetensors.numpy import save_file
 
         # Create minimal BERT model structure
         config = {
@@ -698,28 +886,40 @@ class TestNativeEmbeddingLoading:
         }
         (tmp_path / "config.json").write_text(json.dumps(config))
 
-        # Create minimal safetensors file
-        import struct
-        import numpy as np
-        from safetensors.numpy import save_file
-
-        # Create minimal embeddings weight
-        vocab_size, hidden_size = 30522, 384
-        embeddings = np.random.randn(vocab_size, hidden_size).astype(np.float32)
-        save_file({"embeddings.word_embeddings.weight": embeddings}, str(tmp_path / "model.safetensors"))
+        vocab_size = 30522
+        save_file(
+            {"embeddings.word_embeddings.weight": np.zeros((1, 1), dtype=np.float32)},
+            str(tmp_path / "model.safetensors"),
+        )
 
         from omlx.models.embedding import MLXEmbeddingModel
 
         model = MLXEmbeddingModel(str(tmp_path))
-        result = model._load_native()
+        tokenizer = self.MockNativeTokenizer(vocab_size=vocab_size)
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=tokenizer,
+        ) as mock_from_pretrained, patch(
+            "omlx.models.embedding.MLXEmbeddingModel._validate_native_weights",
+            return_value=None,
+        ) as mock_validate_weights, patch(
+            "omlx.models.xlm_roberta.Model.load_weights",
+            return_value=None,
+        ) as mock_load_weights:
+            result = model._load_native()
+
         assert result is True
         assert model._loaded is True
         assert model._using_native is True
+        mock_from_pretrained.assert_called()
+        mock_validate_weights.assert_called_once()
+        assert mock_load_weights.call_args.kwargs["strict"] is False
 
     def test_load_native_xlm_roberta_model(self, tmp_path):
         """Test native loading of XLMRoBERTa embedding model."""
         import sys
         sys.path.insert(0, str(Path(__file__).parent.parent))
+        from safetensors.numpy import save_file
 
         config = {
             "model_type": "xlm-roberta",
@@ -736,20 +936,118 @@ class TestNativeEmbeddingLoading:
         }
         (tmp_path / "config.json").write_text(json.dumps(config))
 
-        import numpy as np
-        from safetensors.numpy import save_file
-
-        vocab_size, hidden_size = 250002, 768
-        embeddings = np.random.randn(vocab_size, hidden_size).astype(np.float32)
-        save_file({"embeddings.word_embeddings.weight": embeddings}, str(tmp_path / "model.safetensors"))
+        vocab_size = 250002
+        save_file(
+            {"embeddings.word_embeddings.weight": np.zeros((1, 1), dtype=np.float32)},
+            str(tmp_path / "model.safetensors"),
+        )
 
         from omlx.models.embedding import MLXEmbeddingModel
 
         model = MLXEmbeddingModel(str(tmp_path))
-        result = model._load_native()
+        tokenizer = self.MockNativeTokenizer(vocab_size=vocab_size)
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=tokenizer,
+        ) as mock_from_pretrained, patch(
+            "omlx.models.embedding.MLXEmbeddingModel._validate_native_weights",
+            return_value=None,
+        ) as mock_validate_weights, patch(
+            "omlx.models.xlm_roberta.Model.load_weights",
+            return_value=None,
+        ) as mock_load_weights:
+            result = model._load_native()
+
         assert result is True
         assert model._loaded is True
         assert model._using_native is True
+        mock_from_pretrained.assert_called()
+        mock_validate_weights.assert_called_once()
+        assert mock_load_weights.call_args.kwargs["strict"] is False
+
+    def test_load_native_rejects_missing_required_weights(self, tmp_path):
+        """Native loading must fail when core transformer weights are missing."""
+        from safetensors.numpy import save_file
+
+        config = {
+            "model_type": "bert",
+            "architectures": ["BertModel"],
+            "hidden_size": 384,
+            "num_hidden_layers": 2,
+            "vocab_size": 30522,
+            "num_attention_heads": 12,
+            "intermediate_size": 1536,
+            "max_position_embeddings": 512,
+            "hidden_dropout_prob": 0.1,
+            "attention_probs_dropout_prob": 0.1,
+            "pad_token_id": 0,
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+
+        save_file(
+            {"embeddings.word_embeddings.weight": np.random.randn(30522, 384).astype(np.float32)},
+            str(tmp_path / "model.safetensors"),
+        )
+
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel(str(tmp_path))
+        tokenizer = self.MockNativeTokenizer(vocab_size=30522)
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=tokenizer,
+        ):
+            result = model._load_native()
+
+        assert result is False
+        assert model._loaded is False
+
+    def test_load_native_rejects_shape_mismatches(self, tmp_path):
+        """Native loading must fail when a required weight shape is incompatible."""
+        from safetensors.numpy import save_file
+
+        config = {
+            "model_type": "bert",
+            "architectures": ["BertModel"],
+            "hidden_size": 384,
+            "num_hidden_layers": 2,
+            "vocab_size": 30522,
+            "num_attention_heads": 12,
+            "intermediate_size": 1536,
+            "max_position_embeddings": 512,
+            "hidden_dropout_prob": 0.1,
+            "attention_probs_dropout_prob": 0.1,
+            "pad_token_id": 0,
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+
+        self._write_full_native_checkpoint(tmp_path, config)
+
+        import mlx.core as mx
+        from safetensors import safe_open
+
+        weights = {}
+        with safe_open(tmp_path / "model.safetensors", framework="mlx") as f:
+            for key in f.keys():
+                weights[key] = np.array(f.get_tensor(key))
+
+        weights["embeddings.word_embeddings.weight"] = np.random.randn(30523, 384).astype(
+            np.float32
+        )
+        save_file(weights, str(tmp_path / "model.safetensors"))
+
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel(str(tmp_path))
+        tokenizer = self.MockNativeTokenizer(vocab_size=30522)
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=tokenizer,
+        ):
+            result = model._load_native()
+
+        assert result is False
+        assert model._loaded is False
 
     def test_load_native_falls_back_for_unknown_arch(self, tmp_path):
         """Test that native loading returns False for unsupported architectures."""
@@ -790,26 +1088,20 @@ class TestNativeEmbeddingLoading:
             "pad_token_id": 0,
         }
         (tmp_path / "config.json").write_text(json.dumps(config))
+        vocab_size = config["vocab_size"]
 
-        import numpy as np
-        from safetensors.numpy import save_file
-
-        # Create small model weights
-        vocab_size, hidden_size = 1000, 128
-        weights = {
-            "embeddings.word_embeddings.weight": np.random.randn(vocab_size, hidden_size).astype(np.float32) * 0.02,
-            "embeddings.position_embeddings.weight": np.random.randn(512, hidden_size).astype(np.float32) * 0.02,
-            "embeddings.token_type_embeddings.weight": np.zeros((1, hidden_size), dtype=np.float32),
-            "embeddings.LayerNorm.weight": np.ones(hidden_size, dtype=np.float32),
-            "embeddings.LayerNorm.bias": np.zeros(hidden_size, dtype=np.float32),
-        }
-        save_file(weights, str(tmp_path / "model.safetensors"))
+        self._write_full_native_checkpoint(tmp_path, config)
 
         from omlx.models.embedding import MLXEmbeddingModel
 
         model = MLXEmbeddingModel(str(tmp_path))
-        model.load()
-        output = model.embed(["hello world"])
+        tokenizer = self.MockNativeTokenizer(vocab_size=vocab_size)
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=tokenizer,
+        ):
+            model.load()
+            output = model.embed(["hello world"])
 
         # Check normalization
         emb = output.embeddings[0]


### PR DESCRIPTION
## Summary
  - add structured `items` support to `/v1/embeddings` for text and image inputs
  - keep the existing `input` text path while making `input` and `items` mutually exclusive
  - route multimodal embedding requests through custom processor preparation when available
  - preserve native embedding loading safety by validating required weights and tensor shapes before allowing non-strict loading

  ## Why
  The existing embeddings API only accepted plain text input, which blocked multimodal embedding models such as `Qwen3-VL-Embedding-2B-mxfp8` from using their processor-define text/image input path. The server also treated all embedding requests as text-only, so image-aware processors could not receive structured items at all.

  At the same time, native embedding loading needed more precise validation. We want to allow extra Hugging Face checkpoint weights, but we should still fail closed when required native weights are missing or when provided tensor shapes do not match the expected model parameters.

  ## What
  - add `EmbeddingInputItem` and `items` to the embeddings request schema
  - normalize structured embedding items into internal `{text, image}` payloads
  - update the embeddings server path and engine interface to accept structured items
  - pass multimodal items directly to custom embedding processors via `prepare_embedding_inputs` / `prepare_model_inputs`
  - reject image inputs for standard text-only embedding processors with a 400
  - count usage from prepared multimodal inputs so image-only and text+image requests report non-zero usage
  - allow empty-string text items in the structured request format to match the legacy text input behavior
  - validate native embedding checkpoints for required keys and shape compatibility while still allowing extra checkpoint weights
  - add regression coverage for structured requests, multimodal usage accounting, native loading validation, and endpoint behavior

  ## Testing
  - `uv run pytest tests/test_embedding.py tests/integration/test_server_endpoints.py -k 'embedding'`

  ## Manual verification
  - started oMLX with `Qwen3-VL-Embedding-2B-mxfp8` forced to `embedding`
  - verified `/v1/embeddings` succeeds for:
    - text-only items
    - image-only items
    - text+image items
    - image inputs provided as URL
    - image inputs provided as data URI
    - image inputs provided as local path