### PR TITLE
Crash handler can raise before fallback dialog when crash-log directory is not writable

### DIFF
--- a/packaging/omlx_app/__main__.py
+++ b/packaging/omlx_app/__main__.py
@@ -20,7 +20,12 @@ def _get_crash_log_path() -> Path:
 
 def _write_crash_log(exc_text: str) -> Path:
     """Append crash info to the crash log file."""
-    crash_log = _get_crash_log_path()
+    crash_log = Path("/tmp/omlx-crash.log")
+    try:
+        crash_log = _get_crash_log_path()
+    except Exception:
+        pass
+
     try:
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         with open(crash_log, "a") as f:


### PR DESCRIPTION
## Summary

_write_crash_log() calls _get_crash_log_path() before entering its try/except block. If creating `~/Library/Application Support/oMLX` fails (permission error, read-only home, sandbox restriction), the exception escapes while already handling a top-level crash. That can abort the error-reporting path and prevent the user from seeing the intended compatibility/error dialog.

## Files changed

- `packaging/omlx_app/__main__.py` (modified)

## Testing

- Not run in this environment.


Closes #399