### PR TITLE
fix: preserve tool_calls/tool_responses in VLM message formatting

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -595,17 +595,27 @@ class VLMBatchedEngine(BaseEngine):
             if msg_num_images > 0:
                 image_message_ranges.append((idx, msg_num_images))
 
-            formatted_messages.append(
-                get_message_json(
-                    model_type,
-                    content,
-                    role,
-                    skip_image_token=role != "user" or msg_num_images == 0,
-                    skip_audio_token=True,
-                    num_images=msg_num_images,
-                    num_audios=0,
+            # Preserve tool-related messages verbatim so the chat
+            # template receives tool_calls, tool_call_id, and
+            # tool_responses fields.  get_message_json() strips these,
+            # which makes tool results invisible to the model.
+            if role == "tool" or (
+                role == "assistant"
+                and (msg.get("tool_calls") or msg.get("tool_responses"))
+            ):
+                formatted_messages.append(msg)
+            else:
+                formatted_messages.append(
+                    get_message_json(
+                        model_type,
+                        content,
+                        role,
+                        skip_image_token=role != "user" or msg_num_images == 0,
+                        skip_audio_token=True,
+                        num_images=msg_num_images,
+                        num_audios=0,
+                    )
                 )
-            )
 
         return formatted_messages, image_message_ranges
 

--- a/packaging/venvstacks.toml
+++ b/packaging/venvstacks.toml
@@ -51,7 +51,7 @@ requirements = [
     # mlx-vlm from commit (3472132) - aligned with pyproject.toml
     "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@3472132fe6ee7beeae2c2fc35923eaed2e734b3d",
     # dflash-mlx from commit (8e1df22) — block diffusion speculative decoding + temperature sampling
-    "dflash-mlx @ git+https://github.com/jundot/dflash-mlx@8e1df22",
+    "dflash-mlx @ git+https://github.com/jundot/dflash-mlx@814c4a1",
     "Pillow>=9.0.0",
     # ModelScope SDK for downloading models from ModelScope Hub
     "modelscope>=1.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@3472132fe6ee7beeae2c2fc35923eaed2e734b3d",
     "Pillow>=9.0.0",
     # dflash-mlx from commit (8e1df22) — block diffusion speculative decoding + temperature sampling
-    "dflash-mlx @ git+https://github.com/jundot/dflash-mlx@8e1df22",
+    "dflash-mlx @ git+https://github.com/jundot/dflash-mlx@814c4a1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Fix: preserve tool_calls/tool_responses in VLM message formatting

### Problem

Since 53a20e9, text-only messages to VLM models go through `_format_messages_for_vlm_template`, which runs every message through `get_message_json()`. This strips `tool_calls`, `tool_call_id`, and `tool_responses` fields — the chat template never sees tool results, causing infinite tool-call retry loops.

### Change

Pass `role:tool` messages and assistant messages carrying `tool_calls`/`tool_responses` through verbatim instead of running them through `get_message_json()`. Only user/system/plain-assistant messages need VLM image-token formatting.

### Testing

- `test_tool_calling.py` — 137 passed
- `test_vlm_engine.py` — 44 passed  
- Manual end-to-end testing with Gemma 4 E4B + pi agent: multi-turn tool calling works correctly, model reads tool results and responds appropriately

Fixes #788
