### PR TITLE
[Performance] Improve RAM usage

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -742,8 +742,15 @@ class PagedSSDCacheManager(CacheManager):
             self._hot_cache_total_bytes += entry_size
 
         # Flush evicted entries to SSD outside the hot cache lock
-        for evicted_hash, evicted in evicted_entries:
-            self._enqueue_ssd_write(evicted_hash, evicted)
+        # Skip SSD write when hot_cache_only=True (evicted entries are discarded)
+        if not self._hot_cache_only:
+            for evicted_hash, evicted in evicted_entries:
+                self._enqueue_ssd_write(evicted_hash, evicted)
+        elif evicted_entries:
+            logger.debug(
+                f"Discarding {len(evicted_entries)} evicted blocks "
+                f"(hot_cache_only=True)"
+            )
 
     def _enqueue_ssd_write(self, block_hash: bytes, entry: dict) -> bool:
         """Enqueue a hot cache entry for SSD background write.

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -807,9 +807,7 @@ class PagedSSDCacheManager(CacheManager):
         with self._hot_cache_lock:
             old = self._hot_cache.pop(block_hash, None)
             if old:
-                self._hot_cache_total_bytes -= self._hot_cache_entry_size(
-                    old["tensors_raw"]
-                )
+                self._hot_cache_total_bytes -= self._hot_cache_entry_size(old)
 
     def _promote_to_hot_cache(
         self,

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -2143,7 +2143,7 @@ class PagedSSDCacheManager(CacheManager):
                     if blk_meta is None or not _matches(blk_meta.model_name):
                         continue
                     hot_entries.append(entry)
-                    hot_size += self._hot_cache_entry_size(entry["tensors_raw"])
+                    hot_size += self._hot_cache_entry_size(entry)
 
             return PagedSSDCacheStats(
                 hits=self._stats["hits"],

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -1276,6 +1276,10 @@ class PagedSSDCacheManager(CacheManager):
             # Merge CacheList sub_count metadata
             metadata.update(cache_list_meta)
 
+            # Materialize lazy arrays on the inference thread (Metal-safe).
+            if self._hot_cache_only and arrays:
+                mx.eval(*arrays.values())  # noqa: S307 — MLX tensor eval, not Python eval
+
             # Caller (scheduler._cleanup_finished, async store-cache path)
             # already mx.eval's all real KV arrays on the inference thread
             # before submitting to the omlx-store-cache executor. The tiny

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -1324,6 +1324,21 @@ class PagedSSDCacheManager(CacheManager):
                 "block_metadata": block_metadata,
             }
 
+            if self._hot_cache_only:
+                # Hot cache only mode: store mx.array directly (not tensors_raw).
+                # This avoids memory doubling on cache hit - we reuse the same
+                # GPU memory instead of creating new mx.array objects.
+                cache_entry = {
+                    "arrays": arrays,
+                    "file_metadata": metadata,
+                    "num_layers": len(cache_data),
+                    "layer_cache_types": layer_cache_types,
+                    "block_metadata": block_metadata,
+                }
+                self._hot_cache_put(block_hash, cache_entry)
+                self._stats["saves"] += 1
+                return True
+
             if self._hot_cache_enabled:
                 # Write-back mode: store only in hot cache, no SSD index entry.
                 # SSD index entry is created later when block is evicted or
@@ -1331,10 +1346,6 @@ class PagedSSDCacheManager(CacheManager):
                 self._hot_cache_put(block_hash, cache_entry)
                 self._stats["saves"] += 1
                 return True
-
-            if self._hot_cache_only:
-                # Hot cache disabled but hot_cache_only set: block is not retained.
-                return False
 
             # SSD path: add to index for SSD file tracking
             self._index.add(block_metadata)
@@ -1611,18 +1622,24 @@ class PagedSSDCacheManager(CacheManager):
         # Check hot cache first (in-memory, no I/O)
         entry = self._hot_cache_get(block_hash)
         if entry is not None:
-            # Entries from _promote_to_hot_cache() store mx.array objects directly
-            # (safe — they come from SSD loads, not active inference).
-            # Entries from save_block() use tensors_raw (raw bytes).
-            arrays = entry.get("arrays") or self._arrays_from_tensors_raw(
-                entry["tensors_raw"]
-            )
-            cache_data = self._reconstruct_cache_data(
-                arrays,
-                entry["file_metadata"],
-                entry["num_layers"],
-                entry["layer_cache_types"],
-            )
+            # Check for "arrays" first (direct mx.array storage).
+            # This is the fast path for hot_cache_only mode.
+            if "arrays" in entry:
+                cache_data = self._reconstruct_cache_data(
+                    entry["arrays"],
+                    entry["file_metadata"],
+                    entry["num_layers"],
+                    entry["layer_cache_types"],
+                )
+            else:
+                # Fallback: tensors_raw path
+                arrays = self._arrays_from_tensors_raw(entry["tensors_raw"])
+                cache_data = self._reconstruct_cache_data(
+                    arrays,
+                    entry["file_metadata"],
+                    entry["num_layers"],
+                    entry["layer_cache_types"],
+                )
             if cache_data is not None:
                 self._index.touch(block_hash)
                 self._stats["loads"] += 1
@@ -1744,15 +1761,24 @@ class PagedSSDCacheManager(CacheManager):
         entry = self._hot_cache_get(block_hash)
         if entry is not None:
             blk_meta = entry["block_metadata"]
-            arrays = entry.get("arrays") or self._arrays_from_tensors_raw(
-                entry["tensors_raw"]
-            )
-            cache_data = self._reconstruct_cache_data(
-                arrays,
-                entry["file_metadata"],
-                entry["num_layers"],
-                entry["layer_cache_types"],
-            )
+            # Check for "arrays" first (direct mx.array storage)
+            # This is the fast path for hot_cache_only mode.
+            if "arrays" in entry:
+                cache_data = self._reconstruct_cache_data(
+                    entry["arrays"],
+                    entry["file_metadata"],
+                    entry["num_layers"],
+                    entry["layer_cache_types"],
+                )
+            else:
+                # Fallback: tensors_raw path
+                arrays = self._arrays_from_tensors_raw(entry["tensors_raw"])
+                cache_data = self._reconstruct_cache_data(
+                    arrays,
+                    entry["file_metadata"],
+                    entry["num_layers"],
+                    entry["layer_cache_types"],
+                )
             if cache_data is None:
                 return None, None
 

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -925,11 +925,9 @@ class BlockAwarePrefixCache(CacheManager):
                         )
                     )
                 elif cache_type_name == "RotatingKVCache":
-                    # RotatingKVCache: last-block-only or boundary-snapshot strategy
-                    has_valid_state = is_last_block or (
-                        snapshot_cache_data is not None
-                        and layer_idx < len(snapshot_cache_data)
-                    )
+                    # RotatingKVCache: Always store actual data for all blocks.
+                    # This enables walk-back during restore without boundary snapshots.
+                    has_valid_state = True
                     if has_valid_state:
                         # Use snapshot state if available, otherwise use main state
                         if (
@@ -1078,15 +1076,10 @@ class BlockAwarePrefixCache(CacheManager):
                             block_slices.append((mx.zeros((1,)), mx.zeros((1,))))
                 else:
                     # Other non-sliceable cache (ArraysCache/MambaCache)
-                    # GDN recurrent state summarizes the ENTIRE sequence in a
-                    # fixed-size matrix. Each block boundary snapshot captures
-                    # the state at that point in the sequence. Without a snapshot,
-                    # non-last blocks get a placeholder so partial matches are
-                    # detected and rejected during reconstruction.
-                    has_valid_state = is_last_block or (
-                        snapshot_cache_data is not None
-                        and layer_idx < len(snapshot_cache_data)
-                    )
+                    # GDN recurrent state summarizes the ENTIRE sequence.
+                    # Always store actual data for all blocks to enable walk-back
+                    # during restore without boundary snapshots.
+                    has_valid_state = True
                     if has_valid_state:
                         # Use snapshot state if available, otherwise main state
                         if (

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -1846,19 +1846,18 @@ class BlockAwarePrefixCache(CacheManager):
                         if isinstance(ms, (list, tuple)) and len(ms) >= 3:
                             tq_bits = float(ms[1])
                             tq_seed = int(ms[2])
-                        # Dequantize back to fp16 KVCache for merge compatibility.
+                        # Keep TurboQuantKVCache in quantized form to avoid memory doubling.
                         # TQ will be re-applied at decode start (lazy quantization).
+                        # This avoids the dequantize() step which creates FP16 copy.
                         tq = TurboQuantKVCache(bits=tq_bits, seed=tq_seed)
                         tq.keys = cat_ks
                         tq.values = cat_vs
                         tq.offset = _state_length(cat_ks)
                         _rebuild_codecs(tq, cat_ks, cat_vs)
-                        keys, values = tq.dequantize()
-                        cache = KVCache()
-                        cache.keys = keys
-                        cache.values = values
-                        cache.offset = keys.shape[2]
-                        reconstructed_caches.append(cache)
+
+                        # Use TurboQuantKVCache directly without dequantizing
+                        # This keeps memory at quantized level (vs 16-bit)
+                        reconstructed_caches.append(tq)
                     except Exception as e:
                         logger.error(
                             f"TQ layer {layer_idx}: reconstruction failed: {e}"

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1449,7 +1449,8 @@ class Scheduler:
         # Boundary snapshot setup
         block_size = self.config.paged_cache_block_size
         boundary_enabled = (
-            block_size > 0
+            not self.config.hot_cache_only
+            and block_size > 0
             and self.block_aware_cache is not None
             and _prompt_cache_needs_snapshots(prompt_cache)
         )

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -4173,6 +4173,17 @@ class Scheduler:
                                 f"{len(request.prompt_token_ids)} prompt + "
                                 f"{len(request.output_token_ids)} output)"
                             )
+                            # Immediately release _extracted_cache to free copy #1
+                            # (store_cache already cloned to PagedCache blocks)
+                            request._extracted_cache = None
+
+                            # Clear boundary snapshots for this request after store to prevent memory leak.
+                            # Boundary snapshots were needed for proper block storage but are no longer needed.
+                            if request_id in self._boundary_cache_snapshots:
+                                del self._boundary_cache_snapshots[request_id]
+                                logger.debug(
+                                    f"Cleared boundary snapshots for request {request_id}"
+                                )
                         except Exception as e:
                             logger.debug(
                                 f"Failed to submit async store for {request_id}: {e}"

--- a/tests/test_cache_ntuple_state.py
+++ b/tests/test_cache_ntuple_state.py
@@ -323,7 +323,6 @@ class TestPagedSSDV3Format:
 
         manager.close()
 
-
 class TestPrefixCacheNTupleSubState:
     """prefix_cache._extract_block_tensor_slice preserves N-tuple sub-state.
 

