### PR TITLE
feat(admin): populate reasoning parser dropdown dynamically from xgrammar

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -1244,6 +1244,30 @@ async def delete_sub_key(
 
 
 # =============================================================================
+# Grammar API Routes
+# =============================================================================
+
+
+@router.get("/api/grammar/parsers")
+async def list_grammar_parsers(is_admin: bool = Depends(require_admin)):
+    """Return available reasoning parser names from xgrammar.
+
+    Queries ``xgrammar.get_builtin_structural_tag_supported_models()`` at
+    runtime so the list stays in sync with the installed xgrammar version.
+    """
+    try:
+        from xgrammar import get_builtin_structural_tag_supported_models
+
+        supported = get_builtin_structural_tag_supported_models()
+        return [
+            {"value": style, "label": style, "models": models}
+            for style, models in supported.items()
+        ]
+    except ImportError:
+        return []
+
+
+# =============================================================================
 # Models API Routes
 # =============================================================================
 

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -102,6 +102,7 @@
             },
             savingModelSettings: false,
             loadingGenDefaults: false,
+            reasoningParsers: [],
 
             // Status tab state
             stats: {
@@ -880,7 +881,13 @@
                 }
             },
 
-            openModelSettings(model) {
+            async openModelSettings(model) {
+                if (this.reasoningParsers.length === 0) {
+                    try {
+                        const resp = await fetch('/admin/api/grammar/parsers');
+                        if (resp.ok) this.reasoningParsers = await resp.json();
+                    } catch (_) { /* xgrammar not installed */ }
+                }
                 this.selectedModel = model;
                 // Load existing settings if available
                 const settings = model.settings || {};

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -66,14 +66,9 @@
                                     <select x-model="modelSettings.reasoning_parser"
                                             class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all bg-white">
                                         <option value="">None</option>
-                                        <option value="qwen">Qwen</option>
-                                        <option value="qwen_coder">Qwen Coder</option>
-                                        <option value="harmony">Harmony (gpt-oss)</option>
-                                        <option value="llama">Llama</option>
-                                        <option value="deepseek_r1">DeepSeek R1</option>
-                                        <option value="deepseek_v3_2">DeepSeek V3.2</option>
-                                        <option value="kimi">Kimi</option>
-                                        <option value="minimax">MiniMax</option>
+                                        <template x-for="p in reasoningParsers" :key="p.value">
+                                            <option :value="p.value" x-text="p.label + ' (' + p.models.join(', ') + ')'"></option>
+                                        </template>
                                     </select>
                                 </div>
                             </div>

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -786,3 +786,38 @@ class TestGetModelVocabSize:
     def test_returns_none_when_unavailable(self):
         model = MagicMock(spec=[])
         assert self._call(model) is None
+
+
+class TestListGrammarParsers:
+    """Tests for GET /admin/api/grammar/parsers endpoint."""
+
+    @pytest.fixture()
+    def client(self):
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+        from omlx.admin.auth import require_admin
+        from omlx.admin.routes import router
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_admin] = lambda: True
+        yield TestClient(app)
+        app.dependency_overrides.clear()
+
+    def test_returns_list_from_xgrammar(self, client):
+        resp = client.get("/admin/api/grammar/parsers")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+        for item in data:
+            assert "value" in item
+            assert "label" in item
+            assert "models" in item
+            assert isinstance(item["models"], list)
+
+    def test_returns_empty_when_xgrammar_unavailable(self, client):
+        with patch.dict("sys.modules", {"xgrammar": None}):
+            resp = client.get("/admin/api/grammar/parsers")
+        assert resp.status_code == 200
+        assert resp.json() == []


### PR DESCRIPTION
Replace the hardcoded reasoning parser <option> list in the model settings modal with a runtime query to `xgrammar.get_builtin_structural_tag_supported_models()`.

New parsers (e.g. glm47 added in xgrammar 0.1.33) appear automatically after `pip install --upgrade xgrammar` — no code changes or server restart needed. Each dropdown option shows the parser name plus supported model families for easy identification (e.g. "llama (Meta-Llama-3, Llama-3.1, Llama-3.2, Llama-4)")

- Add GET /admin/api/grammar/parsers endpoint
- Fetch parser list in openModelSettings() and store as reactive Alpine data
- Render dropdown options with model family hints (e.g. "qwen (Qwen3)")