### PR TITLE
Add Support for Microsoft Harrier OSS including quantization support

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -312,6 +312,42 @@ def _is_causal_lm_embedding(model_path: Path) -> bool:
     return "embedding" in name_lower or "embed" in name_lower
 
 
+def _has_sentence_transformers_embedding_pipeline(model_path: Path) -> bool:
+    """
+    Detect sentence-transformers style embedding exports via modules.json.
+
+    This allows oMLX to recognize embedding exports whose base transformer
+    architecture is ambiguous (for example gemma3_text) but which include
+    sentence-transformers pooling/normalization modules.
+    """
+    modules_path = model_path / "modules.json"
+    if not modules_path.exists():
+        return False
+
+    try:
+        with open(modules_path) as f:
+            modules = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return False
+
+    if not isinstance(modules, list):
+        return False
+
+    module_types = {
+        module.get("type", "")
+        for module in modules
+        if isinstance(module, dict)
+    }
+    if "sentence_transformers.models.Transformer" not in module_types:
+        return False
+
+    return any(
+        module_type.startswith("sentence_transformers.models.")
+        and module_type != "sentence_transformers.models.Transformer"
+        for module_type in module_types
+    )
+
+
 def detect_model_type(model_path: Path) -> ModelType:
     """
     Detect model type from config.json.
@@ -359,6 +395,9 @@ def detect_model_type(model_path: Path) -> ModelType:
         if arch in CAUSAL_LM_EMBEDDING_ARCHITECTURES:
             if _is_causal_lm_embedding(model_path):
                 return "embedding"
+
+    if _has_sentence_transformers_embedding_pipeline(model_path):
+        return "embedding"
 
     # Check architectures field for embedding (before model_type to avoid
     # false positives from ambiguous model types like qwen3, gemma3-text)

--- a/omlx/models/embedding.py
+++ b/omlx/models/embedding.py
@@ -323,6 +323,25 @@ class MLXEmbeddingModel:
             None,
         )
 
+    def _adapt_model_inputs_for_call(
+        self, model_inputs: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Rename prepared inputs to match the embedding model call signature."""
+        try:
+            call_parameters = inspect.signature(self.model.__call__).parameters
+        except (TypeError, ValueError):
+            return dict(model_inputs)
+
+        adapted_inputs = dict(model_inputs)
+        if (
+            "input_ids" in adapted_inputs
+            and "input_ids" not in call_parameters
+            and "inputs" in call_parameters
+        ):
+            adapted_inputs["inputs"] = adapted_inputs.pop("input_ids")
+
+        return adapted_inputs
+
     def _try_compile(self) -> bool:
         """
         Compile a primitive-output embedding forward function.
@@ -336,7 +355,7 @@ class MLXEmbeddingModel:
 
         try:
             def _compiled_embed(inputs):
-                outputs = base_model(**inputs)
+                outputs = base_model(**self._adapt_model_inputs_for_call(inputs))
                 return self._extract_embeddings_array(outputs)
 
             self._compiled_embed = mx.compile(_compiled_embed)
@@ -459,7 +478,7 @@ class MLXEmbeddingModel:
                     )
                     if not isinstance(inputs, dict):
                         inputs = dict(inputs)
-                    outputs = self.model(**inputs)
+                    outputs = self.model(**self._adapt_model_inputs_for_call(inputs))
                     total_tokens = self._count_prepared_tokens(inputs)
                 else:
                     from mlx_embeddings import generate

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -532,6 +532,43 @@ class TestEmbeddingCompileFallback:
         model.model.assert_called_once()
         assert result.embeddings[0] == pytest.approx([0.3, 0.4, 0.5], abs=1e-5)
 
+    def test_custom_processor_eager_path_remaps_input_ids_for_inputs_signature(self):
+        """Models that accept `inputs` instead of `input_ids` should still work."""
+        import mlx.core as mx
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        class InputsOnlyModel:
+            def __call__(self, inputs, attention_mask=None):
+                assert inputs.tolist() == [[4, 5, 6]]
+                assert attention_mask.tolist() == [[1, 1, 1]]
+
+                outputs = MagicMock(spec=[])
+                outputs.text_embeds = mx.array([[0.7, 0.8, 0.9]])
+                outputs.pooler_output = None
+                outputs.last_hidden_state = None
+                return outputs
+
+        model = MLXEmbeddingModel("test-model")
+        model._loaded = True
+        model._is_compiled = False
+        model._compiled_embed = None
+        model.model = InputsOnlyModel()
+
+        processor = MagicMock(spec=[])
+        processor.prepare_embedding_inputs = MagicMock(
+            return_value={
+                "input_ids": mx.array([[4, 5, 6]]),
+                "attention_mask": mx.array([[1, 1, 1]]),
+            }
+        )
+        model.processor = processor
+
+        with patch("mlx_embeddings.generate") as mock_generate:
+            result = model.embed(["hello world"])
+
+        mock_generate.assert_not_called()
+        assert result.embeddings[0] == pytest.approx([0.7, 0.8, 0.9], abs=1e-5)
+
     def test_custom_processor_receives_image_items_unchanged(self):
         """Custom processors should receive raw image strings unchanged."""
         import mlx.core as mx

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -232,6 +232,45 @@ class TestDetectModelType:
         (tmp_path / "config.json").write_text(json.dumps(config))
         assert detect_model_type(tmp_path) == "llm"
 
+    def test_detect_gemma3_text_model_without_sentence_transformers_modules_is_llm(self, tmp_path):
+        """gemma3_text base transformer without sentence-transformers modules stays LLM."""
+        config = {
+            "model_type": "gemma3_text",
+            "architectures": ["Gemma3TextModel"],
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "llm"
+
+    def test_detect_sentence_transformers_gemma3_text_as_embedding(self, tmp_path):
+        """gemma3_text sentence-transformers exports should be detected as embeddings."""
+        config = {
+            "model_type": "gemma3_text",
+            "architectures": ["Gemma3TextModel"],
+        }
+        modules = [
+            {
+                "idx": 0,
+                "name": "0",
+                "path": "",
+                "type": "sentence_transformers.models.Transformer",
+            },
+            {
+                "idx": 1,
+                "name": "1",
+                "path": "1_Pooling",
+                "type": "sentence_transformers.models.Pooling",
+            },
+            {
+                "idx": 2,
+                "name": "2",
+                "path": "2_Normalize",
+                "type": "sentence_transformers.models.Normalize",
+            },
+        ]
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        (tmp_path / "modules.json").write_text(json.dumps(modules))
+        assert detect_model_type(tmp_path) == "embedding"
+
     def test_detect_vlm_model_type_requires_vision_config(self, tmp_path):
         """VLM_MODEL_TYPES match without vision_config should fall back to LLM."""
         config = {


### PR DESCRIPTION
This PR adds support for Microsoft Harrier OSS embedding models by generalizing on sentence-transformers style embedding exports -- meaning that his PR unlocks basically any sentence-transformer based embedding model export.

It's blocked by the following PR in 3rd party `mlx-embeddings` project right now though - and needs a version/git ref bump once the feature becomes available there: https://github.com/Blaizzy/mlx-embeddings/pull/58 - specifically for Harrier OSS support.