### PR TITLE
Feature/audio voicedesign params

### DIFF
--- a/omlx/api/audio_models.py
+++ b/omlx/api/audio_models.py
@@ -38,6 +38,11 @@ class AudioSpeechRequest(BaseModel):
     response_format: Optional[str] = "wav"
     ref_audio: Optional[str] = None
     ref_text: Optional[str] = None
+    temperature: Optional[float] = None
+    top_k: Optional[int] = None
+    top_p: Optional[float] = None
+    repetition_penalty: Optional[float] = None
+    max_tokens: Optional[int] = None
 
 
 class AudioProcessRequest(BaseModel):

--- a/omlx/api/audio_routes.py
+++ b/omlx/api/audio_routes.py
@@ -239,6 +239,11 @@ async def create_speech(request: AudioSpeechRequest):
             instructions=request.instructions,
             ref_audio=ref_audio_path,
             ref_text=request.ref_text,
+            temperature=request.temperature,
+            top_k=request.top_k,
+            top_p=request.top_p,
+            repetition_penalty=request.repetition_penalty,
+            max_tokens=request.max_tokens,
         )
     except HTTPException:
         raise

--- a/omlx/engine/tts.py
+++ b/omlx/engine/tts.py
@@ -120,6 +120,11 @@ class TTSEngine(BaseNonStreamingEngine):
         instructions: Optional[str] = None,
         ref_audio: Optional[str] = None,
         ref_text: Optional[str] = None,
