### PR TITLE
fix: resolve model aliases in audio endpoints

### DIFF
--- a/omlx/api/audio_routes.py
+++ b/omlx/api/audio_routes.py
@@ -52,6 +52,17 @@ def _get_engine_pool():
     return pool
 
 
+def _resolve_model(model_id: str) -> str:
+    """Resolve a model alias to its real model ID.
+
+    Delegates to the same resolve_model_id used by LLM/chat endpoints,
+    ensuring audio endpoints handle aliases consistently.
+    """
+    from omlx.server import resolve_model_id
+
+    return resolve_model_id(model_id) or model_id
+
+
 async def _read_upload(file: UploadFile) -> bytes:
     """Read an uploaded file in chunks, bailing early if it exceeds the limit."""
     chunks: list[bytes] = []
@@ -95,6 +106,7 @@ async def create_transcription(
     from omlx.exceptions import ModelNotFoundError
 
     pool = _get_engine_pool()
+    model = _resolve_model(model)
 
     # Load the engine via pool (handles model loading and LRU eviction)
     try:
@@ -161,15 +173,16 @@ async def create_speech(request: AudioSpeechRequest):
         raise HTTPException(status_code=400, detail="'input' field must not be empty")
 
     pool = _get_engine_pool()
+    resolved_model = _resolve_model(request.model)
 
     # Load the engine via pool
     try:
-        engine = await pool.get_engine(request.model)
+        engine = await pool.get_engine(resolved_model)
     except ModelNotFoundError as exc:
         avail = ", ".join(exc.available_models) if exc.available_models else "(none)"
         raise HTTPException(
             status_code=404,
-            detail=f"Model '{request.model}' not found. Available: {avail}",
+            detail=f"Model '{resolved_model}' not found. Available: {avail}",
         ) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -177,7 +190,7 @@ async def create_speech(request: AudioSpeechRequest):
     if not isinstance(engine, TTSEngine):
         raise HTTPException(
             status_code=400,
-            detail=f"Model '{request.model}' is not a text-to-speech model",
+            detail=f"Model '{resolved_model}' is not a text-to-speech model",
         )
 
     try:
@@ -210,6 +223,7 @@ async def process_audio(
     from omlx.exceptions import ModelNotFoundError
 
     pool = _get_engine_pool()
+    model = _resolve_model(model)
 
     # Load the engine via pool (handles model loading and LRU eviction)
     try:

--- a/tests/test_audio_sts.py
+++ b/tests/test_audio_sts.py
@@ -261,6 +261,73 @@ class TestSTSEndpointErrors:
 
 
 # ---------------------------------------------------------------------------
+# TestSTSModelAliasResolution
+# ---------------------------------------------------------------------------
+
+
+class TestSTSModelAliasResolution:
+    """Verify that STS endpoint resolves model aliases (#489)."""
+
+    def test_process_resolves_alias(self):
+        """POST /v1/audio/process with alias resolves to real model ID."""
+        from omlx.server import app
+
+        _ensure_audio_routes(app)
+
+        mock_pool = _make_mock_pool(model_id="MossFormer2-SE")
+        mock_pool.resolve_model_id = MagicMock(
+            return_value="MossFormer2-SE"
+        )
+
+        with patch("omlx.server._server_state") as mock_state:
+            mock_state.engine_pool = mock_pool
+            mock_state.global_settings = None
+            mock_state.process_memory_enforcer = None
+            mock_state.hf_downloader = None
+            mock_state.ms_downloader = None
+            mock_state.mcp_manager = None
+            mock_state.api_key = None
+            mock_state.settings_manager = MagicMock()
+            with TestClient(app, raise_server_exceptions=False) as client:
+                response = client.post(
+                    "/v1/audio/process",
+                    data={"model": "denoise"},
+                    files={"file": ("test.wav", TINY_WAV, "audio/wav")},
+                )
+                assert response.status_code == 200
+                mock_pool.get_engine.assert_awaited_once_with("MossFormer2-SE")
+
+    def test_process_direct_model_id(self):
+        """POST /v1/audio/process with direct model ID works without alias."""
+        from omlx.server import app
+
+        _ensure_audio_routes(app)
+
+        mock_pool = _make_mock_pool(model_id="MossFormer2-SE")
+        mock_pool.resolve_model_id = MagicMock(
+            return_value="MossFormer2-SE"
+        )
+
+        with patch("omlx.server._server_state") as mock_state:
+            mock_state.engine_pool = mock_pool
+            mock_state.global_settings = None
+            mock_state.process_memory_enforcer = None
+            mock_state.hf_downloader = None
+            mock_state.ms_downloader = None
+            mock_state.mcp_manager = None
+            mock_state.api_key = None
+            mock_state.settings_manager = MagicMock()
+            with TestClient(app, raise_server_exceptions=False) as client:
+                response = client.post(
+                    "/v1/audio/process",
+                    data={"model": "MossFormer2-SE"},
+                    files={"file": ("test.wav", TINY_WAV, "audio/wav")},
+                )
+                assert response.status_code == 200
+                mock_pool.get_engine.assert_awaited_once_with("MossFormer2-SE")
+
+
+# ---------------------------------------------------------------------------
 # TestSTSEngineUnit
 # ---------------------------------------------------------------------------
 

--- a/tests/test_audio_stt.py
+++ b/tests/test_audio_stt.py
@@ -314,6 +314,78 @@ class TestVideoContainerRemap:
 
 
 # ---------------------------------------------------------------------------
+# TestSTTModelAliasResolution
+# ---------------------------------------------------------------------------
+
+
+class TestSTTModelAliasResolution:
+    """Verify that STT endpoint resolves model aliases (#489)."""
+
+    def test_transcription_resolves_alias(self):
+        """POST /v1/audio/transcriptions with alias resolves to real model ID."""
+        from omlx.server import app
+
+        _ensure_audio_routes(app)
+
+        mock_pool = _make_mock_pool(model_id="Qwen3-ASR-1.7B-bf16")
+        mock_pool.resolve_model_id = MagicMock(
+            return_value="Qwen3-ASR-1.7B-bf16"
+        )
+
+        with patch("omlx.server._server_state") as mock_state:
+            mock_state.engine_pool = mock_pool
+            mock_state.global_settings = None
+            mock_state.process_memory_enforcer = None
+            mock_state.hf_downloader = None
+            mock_state.ms_downloader = None
+            mock_state.mcp_manager = None
+            mock_state.api_key = None
+            mock_state.settings_manager = MagicMock()
+            with TestClient(app, raise_server_exceptions=False) as client:
+                response = client.post(
+                    "/v1/audio/transcriptions",
+                    data={"model": "whisper"},
+                    files={"file": ("test.wav", TINY_WAV, "audio/wav")},
+                )
+                assert response.status_code == 200
+                mock_pool.get_engine.assert_awaited_once_with(
+                    "Qwen3-ASR-1.7B-bf16"
+                )
+
+    def test_transcription_direct_model_id(self):
+        """POST /v1/audio/transcriptions with direct model ID works without alias."""
+        from omlx.server import app
+
+        _ensure_audio_routes(app)
+
+        mock_pool = _make_mock_pool(model_id="Qwen3-ASR-1.7B-bf16")
+        # resolve_model_id returns the same ID when no alias matches
+        mock_pool.resolve_model_id = MagicMock(
+            return_value="Qwen3-ASR-1.7B-bf16"
+        )
+
+        with patch("omlx.server._server_state") as mock_state:
+            mock_state.engine_pool = mock_pool
+            mock_state.global_settings = None
+            mock_state.process_memory_enforcer = None
+            mock_state.hf_downloader = None
+            mock_state.ms_downloader = None
+            mock_state.mcp_manager = None
+            mock_state.api_key = None
+            mock_state.settings_manager = MagicMock()
+            with TestClient(app, raise_server_exceptions=False) as client:
+                response = client.post(
+                    "/v1/audio/transcriptions",
+                    data={"model": "Qwen3-ASR-1.7B-bf16"},
+                    files={"file": ("test.wav", TINY_WAV, "audio/wav")},
+                )
+                assert response.status_code == 200
+                mock_pool.get_engine.assert_awaited_once_with(
+                    "Qwen3-ASR-1.7B-bf16"
+                )
+
+
+# ---------------------------------------------------------------------------
 # Integration test (slow, requires mlx-audio)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_audio_tts.py
+++ b/tests/test_audio_tts.py
@@ -242,6 +242,83 @@ class TestTTSEndpointErrors:
 
 
 # ---------------------------------------------------------------------------
+# TestTTSModelAliasResolution
+# ---------------------------------------------------------------------------
+
+
+class TestTTSModelAliasResolution:
+    """Verify that audio endpoints resolve model aliases (#489)."""
+
+    def test_speech_resolves_alias(self):
+        """POST /v1/audio/speech with alias resolves to real model ID."""
+        from omlx.server import app
+        from omlx.model_settings import ModelSettings
+
+        _ensure_audio_routes(app)
+
+        mock_pool = _make_mock_pool(model_id="Qwen3-TTS-12Hz-1.7B-Base-bf16")
+        # Configure alias resolution on the pool
+        mock_pool.resolve_model_id = MagicMock(
+            return_value="Qwen3-TTS-12Hz-1.7B-Base-bf16"
+        )
+
+        mock_settings_manager = MagicMock()
+
+        with patch("omlx.server._server_state") as mock_state:
+            mock_state.engine_pool = mock_pool
+            mock_state.global_settings = None
+            mock_state.process_memory_enforcer = None
+            mock_state.hf_downloader = None
+            mock_state.ms_downloader = None
+            mock_state.mcp_manager = None
+            mock_state.api_key = None
+            mock_state.settings_manager = mock_settings_manager
+            with TestClient(app, raise_server_exceptions=False) as client:
+                response = client.post(
+                    "/v1/audio/speech",
+                    json={"model": "qwen3-tts", "input": "Hello"},
+                )
+                assert response.status_code == 200
+                # Verify pool.get_engine was called with the resolved ID
+                mock_pool.get_engine.assert_awaited_once_with(
+                    "Qwen3-TTS-12Hz-1.7B-Base-bf16"
+                )
+
+    def test_speech_direct_model_id(self):
+        """POST /v1/audio/speech with direct model ID works without alias."""
+        from omlx.server import app
+
+        _ensure_audio_routes(app)
+
+        mock_pool = _make_mock_pool(model_id="Qwen3-TTS-12Hz-1.7B-Base-bf16")
+        mock_pool.resolve_model_id = MagicMock(
+            return_value="Qwen3-TTS-12Hz-1.7B-Base-bf16"
+        )
+
+        with patch("omlx.server._server_state") as mock_state:
+            mock_state.engine_pool = mock_pool
+            mock_state.global_settings = None
+            mock_state.process_memory_enforcer = None
+            mock_state.hf_downloader = None
+            mock_state.ms_downloader = None
+            mock_state.mcp_manager = None
+            mock_state.api_key = None
+            mock_state.settings_manager = MagicMock()
+            with TestClient(app, raise_server_exceptions=False) as client:
+                response = client.post(
+                    "/v1/audio/speech",
+                    json={
+                        "model": "Qwen3-TTS-12Hz-1.7B-Base-bf16",
+                        "input": "Hello",
+                    },
+                )
+                assert response.status_code == 200
+                mock_pool.get_engine.assert_awaited_once_with(
+                    "Qwen3-TTS-12Hz-1.7B-Base-bf16"
+                )
+
+
+# ---------------------------------------------------------------------------
 # TestTTSVoiceRouting — unit tests for voice/instruct parameter dispatch
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Audio endpoints (`/v1/audio/speech`, `/v1/audio/transcriptions`, `/v1/audio/process`) did not resolve model aliases before engine lookup, causing 404 when using aliases that work in LLM/chat endpoints
- Add `_resolve_model()` helper that delegates to the same `resolve_model_id()` used by LLM endpoints
- Applied to all three audio endpoints

Fixes #489

## Changes

- `omlx/api/audio_routes.py`: Add `_resolve_model()` and call it before `pool.get_engine()` in all three endpoints
- `tests/test_audio_tts.py`: Add `TestTTSModelAliasResolution` — alias resolution + direct model ID
- `tests/test_audio_stt.py`: Add `TestSTTModelAliasResolution` — alias resolution + direct model ID
- `tests/test_audio_sts.py`: Add `TestSTSModelAliasResolution` — alias resolution + direct model ID

## Test plan

- [x] Unit tests pass — 68 audio tests passed (TTS: 20, STT: 21, STS: 27)
- [x] Alias resolution verified for all three endpoints (TTS, STT, STS)
- [x] Direct model ID (no alias) verified for all three endpoints (TTS, STT, STS)