### PR TITLE
fix(admin): support xgrammar 0.1.34+ registry API for parser discovery

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -9,9 +9,11 @@ This module provides HTTP routes for the admin panel including:
 """
 
 import asyncio
+import inspect
 import json
 import logging
 import os
+import re
 import secrets
 import shutil
 import sys
@@ -1324,13 +1326,54 @@ async def delete_sub_key(
 # =============================================================================
 
 
+_SUPPORTED_MODELS_DOC_RE = re.compile(
+    r"Supported models:\s*\n((?:\s*-\s*\S.*\n?)+)",
+)
+
+
+def _models_from_docstring(fn) -> List[str]:
+    """Extract the ``Supported models:`` bullet list from an xgrammar 0.1.34+
+    structural-tag function's docstring. Returns ``[]`` if the section is
+    absent or unparseable."""
+    doc = inspect.getdoc(fn) or ""
+    match = _SUPPORTED_MODELS_DOC_RE.search(doc)
+    if not match:
+        return []
+    return [
+        line.strip().lstrip("-").strip()
+        for line in match.group(1).splitlines()
+        if line.strip().startswith("-")
+    ]
+
+
 @router.get("/api/grammar/parsers")
 async def list_grammar_parsers(is_admin: bool = Depends(require_admin)):
     """Return available reasoning parser names from xgrammar.
 
