### PR TITLE
fix: Devstral/Mistral tool calling broken by empty tool_call_end marker

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -50,7 +50,7 @@ def _parse_xml_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
         Tuple of (cleaned_text, tool_calls or None)
     """
     tool_calls = []
-    pattern = r'<tool_call>(.*?)</tool_call>'
+    pattern = r"<tool_call>(.*?)</tool_call>"
     matches = re.findall(pattern, text, re.DOTALL)
 
     for match in matches:
@@ -60,49 +60,60 @@ def _parse_xml_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
             parsed = json.loads(content)
             name = parsed.get("name", "")
             arguments = parsed.get("arguments", {})
-            tool_calls.append(ToolCall(
-                id=f"call_{uuid.uuid4().hex[:8]}",
-                type="function",
-                function=FunctionCall(
-                    name=name,
-                    arguments=json.dumps(arguments, ensure_ascii=False)
-                        if isinstance(arguments, dict) else str(arguments),
-                ),
-            ))
+            tool_calls.append(
+                ToolCall(
+                    id=f"call_{uuid.uuid4().hex[:8]}",
+                    type="function",
+                    function=FunctionCall(
+                        name=name,
+                        arguments=json.dumps(arguments, ensure_ascii=False)
+                        if isinstance(arguments, dict)
+                        else str(arguments),
+                    ),
+                )
+            )
             continue
         except (json.JSONDecodeError, AttributeError):
             pass
 
         # Qwen/Llama format: <function=name><parameter=key>value</parameter></function>
-        func_match = re.match(r'<function=(\w+)>(.*?)</function>', content, re.DOTALL)
+        func_match = re.match(r"<function=(\w+)>(.*?)</function>", content, re.DOTALL)
         if func_match:
             func_name = func_match.group(1)
             params_text = func_match.group(2)
             arguments = {}
-            for pm in re.finditer(r'<parameter=(\w+)>\s*(.*?)\s*</parameter>', params_text, re.DOTALL):
+            for pm in re.finditer(
+                r"<parameter=(\w+)>\s*(.*?)\s*</parameter>", params_text, re.DOTALL
+            ):
                 key = pm.group(1)
                 val = pm.group(2).strip()
                 try:
                     arguments[key] = json.loads(val)
                 except (json.JSONDecodeError, ValueError):
                     arguments[key] = val
-            tool_calls.append(ToolCall(
-                id=f"call_{uuid.uuid4().hex[:8]}",
-                type="function",
-                function=FunctionCall(
-                    name=func_name,
-                    arguments=json.dumps(arguments, ensure_ascii=False),
-                ),
-            ))
+            tool_calls.append(
+                ToolCall(
+                    id=f"call_{uuid.uuid4().hex[:8]}",
+                    type="function",
+                    function=FunctionCall(
+                        name=func_name,
+                        arguments=json.dumps(arguments, ensure_ascii=False),
+                    ),
+                )
+            )
             continue
 
         # GLM XML format: func_name<arg_key>k</arg_key><arg_value>v</arg_value>...
-        arg_keys = re.findall(r'<arg_key>(.*?)</arg_key>', content)
-        arg_values = re.findall(r'<arg_value>(.*?)</arg_value>', content, re.DOTALL)
+        arg_keys = re.findall(r"<arg_key>(.*?)</arg_key>", content)
+        arg_values = re.findall(r"<arg_value>(.*?)</arg_value>", content, re.DOTALL)
         if arg_keys:
             # Function name is the text before the first <arg_key>
-            name_match = re.match(r'^(.*?)<arg_key>', content, re.DOTALL)
-            func_name = name_match.group(1).strip() if name_match else content.split('<')[0].strip()
+            name_match = re.match(r"^(.*?)<arg_key>", content, re.DOTALL)
+            func_name = (
+                name_match.group(1).strip()
+                if name_match
+                else content.split("<")[0].strip()
+            )
             arguments = {}
             for k, v in zip(arg_keys, arg_values):
                 # Try to parse JSON values (arrays, objects, numbers, booleans)
@@ -110,24 +121,28 @@ def _parse_xml_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
                     arguments[k] = json.loads(v)
                 except (json.JSONDecodeError, ValueError):
                     arguments[k] = v
-            tool_calls.append(ToolCall(
-                id=f"call_{uuid.uuid4().hex[:8]}",
-                type="function",
-                function=FunctionCall(
-                    name=func_name,
-                    arguments=json.dumps(arguments, ensure_ascii=False),
-                ),
-            ))
+            tool_calls.append(
+                ToolCall(
+                    id=f"call_{uuid.uuid4().hex[:8]}",
+                    type="function",
+                    function=FunctionCall(
+                        name=func_name,
+                        arguments=json.dumps(arguments, ensure_ascii=False),
+                    ),
+                )
+            )
 
     if not tool_calls:
         return text, None
 
     # Remove tool call tags from text
-    cleaned = re.sub(r'<tool_call>.*?</tool_call>', '', text, flags=re.DOTALL).strip()
+    cleaned = re.sub(r"<tool_call>.*?</tool_call>", "", text, flags=re.DOTALL).strip()
     return cleaned, tool_calls
 
 
-def _parse_namespaced_tool_calls(text: str, namespace: str) -> Tuple[str, Optional[List[ToolCall]]]:
+def _parse_namespaced_tool_calls(
+    text: str, namespace: str
+) -> Tuple[str, Optional[List[ToolCall]]]:
     """
     Parse namespaced tool call tags like <minimax:tool_call>...</minimax:tool_call>.
 
@@ -138,9 +153,9 @@ def _parse_namespaced_tool_calls(text: str, namespace: str) -> Tuple[str, Option
         Tuple of (cleaned_text, tool_calls or None)
     """
     tool_calls = []
-    tag_start = f'<{namespace}:tool_call>'
-    tag_end = f'</{namespace}:tool_call>'
-    pattern = re.escape(tag_start) + r'(.*?)' + re.escape(tag_end)
+    tag_start = f"<{namespace}:tool_call>"
+    tag_end = f"</{namespace}:tool_call>"
+    pattern = re.escape(tag_start) + r"(.*?)" + re.escape(tag_end)
     matches = re.findall(pattern, text, re.DOTALL)
 
     for match in matches:
@@ -161,19 +176,21 @@ def _parse_namespaced_tool_calls(text: str, namespace: str) -> Tuple[str, Option
                     arguments[key] = json.loads(val)
                 except (json.JSONDecodeError, ValueError):
                     arguments[key] = val
-            tool_calls.append(ToolCall(
-                id=f"call_{uuid.uuid4().hex[:8]}",
-                type="function",
-                function=FunctionCall(
-                    name=func_name,
-                    arguments=json.dumps(arguments, ensure_ascii=False),
-                ),
-            ))
+            tool_calls.append(
+                ToolCall(
+                    id=f"call_{uuid.uuid4().hex[:8]}",
+                    type="function",
+                    function=FunctionCall(
+                        name=func_name,
+                        arguments=json.dumps(arguments, ensure_ascii=False),
+                    ),
+                )
+            )
 
     if not tool_calls:
         return text, None
 
-    cleaned = re.sub(pattern, '', text, flags=re.DOTALL).strip()
+    cleaned = re.sub(pattern, "", text, flags=re.DOTALL).strip()
     return cleaned, tool_calls
 
 
@@ -190,7 +207,9 @@ def _parse_bracket_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]
     """
     tool_calls = []
     # Match with args first (higher fidelity)
-    pattern_with_args = r'\[(?:Calling tool|Tool call):\s*([A-Za-z_][\w.-]*)\(({.*?})\)\]'
+    pattern_with_args = (
+        r"\[(?:Calling tool|Tool call):\s*([A-Za-z_][\w.-]*)\(({.*?})\)\]"
+    )
     matched_spans: list = []
     for match in re.finditer(pattern_with_args, text, re.DOTALL):
         name = match.group(1)
@@ -199,40 +218,44 @@ def _parse_bracket_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]
             arguments = json.loads(args_str)
         except (json.JSONDecodeError, ValueError):
             arguments = {"raw": args_str}
