### PR TITLE
fix(server): report cached tokens in OpenAI-compatible usage details

### DIFF
--- a/omlx/api/adapters/openai.py
+++ b/omlx/api/adapters/openai.py
@@ -26,6 +26,7 @@ from ..openai_models import (
     ChatCompletionChunkDelta,
     ChatCompletionRequest,
     ChatCompletionResponse,
+    PromptTokensDetails,
     Usage,
 )
 from ..thinking import extract_thinking
@@ -133,6 +134,9 @@ class OpenAIAdapter(BaseAdapter):
                 prompt_tokens=response.prompt_tokens,
                 completion_tokens=response.completion_tokens,
                 total_tokens=response.prompt_tokens + response.completion_tokens,
+                prompt_tokens_details=PromptTokensDetails(
+                    cached_tokens=getattr(response, "cached_tokens", 0),
+                ),
             ),
         )
 
@@ -180,6 +184,9 @@ class OpenAIAdapter(BaseAdapter):
                 prompt_tokens=chunk.prompt_tokens,
                 completion_tokens=chunk.completion_tokens,
                 total_tokens=chunk.prompt_tokens + chunk.completion_tokens,
+                prompt_tokens_details=PromptTokensDetails(
+                    cached_tokens=getattr(chunk, "cached_tokens", 0),
+                ),
             )
 
         return f"data: {response.model_dump_json(exclude_none=True)}\n\n"

--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -281,6 +281,13 @@ class ChatCompletionChoice(BaseModel):
     finish_reason: Optional[str] = "stop"
 
 
+class PromptTokensDetails(BaseModel):
+    """Breakdown of prompt tokens used."""
+
+    cached_tokens: Optional[int] = None
+    audio_tokens: Optional[int] = None
+
+
 class Usage(BaseUsage):
     """Token usage statistics for OpenAI API.
 
@@ -288,7 +295,7 @@ class Usage(BaseUsage):
     When present, timing values are in seconds.
     """
 
-    cached_tokens: Optional[int] = None
+    prompt_tokens_details: Optional[PromptTokensDetails] = None
     # Timing metrics (oMLX extension, seconds)
     model_load_duration: Optional[float] = None
     time_to_first_token: Optional[float] = None

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -97,6 +97,7 @@ from .api.openai_models import (
     CompletionResponse,
     ModelInfo,
     ModelsResponse,
+    PromptTokensDetails,
     Usage,
 )
 from .api.embedding_models import (
@@ -1885,6 +1886,9 @@ async def create_completion(
                 prompt_tokens=total_prompt_tokens,
                 completion_tokens=total_completion_tokens,
                 total_tokens=total_prompt_tokens + total_completion_tokens,
+                prompt_tokens_details=PromptTokensDetails(
+                    cached_tokens=total_cached_tokens,
+                ),
             ),
         ).model_dump_json()
 
@@ -2226,6 +2230,9 @@ async def create_chat_completion(
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
                 total_tokens=output.prompt_tokens + output.completion_tokens,
+                prompt_tokens_details=PromptTokensDetails(
+                    cached_tokens=output.cached_tokens,
+                ),
             ),
         ).model_dump_json()
 