-    Queries ``xgrammar.get_builtin_structural_tag_supported_models()`` at
-    runtime so the list stays in sync with the installed xgrammar version.
+    Supports both API generations:
+
+    - **xgrammar 0.1.34+** exposes a per-model registry at
+      ``xgrammar.builtin_structural_tag._structural_tag_registry``; supported
+      model names are pulled from each function's docstring.
+    - **xgrammar 0.1.32–0.1.33** exposes the now-removed helper
+      ``get_builtin_structural_tag_supported_models()``.
+
+    Returns ``[]`` if xgrammar is missing, fails to load (e.g. broken native
+    binding on macOS arm64), or has neither API available.
     """
+    # Prefer the 0.1.34+ registry so newer parsers (qwen3_6, gemma4,
+    # deepseek_v4, ...) are exposed.
+    try:
+        from xgrammar.builtin_structural_tag import _structural_tag_registry
+
+        return [
+            {"value": style, "label": style, "models": _models_from_docstring(fn)}
+            for style, fn in _structural_tag_registry.items()
+        ]
+    except Exception as e:
+        logger.debug("xgrammar 0.1.34+ registry unavailable: %s", e)
+
+    # Fall back to the pre-0.1.34 helper.
     try:
         from xgrammar import get_builtin_structural_tag_supported_models
 
@@ -1339,7 +1382,8 @@ async def list_grammar_parsers(is_admin: bool = Depends(require_admin)):
             {"value": style, "label": style, "models": models}
             for style, models in supported.items()
         ]
-    except ImportError:
+    except Exception as e:
+        logger.warning("xgrammar parser discovery unavailable: %s", e)
         return []
 
 

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -818,7 +818,115 @@ class TestListGrammarParsers:
             assert isinstance(item["models"], list)
 
     def test_returns_empty_when_xgrammar_unavailable(self, client):
-        with patch.dict("sys.modules", {"xgrammar": None}):
+        with patch.dict(
+            "sys.modules",
+            {"xgrammar": None, "xgrammar.builtin_structural_tag": None},
+        ):
             resp = client.get("/admin/api/grammar/parsers")
         assert resp.status_code == 200
         assert resp.json() == []
+
+    def test_returns_empty_when_xgrammar_native_binding_fails(self, client):
+        # Reproduces the symptom in jundot/omlx#1005: the macOS arm64 wheel's
+        # libxgrammar_bindings.dylib fails to load, so calling into xgrammar
+        # raises RuntimeError rather than ImportError. The route must still
+        # return [] cleanly rather than 500.
+        def boom():
+            raise RuntimeError(
+                "Cannot find library: "
+                "libxgrammar_bindings.dylib, libxgrammar_bindings.so"
+            )
+
+        fake_registry_module = SimpleNamespace(_structural_tag_registry=boom)
+        fake_xgrammar = SimpleNamespace(
+            get_builtin_structural_tag_supported_models=boom,
+            builtin_structural_tag=fake_registry_module,
+        )
+        # When tvm_ffi can't find the binding, even importing the registry
+        # submodule blows up; simulate that by removing it from sys.modules
+        # and forcing the helper call itself to fail.
+        with patch.dict(
+            "sys.modules",
+            {
+                "xgrammar": fake_xgrammar,
+                "xgrammar.builtin_structural_tag": None,
+            },
+        ):
+            resp = client.get("/admin/api/grammar/parsers")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_uses_registry_api_when_available(self, client):
+        # xgrammar 0.1.34+ dropped get_builtin_structural_tag_supported_models
+        # in favor of a per-model registry. The route must enumerate the
+        # registry and parse "Supported models:" from each function's
+        # docstring. Without this path, qwen3_6 / gemma4 / deepseek_v4 are
+        # invisible to the admin UI.
+        def fake_qwen3_6_fn():
+            """Get Qwen 3.6 style structural tag format.
+
+            Supported models:
+
+            - Qwen3.6
+            """
+
+        def fake_harmony_fn():
+            """Get Harmony format.
+
+            Supported models:
+
+            - gpt-oss
+            """
+
+        def fake_undocumented_fn():
+            """No supported-models block here."""
+
+        fake_registry = {
+            "qwen3_6": fake_qwen3_6_fn,
+            "harmony": fake_harmony_fn,
+            "mystery": fake_undocumented_fn,
+        }
+        fake_submodule = SimpleNamespace(_structural_tag_registry=fake_registry)
+        fake_xgrammar = SimpleNamespace(builtin_structural_tag=fake_submodule)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "xgrammar": fake_xgrammar,
+                "xgrammar.builtin_structural_tag": fake_submodule,
+            },
+        ):
+            resp = client.get("/admin/api/grammar/parsers")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert {p["value"] for p in data} == {"qwen3_6", "harmony", "mystery"}
+        by_value = {p["value"]: p for p in data}
+        assert by_value["qwen3_6"]["models"] == ["Qwen3.6"]
+        assert by_value["harmony"]["models"] == ["gpt-oss"]
+        assert by_value["mystery"]["models"] == []
+
+    def test_falls_back_to_legacy_helper_when_registry_missing(self, client):
+        # xgrammar 0.1.32–0.1.33 path: registry submodule doesn't exist,
+        # but the old helper does.
+        def fake_supported():
+            return {
+                "qwen": ["Qwen3"],
+                "harmony": ["gpt-oss"],
+            }
+
+        fake_xgrammar = SimpleNamespace(
+            get_builtin_structural_tag_supported_models=fake_supported,
+        )
+        with patch.dict(
+            "sys.modules",
+            {
+                "xgrammar": fake_xgrammar,
+                "xgrammar.builtin_structural_tag": None,
+            },
+        ):
+            resp = client.get("/admin/api/grammar/parsers")
+        assert resp.status_code == 200
+        data = resp.json()
+        by_value = {p["value"]: p for p in data}
+        assert by_value["qwen"]["models"] == ["Qwen3"]
+        assert by_value["harmony"]["models"] == ["gpt-oss"]


### PR DESCRIPTION
References: https://github.com/jundot/omlx/issues/1005 

xgrammar 0.1.34 dropped the top-level
get_builtin_structural_tag_supported_models() helper in favor of a per-model registry (xgrammar.builtin_structural_tag._structural_tag_registry) plus register_model_structural_tag / get_model_structural_tag. With the old helper gone, GET /admin/api/grammar/parsers hit ImportError, the narrow except returned [], and the admin Reasoning Parser dropdown was silently hidden by the reasoningParsers.length > 0 gate in the Alpine template. Newer parser styles like qwen3_6, gemma4, and deepseek_v4 were unreachable as a result.

Update list_grammar_parsers to try the 0.1.34+ registry first (parsing each function's docstring for the "Supported models:" block) and fall back to the pre-0.1.34 helper. Broaden the exception swallow so a broken native binding (xgrammar/xgrammar#1005-style RuntimeError) also yields an empty list rather than a 500.

The compilation call site in server.py needs no change: xgrammar 0.1.34 keeps get_builtin_structural_tag as an alias for
get_model_structural_tag with a backward-compatible signature.