### PR TITLE
fix(server): Anthropic stream emission corner cases around tool_use

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3051,17 +3051,33 @@ async def stream_anthropic_messages(
                     if tool_filter:
                         content_delta = tool_filter.feed(content_delta)
                     if content_delta:
-                        # Close thinking block if transitioning to text
-                        if thinking_block_started and not text_block_started:
-                            yield create_content_block_stop_event(index=block_index)
-                            block_index += 1
-                            thinking_block_started = False
-                        if not text_block_started:
-                            yield create_content_block_start_event(
-                                index=block_index, block_type="text"
-                            )
-                            text_block_started = True
-                        yield create_text_delta_event(index=block_index, text=content_delta)
+                        # When tools are requested AND we haven't yet opened
+                        # a text block, drop pure-whitespace deltas. Models
+                        # often emit a leading newline around <tool_call>
+                        # envelopes that tool_filter passes through
+                        # (whitespace isn't part of the envelope markers).
+                        # Without this guard, the `\n` opens a text block
+                        # that then holds only whitespace — surfacing as
+                        # a phantom empty-ish text block before the
+                        # tool_use blocks.
+                        if (
+                            not text_block_started
+                            and kwargs.get("tools")
+                            and not content_delta.strip()
+                        ):
+                            pass  # drop leading whitespace adjacent to tool envelopes
+                        else:
+                            # Close thinking block if transitioning to text
+                            if thinking_block_started and not text_block_started:
+                                yield create_content_block_stop_event(index=block_index)
+                                block_index += 1
+                                thinking_block_started = False
+                            if not text_block_started:
+                                yield create_content_block_start_event(
+                                    index=block_index, block_type="text"
+                                )
+                                text_block_started = True
+                            yield create_text_delta_event(index=block_index, text=content_delta)
 
             if output.finished:
                 break
@@ -3132,19 +3148,8 @@ async def stream_anthropic_messages(
                 text_block_started = True
             yield create_text_delta_event(index=block_index, text=remaining)
 
-    # 4. Close open blocks
-    if thinking_block_started and not text_block_started:
-        # Only thinking was emitted, close it
-        yield create_content_block_stop_event(index=block_index)
-        block_index += 1
-    if text_block_started:
-        yield create_content_block_stop_event(index=block_index)
-    elif not thinking_block_started:
-        # No content at all - create empty text block
-        yield create_content_block_start_event(index=block_index, block_type="text")
-        yield create_content_block_stop_event(index=block_index)
-
-    # 5. Handle tool calls
+    # 5. Handle tool calls (moved before block-closing so empty-text-block
+    # emission can skip when tool_use blocks will follow).
     # For Harmony models, use tool_calls from output (parsed by HarmonyStreamingParser)
     # For other models, parse from accumulated text
     tool_calls = None
@@ -3175,6 +3180,22 @@ async def stream_anthropic_messages(
         cleaned_text = extraction.cleaned_text
         tool_calls = extraction.tool_calls
 
+    # 4. Close open blocks
+    if thinking_block_started and not text_block_started:
+        # Only thinking was emitted, close it
+        yield create_content_block_stop_event(index=block_index)
+        block_index += 1
+    if text_block_started:
+        yield create_content_block_stop_event(index=block_index)
+    elif not thinking_block_started and not tool_calls:
+        # No content AND no tool_calls — emit an empty text block so the
+        # message is well-formed. When tool_calls will follow, skip this —
+        # the tool_use blocks carry the semantic content, and an empty
+        # preceding text block confuses SDK clients that treat content[0]
+        # as authoritative.
+        yield create_content_block_start_event(index=block_index, block_type="text")
+        yield create_content_block_stop_event(index=block_index)
+
     # Reverse Gemma 4 parameter renaming
     if tool_calls and "gemma" in (resolved_model or request.model or "").lower():
         for tc in tool_calls:
@@ -3187,7 +3208,14 @@ async def stream_anthropic_messages(
                     pass
 
     # Emit tool_use blocks if present
-    tool_block_start = block_index + 1
+    # When neither text nor thinking was streamed AND the empty-text-block
+    # emission was skipped (because tool_calls are about to follow), the
+    # tool_use block takes index 0. Otherwise it follows the last emitted
+    # text/thinking block at block_index+1.
+    if not text_block_started and not thinking_block_started:
+        tool_block_start = 0
+    else:
+        tool_block_start = block_index + 1
     if tool_calls:
         for i, tc in enumerate(tool_calls, start=tool_block_start):
             # Start tool_use block
@@ -3509,7 +3537,10 @@ async def create_anthropic_message(
                         pass
 
         response = convert_internal_to_anthropic_response(
-            text=cleaned_text.strip() if cleaned_text else "",
+            # Bug fix: `if cleaned_text` treats empty-string (fully-consumed tool
+            # markup) as falsy and leaks the uncleaned `regular_content`. Use
+            # `is not None` so a deliberate empty cleanup stays empty.
+            text=cleaned_text.strip() if cleaned_text is not None else regular_content,
             model=request.model,
             prompt_tokens=scale_anthropic_tokens(output.prompt_tokens, request.model),
             completion_tokens=scale_anthropic_tokens(output.completion_tokens, request.model),

--- a/tests/integration/test_e2e_streaming.py
+++ b/tests/integration/test_e2e_streaming.py
@@ -944,6 +944,83 @@ class TestStreamingHelperFunctions:
         assert "tool_use" in stop_reasons
 
     @pytest.mark.asyncio
+    async def test_anthropic_tool_only_stream_starts_with_tool_use_block(self):
+        """A tool-only response should not emit an empty text block before tool_use."""
+        from omlx.server import stream_anthropic_messages
+        from omlx.api.anthropic_models import MessagesRequest
+
+        engine = MockBaseEngine()
+        engine.set_stream_outputs([
+            MockGenerationOutput(
+                text="",
+                new_text="",
+                completion_tokens=1,
+                finished=True,
+                finish_reason="tool_calls",
+                tool_calls=[{
+                    "name": "get_weather",
+                    "arguments": "{\"city\":\"SF\"}",
+                }],
+            ),
+        ])
+
+        anthropic_tools = [{
+            "name": "get_weather",
+            "description": "Get weather",
+            "input_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }]
+        internal_tools = [{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": anthropic_tools[0]["input_schema"],
+            },
+        }]
+        request = MessagesRequest(
+            model="test-model",
+            max_tokens=256,
+            messages=[{"role": "user", "content": "Hi"}],
+            stream=True,
+            tools=anthropic_tools,
+        )
+
+        events = []
+        async for event in stream_anthropic_messages(
+            engine,
+            [{"role": "user", "content": "Hi"}],
+            request,
+            max_tokens=256,
+            temperature=0.7,
+            top_p=0.9,
+            top_k=40,
+            tools=internal_tools,
+        ):
+            events.append(event)
+
+        parsed_events = []
+        for event in events:
+            for line in event.split("\n"):
+                if line.startswith("data: "):
+                    parsed_events.append(json.loads(line[6:]))
+
+        block_starts = [
+            event
+            for event in parsed_events
+            if event.get("type") == "content_block_start"
+        ]
+        assert block_starts[0]["index"] == 0
+        assert block_starts[0]["content_block"]["type"] == "tool_use"
+        assert all(
+            event["content_block"]["type"] != "text"
+            for event in block_starts
+        )
+
+    @pytest.mark.asyncio
     async def test_stream_chat_completion_with_tools_and_tool_calls_keeps_prior_content(self):
         """A tool_call finish should end the turn, not suppress already-generated text."""
         from omlx.server import stream_chat_completion


### PR DESCRIPTION
## Summary

Fix Anthropic `/v1/messages` streaming when a response is mostly or only `tool_use` content.

## Changes

- Drop leading whitespace deltas around tool envelopes before any text block starts.
- Parse tool calls before deciding whether to emit an empty text block.
- Start tool-only streams at content block index `0` instead of emitting an empty text block first.
- Preserve cleaned empty text in non-streaming Anthropic responses.
- Add regression coverage for tool-only Anthropic streams.

## Local validation

Built and installed from this branch into `/Applications/oMLX.app` (`0.3.8.dev2`), with port `8801` owned by the visible app process.

- Focused tests: `201 passed, 12 deselected` for `tests/test_tool_calling.py`, `tests/integration/test_e2e_streaming.py`, and `tests/test_admin_profiles_api.py`.
- Live Anthropic proxy path: `claude-sonnet-4-6` forced `get_weather`; streaming emitted first content block as `tool_use` at index `0`, no leading empty text block, `stop_reason=tool_use`.
- Direct OpenAI control: `Ternary-Bonsai-8B-mlx-2bit` returned `ready`; benchmark tool `OK` in `0.6s`.
- Related Qwen tool path: `Qwen3-Coder-30B-A3B-Instruct-4bit` forced `read_file`; structured `tool_calls`, benchmark tool `OK` in `2.3s`.

Note: benchmark host was not clean; preflight saw active desktop/client load, so throughput is smoke data only.

## Test Plan

- `uv run pytest tests/integration/test_e2e_streaming.py -q`
- `python3 -m py_compile omlx/server.py tests/integration/test_e2e_streaming.py`