### PR TITLE
Feat: allow dynamic DFlash switching on a per-request basis based on context length 

### DIFF
--- a/docs/experimental/dflash_mlx_hook_details.md
+++ b/docs/experimental/dflash_mlx_hook_details.md
@@ -1,0 +1,78 @@
+# DFlash-MLX Hook Details
+
+Date: 2026-04-22
+
+Notes on how dflash-mlx inserts hooks into a model when it loads. 
+
+dflash-mlx installs three types of hooks at the **class level** on model layers when `load_target_bundle()` is called. These hooks wrap attention and projection layers to enable speculative decoding, but they also affect any code path that uses the same model — including fallback engines.
+
+## Hook Types
+
+### 1. Split Full Attention Hook (`_install_split_full_attention_hook`)
+
+Wraps `self_attn.__call__` with a custom split attention path. When `_dflash_split_sdpa_enabled=True`, the hook runs its own manual SDPA computation (separate q/k/v projection, rope, attention) instead of the original optimized path.
+
+**Impact on fallback engine:** Adds Python wrapper overhead and runs a less-optimized attention path even during prefill. Causes ~25% TG TPS regression and ~30-40% slower prefill throughput on the fallback path.
+
+**Mechanism:**
+```python
+# In dflash_mlx.runtime.py line 652
+cls.__call__ = split_call  # wraps original __call__
+
+# split_call checks _dflash_split_sdpa_enabled flag
+# When True: runs custom attention path (manual q/k/v proj, rope, SDPA)
+# When False: calls original_call (unhooked path)
+```
+
+### 2. Speculative Linear Cache Hook (`_install_speculative_linear_cache_hook`)
+
+Wraps `linear_attn.__call__` with speculative logic. Checks if cache is `RecurrentRollbackCache` and armed; otherwise calls original.
+
+**Impact on fallback engine:** Minimal — the cache won't be `RecurrentRollbackCache` in BatchedEngine, so it already calls `original_call`. But the hook wrapper still adds a Python call frame.
+
+**Mechanism:**
+```python
+# In dflash_mlx.runtime.py line 381-400
+def speculative_call(self, x, cache=None):
+    if isinstance(cache, RecurrentRollbackCache) and cache.is_armed:
+        # Run speculative path with tape replay
+        return _speculative_linear_attn(self, x, cache)
+    return original_call(x, cache)  # fallback to original
+```
+
+### 3. Exact Small Proj Hooks (`_install_exact_small_proj_hooks`)
+
+Wraps `in_proj_b` and `in_proj_a` with `_ExactSmallProjPad` class. Pads short sequences to a minimum length (`pad_m=16`) before projection, ensuring the draft model's small-sequence assumptions hold.
+
+**Impact on fallback engine:** Changes weight shape behavior — the wrapped layer adds padding logic that isn't needed for normal inference.
+
+**Mechanism:**
+```python
+# In dflash_mlx.runtime.py line 274-303
+class _ExactSmallProjPad(nn.Module):
+    def __init__(self, linear: nn.Module, *, pad_m: int = 16):
+        self.linear = linear  # stores original wrapped layer
+        self.pad_m = pad_m
+    
+    def __call__(self, x: mx.array) -> mx.array:
+        if x.ndim == 3 and x.shape[1] < self.pad_m:
+            # Pad short sequences before projection
+            pad = mx.zeros((batch_size, self.pad_m - seq_len, hidden_dim))
+            out = self.linear(mx.concatenate([x, pad], axis=1))
+            return out[:, :seq_len, :]
+        return self.linear(x)  # no padding needed
+```
+
+## Hook Lifecycle
+
+Hooks are installed once when `load_target_bundle()` is called in dflash-mlx's runtime. They persist on the model class for the lifetime of the process.
+
+```
+load_target_bundle()
+    │
+    ├─ _install_split_full_attention_hook(self_attn)
+    ├─ _install_speculative_linear_cache_hook(linear_attn)
+    └─ _install_exact_small_proj_hooks(linear_attn)
+```
+
+The hooks are **class-level**, meaning they affect all instances of the attention class — including any fallback engine that shares the same model object.

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -126,6 +126,7 @@ class ModelSettingsRequest(BaseModel):
     dflash_enabled: Optional[bool] = None
     dflash_draft_model: Optional[str] = None
     dflash_draft_quant_bits: Optional[int] = None
+    dflash_max_ctx: Optional[int] = None
     reasoning_parser: Optional[str] = None
     is_pinned: Optional[bool] = None
     is_default: Optional[bool] = None
@@ -1428,6 +1429,7 @@ async def list_models(is_admin: bool = Depends(require_admin)):
                 "dflash_enabled": settings.dflash_enabled,
                 "dflash_draft_model": settings.dflash_draft_model,
                 "dflash_draft_quant_bits": settings.dflash_draft_quant_bits,
+                "dflash_max_ctx": settings.dflash_max_ctx,
                 "is_pinned": settings.is_pinned,
                 "is_default": settings.is_default,
                 "display_name": settings.display_name,
@@ -1655,6 +1657,8 @@ async def update_model_settings(
         current_settings.dflash_draft_model = request.dflash_draft_model or None
     if "dflash_draft_quant_bits" in sent:
         current_settings.dflash_draft_quant_bits = request.dflash_draft_quant_bits or None
+    if "dflash_max_ctx" in sent:
+        current_settings.dflash_max_ctx = request.dflash_max_ctx or None
 
     if "reasoning_parser" in sent:
         current_settings.reasoning_parser = request.reasoning_parser or None

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1532,6 +1532,7 @@
                     dflash_enabled: settings.dflash_enabled || false,
                     dflash_draft_model: settings.dflash_draft_model || '',
                     dflash_draft_quant_bits: settings.dflash_draft_quant_bits ? String(settings.dflash_draft_quant_bits) : '',
+                    dflash_max_ctx: settings.dflash_max_ctx ? String(settings.dflash_max_ctx) : '',
                     ctKwargEntries,
                 };
                 this.showModelSettingsModal = true;
@@ -1612,6 +1613,9 @@
                                 dflash_draft_quant_bits: this.modelSettings.dflash_enabled && this.modelSettings.dflash_draft_quant_bits
                                     ? parseInt(this.modelSettings.dflash_draft_quant_bits)
                                     : null,
+                                dflash_max_ctx: this.modelSettings.dflash_enabled && this.modelSettings.dflash_max_ctx
+                                    ? parseInt(this.modelSettings.dflash_max_ctx)
+                                    : null,
                             };
                         })()),
                     });
@@ -1674,6 +1678,7 @@
                         this.modelSettings.dflash_enabled = false;
                         this.modelSettings.dflash_draft_model = null;
                         this.modelSettings.dflash_draft_quant_bits = null;
+                        this.modelSettings.dflash_max_ctx = null;
                     } else if (response.status === 404) {
                         alert(window.t('js.error.no_config_defaults'));
                     } else if (response.status === 401) {

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -695,7 +695,7 @@
                                         </div>
                                         <div>
                                             <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">Max Prompt Tokens</label>
-                                            <input type="number" x-model.number="modelSettings.dflash_max_ctx" placeholder="4096" min="1024" step="1024"
+                                            <input type="number" x-model.number="modelSettings.dflash_max_ctx" placeholder="4096" min="1024"
                                                    class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
                                             <p class="text-xs text-neutral-400 mt-1">Switch to batched mode when prompt exceeds this (default 4096)</p>
                                         </div>

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -693,6 +693,12 @@
                                                 <option value="8">8-bit</option>
                                             </select>
                                         </div>
+                                        <div>
+                                            <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">Max Prompt Tokens</label>
+                                            <input type="number" x-model.number="modelSettings.dflash_max_ctx" placeholder="4096" min="1024" step="1024"
+                                                   class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
+                                            <p class="text-xs text-neutral-400 mt-1">Switch to batched mode when prompt exceeds this (default 4096)</p>
+                                        </div>
                                     </div>
                                 </div>
                         </div>

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -45,6 +45,8 @@ class BatchedEngine(BaseEngine):
         stream_interval: int = 1,
         enable_thinking: bool | None = None,
         model_settings: Any | None = None,
+        model: Any | None = None,
+        tokenizer: Any | None = None,
     ):
         """
         Initialize the batched engine.
@@ -56,6 +58,8 @@ class BatchedEngine(BaseEngine):
             stream_interval: Tokens to batch before streaming (1=every token)
             enable_thinking: Enable thinking mode for reasoning models (passed to chat_template_kwargs)
             model_settings: Optional per-model settings for post-load transforms
+            model: Optional already-loaded MLX model (shared from another engine)
+            tokenizer: Optional already-loaded tokenizer (shared from another engine)
         """
         self._model_name = model_name
         self._trust_remote_code = trust_remote_code
