### PR TITLE
Fix: Convert ContentPart list content to string in message extraction, fixes 500 Error with Qwen Code CLI

### DIFF
--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -98,12 +98,19 @@ def _extract_text_from_content_list(content: list) -> str:
     """
     text_parts = []
     for item in content:
+        # Convert Pydantic models to dict
         if hasattr(item, 'model_dump'):
             item = item.model_dump()
         elif hasattr(item, 'dict'):
             item = item.dict()
-        if isinstance(item, dict) and item.get("type") == "text":
-            text_parts.append(item.get("text", ""))
+        
+        if isinstance(item, dict):
+            if item.get("type") == "text":
+                text_parts.append(item.get("text", ""))
+        elif isinstance(item, str):
+            # Direct string in content list
+            text_parts.append(item)
+    
     return "\n".join(text_parts) if text_parts else ""
 
 
@@ -257,7 +264,11 @@ def extract_text_content(
         # Handle tool response messages (role="tool")
         if role == "tool":
             tool_call_id = getattr(msg, 'tool_call_id', None) or ''
-            tool_content = content if content else ""
+            # Convert list content to string if needed
+            if isinstance(content, list):
+                tool_content = _extract_text_from_content_list(content)
+            else:
+                tool_content = content if content else ""
             # Apply truncation if configured
             if max_tool_result_tokens and tokenizer and tool_content:
                 from .anthropic_utils import truncate_tool_result
@@ -363,6 +374,11 @@ def extract_text_content(
             # Unknown format, try to convert
             processed_messages.append({"role": role, "content": str(content), **_extra})
 
+    # Final safety check: ensure all content is string type
+    for msg in processed_messages:
+        if not isinstance(msg.get("content"), str):
+            msg["content"] = str(msg.get("content", ""))
+
     return _merge_consecutive_roles(
         _consolidate_system_messages(processed_messages)
     )
@@ -399,7 +415,11 @@ def extract_multimodal_content(
         # Tool response messages - same as extract_text_content
         if role == "tool":
             tool_call_id = getattr(msg, 'tool_call_id', None) or ''
-            tool_content = content if content else ""
+            # Convert list content to string if needed
+            if isinstance(content, list):
+                tool_content = _extract_text_from_content_list(content)
+            else:
+                tool_content = content if content else ""
             if max_tool_result_tokens and tokenizer and tool_content:
                 from .anthropic_utils import truncate_tool_result
                 tool_content = truncate_tool_result(
@@ -604,7 +624,11 @@ def extract_harmony_messages(
         # Tool response messages - preserve role and tool_call_id
         # Parse content as JSON if possible (chat_template applies |tojson)
         if role == "tool":
-            tool_content = content if content else ""
+            # Convert list content to string if needed
+            if isinstance(content, list):
+                tool_content = _extract_text_from_content_list(content)
+            else:
+                tool_content = content if content else ""
             if max_tool_result_tokens and tokenizer and tool_content:
                 from .anthropic_utils import truncate_tool_result
 
@@ -652,15 +676,7 @@ def extract_harmony_messages(
                 msg_dict["content"] = content
             elif isinstance(content, list):
                 # Extract text parts from content array
-                text_parts = []
-                for item in content:
-                    if hasattr(item, 'model_dump'):
-                        item = item.model_dump()
-                    elif hasattr(item, 'dict'):
-                        item = item.dict()
-                    if isinstance(item, dict) and item.get("type") == "text":
-                        text_parts.append(item.get("text", ""))
-                msg_dict["content"] = "\n".join(text_parts)
+                msg_dict["content"] = _extract_text_from_content_list(content)
             else:
                 msg_dict["content"] = str(content)
 

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -244,6 +244,8 @@ class TestExtractTextContent:
         result = extract_text_content(messages)
 
         assert "Hello" in result[0]["content"]
+        # Ensure content is a string, not a list
+        assert isinstance(result[0]["content"], str)
 
     def test_none_content(self):
         """Test extracting message with None content."""
@@ -269,6 +271,25 @@ class TestExtractTextContent:
         assert result[0]["role"] == "user"  # Converted to user
         assert "call_123" in result[0]["content"]
         assert "success" in result[0]["content"]
+
+    def test_tool_response_message_with_content_part_list(self):
+        """Test extracting tool response with ContentPart list content."""
+        messages = [
+            Message(
+                role="tool",
+                content=[ContentPart(type="text", text='{"result": "success"}')],
+                tool_call_id="call_123",
+            )
+        ]
+
+        result = extract_text_content(messages)
+
+        assert len(result) == 1
+        assert result[0]["role"] == "user"  # Converted to user
+        assert "call_123" in result[0]["content"]
+        assert "success" in result[0]["content"]
+        # Ensure content is a string, not a list
+        assert isinstance(result[0]["content"], str)
 
     def test_tool_response_fallback_preserves_role_boundary(self):
         """Fallback tool history must not merge into adjacent user turns."""


### PR DESCRIPTION
A note ahead: this is AI coded with minor guidance from me. The patch is small (31 lines added) and it fixes a 500 error.

## Summary

When using Qwen Code CLI, I got 500 Errors with oMLX but not with plain mlx-server.

The error ValueError: text input must be of type 'str'... was caused by messages with content as a list of ContentPart objects being passed to the MLX tokenizer's apply_chat_template method instead of being converted to strings first.

## Root Cause

    When the Qwen Code client sent messages with content arrays like:

     1 {"role": "user", "content": [{"type": "text", "text": "hi"}]}

    Pydantic parsed these as List[ContentPart] objects. The extract_text_content() function was supposed to convert these to strings, but there were edge cases where:

     1. Tool messages (role="tool") with ContentPart lists weren't being converted
     2. Harmony messages with ContentPart lists weren't being converted properly
     3. The final safety check wasn't ensuring all content was strings

## Fix Applied

     1. `_extract_text_from_content_list()`: Enhanced to handle edge cases and return empty string for empty lists
     2. `extract_text_content()`: Added ContentPart list handling for tool messages and final safety check
     3. `extract_multimodal_content()`: Added ContentPart list handling for tool messages
     4. `extract_harmony_messages()`: Added ContentPart list handling for tool and assistant messages

## Tests Added

     - test_tool_response_message_with_content_part_list: Tests tool messages with ContentPart lists
     - Enhanced test_content_array_with_pydantic: Verifies content is string type

## All existing tests continue to pass.

- _extract_text_from_content_list(): Enhanced to handle edge cases
- extract_text_content(): Add ContentPart list handling for tool messages and final safety check to ensure all content is string type
- extract_multimodal_content(): Add ContentPart list handling for tool messages
- extract_harmony_messages(): Add ContentPart list handling for tool and assistant messages

Fixes ValueError when messages with content arrays are sent to MLX models.