### PR TITLE
fix(tokenizer): prefer lm_head weight as vocab_size source

### DIFF
--- a/omlx/utils/tokenizer.py
+++ b/omlx/utils/tokenizer.py
@@ -39,10 +39,23 @@ def unwrap_tokenizer(tokenizer):
 
 
 def resolve_vocab_size(model: Any) -> int | None:
-    """Extract vocab_size from a model's config/args, handling nested configs.
+    """Extract vocab_size from a model, preferring the authoritative source.
 
-    Tries ``model.config.vocab_size``, then ``model.args.vocab_size``,
-    then ``text_config.vocab_size`` for VLM composite models (e.g. Qwen3.5).
+    Resolution order:
+    1. The ``lm_head`` weight's first dimension (authoritative — this is the
+       exact vocabulary the model emits logits over).
+    2. ``text_config.vocab_size`` when present (the inner language model's
+       vocab on VLM composite configs).
+    3. ``model.config.vocab_size`` / ``model.args.vocab_size`` (top-level).
+
+    Why lm_head and text_config come first for VLMs: several mlx-vlm
+    ``ModelConfig`` dataclasses (e.g. glm4v, glm4v_moe, gemma3) hard-code a
+    top-level ``vocab_size`` default that does not match the inner LM vocab
+    when ``config.json`` omits the top-level key.  For example, GLM-4.6V has
+    ``text_config.vocab_size=151552`` but ``ModelConfig.vocab_size=257152``
+    as a dataclass default.  Code that sizes logits-aligned buffers (e.g.
+    grammar bitmasks) from the top-level value produces a shape mismatch
+    against the real (151552) logits.
 
     Args:
         model: An MLX model object (LLM, VLM, or any object with config/args).
@@ -52,18 +65,45 @@ def resolve_vocab_size(model: Any) -> int | None:
     """
     if model is None:
         return None
+
+    # 1. lm_head weight — authoritative for any model that exposes one.
+    #    VLM adapters wrap the language model under ``_language_model``;
+    #    raw mlx-lm/mlx-vlm models expose ``lm_head`` directly or under
+    #    ``language_model``.
+    for path in (
+        ("_language_model", "lm_head"),
+        ("language_model", "lm_head"),
+        ("lm_head",),
+    ):
+        obj: Any = model
+        for name in path:
+            obj = getattr(obj, name, None)
+            if obj is None:
+                break
+        weight = getattr(obj, "weight", None) if obj is not None else None
+        shape = getattr(weight, "shape", None)
+        try:
+            first_dim = shape[0] if shape is not None else None
+        except (TypeError, IndexError):
+            first_dim = None
+        if isinstance(first_dim, int):
+            return int(first_dim)
+
+    # 2 & 3. Config-based fallbacks.
     for attr in ('config', 'args'):
         config = getattr(model, attr, None)
         if config is None:
             continue
-        vs = getattr(config, 'vocab_size', None)
-        if isinstance(vs, int):
-            return vs
         text_cfg = getattr(config, 'text_config', None)
         if isinstance(text_cfg, dict):
             vs = text_cfg.get('vocab_size')
         elif text_cfg is not None:
             vs = getattr(text_cfg, 'vocab_size', None)
+        else:
+            vs = None
+        if isinstance(vs, int):
+            return vs
+        vs = getattr(config, 'vocab_size', None)
         if isinstance(vs, int):
             return vs
     return None

--- a/omlx/utils/tokenizer.py
+++ b/omlx/utils/tokenizer.py
@@ -45,10 +45,23 @@ def unwrap_tokenizer(tokenizer):
 
 
 def resolve_vocab_size(model: Any) -> int | None:
-    """Extract vocab_size from a model's config/args, handling nested configs.
+    """Extract vocab_size from a model, preferring the authoritative source.
 
-    Tries ``model.config.vocab_size``, then ``model.args.vocab_size``,
-    then ``text_config.vocab_size`` for VLM composite models (e.g. Qwen3.5).
+    Resolution order:
+    1. The ``lm_head`` weight's first dimension (authoritative — this is the
+       exact vocabulary the model emits logits over).
+    2. ``text_config.vocab_size`` when present (the inner language model's
+       vocab on VLM composite configs).
+    3. ``model.config.vocab_size`` / ``model.args.vocab_size`` (top-level).
+
+    Why lm_head and text_config come first for VLMs: several mlx-vlm
+    ``ModelConfig`` dataclasses (e.g. glm4v, glm4v_moe, gemma3) hard-code a
+    top-level ``vocab_size`` default that does not match the inner LM vocab
+    when ``config.json`` omits the top-level key.  For example, GLM-4.6V has
+    ``text_config.vocab_size=151552`` but ``ModelConfig.vocab_size=257152``
+    as a dataclass default.  Code that sizes logits-aligned buffers (e.g.
+    grammar bitmasks) from the top-level value produces a shape mismatch
+    against the real (151552) logits.
 
     Args:
         model: An MLX model object (LLM, VLM, or any object with config/args).
@@ -58,18 +71,45 @@ def resolve_vocab_size(model: Any) -> int | None:
     """
     if model is None:
         return None
