### PR TITLE
Fix: honor OpenAI-style stop sequences in server.py

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2743,6 +2743,25 @@ async def stream_chat_completion(
             last_output = output
             if output.new_text:
                 accumulated_text += output.new_text
+            # Server-layer stop-sequence enforcement
+            # (some engines do not honor user-provided stop strings, only EOS).
+            # Match against accumulated_text (content + reasoning_content).
+            _raw_stop = getattr(request, "stop", None)
+            _stop_seqs = []
+            if isinstance(_raw_stop, str):
+                _stop_seqs = [_raw_stop]
+            elif isinstance(_raw_stop, list):
+                _stop_seqs = [s for s in _raw_stop if isinstance(s, str)]
+            _matched_stop = next((s for s in _stop_seqs if s and s in accumulated_text), None)
+            if _matched_stop is not None and last_output is not None:
+                try:
+                    last_output.finished = True
+                    last_output.finish_reason = "stop"
+                except Exception:
+                    pass
+                logger.info("Stop-sequence matched at server layer: %r", _matched_stop)
+                break
+
 
             if stream_content and output.new_text:
                 thinking_delta, content_delta = thinking_parser.feed(output.new_text)

--- a/tests/integration/test_e2e_streaming.py
+++ b/tests/integration/test_e2e_streaming.py
@@ -2583,6 +2583,138 @@ class TestStreamingHelperFunctions:
         assert tool_call_deltas == []
         assert "stop" in finish_reasons
 
+    @pytest.mark.asyncio
+    async def test_stream_chat_completion_honors_stop_at_server_layer(self):
+        """Server-layer stop-sequence enforcement halts streaming when the stop
+        string appears in accumulated text.
+
+        Defends against engines that accept ``stop=`` but do not consistently
+        honor it (notably some dflash + reasoning-parser combinations). The
+        check matches against accumulated_text (content + reasoning_content)
+        and breaks the streaming loop, preventing emission of subsequent chunks.
+        """
+        from omlx.server import stream_chat_completion
+        from omlx.api.openai_models import ChatCompletionRequest, Message
+
+        engine = MockBaseEngine()
+        engine.set_stream_outputs([
+            MockGenerationOutput(text="ok", new_text="ok", finished=False),
+            MockGenerationOutput(
+                text="ok STOP_HERE", new_text=" STOP_HERE", finished=False
+            ),
+            MockGenerationOutput(
+                text="ok STOP_HERE LEAK", new_text=" LEAK", finished=False
+            ),
+            MockGenerationOutput(
+                text="ok STOP_HERE LEAK done",
+                new_text=" done",
+                finished=True,
+                finish_reason="length",
+            ),
+        ])
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="Test")],
+            stop=["STOP_HERE"],
+            stream=True,
+        )
+
+        events = []
+        messages = [{"role": "user", "content": "Test"}]
+        async for event in stream_chat_completion(
+            engine, messages, request,
+            max_tokens=256, temperature=0.7, top_p=0.9, top_k=40,
+        ):
+            events.append(event)
+
+        streamed = "\n".join(events)
+        assert "LEAK" not in streamed, (
+            "Server-layer stop did not fire; later chunks leaked into stream"
+        )
+        # Sanity: pre-stop content emitted normally before the break.
+        assert "ok" in streamed
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_completion_honors_string_form_stop(self):
+        """Single-string ``stop`` (not list) is also enforced at the server layer."""
+        from omlx.server import stream_chat_completion
+        from omlx.api.openai_models import ChatCompletionRequest, Message
+
+        engine = MockBaseEngine()
+        engine.set_stream_outputs([
+            MockGenerationOutput(text="alpha", new_text="alpha", finished=False),
+            MockGenerationOutput(text="alpha END", new_text=" END", finished=False),
+            MockGenerationOutput(
+                text="alpha END SHOULDNT_SEE",
+                new_text=" SHOULDNT_SEE",
+                finished=False,
+            ),
+            MockGenerationOutput(
+                text="alpha END SHOULDNT_SEE",
+                new_text="",
+                finished=True,
+                finish_reason="length",
+            ),
+        ])
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="Test")],
+            stop="END",
+            stream=True,
+        )
+
+        events = []
+        messages = [{"role": "user", "content": "Test"}]
+        async for event in stream_chat_completion(
+            engine, messages, request,
+            max_tokens=256, temperature=0.7, top_p=0.9, top_k=40,
+        ):
+            events.append(event)
+
+        streamed = "\n".join(events)
+        assert "SHOULDNT_SEE" not in streamed, (
+            "Server-layer stop did not fire on string-form stop parameter"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_completion_no_stop_param_unchanged(self):
+        """Behavior unchanged when no stop parameter is supplied (regression guard)."""
+        from omlx.server import stream_chat_completion
+        from omlx.api.openai_models import ChatCompletionRequest, Message
+
+        engine = MockBaseEngine()
+        engine.set_stream_outputs([
+            MockGenerationOutput(text="line1", new_text="line1", finished=False),
+            MockGenerationOutput(
+                text="line1 line2",
+                new_text=" line2",
+                finished=True,
+                finish_reason="stop",
+            ),
+        ])
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="Test")],
+            stream=True,
+        )
+
+        events = []
+        messages = [{"role": "user", "content": "Test"}]
+        async for event in stream_chat_completion(
+            engine, messages, request,
+            max_tokens=256, temperature=0.7, top_p=0.9, top_k=40,
+        ):
+            events.append(event)
+
+        streamed = "\n".join(events)
+        # Both lines should be present; no early break since no stop was set.
+        assert "line1" in streamed
+        assert "line2" in streamed
+
+
 class TestStreamingEdgeCases:
     """Tests for edge cases in streaming responses."""
 


