### PR TITLE
feat: parse Gemma 4 raw tool call envelopes

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -11,6 +11,9 @@ Uses mlx-lm's modular tool parser system to support multiple model formats:
 
 The tool parser is automatically selected based on the model's chat template.
 
+Also includes fallback parsing for raw formats not yet handled natively,
+including Gemma 4's ``<|tool_call>call:name{...}<tool_call|>`` envelopes.
+
 Also includes structured output (JSON Schema) utilities:
 - parse_json_output: Extract JSON from model output
 - validate_json_schema: Validate JSON against a schema
@@ -194,6 +197,51 @@ def _parse_namespaced_tool_calls(
     return cleaned, tool_calls
 
 
+def _parse_gemma4_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
+    """
+    Fallback parser for Gemma 4 tool-call envelopes.
+
+    Gemma 4 emits raw tool calls in the form:
+    ``<|tool_call>call:function_name{"arg": "value"}<tool_call|>``
+
+    Returns:
+        Tuple of (cleaned_text, tool_calls or None)
+    """
+    tool_calls = []
+    pattern = r"<\|tool_call>(.*?)<tool_call\|>"
+
+    for match in re.finditer(pattern, text, re.DOTALL):
+        content = match.group(1).strip()
+        parsed_match = re.match(r"^call:\s*([A-Za-z_][\w.-]*)(\{.*\})$", content, re.DOTALL)
+        if not parsed_match:
+            continue
+
+        name = parsed_match.group(1)
+        arguments_raw = parsed_match.group(2).strip()
+        try:
+            arguments = json.loads(arguments_raw)
+            arguments_str = json.dumps(arguments, ensure_ascii=False)
+        except (json.JSONDecodeError, ValueError):
+            arguments_str = arguments_raw
+
+        tool_calls.append(
+            ToolCall(
+                id=f"call_{uuid.uuid4().hex[:8]}",
+                type="function",
+                function=FunctionCall(
+                    name=name,
+                    arguments=arguments_str,
+                ),
+            )
+        )
+
+    if not tool_calls:
+        return text, None
+
+    cleaned = re.sub(pattern, "", text, flags=re.DOTALL).strip()
+    return cleaned, tool_calls
+
+
 def _parse_bracket_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
     """
     Fallback parser for bracket-style tool call formats.
@@ -344,6 +392,10 @@ def parse_tool_calls(
                     if idx >= 0:
                         cleaned_text = cleaned_text[:idx].strip()
                 return cleaned_text, tool_calls
+
+    # Fallback: Gemma 4 raw tool-call envelopes
+    if "<|tool_call>" in cleaned_text and "<tool_call|>" in cleaned_text:
+        return _parse_gemma4_tool_calls(cleaned_text)
 
     # Fallback: parse XML <tool_call> tags (GLM, Qwen, generic formats)
     if "<tool_call>" in cleaned_text:

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -1080,6 +1080,69 @@ class TestParseToolCallsEmptyEndMarker:
         assert tool_calls is None or len(tool_calls) == 0
 
 
+class TestParseGemma4ToolCalls:
+    """Tests for Gemma 4 raw tool call parsing."""
+
+    def test_gemma4_tool_call_with_arguments(self):
+        """Gemma 4 envelopes should parse into OpenAI-style tool calls."""
+        from omlx.api.tool_calling import _parse_gemma4_tool_calls
+
+        text = 'Before <|tool_call>call:get_weather{"city":"Tokyo"}<tool_call|> after'
+        cleaned, tool_calls = _parse_gemma4_tool_calls(text)
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "get_weather"
+        assert json.loads(tool_calls[0].function.arguments) == {"city": "Tokyo"}
+        assert cleaned == "Before  after"
+
+    def test_gemma4_tool_call_with_empty_arguments(self):
+        """Gemma 4 no-arg calls should preserve an empty JSON object."""
+        from omlx.api.tool_calling import _parse_gemma4_tool_calls
+
+        text = '<|tool_call>call:get_current_time{}<tool_call|>'
+        cleaned, tool_calls = _parse_gemma4_tool_calls(text)
+        assert cleaned == ""
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "get_current_time"
+        assert tool_calls[0].function.arguments == "{}"
+
+    def test_gemma4_multiple_tool_calls(self):
+        """Multiple Gemma 4 envelopes should all be recovered."""
+        from omlx.api.tool_calling import _parse_gemma4_tool_calls
+
+        text = (
+            '<|tool_call>call:first_tool{"x":1}<tool_call|>'
+            ' middle '
+            '<|tool_call>call:second_tool{"y":2}<tool_call|>'
+        )
+        cleaned, tool_calls = _parse_gemma4_tool_calls(text)
+        assert tool_calls is not None
+        assert len(tool_calls) == 2
+        assert [tc.function.name for tc in tool_calls] == ["first_tool", "second_tool"]
+        assert cleaned == "middle"
+
+    def test_parse_tool_calls_falls_back_to_gemma4_when_native_parser_fails(self):
+        """Gemma 4 raw envelopes should still parse if mlx-lm's parser misses them."""
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = True
+        tok.tool_call_start = "<|tool_call>"
+        tok.tool_call_end = "<tool_call|>"
+
+        def failing_parser(text, tools):
+            raise ValueError("parse error")
+
+        tok.tool_parser = failing_parser
+
+        text = 'Lead <|tool_call>call:get_weather{"city":"Seoul"}<tool_call|> tail'
+        cleaned, tool_calls = parse_tool_calls(text, tok)
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "get_weather"
+        assert json.loads(tool_calls[0].function.arguments) == {"city": "Seoul"}
+        assert cleaned == "Lead  tail"
+
+
 class TestParseBracketToolCalls:
     """Tests for bracket-style tool call parsing (issue #159)."""
 


### PR DESCRIPTION
## Summary
- add a Gemma 4 fallback parser for raw `<|tool_call>call:name{...}<tool_call|>` envelopes
- fall back to that parser when the native mlx-lm parser does not recover any calls
- add focused regression tests for single, empty-args, multiple, and native-parser-failure cases

## Testing
- `PYTHONPATH=$PWD /opt/homebrew/opt/omlx/libexec/bin/python -c "...parser regression checks passed..."`
- `PYTHONPATH=$PWD /opt/homebrew/opt/omlx/libexec/bin/python -m py_compile omlx/api/tool_calling.py tests/test_tool_calling.py omlx/api/openai_models.py omlx/api/shared_models.py`

Closes #534.