### PR TITLE
style(ui): update `Preferences...` to `Settings…` for macOS consistency

### DIFF
--- a/packaging/omlx_app/app.py
+++ b/packaging/omlx_app/app.py
@@ -719,9 +719,9 @@ class OMLXAppDelegate(NSObject):
 
         self.menu.addItem_(NSMenuItem.separatorItem())
 
-        # --- Preferences ---
+        # --- Settings ---
         prefs_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
-            "Preferences...", "openPreferences:", ","
+            "Settings…", "openPreferences:", ","
         )
         prefs_item.setTarget_(self)
         prefs_icon = self._create_menu_icon("gearshape")
@@ -976,9 +976,9 @@ class OMLXAppDelegate(NSObject):
             alert.setInformativeText_(
                 f"Port {self.server_manager.config.port} is in use by another "
                 f"application{pid_info}.\n\n"
-                f"Change the port in Preferences."
+                f"Change the port in Settings."
             )
-            alert.addButtonWithTitle_("Open Preferences")
+            alert.addButtonWithTitle_("Open Settings")
             alert.addButtonWithTitle_("Cancel")
 
             response = alert.runModal()
@@ -1054,7 +1054,7 @@ class OMLXAppDelegate(NSObject):
 
     @objc.IBAction
     def openPreferences_(self, sender):
-        """Open the Preferences window."""
+        """Open the Settings window."""
         from .preferences import PreferencesWindowController
 
         self.preferences_controller = (
@@ -1077,7 +1077,7 @@ class OMLXAppDelegate(NSObject):
         self.welcome_controller.showWindow()
 
     def _on_prefs_saved(self):
-        """Callback after preferences are saved."""
+        """Callback after settings are saved."""
         self.server_manager.update_config(self.config)
         self._build_menu()
 

--- a/packaging/omlx_app/preferences.py
+++ b/packaging/omlx_app/preferences.py
@@ -1,4 +1,4 @@
-"""Preferences window for oMLX app settings - modern macOS native design."""
+"""Settings window for oMLX app settings - modern macOS native design."""
 
 import logging
 import plistlib
@@ -51,7 +51,7 @@ WINDOW_HEIGHT = 606
 
 
 class PreferencesWindowController(NSObject):
-    """Controller for the Preferences window - modern macOS design."""
+    """Controller for the Settings window - modern macOS design."""
 
     def initWithConfig_serverManager_onSave_(
         self, config, server_manager, on_save_callback
@@ -93,7 +93,7 @@ class PreferencesWindowController(NSObject):
         return sep
 
     def showWindow(self):
-        """Create and show the preferences window."""
+        """Create and show the settings window."""
         # Sync from server settings.json (Web admin changes)
         self.config.sync_from_server_settings()
 
@@ -102,7 +102,7 @@ class PreferencesWindowController(NSObject):
         self.window = NSWindow.alloc().initWithContentRect_styleMask_backing_defer_(
             frame, style, NSBackingStoreBuffered, False
         )
-        self.window.setTitle_("oMLX Preferences")
+        self.window.setTitle_("oMLX Settings")
         self.window.center()
         self.window.setReleasedWhenClosed_(False)
 
@@ -124,7 +124,7 @@ class PreferencesWindowController(NSObject):
 
         # === Title ===
         y -= 30
-        title = NSTextField.labelWithString_("Preferences")
+        title = NSTextField.labelWithString_("Settings")
         title.setFont_(NSFont.systemFontOfSize_weight_(22, 0.5))
         title.setFrame_(NSMakeRect(24, y, WINDOW_WIDTH - 48, 30))
         container.addSubview_(title)
@@ -466,7 +466,7 @@ class PreferencesWindowController(NSObject):
 
     @objc.IBAction
     def savePrefs_(self, sender):
-        """Save preferences and apply changes."""
+        """Save settings and apply changes."""
         new_base_path = str(self.base_path_label.stringValue())
         new_model_dir = str(self.model_dir_label.stringValue())
         port_str = str(self.port_field.stringValue()).strip()
@@ -556,7 +556,7 @@ class PreferencesWindowController(NSObject):
 
     @objc.IBAction
     def closePrefs_(self, sender):
-        """Close the preferences window without saving."""
+        """Close the settings window without saving."""
         self.window.close()
 
     @objc.IBAction


### PR DESCRIPTION
This PR updates the Mac app’s UI strings and internal code comments to use `Settings…` instead of `Preferences...`. This change ensures the app remains consistent with the modern macOS design changes introduced in macOS Ventura 13.

Key Changes
* UI Strings: Updated menu items and labels from "Preferences..." to "Settings…".
* Typography: Corrected the ellipsis from three periods (...) to the standard horizontal ellipsis character (…) as per Apple's Human Interface Guidelines.

[!NOTE]
This is a UI-only change. To maintain backward compatibility and minimize risk, no class names, method signatures, or underlying logic have been modified.

Rationale
1. System Consistency: Since macOS Ventura 13, Apple transitioned "System Preferences" to "System Settings." Aligning with this change unifies the experience across iOS, iPadOS, and macOS, providing a cohesive vocabulary across the Apple ecosystem, and reduces cognitive load for users switching between their devices.
2. AppKit Behavior: By default, AppKit now automatically overrides "Preferences" with "Settings" in the App menu unless explicitly disabled via the `NSMenuShouldUpdateSettingsTitle` key. Adopting this change natively in our strings brings us in line with standard OS behavior.
3. Typographic Precision: Using the proper Unicode ellipsis (…) follows professional typesetting standards and Apple's own localization practices.

While "Preferences" has been a staple of the Mac experience for decades, embracing "Settings" respects the current design evolution of the platform and ensures a modern feel for our users.
