### PR TITLE
fix(admin): handle symlinked models in delete_hf_model endpoint (v2)

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -3421,13 +3421,23 @@ async def delete_hf_model(
         raise HTTPException(status_code=404, detail="Model not found")
 
     # Validate path traversal against parent model directory
+    # Symlinks require separate validation: the symlink itself must reside
+    # inside model_dir, but its target may point anywhere.  We only ever
+    # unlink the symlink (never follow it), so validating the parent is safe.
     try:
-        if not model_path.resolve().is_relative_to(parent_model_dir.resolve()):
-            raise HTTPException(status_code=400, detail="Invalid model name")
+        if model_path.is_symlink():
+            # Ensure the symlink lives inside the model directory.
+            # We resolve the *parent* (which cannot be a symlink we created)
+            # and verify the symlink name is legitimate.
+            if not model_path.parent.resolve().is_relative_to(parent_model_dir.resolve()):
+                raise HTTPException(status_code=400, detail="Invalid model name")
+        else:
+            if not model_path.resolve().is_relative_to(parent_model_dir.resolve()):
+                raise HTTPException(status_code=400, detail="Invalid model name")
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid model name")
 
-    if not model_path.is_dir():
+    if not model_path.is_dir() and not model_path.is_symlink():
         raise HTTPException(status_code=400, detail="Not a model directory")
 
     # Unload model if loaded
@@ -3457,11 +3467,15 @@ async def delete_hf_model(
         raise exc_info[1].with_traceback(exc_info[2])
 
     try:
-        if sys.version_info >= (3, 12):
+        if model_path.is_symlink():
+            model_path.unlink()
+            logger.info(f"Deleted model symlink: {model_path}")
+        elif sys.version_info >= (3, 12):
             shutil.rmtree(model_path, onexc=_handle_onexc)
+            logger.info(f"Deleted model directory: {model_path}")
         else:
             shutil.rmtree(model_path, onerror=_handle_onerror)
-        logger.info(f"Deleted model directory: {model_path}")
+            logger.info(f"Deleted model directory: {model_path}")
     except Exception as e:
         logger.error(f"Failed to delete model directory {model_path}: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to delete model: {e}")


### PR DESCRIPTION
## Rebased replacement for #669

Closes #669 (old branch had 150 files diverged from main).

### Problem

The `delete_hf_model` endpoint fails for symlinked models because:
1. `resolve()` follows symlinks, so path validation rejects models whose symlink target is outside `model_dir`
2. `shutil.rmtree()` follows symlinks and deletes the target directory contents instead of just removing the symlink

### Fix (1 file, +19/-5 lines)

**Path traversal validation** — separate handling:
- **Symlinks**: Validate that `model_path.parent.resolve()` is within `parent_model_dir.resolve()`. We only `unlink()` the symlink, so the target location is irrelevant — the symlink itself must live inside our controlled directory. Using `parent.resolve()` gives full path normalization (prevents `..` traversal) without following the symlink.
- **Regular dirs**: Keep existing `resolve()` check unchanged.

**Deletion** — separate handling:
- **Symlinks**: `Path.unlink()` — removes only the symlink, target stays intact
- **Regular dirs**: Keep `shutil.rmtree()` with macOS `._` file compatibility

### Security considerations

The maintainer correctly identified that `absolute()` doesn't normalize `..`, enabling path traversal. This fix avoids that pitfall:
- For symlinks, we resolve the **parent directory** (not the symlink path itself), which normalizes all `..` components in the path leading to the symlink
- The symlink must physically exist inside `model_dir` for the parent check to pass
- We never follow the symlink during validation or deletion

### Testing

- Symlink model: symlink at `models/org/model-name` → `/data/huggingface/org/model-name` — validated by parent check, deleted with `unlink()`
- Regular dir model: `models/org/model-name/` — validated by existing `resolve()` check, deleted with `rmtree()`
- Path traversal attempt: `../../../etc/passwd` — rejected because `parent.resolve()` normalizes to `/etc` which is not within `model_dir`