### PR TITLE
fix(discovery): fall back to directory name for audio model type detection

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -490,6 +490,20 @@ def detect_model_type(model_path: Path) -> ModelType:
     if normalized_type.startswith("lfm") and normalized_type not in EMBEDDING_MODEL_TYPES:
         return "audio_sts"
 
+    # Directory-name fallback for audio models whose config.json omits model_type.
+    # Some model families (e.g. NeMo-format parakeet) do not include a top-level
+    # model_type field, so the checks above find nothing.  As a last resort, match
+    # the first hyphen-separated segment of the model directory name against the
+    # same mlx-audio model-type sets used above.
+    dir_stem = model_path.name.lower().split("-")[0]
+    if dir_stem and dir_stem not in _LLM_TYPE_COLLISIONS:
+        if dir_stem in AUDIO_TTS_MODEL_TYPES:
+            return "audio_tts"
+        if dir_stem in AUDIO_STT_MODEL_TYPES:
+            return "audio_stt"
+        if dir_stem in AUDIO_STS_MODEL_TYPES:
+            return "audio_sts"
+
     return "llm"
 
 


### PR DESCRIPTION
## Summary

Models whose `config.json` omits a top-level `model_type` field were being classified as `llm` by `detect_model_type()`, causing a `KeyError('model_type')` crash at inference time.

## Root Cause

`detect_model_type()` in `model_discovery.py` identifies audio models exclusively by matching `config["model_type"]` and `config["architectures"]` against the mlx-audio model-type sets. Models using NeMo-format config files — notably **`parakeet-tdt`** models — do not include a top-level `model_type` field. This causes:

1. `detect_model_type()` falls through all audio checks and returns `"llm"`
2. A `BatchedEngine` (LLM engine) is loaded for the model
3. The LLM loading path calls `config["model_type"]` without a `.get()` fallback
4. `KeyError: 'model_type'` is raised — reported to the client as HTTP 500

```
POST /v1/audio/transcriptions → 500: 'model_type'
```

The model itself works fine when loaded directly via `mlx_audio.stt.utils.load_model`, which already has its own directory-name fallback in `base_load_model`.

## Fix

After all config-based checks, extract the first hyphen-separated segment of the model directory name and match it against `AUDIO_STT/TTS/STS_MODEL_TYPES` — the same sets already used for config-based detection. The segment is guarded against `_LLM_TYPE_COLLISIONS` to prevent false positives on directories named `llama-...`, `qwen3-...`, etc.

```python
# e.g. "parakeet-tdt-0.6b-v2" → stem = "parakeet" → matches AUDIO_STT_MODEL_TYPES → "audio_stt"
dir_stem = model_path.name.lower().split("-")[0]
if dir_stem and dir_stem not in _LLM_TYPE_COLLISIONS:
    if dir_stem in AUDIO_STT_MODEL_TYPES:
        return "audio_stt"
    ...
```

This mirrors the existing logic in `mlx_audio.utils.base_load_model`, which already resolves model type from the directory name when `config.json` is missing the field.

## Affected Models

Any audio model with a NeMo-format config, including:
- `parakeet-tdt-0.6b-v2` (confirmed: was returning HTTP 500 before fix, now correctly detected as `audio_stt`)
- Any future parakeet or NeMo-converted model added to `~/.omlx/models/`

## Note

A companion PR to [Blaizzy/mlx-audio#657](https://github.com/Blaizzy/mlx-audio/pull/657) adds `model_type: "parakeet"` injection in `ModelConfig.from_dict()`, which addresses the root cause at the mlx-audio level. This omlx fix provides defense-in-depth for any other audio models that may have the same omission.