### PR TITLE
fix: support structuredContent in MCP tool responses

### DIFF
--- a/omlx/mcp/client.py
+++ b/omlx/mcp/client.py
@@ -198,7 +198,10 @@ class MCPClient:
             self._session = ClientSession(self._read, self._write)
             await self._session.__aenter__()
         except Exception:
-            if hasattr(self, '_streamable_http_client') and self._streamable_http_client:
+            if (
+                hasattr(self, "_streamable_http_client")
+                and self._streamable_http_client
+            ):
                 await self._streamable_http_client.__aexit__(None, None, None)
                 self._streamable_http_client = None
             await self._http_client.__aexit__(None, None, None)
@@ -232,7 +235,9 @@ class MCPClient:
                     server_name=self.name,
                     name=tool.name,
                     description=tool.description or "",
-                    input_schema=tool.inputSchema if hasattr(tool, 'inputSchema') else {},
+                    input_schema=tool.inputSchema
+                    if hasattr(tool, "inputSchema")
+                    else {},
                 )
                 self._tools.append(mcp_tool)
                 logger.debug(f"Discovered tool: {mcp_tool.full_name}")
@@ -248,11 +253,11 @@ class MCPClient:
                 await self._session.__aexit__(None, None, None)
                 self._session = None
 
-            if hasattr(self, '_stdio_client') and self._stdio_client:
+            if hasattr(self, "_stdio_client") and self._stdio_client:
                 await self._stdio_client.__aexit__(None, None, None)
                 self._stdio_client = None
 
-            if hasattr(self, '_sse_client') and self._sse_client:
+            if hasattr(self, "_sse_client") and self._sse_client:
                 await self._sse_client.__aexit__(None, None, None)
                 self._sse_client = None
 
@@ -331,7 +336,7 @@ class MCPClient:
             return MCPToolResult(
                 tool_name=tool_name,
                 content=content,
-                is_error=result.isError if hasattr(result, 'isError') else False,
+                is_error=result.isError if hasattr(result, "isError") else False,
             )
 
         except asyncio.TimeoutError:
@@ -351,15 +356,18 @@ class MCPClient:
 
     def _extract_content(self, result) -> Any:
         """Extract content from MCP tool result."""
-        if not hasattr(result, 'content') or not result.content:
+        if not hasattr(result, "content") or not result.content:
+            # Fall back to structuredContent if available (used by web search tools)
+            if hasattr(result, "structuredContent") and result.structuredContent:
+                return result.structuredContent
             return None
 
         # Handle list of content items
         contents = []
         for item in result.content:
-            if hasattr(item, 'text'):
+            if hasattr(item, "text"):
                 contents.append(item.text)
-            elif hasattr(item, 'data'):
+            elif hasattr(item, "data"):
                 contents.append(item.data)
             else:
                 contents.append(str(item))

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -235,9 +235,13 @@ class TestMCPClientConnect:
     async def test_connect_stdio_success(self, stdio_client: MCPClient):
         """Test successful stdio connection."""
         # Mock the internal methods instead of trying to patch imports
-        with patch.object(stdio_client, "_connect_stdio", new_callable=AsyncMock) as mock_connect, \
-             patch.object(stdio_client, "_initialize_session", new_callable=AsyncMock), \
-             patch.object(stdio_client, "_discover_tools", new_callable=AsyncMock):
+        with (
+            patch.object(
+                stdio_client, "_connect_stdio", new_callable=AsyncMock
+            ) as mock_connect,
+            patch.object(stdio_client, "_initialize_session", new_callable=AsyncMock),
+            patch.object(stdio_client, "_discover_tools", new_callable=AsyncMock),
+        ):
             mock_connect.return_value = None
             # Set up session to pass the check
             stdio_client._session = MagicMock()
@@ -251,9 +255,11 @@ class TestMCPClientConnect:
     @pytest.mark.asyncio
     async def test_connect_sse_success(self, sse_client: MCPClient):
         """Test successful SSE connection."""
-        with patch.object(sse_client, "_connect_sse", new_callable=AsyncMock), \
-             patch.object(sse_client, "_initialize_session", new_callable=AsyncMock), \
-             patch.object(sse_client, "_discover_tools", new_callable=AsyncMock):
+        with (
+            patch.object(sse_client, "_connect_sse", new_callable=AsyncMock),
+            patch.object(sse_client, "_initialize_session", new_callable=AsyncMock),
+            patch.object(sse_client, "_discover_tools", new_callable=AsyncMock),
+        ):
             sse_client._session = MagicMock()
 
             result = await sse_client.connect()
@@ -433,9 +439,14 @@ class TestMCPClientDisconnect:
         mock_stdio = AsyncMock()
 
         with (
-            patch.object(client, "_connect_stdio", new_callable=AsyncMock) as mock_connect,
-            patch.object(client, "_initialize_session", new_callable=AsyncMock) as mock_init,
+            patch.object(
+                client, "_connect_stdio", new_callable=AsyncMock
+            ) as mock_connect,
+            patch.object(
+                client, "_initialize_session", new_callable=AsyncMock
+            ) as mock_init,
         ):
+
             async def setup_partial_resources():
                 client._stdio_client = mock_stdio
                 client._session = AsyncMock()
