### PR TITLE
Expose Claude Code context-scaling on /api/status (#163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,47 @@ Drop-in replacement for OpenAI and Anthropic APIs. Supports streaming usage stat
 | `POST /v1/embeddings` | Text embeddings |
 | `POST /v1/rerank` | Document reranking |
 | `GET /v1/models` | List available models |
+| `GET /api/status` | Server status for statuslines and scripts |
+
+### Status API
+
+A lightweight `GET /api/status` endpoint exposes server state for external pollers — Claude Code statuslines, monitoring scripts, terminal prompts. It uses the same bearer-token auth as the OpenAI-compatible endpoints, so any API key works:
+
+```bash
+curl -s -H "Authorization: Bearer $OMLX_API_KEY" \
+    http://localhost:8000/api/status
+```
+
+Returns a flat JSON object with serving stats, memory usage, loaded models, and Claude Code context-scaling configuration. Sample fields:
+
+```json
+{
+  "status": "ok",
+  "version": "0.3.8",
+  "uptime_seconds": 12834.2,
+  "default_model": "Qwen3-Coder-Next-8bit",
+  "loaded_models": ["Qwen3-Coder-Next-8bit"],
+  "models_loaded": 1,
+  "models_loading": 0,
+  "active_requests": 0,
+  "waiting_requests": 0,
+  "total_requests": 247,
+  "total_prompt_tokens": 1842310,
+  "total_completion_tokens": 89422,
+  "total_cached_tokens": 1612988,
+  "cache_efficiency": 87.5,
+  "avg_prefill_tps": 2140.3,
+  "avg_generation_tps": 78.4,
+  "model_memory_used": 17179869184,
+  "model_memory_max": 34359738368,
+  "model_memory_used_formatted": "16.0GB",
+  "model_memory_max_formatted": "32.0GB",
+  "claude_code_context_scaling_enabled": true,
+  "claude_code_target_context_size": 200000
+}
+```
+
+The shape is stable; new fields may be added but existing fields will not change. `claude_code_target_context_size` reflects the value reported to Claude Code so its auto-compact triggers at the right point, and `cache_efficiency` is the percentage of prompt tokens served from the prefix cache.
 
 ### Tool Calling & Structured Output
 

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1455,6 +1455,7 @@ async def server_status(_: bool = Depends(verify_api_key)):
     metrics = get_server_metrics()
     snapshot = metrics.get_snapshot()
 
+    global_settings = _server_state.global_settings
     pool = _server_state.engine_pool
 
     models_discovered = 0
@@ -1515,6 +1516,16 @@ async def server_status(_: bool = Depends(verify_api_key)):
         "model_memory_max": model_memory_max,
         "model_memory_used_formatted": format_size(model_memory_used) if model_memory_used else "0B",
         "model_memory_max_formatted": format_size(model_memory_max) if model_memory_max else "unlimited",
+        "claude_code_context_scaling_enabled": (
+            global_settings.claude_code.context_scaling_enabled
+            if global_settings is not None
+            else False
+        ),
+        "claude_code_target_context_size": (
+            global_settings.claude_code.target_context_size
+            if global_settings is not None
+            else 200000
+        ),
     }
 
 

--- a/tests/test_status_endpoint.py
+++ b/tests/test_status_endpoint.py
@@ -156,3 +156,28 @@ class TestStatusEndpoint:
         data = resp.json()
         assert data["model_memory_max"] is None
         assert data["model_memory_max_formatted"] == "unlimited"
+
+    def test_claude_code_fields_default_when_no_settings(self, client):
+        """Issue #163: when global_settings is None, claude_code fields use safe defaults."""
+        self._state.global_settings = None
+        resp = client.get("/api/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["claude_code_context_scaling_enabled"] is False
+        assert data["claude_code_target_context_size"] == 200000
+
+    def test_claude_code_fields_reflect_settings(self, client):
+        """Issue #163: claude_code fields surface configured values for statusline polling."""
+        claude_code = MagicMock(spec=["context_scaling_enabled", "target_context_size"])
+        claude_code.context_scaling_enabled = True
+        claude_code.target_context_size = 131072
+        global_settings = MagicMock(spec=["claude_code"])
+        global_settings.claude_code = claude_code
+
+        self._state.global_settings = global_settings
+
+        resp = client.get("/api/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["claude_code_context_scaling_enabled"] is True
+        assert data["claude_code_target_context_size"] == 131072


### PR DESCRIPTION
## Summary

Closes #163.

The issue asked for an API endpoint that statuslines (Claude Code, custom prompts) can poll to render oMLX-specific stats — context limit, usage, cache efficiency. oMLX already ships a `GET /api/status` endpoint that covers most of this, but it's missing the Claude Code context-scaling fields and isn't documented in the README, so users don't know it exists.

This PR closes the gap with a minimal change:

1. Surfaces `claude_code_context_scaling_enabled` and `claude_code_target_context_size` on `/api/status`, matching the flat naming already used by the admin `/api/stats` response.
2. Documents `/api/status` in the README under "API Compatibility", with a curl example and a representative response payload, so statusline integrations can discover it.

No new endpoint, no new auth path, no schema break.

## Files changed

| Area | File |
|------|------|
| Server | `omlx/server.py` (`/api/status` response) |
| Tests | `tests/test_status_endpoint.py` (two new test cases) |
| Docs | `README.md` (new "Status API" subsection) |

## Test plan

* `pytest tests/test_status_endpoint.py -v` — all existing cases plus two new ones:
  * `test_claude_code_fields_default_when_no_settings` — verifies safe defaults (`False`, `200000`) when `global_settings` is `None`.
  * `test_claude_code_fields_reflect_settings` — verifies configured values flow through (`True`, `131072`).
* Manual:
  ```
  omlx serve --model-dir ~/models &
  curl -s http://localhost:8000/api/status | jq .claude_code_context_scaling_enabled
  ```

## Sample response

```json
{
  "status": "ok",
  "version": "0.3.8",
  "uptime_seconds": 12834.2,
  "default_model": "Qwen3-Coder-Next-8bit",
  "loaded_models": ["Qwen3-Coder-Next-8bit"],
  "cache_efficiency": 87.5,
  "claude_code_context_scaling_enabled": true,
  "claude_code_target_context_size": 200000,
  "...": "..."
}
```

## Notes for review

* I went with flat field names (`claude_code_context_scaling_enabled`) rather than a nested `claude_code: {...}` block to stay consistent with `/api/stats`. Happy to switch to nested if you'd rather have a cleaner schema for external consumers — easy to flip.
* The README example response shows `cache_efficiency` and the other already-exposed fields so a reader can see the full statusline payload in one place. If you'd prefer a minimal example that only highlights the new fields, let me know.
* No version bump — assuming this rides whatever release goes out next.
