### PR TITLE
fix: parse JSON output in /v1/responses endpoint

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3572,6 +3572,17 @@ async def create_response(
         cleaned_text = extraction.cleaned_text
         tool_calls = extraction.tool_calls
 
+    # Process response_format if specified
+    if response_format and not tool_calls:
+        cleaned_text, parsed_json, is_valid, error = parse_json_output(
+            cleaned_text or regular_content,
+            response_format
+        )
+        if parsed_json is not None:
+            cleaned_text = json.dumps(parsed_json)
+        if not is_valid:
+            logger.warning(f"JSON validation failed: {error}")
+
     # Build output items
     output_items: list[OutputItem] = []
     output_items.append(


### PR DESCRIPTION
## Summary

The `/v1/responses` endpoint was missing the `parse_json_output()` post-processing step that `/v1/chat/completions` already performs. When `response_format` is specified and the model wraps JSON in markdown code blocks (common when xgrammar is unavailable), the raw markdown was returned to the client instead of parsed JSON.

## Changes

- Added `parse_json_output()` call in `create_response()` (non-streaming `/v1/responses`) between tool call extraction and output building, matching the existing pattern in `create_chat_completion()`.

Closes #613
