### PR TITLE
fix(admin): show per-model runtime cache size

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2475,6 +2475,24 @@ def _build_runtime_cache_observability(
         elif not isinstance(ssd_stats, dict):
             ssd_stats = {}
 
+        ssd_manager = getattr(scheduler, "paged_ssd_cache_manager", None)
+        scheduler_model_name = getattr(getattr(scheduler, "config", None), "model_name", "")
+        if ssd_manager is not None and hasattr(ssd_manager, "get_stats_for_model"):
+            try:
+                scoped_ssd_stats = ssd_manager.get_stats_for_model(
+                    scheduler_model_name or model_id
+                )
+                if is_dataclass(scoped_ssd_stats):
+                    ssd_stats = asdict(scoped_ssd_stats)
+                elif isinstance(scoped_ssd_stats, dict):
+                    ssd_stats = scoped_ssd_stats
+            except Exception as exc:
+                logger.warning(
+                    "Failed to collect model-scoped SSD cache stats for model '%s': %s",
+                    model_id,
+                    exc,
+                )
+
         prefix_stats = runtime_stats.get("prefix_cache")
         if is_dataclass(prefix_stats):
             prefix_stats = asdict(prefix_stats)

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -501,6 +501,11 @@ class PagedSSDCacheIndex:
         with self._lock:
             return list(self._index.keys())
 
+    def get_all_metadata(self) -> List[PagedSSDBlockMetadata]:
+        """Get a snapshot of all indexed block metadata."""
+        with self._lock:
+            return list(self._index.values())
+
 
 class PagedSSDCacheManager(CacheManager):
     """
@@ -1736,6 +1741,64 @@ class PagedSSDCacheManager(CacheManager):
                 hot_cache_promotions=self._stats["hot_cache_promotions"],
             )
 
+    def get_stats_for_model(self, model_name: str) -> PagedSSDCacheStats:
+        """Get model-scoped SSD cache statistics.
+
+        The SSD cache directory can be shared across multiple loaded models, so
+        dashboard per-model rows must be filtered by block metadata rather than
+        reusing the global cache totals.
+        """
+        normalized_name = model_name.rstrip("/")
+        basename = os.path.basename(normalized_name) if normalized_name else ""
+
+        def _matches(candidate: str) -> bool:
+            candidate = candidate.rstrip("/")
+            if not candidate:
+                return False
+            if candidate == normalized_name:
+                return True
+            if basename and os.path.basename(candidate) == basename:
+                return True
+            return False
+
+        with self._lock:
+            indexed_entries = [
+                metadata
+                for metadata in self._index.get_all_metadata()
+                if _matches(metadata.model_name)
+            ]
+            indexed_size = sum(metadata.file_size for metadata in indexed_entries)
+            indexed_count = len(indexed_entries)
+
+            with self._hot_cache_lock:
+                hot_entries = []
+                hot_size = 0
+                for entry in self._hot_cache.values():
+                    blk_meta = entry.get("block_metadata")
+                    if blk_meta is None or not _matches(blk_meta.model_name):
+                        continue
+                    hot_entries.append(entry)
+                    hot_size += self._hot_cache_entry_size(entry["tensors_raw"])
+
+            return PagedSSDCacheStats(
+                hits=self._stats["hits"],
+                misses=self._stats["misses"],
+                evictions=self._stats["evictions"],
+                saves=self._stats["saves"],
+                loads=self._stats["loads"],
+                errors=self._stats["errors"],
+                total_size_bytes=indexed_size,
+                max_size_bytes=self._get_effective_max_size(),
+                configured_max_size_bytes=self._max_size,
+                num_files=indexed_count,
+                hot_cache_entries=len(hot_entries),
+                hot_cache_size_bytes=hot_size,
+                hot_cache_max_bytes=self._hot_cache_max_bytes,
+                hot_cache_hits=self._stats["hot_cache_hits"],
+                hot_cache_evictions=self._stats["hot_cache_evictions"],
+                hot_cache_promotions=self._stats["hot_cache_promotions"],
+            )
+
     def get_stats_dict(self) -> Dict[str, Any]:
         """
         Get SSD cache statistics as a dictionary.
@@ -1918,5 +1981,4 @@ class PagedSSDCacheManager(CacheManager):
             Configured maximum cache size in bytes.
         """
         return self._max_size
-
 

--- a/tests/test_admin_api_key.py
+++ b/tests/test_admin_api_key.py
@@ -580,6 +580,126 @@ class TestStatsSecurity:
 class TestRuntimeCacheObservability:
     """Tests for runtime cache observability robustness."""
 
+    def test_runtime_cache_uses_model_scoped_ssd_stats(self):
+        """Per-model rows should not repeat the shared SSD cache total."""
+        cache_dir = Path("/tmp/omlx-cache")
+
+        mock_settings = MagicMock()
+        mock_settings.base_path = Path("/tmp/omlx-base")
+        mock_settings.cache.get_ssd_cache_dir.return_value = cache_dir
+
+        shared_ssd_stats = {
+            "num_files": 999,
+            "total_size_bytes": 999_999_999,
+            "hot_cache_max_bytes": 0,
+            "hot_cache_size_bytes": 0,
+            "hot_cache_entries": 0,
+        }
+
+        manager_a = MagicMock()
+        manager_a.get_stats_for_model.return_value = {
+            "num_files": 3,
+            "total_size_bytes": 4096,
+            "hot_cache_max_bytes": 0,
+            "hot_cache_size_bytes": 0,
+            "hot_cache_entries": 0,
+        }
+        scheduler_a = MagicMock()
+        scheduler_a.config.model_name = "/models/model-a"
+        scheduler_a.paged_ssd_cache_manager = manager_a
+        scheduler_a.get_ssd_cache_stats.return_value = {
+            "block_size": 1024,
+            "indexed_blocks": 12,
+            "ssd_cache": shared_ssd_stats,
+        }
+
+        manager_b = MagicMock()
+        manager_b.get_stats_for_model.return_value = {
+            "num_files": 7,
+            "total_size_bytes": 8192,
+            "hot_cache_max_bytes": 0,
+            "hot_cache_size_bytes": 0,
+            "hot_cache_entries": 0,
+        }
+        scheduler_b = MagicMock()
+        scheduler_b.config.model_name = "/models/model-b"
+        scheduler_b.paged_ssd_cache_manager = manager_b
+        scheduler_b.get_ssd_cache_stats.return_value = {
+            "block_size": 2048,
+            "indexed_blocks": 4,
+            "ssd_cache": shared_ssd_stats,
+        }
+
+        entry_a = SimpleNamespace(
+            engine=SimpleNamespace(
+                _engine=SimpleNamespace(
+                    engine=SimpleNamespace(scheduler=scheduler_a)
+                )
+            )
+        )
+        entry_b = SimpleNamespace(
+            engine=SimpleNamespace(
+                _engine=SimpleNamespace(
+                    engine=SimpleNamespace(scheduler=scheduler_b)
+                )
+            )
+        )
+
+        engine_pool = MagicMock()
+        engine_pool.get_status.return_value = {
+            "models": [
+                {"id": "model-a", "loaded": True},
+                {"id": "model-b", "loaded": True},
+            ]
+        }
+        engine_pool._entries = {
+            "model-a": entry_a,
+            "model-b": entry_b,
+        }
+
+        with patch.object(admin_routes, "_get_engine_pool", return_value=engine_pool):
+            payload = admin_routes._build_runtime_cache_observability(mock_settings)
+
+        assert payload["total_num_files"] == 10
+        assert payload["total_size_bytes"] == 12288
+        assert payload["effective_block_sizes"] == [1024, 2048]
+        assert payload["models"] == [
+            {
+                "id": "model-a",
+                "block_size": 1024,
+                "indexed_blocks": 12,
+                "indexed_blocks_display": "12",
+                "has_sub_block_cache": False,
+                "partial_block_skips": 0,
+                "partial_tokens_skipped": 0,
+                "last_partial_tokens_skipped": 0,
+                "last_tokens_to_next_block": 0,
+                "num_files": 3,
+                "total_size_bytes": 4096,
+                "hot_cache_max_bytes": 0,
+                "hot_cache_size_bytes": 0,
+                "hot_cache_entries": 0,
+            },
+            {
+                "id": "model-b",
+                "block_size": 2048,
+                "indexed_blocks": 4,
+                "indexed_blocks_display": "4",
+                "has_sub_block_cache": False,
+                "partial_block_skips": 0,
+                "partial_tokens_skipped": 0,
+                "last_partial_tokens_skipped": 0,
+                "last_tokens_to_next_block": 0,
+                "num_files": 7,
+                "total_size_bytes": 8192,
+                "hot_cache_max_bytes": 0,
+                "hot_cache_size_bytes": 0,
+                "hot_cache_entries": 0,
+            },
+        ]
+        manager_a.get_stats_for_model.assert_called_once_with("/models/model-a")
+        manager_b.get_stats_for_model.assert_called_once_with("/models/model-b")
+
     def test_runtime_cache_ignores_single_model_stats_failure(self):
         """One model failing stats collection should not break the whole payload."""
         cache_dir = Path("/tmp/omlx-cache")


### PR DESCRIPTION
## Summary
Fix the Runtime Cache dashboard so each model row shows its own SSD cache footprint instead of repeating the shared cache total.

Closes #743.

## Root cause
`_build_runtime_cache_observability()` was copying scheduler-level `ssd_cache` totals directly into each model row. In the current runtime, the SSD cache manager can be shared across models, so those totals are global rather than model-scoped.

## Changes
- add `PagedSSDCacheManager.get_stats_for_model()` to aggregate indexed and hot-cache stats by `model_name`
- update admin runtime cache observability to prefer model-scoped SSD stats when available
- add a regression test proving two model rows can report different cache sizes even when the shared scheduler stats are identical

## Testing
- `.venv/bin/python -m pytest -q tests/test_admin_api_key.py`
