### PR TITLE
feat: preserve thinking across turns for Qwen 3.6+ incl. external clients

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -1348,6 +1348,7 @@ async def list_models(is_admin: bool = Depends(require_admin)):
             "model_type": model_info.get("model_type", "llm"),
             "config_model_type": model_info.get("config_model_type", ""),
             "thinking_default": model_info.get("thinking_default"),
+            "preserve_thinking_default": model_info.get("preserve_thinking_default"),
             "last_access": model_info.get("last_access"),
         }
 

--- a/omlx/api/anthropic_utils.py
+++ b/omlx/api/anthropic_utils.py
@@ -192,6 +192,14 @@ def convert_anthropic_to_internal(
                                     "arguments": tool_input,
                                 },
                             })
+                        elif block_type == "thinking":
+                            # Reconstruct <think> block so preserve_thinking can keep it.
+                            # Append in source order; Anthropic places thinking before
+                            # text/tool_use blocks, so natural ordering already puts
+                            # <think> first in the reassembled message.
+                            thinking_text = block_dict.get("thinking", "")
+                            if thinking_text:
+                                text_parts.append(f"<think>\n{thinking_text}\n</think>")
                         elif block_type == "document":
                             text_parts.append(_decode_document_block(block_dict))
                     msg_dict = _build_message_from_parts(role, text_parts, image_parts) or {
@@ -238,7 +246,13 @@ def convert_anthropic_to_internal(
                                     block_dict.get("content", ""), image_parts
                                 )
                         elif block_type == "thinking":
-                            continue
+                            # Reconstruct <think> block so preserve_thinking can keep it.
+                            # Append in source order — Anthropic emits thinking blocks
+                            # before the text blocks they precede, so appending keeps
+                            # the natural ordering intact across multiple blocks.
+                            thinking_text = block_dict.get("thinking", "")
+                            if thinking_text:
+                                text_parts.append(f"<think>\n{thinking_text}\n</think>")
                         elif block_type == "document":
                             text_parts.append(_decode_document_block(block_dict))
                     msg_dict = _build_message_from_parts(role, text_parts, image_parts)
@@ -292,8 +306,13 @@ def convert_anthropic_to_internal(
                         )
 
                 elif block_type == "thinking":
-                    # Thinking blocks are ignored (reasoning content is not passed to model)
-                    continue
+                    # Reconstruct <think> block so preserve_thinking can keep it.
+                    # Append in source order — Anthropic emits thinking blocks
+                    # before the text blocks they precede, so appending keeps
+                    # the natural ordering intact across multiple blocks.
+                    thinking_text = block_dict.get("thinking", "")
+                    if thinking_text:
+                        text_parts.append(f"<think>\n{thinking_text}\n</think>")
 
                 elif block_type == "document":
                     text_parts.append(_decode_document_block(block_dict))

--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -61,6 +61,8 @@ class Message(BaseModel):
     """
     role: str
     content: Optional[Union[str, List[ContentPart], List[dict]]] = None
+    # Reasoning/thinking content from <think> blocks (OpenAI reasoning_content field)
+    reasoning_content: Optional[str] = None
     # For assistant messages with tool calls
     tool_calls: Optional[List[dict]] = None
     # For tool response messages (role="tool")

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -313,6 +313,19 @@ def extract_text_content(
         role = msg.role
         content = msg.content
 
+        # Reconstruct <think> blocks from reasoning_content for historical
+        # assistant messages.  External clients (e.g. Pi) receive thinking in
+        # the reasoning_content field but only send content back on subsequent
+        # turns.  When the client echoes reasoning_content alongside content we
+        # merge them so that preserve_thinking=True in the chat template has
+        # actual thinking to preserve.
+        reasoning = getattr(msg, "reasoning_content", None)
+        if role == "assistant" and reasoning:
+            text = content if isinstance(content, str) else ""
+            if isinstance(content, list):
+                text = _extract_text_from_content_list(content)
+            content = f"<think>\n{reasoning}\n</think>\n\n{text}"
+
         # Normalize "developer" role to "system" (OpenAI API compatibility)
         if role == "developer":
             role = "system"
@@ -472,6 +485,14 @@ def extract_multimodal_content(
     for msg in messages:
         role = msg.role
         content = msg.content
+
+        # Reconstruct <think> blocks from reasoning_content (see extract_text_content)
+        reasoning = getattr(msg, "reasoning_content", None)
+        if role == "assistant" and reasoning:
+            text = content if isinstance(content, str) else ""
+            if isinstance(content, list):
+                text = _extract_text_from_content_list(content)
+            content = f"<think>\n{reasoning}\n</think>\n\n{text}"
 
         if role == "developer":
             role = "system"

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -57,6 +57,7 @@ class EngineEntry:
     estimated_size: int  # Pre-calculated from safetensors (bytes)
     config_model_type: str = ""  # Raw model_type from config.json (e.g., "deepseekocr_2")
     thinking_default: bool | None = None  # True if model thinks by default, False if not, None if unknown
+    preserve_thinking_default: bool | None = None  # True when template supports preserve_thinking (Qwen 3.6+)
     engine: BaseEngine | EmbeddingEngine | RerankerEngine | STTEngine | STSEngine | TTSEngine | None = None  # Loaded engine instance
     last_access: float = 0.0  # Timestamp for LRU (0 if never loaded)
     is_loading: bool = False  # Prevent concurrent loads
@@ -158,6 +159,7 @@ class EnginePool:
                     estimated_size=info.estimated_size,
                     config_model_type=getattr(info, "config_model_type", ""),
                     thinking_default=getattr(info, "thinking_default", None),
+                    preserve_thinking_default=getattr(info, "preserve_thinking_default", None),
                     is_pinned=model_id in pinned_set,
                 )
 
@@ -867,6 +869,7 @@ class EnginePool:
                     "model_type": e.model_type,
                     "config_model_type": e.config_model_type,
                     "thinking_default": e.thinking_default,
+                    "preserve_thinking_default": e.preserve_thinking_default,
                     "last_access": e.last_access if e.last_access > 0 else None,
                 }
                 for mid, e in sorted(self._entries.items())

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -257,6 +257,7 @@ class DiscoveredModel:
     estimated_size: int  # Estimated memory usage in bytes
     config_model_type: str = ""  # Raw model_type from config.json (e.g., "deepseekocr_2")
     thinking_default: bool | None = None  # True if model thinks by default, False if not, None if unknown
+    preserve_thinking_default: bool | None = None  # True when template supports preserve_thinking (Qwen 3.6+)
 
 
 def _is_unsupported_model(model_path: Path) -> bool:
@@ -539,6 +540,40 @@ def detect_thinking_default(model_path: Path) -> bool | None:
     return None
 
 
+def detect_preserve_thinking(model_path: Path) -> bool | None:
+    """Detect whether a model's chat template supports ``preserve_thinking``.
+
+    Qwen 3.6+ templates strip ``<think>`` blocks from historical assistant
+    turns by default and only keep them when ``preserve_thinking`` is true.
+    Stripping breaks KV prefix cache reuse, so we default to True when the
+    template supports this flag.
+
+    Returns:
+        True if the template references ``preserve_thinking`` (should be
+        enabled), None otherwise (template has no such flag).
+    """
+    template_text = None
+    jinja_path = model_path / "chat_template.jinja"
+    if jinja_path.exists():
+        with contextlib.suppress(OSError):
+            template_text = jinja_path.read_text(encoding="utf-8")
+
+    if template_text is None:
+        tc_path = model_path / "tokenizer_config.json"
+        if tc_path.exists():
+            try:
+                with open(tc_path) as f:
+                    tc = json.load(f)
+                template_text = tc.get("chat_template")
+            except Exception:
+                pass
+
+    if not template_text or "preserve_thinking" not in template_text:
+        return None
+
+    return True
+
+
 def estimate_model_size(model_path: Path) -> int:
     """
     Estimate model memory usage from safetensors/bin file sizes.
@@ -653,6 +688,7 @@ def _register_model(
             pass
 
         thinking_default = detect_thinking_default(model_dir)
+        preserve_thinking_default = detect_preserve_thinking(model_dir)
 
         models[model_id] = DiscoveredModel(
             model_id=model_id,
@@ -662,6 +698,7 @@ def _register_model(
             estimated_size=estimated_size,
             config_model_type=config_model_type,
             thinking_default=thinking_default,
+            preserve_thinking_default=preserve_thinking_default,
         )
 
         size_gb = estimated_size / (1024**3)

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -54,6 +54,7 @@ class ModelSettings:
     model_alias: Optional[str] = None  # API-visible name (alternative to directory name)
     index_cache_freq: Optional[int] = None  # IndexCache: every Nth layer keeps indexer (DSA models only)
     enable_thinking: Optional[bool] = None  # Explicit toggle for thinking/reasoning mode (None = auto)
+    preserve_thinking: Optional[bool] = None  # Keep <think> blocks in historical turns (None = auto, True when template supports it)
     thinking_budget_enabled: bool = False
     thinking_budget_tokens: Optional[int] = None
     reasoning_parser: Optional[str] = None  # xgrammar builtin name: "qwen", "harmony", "llama", etc.

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1944,6 +1944,9 @@ async def create_chat_completion(
         # Dedicated enable_thinking toggle takes precedence over chat_template_kwargs
         if ms.enable_thinking is not None:
             merged_ct_kwargs["enable_thinking"] = ms.enable_thinking
+        # preserve_thinking: keep <think> blocks in historical turns (Qwen 3.6+)
+        if ms.preserve_thinking is not None:
+            merged_ct_kwargs["preserve_thinking"] = ms.preserve_thinking
     # Per-request kwargs override model settings (except forced keys)
     if request.chat_template_kwargs:
         for k, v in request.chat_template_kwargs.items():
@@ -2054,6 +2057,13 @@ async def create_chat_completion(
     # kwarg is True.
     if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
         merged_ct_kwargs["enable_thinking"] = True
+
+    # Auto-set preserve_thinking when thinking is active.  Qwen 3.6+
+    # templates strip <think> blocks from historical turns by default,
+    # which breaks KV prefix cache reuse.  Always preserve unless the
+    # user explicitly opted out.
+    if merged_ct_kwargs.get("enable_thinking") is not False and "preserve_thinking" not in merged_ct_kwargs:
+        merged_ct_kwargs["preserve_thinking"] = True
 
     # Add compiled grammar for logit-level structured output.
     # When a reasoning_parser is configured, the structural tag includes
@@ -3182,6 +3192,9 @@ async def create_anthropic_message(
         # Dedicated enable_thinking toggle takes precedence over chat_template_kwargs
         if ms.enable_thinking is not None:
             merged_ct_kwargs["enable_thinking"] = ms.enable_thinking
+        # preserve_thinking: keep <think> blocks in historical turns (Qwen 3.6+)
+        if ms.preserve_thinking is not None:
+            merged_ct_kwargs["preserve_thinking"] = ms.preserve_thinking
     # Per-request kwargs override model settings (except forced keys)
     if request.chat_template_kwargs:
         for k, v in request.chat_template_kwargs.items():
@@ -3250,6 +3263,10 @@ async def create_anthropic_message(
     # the Anthropic thinking.type field above or model settings).
     if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
         merged_ct_kwargs["enable_thinking"] = True
+
+    # Auto-set preserve_thinking when thinking is active (Qwen 3.6+).
+    if merged_ct_kwargs.get("enable_thinking") is not False and "preserve_thinking" not in merged_ct_kwargs:
+        merged_ct_kwargs["preserve_thinking"] = True
 
     # Merge MCP tools with user-provided Anthropic tools
     user_internal = convert_anthropic_tools_to_internal(request.tools)
@@ -3564,6 +3581,9 @@ async def create_response(
         # Dedicated enable_thinking toggle takes precedence over chat_template_kwargs
         if ms.enable_thinking is not None:
             merged_ct_kwargs["enable_thinking"] = ms.enable_thinking
+        # preserve_thinking: keep <think> blocks in historical turns (Qwen 3.6+)
+        if ms.preserve_thinking is not None:
+            merged_ct_kwargs["preserve_thinking"] = ms.preserve_thinking
 
     # Note: extract_text_content/extract_harmony_messages/extract_multimodal_content
     # are NOT called here because convert_responses_input_to_messages() already
@@ -3666,6 +3686,10 @@ async def create_response(
     # Auto-set enable_thinking when thinking budget is active.
     if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
         merged_ct_kwargs["enable_thinking"] = True
+
+    # Auto-set preserve_thinking when thinking is active (Qwen 3.6+).
+    if merged_ct_kwargs.get("enable_thinking") is not False and "preserve_thinking" not in merged_ct_kwargs:
+        merged_ct_kwargs["preserve_thinking"] = True
 
     # Add compiled grammar for logit-level structured output.
     if compiled_grammar is not None:

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -40,6 +40,7 @@ from omlx.api.anthropic_models import (
     AnthropicTool,
     ContentBlockDocument,
     ContentBlockText,
+    ContentBlockThinking,
     ContentBlockToolResult,
     ContentBlockToolUse,
     MessagesRequest,
@@ -419,6 +420,70 @@ class TestExtractTextContent:
         assert len(result) == 2
         assert result[0]["role"] == "system"
         assert result[0]["content"] == "You are a coding assistant."
+
+
+class TestExtractTextContentReasoningReconstruction:
+    """Tests that extract_text_content reassembles <think> from reasoning_content.
+
+    External clients (e.g. Pi) receive reasoning in the OpenAI reasoning_content
+    field but echo it back alongside normal content on subsequent turns.  For
+    models whose chat template exposes preserve_thinking=True (Qwen 3.6+), we
+    must inject <think>…</think> back into the assistant message so the
+    template has something to preserve — otherwise thinking is silently dropped
+    from conversation history.
+    """
+
+    def test_reasoning_and_content_merged_on_assistant(self):
+        """reasoning_content + content string should produce a <think>…</think> prefix."""
+        messages = [
+            Message(role="assistant", reasoning_content="R", content="A"),
+        ]
+        result = extract_text_content(messages)
+        assert len(result) == 1
+        assert result[0]["role"] == "assistant"
+        assert result[0]["content"] == "<think>\nR\n</think>\n\nA"
+
+    def test_reasoning_with_none_content(self):
+        """reasoning_content with content=None should still emit the <think> block."""
+        messages = [
+            Message(role="assistant", reasoning_content="R", content=None),
+        ]
+        result = extract_text_content(messages)
+        # Non-empty content after reconstruction keeps the message alive.
+        assert len(result) == 1
+        assert result[0]["content"] == "<think>\nR\n</think>\n\n"
+
+    def test_reasoning_with_content_list(self):
+        """reasoning_content + list content should extract text parts and prefix <think>."""
+        messages = [
+            Message(
+                role="assistant",
+                reasoning_content="R",
+                content=[{"type": "text", "text": "A"}],
+            ),
+        ]
+        result = extract_text_content(messages)
+        assert len(result) == 1
+        assert result[0]["content"] == "<think>\nR\n</think>\n\nA"
+
+    def test_reasoning_on_non_assistant_passthrough(self):
+        """reasoning_content on a user message must NOT trigger reconstruction."""
+        messages = [
+            Message(role="user", reasoning_content="R", content="A"),
+        ]
+        result = extract_text_content(messages)
+        assert len(result) == 1
+        # User content left untouched — no <think> wrapper.
+        assert result[0]["content"] == "A"
+
+    def test_no_reasoning_content_passthrough(self):
+        """Without reasoning_content the assistant message should pass through unchanged."""
+        messages = [
+            Message(role="assistant", content="A"),
+        ]
+        result = extract_text_content(messages)
+        assert len(result) == 1
+        assert result[0]["content"] == "A"
 
 
 class TestConvertAnthropicToInternal:
@@ -825,6 +890,118 @@ class TestConvertAnthropicToInternal:
         content = result[0]["content"]
         assert "manual.pdf" in content
         assert "oMLX does not provide PDF parsing" in content
+
+    def test_thinking_block_reconstructed_as_think_tag(self):
+        """Single Anthropic thinking block should be reassembled into a <think> wrapper."""
+        request = MessagesRequest(
+            model="claude-3",
+            max_tokens=1024,
+            messages=[
+                AnthropicMessage(
+                    role="assistant",
+                    content=[
+                        ContentBlockThinking(
+                            type="thinking",
+                            thinking="step by step",
+                            signature="",
+                        ),
+                        ContentBlockText(text="Answer"),
+                    ],
+                ),
+            ],
+        )
+
+        result = convert_anthropic_to_internal(request)
+
+        assert len(result) == 1
+        content = result[0]["content"]
+        assert "<think>\nstep by step\n</think>" in content
+        assert "Answer" in content
+        # <think> must come before the answer text
+        assert content.index("<think>") < content.index("Answer")
+
+    def test_multiple_thinking_blocks_preserve_source_order(self):
+        """Multiple thinking blocks must appear in Anthropic source order (regression guard).
+
+        Earlier drafts inserted at position 0, which reversed the order of
+        consecutive thinking blocks.  Appending preserves natural ordering.
+        """
+        request = MessagesRequest(
+            model="claude-3",
+            max_tokens=1024,
+            messages=[
+                AnthropicMessage(
+                    role="assistant",
+                    content=[
+                        ContentBlockThinking(
+                            type="thinking",
+                            thinking="FIRST",
+                            signature="",
+                        ),
+                        ContentBlockThinking(
+                            type="thinking",
+                            thinking="SECOND",
+                            signature="",
+                        ),
+                        ContentBlockText(text="Answer"),
+                    ],
+                ),
+            ],
+        )
+
+        result = convert_anthropic_to_internal(request)
+
+        content = result[0]["content"]
+        assert content.index("FIRST") < content.index("SECOND")
+        assert content.index("SECOND") < content.index("Answer")
+
+    def test_thinking_block_native_tool_calling_assistant(self):
+        """Native-tool-calling assistant path must also reconstruct thinking blocks.
+
+        Most Qwen 3.6+ models hit this branch (has_tool_calling=True).  Before
+        the fix, the branch silently dropped thinking content, so
+        preserve_thinking=True in the chat template had nothing to preserve.
+        """
+
+        class NativeToolTokenizer:
+            has_tool_calling = True
+
+        request = MessagesRequest(
+            model="claude-3",
+            max_tokens=1024,
+            messages=[
+                AnthropicMessage(
+                    role="assistant",
+                    content=[
+                        ContentBlockThinking(
+                            type="thinking",
+                            thinking="deliberating",
+                            signature="",
+                        ),
+                        ContentBlockText(text="Let me check."),
+                        ContentBlockToolUse(
+                            id="toolu_1",
+                            name="get_weather",
+                            input={"location": "Tokyo"},
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        result = convert_anthropic_to_internal(
+            request,
+            tokenizer=NativeToolTokenizer(),
+        )
+
+        assert len(result) == 1
+        assert result[0]["role"] == "assistant"
+        # tool_calls still structured for native rendering
+        assert result[0]["tool_calls"][0]["function"]["name"] == "get_weather"
+        # <think> wrapper present in the text content
+        content = result[0]["content"]
+        assert "<think>\ndeliberating\n</think>" in content
+        assert "Let me check." in content
 
     def test_document_block_mixed_with_text(self):
         """Test document block alongside text blocks."""


### PR DESCRIPTION
## Summary

Adds `preserve_thinking` support for Qwen 3.6+ so the model can recall its own `<think>` reasoning across chat turns — both in the built-in chat and from external OpenAI/Anthropic-compatible clients (Pi, Claude Code, etc.).

Related: #748.

## Motivation

Qwen 3.6+ chat templates strip `<think>` blocks from historical assistant turns by default, so the model loses its prior chain-of-thought between turns and KV prefix reuse suffers. The model provider explicitly recommends enabling `preserve_thinking` — from the [Qwen3.6-35B-A3B model card](https://huggingface.co/Qwen/Qwen3.6-35B-A3B):

> This capability is particularly beneficial for agent scenarios, where maintaining full reasoning context can enhance decision consistency and, in many cases, reduce overall token consumption by minimizing redundant reasoning. Additionally, it can improve KV cache utilization, optimizing inference efficiency in both thinking and non-thinking modes.

Wiring `preserve_thinking=True` server-side isn't enough though: external OpenAI/Anthropic-compatible clients receive clean `content` (thinking is split into `reasoning_content` by oMLX's reasoning parser) and echo back only `content` on the next turn — so there's nothing to preserve.

This PR wires both halves: the server auto-enables `preserve_thinking` when the template supports it, and the API layer reconstructs `<think>` blocks from client-echoed `reasoning_content` / Anthropic `thinking` blocks before templating.


##  Comparison 
<img width="1007" height="635" alt="Screenshot 2026-04-16 at 11 13 52" src="https://github.com/user-attachments/assets/1b9ba483-8c53-4b32-9fa9-9c9bc8d460bf" />
<img width="1014" height="478" alt="Screenshot 2026-04-16 at 11 38 01" src="https://github.com/user-attachments/assets/6bb41300-de99-4fff-909f-8ef7b0f28552" />


## How it works

**Backend (`feat` commit):** detect `preserve_thinking` support from the chat template at discovery time; add a `ModelSettings` override; auto-enable when thinking is active; pipe through chat/messages/responses endpoints.

**API input reconstruction (`fix` commit):**
- `openai_models.py`: add `reasoning_content` to the `Message` request model.
- `utils.py`: when an assistant message has `reasoning_content`, merge into `<think>\n{reasoning}\n</think>\n\n{content}` before templating.
- `anthropic_utils.py`: stop discarding `thinking` content blocks across all three `convert_anthropic_to_internal` sites (including the native-tool-calling assistant branch, which had no handling at all); append in source order to preserve multi-block ordering.
- Harmony/gpt-oss input path left unchanged (different format).

Precedence matches #748: per-request kwargs > model settings > auto-set > template default.

## Test plan

**Unit (`tests/test_api_utils.py`)** — 8 new cases covering string/list/None content, non-assistant passthrough, missing `reasoning_content` no-op, single + multi-block Anthropic ordering, and the native-tool-calling path. Full fast suite (`pytest -m "not slow"`) green.

**End-to-end methodology** — `Qwen3.6-35B-A3B-8bit`, two-turn recall test:
1. Turn 1: "generate two random 20-digit numbers, give me only one of the two and nothing else" → returns one number in `content`, puts both in `reasoning_content` / `thinking`.
2. Turn 2: "now give me the second number."

| Endpoint | With reasoning echoed | Control (no reasoning) |
|---|---|---|
| OpenAI `/v1/chat/completions` | exact recall ✅ | fabricates different number ✅ |
| Anthropic `/v1/messages` | exact recall ✅ | thinking says "I don't store the second number", fabricates ✅ |

Controls confirm the fix is load-bearing — without reconstruction the model has no access to its prior reasoning; with it, the exact number comes back.

**Regression-safety**: `reasoning_content` defaults to `None`, so clients that don't send it and non-thinking models are untouched.

Assisted by Claude Opus 4.7
