### PR TITLE
[codex] fix Qwen3-VL embedding processor compat

### DIFF
--- a/omlx/models/embedding.py
+++ b/omlx/models/embedding.py
@@ -7,8 +7,8 @@ text embeddings using Apple's MLX framework, with native fallback
 for XLMRoBERTa and BERT embedding models.
 """
 
-import json
 import inspect
+import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,6 +16,10 @@ from typing import Any, Dict, List, Optional, Union
 
 import mlx.core as mx
 from mlx.utils import tree_flatten
+
+from .mlx_embeddings_compat import (
+    patch_qwen3_vl_processor_for_torch_free_image_loading,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -174,6 +178,7 @@ class MLXEmbeddingModel:
 
         # 2. Fallback to mlx-embeddings
         try:
+            patch_qwen3_vl_processor_for_torch_free_image_loading()
             from mlx_embeddings import load
 
             logger.info(f"Loading embedding model via mlx-embeddings: {self.model_name}")

--- a/omlx/models/mlx_embeddings_compat.py
+++ b/omlx/models/mlx_embeddings_compat.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility patches for mlx-embeddings."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_QWEN3_VL_PROCESSOR_PATCHED = False
+
+
+def _ensure_qwen3_vl_mm_token_ids(processor):
+    """Mirror ProcessorMixin multimodal token id fields for manually built processors."""
+    defaults = {
+        "image_ids": [getattr(processor, "image_token_id", None)],
+        "video_ids": [getattr(processor, "video_token_id", None)],
+        "audio_ids": [getattr(processor, "audio_token_id", None)],
+    }
+    for attr_name, value in defaults.items():
+        if not hasattr(processor, attr_name):
+            setattr(processor, attr_name, value)
+    return processor
+
+
+def patch_qwen3_vl_processor_for_torch_free_image_loading() -> None:
+    """Keep mlx-embeddings Qwen3-VL loading off HF AutoImageProcessor."""
+    global _QWEN3_VL_PROCESSOR_PATCHED
+    if _QWEN3_VL_PROCESSOR_PATCHED:
+        return
+
+    try:
+        from mlx_embeddings.models.qwen3_vl import processor as qwen3_vl_processor
+        from mlx_vlm.models.qwen3_vl.processing_qwen3_vl import (
+            Qwen3VLImageProcessor,
+            _qwen_vl_image_kwargs,
+        )
+    except Exception as exc:
+        logger.debug("Qwen3-VL mlx-embeddings compatibility patch skipped: %s", exc)
+        _QWEN3_VL_PROCESSOR_PATCHED = True
+        return
+
+    original_auto_image_processor = getattr(
+        qwen3_vl_processor, "AutoImageProcessor", None
+    )
+
+    class TorchFreeQwen3VLAutoImageProcessor:
+        _omlx_original_auto_image_processor = original_auto_image_processor
+
+        @classmethod
+        def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+            del cls, kwargs
+            image_kwargs = _qwen_vl_image_kwargs(
+                pretrained_model_name_or_path,
+                default_patch_size=16,
+            )
+            return Qwen3VLImageProcessor(**image_kwargs)
+
+    qwen3_vl_processor.AutoImageProcessor = TorchFreeQwen3VLAutoImageProcessor
+
+    processor_cls = getattr(qwen3_vl_processor, "Processor", None)
+    original_build_processor = getattr(processor_cls, "_build_processor", None)
+    if (
+        processor_cls is not None
+        and original_build_processor is not None
+        and not getattr(original_build_processor, "_omlx_patched", False)
+    ):
+
+        def build_processor_with_mm_token_ids(tokenizer, image_processor):
+            processor = original_build_processor(tokenizer, image_processor)
+            return _ensure_qwen3_vl_mm_token_ids(processor)
+
+        build_processor_with_mm_token_ids._omlx_patched = True
+        processor_cls._build_processor = staticmethod(build_processor_with_mm_token_ids)
+
+    _QWEN3_VL_PROCESSOR_PATCHED = True
+    logger.debug("Applied torch-free image loader patch for mlx-embeddings Qwen3-VL")

--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -26,6 +26,9 @@ from ..model_discovery import (
     _is_causal_lm_reranker,
 )
 from ..utils.image import load_image
+from .mlx_embeddings_compat import (
+    patch_qwen3_vl_processor_for_torch_free_image_loading,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +186,7 @@ class MLXRerankerModel:
         handles both embedding and reranking variants of Qwen3-VL. Reranker vs
         embedder is decided by the input dict shape at inference time.
         """
