### PR TITLE
Add native TTS streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ coverage.xml
 .pytest_cache/
 cover/
 
+# Local generated artifacts
+artifacts/
+
 # Translations
 *.mo
 *.pot

--- a/omlx/api/audio_models.py
+++ b/omlx/api/audio_models.py
@@ -43,6 +43,8 @@ class AudioSpeechRequest(BaseModel):
     top_p: Optional[float] = None
     repetition_penalty: Optional[float] = None
     max_tokens: Optional[int] = None
+    stream: Optional[bool] = False
+    streaming_interval: Optional[float] = None
 
 
 class AudioProcessRequest(BaseModel):

--- a/omlx/api/audio_routes.py
+++ b/omlx/api/audio_routes.py
@@ -10,13 +10,16 @@ This module provides OpenAI-compatible audio endpoints:
 
 import base64
 import logging
-import tempfile
+import math
 import os
-from typing import Optional
+import re
+import tempfile
+from typing import AsyncIterator, Optional
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
-from fastapi.responses import Response
+from fastapi.responses import Response, StreamingResponse
 
+from ..engine.audio_utils import wav_bytes_to_pcm_frames, wav_header
 from .audio_models import AudioSpeechRequest, AudioTranscriptionResponse
 
 logger = logging.getLogger(__name__)
@@ -28,6 +31,11 @@ MAX_AUDIO_UPLOAD_BYTES = 100 * 1024 * 1024
 
 # Maximum base64-encoded ref_audio size (~15 MB raw audio, enough for ~60s).
 MAX_REF_AUDIO_BASE64_BYTES = 20 * 1024 * 1024
+
+# Default native TTS chunk cadence. Keep this below the mlx-audio default to
+# improve TTFT while still letting the model process the full input at once.
+DEFAULT_NATIVE_TTS_STREAMING_INTERVAL_SECONDS = 0.2
+MIN_NATIVE_TTS_STREAMING_INTERVAL_SECONDS = 0.01
 
 # Video container extensions that should be routed through ffmpeg decoding.
 # mlx-audio only recognises audio-specific extensions (m4a, aac, ogg, opus),
@@ -86,6 +94,247 @@ async def _read_upload(file: UploadFile) -> bytes:
             )
         chunks.append(chunk)
     return b"".join(chunks)
