### PR TITLE
Fix VLM SpecPrefill threshold forwarding

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1246,6 +1246,8 @@ class VLMBatchedEngine(BaseEngine):
             specprefill_kwargs["specprefill"] = kwargs.pop("specprefill")
         if kwargs.get("specprefill_keep_pct") is not None:
             specprefill_kwargs["specprefill_keep_pct"] = kwargs.pop("specprefill_keep_pct")
+        if kwargs.get("specprefill_threshold") is not None:
+            specprefill_kwargs["specprefill_threshold"] = kwargs.pop("specprefill_threshold")
         if kwargs.get("specprefill_system_end") is not None:
             specprefill_kwargs["specprefill_system_end"] = kwargs.pop("specprefill_system_end")
 

--- a/tests/test_vlm_specprefill.py
+++ b/tests/test_vlm_specprefill.py
@@ -1,0 +1,53 @@
+"""Regression tests for SpecPrefill parameter forwarding in VLM engine."""
+
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from omlx.engine.vlm import VLMBatchedEngine
+
+
+@pytest.mark.asyncio
+async def test_vlm_chat_forwards_specprefill_threshold_and_keep_pct():
+    """VLM chat must pass both SpecPrefill overrides through to add_request()."""
+    engine = VLMBatchedEngine(model_name="test-vlm")
+    engine._loaded = True
+    engine._tokenizer = MagicMock()
+    engine._tokenizer.apply_chat_template.return_value = "<prompt>"
+    engine._tokenizer.encode.side_effect = lambda text, **kwargs: list(range(max(1, len(text.split()))))
+    engine._engine = MagicMock()
+    engine._engine._mlx_executor = ThreadPoolExecutor(max_workers=1)
+    engine._engine.add_request = AsyncMock(return_value="req-1")
+    engine._engine.abort_request = AsyncMock(return_value=True)
+
+    async def _one_output_stream(_request_id):
+        yield MagicMock(
+            output_text="ok",
+            new_text="ok",
+            prompt_tokens=1,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+            tool_calls=None,
+            cached_tokens=0,
+        )
+
+    engine._engine.stream_outputs = _one_output_stream
+
+    async for _ in engine.stream_chat(
+        messages=[{"role": "user", "content": "Hello"}],
+        max_tokens=1,
+        specprefill=True,
+        specprefill_keep_pct=0.2,
+        specprefill_threshold=1024,
+    ):
+        pass
+
+    try:
+        _, kwargs = engine._engine.add_request.call_args
+        assert kwargs["specprefill"] is True
+        assert kwargs["specprefill_keep_pct"] == 0.2
+        assert kwargs["specprefill_threshold"] == 1024
+    finally:
+        engine._engine._mlx_executor.shutdown(wait=False)


### PR DESCRIPTION
## Summary
- forward `specprefill_threshold` through the VLM chat path into `add_request()`
- keep the existing `specprefill` and `specprefill_keep_pct` passthrough behavior intact
- add a regression test covering VLM SpecPrefill threshold and keep-rate forwarding

## Context
VLM-backed models were ignoring explicit SpecPrefill threshold overrides because `VLMBatchedEngine.stream_generate()` forwarded `specprefill` and `specprefill_keep_pct` but dropped `specprefill_threshold`.

This made Qwen VLM benchmarks silently fall back to the default threshold instead of using the configured value.

## Testing
- `pytest -q tests/test_vlm_specprefill.py`