### PR TITLE
feat: add single_model_mode to force unload before load

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -119,6 +119,7 @@ class GlobalSettingsRequest(BaseModel):
     model_dir: Optional[str] = None  # Deprecated: kept for backward compatibility
     max_model_memory: Optional[str] = None
     model_fallback: Optional[bool] = None
+    single_model_mode: Optional[bool] = None
 
     # Memory enforcement
     max_process_memory: Optional[str] = None  # "auto", "disabled", or "XX%"
@@ -1726,6 +1727,7 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
             "model_dir": str(global_settings.model.get_model_dir(global_settings.base_path)),
             "max_model_memory": global_settings.model.max_model_memory,
             "model_fallback": global_settings.model.model_fallback,
+            "single_model_mode": global_settings.model.single_model_mode,
         },
         "memory": {
             "max_process_memory": global_settings.memory.max_process_memory,
@@ -1884,6 +1886,13 @@ async def update_global_settings(
     if request.model_fallback is not None:
         global_settings.model.model_fallback = request.model_fallback
         runtime_applied.append("model_fallback")
+
+    if request.single_model_mode is not None:
+        global_settings.model.single_model_mode = request.single_model_mode
+        pool = _server_state.engine_pool
+        if pool is not None:
+            pool.single_model_mode = request.single_model_mode
+        runtime_applied.append("single_model_mode")
 
     # Apply process memory enforcement settings (Live)
     if request.max_process_memory is not None:
@@ -2682,6 +2691,7 @@ def _build_active_models_data() -> dict:
         "models": models,
         "model_memory_used": status.get("current_model_memory", 0),
         "model_memory_max": status.get("max_model_memory", 0),
+        "single_model_mode": status.get("single_model_mode", False),
         "total_active_requests": total_active,
         "total_waiting_requests": total_waiting,
     }

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -1889,7 +1889,8 @@ async def update_global_settings(
 
     if request.single_model_mode is not None:
         global_settings.model.single_model_mode = request.single_model_mode
-        pool = _server_state.engine_pool
+        server_state = _get_server_state() if _get_server_state else None
+        pool = server_state.engine_pool if server_state is not None else None
         if pool is not None:
             pool.single_model_mode = request.single_model_mode
         runtime_applied.append("single_model_mode")

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -31,6 +31,8 @@ def _has_cli_overrides(args) -> bool:
         return True
     if hasattr(args, "max_model_memory") and args.max_model_memory is not None:
         return True
+    if hasattr(args, "single_model_mode") and args.single_model_mode is not None:
+        return True
     if hasattr(args, "max_process_memory") and args.max_process_memory is not None:
         return True
     if hasattr(args, "host") and args.host is not None:

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -413,6 +413,12 @@ Example directory structure:
         help="Maximum memory for loaded models (e.g., 32GB, 'disabled'). Default: 80%% of system memory.",
     )
     serve_parser.add_argument(
+        "--single-model-mode",
+        action="store_true",
+        default=None,
+        help="Always unload other models before loading a new one, even if memory allows coexistence.",
+    )
+    serve_parser.add_argument(
         "--max-process-memory",
         type=str,
         default=None,

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -419,6 +419,13 @@ Example directory structure:
         help="Always unload other models before loading a new one, even if memory allows coexistence.",
     )
     serve_parser.add_argument(
+        "--no-single-model-mode",
+        dest="single_model_mode",
+        action="store_false",
+        default=None,
+        help="Allow multiple models to coexist in memory (disable single-model mode).",
+    )
+    serve_parser.add_argument(
         "--max-process-memory",
         type=str,
         default=None,

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -355,21 +355,21 @@ class EnginePool:
                     model_id, entry.estimated_size, self._max_model_memory
                 )
 
-            # Single-model mode: unload all other loaded models before
-            # loading the requested one, even if memory would allow
-            # coexistence. This minimizes peak memory during switches.
-            # Pinned models are skipped unless the incoming model is
-            # also pinned (explicit override).
+            # Single-model mode: unload all other non-pinned loaded
+            # models before loading the requested one, even if memory
+            # would allow coexistence. This minimizes peak memory
+            # during switches while preserving the pinned-model
+            # "never evict" contract.
             if self._single_model_mode:
                 loaded_others = [
                     mid for mid, e in self._entries.items()
                     if mid != model_id and e.engine is not None
-                    and (not e.is_pinned or entry.is_pinned)
+                    and not e.is_pinned
                 ]
                 pinned_skipped = [
                     mid for mid, e in self._entries.items()
                     if mid != model_id and e.engine is not None
-                    and e.is_pinned and not entry.is_pinned
+                    and e.is_pinned
                 ]
                 if loaded_others:
                     logger.info(
@@ -381,8 +381,7 @@ class EnginePool:
                 if pinned_skipped:
                     logger.info(
                         f"Single-model mode: skipped pinned models "
-                        f"{pinned_skipped} (incoming model '{model_id}' "
-                        f"is not pinned)"
+                        f"{pinned_skipped} before loading {model_id}"
                     )
 
             # Pre-load eviction: reserve 25% extra for KV cache headroom

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -78,6 +78,7 @@ class EnginePool:
         self,
         max_model_memory: int | None,
         scheduler_config: SchedulerConfig | None = None,
+        single_model_mode: bool = False,
     ):
         """
         Initialize the engine pool.
@@ -86,6 +87,8 @@ class EnginePool:
             max_model_memory: Maximum memory for loaded models in bytes,
                 or None for no limit (disabled)
             scheduler_config: Configuration for BatchedEngine schedulers
+            single_model_mode: When True, unload all other models before
+                loading a new one, even if memory would allow coexistence
         """
         self._entries: dict[str, EngineEntry] = {}
         self._lock = asyncio.Lock()
@@ -95,11 +98,21 @@ class EnginePool:
         self._process_memory_enforcer: object | None = None  # Set by server
         self._settings_manager: object | None = None  # Set by server
         self._suppress_ttl: bool = False  # Suppress TTL during benchmarks
+        self._single_model_mode: bool = single_model_mode
 
     @property
     def max_model_memory(self) -> int | None:
         """Maximum memory for loaded models in bytes, or None if disabled."""
         return self._max_model_memory
+
+    @property
+    def single_model_mode(self) -> bool:
+        """Whether to unload all other models before loading a new one."""
+        return self._single_model_mode
+
+    @single_model_mode.setter
+    def single_model_mode(self, value: bool) -> None:
+        self._single_model_mode = value
 
     @property
     def current_model_memory(self) -> int:
@@ -341,6 +354,22 @@ class EnginePool:
                 raise ModelTooLargeError(
                     model_id, entry.estimated_size, self._max_model_memory
                 )
+
+            # Single-model mode: unload all other loaded models before
+            # loading the requested one, even if memory would allow
+            # coexistence. This minimizes peak memory during switches.
+            if self._single_model_mode:
+                loaded_others = [
+                    mid for mid, e in self._entries.items()
+                    if mid != model_id and e.engine is not None
+                ]
+                if loaded_others:
+                    logger.info(
+                        f"Single-model mode: evicting {loaded_others} "
+                        f"before loading {model_id}"
+                    )
+                    for victim_id in loaded_others:
+                        await self._unload_engine(victim_id)
 
             # Pre-load eviction: reserve 25% extra for KV cache headroom
             # so other models get evicted earlier, leaving room for context.
@@ -712,6 +741,7 @@ class EnginePool:
         """
         return {
             "max_model_memory": self._max_model_memory,
+            "single_model_mode": self._single_model_mode,
             "current_model_memory": self._current_model_memory,
             "model_count": len(self._entries),
             "loaded_count": sum(1 for e in self._entries.values() if e.engine is not None),

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -357,9 +357,7 @@ class EnginePool:
 
             # Single-model mode: unload all other non-pinned loaded
             # models before loading the requested one, even if memory
-            # would allow coexistence. This minimizes peak memory
-            # during switches while preserving the pinned-model
-            # "never evict" contract.
+            # would allow coexistence. Pinned models are never evicted.
             if self._single_model_mode:
                 loaded_others = [
                     mid for mid, e in self._entries.items()
@@ -381,7 +379,7 @@ class EnginePool:
                 if pinned_skipped:
                     logger.info(
                         f"Single-model mode: skipped pinned models "
-                        f"{pinned_skipped} before loading {model_id}"
+                        f"{pinned_skipped}"
                     )
 
             # Pre-load eviction: reserve 25% extra for KV cache headroom

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -358,10 +358,18 @@ class EnginePool:
             # Single-model mode: unload all other loaded models before
             # loading the requested one, even if memory would allow
             # coexistence. This minimizes peak memory during switches.
+            # Pinned models are skipped unless the incoming model is
+            # also pinned (explicit override).
             if self._single_model_mode:
                 loaded_others = [
                     mid for mid, e in self._entries.items()
                     if mid != model_id and e.engine is not None
+                    and (not e.is_pinned or entry.is_pinned)
+                ]
+                pinned_skipped = [
+                    mid for mid, e in self._entries.items()
+                    if mid != model_id and e.engine is not None
+                    and e.is_pinned and not entry.is_pinned
                 ]
                 if loaded_others:
                     logger.info(
@@ -370,6 +378,12 @@ class EnginePool:
                     )
                     for victim_id in loaded_others:
                         await self._unload_engine(victim_id)
+                if pinned_skipped:
+                    logger.info(
+                        f"Single-model mode: skipped pinned models "
+                        f"{pinned_skipped} (incoming model '{model_id}' "
+                        f"is not pinned)"
+                    )
 
             # Pre-load eviction: reserve 25% extra for KV cache headroom
             # so other models get evicted earlier, leaving room for context.

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1097,9 +1097,7 @@ def init_server(
             logger.warning(f"Model directory created (empty): {md}")
 
     # Create engine pool
-    single_model_mode = False
-    if global_settings and hasattr(global_settings, "model"):
-        single_model_mode = getattr(global_settings.model, "single_model_mode", False)
+    single_model_mode = global_settings.model.single_model_mode if global_settings else False
     _server_state.engine_pool = EnginePool(
         max_model_memory=max_model_memory,
         scheduler_config=scheduler_config,

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1097,9 +1097,13 @@ def init_server(
             logger.warning(f"Model directory created (empty): {md}")
 
     # Create engine pool
+    single_model_mode = False
+    if global_settings and hasattr(global_settings, "model"):
+        single_model_mode = getattr(global_settings.model, "single_model_mode", False)
     _server_state.engine_pool = EnginePool(
         max_model_memory=max_model_memory,
         scheduler_config=scheduler_config,
+        single_model_mode=single_model_mode,
     )
 
     # Discover models (use pinned models from settings file)

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -138,6 +138,7 @@ class ModelSettings:
     model_dir: str | None = None  # Deprecated: kept for backward compatibility
     max_model_memory: str = "auto"  # "auto" means 80% of RAM
     model_fallback: bool = False  # Use default model when requested model not found
+    single_model_mode: bool = False  # Unload all other models before loading a new one
 
     def get_model_dirs(self, base_path: Path) -> list[Path]:
         """
@@ -191,6 +192,7 @@ class ModelSettings:
             "model_dir": self.model_dirs[0] if self.model_dirs else self.model_dir,
             "max_model_memory": self.max_model_memory,
             "model_fallback": self.model_fallback,
+            "single_model_mode": self.single_model_mode,
         }
 
     @classmethod
