### PR TITLE
fix(reranker): align JinaForRanking with Jina Reranker V3 listwise scoring

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -113,6 +113,7 @@ EMBEDDING_ARCHITECTURES = {
 SUPPORTED_RERANKER_ARCHITECTURES = {
     "ModernBertForSequenceClassification",  # via mlx-embeddings
     "XLMRobertaForSequenceClassification",  # omlx native implementation
+    "JinaForRanking",  # Jina v3 listwise reranker
 }
 
 # CausalLM-based reranker architectures.
@@ -120,7 +121,6 @@ SUPPORTED_RERANKER_ARCHITECTURES = {
 # Detected by architecture + heuristic (model name or tokenizer hints).
 CAUSAL_LM_RERANKER_ARCHITECTURES = {
     "Qwen3ForCausalLM",
-    "JinaForRanking",  # Jina v3 reranker: uses <|score_token|> logits
 }
 
 # CausalLM-based embedding architectures.

--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -435,117 +435,31 @@ class MLXRerankerModel:
         )
 
     def _get_jina_hidden_states(self, input_ids):
-        """Extract final hidden states from mlx-lm wrappers/backbones."""
+        """Extract final hidden states from the Jina mlx-lm backbone."""
 
-        def _extract_hidden_states(outputs):
-            if outputs is None:
-                return None
-
-            hidden_states = getattr(outputs, "hidden_states", None)
-            if hidden_states is not None:
-                if isinstance(hidden_states, (list, tuple)):
-                    return hidden_states[-1]
-                return hidden_states
-
-            last_hidden_state = getattr(outputs, "last_hidden_state", None)
-            if last_hidden_state is not None:
-                return last_hidden_state
-
-            if isinstance(outputs, tuple):
-                for item in reversed(outputs):
-                    if isinstance(item, (list, tuple)) and item:
-                        candidate = item[-1]
-                        candidate_shape = getattr(candidate, "shape", None)
-                        if candidate_shape is not None and len(candidate_shape) >= 2:
-                            return candidate
-                    item_shape = getattr(item, "shape", None)
-                    if item_shape is not None and len(item_shape) == 3:
-                        return item
-
-            return None
-
-        def _try_call(target, use_hidden_states_flag: bool):
-            if target is None or not callable(target):
-                return None
-            try:
-                if use_hidden_states_flag:
-                    return target(input_ids, output_hidden_states=True)
-                return target(input_ids)
-            except TypeError:
-                return None
-            except Exception:
-                return None
-
-        errors = []
-
-        # Prefer backbone path first (upstream-equivalent call shape).
         backbone = getattr(self.model, "model", None)
-        if callable(backbone):
-            for call_name, args in (
-                ("model.model([input_ids])", ([input_ids],)),
-                ("model.model(input_ids)", (input_ids,)),
-            ):
-                try:
-                    outputs = backbone(*args)
-                except Exception as exc:
-                    errors.append(f"{call_name}: {exc}")
-                    continue
+        if backbone is None or not callable(backbone):
+            model_type = type(self.model).__name__ if self.model is not None else "None"
+            raise ValueError(
+                "Could not find Jina model backbone (model.model). "
+                f"The mlx-lm model wrapper may have changed: {model_type}."
+            )
 
-                hidden_states = _extract_hidden_states(outputs)
-                if (
-                    hidden_states is None
-                    and hasattr(outputs, "shape")
-                    and len(outputs.shape) == 3
-                ):
-                    hidden_states = outputs
-                if hidden_states is not None:
-                    if len(hidden_states.shape) == 2:
-                        return mx.expand_dims(hidden_states, axis=0)
-                    return hidden_states
-                errors.append(f"{call_name}: outputs did not include hidden states")
+        hidden_states = backbone(input_ids)
 
-        candidate_targets = [self.model]
-        for attr in (
-            "backbone",
-            "transformer",
-            "language_model",
-            "base_model",
-        ):
-            candidate = getattr(self.model, attr, None)
-            if candidate is not None and candidate not in candidate_targets:
-                candidate_targets.append(candidate)
+        if not hasattr(hidden_states, "shape"):
+            raise ValueError("Jina backbone did not return hidden states as a tensor.")
 
-        for target in candidate_targets:
-            outputs = _try_call(target, use_hidden_states_flag=True)
-            hidden_states = _extract_hidden_states(outputs)
-            if hidden_states is not None:
-                if len(hidden_states.shape) == 2:
-                    return mx.expand_dims(hidden_states, axis=0)
-                return hidden_states
-            if outputs is None:
-                errors.append(f"{target!r}: call failed with output_hidden_states=True")
+        if len(hidden_states.shape) == 2:
+            return mx.expand_dims(hidden_states, axis=0)
 
-        for target in candidate_targets[1:]:
-            outputs = _try_call(target, use_hidden_states_flag=False)
-            hidden_states = _extract_hidden_states(outputs)
-            if (
-                hidden_states is None
-                and hasattr(outputs, "shape")
-                and len(outputs.shape) == 3
-            ):
-                hidden_states = outputs
-            if hidden_states is not None:
-                if len(hidden_states.shape) == 2:
-                    return mx.expand_dims(hidden_states, axis=0)
-                return hidden_states
-            if outputs is None:
-                errors.append(f"{target!r}: call failed without output_hidden_states")
+        if len(hidden_states.shape) != 3:
+            raise ValueError(
+                "Jina hidden states must be rank 2 or 3. "
+                f"Got shape: {hidden_states.shape}"
+            )
 
-        raise ValueError(
-            "Could not extract Jina hidden states from mlx-lm model wrapper/backbone. "
-            "Expected hidden_states or last_hidden_state from model outputs. "
-            f"Attempted paths: {'; '.join(errors)}"
-        )
+        return hidden_states
 
     def _cosine_similarity(self, query_vec, doc_vecs, eps: float = 1e-8):
         """Compute cosine similarity between one query vector and many docs."""

--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -89,8 +89,9 @@ class MLXRerankerModel:
         self._is_jina_reranker = False
         self._token_true_id: int | None = None
         self._token_false_id: int | None = None
-        self._score_token_id: int | None = None
-        self._rerank_token_id: int | None = None
+        self._doc_embed_token_id: int | None = None
+        self._query_embed_token_id: int | None = None
+        self._jina_projector = None
         self._prefix_tokens: list[int] | None = None
         self._suffix_tokens: list[int] | None = None
         self._is_compiled = False
@@ -158,7 +159,9 @@ class MLXRerankerModel:
         from mlx_lm import load as mlx_lm_load
 
         model_path = str(self.model_name)
-        model, tokenizer_wrapper = mlx_lm_load(model_path)
+        loaded = mlx_lm_load(model_path)
+        model = loaded[0]
+        tokenizer_wrapper = loaded[1]
 
         # mlx-lm returns a TokenizerWrapper; unwrap to get the underlying
         # transformers tokenizer which supports __call__ for batch encoding.
@@ -211,24 +214,43 @@ class MLXRerankerModel:
         """
         Load a Jina v3 reranker model using mlx-lm.
 
-        Jina v3 reranker uses <|score_token|> logits for scoring instead of
-        yes/no logit pairs. The model is based on Qwen3 architecture.
+        Jina v3 reranker uses special-token hidden states + projector + cosine
+        similarity for listwise scoring.
         """
         from mlx_lm import load as mlx_lm_load
 
         model_path = str(self.model_name)
-        model, tokenizer_wrapper = mlx_lm_load(model_path)
+        loaded = mlx_lm_load(model_path)
+        model = loaded[0]
+        tokenizer_wrapper = loaded[1]
 
         # mlx-lm returns a TokenizerWrapper; unwrap to get the underlying
         # transformers tokenizer which supports __call__ for batch encoding.
         tokenizer = getattr(tokenizer_wrapper, "_tokenizer", tokenizer_wrapper)
 
-        # Resolve <|score_token|> and <|rerank_token|> IDs
-        score_token_id = None
-        rerank_token_id = None
-        
-        # Try multiple ways to get token IDs
-        # 1. Check added_tokens_decoder (keys are int IDs, values can be str or Token objects)
+        doc_embed_token_id = self._resolve_token_id(tokenizer, "<|embed_token|>")
+        query_embed_token_id = self._resolve_token_id(tokenizer, "<|rerank_token|>")
+
+        if doc_embed_token_id is None or query_embed_token_id is None:
+            raise ValueError(
+                "Could not resolve required Jina special tokens "
+                "('<|embed_token|>', '<|rerank_token|>'). "
+                "This model may not be a compatible Jina v3 reranker."
+            )
+
+        self._doc_embed_token_id = doc_embed_token_id
+        self._query_embed_token_id = query_embed_token_id
+        self._jina_projector = self._load_jina_projector(self.model_name)
+
+        logger.info(
+            f"Jina reranker tokens: embed_token={doc_embed_token_id}, "
+            f"rerank_token={query_embed_token_id}"
+        )
+
+        return model, tokenizer
+
+    def _resolve_token_id(self, tokenizer: Any, token_text: str) -> int | None:
+        """Resolve token IDs across tokenizer implementations."""
         added_tokens = getattr(tokenizer, "added_tokens_decoder", {}) or {}
         for tid, tinfo in added_tokens.items():
             content = ""
@@ -238,49 +260,305 @@ class MLXRerankerModel:
                 content = tinfo.content
             elif isinstance(tinfo, dict):
                 content = tinfo.get("content", "")
-            
-            if content == "<|score_token|>":
-                score_token_id = int(tid)
-            elif content == "<|rerank_token|>":
-                rerank_token_id = int(tid)
-        
-        # 2. Fallback to convert_tokens_to_ids
-        if score_token_id is None:
+
+            if content == token_text:
+                return int(tid)
+
+        convert_tokens_to_ids = getattr(tokenizer, "convert_tokens_to_ids", None)
+        if callable(convert_tokens_to_ids):
             try:
-                score_token_id = tokenizer.convert_tokens_to_ids("<|score_token|>")
+                token_id = convert_tokens_to_ids(token_text)
             except Exception:
-                pass
-        
-        if rerank_token_id is None:
+                token_id = None
+
+            if isinstance(token_id, int) and token_id >= 0:
+                unk_token_id = getattr(tokenizer, "unk_token_id", None)
+                if unk_token_id is None or token_id != unk_token_id:
+                    return token_id
+
+        get_added_vocab = getattr(tokenizer, "get_added_vocab", None)
+        if callable(get_added_vocab):
             try:
-                rerank_token_id = tokenizer.convert_tokens_to_ids("<|rerank_token|>")
+                added_vocab = get_added_vocab() or {}
             except Exception:
-                pass
-        
-        # 3. Fallback to get_added_vocab
-        if score_token_id is None:
-            added_vocab = getattr(tokenizer, "get_added_vocab", lambda: {})()
-            score_token_id = added_vocab.get("<|score_token|>")
-        
-        if rerank_token_id is None:
-            added_vocab = getattr(tokenizer, "get_added_vocab", lambda: {})()
-            rerank_token_id = added_vocab.get("<|rerank_token|>")
-        
-        if score_token_id is None:
-            raise ValueError(
-                "Could not find '<|score_token|>' in tokenizer added_tokens_decoder. "
-                "This model may not be a compatible Jina v3 reranker."
+                added_vocab = {}
+
+            token_id = added_vocab.get(token_text)
+            if isinstance(token_id, int):
+                return token_id
+
+        get_vocab = getattr(tokenizer, "get_vocab", None)
+        if callable(get_vocab):
+            try:
+                vocab = get_vocab() or {}
+            except Exception:
+                vocab = {}
+
+            token_id = vocab.get(token_text)
+            if isinstance(token_id, int):
+                return token_id
+
+        encode = getattr(tokenizer, "encode", None)
+        if callable(encode):
+            try:
+                encoded = encode(token_text, add_special_tokens=False)
+            except TypeError:
+                encoded = encode(token_text)
+            except Exception:
+                encoded = None
+
+            if hasattr(encoded, "ids"):
+                encoded = encoded.ids
+
+            if (
+                isinstance(encoded, list)
+                and len(encoded) == 1
+                and isinstance(encoded[0], int)
+            ):
+                return encoded[0]
+
+        return None
+
+    def _load_jina_projector(self, model_dir: str | Path):
+        """Load Jina projector weights and return a projection callable."""
+        model_path = Path(model_dir)
+        projector_path = model_path / "projector.safetensors"
+        if not projector_path.exists():
+            raise FileNotFoundError(
+                f"Missing Jina projector file: {projector_path}. "
+                "Expected projector.safetensors for JinaForRanking models."
             )
 
-        self._score_token_id = score_token_id
-        self._rerank_token_id = rerank_token_id
+        from safetensors import safe_open
 
-        logger.info(
-            f"Jina reranker tokens: score_token={score_token_id}, "
-            f"rerank_token={rerank_token_id}"
+        weights = {}
+        with safe_open(projector_path, framework="mlx") as f:
+            for key in f.keys():
+                weights[key] = f.get_tensor(key)
+
+        required_keys = ("linear1.weight", "linear2.weight")
+        missing_keys = [key for key in required_keys if key not in weights]
+        if missing_keys:
+            raise ValueError(
+                f"Jina projector is malformed: missing keys {missing_keys} in "
+                f"{projector_path}. "
+                f"Available keys: {sorted(weights.keys())}"
+            )
+
+        linear1_weight = weights["linear1.weight"]
+        linear2_weight = weights["linear2.weight"]
+
+        if len(linear1_weight.shape) != 2 or len(linear2_weight.shape) != 2:
+            raise ValueError(
+                "Jina projector weights must be 2D matrices: "
+                f"linear1.weight={linear1_weight.shape}, "
+                f"linear2.weight={linear2_weight.shape}."
+            )
+
+        if linear1_weight.shape != (512, 1024) or linear2_weight.shape != (512, 512):
+            raise ValueError(
+                "Unexpected Jina projector shapes. Expected "
+                "linear1.weight=(512, 1024) and linear2.weight=(512, 512), "
+                f"got linear1.weight={linear1_weight.shape}, "
+                f"linear2.weight={linear2_weight.shape}."
+            )
+
+        def _project(x):
+            if x.shape[-1] != linear1_weight.shape[1]:
+                raise ValueError(
+                    "Jina projector input dim mismatch for linear1: "
+                    f"input={x.shape[-1]}, expected={linear1_weight.shape[1]}."
+                )
+            hidden = x @ mx.transpose(linear1_weight)
+            hidden = mx.maximum(hidden, 0)
+            return hidden @ mx.transpose(linear2_weight)
+
+        return _project
+
+    def _sanitize_jina_text(self, text: str) -> str:
+        """Strip conflicting special tokens from user-provided text."""
+        sanitized = str(text)
+        sanitized = sanitized.replace("<|embed_token|>", " ")
+        sanitized = sanitized.replace("<|rerank_token|>", " ")
+        sanitized = sanitized.replace("<|score_token|>", " ")
+        sanitized = sanitized.replace("<|im_start|>", " ")
+        sanitized = sanitized.replace("<|im_end|>", " ")
+        return sanitized.strip()
+
+    def _format_jina_prompt(
+        self,
+        query: str,
+        documents: list[str],
+        instruction: str | None = None,
+    ) -> str:
+        """Format a listwise Jina reranking prompt."""
+        sanitized_query = self._sanitize_jina_text(query)
+        sanitized_docs = [self._sanitize_jina_text(doc) for doc in documents]
+        sanitized_instruction = (
+            self._sanitize_jina_text(instruction) if instruction is not None else None
         )
 
-        return model, tokenizer
+        user_content = (
+            f"I will provide you with {len(sanitized_docs)} passages, each indicated "
+            f"by a numerical identifier. Rank the passages based on their relevance "
+            f"to query: {sanitized_query}\n"
+        )
+        if sanitized_instruction:
+            user_content += f"<instruct>\n{sanitized_instruction}\n</instruct>\n"
+
+        doc_prompts = [
+            f'<passage id="{idx}">\n{doc}<|embed_token|>\n</passage>'
+            for idx, doc in enumerate(sanitized_docs)
+        ]
+        user_content += "\n".join(doc_prompts) + "\n"
+        user_content += f"<query>\n{sanitized_query}<|rerank_token|>\n</query>"
+
+        system_prompt = (
+            "You are a search relevance expert who can determine a ranking of the "
+            "passages based on how relevant they are to the query. If the query is "
+            "a question, how relevant a passage is depends on how well it answers "
+            "the question. If not, try to analyze the intent of the query and "
+            "assess how well each passage satisfies the intent. If an instruction "
+            "is provided, you should follow the instruction when determining the "
+            "ranking."
+        )
+
+        return (
+            "<|im_start|>system\n"
+            f"{system_prompt}"
+            "<|im_end|>\n"
+            "<|im_start|>user\n"
+            f"{user_content}"
+            "<|im_end|>\n"
+            "<|im_start|>assistant\n"
+            "<think>\n\n</think>\n\n"
+        )
+
+    def _get_jina_hidden_states(self, input_ids):
+        """Extract final hidden states from mlx-lm wrappers/backbones."""
+
+        def _extract_hidden_states(outputs):
+            if outputs is None:
+                return None
+
+            hidden_states = getattr(outputs, "hidden_states", None)
+            if hidden_states is not None:
+                if isinstance(hidden_states, (list, tuple)):
+                    return hidden_states[-1]
+                return hidden_states
+
+            last_hidden_state = getattr(outputs, "last_hidden_state", None)
+            if last_hidden_state is not None:
+                return last_hidden_state
+
+            if isinstance(outputs, tuple):
+                for item in reversed(outputs):
+                    if isinstance(item, (list, tuple)) and item:
+                        candidate = item[-1]
+                        candidate_shape = getattr(candidate, "shape", None)
+                        if candidate_shape is not None and len(candidate_shape) >= 2:
+                            return candidate
+                    item_shape = getattr(item, "shape", None)
+                    if item_shape is not None and len(item_shape) == 3:
+                        return item
+
+            return None
+
+        def _try_call(target, use_hidden_states_flag: bool):
+            if target is None or not callable(target):
+                return None
+            try:
+                if use_hidden_states_flag:
+                    return target(input_ids, output_hidden_states=True)
+                return target(input_ids)
+            except TypeError:
+                return None
+            except Exception:
+                return None
+
+        errors = []
+
+        # Prefer backbone path first (upstream-equivalent call shape).
+        backbone = getattr(self.model, "model", None)
+        if callable(backbone):
+            for call_name, args in (
+                ("model.model([input_ids])", ([input_ids],)),
+                ("model.model(input_ids)", (input_ids,)),
+            ):
+                try:
+                    outputs = backbone(*args)
+                except Exception as exc:
+                    errors.append(f"{call_name}: {exc}")
+                    continue
+
+                hidden_states = _extract_hidden_states(outputs)
+                if (
+                    hidden_states is None
+                    and hasattr(outputs, "shape")
+                    and len(outputs.shape) == 3
+                ):
+                    hidden_states = outputs
+                if hidden_states is not None:
+                    if len(hidden_states.shape) == 2:
+                        return mx.expand_dims(hidden_states, axis=0)
+                    return hidden_states
+                errors.append(f"{call_name}: outputs did not include hidden states")
+
+        candidate_targets = [self.model]
+        for attr in (
+            "backbone",
+            "transformer",
+            "language_model",
+            "base_model",
+        ):
+            candidate = getattr(self.model, attr, None)
+            if candidate is not None and candidate not in candidate_targets:
+                candidate_targets.append(candidate)
+
+        for target in candidate_targets:
+            outputs = _try_call(target, use_hidden_states_flag=True)
+            hidden_states = _extract_hidden_states(outputs)
+            if hidden_states is not None:
+                if len(hidden_states.shape) == 2:
+                    return mx.expand_dims(hidden_states, axis=0)
+                return hidden_states
+            if outputs is None:
+                errors.append(f"{target!r}: call failed with output_hidden_states=True")
+
+        for target in candidate_targets[1:]:
+            outputs = _try_call(target, use_hidden_states_flag=False)
+            hidden_states = _extract_hidden_states(outputs)
+            if (
+                hidden_states is None
+                and hasattr(outputs, "shape")
+                and len(outputs.shape) == 3
+            ):
+                hidden_states = outputs
+            if hidden_states is not None:
+                if len(hidden_states.shape) == 2:
+                    return mx.expand_dims(hidden_states, axis=0)
+                return hidden_states
+            if outputs is None:
+                errors.append(f"{target!r}: call failed without output_hidden_states")
+
+        raise ValueError(
+            "Could not extract Jina hidden states from mlx-lm model wrapper/backbone. "
+            "Expected hidden_states or last_hidden_state from model outputs. "
+            f"Attempted paths: {'; '.join(errors)}"
+        )
+
+    def _cosine_similarity(self, query_vec, doc_vecs, eps: float = 1e-8):
+        """Compute cosine similarity between one query vector and many docs."""
+        if len(query_vec.shape) == 2:
+            query_vec = query_vec[0]
+        if len(doc_vecs.shape) == 1:
+            doc_vecs = mx.expand_dims(doc_vecs, axis=0)
+
+        query_norm = mx.linalg.norm(query_vec)
+        doc_norms = mx.linalg.norm(doc_vecs, axis=-1)
+        denom = mx.maximum(doc_norms * query_norm, eps)
+        numer = mx.sum(doc_vecs * query_vec, axis=-1)
+        return numer / denom
 
     def load(self) -> None:
         """Load the model and processor/tokenizer."""
@@ -295,10 +573,10 @@ class MLXRerankerModel:
 
         try:
             if arch == "JinaForRanking":
-                # Jina v3 reranker: uses <|score_token|> logits instead of yes/no
+                # Jina v3 reranker: listwise hidden-state scoring + projector
                 self.model, self.processor = self._load_jina_reranker()
                 self._is_jina_reranker = True
-                self._num_labels = 1  # score token
+                self._num_labels = 1
             elif arch in CAUSAL_LM_RERANKER_ARCHITECTURES:
                 # CausalLM-based reranker (e.g., Qwen3-Reranker)
                 self.model, self.processor = self._load_causal_lm()
@@ -311,6 +589,7 @@ class MLXRerankerModel:
             else:
                 # Use mlx-embeddings for other architectures (ModernBert, etc.)
                 from mlx_embeddings import load
+
                 self.model, self.processor = load(self.model_name)
 
                 # Get num_labels from model config
@@ -362,7 +641,10 @@ class MLXRerankerModel:
             return False
 
         base_model = self.model
+        if not callable(base_model):
+            return False
         try:
+
             def _compiled_seq_logits(inputs):
                 outputs = base_model(**inputs)
                 if hasattr(outputs, "pooler_output") and outputs.pooler_output is not None:
@@ -468,6 +750,12 @@ class MLXRerankerModel:
         tokenizer = self.processor
         prefix_tokens = self._prefix_tokens
         suffix_tokens = self._suffix_tokens
+        if not callable(tokenizer):
+            raise ValueError("CausalLM reranker tokenizer is not initialized.")
+        if prefix_tokens is None or suffix_tokens is None:
+            raise ValueError("CausalLM reranker prompt tokens are not initialized.")
+        if not callable(self.model):
+            raise ValueError("CausalLM reranker model is not initialized.")
 
         # Compute max tokens available for the instruction content
         max_content_tokens = max_length - len(prefix_tokens) - len(suffix_tokens)
@@ -535,65 +823,161 @@ class MLXRerankerModel:
         max_length: int = 8192,
     ) -> RerankOutput:
         """
-        Rerank using Jina v3 reranker with <|score_token|> logits.
+        Rerank using Jina v3 listwise embedding-based scoring.
 
-        Each document is formatted with <|rerank_token|> instruction and the query,
-        then scored by extracting logits at the <|score_token|> position.
+        Builds multi-document prompts, extracts hidden states at special token
+        positions, applies the projector, and computes query-document cosine
+        similarities. Uses deterministic greedy chunking under max_length.
         """
-        import mlx.core as mx
-
         tokenizer = self.processor
-        score_token_id = self._score_token_id
-        rerank_token_id = self._rerank_token_id
+        doc_embed_token_id = self._doc_embed_token_id
+        query_embed_token_id = self._query_embed_token_id
+        projector = self._jina_projector
+        if tokenizer is None:
+            raise ValueError("Jina reranker tokenizer is not initialized.")
 
-        # Format instruction
-        rerank_instruct = "Given a query, retrieve relevant documents that answer the query."
-        if rerank_token_id is not None:
-            instruct_tokens = tokenizer.encode(
-                f"<|rerank_token|>{rerank_instruct}", add_special_tokens=False
+        encode = getattr(tokenizer, "encode", None)
+        if not callable(encode):
+            raise ValueError("Jina reranker tokenizer does not provide encode().")
+
+        if (
+            doc_embed_token_id is None
+            or query_embed_token_id is None
+            or projector is None
+        ):
+            raise ValueError(
+                "Jina reranker is not fully initialized. "
+                "Missing special-token IDs or projector."
             )
-        else:
-            instruct_tokens = tokenizer.encode(rerank_instruct, add_special_tokens=False)
 
-        query_tokens = tokenizer.encode(query, add_special_tokens=False)
-        bos_token_id = getattr(tokenizer, "bos_token_id", None)
-        eos_id = getattr(tokenizer, "eos_token_id", None)
+        def _to_token_ids(text: str) -> list[int]:
+            encoded = encode(text, add_special_tokens=False)
+            if hasattr(encoded, "ids"):
+                return list(encoded.ids)
+            return list(encoded)
 
-        # Compute max content tokens per document
-        # reserved = instruct + query + (BOS if present) + (EOS if present)
-        reserved = len(instruct_tokens) + len(query_tokens)
-        if bos_token_id is not None:
-            reserved += 1
-        if eos_id is not None:
-            reserved += 1
-        max_doc_tokens = max_length - reserved
+        decode = getattr(tokenizer, "decode", None)
 
-        scores = []
+        def _truncate_doc_to_fit(
+            query_text: str, doc_text: str
+        ) -> Tuple[str, list[int]]:
+            doc_token_ids = _to_token_ids(doc_text)
+            if not doc_token_ids:
+                prompt = self._format_jina_prompt(query_text, [""])
+                prompt_ids = _to_token_ids(prompt)[:max_length]
+                return "", prompt_ids
+
+            best_doc = ""
+            best_ids: list[int] = []
+            lo = 0
+            hi = len(doc_token_ids)
+            while lo <= hi:
+                mid = (lo + hi) // 2
+                if callable(decode):
+                    candidate_doc = decode(
+                        doc_token_ids[:mid], skip_special_tokens=False
+                    )
+                else:
+                    candidate_doc = doc_text[:mid]
+
+                prompt = self._format_jina_prompt(query_text, [candidate_doc])
+                prompt_ids = _to_token_ids(prompt)
+                if len(prompt_ids) <= max_length:
+                    best_doc = candidate_doc
+                    best_ids = prompt_ids
+                    lo = mid + 1
+                else:
+                    hi = mid - 1
+
+            if not best_ids:
+                raise ValueError(
+                    "Could not fit even a minimally truncated document into max_length. "
+                    f"max_length={max_length}"
+                )
+
+            return best_doc, best_ids
+
+        sanitized_query = self._sanitize_jina_text(query)
+        sanitized_docs = [self._sanitize_jina_text(doc) for doc in documents]
+
+        scores = [0.0] * len(documents)
         total_tokens = 0
-        for doc in documents:
-            doc_tokens = tokenizer.encode(doc, add_special_tokens=False)[:max_doc_tokens]
+        start = 0
+        while start < len(sanitized_docs):
+            chunk_doc_indices: list[int] = []
+            chunk_docs: list[str] = []
+            chunk_input_ids: list[int] | None = None
+            cursor = start
 
-            # Build input: [BOS] + instruct + [Query] + query + [Document] + doc + [EOS]
-            input_ids = []
-            if bos_token_id is not None:
-                input_ids.append(bos_token_id)
-            input_ids.extend(instruct_tokens)
-            input_ids.extend(query_tokens)
-            input_ids.extend(doc_tokens)
-            # Add eos if available
-            if eos_id is not None:
-                input_ids.append(eos_id)
+            while cursor < len(sanitized_docs):
+                candidate_docs = chunk_docs + [sanitized_docs[cursor]]
+                candidate_prompt = self._format_jina_prompt(
+                    sanitized_query, candidate_docs
+                )
+                candidate_ids = _to_token_ids(candidate_prompt)
 
-            input_ids = input_ids[:max_length]
-            input_array = mx.array([input_ids])
+                if len(candidate_ids) <= max_length:
+                    chunk_docs = candidate_docs
+                    chunk_doc_indices.append(cursor)
+                    chunk_input_ids = candidate_ids
+                    cursor += 1
+                    continue
 
-            logits = self.model(input_array)
-            # Get logits at the last position
-            last_logits = logits[0, -1, :]
-            # Extract score token logits (scalar)
-            score_logit = last_logits[score_token_id].item()
-            scores.append(score_logit)
-            total_tokens += len(input_ids)
+                if chunk_docs:
+                    break
+
+                truncated_doc, truncated_ids = _truncate_doc_to_fit(
+                    sanitized_query,
+                    sanitized_docs[cursor],
+                )
+                chunk_docs = [truncated_doc]
+                chunk_doc_indices = [cursor]
+                chunk_input_ids = truncated_ids
+                cursor += 1
+                break
+
+            if chunk_input_ids is None or not chunk_doc_indices:
+                raise ValueError("Failed to create a valid Jina reranker chunk.")
+
+            input_array = mx.array([chunk_input_ids])
+            hidden_states = self._get_jina_hidden_states(input_array)
+
+            query_positions = [
+                pos
+                for pos, token_id in enumerate(chunk_input_ids)
+                if token_id == query_embed_token_id
+            ]
+            if not query_positions:
+                raise ValueError(
+                    "Jina prompt does not contain '<|rerank_token|>' in tokenized input."
+                )
+
+            doc_positions = [
+                pos
+                for pos, token_id in enumerate(chunk_input_ids)
+                if token_id == doc_embed_token_id
+            ]
+            if len(doc_positions) < len(chunk_docs):
+                raise ValueError(
+                    "Jina prompt/doc mismatch: detected fewer '<|embed_token|>' "
+                    "positions than documents in chunk."
+                )
+
+            selected_doc_positions = doc_positions[: len(chunk_docs)]
+            query_hidden = hidden_states[0, query_positions[0], :]
+            doc_hidden = hidden_states[0, selected_doc_positions, :]
+
+            query_vec = projector(query_hidden)
+            doc_vecs = projector(doc_hidden)
+            similarities = self._cosine_similarity(query_vec, doc_vecs)
+            mx.eval(similarities)
+
+            chunk_scores = similarities.tolist()
+            for original_idx, score in zip(chunk_doc_indices, chunk_scores):
+                scores[original_idx] = float(score)
+
+            total_tokens += len(chunk_input_ids)
+            start = cursor
 
         # Sort by score descending
         indexed_scores = list(enumerate(scores))
@@ -621,6 +1005,8 @@ class MLXRerankerModel:
         processor_class = type(processor).__name__
         if processor_class == "TokenizerWrapper" and hasattr(processor, "_tokenizer"):
             processor = processor._tokenizer
+        if not callable(processor):
+            raise ValueError("SequenceClassification processor is not initialized.")
 
         # Tokenize query-document pairs
         # SequenceClassification models expect pairs as (query, document)
@@ -658,6 +1044,8 @@ class MLXRerankerModel:
                 self._compiled_seq_logits = None
 
         if logits is None:
+            if not callable(self.model):
+                raise ValueError("SequenceClassification model is not initialized.")
             outputs = self.model(
                 input_ids=input_ids,
                 attention_mask=attention_mask,
@@ -672,7 +1060,6 @@ class MLXRerankerModel:
                     "Model output does not contain pooler_output. "
                     "Ensure the model is a SequenceClassification model."
                 )
-
 
         # Ensure computation is done
         mx.eval(logits)

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -85,6 +85,17 @@ class TestDetectModelType:
         (tmp_path / "config.json").write_text(json.dumps(config))
         assert detect_model_type(tmp_path) == "reranker"
 
+    def test_detect_jina_reranker_without_name_heuristic(self, tmp_path):
+        """JinaForRanking should detect as reranker without requiring 'rerank' in directory name."""
+        model_dir = tmp_path / "jina-v3-mlx"
+        model_dir.mkdir()
+        config = {
+            "model_type": "qwen3",
+            "architectures": ["JinaForRanking"],
+        }
+        (model_dir / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(model_dir) == "reranker"
+
     def test_detect_causal_lm_reranker(self, tmp_path):
         """Test detection of CausalLM-based reranker (e.g., Qwen3-Reranker)."""
         reranker_dir = tmp_path / "Qwen3-Reranker-0.6B-mxfp8"

--- a/tests/test_reranker_causal_lm.py
+++ b/tests/test_reranker_causal_lm.py
@@ -263,6 +263,69 @@ class TestJinaReranker:
             model._load_jina_projector(tmp_path)
 
     @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_get_jina_hidden_states_accepts_3d_tensor(self):
+        """_get_jina_hidden_states should return 3D backbone outputs unchanged."""
+        model = MLXRerankerModel("unused")
+        expected = mx.array(np.zeros((1, 4, 8), dtype=np.float32))
+
+        model.model = MagicMock()
+        model.model.model = MagicMock(return_value=expected)
+
+        input_ids = mx.array([[1, 2, 3, 4]])
+        actual = model._get_jina_hidden_states(input_ids)
+
+        assert actual.shape == (1, 4, 8)
+        assert np.allclose(np.array(actual.tolist()), np.array(expected.tolist()))
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_get_jina_hidden_states_expands_2d_tensor(self):
+        """_get_jina_hidden_states should expand 2D backbone outputs to batch form."""
+        model = MLXRerankerModel("unused")
+        returned = mx.array(np.zeros((4, 8), dtype=np.float32))
+
+        model.model = MagicMock()
+        model.model.model = MagicMock(return_value=returned)
+
+        input_ids = mx.array([[1, 2, 3, 4]])
+        actual = model._get_jina_hidden_states(input_ids)
+
+        assert actual.shape == (1, 4, 8)
+
+    def test_get_jina_hidden_states_missing_backbone_raises_clear_error(self):
+        """_get_jina_hidden_states should fail clearly when model.model is missing."""
+        model = MLXRerankerModel("unused")
+        model.model = object()
+
+        with pytest.raises(ValueError, match="Could not find Jina model backbone"):
+            model._get_jina_hidden_states("input_ids")
+
+    def test_get_jina_hidden_states_rejects_unsupported_output(self):
+        """_get_jina_hidden_states should reject non-tensor backbone outputs."""
+        model = MLXRerankerModel("unused")
+
+        class _UnsupportedOutput:
+            pass
+
+        model.model = MagicMock()
+        model.model.model = MagicMock(return_value=_UnsupportedOutput())
+
+        with pytest.raises(
+            ValueError, match="did not return hidden states as a tensor"
+        ):
+            model._get_jina_hidden_states("input_ids")
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_get_jina_hidden_states_rejects_invalid_tensor_rank(self):
+        """_get_jina_hidden_states should reject tensor outputs with unsupported rank."""
+        model = MLXRerankerModel("unused")
+        invalid = mx.array(np.zeros((1, 2, 3, 4), dtype=np.float32))
+        model.model = MagicMock()
+        model.model.model = MagicMock(return_value=invalid)
+        input_ids = mx.array([[1, 2, 3, 4]])
+        with pytest.raises(ValueError, match="Jina hidden states must be rank 2 or 3"):
+            model._get_jina_hidden_states(input_ids)
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
     def test_load_jina_projector_two_layer_mlp(self, tmp_path):
         """Projector should apply linear1 -> ReLU -> linear2 exactly."""
         model_dir = self._make_jina_model_dir(tmp_path)

--- a/tests/test_reranker_causal_lm.py
+++ b/tests/test_reranker_causal_lm.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+from safetensors.numpy import save_file
 
 try:
     import mlx.core as mx
@@ -167,6 +168,226 @@ class TestCausalLMReranker:
             model.rerank("query", ["doc"], max_length=512)
             args, _ = mock_method.call_args
             assert args[2] == 512
+
+
+class TestJinaReranker:
+    """Focused tests for Jina listwise reranker internals."""
+
+    def _make_jina_model_dir(self, tmp_path, name="jina-reranker-v3-mlx"):
+        """Create a mock model directory with Jina architecture config."""
+        model_dir = tmp_path / name
+        model_dir.mkdir()
+        config = {
+            "model_type": "qwen3",
+            "architectures": ["JinaForRanking"],
+        }
+        (model_dir / "config.json").write_text(json.dumps(config))
+        return model_dir
+
+    def test_resolve_token_id_uses_fallback_paths(self):
+        """_resolve_token_id should resolve IDs from decoder and convert fallback."""
+        model = MLXRerankerModel("unused")
+
+        class _TokenInfo:
+            def __init__(self, content):
+                self.content = content
+
+        tokenizer = MagicMock()
+        tokenizer.added_tokens_decoder = {
+            32000: _TokenInfo("<|embed_token|>"),
+        }
+        tokenizer.convert_tokens_to_ids.side_effect = lambda token: (
+            32001 if token == "<|rerank_token|>" else None
+        )
+        tokenizer.get_added_vocab.return_value = {}
+
+        assert model._resolve_token_id(tokenizer, "<|embed_token|>") == 32000
+        assert model._resolve_token_id(tokenizer, "<|rerank_token|>") == 32001
+
+    def test_format_jina_prompt_upstream_parity_invariants(self):
+        """_format_jina_prompt should preserve upstream prompt shape and token placement."""
+        model = MLXRerankerModel("unused")
+
+        query = "what is green tea"
+        docs = ["green tea health benefits", "coffee market prices"]
+        instruction = "Prioritize passages that directly answer the question."
+
+        prompt_with_instruction = model._format_jina_prompt(
+            query,
+            docs,
+            instruction=instruction,
+        )
+
+        expected_system_prompt = (
+            "You are a search relevance expert who can determine a ranking of the "
+            "passages based on how relevant they are to the query. If the query is "
+            "a question, how relevant a passage is depends on how well it answers "
+            "the question. If not, try to analyze the intent of the query and "
+            "assess how well each passage satisfies the intent. If an instruction "
+            "is provided, you should follow the instruction when determining the "
+            "ranking."
+        )
+
+        assert expected_system_prompt in prompt_with_instruction
+        assert '<passage id="0">' in prompt_with_instruction
+        assert '<passage id="1">' in prompt_with_instruction
+        assert prompt_with_instruction.index(
+            '<passage id="0">'
+        ) < prompt_with_instruction.index("<query>")
+        assert (
+            '<passage id="0">\ngreen tea health benefits<|embed_token|>\n</passage>'
+            in prompt_with_instruction
+        )
+        assert (
+            "<query>\nwhat is green tea<|rerank_token|>\n</query>"
+            in prompt_with_instruction
+        )
+        assert (
+            "<instruct>\n"
+            "Prioritize passages that directly answer the question.\n"
+            "</instruct>\n" in prompt_with_instruction
+        )
+        assert (
+            "<|im_start|>assistant\n<think>\n\n</think>\n\n" in prompt_with_instruction
+        )
+        assert "</query><|im_end|>" in prompt_with_instruction
+
+        prompt_without_instruction = model._format_jina_prompt(query, docs)
+        assert "<instruct>" not in prompt_without_instruction
+
+    def test_load_jina_projector_missing_file_raises_clear_error(self, tmp_path):
+        """Missing projector.safetensors should raise a clear FileNotFoundError."""
+        model = MLXRerankerModel("unused")
+
+        with pytest.raises(FileNotFoundError, match="projector.safetensors"):
+            model._load_jina_projector(tmp_path)
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_load_jina_projector_two_layer_mlp(self, tmp_path):
+        """Projector should apply linear1 -> ReLU -> linear2 exactly."""
+        model_dir = self._make_jina_model_dir(tmp_path)
+        model = MLXRerankerModel(str(model_dir))
+
+        w1 = np.zeros((512, 1024), dtype=np.float32)
+        w2 = np.zeros((512, 512), dtype=np.float32)
+
+        w1[0, 0] = 1.5
+        w1[1, 1] = -2.0
+        w1[2, 2] = 0.5
+
+        w2[0, 0] = 1.0
+        w2[1, 1] = -3.0
+        w2[3, 2] = 2.0
+
+        save_file(
+            {
+                "linear1.weight": w1,
+                "linear2.weight": w2,
+            },
+            str(model_dir / "projector.safetensors"),
+        )
+
+        projector = model._load_jina_projector(model_dir)
+
+        x = np.zeros((2, 1024), dtype=np.float32)
+        x[0, 0] = 2.0
+        x[0, 1] = 1.0
+        x[0, 2] = 4.0
+        x[1, 0] = -3.0
+        x[1, 1] = 5.0
+        x[1, 2] = -2.0
+
+        projected = projector(mx.array(x))
+        mx.eval(projected)
+
+        expected = np.maximum(x @ w1.T, 0.0) @ w2.T
+        actual = np.array(projected.tolist(), dtype=np.float32)
+        assert np.allclose(actual, expected, atol=1e-6)
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_rerank_jina_returns_scores_and_sorted_indices(self, tmp_path):
+        """_rerank_jina should produce per-doc scores and descending indices."""
+        model_dir = self._make_jina_model_dir(tmp_path)
+        model = MLXRerankerModel(str(model_dir))
+        model._loaded = True
+        model._is_jina_reranker = True
+        model._doc_embed_token_id = 2001
+        model._query_embed_token_id = 2002
+        model._jina_projector = lambda x: x
+
+        class _Tokenizer:
+            def encode(self, text, add_special_tokens=False):
+                del add_special_tokens
+                ids = []
+                for piece in text.replace("\n", " ").split():
+                    if "<|rerank_token|>" in piece:
+                        ids.append(2002)
+                        remainder = piece.replace("<|rerank_token|>", "")
+                        if remainder:
+                            ids.append(7)
+                    elif "<|embed_token|>" in piece:
+                        ids.append(2001)
+                        remainder = piece.replace("<|embed_token|>", "")
+                        if remainder:
+                            ids.append(7)
+                    else:
+                        ids.append(7)
+                return ids
+
+            def decode(self, token_ids, skip_special_tokens=False):
+                del skip_special_tokens
+                return " ".join(["tok"] * len(token_ids))
+
+        model.processor = _Tokenizer()
+
+        def _fake_hidden_states(input_ids):
+            token_ids = input_ids[0].tolist()
+            hidden_states = np.zeros((1, len(token_ids), 2), dtype=np.float32)
+            doc_vectors = ([0.6, 0.8], [0.95, 0.1], [-0.2, 0.0])
+            doc_idx = 0
+            for pos, token_id in enumerate(token_ids):
+                if token_id == 2002:
+                    hidden_states[0, pos, :] = np.array([1.0, 0.0], dtype=np.float32)
+                elif token_id == 2001 and doc_idx < len(doc_vectors):
+                    hidden_states[0, pos, :] = np.array(
+                        doc_vectors[doc_idx], dtype=np.float32
+                    )
+                    doc_idx += 1
+            return mx.array(hidden_states)
+
+        with patch.object(
+            model, "_get_jina_hidden_states", side_effect=_fake_hidden_states
+        ):
+            result = model._rerank_jina(
+                "query", ["doc a", "doc b", "doc c"], max_length=256
+            )
+
+        assert len(result.scores) == 3
+        assert result.scores[1] > result.scores[0] > result.scores[2]
+        assert result.indices == [1, 0, 2]
+        assert result.total_tokens > 0
+
+    def test_rerank_dispatch_and_max_length_for_jina(self, tmp_path):
+        """rerank() should dispatch to _rerank_jina and honor max_length semantics."""
+        model_dir = self._make_jina_model_dir(tmp_path)
+        model = MLXRerankerModel(str(model_dir))
+        model._loaded = True
+        model._is_jina_reranker = True
+
+        mock_result = RerankOutput(scores=[0.9], indices=[0], total_tokens=10)
+        with patch.object(
+            model, "_rerank_jina", return_value=mock_result
+        ) as mock_method:
+            model.rerank("query", ["doc"])
+            args, _ = mock_method.call_args
+            assert args[2] == 8192
+
+        with patch.object(
+            model, "_rerank_jina", return_value=mock_result
+        ) as mock_method:
+            model.rerank("query", ["doc"], max_length=1024)
+            args, _ = mock_method.call_args
+            assert args[2] == 1024
 
 
 class TestRerankerCompileFallback:


### PR DESCRIPTION
## Problem

The prior Jina inference path treated JinaForRanking like a causal-LM reranker (score-token / last-logit extraction). This diverges from Jina V3 MLX’s actual reranker contract and produced ranking quality inconsistent with the upstream reference.

The issue is scoring path mismatch, not model loading.

## Upstream Jina Reranker V3 MLX contract

The official Jina Jina Reranker V3 MLX reranker uses:

- listwise prompt (all passages + query in one forward pass)
- `<|embed_token|>` positions for document representations
- `<|rerank_token|>` position for query representation
- hidden-state extraction at those positions
- `projector.safetensors` MLP (`linear1 -> ReLU -> linear2`)
- cosine similarity for relevance scores

## Changes

### `omlx/models/reranker.py`

- Replaces Jina internal state (score-token fields → `_doc_embed_token_id`, `_query_embed_token_id`, `_jina_projector`)
- Reworks Jina load path: resolves special tokens and loads projector from `projector.safetensors`
- Replaces Jina scoring with listwise embedding scoring:
  - upstream-compatible prompt structure
  - special-token hidden-state extraction
  - projector application
  - cosine similarity scoring
- Public `MLXRerankerModel.rerank()` contract unchanged
- Non-Jina reranker paths unchanged

### `omlx/model_discovery.py`

- Classifies `JinaForRanking` as a directly supported reranker architecture
- Removes Jina from the CausalLM reranker heuristic bucket (no directory-name heuristic dependency)

## Tests

### `tests/test_reranker_causal_lm.py`

  - token ID resolution fallback
  - prompt parity invariants
  - missing projector error handling
  - projector math
  - rerank output shape/order
  - dispatch/max_length semantics
### `tests/test_model_discovery.py`

  - Jina detection without requiring `rerank` / `reranker` in directory name

## Validation

- `python3 -m pytest tests/test_reranker_causal_lm.py` (`17 passed`)
- `python3 -m pytest tests/test_model_discovery.py` (`79 passed`)
- Manual `/v1/rerank` validation against the Jina Reranker V3 model

## Non-goals

- No public API changes
- No refactor of non-Jina reranker internals
- No changes to unrelated model families

## References

- Issue: #326
- Previous support PR: #331
- Jina model card: https://huggingface.co/jinaai/jina-reranker-V3-mlx
- Jina MLX rerank reference: https://huggingface.co/jinaai/jina-reranker-V3-mlx/blob/main/rerank.py