+
+
+def _decode_ref_audio_base64(request: AudioSpeechRequest) -> Optional[bytes]:
+    """Validate and decode optional base64 ref_audio from a TTS request."""
+    if request.ref_audio is None:
+        return None
+
+    if not request.ref_text:
+        raise HTTPException(
+            status_code=400,
+            detail="'ref_text' is required when 'ref_audio' is provided "
+            "(must be the transcript of the reference audio)",
+        )
+    if len(request.ref_audio) > MAX_REF_AUDIO_BASE64_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"ref_audio exceeds maximum allowed size "
+                f"({MAX_REF_AUDIO_BASE64_BYTES} bytes base64, "
+                f"~60 seconds of audio)"
+            ),
+        )
+    try:
+        return base64.b64decode(request.ref_audio, validate=True)
+    except Exception:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid base64 encoding in 'ref_audio' field",
+        )
+
+
+def _write_ref_audio_tempfile(audio_bytes: Optional[bytes]) -> Optional[str]:
+    """Persist decoded ref audio to a temp file if present."""
+    if audio_bytes is None:
+        return None
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+    try:
+        tmp.write(audio_bytes)
+        return tmp.name
+    finally:
+        tmp.close()
+
+
+def _cleanup_tempfile(path: Optional[str]) -> None:
+    if path and os.path.exists(path):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _resolve_tts_streaming_interval(request: AudioSpeechRequest) -> float:
+    """Return a native TTS streaming interval that is safe for mlx-audio."""
+    if request.streaming_interval is None:
+        return DEFAULT_NATIVE_TTS_STREAMING_INTERVAL_SECONDS
+
+    interval = request.streaming_interval
+    if (
+        not math.isfinite(interval)
+        or interval < MIN_NATIVE_TTS_STREAMING_INTERVAL_SECONDS
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "'streaming_interval' must be at least "
+                f"{MIN_NATIVE_TTS_STREAMING_INTERVAL_SECONDS} seconds"
+            ),
+        )
+    return interval
+
+
+def _split_tts_text(text: str, max_chars: int = 300) -> list[str]:
+    """Split TTS input into conservative sentence-like chunks."""
+    text = text.strip()
+    if not text:
+        return []
+
+    sentences = re.split(r"(?<=[.!?。！？])\s+|\n+", text)
+    sentences = [s.strip() for s in sentences if s and s.strip()]
+    if not sentences:
+        sentences = [text]
+
+    chunks: list[str] = []
+    current = ""
+
+    def flush_current() -> None:
+        nonlocal current
+        if current:
+            chunks.append(current.strip())
+            current = ""
+
+    for sentence in sentences:
+        if len(sentence) > max_chars:
+            flush_current()
+            parts = re.split(r"(?<=[,;:，；：])\s*", sentence)
+            parts = [p.strip() for p in parts if p and p.strip()]
+            buffer = ""
+            for part in parts or [sentence]:
+                while len(part) > max_chars:
+                    if buffer:
+                        chunks.append(buffer.strip())
+                        buffer = ""
+                    chunks.append(part[:max_chars].strip())
+                    part = part[max_chars:].strip()
+                if not part:
+                    continue
+                candidate = f"{buffer} {part}".strip() if buffer else part
+                if len(candidate) <= max_chars:
+                    buffer = candidate
+                else:
+                    if buffer:
+                        chunks.append(buffer.strip())
+                    buffer = part
+            if buffer:
+                chunks.append(buffer.strip())
+            continue
+
+        candidate = f"{current} {sentence}".strip() if current else sentence
+        if current and len(candidate) > max_chars:
+            flush_current()
+            current = sentence
+        else:
+            current = candidate
+
+    flush_current()
+    return chunks or [text]
+
+
+async def _stream_speech_response(
+    engine,
+    request: AudioSpeechRequest,
+    ref_audio_path: Optional[str],
+    streaming_interval: float,
+) -> AsyncIterator[bytes]:
+    """Stream sentence-level TTS as a single WAV header plus PCM chunks."""
+    try:
+        if (
+            hasattr(engine, "supports_native_tts_streaming")
+            and engine.supports_native_tts_streaming()
+            and hasattr(engine, "stream_synthesize_pcm")
+        ):
+            logger.info(
+                "TTS native streaming start: model=%s, text_len=%d, voice=%s",
+                request.model, len(request.input), request.voice,
+            )
+            stream_format: Optional[tuple[int, int, int]] = None
+            try:
+                async for sample_rate, channels, sample_width, pcm_bytes in engine.stream_synthesize_pcm(
+                    request.input,
+                    voice=request.voice,
+                    speed=request.speed,
+                    instructions=request.instructions,
+                    ref_audio=ref_audio_path,
+                    ref_text=request.ref_text,
+                    temperature=request.temperature,
+                    top_k=request.top_k,
+                    top_p=request.top_p,
+                    repetition_penalty=request.repetition_penalty,
+                    max_tokens=request.max_tokens,
+                    streaming_interval=streaming_interval,
+                ):
+                    fmt = (sample_rate, channels, sample_width)
+                    if stream_format is None:
+                        stream_format = fmt
+                        yield wav_header(
+                            sample_rate=sample_rate,
+                            channels=channels,
+                            sample_width=sample_width,
+                        )
+                    elif fmt != stream_format:
+                        raise RuntimeError(
+                            "Inconsistent native streaming PCM format: "
+                            f"expected {stream_format}, got {fmt}"
+                        )
+                    if pcm_bytes:
+                        yield pcm_bytes
+            except NotImplementedError:
+                if stream_format is not None:
+                    raise
+                logger.info(
+                    "TTS native streaming unavailable at runtime; falling back "
+                    "to segmented synthesis: model=%s",
+                    request.model,
+                )
+            else:
+                return
+
+        segments = _split_tts_text(request.input)
+        logger.info(
+            "TTS streaming start: model=%s, text_len=%d, segments=%d, voice=%s",
+            request.model, len(request.input), len(segments), request.voice,
+        )
+
+        stream_format: Optional[tuple[int, int, int]] = None
+        for idx, segment in enumerate(segments, start=1):
+            wav_bytes = await engine.synthesize(
+                segment,
+                voice=request.voice,
+                speed=request.speed,
+                instructions=request.instructions,
+                ref_audio=ref_audio_path,
+                ref_text=request.ref_text,
+                temperature=request.temperature,
+                top_k=request.top_k,
+                top_p=request.top_p,
+                repetition_penalty=request.repetition_penalty,
+                max_tokens=request.max_tokens,
+            )
+            sample_rate, channels, sample_width, pcm_bytes = wav_bytes_to_pcm_frames(wav_bytes)
+            fmt = (sample_rate, channels, sample_width)
+            if stream_format is None:
+                stream_format = fmt
+                yield wav_header(sample_rate=sample_rate, channels=channels, sample_width=sample_width)
+            elif fmt != stream_format:
+                raise RuntimeError(
+                    "Inconsistent WAV format across TTS segments: "
+                    f"expected {stream_format}, got {fmt}"
+                )
+            logger.debug(
+                "TTS streaming segment %d/%d: text_len=%d, pcm_bytes=%d",
+                idx, len(segments), len(segment), len(pcm_bytes),
+            )
+            if pcm_bytes:
+                yield pcm_bytes
+    finally:
+        _cleanup_tempfile(ref_audio_path)
+
+
+async def _stream_with_prefetched_chunk(
+    first_chunk: bytes,
+    stream: AsyncIterator[bytes],
+) -> AsyncIterator[bytes]:
+    """Yield a chunk fetched before response headers, then the rest of the stream."""
+    try:
+        yield first_chunk
+        async for chunk in stream:
+            yield chunk
+    finally:
+        close = getattr(stream, "aclose", None)
+        if close is not None:
+            await close()
 
 
 # ---------------------------------------------------------------------------
@@ -172,40 +421,22 @@ async def create_speech(request: AudioSpeechRequest):
     from omlx.engine.tts import TTSEngine
     from omlx.exceptions import ModelNotFoundError
 
-    # Validate input is non-empty
-    if not request.input:
+    if not request.input or not request.input.strip():
         raise HTTPException(status_code=400, detail="'input' field must not be empty")
+    streaming_interval = DEFAULT_NATIVE_TTS_STREAMING_INTERVAL_SECONDS
+    if request.stream:
+        if request.response_format not in (None, "wav"):
+            raise HTTPException(
+                status_code=400,
+                detail="Streaming TTS currently only supports response_format='wav'",
+            )
+        streaming_interval = _resolve_tts_streaming_interval(request)
 
-    # --- Validate and decode ref_audio (voice clone) ---
-    audio_bytes = None
-    if request.ref_audio is not None:
-        if not request.ref_text:
-            raise HTTPException(
-                status_code=400,
-                detail="'ref_text' is required when 'ref_audio' is provided "
-                "(must be the transcript of the reference audio)",
-            )
-        if len(request.ref_audio) > MAX_REF_AUDIO_BASE64_BYTES:
-            raise HTTPException(
-                status_code=413,
-                detail=(
-                    f"ref_audio exceeds maximum allowed size "
-                    f"({MAX_REF_AUDIO_BASE64_BYTES} bytes base64, "
-                    f"~60 seconds of audio)"
-                ),
-            )
-        try:
-            audio_bytes = base64.b64decode(request.ref_audio, validate=True)
-        except Exception:
-            raise HTTPException(
-                status_code=400,
-                detail="Invalid base64 encoding in 'ref_audio' field",
-            )
+    audio_bytes = _decode_ref_audio_base64(request)
 
     pool = _get_engine_pool()
     resolved_model = _resolve_model(request.model)
 
