### PR TITLE
Gemma 4 interleaved tool call and reasoning fix

### DIFF
--- a/omlx/adapter/gemma4.py
+++ b/omlx/adapter/gemma4.py
@@ -24,8 +24,10 @@ _TOOL_RESPONSE_CLOSE = "<tool_response|>"
 _THINK_OPEN = "<think>\n"
 _THINK_CLOSE = "</think>\n"
 
-_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
-_CHANNEL_BLOCK_RE = re.compile(r"<\|channel>.*?<channel\|>\s*", re.DOTALL)
+_LEADING_THOUGHT_RE = re.compile(
+    r"\A\s*(?:(?:<think>.*?</think>|<\|channel>.*?<channel\|>)\s*)+",
+    re.DOTALL,
+)
 
 
 def _try_parse_json(s: str) -> Any:
@@ -42,7 +44,7 @@ def _try_parse_json(s: str) -> Any:
 
 
 def _strip_thinking(text: Any) -> Any:
-    """Remove ``<think>...</think>`` and raw ``<|channel>...<channel|>`` spans.
+    """Remove leading ``<think>...</think>`` or raw ``<|channel>...<channel|>`` spans.
 
     Gemma 4's multi-turn rule requires that only the final visible answer
     is kept in chat history. Clients such as Open WebUI replay the full
@@ -50,12 +52,15 @@ def _strip_thinking(text: Any) -> Any:
     raw protocol form when a client preserves it). Feeding prior thought
     blocks back primes the model to emit malformed channel markers on the
     next turn, which then leak into user-facing output.
