### PR TITLE
fix(formula): add RUSTFLAGS for tokenizers build on macOS 26

### DIFF
--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -35,8 +35,15 @@ class Omlx < Formula
     system "python3.11", "-m", "venv", libexec
 
     # Build Rust-based packages from source with headerpad to prevent
-    # Homebrew dylib ID fixup failure (Mach-O header too small for absolute paths)
+    # Homebrew dylib ID fixup failure (Mach-O header too small for absolute paths).
+    # RUSTFLAGS passes both headerpad and -undefined dynamic_lookup through
+    # cargo to the linker -- PyO3 extension modules leave Python C API symbols
+    # unresolved until runtime, and the macOS 26 linker rejects them without
+    # the dynamic_lookup flag.
     ENV.append "LDFLAGS", "-Wl,-headerpad_max_install_names"
+    ENV.append "RUSTFLAGS",
+      "-C link-args=-Wl,-undefined,dynamic_lookup " \
+      "-C link-args=-Wl,-headerpad_max_install_names"
 
     # Install omlx (with optional grammar extra for structured output)
     install_spec = build.with?("grammar") ? "#{buildpath}[grammar]" : buildpath.to_s


### PR DESCRIPTION
## Summary

  The Homebrew formula fails to build `tokenizers` from source on macOS 26 (Tahoe). The Apple linker
  rejects undefined Python C API symbols (`_PyDict_Clear`, `_PyErr_SetString`, etc.) in the PyO3 extension
   module.

  The formula already sets `LDFLAGS` with `-headerpad_max_install_names` (#224), but cargo/Rust ignores
  `LDFLAGS`. This adds `RUSTFLAGS` to pass both `-undefined dynamic_lookup` and
  `-headerpad_max_install_names` through cargo to the linker.

  ## Root cause

  `--no-binary tokenizers` forces a source build (needed for headerpad since #224). On macOS 26, PyO3's
  `extension-module` cargo feature is not successfully forwarding `-undefined dynamic_lookup` to the
  linker within Homebrew's build sandbox. Without it, the linker treats unresolved Python symbols as
  errors.

  ## Testing

  Verified on M5 Max macOS 26.4 -- `brew install omlx` completes successfully with this patch.

  Fixes #576, #700