-    # Load the engine via pool
     try:
         engine = await pool.get_engine(resolved_model)
     except ModelNotFoundError as exc:
@@ -223,15 +454,32 @@ async def create_speech(request: AudioSpeechRequest):
             detail=f"Model '{resolved_model}' is not a text-to-speech model",
         )
 
-    ref_audio_path = None
-    try:
-        # Write decoded audio to temp file if voice clone requested
-        if audio_bytes is not None:
-            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
-            ref_audio_path = tmp.name
-            tmp.write(audio_bytes)
-            tmp.close()
+    ref_audio_path = _write_ref_audio_tempfile(audio_bytes)
 
+    if request.stream:
+        stream = _stream_speech_response(
+            engine,
+            request,
+            ref_audio_path,
+            streaming_interval,
+        )
+        try:
+            first_chunk = await stream.__anext__()
+        except StopAsyncIteration as exc:
+            raise HTTPException(
+                status_code=500,
+                detail="TTS streaming produced no audio output",
+            ) from exc
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        return StreamingResponse(
+            _stream_with_prefetched_chunk(first_chunk, stream),
+            media_type="audio/wav",
+        )
+
+    try:
         wav_bytes = await engine.synthesize(
             request.input,
             voice=request.voice,
@@ -250,11 +498,7 @@ async def create_speech(request: AudioSpeechRequest):
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     finally:
-        if ref_audio_path and os.path.exists(ref_audio_path):
-            try:
-                os.unlink(ref_audio_path)
-            except OSError:
-                pass
+        _cleanup_tempfile(ref_audio_path)
 
     return Response(content=wav_bytes, media_type="audio/wav")
 

--- a/omlx/engine/audio_utils.py
+++ b/omlx/engine/audio_utils.py
@@ -2,13 +2,49 @@
 """Shared utilities for audio engines (STT, TTS, STS)."""
 
 import io
+import struct
 import wave
 
 import numpy as np
 
-
 # Default sample rate used when the model does not report one.
 DEFAULT_SAMPLE_RATE = 24000
+_MAX_WAV_CHUNK_SIZE = 0xFFFFFFFF
+
+
+def wav_header(sample_rate: int, channels: int = 1, sample_width: int = 2) -> bytes:
+    """Create a PCM WAV header suitable for streamed/unknown-length audio."""
+    block_align = channels * sample_width
+    byte_rate = sample_rate * block_align
+    bits_per_sample = sample_width * 8
+    return struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF",
+        _MAX_WAV_CHUNK_SIZE,
+        b"WAVE",
+        b"fmt ",
+        16,
+        1,  # PCM
+        channels,
+        sample_rate,
+        byte_rate,
+        block_align,
+        bits_per_sample,
+        b"data",
+        _MAX_WAV_CHUNK_SIZE,
+    )
+
+
+
+def wav_bytes_to_pcm_frames(wav_bytes: bytes) -> tuple[int, int, int, bytes]:
+    """Extract WAV metadata and raw PCM frames from WAV bytes."""
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+        sample_rate = wf.getframerate()
+        channels = wf.getnchannels()
+        sample_width = wf.getsampwidth()
+        pcm_bytes = wf.readframes(wf.getnframes())
+    return sample_rate, channels, sample_width, pcm_bytes
+
 
 
 def audio_to_wav_bytes(audio_array, sample_rate: int) -> bytes:

--- a/omlx/engine/tts.py
+++ b/omlx/engine/tts.py
@@ -11,6 +11,7 @@ when mlx-audio is not installed.
 import asyncio
 import gc
 import logging
+from collections.abc import AsyncIterator
 from typing import Any, Dict, Optional
 
 import mlx.core as mx
@@ -48,10 +49,28 @@ class TTSEngine(BaseNonStreamingEngine):
         self._model = None
         self._kwargs = kwargs
 
+    @staticmethod
+    def _audio_array_to_pcm_bytes(audio: Any) -> bytes:
+        audio_array = np.array(audio).flatten()
+        audio_array = np.clip(audio_array, -1.0, 1.0)
+        return (audio_array * 32767).astype(np.int16).tobytes()
+
     @property
     def model_name(self) -> str:
         """Get the model name."""
         return self._model_name
