### PR TITLE
fix(engine): remove unsupported temperature kwarg from stream_dflash_generate

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -227,7 +227,6 @@ class DFlashEngine(BaseEngine):
                 max_new_tokens=max_tokens,
                 stop_token_ids=stop_ids,
                 prompt_tokens_override=prompt_tokens,
-                temperature=temperature,
             ):
                 event_type = event.get("event")
 


### PR DESCRIPTION
## Summary

`stream_dflash_generate()` in dflash_mlx does not accept a `temperature` parameter (verified against pinned commit `fc7101b`), but the DFlash engine passes it anyway, causing:

```
DFlash streaming generation error: stream_dflash_generate() got an
unexpected keyword argument 'temperature'
```

This removes the unsupported kwarg until dflash_mlx adds temperature support.

## Testing
- DFlash speculative decoding works after this change
- No impact on non-DFlash engines

Related: #747