### PR TITLE
fix: keep tool_call arguments as strings in non-Harmony extractors

### DIFF
--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -387,9 +387,7 @@ def extract_text_content(
                                 "id": tc.get("id", ""),
                                 "function": {
                                     "name": func.get("name", ""),
-                                    "arguments": _try_parse_json(
-                                        func.get("arguments", "{}")
-                                    ),
+                                    "arguments": func.get("arguments", "{}"),
                                 },
                             }
                         )
@@ -408,7 +406,7 @@ def extract_text_content(
                                         if hasattr(tc, "function")
                                         else ""
                                     ),
-                                    "arguments": _try_parse_json(args_str),
+                                    "arguments": args_str,
                                 },
                             }
                         )
@@ -547,9 +545,7 @@ def extract_multimodal_content(
                                 "id": tc.get("id", ""),
                                 "function": {
                                     "name": func.get("name", ""),
-                                    "arguments": _try_parse_json(
-                                        func.get("arguments", "{}")
-                                    ),
+                                    "arguments": func.get("arguments", "{}"),
                                 },
                             }
                         )
@@ -568,7 +564,7 @@ def extract_multimodal_content(
                                         if hasattr(tc, "function")
                                         else ""
                                     ),
-                                    "arguments": _try_parse_json(args_str),
+                                    "arguments": args_str,
                                 },
                             }
                         )


### PR DESCRIPTION
## Summary

- `extract_text_content()` and `extract_multimodal_content()` called `_try_parse_json()` on tool_call `arguments`, converting JSON strings into Python dicts
- Qwen3.x chat templates (and likely others) expect `arguments` as a **string** per the OpenAI API spec — receiving a dict causes `"Can only get item pairs from a mapping"` and HTTP 500
- `_try_parse_json()` was needed only for Harmony (gpt-oss) models whose templates apply `|tojson`. Harmony already uses its own `extract_harmony_messages()` which correctly calls `_try_parse_json()`
- This fix removes `_try_parse_json()` calls from the two general-purpose extractors, keeping arguments as strings

## Changes

- `omlx/api/utils.py`: Replace 4 × `_try_parse_json(...)` with direct string passthrough in `extract_text_content()` and `extract_multimodal_content()`
- No changes to `extract_harmony_messages()` — it retains `_try_parse_json()` as intended

## Test plan

- [x] Multi-turn chat with tool calls on Qwen3.5/3.6 model — second request no longer returns 500
- [ ] Verify Harmony models still work with parsed arguments (no Harmony model available to test)

Fixes #854