### PR TITLE
Bypass proxy for CLI health checks

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -276,7 +276,9 @@ def launch_command(args):
     # Check if oMLX server is running
     base_url = f"http://{host}:{port}"
     try:
-        resp = requests.get(f"{base_url}/health", timeout=3)
+        session = requests.Session()
+        session.trust_env = False
+        resp = session.get(f"{base_url}/health", timeout=3)
         resp.raise_for_status()
     except Exception:
         print(f"oMLX server is not running at {base_url}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -271,10 +271,18 @@ class TestLaunchCommandFunction:
             tools_profile="coding",
         )
 
-        with patch("requests.get", side_effect=[health_response, status_response]):
-            with patch("omlx.integrations.get_integration", return_value=integration):
-                with patch("omlx.settings.GlobalSettings.load", return_value=settings):
-                    launch_command(args)
+        session = MagicMock()
+        session.get.return_value = health_response
+
+        with patch("requests.Session", return_value=session) as session_ctor:
+            with patch("requests.get", return_value=status_response):
+                with patch("omlx.integrations.get_integration", return_value=integration):
+                    with patch("omlx.settings.GlobalSettings.load", return_value=settings):
+                        launch_command(args)
+
+        session_ctor.assert_called_once()
+        assert session.trust_env is False
+        session.get.assert_called_once_with("http://127.0.0.1:8000/health", timeout=3)
 
         integration.launch.assert_called_once_with(
             port=8000,


### PR DESCRIPTION
This extends the existing no-proxy fix to omlx.cli.launch_command so local health checks do not inherit system proxy settings.

Changes:
- Use requests.Session(trust_env=False) for the launch health probe in omly/cli.py
- Add a regression test that asserts the health check uses a session with trust_env disabled

Validation:
- uv run pytest -q tests/test_cli.py
