### PR TITLE
feat(vscode): add VS Code extension with chat, completions, and agent tools

### DIFF
--- a/extensions/vscode/.gitignore
+++ b/extensions/vscode/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.vsix

--- a/extensions/vscode/.vscodeignore
+++ b/extensions/vscode/.vscodeignore
@@ -1,0 +1,8 @@
+src/
+node_modules/
+esbuild.js
+tsconfig.json
+.eslintrc.json
+**/*.ts
+**/*.map
+!dist/**

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,0 +1,99 @@
+# oMLX — VS Code Extension
+
+A VS Code extension for [oMLX](https://github.com/jundot/omlx), a high-performance local LLM inference server for Apple Silicon.
+
+## Features
+
+- **Inline code completions** — Copilot-style ghost-text completions powered by any model loaded in oMLX
+- **Chat sidebar** — Streaming chat panel with full conversation history
+- **Agentic tool loop** — The model can execute code, run terminal commands, read/write files, start servers, and open live previews
+- **Model switcher** — Quick-pick palette showing loaded/unloaded models with size info
+- **Status bar** — Live connection status and tokens-per-second display
+- **Settings panel** — GUI to configure the server URL, API key, and global model parameters
+
+## Requirements
+
+- [oMLX server](https://github.com/jundot/omlx) running locally (default: `http://localhost:8000`)
+- VS Code 1.85 or later
+- macOS with Apple Silicon (M1/M2/M3/M4)
+
+## Installation
+
+### Development (F5)
+
+```bash
+cd extensions/vscode
+npm install
+npm run build
+```
+
+Then press **F5** in VS Code to launch the Extension Development Host.
+
+### VSIX package
+
+```bash
+npm install -g @vscode/vsce
+cd extensions/vscode
+npm run build
+vsce package
+```
+
+Install the generated `.vsix` via **Extensions: Install from VSIX…** in the command palette.
+
+## Configuration
+
+| Setting | Default | Description |
+|---|---|---|
+| `omlx.serverUrl` | `http://localhost:8000` | oMLX server base URL |
+| `omlx.apiKey` | _(empty)_ | Bearer token if the server requires authentication |
+| `omlx.completions.enabled` | `true` | Enable/disable inline completions |
+| `omlx.completions.maxTokens` | `128` | Maximum tokens per completion |
+| `omlx.completions.debounceMs` | `300` | Delay before triggering a completion request |
+| `omlx.completions.contextLines` | `20` | Lines of context sent to the model |
+| `omlx.chat.defaultSystemPrompt` | _(built-in)_ | System prompt prepended to every chat session |
+
+If your server requires an API key, set `omlx.apiKey` in VS Code settings (`Cmd+,` → search `omlx.apiKey`) or open the oMLX Settings panel via the command palette.
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `oMLX: Select Model` | Open the model quick-pick switcher |
+| `oMLX: Open Chat` | Focus the chat sidebar |
+| `oMLX: Open Settings` | Open the settings panel |
+| `oMLX: Toggle Completions` | Enable or disable inline completions |
+| `oMLX: Check Server Health` | Ping the server and show a status notification |
+
+## Agent Tools
+
+When using the chat panel the model can invoke the following tools:
+
+| Tool | Description |
+|---|---|
+| `execute_code` | Run Python, JavaScript, TypeScript, or shell code in a temp file |
+| `run_command` | Execute an arbitrary shell command (requires confirmation) |
+| `read_file` | Read a file relative to the workspace root |
+| `write_file` | Write or overwrite a file (requires confirmation) |
+| `list_files` | List files matching a glob pattern |
+| `open_preview` | Open a URL in the VS Code Simple Browser |
+| `start_server` | Spawn a long-running process and wait for a port to be ready |
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) at the repo root. The extension source lives in `extensions/vscode/src/`.
+
+```
+src/
+  api/          HTTP client and type definitions
+  commands/     VS Code command registrations
+  panels/       Chat and Settings webview panels
+  providers/    Inline completion and status bar providers
+  state/        Shared extension state singleton
+  tools/        Agent tool definitions and executor
+  webviews/     Webview HTML, CSS, and JS assets
+  extension.ts  Activation entry point
+```
+
+## License
+
+Apache 2.0 — see [LICENSE](../../LICENSE).

--- a/extensions/vscode/esbuild.js
+++ b/extensions/vscode/esbuild.js
@@ -1,0 +1,31 @@
+const esbuild = require('esbuild');
+
+const isWatch = process.argv.includes('--watch');
+
+async function main() {
+  const ctx = await esbuild.context({
+    entryPoints: ['src/extension.ts'],
+    bundle: true,
+    outfile: 'dist/extension.js',
+    external: ['vscode'],
+    format: 'cjs',
+    platform: 'node',
+    target: 'node20',
+    sourcemap: true,
+    minify: !isWatch,
+  });
+
+  if (isWatch) {
+    await ctx.watch();
+    console.log('Watching for changes...');
+  } else {
+    await ctx.rebuild();
+    await ctx.dispose();
+    console.log('Build complete.');
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,0 +1,2911 @@
+{
+  "name": "vscode-omlx",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vscode-omlx",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.85.0",
+        "@vscode/vsce": "^2.22.0",
+        "esbuild": "^0.20.0",
+        "typescript": "^5.3.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.8.0.tgz",
+      "integrity": "sha512-X7IZV77bN56l7sbLjkcbQJX1t3U4tgxqztDr/XFbUcUfKk+z2FavcLgKP+OYUNj0wl/pEEtV9lldW9siY8BuHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.5.1.tgz",
+      "integrity": "sha512-WS9w9SfI8SEYO7mTnxGeZ3UwQfhAVYCWglYF2/7GNx3ioHiAs2gPkl9eSwVs8cPrmiGh+zi9ai/OOKoq4cyzDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.4.tgz",
+      "integrity": "sha512-G4LXGGggok1QC48uKu64/SV2DPRDlddmV8EieK8pflsNYMj9/Zz+Y9OHoEBhT15h+zpdwXXLYA/7PJCR/yZ8aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.5.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.116.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
+      "integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vscode/vsce": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-2.32.0.tgz",
+      "integrity": "sha512-3EFJfsgrSftIqt3EtdRcAygy/OJ3hstyI1cDmIgkU9CFZW5C+3djr6mfosndCUqcVYuyjmxOK1xmFp/Bq7+NIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/identity": "^4.1.0",
+        "@vscode/vsce-sign": "^2.0.0",
+        "azure-devops-node-api": "^12.5.0",
+        "chalk": "^2.4.2",
+        "cheerio": "^1.0.0-rc.9",
+        "cockatiel": "^3.1.2",
+        "commander": "^6.2.1",
+        "form-data": "^4.0.0",
+        "glob": "^7.0.6",
+        "hosted-git-info": "^4.0.2",
+        "jsonc-parser": "^3.2.0",
+        "leven": "^3.1.0",
+        "markdown-it": "^12.3.2",
+        "mime": "^1.3.4",
+        "minimatch": "^3.0.3",
+        "parse-semver": "^1.1.1",
+        "read": "^1.0.7",
+        "semver": "^7.5.2",
+        "tmp": "^0.2.1",
+        "typed-rest-client": "^1.8.4",
+        "url-join": "^4.0.1",
+        "xml2js": "^0.5.0",
+        "yauzl": "^2.3.1",
+        "yazl": "^2.2.2"
+      },
+      "bin": {
+        "vsce": "vsce"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "optionalDependencies": {
+        "keytar": "^7.7.0"
+      }
+    },
+    "node_modules/@vscode/vsce-sign": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.9.tgz",
+      "integrity": "sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optionalDependencies": {
+        "@vscode/vsce-sign-alpine-arm64": "2.0.6",
+        "@vscode/vsce-sign-alpine-x64": "2.0.6",
+        "@vscode/vsce-sign-darwin-arm64": "2.0.6",
+        "@vscode/vsce-sign-darwin-x64": "2.0.6",
+        "@vscode/vsce-sign-linux-arm": "2.0.6",
+        "@vscode/vsce-sign-linux-arm64": "2.0.6",
+        "@vscode/vsce-sign-linux-x64": "2.0.6",
+        "@vscode/vsce-sign-win32-arm64": "2.0.6",
+        "@vscode/vsce-sign-win32-x64": "2.0.6"
+      }
+    },
+    "node_modules/@vscode/vsce-sign-alpine-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
+      "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-alpine-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
+      "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
+      "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
+      "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
+      "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
+      "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
+      "integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
+      "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
+      "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/azure-devops-node-api": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+      "integrity": "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/cockatiel": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
+      "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-semver": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+      "integrity": "sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.1.0"
+      }
+    },
+    "node_modules/parse-semver/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
+      }
+    }
+  }
+}

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,0 +1,140 @@
+{
+  "name": "vscode-omlx",
+  "displayName": "oMLX",
+  "description": "Local LLM inference for Apple Silicon — inline completions, chat sidebar, model management",
+  "version": "0.1.0",
+  "publisher": "omlx",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "AI",
+    "Other"
+  ],
+  "keywords": [
+    "llm",
+    "ai",
+    "copilot",
+    "mlx",
+    "apple silicon",
+    "local ai",
+    "chat",
+    "completions"
+  ],
+  "icon": "resources/icon.png",
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "oMLX",
+      "properties": {
+        "omlx.serverUrl": {
+          "type": "string",
+          "default": "http://localhost:8000",
+          "description": "oMLX server URL"
+        },
+        "omlx.apiKey": {
+          "type": "string",
+          "default": "",
+          "description": "API key for oMLX authentication (leave empty if auth is disabled)"
+        },
+        "omlx.completions.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable inline code completions"
+        },
+        "omlx.completions.maxTokens": {
+          "type": "number",
+          "default": 80,
+          "description": "Max tokens for inline completions"
+        },
+        "omlx.completions.debounceMs": {
+          "type": "number",
+          "default": 300,
+          "description": "Debounce delay in milliseconds before triggering completions"
+        },
+        "omlx.completions.contextLines": {
+          "type": "number",
+          "default": 100,
+          "description": "Number of lines before the cursor to include as context"
+        },
+        "omlx.chat.defaultSystemPrompt": {
+          "type": "string",
+          "default": "You are a helpful programming assistant.",
+          "description": "Default system prompt for the chat sidebar"
+        }
+      }
+    },
+    "commands": [
+      {
+        "command": "omlx.selectModel",
+        "title": "oMLX: Select Model",
+        "icon": "$(list-selection)"
+      },
+      {
+        "command": "omlx.openSettings",
+        "title": "oMLX: Open Settings",
+        "icon": "$(settings-gear)"
+      },
+      {
+        "command": "omlx.openChat",
+        "title": "oMLX: Open Chat"
+      },
+      {
+        "command": "omlx.toggleCompletions",
+        "title": "oMLX: Toggle Inline Completions"
+      },
+      {
+        "command": "omlx.checkHealth",
+        "title": "oMLX: Check Server Health"
+      }
+    ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "omlx-sidebar",
+          "title": "oMLX",
+          "icon": "resources/omlx-icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "omlx-sidebar": [
+        {
+          "type": "webview",
+          "id": "omlx.chatView",
+          "name": "Chat"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "omlx.selectModel",
+          "when": "view == omlx.chatView",
+          "group": "navigation"
+        },
+        {
+          "command": "omlx.openSettings",
+          "when": "view == omlx.chatView",
+          "group": "navigation"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "build": "node esbuild.js",
+    "watch": "node esbuild.js --watch",
+    "package": "npm run build && vsce package",
+    "lint": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
+    "@vscode/vsce": "^2.22.0",
+    "esbuild": "^0.20.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/extensions/vscode/resources/omlx-icon.svg
+++ b/extensions/vscode/resources/omlx-icon.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#C0C0C0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Neural network / inference icon -->
+  <!-- Input nodes -->
+  <circle cx="3" cy="6" r="1.5" fill="#C0C0C0" stroke="none"/>
+  <circle cx="3" cy="12" r="1.5" fill="#C0C0C0" stroke="none"/>
+  <circle cx="3" cy="18" r="1.5" fill="#C0C0C0" stroke="none"/>
+  <!-- Hidden nodes -->
+  <circle cx="10" cy="9" r="1.5" fill="#C0C0C0" stroke="none"/>
+  <circle cx="10" cy="15" r="1.5" fill="#C0C0C0" stroke="none"/>
+  <!-- Output node -->
+  <circle cx="17" cy="12" r="1.5" fill="#C0C0C0" stroke="none"/>
+  <!-- Connections input → hidden -->
+  <line x1="4.5" y1="6" x2="8.5" y2="9" stroke="#C0C0C0" stroke-width="1"/>
+  <line x1="4.5" y1="12" x2="8.5" y2="9" stroke="#C0C0C0" stroke-width="1"/>
+  <line x1="4.5" y1="12" x2="8.5" y2="15" stroke="#C0C0C0" stroke-width="1"/>
+  <line x1="4.5" y1="18" x2="8.5" y2="15" stroke="#C0C0C0" stroke-width="1"/>
+  <line x1="4.5" y1="6" x2="8.5" y2="15" stroke="#C0C0C0" stroke-width="0.6" opacity="0.5"/>
+  <line x1="4.5" y1="18" x2="8.5" y2="9" stroke="#C0C0C0" stroke-width="0.6" opacity="0.5"/>
+  <!-- Connections hidden → output -->
+  <line x1="11.5" y1="9" x2="15.5" y2="12" stroke="#C0C0C0" stroke-width="1"/>
+  <line x1="11.5" y1="15" x2="15.5" y2="12" stroke="#C0C0C0" stroke-width="1"/>
+  <!-- Apple Silicon chip hint: M-shaped top -->
+  <path d="M19 8 L21 10 L21 14 L19 16" stroke="#C0C0C0" stroke-width="1.2" fill="none"/>
+</svg>

--- a/extensions/vscode/src/api/client.ts
+++ b/extensions/vscode/src/api/client.ts
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as http from 'node:http';
+import * as https from 'node:https';
+import type { IncomingMessage } from 'node:http';
+import type {
+  AdminModel,
+  ChatChunk,
+  ChatMessage,
+  GlobalSettings,
+  OmlxModel,
+  StatsSnapshot,
+  ToolDefinition,
+} from './types.js';
+
+export interface StreamOptions {
+  temperature?: number;
+  maxTokens?: number;
+  signal?: AbortSignal;
+  tools?: ToolDefinition[];
+}
+
+export class OmlxClient {
+  constructor(
+    private readonly _serverUrl: () => string,
+    private readonly _apiKey: () => string,
+  ) {}
+
+  private _buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+    const key = this._apiKey();
+    if (key) {
+      headers['Authorization'] = `Bearer ${key}`;
+    }
+    return headers;
+  }
+
+  private async _get<T>(path: string): Promise<T> {
+    const url = new URL(path, this._serverUrl());
+    const mod = url.protocol === 'https:' ? https : http;
+    return new Promise((resolve, reject) => {
+      const req = mod.request(
+        url,
+        { method: 'GET', headers: this._buildHeaders() },
+        (res) => {
+          let data = '';
+          res.on('data', (chunk: Buffer) => (data += chunk.toString('utf8')));
+          res.on('end', () => {
+            if (res.statusCode && res.statusCode >= 400) {
+              reject(new Error(`HTTP ${res.statusCode} from ${path}: ${data.slice(0, 200)}`));
+              return;
+            }
+            try {
+              resolve(JSON.parse(data) as T);
+            } catch {
+              reject(new Error(`oMLX: invalid JSON from ${path}: ${data.slice(0, 200)}`));
+            }
+          });
+          res.on('error', reject);
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  private async _post<T>(path: string, body: unknown): Promise<T> {
+    const url = new URL(path, this._serverUrl());
+    const mod = url.protocol === 'https:' ? https : http;
+    const payload = JSON.stringify(body);
+    return new Promise((resolve, reject) => {
+      const req = mod.request(
+        url,
+        {
+          method: 'POST',
+          headers: { ...this._buildHeaders(), 'Content-Length': Buffer.byteLength(payload) },
+        },
+        (res) => {
+          let data = '';
+          res.on('data', (chunk: Buffer) => (data += chunk.toString('utf8')));
+          res.on('end', () => {
+            if (res.statusCode && res.statusCode >= 400) {
+              reject(new Error(`oMLX: HTTP ${res.statusCode} from ${path}`));
+              return;
+            }
+            try {
+              resolve(data ? (JSON.parse(data) as T) : ({} as T));
+            } catch {
+              resolve({} as T);
+            }
+          });
+          res.on('error', reject);
+        },
+      );
+      req.on('error', reject);
+      req.write(payload);
+      req.end();
+    });
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      await this._get('/health');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async listModels(): Promise<OmlxModel[]> {
+    const result = await this._get<{ data: OmlxModel[] }>('/v1/models');
+    return result.data ?? [];
+  }
+
+  async listAdminModels(): Promise<AdminModel[]> {
+    try {
+      // /admin/api/models returns a plain array
+      const result = await this._get<AdminModel[] | { models: AdminModel[] }>(
+        '/admin/api/models',
+      );
+      return Array.isArray(result) ? result : (result.models ?? []);
+    } catch {
+      // Fall back to OpenAI endpoint if admin auth fails
+      const models = await this.listModels();
+      return models.map((m) => ({
+        id: m.id,
+        loaded: true,
+        is_loading: false,
+        pinned: false,
+        is_default: false,
+      }));
+    }
+  }
+
+  async getGlobalSettings(): Promise<GlobalSettings> {
+    return this._get<GlobalSettings>('/admin/api/global-settings');
+  }
+
+  async getStats(): Promise<StatsSnapshot> {
+    return this._get<StatsSnapshot>('/admin/api/stats');
+  }
+
+  async loadModel(modelId: string): Promise<void> {
+    await this._post(`/admin/api/models/${encodeURIComponent(modelId)}/load`, {});
+  }
+
+  async unloadModel(modelId: string): Promise<void> {
+    await this._post(`/admin/api/models/${encodeURIComponent(modelId)}/unload`, {});
+  }
+
+  async completion(prompt: string, model: string, maxTokens: number): Promise<string> {
+    const result = await this._post<{
+      choices: Array<{ text: string }>;
+    }>('/v1/completions', {
+      model,
+      prompt,
+      max_tokens: maxTokens,
+      stream: false,
+      stop: ['\n\n', '```'],
+    });
+    return result.choices?.[0]?.text ?? '';
+  }
+
+  async *chatCompletionsStream(
+    messages: ChatMessage[],
+    model: string,
+    opts: StreamOptions = {},
+  ): AsyncGenerator<ChatChunk> {
+    const url = new URL('/v1/chat/completions', this._serverUrl());
+    const mod = url.protocol === 'https:' ? https : http;
+
+    const body = JSON.stringify({
+      model,
+      messages,
+      stream: true,
+      stream_options: { include_usage: true },
+      temperature: opts.temperature ?? 0.7,
+      max_tokens: opts.maxTokens ?? 2048,
+      ...(opts.tools && opts.tools.length > 0 ? { tools: opts.tools, tool_choice: 'auto' } : {}),
+    });
+
+    const headers = {
+      ...this._buildHeaders(),
+      Accept: 'text/event-stream',
+      'Content-Length': Buffer.byteLength(body),
+    };
+
+    const response = await new Promise<IncomingMessage>((resolve, reject) => {
+      const req = mod.request(url, { method: 'POST', headers }, resolve);
+      req.on('error', reject);
+      if (opts.signal) {
+        opts.signal.addEventListener('abort', () => req.destroy());
+      }
+      req.write(body);
+      req.end();
+    });
+
+    if (response.statusCode && response.statusCode >= 400) {
+      throw new Error(`oMLX: HTTP ${response.statusCode} from /v1/chat/completions`);
+    }
+
+    let buffer = '';
+    for await (const raw of response) {
+      buffer += (raw as Buffer).toString('utf8');
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === 'data: [DONE]') {
+          continue;
+        }
+        if (trimmed.startsWith('data: ')) {
+          try {
+            yield JSON.parse(trimmed.slice(6)) as ChatChunk;
+          } catch {
+            // Malformed chunk — skip
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/vscode/src/api/types.ts
+++ b/extensions/vscode/src/api/types.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+export interface OmlxModel {
+  id: string;
+  object: 'model';
+  owned_by: string;
+}
+
+export interface AdminModel {
+  id: string;
+  loaded: boolean;
+  is_loading: boolean;
+  pinned: boolean;
+  is_default: boolean;
+  estimated_size?: number;
+  estimated_size_formatted?: string;
+}
+
+export interface GlobalSettings {
+  server?: { host: string; port: number; log_level: string };
+  model?: { max_model_memory: string };
+  scheduler?: { max_concurrent_requests: number };
+  cache?: { enabled: boolean };
+  auth?: { api_key_set: boolean; api_key: string };
+}
+
+export interface StatsSnapshot {
+  total_requests: number;
+  total_completion_tokens: number;
+  avg_generation_tps: number;
+  avg_prefill_tps: number;
+}
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string | null;
+  tool_calls?: ToolCall[];
+  tool_call_id?: string;
+}
+
+export interface ToolFunction {
+  name: string;
+  arguments: string;
+}
+
+export interface ToolCall {
+  index: number;
+  id: string;
+  type: 'function';
+  function: ToolFunction;
+}
+
+export interface ToolDefinition {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+}
+
+export interface ChatChunk {
+  id: string;
+  choices: Array<{
+    delta: {
+      role?: string;
+      content?: string;
+      reasoning_content?: string;
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        type?: 'function';
+        function?: { name?: string; arguments?: string };
+      }>;
+    };
+    finish_reason: string | null;
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    generation_tokens_per_second?: number;
+    prompt_tokens_per_second?: number;
+  };
+}
+
+export interface VscodeConfig {
+  serverUrl: string;
+  apiKey: string;
+  completionsEnabled: boolean;
+  completionsMaxTokens: number;
+  completionsDebounceMs: number;
+  completionsContextLines: number;
+  chatDefaultSystemPrompt: string;
+}

--- a/extensions/vscode/src/commands/index.ts
+++ b/extensions/vscode/src/commands/index.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as vscode from 'vscode';
+import type { OmlxClient } from '../api/client.js';
+import type { ExtensionState } from '../state/ExtensionState.js';
+import { showModelSwitcher } from './modelSwitcher.js';
+
+export function registerCommands(
+  context: vscode.ExtensionContext,
+  client: OmlxClient,
+  state: ExtensionState,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('omlx.selectModel', () =>
+      showModelSwitcher(client, state),
+    ),
+
+    vscode.commands.registerCommand('omlx.openSettings', () =>
+      vscode.commands.executeCommand('omlx.openSettingsPanel'),
+    ),
+
+    vscode.commands.registerCommand('omlx.openChat', () =>
+      vscode.commands.executeCommand('omlx.chatView.focus'),
+    ),
+
+    vscode.commands.registerCommand('omlx.toggleCompletions', () => {
+      const config = vscode.workspace.getConfiguration('omlx');
+      const current = config.get<boolean>('completions.enabled', true);
+      config.update(
+        'completions.enabled',
+        !current,
+        vscode.ConfigurationTarget.Global,
+      );
+      vscode.window.setStatusBarMessage(
+        `oMLX completions ${!current ? 'enabled' : 'disabled'}`,
+        3000,
+      );
+    }),
+
+    vscode.commands.registerCommand('omlx.checkHealth', async () => {
+      const healthy = await client.healthCheck();
+      if (healthy) {
+        vscode.window.showInformationMessage('oMLX server is reachable.');
+      } else {
+        vscode.window.showWarningMessage(
+          `oMLX server not reachable at ${vscode.workspace.getConfiguration('omlx').get<string>('serverUrl', 'http://localhost:8000')}`,
+        );
+      }
+    }),
+  );
+}

--- a/extensions/vscode/src/commands/modelSwitcher.ts
+++ b/extensions/vscode/src/commands/modelSwitcher.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as vscode from 'vscode';
+import type { OmlxClient } from '../api/client.js';
+import type { ExtensionState } from '../state/ExtensionState.js';
+
+export async function showModelSwitcher(
+  client: OmlxClient,
+  state: ExtensionState,
+): Promise<void> {
+  const quickPick = vscode.window.createQuickPick();
+  quickPick.placeholder = 'Select an oMLX model';
+  quickPick.busy = true;
+  quickPick.show();
+
+  try {
+    const adminModels = await client.listAdminModels();
+
+    // Loaded models first
+    const sorted = [...adminModels].sort((a, b) => {
+      if (a.loaded && !b.loaded) return -1;
+      if (!a.loaded && b.loaded) return 1;
+      return a.id.localeCompare(b.id);
+    });
+
+    quickPick.items = sorted.map((m) => ({
+      label: m.loaded ? `$(circle-filled) ${m.id}` : `$(circle-outline) ${m.id}`,
+      description: m.loaded
+        ? 'loaded'
+        : m.is_loading
+          ? 'loading…'
+          : m.estimated_size_formatted ?? 'unloaded',
+      detail: m.is_default ? 'default model' : undefined,
+      id: m.id,
+    }));
+    quickPick.busy = false;
+
+    quickPick.onDidAccept(() => {
+      const selected = quickPick.selectedItems[0] as
+        | (vscode.QuickPickItem & { id: string })
+        | undefined;
+      if (selected) {
+        state.selectedModel = selected.id;
+        vscode.window.setStatusBarMessage(`oMLX: model set to ${selected.id}`, 3000);
+      }
+      quickPick.dispose();
+    });
+
+    quickPick.onDidHide(() => quickPick.dispose());
+  } catch (e) {
+    quickPick.dispose();
+    vscode.window.showErrorMessage(
+      `oMLX: Failed to list models — ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+}

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as vscode from 'vscode';
+import { OmlxClient } from './api/client.js';
+import { registerCommands } from './commands/index.js';
+import { ChatPanel } from './panels/ChatPanel.js';
+import { SettingsPanel } from './panels/SettingsPanel.js';
+import { OmlxInlineCompletionProvider } from './providers/inlineCompletion.js';
+import { StatusBarManager } from './providers/statusBar.js';
+import { state } from './state/ExtensionState.js';
+
+const HEALTH_POLL_INTERVAL_MS = 10_000;
+let _shownAuthWarning = false;
+
+export function activate(context: vscode.ExtensionContext): void {
+  // Initialize state with persistent storage
+  state.init(context);
+
+  // Build the client — reads config on every call so no stale credentials
+  const client = new OmlxClient(
+    () => vscode.workspace.getConfiguration('omlx').get<string>('serverUrl', 'http://localhost:8000'),
+    () => vscode.workspace.getConfiguration('omlx').get<string>('apiKey', ''),
+  );
+
+  // ── Status bar ─────────────────────────────────────────
+  const statusBar = new StatusBarManager(state);
+  state.onDidChange(() => statusBar.notifyStateChanged());
+  context.subscriptions.push({ dispose: () => statusBar.dispose() });
+
+  // ── Health polling + auto-select model ────────────────
+  async function pollHealth(): Promise<void> {
+    const healthy = await client.healthCheck();
+    state.serverHealthy = healthy;
+
+    if (healthy && !state.selectedModel) {
+      try {
+        const loaded = await client.listModels();
+        if (loaded.length > 0) {
+          state.selectedModel = loaded[0].id;
+        } else {
+          const admin = await client.listAdminModels();
+          const pick =
+            admin.find((m) => m.is_default && m.loaded) ??
+            admin.find((m) => m.loaded) ??
+            admin[0];
+          if (pick) {
+            state.selectedModel = pick.id;
+          }
+        }
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg.includes('401') && !_shownAuthWarning) {
+          _shownAuthWarning = true;
+          vscode.window
+            .showWarningMessage(
+              'oMLX: API key required. Set it in oMLX Settings.',
+              'Open Settings',
+            )
+            .then((choice) => {
+              if (choice === 'Open Settings') {
+                vscode.commands.executeCommand('omlx.openSettingsPanel');
+              }
+            });
+        }
+      }
+    }
+  }
+  void pollHealth();
+  const healthTimer = setInterval(() => void pollHealth(), HEALTH_POLL_INTERVAL_MS);
+  context.subscriptions.push({ dispose: () => clearInterval(healthTimer) });
+
+  // ── Inline completions ─────────────────────────────────
+  const completionProvider = new OmlxInlineCompletionProvider(client, state);
+  context.subscriptions.push(
+    vscode.languages.registerInlineCompletionItemProvider(
+      { pattern: '**' },
+      completionProvider,
+    ),
+    { dispose: () => completionProvider.dispose() },
+  );
+
+  // ── Chat sidebar ───────────────────────────────────────
+  const chatPanel = new ChatPanel(context.extensionUri, client, state);
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(ChatPanel.viewType, chatPanel),
+    { dispose: () => chatPanel.dispose() },
+  );
+
+  // ── Settings panel command ─────────────────────────────
+  context.subscriptions.push(
+    vscode.commands.registerCommand('omlx.openSettingsPanel', () => {
+      SettingsPanel.createOrShow(context.extensionUri, client);
+    }),
+  );
+
+  // ── Other commands ─────────────────────────────────────
+  registerCommands(context, client, state);
+
+  // ── Config change listener ─────────────────────────────
+  // Re-poll health immediately when server URL changes
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration('omlx.serverUrl')) {
+        void pollHealth();
+      }
+    }),
+  );
+}
+
+export function deactivate(): void {
+  // Interval and disposables are cleaned up via context.subscriptions
+}

--- a/extensions/vscode/src/panels/ChatPanel.ts
+++ b/extensions/vscode/src/panels/ChatPanel.ts
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as vscode from 'vscode';
+import type { OmlxClient } from '../api/client.js';
+import type { ChatMessage, ToolCall } from '../api/types.js';
+import type { ExtensionState } from '../state/ExtensionState.js';
+import { TOOL_DEFINITIONS } from '../tools/definitions.js';
+import { executeTool } from '../tools/executor.js';
+
+const MAX_AGENT_ITERATIONS = 10;
+
+type WebviewMessage =
+  | { type: 'send-message'; content: string; history: ChatMessage[] }
+  | { type: 'cancel-stream' }
+  | { type: 'request-models' }
+  | { type: 'clear-history' }
+  | { type: 'open-settings' }
+  | { type: 'insert-code'; code: string };
+
+export class ChatPanel implements vscode.WebviewViewProvider {
+  public static readonly viewType = 'omlx.chatView';
+
+  private _view: vscode.WebviewView | undefined;
+  private _abortController: AbortController | undefined;
+  private _stateDisposable: vscode.Disposable | undefined;
+
+  constructor(
+    private readonly _extensionUri: vscode.Uri,
+    private readonly _client: OmlxClient,
+    private readonly _state: ExtensionState,
+  ) {}
+
+  resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    _context: vscode.WebviewViewResolveContext,
+    _token: vscode.CancellationToken,
+  ): void {
+    this._view = webviewView;
+
+    webviewView.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [
+        vscode.Uri.joinPath(this._extensionUri, 'src', 'webviews', 'chat'),
+      ],
+    };
+
+    webviewView.webview.html = this._getHtml(webviewView.webview);
+
+    webviewView.webview.onDidReceiveMessage((msg: WebviewMessage) => {
+      void this._handleMessage(msg);
+    });
+
+    this._stateDisposable = this._state.onDidChange((s) => {
+      webviewView.webview.postMessage({ type: 'model-changed', model: s.selectedModel ?? null });
+    });
+
+    webviewView.webview.postMessage({ type: 'model-changed', model: this._state.selectedModel ?? null });
+  }
+
+  private async _handleMessage(msg: WebviewMessage): Promise<void> {
+    switch (msg.type) {
+      case 'send-message':
+        await this._runAgentLoop(msg.history);
+        break;
+      case 'cancel-stream':
+        this._abortController?.abort();
+        break;
+      case 'request-models':
+        this._view?.webview.postMessage({ type: 'model-changed', model: this._state.selectedModel ?? null });
+        break;
+      case 'open-settings':
+        vscode.commands.executeCommand('omlx.openSettingsPanel');
+        break;
+      case 'insert-code': {
+        const editor = vscode.window.activeTextEditor;
+        if (editor) {
+          editor.edit((eb) => eb.insert(editor.selection.active, msg.code));
+        }
+        break;
+      }
+      case 'clear-history':
+        break;
+    }
+  }
+
+  private post(msg: unknown): void {
+    this._view?.webview.postMessage(msg);
+  }
+
+  private async _runAgentLoop(userHistory: ChatMessage[]): Promise<void> {
+    const model = this._state.selectedModel;
+    if (!model) {
+      this.post({ type: 'stream-error', message: 'No model selected. Click the status bar to pick one.' });
+      return;
+    }
+
+    this._abortController?.abort();
+    this._abortController = new AbortController();
+    const signal = this._abortController.signal;
+
+    const config = vscode.workspace.getConfiguration('omlx');
+    const systemPrompt = config.get<string>(
+      'chat.defaultSystemPrompt',
+      'You are a helpful programming assistant. You have tools to execute code, run commands, and read/write files on the user\'s machine.',
+    );
+
+    // Full message history maintained server-side across tool call iterations
+    const messages: ChatMessage[] = [
+      { role: 'system', content: systemPrompt },
+      ...userHistory,
+    ];
+
+    let lastTps: number | undefined;
+
+    try {
+      for (let iteration = 0; iteration < MAX_AGENT_ITERATIONS; iteration++) {
+        if (signal.aborted) break;
+
+        // ── Stream one turn ──────────────────────────────
+        let assistantContent = '';
+        const pendingToolCalls: Map<number, ToolCall> = new Map();
+        let finishReason: string | null = null;
+
+        const gen = this._client.chatCompletionsStream(messages, model, {
+          signal,
+          tools: TOOL_DEFINITIONS,
+        });
+
+        for await (const chunk of gen) {
+          if (signal.aborted) break;
+
+          const choice = chunk.choices[0];
+          if (!choice) continue;
+
+          const delta = choice.delta;
+          finishReason = choice.finish_reason ?? finishReason;
+
+          // Content tokens
+          if (delta.content || delta.reasoning_content) {
+            assistantContent += delta.content ?? '';
+            this.post({
+              type: 'stream-chunk',
+              content: delta.content ?? '',
+              reasoning: delta.reasoning_content ?? '',
+            });
+          }
+
+          // Accumulate tool call deltas by index
+          if (delta.tool_calls) {
+            for (const tc of delta.tool_calls) {
+              const existing = pendingToolCalls.get(tc.index);
+              if (existing) {
+                existing.function.arguments += tc.function?.arguments ?? '';
+              } else {
+                pendingToolCalls.set(tc.index, {
+                  index: tc.index,
+                  id: tc.id ?? `call_${tc.index}`,
+                  type: 'function',
+                  function: { name: tc.function?.name ?? '', arguments: tc.function?.arguments ?? '' },
+                });
+              }
+            }
+          }
+
+          if (chunk.usage?.generation_tokens_per_second) {
+            lastTps = chunk.usage.generation_tokens_per_second;
+            this._state.setLastTps(lastTps);
+          }
+        }
+
+        if (signal.aborted) break;
+
+        const toolCalls = [...pendingToolCalls.values()].sort((a, b) => a.index - b.index);
+
+        // ── No tool calls → final answer ─────────────────
+        if (toolCalls.length === 0 || finishReason === 'stop') {
+          this.post({ type: 'stream-done', usage: { generation_tokens_per_second: lastTps } });
+          break;
+        }
+
+        // ── Tool calls → execute and continue loop ────────
+        // Add assistant turn with tool_calls to history
+        messages.push({ role: 'assistant', content: assistantContent || null, tool_calls: toolCalls });
+
+        for (const tc of toolCalls) {
+          let args: Record<string, unknown> = {};
+          try {
+            args = JSON.parse(tc.function.arguments) as Record<string, unknown>;
+          } catch {
+            args = {};
+          }
+
+          // Tell the webview a tool is running
+          this.post({ type: 'tool-start', id: tc.id, name: tc.function.name, args });
+
+          const result = await executeTool(tc.function.name, args);
+
+          // Send result to webview
+          this.post({ type: 'tool-result', id: tc.id, output: result.output, error: result.error });
+
+          // Add tool result to message history
+          messages.push({
+            role: 'tool',
+            content: result.error
+              ? `Error: ${result.error}\n${result.output}`
+              : result.output,
+            tool_call_id: tc.id,
+          });
+        }
+
+        // Signal webview that tool execution is done, model is responding again
+        this.post({ type: 'tool-loop-continue' });
+      }
+    } catch (e) {
+      if (e instanceof Error && e.name === 'AbortError') return;
+      this.post({ type: 'stream-error', message: e instanceof Error ? e.message : String(e) });
+    }
+  }
+
+  private _getHtml(webview: vscode.Webview): string {
+    const nonce = getNonce();
+    const base = vscode.Uri.joinPath(this._extensionUri, 'src', 'webviews', 'chat');
+    const cssUri = webview.asWebviewUri(vscode.Uri.joinPath(base, 'chat.css'));
+    const jsUri = webview.asWebviewUri(vscode.Uri.joinPath(base, 'chat.js'));
+
+    return getHtmlTemplate()
+      .replace(/\{\{nonce\}\}/g, nonce)
+      .replace(/\{\{cspSource\}\}/g, webview.cspSource)
+      .replace('{{chatCssUri}}', cssUri.toString())
+      .replace('{{chatJsUri}}', jsUri.toString());
+  }
+
+  dispose(): void {
+    this._stateDisposable?.dispose();
+    this._abortController?.abort();
+  }
+}
+
+function getNonce(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let result = '';
+  for (let i = 0; i < 32; i++) result += chars.charAt(Math.floor(Math.random() * chars.length));
+  return result;
+}
+
+function getHtmlTemplate(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src {{cspSource}} 'unsafe-inline'; script-src 'nonce-{{nonce}}'; font-src {{cspSource}}; img-src {{cspSource}} data:;" />
+  <link rel="stylesheet" href="{{chatCssUri}}" />
+  <title>oMLX Chat</title>
+</head>
+<body>
+  <div class="header">
+    <div class="model-badge" id="modelBadge">No model selected</div>
+    <div class="header-actions">
+      <button class="icon-btn" id="clearBtn" title="Clear chat history">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4h6v2"/></svg>
+      </button>
+      <button class="icon-btn" id="settingsBtn" title="Open settings">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      </button>
+    </div>
+  </div>
+
+  <div class="messages" id="messages">
+    <div class="empty-state" id="emptyState">
+      <div class="empty-icon">
+        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+      </div>
+      <p>Ask oMLX anything</p>
+      <p class="empty-hint">Select a model to get started</p>
+    </div>
+  </div>
+
+  <div class="input-area">
+    <div class="error-banner hidden" id="errorBanner"></div>
+    <div class="input-row">
+      <textarea id="inputBox" placeholder="Ask anything\u2026 (Enter to send, Shift+Enter for newline)" rows="1"></textarea>
+      <button class="send-btn" id="sendBtn" title="Send (Enter)">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+      </button>
+      <button class="cancel-btn hidden" id="cancelBtn" title="Cancel">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/></svg>
+      </button>
+    </div>
+    <div class="footer-info">
+      <span id="tpsInfo" class="tps-info hidden"></span>
+    </div>
+  </div>
+
+  <script nonce="{{nonce}}" src="{{chatJsUri}}"></script>
+</body>
+</html>`;
+}

--- a/extensions/vscode/src/panels/SettingsPanel.ts
+++ b/extensions/vscode/src/panels/SettingsPanel.ts
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as vscode from 'vscode';
+import type { OmlxClient } from '../api/client.js';
+import type { VscodeConfig } from '../api/types.js';
+
+type WebviewMessage =
+  | { type: 'ready' }
+  | { type: 'save-vscode-config'; config: Partial<VscodeConfig> }
+  | { type: 'load-model'; modelId: string }
+  | { type: 'unload-model'; modelId: string }
+  | { type: 'refresh' };
+
+export class SettingsPanel {
+  public static readonly viewType = 'omlx.settingsPanel';
+
+  private static _current: SettingsPanel | undefined;
+
+  private readonly _panel: vscode.WebviewPanel;
+  private _disposables: vscode.Disposable[] = [];
+
+  static createOrShow(extensionUri: vscode.Uri, client: OmlxClient): void {
+    if (SettingsPanel._current) {
+      SettingsPanel._current._panel.reveal(vscode.ViewColumn.One);
+      return;
+    }
+    const panel = vscode.window.createWebviewPanel(
+      SettingsPanel.viewType,
+      'oMLX Settings',
+      vscode.ViewColumn.One,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [
+          vscode.Uri.joinPath(extensionUri, 'src', 'webviews', 'settings'),
+        ],
+      },
+    );
+    SettingsPanel._current = new SettingsPanel(panel, extensionUri, client);
+  }
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    private readonly _extensionUri: vscode.Uri,
+    private readonly _client: OmlxClient,
+  ) {
+    this._panel = panel;
+    this._panel.webview.html = this._getHtml();
+    this._panel.onDidDispose(() => this._dispose(), null, this._disposables);
+    this._panel.webview.onDidReceiveMessage(
+      (msg: WebviewMessage) => this._handleMessage(msg),
+      null,
+      this._disposables,
+    );
+  }
+
+  private async _handleMessage(msg: WebviewMessage): Promise<void> {
+    switch (msg.type) {
+      case 'ready':
+        await this._sendSettings();
+        break;
+
+      case 'refresh':
+        await this._sendSettings();
+        break;
+
+      case 'save-vscode-config':
+        await this._saveConfig(msg.config);
+        break;
+
+      case 'load-model':
+        // Fire the load request and immediately start polling — loading can take 60+ seconds
+        this._client.loadModel(msg.modelId).catch(() => {
+          // 409 means already loading (fine), other errors surface via poll
+        });
+        this._pollUntilLoaded(msg.modelId);
+        break;
+
+      case 'unload-model':
+        try {
+          await this._client.unloadModel(msg.modelId);
+          this._panel.webview.postMessage({
+            type: 'model-load-result',
+            modelId: msg.modelId,
+            success: true,
+          });
+        } catch (e) {
+          this._panel.webview.postMessage({
+            type: 'error',
+            message: `Failed to unload ${msg.modelId}: ${e instanceof Error ? e.message : String(e)}`,
+          });
+        }
+        break;
+    }
+  }
+
+  private _pollUntilLoaded(modelId: string, maxAttempts = 60): void {
+    let attempts = 0;
+    const interval = setInterval(async () => {
+      attempts++;
+      try {
+        const models = await this._client.listAdminModels();
+        const model = models.find((m) => m.id === modelId);
+        if (model?.loaded) {
+          clearInterval(interval);
+          this._panel.webview.postMessage({
+            type: 'model-load-result',
+            modelId,
+            success: true,
+          });
+          await this._sendSettings();
+        } else if (attempts >= maxAttempts) {
+          clearInterval(interval);
+          this._panel.webview.postMessage({
+            type: 'error',
+            message: `Timed out waiting for ${modelId} to load`,
+          });
+        }
+      } catch {
+        // Server busy — keep polling
+      }
+    }, 2000);
+    this._disposables.push({ dispose: () => clearInterval(interval) });
+  }
+
+  private async _sendSettings(): Promise<void> {
+    const config = vscode.workspace.getConfiguration('omlx');
+    const vscodeConfig: VscodeConfig = {
+      serverUrl: config.get<string>('serverUrl', 'http://localhost:8000'),
+      apiKey: config.get<string>('apiKey', ''),
+      completionsEnabled: config.get<boolean>('completions.enabled', true),
+      completionsMaxTokens: config.get<number>('completions.maxTokens', 80),
+      completionsDebounceMs: config.get<number>('completions.debounceMs', 300),
+      completionsContextLines: config.get<number>('completions.contextLines', 100),
+      chatDefaultSystemPrompt: config.get<string>(
+        'chat.defaultSystemPrompt',
+        'You are a helpful programming assistant.',
+      ),
+    };
+
+    let serverSettings = null;
+    let stats = null;
+    let models = null;
+
+    try {
+      [serverSettings, stats, models] = await Promise.all([
+        this._client.getGlobalSettings(),
+        this._client.getStats(),
+        this._client.listAdminModels(),
+      ]);
+    } catch {
+      // Server may be offline; send what we have
+    }
+
+    this._panel.webview.postMessage({
+      type: 'settings-loaded',
+      vscodeConfig,
+      serverSettings,
+      stats,
+      models,
+    });
+  }
+
+  private async _saveConfig(partial: Partial<VscodeConfig>): Promise<void> {
+    const config = vscode.workspace.getConfiguration('omlx');
+    const target = vscode.ConfigurationTarget.Global;
+
+    if (partial.serverUrl !== undefined) {
+      await config.update('serverUrl', partial.serverUrl, target);
+    }
+    if (partial.apiKey !== undefined) {
+      await config.update('apiKey', partial.apiKey, target);
+    }
+    if (partial.completionsEnabled !== undefined) {
+      await config.update('completions.enabled', partial.completionsEnabled, target);
+    }
+    if (partial.completionsMaxTokens !== undefined) {
+      await config.update('completions.maxTokens', partial.completionsMaxTokens, target);
+    }
+    if (partial.completionsDebounceMs !== undefined) {
+      await config.update('completions.debounceMs', partial.completionsDebounceMs, target);
+    }
+    if (partial.completionsContextLines !== undefined) {
+      await config.update('completions.contextLines', partial.completionsContextLines, target);
+    }
+    if (partial.chatDefaultSystemPrompt !== undefined) {
+      await config.update('chat.defaultSystemPrompt', partial.chatDefaultSystemPrompt, target);
+    }
+
+    this._panel.webview.postMessage({ type: 'save-success' });
+  }
+
+  private _getHtml(): string {
+    const webview = this._panel.webview;
+    const nonce = getNonce();
+    const base = vscode.Uri.joinPath(this._extensionUri, 'src', 'webviews', 'settings');
+    const cssUri = webview.asWebviewUri(vscode.Uri.joinPath(base, 'settings.css'));
+    const jsUri = webview.asWebviewUri(vscode.Uri.joinPath(base, 'settings.js'));
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; font-src ${webview.cspSource};" />
+  <link rel="stylesheet" href="${cssUri}" />
+  <title>oMLX Settings</title>
+</head>
+<body>
+  <h1>
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+    oMLX Settings
+  </h1>
+
+  <div class="error-banner hidden" id="errorBanner"></div>
+
+  <!-- Extension Settings -->
+  <section>
+    <h2>Extension</h2>
+
+    <div class="field">
+      <label for="serverUrl">Server URL</label>
+      <input type="text" id="serverUrl" placeholder="http://localhost:8000" />
+      <div class="field-desc">URL where oMLX is running</div>
+    </div>
+
+    <div class="field">
+      <label for="apiKey">API Key</label>
+      <input type="password" id="apiKey" placeholder="Leave empty if auth is disabled" />
+    </div>
+
+    <div class="field">
+      <div class="checkbox-row">
+        <input type="checkbox" id="completionsEnabled" />
+        <label for="completionsEnabled">Enable inline completions</label>
+      </div>
+    </div>
+
+    <div class="field">
+      <label for="maxTokens">Max completion tokens</label>
+      <input type="number" id="maxTokens" min="1" max="2048" />
+    </div>
+
+    <div class="field">
+      <label for="debounceMs">Completion debounce (ms)</label>
+      <input type="number" id="debounceMs" min="50" max="2000" />
+      <div class="field-desc">Delay before triggering completions after you stop typing</div>
+    </div>
+
+    <div class="field">
+      <label for="contextLines">Context lines</label>
+      <input type="number" id="contextLines" min="10" max="500" />
+      <div class="field-desc">Lines of code before cursor sent as context</div>
+    </div>
+
+    <div class="field">
+      <label for="systemPrompt">Default system prompt</label>
+      <textarea id="systemPrompt" rows="3"></textarea>
+    </div>
+
+    <div class="save-row">
+      <button class="btn btn-primary" id="saveBtn">Save</button>
+      <span class="save-status" id="saveStatus">&#10003; Saved</span>
+    </div>
+  </section>
+
+  <!-- Server Info -->
+  <section>
+    <h2>Server info <button class="btn btn-secondary" id="refreshBtn" style="font-size:11px;padding:2px 8px;margin-left:8px;">Refresh</button></h2>
+    <div class="info-grid">
+      <span class="info-key">Host</span><span id="serverHost">—</span>
+      <span class="info-key">Port</span><span id="serverPort">—</span>
+      <span class="info-key">Cache</span><span id="serverCache">—</span>
+      <span class="info-key">Max memory</span><span id="serverMaxMem">—</span>
+    </div>
+  </section>
+
+  <!-- Stats -->
+  <section>
+    <h2>Session stats</h2>
+    <div class="stats-grid">
+      <div class="stat-card">
+        <div class="stat-label">Requests</div>
+        <div class="stat-value" id="statRequests">—</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Tokens generated</div>
+        <div class="stat-value" id="statTokens">—</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Avg gen speed</div>
+        <div class="stat-value" id="statGenTps">—</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Avg prefill speed</div>
+        <div class="stat-value" id="statPrefillTps">—</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Model Manager -->
+  <section>
+    <h2>Models</h2>
+    <table class="model-table">
+      <thead>
+        <tr>
+          <th>Model</th>
+          <th>Size</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody id="modelTableBody">
+        <tr><td colspan="3" style="color:var(--vscode-descriptionForeground);padding:12px 8px;">Loading…</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <script nonce="${nonce}" src="${jsUri}"></script>
+</body>
+</html>`;
+  }
+
+  private _dispose(): void {
+    SettingsPanel._current = undefined;
+    for (const d of this._disposables) {
+      d.dispose();
+    }
+    this._disposables = [];
+  }
+}
+
+function getNonce(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let result = '';
+  for (let i = 0; i < 32; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}

--- a/extensions/vscode/src/providers/inlineCompletion.ts
+++ b/extensions/vscode/src/providers/inlineCompletion.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as vscode from 'vscode';
+import type { OmlxClient } from '../api/client.js';
+import type { ExtensionState } from '../state/ExtensionState.js';
+
+export class OmlxInlineCompletionProvider
+  implements vscode.InlineCompletionItemProvider
+{
+  private _debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  private _abortController: AbortController | undefined;
+
+  constructor(
+    private readonly _client: OmlxClient,
+    private readonly _state: ExtensionState,
+  ) {}
+
+  async provideInlineCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    _context: vscode.InlineCompletionContext,
+    token: vscode.CancellationToken,
+  ): Promise<vscode.InlineCompletionList | undefined> {
+    const config = vscode.workspace.getConfiguration('omlx');
+    if (!config.get<boolean>('completions.enabled', true)) {
+      return undefined;
+    }
+
+    const model = this._state.selectedModel;
+    if (!model || !this._state.serverHealthy) {
+      return undefined;
+    }
+
+    // Cancel any previous in-flight request
+    this._abortController?.abort();
+
+    // Debounce
+    await new Promise<void>((resolve, reject) => {
+      if (this._debounceTimer) {
+        clearTimeout(this._debounceTimer);
+      }
+      const debounceMs = config.get<number>('completions.debounceMs', 300);
+      this._debounceTimer = setTimeout(resolve, debounceMs);
+      token.onCancellationRequested(() => {
+        clearTimeout(this._debounceTimer);
+        reject(new Error('cancelled'));
+      });
+    }).catch(() => undefined);
+
+    if (token.isCancellationRequested) {
+      return undefined;
+    }
+
+    const contextLines = config.get<number>('completions.contextLines', 100);
+    const maxTokens = config.get<number>('completions.maxTokens', 80);
+
+    const startLine = Math.max(0, position.line - contextLines);
+    const prefix = document.getText(
+      new vscode.Range(
+        new vscode.Position(startLine, 0),
+        position,
+      ),
+    );
+
+    if (!prefix.trim()) {
+      return undefined;
+    }
+
+    this._abortController = new AbortController();
+    try {
+      const completion = await this._client.completion(prefix, model, maxTokens);
+      if (!completion || token.isCancellationRequested) {
+        return undefined;
+      }
+
+      return new vscode.InlineCompletionList([
+        new vscode.InlineCompletionItem(
+          completion,
+          new vscode.Range(position, position),
+        ),
+      ]);
+    } catch {
+      return undefined;
+    }
+  }
+
+  dispose(): void {
+    if (this._debounceTimer) {
+      clearTimeout(this._debounceTimer);
+    }
+    this._abortController?.abort();
+  }
+}

--- a/extensions/vscode/src/providers/statusBar.ts
+++ b/extensions/vscode/src/providers/statusBar.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as vscode from 'vscode';
+import type { ExtensionState } from '../state/ExtensionState.js';
+
+export class StatusBarManager {
+  private readonly _modelItem: vscode.StatusBarItem;
+  private readonly _tpsItem: vscode.StatusBarItem;
+  private _tpsHideTimer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(private readonly _state: ExtensionState) {
+    this._modelItem = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Left,
+      100,
+    );
+    this._modelItem.command = 'omlx.selectModel';
+    this._modelItem.show();
+
+    this._tpsItem = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Right,
+      100,
+    );
+
+    this._update();
+  }
+
+  private _update(): void {
+    const { serverHealthy, selectedModel, lastTps } = this._state;
+
+    if (!serverHealthy) {
+      this._modelItem.text = '$(circle-slash) oMLX: offline';
+      this._modelItem.tooltip = 'oMLX server is not reachable. Click to select model.';
+      this._modelItem.color = new vscode.ThemeColor('statusBarItem.warningForeground');
+      this._modelItem.backgroundColor = new vscode.ThemeColor(
+        'statusBarItem.warningBackground',
+      );
+    } else if (!selectedModel) {
+      this._modelItem.text = '$(circle-outline) oMLX: no model';
+      this._modelItem.tooltip = 'Click to select a model';
+      this._modelItem.color = undefined;
+      this._modelItem.backgroundColor = undefined;
+    } else {
+      this._modelItem.text = `$(circle-filled) ${selectedModel}`;
+      this._modelItem.tooltip = `oMLX: ${selectedModel} — click to switch model`;
+      this._modelItem.color = undefined;
+      this._modelItem.backgroundColor = undefined;
+    }
+
+    if (lastTps !== undefined) {
+      this._tpsItem.text = `$(zap) ${lastTps.toFixed(1)} tok/s`;
+      this._tpsItem.show();
+
+      if (this._tpsHideTimer) {
+        clearTimeout(this._tpsHideTimer);
+      }
+      this._tpsHideTimer = setTimeout(() => {
+        this._tpsItem.hide();
+        this._tpsHideTimer = undefined;
+      }, 10_000);
+    }
+  }
+
+  notifyStateChanged(): void {
+    this._update();
+  }
+
+  dispose(): void {
+    if (this._tpsHideTimer) {
+      clearTimeout(this._tpsHideTimer);
+    }
+    this._modelItem.dispose();
+    this._tpsItem.dispose();
+  }
+}

--- a/extensions/vscode/src/state/ExtensionState.ts
+++ b/extensions/vscode/src/state/ExtensionState.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as vscode from 'vscode';
+
+type StateChangeListener = (state: ExtensionState) => void;
+
+export class ExtensionState {
+  private static _instance: ExtensionState | undefined;
+
+  private _selectedModel: string | undefined;
+  private _serverHealthy = false;
+  private _lastTps: number | undefined;
+  private _listeners: StateChangeListener[] = [];
+  private _globalState: vscode.Memento | undefined;
+
+  static getInstance(): ExtensionState {
+    if (!ExtensionState._instance) {
+      ExtensionState._instance = new ExtensionState();
+    }
+    return ExtensionState._instance;
+  }
+
+  static reset(): void {
+    ExtensionState._instance = undefined;
+  }
+
+  init(context: vscode.ExtensionContext): void {
+    this._globalState = context.globalState;
+    this._selectedModel = context.globalState.get<string>('omlx.selectedModel');
+  }
+
+  get selectedModel(): string | undefined {
+    return this._selectedModel;
+  }
+
+  set selectedModel(value: string | undefined) {
+    this._selectedModel = value;
+    this._globalState?.update('omlx.selectedModel', value);
+    this._emit();
+  }
+
+  get serverHealthy(): boolean {
+    return this._serverHealthy;
+  }
+
+  set serverHealthy(value: boolean) {
+    if (this._serverHealthy !== value) {
+      this._serverHealthy = value;
+      this._emit();
+    }
+  }
+
+  get lastTps(): number | undefined {
+    return this._lastTps;
+  }
+
+  setLastTps(tps: number): void {
+    this._lastTps = tps;
+    this._emit();
+  }
+
+  onDidChange(listener: StateChangeListener): vscode.Disposable {
+    this._listeners.push(listener);
+    return new vscode.Disposable(() => {
+      this._listeners = this._listeners.filter((l) => l !== listener);
+    });
+  }
+
+  private _emit(): void {
+    for (const listener of this._listeners) {
+      listener(this);
+    }
+  }
+}
+
+export const state = ExtensionState.getInstance();

--- a/extensions/vscode/src/tools/definitions.ts
+++ b/extensions/vscode/src/tools/definitions.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+import type { ToolDefinition } from '../api/types.js';
+
+export const TOOL_DEFINITIONS: ToolDefinition[] = [
+  {
+    type: 'function',
+    function: {
+      name: 'execute_code',
+      description:
+        'Execute code locally and return stdout/stderr. Use this to run calculations, test logic, process data, or produce results. Runs in a temp file with a 30-second timeout.',
+      parameters: {
+        type: 'object',
+        properties: {
+          language: {
+            type: 'string',
+            enum: ['python', 'javascript', 'typescript', 'bash'],
+            description: 'Programming language to use',
+          },
+          code: {
+            type: 'string',
+            description: 'The code to execute',
+          },
+        },
+        required: ['language', 'code'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'run_command',
+      description:
+        'Run a shell command in the workspace directory and return its output. Use for git, npm, file operations, etc.',
+      parameters: {
+        type: 'object',
+        properties: {
+          command: {
+            type: 'string',
+            description: 'Shell command to run',
+          },
+        },
+        required: ['command'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'read_file',
+      description: 'Read the contents of a file. Path can be relative to the workspace root or absolute.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'File path to read',
+          },
+        },
+        required: ['path'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'write_file',
+      description: 'Write or overwrite a file. Path can be relative to workspace root or absolute.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'File path to write',
+          },
+          content: {
+            type: 'string',
+            description: 'Content to write to the file',
+          },
+        },
+        required: ['path', 'content'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'list_files',
+      description: 'List files and directories at a given path.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Directory path (relative to workspace root or absolute). Defaults to workspace root.',
+          },
+        },
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'open_preview',
+      description:
+        'Open a URL in the VS Code built-in browser panel (Simple Browser). Use after starting a server to show the result inline without opening an external browser.',
+      parameters: {
+        type: 'object',
+        properties: {
+          url: {
+            type: 'string',
+            description: 'The URL to preview, e.g. http://localhost:3000',
+          },
+          title: {
+            type: 'string',
+            description: 'Optional panel title shown in the tab',
+          },
+        },
+        required: ['url'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'start_server',
+      description:
+        'Spawn a long-running background process (e.g. a dev server) and wait until the given port is accepting connections before returning. Use run_command for one-shot commands; use this for servers that stay running.',
+      parameters: {
+        type: 'object',
+        properties: {
+          command: {
+            type: 'string',
+            description: 'Shell command to start the server, e.g. "python app.py" or "npm run dev"',
+          },
+          port: {
+            type: 'number',
+            description: 'TCP port to poll until the server is ready',
+          },
+          timeout_seconds: {
+            type: 'number',
+            description: 'How long to wait for the port to open before giving up. Default 30.',
+          },
+        },
+        required: ['command', 'port'],
+      },
+    },
+  },
+];

--- a/extensions/vscode/src/tools/executor.ts
+++ b/extensions/vscode/src/tools/executor.ts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as child_process from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as net from 'node:net';
+import * as os from 'node:os';
+import * as nodePath from 'node:path';
+import * as vscode from 'vscode';
+
+const MAX_OUTPUT_CHARS = 8_000;
+const EXEC_TIMEOUT_MS = 30_000;
+
+export interface ToolResult {
+  output: string;
+  error?: string;
+}
+
+function workspaceRoot(): string {
+  return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? os.homedir();
+}
+
+function resolvePath(p: string): string {
+  if (nodePath.isAbsolute(p)) return p;
+  return nodePath.join(workspaceRoot(), p);
+}
+
+function truncate(s: string): string {
+  if (s.length <= MAX_OUTPUT_CHARS) return s;
+  return s.slice(0, MAX_OUTPUT_CHARS) + `\n… (truncated, ${s.length} chars total)`;
+}
+
+function exec(cmd: string, cwd: string): Promise<ToolResult> {
+  return new Promise((resolve) => {
+    child_process.exec(
+      cmd,
+      { cwd, timeout: EXEC_TIMEOUT_MS, maxBuffer: 4 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        const out = truncate(stdout.trim());
+        const err_out = truncate(stderr.trim());
+        if (err && !stdout) {
+          resolve({ output: err_out || err.message, error: err.message });
+        } else {
+          const combined = [out, err_out].filter(Boolean).join('\n--- stderr ---\n');
+          resolve({ output: combined || '(no output)' });
+        }
+      },
+    );
+  });
+}
+
+async function executeCode(language: string, code: string): Promise<ToolResult> {
+  const ext: Record<string, string> = {
+    python: '.py',
+    javascript: '.js',
+    typescript: '.ts',
+    bash: '.sh',
+  };
+  const runner: Record<string, string> = {
+    python: 'python3',
+    javascript: 'node',
+    typescript: 'npx ts-node --skipProject',
+    bash: 'bash',
+  };
+
+  const fileExt = ext[language] ?? '.txt';
+  const cmd = runner[language];
+  if (!cmd) {
+    return { output: '', error: `Unsupported language: ${language}` };
+  }
+
+  const tmpFile = nodePath.join(os.tmpdir(), `omlx_exec_${Date.now()}${fileExt}`);
+  try {
+    await fs.writeFile(tmpFile, code, 'utf8');
+    const result = await exec(`${cmd} "${tmpFile}"`, workspaceRoot());
+    return result;
+  } finally {
+    await fs.unlink(tmpFile).catch(() => undefined);
+  }
+}
+
+async function runCommand(command: string): Promise<ToolResult> {
+  const confirmed = await vscode.window.showWarningMessage(
+    `oMLX wants to run: \`${command}\``,
+    { modal: true },
+    'Run',
+  );
+  if (confirmed !== 'Run') {
+    return { output: '', error: 'User cancelled command execution.' };
+  }
+  return exec(command, workspaceRoot());
+}
+
+async function readFile(filePath: string): Promise<ToolResult> {
+  const resolved = resolvePath(filePath);
+  try {
+    const content = await fs.readFile(resolved, 'utf8');
+    return { output: truncate(content) };
+  } catch (e) {
+    return { output: '', error: `Cannot read ${resolved}: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+async function writeFile(filePath: string, content: string): Promise<ToolResult> {
+  const resolved = resolvePath(filePath);
+  const confirmed = await vscode.window.showWarningMessage(
+    `oMLX wants to write to: ${resolved}`,
+    { modal: true },
+    'Write',
+  );
+  if (confirmed !== 'Write') {
+    return { output: '', error: 'User cancelled file write.' };
+  }
+  try {
+    await fs.mkdir(nodePath.dirname(resolved), { recursive: true });
+    await fs.writeFile(resolved, content, 'utf8');
+    return { output: `Written ${content.length} chars to ${resolved}` };
+  } catch (e) {
+    return { output: '', error: `Cannot write ${resolved}: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+async function listFiles(dirPath: string = '.'): Promise<ToolResult> {
+  const resolved = resolvePath(dirPath);
+  try {
+    const entries = await fs.readdir(resolved, { withFileTypes: true });
+    const lines = entries.map((e) => (e.isDirectory() ? `${e.name}/` : e.name));
+    return { output: lines.join('\n') || '(empty directory)' };
+  } catch (e) {
+    return { output: '', error: `Cannot list ${resolved}: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+function waitForPort(port: number, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    function attempt() {
+      const sock = net.createConnection({ port, host: '127.0.0.1' });
+      sock.once('connect', () => { sock.destroy(); resolve(); });
+      sock.once('error', () => {
+        sock.destroy();
+        if (Date.now() >= deadline) {
+          reject(new Error(`Port ${port} not open after ${timeoutMs}ms`));
+        } else {
+          setTimeout(attempt, 500);
+        }
+      });
+    }
+    attempt();
+  });
+}
+
+// Track spawned server processes so they can outlive individual tool calls
+const _serverProcesses = new Map<string, child_process.ChildProcess>();
+
+async function openPreview(url: string, title?: string): Promise<ToolResult> {
+  try {
+    // VS Code Simple Browser is built-in — no extension needed
+    await vscode.commands.executeCommand(
+      'simpleBrowser.show',
+      url,
+      { preserveFocus: false, viewColumn: vscode.ViewColumn.Beside },
+    );
+    return { output: `Opened preview: ${url}` };
+  } catch {
+    // Fall back to external browser if Simple Browser isn't available
+    await vscode.env.openExternal(vscode.Uri.parse(url));
+    return { output: `Opened ${url} in external browser` };
+  }
+}
+
+async function startServer(
+  command: string,
+  port: number,
+  timeoutSeconds = 30,
+): Promise<ToolResult> {
+  const confirmed = await vscode.window.showWarningMessage(
+    `oMLX wants to start a server: \`${command}\``,
+    { modal: true },
+    'Start',
+  );
+  if (confirmed !== 'Start') {
+    return { output: '', error: 'User cancelled server start.' };
+  }
+
+  // Kill any existing process on the same key
+  const key = `${port}`;
+  _serverProcesses.get(key)?.kill();
+
+  const proc = child_process.spawn(command, {
+    shell: true,
+    cwd: workspaceRoot(),
+    detached: false,
+    stdio: 'pipe',
+  });
+
+  _serverProcesses.set(key, proc);
+
+  const logs: string[] = [];
+  proc.stdout?.on('data', (d: Buffer) => logs.push(d.toString()));
+  proc.stderr?.on('data', (d: Buffer) => logs.push(d.toString()));
+  proc.on('error', (e) => logs.push(`Process error: ${e.message}`));
+
+  try {
+    await waitForPort(port, timeoutSeconds * 1000);
+    return {
+      output: `Server started on port ${port} (pid ${proc.pid}).\nEarly output:\n${logs.slice(0, 20).join('').slice(0, 1000)}`,
+    };
+  } catch (e) {
+    proc.kill();
+    _serverProcesses.delete(key);
+    return {
+      output: logs.join('').slice(0, 2000),
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+export async function executeTool(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  switch (name) {
+    case 'execute_code':
+      return executeCode(String(args.language ?? ''), String(args.code ?? ''));
+    case 'run_command':
+      return runCommand(String(args.command ?? ''));
+    case 'read_file':
+      return readFile(String(args.path ?? '.'));
+    case 'write_file':
+      return writeFile(String(args.path ?? ''), String(args.content ?? ''));
+    case 'list_files':
+      return listFiles(args.path ? String(args.path) : '.');
+    case 'open_preview':
+      return openPreview(String(args.url ?? ''), args.title ? String(args.title) : undefined);
+    case 'start_server':
+      return startServer(
+        String(args.command ?? ''),
+        Number(args.port ?? 8080),
+        args.timeout_seconds ? Number(args.timeout_seconds) : 30,
+      );
+    default:
+      return { output: '', error: `Unknown tool: ${name}` };
+  }
+}

--- a/extensions/vscode/src/webviews/chat/chat.css
+++ b/extensions/vscode/src/webviews/chat/chat.css
@@ -1,0 +1,401 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  color: var(--vscode-editor-foreground);
+  background: var(--vscode-sideBar-background, var(--vscode-editor-background));
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* ── Header ───────────────────────────────────────────────── */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+  flex-shrink: 0;
+}
+
+.model-badge {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 70%;
+}
+
+.model-badge.loaded {
+  color: var(--vscode-terminal-ansiGreen);
+}
+
+.header-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--vscode-icon-foreground);
+  padding: 3px;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.7;
+}
+
+.icon-btn:hover {
+  background: var(--vscode-toolbar-hoverBackground);
+  opacity: 1;
+}
+
+/* ── Messages ─────────────────────────────────────────────── */
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--vscode-scrollbarSlider-background) transparent;
+}
+
+.messages::-webkit-scrollbar {
+  width: 4px;
+}
+.messages::-webkit-scrollbar-thumb {
+  background: var(--vscode-scrollbarSlider-background);
+  border-radius: 2px;
+}
+
+.empty-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--vscode-descriptionForeground);
+  text-align: center;
+  padding: 20px;
+}
+
+.empty-icon {
+  opacity: 0.4;
+}
+
+.empty-hint {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+/* ── Message Bubbles ──────────────────────────────────────── */
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-width: 100%;
+}
+
+.message-role {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.6;
+}
+
+.message.user .message-role {
+  color: var(--vscode-terminal-ansiBlue);
+  text-align: right;
+}
+
+.message.assistant .message-role {
+  color: var(--vscode-terminal-ansiGreen);
+}
+
+.message-body {
+  padding: 8px 10px;
+  border-radius: 6px;
+  line-height: 1.5;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.message.user .message-body {
+  background: var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-border, transparent);
+  align-self: flex-end;
+  max-width: 90%;
+}
+
+.message.assistant .message-body {
+  background: var(--vscode-editor-inactiveSelectionBackground, transparent);
+  border: 1px solid var(--vscode-widget-border, transparent);
+  align-self: flex-start;
+  width: 100%;
+}
+
+/* Code blocks inside assistant messages */
+.message-body pre {
+  background: var(--vscode-textCodeBlock-background);
+  border: 1px solid var(--vscode-widget-border, transparent);
+  border-radius: 4px;
+  padding: 8px;
+  overflow-x: auto;
+  margin: 6px 0;
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 12px;
+  white-space: pre;
+}
+
+.message-body code {
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 12px;
+  background: var(--vscode-textCodeBlock-background);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.message-body pre code {
+  background: none;
+  padding: 0;
+}
+
+.message-body p {
+  margin: 4px 0;
+}
+
+.message-body p:first-child { margin-top: 0; }
+.message-body p:last-child { margin-bottom: 0; }
+
+/* Reasoning / thinking block */
+.reasoning-block {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  border-left: 2px solid var(--vscode-widget-border, #555);
+  padding-left: 8px;
+  margin-bottom: 6px;
+  font-style: italic;
+  opacity: 0.8;
+}
+
+/* Streaming cursor */
+.cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background: var(--vscode-editor-foreground);
+  animation: blink 1s step-end infinite;
+  vertical-align: text-bottom;
+  margin-left: 1px;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* ── Tool call blocks ─────────────────────────────────── */
+.tool-block {
+  border: 1px solid var(--vscode-widget-border, transparent);
+  border-radius: 6px;
+  overflow: hidden;
+  margin: 6px 0;
+  font-size: 12px;
+}
+
+.tool-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--vscode-input-background);
+  cursor: pointer;
+  user-select: none;
+}
+
+.tool-header:hover {
+  background: var(--vscode-toolbar-hoverBackground);
+}
+
+.tool-icon {
+  font-size: 13px;
+}
+
+.tool-name {
+  font-weight: 600;
+  font-family: var(--vscode-editor-font-family, monospace);
+}
+
+.tool-status {
+  margin-left: auto;
+  font-size: 10px;
+  opacity: 0.7;
+}
+
+.tool-status.running {
+  color: var(--vscode-terminal-ansiYellow);
+}
+
+.tool-status.done {
+  color: var(--vscode-terminal-ansiGreen);
+}
+
+.tool-status.error {
+  color: var(--vscode-terminal-ansiRed);
+}
+
+.tool-body {
+  padding: 8px 10px;
+  background: var(--vscode-textCodeBlock-background);
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 200px;
+  overflow-y: auto;
+  border-top: 1px solid var(--vscode-widget-border, transparent);
+}
+
+.tool-body.hidden { display: none; }
+
+.tool-output-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vscode-descriptionForeground);
+  margin-bottom: 4px;
+}
+
+.tool-error {
+  color: var(--vscode-terminal-ansiRed);
+}
+
+/* Insert code button */
+.insert-btn {
+  margin-top: 4px;
+  font-size: 10px;
+  background: none;
+  border: 1px solid var(--vscode-button-secondaryBorder, var(--vscode-widget-border));
+  color: var(--vscode-button-secondaryForeground, var(--vscode-descriptionForeground));
+  padding: 2px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.insert-btn:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
+/* ── Input Area ───────────────────────────────────────────── */
+.input-area {
+  flex-shrink: 0;
+  padding: 8px 10px;
+  border-top: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+}
+
+.error-banner {
+  background: var(--vscode-inputValidation-errorBackground);
+  border: 1px solid var(--vscode-inputValidation-errorBorder);
+  color: var(--vscode-inputValidation-errorForeground);
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  margin-bottom: 6px;
+}
+
+.hidden { display: none !important; }
+
+.input-row {
+  display: flex;
+  gap: 6px;
+  align-items: flex-end;
+}
+
+textarea {
+  flex: 1;
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border: 1px solid var(--vscode-input-border, transparent);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  resize: none;
+  outline: none;
+  max-height: 120px;
+  overflow-y: auto;
+  line-height: 1.4;
+}
+
+textarea:focus {
+  border-color: var(--vscode-focusBorder);
+}
+
+textarea::placeholder {
+  color: var(--vscode-input-placeholderForeground);
+}
+
+.send-btn,
+.cancel-btn {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.send-btn {
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+.send-btn:hover {
+  background: var(--vscode-button-hoverBackground);
+}
+
+.send-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.cancel-btn {
+  background: var(--vscode-button-secondaryBackground, var(--vscode-input-background));
+  color: var(--vscode-button-secondaryForeground, var(--vscode-editor-foreground));
+}
+
+.cancel-btn:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.footer-info {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+  min-height: 14px;
+}
+
+.tps-info {
+  font-size: 10px;
+  color: var(--vscode-descriptionForeground);
+  opacity: 0.7;
+}

--- a/extensions/vscode/src/webviews/chat/chat.html
+++ b/extensions/vscode/src/webviews/chat/chat.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src {{cspSource}} 'unsafe-inline'; script-src 'nonce-{{nonce}}'; font-src {{cspSource}}; img-src {{cspSource}} data:;" />
+  <link rel="stylesheet" href="{{chatCssUri}}" />
+  <title>oMLX Chat</title>
+</head>
+<body>
+  <div class="header">
+    <div class="model-badge" id="modelBadge">No model selected</div>
+    <div class="header-actions">
+      <button class="icon-btn" id="clearBtn" title="Clear chat history">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4h6v2"/></svg>
+      </button>
+      <button class="icon-btn" id="settingsBtn" title="Open settings">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      </button>
+    </div>
+  </div>
+
+  <div class="messages" id="messages">
+    <div class="empty-state" id="emptyState">
+      <div class="empty-icon">
+        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+      </div>
+      <p>Ask oMLX anything</p>
+      <p class="empty-hint">Select a model to get started</p>
+    </div>
+  </div>
+
+  <div class="input-area">
+    <div class="error-banner hidden" id="errorBanner"></div>
+    <div class="input-row">
+      <textarea
+        id="inputBox"
+        placeholder="Ask anything… (Enter to send, Shift+Enter for newline)"
+        rows="1"
+      ></textarea>
+      <button class="send-btn" id="sendBtn" title="Send (Enter)">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+      </button>
+      <button class="cancel-btn hidden" id="cancelBtn" title="Cancel">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/></svg>
+      </button>
+    </div>
+    <div class="footer-info">
+      <span id="tpsInfo" class="tps-info hidden"></span>
+    </div>
+  </div>
+
+  <script nonce="{{nonce}}" src="{{chatJsUri}}"></script>
+</body>
+</html>

--- a/extensions/vscode/src/webviews/chat/chat.js
+++ b/extensions/vscode/src/webviews/chat/chat.js
@@ -1,0 +1,424 @@
+// @ts-check
+(function () {
+  const vscode = acquireVsCodeApi();
+
+  /** @type {Array<{role: string, content: string}>} */
+  let history = [];
+  let isStreaming = false;
+
+  const messagesEl = /** @type {HTMLElement} */ (document.getElementById('messages'));
+  const emptyStateEl = /** @type {HTMLElement} */ (document.getElementById('emptyState'));
+  const inputBox = /** @type {HTMLTextAreaElement} */ (document.getElementById('inputBox'));
+  const sendBtn = /** @type {HTMLButtonElement} */ (document.getElementById('sendBtn'));
+  const cancelBtn = /** @type {HTMLButtonElement} */ (document.getElementById('cancelBtn'));
+  const clearBtn = /** @type {HTMLButtonElement} */ (document.getElementById('clearBtn'));
+  const settingsBtn = /** @type {HTMLButtonElement} */ (document.getElementById('settingsBtn'));
+  const modelBadge = /** @type {HTMLElement} */ (document.getElementById('modelBadge'));
+  const errorBanner = /** @type {HTMLElement} */ (document.getElementById('errorBanner'));
+  const tpsInfo = /** @type {HTMLElement} */ (document.getElementById('tpsInfo'));
+
+  // ── Minimal markdown renderer ────────────────────────────
+  function renderMarkdown(text) {
+    // Escape HTML first
+    let html = text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+
+    // Fenced code blocks
+    html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_, lang, code) => {
+      return `<pre><code class="language-${lang}">${code.trimEnd()}</code></pre>`;
+    });
+
+    // Inline code
+    html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+    // Bold
+    html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+
+    // Italic
+    html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
+
+    // Headings
+    html = html.replace(/^### (.+)$/gm, '<h3>$1</h3>');
+    html = html.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+    html = html.replace(/^# (.+)$/gm, '<h1>$1</h1>');
+
+    // Unordered lists
+    html = html.replace(/^[-*] (.+)$/gm, '<li>$1</li>');
+    html = html.replace(/(<li>.*<\/li>\n?)+/g, (m) => `<ul>${m}</ul>`);
+
+    // Paragraphs (double newline separated blocks not already in tags)
+    html = html.replace(/\n\n(?!<)/g, '</p><p>');
+    if (!html.startsWith('<')) {
+      html = '<p>' + html + '</p>';
+    }
+
+    return html;
+  }
+
+  // ── DOM helpers ──────────────────────────────────────────
+  function showEmpty(show) {
+    emptyStateEl.style.display = show ? '' : 'none';
+  }
+
+  function scrollToBottom() {
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  }
+
+  /**
+   * @param {'user'|'assistant'} role
+   * @param {string} content
+   * @param {boolean} [isMarkdown]
+   * @returns {HTMLElement} the message-body element
+   */
+  function appendMessage(role, content, isMarkdown) {
+    showEmpty(false);
+    const wrap = document.createElement('div');
+    wrap.className = `message ${role}`;
+
+    const roleEl = document.createElement('div');
+    roleEl.className = 'message-role';
+    roleEl.textContent = role === 'user' ? 'You' : 'oMLX';
+
+    const body = document.createElement('div');
+    body.className = 'message-body';
+    if (isMarkdown) {
+      body.innerHTML = renderMarkdown(content);
+    } else {
+      body.textContent = content;
+    }
+
+    wrap.appendChild(roleEl);
+    wrap.appendChild(body);
+    messagesEl.appendChild(wrap);
+    scrollToBottom();
+    return body;
+  }
+
+  function showError(msg) {
+    errorBanner.textContent = msg;
+    errorBanner.classList.remove('hidden');
+    setTimeout(() => errorBanner.classList.add('hidden'), 6000);
+  }
+
+  function setStreaming(streaming) {
+    isStreaming = streaming;
+    sendBtn.classList.toggle('hidden', streaming);
+    cancelBtn.classList.toggle('hidden', !streaming);
+    inputBox.disabled = streaming;
+  }
+
+  // ── Send message ─────────────────────────────────────────
+  function sendMessage() {
+    const content = inputBox.value.trim();
+    if (!content || isStreaming) return;
+
+    inputBox.value = '';
+    autoResize();
+    errorBanner.classList.add('hidden');
+
+    history.push({ role: 'user', content });
+    appendMessage('user', content);
+
+    setStreaming(true);
+
+    let fullContent = '';
+    let activeWrap = /** @type {HTMLElement|null} */ (null);
+    let activeBody = /** @type {HTMLElement|null} */ (null);
+    let activeCursor = /** @type {HTMLElement|null} */ (null);
+
+    /** Creates an assistant bubble on first content, returns it on subsequent calls */
+    function ensureBubble() {
+      if (activeBody) return;
+      showEmpty(false);
+      activeWrap = document.createElement('div');
+      activeWrap.className = 'message assistant';
+      const roleEl = document.createElement('div');
+      roleEl.className = 'message-role';
+      roleEl.textContent = 'oMLX';
+      activeBody = document.createElement('div');
+      activeBody.className = 'message-body';
+      activeCursor = document.createElement('span');
+      activeCursor.className = 'cursor';
+      activeBody.appendChild(activeCursor);
+      activeWrap.appendChild(roleEl);
+      activeWrap.appendChild(activeBody);
+      messagesEl.appendChild(activeWrap);
+      scrollToBottom();
+    }
+
+    vscode.postMessage({ type: 'send-message', content, history: [...history] });
+
+    currentStreamBody = null;
+    currentStreamCursor = null;
+
+    /** @param {string} c @param {string} [r] */
+    window._onStreamChunk = (c, r) => {
+      if (!c && !r) return;
+      ensureBubble();
+      if (c) {
+        fullContent += c;
+        activeBody.innerHTML = renderMarkdown(fullContent);
+        activeBody.appendChild(activeCursor);
+        scrollToBottom();
+      }
+    };
+
+    window._onToolLoopContinue = () => {
+      // Finalize current bubble (if any) and reset for next model turn
+      if (activeCursor) activeCursor.remove();
+      if (activeBody && fullContent) {
+        activeBody.innerHTML = renderMarkdown(fullContent);
+      }
+      // Reset — next chunk will create a new bubble
+      activeWrap = null;
+      activeBody = null;
+      activeCursor = null;
+      fullContent = '';
+    };
+
+    window._onStreamDone = (tps) => {
+      if (activeCursor) activeCursor.remove();
+      if (activeBody) activeBody.innerHTML = renderMarkdown(fullContent);
+
+      if (fullContent) {
+        history.push({ role: 'assistant', content: fullContent });
+
+        const codeMatch = fullContent.match(/```[\w]*\n([\s\S]+?)```/);
+        if (codeMatch && activeWrap) {
+          const insertBtn = document.createElement('button');
+          insertBtn.className = 'insert-btn';
+          insertBtn.textContent = 'Insert code into editor';
+          insertBtn.addEventListener('click', () => {
+            vscode.postMessage({ type: 'insert-code', code: codeMatch[1] });
+          });
+          activeWrap.appendChild(insertBtn);
+        }
+      }
+
+      if (tps) {
+        tpsInfo.textContent = `${tps.toFixed(1)} tok/s`;
+        tpsInfo.classList.remove('hidden');
+        setTimeout(() => tpsInfo.classList.add('hidden'), 8000);
+      }
+
+      setStreaming(false);
+      scrollToBottom();
+    };
+
+    window._onStreamError = (msg) => {
+      if (activeCursor) activeCursor.remove();
+      if (activeBody) activeBody.innerHTML = '';
+      setStreaming(false);
+      showError(`Error: ${msg}`);
+    };
+  }
+
+  // Placeholders updated by sendMessage
+  let currentStreamBody = null;
+  let currentStreamCursor = null;
+
+  // ── Textarea auto-resize ─────────────────────────────────
+  function autoResize() {
+    inputBox.style.height = 'auto';
+    inputBox.style.height = Math.min(inputBox.scrollHeight, 120) + 'px';
+  }
+
+  // ── Event listeners ──────────────────────────────────────
+  sendBtn.addEventListener('click', sendMessage);
+
+  cancelBtn.addEventListener('click', () => {
+    vscode.postMessage({ type: 'cancel-stream' });
+    setStreaming(false);
+    if (currentStreamBody && currentStreamCursor) {
+      currentStreamCursor.remove();
+    }
+  });
+
+  clearBtn.addEventListener('click', () => {
+    history = [];
+    messagesEl.innerHTML = '';
+    messagesEl.appendChild(emptyStateEl);
+    showEmpty(true);
+    tpsInfo.classList.add('hidden');
+    vscode.postMessage({ type: 'clear-history' });
+  });
+
+  settingsBtn.addEventListener('click', () => {
+    vscode.postMessage({ type: 'open-settings' });
+  });
+
+  inputBox.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  });
+
+  inputBox.addEventListener('input', autoResize);
+
+  // ── Tool call block helpers ──────────────────────────────
+  /** @type {Map<string, {header: HTMLElement, body: HTMLElement, statusEl: HTMLElement}>} */
+  const toolBlockMap = new Map();
+
+  const TOOL_ICONS = {
+    execute_code: '⚡',
+    run_command: '💻',
+    read_file: '📖',
+    write_file: '✏️',
+    list_files: '📁',
+    open_preview: '🌐',
+    start_server: '🚀',
+  };
+
+  /**
+   * @param {string} id
+   * @param {string} name
+   * @param {Record<string, unknown>} args
+   */
+  function createToolBlock(id, name, args) {
+    showEmpty(false);
+
+    const block = document.createElement('div');
+    block.className = 'tool-block';
+
+    const header = document.createElement('div');
+    header.className = 'tool-header';
+
+    const icon = document.createElement('span');
+    icon.className = 'tool-icon';
+    icon.textContent = TOOL_ICONS[name] || '🔧';
+
+    const nameEl = document.createElement('span');
+    nameEl.className = 'tool-name';
+    nameEl.textContent = name;
+
+    const statusEl = document.createElement('span');
+    statusEl.className = 'tool-status running';
+    statusEl.textContent = 'running…';
+
+    header.appendChild(icon);
+    header.appendChild(nameEl);
+    header.appendChild(statusEl);
+
+    const body = document.createElement('div');
+    body.className = 'tool-body hidden';
+
+    // Show args in collapsed body
+    const argsLabel = document.createElement('div');
+    argsLabel.className = 'tool-output-label';
+    argsLabel.textContent = 'Arguments';
+    const argsContent = document.createElement('pre');
+    argsContent.textContent = JSON.stringify(args, null, 2);
+    body.appendChild(argsLabel);
+    body.appendChild(argsContent);
+
+    // Toggle collapse on click
+    header.addEventListener('click', () => {
+      body.classList.toggle('hidden');
+    });
+
+    block.appendChild(header);
+    block.appendChild(body);
+    messagesEl.appendChild(block);
+    scrollToBottom();
+
+    toolBlockMap.set(id, { header, body, statusEl });
+    return { header, body, statusEl };
+  }
+
+  /**
+   * @param {string} id
+   * @param {string} output
+   * @param {string|undefined} error
+   */
+  function updateToolBlock(id, output, error) {
+    const refs = toolBlockMap.get(id);
+    if (!refs) return;
+
+    const { body, statusEl } = refs;
+
+    statusEl.classList.remove('running');
+    if (error) {
+      statusEl.classList.add('error');
+      statusEl.textContent = 'error';
+    } else {
+      statusEl.classList.add('done');
+      statusEl.textContent = 'done';
+    }
+
+    // Append output section
+    const outLabel = document.createElement('div');
+    outLabel.className = 'tool-output-label';
+    outLabel.style.marginTop = '8px';
+    outLabel.textContent = error ? 'Error' : 'Output';
+
+    const outContent = document.createElement('pre');
+    outContent.textContent = error ? `${error}\n${output}` : output;
+    if (error) outContent.classList.add('tool-error');
+
+    body.appendChild(outLabel);
+    body.appendChild(outContent);
+
+    // Auto-expand to show result
+    body.classList.remove('hidden');
+    scrollToBottom();
+  }
+
+  // ── Messages from extension host ────────────────────────
+  window.addEventListener('message', (event) => {
+    const msg = event.data;
+    switch (msg.type) {
+      case 'stream-chunk':
+        if (window._onStreamChunk) {
+          window._onStreamChunk(msg.content || '', msg.reasoning || '');
+        }
+        break;
+
+      case 'stream-done':
+        if (window._onStreamDone) {
+          window._onStreamDone(msg.usage?.generation_tokens_per_second);
+        }
+        break;
+
+      case 'stream-error':
+        if (window._onStreamError) {
+          window._onStreamError(msg.message);
+        }
+        break;
+
+      case 'tool-start':
+        createToolBlock(msg.id, msg.name, msg.args);
+        break;
+
+      case 'tool-result':
+        updateToolBlock(msg.id, msg.output, msg.error);
+        break;
+
+      case 'tool-loop-continue':
+        // Model is about to respond again — add a new assistant bubble
+        if (window._onToolLoopContinue) {
+          window._onToolLoopContinue();
+        }
+        break;
+
+      case 'model-changed':
+        if (msg.model) {
+          modelBadge.textContent = msg.model;
+          modelBadge.classList.add('loaded');
+          emptyStateEl.querySelector('.empty-hint').textContent =
+            'Send a message to start';
+        } else {
+          modelBadge.textContent = 'No model selected';
+          modelBadge.classList.remove('loaded');
+          emptyStateEl.querySelector('.empty-hint').textContent =
+            'Select a model to get started';
+        }
+        break;
+    }
+  });
+
+  // Request initial model state
+  vscode.postMessage({ type: 'request-models' });
+})();

--- a/extensions/vscode/src/webviews/settings/settings.css
+++ b/extensions/vscode/src/webviews/settings/settings.css
@@ -1,0 +1,288 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  color: var(--vscode-editor-foreground);
+  background: var(--vscode-editor-background);
+  padding: 24px;
+  max-width: 800px;
+}
+
+h1 {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+h2 {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--vscode-descriptionForeground);
+  margin-bottom: 12px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+}
+
+section {
+  margin-bottom: 28px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 14px;
+}
+
+label {
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.field-desc {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+}
+
+input[type="text"],
+input[type="number"],
+input[type="password"],
+textarea,
+select {
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border: 1px solid var(--vscode-input-border, transparent);
+  border-radius: 3px;
+  padding: 5px 8px;
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  outline: none;
+  width: 100%;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  border-color: var(--vscode-focusBorder);
+}
+
+input[type="checkbox"] {
+  accent-color: var(--vscode-button-background);
+  width: 14px;
+  height: 14px;
+}
+
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.checkbox-row label {
+  font-weight: normal;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 60px;
+}
+
+/* Number inputs narrower */
+input[type="number"] {
+  max-width: 120px;
+}
+
+/* Buttons */
+.btn {
+  padding: 5px 12px;
+  border-radius: 3px;
+  border: none;
+  cursor: pointer;
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  font-weight: 500;
+}
+
+.btn-primary {
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+
+.btn-primary:hover {
+  background: var(--vscode-button-hoverBackground);
+}
+
+.btn-secondary {
+  background: var(--vscode-button-secondaryBackground, var(--vscode-input-background));
+  color: var(--vscode-button-secondaryForeground, var(--vscode-editor-foreground));
+  border: 1px solid var(--vscode-button-secondaryBorder, var(--vscode-widget-border));
+}
+
+.btn-secondary:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.btn-danger {
+  background: var(--vscode-inputValidation-errorBackground);
+  color: var(--vscode-inputValidation-errorForeground);
+  border: 1px solid var(--vscode-inputValidation-errorBorder);
+}
+
+.save-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.save-status {
+  font-size: 11px;
+  color: var(--vscode-terminal-ansiGreen);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.save-status.visible {
+  opacity: 1;
+}
+
+/* Stats grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+.stat-card {
+  background: var(--vscode-input-background);
+  border: 1px solid var(--vscode-widget-border, transparent);
+  border-radius: 6px;
+  padding: 10px 12px;
+}
+
+.stat-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vscode-descriptionForeground);
+  margin-bottom: 4px;
+}
+
+.stat-value {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+/* Model table */
+.model-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.model-table th {
+  text-align: left;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+  color: var(--vscode-descriptionForeground);
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.model-table td {
+  padding: 7px 8px;
+  border-bottom: 1px solid var(--vscode-widget-border, transparent);
+  vertical-align: middle;
+}
+
+.model-table tr:last-child td {
+  border-bottom: none;
+}
+
+.status-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-right: 6px;
+}
+
+.status-dot.loaded {
+  background: var(--vscode-terminal-ansiGreen);
+}
+
+.status-dot.unloaded {
+  background: var(--vscode-descriptionForeground);
+  opacity: 0.5;
+}
+
+.status-dot.loading {
+  background: var(--vscode-terminal-ansiYellow);
+  animation: pulse 1s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.model-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.model-actions button {
+  padding: 2px 10px;
+  font-size: 11px;
+  border-radius: 3px;
+  border: 1px solid var(--vscode-widget-border, transparent);
+  cursor: pointer;
+  background: var(--vscode-input-background);
+  color: var(--vscode-editor-foreground);
+}
+
+.model-actions button:hover {
+  background: var(--vscode-toolbar-hoverBackground);
+}
+
+.model-actions button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Server info read-only */
+.info-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 12px;
+  font-size: 12px;
+}
+
+.info-key {
+  color: var(--vscode-descriptionForeground);
+  font-weight: 500;
+}
+
+.hidden { display: none !important; }
+
+.error-banner {
+  background: var(--vscode-inputValidation-errorBackground);
+  border: 1px solid var(--vscode-inputValidation-errorBorder);
+  color: var(--vscode-inputValidation-errorForeground);
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  margin-bottom: 16px;
+}

--- a/extensions/vscode/src/webviews/settings/settings.js
+++ b/extensions/vscode/src/webviews/settings/settings.js
@@ -1,0 +1,177 @@
+// @ts-check
+(function () {
+  const vscode = acquireVsCodeApi();
+
+  // ── DOM refs ─────────────────────────────────────────────
+  const errorBanner = /** @type {HTMLElement} */ (document.getElementById('errorBanner'));
+  const saveStatus = /** @type {HTMLElement} */ (document.getElementById('saveStatus'));
+
+  // Extension config fields
+  const serverUrlInput = /** @type {HTMLInputElement} */ (document.getElementById('serverUrl'));
+  const apiKeyInput = /** @type {HTMLInputElement} */ (document.getElementById('apiKey'));
+  const completionsEnabledInput = /** @type {HTMLInputElement} */ (document.getElementById('completionsEnabled'));
+  const maxTokensInput = /** @type {HTMLInputElement} */ (document.getElementById('maxTokens'));
+  const debounceMsInput = /** @type {HTMLInputElement} */ (document.getElementById('debounceMs'));
+  const contextLinesInput = /** @type {HTMLInputElement} */ (document.getElementById('contextLines'));
+  const systemPromptInput = /** @type {HTMLTextAreaElement} */ (document.getElementById('systemPrompt'));
+
+  // Server info
+  const serverHostEl = /** @type {HTMLElement} */ (document.getElementById('serverHost'));
+  const serverPortEl = /** @type {HTMLElement} */ (document.getElementById('serverPort'));
+  const serverCacheEl = /** @type {HTMLElement} */ (document.getElementById('serverCache'));
+  const serverMaxMemEl = /** @type {HTMLElement} */ (document.getElementById('serverMaxMem'));
+
+  // Stats
+  const statRequestsEl = /** @type {HTMLElement} */ (document.getElementById('statRequests'));
+  const statTokensEl = /** @type {HTMLElement} */ (document.getElementById('statTokens'));
+  const statGenTpsEl = /** @type {HTMLElement} */ (document.getElementById('statGenTps'));
+  const statPrefillTpsEl = /** @type {HTMLElement} */ (document.getElementById('statPrefillTps'));
+
+  // Model table
+  const modelTableBody = /** @type {HTMLElement} */ (document.getElementById('modelTableBody'));
+
+  // ── Helpers ──────────────────────────────────────────────
+  function showError(msg) {
+    errorBanner.textContent = msg;
+    errorBanner.classList.remove('hidden');
+  }
+
+  function flashSave() {
+    saveStatus.classList.add('visible');
+    setTimeout(() => saveStatus.classList.remove('visible'), 2500);
+  }
+
+  function populateConfig(config) {
+    if (!config) return;
+    serverUrlInput.value = config.serverUrl ?? '';
+    apiKeyInput.value = config.apiKey ?? '';
+    completionsEnabledInput.checked = config.completionsEnabled ?? true;
+    maxTokensInput.value = String(config.completionsMaxTokens ?? 80);
+    debounceMsInput.value = String(config.completionsDebounceMs ?? 300);
+    contextLinesInput.value = String(config.completionsContextLines ?? 100);
+    systemPromptInput.value = config.chatDefaultSystemPrompt ?? '';
+  }
+
+  function populateServerSettings(settings) {
+    if (!settings) return;
+    if (settings.server) {
+      serverHostEl.textContent = settings.server.host ?? '—';
+      serverPortEl.textContent = String(settings.server.port ?? '—');
+    }
+    if (settings.cache) {
+      serverCacheEl.textContent = settings.cache.enabled ? 'Enabled' : 'Disabled';
+    }
+    if (settings.model) {
+      serverMaxMemEl.textContent = settings.model.max_model_memory ?? '—';
+    }
+  }
+
+  function populateStats(stats) {
+    if (!stats) return;
+    statRequestsEl.textContent = String(stats.total_requests ?? 0);
+    statTokensEl.textContent = String(stats.total_completion_tokens ?? 0);
+    statGenTpsEl.textContent = (stats.avg_generation_tps ?? 0).toFixed(1);
+    statPrefillTpsEl.textContent = (stats.avg_prefill_tps ?? 0).toFixed(1);
+  }
+
+  function populateModels(models) {
+    if (!models) return;
+    modelTableBody.innerHTML = '';
+    for (const m of models) {
+      const tr = document.createElement('tr');
+
+      const statusClass = m.loaded ? 'loaded' : m.is_loading ? 'loading' : 'unloaded';
+      const statusText = m.loaded ? 'Loaded' : m.is_loading ? 'Loading…' : 'Unloaded';
+
+      tr.innerHTML = `
+        <td>
+          <span class="status-dot ${statusClass}"></span>${m.id}
+          ${m.is_default ? ' <small style="opacity:0.5">(default)</small>' : ''}
+        </td>
+        <td>${m.estimated_size_formatted ?? '—'}</td>
+        <td>
+          <div class="model-actions">
+            <button data-action="load" data-id="${m.id}" ${m.loaded || m.is_loading ? 'disabled' : ''}>Load</button>
+            <button data-action="unload" data-id="${m.id}" ${!m.loaded ? 'disabled' : ''}>Unload</button>
+          </div>
+        </td>
+      `;
+      modelTableBody.appendChild(tr);
+    }
+  }
+
+  // ── Event: save extension config ─────────────────────────
+  document.getElementById('saveBtn').addEventListener('click', () => {
+    vscode.postMessage({
+      type: 'save-vscode-config',
+      config: {
+        serverUrl: serverUrlInput.value.trim(),
+        apiKey: apiKeyInput.value,
+        completionsEnabled: completionsEnabledInput.checked,
+        completionsMaxTokens: parseInt(maxTokensInput.value, 10) || 80,
+        completionsDebounceMs: parseInt(debounceMsInput.value, 10) || 300,
+        completionsContextLines: parseInt(contextLinesInput.value, 10) || 100,
+        chatDefaultSystemPrompt: systemPromptInput.value,
+      },
+    });
+  });
+
+  // ── Event: model load/unload buttons ────────────────────
+  modelTableBody.addEventListener('click', (e) => {
+    const btn = /** @type {HTMLButtonElement} */ (e.target);
+    if (btn.tagName !== 'BUTTON') return;
+    const action = btn.dataset.action;
+    const id = btn.dataset.id;
+    if (!id) return;
+
+    // Disable all buttons in this row and show spinner on Load
+    const row = btn.closest('tr');
+    if (row) {
+      row.querySelectorAll('button').forEach((b) => { b.disabled = true; });
+    }
+
+    if (action === 'load') {
+      btn.textContent = 'Loading…';
+      vscode.postMessage({ type: 'load-model', modelId: id });
+    } else if (action === 'unload') {
+      btn.textContent = 'Unloading…';
+      vscode.postMessage({ type: 'unload-model', modelId: id });
+    }
+  });
+
+  // ── Event: refresh ───────────────────────────────────────
+  document.getElementById('refreshBtn').addEventListener('click', () => {
+    vscode.postMessage({ type: 'refresh' });
+  });
+
+  // ── Messages from extension host ────────────────────────
+  window.addEventListener('message', (event) => {
+    const msg = event.data;
+
+    switch (msg.type) {
+      case 'settings-loaded':
+        errorBanner.classList.add('hidden');
+        populateConfig(msg.vscodeConfig);
+        populateServerSettings(msg.serverSettings);
+        populateStats(msg.stats);
+        populateModels(msg.models);
+        break;
+
+      case 'save-success':
+        flashSave();
+        break;
+
+      case 'model-load-result':
+        // Re-request full refresh to update model table
+        vscode.postMessage({ type: 'refresh' });
+        break;
+
+      case 'error':
+        showError(msg.message);
+        break;
+    }
+  });
+
+  // Signal ready — host will send settings-loaded
+  vscode.postMessage({ type: 'ready' });
+})();

--- a/extensions/vscode/tsconfig.json
+++ b/extensions/vscode/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Admittedly this is a big feature add that was vibe coded and probably has a number of issues. Mostly did it for my own benefit and thought I'd share in case it's useful.

Adds a full VS Code extension for oMLX with:
- Inline code completions (Copilot-style, debounced)
- Streaming chat sidebar with conversation history
- Agentic tool loop: execute_code, run_command, read/write files, list_files, open_preview, start_server
- Model quick-pick switcher showing loaded/unloaded state
- Status bar with connection health and tokens-per-second
- Settings panel (server URL, API key, model parameters)
- Auto-selects first loaded model on startup
- Apache 2.0 SPDX headers on all source files

Installation:
cd extensions/vscode
npm install
npm run build
# Press F5 in VS Code to launch Extension Development Host

Or install the pre-built VSIX directly:

Extensions: Install from VSIX… → select extensions/vscode/vscode-omlx-0.1.0.vsix

Test results
3,723 tests pass. 8 pre-existing failures unrelated to this PR:

5× test_grammar.py — optional xgrammar dependency not installed
2× test_admin_* — preserve_thinking/turboquant_skip_last fields missing from test fixtures
1× test_accuracy_benchmark — benchmark count mismatch (16 vs 12)
Notes
All source files carry SPDX-License-Identifier: Apache-2.0 headers
Extension communicates with oMLX via the existing /v1/ and /admin/api/ endpoints — no server changes required
Bundled with esbuild (CommonJS, external: ['vscode']), no runtime npm dependencies

[vscode-omlx-0.1.0.vsix.zip](https://github.com/user-attachments/files/27021193/vscode-omlx-0.1.0.vsix.zip)