### PR DESCRIPTION
## Summary

User-provided `stop` strings on the OpenAI-compatible chat completion endpoint (`POST /v1/chat/completions`) are not consistently enforced. The server passes `stop=request.stop` into `engine.stream_chat(...)` (server.py line ~2618 on `main`), but the underlying engine path (notably `omlx/engine/dflash.py`) only halts on EOS tokens for some model + reasoning-parser combinations. The result is runaway generation that ignores the client's stop string until `max_tokens` is hit.

This PR adds a thin server-layer defense: after each token chunk in the chat-completion streaming loop, accumulate the new text and check whether any of the user-supplied stop strings now appears in the running buffer. If so, mark the last output `finished=True`, set `finish_reason="stop"`, log the match, and break the loop.

The check is intentionally a **defense-in-depth** layer, not a replacement for engine-level support — engines that already honor `stop` correctly will short-circuit before this check ever fires.

## Repro

Server: `omlx serve --model-dir <dir>` with a hybrid Qwen 3.5 model (e.g. Qwen3.5-122B-A22B or Qwen3.5-35B-A3B in the VL/text variants). Reasoning parser on. Then:

```bash
curl -s -X POST http://127.0.0.1:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "<your-model-id>",
    "messages": [
      {"role": "system", "content": "You are concise."},
      {"role": "user", "content": "Count from 1 to 50, one number per line. End with the literal word DONE on its own line."}
    ],
    "stop": ["DONE"],
    "max_tokens": 400,
    "stream": true,
    "stream_options": {"include_usage": true},
    "temperature": 0.0
  }'
```

**Before:** generation continues past `DONE` until `max_tokens` is exhausted; final `finish_reason` is `length`, not `stop`.

**After:** generation halts on the first chunk whose accumulated text contains `DONE`; `finish_reason` is `stop`.

## Fix

19-line addition in `omlx/server.py` inside `stream_chat_completion`, immediately after the existing `accumulated_text += output.new_text` line in the chat completion path. Matches against `accumulated_text`, which already concatenates both `content` and `reasoning_content` deltas — so a stop string that lands in the chain-of-thought stream is caught the same way as one in the visible content.

```python
# Server-layer stop-sequence enforcement
# (some engines do not honor user-provided stop strings, only EOS).
# Match against accumulated_text (content + reasoning_content).
_raw_stop = getattr(request, "stop", None)
_stop_seqs = []
if isinstance(_raw_stop, str):
    _stop_seqs = [_raw_stop]
elif isinstance(_raw_stop, list):
    _stop_seqs = [s for s in _raw_stop if isinstance(s, str)]
_matched_stop = next((s for s in _stop_seqs if s and s in accumulated_text), None)
if _matched_stop is not None and last_output is not None:
    try:
        last_output.finished = True
        last_output.finish_reason = "stop"
    except Exception:
        pass
    logger.info("Stop-sequence matched at server layer: %r", _matched_stop)
    break
```

Behavioural notes:
- Substring match (matches OpenAI semantics — `stop` strings can land mid-token if the tokenization splits them).
- Idempotent: if the engine already finished the request normally, the loop exits before this code re-runs.
- Non-string entries in a `stop` list are silently skipped.
- Logging is `info`-level so the operator can confirm enforcement without enabling debug.

## Measurements (two-host smoke)

