### PR TITLE
feat: Gemma 4 reasoning parser and agentic tool calling

### DIFF
--- a/omlx/adapter/gemma4.py
+++ b/omlx/adapter/gemma4.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gemma 4 reasoning-channel output parsing and message extraction."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+try:
+    from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer
+except ImportError:
+    NaiveStreamingDetokenizer = None
+
+from ..api.utils import _PRESERVE_BOUNDARY_KEY
+from .output_parser import OutputParserFinalizeResult, OutputParserTokenResult
+
+_OPEN_MARKER = "<|channel>thought\n"
+_CLOSE_MARKER = "<channel|>"
+_TURN_END_MARKER = "<turn|>"
+_TOOL_RESPONSE_OPEN = "<|tool_response>"
+_TOOL_RESPONSE_CLOSE = "<tool_response|>"
+_THINK_OPEN = "<think>\n"
+_THINK_CLOSE = "</think>\n"
+
+
+def _try_parse_json(s: str) -> Any:
+    """Parse string as JSON if possible, otherwise return as-is."""
+    if not isinstance(s, str):
+        return s
+    s = s.strip()
+    if not s or not (s.startswith("{") or s.startswith("[")):
+        return s
+    try:
+        return json.loads(s)
+    except (json.JSONDecodeError, ValueError):
+        return s
+
+
+def extract_gemma4_messages(
+    messages: List[Any],
+    max_tool_result_tokens: int | None = None,
+    tokenizer: Any | None = None,
+) -> List[dict]:
+    """Convert OpenAI-format messages to Gemma 4 chat-template format.
+
+    The Gemma 4 chat template does not handle ``role=tool`` messages.
+    Tool results must instead appear on a model-role turn as a
+    ``tool_responses`` list, where each entry is::
+
+        {"name": "<function_name>", "response": <dict_or_scalar>}
+
+    This function:
+    - Passes non-tool messages through unchanged.
+    - Preserves ``tool_calls`` on assistant turns (template renders them
+      as ``<|tool_call>...</tool_call|>``).
+    - Folds consecutive ``role=tool`` messages that follow an assistant
+      turn into a single ``{"role": "assistant", "tool_responses": [...]}``
+      message, resolving function names from the preceding tool_calls by
+      ``tool_call_id``.  Falls back to the raw ``tool_call_id`` as the
+      name when no match is found.
+    - JSON-parses tool result content into a dict/list where possible so
+      the template renders structured responses correctly.
+
+    Args:
+        messages: OpenAI-format Message objects or dicts.
+        max_tool_result_tokens: Maximum token count for tool results
+            (truncation applied when tokenizer is provided).
+        tokenizer: Tokenizer for optional truncation.
+
+    Returns:
+        List of dicts ready for ``tokenizer.apply_chat_template``.
+    """
+    from ..api.utils import (
+        _extract_text_from_content_list,
+    )  # avoid circular at module level
+
+    processed: list[dict] = []
+
+    # Build index of message objects as plain dicts
+    raw: list[dict] = []
+    for msg in messages:
+        if hasattr(msg, "model_dump"):
+            raw.append(msg.model_dump())
+        elif isinstance(msg, dict):
+            raw.append(dict(msg))
+        else:
+            raw.append(
+                {
+                    "role": getattr(msg, "role", "user"),
+                    "content": getattr(msg, "content", ""),
+                }
+            )
+
+    i = 0
+    while i < len(raw):
+        msg = raw[i]
+        role = msg.get("role", "user")
+
+        if role == "developer":
+            role = "system"
+
+        if role == "tool":
+            # Orphaned tool result with no preceding assistant turn — attach
+            # to a synthetic assistant turn with no content.
+            tool_call_id = msg.get("tool_call_id", "")
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                content = _extract_text_from_content_list(content)
+            if max_tool_result_tokens and tokenizer and content:
+                from ..api.anthropic_utils import truncate_tool_result
+
+                content = truncate_tool_result(
+                    content, max_tool_result_tokens, tokenizer
+                )
+            response = _try_parse_json(content)
+            # Fallback name: use tool_call_id
+            processed.append(
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_responses": [
+                        {"name": tool_call_id or "unknown", "response": response}
+                    ],
+                    _PRESERVE_BOUNDARY_KEY: True,
+                }
+            )
+            i += 1
+            continue
+
+        if role == "assistant":
+            # Build a tool_call_id → function_name lookup from this turn's calls.
+            tc_id_to_name: dict[str, str] = {}
+            tool_calls_raw = msg.get("tool_calls") or []
+            for tc in tool_calls_raw:
+                if isinstance(tc, dict):
+                    tc_id = tc.get("id", "")
+                    func_name = (tc.get("function") or {}).get("name", "")
+                else:
+                    tc_id = getattr(tc, "id", "")
+                    func = getattr(tc, "function", None)
+                    func_name = getattr(func, "name", "") if func else ""
+                if tc_id:
+                    tc_id_to_name[tc_id] = func_name
+
+            # Extract content
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                content = _extract_text_from_content_list(content)
+
+            out_msg: dict = {"role": "assistant", "content": content or ""}
+
+            # Preserve tool_calls for template rendering
+            if tool_calls_raw:
+                out_calls = []
+                for tc in tool_calls_raw:
+                    if isinstance(tc, dict):
+                        func = tc.get("function") or {}
+                        out_calls.append(
+                            {
+                                "id": tc.get("id", ""),
+                                "function": {
+                                    "name": func.get("name", ""),
+                                    "arguments": _try_parse_json(
+                                        func.get("arguments", "{}")
+                                    ),
+                                },
+                            }
+                        )
+                    else:
+                        func = getattr(tc, "function", None)
+                        args_str = getattr(func, "arguments", "{}") if func else "{}"
+                        out_calls.append(
+                            {
+                                "id": getattr(tc, "id", ""),
+                                "function": {
+                                    "name": getattr(func, "name", "") if func else "",
+                                    "arguments": _try_parse_json(args_str),
+                                },
+                            }
+                        )
+                out_msg["tool_calls"] = out_calls
+                out_msg[_PRESERVE_BOUNDARY_KEY] = True
+
+            processed.append(out_msg)
+            i += 1
+
+            # Consume any immediately following tool results into a
+            # single model turn with tool_responses.
+            tool_responses = []
+            while i < len(raw) and raw[i].get("role") == "tool":
+                tr = raw[i]
+                tc_id = tr.get("tool_call_id", "")
+                tr_content = tr.get("content", "")
+                if isinstance(tr_content, list):
+                    tr_content = _extract_text_from_content_list(tr_content)
+                if max_tool_result_tokens and tokenizer and tr_content:
+                    from ..api.anthropic_utils import truncate_tool_result
+
+                    tr_content = truncate_tool_result(
+                        tr_content, max_tool_result_tokens, tokenizer
+                    )
+                response = _try_parse_json(tr_content)
+                name = tc_id_to_name.get(tc_id) or tc_id or "unknown"
+                tool_responses.append({"name": name, "response": response})
+                i += 1
+
+            if tool_responses:
+                processed.append(
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_responses": tool_responses,
+                        _PRESERVE_BOUNDARY_KEY: True,
+                    }
+                )
+            continue
+
+        # All other roles (user, system)
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            content = _extract_text_from_content_list(content)
+        out: dict = {"role": role, "content": content if content is not None else ""}
+        processed.append(out)
+        i += 1
+
+    # Standard cleanup passes shared with other extractors
+    from ..api.utils import (
+        _consolidate_system_messages,
+        _drop_void_assistant_messages,
+        _merge_consecutive_roles,
+    )
+
+    return _merge_consecutive_roles(
+        _drop_void_assistant_messages(_consolidate_system_messages(processed))
+    )
+
+
+def _matching_prefix_len(text: str, marker: str) -> int:
+    """Return longest suffix of ``text`` that is a prefix of ``marker``."""
+    max_len = min(len(text), len(marker) - 1)
+    for size in range(max_len, 0, -1):
+        if text.endswith(marker[:size]):
+            return size
+    return 0
+
+
+class Gemma4OutputParserSession:
+    """Suppress Gemma 4 protocol markers and re-emit thought blocks as ``<think>`` tags."""
+
+    def __init__(self, tokenizer: Any):
+        self._tokenizer = tokenizer
+        self._buffer = ""
+        self._in_thought = False
+
+        if hasattr(tokenizer, "detokenizer"):
+            self._detokenizer = tokenizer.detokenizer
+        elif NaiveStreamingDetokenizer is not None:
+            self._detokenizer = NaiveStreamingDetokenizer(tokenizer)
+        else:
+            self._detokenizer = None
+
+        if self._detokenizer is not None:
+            self._detokenizer.reset()
+
+    def _append_text(
+        self,
+        stream_parts: list[str],
+        visible_parts: list[str],
+        text: str,
+    ) -> None:
+        if not text:
+            return
+        stream_parts.append(text)
+        visible_parts.append(text)
+
+    def _active_markers(self) -> list[str]:
+        markers = [_TURN_END_MARKER, _TOOL_RESPONSE_OPEN, _TOOL_RESPONSE_CLOSE]
+        markers.append(_CLOSE_MARKER if self._in_thought else _OPEN_MARKER)
+        return markers
+
+    @staticmethod
+    def _find_next_marker(
+        source: str, pos: int, markers: list[str]
+    ) -> tuple[int, str] | tuple[None, None]:
+        next_idx: int | None = None
+        next_marker: str | None = None
+        for marker in markers:
+            idx = source.find(marker, pos)
+            if idx == -1:
+                continue
+            if next_idx is None or idx < next_idx:
+                next_idx = idx
+                next_marker = marker
+        return next_idx, next_marker
+
+    def _consume_text(
+        self, text: str, *, final: bool = False
+    ) -> OutputParserTokenResult:
+        source = self._buffer + text
+        self._buffer = ""
+
+        stream_parts: list[str] = []
+        visible_parts: list[str] = []
+        pos = 0
+
+        while pos < len(source):
+            markers = self._active_markers()
+            idx, marker = self._find_next_marker(source, pos, markers)
+
+            if idx is None or marker is None:
+                remainder = source[pos:]
+                if not final:
+                    keep = max(
+                        _matching_prefix_len(remainder, marker_text)
+                        for marker_text in markers
+                    )
+                    if keep:
+                        emit = remainder[:-keep]
+                        self._buffer = remainder[-keep:]
+                    else:
+                        emit = remainder
+                else:
+                    emit = remainder
+
+                self._append_text(stream_parts, visible_parts, emit)
+                break
+
+            self._append_text(stream_parts, visible_parts, source[pos:idx])
+
+            if marker == _OPEN_MARKER:
+                stream_parts.append(_THINK_OPEN)
+                visible_parts.append(_THINK_OPEN)
+                self._in_thought = True
+            elif marker == _CLOSE_MARKER:
+                stream_parts.append(_THINK_CLOSE)
+                visible_parts.append(_THINK_CLOSE)
+                self._in_thought = False
+            elif marker == _TURN_END_MARKER:
+                pass
+
+            pos = idx + len(marker)
+
+        return OutputParserTokenResult(
+            stream_text="".join(stream_parts),
+            visible_text="".join(visible_parts),
+        )
+
+    def process_token(self, token_id: int) -> OutputParserTokenResult:
+        if self._detokenizer is not None:
+            self._detokenizer.add_token(token_id)
+            text = self._detokenizer.last_segment
+        else:
+            text = self._tokenizer.decode([token_id])
+        return self._consume_text(text)
+
+    def finalize(self) -> OutputParserFinalizeResult:
+        text = ""
+        if self._detokenizer is not None:
+            self._detokenizer.finalize()
+            text = self._detokenizer.last_segment
+
+        token_result = self._consume_text(text, final=True)
+
+        stream_text = token_result.stream_text
+        visible_text = token_result.visible_text
+
+        if self._buffer:
+            stream_text += self._buffer
+            visible_text += self._buffer
+            self._buffer = ""
+
+        if self._in_thought:
+            stream_text += _THINK_CLOSE
+            visible_text += _THINK_CLOSE
+            self._in_thought = False
+
+        return OutputParserFinalizeResult(
+            stream_text=stream_text,
+            visible_text=visible_text,
+        )