+
+    def supports_native_tts_streaming(self) -> bool:
+        """Return whether the loaded model exposes model-native audio streaming."""
+        if self._model is None:
+            return False
+        import inspect
+
+        try:
+            gen_params = inspect.signature(self._model.generate).parameters
+        except (TypeError, ValueError):
+            return False
+        return "stream" in gen_params and "streaming_interval" in gen_params
 
     async def start(self) -> None:
         """Start the engine (load model if not loaded).
@@ -161,9 +180,7 @@ class TTSEngine(BaseNonStreamingEngine):
         model = self._model
         t0 = time.monotonic()
 
-        def _synthesize_sync():
-            # model.generate() returns an iterable of results,
-            # each with .audio (array) and .sample_rate (int).
+        def _build_generate_kwargs() -> Dict[str, Any]:
             gen_kwargs: Dict[str, Any] = {
                 "text": text,
                 "verbose": False,
@@ -198,6 +215,12 @@ class TTSEngine(BaseNonStreamingEngine):
             if max_tokens is not None:
                 gen_kwargs["max_tokens"] = max_tokens
             gen_kwargs.update(kwargs)
+            return gen_kwargs
+
+        def _synthesize_sync():
+            # model.generate() returns an iterable of results,
+            # each with .audio (array) and .sample_rate (int).
+            gen_kwargs = _build_generate_kwargs()
 
             results = model.generate(**gen_kwargs)
 
@@ -235,6 +258,122 @@ class TTSEngine(BaseNonStreamingEngine):
                     get_mlx_executor(),
                     lambda: (mx.synchronize(), mx.clear_cache()),
                 )
+
+    async def stream_synthesize_pcm(
+        self,
+        text: str,
+        voice: Optional[str] = None,
+        speed: float = 1.0,
+        instructions: Optional[str] = None,
+        ref_audio: Optional[str] = None,
+        ref_text: Optional[str] = None,
+        temperature: Optional[float] = None,
+        top_k: Optional[int] = None,
+        top_p: Optional[float] = None,
+        repetition_penalty: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        streaming_interval: float = 0.4,
+        **kwargs,
+    ) -> AsyncIterator[tuple[int, int, int, bytes]]:
+        """Stream synthesized PCM chunks from models that natively support it."""
+        if self._model is None:
+            raise RuntimeError("Engine not started. Call start() first.")
+        if not self.supports_native_tts_streaming():
+            raise NotImplementedError("Loaded TTS model does not expose native streaming")
+
+        import inspect
+        import time
+
+        logger.info(
+            "TTS native stream start: model=%s, text_len=%d, voice=%s, interval=%.2fs",
+            self._model_name, len(text), voice, streaming_interval,
+        )
+
+        model = self._model
+        t0 = time.monotonic()
+
+        def _build_generate_kwargs() -> Dict[str, Any]:
+            gen_kwargs: Dict[str, Any] = {
+                "text": text,
+                "verbose": False,
+                "stream": True,
+            }
+            gen_params = inspect.signature(model.generate).parameters
+            if "streaming_interval" in gen_params:
+                gen_kwargs["streaming_interval"] = streaming_interval
+            if voice is not None:
+                if "voice" in gen_params:
+                    gen_kwargs["voice"] = voice
+                elif "instruct" in gen_params:
+                    gen_kwargs["instruct"] = voice
+            if instructions is not None and "instruct" in gen_params:
+                gen_kwargs["instruct"] = instructions
+            if speed != 1.0:
+                gen_kwargs["speed"] = speed
+            if ref_audio is not None and "ref_audio" in gen_params:
+                gen_kwargs["ref_audio"] = ref_audio
+                gen_kwargs["ref_text"] = ref_text
+            if temperature is not None:
+                gen_kwargs["temperature"] = temperature
+            if top_k is not None:
+                gen_kwargs["top_k"] = top_k
+            if top_p is not None:
+                gen_kwargs["top_p"] = top_p
+            if repetition_penalty is not None:
+                gen_kwargs["repetition_penalty"] = repetition_penalty
+            if max_tokens is not None:
+                gen_kwargs["max_tokens"] = max_tokens
+            gen_kwargs.update(kwargs)
+            return gen_kwargs
+
+        iterator: Any = None
+        sentinel = object()
+        chunk_count = 0
+        total_bytes = 0
+
+        def _next_pcm_chunk():
+            nonlocal iterator
+            if iterator is None:
+                iterator = iter(model.generate(**_build_generate_kwargs()))
+            try:
+                result = next(iterator)
+            except StopIteration:
+                return sentinel
+            audio = getattr(result, "audio", None)
+            if audio is None:
+                return None
+            sample_rate = int(
+                getattr(result, "sample_rate", getattr(model, "sample_rate", _DEFAULT_SAMPLE_RATE))
+            )
+            return sample_rate, 1, 2, self._audio_array_to_pcm_bytes(audio)
+
+        with self._active_lock:
+            self._active_count += 1
+        try:
+            loop = asyncio.get_running_loop()
+            while True:
+                chunk = await loop.run_in_executor(get_mlx_executor(), _next_pcm_chunk)
+                if chunk is sentinel:
+                    break
+                if chunk is None:
+                    continue
+                sample_rate, channels, sample_width, pcm_bytes = chunk
+                if not pcm_bytes:
+                    continue
+                chunk_count += 1
+                total_bytes += len(pcm_bytes)
+                yield sample_rate, channels, sample_width, pcm_bytes
+        finally:
+            if self._decrement_active():
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(
+                    get_mlx_executor(),
+                    lambda: (mx.synchronize(), mx.clear_cache()),
+                )
+            logger.info(
+                "TTS native stream done: model=%s, %.2fs, chunks=%d, pcm_bytes=%d",
+                self._model_name, time.monotonic() - t0, chunk_count, total_bytes,
+            )
 
     def get_stats(self) -> Dict[str, Any]:
         """Get engine statistics."""

--- a/scripts/generate_tts_count_1_to_30.py
+++ b/scripts/generate_tts_count_1_to_30.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Generate a streamed TTS sample counting from one to thirty.
+
+This is a live utility script for a running oMLX server. It sends one
+continuous TTS request to /v1/audio/speech, writes the raw streamed WAV bytes,
+then writes a finalized WAV with corrected RIFF/data sizes for normal players.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import struct
+import time
+import wave
+from pathlib import Path
+
+import httpx
+
+
+DEFAULT_TEXT = (
+    "one, two, three, four, five, six, seven, eight, nine, ten, "
+    "eleven, twelve, thirteen, fourteen, fifteen, sixteen, seventeen, "
+    "eighteen, nineteen, twenty, twenty one, twenty two, twenty three, "
+    "twenty four, twenty five, twenty six, twenty seven, twenty eight, "
+    "twenty nine, thirty."
+)
+
+DEFAULT_INSTRUCTIONS = (
+    "Count naturally in one continuous, calm voice at an even pace. "
+    "Avoid dramatic pauses or restarts."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a one-to-thirty TTS sample through oMLX streaming."
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("OMLX_BASE_URL", "http://127.0.0.1:8000"),
+        help="oMLX server base URL.",
+    )
+    parser.add_argument(
+        "--model",
+        default=os.environ.get(
+            "OMLX_TTS_MODEL", "Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit"
+        ),
+        help="TTS model ID exposed by /v1/models.",
+    )
+    parser.add_argument(
+        "--voice",
+        default=os.environ.get("OMLX_TTS_VOICE", "vivian"),
+        help="Voice name to use for the TTS model.",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("OMLX_API_KEY", "oMLX"),
+        help="Bearer API key. Use an empty string to omit Authorization.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("artifacts"),
+        help="Directory for generated text, WAV, and metadata files.",
+    )
+    parser.add_argument(
+        "--prefix",
+        default="qwen_tts_count_1_to_30_vivian_continuous",
+        help="Filename prefix for generated artifacts.",
+    )
+    parser.add_argument(
+        "--text",
+        default=DEFAULT_TEXT,
+        help="Text to synthesize.",
+    )
+    parser.add_argument(
+        "--instructions",
+        default=DEFAULT_INSTRUCTIONS,
+        help="Optional synthesis instructions.",
+    )
+    return parser.parse_args()
+
+
+def finalize_stream_wav(raw_path: Path, final_path: Path) -> dict[str, float | int]:
+    raw = bytearray(raw_path.read_bytes())
+    if raw[:4] != b"RIFF" or raw[8:12] != b"WAVE" or raw[36:40] != b"data":
+        raise RuntimeError(f"Unexpected WAV layout in {raw_path}")
+
+    raw[4:8] = struct.pack("<I", len(raw) - 8)
+    raw[40:44] = struct.pack("<I", len(raw) - 44)
+    final_path.write_bytes(raw)
+
+    with wave.open(str(final_path), "rb") as wav:
+        frames = wav.getnframes()
+        sample_rate = wav.getframerate()
+        return {
+            "channels": wav.getnchannels(),
+            "sample_width_bytes": wav.getsampwidth(),
+            "sample_rate_hz": sample_rate,
+            "frames": frames,
+            "duration_seconds": round(frames / sample_rate, 3),
+        }
+
+
+async def generate(args: argparse.Namespace) -> dict:
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    text_path = output_dir / f"{args.prefix}.txt"
+    raw_path = output_dir / f"{args.prefix}_stream.wav"
+    final_path = output_dir / f"{args.prefix}_finalized.wav"
+    meta_path = output_dir / f"{args.prefix}.json"
+
+    text_path.write_text(args.text + "\n")
+
+    payload = {
+        "model": args.model,
+        "input": args.text,
+        "voice": args.voice,
+        "instructions": args.instructions,
+        "response_format": "wav",
+        "stream": True,
+        "speed": 1.0,
+    }
+
+    headers = {"Authorization": f"Bearer {args.api_key}"} if args.api_key else {}
+    timeout = httpx.Timeout(connect=10.0, read=None, write=60.0, pool=60.0)
+
+    chunk_sizes: list[int] = []
+    chunk_offsets: list[float] = []
+    t0 = time.perf_counter()
+
+    async with httpx.AsyncClient(
+        base_url=args.base_url.rstrip("/"),
+        headers=headers,
+        timeout=timeout,
+    ) as client:
+        async with client.stream("POST", "/v1/audio/speech", json=payload) as response:
+            response.raise_for_status()
+            with raw_path.open("wb") as raw_file:
+                async for chunk in response.aiter_raw():
+                    if not chunk:
+                        continue
+                    raw_file.write(chunk)
+                    raw_file.flush()
+                    chunk_sizes.append(len(chunk))
+                    chunk_offsets.append(time.perf_counter() - t0)
+
+    finalized_audio = finalize_stream_wav(raw_path, final_path)
+
+    meta = {
+        "model": args.model,
+        "voice": args.voice,
+        "instructions": args.instructions,
+        "text_file": str(text_path.resolve()),
+        "raw_stream_file": str(raw_path.resolve()),
+        "finalized_file": str(final_path.resolve()),
+        "text": args.text,
+        "chunks": len(chunk_sizes),
+        "bytes": raw_path.stat().st_size,
+        "first_byte_seconds": round(chunk_offsets[0], 3) if chunk_offsets else None,
+        "total_seconds": round(chunk_offsets[-1], 3) if chunk_offsets else None,
+        "inter_chunk_gap_seconds": (
+            round(chunk_offsets[-1] - chunk_offsets[0], 3)
+            if len(chunk_offsets) > 1
+            else 0
+        ),
+        "chunk_sizes_head": chunk_sizes[:8],
+        "chunk_offsets_head_seconds": [round(offset, 3) for offset in chunk_offsets[:8]],
+        "finalized_audio": finalized_audio,
+    }
+    meta_path.write_text(json.dumps(meta, indent=2) + "\n")
+    return meta
+
+
+def main() -> None:
+    meta = asyncio.run(generate(parse_args()))
+    print(json.dumps(meta, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_audio_tts_streaming_integration.py
+++ b/tests/integration/test_audio_tts_streaming_integration.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Live integration test for TTS HTTP streaming against a running oMLX server.
+
+This test verifies the real transport path using httpx streaming against a
+server process started separately (for example in tmux). It is intended for
+real-model validation of the Phase 1 TTS streaming implementation.
+
+Required environment variables:
+- OMLX_TTS_MODEL: model ID exposed by /v1/models
+
+Optional environment variables:
+- OMLX_BASE_URL: server base URL (default: http://127.0.0.1:8000)
+- OMLX_TTS_VOICE: voice to use (default: Chelsie)
+- OMLX_API_KEY: API key if auth is enabled
+
+Run with:
+  OMLX_TTS_MODEL=Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit \
+  pytest tests/integration/test_audio_tts_streaming_integration.py -m "integration or slow" -s -v
+"""
+
+import os
+import time
+
+import httpx
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+BASE_URL = os.environ.get("OMLX_BASE_URL", "http://127.0.0.1:8000").rstrip("/")
+TTS_MODEL = os.environ.get("OMLX_TTS_MODEL")
+TTS_VOICE = os.environ.get("OMLX_TTS_VOICE", "Chelsie")
+API_KEY = os.environ.get("OMLX_API_KEY")
+
+
+def _headers() -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if API_KEY:
+        headers["Authorization"] = f"Bearer {API_KEY}"
+    return headers
+
+
+def _streaming_test_text() -> str:
+    """Return a long, multi-sentence text that should force multiple TTS segments."""
+    part1 = (
+        "Hello, this is a long-form streaming verification for oMLX. "
+        "We want the first audio bytes to arrive before the complete response has finished generating. "
+        "The phrasing is intentionally a little longer than a short demo sentence so that the server must work through meaningful content."
+    )
+    part2 = (
+        "Now we continue with a second paragraph-length sentence that should preserve the same Qwen custom voice characteristics across boundaries. "
+        "If Phase 1 streaming is implemented correctly, this part should arrive later in the same HTTP response instead of being buffered until everything is done."
+    )
+    part3 = (
+        "Finally, we add one more sentence to increase the chance of multiple synthesis calls and multiple transport writes. "
+        "This makes the test more realistic for long assistant responses in agent or chat workflows."
+    )
+    return f"{part1} {part2} {part3}"
+
+
+@pytest.mark.asyncio
+async def test_live_tts_streaming_emits_multiple_http_chunks():
+    """Verify that a running oMLX server emits incremental audio over HTTP streaming."""
+    if not TTS_MODEL:
+        pytest.skip("Set OMLX_TTS_MODEL to run live TTS streaming integration test")
+
+    timeout = httpx.Timeout(connect=10.0, read=None, write=60.0, pool=60.0)
+    async with httpx.AsyncClient(base_url=BASE_URL, headers=_headers(), timeout=timeout) as client:
+        # Verify server is reachable and the target model is exposed.
+        models_resp = await client.get("/v1/models")
+        models_resp.raise_for_status()
+        model_ids = {m["id"] for m in models_resp.json().get("data", [])}
+        assert TTS_MODEL in model_ids, (
+            f"Model {TTS_MODEL!r} not found in /v1/models. Available: {sorted(model_ids)}"
+        )
+
+        payload = {
+            "model": TTS_MODEL,
+            "input": _streaming_test_text(),
+            "voice": TTS_VOICE,
+            "response_format": "wav",
+            "stream": True,
+        }
+
+        chunk_timestamps: list[float] = []
+        raw_chunks: list[bytes] = []
+        t0 = time.perf_counter()
+
+        async with client.stream("POST", "/v1/audio/speech", json=payload) as response:
+            response.raise_for_status()
+            assert "audio/wav" in response.headers.get("content-type", "")
+
+            async for chunk in response.aiter_raw():
+                if not chunk:
+                    continue
+                chunk_timestamps.append(time.perf_counter())
+                raw_chunks.append(chunk)
+
+        t_done = time.perf_counter()
+        assert raw_chunks, "No streaming audio chunks received"
+
+        first_chunk = raw_chunks[0]
+        full_body = b"".join(raw_chunks)
+        t_first = chunk_timestamps[0] - t0
+        total_time = t_done - t0
+
+        # Basic WAV shape: one header at the beginning, audio bytes afterwards.
+        assert first_chunk.startswith(b"RIFF"), first_chunk[:32]
+        assert b"WAVE" in first_chunk[:64], first_chunk[:64]
+        assert len(full_body) > 4096, f"Unexpectedly small audio body: {len(full_body)} bytes"
+        assert full_body.count(b"RIFF") == 1, "Expected one WAV header for the streamed response"
+
+        # Real transport assertions: we expect multiple received chunks and earlier first audio than total completion.
+        assert len(raw_chunks) >= 2, (
+            "Expected multiple HTTP chunks from the live streaming response, "
+            f"got {len(raw_chunks)}"
+        )
+        assert t_first < total_time, (
+            f"First chunk did not arrive before completion: first={t_first:.2f}s total={total_time:.2f}s"
+        )
+
+        # Stronger signal that bytes arrived incrementally, not all at once.
+        inter_chunk_gap = chunk_timestamps[-1] - chunk_timestamps[0]
+        assert inter_chunk_gap > 0.05, (
+            "All chunks arrived effectively at once; expected observable incremental delivery. "
+            f"gap={inter_chunk_gap:.3f}s, chunks={len(raw_chunks)}"
+        )
+
+        print(
+            f"Streaming verified for {TTS_MODEL}: chunks={len(raw_chunks)}, "
+            f"first_byte={t_first:.2f}s, total={total_time:.2f}s, "
+            f"inter_chunk_gap={inter_chunk_gap:.2f}s, bytes={len(full_body)}"
+        )