+
+    # 1. lm_head weight — authoritative for any model that exposes one.
+    #    VLM adapters wrap the language model under ``_language_model``;
+    #    raw mlx-lm/mlx-vlm models expose ``lm_head`` directly or under
+    #    ``language_model``.
+    for path in (
+        ("_language_model", "lm_head"),
+        ("language_model", "lm_head"),
+        ("lm_head",),
+    ):
+        obj: Any = model
+        for name in path:
+            obj = getattr(obj, name, None)
+            if obj is None:
+                break
+        weight = getattr(obj, "weight", None) if obj is not None else None
+        shape = getattr(weight, "shape", None)
+        try:
+            first_dim = shape[0] if shape is not None else None
+        except (TypeError, IndexError):
+            first_dim = None
+        if isinstance(first_dim, int):
+            return int(first_dim)
+
+    # 2 & 3. Config-based fallbacks.
     for attr in ("config", "args"):
         config = getattr(model, attr, None)
         if config is None:
             continue
-        vs = getattr(config, "vocab_size", None)
-        if isinstance(vs, int):
-            return vs
         text_cfg = getattr(config, "text_config", None)
         if isinstance(text_cfg, dict):
             vs = text_cfg.get("vocab_size")
         elif text_cfg is not None:
             vs = getattr(text_cfg, "vocab_size", None)
+        else:
+            vs = None
+        if isinstance(vs, int):
+            return vs
+        vs = getattr(config, "vocab_size", None)
         if isinstance(vs, int):
             return vs
     return None

--- a/tests/test_utils_tokenizer.py
+++ b/tests/test_utils_tokenizer.py
@@ -9,6 +9,7 @@ from omlx.utils.tokenizer import (
     is_gemma4_model,
     is_harmony_model,
     is_qwen3_model,
+    resolve_vocab_size,
 )
 
 
@@ -193,3 +194,154 @@ class TestApplyQwen3Fix:
         assert result["use_fast"] is True
         assert result["padding_side"] == "left"
         assert result["eos_token"] == "<|im_end|>"