--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generic streamed output parser sessions.
+
+This module provides a tiny scheduler-facing abstraction for protocol-specific
+output parsing.  A parser session owns any protocol state needed while a single
+request is generating (e.g. Harmony channel parsing or Gemma 4 reasoning marker
+suppression) and exposes a uniform token-by-token interface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, Protocol
+
+try:
+    from mlx_lm.tokenizer_utils import NaiveStreamingDetokenizer
+except ImportError:
+    NaiveStreamingDetokenizer = None
+
+from .harmony import HarmonyStreamingParser, parse_tool_calls_from_tokens
+from ..utils.tokenizer import is_gemma4_model, is_harmony_model
+
+
+@dataclass
+class OutputParserTokenResult:
+    """Per-token parser result returned during streaming."""
+
+    stream_text: str = ""
+    visible_text: str = ""
+    is_stop: bool = False
+    record_token: bool | None = None
+
+
+@dataclass
+class OutputParserFinalizeResult:
+    """Final parser result returned once a request finishes."""
+
+    stream_text: str = ""
+    visible_text: str = ""
+    tool_calls: list[dict[str, str]] = field(default_factory=list)
+    finish_reason: str | None = None
+
+
+class OutputParserSession(Protocol):
+    """Protocol implemented by per-request output parser sessions."""
+
+    def process_token(self, token_id: int) -> OutputParserTokenResult:
+        """Process one generated token."""
+
+    def finalize(self) -> OutputParserFinalizeResult:
+        """Flush any buffered output when generation ends."""
+
+
+@dataclass(frozen=True)
+class OutputParserFactory:
+    """Factory for creating per-request parser sessions."""
+
+    kind: str
+    create_session: Callable[[Any], OutputParserSession]
+    stop_token_ids: set[int] = field(default_factory=set)
+
+
+class HarmonyOutputParserSession:
+    """Scheduler-facing wrapper around ``HarmonyStreamingParser``."""
+
+    def __init__(self, tokenizer: Any):
+        self._tokenizer = tokenizer
+        self._parser = HarmonyStreamingParser(tokenizer)
+        self._raw_token_ids: list[int] = []
+
+        if hasattr(tokenizer, "detokenizer"):
+            self._detokenizer = tokenizer.detokenizer
+        elif NaiveStreamingDetokenizer is not None:
+            self._detokenizer = NaiveStreamingDetokenizer(tokenizer)
+        else:
+            self._detokenizer = None
+
+        if self._detokenizer is not None:
+            self._detokenizer.reset()
+
+    def process_token(self, token_id: int) -> OutputParserTokenResult:
+        control_text, stream_token, visible_token, is_stop = self._parser.process_token(
+            token_id
+        )
+        self._raw_token_ids.append(token_id)
+
+        stream_text = control_text
+        visible_text = ""
+
+        if stream_token is not None:
+            if self._detokenizer is not None:
+                self._detokenizer.add_token(stream_token)
+                decoded_text = self._detokenizer.last_segment
+            else:
+                decoded_text = self._tokenizer.decode([stream_token])
+
+            stream_text += decoded_text
+            if visible_token is not None:
+                visible_text += decoded_text
+        elif visible_token is not None:
+            if self._detokenizer is not None:
+                self._detokenizer.add_token(visible_token)
+                visible_text += self._detokenizer.last_segment
+            else:
+                visible_text += self._tokenizer.decode([visible_token])
+
+        return OutputParserTokenResult(
+            stream_text=stream_text,
+            visible_text=visible_text,
+            is_stop=is_stop,
+            record_token=True,
+        )
+
+    def finalize(self) -> OutputParserFinalizeResult:
+        stream_text = self._parser.finalize()
+        visible_text = ""
+
+        if self._detokenizer is not None:
+            self._detokenizer.finalize()
+            final_text = self._detokenizer.last_segment
+            if final_text:
+                stream_text += final_text
+                if self._parser.current_channel == "final":
+                    visible_text += final_text
+
+        _, tool_calls = parse_tool_calls_from_tokens(self._raw_token_ids)
+        finish_reason = "tool_calls" if tool_calls else None
+
+        return OutputParserFinalizeResult(
+            stream_text=stream_text,
+            visible_text=visible_text,
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
+        )
+
+
+def detect_output_parser(
+    model_name: str,
+    tokenizer: Any,
+    model_config: Optional[dict[str, Any]] = None,
+) -> OutputParserFactory | None:
+    """Detect a protocol-specific output parser for the model, if needed."""
+
+    if is_harmony_model(model_name, model_config):
+        temp_parser = HarmonyStreamingParser(tokenizer)
+        return OutputParserFactory(
+            kind="harmony",
+            create_session=HarmonyOutputParserSession,
+            stop_token_ids=temp_parser.get_stop_token_ids(),
+        )
+
+    if is_gemma4_model(model_name, model_config):
+        from .gemma4 import Gemma4OutputParserSession
+
+        return OutputParserFactory(
+            kind="gemma4",
+            create_session=Gemma4OutputParserSession,
+            stop_token_ids=set(),
+        )
+
+    return None
+
+
+def detect_message_extractor(
+    model_name: str,
+    model_config: Optional[dict[str, Any]] = None,
+) -> Callable:
+    """Return the appropriate message extractor function for the model.
+
+    The returned callable has the signature::
+
+        extractor(messages, max_tool_result_tokens=None, tokenizer=None) -> list[dict]
+
+    This mirrors how ``detect_output_parser`` decouples model-specific
+    knowledge from the server layer — the engine stores the extractor at
+    load time and the server just calls ``engine.message_extractor(...)``.
+    """
+    if is_harmony_model(model_name, model_config):
+        from ..api.utils import extract_harmony_messages
+
+        return extract_harmony_messages
+
+    if is_gemma4_model(model_name, model_config):
+        from .gemma4 import extract_gemma4_messages
+
+        return extract_gemma4_messages
+
+    # Default: caller decides between extract_text_content and
+    # extract_multimodal_content based on engine type (VLM vs text).
+    return None

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -105,14 +105,14 @@ def _extract_text_from_content_list(content: list) -> str:
             item = item.model_dump()
         elif hasattr(item, "dict"):
             item = item.dict()
