### PR TITLE
fix: Guard cached VLM prefill for non-mRoPE models like Gemma 4

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1201,10 +1201,14 @@ class Scheduler:
             # Setting _rope_deltas=None makes the language model use
             # _position_ids (set by get_input_embeddings) instead.
             # Saved and restored after prefill for decode rope_deltas capture.
+            # Only applies to mRoPE VLMs (Qwen2-VL, Qwen2.5-VL, GLM-4V, etc.);
+            # non-mRoPE VLMs like Gemma 4 have no _rope_deltas attribute.
             _saved_rope_deltas = None
-            if start_offset > 0 and hasattr(self.model, "_language_model"):
-                _saved_rope_deltas = self.model._language_model._rope_deltas
-                self.model._language_model._rope_deltas = None
+            if start_offset > 0:
+                lm = getattr(self.model, "_language_model", None)
+                if lm is not None and hasattr(lm, "_rope_deltas"):
+                    _saved_rope_deltas = lm._rope_deltas
+                    lm._rope_deltas = None
 
         # Prefill tokens[0:N-1] (leave last token for insert())
         prefill_tokens = tokens[:-1]


### PR DESCRIPTION
While the [original commit](512c21b216d499efea9e8241acd17a2f5cca5883) specifically stated that Gemma 4 26B was tested with the code changes, I've been having issues with images on that model while running with oMLX. The fix in this PR solves the issue a is a low impact change, but I suggest double checking during the review, in any case.

---

## Problem

Sending an image to a non-mRoPE VLM (Gemma 4, Pixtral, LLaVA, etc.) via Open WebUI crashed the engine loop with `AttributeError: 'LanguageModel' object has no attribute '_rope_deltas'` whenever the vision-feature cache served a hit (i.e. the second and later request for the same image on any given server lifetime).

```
File "omlx/scheduler.py", line 1206, in _do_external_prefill
  _saved_rope_deltas = self.model._language_model._rope_deltas
AttributeError: 'LanguageModel' object has no attribute '_rope_deltas'
```

### Root cause

The cached-VLM-prefill branch introduced in `512c21b2` (`omlx/scheduler.py:1205-1207`) saves and clears `_rope_deltas` on the underlying language model so the mRoPE `_position_ids` path is forced during re-prefill. The guard only verified that the wrapper exposed `_language_model`, not that the language model itself actually carries `_rope_deltas`:

```python
# before this fix
_saved_rope_deltas = None
if start_offset > 0 and hasattr(self.model, "_language_model"):
    _saved_rope_deltas = self.model._language_model._rope_deltas
    self.model._language_model._rope_deltas = None
```

`_rope_deltas` is an mRoPE-specific attribute. In the mlx-vlm tree it is declared on the `LanguageModel` classes of the mRoPE VLMs only: Qwen2-VL, Qwen2.5-VL, GLM-4V (OCR and MoE variants), Ernie4.5-MoE-VL, Qwen3-VL-MoE, Qwen3.5-MoE, MiniCPM-O, and Falcon-OCR. Non-mRoPE VLMs such as Gemma 4, Pixtral, and LLaVA have no `_rope_deltas` attribute, so the bare access crashed.

The crash only fires when `start_offset > 0`, which requires the vision-feature cache at `~/.omlx/cache/vision_features/` to already hold an entry for the image. The first request for a given image populates the cache and succeeds. Subsequent requests hit the cached-prefill branch and crash. This explains why the bug is easy to miss in smoke tests but reliably reproduces under normal use.

## Fix

Tighten the guard to inspect the language model directly, and fetch the wrapper via `getattr` for symmetry:

```python
_saved_rope_deltas = None
if start_offset > 0:
    lm = getattr(self.model, "_language_model", None)
    if lm is not None and hasattr(lm, "_rope_deltas"):
        _saved_rope_deltas = lm._rope_deltas
        lm._rope_deltas = None
```

The restore block at `omlx/scheduler.py:1332` is already safe. It only runs when `_saved_rope_deltas is not None`, which implies the attribute existed and was read successfully, so the restore cannot re-introduce the crash.

## Behaviour after the fix

- mRoPE VLMs: unchanged. `_rope_deltas` is still saved, cleared before prefill, and restored after.
- Non-mRoPE VLMs: the save/clear/restore sequence is simply skipped, matching the behaviour on the non-cached-prefill path. Cached-prefill proceeds normally.

## Reproduction

1. Start the omlx server with a Gemma 4 (or any non-mRoPE) VLM loaded.
2. Send an image request via any client (Open WebUI tested). The first request populates the vision-feature cache and returns normally.
3. Send any subsequent image request that reuses the cached vision features. Before the fix, the engine loop raised `AttributeError` and the request returned an error.

After the fix, both requests complete normally.

## Scope

Single-line-of-reasoning change in `omlx/scheduler.py`. No other files need to change. No API surface or model-adapter changes.