### PR TITLE
fix: correct VLM batched inference for different-length prompts

### DIFF
--- a/omlx/models/vlm.py
+++ b/omlx/models/vlm.py
@@ -47,12 +47,15 @@ class _IntOffsetCacheProxy:
     def offset(self):
         raw = self._cache.offset
         if isinstance(raw, mx.array):
-            # Extract per-request offset from the authoritative mx.array.
-            # _idx/_offset are unreliable shortcuts: _idx wraps at max_size
-            # (BatchRotatingKVCache), _offset diverges after merge() which
-            # sets it to buffer size instead of actual token offset.
-            # Mask computation uses make_mask() on the real cache (via
-            # __getattr__), so this value is only used for RoPE/position_ids.
+            # BatchKVCache: _idx is the shared buffer write index.
+            # Per-element offset[i] = _idx - left_padding[i], so offset[0]
+            # is wrong when left_padding[0] > 0 (shorter prompt in batch).
+            # _idx matches make_mask() and is correct for all batch sizes.
+            # Guard: only when _offset is absent — BatchRotatingKVCache has
+            # both _idx (wraps at max_size) and _offset (diverges after
+            # merge()), so it must fall through to the mx.array path.
+            if hasattr(self._cache, "_idx") and not hasattr(self._cache, "_offset"):
+                return self._cache._idx
             if raw.ndim == 0:
                 return int(raw.item())
             return int(raw.reshape(-1)[0].item())