-        
+
         if isinstance(item, dict):
             if item.get("type") == "text":
                 text_parts.append(item.get("text", ""))
         elif isinstance(item, str):
             # Direct string in content list
             text_parts.append(item)
-    
+
     return "\n".join(text_parts) if text_parts else ""
 
 
@@ -180,6 +180,9 @@ def _drop_void_assistant_messages(messages: list[dict]) -> list[dict]:
     assistant message has empty content and no tool_calls.  These void messages
     carry no information and can appear when a client echoes back a response
     that had only tool calls which were not preserved in its history.
+
+    Messages with ``tool_responses`` (Gemma 4 format) are never dropped even
+    when content is empty — they carry tool result data.
     """
     return [
         msg
@@ -188,6 +191,7 @@ def _drop_void_assistant_messages(messages: list[dict]) -> list[dict]:
             msg.get("role") == "assistant"
             and not msg.get("content")
             and not msg.get("tool_calls")
+            and not msg.get("tool_responses")
         )
     ]
 
@@ -776,7 +780,9 @@ def extract_harmony_messages(
             processed_messages.append({"role": role, "content": content})
         elif isinstance(content, list):
             # Extract text parts from content array
-            processed_messages.append({"role": role, "content": _extract_text_from_content_list(content)})
+            processed_messages.append(
+                {"role": role, "content": _extract_text_from_content_list(content)}
+            )
         else:
             processed_messages.append({"role": role, "content": str(content)})
 

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -106,6 +106,26 @@ class BatchedEngine(BaseEngine):
         return None
 
     @property
+    def message_extractor(self):
+        """Return the model-specific message extractor function, or ``None``.
+
+        ``None`` means the server should use its default extractor
+        (``extract_text_content`` or ``extract_multimodal_content``).
+        """
+        try:
+            from ..adapter.output_parser import detect_message_extractor
+            model_config = None
+            if self._model is not None and hasattr(self._model, "config"):
+                cfg = self._model.config
+                if hasattr(cfg, "model_type"):
+                    model_config = {"model_type": cfg.model_type}
+                elif isinstance(cfg, dict):
+                    model_config = cfg
+            return detect_message_extractor(self._model_name, model_config)
+        except Exception:
+            return None
+
+    @property
     def grammar_compiler(self):
         """Lazily create and return a GrammarCompiler for this model.
 

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -181,6 +181,16 @@ class VLMBatchedEngine(BaseEngine):
         return None
 
     @property
+    def message_extractor(self):
+        """Return the model-specific message extractor function, or ``None``."""
+        try:
+            from ..adapter.output_parser import detect_message_extractor
+            model_config = {"model_type": self.model_type} if self.model_type else None
+            return detect_message_extractor(self._model_name, model_config)
+        except Exception:
+            return None
+
+    @property
     def is_ocr_model(self) -> bool:
         return (self.model_type or "") in OCR_MODEL_TYPES
 
@@ -352,37 +362,53 @@ class VLMBatchedEngine(BaseEngine):
         logger.info("VLMBatchedEngine stopped")
 
     def _inject_tool_calling(self, tokenizer) -> None:
-        """Inject mlx-lm's tool calling attributes into VLM tokenizer.
+        """Inject tool calling attributes into VLM tokenizer.
 
         mlx-vlm's TokenizerWrapper lacks tool calling support (has_tool_calling,
