### PR TITLE
fix(server): gate preserve_thinking auto-set on template detection

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2058,11 +2058,16 @@ async def create_chat_completion(
     if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
         merged_ct_kwargs["enable_thinking"] = True
 
-    # Auto-set preserve_thinking when thinking is active.  Qwen 3.6+
-    # templates strip <think> blocks from historical turns by default,
-    # which breaks KV prefix cache reuse.  Always preserve unless the
-    # user explicitly opted out.
-    if merged_ct_kwargs.get("enable_thinking") is not False and "preserve_thinking" not in merged_ct_kwargs:
+    # Auto-set preserve_thinking only when the template advertises support
+    # for it (Qwen 3.6+). Other templates silently ignore unknown kwargs
+    # today but strict templates could raise, so gate on the detected flag.
+    _entry = get_engine_pool().get_entry(resolved_model)
+    if (
+        _entry is not None
+        and _entry.preserve_thinking_default is True
+        and merged_ct_kwargs.get("enable_thinking") is not False
+        and "preserve_thinking" not in merged_ct_kwargs
+    ):
         merged_ct_kwargs["preserve_thinking"] = True
 
     # Add compiled grammar for logit-level structured output.
@@ -3264,8 +3269,16 @@ async def create_anthropic_message(
     if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
         merged_ct_kwargs["enable_thinking"] = True
 
-    # Auto-set preserve_thinking when thinking is active (Qwen 3.6+).
-    if merged_ct_kwargs.get("enable_thinking") is not False and "preserve_thinking" not in merged_ct_kwargs:
+    # Auto-set preserve_thinking only when the template advertises support
+    # for it (Qwen 3.6+). Gated on detection so other templates don't
+    # receive an unknown kwarg.
+    _entry = get_engine_pool().get_entry(resolved_model)
+    if (
+        _entry is not None
+        and _entry.preserve_thinking_default is True
+        and merged_ct_kwargs.get("enable_thinking") is not False
+        and "preserve_thinking" not in merged_ct_kwargs
+    ):
         merged_ct_kwargs["preserve_thinking"] = True
 
     # Merge MCP tools with user-provided Anthropic tools
@@ -3687,8 +3700,16 @@ async def create_response(
     if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
         merged_ct_kwargs["enable_thinking"] = True
 
-    # Auto-set preserve_thinking when thinking is active (Qwen 3.6+).
-    if merged_ct_kwargs.get("enable_thinking") is not False and "preserve_thinking" not in merged_ct_kwargs:
+    # Auto-set preserve_thinking only when the template advertises support
+    # for it (Qwen 3.6+). Gated on detection so other templates don't
+    # receive an unknown kwarg.
+    _entry = get_engine_pool().get_entry(resolved_model)
+    if (
+        _entry is not None
+        and _entry.preserve_thinking_default is True
+        and merged_ct_kwargs.get("enable_thinking") is not False
+        and "preserve_thinking" not in merged_ct_kwargs
+    ):
         merged_ct_kwargs["preserve_thinking"] = True
 
     # Add compiled grammar for logit-level structured output.

--- a/tests/test_thinking_toggle.py
+++ b/tests/test_thinking_toggle.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from omlx.model_discovery import detect_thinking_default
+from omlx.model_discovery import detect_preserve_thinking, detect_thinking_default
 from omlx.model_settings import ModelSettings
 
 
@@ -104,3 +104,80 @@ class TestModelSettingsEnableThinking:
     def test_set_to_false(self):
         ms = ModelSettings(enable_thinking=False)
         assert ms.enable_thinking is False
+
+
+# ---------------------------------------------------------------------------
+# detect_preserve_thinking
+# ---------------------------------------------------------------------------
+
+
+class TestDetectPreserveThinking:
+    """Test chat template heuristic for preserve_thinking support detection."""
+
+    def test_qwen36_pattern_returns_true(self, tmp_path):
+        """Qwen 3.6+ pattern: template references preserve_thinking kwarg."""
+        template = (
+            "{%- if (preserve_thinking is defined and preserve_thinking is true) "
+            "or (loop.index0 > ns.last_query_index) -%}\n"
+            "  <think>{{ reasoning_content }}</think>\n"
+            "{%- endif -%}"
+        )
+        (tmp_path / "chat_template.jinja").write_text(template)
+        assert detect_preserve_thinking(tmp_path) is True
+
+    def test_no_preserve_thinking_returns_none(self, tmp_path):
+        """Template without preserve_thinking reference returns None."""
+        template = "{%- if enable_thinking is false -%}suppress{%- endif -%}"
+        (tmp_path / "chat_template.jinja").write_text(template)
+        assert detect_preserve_thinking(tmp_path) is None
+
+    def test_no_template_files_returns_none(self, tmp_path):
+        """Directory without any template file returns None."""
+        assert detect_preserve_thinking(tmp_path) is None
+
+    def test_jinja_file_takes_priority_over_tokenizer_config(self, tmp_path):
+        """chat_template.jinja is preferred over tokenizer_config.json."""
+        (tmp_path / "chat_template.jinja").write_text(
+            "{%- if preserve_thinking -%}keep{%- endif -%}"
+        )
+        tc = {"chat_template": "{{ messages[0].content }}"}
+        (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
+
+        assert detect_preserve_thinking(tmp_path) is True
+
+    def test_falls_back_to_tokenizer_config(self, tmp_path):
+        """When no jinja file exists, reads from tokenizer_config.json."""
+        tc = {"chat_template": "{%- if preserve_thinking -%}keep{%- endif -%}"}
+        (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
+        assert detect_preserve_thinking(tmp_path) is True
+
+    def test_tokenizer_config_without_chat_template_key(self, tmp_path):
+        """tokenizer_config.json without chat_template key returns None."""
+        (tmp_path / "tokenizer_config.json").write_text(json.dumps({"model_type": "llama"}))
+        assert detect_preserve_thinking(tmp_path) is None
+
+    def test_malformed_tokenizer_config_returns_none(self, tmp_path):
+        """Malformed JSON in tokenizer_config.json returns None gracefully."""
+        (tmp_path / "tokenizer_config.json").write_text("not valid json{{{")
+        assert detect_preserve_thinking(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# ModelSettings.preserve_thinking field
+# ---------------------------------------------------------------------------
+
+
+class TestModelSettingsPreserveThinking:
+    """Test preserve_thinking field on ModelSettings dataclass."""
+
+    def test_default_is_none(self):
+        ms = ModelSettings()
+        assert ms.preserve_thinking is None
+
+    def test_set_to_true(self):
+        ms = ModelSettings(preserve_thinking=True)
+        assert ms.preserve_thinking is True
+
+    def test_set_to_false(self):
+        ms = ModelSettings(preserve_thinking=False)
+        assert ms.preserve_thinking is False


### PR DESCRIPTION
## Summary

Follow-up to #814. The auto-set of `preserve_thinking=True` was unconditional for any thinking-enabled model. Jinja silently ignores unknown kwargs so it worked in practice, but the `preserve_thinking_default` detection flag that was already plumbed through `DiscoveredModel → EngineEntry → admin routes` was not actually used at the gating point.

This PR closes the loop: only templates that advertise `preserve_thinking` support (Qwen 3.6+) receive the kwarg. Other models get nothing, which prevents strict templates from ever raising on it.

Applied identically to all three endpoints:
- `/v1/chat/completions`
- `/v1/messages`
- `/v1/responses`

Also backfills `detect_preserve_thinking` unit tests that were missing from #814.

## Test plan

- [x] `pytest tests/test_thinking_toggle.py -v` → 23 passed
- [ ] Smoke test with Qwen3.6-35B-A3B (kwarg still propagates to the template)
- [ ] Smoke test with a non-Qwen 3.6 thinking model (kwarg no longer propagates)