### PR TITLE
fix: update menubar content in real time while menu is open

### DIFF
--- a/packaging/omlx_app/app.py
+++ b/packaging/omlx_app/app.py
@@ -562,25 +562,7 @@ class OMLXAppDelegate(NSObject):
         # All three items are always present; setHidden_ controls visibility so
         # _refresh_menu_in_place() can toggle them without replacing the NSMenu.
 
-        # Stop Server — visible when RUNNING / STARTING / UNRESPONSIVE
-        stop_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
-            "Stop Server", "stopServer:", ""
-        )
-        stop_item.setTarget_(self)
-        stop_icon = self._create_menu_icon("stop.circle")
-        if stop_icon:
-            stop_item.setImage_(stop_icon)
-        stop_item.setHidden_(
-            status not in (
-                ServerStatus.RUNNING,
-                ServerStatus.STARTING,
-                ServerStatus.UNRESPONSIVE,
-            )
-        )
-        self.menu.addItem_(stop_item)
-        self._stop_item = stop_item
-
-        # Force Restart — visible when UNRESPONSIVE / ERROR
+        # Force Restart — visible when UNRESPONSIVE / ERROR (most important, shown first)
         restart_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
             "Force Restart", "forceRestart:", ""
         )
@@ -593,6 +575,25 @@ class OMLXAppDelegate(NSObject):
         )
         self.menu.addItem_(restart_item)
         self._restart_item = restart_item
+
+        # Stop Server — visible when RUNNING / STARTING / STOPPING / UNRESPONSIVE
+        stop_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            "Stop Server", "stopServer:", ""
+        )
+        stop_item.setTarget_(self)
+        stop_icon = self._create_menu_icon("stop.circle")
+        if stop_icon:
+            stop_item.setImage_(stop_icon)
+        stop_item.setHidden_(
+            status not in (
+                ServerStatus.RUNNING,
+                ServerStatus.STARTING,
+                ServerStatus.STOPPING,
+                ServerStatus.UNRESPONSIVE,
+            )
+        )
+        self.menu.addItem_(stop_item)
+        self._stop_item = stop_item
 
         # Start Server — visible when STOPPED
         start_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
@@ -790,6 +791,7 @@ class OMLXAppDelegate(NSObject):
                 status not in (
                     ServerStatus.RUNNING,
                     ServerStatus.STARTING,
+                    ServerStatus.STOPPING,
                     ServerStatus.UNRESPONSIVE,
                 )
             )
@@ -800,11 +802,17 @@ class OMLXAppDelegate(NSObject):
         if self._start_item:
             self._start_item.setHidden_(status != ServerStatus.STOPPED)
 
-        # Toggle Admin Panel / Chat enabled state
+        # Toggle Admin Panel / Chat enabled state and keep icon template in sync
         if self._admin_panel_item:
             self._admin_panel_item.setEnabled_(is_running)
+            icon = self._admin_panel_item.image()
+            if icon:
+                icon.setTemplate_(True)
         if self._chat_item:
             self._chat_item.setEnabled_(is_running)
+            icon = self._chat_item.image()
+            if icon:
+                icon.setTemplate_(True)
 
     # --- NSMenuDelegate ---
 
@@ -899,14 +907,16 @@ class OMLXAppDelegate(NSObject):
         prev_status = self.server_manager.status
 
         if self.server_manager.status == ServerStatus.RUNNING:
-            # Refresh stats periodically
+            # Refresh stats periodically — skip blocking HTTP when menu is open
             now = time.time()
             if now - self._last_stats_fetch >= 5:
-                self._fetch_stats()
-                self._last_stats_fetch = now
                 if self._menu_is_open:
+                    # Menu is tracking on main thread; avoid sync HTTP (up to 6s).
+                    # In-place refresh only; fetch will run after menu closes.
                     self._refresh_menu_in_place()
                 else:
+                    self._fetch_stats()
+                    self._last_stats_fetch = now
                     self._build_menu()
 
         elif self.server_manager.status in (


### PR DESCRIPTION
Fixes #425

## Problem

After clicking "Start Server", the menu bar content (server status text, Admin Panel / Chat button enabled state) never updates while the menu is open. The user must close and reopen the menu to see the latest state. Even if the menu stays open, the content is completely frozen.

## Root Causes

**1. `NSTimer` registered under `NSDefaultRunLoopMode` only (`app.py:136`)**

When the status-bar menu is open, macOS enters `NSEventTrackingRunLoopMode`. `NSDefaultRunLoopMode` is suspended during this time, so `healthCheck_` never fires and the menu content freezes completely.

**2. `_build_menu()` replaces the entire `NSMenu` object (`app.py:490, 730`)**

Even if the timer fired, calling `self.status_item.setMenu_(newMenu)` while a menu is being displayed would close it — causing disruptive flicker and not the desired in-place update.

## Fix

Two complementary changes in `packaging/omlx_app/app.py`:

### 1. `NSRunLoopCommonModes`
Register the health-check timer under `NSRunLoopCommonModes` instead of `NSDefaultRunLoopMode` so it fires in all run-loop modes, including during menu interaction.

```python
# Before
NSRunLoop.currentRunLoop().addTimer_forMode_(self.health_timer, NSDefaultRunLoopMode)

# After
NSRunLoop.currentRunLoop().addTimer_forMode_(self.health_timer, NSRunLoopCommonModes)
```

### 2. In-place menu item updates via `_refresh_menu_in_place()`
Instead of replacing the `NSMenu` object, store references to the key `NSMenuItem` objects and mutate them directly:
- Status header: `setAttributedTitle_()` with updated color/text
- Server control buttons: `setHidden_()` to toggle Start / Stop / Force Restart visibility
- Admin Panel / Chat: `setEnabled_()` based on running state

### 3. `NSMenuDelegate` — `menuWillOpen_` / `menuDidClose_`
- `menuWillOpen_`: always refreshes menu content right before it appears, so even without the timer the menu is never stale on open.
- `menuDidClose_`: clears the `_menu_is_open` flag so `healthCheck_` uses `_build_menu()` (full rebuild with stats) when the menu is closed.

## Test Steps

1. Launch the app — menu shows "● oMLX Server is stopped" + "Start Server"
2. Open the menu and **keep it open**, then click "Start Server"
3. ✅ Status text updates in place: "Stopped" → "Starting..." → "Running" — no need to close the menu
4. ✅ "Admin Panel" and "Chat with oMLX" become enabled automatically once running
5. Close and reopen the menu — state is correct immediately (`menuWillOpen_`)
6. Menubar icon updates alongside status changes