--- a/tests/test_audio_tts.py
+++ b/tests/test_audio_tts.py
@@ -10,12 +10,12 @@ required. Integration tests (marked @pytest.mark.slow) need a real model.
 
 import base64
 import io
+import struct
 import wave
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -36,6 +36,7 @@ def _make_wav_bytes(duration_secs: float = 0.1, sample_rate: int = 22050) -> byt
 
 DUMMY_WAV = _make_wav_bytes()
 RIFF_MAGIC = b"RIFF"
+MAX_WAV_CHUNK_SIZE = 0xFFFFFFFF
 
 
 def _make_mock_tts_engine(wav_bytes: bytes = None) -> MagicMock:
@@ -43,6 +44,7 @@ def _make_mock_tts_engine(wav_bytes: bytes = None) -> MagicMock:
     from omlx.engine.tts import TTSEngine
     engine = MagicMock(spec=TTSEngine)
     engine.synthesize = AsyncMock(return_value=wav_bytes or DUMMY_WAV)
+    engine.supports_native_tts_streaming.return_value = False
     return engine
 
 
@@ -207,6 +209,16 @@ class TestTTSEndpointErrors:
         # Either rejected at validation or handled; must not be 5xx from server crash
         assert response.status_code != 500
 
+    def test_whitespace_input_returns_error(self, server_tts_client):
+        """Whitespace-only input is rejected before synthesis."""
+        client, mock_pool = server_tts_client
+        response = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "   ", "stream": True},
+        )
+        assert response.status_code == 400
+        mock_pool.get_engine.assert_not_awaited()
+
     def test_unsupported_model_returns_error(self, server_tts_client):
         """Requesting an unknown model returns 4xx."""
         client, mock_pool = server_tts_client
