### PR TITLE
perf(api): pass reasoning_content as message field for native templates

### DIFF
--- a/omlx/api/anthropic_utils.py
+++ b/omlx/api/anthropic_utils.py
@@ -126,6 +126,7 @@ def convert_anthropic_to_internal(
     max_tool_result_tokens: int | None = None,
     tokenizer: Any | None = None,
     preserve_images: bool = False,
+    native_reasoning_content: bool = False,
 ) -> list[dict[str, Any]]:
     """
     Convert Anthropic Messages API format to internal format.
@@ -142,6 +143,10 @@ def convert_anthropic_to_internal(
         tokenizer: Tokenizer instance for token counting and truncation.
         preserve_images: If True, preserve image blocks as OpenAI image_url
             format for VLM processing.
+        native_reasoning_content: If True, attach Anthropic ``thinking`` blocks
+            as a ``reasoning_content`` field on assistant messages (Qwen 3.6+
+            templates).  If False, inline each block as ``<think>...</think>``
+            in the message content as a fallback.
 
     Returns:
         List of {"role": str, "content": str or list}
@@ -169,6 +174,7 @@ def convert_anthropic_to_internal(
                     text_parts: list[str] = []
                     image_parts: list[dict] = []
                     tool_calls: list[dict] = []
+                    thinking_parts: list[str] = []
                     for block in content:
                         block_dict = _content_block_to_dict(block)
                         if block_dict is None:
@@ -193,19 +199,24 @@ def convert_anthropic_to_internal(
                                 },
                             })
                         elif block_type == "thinking":
-                            # Reconstruct <think> block so preserve_thinking can keep it.
-                            # Append in source order; Anthropic places thinking before
-                            # text/tool_use blocks, so natural ordering already puts
-                            # <think> first in the reassembled message.
+                            # Native mode: collect for reasoning_content field.
+                            # Fallback: inline as <think>...</think> in source
+                            # order (Anthropic emits thinking first, so appending
+                            # preserves the natural ordering).
                             thinking_text = block_dict.get("thinking", "")
                             if thinking_text:
-                                text_parts.append(f"<think>\n{thinking_text}\n</think>")
+                                if native_reasoning_content:
+                                    thinking_parts.append(thinking_text)
+                                else:
+                                    text_parts.append(f"<think>\n{thinking_text}\n</think>")
                         elif block_type == "document":
                             text_parts.append(_decode_document_block(block_dict))
                     msg_dict = _build_message_from_parts(role, text_parts, image_parts) or {
                         "role": role,
                         "content": "",
                     }
+                    if thinking_parts:
+                        msg_dict["reasoning_content"] = "\n".join(thinking_parts)
                     if tool_calls:
                         msg_dict["tool_calls"] = tool_calls
                         msg_dict[_PRESERVE_ROLE_BOUNDARY] = True
@@ -246,12 +257,12 @@ def convert_anthropic_to_internal(
                                     block_dict.get("content", ""), image_parts
                                 )
                         elif block_type == "thinking":
-                            # Reconstruct <think> block so preserve_thinking can keep it.
-                            # Append in source order — Anthropic emits thinking blocks
-                            # before the text blocks they precede, so appending keeps
-                            # the natural ordering intact across multiple blocks.
+                            # User messages don't carry reasoning_content in the
+                            # Qwen 3.6 template, so native mode simply drops these
+                            # blocks.  Fallback keeps the legacy <think> inline
+                            # behaviour in source order.
                             thinking_text = block_dict.get("thinking", "")
-                            if thinking_text:
+                            if thinking_text and not native_reasoning_content:
                                 text_parts.append(f"<think>\n{thinking_text}\n</think>")
                         elif block_type == "document":
                             text_parts.append(_decode_document_block(block_dict))
@@ -265,6 +276,7 @@ def convert_anthropic_to_internal(
             # Content blocks list
             text_parts: list[str] = []
             image_parts: list[dict] = []
+            thinking_parts: list[str] = []
             saw_tool_markup = False
             for block in content:
                 block_dict = _content_block_to_dict(block)
@@ -306,13 +318,14 @@ def convert_anthropic_to_internal(
                         )
 
                 elif block_type == "thinking":
-                    # Reconstruct <think> block so preserve_thinking can keep it.
-                    # Append in source order — Anthropic emits thinking blocks
-                    # before the text blocks they precede, so appending keeps
-                    # the natural ordering intact across multiple blocks.
+                    # Native mode: collect for reasoning_content (assistant only).
+                    # Fallback: inline as <think>...</think> in source order.
                     thinking_text = block_dict.get("thinking", "")
                     if thinking_text:
-                        text_parts.append(f"<think>\n{thinking_text}\n</think>")
+                        if native_reasoning_content and role == "assistant":
+                            thinking_parts.append(thinking_text)
+                        elif not native_reasoning_content:
+                            text_parts.append(f"<think>\n{thinking_text}\n</think>")
 
                 elif block_type == "document":
                     text_parts.append(_decode_document_block(block_dict))
@@ -321,6 +334,8 @@ def convert_anthropic_to_internal(
                 "role": role,
                 "content": "",
             }
+            if thinking_parts:
+                msg_dict["reasoning_content"] = "\n".join(thinking_parts)
             if saw_tool_markup:
                 msg_dict[_PRESERVE_ROLE_BOUNDARY] = True
             processed_messages.append(msg_dict)

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -193,8 +193,9 @@ def _drop_void_assistant_messages(messages: list[dict]) -> list[dict]:
     carry no information and can appear when a client echoes back a response
     that had only tool calls which were not preserved in its history.
 
-    Messages with ``tool_responses`` (Gemma 4 format) are never dropped even
-    when content is empty — they carry tool result data.
+    Messages with ``tool_responses`` (Gemma 4 format) or ``reasoning_content``
+    (Qwen 3.6+ native reasoning field) are never dropped even when content is
+    empty — they carry their own payload the template renders.
     """
     return [
         msg
@@ -204,6 +205,7 @@ def _drop_void_assistant_messages(messages: list[dict]) -> list[dict]:
             and not msg.get("content")
             and not msg.get("tool_calls")
             and not msg.get("tool_responses")
+            and not msg.get("reasoning_content")
         )
     ]
 
