### PR TITLE
feat: add voice cloning support to TTS endpoint

### DIFF
--- a/omlx/api/audio_models.py
+++ b/omlx/api/audio_models.py
@@ -36,6 +36,8 @@ class AudioSpeechRequest(BaseModel):
     instructions: Optional[str] = None
     speed: Optional[float] = 1.0
     response_format: Optional[str] = "wav"
+    ref_audio: Optional[str] = None
+    ref_text: Optional[str] = None
 
 
 class AudioProcessRequest(BaseModel):

--- a/omlx/api/audio_routes.py
+++ b/omlx/api/audio_routes.py
@@ -186,6 +186,8 @@ async def create_speech(request: AudioSpeechRequest):
             voice=request.voice,
             speed=request.speed,
             instructions=request.instructions,
+            ref_audio=request.ref_audio,
+            ref_text=request.ref_text,
         )
     except HTTPException:
         raise

--- a/omlx/engine/tts.py
+++ b/omlx/engine/tts.py
@@ -117,6 +117,8 @@ class TTSEngine(BaseNonStreamingEngine):
         voice: Optional[str] = None,
         speed: float = 1.0,
         instructions: Optional[str] = None,
+        ref_audio: Optional[str] = None,
+        ref_text: Optional[str] = None,
         **kwargs,
     ) -> bytes:
         """
@@ -127,6 +129,10 @@ class TTSEngine(BaseNonStreamingEngine):
             voice: Optional voice/speaker identifier
             speed: Speech speed multiplier (1.0 = normal)
             instructions: Optional voice description for instruct-capable models
+            ref_audio: Optional base64 data URI or URL of reference audio for
+                voice cloning (requires a model that supports
+                ``generate_voice_clone``, e.g. Qwen3-TTS Base)
+            ref_text: Optional transcript of the reference audio
             **kwargs: Additional model-specific parameters
 
         Returns:
@@ -138,13 +144,59 @@ class TTSEngine(BaseNonStreamingEngine):
         import time
 
         logger.info(
-            "TTS synthesize: model=%s, text_len=%d, voice=%s, speed=%.1f",
+            "TTS synthesize: model=%s, text_len=%d, voice=%s, speed=%.1f, "
+            "voice_clone=%s",
             self._model_name, len(text), voice, speed,
+            bool(ref_audio),
         )
 
         model = self._model
         t0 = time.monotonic()
 
+        # --- Voice-clone path ---
+        if ref_audio is not None:
+            if not hasattr(model, "generate_voice_clone"):
+                raise RuntimeError(
+                    f"Model '{self._model_name}' does not support voice "
+                    "cloning (missing generate_voice_clone method)"
+                )
+
+            ref_audio_path = self._decode_ref_audio(ref_audio)
+
+            def _clone_sync():
+                try:
+                    results = model.generate_voice_clone(
+                        text=text,
+                        language=voice,
+                        ref_audio=ref_audio_path,
+                        ref_text=ref_text or "",
+                    )
+                    audio_chunks = []
+                    sample_rate = _DEFAULT_SAMPLE_RATE
+                    for result in results:
+                        audio_chunks.append(np.array(result.audio))
+                        if hasattr(result, "sample_rate"):
+                            sample_rate = result.sample_rate
+                    if not audio_chunks:
+                        raise RuntimeError("Voice clone produced no audio output")
+                    audio = np.concatenate(audio_chunks, axis=0)
+                    return _audio_to_wav_bytes(audio, int(sample_rate))
+                finally:
+                    self._cleanup_ref_audio(ref_audio_path)
+
+            loop = asyncio.get_running_loop()
+            result = await loop.run_in_executor(
+                get_mlx_executor(), _clone_sync
+            )
+
+            elapsed = time.monotonic() - t0
+            logger.info(
+                "TTS voice-clone done: model=%s, %.2fs, %d bytes output",
+                self._model_name, elapsed, len(result),
+            )
+            return result
+
+        # --- Standard synthesis path ---
         def _synthesize_sync():
             # model.generate() returns an iterable of results,
             # each with .audio (array) and .sample_rate (int).
@@ -195,6 +247,62 @@ class TTSEngine(BaseNonStreamingEngine):
             self._model_name, elapsed, len(result),
         )
         return result
+
+    # ------------------------------------------------------------------
+    # Voice-clone helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _decode_ref_audio(ref_audio: str) -> str:
+        """Decode a base64 data URI or URL to a temporary WAV file path.
+
+        Supported formats:
+        - ``data:audio/...;base64,<data>`` (data URI)
+        - Raw base64 string (no ``data:`` prefix)
+        - ``http://`` / ``https://`` URL (downloaded to a temp file)
+
+        Returns:
+            Absolute path to a temporary WAV file.  The caller is
+            responsible for cleaning up via :meth:`_cleanup_ref_audio`.
+        """
+        import base64
+        import tempfile
+        import urllib.request
+
+        if ref_audio.startswith(("http://", "https://")):
+            tmp = tempfile.NamedTemporaryFile(
+                delete=False, suffix=".wav", prefix="omlx_ref_"
+            )
+            try:
+                urllib.request.urlretrieve(ref_audio, tmp.name)
+            except Exception:
+                import os
+                os.unlink(tmp.name)
+                raise
+            return tmp.name
+
+        # Strip data-URI header if present
+        data = ref_audio
+        if data.startswith("data:"):
+            # data:audio/wav;base64,<payload>
+            _, _, data = data.partition(",")
+
+        raw = base64.b64decode(data)
+        tmp = tempfile.NamedTemporaryFile(
+            delete=False, suffix=".wav", prefix="omlx_ref_"
+        )
+        tmp.write(raw)
+        tmp.close()
+        return tmp.name
+
+    @staticmethod
+    def _cleanup_ref_audio(path: str) -> None:
+        """Remove a temporary reference-audio file (best-effort)."""
+        import os
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
 
     def get_stats(self) -> Dict[str, Any]:
         """Get engine statistics."""

--- a/tests/test_audio_tts.py
+++ b/tests/test_audio_tts.py
@@ -334,6 +334,223 @@ class TestTTSVoiceRouting:
 
 
 # ---------------------------------------------------------------------------
+# TestTTSVoiceClone — unit tests for voice-clone (ref_audio) path
+# ---------------------------------------------------------------------------
+
+
+class TestTTSVoiceClone:
+    """Verify the voice-clone code path in TTSEngine.synthesize()."""
+
+    @pytest.fixture
+    def _ref_audio_b64(self):
+        """Return a base64 data URI containing a minimal valid WAV."""
+        import base64
+        wav = _make_wav_bytes(duration_secs=0.05)
+        return "data:audio/wav;base64," + base64.b64encode(wav).decode()
+
+    @pytest.fixture
+    def _make_clone_engine(self):
+        """Build a TTSEngine whose model has generate_voice_clone."""
+        import asyncio
+        from omlx.engine.tts import TTSEngine
+
+        def _build(clone_returns_audio=True):
+            engine = TTSEngine("test-clone-model")
+            mock_model = MagicMock()
+
+            if clone_returns_audio:
+                import numpy as np
+                chunk = MagicMock()
+                chunk.audio = np.zeros(1000, dtype=np.float32)
+                chunk.sample_rate = 22050
+                mock_model.generate_voice_clone = MagicMock(return_value=[chunk])
+            else:
+                mock_model.generate_voice_clone = MagicMock(return_value=[])
+
+            # Also give it generate() for the non-clone path
+            mock_model.generate = MagicMock(return_value=[])
+            engine._model = mock_model
+            return engine
+
+        return _build
+
+    def test_voice_clone_calls_generate_voice_clone(
+        self, _make_clone_engine, _ref_audio_b64
+    ):
+        """When ref_audio is provided, generate_voice_clone is called."""
+        import asyncio
+        engine = _make_clone_engine()
+        asyncio.run(engine.synthesize(
+            "Hello", ref_audio=_ref_audio_b64, ref_text="hello",
+        ))
+        engine._model.generate_voice_clone.assert_called_once()
+        engine._model.generate.assert_not_called()
+
+    def test_voice_clone_passes_ref_text(
+        self, _make_clone_engine, _ref_audio_b64
+    ):
+        """ref_text is forwarded to generate_voice_clone."""
+        import asyncio
+        engine = _make_clone_engine()
+        asyncio.run(engine.synthesize(
+            "Hi", ref_audio=_ref_audio_b64, ref_text="reference text",
+        ))
+        call_kwargs = engine._model.generate_voice_clone.call_args.kwargs
+        assert call_kwargs["ref_text"] == "reference text"
+
+    def test_voice_clone_returns_wav(
+        self, _make_clone_engine, _ref_audio_b64
+    ):
+        """Voice-clone path returns valid WAV bytes."""
+        import asyncio
+        engine = _make_clone_engine()
+        result = asyncio.run(engine.synthesize(
+            "Test", ref_audio=_ref_audio_b64, ref_text="test",
+        ))
+        assert isinstance(result, bytes)
+        assert result[:4] == RIFF_MAGIC
+
+    def test_voice_clone_no_audio_raises(
+        self, _make_clone_engine, _ref_audio_b64
+    ):
+        """Voice-clone with empty model output raises RuntimeError."""
+        import asyncio
+        engine = _make_clone_engine(clone_returns_audio=False)
+        with pytest.raises(RuntimeError, match="no audio"):
+            asyncio.run(engine.synthesize(
+                "Fail", ref_audio=_ref_audio_b64, ref_text="fail",
+            ))
+
+    def test_voice_clone_missing_method_raises(self, _ref_audio_b64):
+        """Model without generate_voice_clone raises RuntimeError."""
+        import asyncio
+        from omlx.engine.tts import TTSEngine
+        engine = TTSEngine("no-clone-model")
+        mock_model = MagicMock(spec=[])  # no attributes
+        engine._model = mock_model
+        with pytest.raises(RuntimeError, match="does not support voice cloning"):
+            asyncio.run(engine.synthesize(
+                "Fail", ref_audio=_ref_audio_b64,
+            ))
+
+    def test_without_ref_audio_uses_generate(self, _make_clone_engine):
+        """Without ref_audio, the standard generate() path is used."""
+        import asyncio
+        import numpy as np
+        engine = _make_clone_engine()
+        # Make generate() return audio so it doesn't raise
+        chunk = MagicMock()
+        chunk.audio = np.zeros(1000, dtype=np.float32)
+        chunk.sample_rate = 22050
+        engine._model.generate.return_value = [chunk]
+        import inspect
+        engine._model.generate.__signature__ = inspect.Signature(
+            parameters=[
+                inspect.Parameter("text", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+                inspect.Parameter("verbose", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=False),
+            ]
+        )
+        asyncio.run(engine.synthesize("Hello"))
+        engine._model.generate.assert_called_once()
+        engine._model.generate_voice_clone.assert_not_called()
+
+    def test_ref_audio_temp_file_cleaned_up(
+        self, _make_clone_engine, _ref_audio_b64
+    ):
+        """Temporary reference audio file is removed after synthesis."""
+        import asyncio
+        import os
+        engine = _make_clone_engine()
+        # Capture the ref_audio path passed to generate_voice_clone
+        captured_path = []
+        original = engine._model.generate_voice_clone
+
+        def _capture(*args, **kwargs):
+            captured_path.append(kwargs.get("ref_audio", args[2] if len(args) > 2 else None))
+            return original(*args, **kwargs)
+
+        engine._model.generate_voice_clone = _capture
+        asyncio.run(engine.synthesize(
+            "Test", ref_audio=_ref_audio_b64, ref_text="test",
+        ))
+        assert captured_path
+        assert not os.path.exists(captured_path[0])
+
+
+class TestTTSVoiceCloneEndpoint:
+    """Verify the /v1/audio/speech endpoint passes voice-clone params."""
+
+    def test_ref_audio_forwarded_to_engine(self, server_tts_client):
+        """ref_audio and ref_text are forwarded to synthesize()."""
+        import base64
+        client, mock_pool = server_tts_client
+        ref_b64 = "data:audio/wav;base64," + base64.b64encode(b"RIFF").decode()
+        response = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts",
+                "input": "Hello",
+                "ref_audio": ref_b64,
+                "ref_text": "hello",
+            },
+        )
+        assert response.status_code == 200
+        synthesize: AsyncMock = mock_pool.get_engine.return_value.synthesize
+        call_kwargs = synthesize.call_args.kwargs
+        assert call_kwargs.get("ref_audio") == ref_b64
+        assert call_kwargs.get("ref_text") == "hello"
+
+    def test_no_ref_audio_still_works(self, server_tts_client):
+        """Without ref_audio, endpoint works as before."""
+        client, mock_pool = server_tts_client
+        response = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "Hello"},
+        )
+        assert response.status_code == 200
+        synthesize: AsyncMock = mock_pool.get_engine.return_value.synthesize
+        call_kwargs = synthesize.call_args.kwargs
+        assert call_kwargs.get("ref_audio") is None
+        assert call_kwargs.get("ref_text") is None
+
+
+# ---------------------------------------------------------------------------
+# TestTTSDecodeRefAudio — unit tests for _decode_ref_audio helper
+# ---------------------------------------------------------------------------
+
+
+class TestTTSDecodeRefAudio:
+    """Verify _decode_ref_audio handles different input formats."""
+
+    def test_data_uri(self):
+        """data:audio/wav;base64,... is decoded correctly."""
+        import base64
+        import os
+        from omlx.engine.tts import TTSEngine
+        payload = b"fake-wav-content"
+        data_uri = "data:audio/wav;base64," + base64.b64encode(payload).decode()
+        path = TTSEngine._decode_ref_audio(data_uri)
+        try:
+            with open(path, "rb") as f:
+                assert f.read() == payload
+        finally:
+            os.unlink(path)
+
+    def test_raw_base64(self):
+        """Raw base64 string (no data: prefix) is decoded correctly."""
+        import base64
+        import os
+        from omlx.engine.tts import TTSEngine
+        payload = b"raw-audio-bytes"
+        path = TTSEngine._decode_ref_audio(base64.b64encode(payload).decode())
+        try:
+            with open(path, "rb") as f:
+                assert f.read() == payload
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
 # Integration test (slow, requires mlx-audio)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `ref_audio` (base64 data URI / URL) and `ref_text` parameters to `AudioSpeechRequest` and `/v1/audio/speech` endpoint
- When `ref_audio` is provided, `TTSEngine.synthesize()` calls `model.generate_voice_clone()` instead of `model.generate()`, enabling Qwen3-TTS Base voice cloning
- Supports base64 data URIs, raw base64 strings, and HTTP(S) URLs for reference audio input
- Temporary reference audio files are cleaned up after synthesis
- Existing functionality is unchanged when `ref_audio` is not provided

## Files changed

| File | Change |
|------|--------|
| `omlx/api/audio_models.py` | Add `ref_audio`, `ref_text` fields to `AudioSpeechRequest` |
| `omlx/api/audio_routes.py` | Forward new params to `engine.synthesize()` |
| `omlx/engine/tts.py` | Voice-clone path + `_decode_ref_audio` / `_cleanup_ref_audio` helpers |
| `tests/test_audio_tts.py` | 11 new unit tests (engine, endpoint, decoder) |

## Test plan

- [x] All 29 TTS tests pass (18 existing + 11 new)
- [x] Voice-clone path calls `generate_voice_clone` with correct args
- [x] Standard synthesis path unchanged when `ref_audio` is absent
- [x] Temp files cleaned up after synthesis
- [x] Models without `generate_voice_clone` raise clear error
- [x] Integration test with real Qwen3-TTS Base model (requires mlx-audio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)