--- a/omlx/patches/vlm_attention_mask.py
+++ b/omlx/patches/vlm_attention_mask.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Patch mlx-vlm Qwen3_5Attention to remove mask truncation.
+
+mlx-vlm's Qwen3_5Attention.__call__ truncates the attention mask via
+``mask[..., :kv_seq_len]`` using a scalar ``kv_seq_len`` derived from
+``cache.offset``.  With batched caches containing different per-element
+offsets (BatchKVCache), any scalar reduction is lossy -- the mask gets
+truncated too short for the longer prompt, causing
+``ValueError: [broadcast_shapes]``.
+
+The mask from ``create_attention_mask()`` / ``BatchKVCache.make_mask()``
+is already correctly sized.  The mlx-lm version of the same model
+(Qwen3NextAttention) does NOT truncate -- it passes the mask directly
+to SDPA.  This patch makes the mlx-vlm code path match.
+
+Supported model types: qwen3_5
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any, Optional
+
+try:
+    import mlx.core as mx
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_MODEL_TYPES = {"qwen3_5"}
+
+# Track whether the class-level patch has been applied
+_class_patch_applied = False
+
+
+def _get_model_type(model: Any) -> str | None:
+    """Extract model_type string from a loaded model."""
+    for attr in ("model_type", "args"):
+        obj = getattr(model, attr, None)
+        if obj is None:
+            continue
+        if isinstance(obj, str):
+            return obj
+        mt = getattr(obj, "model_type", None)
+        if isinstance(mt, str):
+            return mt
+    return None
+
+
+def _make_patched_attention_call():
+    """Create a patched __call__ for Qwen3_5Attention.
+
+    Removes the mask truncation (``mask[..., :kv_seq_len]``) that uses a
+    scalar ``kv_seq_len`` derived from ``cache.offset``.  The mask from
+    ``create_attention_mask()`` is already correctly sized for batched
+    inference.
+    """
+    from mlx_vlm.models.base import scaled_dot_product_attention
+    from mlx_vlm.models.qwen3_5.language import apply_multimodal_rotary_pos_emb
+
+    def patched_call(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        position_ids: Optional[mx.array] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        q_proj_output = self.q_proj(x)
+        queries, gate = mx.split(
+            q_proj_output.reshape(B, L, self.num_attention_heads, -1), 2, axis=-1
+        )
+        gate = gate.reshape(B, L, -1)
+
+        keys, values = self.k_proj(x), self.v_proj(x)
+
+        queries = self.q_norm(queries).transpose(0, 2, 1, 3)
+        keys = self.k_norm(
+            keys.reshape(B, L, self.num_key_value_heads, -1)
+        ).transpose(0, 2, 1, 3)
+        values = values.reshape(
+            B, L, self.num_key_value_heads, -1
+        ).transpose(0, 2, 1, 3)
+
+        if position_ids is None:
+            position_ids = mx.arange(cache.offset, cache.offset + L)
+            position_ids = mx.expand_dims(position_ids, axis=0)
+            position_ids = mx.tile(position_ids, (3, 1, 1))
+
+        cos, sin = self.rotary_emb(values, position_ids)
+
+        # Mask truncation removed: the mask from create_attention_mask()
+        # is already correctly sized.  The original code truncated via
+        # mask[..., :kv_seq_len] using a scalar kv_seq_len derived from
+        # cache.offset, which is wrong for batched caches with different
+        # per-element offsets.
+
+        queries, keys = apply_multimodal_rotary_pos_emb(queries, keys, cos, sin)
+
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+
+        return self.o_proj(output * mx.sigmoid(gate))
+
+    return patched_call
+
+
+def apply_vlm_attention_mask_patch(model: Any) -> bool:
+    """Apply mask-truncation removal to mlx-vlm Qwen3_5Attention.
+
+    Args:
+        model: A loaded model instance (VLMModelAdapter or raw VLM).
+
+    Returns:
+        True if the patch was applied, False if not needed or not supported.
+    """
+    global _class_patch_applied
+
+    model_type = _get_model_type(model)
+    if model_type not in _SUPPORTED_MODEL_TYPES:
+        return False
+
+    if _class_patch_applied:
+        return True
+
+    try:
+        from mlx_vlm.models.qwen3_5.language import Qwen3_5Attention
+    except ImportError:
+        logger.debug("VLM attention mask patch: qwen3_5 module not found")
+        return False
+
+    # Forward compatibility: skip if upstream already removed the truncation
+    try:
+        source = inspect.getsource(Qwen3_5Attention.__call__)
+        if "kv_seq_len" not in source:
+            logger.debug(
+                "VLM attention mask patch: upstream already removed truncation, skipping"
+            )
+            _class_patch_applied = True
+            return False
+    except (OSError, TypeError):
+        pass
+
+    Qwen3_5Attention.__call__ = _make_patched_attention_call()
+
+    _class_patch_applied = True
+    logger.info("VLM attention mask truncation patch applied for qwen3_5")
+    return True

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -40,6 +40,14 @@ def apply_post_load_transforms(model: Any, model_settings: Any = None) -> Any:
     if apply_gated_delta_advance_patch(model):
         logger.info("GatedDeltaNet advance() patch applied")
 
+    # VLM attention mask patch: remove mask truncation in mlx-vlm
+    # Qwen3_5Attention that breaks batched inference with different
+    # prompt lengths (auto-detected by model type)
+    from ..patches.vlm_attention_mask import apply_vlm_attention_mask_patch
+
+    if apply_vlm_attention_mask_patch(model):
+        logger.info("VLM attention mask truncation patch applied")
+
     if model_settings is None:
         return model
 

--- a/tests/test_vlm_model_adapter.py
+++ b/tests/test_vlm_model_adapter.py
@@ -320,21 +320,25 @@ class TestIntOffsetCacheProxy:
         proxy = _IntOffsetCacheProxy(cache)
         assert proxy.offset == 7
 
-    def test_batched_offset_returns_first_element(self):
-        """Proxy extracts offset[0] from mx.array — the authoritative source.
+    def test_batch_kv_cache_returns_idx(self):
+        """BatchKVCache proxy returns _idx (shared buffer write index).
 
-        _idx/_offset are unreliable: _idx wraps at max_size for
-        BatchRotatingKVCache, _offset diverges after merge().
-        The mx.array offset is always correct per-request.
+        Per-element offset[i] = _idx - left_padding[i], so offset[0] is
+        wrong when left_padding[0] > 0 (shorter prompt in batch). _idx
+        matches make_mask() and is the correct scalar for RoPE position.
+        BatchKVCache has _idx but NOT _offset (which distinguishes it
+        from BatchRotatingKVCache).
         """
         import mlx.core as mx
         from omlx.models.vlm import _IntOffsetCacheProxy
 
         cache = MagicMock(spec=[])
-        cache.offset = mx.array([625])
-        cache._idx = 42  # irrelevant, should not be used
+        # Simulate BatchKVCache: 2 prompts, lengths 3 and 5
+        # left_padding = [2, 0], _idx = 5, offset = [3, 5]
+        cache.offset = mx.array([3, 5])
+        cache._idx = 5  # shared buffer write index
         proxy = _IntOffsetCacheProxy(cache)
-        assert proxy.offset == 625
+        assert proxy.offset == 5
 
     def test_rotating_cache_wrap_returns_real_offset(self):
         """After RotatingKVCache wraps, proxy returns real offset, not _idx.


### PR DESCRIPTION
## Problem

Concurrent inference requests with different prompt lengths crash on mlx-vlm models (e.g. Qwen3.5) with `ValueError: [broadcast_shapes]`.

**Error:**
```
ValueError: [broadcast_shapes] Cannot broadcast shapes (1,28,403,403) and (1,1,403,399)
```

**Root Cause:**
The mlx-vlm `Qwen3_5Attention.__call__` truncates the attention mask using a scalar `kv_seq_len` derived from `cache.offset`:

```python
kv_seq_len = keys.shape[-2]
if position_ids is None:
    kv_seq_len += cache.offset + 1
# ...
if mask is not None and isinstance(mask, mx.array):
    if isinstance(kv_seq_len, mx.array):
        kv_seq_len = kv_seq_len.max().item()
    mask = mask[..., : int(kv_seq_len)]
```

With `BatchKVCache` containing different per-element offsets (e.g. prompts of length 399 and 403), any scalar reduction of `cache.offset` is lossy -- the mask gets truncated too short for the longer prompt, causing a shape mismatch at SDPA.

The mlx-lm version of the same model (`Qwen3NextAttention`) does **not** truncate the mask -- it passes it directly to SDPA. The truncation is a VLM-specific artifact that is incorrect for batched text-only inference.

---

## Solution

Two changes in `omlx/models/vlm.py`, following the existing monkey-patching pattern (see `patches/gated_delta_advance.py`).

### Change 1: Fix `_IntOffsetCacheProxy.offset` to use correct index per cache type

The proxy converts `mx.array` offsets to Python `int` for mlx-vlm compatibility. The previous implementation used `offset[0]` which is wrong when `left_padding[0] > 0` (shorter prompt in batch).

```python
@property
def offset(self):
    raw = self._cache.offset
    if isinstance(raw, mx.array):
        # BatchKVCache: _idx is the shared buffer write index.
        # Guard: only when _offset is absent — BatchRotatingKVCache has
        # both _idx (wraps at max_size) and _offset (diverges after
        # merge()), so it must fall through to the mx.array path.
        if hasattr(self._cache, "_idx") and not hasattr(self._cache, "_offset"):
            return self._cache._idx
        if raw.ndim == 0:
            return int(raw.item())
        return int(raw.reshape(-1)[0].item())
    return raw
```

**Key details:**
- `BatchKVCache._idx` is the shared buffer write position, matching what `make_mask()` uses
- `BatchRotatingKVCache` has both `_idx` and `_offset`, so it falls through to the `mx.array` path (preserving merge() correctness)
- Falls back to scalar extraction for other cache types

### Change 2: Remove mask truncation in mlx-vlm `Qwen3_5Attention`

New patch file `patches/vlm_attention_mask.py` that monkey-patches `mlx_vlm.models.qwen3_5.language.Qwen3_5Attention.__call__` to remove the mask truncation (lines 181-184). The patched method matches mlx-lm's `Qwen3NextAttention` behavior: pass the mask directly to SDPA without truncation.

```python
# Original (broken for batched inference):
if mask is not None and isinstance(mask, mx.array):
    if isinstance(kv_seq_len, mx.array):
        kv_seq_len = kv_seq_len.max().item()
    mask = mask[..., : int(kv_seq_len)]

# Patched: mask truncation removed entirely.
# The mask from create_attention_mask() / BatchKVCache.make_mask()
# is already correctly sized.
```

**Key features:**
- Forward-compatible: skips patch if upstream already removed the truncation (checks for `kv_seq_len` in source)
- Follows the same class-level monkey-patching pattern as `gated_delta_advance.py`
- Registered in `apply_post_load_transforms()`, auto-detected by model type

---

## Testing

### Concurrency benchmark -- all levels pass with 0 errors

```
$ python concurrency_bench.py --concurrency 1,2,4,8 --vary-prompts --model Qwen3.5-27B-4bit

  conc= 1:   24.4 agg tok/s | 1 ok, 0 errors
  conc= 2:   39.4 agg tok/s | 2 ok, 0 errors
  conc= 4:   42.7 agg tok/s | 4 ok, 0 errors
  conc= 8:   39.7 agg tok/s | 8 ok, 0 errors
```

The `--vary-prompts` flag uses 4 different prompts of varying lengths, ensuring no prefix cache benefit and exercising the batched-different-lengths code path that previously crashed.

<details>
<summary>Benchmark script (concurrency_bench.py)</summary>

```python
#!/usr/bin/env python3
"""Concurrency benchmark for oMLX.

Measures whether concurrent requests with different prompt lengths
crash or succeed, and reports aggregate throughput.

Usage:
    python concurrency_bench.py --url http://localhost:8000 --concurrency 1,2,4,8 --vary-prompts
"""

import argparse
import asyncio
import json
import time

import httpx

VARIED_PROMPTS = [
    (
        "You are an expert marine biologist. A deep-sea expedition off the coast of "
        "Papua New Guinea has discovered a previously unknown species of bioluminescent "
        "octopus living at a depth of 4,200 meters near a hydrothermal vent field. The "
        "creature displays remarkable behaviors never before observed in cephalopods: it "
        "appears to cultivate colonies of chemosynthetic bacteria on its skin, arranging "
        "them in geometric patterns that shift in response to water current changes. "
        "Write a detailed scientific description of this new species."
    ),
    (
        "You are a historian specializing in medieval trade routes. In 1287, a Venetian "
        "merchant named Marco Bellini set out from Constantinople with a caravan of forty "
        "camels loaded with silk, spices, and Murano glass. His journey would take him "
        "through the Seljuk territories of Anatolia, across the harsh Armenian highlands, "
        "and down into the fertile crescent of Mesopotamia before reaching the bustling "
        "markets of Baghdad. Continue narrating his journey from the point where "
        "he reaches the gates of Baghdad."
    ),
    (
        "You are a quantum computing researcher explaining your latest breakthrough. Your "
        "team has developed a novel error-correction scheme for topological qubits that "
        "achieves a logical error rate of 10^-12 using only 17 physical qubits per logical "
        "qubit. Explain the theoretical foundations and practical implications."
    ),
    (
        "You are an architect designing a sustainable community for 500 residents in the "
        "Atacama Desert of Chile. The site receives less than 15 millimeters of rainfall "
        "per year but has over 330 days of sunshine. Describe the layout and engineering."
    ),
]


def parse_args():
    p = argparse.ArgumentParser()
    p.add_argument("--url", default="http://localhost:8000")
    p.add_argument("--concurrency", default="1,2,4,8")
    p.add_argument("--max-tokens", type=int, default=128)
    p.add_argument("--vary-prompts", action="store_true")
    p.add_argument("--model", default=None)
    return p.parse_args()


async def send_request(client, url, payload):
    t0 = time.monotonic()
    resp = await client.post(
        f"{url}/v1/chat/completions", json=payload,
        timeout=httpx.Timeout(300.0, connect=10.0),
    )
    resp.raise_for_status()
    dur = time.monotonic() - t0
    tokens = resp.json().get("usage", {}).get("completion_tokens", 0)
    return {"tokens": tokens, "duration": dur, "tok_s": tokens / dur if dur > 0 else 0}


async def run_level(client, url, prompts, concurrency, max_tokens, model):
    payloads = []
    for i in range(concurrency):
        p = {"messages": [{"role": "user", "content": prompts[i % len(prompts)]}],
             "max_tokens": max_tokens, "temperature": 0, "stream": False}
        if model:
            p["model"] = model
        payloads.append(p)

    t0 = time.monotonic()
    results = await asyncio.gather(
        *[send_request(client, url, p) for p in payloads], return_exceptions=True
    )
    wall = time.monotonic() - t0

    ok = [r for r in results if not isinstance(r, Exception)]
    errors = [r for r in results if isinstance(r, Exception)]
    total_tok = sum(r["tokens"] for r in ok)
    agg = total_tok / wall if wall > 0 else 0
    print(f"  conc={concurrency:>2}: {agg:6.1f} agg tok/s | {len(ok)} ok, {len(errors)} errors")
    for e in errors:
        print(f"    ERROR: {e}")


async def main():
    args = parse_args()
    levels = [int(x) for x in args.concurrency.split(",")]
    url = args.url.rstrip("/")
    prompts = VARIED_PROMPTS if args.vary_prompts else [VARIED_PROMPTS[0]]

    async with httpx.AsyncClient() as client:
        # Warmup
        warmup = {"messages": [{"role": "user", "content": "Hi"}],
                  "max_tokens": 4, "stream": False}
        if args.model:
            warmup["model"] = args.model
        await client.post(f"{url}/v1/chat/completions", json=warmup,
                          timeout=httpx.Timeout(300.0, connect=10.0))

        for level in levels:
            await run_level(client, url, prompts, level, args.max_tokens, args.model)


if __name__ == "__main__":
    asyncio.run(main())
```

</details>

### Unit tests -- updated and passing

```
$ python -m pytest tests/test_vlm_model_adapter.py -v
# 22 passed in 0.14s
```

The existing `test_batched_offset_returns_first_element` was updated to `test_batch_kv_cache_returns_idx` — the old test asserted `offset[0]` (625) as correct, but for `BatchKVCache` the correct value is `_idx` (the shared buffer write index). The test now uses realistic `BatchKVCache` state (2 prompts with left padding) and asserts `_idx`.

---

## Impact

**Before:**
- Concurrent requests with different prompt lengths crash with `ValueError: [broadcast_shapes]`
- Only single-request inference or same-length batches work on VLM models
- Continuous batching throughput gains unavailable for real workloads

**After:**
- Concurrent requests with different prompt lengths work correctly
- Both `BatchKVCache` and `BatchRotatingKVCache` return correct offsets for RoPE
- mlx-vlm attention path matches mlx-lm behavior for batched text-only inference

---

## Why This is the Proper Fix

1. **Change 1** (`_idx` for `BatchKVCache`) gives the correct scalar for both mask sizing and RoPE -- `_idx` equals the max offset plus any padding, which is what `make_mask()` uses
2. **Change 2** (remove mask truncation) eliminates the consumer that caused the crash entirely -- the mask from `create_attention_mask()` is already correct
3. Together they make the mlx-vlm code path behave like the working mlx-lm code path for batched inference

---

## Files Changed

```
omlx/models/vlm.py                       | 14 +++++++-----
omlx/patches/vlm_attention_mask.py       | 148 +++++++++++++++++++++++++++++++
omlx/utils/model_loading.py              |   8 ++++++++
tests/test_vlm_model_adapter.py          |  21 ++++++-----
4 files changed, 175 insertions(+), 16 deletions(-)
```