+        patch_qwen3_vl_processor_for_torch_free_image_loading()
         from mlx_embeddings import load as mlx_emb_load
 
         return mlx_emb_load(
@@ -611,6 +615,7 @@ class MLXRerankerModel:
                 self._num_labels = getattr(self.model.config, "num_labels", None)
             else:
                 # Use mlx-embeddings for other architectures (ModernBert, etc.)
+                patch_qwen3_vl_processor_for_torch_free_image_loading()
                 from mlx_embeddings import load
 
                 self.model, self.processor = load(

--- a/tests/test_mlx_embeddings_compat.py
+++ b/tests/test_mlx_embeddings_compat.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for mlx-embeddings compatibility patches."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _install_fake_module(monkeypatch, name, module):
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def test_qwen3_vl_auto_image_processor_uses_mlx_vlm_torch_free_loader(monkeypatch):
+    """Qwen3-VL Processor should use mlx-vlm's torch-free image processor."""
+    processor_module = types.ModuleType("mlx_embeddings.models.qwen3_vl.processor")
+
+    class TorchBoundAutoImageProcessor:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            raise RuntimeError("torch/torchvision required")
+
+    processor_module.AutoImageProcessor = TorchBoundAutoImageProcessor
+
+    qwen3_vl_package = types.ModuleType("mlx_embeddings.models.qwen3_vl")
+    qwen3_vl_package.processor = processor_module
+
+    _install_fake_module(
+        monkeypatch, "mlx_embeddings", types.ModuleType("mlx_embeddings")
+    )
+    _install_fake_module(
+        monkeypatch, "mlx_embeddings.models", types.ModuleType("mlx_embeddings.models")
+    )
+    _install_fake_module(
+        monkeypatch, "mlx_embeddings.models.qwen3_vl", qwen3_vl_package
+    )
+    _install_fake_module(
+        monkeypatch, "mlx_embeddings.models.qwen3_vl.processor", processor_module
+    )
+
+    mlx_vlm_processing = types.ModuleType("mlx_vlm.models.qwen3_vl.processing_qwen3_vl")
+    captured = {}
+
+    class TorchFreeImageProcessor:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+
+    def fake_image_kwargs(model_path, default_patch_size=16):
+        captured["model_path"] = model_path
+        captured["default_patch_size"] = default_patch_size
+        return {"patch_size": default_patch_size, "merge_size": 2}
+
+    mlx_vlm_processing.Qwen3VLImageProcessor = TorchFreeImageProcessor
+    mlx_vlm_processing._qwen_vl_image_kwargs = fake_image_kwargs
+
+    _install_fake_module(monkeypatch, "mlx_vlm", types.ModuleType("mlx_vlm"))
+    _install_fake_module(
+        monkeypatch, "mlx_vlm.models", types.ModuleType("mlx_vlm.models")
+    )
+    _install_fake_module(
+        monkeypatch,
+        "mlx_vlm.models.qwen3_vl",
+        types.ModuleType("mlx_vlm.models.qwen3_vl"),
+    )
+    _install_fake_module(
+        monkeypatch,
+        "mlx_vlm.models.qwen3_vl.processing_qwen3_vl",
+        mlx_vlm_processing,
+    )
+
+    module_path = (
+        Path(__file__).resolve().parents[1] / "omlx/models/mlx_embeddings_compat.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "mlx_embeddings_compat_under_test", module_path
+    )
+    mlx_embeddings_compat = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mlx_embeddings_compat)
+
+    monkeypatch.setattr(mlx_embeddings_compat, "_QWEN3_VL_PROCESSOR_PATCHED", False)
+
+    mlx_embeddings_compat.patch_qwen3_vl_processor_for_torch_free_image_loading()
+
+    image_processor = processor_module.AutoImageProcessor.from_pretrained(
+        "/models/Qwen3-VL-Embedding-8B-8bit-mlx",
+        trust_remote_code=True,
+        local_files_only=True,
+        use_fast=False,
+    )
+
+    assert isinstance(image_processor, TorchFreeImageProcessor)
+    assert captured["model_path"] == "/models/Qwen3-VL-Embedding-8B-8bit-mlx"
+    assert captured["default_patch_size"] == 16
+    assert captured["kwargs"] == {"patch_size": 16, "merge_size": 2}
+
+
+def test_qwen3_vl_build_processor_gets_multimodal_token_id_fields(monkeypatch):
+    """Qwen3-VL ProcessorMixin fields should exist when __init__ is bypassed."""
+    processor_module = types.ModuleType("mlx_embeddings.models.qwen3_vl.processor")
+
+    class TorchBoundAutoImageProcessor:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            raise RuntimeError("torch/torchvision required")
+
+    class ManuallyBuiltProcessor:
+        image_token_id = 151655
+        video_token_id = 151656
+
+    class MlxEmbeddingsProcessor:
+        @staticmethod
+        def _build_processor(tokenizer, image_processor):
+            del tokenizer, image_processor
+            return ManuallyBuiltProcessor()
+
+    processor_module.AutoImageProcessor = TorchBoundAutoImageProcessor
+    processor_module.Processor = MlxEmbeddingsProcessor
+
+    qwen3_vl_package = types.ModuleType("mlx_embeddings.models.qwen3_vl")
+    qwen3_vl_package.processor = processor_module
+
+    _install_fake_module(
+        monkeypatch, "mlx_embeddings", types.ModuleType("mlx_embeddings")
+    )
+    _install_fake_module(
+        monkeypatch, "mlx_embeddings.models", types.ModuleType("mlx_embeddings.models")
+    )
+    _install_fake_module(
+        monkeypatch, "mlx_embeddings.models.qwen3_vl", qwen3_vl_package
+    )
+    _install_fake_module(
+        monkeypatch, "mlx_embeddings.models.qwen3_vl.processor", processor_module
+    )
+
+    mlx_vlm_processing = types.ModuleType("mlx_vlm.models.qwen3_vl.processing_qwen3_vl")
+
+    class TorchFreeImageProcessor:
+        pass
+
+    mlx_vlm_processing.Qwen3VLImageProcessor = TorchFreeImageProcessor
+    mlx_vlm_processing._qwen_vl_image_kwargs = lambda *args, **kwargs: {}
+
+    _install_fake_module(monkeypatch, "mlx_vlm", types.ModuleType("mlx_vlm"))
+    _install_fake_module(
+        monkeypatch, "mlx_vlm.models", types.ModuleType("mlx_vlm.models")
+    )
+    _install_fake_module(
+        monkeypatch,
+        "mlx_vlm.models.qwen3_vl",
+        types.ModuleType("mlx_vlm.models.qwen3_vl"),
+    )
+    _install_fake_module(
+        monkeypatch,
+        "mlx_vlm.models.qwen3_vl.processing_qwen3_vl",
+        mlx_vlm_processing,
+    )
+
+    module_path = (
+        Path(__file__).resolve().parents[1] / "omlx/models/mlx_embeddings_compat.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "mlx_embeddings_compat_under_test_mm_ids", module_path
+    )
+    mlx_embeddings_compat = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mlx_embeddings_compat)
+
+    monkeypatch.setattr(mlx_embeddings_compat, "_QWEN3_VL_PROCESSOR_PATCHED", False)
+
+    mlx_embeddings_compat.patch_qwen3_vl_processor_for_torch_free_image_loading()
+
+    processor = MlxEmbeddingsProcessor._build_processor(object(), object())
+
+    assert processor.image_ids == [151655]
+    assert processor.video_ids == [151656]
+    assert processor.audio_ids == [None]