-        tool_parser, etc). We reuse mlx-lm's _infer_tool_parser() to detect the
-        parser type from the chat template, then set the attributes directly on
-        the wrapper instance so parse_tool_calls() can use native tool parsing.
+        tool_parser, etc). We prefer mlx_vlm.tool_parsers which is a superset of
+        mlx_lm's — it recognises additional markers such as Gemma4's <|tool_call>
+        and loads the correct per-model parser.  Falls back to mlx_lm if the
+        mlx_vlm.tool_parsers package is not present.
         """
-        try:
-            from mlx_lm.tokenizer_utils import _infer_tool_parser
-        except ImportError:
-            return
-
         chat_template = getattr(tokenizer, "chat_template", None)
         if not chat_template:
             return
 
-        tool_parser_type = _infer_tool_parser(chat_template)
-        if tool_parser_type is None:
-            return
-
+        # Prefer mlx_vlm.tool_parsers (superset; knows about Gemma4 etc.)
         try:
-            import importlib
+            from mlx_vlm.tool_parsers import (
+                _infer_tool_parser,
+                load_tool_module,
+            )
 
-            tool_module = importlib.import_module(
-                f"mlx_lm.tool_parsers.{tool_parser_type}"
-            )
+            tool_parser_type = _infer_tool_parser(chat_template)
+            if tool_parser_type is None:
+                return
+            try:
+                tool_module = load_tool_module(tool_parser_type)
+            except ImportError:
+                logger.warning(f"VLM tool parser module not found: {tool_parser_type}")
+                return
         except ImportError:
-            logger.warning(
-                f"VLM tool parser module not found: {tool_parser_type}"
-            )
-            return
+            # Fallback: mlx_lm only (no Gemma4 support)
+            try:
+                import importlib
+
+                from mlx_lm.tokenizer_utils import (
+                    _infer_tool_parser as _mlx_lm_infer,
+                )
+            except ImportError:
+                return
+            tool_parser_type = _mlx_lm_infer(chat_template)
+            if tool_parser_type is None:
+                return
+            try:
+                tool_module = importlib.import_module(
+                    f"mlx_lm.tool_parsers.{tool_parser_type}"
+                )
+            except ImportError:
+                logger.warning(f"VLM tool parser module not found: {tool_parser_type}")
+                return
 
         tool_call_start = tool_module.tool_call_start
         tool_call_end = tool_module.tool_call_end

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -84,17 +84,16 @@ try:
 except ImportError:
     NaiveStreamingDetokenizer = None
 
-# Import Harmony adapter for gpt-oss models
+# Import protocol-specific output parser support
 try:
-    from .adapter.harmony import HarmonyStreamingParser, parse_tool_calls_from_tokens
-    from .utils.tokenizer import is_harmony_model
+    from .adapter.output_parser import OutputParserFactory, OutputParserSession, detect_output_parser
 
-    HAS_HARMONY_ADAPTER = True
+    HAS_OUTPUT_PARSER = True
 except ImportError:
-    HarmonyStreamingParser = None
-    parse_tool_calls_from_tokens = None
-    is_harmony_model = None
-    HAS_HARMONY_ADAPTER = False
+    OutputParserFactory = None
+    OutputParserSession = None
+    detect_output_parser = None
+    HAS_OUTPUT_PARSER = False
 
 logger = logging.getLogger(__name__)
 
@@ -1331,13 +1330,12 @@ class Scheduler:
         # NOTE: No pooling - each request gets a fresh instance to prevent state contamination
         self._request_detokenizers: Dict[str, Any] = {}  # request_id → active detokenizer
 
-        # Harmony model support (gpt-oss)
-        self._harmony_parser: Optional["HarmonyStreamingParser"] = None
+        # Protocol-specific output parser support (e.g. Harmony, Gemma 4)
+        self._output_parser_factory: Optional["OutputParserFactory"] = None
+        self._output_parser_kind: Optional[str] = None
+        self._output_parser_sessions: Dict[str, "OutputParserSession"] = {}
         self._is_harmony_model: bool = False
-        self._harmony_parsers: Dict[str, "HarmonyStreamingParser"] = {}  # Per-request parsers
-        self._harmony_stop_tokens: Optional[Set[int]] = None  # Cached stop tokens
-        if HAS_HARMONY_ADAPTER and is_harmony_model is not None:
-            # Check if model uses Harmony format
+        if HAS_OUTPUT_PARSER and detect_output_parser is not None:
             try:
                 model_config = None
                 if hasattr(model, 'config'):
@@ -1363,18 +1361,24 @@ class Scheduler:
                     except Exception as e:
                         logger.debug(f"Failed to extract model.args: {e}")
 
-                if is_harmony_model(self.config.model_name, model_config):
-                    self._is_harmony_model = True
-                    # Cache Harmony stop tokens to avoid creating temporary parsers
-                    temp_parser = HarmonyStreamingParser(self.tokenizer)
-                    self._harmony_stop_tokens = temp_parser.get_stop_token_ids()
+                self._output_parser_factory = detect_output_parser(
+                    self.config.model_name,
+                    self.tokenizer,
+                    model_config,
+                )
+                if self._output_parser_factory is not None:
+                    self._output_parser_kind = self._output_parser_factory.kind
+                    self._is_harmony_model = self._output_parser_kind == "harmony"
                     logger.info(
-                        f"Harmony model detected: {self.config.model_name}, "
-                        f"stop_tokens={self._harmony_stop_tokens}, "
-                        "streaming parser will be used for each request"
+                        "Output parser detected: %s for %s, stop_tokens=%s",
+                        self._output_parser_kind,
+                        self.config.model_name,
+                        sorted(self._output_parser_factory.stop_token_ids),
                     )
             except Exception as e:
-                logger.warning(f"Error detecting Harmony model: {e}, assuming non-Harmony")
+                logger.warning(f"Error detecting output parser: {e}, assuming none")
+                self._output_parser_factory = None
+                self._output_parser_kind = None
                 self._is_harmony_model = False
 
         # Statistics
@@ -1654,9 +1658,9 @@ class Scheduler:
         if self._generation_config_eos is not None:
             stop_tokens.update(self._generation_config_eos)
 
-        # Add Harmony stop tokens for gpt-oss models (use cached tokens)
-        if self._is_harmony_model and self._harmony_stop_tokens:
-            stop_tokens.update(self._harmony_stop_tokens)
+        # Add protocol-specific stop tokens (e.g. Harmony action stops)
+        if self._output_parser_factory is not None:
+            stop_tokens.update(self._output_parser_factory.stop_token_ids)
 
         return stop_tokens
 
@@ -1714,52 +1718,22 @@ class Scheduler:
         detok = self._request_detokenizers.pop(request_id, None)
         # Let GC collect - no pooling to prevent state contamination
 
-    def _get_harmony_parser(self, request_id: str) -> Optional["HarmonyStreamingParser"]:
-        """Get or create a Harmony parser for a request.
-
-        Each request gets its own parser instance to maintain independent state.
-        """
-        if not self._is_harmony_model or not HAS_HARMONY_ADAPTER:
+    def _get_output_parser_session(
+        self, request_id: str
+    ) -> Optional["OutputParserSession"]:
+        """Get or create a protocol-specific output parser session."""
+        if self._output_parser_factory is None:
             return None
 
-        if request_id not in self._harmony_parsers:
-            self._harmony_parsers[request_id] = HarmonyStreamingParser(self.tokenizer)
-        return self._harmony_parsers[request_id]
+        if request_id not in self._output_parser_sessions:
+            self._output_parser_sessions[request_id] = (
+                self._output_parser_factory.create_session(self.tokenizer)
+            )
+        return self._output_parser_sessions[request_id]
 
-    def _get_harmony_detokenizer(self, request_id: str) -> Any:
-        """Get or create a streaming detokenizer for Harmony.
-
-        Uses a single detokenizer per request since we process tokens sequentially.
-        For final channel where stream_token == visible_token, we decode once
-        and reuse the result.
-
-        This ensures proper UTF-8 handling for multi-byte characters.
-        """
-        key = f"{request_id}_harmony"
-
-        if key not in self._request_detokenizers:
-            if NaiveStreamingDetokenizer is not None:
-                detok = NaiveStreamingDetokenizer(self.tokenizer)
-            elif hasattr(self.tokenizer, 'detokenizer'):
-                detok = self.tokenizer.detokenizer
-            else:
-                return None
-
-            detok.reset()
-            self._request_detokenizers[key] = detok
-
-        return self._request_detokenizers.get(key)
-
-    def _cleanup_harmony_parser(self, request_id: str):
-        """Clean up Harmony parser and detokenizer for a finished request."""
-        parser = self._harmony_parsers.pop(request_id, None)
-        if parser is not None:
-            try:
-                # Ensure parser is finalized before cleanup
-                parser.finalize()
-            except Exception as e:
-                logger.debug(f"Error finalizing Harmony parser for {request_id}: {e}")
-        self._request_detokenizers.pop(f"{request_id}_harmony", None)
+    def _cleanup_output_parser_session(self, request_id: str):
+        """Remove any per-request protocol parser session."""
+        self._output_parser_sessions.pop(request_id, None)
 
     def _get_xtc_special_tokens(self) -> list[int]:
         """Get special tokens to exclude from XTC sampling (newline + EOS).
