### PR TITLE
Improve streaming chat rendering and viewport containment

### DIFF
--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -64,6 +64,14 @@
         background-color: var(--bg-primary) !important;
         color: var(--text-primary) !important;
     }
+    html, body {
+        height: 100%;
+        overflow: hidden;
+    }
+    .chat-shell {
+        height: 100dvh;
+        min-height: 100vh;
+    }
 
     /* Scrollbar */
     .custom-scrollbar::-webkit-scrollbar { width: 6px; }
@@ -348,7 +356,7 @@
         document.documentElement.setAttribute('data-theme', theme);
     })();
 </script>
-<div class="h-screen flex overflow-hidden" x-data="chatApp()" x-init="init()">
+<div class="chat-shell flex overflow-hidden" x-data="chatApp()" x-init="init()">
     <!-- API Key Modal -->
     <div class="api-key-modal fixed inset-0 bg-black/50 flex items-center justify-center z-[1000]" :class="{ 'hidden': apiKeySet }" x-cloak>
         <div class="bg-surface rounded-2xl p-8 max-w-[400px] w-[90%] shadow-2xl">
@@ -621,10 +629,17 @@
                                         <span class="thinking-text">Thinking</span>
                                         <svg class="thinking-toggle" :class="{ collapsed: !msg._thinkingOpen }" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"/></svg>
                                     </div>
-                                    <div class="thinking-content markdown-content thinking-markdown" :class="{ collapsed: !msg._thinkingOpen }" x-html="renderMarkdown(msg._thinking)"></div>
+                                    <div class="thinking-content markdown-content thinking-markdown"
+                                         :class="{ collapsed: !msg._thinkingOpen }"
+                                         data-math-pending="true"
+                                         :data-math-version="msg._thinking ? String(msg._thinking.length) : '0'"
+                                         x-html="renderMarkdown(msg._thinking)"></div>
                                 </div>
                             </template>
-                            <div class="message-body markdown-content" x-html="renderMarkdown(msg.content)"></div>
+                            <div class="message-body markdown-content"
+                                 data-math-pending="true"
+                                 :data-math-version="typeof msg.content === 'string' ? String(msg.content.length) : '0'"
+                                 x-html="renderMarkdown(msg.content)"></div>
                         </div>
 
                     </div>
@@ -690,7 +705,11 @@
                                 <span class="thinking-text" x-text="finalContent ? 'Thinking' : 'Thinking...'"></span>
                                 <svg class="thinking-toggle" :class="{ collapsed: !streamingThinkingOpen }" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="18 15 12 9 6 15"/></svg>
                             </div>
-                            <div class="thinking-content markdown-content thinking-markdown" :class="{ collapsed: !streamingThinkingOpen }" x-html="renderMarkdown(streamingThinking)"></div>
+                            <div class="thinking-content markdown-content thinking-markdown"
+                                 :class="{ collapsed: !streamingThinkingOpen }"
+                                 data-math-pending="true"
+                                 :data-math-version="String(streamingThinking.length)"
+                                 x-html="renderMarkdown(streamingThinking)"></div>
                         </div>
                         <div x-show="streamingContent" class="markdown-content" x-ref="streamingOutput" x-effect="updateStreamingDOM()"></div>
                     </div>
@@ -878,6 +897,10 @@
             // Live thinking bubble state (shown during streaming)
             streamingThinking: '',          // accumulated reasoning_content for current stream
             streamingThinkingOpen: false,   // whether the live thinking bubble is expanded
+            streamRenderState: {
+                stableIndex: 0,
+                stableText: ''
+            },
 
             // Scroll state
             autoScrollEnabled: true,
@@ -1287,6 +1310,7 @@
                 this.systemPrompt = localStorage.getItem('omlx_chat_system_prompt') || '';
                 this.isMobile = window.innerWidth < 768;
                 this.sidebarOpen = window.innerWidth >= 768;
