### PR TITLE
fix: clean errors for non-LLM engines and missing STT processors (#507, #800)

### DIFF
--- a/omlx/engine/stt.py
+++ b/omlx/engine/stt.py
@@ -21,6 +21,62 @@ from .base import BaseNonStreamingEngine
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Error helpers (#800): turn opaque mlx-audio/HF processor failures into
+# actionable RuntimeErrors that tell users which file is missing and where
+# to find a compatible variant.
+# ---------------------------------------------------------------------------
+
+
+_MISSING_PROCESSOR_HINTS = (
+    "preprocessor_config.json",
+    "feature extractor",
+    "featureextractor",
+)
+
+
+def _looks_like_missing_processor(message: str) -> bool:
+    """True if the error text from mlx-audio / HF points at a missing processor."""
+    lowered = message.lower()
+    return any(h in lowered for h in _MISSING_PROCESSOR_HINTS)
+
+
+def _missing_processor_hint(model_name: str) -> str:
+    return (
+        f"STT model '{model_name}' is missing the HuggingFace processor / "
+        "feature-extractor configuration (preprocessor_config.json and/or "
+        "tokenizer files). MLX-converted repositories sometimes omit these. "
+        "Fix: either use an HF-compatible variant of the model or copy "
+        "preprocessor_config.json, tokenizer.json and special_tokens_map.json "
+        "from the upstream HuggingFace repo into the local model directory."
+    )
+
+
+def _wrap_stt_load_error(model_name: str, exc: Exception) -> Exception:
+    """Return a clearer exception for known mlx-audio STT load failures."""
+    message = str(exc)
+    if _looks_like_missing_processor(message):
+        return RuntimeError(
+            f"{_missing_processor_hint(model_name)} Original error: {message}"
+        )
+    return exc
+
+
+def _validate_stt_processor(model_name: str, model: Any) -> None:
+    """Fail fast if a Whisper-family mlx-audio model loaded without a processor."""
+    module_name = type(model).__module__ or ""
+    is_whisper_like = "whisper" in module_name.lower()
+    if not is_whisper_like:
+        return
+    # mlx-audio Whisper attaches a HF processor to ``_processor``; it's set
+    # to None when WhisperProcessor.from_pretrained() failed on load.
+    if not hasattr(model, "_processor"):
+        return
+    if getattr(model, "_processor") is not None:
+        return
+    raise RuntimeError(_missing_processor_hint(model_name))
+
+
 class STTEngine(BaseNonStreamingEngine):
     """
     Engine for audio transcription (Speech-to-Text).
@@ -78,9 +134,23 @@ class STTEngine(BaseNonStreamingEngine):
             return _load_model(model_name)
 
         loop = asyncio.get_running_loop()
-        self._model = await loop.run_in_executor(
-            get_mlx_executor(), _load_sync
-        )
+        try:
+            model = await loop.run_in_executor(get_mlx_executor(), _load_sync)
+        except Exception as exc:
+            # #800: MLX-packaged repos (Qwen3-ASR-*-MLX-*, some mlx-community
+            # whisper variants) often omit preprocessor_config.json, which
+            # mlx-audio / HuggingFace AutoFeatureExtractor reports with an
+            # opaque OSError. Re-raise with an actionable message instead.
+            raise _wrap_stt_load_error(model_name, exc) from exc
+
+        # #800: Whisper models in mlx-audio load silently without a
+        # HuggingFace processor when preprocessor_config.json is missing
+        # (mlx-audio only emits a warning). Fail fast at start so callers
+        # see the real problem instead of a downstream "Processor not found"
+        # 500 during transcribe.
+        _validate_stt_processor(model_name, model)
+
+        self._model = model
         logger.info(f"STT engine started: {self._model_name}")
 
     async def stop(self) -> None:

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -692,8 +692,52 @@ async def get_engine(
                 detail=f"Model '{model_id}' is not a reranker model. "
                 f"Use a SequenceClassification model for reranking."
             )
+    elif engine_type == EngineType.LLM:
+        # #507: non-LLM engines (STT/TTS/STS/Embedding/Reranker) previously
+        # fell through and crashed on `engine.model_type` with an unhandled
+        # 500. Reject with a clear 400 pointing the caller at the right
+        # endpoint.
+        if not isinstance(engine, BaseEngine):
+            _endpoint_hint = _suggest_endpoint_for_engine(engine)
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Model '{model_id}' is not an LLM / chat model. "
+                    f"{_endpoint_hint}"
+                ),
+            )
 
     return engine
+
+
+def _suggest_endpoint_for_engine(engine: object) -> str:
+    """Return a one-line hint pointing at the correct endpoint for a non-LLM engine."""
+    # Import audio engine classes lazily so that oMLX without the [audio]
+    # extra still imports this module.
+    try:
+        from omlx.engine.stt import STTEngine
+    except Exception:  # pragma: no cover - defensive
+        STTEngine = None  # type: ignore[assignment]
+    try:
+        from omlx.engine.tts import TTSEngine
+    except Exception:  # pragma: no cover - defensive
+        TTSEngine = None  # type: ignore[assignment]
+    try:
+        from omlx.engine.sts import STSEngine
+    except Exception:  # pragma: no cover - defensive
+        STSEngine = None  # type: ignore[assignment]
+
+    if STTEngine is not None and isinstance(engine, STTEngine):
+        return "Use /v1/audio/transcriptions for speech-to-text models."
+    if TTSEngine is not None and isinstance(engine, TTSEngine):
+        return "Use /v1/audio/speech for text-to-speech models."
+    if STSEngine is not None and isinstance(engine, STSEngine):
+        return "Use /v1/audio/process for speech-to-speech / audio processing models."
+    if isinstance(engine, EmbeddingEngine):
+        return "Use /v1/embeddings for embedding models."
+    if isinstance(engine, RerankerEngine):
+        return "Use /v1/rerank for reranker models."
+    return "Use the model's dedicated endpoint (see /v1/models)."
 
 
 async def get_engine_for_model(model: str | None = None) -> BaseEngine:

--- a/tests/test_audio_stt.py
+++ b/tests/test_audio_stt.py
@@ -387,6 +387,165 @@ class TestSTTModelAliasResolution:
 
 
 # ---------------------------------------------------------------------------
+# TestSTTProcessorErrors — actionable errors for MLX STT models (#800)
+# ---------------------------------------------------------------------------
+
+
+class TestSTTProcessorErrors:
+    """Issue #800: STT with MLX-packaged whisper/Qwen3-ASR fails opaquely.
+
+    Root cause: the MLX-converted repos (``mlx-community/whisper-*``,
+    ``Qwen3-ASR-*-MLX-*``) usually omit the HuggingFace processor files
+    (``preprocessor_config.json``, ``tokenizer.json`` …) so:
+      * Whisper: model loads but ``_processor`` is ``None``; transcribe
+        later fails with ``ValueError: Processor not found``.
+      * Qwen3-ASR: ``load_model`` itself raises
+        ``OSError: Can't load feature extractor for '<path>' …
+        preprocessor_config.json``.
+
+    Both paths surface to users as a bare HTTP 500. The fix re-wraps these
+    into a clear ``RuntimeError`` pointing at the missing config so the
+    user knows which files to add / which variant to download.
+    """
+
+    def _stt_engine(self, model_name: str = "mlx-community/whisper-large-v3-turbo"):
+        from omlx.engine.stt import STTEngine
+
+        return STTEngine(model_name)
+
+    def test_qwen3_asr_missing_feature_extractor_raises_actionable_error(
+        self, monkeypatch
+    ):
+        """``load_model`` raising ``Can't load feature extractor`` becomes a
+        clear message pointing at ``preprocessor_config.json``."""
+        import asyncio
+
+        from omlx.engine import stt as stt_mod
+
+        def _failing_load(*args, **kwargs):
+            raise OSError(
+                "Can't load feature extractor for '/models/Qwen3-ASR-0.6B-MLX-4bit'. "
+                "If you were trying to load it from 'https://huggingface.co/models', "
+                "make sure you don't have a local directory with the same name. "
+                "Otherwise, make sure '/models/Qwen3-ASR-0.6B-MLX-4bit' is the "
+                "correct path to a directory containing a preprocessor_config.json file"
+            )
+
+        import sys
+        import types
+        fake_utils = types.ModuleType("mlx_audio.stt.utils")
+        fake_utils.load_model = _failing_load
+        fake_stt = sys.modules.setdefault("mlx_audio.stt", types.ModuleType("mlx_audio.stt"))
+        fake_audio = sys.modules.setdefault("mlx_audio", types.ModuleType("mlx_audio"))
+        monkeypatch.setitem(sys.modules, "mlx_audio", fake_audio)
+        monkeypatch.setitem(sys.modules, "mlx_audio.stt", fake_stt)
+        monkeypatch.setitem(sys.modules, "mlx_audio.stt.utils", fake_utils)
+
+        engine = self._stt_engine("Qwen3-ASR-0.6B-MLX-4bit")
+        with pytest.raises(RuntimeError) as exc_info:
+            asyncio.run(engine.start())
+
+        message = str(exc_info.value).lower()
+        assert "preprocessor_config.json" in message
+        assert "qwen3-asr-0.6b-mlx-4bit" in message
+
+    def test_whisper_without_processor_fails_start_with_actionable_error(
+        self, monkeypatch
+    ):
+        """Whisper models that load without a HuggingFace processor must
+        fail fast at ``start()`` with a clear message, not silently later."""
+        import asyncio
+        import sys
+        import types
+
+        # Build a fake whisper-like model that mimics mlx-audio's Whisper
+        # (missing _processor => None).
+        class FakeWhisperModel:
+            """Masquerade as mlx_audio.stt.models.whisper.whisper.Model."""
+            _processor = None
+
+            def generate(self, *args, **kwargs):  # pragma: no cover
+                raise AssertionError("transcribe should not run")
+
+        FakeWhisperModel.__module__ = "mlx_audio.stt.models.whisper.whisper"
+        FakeWhisperModel.__qualname__ = "Model"
+
+        def _load_returning_no_processor(*args, **kwargs):
+            return FakeWhisperModel()
+
+        fake_utils = types.ModuleType("mlx_audio.stt.utils")
+        fake_utils.load_model = _load_returning_no_processor
+        fake_stt = sys.modules.setdefault("mlx_audio.stt", types.ModuleType("mlx_audio.stt"))
+        fake_audio = sys.modules.setdefault("mlx_audio", types.ModuleType("mlx_audio"))
+        monkeypatch.setitem(sys.modules, "mlx_audio", fake_audio)
+        monkeypatch.setitem(sys.modules, "mlx_audio.stt", fake_stt)
+        monkeypatch.setitem(sys.modules, "mlx_audio.stt.utils", fake_utils)
+
+        engine = self._stt_engine("mlx-community/whisper-large-v3-turbo")
+        with pytest.raises(RuntimeError) as exc_info:
+            asyncio.run(engine.start())
+
+        message = str(exc_info.value).lower()
+        assert "processor" in message
+        assert "preprocessor_config.json" in message or "hugging" in message
+
+    def test_whisper_with_processor_starts_successfully(self, monkeypatch):
+        """A whisper-like model that *does* have a processor loads without error."""
+        import asyncio
+        import sys
+        import types
+
+        class FakeWhisperModel:
+            _processor = object()  # any non-None value
+
+            def generate(self, *args, **kwargs):  # pragma: no cover
+                raise AssertionError("transcribe should not run")
+
+        FakeWhisperModel.__module__ = "mlx_audio.stt.models.whisper.whisper"
+        FakeWhisperModel.__qualname__ = "Model"
+
+        fake_utils = types.ModuleType("mlx_audio.stt.utils")
+        fake_utils.load_model = lambda *a, **kw: FakeWhisperModel()
+        fake_stt = sys.modules.setdefault("mlx_audio.stt", types.ModuleType("mlx_audio.stt"))
+        fake_audio = sys.modules.setdefault("mlx_audio", types.ModuleType("mlx_audio"))
+        monkeypatch.setitem(sys.modules, "mlx_audio", fake_audio)
+        monkeypatch.setitem(sys.modules, "mlx_audio.stt", fake_stt)
+        monkeypatch.setitem(sys.modules, "mlx_audio.stt.utils", fake_utils)
+
+        engine = self._stt_engine("mlx-community/whisper-tiny")
+        # Should not raise.
+        asyncio.run(engine.start())
+        asyncio.run(engine.stop())
+
+    def test_non_whisper_model_without_processor_attribute_starts(self, monkeypatch):
+        """Models that legitimately don't use _processor (non-whisper families)
+        must not be incorrectly rejected."""
+        import asyncio
+        import sys
+        import types
+
+        class FakeParakeetModel:
+            # no _processor attribute at all
+            def generate(self, *args, **kwargs):  # pragma: no cover
+                raise AssertionError("transcribe should not run")
+
+        FakeParakeetModel.__module__ = "mlx_audio.stt.models.parakeet.parakeet"
+        FakeParakeetModel.__qualname__ = "Model"
+
+        fake_utils = types.ModuleType("mlx_audio.stt.utils")
+        fake_utils.load_model = lambda *a, **kw: FakeParakeetModel()
+        fake_stt = sys.modules.setdefault("mlx_audio.stt", types.ModuleType("mlx_audio.stt"))
+        fake_audio = sys.modules.setdefault("mlx_audio", types.ModuleType("mlx_audio"))
+        monkeypatch.setitem(sys.modules, "mlx_audio", fake_audio)
+        monkeypatch.setitem(sys.modules, "mlx_audio.stt", fake_stt)
+        monkeypatch.setitem(sys.modules, "mlx_audio.stt.utils", fake_utils)
+
+        engine = self._stt_engine("mlx-community/parakeet-tdt")
+        asyncio.run(engine.start())
+        asyncio.run(engine.stop())
+
+
+# ---------------------------------------------------------------------------
 # Integration test (slow, requires mlx-audio)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -322,3 +322,96 @@ class TestModelFallback:
         with pytest.raises(HTTPException) as exc_info:
             await get_engine("unknown-model", EngineType.EMBEDDING)
         assert exc_info.value.status_code == 404
+
+
+class TestGetEngineLLMTypeValidation:
+    """LLM endpoints must reject non-LLM engines with a clean 400 (#507).
+
+    Issue #507: POST /v1/chat/completions against an STT/TTS/STS/Embedding
+    model was producing an unhandled 500 with `'STTEngine' object has no
+    attribute 'model_type'` because `get_engine(..., EngineType.LLM)` never
+    validated that the resolved engine was actually an LLM. The fix adds an
+    isinstance check mirroring the one already in place for EMBEDDING and
+    RERANKER.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_server_state(self):
+        state = ServerState()
+        with patch("omlx.server._server_state", state):
+            self._state = state
+            yield
+
+    def _pool_returning(self, engine):
+        pool = MagicMock()
+        pool.resolve_model_id.side_effect = lambda mid, _sm: mid
+        pool.get_engine = AsyncMock(return_value=engine)
+        self._state.engine_pool = pool
+        return pool
+
+    @pytest.mark.asyncio
+    async def test_llm_rejects_stt_engine(self):
+        """Requesting an STT model on an LLM endpoint returns HTTP 400, not 500."""
+        from omlx.engine.stt import STTEngine
+        stt = MagicMock(spec=STTEngine)
+        self._pool_returning(stt)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_engine("whisper-large-v3-turbo", EngineType.LLM)
+        assert exc_info.value.status_code == 400
+        detail = str(exc_info.value.detail).lower()
+        assert "not an llm" in detail or "not a chat" in detail or "not a text" in detail
+
+    @pytest.mark.asyncio
+    async def test_llm_rejects_tts_engine(self):
+        """Requesting a TTS model on an LLM endpoint returns HTTP 400."""
+        from omlx.engine.tts import TTSEngine
+        tts = MagicMock(spec=TTSEngine)
+        self._pool_returning(tts)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_engine("qwen3-tts", EngineType.LLM)
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_llm_rejects_sts_engine(self):
+        """Requesting an STS model on an LLM endpoint returns HTTP 400."""
+        from omlx.engine.sts import STSEngine
+        sts = MagicMock(spec=STSEngine)
+        self._pool_returning(sts)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_engine("deepfilternet", EngineType.LLM)
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_llm_rejects_embedding_engine(self):
+        """Requesting an embedding model on an LLM endpoint returns HTTP 400."""
+        from omlx.engine.embedding import EmbeddingEngine
+        emb = MagicMock(spec=EmbeddingEngine)
+        self._pool_returning(emb)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_engine("bge-small", EngineType.LLM)
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_llm_rejects_reranker_engine(self):
+        """Requesting a reranker model on an LLM endpoint returns HTTP 400."""
+        from omlx.engine.reranker import RerankerEngine
+        rr = MagicMock(spec=RerankerEngine)
+        self._pool_returning(rr)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_engine("jina-reranker", EngineType.LLM)
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_llm_accepts_llm_engine(self):
+        """A genuine LLM engine passes validation and is returned as-is."""
+        from omlx.engine.base import BaseEngine
+        llm = MagicMock(spec=BaseEngine)
+        self._pool_returning(llm)
+
+        engine = await get_engine("llama-3", EngineType.LLM)
+        assert engine is llm


### PR DESCRIPTION
## Summary

Two related STT-path bugs that both surface as unhelpful HTTP 500s today.

Closes #507. Closes #800.

## #507 — `POST /v1/chat/completions` on a non-LLM model returns 500

**Repro:** OpenWebUI auto-picks the only loaded model. If that model is a transcription model, the request crashes with:

```
POST /v1/chat/completions → 500 (unhandled):
  'STTEngine' object has no attribute 'model_type'
```

**Root cause:** `omlx/server.py::get_engine(..., EngineType.LLM)` validated `EngineType.EMBEDDING` and `EngineType.RERANKER` but silently accepted *any* engine for the LLM path, then failed downstream on `engine.model_type`.

**Fix:** Add an `isinstance(engine, BaseEngine)` check for LLM requests and return HTTP 400 with a pointer to the right endpoint:

```
Model 'whisper-large-v3-turbo' is not an LLM / chat model.
Use /v1/audio/transcriptions for speech-to-text models.
```

The hint is produced by `_suggest_endpoint_for_engine()`, which covers STT/TTS/STS/Embedding/Reranker and falls back to a generic message for unknown families. Audio modules are imported lazily so the server still loads without the `[audio]` extra.

## #800 — STT fails opaquely with MLX-converted whisper / Qwen3-ASR repos

**Repro:** Download `mlx-community/whisper-large-v3-turbo` via the model downloader and POST to `/v1/audio/transcriptions`:

```
POST /v1/audio/transcriptions → 500:
  Processor not found. Make sure the model was loaded with a HuggingFace processor.
```

With `Qwen3-ASR-0.6B-MLX-4bit`:

```
POST /v1/audio/transcriptions → 500:
  Can't load feature extractor for '…/Qwen3-ASR-0.6B-MLX-4bit'.
  Make sure '…/Qwen3-ASR-0.6B-MLX-4bit' is the correct path to a
  directory containing a preprocessor_config.json file
```

**Root cause:** MLX-converted repositories frequently omit HuggingFace processor config files (`preprocessor_config.json`, `tokenizer.json`, `special_tokens_map.json`). mlx-audio's whisper loader swallows the failure into a warning and sets `_processor = None`; Qwen3-ASR's loader raises `OSError` outright.

**Fix:** `STTEngine.start()` now detects both flavours and re-raises as a `RuntimeError` that explains exactly what's missing and how to remediate:

```
STT model 'mlx-community/whisper-large-v3-turbo' is missing the
HuggingFace processor / feature-extractor configuration
(preprocessor_config.json and/or tokenizer files). MLX-converted
repositories sometimes omit these. Fix: either use an HF-compatible
variant of the model or copy preprocessor_config.json, tokenizer.json
and special_tokens_map.json from the upstream HuggingFace repo into
the local model directory.
```

Detection is narrow:
- **Load-time failures** → re-wrap only when the message mentions `preprocessor_config.json` / `feature extractor` (otherwise the original exception propagates).
- **Whisper silent processor-miss** → post-load check only for classes in `mlx_audio.stt.models.whisper.*` that expose a `_processor` attribute. Non-whisper families (Parakeet, Canary, Qwen3-ASR without the silent path, …) are unaffected.

## Files changed

| File | Change |
|---|---|
| `omlx/server.py` | `get_engine` LLM type validation + `_suggest_endpoint_for_engine` helper |
| `omlx/engine/stt.py` | Load-error wrapping + Whisper processor validation |
| `tests/test_server.py` | 6 new tests (`TestGetEngineLLMTypeValidation`) |
| `tests/test_audio_stt.py` | 4 new tests (`TestSTTProcessorErrors`) |

## Local verification against real models

Verified on a running oMLX server against the actual `~/.omlx/models/` layout (whisper-large-v3-turbo happens to ship *without* `preprocessor_config.json`, so it reproduces #800 directly).

### #800 — whisper-large-v3-turbo (missing `preprocessor_config.json`)

```text
$ curl -F model=whisper-large-v3-turbo -F file=@silence.wav /v1/audio/transcriptions
{"error":{"message":"STT model '/Users/coder/.omlx/models/whisper-large-v3-turbo'
  is missing the HuggingFace processor / feature-extractor configuration
  (preprocessor_config.json and/or tokenizer files). MLX-converted repositories
  sometimes omit these. Fix: either use an HF-compatible variant of the model
  or copy preprocessor_config.json, tokenizer.json and special_tokens_map.json
  from the upstream HuggingFace repo into the local model directory.",
  "type":"server_error",…}}
HTTP=500
```

(Still a 500 because STT load failure is a server-side problem, but the body now names the exact missing file instead of the generic "Processor not found".)

### #507 — chat completions against STT / TTS / LLM

```text
$ curl … /v1/chat/completions  -d '{"model":"Qwen3-ASR-0.6B-bf16", "messages":[…]}'
{"error":{"message":"Model 'Qwen3-ASR-0.6B-bf16' is not an LLM / chat model.
  Use /v1/audio/transcriptions for speech-to-text models.",
  "type":"invalid_request_error",…}}
HTTP=400

$ curl … /v1/chat/completions  -d '{"model":"Qwen3-TTS-12Hz-0.6B-Base-bf16", "messages":[…]}'
{"error":{"message":"Model 'Qwen3-TTS-12Hz-0.6B-Base-bf16' is not an LLM / chat model.
  Use /v1/audio/speech for text-to-speech models.",
  "type":"invalid_request_error",…}}
HTTP=400

# Regression check: a real LLM still works end-to-end
$ curl … /v1/chat/completions  -d '{"model":"Qwen3-4B-Instruct-2507-MLX-6bit", "messages":[…]}'
{"id":"chatcmpl-…","choices":[{"index":0,"message":{"role":"assistant","content":"OK."…}
HTTP=200
```

### Regression — STT still works for a model with complete HF config

`Qwen3-ASR-0.6B-bf16` ships with `preprocessor_config.json` and is unaffected:

```text
$ curl -F model=Qwen3-ASR-0.6B-bf16 -F file=@silence.wav /v1/audio/transcriptions
{"text":"","language":null,"duration":0.74,"segments":[{"text":"","language":"None","start":0.0,"end":1.0}]}
HTTP=200
```

## Test plan

- [x] `pytest tests/test_server.py::TestGetEngineLLMTypeValidation` — 6 passed
- [x] `pytest tests/test_audio_stt.py::TestSTTProcessorErrors` — 4 passed
- [x] `pytest tests/test_server.py tests/test_audio_*.py` — no regressions introduced by this PR (pre-existing failures in `test_audio_discovery.py::TestDetectAudioModelType` verified to also fail on `upstream/main` unmodified)
- [x] Live server: `/v1/audio/transcriptions` against `whisper-large-v3-turbo` (genuine missing-processor case) returns a 5xx whose body names `preprocessor_config.json`
- [x] Live server: `/v1/chat/completions` against an STT model returns 400 + `/v1/audio/transcriptions` hint; same with a TTS model + `/v1/audio/speech` hint; a real LLM still returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)