+        temperature: Optional[float] = None,
+        top_k: Optional[int] = None,
+        top_p: Optional[float] = None,
+        repetition_penalty: Optional[float] = None,
+        max_tokens: Optional[int] = None,
         **kwargs,
     ) -> bytes:
         """
@@ -130,6 +135,13 @@ class TTSEngine(BaseNonStreamingEngine):
             voice: Optional voice/speaker identifier
             speed: Speech speed multiplier (1.0 = normal)
             instructions: Optional voice description for instruct-capable models
+            ref_audio: Optional path to reference audio file (voice cloning)
+            ref_text: Optional transcript of the reference audio
+            temperature: Sampling temperature for generation
+            top_k: Top-k sampling parameter
+            top_p: Top-p (nucleus) sampling parameter
+            repetition_penalty: Repetition penalty for generation
+            max_tokens: Maximum number of tokens to generate
             **kwargs: Additional model-specific parameters
 
         Returns:
@@ -150,35 +162,57 @@ class TTSEngine(BaseNonStreamingEngine):
         t0 = time.monotonic()
 
         def _synthesize_sync():
-            # model.generate() returns an iterable of results,
-            # each with .audio (array) and .sample_rate (int).
-            gen_kwargs: Dict[str, Any] = {
-                "text": text,
-                "verbose": False,
-            }
-            import inspect
-            gen_params = inspect.signature(model.generate).parameters
-            if voice is not None:
-                # Route voice to the correct generate() kwarg.
-                # Models with 'voice' param (CustomVoice, Kokoro) get it as
-                # a speaker name. Models with only 'instruct' (non-Qwen TTS)
-                # get it as a voice description fallback.
-                if "voice" in gen_params:
-                    gen_kwargs["voice"] = voice
-                elif "instruct" in gen_params:
-                    gen_kwargs["instruct"] = voice
-            if instructions is not None and "instruct" in gen_params:
-                gen_kwargs["instruct"] = instructions
-            if speed != 1.0:
-                gen_kwargs["speed"] = speed
-            if ref_audio is not None and "ref_audio" in gen_params:
-                gen_kwargs["ref_audio"] = ref_audio
-                gen_kwargs["ref_text"] = ref_text
+            # Build generation kwargs from non-None params
+            gen_kwargs: Dict[str, Any] = {}
+            if temperature is not None:
+                gen_kwargs["temperature"] = temperature
+            if top_k is not None:
+                gen_kwargs["top_k"] = top_k
+            if top_p is not None:
+                gen_kwargs["top_p"] = top_p
+            if repetition_penalty is not None:
+                gen_kwargs["repetition_penalty"] = repetition_penalty
+            if max_tokens is not None:
+                gen_kwargs["max_tokens"] = max_tokens
             gen_kwargs.update(kwargs)
 
-            results = model.generate(**gen_kwargs)
+            # VoiceDesign path: model has generate_voice_design() and
+            # instructions were provided (voice description).
+            if (
+                hasattr(model, "generate_voice_design")
+                and instructions is not None
+            ):
+                logger.info("Using VoiceDesign path for %s", self._model_name)
+                results = model.generate_voice_design(
+                    text=text, instruct=instructions, **gen_kwargs
+                )
+            else:
+                # Standard generate() path with param introspection
+                std_kwargs: Dict[str, Any] = {
+                    "text": text,
+                    "verbose": False,
+                }
+                import inspect
+                gen_params = inspect.signature(model.generate).parameters
+                if voice is not None:
+                    if "voice" in gen_params:
+                        std_kwargs["voice"] = voice
+                    elif "instruct" in gen_params:
+                        std_kwargs["instruct"] = voice
+                if instructions is not None and "instruct" in gen_params:
+                    std_kwargs["instruct"] = instructions
+                if speed != 1.0:
+                    std_kwargs["speed"] = speed
+                if ref_audio is not None and "ref_audio" in gen_params:
+                    std_kwargs["ref_audio"] = ref_audio
+                    std_kwargs["ref_text"] = ref_text
+                std_kwargs.update(gen_kwargs)
+
+                results = model.generate(**std_kwargs)
+
+            # Use model.sample_rate if available (e.g. Qwen3-TTS)
+            sample_rate = getattr(model, "sample_rate", _DEFAULT_SAMPLE_RATE)
             audio_chunks = []
-            sample_rate = _DEFAULT_SAMPLE_RATE
 
             for result in results:
                 audio_chunks.append(np.array(result.audio))

--- a/tests/test_audio_tts.py
+++ b/tests/test_audio_tts.py
@@ -329,15 +329,18 @@ class TestTTSVoiceRouting:
 
     @pytest.fixture
     def _run_synthesize(self):
-        """Helper: run TTSEngine.synthesize and return the kwargs passed to generate()."""
+        """Helper: run TTSEngine.synthesize and return the kwargs passed to generate().
+
+        Uses a plain FakeModel (not MagicMock) so that hasattr() checks for
+        generate_voice_design work correctly — MagicMock auto-creates attributes.
+        """
         import asyncio
         from omlx.engine.tts import TTSEngine
 
-        def _run(generate_sig_params, voice_value=None, instructions_value=None):
+        def _run(generate_sig_params, voice_value=None, instructions_value=None,
+                 has_voice_design=False, **synth_kwargs):
             engine = TTSEngine("test-model")
 
-            # Build a mock model whose generate() has the requested signature
-            mock_model = MagicMock()
             import inspect
             sig_params = {
                 "text": inspect.Parameter("text", inspect.Parameter.POSITIONAL_OR_KEYWORD),
@@ -345,20 +348,35 @@ class TestTTSVoiceRouting:
             }
             for p in generate_sig_params:
                 sig_params[p] = inspect.Parameter(p, inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None)
-            mock_model.generate = MagicMock()
-            mock_model.generate.__signature__ = inspect.Signature(parameters=list(sig_params.values()))
-            mock_model.generate.return_value = []  # no audio chunks
 
-            engine._model = mock_model
+            generate_mock = MagicMock()
+            generate_mock.__signature__ = inspect.Signature(parameters=list(sig_params.values()))
+            generate_mock.return_value = []  # no audio chunks
+
+            # Plain object — hasattr only returns True for explicitly set attrs
+            class FakeModel:
+                pass
+
+            fake_model = FakeModel()
+            fake_model.generate = generate_mock
+
+            if has_voice_design:
+                vd_mock = MagicMock(return_value=[])
+                fake_model.generate_voice_design = vd_mock
+
+            engine._model = fake_model
 
             try:
                 asyncio.run(engine.synthesize(
                     "Hello", voice=voice_value, instructions=instructions_value,
+                    **synth_kwargs,
                 ))
             except RuntimeError:
                 pass  # "no audio output" is expected with empty generate
 
-            return mock_model.generate.call_args
+            if has_voice_design and instructions_value is not None:
+                return fake_model.generate_voice_design.call_args
+            return fake_model.generate.call_args
 
         return _run
 
@@ -428,7 +446,6 @@ class TestTTSVoiceClonePassthrough:
         def _run(ref_audio_path=None, ref_text=None):
             engine = TTSEngine("test-model")
 
-            mock_model = MagicMock()
             import inspect
             sig_params = {
                 "text": inspect.Parameter("text", inspect.Parameter.POSITIONAL_OR_KEYWORD),
@@ -437,11 +454,18 @@ class TestTTSVoiceClonePassthrough:
                 "ref_audio": inspect.Parameter("ref_audio", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None),
                 "ref_text": inspect.Parameter("ref_text", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None),
             }
-            mock_model.generate = MagicMock()
-            mock_model.generate.__signature__ = inspect.Signature(parameters=list(sig_params.values()))
-            mock_model.generate.return_value = []
 
-            engine._model = mock_model
+            generate_mock = MagicMock()
+            generate_mock.__signature__ = inspect.Signature(parameters=list(sig_params.values()))
+            generate_mock.return_value = []
+
+            class FakeModel:
+                pass
+
+            fake_model = FakeModel()
+            fake_model.generate = generate_mock
+
+            engine._model = fake_model
 
             try:
                 asyncio.run(engine.synthesize(
@@ -450,7 +474,7 @@ class TestTTSVoiceClonePassthrough:
             except RuntimeError:
                 pass  # "no audio output" expected
 
-            return mock_model.generate.call_args
+            return fake_model.generate.call_args
 
         return _run
 
@@ -626,6 +650,213 @@ class TestTTSVoiceCloneEndpoint:
         if synthesize.called:
             call_kwargs = synthesize.call_args.kwargs
             assert call_kwargs.get("ref_audio") is None
+
+
+# ---------------------------------------------------------------------------
+# TestTTSVoiceDesign — VoiceDesign path detection and routing
+# ---------------------------------------------------------------------------
+
+
+class TestTTSVoiceDesign:
+    """Verify VoiceDesign path: generate_voice_design() is called when available."""
+
+    def test_voicedesign_path_called(self, _run_synthesize_vd):
+        """When model has generate_voice_design and instructions given, use VD path."""
+        call = _run_synthesize_vd(instructions="female, calm, slow")
+        assert call is not None
+        kwargs = call.kwargs if call else {}
+        assert kwargs.get("text") == "Hello"
+        assert kwargs.get("instruct") == "female, calm, slow"
+
+    def test_voicedesign_not_called_without_instructions(self, _run_synthesize_vd):
+        """Without instructions, standard generate() is used even with VD model."""
+        call = _run_synthesize_vd(instructions=None)
+        # Should be None because generate_voice_design was not called
+        assert call is None
+
+    def test_voicedesign_gen_params_forwarded(self, _run_synthesize_vd):
+        """Generation params are forwarded to generate_voice_design()."""
+        call = _run_synthesize_vd(
+            instructions="male, deep",
+            temperature=0.8,
+            top_k=30,
+        )
+        kwargs = call.kwargs if call else {}
+        assert kwargs.get("temperature") == 0.8
+        assert kwargs.get("top_k") == 30
+
+    @pytest.fixture
+    def _run_synthesize_vd(self):
+        """Helper: run synthesize on a VoiceDesign-capable model."""
+        import asyncio
+        from omlx.engine.tts import TTSEngine
+
+        def _run(instructions=None, **gen_params):
+            engine = TTSEngine("test-vd-model")
+
+            class FakeModel:
+                pass
+
+            fake_model = FakeModel()
+
+            # Standard generate with basic sig
+            import inspect
+            sig_params = {
+                "text": inspect.Parameter("text", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+                "verbose": inspect.Parameter("verbose", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=False),
+            }
+            gen_mock = MagicMock()
+            gen_mock.__signature__ = inspect.Signature(parameters=list(sig_params.values()))
+            gen_mock.return_value = []
+            fake_model.generate = gen_mock
+
+            # VoiceDesign method
+            vd_mock = MagicMock(return_value=[])
+            fake_model.generate_voice_design = vd_mock
+
+            engine._model = fake_model
+
+            try:
+                asyncio.run(engine.synthesize(
+                    "Hello", instructions=instructions, **gen_params,
+                ))
+            except RuntimeError:
+                pass
+
+            if vd_mock.called:
+                return vd_mock.call_args
+            return None
+
+        return _run
+
+
+# ---------------------------------------------------------------------------
+# TestTTSGenerationParams — generation param passthrough to standard path
+# ---------------------------------------------------------------------------
+
+
+class TestTTSGenerationParams:
+    """Verify generation params are forwarded to model.generate()."""
+
+    def test_temperature_forwarded(self, _run_synthesize):
+        """temperature is passed to generate()."""
+        call = _run_synthesize(["voice"], temperature=0.9)
+        kwargs = call.kwargs if call else {}
+        assert kwargs.get("temperature") == 0.9
+
+    def test_top_k_forwarded(self, _run_synthesize):
+        """top_k is passed to generate()."""
+        call = _run_synthesize(["voice"], top_k=50)
+        kwargs = call.kwargs if call else {}
+        assert kwargs.get("top_k") == 50
+
+    def test_top_p_forwarded(self, _run_synthesize):
+        """top_p is passed to generate()."""
+        call = _run_synthesize(["voice"], top_p=0.95)
+        kwargs = call.kwargs if call else {}
+        assert kwargs.get("top_p") == 0.95
+
+    def test_repetition_penalty_forwarded(self, _run_synthesize):
+        """repetition_penalty is passed to generate()."""
+        call = _run_synthesize(["voice"], repetition_penalty=1.05)
+        kwargs = call.kwargs if call else {}
+        assert kwargs.get("repetition_penalty") == 1.05
+
+    def test_max_tokens_forwarded(self, _run_synthesize):
+        """max_tokens is passed to generate()."""
+        call = _run_synthesize(["voice"], max_tokens=2048)
+        kwargs = call.kwargs if call else {}
+        assert kwargs.get("max_tokens") == 2048
+
+    def test_none_params_not_forwarded(self, _run_synthesize):
+        """None generation params are not included in kwargs."""
+        call = _run_synthesize(["voice"])
+        kwargs = call.kwargs if call else {}
+        for key in ("temperature", "top_k", "top_p", "repetition_penalty", "max_tokens"):
+            assert key not in kwargs
+
+    @pytest.fixture
+    def _run_synthesize(self):
+        """Reuse voice routing fixture pattern for gen param tests."""
+        import asyncio
+        from omlx.engine.tts import TTSEngine
+
+        def _run(generate_sig_params, **synth_kwargs):
+            engine = TTSEngine("test-model")
+
+            import inspect
+            sig_params = {
+                "text": inspect.Parameter("text", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+                "verbose": inspect.Parameter("verbose", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=False),
+            }
+            for p in generate_sig_params:
+                sig_params[p] = inspect.Parameter(p, inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None)
+
+            generate_mock = MagicMock()
+            generate_mock.__signature__ = inspect.Signature(parameters=list(sig_params.values()))
+            generate_mock.return_value = []
+
+            class FakeModel:
+                pass
+
+            fake_model = FakeModel()
+            fake_model.generate = generate_mock
+            engine._model = fake_model
+
+            try:
+                asyncio.run(engine.synthesize("Hello", **synth_kwargs))
+            except RuntimeError:
+                pass
+
+            return fake_model.generate.call_args
+
+        return _run
+
+
+# ---------------------------------------------------------------------------
+# TestTTSGenParamsEndpoint — generation params accepted via API
+# ---------------------------------------------------------------------------
+
+
+class TestTTSGenParamsEndpoint:
+    """Verify generation params are accepted and forwarded by the endpoint."""
+
+    def test_gen_params_forwarded_to_synthesize(self, server_tts_client):
+        """Generation params from request body reach engine.synthesize()."""
+        client, mock_pool = server_tts_client
+        client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts",
+                "input": "Hello",
+                "temperature": 0.8,
+                "top_k": 30,
+                "top_p": 0.95,
+                "repetition_penalty": 1.1,
+                "max_tokens": 1024,
+            },
+        )
+        synthesize: AsyncMock = mock_pool.get_engine.return_value.synthesize
+        assert synthesize.called
+        call_kwargs = synthesize.call_args.kwargs
+        assert call_kwargs.get("temperature") == 0.8
+        assert call_kwargs.get("top_k") == 30
+        assert call_kwargs.get("top_p") == 0.95
+        assert call_kwargs.get("repetition_penalty") == 1.1
+        assert call_kwargs.get("max_tokens") == 1024
+
+    def test_gen_params_default_none(self, server_tts_client):
+        """Without gen params in request, they're passed as None."""
+        client, mock_pool = server_tts_client
+        client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "Hello"},
+        )
+        synthesize: AsyncMock = mock_pool.get_engine.return_value.synthesize
+        assert synthesize.called
+        call_kwargs = synthesize.call_args.kwargs
+        assert call_kwargs.get("temperature") is None
+        assert call_kwargs.get("top_k") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Extends PR #676's voice cloning support with two additional Qwen3-TTS capabilities:

  - VoiceDesign: when a model exposes `generate_voice_design()` and instructions are provided, routes through the dedicated VD path instead of `standard generate()`
  - Generation params: `temperature`, `top_k`, `top_p`, `repetition_penalty`, and `max_tokens` are accepted in the API schema and forwarded to whichever generation path is used

Also fixes test fixtures to use plain FakeModel instead of MagicMock,preventing false hasattr() positives for VoiceDesign detection.

You can test this with the following CLI commands:

```
# request VoiceDesign TTS
curl -X POST http://localhost:8000/v1/audio/speech \
    -H "Content-Type: application/json" \
    -d '{
      "model": "Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16",
      "input": "Hello, this is a test of voice design.",
      "instructions": "female, calm, slow, clear enunciation",
      "temperature": 0.9
    }' --output voice_design.wav

# play wav file
afplay voice_design.wav
```

And cloning works with the designed voice, thanks to  PR #676 

```
# request cloned voice TTS
curl -X POST http://localhost:8000/v1/audio/speech \
    -H "Content-Type: application/json" \
    -d '{
      "model": "Qwen3-TTS-12Hz-1.7B-Base-bf16",
      "input": "Now I am saying something completely different in the same voice.",
      "voice": "en",
      "ref_audio": "'$(base64 -i ~/voice_design.wav)'",
      "ref_text": "Hello, this is a test of voice design.",
      "temperature": 0.9
    }' --output cloned.wav

# play wav file
afplay cloned.wav
```
