### PR TITLE
bump mlx-lm to 0.31.3 and mlx-vlm to latest main

### DIFF
--- a/packaging/venvstacks.toml
+++ b/packaging/venvstacks.toml
@@ -15,8 +15,8 @@ runtime = "cpython-3.11"
 requirements = [
     # Core MLX
     "mlx==0.31.1",
-    # mlx-lm from commit (dcbf6e3) - aligned with pyproject.toml
-    "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@dcbf6e33d135a1b7c6767ca0fe7ebbd23df814a7",
+    # mlx-lm from commit (d9c63ff) - aligned with pyproject.toml
+    "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@d9c63fff67a96c1a1a32934fdf4c2c08c2bb9e7f",
     # regex for mlx-lm's Gemma 4 tool parser (uses recursive patterns)
     "regex",
     # mlx-embeddings from latest commit (32981fa) - aligned with pyproject.toml
@@ -48,8 +48,8 @@ requirements = [
     "mcp>=1.0.0",
     # Harmony format parser for gpt-oss models
     "openai-harmony",
-    # mlx-vlm from commit (23e1dff) - aligned with pyproject.toml
-    "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@23e1dffd224488141a4f022b6d21d6a730f11507",
+    # mlx-vlm from commit (3472132) - aligned with pyproject.toml
+    "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@3472132fe6ee7beeae2c2fc35923eaed2e734b3d",
     "Pillow>=9.0.0",
     # ModelScope SDK for downloading models from ModelScope Hub
     "modelscope>=1.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 
 dependencies = [
     "mlx>=0.31.1",
-    # mlx-lm from commit (dcbf6e3) - Gemma 4 tool call parser + multi-token think/tool support
-    "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@dcbf6e33d135a1b7c6767ca0fe7ebbd23df814a7",
+    # mlx-lm from commit (d9c63ff) - v0.31.3 patch bump; retains Gemma 4 tool call parser + multi-token think/tool support
+    "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@d9c63fff67a96c1a1a32934fdf4c2c08c2bb9e7f",
     # regex for mlx-lm's Gemma 4 tool parser (uses recursive patterns)
     "regex",
     # mlx-embeddings from latest commit (32981fa)
@@ -61,8 +61,8 @@ dependencies = [
     "jsonschema>=4.0.0",
     # Harmony format parser for gpt-oss models
     "openai-harmony",
-    # mlx-vlm from commit (23e1dff) - Gemma 4 multi-image fix + nested tool parser
-    "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@23e1dffd224488141a4f022b6d21d6a730f11507",
+    # mlx-vlm from commit (3472132) - Gemma 4 hyphenated tool names + audio preprocessing fixes + TurboQuant race fix + quantized projection loading + batched cache offset snapshot
+    "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@3472132fe6ee7beeae2c2fc35923eaed2e734b3d",
     "Pillow>=9.0.0",
 ]
 
@@ -130,7 +130,7 @@ include = ["omlx*"]
 # mlx-lm is pinned to a git commit; override transitive pins
 # (e.g. mlx-audio → mlx-lm==0.31.1) so the resolver accepts it.
 override-dependencies = [
-    "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@dcbf6e33d135a1b7c6767ca0fe7ebbd23df814a7",
+    "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@d9c63fff67a96c1a1a32934fdf4c2c08c2bb9e7f",
 ]
 
 [tool.black]


### PR DESCRIPTION
## Summary
- Bump `mlx-lm` pin from `dcbf6e3` to `d9c63ff` (v0.31.3 patch bump, #1124)
- Bump `mlx-vlm` pin from `23e1dff` to `3472132` (5 upstream fixes, non-breaking)
- Keep `pyproject.toml` dependencies, `[tool.uv] override-dependencies`, and `packaging/venvstacks.toml` in lockstep

## mlx-vlm changes pulled in
- Fix Gemma 4 tool parser to accept hyphenated function names (Blaizzy/mlx-vlm#963)
- Fix Gemma 4 audio — mel preprocessing, weight loading, feature extractor (Blaizzy/mlx-vlm#931)
- Fix race condition in TurboQuant fused fast-quantize kernels (Blaizzy/mlx-vlm#967)
- Fix Gemma 4 quantized per-layer projection loading (Blaizzy/mlx-vlm#935)
- Snapshot `cache.offset` to prevent alias mutation under batched caches (Blaizzy/mlx-vlm#966)

## mlx-lm changes pulled in
- `0.31.2` → `0.31.3` patch bump only (ml-explore/mlx-lm#1124)

Both compare ranges (`dcbf6e3..d9c63ff` and `23e1dff..3472132`) contain only bug fixes and a patch version bump. No public API, signature, or required-argument changes — so existing oMLX adapters (`VLMModelAdapter`, `BatchedEngine`, scheduler integration with `BatchGenerator`, Gemma 4 tool-call paths) should be fully compatible.

Rationale for picking HEAD of both `main` branches:
- `mlx-vlm@3472132` includes the Gemma 4 hyphenated-tool-name fix, which improves OpenAI-spec compliance for oMLX's Gemma 4 tool-calling path.
- `mlx-vlm@3472132` also fixes a TurboQuant kernel race that can affect quantized VLMs under oMLX continuous batching.
- `mlx-lm@d9c63ff` is just a patch-version bump; staying in lockstep keeps the override free of surprises.

## Test plan
- [ ] `pip install -e .` resolves against the new git pins in a clean venv
- [ ] `pytest -m "not slow"` passes
- [ ] Smoke test: load a Gemma 4 VLM + hyphenated tool name → parsed correctly
- [ ] Smoke test: load a quantized VLM under `--max-concurrent-requests 8` → no TurboQuant race
- [ ] `packaging/build.py --skip-venv` still builds the app bundle without resolver errors