-        tool_calls.append(ToolCall(
-            id=f"call_{uuid.uuid4().hex[:8]}",
-            type="function",
-            function=FunctionCall(
-                name=name,
-                arguments=json.dumps(arguments, ensure_ascii=False),
-            ),
-        ))
+        tool_calls.append(
+            ToolCall(
+                id=f"call_{uuid.uuid4().hex[:8]}",
+                type="function",
+                function=FunctionCall(
+                    name=name,
+                    arguments=json.dumps(arguments, ensure_ascii=False),
+                ),
+            )
+        )
         matched_spans.append(match.span())
 
     # Match without args (model-generated simplified form)
-    pattern_no_args = r'\[(?:Calling tool|Tool call):\s*([A-Za-z_][\w.-]*)\]'
+    pattern_no_args = r"\[(?:Calling tool|Tool call):\s*([A-Za-z_][\w.-]*)\]"
     for match in re.finditer(pattern_no_args, text):
         # Skip if this span overlaps with an already-matched with-args span
         start, end = match.span()
         if any(s <= start < e for s, e in matched_spans):
             continue
         name = match.group(1)
-        tool_calls.append(ToolCall(
-            id=f"call_{uuid.uuid4().hex[:8]}",
-            type="function",
-            function=FunctionCall(
-                name=name,
-                arguments="{}",
-            ),
-        ))
+        tool_calls.append(
+            ToolCall(
+                id=f"call_{uuid.uuid4().hex[:8]}",
+                type="function",
+                function=FunctionCall(
+                    name=name,
+                    arguments="{}",
+                ),
+            )
+        )
         matched_spans.append((start, end))
 
     if not tool_calls:
         return text, None
 
     # Remove all matched spans from text
-    cleaned = re.sub(pattern_with_args, '', text, flags=re.DOTALL)
-    cleaned = re.sub(pattern_no_args, '', cleaned).strip()
+    cleaned = re.sub(pattern_with_args, "", text, flags=re.DOTALL)
+    cleaned = re.sub(pattern_no_args, "", cleaned).strip()
     return cleaned, tool_calls
 
 
@@ -261,64 +284,79 @@ def parse_tool_calls(
 
     # Remove thinking tags if present (reasoning models)
     cleaned_text = re.sub(
-        r'<think>.*?</think>',
-        '',
-        cleaned_text,
-        flags=re.DOTALL
+        r"<think>.*?</think>", "", cleaned_text, flags=re.DOTALL
     ).strip()
 
     # Try mlx-lm's native tool parser first
-    if getattr(tokenizer, 'has_tool_calling', False):
+    if getattr(tokenizer, "has_tool_calling", False):
         tool_call_start = tokenizer.tool_call_start
         tool_call_end = tokenizer.tool_call_end
         tool_parser = tokenizer.tool_parser
 
-        if tool_call_start is not None and tool_call_end is not None and tool_parser is not None:
+        if tool_call_start is not None and tool_parser is not None:
             tool_calls = []
             start_escaped = re.escape(tool_call_start)
-            end_escaped = re.escape(tool_call_end)
-            pattern = rf'{start_escaped}(.*?){end_escaped}'
 
-            matches = re.findall(pattern, text, re.DOTALL)
+            if tool_call_end:
+                # Paired markers (e.g. <tool_call>...</tool_call>)
+                end_escaped = re.escape(tool_call_end)
+                pattern = rf"{start_escaped}(.*?){end_escaped}"
+                matches = re.findall(pattern, text, re.DOTALL)
+            else:
+                # One-sided marker (e.g. Mistral/Devstral "[TOOL_CALLS]"):
+                # split on the start marker and parse each segment.
+                # The model emits: [TOOL_CALLS]name[ARGS]{...}[TOOL_CALLS]name2[ARGS]{...}
+                parts = re.split(start_escaped, text)
+                # First part is pre-marker text, rest are tool call segments
+                matches = [p for p in parts[1:] if p.strip()]
 
             for match in matches:
                 try:
                     parsed = tool_parser(match.strip(), tools)
-                    name = parsed.get('name', '')
-                    arguments = parsed.get('arguments', {})
-                    tool_calls.append(ToolCall(
-                        id=f"call_{uuid.uuid4().hex[:8]}",
-                        type="function",
-                        function=FunctionCall(
-                            name=name,
-                            arguments=json.dumps(arguments, ensure_ascii=False)
-                                if isinstance(arguments, dict) else str(arguments)
+                    name = parsed.get("name", "")
+                    arguments = parsed.get("arguments", {})
+                    tool_calls.append(
+                        ToolCall(
+                            id=f"call_{uuid.uuid4().hex[:8]}",
+                            type="function",
+                            function=FunctionCall(
+                                name=name,
+                                arguments=json.dumps(arguments, ensure_ascii=False)
+                                if isinstance(arguments, dict)
+                                else str(arguments),
+                            ),
                         )
-                    ))
+                    )
                 except (ValueError, json.JSONDecodeError, AttributeError, KeyError):
                     continue
 
             if tool_calls:
-                cleaned_text = re.sub(
-                    rf'{start_escaped}.*?{end_escaped}',
-                    '',
-                    cleaned_text,
-                    flags=re.DOTALL
-                ).strip()
+                if tool_call_end:
+                    cleaned_text = re.sub(
+                        rf"{start_escaped}.*?{re.escape(tool_call_end)}",
+                        "",
+                        cleaned_text,
+                        flags=re.DOTALL,
+                    ).strip()
+                else:
+                    # One-sided: everything from first marker to end is tool calls
+                    idx = cleaned_text.find(tool_call_start)
+                    if idx >= 0:
+                        cleaned_text = cleaned_text[:idx].strip()
                 return cleaned_text, tool_calls
 
     # Fallback: parse XML <tool_call> tags (GLM, Qwen, generic formats)
-    if '<tool_call>' in cleaned_text:
+    if "<tool_call>" in cleaned_text:
         return _parse_xml_tool_calls(cleaned_text)
 
     # Fallback: namespaced tool_call tags (e.g. <minimax:tool_call>)
-    ns_match = re.search(r'<([A-Za-z_][\w.-]*):tool_call>', cleaned_text)
+    ns_match = re.search(r"<([A-Za-z_][\w.-]*):tool_call>", cleaned_text)
     if ns_match:
         ns = ns_match.group(1)
         return _parse_namespaced_tool_calls(cleaned_text, ns)
 
     # Fallback: bracket tool call formats (from text-formatted history)
-    if '[Calling tool:' in cleaned_text or '[Tool call:' in cleaned_text:
+    if "[Calling tool:" in cleaned_text or "[Tool call:" in cleaned_text:
         return _parse_bracket_tool_calls(cleaned_text)
 
     return cleaned_text, None
@@ -426,7 +464,7 @@ class ToolCallStreamFilter:
         self._namespaced_open_re = re.compile(r"<([A-Za-z_][\w.-]*):tool_call>")
         self._bracket_prefixes = ["[Calling tool:", "[Tool call:"]
         self._bracket_call_re = re.compile(
-            r'^\[(?:Calling tool|Tool call):\s*([A-Za-z_][\w.-]*)(?:\(({.*?})\))?\]',
+            r"^\[(?:Calling tool|Tool call):\s*([A-Za-z_][\w.-]*)(?:\(({.*?})\))?\]",
             re.DOTALL,
         )
         self._buffer = ""
@@ -438,7 +476,9 @@ class ToolCallStreamFilter:
         """Whether this filter should run for tool-enabled streams."""
         return True
 
-    def _find_start_envelope(self, text: str) -> Optional[Tuple[int, int, Optional[str]]]:
+    def _find_start_envelope(
+        self, text: str
+    ) -> Optional[Tuple[int, int, Optional[str]]]:
         """Find earliest complete opening envelope.
 
         Returns:
@@ -456,7 +496,9 @@ class ToolCallStreamFilter:
         ns_match = self._namespaced_open_re.search(text)
         if ns_match:
             ns = ns_match.group(1)
-            starts.append((ns_match.start(), len(ns_match.group(0)), f"</{ns}:tool_call>"))
+            starts.append(
+                (ns_match.start(), len(ns_match.group(0)), f"</{ns}:tool_call>")
+            )
 
         for bp in self._bracket_prefixes:
             bracket_idx = text.find(bp)
@@ -613,7 +655,7 @@ class ToolCallStreamFilter:
                 continue
 
             # Preserve balanced literal bracket text that is not being suppressed.
-            out.append(text[bracket_idx:close_idx + 1])
+            out.append(text[bracket_idx : close_idx + 1])
             cursor = close_idx + 1
 
         return "".join(out)
@@ -638,10 +680,12 @@ class ToolCallStreamFilter:
             if self._suppressing_until is not None:
                 end_idx = self._buffer.find(self._suppressing_until)
                 if end_idx < 0:
-                    keep = self._partial_prefix_len(self._buffer, self._suppressing_until)
+                    keep = self._partial_prefix_len(
+                        self._buffer, self._suppressing_until
+                    )
                     self._buffer = self._buffer[-keep:] if keep else ""
                     break
-                self._buffer = self._buffer[end_idx + len(self._suppressing_until):]
+                self._buffer = self._buffer[end_idx + len(self._suppressing_until) :]
                 self._suppressing_until = None
                 continue
 
@@ -649,8 +693,10 @@ class ToolCallStreamFilter:
             if start:
                 idx, consume_len, close_marker = start
                 if idx > 0:
-                    out.append(self._sanitize_prefix_before_suppression(self._buffer[:idx]))
-                self._buffer = self._buffer[idx + consume_len:]
+                    out.append(
+                        self._sanitize_prefix_before_suppression(self._buffer[:idx])
+                    )
+                self._buffer = self._buffer[idx + consume_len :]
                 if close_marker is not None:
                     self._suppressing_until = close_marker
                 continue
@@ -694,9 +740,7 @@ class ToolCallStreamFilter:
         return buf
 
 
-def convert_tools_for_template(
-    tools: Optional[List]
-) -> Optional[List[dict]]:
+def convert_tools_for_template(tools: Optional[List]) -> Optional[List[dict]]:
     """
     Convert OpenAI tools format to format expected by tokenizer.apply_chat_template.
 
@@ -730,20 +774,26 @@ def convert_tools_for_template(
             if isinstance(tool_func, dict):
                 func_name = tool_func.get("name", "")
                 func_desc = tool_func.get("description", "")
-                func_params = tool_func.get("parameters", {"type": "object", "properties": {}})
+                func_params = tool_func.get(
+                    "parameters", {"type": "object", "properties": {}}
+                )
             else:
                 func_name = getattr(tool_func, "name", "")
                 func_desc = getattr(tool_func, "description", "")
-                func_params = getattr(tool_func, "parameters", {"type": "object", "properties": {}})
+                func_params = getattr(
+                    tool_func, "parameters", {"type": "object", "properties": {}}
+                )
 
-            converted.append({
-                "type": "function",
-                "function": {
-                    "name": func_name,
-                    "description": func_desc,
-                    "parameters": func_params
+            converted.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": func_name,
+                        "description": func_desc,
+                        "parameters": func_params,
+                    },
                 }
-            })
+            )
 
     return converted if converted else None
 
@@ -764,7 +814,7 @@ def format_tool_call_for_message(tool_call: ToolCall) -> dict:
         "function": {
             "name": tool_call.function.name,
             "arguments": tool_call.function.arguments,
-        }
+        },
     }
 
 
