### PR TITLE
Fix/xgrammar macos dylib

### DIFF
--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -54,6 +54,40 @@ class Omlx < Formula
     # python-multipart is declared in omlx's [audio] extra, not in mlx-audio
     system libexec/"bin/pip", "install", "python-multipart>=0.0.5"
 
+    # Patch the macOS arm64 xgrammar wheel so its native binding loads.
+    # The 0.1.32+ wheel ships libxgrammar_bindings.dylib with
+    # @rpath/libtvm_ffi.dylib but no LC_RPATH pointing at where tvm_ffi
+    # installs its native lib, and the dist-info is missing a RECORD
+    # entry for the dylib so tvm_ffi's manifest-based lookup fails.
+    # Both manifest as RuntimeError("Cannot find library: ...") at
+    # `import xgrammar`, which crashes /admin/api/grammar/parsers and
+    # hides the Reasoning Parser dropdown. Tracking upstream:
+    # jundot/omlx#1005.
+    if build.with?("grammar")
+      py = libexec/"bin/python"
+      site = Utils.safe_popen_read(py, "-c",
+                                   "import site; print(site.getsitepackages()[0])").chomp
+      dylib = "#{site}/xgrammar/libxgrammar_bindings.dylib"
+      dist  = Dir["#{site}/xgrammar-*.dist-info"].first
+      tvmlib = Utils.safe_popen_read(py, "-c",
+        "import os, tvm_ffi; print(os.path.join(os.path.dirname(tvm_ffi.__file__), 'lib'))").chomp
+
+      if File.exist?(dylib)
+        rpaths = Utils.safe_popen_read("/usr/bin/otool", "-l", dylib)
+        unless rpaths.include?(tvmlib)
+          system "/usr/bin/install_name_tool", "-add_rpath", tvmlib, dylib
+          system "/usr/bin/codesign", "--force", "--sign", "-", dylib
+        end
+      end
+
+      if dist
+        record = "#{dist}/RECORD"
+        unless File.exist?(record) && File.read(record).include?("libxgrammar_bindings.dylib")
+          File.open(record, "a") { |f| f.puts "xgrammar/libxgrammar_bindings.dylib,," }
+        end
+      end
+    end
+
     bin.install_symlink Dir[libexec/"bin/omlx"]
   end
 

--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -63,29 +63,56 @@ class Omlx < Formula
     # `import xgrammar`, which crashes /admin/api/grammar/parsers and
     # hides the Reasoning Parser dropdown. Tracking upstream:
     # jundot/omlx#1005.
+    #
+    # Implemented via shell commands (rather than Ruby File I/O) so the
+    # behavior matches the manual reproduction script and so each step
+    # is visible in `brew install --verbose` output.
     if build.with?("grammar")
+      ohai "Patching xgrammar macOS arm64 wheel"
       py = libexec/"bin/python"
       site = Utils.safe_popen_read(py, "-c",
                                    "import site; print(site.getsitepackages()[0])").chomp
-      dylib = "#{site}/xgrammar/libxgrammar_bindings.dylib"
-      dist  = Dir["#{site}/xgrammar-*.dist-info"].first
       tvmlib = Utils.safe_popen_read(py, "-c",
         "import os, tvm_ffi; print(os.path.join(os.path.dirname(tvm_ffi.__file__), 'lib'))").chomp
+      dylib = "#{site}/xgrammar/libxgrammar_bindings.dylib"
+      dist_dirs = Dir["#{site}/xgrammar-*.dist-info"]
 
-      if File.exist?(dylib)
-        rpaths = Utils.safe_popen_read("/usr/bin/otool", "-l", dylib)
-        unless rpaths.include?(tvmlib)
-          system "/usr/bin/install_name_tool", "-add_rpath", tvmlib, dylib
-          system "/usr/bin/codesign", "--force", "--sign", "-", dylib
-        end
+      ohai "  site=#{site}"
+      ohai "  tvmlib=#{tvmlib}"
+      ohai "  dylib=#{dylib} (exists? #{File.exist?(dylib)})"
+      ohai "  dist-info=#{dist_dirs.inspect}"
+
+      odie "xgrammar dylib not found at #{dylib}" unless File.exist?(dylib)
+      odie "xgrammar dist-info not found under #{site}" if dist_dirs.empty?
+
+      # Patch 1: add tvm_ffi/lib to the dylib's rpath, then re-codesign so
+      # macOS will load the modified dylib.
+      rpaths = Utils.safe_popen_read("/usr/bin/otool", "-l", dylib)
+      if rpaths.include?(tvmlib)
+        ohai "  rpath already points at tvm_ffi/lib"
+      else
+        ohai "  adding rpath -> #{tvmlib}"
+        system "/usr/bin/install_name_tool", "-add_rpath", tvmlib, dylib
+        system "/usr/bin/codesign", "--force", "--sign", "-", dylib
       end
 