@@ -465,8 +476,11 @@ class TestMCPClientDisconnect:
 
         with (
             patch("omlx.mcp.client.MCPClient._connect_streamable_http") as mock_connect,
-            patch.object(client, "_initialize_session", new_callable=AsyncMock) as mock_init,
+            patch.object(
+                client, "_initialize_session", new_callable=AsyncMock
+            ) as mock_init,
         ):
+
             async def setup_and_fail():
                 client._http_client = mock_http_client
                 client._streamable_http_client = mock_streamable
@@ -543,6 +557,7 @@ class TestMCPClientCallTool:
     @pytest.mark.asyncio
     async def test_call_tool_timeout(self, connected_client: MCPClient):
         """Test tool call timeout."""
+
         async def slow_call(*args, **kwargs):
             await asyncio.sleep(10)
 
@@ -591,6 +606,23 @@ class TestMCPClientCallTool:
 
         assert result.is_error is False
         assert result.content == ["Line 1", "Line 2"]
+
+    @pytest.mark.asyncio
+    async def test_call_tool_structured_content(self, connected_client: MCPClient):
+        """Test tool call with structuredContent (used by web search tools)."""
+        mock_result = MagicMock()
+        mock_result.content = []
+        mock_result.structuredContent = {"results": ["Result 1", "Result 2"]}
+        mock_result.isError = False
+        connected_client._session.call_tool.return_value = mock_result
+
+        result = await connected_client.call_tool("web_search", {"query": "test"})
+
+        assert result.is_error is False
+        assert result.content == {"results": ["Result 1", "Result 2"]}
+        connected_client._session.call_tool.assert_called_with(
+            "web_search", {"query": "test"}
+        )
 
     @pytest.mark.asyncio
     async def test_call_tool_data_content(self, connected_client: MCPClient):

--- a/tests/test_structured_content.py
+++ b/tests/test_structured_content.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for structuredContent support in MCP tool results.
+
+This addresses issue #469: MCP web search returns no output.
+Web search MCP servers return results in structuredContent field.
+"""
+
+from unittest.mock import MagicMock
+
+
+def test_extract_content_with_structured_content():
+    """Test that _extract_content falls back to structuredContent when content is empty."""
+    from omlx.mcp.client import MCPClient
+    from omlx.mcp.types import MCPServerConfig, MCPTransport
+
+    config = MCPServerConfig(
+        name="test",
+        transport=MCPTransport.STDIO,
+        command="python",
+    )
+    client = MCPClient(config)
+
+    mock_result = MagicMock()
+    mock_result.content = []
+    mock_result.structuredContent = {"results": ["Result 1", "Result 2"]}
+
+    result = client._extract_content(mock_result)
+
+    assert result == {"results": ["Result 1", "Result 2"]}
+
+
+def test_extract_content_with_text_content():
+    """Test that _extract_content still works with regular text content."""
+    from omlx.mcp.client import MCPClient
+    from omlx.mcp.types import MCPServerConfig, MCPTransport
+
+    config = MCPServerConfig(
+        name="test",
+        transport=MCPTransport.STDIO,
+        command="python",
+    )
+    client = MCPClient(config)
+
+    mock_result = MagicMock()
+    mock_result.content = [MagicMock(text="Tool output")]
+
+    result = client._extract_content(mock_result)
+
+    assert result == "Tool output"
+
+
+def test_extract_content_empty_no_structured():
+    """Test that _extract_content returns None when both content and structuredContent are empty."""
+    from omlx.mcp.client import MCPClient
+    from omlx.mcp.types import MCPServerConfig, MCPTransport
+
+    config = MCPServerConfig(
+        name="test",
+        transport=MCPTransport.STDIO,
+        command="python",
+    )
+    client = MCPClient(config)
+
+    mock_result = MagicMock()
+    mock_result.content = []
+    mock_result.structuredContent = None
+
+    result = client._extract_content(mock_result)
+
+    assert result is None
+
+
+def test_extract_content_priority_text_over_structured():
+    """Test that text content takes priority over structuredContent."""
+    from omlx.mcp.client import MCPClient
+    from omlx.mcp.types import MCPServerConfig, MCPTransport
+
+    config = MCPServerConfig(
+        name="test",
+        transport=MCPTransport.STDIO,
+        command="python",
+    )
+    client = MCPClient(config)
+
+    mock_result = MagicMock()
+    mock_result.content = [MagicMock(text="Text content")]
+    mock_result.structuredContent = {"results": ["Structured"]}
+
+    result = client._extract_content(mock_result)
+
+    assert result == "Text content"


### PR DESCRIPTION
## Summary

Fixes issue #469 where MCP web search tools (e.g., victor/websearch HuggingFace Space) returned empty output despite successful tool execution.

## Problem

MCP web search servers return results in the `structuredContent` field of `CallToolResult`, but the `_extract_content` method only checked the `content` field, resulting in empty responses.

## Solution

Modified `_extract_content` in `omlx/mcp/client.py` to fall back to `structuredContent` when `content` is empty or not present.

## Changes

- **omlx/mcp/client.py**: Added structuredContent fallback in `_extract_content` method (lines 359-361)
- **tests/test_mcp_client.py**: Added test case `test_call_tool_structured_content` to verify the fix

## Testing

All 36 MCP client tests pass, including the new test:

```
tests/test_mcp_client.py: 36/36 passed (including test_call_tool_structured_content)
```

## Related

Closes #469