@@ -772,9 +822,9 @@ def format_tool_call_for_message(tool_call: ToolCall) -> dict:
 # Structured Output (JSON Schema) Utilities
 # =============================================================================
 
+
 def validate_json_schema(
-    data: Any,
-    schema: Dict[str, Any]
+    data: Any, schema: Dict[str, Any]
 ) -> Tuple[bool, Optional[str]]:
     """
     Validate JSON data against a JSON Schema.
@@ -820,7 +870,7 @@ def extract_json_from_text(text: str) -> Optional[Dict[str, Any]]:
 
     # Strategy 2: Extract from markdown code blocks
     # Match ```json ... ``` or ``` ... ```
-    code_block_pattern = r'```(?:json)?\s*([\s\S]*?)\s*```'
+    code_block_pattern = r"```(?:json)?\s*([\s\S]*?)\s*```"
     matches = re.findall(code_block_pattern, text)
     for match in matches:
         try:
@@ -831,8 +881,8 @@ def extract_json_from_text(text: str) -> Optional[Dict[str, Any]]:
     # Strategy 3: Find JSON object or array in text
     # Look for { ... } or [ ... ]
     json_patterns = [
-        r'(\{[\s\S]*\})',  # Object
-        r'(\[[\s\S]*\])',  # Array
+        r"(\{[\s\S]*\})",  # Object
+        r"(\[[\s\S]*\])",  # Array
     ]
     for pattern in json_patterns:
         match = re.search(pattern, text)
@@ -846,8 +896,7 @@ def extract_json_from_text(text: str) -> Optional[Dict[str, Any]]:
 
 
 def parse_json_output(
-    text: str,
-    response_format: Optional[Union[ResponseFormat, Dict[str, Any]]] = None
+    text: str, response_format: Optional[Union[ResponseFormat, Dict[str, Any]]] = None
 ) -> Tuple[str, Optional[Dict[str, Any]], bool, Optional[str]]:
     """
     Parse JSON from model output when response_format is set.
@@ -871,10 +920,7 @@ def parse_json_output(
 
     # Normalize response_format to dict
     if isinstance(response_format, ResponseFormat):
-        rf_dict = {
-            "type": response_format.type,
-            "json_schema": None
-        }
+        rf_dict = {"type": response_format.type, "json_schema": None}
         if response_format.json_schema:
             rf_dict["json_schema"] = {
                 "name": response_format.json_schema.name,
@@ -918,7 +964,7 @@ def parse_json_output(
 
 
 def build_json_system_prompt(
-    response_format: Optional[Union[ResponseFormat, Dict[str, Any]]] = None
+    response_format: Optional[Union[ResponseFormat, Dict[str, Any]]] = None,
 ) -> Optional[str]:
     """
     Build a system prompt instruction for JSON output.
@@ -937,10 +983,7 @@ def build_json_system_prompt(
 
     # Normalize to dict
     if isinstance(response_format, ResponseFormat):
-        rf_dict = {
-            "type": response_format.type,
-            "json_schema": None
-        }
+        rf_dict = {"type": response_format.type, "json_schema": None}
         if response_format.json_schema:
             rf_dict["json_schema"] = {
                 "name": response_format.json_schema.name,

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -46,10 +46,11 @@ def detect_and_strip_partial(messages: list[dict]) -> bool:
 
 # Pattern to match special tokens that should be removed from output
 SPECIAL_TOKENS_PATTERN = re.compile(
-    r'<\|im_end\|>|<\|im_start\|>|<\|endoftext\|>|'
-    r'<\|end\|>|<\|eot_id\|>|<\|start_header_id\|>|<\|end_header_id\|>|'
-    r'</s>|<s>|<pad>|\[PAD\]|\[SEP\]|\[CLS\]'
+    r"<\|im_end\|>|<\|im_start\|>|<\|endoftext\|>|"
+    r"<\|end\|>|<\|eot_id\|>|<\|start_header_id\|>|<\|end_header_id\|>|"
+    r"</s>|<s>|<pad>|\[PAD\]|\[SEP\]|\[CLS\]"
 )
+
 
 def clean_special_tokens(text: str) -> str:
     """Clean model output by removing only special tokens.
@@ -64,7 +65,7 @@ def clean_special_tokens(text: str) -> str:
     """
     if not text:
         return text
-    return SPECIAL_TOKENS_PATTERN.sub('', text).strip()
+    return SPECIAL_TOKENS_PATTERN.sub("", text).strip()
 
 
 def clean_output_text(text: str) -> str:
@@ -78,8 +79,9 @@ def clean_output_text(text: str) -> str:
     """
     if not text:
         return text
-    text = SPECIAL_TOKENS_PATTERN.sub('', text)
+    text = SPECIAL_TOKENS_PATTERN.sub("", text)
     from .thinking import extract_thinking
+
     _, content = extract_thinking(text)
     return content.strip()
 
@@ -98,9 +100,9 @@ def _extract_text_from_content_list(content: list) -> str:
     """
     text_parts = []
     for item in content:
-        if hasattr(item, 'model_dump'):
+        if hasattr(item, "model_dump"):
             item = item.model_dump()
-        elif hasattr(item, 'dict'):
+        elif hasattr(item, "dict"):
             item = item.dict()
         if isinstance(item, dict) and item.get("type") == "text":
             text_parts.append(item.get("text", ""))
@@ -115,9 +117,9 @@ def _extract_multimodal_content_list(content: list) -> list:
     """
     parts = []
     for item in content:
-        if hasattr(item, 'model_dump'):
+        if hasattr(item, "model_dump"):
             item = item.model_dump()
-        elif hasattr(item, 'dict'):
+        elif hasattr(item, "dict"):
             item = item.dict()
         if isinstance(item, dict):
             item_type = item.get("type")
@@ -134,22 +136,26 @@ def _extract_multimodal_content_list(content: list) -> list:
                 elif isinstance(image_url_value, dict):
                     url = image_url_value.get("url")
                 if url:
-                    parts.append({
-                        "type": "image_url",
-                        "image_url": {"url": url},
-                    })
+                    parts.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": url},
+                        }
+                    )
             elif item_type == "image":
                 # Anthropic format: convert to OpenAI image_url format
                 source = item.get("source", {})
                 if source.get("type") == "base64":
                     media_type = source.get("media_type", "image/jpeg")
                     data = source.get("data", "")
-                    parts.append({
-                        "type": "image_url",
-                        "image_url": {
-                            "url": f"data:{media_type};base64,{data}",
-                        },
-                    })
+                    parts.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:{media_type};base64,{data}",
+                            },
+                        }
+                    )
     return parts
 
 
