### PR TITLE
fix(specprefill): Don't re-tokenize system prompt in VLM models

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1361,7 +1361,7 @@ class VLMBatchedEngine(BaseEngine):
                     non_system_prompt = self._tokenizer.apply_chat_template(
                         non_system, tokenize=False, add_generation_prompt=True,
                     )
-                    full_tokens = len(self._tokenizer.encode(prompt))
+                    full_tokens = len(prompt)
                     non_system_tokens = len(self._tokenizer.encode(non_system_prompt))
                     system_end = full_tokens - non_system_tokens
                     if system_end > 0:


### PR DESCRIPTION
fixes #916