### PR TITLE
fix(formula): allow rpds-py wheels

### DIFF
--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -43,7 +43,7 @@ class Omlx < Formula
 
     # Install omlx (with optional grammar extra for structured output)
     install_spec = build.with?("grammar") ? "#{buildpath}[grammar]" : buildpath.to_s
-    system libexec/"bin/pip", "install", "--no-binary", "pydantic-core,rpds-py,tiktoken", install_spec
+    system libexec/"bin/pip", "install", "--no-binary", "pydantic-core,tiktoken", install_spec
 
     # Install mlx-audio with patched mlx-lm pin to avoid version conflict
     resource("mlx-audio").stage do


### PR DESCRIPTION
## Summary
- remove `rpds-py` from the formula's `--no-binary` package list
- keep source builds for `pydantic-core` and `tiktoken`

Fixes #836

## Testing
- `ruby -c Formula/omlx.rb`
- `git diff --check`
- `/opt/homebrew/bin/python3.11 -m pip download --only-binary=:all: --dest /tmp/omlx-rpds-wheel-check-py311 'rpds-py'`

The Python 3.11 wheel download resolves to `rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl`, so the package can use a prebuilt arm64 wheel instead of forcing a Rust source build during every Homebrew upgrade.
