### PR TITLE
feat(admin): expose paged KV occupancy in runtime cache stats

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -3036,6 +3036,13 @@ def _build_runtime_cache_observability(
         if not isinstance(block_size, int) or block_size <= 0:
             block_size = int(prefix_stats.get("block_size", 0) or 0)
 
+        max_blocks = int(prefix_stats.get("max_blocks", 0) or 0)
+        allocated_blocks = int(prefix_stats.get("allocated_blocks", 0) or 0)
+        free_blocks = int(prefix_stats.get("free_blocks", 0) or 0)
+        shared_blocks = int(prefix_stats.get("shared_blocks", 0) or 0)
+        total_tokens_cached = int(prefix_stats.get("total_tokens_cached", 0) or 0)
+        utilization = float(prefix_stats.get("utilization", 0.0) or 0.0)
+        cache_hit_rate = float(prefix_stats.get("cache_hit_rate", 0.0) or 0.0)
         partial_block_skips = int(prefix_stats.get("partial_block_skips", 0) or 0)
         partial_tokens_skipped = int(prefix_stats.get("partial_tokens_skipped", 0) or 0)
         last_partial_tokens_skipped = int(
@@ -3060,6 +3067,13 @@ def _build_runtime_cache_observability(
                 f"<{block_size}" if has_sub_block_cache else str(indexed_blocks_value)
             ),
             "has_sub_block_cache": has_sub_block_cache,
+            "max_blocks": max_blocks,
+            "allocated_blocks": allocated_blocks,
+            "free_blocks": free_blocks,
+            "shared_blocks": shared_blocks,
+            "total_tokens_cached": total_tokens_cached,
+            "utilization": utilization,
+            "cache_hit_rate": cache_hit_rate,
             "partial_block_skips": partial_block_skips,
             "partial_tokens_skipped": partial_tokens_skipped,
             "last_partial_tokens_skipped": last_partial_tokens_skipped,

--- a/tests/test_admin_api_key.py
+++ b/tests/test_admin_api_key.py
@@ -738,6 +738,13 @@ class TestRuntimeCacheObservability:
                 "indexed_blocks": 12,
                 "indexed_blocks_display": "12",
                 "has_sub_block_cache": False,
+                "max_blocks": 0,
+                "allocated_blocks": 0,
+                "free_blocks": 0,
+                "shared_blocks": 0,
+                "total_tokens_cached": 0,
+                "utilization": 0.0,
+                "cache_hit_rate": 0.0,
                 "partial_block_skips": 0,
                 "partial_tokens_skipped": 0,
                 "last_partial_tokens_skipped": 0,
@@ -754,6 +761,13 @@ class TestRuntimeCacheObservability:
                 "indexed_blocks": 4,
                 "indexed_blocks_display": "4",
                 "has_sub_block_cache": False,
+                "max_blocks": 0,
+                "allocated_blocks": 0,
+                "free_blocks": 0,
+                "shared_blocks": 0,
+                "total_tokens_cached": 0,
+                "utilization": 0.0,
+                "cache_hit_rate": 0.0,
                 "partial_block_skips": 0,
                 "partial_tokens_skipped": 0,
                 "last_partial_tokens_skipped": 0,
@@ -767,6 +781,72 @@ class TestRuntimeCacheObservability:
         ]
         manager_a.get_stats_for_model.assert_called_once_with("/models/model-a")
         manager_b.get_stats_for_model.assert_called_once_with("/models/model-b")
+
+    def test_runtime_cache_exposes_paged_kv_occupancy(self):
+        """Per-model rows should expose paged-KV occupancy from prefix cache."""
+        cache_dir = Path("/tmp/omlx-cache")
+
+        mock_settings = MagicMock()
+        mock_settings.base_path = Path("/tmp/omlx-base")
+        mock_settings.cache.get_ssd_cache_dir.return_value = cache_dir
+
+        scheduler = MagicMock()
+        scheduler.get_ssd_cache_stats.return_value = {
+            "block_size": 1024,
+            "indexed_blocks": 12,
+            "ssd_cache": {
+                "num_files": 3,
+                "total_size_bytes": 4096,
+                "hot_cache_max_bytes": 0,
+                "hot_cache_size_bytes": 0,
+                "hot_cache_entries": 0,
+            },
+            "prefix_cache": {
+                "max_blocks": 1024,
+                "allocated_blocks": 640,
+                "free_blocks": 384,
+                "shared_blocks": 8,
+                "total_tokens_cached": 131072,
+                "utilization": 0.625,
+                "cache_hit_rate": 0.75,
+            },
+        }
+
+        entry = SimpleNamespace(
+            engine=SimpleNamespace(
+                _engine=SimpleNamespace(engine=SimpleNamespace(scheduler=scheduler))
+            )
+        )
+        engine_pool = MagicMock()
+        engine_pool.get_status.return_value = {
+            "models": [{"id": "qwen-a3b", "loaded": True}]
+        }
+        engine_pool._entries = {"qwen-a3b": entry}
+
+        with patch.object(admin_routes, "_get_engine_pool", return_value=engine_pool):
+            payload = admin_routes._build_runtime_cache_observability(mock_settings)
+
+        model_payload = payload["models"][0]
+        assert {
+            key: model_payload[key]
+            for key in (
+                "max_blocks",
+                "allocated_blocks",
+                "free_blocks",
+                "shared_blocks",
+                "total_tokens_cached",
+                "utilization",
+                "cache_hit_rate",
+            )
+        } == {
+            "max_blocks": 1024,
+            "allocated_blocks": 640,
+            "free_blocks": 384,
+            "shared_blocks": 8,
+            "total_tokens_cached": 131072,
+            "utilization": 0.625,
+            "cache_hit_rate": 0.75,
+        }
 
     def test_runtime_cache_ignores_single_model_stats_failure(self):
         """One model failing stats collection should not break the whole payload."""


### PR DESCRIPTION
Exposes per-model paged-KV cache occupancy in `/admin/api/stats` under each `runtime_cache.models[]` row. The data is already computed by `PagedCacheManager.get_memory_usage()` and flows through `BlockAwarePrefixCache.get_stats_dict()` → `scheduler.get_ssd_cache_stats()` to the admin route's existing `runtime_stats["prefix_cache"]` read, this PR just surfaces it.

I've been running a local mactop-style TUI against the admin stats and wanted to see how full the paged cache was and what the dedup hit rate looked like, without scraping `indexed_blocks` as a proxy or going into logs.

Seven new fields per row, sourced from `prefix_stats` and matching `get_memory_usage()` verbatim: `max_blocks`, `allocated_blocks`, `free_blocks`, `shared_blocks`, `total_tokens_cached`, `utilization`, `cache_hit_rate`. A few semantics to call out: `utilization` and `cache_hit_rate` are fractions in [0, 1], not percentages; `cache_hit_rate` is cumulative since the manager's stats reset (happy to rename or split into raw counters if you'd prefer); `allocated_blocks` includes the reserved null block.

I tried to make this additive only with no renames, no removals. No changes outside the admin route and its test. The dashboard template renders explicit columns so the new JSON fields are ignored by the current UI; wiring them into the dashboard can be a follow-up. Follows the shape of #744 and #256.

Tested with `python -m pytest tests/test_admin_api_key.py::TestRuntimeCacheObservability -xvs` — one new test verifying the fields with distinct-valued mocks, existing tests updated to include the new keys at zero defaults in their exact-payload assertions. All four pass.