-      if dist
-        record = "#{dist}/RECORD"
-        unless File.exist?(record) && File.read(record).include?("libxgrammar_bindings.dylib")
-          File.open(record, "a") { |f| f.puts "xgrammar/libxgrammar_bindings.dylib,," }
-        end
+      # Patch 2: ensure RECORD lists the dylib so tvm_ffi's manifest-based
+      # lookup finds it. Use a shell append redirect for parity with the
+      # repro script and to sidestep any Ruby File.open quirks in the
+      # brew install context.
+      record = "#{dist_dirs.first}/RECORD"
+      if File.exist?(record) && File.read(record).include?("libxgrammar_bindings.dylib")
+        ohai "  RECORD already lists the dylib"
+      else
+        ohai "  appending dylib entry to #{record}"
+        system "/bin/sh", "-c",
+               "echo 'xgrammar/libxgrammar_bindings.dylib,,' >> #{record}"
       end
+
+      # Verify the patch took. Failing here is much less confusing than
+      # the user discovering it later via a 500 from the admin route.
+      ohai "  verifying import xgrammar..."
+      system py, "-c", "import xgrammar; print('xgrammar import OK')"
     end
 
     bin.install_symlink Dir[libexec/"bin/omlx"]

--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -54,68 +54,72 @@ class Omlx < Formula
     # python-multipart is declared in omlx's [audio] extra, not in mlx-audio
     system libexec/"bin/pip", "install", "python-multipart>=0.0.5"
 
-    # Patch the macOS arm64 xgrammar wheel so its native binding loads.
-    # The 0.1.32+ wheel ships libxgrammar_bindings.dylib with
-    # @rpath/libtvm_ffi.dylib but no LC_RPATH pointing at where tvm_ffi
-    # installs its native lib, and the dist-info is missing a RECORD
-    # entry for the dylib so tvm_ffi's manifest-based lookup fails.
-    # Both manifest as RuntimeError("Cannot find library: ...") at
-    # `import xgrammar`, which crashes /admin/api/grammar/parsers and
-    # hides the Reasoning Parser dropdown. Tracking upstream:
-    # jundot/omlx#1005.
-    #
-    # Implemented via shell commands (rather than Ruby File I/O) so the
-    # behavior matches the manual reproduction script and so each step
-    # is visible in `brew install --verbose` output.
-    if build.with?("grammar")
-      ohai "Patching xgrammar macOS arm64 wheel"
-      py = libexec/"bin/python"
-      site = Utils.safe_popen_read(py, "-c",
-                                   "import site; print(site.getsitepackages()[0])").chomp
-      tvmlib = Utils.safe_popen_read(py, "-c",
-        "import os, tvm_ffi; print(os.path.join(os.path.dirname(tvm_ffi.__file__), 'lib'))").chomp
-      dylib = "#{site}/xgrammar/libxgrammar_bindings.dylib"
-      dist_dirs = Dir["#{site}/xgrammar-*.dist-info"]
+    bin.install_symlink Dir[libexec/"bin/omlx"]
+  end
 
-      ohai "  site=#{site}"
-      ohai "  tvmlib=#{tvmlib}"
-      ohai "  dylib=#{dylib} (exists? #{File.exist?(dylib)})"
-      ohai "  dist-info=#{dist_dirs.inspect}"
+  # Patch the macOS arm64 xgrammar wheel so its native binding loads.
+  # The 0.1.32+ wheel ships libxgrammar_bindings.dylib with
+  # @rpath/libtvm_ffi.dylib but no LC_RPATH pointing at where tvm_ffi
+  # installs its native lib, and the dist-info is missing a RECORD
+  # entry for the dylib so tvm_ffi's manifest-based lookup fails.
+  # Both manifest as RuntimeError("Cannot find library: ...") at
+  # `import xgrammar`, which crashes /admin/api/grammar/parsers and
+  # hides the Reasoning Parser dropdown. Tracking upstream:
+  # jundot/omlx#1005.
+  #
+  # Runs in post_install rather than install because Homebrew's
+  # post-install "Cleaning" step deletes every dist-info/RECORD file
+  # in the keg as part of its relocation pass (RECORD hashes become
+  # invalid once brew rewrites Mach-O install names). Anything we
+  # write to RECORD inside `def install` is wiped before the user
+  # sees it.
+  def post_install
+    return unless build.with?("grammar")
 
