### PR TITLE
Add OpenCode vision modality metadata for VLM models

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -330,6 +330,7 @@ def launch_command(args):
     # Fetch model limits from server
     context_window = None
     max_tokens = None
+    model_type = None
     try:
         resp = requests.get(f"{base_url}/v1/models/status", headers=headers, timeout=5)
         if resp.ok:
@@ -337,6 +338,7 @@ def launch_command(args):
                 if m["id"] == model:
                     context_window = m.get("max_context_window")
                     max_tokens = m.get("max_tokens")
+                    model_type = m.get("model_type")
                     break
     except Exception:
         pass
@@ -352,6 +354,7 @@ def launch_command(args):
         tools_profile=tools_profile,
         context_window=context_window,
         max_tokens=max_tokens,
+        model_type=model_type,
     )
 
 

--- a/omlx/integrations/opencode.py
+++ b/omlx/integrations/opencode.py
@@ -31,6 +31,17 @@ class OpenCodeIntegration(Integration):
             f"launch opencode --model {model or 'select-a-model'}"
         )
 
+    @staticmethod
+    def _modalities_for_model(model_type: str | None) -> dict[str, list[str]]:
+        """Build OpenCode modality metadata for the selected oMLX model."""
+        input_modalities = ["text"]
+        if model_type == "vlm":
+            input_modalities.append("image")
+        return {
+            "input": input_modalities,
+            "output": ["text"],
+        }
+
     def configure(
         self,
         port: int,
@@ -39,6 +50,7 @@ class OpenCodeIntegration(Integration):
         host: str = "127.0.0.1",
         context_window: int | None = None,
         max_tokens: int | None = None,
+        model_type: str | None = None,
     ) -> None:
         def updater(config: dict) -> None:
             config.setdefault("provider", {})
@@ -52,7 +64,12 @@ class OpenCodeIntegration(Integration):
             if api_key:
                 provider_config["options"]["apiKey"] = api_key
             if model:
-                model_entry: dict = {"name": model}
+                model_entry: dict = {
+                    "name": model,
+                    "modalities": self._modalities_for_model(model_type),
+                }
+                if model_type == "vlm":
+                    model_entry["attachment"] = True
                 if context_window:
                     model_entry["limit"] = {
                         "context": context_window,
@@ -70,9 +87,11 @@ class OpenCodeIntegration(Integration):
     def launch(self, port: int, api_key: str, model: str, host: str = "127.0.0.1", **kwargs) -> None:
         context_window = kwargs.pop("context_window", None)
         max_tokens = kwargs.pop("max_tokens", None)
+        model_type = kwargs.pop("model_type", None)
         self.configure(
             port, api_key, model, host=host,
             context_window=context_window, max_tokens=max_tokens,
+            model_type=model_type,
         )
 
         env = os.environ.copy()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -231,6 +231,63 @@ class TestLaunchCommandOptions:
         assert "--model" in result.stdout
 
 
+class TestLaunchCommandFunction:
+    """Tests for launch command runtime behavior."""
+
+    def test_launch_command_passes_model_type_to_integration(self):
+        """VLM model metadata should be forwarded to integrations."""
+        from omlx.cli import launch_command
+
+        integration = MagicMock()
+        integration.display_name = "OpenCode"
+        integration.is_installed.return_value = True
+
+        health_response = MagicMock()
+        health_response.raise_for_status.return_value = None
+
+        status_response = MagicMock()
+        status_response.ok = True
+        status_response.json.return_value = {
+            "models": [
+                {
+                    "id": "qwen2.5-vl",
+                    "model_type": "vlm",
+                    "max_context_window": 32768,
+                    "max_tokens": 8192,
+                }
+            ]
+        }
+
+        settings = MagicMock()
+        settings.server.host = "127.0.0.1"
+        settings.server.port = 8000
+
+        args = argparse.Namespace(
+            tool="opencode",
+            host=None,
+            port=None,
+            api_key="test-key",
+            model="qwen2.5-vl",
+            tools_profile="coding",
+        )
+
+        with patch("requests.get", side_effect=[health_response, status_response]):
+            with patch("omlx.integrations.get_integration", return_value=integration):
+                with patch("omlx.settings.GlobalSettings.load", return_value=settings):
+                    launch_command(args)
+
+        integration.launch.assert_called_once_with(
+            port=8000,
+            api_key="test-key",
+            model="qwen2.5-vl",
+            host="127.0.0.1",
+            tools_profile="coding",
+            context_window=32768,
+            max_tokens=8192,
+            model_type="vlm",
+        )
+
+
 class TestServeCommandFunctions:
     """Tests for serve command function."""
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -163,6 +163,10 @@ class TestOpenCodeIntegration:
         assert config["provider"]["omlx"]["npm"] == "@ai-sdk/openai-compatible"
         assert config["provider"]["omlx"]["options"]["apiKey"] == "test-key"
         assert config["provider"]["omlx"]["models"]["qwen3.5"]["name"] == "qwen3.5"
+        assert config["provider"]["omlx"]["models"]["qwen3.5"]["modalities"] == {
+            "input": ["text"],
+            "output": ["text"],
+        }
         assert config["model"] == "omlx/qwen3.5"
 
     def test_configure_custom_host(self, tmp_path):
@@ -243,6 +247,26 @@ class TestOpenCodeIntegration:
         model_config = config["provider"]["omlx"]["models"]["qwen3.5"]
         assert model_config["limit"]["context"] == 32768
         assert model_config["limit"]["output"] == 8192
+
+    def test_configure_vlm_modalities(self, tmp_path):
+        oc = OpenCodeIntegration()
+        config_path = tmp_path / "opencode" / "opencode.json"
+
+        with patch.object(OpenCodeIntegration, "CONFIG_PATH", config_path):
+            oc.configure(
+                port=8000,
+                api_key="key",
+                model="qwen2.5-vl",
+                model_type="vlm",
+            )
+
+        config = json.loads(config_path.read_text())
+        model_config = config["provider"]["omlx"]["models"]["qwen2.5-vl"]
+        assert model_config["attachment"] is True
+        assert model_config["modalities"] == {
+            "input": ["text", "image"],
+            "output": ["text"],
+        }
 
     def test_configure_with_context_window_only(self, tmp_path):
         oc = OpenCodeIntegration()


### PR DESCRIPTION
## Summary
- pass the selected model_type through `omlx launch` into the OpenCode integration
- write explicit OpenCode `modalities` metadata for all custom oMLX models
- mark VLM selections as image-capable attachments so OpenCode can send image inputs

## Testing
- `uv run --dev pytest tests/test_integrations.py tests/test_cli.py -q`
- Manual validation against local oMLX/OpenCode:
  - launched the repo build of `omlx serve` on `127.0.0.1:8001`
  - confirmed `/v1/models/status` reports `Qwen3.5-122B-A10B-4bit` as `model_type: "vlm"`
  - confirmed `omlx launch opencode ...` writes `~/.config/opencode/opencode.json` with:
    - `modalities.input = ["text", "image"]`
    - `modalities.output = ["text"]`
    - `attachment = true`
  - confirmed `opencode models omlx --verbose` reports `capabilities.input.image = true`
  - confirmed a fresh OpenCode process + new session + new image successfully answered an image prompt

## Notes
- During manual validation, a stale OpenCode process/session and reusing an image from a pre-change run produced a false negative even after the config was correct. Restarting OpenCode and testing with a new image avoided the cached pre-patch state.
- Follow-up ergonomics/documentation issue: #518
