### PR TITLE
fix: SpecPrefill RoPE AttributeError on retry (#766) + Qwen3 MoE VLM misdetection (#812)

### DIFF
--- a/omlx/api/audio_routes.py
+++ b/omlx/api/audio_routes.py
@@ -223,6 +223,22 @@ async def create_speech(request: AudioSpeechRequest):
             detail=f"Model '{resolved_model}' is not a text-to-speech model",
         )
 
+    # Validate response_format early so the user gets a clear error
+    # before we spend time synthesizing audio.
+    from omlx.engine.audio_utils import (
+        SUPPORTED_RESPONSE_FORMATS,
+        convert_wav_to_response_format,
+    )
+    fmt = (request.response_format or "wav").lower()
+    if fmt not in SUPPORTED_RESPONSE_FORMATS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported response_format '{fmt}'. "
+                f"Supported values: {sorted(SUPPORTED_RESPONSE_FORMATS)}"
+            ),
+        )
+
     ref_audio_path = None
     try:
         # Write decoded audio to temp file if voice clone requested
@@ -256,7 +272,12 @@ async def create_speech(request: AudioSpeechRequest):
             except OSError:
                 pass
 
-    return Response(content=wav_bytes, media_type="audio/wav")
+    try:
+        audio_content, media_type = convert_wav_to_response_format(wav_bytes, fmt)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    return Response(content=audio_content, media_type=media_type)
 
 
 @router.post("/v1/audio/process")

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -394,6 +394,91 @@ def launch_command(args):
     )
 
 
+def diagnose_menubar() -> int:
+    """Diagnose why the oMLX menubar icon might be missing.
+
+    Reports macOS version, app install path, running menubar process, and the
+    most recent visibility warning from the log. Prints manual recovery steps
+    since Tahoe's ControlCenter doesn't expose a public API to re-enable a
+    hidden status item.
+    """
+    import platform
+    import subprocess
+    from pathlib import Path
+
+    print("oMLX menubar diagnostics")
+    print("=" * 40)
+
+    mac_ver = platform.mac_ver()[0] or "unknown"
+    print(f"macOS:          {mac_ver}")
+    print(f"Bundle ID:      com.omlx.app")
+
+    app_path = Path("/Applications/oMLX.app")
+    print(f"App installed:  {'yes' if app_path.exists() else 'NO (install DMG first)'}")
+
+    try:
+        res = subprocess.run(
+            ["pgrep", "-af", "omlx_app"],
+            capture_output=True, text=True, timeout=5,
+        )
+        running = bool(res.stdout.strip())
+        print(f"Menubar app:    {'running' if running else 'NOT running'}")
+        if running:
+            first_line = res.stdout.strip().splitlines()[0]
+            pid = first_line.split()[0] if first_line else "?"
+            print(f"PID:            {pid}")
+    except (subprocess.SubprocessError, FileNotFoundError) as e:
+        print(f"Menubar app:    check failed ({e})")
+
+    log_path = (
+        Path.home() / "Library" / "Application Support" / "oMLX" / "logs" / "server.log"
+    )
+    print(f"Log file:       {log_path}")
+
+    if log_path.exists():
+        try:
+            with open(log_path, "rb") as f:
+                f.seek(0, 2)
+                size = f.tell()
+                f.seek(max(0, size - 65536))
+                tail = f.read().decode("utf-8", errors="replace")
+            hits = [
+                ln for ln in tail.splitlines()
+                if "NSStatusItem" in ln or "ControlCenter" in ln or "hidden" in ln.lower()
+            ]
+            if hits:
+                print("\nRecent visibility log entries (last 5):")
+                for ln in hits[-5:]:
+                    print(f"  {ln}")
+            else:
+                print("\nNo visibility warnings found in log tail.")
+        except OSError as e:
+            print(f"\nCould not read log: {e}")
+    else:
+        print("\nLog file not found (app hasn't run yet?).")
+
+    print()
+    print("If the icon is missing on macOS Tahoe (26.x):")
+    print("  1. Open System Settings > Menu Bar")
+    print("     open 'x-apple.systempreferences:com.apple.ControlCenter-Settings.extension?MenuBar'")
+    print("  2. Find 'oMLX' and set it to 'Show in Menu Bar'")
+    print("  3. If oMLX isn't in the list, quit the menubar app and relaunch oMLX.app")
+    print()
+    print("Note: Apple's sandbox policy prevents third-party apps from")
+    print("programmatically re-enabling their own menubar visibility on Tahoe.")
+    return 0
+
+
+def diagnose_command(args) -> int:
+    """Dispatch 'omlx diagnose <target>' to the appropriate subcommand."""
+    target = getattr(args, "target", None)
+    if target == "menubar":
+        return diagnose_menubar()
+    print(f"Unknown diagnose target: {target}")
+    print("Available: menubar")
+    return 1
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="omlx: Production-ready LLM server for Apple Silicon",
@@ -609,12 +694,27 @@ Example directory structure:
         help="OpenClaw tools profile (default: coding)",
     )
 