@@ -3201,8 +3175,8 @@ class Scheduler:
         # Clean up streaming detokenizer to prevent state contamination
         self._cleanup_detokenizer(request_id)
 
-        # Clean up Harmony parser
-        self._cleanup_harmony_parser(request_id)
+        # Clean up protocol-specific output parser session
+        self._cleanup_output_parser_session(request_id)
 
         # Clean up VLM adapter state to prevent contamination
         if hasattr(self.model, 'clear_vlm_position_state'):
@@ -3691,57 +3665,30 @@ class Scheduler:
             # Only append token if not stopping due to EOS token
             new_text = ""
 
-            # Check if this request uses Harmony format
-            harmony_parser = self._get_harmony_parser(request_id)
+            # Check if this request uses a protocol-specific output parser
+            parser_session = self._get_output_parser_session(request_id)
 
-            if harmony_parser is not None:
-                # Harmony model: process token through parser
-                # Returns: (control_text, stream_token, visible_token, is_stop)
-                control_text, stream_token, visible_token, harmony_is_stop = (
-                    harmony_parser.process_token(response.token)
-                )
+            if parser_session is not None:
+                parser_result = parser_session.process_token(response.token)
+                new_text = parser_result.stream_text
+                if parser_result.visible_text:
+                    request.output_text += parser_result.visible_text
 
-                # Start with control text (e.g., <think>, </think>)
-                new_text = control_text
-
-                # Get Harmony detokenizer for proper UTF-8 handling
-                harmony_detok = self._get_harmony_detokenizer(request_id)
-
-                # Decode stream token if present
-                if stream_token is not None:
-                    if harmony_detok is not None:
-                        harmony_detok.add_token(stream_token)
-                        decoded_text = harmony_detok.last_segment
-                    else:
-                        # Fallback to single-token decode (may break UTF-8)
-                        decoded_text = self.tokenizer.decode([stream_token])
-
-                    new_text += decoded_text
-
-                    # For final channel, stream_token == visible_token
-                    # Reuse decoded text instead of decoding again
-                    if visible_token is not None:
-                        request.output_text += decoded_text
-                elif visible_token is not None:
-                    # This case shouldn't happen in current design but handle it
-                    if harmony_detok is not None:
-                        harmony_detok.add_token(visible_token)
-                        request.output_text += harmony_detok.last_segment
-                    else:
-                        request.output_text += self.tokenizer.decode([visible_token])
-
-                # Harmony stop token can override finish reason
-                if harmony_is_stop and not is_finished:
+                # Parser-defined stop token can override finish reason
+                if parser_result.is_stop and not is_finished:
                     is_finished = True
                     is_stop = True
 
-                # For Harmony, always track all tokens including stop tokens
-                # This is needed for tool call parsing (parse_tool_calls_from_tokens)
-                # which requires the complete token sequence including <|call|>/<|return|>
-                request.append_output_token(response.token)
+                should_record_token = (
+                    parser_result.record_token
+                    if parser_result.record_token is not None
+                    else not is_stop
+                )
+                if should_record_token:
+                    request.append_output_token(response.token)
 
             elif not is_stop:
-                # Non-Harmony: standard processing
+                # Standard processing without a protocol parser
                 request.append_output_token(response.token)
 
                 # Decode the new token using streaming detokenizer for proper UTF-8 handling
@@ -3754,8 +3701,8 @@ class Scheduler:
                     new_text = self.tokenizer.decode([response.token])
 
             # Prepend <think> tag for first chunk if this is a reasoning model
-            # (skip for Harmony models - parser handles <think> for analysis channel)
-            if harmony_parser is None and getattr(request, 'needs_think_prefix', False):
+            # (skip when a protocol parser already manages reasoning formatting)
+            if parser_session is None and getattr(request, 'needs_think_prefix', False):
                 if not getattr(request, 'think_prefix_sent', False):
                     think_tag = getattr(self.tokenizer, 'think_start', '<think>')
                     new_text = think_tag + "\n" + new_text
@@ -3795,43 +3742,19 @@ class Scheduler:
                 output.finish_reason = response.finish_reason
                 finished_ids.add(request_id)
 
-                if harmony_parser is not None:
-                    # Harmony: finalize parser and get any remaining stream output
-                    logger.info(
-                        f"Harmony finished: channel={harmony_parser.current_channel}, "
-                        f"output_text='{request.output_text[:100]}...'"
-                    )
-                    final_control = harmony_parser.finalize()
-                    if final_control:
-                        output.new_text += final_control
-
-                    # Finalize Harmony detokenizer to flush any remaining bytes
-                    harmony_detok = self._get_harmony_detokenizer(request_id)
-                    if harmony_detok is not None:
-                        harmony_detok.finalize()
-                        final_text = harmony_detok.last_segment
-                        if final_text:
-                            output.new_text += final_text
-                            # If we were in final channel, also add to output_text
-                            if harmony_parser.current_channel == "final":
-                                request.output_text += final_text
-
-                    # Extract tool calls using parse_tool_calls_from_tokens (non-streaming)
-                    if parse_tool_calls_from_tokens is not None:
-                        token_ids = list(request.output_token_ids)
-                        logger.info(
-                            f"Harmony parse_tool_calls_from_tokens: {len(token_ids)} tokens"
-                        )
-                        _, tool_calls = parse_tool_calls_from_tokens(token_ids)
-                        logger.info(f"Harmony tool_calls extracted: {tool_calls}")
-                        if tool_calls:
-                            output.tool_calls = tool_calls
-                            output.finish_reason = "tool_calls"
-
-                    # For Harmony, output_text is already accumulated (final channel only)
+                if parser_session is not None:
+                    final_result = parser_session.finalize()
+                    if final_result.stream_text:
+                        output.new_text += final_result.stream_text
+                    if final_result.visible_text:
+                        request.output_text += final_result.visible_text
+                    if final_result.tool_calls:
+                        output.tool_calls = final_result.tool_calls
+                    if final_result.finish_reason:
+                        output.finish_reason = final_result.finish_reason
                     output.output_text = request.output_text
                 else:
-                    # Non-Harmony: standard finalization
+                    # Standard finalization without a protocol parser
                     # Finalize detokenizer to flush any remaining bytes
                     detokenizer = self._get_detokenizer(request_id)
                     if detokenizer is not None:
@@ -4044,8 +3967,8 @@ class Scheduler:
             # Clean up streaming detokenizer
             self._cleanup_detokenizer(request_id)
 
-            # Clean up Harmony parser
-            self._cleanup_harmony_parser(request_id)
+            # Clean up protocol-specific output parser session
+            self._cleanup_output_parser_session(request_id)
 
             # Clean up VLM adapter state (position_ids, rope_deltas, pending embeddings)
             if hasattr(self.model, 'clear_vlm_position_state'):
@@ -4120,8 +4043,8 @@ class Scheduler:
         # Clear detokenizer state to prevent contamination after recovery
         self._request_detokenizers.clear()
 