@@ -158,6 +164,25 @@ def _extract_multimodal_content_list(content: list) -> list:
 # (e.g., JSON schema instructions), and tool messages carry tool_call_id.
 _MERGEABLE_ROLES = {"user", "assistant"}
 _PRESERVE_BOUNDARY_KEY = "_preserve_role_boundary"
+
+
+def _drop_void_assistant_messages(messages: list[dict]) -> list[dict]:
+    """Drop assistant messages that have no content and no tool_calls.
+
+    Strict chat templates (e.g., Devstral/Mistral) raise an error when an
+    assistant message has empty content and no tool_calls.  These void messages
+    carry no information and can appear when a client echoes back a response
+    that had only tool calls which were not preserved in its history.
+    """
+    return [
+        msg
+        for msg in messages
+        if not (
+            msg.get("role") == "assistant"
+            and not msg.get("content")
+            and not msg.get("tool_calls")
+        )
+    ]
 
 
 def _consolidate_system_messages(messages: list[dict]) -> list[dict]:
@@ -256,71 +281,82 @@ def extract_text_content(
 
         # Handle tool response messages (role="tool")
         if role == "tool":
-            tool_call_id = getattr(msg, 'tool_call_id', None) or ''
+            tool_call_id = getattr(msg, "tool_call_id", None) or ""
             tool_content = content if content else ""
             # Apply truncation if configured
             if max_tool_result_tokens and tokenizer and tool_content:
                 from .anthropic_utils import truncate_tool_result
+
                 tool_content = truncate_tool_result(
                     tool_content, max_tool_result_tokens, tokenizer
                 )
             # Preserve structured format for models with native tool calling
             # so the chat template renders tool results in the model's native format
-            if getattr(tokenizer, 'has_tool_calling', False):
-                processed_messages.append({
-                    "role": "tool",
-                    "tool_call_id": tool_call_id,
-                    "content": tool_content,
-                })
+            if getattr(tokenizer, "has_tool_calling", False):
+                processed_messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call_id,
+                        "content": tool_content,
+                    }
+                )
             else:
-                processed_messages.append({
-                    "role": "user",  # mlx-lm expects user/assistant roles
-                    "content": f"[Tool Result ({tool_call_id})]: {tool_content}",
-                    _PRESERVE_BOUNDARY_KEY: True,
-                })
+                processed_messages.append(
+                    {
+                        "role": "user",  # mlx-lm expects user/assistant roles
+                        "content": f"[Tool Result ({tool_call_id})]: {tool_content}",
+                        _PRESERVE_BOUNDARY_KEY: True,
+                    }
+                )
             continue
 
         # Handle assistant messages with tool_calls
-        if role == "assistant" and hasattr(msg, 'tool_calls') and msg.tool_calls:
+        if role == "assistant" and hasattr(msg, "tool_calls") and msg.tool_calls:
             if isinstance(content, list):
                 content = _extract_text_from_content_list(content)
             msg_dict = {"role": role, "content": content if content else ""}
-            if getattr(msg, 'name', None):
+            if getattr(msg, "name", None):
                 msg_dict["name"] = msg.name
 
             # Preserve structured tool_calls for models with native tool calling
             # so the chat template renders them in the model's native format.
             # Without this, models mimic text-formatted tool calls from history
             # instead of generating their native parseable format.
-            if getattr(tokenizer, 'has_tool_calling', False):
+            if getattr(tokenizer, "has_tool_calling", False):
                 tool_calls_list = []
                 for tc in msg.tool_calls:
                     if isinstance(tc, dict):
                         func = tc.get("function", {})