@@ -205,6 +207,7 @@ class ModelSettings:
             model_dir=data.get("model_dir"),
             max_model_memory=data.get("max_model_memory", "auto"),
             model_fallback=data.get("model_fallback", False),
+            single_model_mode=data.get("single_model_mode", False),
         )
 
 
@@ -833,6 +836,8 @@ class GlobalSettings:
             self.model.model_dir = dirs[0] if dirs else None
         if hasattr(args, "max_model_memory") and args.max_model_memory is not None:
             self.model.max_model_memory = args.max_model_memory
+        if hasattr(args, "single_model_mode") and args.single_model_mode:
+            self.model.single_model_mode = True
 
         # Memory enforcement settings
         if (

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -757,6 +757,8 @@ class GlobalSettings:
             self.model.model_dir = dirs[0] if dirs else None
         if max_model_memory := os.getenv("OMLX_MAX_MODEL_MEMORY"):
             self.model.max_model_memory = max_model_memory
+        if single_model_mode := os.getenv("OMLX_SINGLE_MODEL_MODE"):
+            self.model.single_model_mode = single_model_mode.lower() in ("true", "1", "yes")
 
         # Memory enforcement settings
         if max_process_memory := os.getenv("OMLX_MAX_PROCESS_MEMORY"):
@@ -836,8 +838,8 @@ class GlobalSettings:
             self.model.model_dir = dirs[0] if dirs else None
         if hasattr(args, "max_model_memory") and args.max_model_memory is not None:
             self.model.max_model_memory = args.max_model_memory
-        if hasattr(args, "single_model_mode") and args.single_model_mode:
-            self.model.single_model_mode = True
+        if hasattr(args, "single_model_mode") and args.single_model_mode is not None:
+            self.model.single_model_mode = args.single_model_mode
 
         # Memory enforcement settings
         if (

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -1171,8 +1171,8 @@ class TestSingleModelMode:
         assert pool._entries["model-b"].engine is not None
 
     @pytest.mark.asyncio
-    async def test_keeps_pinned_if_incoming_is_pinned(self, small_mock_model_dir):
-        """Test that pinned models are never evicted, even by another pinned model."""
+    async def test_never_evicts_pinned_even_if_incoming_pinned(self, small_mock_model_dir):
+        """Test that pinned models are never evicted, even when incoming model is also pinned."""
         pool = EnginePool(max_model_memory=10 * 1024**3, single_model_mode=True)
         pool.discover_models(str(small_mock_model_dir))
 
@@ -1200,7 +1200,7 @@ class TestSingleModelMode:
             await pool.get_engine("model-a")
             await pool.get_engine("model-b")
 
-        # model-a should stay loaded because pinned models are never evicted
+        # model-a should still be loaded — pinned models are never evicted
         mock_engine_a.stop.assert_not_called()
         assert pool._entries["model-a"].engine is not None
         assert pool._entries["model-b"].engine is not None

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -1171,8 +1171,8 @@ class TestSingleModelMode:
         assert pool._entries["model-b"].engine is not None
 
     @pytest.mark.asyncio
-    async def test_evicts_pinned_if_incoming_is_pinned(self, small_mock_model_dir):
-        """Test that pinned models ARE evicted when incoming model is also pinned."""
+    async def test_keeps_pinned_if_incoming_is_pinned(self, small_mock_model_dir):
+        """Test that pinned models are never evicted, even by another pinned model."""
         pool = EnginePool(max_model_memory=10 * 1024**3, single_model_mode=True)
         pool.discover_models(str(small_mock_model_dir))
 
@@ -1200,10 +1200,43 @@ class TestSingleModelMode:
             await pool.get_engine("model-a")
             await pool.get_engine("model-b")
 
-        # model-a should be evicted (both pinned overrides)
-        mock_engine_a.stop.assert_called_once()
-        assert pool._entries["model-a"].engine is None
+        # model-a should stay loaded because pinned models are never evicted
+        mock_engine_a.stop.assert_not_called()
+        assert pool._entries["model-a"].engine is not None
         assert pool._entries["model-b"].engine is not None
+
+    @pytest.mark.asyncio
+    async def test_preload_pinned_models_keeps_all_pins(self, small_mock_model_dir):
+        """Test startup preload keeps multiple pinned models loaded."""
+        pool = EnginePool(max_model_memory=10 * 1024**3, single_model_mode=True)
+        pool.discover_models(
+            str(small_mock_model_dir), pinned_models=["model-a", "model-b"]
+        )
+
+        mock_engine_a = MagicMock()
+        mock_engine_a.start = AsyncMock()
+        mock_engine_a.stop = AsyncMock()
+
+        mock_engine_b = MagicMock()
+        mock_engine_b.start = AsyncMock()
+        mock_engine_b.stop = AsyncMock()
+
+        engines = {"model-a": mock_engine_a, "model-b": mock_engine_b}
+
+        def create_engine(*args, **kwargs):
+            model_name = kwargs.get("model_name", "")
+            for key, eng in engines.items():
+                if key in model_name:
+                    return eng
+            return mock_engine_a
+
+        with patch("omlx.engine_pool.BatchedEngine", side_effect=create_engine):
+            await pool.preload_pinned_models()
+
+        assert pool._entries["model-a"].engine is not None
+        assert pool._entries["model-b"].engine is not None
+        mock_engine_a.stop.assert_not_called()
+        mock_engine_b.stop.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_same_model_no_eviction(self, small_mock_model_dir):

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -1024,3 +1024,199 @@ class TestResolveModelId:
         # Exact match should be returned directly
         result = pool.resolve_model_id("model-a", settings_manager=None)
         assert result == "model-a"
+
+
+class TestSingleModelMode:
+    """Tests for single_model_mode eviction behavior."""
+
+    def test_default_off(self, small_mock_model_dir):
+        """Test that single_model_mode defaults to False."""
+        pool = EnginePool(max_model_memory=10 * 1024**3)
+        assert pool.single_model_mode is False
+
+    def test_enabled_via_constructor(self, small_mock_model_dir):
+        """Test that single_model_mode can be enabled via constructor."""
+        pool = EnginePool(max_model_memory=10 * 1024**3, single_model_mode=True)
+        assert pool.single_model_mode is True
+
+    def test_setter(self, small_mock_model_dir):
+        """Test runtime toggle via setter."""
+        pool = EnginePool(max_model_memory=10 * 1024**3)
+        pool.single_model_mode = True
+        assert pool.single_model_mode is True
+        pool.single_model_mode = False
+        assert pool.single_model_mode is False
+
+    def test_status_includes_single_model_mode(self, small_mock_model_dir):
+        """Test that get_status includes single_model_mode."""
+        pool = EnginePool(max_model_memory=10 * 1024**3, single_model_mode=True)
+        pool.discover_models(str(small_mock_model_dir))
+
+        status = pool.get_status()
+        assert status["single_model_mode"] is True
+
+    def test_status_default_false(self, small_mock_model_dir):
+        """Test that get_status shows False by default."""
+        pool = EnginePool(max_model_memory=10 * 1024**3)
+        pool.discover_models(str(small_mock_model_dir))
+
+        status = pool.get_status()
+        assert status["single_model_mode"] is False
+
+    @pytest.mark.asyncio
+    async def test_evicts_other_model_before_load(self, small_mock_model_dir):
+        """Test that single_model_mode unloads other models before loading."""
+        # Large memory limit so both would normally coexist
+        pool = EnginePool(max_model_memory=10 * 1024**3, single_model_mode=True)
+        pool.discover_models(str(small_mock_model_dir))
+
+        mock_engine_a = MagicMock()
+        mock_engine_a.start = AsyncMock()
+        mock_engine_a.stop = AsyncMock()
+
+        mock_engine_b = MagicMock()
+        mock_engine_b.start = AsyncMock()
+        mock_engine_b.stop = AsyncMock()
+
+        engines = {"model-a": mock_engine_a, "model-b": mock_engine_b}
+
+        def create_engine(*args, **kwargs):
+            model_name = kwargs.get("model_name", "")
+            for key, eng in engines.items():
+                if key in model_name:
+                    return eng
+            return mock_engine_a
+
+        with patch("omlx.engine_pool.BatchedEngine", side_effect=create_engine):
+            # Load model-a
+            await pool.get_engine("model-a")
+            assert pool._entries["model-a"].engine is not None
+            assert pool._entries["model-b"].engine is None
+
+            # Load model-b — should evict model-a first
+            await pool.get_engine("model-b")
+
+        # model-a should have been unloaded
+        mock_engine_a.stop.assert_called_once()
+        assert pool._entries["model-a"].engine is None
+        assert pool._entries["model-b"].engine is not None
+
+    @pytest.mark.asyncio
+    async def test_no_eviction_when_disabled(self, small_mock_model_dir):
+        """Test that models coexist when single_model_mode is off."""
+        pool = EnginePool(max_model_memory=10 * 1024**3, single_model_mode=False)
+        pool.discover_models(str(small_mock_model_dir))
+
+        mock_engine_a = MagicMock()
+        mock_engine_a.start = AsyncMock()
+        mock_engine_a.stop = AsyncMock()
+
+        mock_engine_b = MagicMock()
+        mock_engine_b.start = AsyncMock()
+
+        engines = {"model-a": mock_engine_a, "model-b": mock_engine_b}
+
+        def create_engine(*args, **kwargs):
+            model_name = kwargs.get("model_name", "")
+            for key, eng in engines.items():
+                if key in model_name:
+                    return eng
+            return mock_engine_a
+
+        with patch("omlx.engine_pool.BatchedEngine", side_effect=create_engine):
+            await pool.get_engine("model-a")
+            await pool.get_engine("model-b")
+
+        # Both should be loaded
+        assert pool._entries["model-a"].engine is not None
+        assert pool._entries["model-b"].engine is not None
+        mock_engine_a.stop.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_pinned_models(self, small_mock_model_dir):
+        """Test that pinned models are not evicted in single_model_mode."""
+        pool = EnginePool(max_model_memory=10 * 1024**3, single_model_mode=True)
+        pool.discover_models(str(small_mock_model_dir))
+
+        # Pin model-a
+        pool._entries["model-a"].is_pinned = True
+
+        mock_engine_a = MagicMock()
+        mock_engine_a.start = AsyncMock()
+        mock_engine_a.stop = AsyncMock()
+
+        mock_engine_b = MagicMock()
+        mock_engine_b.start = AsyncMock()
+        mock_engine_b.stop = AsyncMock()
+
+        engines = {"model-a": mock_engine_a, "model-b": mock_engine_b}
+
+        def create_engine(*args, **kwargs):
+            model_name = kwargs.get("model_name", "")
+            for key, eng in engines.items():
+                if key in model_name:
+                    return eng
+            return mock_engine_a
+
+        with patch("omlx.engine_pool.BatchedEngine", side_effect=create_engine):
+            # Load pinned model-a
+            await pool.get_engine("model-a")
+
+            # Load model-b — model-a should NOT be evicted (pinned)
+            await pool.get_engine("model-b")
+
+        # model-a should still be loaded (pinned)
+        assert pool._entries["model-a"].engine is not None
+        mock_engine_a.stop.assert_not_called()
+        assert pool._entries["model-b"].engine is not None
+
+    @pytest.mark.asyncio
+    async def test_evicts_pinned_if_incoming_is_pinned(self, small_mock_model_dir):
+        """Test that pinned models ARE evicted when incoming model is also pinned."""
+        pool = EnginePool(max_model_memory=10 * 1024**3, single_model_mode=True)
+        pool.discover_models(str(small_mock_model_dir))
+
+        # Pin model-a, incoming model-b is also pinned
+        pool._entries["model-a"].is_pinned = True
+        pool._entries["model-b"].is_pinned = True
+
+        mock_engine_a = MagicMock()
+        mock_engine_a.start = AsyncMock()
+        mock_engine_a.stop = AsyncMock()
+
+        mock_engine_b = MagicMock()
+        mock_engine_b.start = AsyncMock()
+
+        engines = {"model-a": mock_engine_a, "model-b": mock_engine_b}
+
+        def create_engine(*args, **kwargs):
+            model_name = kwargs.get("model_name", "")
+            for key, eng in engines.items():
+                if key in model_name:
+                    return eng
+            return mock_engine_a
+
+        with patch("omlx.engine_pool.BatchedEngine", side_effect=create_engine):
+            await pool.get_engine("model-a")
+            await pool.get_engine("model-b")
+
+        # model-a should be evicted (both pinned overrides)
+        mock_engine_a.stop.assert_called_once()
+        assert pool._entries["model-a"].engine is None
+        assert pool._entries["model-b"].engine is not None
+
+    @pytest.mark.asyncio
+    async def test_same_model_no_eviction(self, small_mock_model_dir):
+        """Test that requesting the already-loaded model doesn't trigger eviction."""
+        pool = EnginePool(max_model_memory=10 * 1024**3, single_model_mode=True)
+        pool.discover_models(str(small_mock_model_dir))
+
+        mock_engine = MagicMock()
+        mock_engine.start = AsyncMock()
+
+        with patch("omlx.engine_pool.BatchedEngine", return_value=mock_engine):
+            await pool.get_engine("model-a")
+            await pool.get_engine("model-a")  # Same model again
+
+        # start should only be called once
+        assert mock_engine.start.call_count == 1


### PR DESCRIPTION
## Context

This fixes a recurring production issue for oMLX on Apple Silicon laptops.

Right now:
- oMLX will happily load as many models as fit inside `max_model_memory`
- It only evicts when you go over the limit
- `max_model_memory` was designed as an upper bound, not a target
- On laptop installations with multiple models available, users end up with 2-3 loaded at near-full memory utilisation
- KV cache, context windows, and the OS get squeezed out, and inference falls over with 507 errors on any reasonable context window

Users have been working around this by artificially setting `max_model_memory` 30-40% lower than actual available RAM. That breaks the semantics of the setting, wastes memory, and is not discoverable.

This PR adds an opt-in `single_model_mode` that evicts all other non-pinned loaded models before loading a different model, even when `max_model_memory` would otherwise allow coexistence. The goal is to preserve headroom for KV cache, context windows, and the OS on memory-constrained Apple Silicon machines. Existing behavior remains the default, pinned models remain protected, and the setting can be configured via settings, environment, CLI, or the admin API.

## What this changes

When enabled, oMLX evicts all other non-pinned loaded models before loading the requested one, regardless of whether memory would allow coexistence.

The eviction block is placed in `get_engine()` after the "already loaded" early return and after the "too large" check, but before the existing headroom-based eviction. This means:
- Same-model requests are a no-op (the early return fires first)
- Models are not unloaded for requests that will fail anyway (the size check rejects first)
- The existing headroom and process-memory checks still run after as a safety net (they can still matter when pinned models remain loaded)

**Pinned models:** Pinned models are never evicted by `single_model_mode`. If multiple pinned models exist, they will coexist regardless of this setting. The mode only evicts non-pinned models.

**Same-model no-op:** If the requested model is already loaded, nothing is evicted.

## Configuration

```json
// settings.json → model section
{
  "model": {
    "single_model_mode": true
  }
}
```

```bash
# CLI
omlx serve --single-model-mode
omlx serve --no-single-model-mode   # explicitly disable (overrides config)

# Environment variable
OMLX_SINGLE_MODEL_MODE=true

# Admin API (runtime toggle, no restart needed)
POST /admin/api/global-settings
{"single_model_mode": true}
```

## Files changed

| File | Change |
|---|---|
| `omlx/settings.py` | `single_model_mode: bool` on `ModelSettings` dataclass, with `to_dict`/`from_dict`/env/CLI override wiring |
| `omlx/engine_pool.py` | Flag on `EnginePool.__init__`, property with setter (for runtime admin toggle), eviction block in `get_engine()`, included in `get_status()` |
| `omlx/server.py` | Reads the setting and passes it to `EnginePool` |
| `omlx/cli.py` | `--single-model-mode` and `--no-single-model-mode` CLI flags |
| `omlx/admin/routes.py` | Added to admin settings request model, GET status endpoint, and live POST update |
| `tests/test_engine_pool.py` | New tests in `TestSingleModelMode` |

## Known limitations

- **Pinned models are never evicted**, so multiple pinned models may still coexist when this mode is enabled.
- **Runtime toggling affects future model loads only.** Flipping `single_model_mode` on via the admin API does not proactively unload currently loaded models. They are evicted on the next model switch.
- **SpecPrefill draft models** are loaded internally by the serving engine and are not separately managed by the engine pool. They are unloaded when the parent model is evicted and must reload on next use.
- **This does not guarantee elimination of all OOM failures.** Process memory enforcement, KV cache growth, and pinned model coexistence can still be limiting factors.

## Known interaction: in-flight requests

`_unload_engine()` aborts any active requests on the victim model. This is the same behavior as the existing LRU eviction. With `single_model_mode`, a model switch mid-request will kill the in-flight connection. This is intentional — the user opted into aggressive eviction.

## Test results

61 passed in `tests/test_engine_pool.py` (0 regressions)

`TestSingleModelMode` covers: default off, constructor flag, runtime setter, status reporting, eviction on switch, no-eviction when disabled, pinned model protection, pinned models kept even when incoming is pinned, same-model no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)