--- a/tests/test_hot_cache.py
+++ b/tests/test_hot_cache.py
@@ -551,6 +551,81 @@ class TestHotCacheStatsAccuracy:
 
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestHotCacheOnlyMode:
+    """Contrast behavior when hot_cache_only=True vs False."""
+
+    def test_eviction_discard_vs_write(self, tmp_path):
+        """hot_cache_only=True should discard evicted blocks, False should write to SSD."""
+        block_hash = b"evict_contrast_hash"
+        cache_data = [(mx.zeros((1, 4, 16, 16)), mx.zeros((1, 4, 16, 16)))]
+
+        # Case 1: hot_cache_only = True (Discard)
+        mgr_true = PagedSSDCacheManager(
+            cache_dir=tmp_path / "evict_true",
+            max_size_bytes=1024**3,
+            hot_cache_max_bytes=100,  # Force immediate eviction
+            hot_cache_only=True,
+        )
+        mgr_true.save_block(block_hash, cache_data, 16, layer_cache_types=["KVCache"])
+        # Save another block to trigger eviction of first
+        mgr_true.save_block(
+            b"evict_trigger", cache_data, 16, layer_cache_types=["KVCache"]
+        )
+
+        # No SSD files should exist
+        ssd_files = list((tmp_path / "evict_true").rglob("*.safetensors"))
+        assert len(ssd_files) == 0
+        mgr_true.close()
+
+        # Case 2: hot_cache_only = False (Write to SSD)
+        mgr_false = PagedSSDCacheManager(
+            cache_dir=tmp_path / "evict_false",
+            max_size_bytes=1024**3,
+            hot_cache_max_bytes=100,  # Force immediate eviction
+            hot_cache_only=False,
+        )
+        mgr_false.save_block(block_hash, cache_data, 16, layer_cache_types=["KVCache"])
+        # Save another block to trigger eviction
+        mgr_false.save_block(
+            b"evict_trigger", cache_data, 16, layer_cache_types=["KVCache"]
+        )
+
+        # Wait for background writer
+        import time
+
+        time.sleep(0.5)
+        ssd_files = list((tmp_path / "evict_false").rglob("*.safetensors"))
+        assert len(ssd_files) >= 1
+        mgr_false.close()
+
+    def test_entry_size_calculation(self):
+        """Verify size calculation for both array and tensor_raw formats."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=Path("/tmp/size_test"), max_size_bytes=1024**3
+        )
+
+        # 1. Array format
+        arrays = {"k": mx.zeros((1, 8, 16, 16)), "v": mx.zeros((1, 8, 16, 16))}
+        entry_arrays = {"arrays": arrays}
+        # 1*8*16*16 * 4 bytes * 2 tensors = 16384 bytes
+        expected_size = 1 * 8 * 16 * 16 * 4 * 2
+        assert mgr._hot_cache_entry_size(entry_arrays) == expected_size
+
+        # 2. Tensors_raw format
+        raw_data = bytes(1024)
+        tensors_raw = {
+            "k": (raw_data, "F32", [1, 8, 16, 16]),
+            "v": (raw_data, "F32", [1, 8, 16, 16]),
+        }
+        entry_raw = {"tensors_raw": tensors_raw}
+        # 1024 * 2 = 2048 bytes
+        assert mgr._hot_cache_entry_size(entry_raw) == 2048
+
+        # 3. Empty/Unknown
+        assert mgr._hot_cache_entry_size({}) == 0
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
 class TestHotCacheWriteBack:
     """Test write-back behavior: no SSD writes until eviction or shutdown."""
 

--- a/tests/test_hybrid_cache.py
+++ b/tests/test_hybrid_cache.py
@@ -305,10 +305,10 @@ class TestExtractBlockTensorSliceLastBlock:
         keys0, values0 = result[0]
         assert keys0.shape == (1, 8, 4, 64)
 
-        # RotatingKVCache layer: placeholder
+        # RotatingKVCache layer: full state (always stored to enable walk-back)
         keys1, values1 = result[1]
-        assert keys1.shape == (1,)
-        assert values1.shape == (1,)
+        assert keys1.shape == (1, 8, 256, 64)
+        assert values1.shape == (1, 8, 256, 64)
 
     def test_rotating_last_block_full_state(self, prefix_cache):
         """Test RotatingKVCache last block stores full state."""
@@ -349,15 +349,15 @@ class TestExtractBlockTensorSliceLastBlock:
         )
         assert block0 is not None
         assert block0[0][0].shape == (1, 8, 4, 64)  # KVCache slice
-        assert block0[1][0].shape == (1,)  # RotatingKVCache placeholder
+        assert block0[1][0].shape == (1, 8, 256, 64)  # RotatingKVCache full state
 
-        # Block 1 (non-last): KVCache sliced, RotatingKVCache placeholder
+        # Block 1 (non-last): KVCache sliced, RotatingKVCache full state
         block1 = prefix_cache._extract_block_tensor_slice(
             cache_data, 4, 8, model_cache_config=config, is_last_block=False
         )
         assert block1 is not None
         assert block1[0][0].shape == (1, 8, 4, 64)
-        assert block1[1][0].shape == (1,)
+        assert block1[1][0].shape == (1, 8, 256, 64)
 
         # Block 3 (last): KVCache sliced, RotatingKVCache full state
         block3 = prefix_cache._extract_block_tensor_slice(

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -642,6 +642,81 @@ class TestPagedSSDCacheManagerWithMLX:
             assert keys.shape == (1, 8, 64, 64)
             assert values.shape == (1, 8, 64, 64)
 
+    def test_save_block_hot_cache_only_arrays_vs_tensors_raw(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """Contrast storage format between hot_cache_only=True and False."""
+        mx = mock_mlx
+        block_hash = b"format_contrast_hash"
+        cache_data = [(mx.zeros((1, 4, 16, 16)), mx.zeros((1, 4, 16, 16)))]
+
+        # Case 1: hot_cache_only = True (should store as 'arrays')
+        mgr_true = PagedSSDCacheManager(
+            cache_dir=tmp_path / "cache_true",
+            max_size_bytes=1024**3,
+            hot_cache_only=True,
+        )
+        mgr_true.save_block(block_hash, cache_data, 16, layer_cache_types=["KVCache"])
+        entry_true = mgr_true._hot_cache_get(block_hash)
+        assert entry_true is not None
+        assert "arrays" in entry_true
+        assert "tensors_raw" not in entry_true
+        mgr_true.close()
+
+        # Case 2: hot_cache_only = False (should store as 'tensors_raw')
+        mgr_false = PagedSSDCacheManager(
+            cache_dir=tmp_path / "cache_false",
+            max_size_bytes=1024**3,
+            hot_cache_only=False,
+        )
+        mgr_false.save_block(block_hash, cache_data, 16, layer_cache_types=["KVCache"])
+        entry_false = mgr_false._hot_cache_get(block_hash)
+        assert entry_false is not None
+        assert "tensors_raw" in entry_false
+        assert "arrays" not in entry_false
+        mgr_false.close()
+
+    def test_load_block_arrays_vs_tensors_raw_path(self, tmp_path: Path, mock_mlx):
+        """Contrast load paths: fast path (arrays) vs fallback (tensors_raw)."""
+        mx = mock_mlx
+        block_hash = b"load_path_contrast"
+        cache_data = [(mx.zeros((1, 4, 16, 16)), mx.zeros((1, 4, 16, 16)))]
+
+        # 1. Test Fast Path (hot_cache_only=True)
+        mgr_true = PagedSSDCacheManager(
+            cache_dir=tmp_path / "load_true",
+            max_size_bytes=1024**3,
+            hot_cache_only=True,
+        )
+        mgr_true.save_block(block_hash, cache_data, 16, layer_cache_types=["KVCache"])
+
+        # We can verify the fast path by mocking _arrays_from_tensors_raw and seeing it's NOT called
+        with patch.object(
+            PagedSSDCacheManager, "_arrays_from_tensors_raw"
+        ) as mock_fallback:
+            loaded = mgr_true.load_block(block_hash)
+            assert loaded is not None
+            mock_fallback.assert_not_called()
+        mgr_true.close()
+
+        # 2. Test Fallback Path (hot_cache_only=False)
+        mgr_false = PagedSSDCacheManager(
+            cache_dir=tmp_path / "load_false",
+            max_size_bytes=1024**3,
+            hot_cache_only=False,
+        )
+        mgr_false.save_block(block_hash, cache_data, 16, layer_cache_types=["KVCache"])
+
+        with patch.object(
+            PagedSSDCacheManager,
+            "_arrays_from_tensors_raw",
+            wraps=mgr_false._arrays_from_tensors_raw,
+        ) as mock_fallback:
+            loaded = mgr_false.load_block(block_hash)
+            assert loaded is not None
+            mock_fallback.assert_called()
+        mgr_false.close()
+
     def test_load_block_with_metadata(self, tmp_path: Path, mock_mlx):
         """Test loading block with metadata."""
         mx = mock_mlx

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -683,9 +683,9 @@ class TestArraysCacheLastBlockOnly:
         assert result is not None
         assert len(result) == 1
         keys, values = result[0]
-        # Should be placeholder
-        assert keys.shape == (1,)
-        assert values.shape == (1,)
+        # Should be full state (always stored to enable walk-back)
+        assert keys.shape == (1, 3, 64)
+        assert values.shape == (1, 32, 128, 128)
 
     def test_extract_block_hybrid_model_arrays_cache_and_kvcache(
         self, prefix_cache, mx
@@ -723,8 +723,8 @@ class TestArraysCacheLastBlockOnly:
         assert len(result) == 2
         # KVCache layer should be sliced normally
         assert result[0][0].shape[2] == 4  # seq_len slice
-        # ArraysCache layer should be placeholder
-        assert result[1][0].shape == (1,)
+        # ArraysCache layer should be full state (always stored to enable walk-back)
+        assert result[1][0].shape == (1, 3, 64)
 
         # Last block
         result = prefix_cache._extract_block_tensor_slice(

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -314,3 +314,23 @@ def test_ssd_type_map_completeness():
         "TurboQuantSplitState": TurboQuantSplitState,
     }
     assert set(_type_map.keys()) == expected_types
+
+
+def test_turboquant_reconstruct_keeps_quantized():
+    """Verify that reconstructed TurboQuantKVCache stays in quantized form."""
+    keys = mx.random.normal((1, 2, 16, 64))
+    values = mx.random.normal((1, 2, 16, 64))
+
+    tq = TurboQuantKVCache(bits=4.0, seed=7)
+    tq.update_and_fetch(keys, values)
+    ks, vs = tq.state
+
+    # Simulate the logic in BlockAwarePrefixCache.reconstruct_cache
+    tq2 = TurboQuantKVCache(bits=4.0, seed=7)
+    tq2.keys = ks
+    tq2.values = vs
+    tq2.offset = 16
+    _rebuild_codecs(tq2, ks, vs)
+
+    # The reconstructed object should be a TurboQuantKVCache, not a KVCache
+    assert isinstance(tq2, TurboQuantKVCache)


### PR DESCRIPTION
# About
This PR optimizes memory usage and improves the reliability of the KV cache system, focusing on reducing memory duplication in `hot_cache_only` mode and optimizing `TurboQuantKVCache` reconstruction.

# Features
- Direct `mx.array` storage in hot cache for `hot_cache_only` mode.
- Quantized-form retention for `TurboQuantKVCache` during reconstruction.
- Walk-back restore support for all blocks in prefix cache.
- Memory leak prevention for boundary snapshots.

# Changes
- Updated `PagedSSDCacheManager` to support direct array storage and updated stats collection.
- Modified `BlockAwarePrefixCache` to avoid dequantization of TQ cache and ensure all blocks are stored.
- Adjusted `Scheduler` to manage boundary snapshots and prevent leaks.
- Added integration tests for memory leak detection.

## Memory Optimization in Hot Cache
Implemented a fast path in `PagedSSDCacheManager` that stores and retrieves `mx.array` objects directly when `hot_cache_only` is enabled. This avoids converting arrays to raw bytes and back, which previously caused memory doubling during cache hits.

## TurboQuant and Prefix Cache Improvements
Modified `BlockAwarePrefixCache` to keep `TurboQuantKVCache` in its quantized state during reconstruction instead of converting to FP16. Additionally, changed the storage strategy for `RotatingKVCache` and other non-sliceable caches to always store actual data, enabling reliable walk-back restoration without relying on boundary snapshots.

## Leak Fix and Reliability
Fixed a memory leak in the `Scheduler` by explicitly clearing boundary snapshots from `_boundary_cache_snapshots` once the paged cache has been stored. Also updated boundary snapshot logic to be disabled when `hot_cache_only` is active.

# Testing

- [x] Unit Test pass
  - Added several tests about cache management.

<details>

<summary>Before fix</summary>

```python
FAILED tests/test_accuracy_benchmark.py::TestAccuracyBenchmarkRequest::test_all_valid_benchmarks - AssertionError: assert 16 == 12
FAILED tests/test_admin_api_key.py::TestListModelsSettings::test_list_models_includes_all_model_settings_fields - AssertionError: Missing fields: {'turboquant_skip_last', 'preserve_thinking'}, Extra fields: set()
FAILED tests/test_admin_profiles_api.py::test_all_model_settings_fields_classified - AssertionError: New ModelSettings field(s) {'preserve_thinking'} must be classified in UNIVERSAL_PROFILE_FIELDS, MODEL_SPECIFIC_PROFILE_FIELDS, or EXCLUDED_FROM_PROFILES. I...
FAILED tests/test_engine_core.py::TestEngineCoreAddRequest::test_add_request_returns_id - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreAddRequest::test_add_request_with_custom_id - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreAddRequest::test_add_request_creates_collector - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreAddRequest::test_add_request_with_default_sampling_params - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreAbortRequest::test_abort_request_wakes_blocked_stream_outputs - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreGenerateCancellation::test_generate_cancel_aborts_request - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreErrorPropagation::test_error_output_propagates_to_collector - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreErrorPropagation::test_stream_outputs_raises_on_error - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreErrorPropagation::test_generate_raises_on_error - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreAbortAllRequests::test_abort_all_requests - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreAbortAllRequests::test_abort_all_requests_engine_keeps_running - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_grammar.py::TestCompileWithStructuralTag::test_calls_get_builtin_structural_tag - ModuleNotFoundError: No module named 'xgrammar'
FAILED tests/test_grammar.py::TestCompileWithStructuralTag::test_reasoning_false_when_thinking_disabled - ModuleNotFoundError: No module named 'xgrammar'
FAILED tests/test_grammar.py::TestCompileWithStructuralTag::test_patches_user_grammar_into_tag - ModuleNotFoundError: No module named 'xgrammar'
FAILED tests/test_grammar.py::TestCompileGrammarForRequest::test_reasoning_parser_uses_structural_tag - ModuleNotFoundError: No module named 'xgrammar'
FAILED tests/test_grammar.py::TestCompileGrammarForRequest::test_reasoning_parser_with_thinking_disabled - ModuleNotFoundError: No module named 'xgrammar'
FAILED tests/test_scheduler.py::TestSchedulerAbortRequest::test_abort_running_request_removes_from_batch - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerAbortRequest::test_abort_running_request_always_calls_remove - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerAbortRequest::test_abort_cleans_all_scheduler_state - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerBoundarySnapshots::test_capture_boundary_snapshot_at_block_boundary - KeyError: 'req-boundary'
FAILED tests/test_scheduler.py::TestSchedulerBoundarySnapshots::test_cleanup_finished_skips_output_tokens_for_reasoning_model - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerBoundarySnapshots::test_cleanup_finished_stores_output_tokens_for_non_reasoning_model - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerBoundarySnapshots::test_cleanup_finished_uses_boundary_snapshot_for_partial_trailing_tokens - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerRotatingBlockAlignment::test_cleanup_finished_always_calls_remove_for_mapped_uid - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerRotatingBlockAlignment::test_cleanup_finished_removes_uid_from_active_batch - RuntimeError: There is no Stream(gpu, 1) in current thread.
========  28 failed, 3797 passed, 30 skipped, 54 deselected in 232.83s (0:03:52) ======== 

```

</details>

<details>

<summary>After fix</summary>

```python

FAILED tests/test_accuracy_benchmark.py::TestAccuracyBenchmarkRequest::test_all_valid_benchmarks - AssertionError: assert 16 == 12
FAILED tests/test_admin_api_key.py::TestListModelsSettings::test_list_models_includes_all_model_settings_fields - AssertionError: Missing fields: {'turboquant_skip_last', 'preserve_thinking'}, Extr...
FAILED tests/test_admin_profiles_api.py::test_all_model_settings_fields_classified - AssertionError: New ModelSettings field(s) {'preserve_thinking'} must be classified...
FAILED tests/test_engine_core.py::TestEngineCoreAddRequest::test_add_request_returns_id - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreAddRequest::test_add_request_with_custom_id - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreAddRequest::test_add_request_creates_collector - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreAddRequest::test_add_request_with_default_sampling_params - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreAbortRequest::test_abort_request_wakes_blocked_stream_outputs - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreGenerateCancellation::test_generate_cancel_aborts_request - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreErrorPropagation::test_error_output_propagates_to_collector - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreErrorPropagation::test_stream_outputs_raises_on_error - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreErrorPropagation::test_generate_raises_on_error - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreAbortAllRequests::test_abort_all_requests - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_engine_core.py::TestEngineCoreAbortAllRequests::test_abort_all_requests_engine_keeps_running - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_grammar.py::TestCompileWithStructuralTag::test_calls_get_builtin_structural_tag - ModuleNotFoundError: No module named 'xgrammar'
FAILED tests/test_grammar.py::TestCompileWithStructuralTag::test_reasoning_false_when_thinking_disabled - ModuleNotFoundError: No module named 'xgrammar'
FAILED tests/test_grammar.py::TestCompileWithStructuralTag::test_patches_user_grammar_into_tag - ModuleNotFoundError: No module named 'xgrammar'
FAILED tests/test_grammar.py::TestCompileGrammarForRequest::test_reasoning_parser_uses_structural_tag - ModuleNotFoundError: No module named 'xgrammar'
FAILED tests/test_grammar.py::TestCompileGrammarForRequest::test_reasoning_parser_with_thinking_disabled - ModuleNotFoundError: No module named 'xgrammar'
FAILED tests/test_scheduler.py::TestSchedulerAbortRequest::test_abort_running_request_removes_from_batch - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerAbortRequest::test_abort_running_request_always_calls_remove - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerAbortRequest::test_abort_cleans_all_scheduler_state - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerBoundarySnapshots::test_capture_boundary_snapshot_at_block_boundary - KeyError: 'req-boundary'
FAILED tests/test_scheduler.py::TestSchedulerBoundarySnapshots::test_cleanup_finished_skips_output_tokens_for_reasoning_model - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerBoundarySnapshots::test_cleanup_finished_stores_output_tokens_for_non_reasoning_model - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerBoundarySnapshots::test_cleanup_finished_uses_boundary_snapshot_for_partial_trailing_tokens - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerRotatingBlockAlignment::test_cleanup_finished_always_calls_remove_for_mapped_uid - RuntimeError: There is no Stream(gpu, 1) in current thread.
FAILED tests/test_scheduler.py::TestSchedulerRotatingBlockAlignment::test_cleanup_finished_removes_uid_from_active_batch - RuntimeError: There is no Stream(gpu, 1) in current thread.
======== 28 failed, 3802 passed, 30 skipped, 55 deselected in 231.61s (0:03:51) ========

```

</details>

Memory usage sequence with `gemma-4-26B-A4B-it-oQ3-fp16`

| Step | Activity/Phase        | Memory Usage (GB) Before Fix | Memory Usage (GB) After Fix | Notes                                                                                                                         |
| :--- | :-------------------- | :--------------------------- | :-------------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
| 1    | Model Loading         | 13                           | 13                          | Initial model initialization and allocation.                                                                                  |
| 2    | Prefill (Initial)     | 14 – 20                      | 14 – 20                     | Initial processing of 65k tokens.                                                                                             |
| 3    | Decode (Initial)      | 14~17                        | 14~17                       | Initial decoding phase execution.                                                                                             |
| 4    | Post-Decode (1st Run) | 30                           | **14**                      | Memory has successfully stabilized following cache activation. This represents the sustained minimum memory footprint.        |
| 5    | Prefill (2nd Run)     | 44                           | 17                          | Send same 65k tokens. Cache hit scenario. Processing was instantaneous and did not require full load measurement.             |
| 6    | Decode (2nd Run)      | 30                           | 17~20                       | Execution of the second decoding phase.                                                                                       |
| 7    | Post-Decode (2nd Run) | 30                           | **14**                      | **Crucially, the memory increase was successfully mitigated compared to the initial run, eliminating the extra ~15GB spike.** |

- [x] Hot cache is working
- [x] SSD cache is working 

## hot_cache_only: true

```settings.json
  "cache": {
    "enabled": true,
    "hot_cache_only": true,
    "ssd_cache_dir": "/<home>/.omlx/cache",
    "ssd_cache_max_size": "46GB",
    "hot_cache_max_size": "16GB",
    "initial_cache_blocks": 256
  },
```

- cache is working with
    - gemma-4-26B-A4B-it-oQ3-fp16
        - TurboQuant KV Cache 3bit
    - Qwen3.6-35B-A3B-MLX-oQ4-FP16
        - TurboQuant KV Cache 3bit


## hot_cache_only: false

```settings.json
  "cache": {
    "enabled": true,
    "hot_cache_only": false,
    "ssd_cache_dir": "/<home>/.omlx/cache",
    "ssd_cache_max_size": "46GB",
    "hot_cache_max_size": "16GB",
    "initial_cache_blocks": 256
  },

```

- cache is working with (even after reload the model)
    - gemma-4-26B-A4B-it-oQ3-fp16
        - TurboQuant KV Cache 3bit
    - Qwen3.6-35B-A3B-MLX-oQ4-FP16
        - TurboQuant KV Cache 3bit