@@ -2554,7 +2561,9 @@ async def stream_completion(
                     prompt_tokens=pt,
                     completion_tokens=ct,
                     total_tokens=pt + ct,
-                    cached_tokens=last_output.cached_tokens or None,
+                    prompt_tokens_details=PromptTokensDetails(
+                        cached_tokens=last_output.cached_tokens,
+                    ),
                     model_load_duration=round(model_load_duration, 2) if model_load_duration > 1.0 else None,
                     time_to_first_token=round(ttft, 2),
                     total_time=round(total_time, 2),
@@ -2860,7 +2869,9 @@ async def stream_chat_completion(
                     prompt_tokens=pt,
                     completion_tokens=ct,
                     total_tokens=pt + ct,
-                    cached_tokens=last_output.cached_tokens or None,
+                    prompt_tokens_details=PromptTokensDetails(
+                        cached_tokens=last_output.cached_tokens,
+                    ),
                     model_load_duration=round(model_load_duration, 2) if model_load_duration > 1.0 else None,
                     time_to_first_token=round(ttft, 2),
                     total_time=round(total_time, 2),

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -608,6 +608,27 @@ class TestCompletionEndpoint:
         data = response.json()
         assert "choices" in data
 
+    def test_completion_includes_cached_tokens_on_cache_hit(self, client, mock_llm_engine):
+        """Non-streaming completion responses should expose cached token counts."""
+        mock_llm_engine.generate = AsyncMock(return_value=MockGenerationOutput(
+            text="Generated response.",
+            prompt_tokens=2215,
+            completion_tokens=5,
+            cached_tokens=2048,
+        ))
+
+        response = client.post(
+            "/v1/completions",
+            json={
+                "model": "test-model",
+                "prompt": "Cache hit prompt",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["usage"]["prompt_tokens_details"]["cached_tokens"] == 2048
+
 
 class TestChatCompletionEndpoint:
     """Tests for the /v1/chat/completions endpoint."""
@@ -662,6 +683,29 @@ class TestChatCompletionEndpoint:
         )
 
         assert response.status_code == 200
+
+    def test_chat_completion_includes_cached_tokens_on_cache_hit(self, client, mock_llm_engine):
+        """Non-streaming chat responses should expose cached token counts."""
+        mock_llm_engine.chat = AsyncMock(return_value=MockGenerationOutput(
+            text="Chat response.",
+            prompt_tokens=2215,
+            completion_tokens=5,
+            cached_tokens=2048,
+            finish_reason="stop",
+            finished=True,
+        ))
+
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Cache hit prompt"}],
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["usage"]["prompt_tokens_details"]["cached_tokens"] == 2048
 
     def test_chat_completion_sanitizes_reasoning_tool_call_markup(self, client, mock_llm_engine):
         """Thinking-only tool calls should become structured tool_calls without leaked markup."""

--- a/tests/test_stream_usage.py
+++ b/tests/test_stream_usage.py
@@ -9,6 +9,7 @@ from omlx.api.openai_models import (
     ChatCompletionChunk,
     ChatCompletionRequest,
     CompletionRequest,
+    PromptTokensDetails,
     StreamOptions,
     Usage,
 )
@@ -66,14 +67,14 @@ class TestUsageExtendedFields:
     def test_basic_usage_unchanged(self):
         usage = Usage(prompt_tokens=10, completion_tokens=5)
         assert usage.total_tokens == 15
-        assert usage.cached_tokens is None
+        assert usage.prompt_tokens_details is None
         assert usage.time_to_first_token is None
 
     def test_usage_with_timing(self):
         usage = Usage(
             prompt_tokens=100,
             completion_tokens=50,
-            cached_tokens=20,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=20),
             time_to_first_token=0.5,
             total_time=2.0,
             prompt_eval_duration=0.5,
@@ -82,7 +83,7 @@ class TestUsageExtendedFields:
             generation_tokens_per_second=33.33,
         )
         assert usage.total_tokens == 150
-        assert usage.cached_tokens == 20
+        assert usage.prompt_tokens_details.cached_tokens == 20
         assert usage.time_to_first_token == 0.5
         assert usage.generation_tokens_per_second == 33.33
 
@@ -90,7 +91,7 @@ class TestUsageExtendedFields:
         """None timing fields should be excluded with exclude_none."""
         usage = Usage(prompt_tokens=10, completion_tokens=5)
         dumped = usage.model_dump(exclude_none=True)
-        assert "cached_tokens" not in dumped
+        assert "prompt_tokens_details" not in dumped
         assert "time_to_first_token" not in dumped
         assert "model_load_duration" not in dumped
         # Standard fields should still be present
@@ -106,7 +107,7 @@ class TestUsageExtendedFields:
         )
         dumped = usage.model_dump(exclude_none=True)
         assert dumped["model_load_duration"] == 55.93
-        assert "cached_tokens" not in dumped
+        assert "prompt_tokens_details" not in dumped
 
 
 class TestUsageChunkFormat:
@@ -147,7 +148,7 @@ class TestUsageChunkFormat:
                 prompt_tokens=9752,
                 completion_tokens=554,
                 total_tokens=10306,
-                cached_tokens=0,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=0),
                 model_load_duration=55.93,
                 time_to_first_token=115.05,
                 total_time=182.47,
@@ -162,7 +163,7 @@ class TestUsageChunkFormat:
         assert usage["prompt_tokens"] == 9752
         assert usage["completion_tokens"] == 554
         assert usage["total_tokens"] == 10306
-        assert usage["cached_tokens"] == 0
+        assert usage["prompt_tokens_details"]["cached_tokens"] == 0
         assert usage["model_load_duration"] == 55.93
         assert usage["time_to_first_token"] == 115.05
         assert usage["total_time"] == 182.47


### PR DESCRIPTION
## Summary

Fixes #919 by reporting cache-hit counts in the OpenAI-compatible usage shape for:

- `/v1/chat/completions`
- `/v1/completions`

Instead of the previous top-level `usage.cached_tokens`, this change now reports cached prompt tokens under:

- `usage.prompt_tokens_details.cached_tokens`

This matches the current OpenAI schema more closely: [Completions object](https://developers.openai.com/api/reference/resources/completions)

## What changed

- Added `prompt_tokens_details` to the OpenAI usage model
- Populated `prompt_tokens_details.cached_tokens` in non-streaming and streaming OpenAI responses
- Updated the OpenAI adapter to emit the same nested usage shape
- Updated regression tests for the new response schema

## Validation

### Unit / integration tests

```bash
pytest -q tests/test_openai_models.py tests/test_stream_usage.py
pytest -q tests/integration/test_server_endpoints.py -k 'cached_tokens_on_cache_hit'