-      odie "xgrammar dylib not found at #{dylib}" unless File.exist?(dylib)
-      odie "xgrammar dist-info not found under #{site}" if dist_dirs.empty?
+    ohai "Patching xgrammar macOS arm64 wheel"
+    py = libexec/"bin/python"
+    site = Utils.safe_popen_read(py, "-c",
+                                 "import site; print(site.getsitepackages()[0])").chomp
+    tvmlib = Utils.safe_popen_read(py, "-c",
+      "import os, tvm_ffi; print(os.path.join(os.path.dirname(tvm_ffi.__file__), 'lib'))").chomp
+    dylib = "#{site}/xgrammar/libxgrammar_bindings.dylib"
+    dist_dirs = Dir["#{site}/xgrammar-*.dist-info"]
 
-      # Patch 1: add tvm_ffi/lib to the dylib's rpath, then re-codesign so
-      # macOS will load the modified dylib.
-      rpaths = Utils.safe_popen_read("/usr/bin/otool", "-l", dylib)
-      if rpaths.include?(tvmlib)
-        ohai "  rpath already points at tvm_ffi/lib"
-      else
-        ohai "  adding rpath -> #{tvmlib}"
-        system "/usr/bin/install_name_tool", "-add_rpath", tvmlib, dylib
-        system "/usr/bin/codesign", "--force", "--sign", "-", dylib
-      end
+    ohai "  site=#{site}"
+    ohai "  tvmlib=#{tvmlib}"
+    ohai "  dylib=#{dylib} (exists? #{File.exist?(dylib)})"
+    ohai "  dist-info=#{dist_dirs.inspect}"
 
-      # Patch 2: ensure RECORD lists the dylib so tvm_ffi's manifest-based
-      # lookup finds it. Use a shell append redirect for parity with the
-      # repro script and to sidestep any Ruby File.open quirks in the
-      # brew install context.
-      record = "#{dist_dirs.first}/RECORD"
-      if File.exist?(record) && File.read(record).include?("libxgrammar_bindings.dylib")
-        ohai "  RECORD already lists the dylib"
-      else
-        ohai "  appending dylib entry to #{record}"
-        system "/bin/sh", "-c",
-               "echo 'xgrammar/libxgrammar_bindings.dylib,,' >> #{record}"
-      end
+    odie "xgrammar dylib not found at #{dylib}" unless File.exist?(dylib)
+    odie "xgrammar dist-info not found under #{site}" if dist_dirs.empty?
 
-      # Verify the patch took. Failing here is much less confusing than
-      # the user discovering it later via a 500 from the admin route.
-      ohai "  verifying import xgrammar..."
-      system py, "-c", "import xgrammar; print('xgrammar import OK')"
+    # Patch 1: add tvm_ffi/lib to the dylib's rpath, then re-codesign so
+    # macOS will load the modified dylib.
+    rpaths = Utils.safe_popen_read("/usr/bin/otool", "-l", dylib)
+    if rpaths.include?(tvmlib)
+      ohai "  rpath already points at tvm_ffi/lib"
+    else
+      ohai "  adding rpath -> #{tvmlib}"
+      system "/usr/bin/install_name_tool", "-add_rpath", tvmlib, dylib
+      system "/usr/bin/codesign", "--force", "--sign", "-", dylib
     end
 
-    bin.install_symlink Dir[libexec/"bin/omlx"]
+    # Patch 2: ensure RECORD lists the dylib so tvm_ffi's manifest-based
+    # lookup finds it. Brew's clean pass already deleted every RECORD by
+    # the time post_install runs, so we always (re)create one.
+    record = "#{dist_dirs.first}/RECORD"
+    if File.exist?(record) && File.read(record).include?("libxgrammar_bindings.dylib")
+      ohai "  RECORD already lists the dylib"
+    else
+      ohai "  writing dylib entry to #{record}"
+      system "/bin/sh", "-c",
+             "echo 'xgrammar/libxgrammar_bindings.dylib,,' >> #{record}"
+    end
+
+    # Verify the patch took. Failing here is much less confusing than
+    # the user discovering it later via a 500 from the admin route.
+    ohai "  verifying import xgrammar..."
+    system py, "-c", "import xgrammar; print('xgrammar import OK')"
   end
 
   test do


