### PR TITLE
fix: treat lfm2 as ambiguous model type (LLM + embedding + audio)

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -86,7 +86,6 @@ EMBEDDING_MODEL_TYPES = {
     "siglip",
     "colqwen2_5",
     "colqwen2-5",
-    "lfm2",
 }
 
 # Model types that have both embedding and LLM variants.
@@ -95,6 +94,7 @@ AMBIGUOUS_EMBEDDING_MODEL_TYPES = {
     "qwen3",
     "gemma3-text",
     "gemma3_text",
+    "lfm2",
 }
 
 # Known embedding architectures
@@ -512,8 +512,8 @@ def detect_model_type(model_path: Path) -> ModelType:
         return "audio_stt"
     if normalized_type in AUDIO_STS_MODEL_TYPES or model_type in AUDIO_STS_MODEL_TYPES:
         return "audio_sts"
-    # LFM2 audio: model_type starts with "lfm" and is not an embedding
-    if normalized_type.startswith("lfm") and normalized_type not in EMBEDDING_MODEL_TYPES:
+    # LFM2 audio: specific model_type for audio variants
+    if normalized_type == "lfm_audio":
         return "audio_sts"
 
     return "llm"


### PR DESCRIPTION
## Problem

LFM2.5 Instruct models (e.g. LFM2.5-1.2B-Instruct-MLX-4bit) are misdetected as **embedding** models and fail on /v1/chat/completions requests.

Root cause: lfm2 is listed in EMBEDDING_MODEL_TYPES, so any model with model_type: lfm2 is unconditionally classified as embedding — even when the architecture is Lfm2ForCausalLM (a standard LLM).

## LFM2 family variants

| Model | model_type | Architecture | Expected type |
|---|---|---|---|
| LFM2.5-1.2B-Instruct | lfm2 | Lfm2ForCausalLM | llm |
| LFM2.5-1.2B-Thinking | lfm2 | Lfm2ForCausalLM | llm |
| LFM2 embedding | lfm2 | BertModel etc. | embedding |
| LFM2 audio (STS) | lfm_audio | LFM2AudioModel | audio_sts |

## Fix

1. Move lfm2 from EMBEDDING_MODEL_TYPES → AMBIGUOUS_EMBEDDING_MODEL_TYPES (same pattern as qwen3, gemma3-text)
2. Narrow the LFM2 audio catch-all from startswith(lfm) to exact match lfm_audio to prevent LLM variants from being misclassified as audio_sts

## Verification

Tested locally on oMLX 0.3.7 with LFM2.5-1.2B-Instruct-MLX-4bit:
- Before: Discovered model: LFM2.5-1.2B-Instruct-MLX-4bit (type: embedding, engine: embedding)
- After: Discovered model: LFM2.5-1.2B-Instruct-MLX-4bit (type: llm, engine: batched)

Chat completions now work correctly.