@@ -64,8 +68,8 @@ class BatchedEngine(BaseEngine):
         self._enable_thinking = enable_thinking
         self._model_settings = model_settings
 
-        self._model = None
-        self._tokenizer = None
+        self._model = model
+        self._tokenizer = tokenizer
         self._engine = None
         self._loaded = False
         self._grammar_compiler = None
@@ -193,33 +197,35 @@ class BatchedEngine(BaseEngine):
         from ..engine_core import AsyncEngineCore, EngineConfig
         from ..scheduler import SchedulerConfig
 
-        # Build tokenizer config with model-specific fixes
-        tokenizer_config = get_tokenizer_config(
-            self._model_name,
-            trust_remote_code=self._trust_remote_code,
-        )
-
-        # Load model on the global MLX executor to avoid blocking the event loop
-        # while ensuring no concurrent Metal operations. See issue #85.
-        from ..engine_core import get_mlx_executor
-
-        def _load_model_sync():
-            return load(
+        # If model/tokenizer already provided (shared from another engine), skip loading
+        if self._model is None:
+            # Build tokenizer config with model-specific fixes
+            tokenizer_config = get_tokenizer_config(
                 self._model_name,
-                tokenizer_config=tokenizer_config,
+                trust_remote_code=self._trust_remote_code,
             )
 
-        loop = asyncio.get_running_loop()
-        self._model, self._tokenizer = await loop.run_in_executor(
-            get_mlx_executor(), _load_model_sync
-        )
+            # Load model on the global MLX executor to avoid blocking the event loop
+            # while ensuring no concurrent Metal operations. See issue #85.
+            from ..engine_core import get_mlx_executor
 
-        # Apply post-load transforms (e.g., IndexCache for DSA models)
-        from ..utils.model_loading import apply_post_load_transforms
+            def _load_model_sync():
+                return load(
+                    self._model_name,
+                    tokenizer_config=tokenizer_config,
+                )
 
-        self._model = apply_post_load_transforms(
-            self._model, self._model_settings
-        )
+            loop = asyncio.get_running_loop()
+            self._model, self._tokenizer = await loop.run_in_executor(
+                get_mlx_executor(), _load_model_sync
+            )
+        else:
+            # Model already loaded — apply post-load transforms if needed
+            from ..utils.model_loading import apply_post_load_transforms
+
+            self._model = apply_post_load_transforms(
+                self._model, self._model_settings
+            )
 
         # TurboQuant KV cache: patch attention and set kv_bits on scheduler
         if self._model_settings is not None:

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -219,8 +219,7 @@ class BatchedEngine(BaseEngine):
             self._model, self._tokenizer = await loop.run_in_executor(
                 get_mlx_executor(), _load_model_sync
             )
-        else:
-            # Model already loaded — apply post-load transforms if needed
+
             from ..utils.model_loading import apply_post_load_transforms
 
             self._model = apply_post_load_transforms(

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -64,7 +64,6 @@ class DFlashEngine(BaseEngine):
         self._active_request = False
         self._model_type_str = None
         self._fallback_engine: BaseEngine | None = None
-        self._in_fallback_mode = False
 
         raw = os.environ.get("DFLASH_MAX_CTX", str(DEFAULT_MAX_DFLASH_CTX)).strip()
         try:
@@ -119,7 +118,6 @@ class DFlashEngine(BaseEngine):
             self._model_type_str = config.model_type
 
         self._loaded = True
-        self._in_fallback_mode = False
         logger.info(
             f"DFlashEngine loaded: target={self._model_name}, "
             f"draft={self._draft_model_path}, "
@@ -127,45 +125,11 @@ class DFlashEngine(BaseEngine):
             f"fallback={self._fallback_engine_type}"
         )
 
-    async def _evict_dflash_and_start_fallback(self) -> None:
-        """Evict dflash models from memory, verify release, then start fallback engine."""
-        from ..engine_core import get_mlx_executor
+    async def _init_fallback_engine(self) -> None:
+        """Create and start fallback engine sharing target model (no eviction)."""
+        shared_model = self._target_model
+        shared_tokenizer = self._tokenizer_obj
 
-        loop = asyncio.get_running_loop()
-        pre_active = mx.get_active_memory()
-
-        # Release dflash model references
-        self._target_model = None
-        self._draft_model = None
-        self._executor_tokenizer = None
-
-        # Force memory reclaim with settle barrier
-        gc.collect()
-        await loop.run_in_executor(
-            get_mlx_executor(),
-            lambda: (mx.synchronize(), mx.clear_cache()),
-        )
-
-        # Poll for actual memory release (same pattern as engine_pool._unload_engine)
-        for settle_round in range(10):
-            active_now = mx.get_active_memory()
-            freed = pre_active - active_now
-            if freed > 0:
-                logger.info(
-                    f"DFlash models evicted: freed={freed / 1024**3:.2f}GB "
-                    f"(round {settle_round + 1})"
-                )
-                break
-            await asyncio.sleep(0.5)
-            gc.collect()
-            await loop.run_in_executor(
-                get_mlx_executor(),
-                lambda: (mx.synchronize(), mx.clear_cache()),
-            )
-        else:
-            logger.warning("DFlash model eviction: memory settle timed out")
-
-        # Start fallback engine with shared target model
         if self._fallback_engine_type == "vlm":
             from .vlm import VLMBatchedEngine
             self._fallback_engine = VLMBatchedEngine(
@@ -185,7 +149,6 @@ class DFlashEngine(BaseEngine):
                 tokenizer=shared_tokenizer,
             )
         await self._fallback_engine.start()
-        self._in_fallback_mode = True
         logger.info(
             f"DFlash fallback engine started: {self._fallback_engine_type}"
         )
@@ -198,8 +161,6 @@ class DFlashEngine(BaseEngine):
         self._draft_model = None
         self._tokenizer_obj = None
         self._executor_tokenizer = None
-        self._in_fallback_mode = False
-        self._loaded = False
         logger.info("DFlashEngine stopped")
 
     def _apply_chat_template(
@@ -355,22 +316,12 @@ class DFlashEngine(BaseEngine):
         use_batched = len(prompt_tokens) >= self._max_dflash_ctx
 
         if use_batched:
-            if not self._in_fallback_mode:
+            if self._fallback_engine is None:
                 logger.info(
                     f"Switching to batched mode: prompt={len(prompt_tokens)} tokens "
                     f"(exceeds max_dflash_ctx={self._max_dflash_ctx})"
                 )
-                await self._evict_dflash_and_start_fallback()
-            return await self._fallback_engine.generate(
-                prompt=prompt, max_tokens=max_tokens, temperature=temperature,
-                top_p=top_p, top_k=top_k, min_p=min_p,
-                repetition_penalty=repetition_penalty,
-                presence_penalty=presence_penalty, stop=stop, **kwargs,
-            )
-
-        # Already in fallback mode but short context came in.
-        # Stay in fallback mode (reloading dflash models is expensive).
-        if self._in_fallback_mode:
+                await self._init_fallback_engine()
             return await self._fallback_engine.generate(
                 prompt=prompt, max_tokens=max_tokens, temperature=temperature,
                 top_p=top_p, top_k=top_k, min_p=min_p,
@@ -433,23 +384,12 @@ class DFlashEngine(BaseEngine):
         use_batched = len(prompt_tokens) >= self._max_dflash_ctx
 
         if use_batched:
-            if not self._in_fallback_mode:
+            if self._fallback_engine is None:
                 logger.info(
                     f"Switching to batched mode: prompt={len(prompt_tokens)} tokens "
                     f"(exceeds max_dflash_ctx={self._max_dflash_ctx})"
                 )
-                await self._evict_dflash_and_start_fallback()
-            async for output in self._fallback_engine.stream_generate(
-                prompt=prompt, max_tokens=max_tokens, temperature=temperature,
-                top_p=top_p, top_k=top_k, min_p=min_p,
-                repetition_penalty=repetition_penalty,
-                presence_penalty=presence_penalty, stop=stop, **kwargs,
-            ):
-                yield output
-            return
-
-        # Already in fallback mode — stay there
-        if self._in_fallback_mode:
+                await self._init_fallback_engine()
             async for output in self._fallback_engine.stream_generate(
                 prompt=prompt, max_tokens=max_tokens, temperature=temperature,
                 top_p=top_p, top_k=top_k, min_p=min_p,
@@ -573,7 +513,6 @@ class DFlashEngine(BaseEngine):
             "draft_model": self._draft_model_path,
             "max_dflash_ctx": self._max_dflash_ctx,
             "fallback_engine_type": self._fallback_engine_type,
-            "in_fallback_mode": self._in_fallback_mode,
             "loaded": self._loaded,
         }
 

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -13,6 +13,7 @@ import copy
 import gc
 import logging
 import os
+import threading
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -21,11 +22,66 @@ import mlx.core as mx
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_special_tokens, detect_and_strip_partial
 from .base import BaseEngine, GenerationOutput
+from dflash_mlx.runtime import _ExactSmallProjPad, _target_text_model
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_DFLASH_CTX = 4096
 
+# Lock for toggling dflash hooks on the shared model. Prevents concurrent
+# flag changes when requests arrive simultaneously from different threads
+# (e.g., async request handler + MLX executor thread).
+_dflash_toggle_lock = threading.Lock()
+
+def _get_text_model(model: Any) -> Any:
+    """Get the inner text model from a wrapped target model."""
+    return _target_text_model(model)
+
+def _enable_dflash_hooks(model: Any) -> None:
+    """Re-enable dflash-mlx hooks on all layers of the model.
+
+    Sets _dflash_split_sdpa_enabled = True on self_attn layers so that the
+    split_call wrapper runs its custom attention path instead of falling
+    through to original_call. Also re-wraps _ExactSmallProjPad on linear_attn
+    layers if they were unwrapped by a previous fallback request.
+
+    Call this before any DFlash speculative decoding request.
+    """
+    text_model = _get_text_model(model)
+    for layer in text_model.layers:
+        if hasattr(layer, "self_attn"):
+            layer.self_attn._dflash_split_sdpa_enabled = True
+        if hasattr(layer, "linear_attn"):
+            linear = layer.linear_attn
+            for attr_name in ("in_proj_b", "in_proj_a"):
+                proj = getattr(linear, attr_name, None)
+                if proj is not None and type(proj).__name__ != "_ExactSmallProjPad":
+                    # Was unwrapped by _disable_dflash_hooks — re-wrap it
+                    setattr(linear, attr_name, _ExactSmallProjPad(proj))
+
+    text_model._dflash_speculative_hooks_installed = True
+
+def _disable_dflash_hooks(model: Any) -> None:
+    """Disable dflash-mlx hooks on all layers of the model.
+
+    Sets _dflash_split_sdpa_enabled = False on self_attn layers so that the
+    split_call wrapper falls through to original_call. Also unwraps
+    _ExactSmallProjPad on linear_attn layers.
+
+    Call this before passing the model to BatchedEngine for the fallback path.
+    """
+    text_model = _get_text_model(model)
+    for layer in text_model.layers:
+        if hasattr(layer, "self_attn"):
+            layer.self_attn._dflash_split_sdpa_enabled = False
+        if hasattr(layer, "linear_attn"):
+            linear = layer.linear_attn
+            for attr_name in ("in_proj_b", "in_proj_a"):
+                proj = getattr(linear, attr_name, None)
+                if proj is not None and type(proj).__name__ == "_ExactSmallProjPad":
+                    setattr(linear, attr_name, proj.linear)
+
+    text_model._dflash_speculative_hooks_installed = False
 
 class DFlashEngine(BaseEngine):
     """
@@ -130,8 +186,17 @@ class DFlashEngine(BaseEngine):
         )
 
     async def _init_fallback_engine(self) -> None:
-        """Create and start fallback engine sharing target model (no eviction)."""
+        """Create and start fallback engine sharing target model (no eviction).
+
+        Before passing the model to BatchedEngine, disable dflash-mlx hooks
+        that wrap self_attn/linear_attn.__call__ at the class level. These hooks
+        add Python overhead and run a less-optimized attention path even during
+        prefill, which can cause a ~25% throughput regression on the fallback path.
+        """
         shared_model = self._target_model
+        with _dflash_toggle_lock:
+            _disable_dflash_hooks(shared_model)
+
         shared_tokenizer = self._tokenizer_obj
 
         if self._fallback_engine_type == "vlm":
@@ -330,6 +395,11 @@ class DFlashEngine(BaseEngine):
                 presence_penalty=presence_penalty, stop=stop, **kwargs,
             )
 
+        # Re-enable dflash hooks before speculative decoding path.
+        # After a long-context fallback request, hooks may have been disabled.
+        with _dflash_toggle_lock:
+            _enable_dflash_hooks(self._target_model)
+
         from ..engine_core import get_mlx_executor
         from dflash_mlx.generate import get_stop_token_ids
         from dflash_mlx.runtime import generate_dflash_once
@@ -399,6 +469,10 @@ class DFlashEngine(BaseEngine):
             ):
                 yield output
             return
+
+        # Re-enable dflash hooks before speculative decoding path.
+        with _dflash_toggle_lock:
+            _enable_dflash_hooks(self._target_model)
 
         prompt_len = len(prompt_tokens)
         loop = asyncio.get_running_loop()

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -115,6 +115,12 @@ class DFlashEngine(BaseEngine):
         result = await loop.run_in_executor(get_mlx_executor(), _load_models)
         self._target_model, self._tokenizer_obj, target_meta, self._draft_model = result
 
+        from ..utils.model_loading import apply_post_load_transforms
+
+        self._target_model = apply_post_load_transforms(
+            self._target_model, self._model_settings
+        )
+
         # Deep-copy tokenizer for executor-thread usage (dflash generation).
         # The original self._tokenizer_obj stays for event-loop operations
         # (encode, apply_chat_template, count_chat_tokens).

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -214,9 +214,6 @@ class DFlashEngine(BaseEngine):
         )
         return len(self._tokenizer_obj.encode(prompt))
 
-    def _should_fallback(self, prompt_tokens: list[int]) -> bool:
-        return len(prompt_tokens) >= self._max_dflash_ctx
-
     def _run_generate_streaming(
         self,
         prompt_tokens: list[int],
@@ -521,6 +518,6 @@ class DFlashEngine(BaseEngine):
         }
 
     def get_cache_stats(self) -> dict[str, Any] | None:
-        if self._fallback_engine is not None:
-            return self._fallback_engine.get_cache_stats()
+        # The DFlashEngine doesn't use paged KV cache / SSD tiering, so this is a stub.
+        # The "fallback" BatchedEngine reports it's own cache stats separately.
         return None

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -28,10 +28,15 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_DFLASH_CTX = 4096
 
-# Lock for toggling dflash hooks on the shared model. Prevents concurrent
-# flag changes when requests arrive simultaneously from different threads
-# (e.g., async request handler + MLX executor thread).
+# Lock for toggling dflash hooks on the shared model.
 _dflash_toggle_lock = threading.Lock()
+
+# Reference count of active DFlash requests. Used to prevent disabling hooks
+# while a DFlash generation is in-flight on the shared model.
+_dflash_active_count = 0
+_dflash_active_lock = threading.Lock()
+_dflash_active_cond = threading.Condition(_dflash_active_lock)
+
 
 def _get_text_model(model: Any) -> Any:
     """Get the inner text model from a wrapped target model."""
@@ -82,6 +87,25 @@ def _disable_dflash_hooks(model: Any) -> None:
                     setattr(linear, attr_name, proj.linear)
 
     text_model._dflash_speculative_hooks_installed = False
+
+def _enter_dflash_request() -> None:
+    """
+    Acquire a DFlash request slot. Blocks until no in-flight DFlash requests.
+    Ensures there are not DFlash and non-DFlash requests being served at the same time.
+    """
+    global _dflash_active_count
+    with _dflash_active_cond:
+        while _dflash_active_count > 0:
+            logger.debug("DFlash: waiting for in-flight requests to complete...")
+            _dflash_active_cond.wait(timeout=30)
+        _dflash_active_count += 1
+
+def _exit_dflash_request() -> None:
+    """Release a DFlash request slot and wake any waiting fallback engine."""
+    global _dflash_active_count
+    with _dflash_active_cond:
+        _dflash_active_count -= 1
+        _dflash_active_cond.notify_all()
 
 class DFlashEngine(BaseEngine):
     """
@@ -192,8 +216,16 @@ class DFlashEngine(BaseEngine):
         that wrap self_attn/linear_attn.__call__ at the class level. These hooks
         add Python overhead and run a less-optimized attention path even during
         prefill, which can cause a ~25% throughput regression on the fallback path.
+
+        Waits for any in-flight DFlash requests to complete before disabling hooks,
+        ensuring no concurrent DFlash + batched execution on the shared model.
         """
         shared_model = self._target_model
+
+        # Wait for all in-flight DFlash requests to finish before disabling hooks.
+        _enter_dflash_request()  # ensures count is 0 when we proceed
+        _exit_dflash_request()   # release our dummy slot
+
         with _dflash_toggle_lock:
             _disable_dflash_hooks(shared_model)
 
@@ -397,41 +429,45 @@ class DFlashEngine(BaseEngine):
 
         # Re-enable dflash hooks before speculative decoding path.
         # After a long-context fallback request, hooks may have been disabled.
-        with _dflash_toggle_lock:
-            _enable_dflash_hooks(self._target_model)
+        _enter_dflash_request()
+        try:
+            with _dflash_toggle_lock:
+                _enable_dflash_hooks(self._target_model)
 
-        from ..engine_core import get_mlx_executor
-        from dflash_mlx.generate import get_stop_token_ids
-        from dflash_mlx.runtime import generate_dflash_once
+            from ..engine_core import get_mlx_executor
+            from dflash_mlx.generate import get_stop_token_ids
+            from dflash_mlx.runtime import generate_dflash_once
 
-        loop = asyncio.get_running_loop()
-        stop_ids = get_stop_token_ids(self._tokenizer_obj)
+            loop = asyncio.get_running_loop()
+            stop_ids = get_stop_token_ids(self._tokenizer_obj)
 
-        def _run():
-            return generate_dflash_once(
-                target_model=self._target_model,
-                tokenizer=self._executor_tokenizer,
-                draft_model=self._draft_model,
-                prompt="",
-                max_new_tokens=max_tokens,
-                stop_token_ids=stop_ids,
-                prompt_tokens_override=prompt_tokens,
-                temperature=temperature,
+            def _run():
+                return generate_dflash_once(
+                    target_model=self._target_model,
+                    tokenizer=self._executor_tokenizer,
+                    draft_model=self._draft_model,
+                    prompt="",
+                    max_new_tokens=max_tokens,
+                    stop_token_ids=stop_ids,
+                    prompt_tokens_override=prompt_tokens,
+                    temperature=temperature,
+                )
+
+            summary = await loop.run_in_executor(get_mlx_executor(), _run)
+
+            generated = summary.get("generated_token_ids", [])
+            text = self._tokenizer_obj.decode(generated, skip_special_tokens=True)
+            text = clean_special_tokens(text)
+
+            return GenerationOutput(
+                text=text,
+                tokens=generated,
+                prompt_tokens=summary.get("prompt_token_count", len(prompt_tokens)),
+                completion_tokens=summary.get("generation_tokens", len(generated)),
+                finish_reason="stop",
             )
-
-        summary = await loop.run_in_executor(get_mlx_executor(), _run)
-
-        generated = summary.get("generated_token_ids", [])
-        text = self._tokenizer_obj.decode(generated, skip_special_tokens=True)
-        text = clean_special_tokens(text)
-
-        return GenerationOutput(
-            text=text,
-            tokens=generated,
-            prompt_tokens=summary.get("prompt_token_count", len(prompt_tokens)),
-            completion_tokens=summary.get("generation_tokens", len(generated)),
-            finish_reason="stop",
-        )
+        finally:
+            _exit_dflash_request()
 
     async def stream_generate(
         self,
@@ -471,51 +507,55 @@ class DFlashEngine(BaseEngine):
             return
 
         # Re-enable dflash hooks before speculative decoding path.
-        with _dflash_toggle_lock:
-            _enable_dflash_hooks(self._target_model)
+        _enter_dflash_request()
+        try:
+            with _dflash_toggle_lock:
+                _enable_dflash_hooks(self._target_model)
 
-        prompt_len = len(prompt_tokens)
-        loop = asyncio.get_running_loop()
-        queue: asyncio.Queue = asyncio.Queue()
+            prompt_len = len(prompt_tokens)
+            loop = asyncio.get_running_loop()
+            queue: asyncio.Queue = asyncio.Queue()
 
-        from ..engine_core import get_mlx_executor
-        loop.run_in_executor(
-            get_mlx_executor(),
-            self._run_generate_streaming,
-            prompt_tokens,
-            max_tokens,
-            temperature,
-            queue,
-            loop,
-        )
-
-        total_text = ""
-        total_completion = 0
-
-        while True:
-            new_text, new_tokens, finished, metrics = await queue.get()
-
-            total_text += new_text
-            total_completion += len(new_tokens)
-
-            finish_reason = None
-            if finished:
-                finish_reason = "stop"
-                if metrics and metrics.get("error"):
-                    finish_reason = "error"
-
-            yield GenerationOutput(
-                text=total_text,
-                new_text=new_text,
-                tokens=new_tokens,
-                prompt_tokens=prompt_len,
-                completion_tokens=total_completion,
-                finished=finished,
-                finish_reason=finish_reason,
+            from ..engine_core import get_mlx_executor
+            loop.run_in_executor(
+                get_mlx_executor(),
+                self._run_generate_streaming,
+                prompt_tokens,
+                max_tokens,
+                temperature,
+                queue,
+                loop,
             )
 
-            if finished:
-                break
+            total_text = ""
+            total_completion = 0
+
+            while True:
+                new_text, new_tokens, finished, metrics = await queue.get()
+
+                total_text += new_text
+                total_completion += len(new_tokens)
+
+                finish_reason = None
+                if finished:
+                    finish_reason = "stop"
+                    if metrics and metrics.get("error"):
+                        finish_reason = "error"
+
+                yield GenerationOutput(
+                    text=total_text,
+                    new_text=new_text,
+                    tokens=new_tokens,
+                    prompt_tokens=prompt_len,
+                    completion_tokens=total_completion,
+                    finished=finished,
+                    finish_reason=finish_reason,
+                )
+
+                if finished:
+                    break
+        finally:
+            _exit_dflash_request()
 
     async def chat(
         self,

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -29,13 +29,15 @@ DEFAULT_MAX_DFLASH_CTX = 4096
 
 class DFlashEngine(BaseEngine):
     """
-    DFlash speculative decoding engine with automatic fallback.
+    DFlash speculative decoding engine with per-request mode switching.
 
     For prompts within max_dflash_ctx tokens, uses block diffusion speculative
-    decoding for 3-4x faster generation. For longer prompts, evicts dflash
-    models from memory and delegates to a fallback engine (BatchedEngine or
-    VLMBatchedEngine) that provides paged cache, SSD cache, and continuous
-    batching.
+    decoding for 3-4x faster generation. For longer prompts, delegates to a fallback
+    engine (BatchedEngine or VLMBatchedEngine) that provides paged cache, SSD cache,
+    and continuous batching.
+
+    The target model is loaded once and shared across both dflash and batched modes,
+    avoiding model reload overhead when switching between them.
     """
 
     def __init__(
@@ -345,12 +347,14 @@ class DFlashEngine(BaseEngine):
 
         prompt_tokens = self._tokenizer_obj.encode(prompt)
 
-        # Fallback: evict dflash models, start LLM/VLM engine
-        if self._should_fallback(prompt_tokens):
+        # Determine if we should use batched mode
+        use_batched = len(prompt_tokens) >= self._max_dflash_ctx
+
+        if use_batched:
             if not self._in_fallback_mode:
                 logger.info(
-                    f"DFlash context fallback: {len(prompt_tokens)} >= {self._max_dflash_ctx}, "
-                    f"evicting dflash models and switching to {self._fallback_engine_type} engine"
+                    f"Switching to batched mode: prompt={len(prompt_tokens)} tokens "
+                    f"(exceeds max_dflash_ctx={self._max_dflash_ctx})"
                 )
                 await self._evict_dflash_and_start_fallback()
             return await self._fallback_engine.generate(
@@ -421,12 +425,14 @@ class DFlashEngine(BaseEngine):
 
         prompt_tokens = self._tokenizer_obj.encode(prompt)
 
-        # Fallback: evict dflash models, start LLM/VLM engine
-        if self._should_fallback(prompt_tokens):
+        # Determine if we should use batched mode
+        use_batched = len(prompt_tokens) >= self._max_dflash_ctx
+
+        if use_batched:
             if not self._in_fallback_mode:
                 logger.info(
-                    f"DFlash context fallback: {len(prompt_tokens)} >= {self._max_dflash_ctx}, "
-                    f"evicting dflash models and switching to {self._fallback_engine_type} engine"
+                    f"Switching to batched mode: prompt={len(prompt_tokens)} tokens "
+                    f"(exceeds max_dflash_ctx={self._max_dflash_ctx})"
                 )
                 await self._evict_dflash_and_start_fallback()
             async for output in self._fallback_engine.stream_generate(

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -145,7 +145,7 @@ class DFlashEngine(BaseEngine):
         self._model_type_str = None
         self._fallback_engine: BaseEngine | None = None
         if self._model_settings is not None and self._model_settings.dflash_max_ctx is not None:
-            self._max_dflash_ctx = self._model_settings.dflash_max_ctx
+            self._max_dflash_ctx = max(1024, self._model_settings.dflash_max_ctx)
         else:
             self._max_dflash_ctx = DEFAULT_MAX_DFLASH_CTX
 

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -2,10 +2,13 @@
 """
 DFlash engine for block diffusion speculative decoding.
 
-This engine wraps dflash-mlx to provide 3-4x faster decoding on Apple Silicon.
-For short/medium contexts it uses speculative decoding; for long contexts
-(>DFLASH_MAX_CTX) it evicts dflash models and switches to omlx's BatchedEngine
-or VLMBatchedEngine which have paged cache, SSD cache, and continuous batching.
+For prompts within max_dflash_ctx tokens, uses block diffusion speculative
+decoding for 3-4x faster generation. For longer prompts, delegates to a fallback
+engine (BatchedEngine or VLMBatchedEngine) that provides paged cache, SSD cache,
+and continuous batching.
+
+The target model is loaded once and shared across both dflash and batched modes,
+avoiding model reload overhead when switching between them.
 """
 
 import asyncio

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -64,21 +64,8 @@ class DFlashEngine(BaseEngine):
         self._active_request = False
         self._model_type_str = None
         self._fallback_engine: BaseEngine | None = None
-
-        raw = os.environ.get("DFLASH_MAX_CTX", None)
-        if raw is not None:
-            # Env var takes priority over model settings
-            try:
-                self._max_dflash_ctx = max(1, int(raw))
-            except ValueError:
-                self._max_dflash_ctx = DEFAULT_MAX_DFLASH_CTX
-        elif self._model_settings is not None:
-            # Per-model setting (None = use default)
-            val = getattr(self._model_settings, "dflash_max_ctx", None)
-            if val is not None:
-                self._max_dflash_ctx = max(1, int(val))
-            else:
-                self._max_dflash_ctx = DEFAULT_MAX_DFLASH_CTX
+        if self._model_settings is not None and self._model_settings.dflash_max_ctx is not None:
+            self._max_dflash_ctx = self._model_settings.dflash_max_ctx
         else:
             self._max_dflash_ctx = DEFAULT_MAX_DFLASH_CTX
 

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -165,13 +165,15 @@ class DFlashEngine(BaseEngine):
         else:
             logger.warning("DFlash model eviction: memory settle timed out")
 
-        # Start fallback engine
+        # Start fallback engine with shared target model
         if self._fallback_engine_type == "vlm":
             from .vlm import VLMBatchedEngine
             self._fallback_engine = VLMBatchedEngine(
                 model_name=self._model_name,
                 scheduler_config=self._scheduler_config,
                 model_settings=self._model_settings,
+                model=shared_model,
+                tokenizer=shared_tokenizer,
             )
         else:
             from .batched import BatchedEngine
@@ -179,6 +181,8 @@ class DFlashEngine(BaseEngine):
                 model_name=self._model_name,
                 scheduler_config=self._scheduler_config,
                 model_settings=self._model_settings,
+                model=shared_model,
+                tokenizer=shared_tokenizer,
             )
         await self._fallback_engine.start()
         self._in_fallback_mode = True

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -65,10 +65,21 @@ class DFlashEngine(BaseEngine):
         self._model_type_str = None
         self._fallback_engine: BaseEngine | None = None
 
-        raw = os.environ.get("DFLASH_MAX_CTX", str(DEFAULT_MAX_DFLASH_CTX)).strip()
-        try:
-            self._max_dflash_ctx = max(1, int(raw))
-        except ValueError:
+        raw = os.environ.get("DFLASH_MAX_CTX", None)
+        if raw is not None:
+            # Env var takes priority over model settings
+            try:
+                self._max_dflash_ctx = max(1, int(raw))
+            except ValueError:
+                self._max_dflash_ctx = DEFAULT_MAX_DFLASH_CTX
+        elif self._model_settings is not None:
+            # Per-model setting (None = use default)
+            val = getattr(self._model_settings, "dflash_max_ctx", None)
+            if val is not None:
+                self._max_dflash_ctx = max(1, int(val))
+            else:
+                self._max_dflash_ctx = DEFAULT_MAX_DFLASH_CTX
+        else:
             self._max_dflash_ctx = DEFAULT_MAX_DFLASH_CTX
 
     @property

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -175,7 +175,22 @@ class VLMBatchedEngine(BaseEngine):
         stream_interval: int = 1,
         enable_thinking: bool | None = None,
         model_settings: Any | None = None,
+        model: Any | None = None,
+        tokenizer: Any | None = None,
     ):
+        """
+        Initialize the VLM batched engine.
+
+        Args:
+            model_name: Model identifier for loading (ignored if model is provided)
+            trust_remote_code: Allow remote code execution during loading
+            scheduler_config: Scheduler configuration
+            stream_interval: Tokens to batch before streaming
+            enable_thinking: Enable thinking mode for reasoning models
+            model_settings: Per-model settings for post-load transforms
+            model: Optional already-loaded VLM model (shared from DFlashEngine)
+            tokenizer: Optional already-loaded tokenizer (shared from DFlashEngine)
+        """
         self._model_name = model_name
         self._trust_remote_code = trust_remote_code
         self._scheduler_config = scheduler_config
@@ -183,8 +198,9 @@ class VLMBatchedEngine(BaseEngine):
         self._enable_thinking = enable_thinking
         self._model_settings = model_settings
 
-        self._vlm_model = None
-        self._processor = None
+        # Model/tokenizer may be shared from DFlashEngine (no reload)
+        self._vlm_model = model
+        self._processor = tokenizer
         self._tokenizer = None
         self._adapter = None
         self._engine = None
@@ -286,30 +302,36 @@ class VLMBatchedEngine(BaseEngine):
         return ids
 
     async def start(self) -> None:
-        """Load VLM model and processor via mlx-vlm, create engine with VLMModelAdapter."""
+        """Load VLM model and processor via mlx-vlm, create engine with VLMModelAdapter.
+
+        If model/tokenizer already provided (shared from DFlashEngine), skip loading
+        and use the shared references directly.
+        """
         if self._loaded:
             return
-
-        from mlx_vlm.utils import load as vlm_load
 
         from ..engine_core import AsyncEngineCore, EngineConfig
         from ..scheduler import SchedulerConfig
 
         # Load VLM model on the global MLX executor to avoid blocking the event loop
         # while ensuring no concurrent Metal operations. See issue #85.
-        from ..engine_core import get_mlx_executor
+        if self._vlm_model is None:
+            from mlx_vlm.utils import load as vlm_load
 
-        def _load_vlm_sync():
-            # Patch transformers bug: video_processor_class_from_name crashes
-            # when torchvision is not available (extractors is None, `in` fails).
-            # oMLX does not support video input, so we skip video processing.
-            _patch_video_processor_bug()
-            return vlm_load(self._model_name)
+            # Load VLM model from scratch (not shared)
+            from ..engine_core import get_mlx_executor
 
-        loop = asyncio.get_running_loop()
-        self._vlm_model, self._processor = await loop.run_in_executor(
-            get_mlx_executor(), _load_vlm_sync
-        )
+            def _load_vlm_sync():
+                # Patch transformers bug: video_processor_class_from_name crashes
+                # when torchvision is not available (extractors is None, `in` fails).
+                # oMLX does not support video input, so we skip video processing.
+                _patch_video_processor_bug()
+                return vlm_load(self._model_name)
+
+            loop = asyncio.get_running_loop()
+            self._vlm_model, self._processor = await loop.run_in_executor(
+                get_mlx_executor(), _load_vlm_sync
+            )
 
         # Initialize vision feature cache
         vision_ssd_dir = None

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -44,6 +44,7 @@ MODEL_SPECIFIC_PROFILE_FIELDS = (
     "dflash_enabled",
     "dflash_draft_model",
     "dflash_draft_quant_bits",
+    "dflash_max_ctx",
     "specprefill_enabled",
     "specprefill_draft_model",
     "specprefill_keep_pct",

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -108,6 +108,7 @@ class ModelSettings:
     dflash_enabled: bool = False
     dflash_draft_model: Optional[str] = None  # Path/repo for DFlash draft checkpoint
     dflash_draft_quant_bits: Optional[int] = None  # Draft model quantization (None=bf16, 4)
+    dflash_max_ctx: Optional[int] = None  # Max prompt tokens for DFlash (None=use default)
 
     # Model management flags
     is_pinned: bool = False

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -63,6 +63,7 @@ class ModelSettings:
         dflash_enabled: Enable DFlash speculative decoding.
         dflash_draft_model: Path/repo for DFlash draft checkpoint.
         dflash_draft_quant_bits: Draft model quantization bits.
+        dflash_max_ctx: Max context for DFlash.
         is_pinned: Keep model loaded in memory.
         is_default: Use this model when no model is specified.
         display_name: Human-readable name for UI display.

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -147,27 +147,6 @@ class TestDFlashEnginePoolRouting:
 class TestDFlashEngineMaxCtx:
     """Test DFlashEngine max_dflash_ctx resolution logic."""
 
-    def _clear_env(self):
-        """Clear DFLASH_MAX_CTX env var so model_settings takes effect."""
-        import os
-        os.environ.pop("DFLASH_MAX_CTX", None)
-
-    def test_max_ctx_from_model_settings(self):
-        """max_dflash_ctx should be read from model_settings when env var is not set."""
-        try:
-            from omlx.engine.dflash import DFlashEngine, DEFAULT_MAX_DFLASH_CTX
-        except ImportError:
-            pytest.skip("dflash-mlx not installed")
-
-        self._clear_env()
-        settings = ModelSettings(dflash_max_ctx=4096)
-        engine = DFlashEngine(
-            model_name="test-model",
-            draft_model_path="test-draft",
-            model_settings=settings,
-        )
-        assert engine._max_dflash_ctx == 4096
-
     def test_max_ctx_defaults_when_none(self):
         """When model_settings.dflash_max_ctx is None, use DEFAULT_MAX_DFLASH_CTX."""
         try:
@@ -175,7 +154,6 @@ class TestDFlashEngineMaxCtx:
         except ImportError:
             pytest.skip("dflash-mlx not installed")
 
-        self._clear_env()
         settings = ModelSettings()  # dflash_max_ctx is None
         engine = DFlashEngine(
             model_name="test-model",
@@ -191,53 +169,26 @@ class TestDFlashEngineMaxCtx:
         except ImportError:
             pytest.skip("dflash-mlx not installed")
 
-        self._clear_env()
         engine = DFlashEngine(
             model_name="test-model",
             draft_model_path="test-draft",
         )
         assert engine._max_dflash_ctx == DEFAULT_MAX_DFLASH_CTX
 
-    def test_max_ctx_env_var_override(self):
-        """DFLASH_MAX_CTX env var should override model settings."""
-        import os
-        try:
-            from omlx.engine.dflash import DFlashEngine
-        except ImportError:
-            pytest.skip("dflash-mlx not installed")
-
-        os.environ["DFLASH_MAX_CTX"] = "2048"
-        try:
-            settings = ModelSettings(dflash_max_ctx=4096)
-            engine = DFlashEngine(
-                model_name="test-model",
-                draft_model_path="test-draft",
-                model_settings=settings,
-            )
-            # Env var takes priority over model settings
-            assert engine._max_dflash_ctx == 2048
-        finally:
-            os.environ.pop("DFLASH_MAX_CTX", None)
-
-    def test_max_ctx_invalid_env_var_falls_back(self):
-        """Invalid env var value should fall back to DEFAULT_MAX_DFLASH_CTX."""
-        import os
+    def test_max_ctx_from_model_settings(self):
+        """max_dflash_ctx should be read from model_settings when set."""
         try:
             from omlx.engine.dflash import DFlashEngine, DEFAULT_MAX_DFLASH_CTX
         except ImportError:
             pytest.skip("dflash-mlx not installed")
 
-        os.environ["DFLASH_MAX_CTX"] = "not-a-number"
-        try:
-            settings = ModelSettings(dflash_max_ctx=4096)
-            engine = DFlashEngine(
-                model_name="test-model",
-                draft_model_path="test-draft",
-                model_settings=settings,
-            )
-            assert engine._max_dflash_ctx == DEFAULT_MAX_DFLASH_CTX
-        finally:
-            os.environ.pop("DFLASH_MAX_CTX", None)
+        settings = ModelSettings(dflash_max_ctx=8192)
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            model_settings=settings,
+        )
+        assert engine._max_dflash_ctx == 8192
 
 
 class TestDFlashRoutingLogic:

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -143,3 +143,149 @@ class TestDFlashEnginePoolRouting:
         )
         assert settings.dflash_enabled is True
         assert settings.dflash_draft_model == "z-lab/Qwen3.5-4B-DFlash"
+
+class TestDFlashEngineMaxCtx:
+    """Test DFlashEngine max_dflash_ctx resolution logic."""
+
+    def _clear_env(self):
+        """Clear DFLASH_MAX_CTX env var so model_settings takes effect."""
+        import os
+        os.environ.pop("DFLASH_MAX_CTX", None)
+
+    def test_max_ctx_from_model_settings(self):
+        """max_dflash_ctx should be read from model_settings when env var is not set."""
+        try:
+            from omlx.engine.dflash import DFlashEngine, DEFAULT_MAX_DFLASH_CTX
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        self._clear_env()
+        settings = ModelSettings(dflash_max_ctx=4096)
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            model_settings=settings,
+        )
+        assert engine._max_dflash_ctx == 4096
+
+    def test_max_ctx_defaults_when_none(self):
+        """When model_settings.dflash_max_ctx is None, use DEFAULT_MAX_DFLASH_CTX."""
+        try:
+            from omlx.engine.dflash import DFlashEngine, DEFAULT_MAX_DFLASH_CTX
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        self._clear_env()
+        settings = ModelSettings()  # dflash_max_ctx is None
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            model_settings=settings,
+        )
+        assert engine._max_dflash_ctx == DEFAULT_MAX_DFLASH_CTX
+
+    def test_max_ctx_defaults_when_no_model_settings(self):
+        """When model_settings is None, use DEFAULT_MAX_DFLASH_CTX."""
+        try:
+            from omlx.engine.dflash import DFlashEngine, DEFAULT_MAX_DFLASH_CTX
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        self._clear_env()
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+        )
+        assert engine._max_dflash_ctx == DEFAULT_MAX_DFLASH_CTX
+
+    def test_max_ctx_env_var_override(self):
+        """DFLASH_MAX_CTX env var should override model settings."""
+        import os
+        try:
+            from omlx.engine.dflash import DFlashEngine
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        os.environ["DFLASH_MAX_CTX"] = "2048"
+        try:
+            settings = ModelSettings(dflash_max_ctx=4096)
+            engine = DFlashEngine(
+                model_name="test-model",
+                draft_model_path="test-draft",
+                model_settings=settings,
+            )
+            # Env var takes priority over model settings
+            assert engine._max_dflash_ctx == 2048
+        finally:
+            os.environ.pop("DFLASH_MAX_CTX", None)
+
+    def test_max_ctx_invalid_env_var_falls_back(self):
+        """Invalid env var value should fall back to DEFAULT_MAX_DFLASH_CTX."""
+        import os
+        try:
+            from omlx.engine.dflash import DFlashEngine, DEFAULT_MAX_DFLASH_CTX
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        os.environ["DFLASH_MAX_CTX"] = "not-a-number"
+        try:
+            settings = ModelSettings(dflash_max_ctx=4096)
+            engine = DFlashEngine(
+                model_name="test-model",
+                draft_model_path="test-draft",
+                model_settings=settings,
+            )
+            assert engine._max_dflash_ctx == DEFAULT_MAX_DFLASH_CTX
+        finally:
+            os.environ.pop("DFLASH_MAX_CTX", None)
+
+
+class TestDFlashRoutingLogic:
+    """Test context-size-based routing to batched mode."""
+
+    def test_short_prompt_uses_dflash(self):
+        """Prompts shorter than max_dflash_ctx should route to DFlash."""
+        try:
+            from omlx.engine.dflash import DFlashEngine
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        settings = ModelSettings(dflash_max_ctx=8192)
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            model_settings=settings,
+        )
+
+        # Simulate prompt encoding and check routing decision
+        class MockTokenizer:
+            def encode(self, text):
+                return list(range(len(text)))  # 1 token per char
+
+        engine._tokenizer_obj = MockTokenizer()
+        prompt = "hello world"  # 11 tokens < 8192
+        prompt_tokens = engine._tokenizer_obj.encode(prompt)
+        assert len(prompt_tokens) < engine._max_dflash_ctx
+
+    def test_long_prompt_exceeds_max_ctx(self):
+        """Prompts at or above max_dflash_ctx should route to batched."""
+        try:
+            from omlx.engine.dflash import DFlashEngine
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        settings = ModelSettings(dflash_max_ctx=100)
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            model_settings=settings,
+        )
+
+        class MockTokenizer:
+            def encode(self, text):
+                return list(range(len(text)))
+
+        engine._tokenizer_obj = MockTokenizer()
+        prompt = "x" * 100  # exactly 100 tokens = max_ctx
+        prompt_tokens = engine._tokenizer_obj.encode(prompt)
+        assert len(prompt_tokens) >= engine._max_dflash_ctx

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -231,12 +231,14 @@ class TestDFlashRoutingLogic:
             draft_model_path="test-draft",
             model_settings=settings,
         )
+        # Clamped to 1024 minimum, so effective value is 1024
+        assert engine._max_dflash_ctx == 1024
 
         class MockTokenizer:
             def encode(self, text):
                 return list(range(len(text)))
 
         engine._tokenizer_obj = MockTokenizer()
-        prompt = "x" * 100  # exactly 100 tokens = max_ctx
+        prompt = "x" * 1024  # exactly 1024 tokens = effective max_ctx
         prompt_tokens = engine._tokenizer_obj.encode(prompt)
         assert len(prompt_tokens) >= engine._max_dflash_ctx

--- a/tests/test_dflash_hook_toggles.py
+++ b/tests/test_dflash_hook_toggles.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for DFlash hook toggle functions.
+
+These tests verify that _enable_dflash_hooks and _disable_dflash_hooks
+correctly toggle the dflash-mlx internal attributes on a model structure.
+They serve as a regression guard: if dflash-mlx renames attributes or
+changes its internal API, these tests will fail immediately.
+
+No real model is loaded — the test constructs a minimal mock that mirrors
+the structure dflash-mlx expects (layers with self_attn and linear_attn).
+"""
+
+import pytest
+
+class _MockSelfAttn:
+    """Mock self-attention layer that mirrors dflash-mlx's structure."""
+
+    def __init__(self):
+        # This is the attribute split_call checks at runtime
+        self._dflash_split_sdpa_enabled = False
+
+class _MockLinearAttn:
+    """Mock linear attention layer with in_proj projections."""
+
+    def __init__(self):
+        self.in_proj_b = _MockLinear()
+        self.in_proj_a = _MockLinear()
+
+class _MockLinear:
+    """Mock linear layer (the raw projection inside _ExactSmallProjPad)."""
+
+    def __init__(self):
+        self.weight = None
+        self.bias = None
+
+class _MockLayer:
+    """Single transformer layer with self_attn and linear_attn."""
+
+    def __init__(self):
+        self.self_attn = _MockSelfAttn()
+        self.linear_attn = _MockLinearAttn()
+
+class _MockTextModel:
+    """Minimal text model with layers attribute."""
+
+    def __init__(self, num_layers=40):
+        self.layers = [_MockLayer() for _ in range(num_layers)]
+
+class _MockTargetModel:
+    """Wraps a text model the way dflash-mlx does (has .model attribute)."""
+
+    def __init__(self, num_layers=40):
+        self.model = _MockTextModel(num_layers)
+
+class TestEnableDFlashHooks:
+    """Test that _enable_dflash_hooks correctly re-enables hooks."""
+
+    def test_sets_split_sdpa_enabled_true(self):
+        """All self_attn layers should have _dflash_split_sdpa_enabled = True."""
+        try:
+            from omlx.engine.dflash import _enable_dflash_hooks, _get_text_model
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        model = _MockTargetModel(num_layers=40)
+        text_model = _get_text_model(model)
+
+        # Initially all False (set by _MockSelfAttn.__init__)
+        for layer in text_model.layers:
+            assert layer.self_attn._dflash_split_sdpa_enabled is False
+
+        _enable_dflash_hooks(model)
+
+        for layer in text_model.layers:
+            assert layer.self_attn._dflash_split_sdpa_enabled is True
+
+    def test_sets_hooks_installed_flag(self):
+        """text_model._dflash_speculative_hooks_installed should be True."""
+        try:
+            from omlx.engine.dflash import _enable_dflash_hooks, _get_text_model
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        model = _MockTargetModel(num_layers=40)
+        text_model = _get_text_model(model)
+
+        assert getattr(text_model, "_dflash_speculative_hooks_installed", None) is not True
+
+        _enable_dflash_hooks(model)
+
+        assert text_model._dflash_speculative_hooks_installed is True
+
+    def test_re_wraps_exact_small_proj_pad(self):
+        """If projections were unwrapped, _enable should re-wrap them."""
+        try:
+            from omlx.engine.dflash import _enable_dflash_hooks, _get_text_model
+            from dflash_mlx.runtime import _ExactSmallProjPad
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        model = _MockTargetModel(num_layers=40)
+        text_model = _get_text_model(model)
+
+        # Simulate unwrapped state: replace _ExactSmallProjPad with raw linear
+        for layer in text_model.layers:
+            proj_b = layer.linear_attn.in_proj_b
+            proj_a = layer.linear_attn.in_proj_a
+            # Wrap them first (as they would be after initial dflash init)
+            layer.linear_attn.in_proj_b = _ExactSmallProjPad(proj_b)
+            layer.linear_attn.in_proj_a = _ExactSmallProjPad(proj_a)
+
+        # Now simulate _disable having unwrapped them
+        for layer in text_model.layers:
+            layer.linear_attn.in_proj_b = layer.linear_attn.in_proj_b.linear
+            layer.linear_attn.in_proj_a = layer.linear_attn.in_proj_a.linear
+
+        # Verify they're unwrapped
+        for layer in text_model.layers:
+            assert type(layer.linear_attn.in_proj_b).__name__ != "_ExactSmallProjPad"
+
+        # Re-enable should re-wrap
+        _enable_dflash_hooks(model)
+
+        for layer in text_model.layers:
+            assert type(layer.linear_attn.in_proj_b).__name__ == "_ExactSmallProjPad"
+            assert type(layer.linear_attn.in_proj_a).__name__ == "_ExactSmallProjPad"
+
+    def test_idempotent_when_already_enabled(self):
+        """Calling _enable twice should be safe (no double-wrap on already-wrapped)."""
+        try:
+            from omlx.engine.dflash import _enable_dflash_hooks, _get_text_model
+            from dflash_mlx.runtime import _ExactSmallProjPad
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        model = _MockTargetModel(num_layers=40)
+        text_model = _get_text_model(model)
+
+        # Pre-wrap projections (as dflash-mlx would do on init)
+        for layer in text_model.layers:
+            raw_b = layer.linear_attn.in_proj_b
+            raw_a = layer.linear_attn.in_proj_a
+            layer.linear_attn.in_proj_b = _ExactSmallProjPad(raw_b)
+            layer.linear_attn.in_proj_a = _ExactSmallProjPad(raw_a)
+
+        # First enable
+        _enable_dflash_hooks(model)
+
+        # Verify still single-wrapped (not double-wrapped)
+        for layer in text_model.layers:
+            assert type(layer.linear_attn.in_proj_b).__name__ == "_ExactSmallProjPad"
+            # The inner .linear should be the raw _MockLinear, not another _ExactSmallProjPad
+            assert type(layer.linear_attn.in_proj_b.linear).__name__ == "_MockLinear"
+
+        # Second enable should be safe (no-op on already-wrapped)
+        _enable_dflash_hooks(model)
+
+        for layer in text_model.layers:
+            assert type(layer.linear_attn.in_proj_b).__name__ == "_ExactSmallProjPad"
+            assert type(layer.linear_attn.in_proj_b.linear).__name__ == "_MockLinear"
+
+class TestDisableDFlashHooks:
+    """Test that _disable_dflash_hooks correctly disables hooks."""
+
+    def test_sets_split_sdpa_enabled_false(self):
+        """All self_attn layers should have _dflash_split_sdpa_enabled = False."""
+        try:
+            from omlx.engine.dflash import _disable_dflash_hooks, _get_text_model
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        model = _MockTargetModel(num_layers=40)
+        text_model = _get_text_model(model)
+
+        # Pre-enable (as dflash-mlx would set on init)
+        for layer in text_model.layers:
+            layer.self_attn._dflash_split_sdpa_enabled = True
+
+        _disable_dflash_hooks(model)
+
+        for layer in text_model.layers:
+            assert layer.self_attn._dflash_split_sdpa_enabled is False
+
+    def test_unwraps_exact_small_proj_pad(self):
+        """Projections wrapped in _ExactSmallProjPad should be unwrapped."""
+        try:
+            from omlx.engine.dflash import _disable_dflash_hooks, _get_text_model
+            from dflash_mlx.runtime import _ExactSmallProjPad
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        model = _MockTargetModel(num_layers=40)
+        text_model = _get_text_model(model)
+
+        # Pre-wrap projections (as dflash-mlx would do on init)
+        for layer in text_model.layers:
+            raw_b = layer.linear_attn.in_proj_b
+            raw_a = layer.linear_attn.in_proj_a
+            layer.linear_attn.in_proj_b = _ExactSmallProjPad(raw_b)
+            layer.linear_attn.in_proj_a = _ExactSmallProjPad(raw_a)
+
+        _disable_dflash_hooks(model)
+
+        for layer in text_model.layers:
+            assert type(layer.linear_attn.in_proj_b).__name__ != "_ExactSmallProjPad"
+            assert type(layer.linear_attn.in_proj_a).__name__ != "_ExactSmallProjPad"
+            # Should be the raw linear layer
+            assert hasattr(layer.linear_attn.in_proj_b, "weight")
+            assert hasattr(layer.linear_attn.in_proj_a, "weight")
+
+    def test_sets_hooks_installed_flag_false(self):
+        """text_model._dflash_speculative_hooks_installed should be False."""
+        try:
+            from omlx.engine.dflash import _disable_dflash_hooks, _get_text_model
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        model = _MockTargetModel(num_layers=40)
+        text_model = _get_text_model(model)
+
+        # Pre-enable
+        for layer in text_model.layers:
+            layer.self_attn._dflash_split_sdpa_enabled = True
+        text_model._dflash_speculative_hooks_installed = True
+
+        _disable_dflash_hooks(model)
+
+        assert text_model._dflash_speculative_hooks_installed is False
+
+class TestToggleRoundTrip:
+    """Test that disable then re-enable restores the model to working state."""
+
+    def test_disable_then_enable_restores_all_flags(self):
+        """After disable+enable, all flags should be True again."""
+        try:
+            from omlx.engine.dflash import (
+                _enable_dflash_hooks,
+                _disable_dflash_hooks,
+                _get_text_model,
+            )
+            from dflash_mlx.runtime import _ExactSmallProjPad
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        model = _MockTargetModel(num_layers=40)
+        text_model = _get_text_model(model)
+
+        # Simulate initial dflash-mlx state
+        for layer in text_model.layers:
+            layer.self_attn._dflash_split_sdpa_enabled = True
+            layer.linear_attn.in_proj_b = _ExactSmallProjPad(layer.linear_attn.in_proj_b)
+            layer.linear_attn.in_proj_a = _ExactSmallProjPad(layer.linear_attn.in_proj_a)
+        text_model._dflash_speculative_hooks_installed = True
+
+        # Disable (as _init_fallback_engine would do)
+        _disable_dflash_hooks(model)
+
+        # Verify disabled
+        assert text_model._dflash_speculative_hooks_installed is False
+        for layer in text_model.layers:
+            assert layer.self_attn._dflash_split_sdpa_enabled is False
+
+        # Re-enable (as generate/stream_generate would do)
+        _enable_dflash_hooks(model)
+
+        # Verify fully restored
+        assert text_model._dflash_speculative_hooks_installed is True
+        for layer in text_model.layers:
+            assert layer.self_attn._dflash_split_sdpa_enabled is True
+            assert type(layer.linear_attn.in_proj_b).__name__ == "_ExactSmallProjPad"
+            assert type(layer.linear_attn.in_proj_a).__name__ == "_ExactSmallProjPad"
+
+    def test_multiple_disable_enable_cycles(self):
+        """Multiple disable/enable cycles should be idempotent."""
+        try:
+            from omlx.engine.dflash import (
+                _enable_dflash_hooks,
+                _disable_dflash_hooks,
+                _get_text_model,
+            )
+            from dflash_mlx.runtime import _ExactSmallProjPad
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        model = _MockTargetModel(num_layers=40)
+        text_model = _get_text_model(model)
+
+        # Simulate initial dflash-mlx state
+        for layer in text_model.layers:
+            layer.self_attn._dflash_split_sdpa_enabled = True
+            layer.linear_attn.in_proj_b = _ExactSmallProjPad(layer.linear_attn.in_proj_b)
+            layer.linear_attn.in_proj_a = _ExactSmallProjPad(layer.linear_attn.in_proj_a)
+        text_model._dflash_speculative_hooks_installed = True
+
+        for cycle in range(3):
+            _disable_dflash_hooks(model)
+            assert text_model._dflash_speculative_hooks_installed is False
+
+            _enable_dflash_hooks(model)
+            assert text_model._dflash_speculative_hooks_installed is True
+            for layer in text_model.layers:
+                assert layer.self_attn._dflash_split_sdpa_enabled is True
+                assert type(layer.linear_attn.in_proj_b).__name__ == "_ExactSmallProjPad"


### PR DESCRIPTION
Related issue and some discussion: #873

### Motivation

DFlash (speculative decoding) can provide a substantial increase in token generation speed but it doesn't fit well with agentic workflows. Above ~4k context the benefits taper off, and at large contexts (32k) the effect is negative.

### Current status

The current implementation in oMLX uses DFlash for requests below a preset `max_dflash_ctx` of 4096 tokens. If the server receives a request with a context above that threshold, it goes int fallback mode, unloads the draft model and disables DFlash for all prompts (regardless of context size) for the remainder of the session. This status is only reset once the model is unloaded and loaded again.

### Proposal

Per-request routing: instead of a permanent "fallback" mode, DFlashEngine now supports per-request mode switching; each request to the model is handled by either BatchedEngine or DFlashEngine based on context length. 

Shared target model: the target model is loaded once and shared across both DFlash and batched paths. BatchedEngine now accepts optional model/tokenizer params, and its `start()` skips loading when a model is already provided. The target model is loaded once in memory and shared by both engines.

No eviction: removed the evict_dflash and start_fallback pattern. Target model and draft model stay loaded; switching between modes is just a routing decision.

Per-model max_dflash_ctx: added dflash_max_ctx option to ModelSettings, configurable via the admin UI (default 4096). The DFLASH_MAX_CTX env var still takes priority as a global override (also used internally by `bstnxbt/dflash-mlx`).

### Outcome

A model configured with DFlash can receive both large-context and small-context prompts over the course of a session and dynamically use batched mode (with it's own KV cache) or DFlash mode (separate KV cache) with a configurable threshold.

For agentic workflows (depending on your agent) this means you can keep a long-running, large-context session going and also fire off smaller ad-hoc prompts in between that will benefit from DFlash, potentially through automatic delegation to subagents (for small tasks, with the main context stripped out).