### PR TITLE
fix: handle list-type host in settings and fix [object Object] error display

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2279,6 +2279,17 @@ async def update_global_settings(
 
     # Apply server settings
     if request.host is not None:
+        from ..utils.network import is_valid_bind_host
+
+        parts = [h.strip() for h in request.host.split(",") if h.strip()]
+        if not parts:
+            raise HTTPException(status_code=400, detail="Host cannot be empty")
+        for part in parts:
+            if not is_valid_bind_host(part):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid host: {part!r} (must be a hostname or IP address)",
+                )
         global_settings.server.host = request.host
     if request.port is not None:
         global_settings.server.port = request.port

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -774,7 +774,7 @@
                         window.location.href = '/admin';
                     } else {
                         const data = await response.json();
-                        this.saveError = Array.isArray(data.detail) ? data.detail.join(', ') : (data.detail || window.t('js.error.save_settings_failed'));
+                        this.saveError = Array.isArray(data.detail) ? data.detail.map(e => (e && typeof e === 'object') ? (e.msg || JSON.stringify(e)) : String(e)).join(', ') : (data.detail || window.t('js.error.save_settings_failed'));
                         // Reload settings to revert to server values
                         await this.loadGlobalSettings();
                     }
@@ -3201,7 +3201,7 @@
                         window.location.href = '/admin';
                     } else {
                         const data = await response.json();
-                        alert(Array.isArray(data.detail) ? data.detail.join(', ') : (data.detail || 'Failed to save'));
+                        alert(Array.isArray(data.detail) ? data.detail.map(e => (e && typeof e === 'object') ? (e.msg || JSON.stringify(e)) : String(e)).join(', ') : (data.detail || 'Failed to save'));
                     }
                 } catch (err) {
                     console.error('Failed to save HF mirror endpoint:', err);

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -259,14 +259,16 @@ def serve_command(args):
     )
 
     # Start server
-    print(f"Starting server at http://{settings.server.host}:{settings.server.port}")
+    hosts = [h.strip() for h in settings.server.host.split(",") if h.strip()]
+    for h in hosts:
+        print(f"Starting server at http://{h}:{settings.server.port}")
     # uvicorn does not support "trace" — map to "debug" for its internal logging
     uvicorn_level = "debug" if settings.server.log_level == "trace" else settings.server.log_level
     # Only show access logs at trace level
     show_access_log = settings.server.log_level == "trace"
     uvicorn.run(
         app,
-        host=settings.server.host,
+        host=hosts if len(hosts) > 1 else hosts[0],
         port=settings.server.port,
         log_level=uvicorn_level,
         access_log=show_access_log,

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -123,8 +123,9 @@ class ServerSettings:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ServerSettings:
         """Create from dictionary."""
+        _host = data.get("host", "127.0.0.1")
         return cls(
-            host=data.get("host", "127.0.0.1"),
+            host=", ".join(_host) if isinstance(_host, list) else str(_host),
             port=data.get("port", 8000),
             log_level=data.get("log_level", "info"),
             cors_origins=data.get("cors_origins", ["*"]),

--- a/omlx/utils/network.py
+++ b/omlx/utils/network.py
@@ -64,6 +64,25 @@ def is_valid_alias(value: str) -> bool:
     return is_valid_ip(value)
 
 
+def is_valid_bind_host(value: str) -> bool:
+    """Return True if ``value`` is a valid host to bind a server socket to.
+
+    Accepts any parseable IP address (including ``0.0.0.0`` and ``::``) and
+    valid DNS hostnames. Unlike :func:`is_valid_alias`, unspecified addresses
+    are allowed because they are legitimate bind targets.
+    """
+    if not isinstance(value, str):
+        return False
+    value = value.strip()
+    if not value:
+        return False
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        return is_valid_hostname(value)
+
+
 def _local_ipv4_addresses() -> list[str]:
     """Best-effort enumeration of non-loopback IPv4 addresses.
 


### PR DESCRIPTION
Superseded by a new PR that adapts to the `uvicorn.Config + bind_socket()` refactor introduced in #1526. The core logic is the same but the `cli.py` changes are rewritten to work with the new pre-bind approach.