### PR TITLE
fix(server): omit SSE comments for OpenAI streams

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1302,6 +1302,7 @@ async def _with_sse_keepalive(
     http_request: Optional["FastAPIRequest"] = None,
     interval: float = 10.0,
     disconnect_poll: float = 2.0,
+    send_comments: bool = True,
 ) -> AsyncIterator[str]:
     """Wrap an SSE generator to send periodic keep-alive comments.
 
@@ -1321,7 +1322,8 @@ async def _with_sse_keepalive(
 
     # Send initial keepalive immediately so clients with short read
     # timeouts (e.g. openclaw ~15s) don't disconnect during prefill.
-    yield ": keep-alive\n\n"
+    if send_comments:
+        yield ": keep-alive\n\n"
 
     try:
         while True:
@@ -1351,7 +1353,7 @@ async def _with_sse_keepalive(
                         pass  # is_disconnected() can fail if scope is already closed
                 # Send keepalive at the configured interval
                 keepalive_elapsed += wait_time
-                if keepalive_elapsed >= interval:
+                if send_comments and keepalive_elapsed >= interval:
                     keepalive_elapsed = 0.0
                     yield ": keep-alive\n\n"
             if task.done():
@@ -1862,6 +1864,7 @@ async def create_completion(
             _with_sse_keepalive(
                 stream_completion(engine, prompts[0], request, model_load_duration=model_load_duration),
                 http_request=http_request,
+                send_comments=False,
             ),
             media_type="text/event-stream",
             headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"},
@@ -2181,6 +2184,7 @@ async def create_chat_completion(
             _with_sse_keepalive(
                 stream_chat_completion(engine, messages, request, model_load_duration=model_load_duration, resolved_model=resolved_model, **chat_kwargs),
                 http_request=http_request,
+                send_comments=False,
             ),
             media_type="text/event-stream",
             headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"},
@@ -3848,6 +3852,7 @@ async def create_response(
                     **chat_kwargs,
                 ),
                 http_request=http_request,
+                send_comments=False,
             ),
             media_type="text/event-stream",
             headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"},

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -35,6 +35,17 @@ class TestSSEKeepaliveExceptionHandling:
         assert "data: chunk2\n\n" in items
 
     @pytest.mark.asyncio
+    async def test_comments_can_be_disabled_for_strict_clients(self):
+        """Strict OpenAI-compatible SSE clients can opt out of comment frames."""
+
+        async def gen():
+            yield "data: chunk1\n\n"
+            yield "data: [DONE]\n\n"
+
+        items = await _collect(_with_sse_keepalive(gen(), send_comments=False))
+        assert items == ["data: chunk1\n\n", "data: [DONE]\n\n"]
+
+    @pytest.mark.asyncio
     async def test_generator_exception_yields_error_sse(self):
         """When inner generator raises, keepalive wrapper should yield
         error SSE data and [DONE] instead of propagating the exception."""


### PR DESCRIPTION
## Summary
- add a `send_comments` switch to the SSE keepalive wrapper
- disable `: keep-alive` comment frames for OpenAI-compatible streaming endpoints (`/v1/completions`, `/v1/chat/completions`, `/v1/responses`)
- keep the wrapper and disconnect polling in place, and leave comment keepalives enabled for existing non-OpenAI callers
- add coverage for comment-free pass-through mode

Fixes #839

## Testing
- `.venv/bin/python -m pytest tests/test_sse_keepalive.py`
- `python3 -m py_compile omlx/server.py tests/test_sse_keepalive.py`
- `git diff --check`