-                        tool_calls_list.append({
-                            "id": tc.get("id", ""),
-                            "function": {
-                                "name": func.get("name", ""),
-                                "arguments": _try_parse_json(
-                                    func.get("arguments", "{}")
-                                ),
+                        tool_calls_list.append(
+                            {
+                                "id": tc.get("id", ""),
+                                "function": {
+                                    "name": func.get("name", ""),
+                                    "arguments": _try_parse_json(
+                                        func.get("arguments", "{}")
+                                    ),
+                                },
                             }
-                        })
+                        )
                     else:
                         args_str = (
-                            getattr(tc.function, 'arguments', '{}')
-                            if hasattr(tc, 'function') else '{}'
+                            getattr(tc.function, "arguments", "{}")
+                            if hasattr(tc, "function")
+                            else "{}"
                         )
-                        tool_calls_list.append({
-                            "id": getattr(tc, 'id', ''),
-                            "function": {
-                                "name": (
-                                    getattr(tc.function, 'name', '')
-                                    if hasattr(tc, 'function') else ''
-                                ),
-                                "arguments": _try_parse_json(args_str),
+                        tool_calls_list.append(
+                            {
+                                "id": getattr(tc, "id", ""),
+                                "function": {
+                                    "name": (
+                                        getattr(tc.function, "name", "")
+                                        if hasattr(tc, "function")
+                                        else ""
+                                    ),
+                                    "arguments": _try_parse_json(args_str),
+                                },
                             }
-                        })
+                        )
                 msg_dict["tool_calls"] = tool_calls_list
             else:
                 # Text fallback for models without native tool calling
@@ -342,9 +378,9 @@ def extract_text_content(
 
         # Build optional extra fields from the source message
         _extra: dict = {}
-        if getattr(msg, 'name', None):
+        if getattr(msg, "name", None):
             _extra["name"] = msg.name
-        if getattr(msg, 'partial', False):
+        if getattr(msg, "partial", False):
             _extra["partial"] = True
 
         # Handle None content
@@ -358,13 +394,15 @@ def extract_text_content(
         elif isinstance(content, list):
             # Content array - extract text parts only
             combined_text = _extract_text_from_content_list(content)
-            processed_messages.append({"role": role, "content": combined_text, **_extra})
+            processed_messages.append(
+                {"role": role, "content": combined_text, **_extra}
+            )
         else:
             # Unknown format, try to convert
             processed_messages.append({"role": role, "content": str(content), **_extra})
 
-    return _merge_consecutive_roles(
-        _consolidate_system_messages(processed_messages)
+    return _drop_void_assistant_messages(
+        _merge_consecutive_roles(_consolidate_system_messages(processed_messages))
     )
 
 
@@ -398,64 +436,75 @@ def extract_multimodal_content(
 
         # Tool response messages - same as extract_text_content
         if role == "tool":
-            tool_call_id = getattr(msg, 'tool_call_id', None) or ''
+            tool_call_id = getattr(msg, "tool_call_id", None) or ""
             tool_content = content if content else ""
             if max_tool_result_tokens and tokenizer and tool_content:
                 from .anthropic_utils import truncate_tool_result
+
                 tool_content = truncate_tool_result(
                     tool_content, max_tool_result_tokens, tokenizer
                 )
-            if getattr(tokenizer, 'has_tool_calling', False):
-                processed_messages.append({
-                    "role": "tool",
-                    "tool_call_id": tool_call_id,
-                    "content": tool_content,
-                })
+            if getattr(tokenizer, "has_tool_calling", False):
+                processed_messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call_id,
+                        "content": tool_content,
+                    }
+                )
             else:
-                processed_messages.append({
-                    "role": "user",
-                    "content": f"[Tool Result ({tool_call_id})]: {tool_content}",
-                    _PRESERVE_BOUNDARY_KEY: True,
-                })
+                processed_messages.append(
+                    {
+                        "role": "user",
+                        "content": f"[Tool Result ({tool_call_id})]: {tool_content}",
+                        _PRESERVE_BOUNDARY_KEY: True,
+                    }
+                )
             continue
 
         # Assistant with tool_calls - same as extract_text_content
-        if role == "assistant" and hasattr(msg, 'tool_calls') and msg.tool_calls:
+        if role == "assistant" and hasattr(msg, "tool_calls") and msg.tool_calls:
             if isinstance(content, list):
                 content = _extract_text_from_content_list(content)
             msg_dict = {"role": role, "content": content if content else ""}
-            if getattr(msg, 'name', None):
+            if getattr(msg, "name", None):
                 msg_dict["name"] = msg.name
 
-            if getattr(tokenizer, 'has_tool_calling', False):
+            if getattr(tokenizer, "has_tool_calling", False):
                 tool_calls_list = []
                 for tc in msg.tool_calls:
                     if isinstance(tc, dict):
                         func = tc.get("function", {})
-                        tool_calls_list.append({
-                            "id": tc.get("id", ""),
-                            "function": {
-                                "name": func.get("name", ""),
-                                "arguments": _try_parse_json(
-                                    func.get("arguments", "{}")
-                                ),
+                        tool_calls_list.append(
+                            {
+                                "id": tc.get("id", ""),
+                                "function": {
+                                    "name": func.get("name", ""),
+                                    "arguments": _try_parse_json(
+                                        func.get("arguments", "{}")
+                                    ),
+                                },
                             }
-                        })
+                        )
                     else:
                         args_str = (
-                            getattr(tc.function, 'arguments', '{}')
-                            if hasattr(tc, 'function') else '{}'
+                            getattr(tc.function, "arguments", "{}")
+                            if hasattr(tc, "function")
+                            else "{}"
                         )
-                        tool_calls_list.append({
-                            "id": getattr(tc, 'id', ''),
-                            "function": {
-                                "name": (
-                                    getattr(tc.function, 'name', '')
-                                    if hasattr(tc, 'function') else ''
-                                ),
-                                "arguments": _try_parse_json(args_str),
+                        tool_calls_list.append(
+                            {
+                                "id": getattr(tc, "id", ""),
+                                "function": {
+                                    "name": (
+                                        getattr(tc.function, "name", "")
+                                        if hasattr(tc, "function")
+                                        else ""
+                                    ),
+                                    "arguments": _try_parse_json(args_str),
+                                },
                             }
-                        })
+                        )
                 msg_dict["tool_calls"] = tool_calls_list
             else:
                 tool_calls_text = []
@@ -476,9 +525,9 @@ def extract_multimodal_content(
 
         # Build optional extra fields from the source message
         _extra: dict = {}
-        if getattr(msg, 'name', None):
+        if getattr(msg, "name", None):
             _extra["name"] = msg.name
-        if getattr(msg, 'partial', False):
+        if getattr(msg, "partial", False):
             _extra["partial"] = True
 
         if content is None:
@@ -490,25 +539,30 @@ def extract_multimodal_content(
         elif isinstance(content, list):
             # Preserve image_url parts for VLM processing
             multimodal_parts = _extract_multimodal_content_list(content)
-            has_images = any(
-                p.get("type") == "image_url" for p in multimodal_parts
-            )
+            has_images = any(p.get("type") == "image_url" for p in multimodal_parts)
             if has_images:
                 # Keep as content list for VLM engine
-                processed_messages.append({"role": role, "content": multimodal_parts, **_extra})
+                processed_messages.append(
+                    {"role": role, "content": multimodal_parts, **_extra}
+                )
             else:
                 # Text-only, flatten to string
                 combined_text = _extract_text_from_content_list(content)
-                processed_messages.append({"role": role, "content": combined_text, **_extra})
+                processed_messages.append(
+                    {"role": role, "content": combined_text, **_extra}
+                )
         else:
             processed_messages.append({"role": role, "content": str(content), **_extra})
 
-    return _consolidate_system_messages(processed_messages)
+    return _drop_void_assistant_messages(
+        _consolidate_system_messages(processed_messages)
+    )
 
 
 # =============================================================================
 # Harmony (gpt-oss) Message Extraction
 # =============================================================================
+
 
 def _try_parse_json(s: str):
     """
@@ -524,7 +578,7 @@ def _try_parse_json(s: str):
     if not s:
         return s
     # Quick check: must start with { or [ to be JSON object/array
-    if not (s.startswith('{') or s.startswith('[')):
+    if not (s.startswith("{") or s.startswith("[")):
         return s
     try:
         return json.loads(s)
@@ -614,9 +668,7 @@ def extract_harmony_messages(
                 parsed_json = _try_parse_json(tool_content)
                 if isinstance(parsed_json, (dict, list)):
                     # Valid JSON - pretty-print for line-boundary truncation
-                    pretty = json.dumps(
-                        parsed_json, indent=2, ensure_ascii=False
-                    )
+                    pretty = json.dumps(parsed_json, indent=2, ensure_ascii=False)
                     truncated = truncate_tool_result(
                         pretty, max_tool_result_tokens, tokenizer
                     )
@@ -634,11 +686,13 @@ def extract_harmony_messages(
             else:
                 # No truncation configured - just parse JSON if possible
                 parsed_content = _try_parse_json(tool_content)
-            processed_messages.append({
-                "role": "tool",
-                "tool_call_id": getattr(msg, 'tool_call_id', '') or '',
-                "content": parsed_content,
-            })
+            processed_messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": getattr(msg, "tool_call_id", "") or "",
+                    "content": parsed_content,
+                }
+            )
             continue
 
         # Assistant messages - preserve tool_calls field
@@ -654,9 +708,9 @@ def extract_harmony_messages(
                 # Extract text parts from content array
                 text_parts = []
                 for item in content:
-                    if hasattr(item, 'model_dump'):
+                    if hasattr(item, "model_dump"):
                         item = item.model_dump()
-                    elif hasattr(item, 'dict'):
+                    elif hasattr(item, "dict"):
                         item = item.dict()
                     if isinstance(item, dict) and item.get("type") == "text":
                         text_parts.append(item.get("text", ""))
@@ -666,28 +720,38 @@ def extract_harmony_messages(
 
             # Preserve tool_calls field for chat_template
             # Parse arguments as JSON if possible (chat_template applies |tojson)
-            if hasattr(msg, 'tool_calls') and msg.tool_calls:
+            if hasattr(msg, "tool_calls") and msg.tool_calls:
                 tool_calls_list = []
                 for tc in msg.tool_calls:
                     if isinstance(tc, dict):
                         args_str = tc.get("function", {}).get("arguments", "{}")
-                        tool_calls_list.append({
-                            "id": tc.get("id", ""),
-                            "function": {
-                                "name": tc.get("function", {}).get("name", ""),
-                                "arguments": _try_parse_json(args_str),
+                        tool_calls_list.append(
+                            {
+                                "id": tc.get("id", ""),
+                                "function": {
+                                    "name": tc.get("function", {}).get("name", ""),
+                                    "arguments": _try_parse_json(args_str),
+                                },
                             }
-                        })
+                        )
                     else:
                         # Pydantic model
-                        args_str = getattr(tc.function, 'arguments', '{}') if hasattr(tc, 'function') else '{}'
-                        tool_calls_list.append({
-                            "id": getattr(tc, 'id', ''),
-                            "function": {
-                                "name": getattr(tc.function, 'name', '') if hasattr(tc, 'function') else '',
-                                "arguments": _try_parse_json(args_str),
+                        args_str = (
+                            getattr(tc.function, "arguments", "{}")
+                            if hasattr(tc, "function")
+                            else "{}"
+                        )
+                        tool_calls_list.append(
+                            {
+                                "id": getattr(tc, "id", ""),
+                                "function": {
+                                    "name": getattr(tc.function, "name", "")
+                                    if hasattr(tc, "function")
+                                    else "",
+                                    "arguments": _try_parse_json(args_str),
+                                },
                             }
-                        })
+                        )
                 msg_dict["tool_calls"] = tool_calls_list
                 msg_dict[_PRESERVE_BOUNDARY_KEY] = True
 
@@ -703,9 +767,9 @@ def extract_harmony_messages(
             # Extract text parts from content array
             text_parts = []
             for item in content:
-                if hasattr(item, 'model_dump'):
+                if hasattr(item, "model_dump"):
                     item = item.model_dump()
-                elif hasattr(item, 'dict'):
+                elif hasattr(item, "dict"):
                     item = item.dict()
                 if isinstance(item, dict) and item.get("type") == "text":
                     text_parts.append(item.get("text", ""))
@@ -713,6 +777,6 @@ def extract_harmony_messages(
         else:
             processed_messages.append({"role": role, "content": str(content)})
 
-    return _merge_consecutive_roles(
-        _consolidate_system_messages(processed_messages)
+    return _drop_void_assistant_messages(
+        _merge_consecutive_roles(_consolidate_system_messages(processed_messages))
     )

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -9,6 +9,7 @@ text processing, content extraction, and format conversion.
 from omlx.api.utils import (
     SPECIAL_TOKENS_PATTERN,
     _consolidate_system_messages,
+    _drop_void_assistant_messages,
     _merge_consecutive_roles,
     clean_output_text,
     detect_and_strip_partial,
@@ -246,11 +247,20 @@ class TestExtractTextContent:
         assert "Hello" in result[0]["content"]
 
     def test_none_content(self):
-        """Test extracting message with None content."""
+        """Test that assistant with None content and no tool_calls is dropped (void message)."""
         messages = [Message(role="assistant", content=None)]
 
         result = extract_text_content(messages)
 
+        assert len(result) == 0
+
+    def test_none_content_non_assistant_preserved(self):
+        """Test that non-assistant messages with None content are preserved."""
+        messages = [Message(role="user", content=None)]
+
+        result = extract_text_content(messages)
+
+        assert len(result) == 1
         assert result[0]["content"] == ""
 
     def test_tool_response_message(self):
@@ -354,6 +364,7 @@ class TestExtractTextContent:
     def test_assistant_tool_calls_with_content_array(self):
         """Content array in assistant+tool_calls should be converted to string."""
         from unittest.mock import MagicMock
+
         mock_tokenizer = MagicMock(spec=[])
         mock_tokenizer.has_tool_calling = True
 
@@ -540,6 +551,7 @@ class TestConvertAnthropicToInternal:
 
     def test_native_tool_calling_preserves_structured_tool_history(self):
         """Tool use/result blocks should stay structured when tokenizer supports tools."""
+
         class NativeToolTokenizer:
             has_tool_calling = True
 
@@ -667,6 +679,7 @@ class TestConvertAnthropicToInternal:
 
     def test_tool_result_with_image_native_path(self):
         """Images in tool_result are preserved in native tool calling path."""
+
         class NativeToolTokenizer:
             has_tool_calling = True
 
@@ -1364,7 +1377,10 @@ class TestExtractMultimodalContent:
                 role="user",
                 content=[
                     {"type": "text", "text": "Analyze"},
-                    {"type": "input_image", "image_url": {"url": "https://example.com/a.png"}},
+                    {
+                        "type": "input_image",
+                        "image_url": {"url": "https://example.com/a.png"},
+                    },
                 ],
             )
         ]
@@ -1464,7 +1480,9 @@ class TestExtractTextContentPreservesNamePartial:
                 role="assistant",
                 content="Let me call a tool",
                 name="Kimi",
-                tool_calls=[{"id": "1", "function": {"name": "search", "arguments": "{}"}}],
+                tool_calls=[
+                    {"id": "1", "function": {"name": "search", "arguments": "{}"}}
+                ],
             ),
         ]
         result = extract_text_content(messages)
@@ -1572,3 +1590,75 @@ class TestNameFieldSchemaAcceptance:
         msgs = [Message(role="user", content="Hello")]
         result = extract_text_content(msgs)
         assert "name" not in result[0]
+
+
+class TestDropVoidAssistantMessages:
+    """Tests for _drop_void_assistant_messages."""
+
+    def test_drops_empty_content_no_tool_calls(self):
+        """Assistant message with empty content and no tool_calls should be dropped."""
+        msgs = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "Again"},
+        ]
+        result = _drop_void_assistant_messages(msgs)
+        assert len(result) == 2
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "user"
+
+    def test_drops_none_content_no_tool_calls(self):
+        """Assistant message with None content and no tool_calls should be dropped."""
+        msgs = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": None},
+            {"role": "user", "content": "Again"},
+        ]
+        result = _drop_void_assistant_messages(msgs)
+        assert len(result) == 2
+
+    def test_keeps_assistant_with_content(self):
+        """Assistant message with non-empty content should be kept."""
+        msgs = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "Thanks"},
+        ]
+        result = _drop_void_assistant_messages(msgs)
+        assert len(result) == 3
+
+    def test_keeps_assistant_with_tool_calls(self):
+        """Assistant message with tool_calls should be kept even if content is empty."""
+        msgs = [
+            {"role": "user", "content": "List files"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "1", "function": {"name": "ls"}}],
+            },
+            {"role": "user", "content": "Thanks"},
+        ]
+        result = _drop_void_assistant_messages(msgs)
+        assert len(result) == 3
+
+    def test_preserves_other_roles(self):
+        """Non-assistant messages should never be dropped."""
+        msgs = [
+            {"role": "system", "content": ""},
+            {"role": "user", "content": ""},
+            {"role": "tool", "content": ""},
+        ]
+        result = _drop_void_assistant_messages(msgs)
+        assert len(result) == 3
+
+    def test_extract_text_content_drops_void_assistant(self):
+        """Integration: extract_text_content should drop void assistant messages."""
+        msgs = [
+            Message(role="user", content="Hello"),
+            Message(role="assistant", content=None),
+            Message(role="user", content="Tell me about this repo"),
+        ]
+        result = extract_text_content(msgs)
+        # The void assistant message should be dropped, and the two user
+        # messages merged by _merge_consecutive_roles
+        assert all(m["role"] != "assistant" or m.get("content") for m in result)

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -164,7 +164,7 @@ class TestExtractJsonFromText:
 
     def test_pure_json_array(self):
         """Test extracting pure JSON array."""
-        text = '[1, 2, 3]'
+        text = "[1, 2, 3]"
 
         result = extract_json_from_text(text)
 
@@ -180,11 +180,11 @@ class TestExtractJsonFromText:
 
     def test_json_in_markdown_code_block(self):
         """Test extracting JSON from markdown code block."""
-        text = '''Here is the result:
+        text = """Here is the result:
 ```json
 {"name": "John", "age": 30}
 ```
-'''
+"""
 
         result = extract_json_from_text(text)
 
@@ -192,11 +192,11 @@ class TestExtractJsonFromText:
 
     def test_json_in_plain_code_block(self):
         """Test extracting JSON from plain code block."""
-        text = '''Result:
+        text = """Result:
 ```
 {"status": "ok"}
 ```
-'''
+"""
 
         result = extract_json_from_text(text)
 
@@ -212,7 +212,7 @@ class TestExtractJsonFromText:
 
     def test_no_json_found(self):
         """Test when no valid JSON is found."""
-        text = 'This is just plain text without any JSON.'
+        text = "This is just plain text without any JSON."
 
         result = extract_json_from_text(text)
 
@@ -369,9 +369,9 @@ class TestParseJsonOutput:
 
     def test_json_from_code_block(self):
         """Test extracting JSON from code block."""
-        text = '''```json
+        text = """```json
 {"result": true}
-```'''
+```"""
         response_format = {"type": "json_object"}
 
         cleaned, parsed, is_valid, error = parse_json_output(text, response_format)
@@ -568,7 +568,10 @@ class TestConvertToolsForTemplate:
         result = convert_tools_for_template(tools)
 
         assert result is not None
-        assert result[0]["function"]["parameters"] == {"type": "object", "properties": {}}
+        assert result[0]["function"]["parameters"] == {
+            "type": "object",
+            "properties": {},
+        }
 
 
 class TestFormatToolCallForMessage:
@@ -770,7 +773,9 @@ class TestToolCallStreamFilter:
         result += f.finish()
         assert result == "literal [Calling tool: maybe later] and then  done"
 
-    def test_unresolved_bracket_prefix_before_parseable_envelope_does_not_leak_marker(self):
+    def test_unresolved_bracket_prefix_before_parseable_envelope_does_not_leak_marker(
+        self,
+    ):
         """An unresolved early bracket prefix must not leak when a later call is parseable."""
         f = ToolCallStreamFilter(_make_tokenizer())
         text = (
@@ -821,7 +826,7 @@ class TestToolCallStreamFilter:
     def test_hyphen_namespaced_tool_call_open_suppresses_markup(self):
         """Hyphenated namespace tool-call open tag should trigger suppression."""
         f = ToolCallStreamFilter(_make_tokenizer())
-        result = f.feed("Before <foo-bar:tool_call><invoke name=\"x\">")
+        result = f.feed('Before <foo-bar:tool_call><invoke name="x">')
         assert result == "Before "
         assert f.finish() == ""
 
@@ -940,18 +945,14 @@ class TestToolCallStreamFilterSuppressAfterMarker:
 
     def test_suppress_after_marker_basic(self):
         """Everything after a one-sided marker should be suppressed."""
-        f = ToolCallStreamFilter(
-            _make_tokenizer_with_end("[TOOL_CALLS]", "")
-        )
+        f = ToolCallStreamFilter(_make_tokenizer_with_end("[TOOL_CALLS]", ""))
         result = f.feed('[TOOL_CALLS]func_name[ARGS]{"key":"val"}')
         result += f.finish()
         assert result == ""
 
     def test_suppress_after_marker_with_preceding_text(self):
         """Text before one-sided marker should pass through."""
-        f = ToolCallStreamFilter(
-            _make_tokenizer_with_end("[TOOL_CALLS]", "")
-        )
+        f = ToolCallStreamFilter(_make_tokenizer_with_end("[TOOL_CALLS]", ""))
         r1 = f.feed("Hello ")
         r2 = f.feed('[TOOL_CALLS]func_name[ARGS]{"key":"val"}')
         result = r1 + r2 + f.finish()
@@ -959,9 +960,7 @@ class TestToolCallStreamFilterSuppressAfterMarker:
 
     def test_suppress_after_marker_partial_prefix(self):
         """Partial one-sided marker prefix should be buffered."""
-        f = ToolCallStreamFilter(
-            _make_tokenizer_with_end("[TOOL_CALLS]", "")
-        )
+        f = ToolCallStreamFilter(_make_tokenizer_with_end("[TOOL_CALLS]", ""))
         r1 = f.feed("[TOOL")
         r2 = f.feed('_CALLS]func_name[ARGS]{"key":"val"}')
         result = r1 + r2 + f.finish()
@@ -969,9 +968,7 @@ class TestToolCallStreamFilterSuppressAfterMarker:
 
     def test_suppress_after_marker_multi_feed(self):
         """Permanent suppression persists across multiple feeds."""
-        f = ToolCallStreamFilter(
-            _make_tokenizer_with_end("[TOOL_CALLS]", "")
-        )
+        f = ToolCallStreamFilter(_make_tokenizer_with_end("[TOOL_CALLS]", ""))
         r1 = f.feed("Hi [TOOL_CALLS]start")
         r2 = f.feed(" more data")
         r3 = f.feed(" even more")
@@ -998,6 +995,89 @@ class TestParseToolCallsEmptyEndMarker:
         assert tool_calls is not None
         assert len(tool_calls) == 1
         assert tool_calls[0].function.name == "test_func"
+
+    def test_empty_end_marker_parses_content_after_marker(self):
+        """One-sided marker should pass everything after it to the parser."""
+        received_inputs = []
+
+        def mock_parser(text, tools):
+            received_inputs.append(text)
+            return {"name": "list_files", "arguments": {"path": "."}}
+
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = True
+        tok.tool_call_start = "[TOOL_CALLS]"
+        tok.tool_call_end = ""
+        tok.tool_parser = mock_parser
+
+        text = '[TOOL_CALLS]list_files[ARGS]{"path": "."}'
+        cleaned, tool_calls = parse_tool_calls(text, tok)
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "list_files"
+        # Parser should receive the content after [TOOL_CALLS], not empty string
+        assert len(received_inputs) == 1
+        assert received_inputs[0] == 'list_files[ARGS]{"path": "."}'
+
+    def test_empty_end_marker_cleans_text_before_marker(self):
+        """Text before a one-sided marker should be preserved as cleaned_text."""
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = True
+        tok.tool_call_start = "[TOOL_CALLS]"
+        tok.tool_call_end = ""
+        tok.tool_parser = lambda text, tools: {
+            "name": "read_file",
+            "arguments": {"path": "README.md"},
+        }
+
+        text = 'Let me check that file.[TOOL_CALLS]read_file[ARGS]{"path": "README.md"}'
+        cleaned, tool_calls = parse_tool_calls(text, tok)
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert cleaned == "Let me check that file."
+
+    def test_empty_end_marker_multiple_tool_calls(self):
+        """Multiple one-sided tool calls should each be parsed separately."""
+        call_count = [0]
+
+        def mock_parser(text, tools):
+            call_count[0] += 1
+            if "list_files" in text:
+                return {"name": "list_files", "arguments": {"path": "."}}
+            elif "read_file" in text:
+                return {"name": "read_file", "arguments": {"path": "README.md"}}
+            raise ValueError(f"Unexpected: {text}")
+
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = True
+        tok.tool_call_start = "[TOOL_CALLS]"
+        tok.tool_call_end = ""
+        tok.tool_parser = mock_parser
+
+        text = '[TOOL_CALLS]list_files[ARGS]{"path": "."}[TOOL_CALLS]read_file[ARGS]{"path": "README.md"}'
+        cleaned, tool_calls = parse_tool_calls(text, tok)
+        assert tool_calls is not None
+        assert len(tool_calls) == 2
+        assert tool_calls[0].function.name == "list_files"
+        assert tool_calls[1].function.name == "read_file"
+        assert call_count[0] == 2
+
+    def test_empty_end_marker_parser_failure_skips(self):
+        """If the parser fails on a segment, it should be skipped gracefully."""
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = True
+        tok.tool_call_start = "[TOOL_CALLS]"
+        tok.tool_call_end = ""
+
+        def failing_parser(text, tools):
+            raise ValueError("parse error")
+
+        tok.tool_parser = failing_parser
+
+        text = "[TOOL_CALLS]bad_input"
+        cleaned, tool_calls = parse_tool_calls(text, tok)
+        # Should fall through to other fallback parsers, not crash
+        assert tool_calls is None or len(tool_calls) == 0
 
 
 class TestParseBracketToolCalls:
@@ -1054,10 +1134,7 @@ class TestParseBracketToolCalls:
         """Both [Tool call:] and [Calling tool:] in same text should parse."""
         from omlx.api.tool_calling import _parse_bracket_tool_calls
 
-        text = (
-            '[Tool call: tool_a({"x":1})] middle '
-            '[Calling tool: tool_b({"y":2})]'
-        )
+        text = '[Tool call: tool_a({"x":1})] middle [Calling tool: tool_b({"y":2})]'
         cleaned, tool_calls = _parse_bracket_tool_calls(text)
         assert tool_calls is not None
         assert len(tool_calls) == 2
@@ -1092,7 +1169,9 @@ class TestParseToolCallsWithThinkingFallback:
         tok = self._make_tokenizer()
 
         cleaned, tool_calls = parse_tool_calls_with_thinking_fallback(
-            thinking, regular, tokenizer=tok,
+            thinking,
+            regular,
+            tokenizer=tok,
         )
         assert tool_calls is not None
         assert len(tool_calls) == 1
@@ -1106,7 +1185,9 @@ class TestParseToolCallsWithThinkingFallback:
         tok = self._make_tokenizer()
 
         cleaned, tool_calls = parse_tool_calls_with_thinking_fallback(
-            thinking, regular, tokenizer=tok,
+            thinking,
+            regular,
+            tokenizer=tok,
         )
         assert tool_calls is not None
         assert len(tool_calls) == 1
@@ -1119,7 +1200,9 @@ class TestParseToolCallsWithThinkingFallback:
         tok = self._make_tokenizer()
 
         cleaned, tool_calls = parse_tool_calls_with_thinking_fallback(
-            thinking, regular, tokenizer=tok,
+            thinking,
+            regular,
+            tokenizer=tok,
         )
         assert tool_calls is None
         assert cleaned == "Here is my answer."
@@ -1131,7 +1214,9 @@ class TestParseToolCallsWithThinkingFallback:
         tok = self._make_tokenizer()
 
         cleaned, tool_calls = parse_tool_calls_with_thinking_fallback(
-            thinking, regular, tokenizer=tok,
+            thinking,
+            regular,
+            tokenizer=tok,
         )
         assert tool_calls is None
         assert cleaned == "Just a regular response."
@@ -1139,15 +1224,17 @@ class TestParseToolCallsWithThinkingFallback:
     def test_thinking_fallback_qwen_format(self):
         """Qwen/Llama XML format inside thinking is recovered."""
         thinking = (
-            '<tool_call>'
-            '<function=read><parameter=filePath>/src/main.py</parameter></function>'
-            '</tool_call>'
+            "<tool_call>"
+            "<function=read><parameter=filePath>/src/main.py</parameter></function>"
+            "</tool_call>"
         )
         regular = ""
         tok = self._make_tokenizer()
 
         cleaned, tool_calls = parse_tool_calls_with_thinking_fallback(
-            thinking, regular, tokenizer=tok,
+            thinking,
+            regular,
+            tokenizer=tok,
         )
         assert tool_calls is not None
         assert len(tool_calls) == 1
@@ -1156,14 +1243,15 @@ class TestParseToolCallsWithThinkingFallback:
     def test_cleaned_text_from_regular_not_thinking(self):
         """cleaned_text always comes from regular_content, not thinking."""
         thinking = (
-            'reasoning here '
-            '<tool_call>{"name": "func", "arguments": {}}</tool_call>'
+            'reasoning here <tool_call>{"name": "func", "arguments": {}}</tool_call>'
         )
         regular = "visible response text"
         tok = self._make_tokenizer()
 
         cleaned, tool_calls = parse_tool_calls_with_thinking_fallback(
-            thinking, regular, tokenizer=tok,
+            thinking,
+            regular,
+            tokenizer=tok,
         )
         assert tool_calls is not None
         assert cleaned == "visible response text"
@@ -1171,9 +1259,9 @@ class TestParseToolCallsWithThinkingFallback:
     def test_extract_tool_calls_with_thinking_sanitizes_reasoning_markup(self):
         """Sanitized reasoning should keep prose but drop tool-call control text."""
         thinking = (
-            'Need to inspect first.'
+            "Need to inspect first."
             '<tool_call>{"name": "read_file", "arguments": {"path": "/tmp/a.py"}}</tool_call>'
-            'Then continue.'
+            "Then continue."
         )
         tok = self._make_tokenizer()
 
@@ -1186,14 +1274,16 @@ class TestParseToolCallsWithThinkingFallback:
         assert "Need to inspect first." in result.cleaned_thinking
         assert "Then continue." in result.cleaned_thinking
 
-    def test_extract_tool_calls_with_thinking_sanitizes_reasoning_even_when_regular_wins(self):
+    def test_extract_tool_calls_with_thinking_sanitizes_reasoning_even_when_regular_wins(
+        self,
+    ):
         """Thinking cleanup should still run when regular content provides tool calls."""
         thinking = (
-            'Reason about it.'
+            "Reason about it."
             '<tool_call>{"name": "wrong_tool", "arguments": {}}</tool_call>'
         )
         regular = (
-            'Visible text'
+            "Visible text"
             '<tool_call>{"name": "correct_tool", "arguments": {}}</tool_call>'
         )
         tok = self._make_tokenizer()


### PR DESCRIPTION
## Summary

Fixes Devstral (and any Mistral model with `tool_call_end=""`) tool calling being completely broken — tool calls produce silent empty responses, and subsequent turns crash with a 400 template error.

Closes #464

## Root Cause

Two bugs, same origin — Devstral's tool calling format uses a **one-sided marker** (`tool_call_start="[TOOL_CALLS]"`, `tool_call_end=""`). The model outputs `[TOOL_CALLS]name[ARGS]{...}` with no closing marker.

**Bug 1 — `parse_tool_calls()` silent failure:**  
The condition `tool_call_end is not None` passes (empty string ≠ None), then the regex `r'\[TOOL_CALLS\](.*?)'` with non-greedy `(.*?)` and empty end anchor captures **zero characters every time**. The parser fails silently (exception swallowed), no tool calls are ever extracted. Meanwhile `ToolCallStreamFilter` correctly suppresses the raw markup from content, so the response has `content=None, tool_calls=None` — a silent empty response.

**Bug 2 — Void assistant messages crash strict chat templates:**  
The empty response from Bug 1 gets echoed back by the client as `{"role": "assistant", "content": null}` with no `tool_calls`. Devstral's Jinja chat template explicitly rejects assistant messages with empty content AND no tool_calls with `raise_exception()`.

## Changes

- **`omlx/api/tool_calling.py`**: When `tool_call_end` is falsy, split on the start marker with `re.split()` and parse each segment individually, instead of the broken start/end regex pair. Each segment is passed to the model's native `tool_parser` one at a time (it handles one call per invocation).

- **`omlx/api/utils.py`**: Added `_drop_void_assistant_messages()` — filters out assistant messages with no content AND no tool_calls before template rendering. Wired into all three extract functions (`extract_text_content`, `extract_multimodal_content`, `extract_harmony_messages`).

## Why this is safe for other models

- **Bug 1 fix**: Gated by `if tool_call_end:` / `else:`. Models with paired markers (e.g. `<tool_call>...</tool_call>`) have truthy `tool_call_end` and take the existing path unchanged. Only models with empty/falsy `tool_call_end` (Mistral/Devstral) take the new path.

- **Bug 2 fix**: Only drops assistant messages where content is empty/None AND there are no tool_calls. These are semantically empty no-op messages. The OpenAI API itself doesn't allow them. Dropping them is strictly better than crashing on strict templates, and harmless on lenient ones.

## Tests

- 5 new tests in `TestParseToolCallsEmptyEndMarker`: content parsing, text cleaning, multiple tool calls, parser failure handling, native parser invocation
- 7 new tests in `TestDropVoidAssistantMessages`: void message dropping, content/tool_call preservation, role filtering, integration with `extract_text_content`
- Updated `test_none_content` to reflect new void-dropping behavior
- All 225 tests in the modified files pass; integration and streaming tests unaffected