### PR TITLE
fix: route voice param correctly for CustomVoice TTS models

### DIFF
--- a/omlx/engine/tts.py
+++ b/omlx/engine/tts.py
@@ -151,14 +151,16 @@ class TTSEngine(BaseNonStreamingEngine):
                 "verbose": False,
             }
             if voice is not None:
-                # VoiceDesign models expect voice description in 'instruct',
-                # not 'voice'. Detect by checking if generate() accepts 'instruct'.
+                # Route the voice value to the correct generate() parameter.
+                # Models like CustomVoice accept a speaker name via 'voice';
+                # VoiceDesign-only models accept a description via 'instruct'.
+                # When both exist, 'voice' takes priority (CustomVoice).
                 import inspect
                 gen_params = inspect.signature(model.generate).parameters
-                if "instruct" in gen_params and voice != "default":
-                    gen_kwargs["instruct"] = voice
-                else:
+                if "voice" in gen_params:
                     gen_kwargs["voice"] = voice
+                elif "instruct" in gen_params:
+                    gen_kwargs["instruct"] = voice
             if speed != 1.0:
                 gen_kwargs["speed"] = speed
             gen_kwargs.update(kwargs)

--- a/tests/test_audio_tts.py
+++ b/tests/test_audio_tts.py
@@ -242,6 +242,72 @@ class TestTTSEndpointErrors:
 
 
 # ---------------------------------------------------------------------------
+# TestTTSVoiceRouting — unit tests for voice/instruct parameter dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestTTSVoiceRouting:
+    """Verify that the voice value is routed to the correct generate() kwarg."""
+
+    @pytest.fixture
+    def _run_synthesize(self):
+        """Helper: run TTSEngine.synthesize and return the kwargs passed to generate()."""
+        import asyncio
+        from omlx.engine.tts import TTSEngine
+
+        def _run(generate_sig_params, voice_value):
+            engine = TTSEngine("test-model")
+
+            # Build a mock model whose generate() has the requested signature
+            mock_model = MagicMock()
+            params = [
+                MagicMock(name="text", default=MagicMock()),
+                MagicMock(name="verbose", default=False),
+            ]
+            import inspect
+            sig_params = {
+                "text": inspect.Parameter("text", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+                "verbose": inspect.Parameter("verbose", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=False),
+            }
+            for p in generate_sig_params:
+                sig_params[p] = inspect.Parameter(p, inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None)
+            mock_model.generate = MagicMock()
+            mock_model.generate.__signature__ = inspect.Signature(parameters=list(sig_params.values()))
+            mock_model.generate.return_value = []  # no audio chunks
+
+            engine._model = mock_model
+
+            try:
+                asyncio.run(engine.synthesize("Hello", voice=voice_value))
+            except RuntimeError:
+                pass  # "no audio output" is expected with empty generate
+
+            return mock_model.generate.call_args
+
+        return _run
+
+    def test_customvoice_routes_to_voice(self, _run_synthesize):
+        """Model with 'voice' param: value goes to voice, not instruct."""
+        call = _run_synthesize(["voice", "instruct"], "Vivian")
+        kwargs = call.kwargs if call else {}
+        assert kwargs.get("voice") == "Vivian"
+        assert "instruct" not in kwargs
+
+    def test_voicedesign_routes_to_instruct(self, _run_synthesize):
+        """Model with only 'instruct' param: value goes to instruct."""
+        call = _run_synthesize(["instruct"], "female, calm, slow")
+        kwargs = call.kwargs if call else {}
+        assert kwargs.get("instruct") == "female, calm, slow"
+        assert "voice" not in kwargs
+
+    def test_voice_only_model(self, _run_synthesize):
+        """Model with only 'voice' param (e.g. Kokoro): value goes to voice."""
+        call = _run_synthesize(["voice"], "af_heart")
+        kwargs = call.kwargs if call else {}
+        assert kwargs.get("voice") == "af_heart"
+
+
+# ---------------------------------------------------------------------------
 # Integration test (slow, requires mlx-audio)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Fix voice parameter routing in `TTSEngine.synthesize()` that caused HTTP 500 for CustomVoice models (e.g. `Qwen3-TTS-12Hz-1.7B-CustomVoice`)
- The previous logic checked for `instruct` first, misrouting the speaker name when a model accepts both `voice` and `instruct` parameters
- Now prioritizes `voice` when present; falls back to `instruct` only for VoiceDesign-only models

Fixes #461

## Changes

- `omlx/engine/tts.py`: Swap parameter priority — check `voice` before `instruct`
- `tests/test_audio_tts.py`: Add `TestTTSVoiceRouting` with 3 test cases covering CustomVoice, VoiceDesign, and voice-only models

## Test plan

- [x] Unit tests pass (`pytest tests/test_audio_tts.py` — 15 passed)
- [x] Manual verification with `Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16` — tested all 7 available speakers:
  - `vivian` (Chinese text) — 200 OK, valid WAV
  - `aiden` (Japanese text) — 200 OK, valid WAV
  - `serena` (English text) — 200 OK, valid WAV
  - `ryan` (English text) — 200 OK, valid WAV
  - `eric` (English text) — 200 OK, valid WAV
  - `dylan` (Chinese text) — 200 OK, valid WAV
  - `vivian` (English text) — 200 OK, valid WAV
- [x] `Qwen3-TTS-12Hz-1.7B-Base-bf16` and `Qwen3-TTS-12Hz-0.6B-Base-bf16` also verified working with voice param