### PR TITLE
fix(scheduler): activate Metal stream in MLX executor thread

### DIFF
--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -32,6 +32,38 @@ logger = logging.getLogger(__name__)
 _global_mlx_executor: concurrent.futures.ThreadPoolExecutor | None = None
 
 
+def _init_mlx_thread() -> None:
+    """Move mlx_lm.generate.generation_stream into the executor thread.
+
+    generation_stream is created at mlx_lm.generate import time in whichever
+    thread imports it first (the main thread when omlx.scheduler is imported
+    at server startup).  All MLX GPU ops are serialized onto this executor
+    thread, and arrays produced inside `with mx.stream(generation_stream):`
+    blocks carry that stream reference — subsequent .item() / mx.synchronize()
+    calls then try to resolve the main thread's stream object from this thread
+    and fail with "There is no Stream(gpu, 0) in current thread".
+
+    Fix: on executor-thread init, create a new Metal stream HERE and replace
+    the module-level generation_stream in both mlx_lm.generate and
+    omlx.scheduler (which imported it by name).  This runs before any model is
+    loaded, so subsequent BatchGenerator ops tag arrays with the new stream.
+    """
+    import sys
+    import mlx.core as mx
+
+    stream = mx.new_stream(mx.gpu)
+
+    gen_mod = sys.modules.get("mlx_lm.generate")
+    if gen_mod is not None:
+        gen_mod.generation_stream = stream
+
+    sched_mod = sys.modules.get("omlx.scheduler")
+    if sched_mod is not None:
+        sched_mod.generation_stream = stream
+
+    logger.info(f"MLX executor thread initialized: generation_stream = {stream}")
+
+
 def get_mlx_executor() -> concurrent.futures.ThreadPoolExecutor:
     """Get or create the global MLX executor (lazy singleton).
 
@@ -43,7 +75,8 @@ def get_mlx_executor() -> concurrent.futures.ThreadPoolExecutor:
     global _global_mlx_executor
     if _global_mlx_executor is None:
         _global_mlx_executor = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="mlx-global"
+            max_workers=1, thread_name_prefix="mlx-global",
+            initializer=_init_mlx_thread,
         )
     return _global_mlx_executor
 


### PR DESCRIPTION
## Summary
- Fixes `RuntimeError: There is no Stream(gpu, 0) in current thread` triggered by RotatingKVCache models (e.g. Qwen3.5) via `POST /v1/chat/completions`.
- Adds a `ThreadPoolExecutor(initializer=...)` that creates a Metal stream in the `mlx-global` worker thread and rebinds `generation_stream` on both `mlx_lm.generate` and `omlx.scheduler`, so arrays produced under `with mx.stream(generation_stream):` are tagged with a stream that exists in the executor thread.
- Single-file change (+34/-1) in `omlx/engine_core.py`.

## Root cause
- `mlx_lm.generate.generation_stream = mx.new_stream(...)` runs at import time in whichever thread first imports the module — that's the main thread (via `omlx.scheduler`).
- All MLX GPU ops serialize onto the single-worker `mlx-global` executor. Metal streams are thread-local, so `.item()` / `mx.synchronize(generation_stream)` in the executor thread cannot resolve the main-thread stream object.
- A simple `.item()` call in an executor worker works; the failure only surfaces with arrays produced inside `with mx.stream(generation_stream):` blocks (see `mlx_lm/generate.py` lines 425, 604, 1847, 1857), which tag the array's owning stream. `cache.py:filter()` → `.min().item()` is the typical crash site.

## Test plan
- [x] Start `omlx serve --model-dir ~/.omlx/models` with a Qwen3.5-MLX-4bit model symlinked.
- [x] `curl -X POST /v1/chat/completions` — returns a real completion instead of 500.
- [x] Short chat (5 tokens): 2.45 s.
- [x] Length sweep (prefill/decode across 64/512/2k/8k input tokens) — no crash.
- [x] Concurrency 1/2/4 at 512 & 2048 input — no crash; aggregate throughput scales 1.4–1.6×.

## Notes
- The fix is minimal and contained; no public API changes.
- Non-reasoning / non-RotatingKVCache models were already working; this patch should not affect them.