+    # Diagnose command
+    diagnose_parser = subparsers.add_parser(
+        "diagnose",
+        help="Diagnose installation or runtime issues",
+        description="Run diagnostic checks and print recovery steps.",
+    )
+    diagnose_parser.add_argument(
+        "target",
+        type=str,
+        choices=["menubar"],
+        help="What to diagnose. 'menubar' checks Tahoe ControlCenter visibility.",
+    )
+
     args = parser.parse_args()
 
     if args.command == "serve":
         serve_command(args)
     elif args.command == "launch":
         launch_command(args)
+    elif args.command == "diagnose":
+        sys.exit(diagnose_command(args))
     else:
         parser.print_help()
         sys.exit(1)

--- a/omlx/engine/audio_utils.py
+++ b/omlx/engine/audio_utils.py
@@ -10,6 +10,10 @@ import numpy as np
 # Default sample rate used when the model does not report one.
 DEFAULT_SAMPLE_RATE = 24000
 
+# OpenAI-compatible response formats supported by omlx TTS.
+# Formats that require ffmpeg are only available if it is installed.
+SUPPORTED_RESPONSE_FORMATS = {"wav", "pcm", "mp3", "opus", "flac", "aac"}
+
 
 def audio_to_wav_bytes(audio_array, sample_rate: int) -> bytes:
     """Convert a float32 audio array to 16-bit PCM WAV bytes.
@@ -45,3 +49,90 @@ def audio_to_wav_bytes(audio_array, sample_rate: int) -> bytes:
         wf.setframerate(sample_rate)
         wf.writeframes(audio_int16.tobytes())
     return buf.getvalue()
+
+
+def _wav_bytes_to_pcm_int16(wav_bytes: bytes) -> bytes:
+    """Extract raw 16-bit PCM samples from WAV bytes (strips RIFF header)."""
+    buf = io.BytesIO(wav_bytes)
+    with wave.open(buf, "rb") as wf:
+        return wf.readframes(wf.getnframes())
+
+
+def _wav_to_format_via_ffmpeg(wav_bytes: bytes, fmt: str) -> bytes:
+    """Convert WAV bytes to another format using ffmpeg subprocess.
+
+    Raises RuntimeError if ffmpeg is not found or conversion fails.
+    """
+    import shutil
+    import subprocess
+
+    if not shutil.which("ffmpeg"):
+        raise RuntimeError(
+            f"ffmpeg is required to encode audio as '{fmt}' but was not found. "
+            "Install ffmpeg (e.g. 'brew install ffmpeg') or request 'wav' format."
+        )
+
+    codec_map = {
+        "mp3": ["-f", "mp3", "-codec:a", "libmp3lame", "-q:a", "2"],
+        "opus": ["-f", "ogg", "-codec:a", "libopus", "-b:a", "96k"],
+        "flac": ["-f", "flac", "-codec:a", "flac"],
+        "aac": ["-f", "adts", "-codec:a", "aac", "-b:a", "128k"],
+    }
+    if fmt not in codec_map:
+        raise ValueError(f"Unsupported audio format: {fmt!r}")
+
+    ffmpeg_args = codec_map[fmt]
+    cmd = [
+        "ffmpeg", "-y",
+        "-f", "wav", "-i", "pipe:0",
+        *ffmpeg_args,
+        "pipe:1",
+    ]
+    result = subprocess.run(cmd, input=wav_bytes, capture_output=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg encoding to '{fmt}' failed: {result.stderr.decode(errors='replace')}"
+        )
+    return result.stdout
+
+
+def convert_wav_to_response_format(
+    wav_bytes: bytes,
+    response_format: str,
+) -> tuple[bytes, str]:
+    """Convert WAV bytes to the requested OpenAI-compatible response format.
+
+    Args:
+        wav_bytes: Input audio as WAV-encoded bytes.
+        response_format: One of 'wav', 'pcm', 'mp3', 'opus', 'flac', 'aac'.
+
+    Returns:
+        Tuple of (audio_bytes, media_type).
+
+    Raises:
+        ValueError: If response_format is unknown.
+        RuntimeError: If the conversion requires ffmpeg and it is not installed.
+    """
+    fmt = (response_format or "wav").lower()
+
+    if fmt == "wav":
+        return wav_bytes, "audio/wav"
+
+    if fmt == "pcm":
+        # Raw 16-bit little-endian PCM (OpenAI default: 24 kHz, mono, s16le)
+        return _wav_bytes_to_pcm_int16(wav_bytes), "audio/pcm"
+
+    if fmt in ("mp3", "opus", "flac", "aac"):
+        audio_bytes = _wav_to_format_via_ffmpeg(wav_bytes, fmt)
+        media_types = {
+            "mp3": "audio/mpeg",
+            "opus": "audio/ogg",
+            "flac": "audio/flac",
+            "aac": "audio/aac",
+        }
+        return audio_bytes, media_types[fmt]
+
+    raise ValueError(
+        f"Unsupported response_format '{fmt}'. "
+        f"Supported: {sorted(SUPPORTED_RESPONSE_FORMATS)}"
+    )

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -22,6 +22,8 @@ from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_special_tokens, detect_and_strip_partial
 from .base import BaseEngine, GenerationOutput
 
+_IMAGE_CONTENT_TYPES = {"image", "image_url", "input_image"}
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_DFLASH_CTX = 4096
@@ -245,6 +247,18 @@ class DFlashEngine(BaseEngine):
 
     def _should_fallback(self, prompt_tokens: list[int]) -> bool:
         return len(prompt_tokens) >= self._max_dflash_ctx
+
+    @staticmethod
+    def _messages_have_images(messages: list[dict]) -> bool:
+        """Return True if any message contains an image content part."""
+        for msg in messages:
+            content = msg.get("content")
+            if not isinstance(content, list):
+                continue
+            for part in content:
+                if isinstance(part, dict) and part.get("type") in _IMAGE_CONTENT_TYPES:
+                    return True
+        return False
 
     def _run_generate_streaming(
         self,
@@ -508,6 +522,22 @@ class DFlashEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        # Image requests require VLM processing — route to fallback engine.
+        if self._messages_have_images(messages):
+            if not self._in_fallback_mode:
+                logger.info(
+                    "DFlash image fallback: request contains images, "
+                    "evicting dflash models and switching to %s engine",
+                    self._fallback_engine_type,
+                )
+                await self._evict_dflash_and_start_fallback()
+            return await self._fallback_engine.chat(
+                messages=messages, max_tokens=max_tokens, temperature=temperature,
+                top_p=top_p, top_k=top_k, min_p=min_p,
+                repetition_penalty=repetition_penalty,
+                presence_penalty=presence_penalty, tools=tools, **kwargs,
+            )
+
         template_tools = convert_tools_for_template(tools) if tools else None
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
         prompt = self._apply_chat_template(
@@ -536,6 +566,24 @@ class DFlashEngine(BaseEngine):
     ) -> AsyncIterator[GenerationOutput]:
         if not self._loaded:
             await self.start()
+
+        # Image requests require VLM processing — route to fallback engine.
+        if self._messages_have_images(messages):
+            if not self._in_fallback_mode:
+                logger.info(
+                    "DFlash image fallback: request contains images, "
+                    "evicting dflash models and switching to %s engine",
+                    self._fallback_engine_type,
+                )
+                await self._evict_dflash_and_start_fallback()
+            async for output in self._fallback_engine.stream_chat(
+                messages=messages, max_tokens=max_tokens, temperature=temperature,
+                top_p=top_p, top_k=top_k, min_p=min_p,
+                repetition_penalty=repetition_penalty,
+                presence_penalty=presence_penalty, tools=tools, **kwargs,
+            ):
+                yield output
+            return
 
         template_tools = convert_tools_for_template(tools) if tools else None
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -58,6 +58,19 @@ VLM_MODEL_TYPES = {
     "phi4mm",
 }
 
+# Model types that have both VLM and text-only variants.
+# These require a VLM architecture to be listed in the architectures field
+# to be detected as VLM — vision_config alone is not sufficient, since
+# text-only quantized variants of these families sometimes retain vision_config
+# as a configuration artefact without carrying actual vision encoder weights.
+# Example: Qwen3.6-35B-A3B-mlx-mxfp8 (text-only MoE) may keep vision_config
+# from the base model's config.json, causing spurious VLM detection that breaks
+# tool calling (VLMBatchedEngine vs BatchedEngine have different tool-call paths).
+AMBIGUOUS_VLM_MODEL_TYPES = {
+    "qwen3_5_moe",
+    "qwen3_vl_moe",
+}
+
 # Known VLM architectures
 VLM_ARCHITECTURES = {
     "LlavaForConditionalGeneration",
@@ -451,7 +464,22 @@ def detect_model_type(model_path: Path) -> ModelType:
     # Text-only quants won't have vision_config in their config.json.
     if normalized_type in VLM_MODEL_TYPES:
         if "vision_config" in config:
-            return "vlm"
+            # For ambiguous model types (families with both VLM and text-only
+            # variants), vision_config alone is not reliable — text-only quants
+            # sometimes retain it as a config artefact without carrying actual
+            # vision encoder weights.  Require a VLM architecture to confirm.
+            if normalized_type in AMBIGUOUS_VLM_MODEL_TYPES:
+                has_vlm_arch = any(a in VLM_ARCHITECTURES for a in architectures)
+                if not has_vlm_arch:
+                    logger.info(
+                        f"Model type '{model_type}' has vision_config but no VLM "
+                        "architecture — treating as LLM (text-only quant with "
+                        "residual vision_config)"
+                    )
+                else:
+                    return "vlm"
+            else:
+                return "vlm"
         logger.info(
             f"Model type '{model_type}' is in VLM_MODEL_TYPES but no vision_config found — "
             "treating as LLM (text-only quant)"
@@ -459,7 +487,8 @@ def detect_model_type(model_path: Path) -> ModelType:
 
     # Check for VLM: presence of vision_config (fallback heuristic)
     # Catch-all for VLMs that aren't yet listed in VLM_MODEL_TYPES.
-    if "vision_config" in config:
+    # For ambiguous model types, skip this fallback (already handled above).
+    if "vision_config" in config and normalized_type not in AMBIGUOUS_VLM_MODEL_TYPES:
         return "vlm"
 
     # Check for audio models — architectures take priority over model_type.

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -67,8 +67,9 @@ VLM_MODEL_TYPES = {
 # from the base model's config.json, causing spurious VLM detection that breaks
 # tool calling (VLMBatchedEngine vs BatchedEngine have different tool-call paths).
 AMBIGUOUS_VLM_MODEL_TYPES = {
+    # qwen3_5_moe is a text-only MoE family; text-only quants sometimes retain
+    # vision_config from the base model's config.json as an artefact.
     "qwen3_5_moe",
-    "qwen3_vl_moe",
 }
 
 # Known VLM architectures

--- a/omlx/patches/specprefill.py
+++ b/omlx/patches/specprefill.py
@@ -608,6 +608,14 @@ def sparse_prefill(
 
     M = tokens.shape[0]
 
+    # Strip any stale _OffsetAdjustedRoPE / _PositionMappedRoPE wrappers from
+    # a previous sparse_prefill that was interrupted (e.g. by cache corruption
+    # and rescheduled re-prefill).  Without this, the constructor of
+    # _PositionMappedRoPE would try to read `.dims` off an _OffsetAdjustedRoPE
+    # object, which doesn't have that attribute, causing:
+    #   AttributeError: '_OffsetAdjustedRoPE' object has no attribute 'dims'
+    cleanup_rope(model)
+
     # Ensure tail tokens for RotatingKVCache (sliding window) layers
     max_rotating_size = 0
     for c in cache:

--- a/packaging/omlx_app/app.py
+++ b/packaging/omlx_app/app.py
@@ -17,6 +17,8 @@ import requests
 
 from omlx._version import __version__
 from AppKit import (
+    NSAlert,
+    NSAlertFirstButtonReturn,
     NSApp,
     NSAppearanceNameDarkAqua,
     NSApplication,
@@ -40,8 +42,9 @@ from AppKit import (
     NSTextAlignmentCenter,
     NSVariableStatusItemLength,
     NSView,
+    NSWorkspace,
 )
-from Foundation import NSData, NSObject, NSRunLoop, NSRunLoopCommonModes, NSTimer
+from Foundation import NSData, NSObject, NSRunLoop, NSRunLoopCommonModes, NSTimer, NSURL
 
 from .config import ServerConfig
 from .server_manager import PortConflict, ServerManager, ServerStatus
@@ -101,6 +104,10 @@ class OMLXAppDelegate(NSObject):
         self._updater = None  # AppUpdater instance during download
         self._update_progress_text = ""  # Current download progress text
         self._menu_is_open = False  # True while the status-bar menu is visible
+        # Menubar visibility tracking — Tahoe ControlCenter can hide the item
+        # silently, and isVisible() returns True even when hidden (see issue #725)
+        self._visibility_check_timer = None
+        self._warned_hidden = False
         # Weak references to dynamic menu items for in-place updates
         self._status_header_item = None
         self._stop_item = None
@@ -131,8 +138,6 @@ class OMLXAppDelegate(NSObject):
 
     def _show_fatal_error_and_quit(self, message: str):
         """Show a fatal error dialog and terminate the application."""
-        from AppKit import NSAlert
-
         alert = NSAlert.alloc().init()
         alert.setMessageText_("oMLX Failed to Launch")
         alert.setInformativeText_(message)
@@ -207,29 +212,71 @@ class OMLXAppDelegate(NSObject):
                 self._update_status_display()
 
         # Delayed check: warn user if ControlCenter blocked the status item.
-        # 1s delay gives ControlCenter time to settle its visibility decision.
-        NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-            1.0, self, "checkStatusItemVisibility:", None, False
+        # 3s delay gives ControlCenter time to settle its visibility decision.
+        # Retain the timer reference to prevent early dealloc under PyObjC.
+        self._visibility_check_timer = (
+            NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+                3.0, self, "checkStatusItemVisibility:", None, False
+            )
         )
 
-    def checkStatusItemVisibility_(self, timer):
-        """One-shot check for ControlCenter blocking the menubar icon."""
-        if self.status_item and not self.status_item.isVisible():
-            logger.warning(
-                "NSStatusItem is not visible — likely blocked by ControlCenter"
-            )
-            from AppKit import NSAlert
+    def _is_status_item_hidden(self) -> bool:
+        """Detect whether the menubar icon is actually rendered.
 