+                this.resetStreamRenderState();
             },
 
             loadChat(chatId) {
@@ -1298,6 +1322,7 @@
                     if (chat.model) {
                         this.currentModel = chat.model;
                     }
+                    this.scheduleEnhanceMessages();
                 }
                 this.isMobile = window.innerWidth < 768;
                 this.sidebarOpen = window.innerWidth >= 768;
@@ -1404,6 +1429,7 @@
                     this.statusTimelineVisible = false;
                     this.streamingThinking = '';
                     this.streamingThinkingOpen = false;
+                    this.resetStreamRenderState();
                 }
                 this.isStreaming = true;
                 this.streamingContent = '';
@@ -1646,6 +1672,7 @@
                         }
 
                         this.streamingContent = '';
+                        this.resetStreamRenderState();
 
                         // Recurse — model synthesises final answer using tool results
                         await this.streamResponse(depth + 1);
@@ -1665,6 +1692,7 @@
                         _thinkingOpen: false,
                     });
                     this.saveCurrentChat();
+                    this.scheduleEnhanceMessages();
 
                 } catch (error) {
                     console.log('[streamResponse] catch error:', error.name, error.message);
@@ -1686,6 +1714,7 @@
                                 _thinkingOpen: false,
                             });
                             this.saveCurrentChat();
+                            this.scheduleEnhanceMessages();
                         }
                     } else {
                         console.error('Streaming error:', error);
@@ -1695,6 +1724,7 @@
                             model: this.currentModel,
                             _perfVisible: false,
                         });
+                        this.scheduleEnhanceMessages();
                     }
                 } finally {
                     // Attach performance timeline and thinking to the final assistant message, once per prompt
@@ -1716,6 +1746,7 @@
                     }
                     this.isStreaming = false;
                     this.streamingContent = '';
+                    this.resetStreamRenderState();
                     this.engineStatus = null;
                     // Don't reset finalContent here — keeps the status block hidden after completion
                     // It gets reset at the start of the next depth=0 streamResponse call
@@ -1743,6 +1774,7 @@
                 // Find the user message before this assistant message
                 const messagesToKeep = this.messages.slice(0, index);
                 this.messages = messagesToKeep;
+                this.scheduleEnhanceMessages();
 
                 await this.streamResponse();
             },
@@ -1802,6 +1834,7 @@
 
                 // Remove all messages from this index onwards
                 this.messages = this.messages.slice(0, index);
+                this.scheduleEnhanceMessages();
 
                 // Build message content, preserving images
                 let content;
@@ -1932,11 +1965,6 @@
                         html = thinkingHtml + html;
                     }
 
