### PR TITLE
feat(vlm): support Gemma 4 tool calling

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -67,6 +67,12 @@ OCR_EXTRA_STOP_SEQUENCES: List[str] = [
     "<|endofassistant|>",
 ]
 
+# VLM model types that require tool parser selection without relying on a
+# chat_template in tokenizer_config.json.
+VLM_TOOL_PARSER_TYPES: Dict[str, str] = {
+    "gemma4": "function_gemma4",
+}
+
 # Per-model OCR generation defaults from official configs.
 # Applied automatically when no explicit user override is provided.
 OCR_MODEL_GENERATION_DEFAULTS: Dict[str, Dict[str, Any]] = {
@@ -351,34 +357,69 @@ class VLMBatchedEngine(BaseEngine):
         self._loaded = False
         logger.info("VLMBatchedEngine stopped")
 
+    def _get_tool_parser_type(self, tokenizer) -> Optional[str]:
+        """Resolve the tool parser type for a VLM tokenizer.
+
+        Prefer tokenizer-config and chat-template inference to match mlx-lm's
+        native behavior. Fall back to model-type overrides for models like
+        Gemma 4 whose tokenizer_config.json currently lacks a chat template.
+        """
+        tokenizer_config = getattr(tokenizer, "init_kwargs", None)
+        tool_parser_type = None
+        if isinstance(tokenizer_config, dict):
+            tool_parser_type = tokenizer_config.get("tool_parser_type")
+
+        chat_template = getattr(tokenizer, "chat_template", None)
+        if tool_parser_type is None and isinstance(chat_template, str):
+            try:
+                from mlx_lm.tokenizer_utils import _infer_tool_parser
+            except ImportError:
+                _infer_tool_parser = None
+
+            if _infer_tool_parser is not None:
+                tool_parser_type = _infer_tool_parser(chat_template)
+
+        if tool_parser_type is None:
+            config = getattr(getattr(self, "_vlm_model", None), "config", None)
+            model_type = self.model_type or getattr(config, "model_type", None)
+            tool_parser_type = VLM_TOOL_PARSER_TYPES.get(str(model_type or "").lower())
+            if tool_parser_type is not None and isinstance(tokenizer_config, dict):
+                tokenizer_config["tool_parser_type"] = tool_parser_type
+
+        return tool_parser_type
+
+    @staticmethod
+    def _load_tool_parser_module(tool_parser_type: str):
+        """Load a tool parser module from mlx-lm or oMLX local fallbacks."""
+        import importlib
+
+        module_names = (
+            f"mlx_lm.tool_parsers.{tool_parser_type}",
+            f"omlx.tool_parsers.{tool_parser_type}",
+        )
+
+        for module_name in module_names:
+            try:
+                return importlib.import_module(module_name)
+            except ImportError:
+                continue
+
+        return None
+
     def _inject_tool_calling(self, tokenizer) -> None:
         """Inject mlx-lm's tool calling attributes into VLM tokenizer.
 
         mlx-vlm's TokenizerWrapper lacks tool calling support (has_tool_calling,
-        tool_parser, etc). We reuse mlx-lm's _infer_tool_parser() to detect the
-        parser type from the chat template, then set the attributes directly on
-        the wrapper instance so parse_tool_calls() can use native tool parsing.
+        tool_parser, etc). We resolve the parser type using mlx-lm's native
+        tokenizer heuristics first, then apply model-type fallbacks for VLMs
+        whose tokenizer config lacks chat-template metadata.
         """
-        try:
-            from mlx_lm.tokenizer_utils import _infer_tool_parser
-        except ImportError:
-            return
-
-        chat_template = getattr(tokenizer, "chat_template", None)
-        if not chat_template:
-            return
-
-        tool_parser_type = _infer_tool_parser(chat_template)
+        tool_parser_type = self._get_tool_parser_type(tokenizer)
         if tool_parser_type is None:
             return
 
-        try:
-            import importlib
-
-            tool_module = importlib.import_module(
-                f"mlx_lm.tool_parsers.{tool_parser_type}"
-            )
-        except ImportError:
+        tool_module = self._load_tool_parser_module(tool_parser_type)
+        if tool_module is None:
             logger.warning(
                 f"VLM tool parser module not found: {tool_parser_type}"
             )

--- a/omlx/tool_parsers/__init__.py
+++ b/omlx/tool_parsers/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local tool parser fallbacks for oMLX."""

--- a/omlx/tool_parsers/function_gemma4.py
+++ b/omlx/tool_parsers/function_gemma4.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gemma 4 function-calling parser compatible with mlx-lm's parser API."""
+
+import json
+import re
+from typing import Any, Optional
+
+_tool_call_regex = re.compile(r"call:([\w.-]+)(\{.*\})\s*\Z", re.DOTALL)
+
+
+def parse_tool_call(text: str, _: Optional[Any] = None):
+    match = _tool_call_regex.search(text.strip())
+    if not match:
+        raise ValueError("No function provided.")
+
+    func_name, args_str = match.groups()
+    arguments = json.loads(args_str)
+    if not isinstance(arguments, dict):
+        raise ValueError("Tool arguments must be a JSON object.")
+
+    return dict(name=func_name, arguments=arguments)
+
+
+tool_call_start = "<|tool_call>"
+tool_call_end = "<tool_call|>"

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -1080,6 +1080,60 @@ class TestParseToolCallsEmptyEndMarker:
         assert tool_calls is None or len(tool_calls) == 0
 
 
+class TestParseToolCallsGemma4:
+    """Tests for Gemma 4 paired tool-call markers and JSON arguments."""
+
+    def test_gemma4_native_parser_single_call(self):
+        """Gemma 4 paired markers should parse a single JSON tool call."""
+        from omlx.tool_parsers.function_gemma4 import parse_tool_call
+
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = True
+        tok.tool_call_start = "<|tool_call>"
+        tok.tool_call_end = "<tool_call|>"
+        tok.tool_parser = parse_tool_call
+
+        text = "Let me check.<|tool_call>call:get_current_time{}<tool_call|>"
+        cleaned, tool_calls = parse_tool_calls(text, tok)
+
+        assert cleaned == "Let me check."
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "get_current_time"
+        assert tool_calls[0].function.arguments == "{}"
+
+    def test_gemma4_native_parser_multiple_calls(self):
+        """Gemma 4 multiple paired tool calls should all be parsed."""
+        from omlx.tool_parsers.function_gemma4 import parse_tool_call
+
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = True
+        tok.tool_call_start = "<|tool_call>"
+        tok.tool_call_end = "<tool_call|>"
+        tok.tool_parser = parse_tool_call
+
+        text = (
+            "<|tool_call>call:get_current_time{}<tool_call|>"
+            '<|tool_call>call:get_weather{"city": "Bangkok"}<tool_call|>'
+        )
+        cleaned, tool_calls = parse_tool_calls(text, tok)
+
+        assert cleaned == ""
+        assert tool_calls is not None
+        assert len(tool_calls) == 2
+        assert tool_calls[0].function.name == "get_current_time"
+        assert tool_calls[0].function.arguments == "{}"
+        assert tool_calls[1].function.name == "get_weather"
+        assert json.loads(tool_calls[1].function.arguments) == {"city": "Bangkok"}
+
+    def test_gemma4_parser_rejects_non_object_arguments(self):
+        """Gemma 4 tool arguments must decode to a JSON object."""
+        from omlx.tool_parsers.function_gemma4 import parse_tool_call
+
+        with pytest.raises(ValueError):
+            parse_tool_call('call:get_weather["Bangkok"]')
+
+
 class TestParseBracketToolCalls:
     """Tests for bracket-style tool call parsing (issue #159)."""
 

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -123,8 +123,45 @@ class TestInjectToolCalling:
         assert tokenizer.has_tool_calling is True
         assert tokenizer.tool_call_start == "<tool_call>"
 
+    def test_injects_gemma4_parser_from_model_type_without_chat_template(self):
+        """Gemma 4 falls back to model_type when chat_template is missing."""
+        engine = _make_loaded_engine(model_type="gemma4")
+        tokenizer = MockVLMTokenizer(
+            chat_template=None,
+            vocab={"<|tool_call>": 100, "<tool_call|>": 101},
+        )
+
+        engine._inject_tool_calling(tokenizer)
+
+        assert tokenizer.has_tool_calling is True
+        assert tokenizer.tool_call_start == "<|tool_call>"
+        assert tokenizer.tool_call_end == "<tool_call|>"
+        assert tokenizer.tool_parser("call:get_current_time{}") == {
+            "name": "get_current_time",
+            "arguments": {},
+        }
+
+    def test_prefers_chat_template_parser_over_gemma4_model_type_fallback(self):
+        """Chat-template inference should win over model-type fallback."""
+        engine = _make_loaded_engine(model_type="gemma4")
+        tokenizer = MockVLMTokenizer(
+            chat_template="some template with <tool_call> and tool_call.name",
+            vocab={
+                "<tool_call>": 100,
+                "</tool_call>": 101,
+                "<|tool_call>": 102,
+                "<tool_call|>": 103,
+            },
+        )
+
+        engine._inject_tool_calling(tokenizer)
+
+        assert tokenizer.has_tool_calling is True
+        assert tokenizer.tool_call_start == "<tool_call>"
+        assert tokenizer.tool_call_end == "</tool_call>"
+
     def test_skips_when_no_chat_template(self):
-        """No chat template → no injection."""
+        """No chat template and no model-type override → no injection."""
         engine = _make_engine()
         tokenizer = MockVLMTokenizer(chat_template=None)
 


### PR DESCRIPTION
## Summary
- add a Gemma 4 tool parser that understands `<|tool_call>call:name{...}<tool_call|>` JSON payloads
- add a VLM model-type fallback so `gemma4` selects the parser even when tokenizer config lacks a chat template
- cover the new parser and fallback path with unit tests

Related to #534.
