### PR TITLE
fix: remove 'MoE only' label from SpecPrefill docs

### DIFF
--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -632,7 +632,7 @@
                                     <div class="flex items-start justify-between gap-3">
                                         <div class="min-w-0">
                                             <span class="text-sm font-medium text-neutral-700">SpecPrefill</span>
-                                            <p class="text-xs text-neutral-500 mt-0.5">Attention-based sparse prefill for MoE/hybrid models. (<a href="https://arxiv.org/abs/2502.02789" target="_blank" rel="noopener" class="text-blue-500 hover:text-blue-700 underline">Paper</a>) (<a href="https://huggingface.co/Thump604/specprefill-paper" target="_blank" rel="noopener" class="text-blue-500 hover:text-blue-700 underline">HuggingFace</a>)</p>
+                                            <p class="text-xs text-neutral-500 mt-0.5">Attention-based sparse prefill. (<a href="https://arxiv.org/abs/2502.02789" target="_blank" rel="noopener" class="text-blue-500 hover:text-blue-700 underline">Paper</a>) (<a href="https://huggingface.co/Thump604/specprefill-paper" target="_blank" rel="noopener" class="text-blue-500 hover:text-blue-700 underline">HuggingFace</a>)</p>
                                         </div>
                                         <button type="button" @click="modelSettings.specprefill_enabled = !modelSettings.specprefill_enabled"
                                                 :class="modelSettings.specprefill_enabled ? 'bg-black' : 'bg-neutral-200'"

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -56,7 +56,7 @@ class ModelSettings:
         turboquant_kv_enabled: Enable TurboQuant KV cache compression.
         turboquant_kv_bits: TurboQuant bit depth (2/2.5/3/3.5/4/6/8).
         turboquant_skip_last: Skip last KVCache layer to prevent corruption.
-        specprefill_enabled: Enable SpecPrefill (experimental sparse prefill for MoE).
+        specprefill_enabled: Enable SpecPrefill (experimental attention-based sparse prefill).
         specprefill_draft_model: Path to draft model for SpecPrefill.
         specprefill_keep_pct: Keep rate for SpecPrefill (0.1–0.5).
         specprefill_threshold: Min tokens to trigger SpecPrefill.
@@ -98,7 +98,7 @@ class ModelSettings:
     turboquant_kv_bits: float = 4  # 2, 2.5, 3, 3.5, 4, 6, 8
     turboquant_skip_last: bool = True  # Skip last KVCache layer (prevents corruption on sensitive models)
 
-    # SpecPrefill (experimental: attention-based sparse prefill for MoE models)
+    # SpecPrefill (experimental: attention-based sparse prefill)
     specprefill_enabled: bool = False
     specprefill_draft_model: Optional[str] = None  # Path to draft model (must share tokenizer)
     specprefill_keep_pct: Optional[float] = None  # Keep rate (0.1-0.5, default 0.2)


### PR DESCRIPTION
SpecPrefill works on all architectures (dense, MoE, hybrid) - the code
has always been architecture-agnostic with extractors for llama, qwen,
gemma4, and nemotron-h. The 'for MoE models' label was misleading.

Fixes 3 locations:
- omlx/model_settings.py lines 59 and 101
- omlx/admin/templates/dashboard/_modal_model_settings.html line 635
