### PR TITLE
fix: copy block_ids before storing in prefix index

### DIFF
--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -2018,7 +2018,7 @@ class BlockAwarePrefixCache(CacheManager):
 
             parent_hash = block_hash
             prefix_len += len(block_tokens)
-            self._prefix_index[block_hash] = (prefix_len, block_ids, i + 1)
+            self._prefix_index[block_hash] = (prefix_len, tuple(block_ids[: i + 1]), i + 1)
 
     def get_stats(self) -> PrefixCacheStats:
         """

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -504,6 +504,32 @@ class TestPrefixIndexOperations:
         prefix_len, matched_ids, num_blocks = result
         assert prefix_len == 4
 
+    def test_prefix_index_immutable_after_store(self, prefix_cache, paged_cache):
+        """Test that _prefix_index entries are not affected by later mutations
+        of the original block_ids list (e.g., from CoW or block reallocation).
+
+        Regression test for: storing a mutable list reference in _prefix_index
+        allows CoW operations to silently corrupt the index.
+        """
+        tokens = [1, 2, 3, 4, 5, 6, 7, 8]  # 2 blocks (block_size=4)
+
+        # Allocate blocks
+        blocks = paged_cache.get_new_blocks(2)
+        block_ids = [b.block_id for b in blocks]
+        original_ids = list(block_ids)  # snapshot for assertion
+
+        # Store into prefix index
+        prefix_cache._update_prefix_index(tokens, block_ids)
+
+        # Simulate CoW: mutate the original list in-place
+        block_ids[0] = 9999
+
+        # Verify: prefix_index must still contain the original block IDs
+        result = prefix_cache._find_best_prefix_match(tokens)
+        assert result is not None
+        _, matched_ids, num_blocks = result
+        assert list(matched_ids[:num_blocks]) == original_ids[:num_blocks]
+
 
 class TestValidateBlockCacheData:
     """Tests for _validate_block_cache_data method."""


### PR DESCRIPTION
## Problem

In `_update_prefix_index()`, the `block_ids` list is stored directly into `_prefix_index`.

But this is the same object as `block_table.block_ids`. So if this list is changed later (for example, CoW replaces a block ID), the prefix index entry also changes.

This may cause wrong block hit when another request looks up the same prefix.

## Fix

Use `tuple(block_ids[:i+1])` to store an immutable copy.

- `tuple` cannot be changed after creation
- `[:i+1]` only keeps blocks needed for this prefix length

## Test

- Added `test_prefix_index_immutable_after_store`
- `pytest tests/test_prefix_cache.py -v` — all 73 passed
- `pytest -m "not slow"` — 2971 passed, no new failures