### PR TITLE
feat: DDTree tree-based speculative decoding (rides DFlash)

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -122,6 +122,10 @@ class ModelSettingsRequest(BaseModel):
     dflash_enabled: Optional[bool] = None
     dflash_draft_model: Optional[str] = None
     dflash_draft_quant_bits: Optional[int] = None
+    # DDTree (tree-based speculative decoding on top of DFlash drafter)
+    ddtree_enabled: Optional[bool] = None
+    ddtree_budget: Optional[int] = None
+    ddtree_exact_commit: Optional[bool] = None
     reasoning_parser: Optional[str] = None
     is_pinned: Optional[bool] = None
     is_default: Optional[bool] = None
@@ -1375,6 +1379,7 @@ async def list_models(is_admin: bool = Depends(require_admin)):
                 "index_cache_freq": settings.index_cache_freq,
                 "turboquant_kv_enabled": settings.turboquant_kv_enabled,
                 "turboquant_kv_bits": settings.turboquant_kv_bits,
+                "turboquant_skip_last": settings.turboquant_skip_last,
                 "specprefill_enabled": settings.specprefill_enabled,
                 "specprefill_draft_model": settings.specprefill_draft_model,
                 "specprefill_keep_pct": settings.specprefill_keep_pct,
@@ -1382,6 +1387,9 @@ async def list_models(is_admin: bool = Depends(require_admin)):
                 "dflash_enabled": settings.dflash_enabled,
                 "dflash_draft_model": settings.dflash_draft_model,
                 "dflash_draft_quant_bits": settings.dflash_draft_quant_bits,
+                "ddtree_enabled": settings.ddtree_enabled,
+                "ddtree_budget": settings.ddtree_budget,
+                "ddtree_exact_commit": settings.ddtree_exact_commit,
                 "is_pinned": settings.is_pinned,
                 "is_default": settings.is_default,
                 "display_name": settings.display_name,
@@ -1608,6 +1616,25 @@ async def update_model_settings(
         current_settings.dflash_draft_model = request.dflash_draft_model or None
     if "dflash_draft_quant_bits" in sent:
         current_settings.dflash_draft_quant_bits = request.dflash_draft_quant_bits or None
+    # DDTree settings (enforce dependency on DFlash: ddtree requires dflash)
+    if "ddtree_enabled" in sent:
+        requested = bool(request.ddtree_enabled)
+        if requested and not current_settings.dflash_enabled:
+            raise HTTPException(
+                status_code=400,
+                detail="ddtree_enabled requires dflash_enabled=true",
+            )
+        current_settings.ddtree_enabled = requested
+    if "ddtree_budget" in sent and request.ddtree_budget is not None:
+        budget = int(request.ddtree_budget)
+        if budget < 1 or budget > 32:
+            raise HTTPException(
+                status_code=400,
+                detail="ddtree_budget must be in [1, 32]",
+            )
+        current_settings.ddtree_budget = budget
+    if "ddtree_exact_commit" in sent:
+        current_settings.ddtree_exact_commit = bool(request.ddtree_exact_commit)
 
     if "reasoning_parser" in sent:
         current_settings.reasoning_parser = request.reasoning_parser or None
@@ -1632,6 +1659,7 @@ async def update_model_settings(
             or "index_cache_freq" in sent
             or "dflash_enabled" in sent
             or "dflash_draft_model" in sent
+            or "ddtree_enabled" in sent
         )
     )
     if requires_reload:

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -952,6 +952,9 @@
                     dflash_enabled: settings.dflash_enabled || false,
                     dflash_draft_model: settings.dflash_draft_model || '',
                     dflash_draft_quant_bits: settings.dflash_draft_quant_bits ? String(settings.dflash_draft_quant_bits) : '',
+                    ddtree_enabled: settings.ddtree_enabled || false,
+                    ddtree_budget: Number.isFinite(settings.ddtree_budget) ? settings.ddtree_budget : 4,
+                    ddtree_exact_commit: settings.ddtree_exact_commit || false,
                     ctKwargEntries,
                 };
                 this.showModelSettingsModal = true;
@@ -1032,6 +1035,11 @@
                                 dflash_draft_quant_bits: this.modelSettings.dflash_enabled && this.modelSettings.dflash_draft_quant_bits
                                     ? parseInt(this.modelSettings.dflash_draft_quant_bits)
                                     : null,
+                                ddtree_enabled: this.modelSettings.dflash_enabled && this.modelSettings.ddtree_enabled,
+                                ddtree_budget: this.modelSettings.ddtree_enabled
+                                    ? (parseInt(this.modelSettings.ddtree_budget) || 4)
+                                    : 4,
+                                ddtree_exact_commit: this.modelSettings.ddtree_enabled && this.modelSettings.ddtree_exact_commit,
                             };
                         })()),
                     });

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -477,6 +477,50 @@
                                         </div>
                                     </div>
                                 </div>