@@ -241,6 +253,234 @@ class TestTTSEndpointErrors:
             json={"input": "No model specified"},
         )
         assert response.status_code >= 400
+
+
+# ---------------------------------------------------------------------------
+# TestTTSStreaming
+# ---------------------------------------------------------------------------
+
+
+class TestTTSStreaming:
+    """Streaming-specific TTS endpoint behaviour."""
+
+    def test_streaming_response_returns_wav(self, server_tts_client):
+        """stream=true returns streamed WAV bytes."""
+        client, _ = server_tts_client
+        response = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "Hello world.", "stream": True},
+        )
+        assert response.status_code == 200
+        assert response.content[:4] == RIFF_MAGIC
+        assert "audio/wav" in response.headers.get("content-type", "")
+
+    def test_streaming_wav_header_advertises_unknown_length(self, server_tts_client):
+        """stream=true emits a WAV header that does not declare zero frames."""
+        client, _ = server_tts_client
+        response = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "Hello world.", "stream": True},
+        )
+        assert response.status_code == 200
+        riff_size = struct.unpack_from("<I", response.content, 4)[0]
+        data_size = struct.unpack_from("<I", response.content, 40)[0]
+        assert riff_size == MAX_WAV_CHUNK_SIZE
+        assert data_size == MAX_WAV_CHUNK_SIZE
+
+        with wave.open(io.BytesIO(response.content), "rb") as wf:
+            assert wf.getnframes() > 0
+            assert wf.readframes(wf.getnframes())
+
+    def test_streaming_multi_sentence_calls_synthesize_per_segment(self, server_tts_client):
+        """stream=true splits long text into multiple synthesize calls."""
+        client, mock_pool = server_tts_client
+        engine = mock_pool.get_engine.return_value
+        engine.synthesize = AsyncMock(side_effect=[
+            _make_wav_bytes(0.05, sample_rate=24000),
+            _make_wav_bytes(0.05, sample_rate=24000),
+        ])
+
+        long_input = (
+            ("Hello world " * 18).strip() + ". " + ("Second sentence " * 18).strip() + "."
+        )
+        response = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts",
+                "input": long_input,
+                "stream": True,
+            },
+        )
+        assert response.status_code == 200
+        assert engine.synthesize.await_count == 2
+        assert response.content[:4] == RIFF_MAGIC
+
+    def test_streaming_preserves_voice_across_segments(self, server_tts_client):
+        """voice is forwarded on every streaming synthesize call."""
+        client, mock_pool = server_tts_client
+        engine = mock_pool.get_engine.return_value
+        engine.synthesize = AsyncMock(side_effect=[
+            _make_wav_bytes(0.05, sample_rate=24000),
+            _make_wav_bytes(0.05, sample_rate=24000),
+        ])
+
+        long_input = (
+            ("Hello world " * 18).strip() + ". " + ("Second sentence " * 18).strip() + "."
+        )
+        response = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts",
+                "input": long_input,
+                "voice": "Chelsie",
+                "temperature": 0.7,
+                "top_k": 20,
+                "top_p": 0.9,
+                "repetition_penalty": 1.05,
+                "max_tokens": 512,
+                "stream": True,
+            },
+        )
+        assert response.status_code == 200
+        assert engine.synthesize.await_count == 2
+        for call in engine.synthesize.await_args_list:
+            assert call.kwargs.get("voice") == "Chelsie"
+            assert call.kwargs.get("temperature") == 0.7
+            assert call.kwargs.get("top_k") == 20
+            assert call.kwargs.get("top_p") == 0.9
+            assert call.kwargs.get("repetition_penalty") == 1.05
+            assert call.kwargs.get("max_tokens") == 512
+
+    def test_streaming_rejects_non_wav_response_format(self, server_tts_client):
+        """stream=true only supports response_format=wav in phase 1."""
+        client, _ = server_tts_client
+        response = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts",
+                "input": "Hello world.",
+                "response_format": "mp3",
+                "stream": True,
+            },
+        )
+        assert response.status_code == 400
+        detail = response.json().get("detail") or response.json().get("error", {}).get("message", "")
+        assert "wav" in detail.lower()
+
+    def test_streaming_rejects_too_small_streaming_interval(self, server_tts_client):
+        """Native streaming intervals too small for mlx-audio are rejected."""
+        client, mock_pool = server_tts_client
+        response = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts",
+                "input": "Hello world.",
+                "stream": True,
+                "streaming_interval": 0.001,
+            },
+        )
+        assert response.status_code == 400
+        detail = response.json().get("detail") or response.json().get("error", {}).get("message", "")
+        assert "streaming_interval" in detail
+        mock_pool.get_engine.assert_not_awaited()
+
+    def test_streaming_uses_native_full_input_when_available(self, server_tts_client):
+        """stream=true uses model-native streaming without route-level text splitting."""
+        client, mock_pool = server_tts_client
+        engine = mock_pool.get_engine.return_value
+        engine.supports_native_tts_streaming.return_value = True
+        engine.synthesize = AsyncMock()
+        calls = []
+
+        async def stream_synthesize_pcm(text, **kwargs):
+            calls.append((text, kwargs))
+            yield 24000, 1, 2, b"\x00\x00" * 120
+            yield 24000, 1, 2, b"\x01\x00" * 120
+
+        engine.stream_synthesize_pcm = stream_synthesize_pcm
+        long_input = (
+            ("Hello world " * 18).strip() + ". " + ("Second sentence " * 18).strip() + "."
+        )
+
+        response = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts",
+                "input": long_input,
+                "voice": "Vivian",
+                "stream": True,
+                "streaming_interval": 0.25,
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.content[:4] == RIFF_MAGIC
+        assert engine.synthesize.await_count == 0
+        assert calls[0][0] == long_input
+        assert calls[0][1]["voice"] == "Vivian"
+        assert calls[0][1]["streaming_interval"] == 0.25
+
+    def test_native_streaming_uses_low_latency_default_interval(self, server_tts_client):
+        """Native streaming defaults to a low TTFT interval when none is provided."""
+        client, mock_pool = server_tts_client
+        engine = mock_pool.get_engine.return_value
+        engine.supports_native_tts_streaming.return_value = True
+        calls = []
+
+        async def stream_synthesize_pcm(text, **kwargs):
+            calls.append((text, kwargs))
+            yield 24000, 1, 2, b"\x00\x00" * 120
+
+        engine.stream_synthesize_pcm = stream_synthesize_pcm
+
+        response = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "qwen3-tts",
+                "input": "Count from one to thirty in a single continuous sentence.",
+                "stream": True,
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.content[:4] == RIFF_MAGIC
+        assert calls[0][1]["streaming_interval"] == 0.2
+
+    def test_native_streaming_not_implemented_falls_back_before_header(self, server_tts_client):
+        """Compatibility stream kwargs that raise NotImplementedError use segmented fallback."""
+        client, mock_pool = server_tts_client
+        engine = mock_pool.get_engine.return_value
+        engine.supports_native_tts_streaming.return_value = True
+        engine.synthesize = AsyncMock(return_value=_make_wav_bytes(0.05, sample_rate=24000))
+
+        async def stream_synthesize_pcm(text, **kwargs):
+            raise NotImplementedError("streaming is not implemented for this model")
+            yield  # pragma: no cover
+
+        engine.stream_synthesize_pcm = stream_synthesize_pcm
+
+        response = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "Hello world.", "stream": True},
+        )
+
+        assert response.status_code == 200
+        assert response.content[:4] == RIFF_MAGIC
+        engine.synthesize.assert_awaited_once()
+
+    def test_streaming_engine_error_returns_500(self, server_tts_client):
+        """Synthesis failures before the first chunk return an HTTP error."""
+        client, mock_pool = server_tts_client
+        engine = mock_pool.get_engine.return_value
+        engine.synthesize = AsyncMock(side_effect=RuntimeError("synthesis failed"))
+
+        response = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "Hello world.", "stream": True},
+        )
+
+        assert response.status_code == 500
+        assert "audio/wav" not in response.headers.get("content-type", "")
 
 
 # ---------------------------------------------------------------------------
