### PR TITLE
fix(vlm): use mlx-lm decode model for batch=1, 2x VLM generation speed

### DIFF
--- a/omlx/models/vlm.py
+++ b/omlx/models/vlm.py
@@ -256,9 +256,9 @@ class VLMModelAdapter(nn.Module):
             result = self._forward_with_embeddings(input_ids, wrapped_cache, **kwargs)
         else:
             # Standard decode/prefill path: token IDs only.
-            # Use mlx-lm decode model for batched decode (batch > 1)
-            # since mlx-vlm language models may not handle batching.
-            if self._decode_model is not None and input_ids.shape[0] > 1:
+            # Use mlx-lm decode model for ALL decode when available.
+            # Avoids _IntOffsetCacheProxy overhead (48 layers x 0.185ms/token). See #687.
+            if self._decode_model is not None and input_ids.shape[0] >= 1:
                 result = self._decode_model(input_ids, cache=cache, **kwargs)
             else:
                 if hasattr(self._vlm_model, "_set_position_state"):

--- a/tests/test_vlm_model_adapter.py
+++ b/tests/test_vlm_model_adapter.py
@@ -162,6 +162,50 @@ class TestVLMModelAdapter:
         assert call_args[0][0] is input_ids
         assert len(call_args[1]["cache"]) == 1
 
+    def test_forward_uses_decode_model_at_batch_1(self):
+        """Test that decode_model is used for batch=1 decode (no proxy overhead)."""
+        from omlx.models.vlm import VLMModelAdapter
+
+        vlm = self._make_mock_vlm_model()
+        decode_model = MagicMock()
+        decode_logits = MockMXArray(shape=(1, 10, 32000))
+        decode_model.return_value = decode_logits
+        adapter = VLMModelAdapter(vlm, decode_model=decode_model)
+
+        input_ids = MockMXArray(shape=(1, 10))
+        cache = [MagicMock()]
+
+        result = adapter(input_ids, cache=cache)
+
+        # decode_model should be called (fast path, no proxy wrapping)
+        decode_model.assert_called_once()
+        call_args = decode_model.call_args
+        assert call_args[0][0] is input_ids
+        # cache should be passed directly (no _IntOffsetCacheProxy wrapping)
+        assert call_args[1]["cache"] is cache
+        # language_model should NOT be called
+        vlm.language_model.assert_not_called()
+
+    def test_forward_without_decode_model_falls_back_to_language_model(self):
+        """Test that without decode_model, language_model is used with wrapped cache."""
+        from omlx.models.vlm import VLMModelAdapter
+
+        vlm = self._make_mock_vlm_model()
+        adapter = VLMModelAdapter(vlm)  # no decode_model
+
+        input_ids = MockMXArray(shape=(1, 10))
+        cache = [MagicMock()]
+        vlm.language_model.__call__ = MagicMock(return_value=MagicMock())
+
+        adapter(input_ids, cache=cache)
+
+        # language_model should be called (fallback path)
+        vlm.language_model.assert_called_once()
+        # cache should be wrapped with _IntOffsetCacheProxy
+        call_args = vlm.language_model.call_args
+        from omlx.models.vlm import _IntOffsetCacheProxy
+        assert isinstance(call_args[1]["cache"][0], _IntOffsetCacheProxy)
+
     def test_forward_with_embeddings(self):
         """Test forward pass with pending embeddings injects inputs_embeds."""
         from omlx.models.vlm import VLMModelAdapter


### PR DESCRIPTION
## Summary

Use the mlx-lm decode model for single-request VLM decode (`batch=1`), avoiding the `_IntOffsetCacheProxy` overhead.

**One-line change:** `input_ids.shape[0] > 1` → `input_ids.shape[0] >= 1` in `VLMModelAdapter.__call__()`.

## Problem

The mlx-lm decode model (already loaded, zero-copy weight sharing) was only used for `batch > 1`. For the common `batch=1` case, every generation step:
1. Creates 48 `_IntOffsetCacheProxy` objects (`_wrap_caches()`)
2. Each proxy converts `mx.array` offset to Python `int` via `raw.max().item()`
3. This triggers 48 implicit `mx.eval` GPU→CPU synchronizations per token

**Cost:** 8.88ms per token (48 layers × 0.185ms).

## Results (Mac Studio M3 Ultra 96GB, Qwen3-VL-30B-A3B-Instruct-4bit)

| Output Tokens | Before | After | Improvement |
|---|---|---|---|
| 50 | 43.7 tok/s | 87.6 tok/s | **+100%** |
| 100 | 45.2 | 94.4 | **+109%** |
| 200 | 45.5 | 98.4 | **+116%** |
| 400 | 45.9 | 99.5 | **+117%** |

Quality verified: 20/20 valid JSON on production extraction prompt, no regression.

Concurrency also improves: `conc=4` with patch achieves 0.99 photos/s at 100% JSON validity (vs 0.86 pre-patch).

## Three-Layer Decomposition

| Path | tok/s |
|---|---|
| Raw mlx-lm (text model) | 100.5 |
| Raw mlx-vlm (VL model, text) | 77.5 |
| oMLX VLM path (before) | 45.9 |
| **oMLX VLM path (after)** | **99.5** |

The fix eliminates the entire oMLX VLM serving overhead, making VLM decode match the raw mlx-lm ceiling.

Fixes #687