-                    // Schedule code copy buttons and math rendering after DOM update
-                    this.$nextTick(() => {
-                        this.addCodeCopyButtons();
-                        this.renderMath();
-                    });
                     return html;
                 } catch (e) {
                     return text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -2009,43 +2037,71 @@
 
                 if (!this.streamingContent) {
                     container.innerHTML = '';
+                    this.resetStreamRenderState();
                     return;
                 }
 
                 const text = this.streamingContent;
 
-                // Detect if we're in an incomplete think block
-                const lastOpenThink = text.lastIndexOf('<think>');
-                const lastCloseThink = text.lastIndexOf('</think>');
-                const isInIncompleteThink = lastOpenThink !== -1 && lastCloseThink < lastOpenThink;
+                if (text.includes('<think>')) {
+                    container.innerHTML = this.renderStreamingMarkdown(text);
 
-                // Fast path: thinking container already exists, just update its text
-                if (isInIncompleteThink) {
-                    const existingEl = container.querySelector('#streaming-thinking-content');
-                    if (existingEl) {
-                        const thinkingText = text.substring(lastOpenThink + 7);
-                        existingEl.innerHTML = this.escapeHtml(thinkingText).replace(/\n/g, '<br>');
-                        this.scrollThinkingContent();
+                    this.$nextTick(() => {
+                        this.addCodeCopyButtons(container);
+                        this.renderMathInRoot(container);
                         this.scrollToBottom();
-                        return;
-                    }
+                    });
+                    return;
                 }
 
-                // Full render path (first render or structural change)
-                container.innerHTML = this.renderStreamingMarkdown(text);
+                const { stableRoot, tailRoot } = this.ensureStreamingRoots(container);
+                const cutoff = this.findStableRenderCutoff(text);
+                const safeCutoff = Math.max(cutoff, this.streamRenderState.stableIndex);
+
+                if (safeCutoff > this.streamRenderState.stableIndex) {
+                    this.streamRenderState.stableText = text.slice(0, safeCutoff);
+                    stableRoot.innerHTML = this.streamRenderState.stableText
+                        ? DOMPurify.sanitize(marked.parse(this.streamRenderState.stableText))
+                        : '';
+                    this.addCodeCopyButtons(stableRoot);
+                    this.renderMathInRoot(stableRoot);
+                    this.streamRenderState.stableIndex = safeCutoff;
+                }
+
+                const tailText = text.slice(this.streamRenderState.stableIndex);
+                tailRoot.innerHTML = tailText ? DOMPurify.sanitize(marked.parse(tailText)) : '';
 
                 this.$nextTick(() => {
-                    this.addCodeCopyButtons();
-                    this.renderMath();
-                    if (isInIncompleteThink) {
-                        this.scrollThinkingContent();
-                    }
                     this.scrollToBottom();
                 });
             },
 
-            addCodeCopyButtons() {
-                const container = document.getElementById('messagesContainer');
+            ensureStreamingRoots(container) {
+                let stableRoot = container.querySelector('[data-streaming-stable-root]');
+                let tailRoot = container.querySelector('[data-streaming-tail-root]');
+                if (!stableRoot || !tailRoot) {
+                    this.resetStreamingRoots(container);
+                    stableRoot = container.querySelector('[data-streaming-stable-root]');
+                    tailRoot = container.querySelector('[data-streaming-tail-root]');
+                }
+                return { stableRoot, tailRoot };
+            },
+
+            resetStreamingRoots(container) {
+                container.innerHTML = `
+                    <div data-streaming-stable-root="true"></div>
+                    <div data-streaming-tail-root="true"></div>
+                `;
+                this.resetStreamRenderState();
+            },
+
+            resetStreamRenderState() {
+                this.streamRenderState.stableIndex = 0;
+                this.streamRenderState.stableText = '';
+            },
+
+            addCodeCopyButtons(root = null) {
+                const container = root || document.getElementById('messagesContainer');
                 if (!container) return;
 
                 const codeBlocks = container.querySelectorAll('pre code');
@@ -2079,19 +2135,17 @@
                 });
             },
 
