### PR TITLE
Bypass proxy for local oMLX health checks

### DIFF
--- a/packaging/omlx_app/app.py
+++ b/packaging/omlx_app/app.py
@@ -841,6 +841,7 @@ class OMLXAppDelegate(NSObject):
 
             if self._admin_session is None:
                 self._admin_session = requests.Session()
+                self._admin_session.trust_env = False
 
             session = self._admin_session
 

--- a/packaging/omlx_app/config.py
+++ b/packaging/omlx_app/config.py
@@ -121,6 +121,7 @@ class ServerConfig:
 
         try:
             session = requests.Session()
+            session.trust_env = False
 
             if current_key:
                 # Login with current API key

--- a/packaging/omlx_app/server_manager.py
+++ b/packaging/omlx_app/server_manager.py
@@ -105,7 +105,9 @@ class ServerManager:
 
     def check_health(self) -> bool:
         try:
-            response = requests.get(self._get_health_url(), timeout=2)
+            session = requests.Session()
+            session.trust_env = False
+            response = session.get(self._get_health_url(), timeout=2)
             return response.status_code == 200
         except requests.RequestException:
             return False
@@ -232,7 +234,9 @@ class ServerManager:
     def _is_omlx_server(self) -> bool:
         """Check if the process on the port is an oMLX server."""
         try:
-            resp = requests.get(self._get_health_url(), timeout=2)
+            session = requests.Session()
+            session.trust_env = False
+            resp = session.get(self._get_health_url(), timeout=2)
             return resp.status_code == 200
         except requests.RequestException:
             return False


### PR DESCRIPTION
Fix oMLX menu status detection when a system proxy is enabled. Local 127.0.0.1 health checks and admin sessions now ignore environment proxy settings, so the app no longer misdetects a running server as starting when Shadowsocks is on.\n\nValidation:\n- py_compile passed for packaging/omlx_app/app.py, config.py, server_manager.py\n- Reproduced that requests.Session(trust_env=False) returns 200 from http://127.0.0.1:48000/health while the default session can inherit the proxy