+
+                                <!-- DDTree (requires DFlash) -->
+                                <div class="p-4 bg-neutral-50 rounded-xl space-y-3"
+                                     :class="!modelSettings.dflash_enabled ? 'opacity-60' : ''">
+                                    <div class="flex items-start justify-between gap-3">
+                                        <div class="min-w-0">
+                                            <span class="text-sm font-medium text-neutral-700">DDTree</span>
+                                            <p class="text-xs text-neutral-500 mt-0.5">Tree-based speculative decoding layered on top of DFlash. ~10-15% faster than DFlash on code/structured output. Requires DFlash to be enabled. (MLX impl by humanrouter: <a href="https://github.com/humanrouter/ddtree-mlx" target="_blank" rel="noopener" class="text-blue-500 hover:text-blue-700 underline">GitHub</a>) (<a href="https://liranringel.github.io/ddtree/" target="_blank" rel="noopener" class="text-blue-500 hover:text-blue-700 underline">Paper</a>)</p>
+                                        </div>
+                                        <button type="button"
+                                                @click="modelSettings.dflash_enabled && (modelSettings.ddtree_enabled = !modelSettings.ddtree_enabled)"
+                                                :disabled="!modelSettings.dflash_enabled"
+                                                :class="modelSettings.ddtree_enabled ? 'bg-black' : 'bg-neutral-200'"
+                                                class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black disabled:cursor-not-allowed">
+                                            <span :class="modelSettings.ddtree_enabled ? 'translate-x-5' : 'translate-x-0'"
+                                                  class="block w-5 h-5 bg-white rounded-full shadow-sm transform transition-transform duration-300 absolute top-0.5 left-0.5"></span>
+                                        </button>
+                                    </div>
+                                    <div x-show="modelSettings.dflash_enabled && modelSettings.ddtree_enabled" x-transition class="space-y-3 pt-1">
+                                        <div>
+                                            <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">Tree Budget</label>
+                                            <div class="flex items-center gap-3">
+                                                <input type="range" min="1" max="16" step="1"
+                                                       x-model.number="modelSettings.ddtree_budget"
+                                                       class="flex-1"/>
+                                                <span class="text-sm font-mono w-10 text-right" x-text="modelSettings.ddtree_budget"></span>
+                                            </div>
+                                            <p class="text-xs text-neutral-400 mt-1">Tree node count excluding root (paper recommends 4 for hybrid models).</p>
+                                        </div>
+                                        <div class="flex items-start justify-between gap-3">
+                                            <div class="min-w-0">
+                                                <span class="text-sm font-medium text-neutral-700">Exact Commit</span>
+                                                <p class="text-xs text-neutral-500 mt-0.5">Re-forward accepted tokens sequentially on commit. Slower but strictly lossless. Usually unnecessary.</p>
+                                            </div>
+                                            <button type="button"
+                                                    @click="modelSettings.ddtree_exact_commit = !modelSettings.ddtree_exact_commit"
+                                                    :class="modelSettings.ddtree_exact_commit ? 'bg-black' : 'bg-neutral-200'"
+                                                    class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
+                                                <span :class="modelSettings.ddtree_exact_commit ? 'translate-x-5' : 'translate-x-0'"
+                                                      class="block w-5 h-5 bg-white rounded-full shadow-sm transform transition-transform duration-300 absolute top-0.5 left-0.5"></span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
                         </div>
                     </div>
                 </div>

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -70,6 +70,42 @@ class DFlashEngine(BaseEngine):
         except ValueError:
             self._max_dflash_ctx = DEFAULT_MAX_DFLASH_CTX
 
+        # DDTree (tree-based speculative decoding on top of DFlash drafter).
+        # Reads optional per-model settings; resolves ImportError lazily.
+        self._ddtree_enabled = bool(
+            getattr(model_settings, "ddtree_enabled", False)
+        ) if model_settings is not None else False
+        self._ddtree_budget = int(
+            getattr(model_settings, "ddtree_budget", 4) or 4
+        ) if model_settings is not None else 4
+        self._ddtree_exact_commit = bool(
+            getattr(model_settings, "ddtree_exact_commit", False)
+        ) if model_settings is not None else False
+        self._ddtree_import_ok: bool | None = None  # resolved on first use
+
+    def _ddtree_available(self) -> bool:
+        """Check ddtree_mlx importability; cache result, warn once on failure."""
+        if self._ddtree_import_ok is not None:
+            return self._ddtree_import_ok
+        try:
+            import ddtree_mlx.runtime  # noqa: F401
+            self._ddtree_import_ok = True
+        except ImportError as e:
+            logger.warning(
+                f"DDTree enabled but ddtree-mlx is not installed "
+                f"({e}); falling back to DFlash."
+            )
+            self._ddtree_import_ok = False
+        return self._ddtree_import_ok
+
+    def _use_ddtree(self) -> bool:
+        """True iff DDTree is enabled, import succeeded, and no fallback in effect."""
+        return (
+            self._ddtree_enabled
+            and not self._in_fallback_mode
+            and self._ddtree_available()
+        )
+
     @property
     def model_name(self) -> str:
         return self._model_name
@@ -118,11 +154,16 @@ class DFlashEngine(BaseEngine):
 
         self._loaded = True
         self._in_fallback_mode = False
+        ddtree_state = (
+            "on" if self._ddtree_enabled and self._ddtree_available() else "off"
+        )
         logger.info(
             f"DFlashEngine loaded: target={self._model_name}, "
             f"draft={self._draft_model_path}, "
             f"max_ctx={self._max_dflash_ctx}, "
-            f"fallback={self._fallback_engine_type}"
+            f"fallback={self._fallback_engine_type}, "
+            f"ddtree={ddtree_state} "
+            f"(budget={self._ddtree_budget}, exact_commit={self._ddtree_exact_commit})"
         )
 
     async def _evict_dflash_and_start_fallback(self) -> None:
@@ -254,9 +295,8 @@ class DFlashEngine(BaseEngine):
         queue: asyncio.Queue,
         loop: asyncio.AbstractEventLoop,
     ) -> None:
-        """Run dflash generation with streaming on MLX executor thread."""
+        """Run dflash/ddtree generation with streaming on MLX executor thread."""
         from dflash_mlx.generate import get_stop_token_ids
-        from dflash_mlx.runtime import stream_dflash_generate
 
         try:
             stop_ids = get_stop_token_ids(self._executor_tokenizer)
@@ -268,6 +308,61 @@ class DFlashEngine(BaseEngine):
                 detokenizer = NaiveStreamingDetokenizer(self._executor_tokenizer)
             except ImportError:
                 pass
