### PR TITLE
fix: prevent Enter from sending message during CJK IME composition

### DIFF
--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -735,7 +735,7 @@
 
                         <textarea
                             x-model="inputMessage"
-                            @keydown.enter="if (!isMobile && !$event.shiftKey) { $event.preventDefault(); sendMessage(); }"
+                            @keydown.enter="if (!isMobile && !$event.shiftKey && !$event.isComposing && $event.keyCode !== 229) { $event.preventDefault(); sendMessage(); }"
                             @input="autoResize($event.target)"
                             @paste="handlePaste($event)"
                             :placeholder="isMobile ? window.t('chat.input_placeholder_mobile') : window.t('chat.input_placeholder')"


### PR DESCRIPTION
## Problem

When using CJK (Chinese/Japanese/Korean) input methods in the chat textarea, 
pressing Enter to confirm character selection immediately sends the message 
instead of completing the IME composition.

## Fix

Add `isComposing` and `keyCode !== 229` guards to the keydown handler in 
`omlx/admin/templates/chat.html`:

| Guard | Purpose |
|---|---|
| `!$event.isComposing` | W3C standard — `true` while IME is composing |
| `$event.keyCode !== 229` | Legacy fallback — older browsers report keyCode 229 during IME |

## Testing

- [x] Chinese (Pinyin / Zhuyin) — Enter confirms character, does not send
- [x] Japanese (Hiragana → Kanji conversion) — Enter confirms, does not send
- [x] Korean (Hangul composition) — Enter confirms, does not send
- [x] English direct input — Enter sends message as before
- [x] Shift+Enter — Inserts newline as before

## Scope

One-line change in `omlx/admin/templates/chat.html`. No other files affected.