### PR TITLE
fix: downgrade RotatingKVCache base_size mismatch log from warning to debug

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1186,7 +1186,7 @@ class Scheduler:
         # derived from block_table.num_tokens and therefore trustworthy.
         if boundary_enabled and hasattr(request, "cached_tokens") and request.cached_tokens > 0:
             if base_size != request.cached_tokens:
-                logger.warning(
+                logger.debug(
                     "Cache base_size mismatch: computed %d, expected %d "
                     "(cached_tokens). Using cached_tokens for boundary "
                     "alignment.",


### PR DESCRIPTION
## Summary

For models using `RotatingKVCache` (e.g. gemma-4), `cache.offset` is a global token counter that accumulates indefinitely past the window size, while `cached_tokens` is correctly bounded at `window_size`. This means the "mismatch" fires on every request once the cache window fills — it is expected behavior for a sliding-window cache, not an anomaly.

The log was at `WARNING` level, implying something went wrong. Downgrade to `DEBUG` so the information remains available for diagnostics without flooding logs on every gemma-4 inference call.

## Details

- `RotatingKVCache.offset` = total tokens ever processed (unbounded)
- `RotatingKVCache.size()` = `min(offset, max_size)` = actual stored tokens
- `cached_tokens` (from `block_table.num_tokens`) = actual stored tokens

The correction at the call site (`base_size = request.cached_tokens`) is correct and still applied; only the log level changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)