+
+            if self._use_ddtree():
+                from ddtree_mlx.runtime import generate_ddtree_once
+
+                if self._ddtree_exact_commit:
+                    os.environ["DDTREE_EXACT_COMMIT"] = "1"
+
+                summary = generate_ddtree_once(
+                    target_model=self._target_model,
+                    draft_model=self._draft_model,
+                    tokenizer=self._executor_tokenizer,
+                    prompt_tokens=prompt_tokens,
+                    max_new_tokens=max_tokens,
+                    tree_budget=self._ddtree_budget,
+                    stop_token_ids=stop_ids,
+                )
+                gen_tokens_list = summary.get("generated_token_ids", [])
+
+                # DDTree produces the full result in one call; emit per-token
+                # events for OpenAI-streaming compatibility.
+                for token_id in gen_tokens_list:
+                    if token_id in stop_ids:
+                        continue
+                    if detokenizer is not None:
+                        detokenizer.add_token(token_id)
+                        text = detokenizer.last_segment
+                    else:
+                        text = self._executor_tokenizer.decode([token_id])
+                    asyncio.run_coroutine_threadsafe(
+                        queue.put((text, [token_id], False, None)), loop
+                    )
+
+                gen_count = int(summary.get("generation_tokens", len(gen_tokens_list)))
+                tps = float(summary.get("tokens_per_second", 0.0))
+                accept = float(summary.get("avg_acceptance", 0.0))
+                fast = float(summary.get("fast_path_ratio", 0.0))
+                logger.info(
+                    f"DDTree generation complete: {gen_count} tokens, "
+                    f"{tps:.1f} tok/s, avg_acceptance={accept:.2f}, "
+                    f"fast_path_ratio={fast:.0%}"
+                )
+                metrics = {
+                    "prompt_tokens": len(prompt_tokens),
+                    "completion_tokens": gen_count,
+                    "avg_acceptance": accept,
+                    "fast_path_ratio": fast,
+                    "tokens_per_second": tps,
+                    "engine": "ddtree",
+                }
+                asyncio.run_coroutine_threadsafe(
+                    queue.put(("", [], True, metrics)), loop
+                )
+                return
+
+            from dflash_mlx.runtime import stream_dflash_generate
 
             for event in stream_dflash_generate(
                 target_model=self._target_model,
@@ -372,10 +467,48 @@ class DFlashEngine(BaseEngine):
 
         from ..engine_core import get_mlx_executor
         from dflash_mlx.generate import get_stop_token_ids
-        from dflash_mlx.runtime import generate_dflash_once
 
         loop = asyncio.get_running_loop()
         stop_ids = get_stop_token_ids(self._tokenizer_obj)
+
+        if self._use_ddtree():
+            from ddtree_mlx.runtime import generate_ddtree_once
+
+            # DDTREE_EXACT_COMMIT is read inside ddtree-mlx on each call.
+            if self._ddtree_exact_commit:
+                os.environ["DDTREE_EXACT_COMMIT"] = "1"
+            budget = self._ddtree_budget
+
+            def _run():
+                return generate_ddtree_once(
+                    target_model=self._target_model,
+                    draft_model=self._draft_model,
+                    tokenizer=self._executor_tokenizer,
+                    prompt_tokens=prompt_tokens,
+                    max_new_tokens=max_tokens,
+                    tree_budget=budget,
+                    stop_token_ids=stop_ids,
+                )
+
+            summary = await loop.run_in_executor(get_mlx_executor(), _run)
+            generated = summary.get("generated_token_ids", [])
+            text = self._tokenizer_obj.decode(generated, skip_special_tokens=True)
+            text = clean_special_tokens(text)
+            logger.info(
+                f"DDTree generation: {len(generated)} tokens, "
+                f"{summary.get('tokens_per_second', 0):.1f} tok/s, "
+                f"avg_acceptance={summary.get('avg_acceptance', 0):.2f}, "
+                f"fast_path_ratio={summary.get('fast_path_ratio', 0):.0%}"
+            )
+            return GenerationOutput(
+                text=text,
+                tokens=generated,
+                prompt_tokens=len(prompt_tokens),
+                completion_tokens=int(summary.get("generation_tokens", len(generated))),
+                finish_reason="stop",
+            )
+
+        from dflash_mlx.runtime import generate_dflash_once
 
         def _run():
             return generate_dflash_once(
@@ -565,6 +698,10 @@ class DFlashEngine(BaseEngine):
             "fallback_engine_type": self._fallback_engine_type,
             "in_fallback_mode": self._in_fallback_mode,
             "loaded": self._loaded,
+            "ddtree_enabled": self._ddtree_enabled,
+            "ddtree_budget": self._ddtree_budget,
+            "ddtree_exact_commit": self._ddtree_exact_commit,
+            "ddtree_active": self._use_ddtree(),
         }
 
     def get_cache_stats(self) -> dict[str, Any] | None:

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -74,6 +74,12 @@ class ModelSettings:
     dflash_draft_model: Optional[str] = None  # Path/repo for DFlash draft checkpoint
     dflash_draft_quant_bits: Optional[int] = None  # Draft model quantization (None=bf16, 4)
 
+    # DDTree (tree-based speculative decoding — rides on top of DFlash drafter)
+    # Requires dflash_enabled=True; shares the same draft model.
+    ddtree_enabled: bool = False
+    ddtree_budget: int = 4  # Tree node budget excluding root (paper: 4 is optimal for hybrid)
+    ddtree_exact_commit: bool = False  # Strict lossless re-forward on commit (slow but safe)
+
     # Model management flags
     is_pinned: bool = False
     is_default: bool = False  # Only one model can be default

--- a/packaging/venvstacks.toml
+++ b/packaging/venvstacks.toml
@@ -52,6 +52,8 @@ requirements = [
     "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@3472132fe6ee7beeae2c2fc35923eaed2e734b3d",
     # dflash-mlx v0.1.3 (814c4a1) — block diffusion speculative decoding + temperature sampling
     "dflash-mlx @ git+https://github.com/jundot/dflash-mlx@814c4a1",
+    # ddtree-mlx v0.1.0 (4b12590) — tree-based speculative decoding on top of dflash (py>=3.11)
+    "ddtree-mlx @ git+https://github.com/humanrouter/ddtree-mlx@4b12590 ; python_version >= '3.11'",
     "Pillow>=9.0.0",
     # ModelScope SDK for downloading models from ModelScope Hub
     "modelscope>=1.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ dependencies = [
     "Pillow>=9.0.0",
     # dflash-mlx v0.1.3 (814c4a1) — block diffusion speculative decoding + temperature sampling
     "dflash-mlx @ git+https://github.com/jundot/dflash-mlx@814c4a1",
+    # ddtree-mlx v0.1.0 (4b12590) — tree-based speculative decoding on top of dflash
+    # Requires Python >=3.11; engine falls back gracefully when not installed.
+    "ddtree-mlx @ git+https://github.com/humanrouter/ddtree-mlx@4b12590 ; python_version >= '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/scripts/bench_ddtree.py
+++ b/scripts/bench_ddtree.py
@@ -21,8 +21,6 @@ import statistics
 import time
 from typing import Any
 
-import mlx.core as mx
-
 
 CODE_PROMPTS = [
     "Write a Python function `mergesort` that sorts a list of integers in-place. Include a brief test harness.",
@@ -55,20 +53,24 @@ def _run_ar(
     max_new: int,
     stop_ids: list[int],
 ) -> dict:
-    from dflash_mlx.generate import decode_token
+    """Autoregressive baseline via mlx_lm.stream_generate."""
+    from mlx_lm import stream_generate
+    from mlx_lm.sample_utils import make_sampler
 
-    start = time.perf_counter()
+    sampler = make_sampler(temp=0.0)
     tokens: list[int] = []
-    past = None
-    cur = mx.array(prompt_tokens)[None, :]
-    for _ in range(max_new):
-        logits, past = decode_token(target_model, cur, past)
-        tok = int(mx.argmax(logits[:, -1, :], axis=-1).item())
-        tokens.append(tok)
-        if tok in stop_ids:
+    start = time.perf_counter()
+    for resp in stream_generate(
+        target_model,
+        tokenizer,
+        prompt=prompt_tokens,
+        max_tokens=max_new,
+        sampler=sampler,
+    ):
+        tid = int(getattr(resp, "token", 0))
+        if tid in stop_ids:
             break
-        cur = mx.array([[tok]])
-    mx.eval(cur)
+        tokens.append(tid)
     elapsed = time.perf_counter() - start
     return {
         "tokens": tokens,
@@ -154,7 +156,8 @@ def main() -> int:
 
     print(f"Loading {args.model} ...")
     target_model, tokenizer, draft_model, draft_ref = load_runtime_components(
-        model_ref=args.model, draft_ref=args.draft,
+        model_ref=args.model,
+        draft_ref=args.draft,  # None => registry lookup in dflash-mlx
     )
     stop_ids = get_stop_token_ids(tokenizer)
     print(f"Loaded target={args.model} draft={draft_ref}\n")

--- a/scripts/bench_ddtree.py
+++ b/scripts/bench_ddtree.py
@@ -26,12 +26,18 @@ CODE_PROMPTS = [
     "Write a Python function `mergesort` that sorts a list of integers in-place. Include a brief test harness.",
     "Implement a minimal HTTP GET in Go using net/http. Show the full file including imports and error handling.",
     "Write a Rust function that computes the fibonacci numbers up to N using iteration, with a doctest.",
+    "Write a TypeScript class `LRUCache<K, V>` with get/set that evicts the least recently used entry. No external deps.",
+    "Implement binary search in C. Provide the full file including a small main() that tests it on a sorted array.",
+    "Write a Python decorator `@retry(times=3, delay=0.1)` that retries a function on exception. Include type hints and a short example.",
 ]
 
 PROSE_PROMPTS = [
     "Write a short paragraph describing a foggy morning at a coastal lighthouse. No dialogue.",
     "Explain to a beginner, in two short paragraphs, how a CPU pipeline stall happens.",
     "Compose a three-sentence summary of the plot of Moby Dick.",
+    "Describe, in one paragraph, the taste and texture of a perfectly ripe peach on a summer afternoon.",
+    "Write a short motivational message (2-3 sentences) for someone who just failed an important exam.",
+    "Explain in plain language, in two paragraphs, why the sky appears blue during the day and red at sunset.",
 ]
 
 

--- a/scripts/bench_ddtree.py
+++ b/scripts/bench_ddtree.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Benchmark AR vs DFlash vs DDTree on a target model + DFlash drafter.
+
+Uses dflash-mlx and ddtree-mlx directly (no omlx engine) so the measurements
+reflect the underlying algorithms rather than server overhead.
+
+Usage:
+    uv run python scripts/bench_ddtree.py \\
+        --model mlx-community/Qwen3.5-4B-4bit \\
+        --draft z-lab/Qwen3.5-4B-DFlash \\
+        --max-tokens 256 \\
+        --budgets 2 4 6 \\
+        --prompts 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+from typing import Any
+
+import mlx.core as mx
+
+
+CODE_PROMPTS = [
+    "Write a Python function `mergesort` that sorts a list of integers in-place. Include a brief test harness.",
+    "Implement a minimal HTTP GET in Go using net/http. Show the full file including imports and error handling.",
+    "Write a Rust function that computes the fibonacci numbers up to N using iteration, with a doctest.",
+]
+
+PROSE_PROMPTS = [
+    "Write a short paragraph describing a foggy morning at a coastal lighthouse. No dialogue.",
+    "Explain to a beginner, in two short paragraphs, how a CPU pipeline stall happens.",
+    "Compose a three-sentence summary of the plot of Moby Dick.",
+]
+
+
+def _tokenize(tokenizer, text: str) -> list[int]:
+    return list(
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": text}],
+            tokenize=True,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+    )
+
+
+def _run_ar(
+    target_model: Any,
+    tokenizer: Any,
+    prompt_tokens: list[int],
+    max_new: int,
+    stop_ids: list[int],
+) -> dict:
+    from dflash_mlx.generate import decode_token
+
+    start = time.perf_counter()
+    tokens: list[int] = []
+    past = None
+    cur = mx.array(prompt_tokens)[None, :]
+    for _ in range(max_new):
+        logits, past = decode_token(target_model, cur, past)
+        tok = int(mx.argmax(logits[:, -1, :], axis=-1).item())
+        tokens.append(tok)
+        if tok in stop_ids:
+            break
+        cur = mx.array([[tok]])
+    mx.eval(cur)
+    elapsed = time.perf_counter() - start
+    return {
+        "tokens": tokens,
+        "elapsed_s": elapsed,
+        "tok_s": len(tokens) / elapsed if elapsed else 0.0,
+    }
+
+
+def _run_dflash(
+    target_model: Any,
+    draft_model: Any,
+    tokenizer: Any,
+    prompt_tokens: list[int],
+    max_new: int,
+    stop_ids: list[int],
+) -> dict:
+    from dflash_mlx.runtime import generate_dflash_once
+
+    start = time.perf_counter()
+    summary = generate_dflash_once(
+        target_model=target_model,
+        tokenizer=tokenizer,
+        draft_model=draft_model,
+        prompt="",
+        max_new_tokens=max_new,
+        stop_token_ids=stop_ids,
+        prompt_tokens_override=prompt_tokens,
+        temperature=0.0,
+    )
+    elapsed = time.perf_counter() - start
+    tokens = summary.get("generated_token_ids", [])
+    return {
+        "tokens": tokens,
+        "elapsed_s": elapsed,
+        "tok_s": len(tokens) / elapsed if elapsed else 0.0,
+        "acceptance": float(summary.get("acceptance_ratio", 0.0)),
+    }
+
+
+def _run_ddtree(
+    target_model: Any,
+    draft_model: Any,
+    tokenizer: Any,
+    prompt_tokens: list[int],
+    max_new: int,
+    stop_ids: list[int],
+    budget: int,
+) -> dict:
+    from ddtree_mlx.runtime import generate_ddtree_once
+
+    start = time.perf_counter()
+    summary = generate_ddtree_once(
+        target_model=target_model,
+        draft_model=draft_model,
+        tokenizer=tokenizer,
+        prompt_tokens=prompt_tokens,
+        max_new_tokens=max_new,
+        tree_budget=budget,
+        stop_token_ids=stop_ids,
+    )
+    elapsed = time.perf_counter() - start
+    tokens = summary.get("generated_token_ids", [])
+    return {
+        "tokens": tokens,
+        "elapsed_s": elapsed,
+        "tok_s": float(summary.get("tokens_per_second", len(tokens) / elapsed if elapsed else 0.0)),
+        "avg_acceptance": float(summary.get("avg_acceptance", 0.0)),
+        "fast_path_ratio": float(summary.get("fast_path_ratio", 0.0)),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="mlx-community/Qwen3.5-4B-4bit")
+    parser.add_argument("--draft", default=None, help="DFlash drafter ref (None=registry lookup)")
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--budgets", type=int, nargs="+", default=[2, 4, 6])
+    parser.add_argument("--prompts", type=int, default=2, help="Prompts per category")
+    parser.add_argument("--categories", nargs="+", default=["code", "prose"], choices=["code", "prose"])
+    args = parser.parse_args()
+
+    from dflash_mlx.generate import get_stop_token_ids, load_runtime_components
+
+    print(f"Loading {args.model} ...")
+    target_model, tokenizer, draft_model, draft_ref = load_runtime_components(
+        model_ref=args.model, draft_ref=args.draft,
+    )
+    stop_ids = get_stop_token_ids(tokenizer)
+    print(f"Loaded target={args.model} draft={draft_ref}\n")
+
+    prompt_sets: dict[str, list[str]] = {}
+    if "code" in args.categories:
+        prompt_sets["code"] = CODE_PROMPTS[: args.prompts]
+    if "prose" in args.categories:
+        prompt_sets["prose"] = PROSE_PROMPTS[: args.prompts]
+
+    # Warm up with one small generation so MLX compiles its kernels.
+    print("Warming up...")
+    warm_tokens = _tokenize(tokenizer, "Hi")
+    _run_ar(target_model, tokenizer, warm_tokens, 8, stop_ids)
+    _run_dflash(target_model, draft_model, tokenizer, warm_tokens, 8, stop_ids)
+    _run_ddtree(target_model, draft_model, tokenizer, warm_tokens, 8, stop_ids, budget=4)
+    print("Warmup done.\n")
+
+    results: dict[str, dict[str, list[float]]] = {}
+    for cat, prompts in prompt_sets.items():
+        cat_results: dict[str, list[float]] = {
+            "ar_tps": [], "dflash_tps": [], "dflash_acc": [],
+        }
+        for b in args.budgets:
+            cat_results[f"ddtree_b{b}_tps"] = []
+            cat_results[f"ddtree_b{b}_acc"] = []
+            cat_results[f"ddtree_b{b}_fast"] = []
+
+        print(f"=== category: {cat} ({len(prompts)} prompts, max_new={args.max_tokens}) ===")
+        for i, p in enumerate(prompts):
+            ptoks = _tokenize(tokenizer, p)
+            print(f"  [{i + 1}/{len(prompts)}] prompt={len(ptoks)} tok")
+
+            ar = _run_ar(target_model, tokenizer, ptoks, args.max_tokens, stop_ids)
+            cat_results["ar_tps"].append(ar["tok_s"])
+            print(f"    AR        : {ar['tok_s']:6.1f} tok/s  ({len(ar['tokens'])} tok / {ar['elapsed_s']:.2f}s)")
+
+            df = _run_dflash(target_model, draft_model, tokenizer, ptoks, args.max_tokens, stop_ids)
+            cat_results["dflash_tps"].append(df["tok_s"])
+            cat_results["dflash_acc"].append(df["acceptance"])
+            print(f"    DFlash    : {df['tok_s']:6.1f} tok/s  (accept={df['acceptance']:.0%})")
+
+            for b in args.budgets:
+                dt = _run_ddtree(
+                    target_model, draft_model, tokenizer, ptoks,
+                    args.max_tokens, stop_ids, budget=b,
+                )
+                cat_results[f"ddtree_b{b}_tps"].append(dt["tok_s"])
+                cat_results[f"ddtree_b{b}_acc"].append(dt["avg_acceptance"])
+                cat_results[f"ddtree_b{b}_fast"].append(dt["fast_path_ratio"])
+                print(
+                    f"    DDTree b={b}: {dt['tok_s']:6.1f} tok/s  "
+                    f"(avg_accept={dt['avg_acceptance']:.2f}, fast={dt['fast_path_ratio']:.0%})"
+                )
+        results[cat] = cat_results
+
+    print("\n=== summary (mean across prompts) ===")
+    for cat, m in results.items():
+        ar_mean = statistics.mean(m["ar_tps"]) if m["ar_tps"] else 0.0
+        df_mean = statistics.mean(m["dflash_tps"]) if m["dflash_tps"] else 0.0
+        df_acc = statistics.mean(m["dflash_acc"]) if m["dflash_acc"] else 0.0
+        print(f"\n  [{cat}]")
+        print(f"    AR        : {ar_mean:6.1f} tok/s")
+        print(
+            f"    DFlash    : {df_mean:6.1f} tok/s "
+            f"({df_mean / ar_mean:.2f}x AR, accept={df_acc:.0%})"
+        )
+        for b in args.budgets:
+            tps_key = f"ddtree_b{b}_tps"
+            acc_key = f"ddtree_b{b}_acc"
+            fast_key = f"ddtree_b{b}_fast"
+            tps = statistics.mean(m[tps_key]) if m[tps_key] else 0.0
+            acc = statistics.mean(m[acc_key]) if m[acc_key] else 0.0
+            fast = statistics.mean(m[fast_key]) if m[fast_key] else 0.0
+            vs_ar = tps / ar_mean if ar_mean else 0.0
+            vs_df = tps / df_mean if df_mean else 0.0
+            print(
+                f"    DDTree b={b}: {tps:6.1f} tok/s "
+                f"({vs_ar:.2f}x AR, {vs_df:.2f}x DFlash, "
+                f"accept={acc:.2f}, fast={fast:.0%})"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ddtree_engine.py
+++ b/tests/test_ddtree_engine.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for DDTree integration (rides on top of DFlash)."""
+
+import pytest
+
+from omlx.model_settings import ModelSettings
+
+
+class TestDDTreeModelSettings:
+    """DDTree fields in ModelSettings."""
+
+    def test_default_values(self):
+        settings = ModelSettings()
+        assert settings.ddtree_enabled is False
+        assert settings.ddtree_budget == 4
+        assert settings.ddtree_exact_commit is False
+
+    def test_to_dict_includes_ddtree_fields_when_enabled(self):
+        settings = ModelSettings(
+            dflash_enabled=True,
+            ddtree_enabled=True,
+            ddtree_budget=6,
+            ddtree_exact_commit=True,
+        )
+        d = settings.to_dict()
+        assert d["ddtree_enabled"] is True
+        assert d["ddtree_budget"] == 6
+        assert d["ddtree_exact_commit"] is True
+
+    def test_to_dict_budget_always_present(self):
+        """ddtree_budget has a non-None default so it always serializes."""
+        settings = ModelSettings()
+        d = settings.to_dict()
+        assert d["ddtree_budget"] == 4
+
+    def test_from_dict_with_ddtree_fields(self):
+        data = {
+            "dflash_enabled": True,
+            "ddtree_enabled": True,
+            "ddtree_budget": 8,
+            "ddtree_exact_commit": True,
+        }
+        settings = ModelSettings.from_dict(data)
+        assert settings.ddtree_enabled is True
+        assert settings.ddtree_budget == 8
+        assert settings.ddtree_exact_commit is True
+
+    def test_from_dict_ignores_unknown_ddtree_fields(self):
+        data = {"ddtree_enabled": True, "ddtree_legacy_field": "ignored"}
+        settings = ModelSettings.from_dict(data)
+        assert settings.ddtree_enabled is True
+
+    def test_roundtrip_serialization(self):
+        original = ModelSettings(
+            dflash_enabled=True,
+            ddtree_enabled=True,
+            ddtree_budget=2,
+            ddtree_exact_commit=False,
+        )
+        d = original.to_dict()
+        restored = ModelSettings.from_dict(d)
+        assert restored.ddtree_enabled == original.ddtree_enabled
+        assert restored.ddtree_budget == original.ddtree_budget
+        assert restored.ddtree_exact_commit == original.ddtree_exact_commit
+
+
+class TestDDTreeEngineInit:
+    """DFlashEngine picks up DDTree settings from model_settings."""
+
+    def _engine(self, **settings_kwargs):
+        from omlx.engine.dflash import DFlashEngine
+
+        s = ModelSettings(
+            dflash_enabled=True,
+            dflash_draft_model="z-lab/Qwen3.5-4B-DFlash",
+            **settings_kwargs,
+        )
+        return DFlashEngine(
+            model_name="test-model",
+            draft_model_path="z-lab/Qwen3.5-4B-DFlash",
+            model_settings=s,
+        )
+
+    def test_ddtree_disabled_by_default(self):
+        e = self._engine()
+        assert e._ddtree_enabled is False
+        assert e._ddtree_budget == 4
+        assert e._ddtree_exact_commit is False
+        assert e._use_ddtree() is False
+
+    def test_ddtree_enabled_reads_settings(self):
+        e = self._engine(ddtree_enabled=True, ddtree_budget=6, ddtree_exact_commit=True)
+        assert e._ddtree_enabled is True
+        assert e._ddtree_budget == 6
+        assert e._ddtree_exact_commit is True
+
+    def test_use_ddtree_true_when_importable(self):
+        pytest.importorskip("ddtree_mlx")
+        e = self._engine(ddtree_enabled=True)
+        assert e._use_ddtree() is True
+
+    def test_use_ddtree_false_in_fallback_mode(self):
+        pytest.importorskip("ddtree_mlx")
+        e = self._engine(ddtree_enabled=True)
+        e._in_fallback_mode = True
+        assert e._use_ddtree() is False
+
+    def test_import_failure_is_cached_and_logged_once(self, monkeypatch, caplog):
+        """If ddtree_mlx import fails, _use_ddtree returns False and warns once."""
+        import builtins
+        import importlib
+        import logging
+
+        e = self._engine(ddtree_enabled=True)
+
+        real_import = builtins.__import__
+
+        def _raising_import(name, *args, **kwargs):
+            if name.startswith("ddtree_mlx"):
+                raise ImportError("simulated missing ddtree_mlx")
+            return real_import(name, *args, **kwargs)
+
+        # Force the engine's import cache to re-resolve under our mock.
+        e._ddtree_import_ok = None
+        # Evict real ddtree_mlx from sys.modules so the import actually runs.
+        import sys
+        for mod in list(sys.modules):
+            if mod.startswith("ddtree_mlx"):
+                sys.modules.pop(mod, None)
+
+        monkeypatch.setattr(builtins, "__import__", _raising_import)
+        caplog.set_level(logging.WARNING, logger="omlx.engine.dflash")
+        try:
+            assert e._use_ddtree() is False
+            assert e._ddtree_import_ok is False
+            # Second call must not re-warn (cached).
+            caplog.clear()
+            assert e._use_ddtree() is False
+            assert not any(
+                "ddtree-mlx is not installed" in rec.message
+                for rec in caplog.records
+            )
+        finally:
+            monkeypatch.setattr(builtins, "__import__", real_import)
+            # Re-import ddtree_mlx so other tests see it again.
+            try:
+                importlib.import_module("ddtree_mlx")
+            except ImportError:
+                pass
+
+    def test_get_stats_includes_ddtree_fields(self):
+        e = self._engine(ddtree_enabled=True, ddtree_budget=6)
+        stats = e.get_stats()
+        assert stats["engine_type"] == "dflash"
+        assert stats["ddtree_enabled"] is True
+        assert stats["ddtree_budget"] == 6
+        assert stats["ddtree_exact_commit"] is False
+        # ddtree_active is computed; depends on ddtree_mlx importability.
+        assert "ddtree_active" in stats
+
+
+class TestDDTreeAdminRequest:
+    """ModelSettingsRequest accepts DDTree fields and enforces DFlash dependency."""
+
+    def test_accepts_ddtree_fields(self):
+        from omlx.admin.routes import ModelSettingsRequest
+
+        req = ModelSettingsRequest.model_validate(
+            {"ddtree_enabled": True, "ddtree_budget": 6, "ddtree_exact_commit": True}
+        )
+        assert req.ddtree_enabled is True
+        assert req.ddtree_budget == 6
+        assert req.ddtree_exact_commit is True
+
+    def test_none_defaults(self):
+        from omlx.admin.routes import ModelSettingsRequest
+
+        req = ModelSettingsRequest.model_validate({})
+        assert req.ddtree_enabled is None
+        assert req.ddtree_budget is None
+        assert req.ddtree_exact_commit is None


### PR DESCRIPTION
## Summary

Integrates [ddtree-mlx](https://github.com/humanrouter/ddtree-mlx) (MIT, v0.1.0) — tree-based speculative decoding that layers on top of the existing DFlash drafter. Instead of verifying a linear block of draft tokens, DDTree builds a top-K tree at each position and verifies the whole tree in one forward pass, accepting more tokens per cycle.

DDTree shares the DFlash draft model, fallback engine, and memory-eviction logic. Enabling it does not load a second model.

Based on *[Accelerating Speculative Decoding with Block Diffusion Draft Trees](https://liranringel.github.io/ddtree/DDTree.pdf)* (Ringel & Romano, 2025).

## Design

- Dependency pinned to SHA `4b12590` with `; python_version >= '3.11'` marker. Python 3.10 installs continue to work — the engine's `_ddtree_available()` caches the ImportError and falls back to DFlash with a one-time warning.
- New per-model settings: `ddtree_enabled`, `ddtree_budget` (1–32, default 4), `ddtree_exact_commit`. `ddtree_enabled` requires `dflash_enabled`; the admin API enforces this with HTTP 400 rather than silently persisting an unusable config.
- `DFlashEngine` branches inside `generate()` and `_run_generate_streaming()` to `ddtree_mlx.runtime.generate_ddtree_once` when `_use_ddtree()` is true. `_use_ddtree()` returns false in the long-context fallback path, so tiled-decode / SSD-cache / continuous-batching engines run unaffected.
- Streaming compatibility: ddtree-mlx has no native streaming API, so the streaming path runs DDTree to completion then emits per-token chunks post-hoc. Clients still see a valid SSE stream; the tokens just arrive together.
- Admin dashboard gains a DDTree card below DFlash: visually dimmed until DFlash is on, nested budget slider + exact-commit toggle appear only when both are enabled.

## Runtime contract (what DDTree applies to, and what it doesn't)

DDTree rides on the DFlash path. Requests route like this:

| Prompt length | Concurrency | Path |
|---|---|---|
| `< DFLASH_MAX_CTX` (default 4096) | 1 request at a time | **DDTree** (when enabled), else DFlash |
| `≥ DFLASH_MAX_CTX` | — | Auto-fallback: `BatchedEngine` / `VLMBatchedEngine` with continuous batching. DDTree does NOT run. |

Concurrency: `omlx/engine_core.py:get_mlx_executor()` pins **all** MLX GPU work onto a single thread (`max_workers=1`, required to avoid Metal command-buffer races — issue #85). Concurrent requests on `DFlashEngine` therefore queue and run serially on that executor; DDTree is strictly a single-request optimization. Continuous batching for concurrent workloads still comes from `BatchedEngine`, which this PR does not modify.

This was verified at runtime on 27B:
- 1433-token prompt, 128 out → DDTree active, `_in_fallback_mode=False`, coherent output (12.0 tok/s, prefill dominates)
- 2137-token prompt (exceeding `DFLASH_MAX_CTX=2000` override) → auto-fallback, `_in_fallback_mode=True`, coherent output (4.7 tok/s on BatchedEngine, no DDTree)
- Two concurrent short requests on a fresh engine → both returned distinct, coherent outputs, no state corruption (ratio 0.66 of serial, bounded by single-worker executor)

## Measured speed (6 prompts × 192 tok, `scripts/bench_ddtree.py`)

**Qwen3.5-4B-MLX-4bit:**

| | AR | DFlash | DDTree b=2 | DDTree b=4 | DDTree b=6 | DDTree b=8 |
|---|---:|---:|---:|---:|---:|---:|
| code (tok/s) | 96.8 | 83.8 | 97.6 | **101.2** | 99.9 | 91.4 |
| code (× DFlash) | — | 1.00× | 1.16× | **1.21×** | 1.19× | 1.09× |
| code (accept/cycle) | — | 76% | 2.52 | 3.37 | 3.95 | 4.40 |
| prose (tok/s) | 78.7 | 25.5 | **45.1** | 39.7 | 33.5 | 30.8 |
| prose (× DFlash) | — | 1.00× | **1.77×** | 1.56× | 1.32× | 1.21× |
| prose (accept/cycle) | — | 51% | 1.96 | 2.29 | 2.42 | 2.58 |

**Qwen3.5-27B-4bit** (matches the upstream paper's target model, different hardware):

| | AR | DFlash | DDTree b=2 | DDTree b=4 | DDTree b=6 | DDTree b=8 |
|---|---:|---:|---:|---:|---:|---:|
| code (tok/s) | 16.6 | 18.2 | 17.8 | **19.5** | 18.5 | 16.2 |
| code (× DFlash) | — | 1.00× | 0.98× | **1.07×** | 1.02× | 0.89× |
| code (accept/cycle) | — | 81% | 2.68 | 3.96 | 4.76 | 5.27 |
| prose (tok/s) | 15.9 | 7.5 | **13.4** | 11.9 | 10.3 | 8.6 |
| prose (× DFlash) | — | 1.00× | **1.78×** | 1.58× | 1.37× | 1.14× |
| prose (accept/cycle) | — | 57% | 2.09 | 2.48 | 2.68 | 2.81 |

Additional single-shot sanity run on 27B with thinking-mode off (to isolate code-acceptance regime): DDTree b=4, 768 output tokens → **33.6 tok/s (≈2.02× AR)**. Higher than the bench mean because longer structured-code output has higher draft acceptance throughout.

**Findings:**

- **DFlash numbers replicate upstream.** 27B code DFlash 1.10× AR, accept 81%, matches the README's 1.38× / 85% within hardware variance (README is on M3 Ultra 256GB).
- **DDTree acceptance density also replicates.** 27B code DDTree b=4 accepts 3.96 tokens/cycle ≈ README's 4.2/cycle.
- **DDTree wins over DFlash at the right budget on every model × category.** Peak speedups vs DFlash: **+21%** (4B code), **+77%** (4B prose), **+7%** (27B code), **+78%** (27B prose).
- **Sweet spot is budget=4 for code, budget=2 for prose.** Higher budgets keep pushing acceptance density up (b=8 on 27B code reaches 5.27 tokens/cycle) but the extra verification cost swamps the gain past the sweet spot. The paper's default of 4 is well-chosen for code.
- **The upstream 1.52× AR claim is partially met.** Our 27B code DDTree b=4 is 1.18× AR (bench mean) / 2.02× AR (longer single-shot) vs upstream's 1.52×. Both absolute speeds are lower on our hardware than on M3 Ultra; the ratio delta reflects the hardware delta more than any integration issue.
- **DDTree is reliably faster than DFlash on prose** (+77-78% at b=2 on both models). DFlash's low draft-acceptance on low-entropy prose penalizes it heavily; tree branching rescues the cycle.

Both features are strictly lossless — every token is still verified against the target model.

## When to enable this

Not a universal win — opt-in per model, following the workload:

| Setup | AR | DDTree best | Recommendation |
|---|---|---|---|
| 27B code-heavy | 16.6 tok/s | 19.5 tok/s (b=4) / 33.6 tok/s (longer, structured) | **On**, `ddtree_budget=4` |
| 27B prose-heavy | 15.9 tok/s | 13.4 tok/s (b=2) | **Off** — AR wins on low-acceptance prose |
| 4B code | 96.8 tok/s | 101.2 tok/s (b=4) | Marginal (+5% AR). Optional. |
| 4B prose | 78.7 tok/s | 45.1 tok/s (b=2) | **Off** — AR 1.7× faster |

High-concurrency / long-context workloads should stay on `BatchedEngine` (no DFlash/DDTree), since DFlashEngine is single-request and auto-falls back past `DFLASH_MAX_CTX` anyway.

## Testing

- 14 new unit tests in `tests/test_ddtree_engine.py`: settings round-trip, `_use_ddtree()` truth table, ImportError caching, admin request model.
- Full non-integration suite: 3524 passed, 0 regressions.
- Real-model smoke (short prompt, 27B + 4B): `DFlashEngine.generate()` + `DFlashEngine.stream_generate()` both routed through DDTree. Streaming path emitted 33 events for 32 tokens and terminated with `finished=True`.
- Runtime contract (27B): medium-context DDTree, long-context fallback, concurrent-request safety — all verified in a runtime harness (see "Runtime contract" section above).
- Jinja template: renders cleanly with 15 DDTree markup sites.

## Drive-by fix

`omlx/admin/routes.py` now emits `turboquant_skip_last` in the `list_models` response. This unblocked `tests/test_admin_api_key.py::TestListModelsSettings::test_list_models_includes_all_model_settings_fields`, which was failing on `main` before this PR (same fix as in #757).

## Test plan

- [ ] Pull the branch and run `uv sync` on Python 3.11+ — `ddtree-mlx 0.1.0 (4b12590)` installs
- [ ] `uv run pytest tests/test_ddtree_engine.py tests/test_dflash_engine.py tests/test_admin_api_key.py` — all pass
- [ ] With a model that has a DFlash drafter (e.g. `mlx-community/Qwen3.5-4B-MLX-4bit`), toggle DFlash on in the admin modal, then DDTree, set budget, save, reload — settings persist
- [ ] Send a non-streaming chat completion — server logs `DDTree generation: N tokens, X.X tok/s, avg_acceptance=…, fast_path_ratio=…`
- [ ] Send a streaming chat completion — per-token SSE events arrive and stream terminates
- [ ] Toggle DDTree on with DFlash off via the API — `PUT` returns HTTP 400
- [ ] Long prompt (> `DFLASH_MAX_CTX`, default 4096) — engine logs `DFlash context fallback:` and routes through `BatchedEngine` (DDTree not used, as designed)
- [ ] Optional: `scripts/bench_ddtree.py --model <yours> --prompts 6 --budgets 2 4 6 8` to confirm the speedup ranking on your hardware
