### PR TITLE
fix(admin): handle xgrammar parser load failures

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -1339,7 +1339,8 @@ async def list_grammar_parsers(is_admin: bool = Depends(require_admin)):
             {"value": style, "label": style, "models": models}
             for style, models in supported.items()
         ]
-    except ImportError:
+    except Exception as e:
+        logger.warning("xgrammar parser discovery unavailable: %s", e)
         return []
 
 

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -822,3 +822,18 @@ class TestListGrammarParsers:
             resp = client.get("/admin/api/grammar/parsers")
         assert resp.status_code == 200
         assert resp.json() == []
+
+    def test_returns_empty_when_xgrammar_native_binding_fails(self, client):
+        def raise_binding_error():
+            raise RuntimeError(
+                "Cannot find library: "
+                "libxgrammar_bindings.dylib, libxgrammar_bindings.so"
+            )
+
+        fake_xgrammar = SimpleNamespace(
+            get_builtin_structural_tag_supported_models=raise_binding_error
+        )
+        with patch.dict("sys.modules", {"xgrammar": fake_xgrammar}):
+            resp = client.get("/admin/api/grammar/parsers")
+        assert resp.status_code == 200
+        assert resp.json() == []


### PR DESCRIPTION
## Summary
- prevent `/admin/api/grammar/parsers` from returning 500 when `xgrammar` imports but its native binding cannot be loaded
- log the discovery failure and return an empty parser list, matching the existing optional-dependency behavior when `xgrammar` is absent
- add a regression test for the native binding load failure reported in #1005

Fixes #1005

## Testing
- `.venv/bin/python -m pytest tests/test_grammar.py::TestListGrammarParsers`
- `python3 -m py_compile omlx/admin/routes.py tests/test_grammar.py`
- `git diff --check`