@@ -285,10 +287,42 @@ def _merge_consecutive_roles(messages: list[dict]) -> list[dict]:
     return merged
 
 
+def _apply_reasoning_reconstruction(
+    role: str,
+    content: Any,
+    reasoning: str | None,
+    native: bool,
+) -> tuple[Any, str | None]:
+    """Reconstruct reasoning on a historical assistant message.
+
+    External clients echo reasoning back via the OpenAI ``reasoning_content``
+    field (or Anthropic ``thinking`` blocks).  Chat templates fall into two
+    camps:
+
+    * ``native=True`` — template understands ``message.reasoning_content``
+      as a top-level field (Qwen 3.6+).  Content stays clean and reasoning
+      travels separately.
+    * ``native=False`` — template only parses ``<think>...</think>`` embedded
+      in content.  Reasoning is inlined into content as a fallback.
+
+    Returns ``(new_content, reasoning_out)`` where ``reasoning_out`` is the
+    string to attach as a ``reasoning_content`` field, or ``None`` to skip.
+    """
+    if role != "assistant" or not reasoning:
+        return content, None
+    text = content if isinstance(content, str) else ""
+    if isinstance(content, list):
+        text = _extract_text_from_content_list(content)
+    if native:
+        return text, reasoning
+    return f"<think>\n{reasoning}\n</think>\n\n{text}", None
+
+
 def extract_text_content(
     messages: List[Message],
     max_tool_result_tokens: int | None = None,
     tokenizer: Any | None = None,
+    native_reasoning_content: bool = False,
 ) -> List[dict]:
     """
     Extract text content from OpenAI-format messages.
@@ -303,6 +337,9 @@ def extract_text_content(
         messages: List of Message objects
         max_tool_result_tokens: Maximum token count for tool results.
         tokenizer: Tokenizer instance for token counting and truncation.
+        native_reasoning_content: If True, pass ``reasoning_content`` through
+            as a message-level field (Qwen 3.6+ templates).  If False, inline
+            ``<think>...</think>`` into content as a fallback.
 
     Returns:
         List of {"role": str, "content": str}
@@ -313,18 +350,13 @@ def extract_text_content(
         role = msg.role
         content = msg.content
 
-        # Reconstruct <think> blocks from reasoning_content for historical
-        # assistant messages.  External clients (e.g. Pi) receive thinking in
-        # the reasoning_content field but only send content back on subsequent
-        # turns.  When the client echoes reasoning_content alongside content we
-        # merge them so that preserve_thinking=True in the chat template has
-        # actual thinking to preserve.
+        # Reconstruct reasoning for historical assistant messages.  Native
+        # mode passes reasoning as a separate field; fallback inlines it as
+        # <think>...</think> in content.
         reasoning = getattr(msg, "reasoning_content", None)
-        if role == "assistant" and reasoning:
-            text = content if isinstance(content, str) else ""
-            if isinstance(content, list):
-                text = _extract_text_from_content_list(content)
-            content = f"<think>\n{reasoning}\n</think>\n\n{text}"
+        content, reasoning_out = _apply_reasoning_reconstruction(
+            role, content, reasoning, native_reasoning_content
+        )
 
         # Normalize "developer" role to "system" (OpenAI API compatibility)
         if role == "developer":
@@ -370,6 +402,8 @@ def extract_text_content(
             if isinstance(content, list):
                 content = _extract_text_from_content_list(content)
             msg_dict = {"role": role, "content": content if content else ""}
+            if reasoning_out is not None:
+                msg_dict["reasoning_content"] = reasoning_out
             if getattr(msg, "name", None):
                 msg_dict["name"] = msg.name
 
@@ -437,6 +471,8 @@ def extract_text_content(
             _extra["name"] = msg.name
         if getattr(msg, "partial", False):
             _extra["partial"] = True
+        if reasoning_out is not None:
+            _extra["reasoning_content"] = reasoning_out
 
         # Handle None content
         if content is None:
@@ -465,6 +501,7 @@ def extract_multimodal_content(
     messages: List[Message],
     max_tool_result_tokens: int | None = None,
     tokenizer: Any | None = None,
+    native_reasoning_content: bool = False,
 ) -> List[dict]:
     """
     Extract content from messages, preserving image_url parts for VLM.