+
+
+def _stub_lm_head(vocab_size: int):
+    """Build a stub lm_head whose weight has shape (vocab_size, hidden)."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(weight=SimpleNamespace(shape=(vocab_size, 16)))
+
+
+class TestResolveVocabSize:
+    """Test cases for resolve_vocab_size function.
+
+    Covers the three-level resolution order:
+      1. lm_head.weight.shape[0] (authoritative)
+      2. text_config.vocab_size (inner LM vocab on VLM composite)
+      3. config.vocab_size / args.vocab_size (top-level fallback)
+    """
+
+    def test_returns_none_for_none_model(self):
+        """resolve_vocab_size(None) returns None without crashing."""
+        assert resolve_vocab_size(None) is None
+
+    def test_lm_head_authoritative_pure_llm(self):
+        """Pure LLM with model.lm_head: returns lm_head's first dim."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            lm_head=_stub_lm_head(32000),
+            config=SimpleNamespace(vocab_size=32000),
+        )
+        assert resolve_vocab_size(model) == 32000
+
+    def test_lm_head_authoritative_via_language_model(self):
+        """Raw mlx-vlm wrapping: model.language_model.lm_head."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            language_model=SimpleNamespace(lm_head=_stub_lm_head(151552)),
+            config=SimpleNamespace(vocab_size=257152),
+        )
+        assert resolve_vocab_size(model) == 151552
+
+    def test_lm_head_authoritative_via_underscore_language_model(self):
+        """oMLX VLM-adapter wrapping: model._language_model.lm_head."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            _language_model=SimpleNamespace(lm_head=_stub_lm_head(151552)),
+            config=SimpleNamespace(vocab_size=257152),
+        )
+        assert resolve_vocab_size(model) == 151552
+
+    def test_lm_head_overrides_wrong_top_level_vocab_size(self):
+        """The bug case: GLM-4.6V-style mismatch where ModelConfig
+        defaults to 257152 but actual logits vocab is 151552. The
+        lm_head probe wins over the top-level config value.
+        """
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            language_model=SimpleNamespace(lm_head=_stub_lm_head(151552)),
+            config=SimpleNamespace(
+                vocab_size=257152,
+                text_config=SimpleNamespace(vocab_size=151552),
+            ),
+        )
+        assert resolve_vocab_size(model) == 151552
+
+    def test_text_config_fallback_when_lm_head_missing(self):
+        """No lm_head exposed anywhere: fall back to text_config.vocab_size."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                vocab_size=257152,
+                text_config=SimpleNamespace(vocab_size=151552),
+            ),
+        )
+        assert resolve_vocab_size(model) == 151552
+
+    def test_text_config_dict_fallback(self):
+        """text_config can be a dict (some configs use dataclass-as-dict)."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                vocab_size=None,
+                text_config={"vocab_size": 151552},
+            ),
+        )
+        assert resolve_vocab_size(model) == 151552
+
+    def test_top_level_config_fallback(self):
+        """No lm_head, no text_config: top-level config.vocab_size."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(config=SimpleNamespace(vocab_size=32000))
+        assert resolve_vocab_size(model) == 32000
+
+    def test_args_attr_fallback(self):
+        """Older mlx-lm models expose vocab via args, not config."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(args=SimpleNamespace(vocab_size=32000))
+        assert resolve_vocab_size(model) == 32000
+
+    def test_malformed_shape_falls_back_gracefully(self):
+        """A weight whose .shape is non-subscriptable (e.g. a bare object)
+        must not crash; the resolver should fall back to config.
+
+        Bad shape lives under `_language_model.lm_head` (the first wrapping
+        path probed) so the test directly exercises the try/except guard
+        for shape=object() rather than falling through earlier paths
+        whose shape=None happens to short-circuit safely.
+        """
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            _language_model=SimpleNamespace(
+                lm_head=SimpleNamespace(weight=SimpleNamespace(shape=object()))
+            ),
+            config=SimpleNamespace(vocab_size=32000),
+        )
+        assert resolve_vocab_size(model) == 32000
+
+    def test_none_shape_falls_back_gracefully(self):
+        """Weight present but .shape is None: skip lm_head, fall back."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            lm_head=SimpleNamespace(weight=SimpleNamespace(shape=None)),
+            config=SimpleNamespace(vocab_size=32000),
+        )
+        assert resolve_vocab_size(model) == 32000
+
+    def test_empty_shape_falls_back_gracefully(self):
+        """Weight present but .shape is empty: skip lm_head, fall back."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            lm_head=SimpleNamespace(weight=SimpleNamespace(shape=())),
+            config=SimpleNamespace(vocab_size=32000),
+        )
+        assert resolve_vocab_size(model) == 32000
+
+    def test_returns_none_when_all_sources_unavailable(self):
+        """No lm_head, no config, no args: returns None."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace()
+        assert resolve_vocab_size(model) is None

--- a/tests/test_utils_tokenizer.py
+++ b/tests/test_utils_tokenizer.py
@@ -11,6 +11,7 @@ from omlx.utils.tokenizer import (
     is_harmony_model,
     is_qwen3_model,
     repair_misconverted_unlimited_ocr_tokenizer,
+    resolve_vocab_size,
 )
 
 
@@ -678,3 +679,154 @@ class TestMistralCommonTokenizerConfig:
         repo = self._make_mistral_repo(tmp_path)
         config = get_tokenizer_config(str(repo))
         assert "eos_token" not in config
+
+
+def _stub_lm_head(vocab_size: int):
+    """Build a stub lm_head whose weight has shape (vocab_size, hidden)."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(weight=SimpleNamespace(shape=(vocab_size, 16)))
+
+
+class TestResolveVocabSize:
+    """Test cases for resolve_vocab_size function.
+
+    Covers the three-level resolution order:
+      1. lm_head.weight.shape[0] (authoritative)
+      2. text_config.vocab_size (inner LM vocab on VLM composite)
+      3. config.vocab_size / args.vocab_size (top-level fallback)
+    """
+
+    def test_returns_none_for_none_model(self):
+        """resolve_vocab_size(None) returns None without crashing."""
+        assert resolve_vocab_size(None) is None
+
+    def test_lm_head_authoritative_pure_llm(self):
+        """Pure LLM with model.lm_head: returns lm_head's first dim."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            lm_head=_stub_lm_head(32000),
+            config=SimpleNamespace(vocab_size=32000),
+        )
+        assert resolve_vocab_size(model) == 32000
+
+    def test_lm_head_authoritative_via_language_model(self):
+        """Raw mlx-vlm wrapping: model.language_model.lm_head."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            language_model=SimpleNamespace(lm_head=_stub_lm_head(151552)),
+            config=SimpleNamespace(vocab_size=257152),
+        )
+        assert resolve_vocab_size(model) == 151552
+
+    def test_lm_head_authoritative_via_underscore_language_model(self):
+        """oMLX VLM-adapter wrapping: model._language_model.lm_head."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            _language_model=SimpleNamespace(lm_head=_stub_lm_head(151552)),
+            config=SimpleNamespace(vocab_size=257152),
+        )
+        assert resolve_vocab_size(model) == 151552
+
+    def test_lm_head_overrides_wrong_top_level_vocab_size(self):
+        """The bug case: GLM-4.6V-style mismatch where ModelConfig
+        defaults to 257152 but actual logits vocab is 151552. The
+        lm_head probe wins over the top-level config value.
+        """
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            language_model=SimpleNamespace(lm_head=_stub_lm_head(151552)),
+            config=SimpleNamespace(
+                vocab_size=257152,
+                text_config=SimpleNamespace(vocab_size=151552),
+            ),
+        )
+        assert resolve_vocab_size(model) == 151552
+
+    def test_text_config_fallback_when_lm_head_missing(self):
+        """No lm_head exposed anywhere: fall back to text_config.vocab_size."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                vocab_size=257152,
+                text_config=SimpleNamespace(vocab_size=151552),
+            ),
+        )
+        assert resolve_vocab_size(model) == 151552
+
+    def test_text_config_dict_fallback(self):
+        """text_config can be a dict (some configs use dataclass-as-dict)."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                vocab_size=None,
+                text_config={"vocab_size": 151552},
+            ),
+        )
+        assert resolve_vocab_size(model) == 151552
+
+    def test_top_level_config_fallback(self):
+        """No lm_head, no text_config: top-level config.vocab_size."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(config=SimpleNamespace(vocab_size=32000))
+        assert resolve_vocab_size(model) == 32000
+
+    def test_args_attr_fallback(self):
+        """Older mlx-lm models expose vocab via args, not config."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(args=SimpleNamespace(vocab_size=32000))
+        assert resolve_vocab_size(model) == 32000
+
+    def test_malformed_shape_falls_back_gracefully(self):
+        """A weight whose .shape is non-subscriptable (e.g. a bare object)
+        must not crash; the resolver should fall back to config.
+
+        Bad shape lives under `_language_model.lm_head` (the first wrapping
+        path probed) so the test directly exercises the try/except guard
+        for shape=object() rather than falling through earlier paths
+        whose shape=None happens to short-circuit safely.
+        """
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            _language_model=SimpleNamespace(
+                lm_head=SimpleNamespace(weight=SimpleNamespace(shape=object()))
+            ),
+            config=SimpleNamespace(vocab_size=32000),
+        )
+        assert resolve_vocab_size(model) == 32000
+
+    def test_none_shape_falls_back_gracefully(self):
+        """Weight present but .shape is None: skip lm_head, fall back."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            lm_head=SimpleNamespace(weight=SimpleNamespace(shape=None)),
+            config=SimpleNamespace(vocab_size=32000),
+        )
+        assert resolve_vocab_size(model) == 32000
+
+    def test_empty_shape_falls_back_gracefully(self):
+        """Weight present but .shape is empty: skip lm_head, fall back."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace(
+            lm_head=SimpleNamespace(weight=SimpleNamespace(shape=())),
+            config=SimpleNamespace(vocab_size=32000),
+        )
+        assert resolve_vocab_size(model) == 32000
+
+    def test_returns_none_when_all_sources_unavailable(self):
+        """No lm_head, no config, no args: returns None."""
+        from types import SimpleNamespace
+
+        model = SimpleNamespace()
+        assert resolve_vocab_size(model) is None


### PR DESCRIPTION
## What this fixes

Users running grammar-constrained output (`[grammar]` extra) on GLM-4.6V — and on several other VLM families — hit a shape-mismatch crash on the first constrained-decode step, with no clear error about why. The xgrammar bitmask is allocated for the wrong vocabulary, then doesn't fit the model's actual logits tensor.

The root cause is `omlx/utils/tokenizer.py::resolve_vocab_size()` returning the wrong number, which then propagates to every consumer that sizes logits-aligned buffers from it. Two such consumers: `omlx/api/grammar.py::create_grammar_compiler()` (xgrammar bitmask) and the scheduler's `_get_model_vocab_size()` bookkeeping.

## Affected models

Three mlx-vlm `ModelConfig` dataclasses ship a hard-coded top-level `vocab_size` default that doesn't match the inner LM's actual vocab when `config.json` omits the top-level key (as it typically does for these models):

| mlx-vlm dataclass | `ModelConfig.vocab_size` default | Actual `text_config.vocab_size` |
| ----------------- | -------------------------------- | ------------------------------- |
| `glm4v` (GLM-4.6V) | `257152`                        | `151552`                        |
| `glm4v_moe`        | `257152`                        | per-model from `config.json`; e.g. `151552` for GLM-4.6V-Flash |
| `gemma3`           | `257152`                        | `262208`                        |

`resolve_vocab_size()` previously read the top-level value first, so it returned the wrong vocab on any of the above. Concrete public shape: GLM-4.6V has `text_config.vocab_size=151552` but `ModelConfig.vocab_size=257152` as a dataclass default; sizing from the top-level value mismatches the real 151552-wide logits.

## Fix

Re-order the resolution to prefer authoritative sources:

1. **`lm_head.weight.shape[0]`** — authoritative; this is the exact vocabulary the model emits logits over, regardless of whatever the config dataclass says. Probed under `_language_model.lm_head` (VLM adapter), `language_model.lm_head` (raw mlx-vlm), and `lm_head` (raw mlx-lm) so the lookup works for every wrapping shape we ship.
2. **`text_config.vocab_size`** — inner LM vocab on VLM composite configs (object and dict forms). Correct when `lm_head` is unavailable.
3. **`model.config.vocab_size` / `model.args.vocab_size`** — original top-level fallback, consulted last for compatibility with pure-LLM configs that don't have a `text_config`.

For pure-LLM models the new order returns the same value the old order did, because `lm_head.weight.shape[0]` and `config.vocab_size` agree. The change only affects models where the two disagree, which is exactly the broken case.

## Rebase (2026-09-09)

Rebased onto current `jundot/omlx` `main` at `94530d8d` (`feat(cluster): make TP and pipeline serving request-safe (#3258)`). The old head `b1f91b1d` conflicted because upstream's `omlx/utils/tokenizer.py` has since grown (new imports, detokenizer helpers, LFM2/Laguna/Mistral-common tokenizer-config handling) and `tests/test_utils_tokenizer.py` gained `TestMistralCommonTokenizerConfig`.

Conflict resolution, no behavior change beyond the intended fix:

- `omlx/utils/tokenizer.py`: kept upstream's file intact and replaced only `resolve_vocab_size()` with the lm_head-first implementation (double-quote style to match the file).
- `tests/test_utils_tokenizer.py`: kept upstream's `TestMistralCommonTokenizerConfig` and added the PR's `TestResolveVocabSize` (13 cases) alongside it; imports now include both `repair_misconverted_unlimited_ocr_tokenizer` and `resolve_vocab_size`.

New head: `95e5ae21`.

## Verification (fresh, on the rebased head)

Run in an isolated worktree against the rebased commit with the project venv (Python 3.12.11):

```
$ PYTHONPATH=<worktree> .venv/bin/python -m pytest tests/test_utils_tokenizer.py -q --tb=short
66 passed in 2.70s

$ PYTHONPATH=<worktree> .venv/bin/python -m pytest tests/test_grammar.py -q --tb=short
93 passed, 3 skipped in 2.54s

$ PYTHONPATH=<worktree> .venv/bin/python -m pytest tests/test_grammar.py::TestGetModelVocabSize -q
4 passed

$ .venv/bin/python -m ruff check omlx/utils/tokenizer.py tests/test_utils_tokenizer.py
All checks passed!
$ .venv/bin/python -m ruff format --check omlx/utils/tokenizer.py tests/test_utils_tokenizer.py
2 files already formatted
```

Resolver spot-check on the rebased code with a GLM-style stub (conflicting top-level `257152`, `text_config` `151552`, `lm_head` width `151552`): returns `151552`; the same stub without `lm_head` falls back to `text_config` (`151552`); `resolve_vocab_size(None)` returns `None`.

## Verification limits

- The resolver check above is a weight-free stub comparison, not a model-inference run.
- No fresh end-to-end constrained-decode run (GLM-4.6V-Flash with `[grammar]`, Llama 3.1, Qwen2-VL) was performed in this pass. The original PR's end-to-end claims (151552-wide bitmasks matching logits; unchanged ints on Llama 3.1 / Qwen2-VL) are historical and are **not** presented as newly verified here.
- Historical counts from the pre-rebase PR (`41 passed` on the tokenizer file) are superseded by the `66 passed` result above; the file has grown upstream since.

## Why not fix this in mlx-vlm

The dataclass defaults in `glm4v`, `glm4v_moe`, `gemma3` `ModelConfig` are arguably wrong (they should be `None` or read from `text_config`), and an upstream fix would obsolete most of this PR. But:

* The defaults exist on purpose for some mlx-vlm internals that instantiate `ModelConfig` without a `config.json`, so changing them is a behavior question, not just a bug fix — out of scope here.
* Even with mlx-vlm fixed, `lm_head.weight.shape[0]` is still the more authoritative source — config can drift from weights, weights can't drift from themselves. The new resolution order also defends against runtime config-weight drift on any future model where the two could disagree, not just the specific dataclasses currently broken.

## Risk

The new lm_head probe is gated by `getattr` chains and a defensive shape extraction (try/except around `shape[0]`), so it returns `None` (falling back to the old config path) on any model that doesn't expose `lm_head` in any of the three wrapping shapes, or whose `weight.shape` is not subscriptable. No code that previously succeeded should now fail.

Tied embeddings: `lm_head.weight` is `embed_tokens.weight` and still maps accurately to the logits vocab dimension.

Padded vocabularies: when a model pads its vocab to a multiple of 64 (or similar) for tensor-core efficiency, `lm_head.weight.shape[0]` returns the padded size — which is exactly what logits-aligned buffers (e.g. `xgrammar` bitmasks) need to allocate to avoid shape mismatches against the actual logits tensor. The new resolution order is strictly safer than the old `config`-first order in this case too.