+
+    The match is anchored to the start of the message: the rendered thought
+    block always precedes the visible answer, so this catches every
+    legitimate occurrence while leaving inline mentions (e.g. an assistant
+    explaining how ``<think>`` tags work) untouched.
     """
     if not isinstance(text, str) or not text:
         return text
-    text = _CHANNEL_BLOCK_RE.sub("", text)
-    text = _THINK_BLOCK_RE.sub("", text)
-    return text.lstrip()
+    return _LEADING_THOUGHT_RE.sub("", text, count=1)
 
 
 def extract_gemma4_messages(

--- a/omlx/adapter/gemma4.py
+++ b/omlx/adapter/gemma4.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, List
 
 try:
@@ -15,12 +16,16 @@ from ..api.utils import _PRESERVE_BOUNDARY_KEY
 from .output_parser import OutputParserFinalizeResult, OutputParserTokenResult
 
 _OPEN_MARKER = "<|channel>thought\n"
+_OPEN_MARKER_BARE = "<|channel>"
 _CLOSE_MARKER = "<channel|>"
 _TURN_END_MARKER = "<turn|>"
 _TOOL_RESPONSE_OPEN = "<|tool_response>"
 _TOOL_RESPONSE_CLOSE = "<tool_response|>"
 _THINK_OPEN = "<think>\n"
 _THINK_CLOSE = "</think>\n"
+
+_THINK_BLOCK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
+_CHANNEL_BLOCK_RE = re.compile(r"<\|channel>.*?<channel\|>\s*", re.DOTALL)
 
 
 def _try_parse_json(s: str) -> Any:
@@ -34,6 +39,23 @@ def _try_parse_json(s: str) -> Any:
         return json.loads(s)
     except (json.JSONDecodeError, ValueError):
         return s
+
+
+def _strip_thinking(text: Any) -> Any:
+    """Remove ``<think>...</think>`` and raw ``<|channel>...<channel|>`` spans.
+
+    Gemma 4's multi-turn rule requires that only the final visible answer
+    is kept in chat history. Clients such as Open WebUI replay the full
+    assistant content (including the rendered ``<think>`` block, or the
+    raw protocol form when a client preserves it). Feeding prior thought
+    blocks back primes the model to emit malformed channel markers on the
+    next turn, which then leak into user-facing output.
+    """
+    if not isinstance(text, str) or not text:
+        return text
+    text = _CHANNEL_BLOCK_RE.sub("", text)
+    text = _THINK_BLOCK_RE.sub("", text)
+    return text.lstrip()
 
 
 def extract_gemma4_messages(
@@ -146,6 +168,9 @@ def extract_gemma4_messages(
             content = msg.get("content", "")
             if isinstance(content, list):
                 content = _extract_text_from_content_list(content)
+            # Per Gemma 4's multi-turn rule, prior thought blocks must not
+            # be fed back into the next turn. Strip them before rendering.
+            content = _strip_thinking(content)
 
             out_msg: dict = {"role": "assistant", "content": content or ""}
 
@@ -286,12 +311,16 @@ class Gemma4OutputParserSession:
         # Channel open/close are tracked unconditionally so a stray
         # ``<channel|>`` outside a thought block (occasionally emitted in long
         # multi-turn contexts) is absorbed instead of leaking into visible
-        # text. Tool-call markup is intentionally not tracked here — the
+        # text. ``_OPEN_MARKER_BARE`` is a defensive fallback for malformed
+        # opens (e.g. ``<|channel>thought<channel|>`` with no newline, or a
+        # bare ``<|channel>`` emitted when the model is confused by polluted
+        # history). Tool-call markup is intentionally not tracked here — the
         # downstream ``ToolCallStreamFilter`` removes it from stream deltas
         # while ``parse_tool_calls`` still sees the raw markers in
         # ``output_text`` for extraction.
         return [
             _OPEN_MARKER,
+            _OPEN_MARKER_BARE,
             _CLOSE_MARKER,
             _TURN_END_MARKER,
             _TOOL_RESPONSE_OPEN,
@@ -345,7 +374,28 @@ class Gemma4OutputParserSession:
                 self._append_text(stream_parts, visible_parts, emit)
                 break
 
+            # Streaming defer: a bare ``<|channel>`` (or ``<|channel>thought``
+            # without trailing newline) at the end of the source could still
+            # extend to the canonical ``<|channel>thought\n`` once more
+            # tokens arrive. Buffer and wait so the canonical match wins.
+            if not final and marker == _OPEN_MARKER_BARE:
+                suffix = source[idx:]
+                if (
+                    len(suffix) < len(_OPEN_MARKER)
+                    and _OPEN_MARKER.startswith(suffix)
+                ):
+                    self._append_text(
+                        stream_parts, visible_parts, source[pos:idx]
+                    )
+                    self._buffer = suffix
+                    return OutputParserTokenResult(
+                        stream_text="".join(stream_parts),
+                        visible_text="".join(visible_parts),
+                    )
+
             self._append_text(stream_parts, visible_parts, source[pos:idx])
+
+            advance = len(marker)
 
             if marker == _OPEN_MARKER:
                 # Nested open while already in a thought block: drop the stray
@@ -355,6 +405,21 @@ class Gemma4OutputParserSession:
                     stream_parts.append(_THINK_OPEN)
                     visible_parts.append(_THINK_OPEN)
                     self._in_thought = True
+            elif marker == _OPEN_MARKER_BARE:
+                # Defensive fallback for malformed opens: ``<|channel>thought``
+                # without the trailing newline, or a bare ``<|channel>`` with
+                # an unrecognised channel name. Treat as a thought open and
+                # absorb the optional ``thought`` keyword and newline so they
+                # don't leak as visible text.
+                if not self._in_thought:
+                    stream_parts.append(_THINK_OPEN)
+                    visible_parts.append(_THINK_OPEN)
+                    self._in_thought = True
+                after = idx + advance
+                if source.startswith("thought\n", after):
+                    advance += len("thought\n")
+                elif source.startswith("thought", after):
+                    advance += len("thought")
             elif marker == _CLOSE_MARKER:
                 # Stray close outside a thought block: drop silently to keep
                 # the marker out of visible content.
@@ -364,7 +429,7 @@ class Gemma4OutputParserSession:
                     self._in_thought = False
             # _TURN_END_MARKER, _TOOL_RESPONSE_OPEN / _CLOSE: silent drop.
 
-            pos = idx + len(marker)
+            pos = idx + advance
 
         return OutputParserTokenResult(
             stream_text="".join(stream_parts),

--- a/tests/test_gemma4_messages.py
+++ b/tests/test_gemma4_messages.py
@@ -3,7 +3,11 @@
 
 from __future__ import annotations
 
-from omlx.adapter.gemma4 import extract_gemma4_messages
+from omlx.adapter.gemma4 import (
+    Gemma4OutputParserSession,
+    _strip_thinking,
+    extract_gemma4_messages,
+)
 from omlx.api.openai_models import Message
 
 
@@ -193,3 +197,214 @@ class TestExtractGemma4Messages:
         assert isinstance(content, list)
         types = [p["type"] for p in content]
         assert "image_url" in types
+
+    def test_multi_turn_rule_strips_prior_thought_block(self):
+        """Per Gemma 4 docs: only the final visible answer is kept in chat
+        history; prior thought blocks must not be fed back on the next turn.
+        """
+        messages = [
+            Message(role="user", content="What is 1+1?"),
+            Message(
+                role="assistant",
+                content="<think>\nLet me compute.\n</think>\n2",
+            ),
+            Message(role="user", content="What is 2+2?"),
+        ]
+        result = extract_gemma4_messages(messages)
+        assert result[1] == {"role": "assistant", "content": "2"}
+
+    def test_multi_turn_strips_raw_channel_form(self):
+        """Clients that preserve the protocol form (raw channel markers in
+        assistant content) also need their thought blocks stripped."""
+        messages = [
+            Message(
+                role="assistant",
+                content="<|channel>thought\nreasoning here\n<channel|>final",
+            ),
+        ]
+        result = extract_gemma4_messages(messages)
+        assert result[0]["content"] == "final"
+
+    def test_multi_turn_preserves_inline_think_mention(self):
+        """An assistant explaining the protocol must not have its examples
+        gutted on subsequent turns."""
+        explanation = "You write `<think>like this</think>` to enable reasoning."
+        messages = [Message(role="assistant", content=explanation)]
+        result = extract_gemma4_messages(messages)
+        assert result[0]["content"] == explanation
+
+    def test_strip_keeps_tool_calls(self):
+        """Stripping leading thought from assistant content must not drop
+        the structured ``tool_calls`` field."""
+        msg = Message(
+            role="assistant",
+            content="<think>\nplanning\n</think>\n",
+            tool_calls=[_tool_call_dict("c1", "search")],
+        )
+        result = extract_gemma4_messages([msg])
+        assert "tool_calls" in result[0]
+        assert result[0]["tool_calls"][0]["function"]["name"] == "search"
+
+
+class TestStripThinking:
+    """``_strip_thinking`` removes leading thought blocks only."""
+
+    def test_strips_canonical_channel_block(self):
+        """Per Gemma 4 spec: ``<|channel>thought\\n[reasoning]<channel|>[answer]``."""
+        text = "<|channel>thought\ninternal reasoning\n<channel|>the answer"
+        assert _strip_thinking(text) == "the answer"
+
+    def test_strips_empty_channel_block_per_spec(self):
+        """Per Gemma 4 spec: thinking-disabled larger models still emit an
+        empty thought block before the final answer."""
+        text = "<|channel>thought\n<channel|>the answer"
+        assert _strip_thinking(text) == "the answer"
+
+    def test_strips_rendered_think_block(self):
+        text = "<think>\nreasoning\n</think>\nthe answer"
+        assert _strip_thinking(text) == "the answer"
+
+    def test_strips_multiple_consecutive_blocks(self):
+        text = "<think>a</think>\n<think>b</think>\nanswer"
+        assert _strip_thinking(text) == "answer"
+
+    def test_strips_mixed_channel_and_think_blocks(self):
+        text = "<|channel>x<channel|><think>y</think>answer"
+        assert _strip_thinking(text) == "answer"
+
+    def test_preserves_inline_think_mention(self):
+        text = "You write `<think>like this</think>` to enable reasoning."
+        assert _strip_thinking(text) == text
+
+    def test_preserves_inline_channel_mention(self):
+        text = "The `<|channel>` token marks reasoning."
+        assert _strip_thinking(text) == text
+
+    def test_handles_leading_whitespace(self):
+        assert _strip_thinking("   <think>x</think>answer") == "answer"
+
+    def test_empty_string_unchanged(self):
+        assert _strip_thinking("") == ""
+
+    def test_non_string_passthrough(self):
+        assert _strip_thinking(None) is None
+        assert _strip_thinking(42) == 42
+
+
+class _FakeTokenizer:
+    """Tokenizer stub that bypasses the streaming detokenizer path."""
+
+    detokenizer = None
+
+    def decode(self, ids):
+        return ""
+
+
+class TestGemma4OutputParserSession:
+    """Output parser converts Gemma 4 channel markers to ``<think>`` tags."""
+
+    def _make_session(self):
+        return Gemma4OutputParserSession(_FakeTokenizer())
+
+    def test_canonical_thought_block_per_spec(self):
+        """``<|channel>thought\\n[reasoning]<channel|>[answer]`` per Gemma 4 spec."""
+        sess = self._make_session()
+        result = sess._consume_text(
+            "<|channel>thought\nreasoning\n<channel|>final answer",
+            final=True,
+        )
+        assert result.visible_text == "<think>\nreasoning\n</think>\nfinal answer"
+        assert sess._in_thought is False
+
+    def test_empty_thought_block_per_spec(self):
+        """Thinking-disabled larger models emit an empty thought block per spec."""
+        sess = self._make_session()
+        result = sess._consume_text(
+            "<|channel>thought\n<channel|>the answer", final=True
+        )
+        assert result.visible_text == "<think>\n</think>\nthe answer"
+
+    def test_no_newline_open_marker_defensive(self):
+        """``<|channel>thought<channel|>`` with no newline is recovered via
+        the bare-marker fallback, with the ``thought`` keyword absorbed."""
+        sess = self._make_session()
+        result = sess._consume_text(
+            "<|channel>thought<channel|>after", final=True
+        )
+        assert result.visible_text == "<think>\n</think>\nafter"
+
+    def test_bare_open_with_non_thought_channel(self):
+        """A bare ``<|channel>X<channel|>`` (unknown channel name) is wrapped
+        defensively as a thought block rather than leaking the markers."""
+        sess = self._make_session()
+        result = sess._consume_text(
+            "<|channel>X<channel|>after", final=True
+        )
+        assert result.visible_text == "<think>\nX</think>\nafter"
+
+    def test_streaming_canonical_split_at_marker_boundary(self):
+        """Open marker arriving across two chunks must still match canonical."""
+        sess = self._make_session()
+        r1 = sess._consume_text("<|channel>")
+        # Streaming defer: nothing emitted yet because the bare match could
+        # still extend to the canonical form.
+        assert r1.visible_text == ""
+        r2 = sess._consume_text(
+            "thought\nreasoning\n<channel|>answer", final=True
+        )
+        assert r1.visible_text + r2.visible_text == (
+            "<think>\nreasoning\n</think>\nanswer"
+        )
+
+    def test_streaming_defer_prefers_canonical_over_bare(self):
+        """When ``<|channel>thought`` arrives without a newline at the chunk
+        boundary, the parser must defer rather than commit the bare match."""
+        sess = self._make_session()
+        r1 = sess._consume_text("<|channel>thought")
+        assert r1.visible_text == ""
+        r2 = sess._consume_text("\nreasoning\n<channel|>answer", final=True)
+        assert r1.visible_text + r2.visible_text == (
+            "<think>\nreasoning\n</think>\nanswer"
+        )
+
+    def test_stray_close_marker_dropped(self):
+        """A ``<channel|>`` outside a thought block is absorbed silently."""
+        sess = self._make_session()
+        result = sess._consume_text("hello<channel|>world", final=True)
+        assert result.visible_text == "helloworld"
+
+    def test_turn_end_marker_dropped(self):
+        sess = self._make_session()
+        result = sess._consume_text("done<turn|>", final=True)
+        assert result.visible_text == "done"
+
+    def test_tool_response_markers_dropped(self):
+        sess = self._make_session()
+        result = sess._consume_text(
+            "<|tool_response>{\"x\":1}<tool_response|>after", final=True
+        )
+        assert result.visible_text == '{"x":1}after'
+
+    def test_finalize_closes_orphan_thought(self):
+        """A thought block left open at end-of-stream is closed in finalize."""
+        sess = self._make_session()
+        first = sess._consume_text("<|channel>thought\nincomplete reasoning")
+        final = sess.finalize()
+        combined = first.visible_text + final.visible_text
+        assert "<think>\n" in combined
+        assert combined.endswith("</think>\n")
+        assert sess._in_thought is False
+
+    def test_double_bare_open_does_not_re_emit_think(self):
+        """The user's reported double ``<|channel><|channel>`` artefact: the
+        second open while already inside a thought block must not re-emit a
+        nested ``<think>`` opener."""
+        sess = self._make_session()
+        result = sess._consume_text(
+            "<|channel>thought\nfirst<|channel>second\n<channel|>after",
+            final=True,
+        )
+        # Exactly one <think> opener despite two <|channel>... opens.
+        assert result.visible_text.count("<think>\n") == 1
+        assert result.visible_text.count("</think>\n") == 1
+        assert result.visible_text.endswith("after")


### PR DESCRIPTION
Multi-turn tool-call flows with Gemma 4 in Open WebUI were leaking the literal word "thought" into the visible answer and producing empty `<|channel><|channel>` sequences. This often would break the separation between reasoning blocks and response blocks, mixing both together in the UI. 

After reviewing [the model card](https://ai.google.dev/gemma/docs/core/model_card_4#2_thinking_mode_configuration), I noticed that this isn't something specific to Open WebUI, but an incomplete implementation of thinking blocks in multi-turn conversations, particularly when there are interleaved tool calls in the middle. 

```
3. Multi-Turn Conversations

No Thinking Content in History: In multi-turn conversations, the historical model output should only include the final response. Thoughts from previous model turns must not be added before the next user turn begins.
```

This change addresses both the root cause and the parser fragility that made it visible. I've been running it without problems on top of v0.3.6 and then now on v0.3.8.

## Background

Gemma 4's multi-turn rule states that [only the final visible answer should be kept in chat history](https://ai.google.dev/gemma/docs/core/model_card_4#3_multi-turn_conversations) and that prior thought blocks must not be fed back into the next turn. The previous adapter code passed assistant content through verbatim, so clients such as Open WebUI replayed the rendered `<think>...</think>` block (or the raw `<|channel>thought...<channel|>` form when preserved) on every subsequent turn. The polluted history then primed the model to emit malformed channel markers on follow-up turns.

The output parser only recognised the canonical open form `<|channel>thought\n`. When the model emitted the no-newline variant `<|channel>thought<channel|>` or a bare `<|channel>`, the parser failed to match the open, treated everything up to the close as visible text, and silently dropped the close. The literal `thought` keyword and any malformed channel content then leaked into the user-facing reply.

## Changes

`omlx/adapter/gemma4.py`:

1. Added a `_strip_thinking` helper that removes leading `<think>...</think>` or raw `<|channel>...<channel|>` spans from assistant content inside `extract_gemma4_messages` before the message reaches the chat template. The match is anchored to the start of the message because the rendered thought block always precedes the visible answer, which keeps inline mentions intact (an assistant explaining how reasoning tags work, for example, is preserved). This honours Gemma 4's multi-turn history rule and prevents the model from being primed by its own reasoning output.

2. Added `<|channel>` as a defensive bare-open marker in `Gemma4OutputParserSession`. A streaming-defer guard ensures that when the bare match could still extend to the canonical form once more tokens arrive, the parser buffers and waits, preserving canonical streaming. When the bare form does commit, the parser optionally absorbs a trailing `thought` keyword and newline so they do not leak as visible text. Stray bare opens are wrapped in `<think>` rather than allowed through.

## Test plan

- [x] `uv run pytest tests/test_gemma4_messages.py` passes (14 tests).
- [x] Manual smoke tests cover canonical, no-newline, bare, double-bare, and chunked-streaming inputs.
- [x] End-to-end verification in Open WebUI with a multi-turn tool-call flow that previously reproduced the leak.
- [x] End-to-end verification using the Pi coding agent in a local codebase and Gemma 4 26B A4B as the model.

An asterisk here about testing: if I run Gemma 4 in Pi in this branch, it'll strip out the reasoning tags in the thinking and response blocks. This seems to be an issue in Pi itself as I can reproduce it if I ask the model, from a new session, to simply print a thinking tag in the chat. When I enter a thinking tag myself, it's also stripped before reaching the model.

I'm mentioning this only for completeness, but it isn't a regression. Running on the current main, at v0.3.8, has the same result.

## Samples

Attached are screenshots from Open WebUI and corresponding full trace logs for v0.3.8 vs. this branch.

### Logs

v0.3.8
[omlx-trace.main.log](https://github.com/user-attachments/files/27272523/omlx-trace.main.log)

Fix
[omlx-trace.fix.log](https://github.com/user-attachments/files/27272527/omlx-trace.fix.log)

### Screenshots

v0.3.8
<img width="1026" height="326" alt="v0 3 8-top" src="https://github.com/user-attachments/assets/549b609e-7cad-4f22-bdef-81c3a50c2b2e" />

Notice the mixup between reasoning block and response:

<img width="1005" height="501" alt="v0 3 8-bottom" src="https://github.com/user-attachments/assets/10a65a4f-3726-4f7b-ae9f-1ad5e9430dc4" />

Fix
<img width="1024" height="549" alt="fix" src="https://github.com/user-attachments/assets/1d75c45b-ceff-4bd0-a527-9e28e8006bef" />