-            renderMath(retries = 0) {
+            renderMathInRoot(root, retries = 0) {
+                if (!root) return;
                 if (typeof renderMathInElement === 'undefined') {
                     if (retries < 20) {
-                        setTimeout(() => this.renderMath(retries + 1), 100);
+                        setTimeout(() => this.renderMathInRoot(root, retries + 1), 100);
                     }
                     return;
                 }
 
-                const container = document.getElementById('messagesContainer');
-                if (!container) return;
-
                 try {
-                    renderMathInElement(container, {
+                    renderMathInElement(root, {
                         delimiters: [
                             {left: '$$', right: '$$', display: true},
                             {left: '$', right: '$', display: false},
@@ -2106,6 +2160,123 @@
                 } catch (e) {
                     console.error('Math rendering error:', e);
                 }
+            },
+
+            renderPendingMath(root = null) {
+                const container = root || document.getElementById('messagesContainer');
+                if (!container) return;
+
+                const targets = container.querySelectorAll('[data-math-pending="true"]');
+                targets.forEach((element) => {
+                    const version = element.dataset.mathVersion || '0';
+                    if (element.dataset.mathRenderedVersion === version) return;
+                    this.renderMathInRoot(element);
+                    element.dataset.mathRenderedVersion = version;
+                });
+            },
+
+            scheduleEnhanceMessages() {
+                this.$nextTick(() => {
+                    const container = document.getElementById('messagesContainer');
+                    if (!container) return;
+                    this.addCodeCopyButtons(container);
+                    this.renderPendingMath(container);
+                });
+            },
+
+            findStableRenderCutoff(text) {
+                if (!text) return 0;
+
+                let inFence = false;
+                let inInlineCode = false;
+                let inInlineMath = false;
+                let inDisplayMath = false;
+                let inParenMath = false;
+                let inBracketMath = false;
+                let lastSafeBoundary = 0;
+                let lastWasNewline = false;
+                let lastPromotedBoundary = 0;
+
+                for (let i = 0; i < text.length; i++) {
+                    const ch = text[i];
+                    const prev = i > 0 ? text[i - 1] : '';
+                    const next = i + 1 < text.length ? text[i + 1] : '';
+                    const nextTwo = text.slice(i, i + 2);
+                    const nextThree = text.slice(i, i + 3);
+                    const escaped = prev === '\\';
+
+                    if (!inInlineCode && !inInlineMath && !inDisplayMath && !inParenMath && !inBracketMath && nextThree === '```') {
+                        inFence = !inFence;
+                        i += 2;
+                        lastWasNewline = false;
+                        continue;
+                    }
+
+                    if (!inFence && !inInlineMath && !inDisplayMath && !inParenMath && !inBracketMath && ch === '`' && !escaped) {
+                        inInlineCode = !inInlineCode;
+                        lastWasNewline = false;
+                        continue;
+                    }
+
+                    if (!inFence && !inInlineCode) {
+                        if (!inInlineMath && !inParenMath && !inBracketMath && nextTwo === '$$' && !escaped) {
+                            inDisplayMath = !inDisplayMath;
+                            i += 1;
+                            lastWasNewline = false;
+                            continue;
+                        }
+
+                        if (!inDisplayMath && !inInlineMath && !inBracketMath && nextTwo === '\\(' && !escaped) {
+                            inParenMath = true;
+                            i += 1;
+                            lastWasNewline = false;
+                            continue;
+                        }
+
+                        if (inParenMath && nextTwo === '\\)' && !escaped) {
+                            inParenMath = false;
+                            i += 1;
+                            lastWasNewline = false;
+                            continue;
+                        }
+
+                        if (!inDisplayMath && !inInlineMath && !inParenMath && nextTwo === '\\[' && !escaped) {
+                            inBracketMath = true;
+                            i += 1;
+                            lastWasNewline = false;
+                            continue;
+                        }
+
+                        if (inBracketMath && nextTwo === '\\]' && !escaped) {
+                            inBracketMath = false;
+                            i += 1;
+                            lastWasNewline = false;
+                            continue;
+                        }
+
+                        if (!inDisplayMath && !inParenMath && !inBracketMath && ch === '$' && !escaped) {
+                            inInlineMath = !inInlineMath;
+                            lastWasNewline = false;
+                            continue;
+                        }
+                    }
+
+                    const balanced = !inFence && !inInlineCode && !inInlineMath && !inDisplayMath && !inParenMath && !inBracketMath;
+
+                    if (balanced) {
+                        if (ch === '\n' && lastWasNewline) {
+                            lastSafeBoundary = i + 1;
+                            lastPromotedBoundary = lastSafeBoundary;
+                        } else if ((ch === '.' || ch === '!' || ch === '?' || ch === '\n') && (i + 1 - lastPromotedBoundary) >= 240) {
+                            lastSafeBoundary = i + 1;
+                            lastPromotedBoundary = lastSafeBoundary;
+                        }
+                    }
+
+                    lastWasNewline = ch === '\n';
+                }
+
+                return lastSafeBoundary;
             },
 
             // Check if scroll is at bottom


### PR DESCRIPTION


Refactor chat streaming rendering to scope KaTeX work to the active content instead of rescanning the entire transcript on each update. Add stream render state so stable streamed content is promoted incrementally while incomplete tail content remains isolated until it is safe to render.

Preserve completed-message math enhancement after x-html updates, and tighten the chat layout so page-level overflow stays contained within the chat viewport rather than creating blank space below the composer.

fixes #609 

https://github.com/user-attachments/assets/5f5d7e75-b219-46de-bffd-3dfc4f885008