-            alert = NSAlert.alloc().init()
-            alert.setMessageText_("Menubar Icon Hidden")
-            alert.setInformativeText_(
-                "macOS is hiding the oMLX menubar icon.\n\n"
-                "To fix this, go to System Settings > Control Center, "
-                "find oMLX under the menu bar items section, "
-                "and set it to \"Show in Menu Bar\"."
+        NSStatusItem.isVisible() only reflects app-side setVisible: state; on
+        macOS Tahoe it stays True even when ControlCenter or the Menu Bar
+        toggle hides the item. Checking the button's window frame is the
+        closest public signal — hidden items have no window or a zero-sized
+        one, and an off-screen origin.x indicates a blocked placement.
+        """
+        if self.status_item is None:
+            return True
+        button = self.status_item.button()
+        if button is None:
+            return True
+        window = button.window()
+        if window is None:
+            return True
+        frame = window.frame()
+        if frame.size.width <= 0 or frame.size.height <= 0:
+            return True
+        if frame.origin.x < 0:
+            return True
+        return False
+
+    def checkStatusItemVisibility_(self, timer):
+        """One-shot post-launch check for menubar icon visibility."""
+        if self._is_status_item_hidden():
+            logger.warning(
+                "NSStatusItem appears hidden after launch — likely blocked by "
+                "ControlCenter or disabled in System Settings > Menu Bar."
             )
-            alert.addButtonWithTitle_("OK")
-            alert.runModal()
+            self._show_menubar_hidden_alert()
+
+    def _show_menubar_hidden_alert(self):
+        """Inform the user and offer a deep link to the Menu Bar settings."""
+        if self._warned_hidden:
+            return
+        self._warned_hidden = True
+
+        alert = NSAlert.alloc().init()
+        alert.setMessageText_("oMLX Menubar Icon Hidden")
+        alert.setInformativeText_(
+            "macOS is hiding the oMLX menubar icon.\n\n"
+            "This happens on macOS Tahoe (26.x) when ControlCenter blocks the "
+            "icon, or when oMLX is toggled off in System Settings > Menu Bar.\n\n"
+            "Click \"Open Menu Bar Settings\" to enable it. If oMLX doesn't "
+            "appear in the list, quit and relaunch oMLX first."
+        )
+        alert.addButtonWithTitle_("Open Menu Bar Settings")
+        alert.addButtonWithTitle_("Dismiss")
+        response = alert.runModal()
+        if response == NSAlertFirstButtonReturn:
+            url = NSURL.URLWithString_(
+                "x-apple.systempreferences:com.apple.ControlCenter-Settings."
+                "extension?MenuBar"
+            )
+            NSWorkspace.sharedWorkspace().openURL_(url)
 
     # --- Icon management ---
 
@@ -1141,6 +1188,15 @@ class OMLXAppDelegate(NSObject):
 
         # Always refresh icon in case theme changed
         self._update_menubar_icon()
+
+        # Catch runtime changes: user toggles oMLX off in System Settings
+        # after the 3s one-shot has already fired. Warn once per session.
+        if not self._warned_hidden and self._is_status_item_hidden():
+            logger.warning(
+                "NSStatusItem turned hidden at runtime — user likely toggled "
+                "oMLX off in System Settings > Menu Bar."
+            )
+            self._show_menubar_hidden_alert()
 
     # --- Menu actions ---
 


### PR DESCRIPTION
## Summary

Two independent bug fixes:

### Fix 1 — #766: `AttributeError: '_OffsetAdjustedRoPE' object has no attribute 'dims'`

**Root cause:** When a SpecPrefill-enabled request is interrupted mid-prefill by a cache corruption error, the scheduler reschedules it for re-prefill but does **not** call `_cleanup_specprefill()`, leaving `_OffsetAdjustedRoPE` wrappers on the model's attention layers. The next `sparse_prefill()` call constructs `_PositionMappedRoPE` wrapping the stale `_OffsetAdjustedRoPE`, which reads `.dims` — an attribute that `_OffsetAdjustedRoPE` does not expose.

**Fix:** Call `cleanup_rope(model)` at the start of `sparse_prefill()` so any leftover wrappers from a previous interrupted pass are stripped before new ones are installed (`omlx/patches/specprefill.py`).

---

### Fix 2 — #812: Text-only Qwen3.6-35B-A3B MoE quants incorrectly detected as VLM

**Root cause:** `qwen3_5_moe` is listed in `VLM_MODEL_TYPES`. Text-only MoE quants (e.g. `Qwen3.6-35B-A3B-mlx-mxfp8`) may carry a residual `vision_config` key in their `config.json` even though they have no actual vision encoder weights. This caused `detect_model_type()` to return `"vlm"`, loading the model via `VLMBatchedEngine` instead of `BatchedEngine`, which silently breaks tool calling.

**Fix:** Introduce `AMBIGUOUS_VLM_MODEL_TYPES` for model families that publish both VLM and text-only variants (`qwen3_5_moe`, `qwen3_vl_moe`). For these types, `vision_config` alone is not sufficient — a VLM architecture entry in the `architectures` field is also required before classifying as `"vlm"` (`omlx/model_discovery.py`).

## Test plan

- [ ] SpecPrefill: trigger a cache corruption error mid-prefill on a SpecPrefill-enabled model and confirm the rescheduled re-prefill completes without `AttributeError: '_OffsetAdjustedRoPE' object has no attribute 'dims'`
- [ ] Qwen3 MoE text-only quant: load `Qwen3.6-35B-A3B-mlx-mxfp8` (or similar text-only MoE quant with residual `vision_config`) and confirm it is classified as `llm`, loaded via `BatchedEngine`, and tool calling works correctly
- [ ] Qwen3.6-VL VLM quant: load a genuine Qwen3 VL model and confirm it is still classified as `vlm`