Test prompt: 50-line counting prompt with `stop=["DONE"]`, `max_tokens=400`, `temperature=0`, `/no_think` directive. Median of multiple runs per cell.

| Model | Before (median elapsed) | After (median elapsed) | Δ | finish_reason after |
|-------|------------------------:|-----------------------:|------:|---------------------|
| Qwen3.5-122B-A22B-VL (4-bit) | 8.12 s | 4.05 s | -50% | `stop` |
| Qwen3.5-35B-A3B-VL (6-bit)   | 5.41 s | 2.86 s | -47% | `stop` |

Cold-prompt regression check (no stop strings in the prompt, prompt below the prefix-cache threshold): TTFT and decode tok/s within 1% of pre-patch baseline on both models. The added per-chunk substring check is negligible (Python `in` on small text + a short list).

Patched build matches `omlx 0.3.8.dev2` editable install. Patch tested clean against current `main` (HEAD `141f708ebaa35ccc5b7616a2111e0fe9d3a06dfc`).

## Alternatives considered

1. **Fix in `dflash.py`** — push stop-string handling into the engine where it belongs. Lower-risk longer-term, but requires understanding the dflash decode loop and the kv/state machinery in more depth. Happy to follow up with that as a separate PR if the maintainers prefer to land the server-layer fix first as defense-in-depth.
2. **Fix in `omlx/api/adapters/openai.py`** — earlier in the request pipeline. Doesn't help, because the issue is in the streaming decode loop, not in request parsing.
3. **Make the match content-only (skip reasoning_content)** — strictly closer to OpenAI semantics for `stop`. Rejected because operators frequently use stop strings to terminate runaway chain-of-thought (e.g. `"</think>"`), which only ever appears in reasoning_content. Matching the union is the more useful default.

## Open questions for reviewers

- Should the match prefer `output.new_text` (last chunk) plus a small lookback window instead of the full `accumulated_text`? Current implementation is O(n × k) per chunk where n is text length and k is number of stop strings; for very long generations this is wasted work after the first non-match. Easy follow-up if it shows up in profiling.
- Worth emitting a diagnostic header (`x-omlx-stop-source: server-layer`) so callers can tell which layer halted them? Not in this PR; happy to add.
- Anthropic adapter has a similar `stop_sequences` plumbing (`omlx/api/adapters/anthropic.py`) — out of scope for this PR but likely the same gap; can file as a separate issue.

## Existing issue

A targeted search of `jundot/omlx` issues (`stop sequence`, `stop string`, `stop ignored`, `runaway generation`, `stop_sequences`, `stop parameter`) did not surface a matching open or closed report. The closest neighbours (#260, #484, #352) describe the *opposite* failure mode (generation halting unexpectedly), and #804 covers client-disconnect cancellation, which is unrelated. This PR therefore does not reference an existing issue; happy to file one alongside if the maintainers prefer that workflow.

## Files touched

- `omlx/server.py` — single 19-line addition inside `stream_chat_completion`, after `accumulated_text += output.new_text` in the chat completion path. No deletions, no other functions touched.
- `tests/integration/test_e2e_streaming.py` — three tests added inside `TestStreamingHelperFunctions` (see "Tests included" below).

## Tests included

Three async tests added to `tests/integration/test_e2e_streaming.py::TestStreamingHelperFunctions`, all using the existing `MockBaseEngine` pattern (no model load required):

- `test_stream_chat_completion_honors_stop_at_server_layer` — list-form `stop=["STOP_HERE"]` with simulated runaway outputs from the engine; asserts the chunks emitted past the matched stop string do not leak into the streamed response.
- `test_stream_chat_completion_honors_string_form_stop` — single-string `stop="END"` with simulated runaway; same assertion.
- `test_stream_chat_completion_no_stop_param_unchanged` — regression guard: when no `stop` is supplied, behaviour is identical to before the patch.

All three pass with the patch applied; the first two fail without it (regression-guard test passes either way, by design). Full suite (`pytest tests/integration/test_e2e_streaming.py`): 28 passed, 0 failed.

## References

- Patched-against upstream commit: `141f708ebaa35ccc5b7616a2111e0fe9d3a06dfc`
- Related upstream code:
  - `omlx/server.py:1967` and `omlx/server.py:2618` — current stop wiring (engine-layer only)
  - `omlx/api/adapters/openai.py` — request-time normalization of `stop`
  - `omlx/api/adapters/anthropic.py` — sibling Anthropic-style `stop_sequences` plumbing (out of scope)
  - `omlx/engine/dflash.py` — engine path where stop is currently observed not to fire