### PR DESCRIPTION
References: https://github.com/jundot/omlx/issues/1005

## Summary

  Patch the macOS arm64 xgrammar wheel after install so its native binding actually
  loads. Without this, `import xgrammar` raises and the admin Reasoning Parser
  dropdown stays hidden — the original symptom in #1005.

  The patch is split across the two root causes:

  - **Add `LC_RPATH`** pointing at the `apache-tvm-ffi` package's lib directory,
    then ad-hoc re-codesign. The xgrammar wheel ships
    `libxgrammar_bindings.dylib` with `@rpath/libtvm_ffi.dylib` declared but no
    rpath pointing at where `libtvm_ffi.dylib` actually lives, so dyld fails to
    resolve it. (See #1005 comment for `otool -l` evidence — zero `LC_RPATH`
    entries on the stock 0.2.0 wheel.) **This is an upstream xgrammar wheel
    bug**; fix suggestion for mlc-ai/xgrammar:
    `-Wl,-rpath,@loader_path/../tvm_ffi/lib` 

  - **Append the dylib to dist-info `RECORD`** so `tvm_ffi.libinfo._find_library_by_basename`
    can locate it. The stock pip wheel ships RECORD correctly, but Homebrew's
    post-install relocation pass deletes every `dist-info/RECORD` in the keg as
    part of stripping invalidated SHA256 hashes (visible in `brew install
    --verbose` as a long list of `rm .../dist-info/RECORD` lines, including
    `xgrammar-*.dist-info/RECORD`). This is a **brew × tvm_ffi collision**, not
    an xgrammar or omlx bug per se — but it manifests on every brew install
    and the only place to fix it without touching brew or tvm_ffi is in our
    Formula.

  Both manifest as the same symptom (`RuntimeError: Cannot find library: ...`
  or `dlopen(...): Library not loaded: @rpath/libtvm_ffi.dylib`) at
  `import xgrammar`, so they're patched together.

  ## Why post_install, not install

  Brew's "Cleaning" step runs **after** `def install` returns and **before**
  `def post_install`. Anything written into RECORD in `install` is wiped before
  the user ever runs Python. I confirmed this empirically — an earlier version
  of this patch lived in `def install`, the build-time verification call
  (`python -c "import xgrammar"`) printed `xgrammar import OK`, and then
  post-install the import failed because brew had cleaned up after us. Moving
  the patch to `post_install` puts it after the cleaning pass.


## Test plan

  - [x] `brew install --HEAD --build-from-source --verbose --with-grammar` —
        `==> Patching xgrammar macOS arm64 wheel` block fires *after* the
        `==> Cleaning` rm spam, ending with `xgrammar import OK`.
  - [x] `python -c "import xgrammar"` succeeds post-install with no manual
        intervention.
  - [x] Reproduced both failure modes by force-reinstalling xgrammar (which
        wipes the rpath) and confirmed the import re-breaks with the exact
        `dlopen(...): Library not loaded: @rpath/libtvm_ffi.dylib` message;
        re-running the patch logic restores it.
  - [x] Idempotent: re-running the patch (`brew reinstall`, manual re-run,
        etc.) is a no-op on already-patched installs.
  - [x] Gated on `build.with?("grammar")` — non-grammar installs do nothing.

  ## Reservations

  This is a downstream workaround for a wheel-side bug + a brew design
  choice. The cleanest long-term fix is upstream xgrammar building a wheel
  with the correct rpath, at which point Bug 2a goes away entirely. Bug 2b
  (brew × RECORD) would still bite anyone whose wheel relies on RECORD-based
  manifest discovery, but the surface area shrinks dramatically once xgrammar
  itself works without manifest fallbacks.

  If this approach doesn't fit the project — e.g., you'd rather wait for
  upstream xgrammar to ship a corrected wheel — totally reasonable to close
  this PR and link the upstream issue in #1005 as the resolution path. I'll
  keep the patch on my fork either way.

