### PR TITLE
fix: enable Gemma4 tool calling via mlx-vlm parser infrastructure

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -352,15 +352,16 @@ class VLMBatchedEngine(BaseEngine):
         logger.info("VLMBatchedEngine stopped")
 
     def _inject_tool_calling(self, tokenizer) -> None:
-        """Inject mlx-lm's tool calling attributes into VLM tokenizer.
+        """Inject tool calling attributes into VLM tokenizer.
 
         mlx-vlm's TokenizerWrapper lacks tool calling support (has_tool_calling,
-        tool_parser, etc). We reuse mlx-lm's _infer_tool_parser() to detect the
-        parser type from the chat template, then set the attributes directly on
-        the wrapper instance so parse_tool_calls() can use native tool parsing.
+        tool_parser, etc). We use mlx-vlm's _infer_tool_parser (which extends
+        mlx-lm's with VLM-specific models) and load_tool_module (which prefers
+        mlx_vlm.tool_parsers over mlx_lm.tool_parsers) to detect and wire up
+        the right parser for the model's chat template.
         """
         try:
-            from mlx_lm.tokenizer_utils import _infer_tool_parser
+            from mlx_vlm.tool_parsers import _infer_tool_parser, load_tool_module
         except ImportError:
             return
 
@@ -373,11 +374,7 @@ class VLMBatchedEngine(BaseEngine):
             return
 
         try:
-            import importlib
-
-            tool_module = importlib.import_module(
-                f"mlx_lm.tool_parsers.{tool_parser_type}"
-            )
+            tool_module = load_tool_module(tool_parser_type)
         except ImportError:
             logger.warning(
                 f"VLM tool parser module not found: {tool_parser_type}"


### PR DESCRIPTION
Fixes tool calling for Gemma4 VLM models by delegating to mlx-vlm's own parser infrastructure rather than mlx-lm's.

## Problem

`_inject_tool_calling` was importing `_infer_tool_parser` directly from `mlx_lm.tokenizer_utils`, which has no knowledge of Gemma4's `<|tool_call>` template marker. It returned `None` for Gemma4, so `has_tool_calling` was never set and raw tool call XML was passed through into the context instead of being parsed.

## Change

Switch to mlx-vlm's own `_infer_tool_parser` and `load_tool_module` (available since mlx-vlm commit `43b9b20`, already pinned by this project):

- `mlx_vlm.tool_parsers._infer_tool_parser` calls mlx-lm's version first, then checks VLM-specific extras — including `<|tool_call>` → `gemma4`. Strictly a superset, no regressions for other models.
- `mlx_vlm.tool_parsers.load_tool_module` prefers `mlx_vlm.tool_parsers.*` over `mlx_lm.tool_parsers.*`, so Gemma4 gets the correct parser (right tokens, right escape format) rather than the unrelated `function_gemma` parser from mlx-lm.
- The existing `try/except ImportError` guard means this degrades gracefully if run against an older mlx-vlm without the `tool_parsers` package.

Any future VLM model that mlx-vlm adds tool support for will be picked up automatically with no further changes needed here.