### PR DESCRIPTION
## Summary

Fix Qwen3-VL embedding/reranker loading in the DMG app when torch and torchvision are not installed.

This adds a small oMLX compatibility patch around `mlx-embeddings` Qwen3-VL processor loading. It routes the image processor through the torch-free `mlx-vlm` Qwen3-VL image processor and fills the multimodal token id fields that `transformers` now expects during `apply_chat_template()`.

## Root Cause

`mlx-embeddings` currently builds its Qwen3-VL processor by importing HF `AutoImageProcessor`, which requires torch/torchvision in newer transformers. It also manually creates `Qwen3VLProcessor` with `object.__new__`, bypassing `ProcessorMixin.__init__`; with current transformers that leaves `image_ids`, `video_ids`, and `audio_ids` unset and embedding inference fails after load.

There is also an upstream root-cause PR in `mlx-embeddings`: Blaizzy/mlx-embeddings#61. Until that lands and oMLX pins a fixed commit, this keeps the bundled app working without adding torch to the DMG.

## Impact

- Restores loading and inference for Qwen3-VL embedding models in torch-free oMLX app environments.
- Applies before `mlx_embeddings.load()` in both embedding and reranker paths.
- Keeps the patch scoped to Qwen3-VL processor compatibility.

Fixes #1037.

## Validation

- `uv run pytest tests/test_embedding.py tests/test_mlx_embeddings_compat.py -q`
- `uv run python -m py_compile omlx/models/mlx_embeddings_compat.py omlx/models/embedding.py omlx/models/reranker.py tests/test_mlx_embeddings_compat.py`
- `uv run ruff check --select I omlx/models/mlx_embeddings_compat.py omlx/models/embedding.py omlx/models/reranker.py tests/test_mlx_embeddings_compat.py`
- `git diff --check`
- Manual local DMG smoke test with `Qwen3-VL-Embedding-8B-8bit-mlx`: model loads and `/v1/embeddings` succeeds.

## Related

- jundot/omlx#1037
- Blaizzy/mlx-embeddings#61
