### PR TITLE
fix(packaging): find pyenv Python with working pip for sdist wheels

### DIFF
--- a/packaging/build.py
+++ b/packaging/build.py
@@ -246,10 +246,26 @@ def _find_target_python() -> str:
     target_minor = match.group(1)  # e.g. "3.11"
     candidates = [
         shutil.which(f"python{target_minor}"),
+        # pyenv-managed interpreters (not on PATH by default)
+        str(Path.home() / ".pyenv" / "versions" / f"{target_minor}" / "bin" / f"python{target_minor}"),
         str(BUILD_DIR / f"cpython-{target_minor}" / "bin" / f"python{target_minor}"),
     ]
+    # Also check pyenv versions with patch numbers (e.g. 3.11.14)
+    pyenv_versions = Path.home() / ".pyenv" / "versions"
+    if pyenv_versions.is_dir():
+        for entry in sorted(pyenv_versions.iterdir(), reverse=True):
+            if entry.name.startswith(f"{target_minor}."):
+                candidates.insert(1, str(entry / "bin" / f"python{target_minor}"))
+                break
     for path in candidates:
-        if path and Path(path).exists():
+        if not path or not Path(path).exists():
+            continue
+        # Verify the interpreter has pip (venvstacks runtimes strip it)
+        check = subprocess.run(
+            [path, "-m", "pip", "--version"],
+            capture_output=True,
+        )
+        if check.returncode == 0:
             return path
 
     print(f"  Warning: python{target_minor} not found, using {sys.executable}")


### PR DESCRIPTION
## Summary

- `_find_target_python()` in `packaging/build.py` preferred the venvstacks runtime under `_build/cpython-3.11` when `shutil.which("python3.11")` came back empty. That interpreter has `pip` stripped, so the subsequent `pip wheel` call for sdist-only deps like `webrtcvad` crashes with `No module named pip` and breaks the whole build.
- Adds a pyenv fallback (`~/.pyenv/versions/<minor>.*`) so pyenv-managed installs are considered before the stripped runtime.
- Verifies each candidate actually has a working `pip` before selecting it.

## Reproduction

On a machine where `python3.11` isn't shimmed onto `PATH` (common with pyenv + `pyenv local`), running `python3.11 build.py` from source fails mid-lock:

```
[1/4] Building venvstacks layers...
  sdist-only dependency detected: webrtcvad, building wheel...
  Building wheel for webrtcvad (sdist-only, using /Users/.../packaging/_build/cpython-3.11/bin/python3.11)...
/Users/.../packaging/_build/cpython-3.11/bin/python3.11: No module named pip
  ✗ Failed to build wheel for webrtcvad
```

With the fix, the target Python resolves to the pyenv install that does have pip, and the sdist wheel build succeeds.

## Test plan

- [x] `python3.11 packaging/build.py` succeeds end-to-end on a pyenv-only setup (no python3.11 on PATH).
- [x] On a machine where `python3.11` IS on PATH, behavior is unchanged — the `shutil.which` candidate still wins.