### PR TITLE
fix: add uv override for git-pinned mlx-lm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,13 @@ include = ["omlx*"]
 "omlx.admin" = ["templates/**/*.html", "static/**/*", "i18n/*.json"]
 "omlx.eval" = ["data/*.jsonl"]
 
+[tool.uv]
+# mlx-lm is pinned to a git commit; override transitive pins
+# (e.g. mlx-audio → mlx-lm==0.31.1) so the resolver accepts it.
+override-dependencies = [
+    "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@564281f",
+]
+
 [tool.black]
 line-length = 88
 target-version = ["py310", "py311", "py312", "py313"]


### PR DESCRIPTION
Fixes #495. mlx-audio==0.4.1 declares mlx-lm==0.31.1 as a transitive dependency, which conflicts with the git-commit pin of mlx-lm in pyproject.toml. The uv resolver rejects the unresolvable constraint.

Adds [tool.uv] override-dependencies to force the git-pinned mlx-lm across all transitive consumers, allowing uv sync to resolve cleanly.