-        # Clear Harmony parsers
-        self._harmony_parsers.clear()
+        # Clear protocol-specific output parser sessions
+        self._output_parser_sessions.clear()
 
         logger.info("Cache recovery completed")
 
@@ -4370,8 +4293,8 @@ class Scheduler:
         # Clear detokenizers
         self._request_detokenizers.clear()
 
-        # Clear Harmony parsers
-        self._harmony_parsers.clear()
+        # Clear protocol-specific output parser sessions
+        self._output_parser_sessions.clear()
 
         # Cancel any pending deferred Metal cache clear
         self._deferred_clear_steps = None

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -150,7 +150,7 @@ from .api.tool_calling import (
     sanitize_tool_call_markup,
 )
 from .api.thinking import ThinkingParser, extract_thinking
-from .api.utils import clean_output_text, clean_special_tokens, extract_harmony_messages, extract_multimodal_content, extract_text_content
+from .api.utils import clean_output_text, clean_special_tokens, extract_multimodal_content, extract_text_content
 from .engine import BaseEngine, BatchedEngine, VLMBatchedEngine
 from .engine.embedding import EmbeddingEngine
 from .engine.reranker import RerankerEngine
@@ -1857,10 +1857,9 @@ async def create_chat_completion(
 
     # Extract messages - different engines need different content handling
     is_vlm = isinstance(engine, VLMBatchedEngine)
-    if engine.model_type == "gpt_oss":
-        messages = extract_harmony_messages(
-            request.messages, max_tool_result_tokens, engine.tokenizer
-        )
+    extractor = getattr(engine, "message_extractor", None)
+    if extractor is not None:
+        messages = extractor(request.messages, max_tool_result_tokens, engine.tokenizer)
     elif is_vlm:
         # VLM: preserve image_url content parts for vision processing
         messages = extract_multimodal_content(

--- a/omlx/utils/tokenizer.py
+++ b/omlx/utils/tokenizer.py
@@ -104,6 +104,29 @@ def is_harmony_model(model_name: str, config: dict[str, Any] | None = None) -> b
     return False
 
 
+def is_gemma4_model(model_name: str, config: dict[str, Any] | None = None) -> bool:
+    """
+    Check if the model is a Gemma 4 model.
+
+    Detection priority:
+    1. model_type == "gemma4" in config.json
+    2. Fallback: model_name contains "gemma-4" or "gemma4" (case-insensitive)
+    """
+    if config is not None:
+        model_type = config.get("model_type", "")
+        if model_type == "gemma4":
+            logger.debug(f"Gemma 4 model detected via config.model_type: {model_name}")
+            return True
+
+    if model_name:
+        name_lower = model_name.lower()
+        if "gemma-4" in name_lower or "gemma4" in name_lower:
+            logger.debug(f"Gemma 4 model detected via model name pattern: {model_name}")
+            return True
+
+    return False
+
+
 def is_qwen3_model(model_name: str) -> bool:
     """
     Check if the model is a Qwen3 model.

--- a/tests/test_gemma4_messages.py
+++ b/tests/test_gemma4_messages.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Gemma 4 message extraction."""
+
+from __future__ import annotations
+
+from omlx.adapter.gemma4 import extract_gemma4_messages
+from omlx.api.openai_models import Message
+
+
+def _tool_call_dict(id: str, name: str, args: str = "{}") -> dict:
+    return {"id": id, "type": "function", "function": {"name": name, "arguments": args}}
+
+
+def _assistant_with_calls(*calls) -> Message:
+    return Message(role="assistant", content="", tool_calls=list(calls))
+
+
+def _tool_result(id: str, content: str) -> Message:
+    return Message(role="tool", content=content, tool_call_id=id)
+
+
+class TestExtractGemma4Messages:
+    def test_plain_messages_pass_through(self):
+        messages = [
+            Message(role="user", content="Hello"),
+            Message(role="assistant", content="Hi"),
+        ]
+        result = extract_gemma4_messages(messages)
+        assert len(result) == 2
+        assert result[0] == {"role": "user", "content": "Hello"}
+        assert result[1] == {"role": "assistant", "content": "Hi"}
+
+    def test_tool_result_folded_onto_model_turn(self):
+        """Single tool result becomes a model turn with tool_responses."""
+        messages = [
+            Message(role="user", content="What's the weather?"),
+            _assistant_with_calls(_tool_call_dict("c1", "get_weather")),
+            _tool_result("c1", "sunny"),
+        ]
+        result = extract_gemma4_messages(messages)
+        # user + assistant(tool_calls) + assistant(tool_responses)
+        assert len(result) == 3
+        tr_msg = result[2]
+        assert tr_msg["role"] == "assistant"
+        assert tr_msg["content"] == ""
+        assert tr_msg["tool_responses"] == [
+            {"name": "get_weather", "response": "sunny"}
+        ]
+
+    def test_function_name_resolved_from_tool_call_id(self):
+        messages = [
+            _assistant_with_calls(
+                _tool_call_dict("c1", "search"),
+                _tool_call_dict("c2", "calculate"),
+            ),
+            _tool_result("c2", "42"),
+            _tool_result("c1", "results"),
+        ]
+        result = extract_gemma4_messages(messages)
+        tr_msg = result[-1]
+        names = {tr["name"] for tr in tr_msg["tool_responses"]}
+        assert names == {"calculate", "search"}
+
+    def test_multiple_tool_results_batched(self):
+        """Multiple consecutive tool results land in a single tool_responses turn."""
+        messages = [
+            _assistant_with_calls(
+                _tool_call_dict("c1", "fn_a"),
+                _tool_call_dict("c2", "fn_b"),
+            ),
+            _tool_result("c1", "result_a"),
+            _tool_result("c2", "result_b"),
+        ]
+        result = extract_gemma4_messages(messages)
+        tr_msg = result[-1]
+        assert len(tr_msg["tool_responses"]) == 2
+        assert tr_msg["tool_responses"][0] == {"name": "fn_a", "response": "result_a"}
+        assert tr_msg["tool_responses"][1] == {"name": "fn_b", "response": "result_b"}
+
+    def test_json_response_parsed_to_dict(self):
+        """JSON-parseable tool result content becomes a dict."""
+        messages = [
+            _assistant_with_calls(_tool_call_dict("c1", "fn")),
+            _tool_result("c1", '{"value": 42}'),
+        ]
+        result = extract_gemma4_messages(messages)
+        response = result[-1]["tool_responses"][0]["response"]
+        assert response == {"value": 42}
+
+    def test_non_json_response_stays_string(self):
+        messages = [
+            _assistant_with_calls(_tool_call_dict("c1", "fn")),
+            _tool_result("c1", "plain text result"),
+        ]
+        result = extract_gemma4_messages(messages)
+        assert result[-1]["tool_responses"][0]["response"] == "plain text result"
+
+    def test_orphaned_tool_result_fallback_to_tool_call_id_as_name(self):
+        """Tool result with no preceding assistant turn uses tool_call_id as name."""
+        messages = [_tool_result("call_xyz", "orphaned")]
+        result = extract_gemma4_messages(messages)
+        assert result[0]["tool_responses"][0]["name"] == "call_xyz"
+
+    def test_tool_calls_preserved_on_assistant_turn(self):
+        """Assistant turn tool_calls are kept so the template renders them."""
+        messages = [
+            _assistant_with_calls(_tool_call_dict("c1", "do_thing", '{"x": 1}'))
+        ]
+        result = extract_gemma4_messages(messages)
+        assert "tool_calls" in result[0]
+        assert result[0]["tool_calls"][0]["function"]["name"] == "do_thing"
+        # arguments should be parsed to dict
+        assert result[0]["tool_calls"][0]["function"]["arguments"] == {"x": 1}
+
+    def test_multi_turn_agentic_conversation(self):
+        """Full agentic loop: user → tool call → result → follow-up answer."""
+        messages = [
+            Message(role="user", content="Look it up"),
+            _assistant_with_calls(_tool_call_dict("c1", "search")),
+            _tool_result("c1", "found it"),
+            Message(role="assistant", content="Here is what I found."),
+        ]
+        result = extract_gemma4_messages(messages)
+        assert result[0] == {"role": "user", "content": "Look it up"}
+        assert "tool_calls" in result[1]
+        assert result[2]["tool_responses"][0]["name"] == "search"
+        assert result[3] == {"role": "assistant", "content": "Here is what I found."}
+
+    def test_system_message_preserved(self):
+        messages = [
+            Message(role="system", content="You are helpful."),
+            Message(role="user", content="Hi"),
+        ]
+        result = extract_gemma4_messages(messages)
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] == "You are helpful."
+
+    def test_developer_role_normalised_to_system(self):
+        messages = [Message(role="developer", content="Be concise.")]
+        result = extract_gemma4_messages(messages)
+        assert result[0]["role"] == "system"

--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for protocol-specific output parser sessions."""
+
+from __future__ import annotations
+
+from openai_harmony import load_harmony_encoding
+
+from omlx.adapter.gemma4 import Gemma4OutputParserSession
+from omlx.adapter.output_parser import detect_output_parser
+
+
+class FakeDetokenizer:
+    def __init__(self, decode_one):
+        self._decode_one = decode_one
+        self.last_segment = ""
+
+    def reset(self):
+        self.last_segment = ""
+
+    def add_token(self, token_id: int):
+        self.last_segment = self._decode_one(token_id)
+
+    def finalize(self):
+        self.last_segment = ""
+
+
+class GemmaTokenizer:
+    def __init__(self, token_map: dict[int, str]):
+        self._token_map = token_map
+
+    @property
+    def detokenizer(self):
+        return FakeDetokenizer(lambda token_id: self._token_map[token_id])
+
+    def decode(self, token_ids, skip_special_tokens: bool = True):
+        return "".join(self._token_map[token_id] for token_id in token_ids)
+
+
+class HarmonyTokenizer:
+    def __init__(self, encoding):
+        self._encoding = encoding
+
+    def convert_tokens_to_ids(self, token: str) -> int:
+        ids = self._encoding.encode(token, allowed_special="all")
+        return ids[0] if ids else -1
+
+    def decode(self, token_ids, skip_special_tokens: bool = True):
+        return self._encoding.decode(token_ids)
+
+    @property
+    def detokenizer(self):
+        return FakeDetokenizer(lambda token_id: self._encoding.decode([token_id]))
+
+
+class TestGemma4OutputParserSession:
+    def test_normal_reasoning_block(self):
+        token_map = {
+            1: "<|channel>",
+            2: "thought\n",
+            3: "reasoning",
+            4: "<channel|>",
+            5: "final answer",
+        }
+        tokenizer = GemmaTokenizer(token_map)
+        session = Gemma4OutputParserSession(tokenizer)
+
+        stream = []
+        visible = []
+        for token_id in [1, 2, 3, 4, 5]:
+            result = session.process_token(token_id)
+            stream.append(result.stream_text)
+            visible.append(result.visible_text)
+        final = session.finalize()
+        stream.append(final.stream_text)
+        visible.append(final.visible_text)
+
+        full_stream = "".join(stream)
+        full_visible = "".join(visible)
+
+        assert full_stream == "<think>\nreasoning</think>\nfinal answer"
+        assert full_visible == full_stream
+        assert "<|channel>" not in full_stream
+        assert "<channel|>" not in full_stream
+
+    def test_empty_thought_block(self):
+        token_map = {
+            1: "<|channel>thought\n",
+            2: "<channel|>",
+            3: "answer",
+        }
+        tokenizer = GemmaTokenizer(token_map)
+        session = Gemma4OutputParserSession(tokenizer)
+
+        parts = []
+        for token_id in [1, 2, 3]:
+            parts.append(session.process_token(token_id).stream_text)
+        parts.append(session.finalize().stream_text)
+
+        assert "".join(parts) == "<think>\n</think>\nanswer"
+
+    def test_partial_marker_across_tokens(self):
+        token_map = {
+            1: "<|chan",
+            2: "nel>thought\nstep 1",
+            3: " and step 2<chan",
+            4: "nel|>",
+            5: "done",
+        }
+        tokenizer = GemmaTokenizer(token_map)
+        session = Gemma4OutputParserSession(tokenizer)
+
+        parts = []
+        for token_id in [1, 2, 3, 4, 5]:
+            parts.append(session.process_token(token_id).stream_text)
+        parts.append(session.finalize().stream_text)
+
+        text = "".join(parts)
+        assert text == "<think>\nstep 1 and step 2</think>\ndone"
+        assert "<|channel>thought" not in text
+        assert "<channel|>" not in text
+
+    def test_suppresses_turn_end_marker(self):
+        token_map = {
+            1: "<|channel>thought\n",
+            2: "reasoning",
+            3: "<channel|>",
+            4: "answer",
+            5: "<turn|>",
+        }
+        tokenizer = GemmaTokenizer(token_map)
+        session = Gemma4OutputParserSession(tokenizer)
+
+        parts = []
+        for token_id in [1, 2, 3, 4, 5]:
+            result = session.process_token(token_id)
+            parts.append(result.stream_text)
+            assert "<turn|>" not in result.stream_text
+            assert "<turn|>" not in result.visible_text
+        parts.append(session.finalize().stream_text)
+
+        text = "".join(parts)
+        assert text == "<think>\nreasoning</think>\nanswer"
+        assert "<turn|>" not in text
+
+
+class TestOutputParserFactory:
+    def test_detects_gemma4(self):
+        tokenizer = GemmaTokenizer({1: "x"})
+        factory = detect_output_parser(
+            "google/gemma-4b",
+            tokenizer,
+            {"model_type": "gemma4"},
+        )
+
+        assert factory is not None
+        assert factory.kind == "gemma4"
+
+    def test_harmony_wrapper_regression(self):
+        encoding = load_harmony_encoding("HarmonyGptOss")
+        tokenizer = HarmonyTokenizer(encoding)
+        factory = detect_output_parser(
+            "gpt-oss-20b",
+            tokenizer,
+            {"model_type": "gpt_oss"},
+        )
+
+        assert factory is not None
+        assert factory.kind == "harmony"
+
+        session = factory.create_session(tokenizer)
+        tokens = encoding.encode(
+            "<|channel|>analysis<|message|>thinking<|end|>"
+            "<|start|>assistant<|channel|>final<|message|>Answer<|return|>",
+            allowed_special="all",
+        )
+
+        stream = []
+        visible = []
+        saw_stop = False
+        for token in tokens:
+            result = session.process_token(token)
+            stream.append(result.stream_text)
+            visible.append(result.visible_text)
+            saw_stop = saw_stop or result.is_stop
+        final = session.finalize()
+        stream.append(final.stream_text)
+        visible.append(final.visible_text)
+
+        assert saw_stop is True
+        assert "<think>\n" in "".join(stream)
+        assert "</think>\n" in "".join(stream)
+        assert "".join(visible) == "Answer"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1546,6 +1546,99 @@ class TestDetectNeedsThinkPrefix:
         assert scheduler._detect_needs_think_prefix(request) is True
 
 
+class TestOutputParserSmoke:
+    """Smoke tests for scheduler output parser session integration."""
+
+    class _Detokenizer:
+        def __init__(self, decode_one):
+            self._decode_one = decode_one
+            self.last_segment = ""
+
+        def reset(self):
+            self.last_segment = ""
+
+        def add_token(self, token_id):
+            self.last_segment = self._decode_one(token_id)
+
+        def finalize(self):
+            self.last_segment = ""
+
+    class _GemmaTokenizer:
+        def __init__(self, token_map):
+            self._token_map = token_map
+            self.eos_token_id = 2
+            self.pad_token_id = 0
+            self.bos_token_id = 1
+
+        @property
+        def detokenizer(self):
+            return TestOutputParserSmoke._Detokenizer(
+                lambda token_id: self._token_map[token_id]
+            )
+
+        def encode(self, text: str, add_special_tokens: bool = True):
+            if text == "\n":
+                return [198]
+            return [10]
+
+        def decode(self, token_ids, skip_special_tokens: bool = True):
+            return "".join(self._token_map.get(token_id, "") for token_id in token_ids)
+
+    def test_gemma4_session_selected_and_markers_hidden(self, mock_model):
+        mock_model.config.model_type = "gemma4"
+        tokenizer = self._GemmaTokenizer(
+            {
+                11: "<|channel>",
+                12: "thought\n",
+                13: "reasoning",
+                14: "<channel|>",
+                15: "answer",
+                16: "<turn|>",
+            }
+        )
+        scheduler = Scheduler(
+            model=mock_model,
+            tokenizer=tokenizer,
+            config=SchedulerConfig(model_name="google/gemma-4b"),
+        )
+
+        assert scheduler._output_parser_kind == "gemma4"
+
+        request = Request(
+            request_id="gemma-req",
+            prompt="prompt",
+            sampling_params=SamplingParams(max_tokens=5),
+            prompt_token_ids=[1, 2, 3],
+            num_prompt_tokens=3,
+            status=RequestStatus.RUNNING,
+            batch_uid=99,
+        )
+        scheduler.running[request.request_id] = request
+        scheduler.requests[request.request_id] = request
+        scheduler.uid_to_request_id[99] = request.request_id
+        scheduler.request_id_to_uid[request.request_id] = 99
+
+        responses = [
+            type("Resp", (), {"uid": 99, "token": 11, "finish_reason": None})(),
+            type("Resp", (), {"uid": 99, "token": 12, "finish_reason": None})(),
+            type("Resp", (), {"uid": 99, "token": 13, "finish_reason": None})(),
+            type("Resp", (), {"uid": 99, "token": 14, "finish_reason": None})(),
+            type("Resp", (), {"uid": 99, "token": 15, "finish_reason": None})(),
+            type("Resp", (), {"uid": 99, "token": 16, "finish_reason": "length"})(),
+        ]
+
+        outputs, finished_ids = scheduler._process_batch_responses(responses)
+
+        assert finished_ids == {"gemma-req"}
+        assert outputs[-1].finished is True
+        assert outputs[-1].output_text == "<think>\nreasoning</think>\nanswer"
+
+        full_stream = "".join(output.new_text for output in outputs)
+        assert "<|channel>" not in full_stream
+        assert "<channel|>" not in full_stream
+        assert full_stream == "<think>\nreasoning</think>\nanswer"
+
+
 class TestVLMPositionStateClearing:
     """Tests for conditional mRoPE position state clearing (#531).
 

--- a/tests/test_utils_tokenizer.py
+++ b/tests/test_utils_tokenizer.py
@@ -6,6 +6,7 @@ import pytest
 from omlx.utils.tokenizer import (
     apply_qwen3_fix,
     get_tokenizer_config,
+    is_gemma4_model,
     is_harmony_model,
     is_qwen3_model,
 )
@@ -55,6 +56,27 @@ class TestIsHarmonyModel:
         """Test with empty config dict."""
         assert is_harmony_model("gpt-oss", {}) is True
         assert is_harmony_model("llama", {}) is False
+
+
+class TestIsGemma4Model:
+    """Test cases for is_gemma4_model function."""
+
+    def test_gemma4_model_via_config_model_type(self):
+        config = {"model_type": "gemma4"}
+        assert is_gemma4_model("some-model", config) is True
+
+    def test_gemma4_model_via_name(self):
+        assert is_gemma4_model("google/gemma-4b", None) is True
+        assert is_gemma4_model("GEMMA-4-27B", None) is True
+        assert is_gemma4_model("my-gemma4-model", None) is True
+
+    def test_not_gemma4_model(self):
+        assert is_gemma4_model("gemma-3-27b", None) is False
+        assert is_gemma4_model("llama-3.1-8b", None) is False
+
+    def test_not_gemma4_with_different_model_type(self):
+        config = {"model_type": "gemma"}
+        assert is_gemma4_model("some-model", config) is False
 
 
 class TestIsQwen3Model:


### PR DESCRIPTION
Adds generic output parser sessions and complete Gemma 4 reasoning + agentic tool calling support. Supersedes #561.

---

## Reasoning parser

Refactors the scheduler to support pluggable per-model output parser sessions. First implementation handles Gemma 4's `<|channel>thought` reasoning channel — strips it from streamed output and re-emits as `<think>…</think>` in `reasoning_content`.

- `omlx/adapter/output_parser.py` (new): `detect_output_parser()` factory
- `omlx/adapter/gemma4.py` (new): `Gemma4OutputParserSession`
- `omlx/scheduler.py`: threads parser session through generation loop
- `omlx/utils/tokenizer.py`: helpers for the session

## Tool call output parsing

`_inject_tool_calling` was using `mlx_lm._infer_tool_parser` which has no knowledge of Gemma 4's `<|tool_call>` marker — it returned `None`, `has_tool_calling` was never set, and raw markup leaked into response content. The pinned mlx-vlm (`43b9b20`) ships `mlx_vlm.tool_parsers` as a superset that adds `<|tool_call>` → `gemma4` detection and the correct parser. `_inject_tool_calling` now prefers this, falling back to the mlx_lm path for older installs.

## Tool result ingestion (message extractor pattern)

The Gemma 4 chat template has no handling for `role=tool` messages. Tool results must appear on a model-role turn as `tool_responses`:

```python
{"role": "assistant", "tool_responses": [{"name": fn_name, "response": {...}}]}
```

Passing raw `role=tool` messages caused the template to emit `<|tool_response>` literals in content and halt after the first tool call. Two secondary bugs: `_merge_consecutive_roles` was collapsing the `tool_calls` and `tool_responses` turns into one (fixed with `_PRESERVE_BOUNDARY_KEY`); `_drop_void_assistant_messages` was stripping the `tool_responses` turn (fixed with a `tool_responses` guard).

Design mirrors `detect_output_parser` — model-specific logic stays out of `server.py`:
- `detect_message_extractor()` in `output_parser.py` returns the right extractor callable
- `BatchedEngine` / `VLMBatchedEngine` expose it as a `message_extractor` property
- `server.py` calls `getattr(engine, "message_extractor", None)` — no model-type chains
- All Gemma 4 logic lives in `omlx/adapter/gemma4.py`

## Tests

| File | Coverage |
|---|---|
| `tests/test_gemma4_messages.py` | 11 tests: message conversion, tool result folding, name resolution, multi-turn agentic loops |
| `tests/test_output_parser.py` | Reasoning parser session |
| `tests/test_scheduler.py` | Scheduler integration |
| `tests/test_utils_tokenizer.py` | Tokenizer helpers |