@@ -476,6 +513,8 @@ def extract_multimodal_content(
         messages: List of Message objects
         max_tool_result_tokens: Maximum token count for tool results.
         tokenizer: Tokenizer instance for token counting and truncation.
+        native_reasoning_content: If True, pass ``reasoning_content`` through
+            as a message-level field.  See ``extract_text_content``.
 
     Returns:
         List of message dicts. Messages with images have content as list.
@@ -486,13 +525,11 @@ def extract_multimodal_content(
         role = msg.role
         content = msg.content
 
-        # Reconstruct <think> blocks from reasoning_content (see extract_text_content)
+        # Reconstruct reasoning (see extract_text_content).
         reasoning = getattr(msg, "reasoning_content", None)
-        if role == "assistant" and reasoning:
-            text = content if isinstance(content, str) else ""
-            if isinstance(content, list):
-                text = _extract_text_from_content_list(content)
-            content = f"<think>\n{reasoning}\n</think>\n\n{text}"
+        content, reasoning_out = _apply_reasoning_reconstruction(
+            role, content, reasoning, native_reasoning_content
+        )
 
         if role == "developer":
             role = "system"
@@ -534,6 +571,8 @@ def extract_multimodal_content(
             if isinstance(content, list):
                 content = _extract_text_from_content_list(content)
             msg_dict = {"role": role, "content": content if content else ""}
+            if reasoning_out is not None:
+                msg_dict["reasoning_content"] = reasoning_out
             if getattr(msg, "name", None):
                 msg_dict["name"] = msg.name
 
@@ -596,6 +635,8 @@ def extract_multimodal_content(
             _extra["name"] = msg.name
         if getattr(msg, "partial", False):
             _extra["partial"] = True
+        if reasoning_out is not None:
+            _extra["reasoning_content"] = reasoning_out
 
         if content is None:
             processed_messages.append({"role": role, "content": "", **_extra})

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1953,7 +1953,12 @@ async def create_chat_completion(
             if k not in forced_keys:
                 merged_ct_kwargs[k] = v
 
-    # Extract messages - different engines need different content handling
+    # Extract messages - different engines need different content handling.
+    # Templates that expose message.reasoning_content natively (Qwen 3.6+)
+    # get reasoning as a separate field; others fall back to <think> inlined
+    # in content.
+    _entry = get_engine_pool().get_entry(resolved_model)
+    native_reasoning = bool(_entry and _entry.preserve_thinking_default is True)
     is_vlm = isinstance(engine, VLMBatchedEngine)
     extractor = getattr(engine, "message_extractor", None)
     if extractor is not None:
@@ -1961,11 +1966,17 @@ async def create_chat_completion(
     elif is_vlm:
         # VLM: preserve image_url content parts for vision processing
         messages = extract_multimodal_content(
-            request.messages, max_tool_result_tokens, engine.tokenizer
+            request.messages,
+            max_tool_result_tokens,
+            engine.tokenizer,
+            native_reasoning_content=native_reasoning,
         )
     else:
         messages = extract_text_content(
-            request.messages, max_tool_result_tokens, engine.tokenizer
+            request.messages,
+            max_tool_result_tokens,
+            engine.tokenizer,
+            native_reasoning_content=native_reasoning,
         )
 
     # Compile grammar for structured output (logit-level enforcement).
@@ -3223,6 +3234,8 @@ async def create_anthropic_message(
     # Convert Anthropic format to internal format
     # Harmony models need special handling to preserve tool format
     is_vlm = isinstance(engine, VLMBatchedEngine)
+    _entry = get_engine_pool().get_entry(resolved_model)
+    native_reasoning = bool(_entry and _entry.preserve_thinking_default is True)
     if engine.model_type == "gpt_oss":
         messages = convert_anthropic_to_internal_harmony(
             request, max_tool_result_tokens, engine.tokenizer
@@ -3231,6 +3244,7 @@ async def create_anthropic_message(
         messages = convert_anthropic_to_internal(
             request, max_tool_result_tokens, engine.tokenizer,
             preserve_images=is_vlm,
+            native_reasoning_content=native_reasoning,
         )
 
     # Apply model-specific message extraction (e.g. Gemma 4 converts

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -486,6 +486,90 @@ class TestExtractTextContentReasoningReconstruction:
         assert result[0]["content"] == "A"
 
 
+class TestExtractTextContentNativeReasoningContent:
+    """Tests that extract_text_content forwards reasoning_content as a field
+    when the caller opts into native mode.
+
+    Qwen 3.6+ chat templates read ``message.reasoning_content`` directly.
+    Passing reasoning as a separate field avoids the whitespace round-trip
+    that the fallback ``<think>`` reconstruction introduces, which improves
+    KV prefix cache reuse.
+    """
+
+    def test_native_mode_passes_reasoning_as_field(self):
+        """Content stays clean; reasoning rides as a top-level field."""
+        messages = [
+            Message(role="assistant", reasoning_content="R", content="A"),
+        ]
+        result = extract_text_content(messages, native_reasoning_content=True)
+        assert len(result) == 1
+        assert result[0]["role"] == "assistant"
+        assert result[0]["content"] == "A"
+        assert result[0]["reasoning_content"] == "R"
+        # No <think> tag in content
+        assert "<think>" not in result[0]["content"]
+
+    def test_native_mode_with_none_content(self):
+        """None content + reasoning_content still emits the field (and empty content)."""
+        messages = [
+            Message(role="assistant", reasoning_content="R", content=None),
+        ]
+        result = extract_text_content(messages, native_reasoning_content=True)
+        assert len(result) == 1
+        # Empty content but message survives because reasoning_content exists.
+        # Note: _drop_void_assistant_messages may still drop this; verify it's
+        # retained via the reasoning_content presence.
+        assert result[0]["reasoning_content"] == "R"
+
+    def test_native_mode_with_list_content(self):
+        """List content gets flattened to text; reasoning kept separate."""
+        messages = [
+            Message(
+                role="assistant",
+                reasoning_content="R",
+                content=[{"type": "text", "text": "A"}],
+            ),
+        ]
+        result = extract_text_content(messages, native_reasoning_content=True)
+        assert len(result) == 1
+        assert result[0]["content"] == "A"
+        assert result[0]["reasoning_content"] == "R"
+
+    def test_native_mode_with_tool_calls(self):
+        """Assistant with tool_calls + reasoning_content: field survives alongside tool_calls."""
+        messages = [
+            Message(
+                role="assistant",
+                reasoning_content="R",
+                content="calling",
+                tool_calls=[{"id": "c1", "function": {"name": "fn", "arguments": "{}"}}],
+            ),
+        ]
+
+        class NativeToolTokenizer:
+            has_tool_calling = True
+
+        result = extract_text_content(
+            messages,
+            tokenizer=NativeToolTokenizer(),
+            native_reasoning_content=True,
+        )
+        assert len(result) == 1
+        assert result[0]["content"] == "calling"
+        assert result[0]["reasoning_content"] == "R"
+        assert result[0]["tool_calls"][0]["function"]["name"] == "fn"
+
+    def test_native_mode_non_assistant_does_not_emit_field(self):
+        """reasoning_content on a user message must not produce a field."""
+        messages = [
+            Message(role="user", reasoning_content="R", content="A"),
+        ]
+        result = extract_text_content(messages, native_reasoning_content=True)
+        assert len(result) == 1
+        assert result[0]["content"] == "A"
+        assert "reasoning_content" not in result[0]
+
+
 class TestConvertAnthropicToInternal:
     """Tests for convert_anthropic_to_internal function."""
 
@@ -1034,6 +1118,127 @@ class TestConvertAnthropicToInternal:
         content = result[0]["content"]
         assert "Please read this:" in content
         assert "Doc content here" in content
+
+
+class TestConvertAnthropicToInternalNativeReasoning:
+    """Tests that convert_anthropic_to_internal forwards Anthropic thinking
+    blocks as ``reasoning_content`` when ``native_reasoning_content=True``.
+
+    Matches Qwen 3.6+ chat template expectations (first-class field over
+    fallback ``<think>`` parsing in content).
+    """
+
+    def test_native_mode_thinking_becomes_reasoning_field(self):
+        """Single thinking block surfaces as reasoning_content, not in content."""
+        request = MessagesRequest(
+            model="claude-3",
+            max_tokens=1024,
+            messages=[
+                AnthropicMessage(
+                    role="assistant",
+                    content=[
+                        ContentBlockThinking(
+                            type="thinking",
+                            thinking="step by step",
+                            signature="",
+                        ),
+                        ContentBlockText(text="Answer"),
+                    ],
+                ),
+            ],
+        )
+
+        result = convert_anthropic_to_internal(request, native_reasoning_content=True)
+
+        assert len(result) == 1
+        assert result[0]["content"] == "Answer"
+        assert result[0]["reasoning_content"] == "step by step"
+        assert "<think>" not in result[0]["content"]
+
+    def test_native_mode_multiple_thinking_blocks_joined(self):
+        """Multiple thinking blocks concatenate with newline into one field."""
+        request = MessagesRequest(
+            model="claude-3",
+            max_tokens=1024,
+            messages=[
+                AnthropicMessage(
+                    role="assistant",
+                    content=[
+                        ContentBlockThinking(
+                            type="thinking", thinking="FIRST", signature=""
+                        ),
+                        ContentBlockThinking(
+                            type="thinking", thinking="SECOND", signature=""
+                        ),
+                        ContentBlockText(text="Answer"),
+                    ],
+                ),
+            ],
+        )
+
+        result = convert_anthropic_to_internal(request, native_reasoning_content=True)
+
+        assert result[0]["content"] == "Answer"
+        assert result[0]["reasoning_content"] == "FIRST\nSECOND"
+
+    def test_native_mode_tool_calling_assistant(self):
+        """Native-tool-calling path: tool_calls structure + reasoning_content field."""
+
+        class NativeToolTokenizer:
+            has_tool_calling = True
+
+        request = MessagesRequest(
+            model="claude-3",
+            max_tokens=1024,
+            messages=[
+                AnthropicMessage(
+                    role="assistant",
+                    content=[
+                        ContentBlockThinking(
+                            type="thinking",
+                            thinking="deliberating",
+                            signature="",
+                        ),
+                        ContentBlockText(text="Let me check."),
+                        ContentBlockToolUse(
+                            id="toolu_1",
+                            name="get_weather",
+                            input={"location": "Tokyo"},
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        result = convert_anthropic_to_internal(
+            request,
+            tokenizer=NativeToolTokenizer(),
+            native_reasoning_content=True,
+        )
+
+        assert len(result) == 1
+        assert result[0]["content"] == "Let me check."
+        assert result[0]["reasoning_content"] == "deliberating"
+        assert result[0]["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert "<think>" not in result[0]["content"]
+
+    def test_native_mode_no_thinking_no_field(self):
+        """Assistant without thinking blocks gets no reasoning_content field."""
+        request = MessagesRequest(
+            model="claude-3",
+            max_tokens=1024,
+            messages=[
+                AnthropicMessage(
+                    role="assistant",
+                    content=[ContentBlockText(text="Just a reply")],
+                ),
+            ],
+        )
+
+        result = convert_anthropic_to_internal(request, native_reasoning_content=True)
+
+        assert result[0]["content"] == "Just a reply"
+        assert "reasoning_content" not in result[0]
 
 
 class TestConvertAnthropicToolsToInternal:


### PR DESCRIPTION
## Summary

Stacked on top of #856.

Qwen 3.6+ chat templates support `message.reasoning_content` as a first-class message field. The `<think>...</think>` reconstruction added in #814 is actually the fallback path that the template falls into when the field is absent:

```jinja
{%- if message.reasoning_content is string %}
    {%- set reasoning_content = message.reasoning_content %}
{%- else %}
    {%- if '</think>' in content %}
        {%- set reasoning_content = content.split('</think>')[0]... %}
        {%- set content = content.split('</think>')[-1].lstrip('\n') %}
    {%- endif %}
{%- endif %}
```

Switching to the field-based path on supported templates avoids the whitespace round-trip between `extract_thinking.strip()` (output side) and the reconstructor's `\n` delimiters (input side), which should improve the KV prefix cache reuse #814 cited as motivation.

## Changes

- Adds `native_reasoning_content` parameter to `extract_text_content`, `extract_multimodal_content`, and `convert_anthropic_to_internal`
- `server.py` reads `preserve_thinking_default` off the engine entry and threads it into each extractor call site (chat completions text + multimodal, Anthropic messages)
- Teaches `_drop_void_assistant_messages` to preserve assistant messages that carry `reasoning_content` but no text content (otherwise native-mode turns get dropped)
- When `native_reasoning_content=False` (default), behaviour is identical to #814 — the 8 existing reasoning/thinking tests pass unchanged as a regression gate

## Test plan

- [x] `pytest tests/test_api_utils.py -v` → 161 passed (including the 8 #814 tests + 9 new native-mode tests)
- [x] `pytest tests/test_thinking_toggle.py -v` → 23 passed
- [x] `pytest tests/ -m "not slow" -k "anthropic or thinking"` → 172 passed
- [ ] Smoke test with Qwen3.6 — confirm `reasoning_content` field survives through to the template render
- [ ] Confirm non-Qwen3.6 thinking models still use the `<think>` fallback path (no regression)