@@ -320,6 +560,49 @@ class TestTTSModelAliasResolution:
 
 
 # ---------------------------------------------------------------------------
+# TestTTSNativeStreamingCapability
+# ---------------------------------------------------------------------------
+
+
+class TestTTSNativeStreamingCapability:
+    """Verify native streaming detection is stricter than a stream kwarg."""
+
+    def _engine_with_generate_params(self, params):
+        import inspect
+
+        from omlx.engine.tts import TTSEngine
+
+        sig_params = {
+            "text": inspect.Parameter("text", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+        }
+        for p in params:
+            sig_params[p] = inspect.Parameter(
+                p,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=None,
+            )
+
+        generate_mock = MagicMock()
+        generate_mock.__signature__ = inspect.Signature(parameters=list(sig_params.values()))
+
+        class FakeModel:
+            pass
+
+        engine = TTSEngine("test-model")
+        engine._model = FakeModel()
+        engine._model.generate = generate_mock
+        return engine
+
+    def test_stream_kwarg_alone_is_not_native_streaming(self):
+        engine = self._engine_with_generate_params(["stream"])
+        assert engine.supports_native_tts_streaming() is False
+
+    def test_streaming_interval_marks_native_streaming(self):
+        engine = self._engine_with_generate_params(["stream", "streaming_interval"])
+        assert engine.supports_native_tts_streaming() is True
+
+
+# ---------------------------------------------------------------------------
 # TestTTSVoiceRouting — unit tests for voice/instruct parameter dispatch
 # ---------------------------------------------------------------------------
 
@@ -335,6 +618,7 @@ class TestTTSVoiceRouting:
         generate_voice_design work correctly — MagicMock auto-creates attributes.
         """
         import asyncio
+
         from omlx.engine.tts import TTSEngine
 
         def _run(generate_sig_params, voice_value=None, instructions_value=None,
@@ -435,6 +719,7 @@ class TestTTSVoiceClonePassthrough:
     def _run_synthesize_clone(self):
         """Helper: run TTSEngine.synthesize with ref_audio/ref_text and return generate() kwargs."""
         import asyncio
+
         from omlx.engine.tts import TTSEngine
 
         def _run(ref_audio_path=None, ref_text=None):
@@ -695,6 +980,7 @@ class TestTTSGenerationParams:
     def _run_synthesize(self):
         """Reuse voice routing fixture pattern for gen param tests."""
         import asyncio
+
         from omlx.engine.tts import TTSEngine
 
         def _run(generate_sig_params, **synth_kwargs):


### PR DESCRIPTION
Closes #948

## Summary
- add `stream` and `streaming_interval` support to `/v1/audio/speech`
- stream WAV responses via native mlx-audio PCM chunks when available, with a segmented synthesis fallback
- validate streaming intervals before loading the engine and keep ref-audio cleanup safe
- add unit/integration coverage plus a live TTS sample generation helper

## Validation
- `uv run pytest tests/test_audio_tts.py -q`

## Notes
- intentionally leaves `streaming_plan.md` and `uv.lock` out of this PR for a cleaner feature diff