### PR TITLE
feat(engine): specprefill draft model compatibility check + troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,38 @@ FastAPI Server (OpenAI / Anthropic API)
 
 </details>
 
+## Troubleshooting
+
+### Speculative Decoding
+
+#### DFlash
+
+DFlash is a Rust-based block-diffusion drafter that works with Qwen models only. This is
+a hard limitation of the [dflash-mlx](https://github.com/bstnxbt/dflash-mlx) Rust backend.
+DFlash is not available for Gemma, Llama, or other architectures.
+
+#### SpecPrefill
+
+SpecPrefill uses `mlx_lm.load()` to load the draft model. Any model type supported by
+[mlx-lm](https://github.com/ml-explore/mlx-lm) can be used as a draft. If your draft model
+fails to load with an error like "Model type X not supported", this means mlx-lm does not
+yet have a model loader for that architecture.
+
+Known unsupported draft model types:
+- `gemma4_assistant` — See [mlx-lm#XXXX](https://github.com/ml-explore/mlx-lm/issues)
+
+To request support for a new model type, please open an issue at
+https://github.com/ml-explore/mlx-lm with the model architecture details.
+
+### Structured Output
+
+Structured output requires the `--with-grammar` install flag which includes xgrammar. If
+you installed without this flag and need structured output, reinstall with:
+
+```bash
+brew reinstall jundot/omlx/omlx --with-grammar
+```
+
 ## Development
 
 ### CLI Server

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -7,8 +7,10 @@ for better throughput when serving multiple concurrent requests.
 """
 
 import copy
+import json
 import logging
 from collections.abc import AsyncIterator
+from pathlib import Path
 from typing import Any
 
 from ..api.tool_calling import convert_tools_for_template
@@ -27,6 +29,48 @@ try:
 except ImportError:
     HAS_HARMONY_ADAPTER = False
     preprocess_harmony_messages = None  # type: ignore
+
+
+# Known model types that mlx_lm cannot load. mlx_lm uses
+# ``importlib.import_module(f"mlx_lm.models.{model_type}")`` which fails for
+# unsupported architectures. Track upstream mlx-lm issues at:
+#   https://github.com/ml-explore/mlx-lm/issues
+_KNOWN_UNSUPPORTED_DRAFT_TYPES = {
+    "gemma4_assistant": (
+        "gemma4_assistant is not supported by mlx-lm. "
+        "This model type requires support in Apple's mlx-lm library. "
+        "Please file a feature request at https://github.com/ml-explore/mlx-lm"
+    ),
+}
+
+
+def _is_specprefill_compatible(model_path: str) -> tuple[bool, str]:
+    """Check if a model is likely loadable by mlx_lm.load() as a specprefill draft.
+
+    Returns (compatible: bool, hint: str).
+    If compatible=False, hint explains why and links to upstream.
+
+    This is a best-effort pre-check based on config.json model_type.
+    HF repos without a local config.json are assumed compatible
+    (mlx_lm will handle download and type detection).
+    """
+    cfg_path = Path(model_path) / "config.json"
+    if not cfg_path.exists():
+        # HF repo path — mlx_lm handles it
+        return True, ""
+
+    try:
+        with open(cfg_path) as f:
+            cfg = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        # Can't read config — defer to mlx_lm.load() which will surface the error
+        return True, ""
+
+    model_type = cfg.get("model_type", "")
+    hint = _KNOWN_UNSUPPORTED_DRAFT_TYPES.get(model_type, "")
+    if hint:
+        return False, hint
+    return True, ""
 
 
 class BatchedEngine(BaseEngine):
@@ -273,6 +317,12 @@ class BatchedEngine(BaseEngine):
             specprefill_draft = getattr(self._model_settings, "specprefill_draft_model", None)
             specprefill_enabled = getattr(self._model_settings, "specprefill_enabled", False)
             if specprefill_enabled and specprefill_draft:
+                # Pre-check: surface known incompatibilities before mlx_lm.load() fails
+                compatible, hint = _is_specprefill_compatible(specprefill_draft)
+                if not compatible:
+                    logger.warning(
+                        f"SpecPrefill: draft model may not be loadable — {hint}"
+                    )
                 try:
                     def _load_draft():
                         draft_model, _ = load(specprefill_draft)


### PR DESCRIPTION
## Motivation

When SpecPrefill draft model loading fails, the error ("Model type X not supported") gives users no context about why it failed or what to do. The root cause is that OMLX uses `mlx_lm.load()` which only supports model types that Apple's mlx-lm library has loaders for.

This PR adds a pre-check before `mlx_lm.load()` that identifies known-unsupported model types and surfaces a clear, actionable message pointing users to the upstream mlx-lm issue tracker.

## Changes

### `omlx/engine/batched.py`
- Add `_is_specprefill_compatible(model_path)` function — reads `config.json` and checks against `_KNOWN_UNSUPPORTED_DRAFT_TYPES`
- Known unsupported: `gemma4_assistant` (Gemma 4 MTP assistant model)
- If incompatible: logs a warning with the hint before the load attempt
- Example warning: `SpecPrefill: draft model may not be loadable — gemma4_assistant is not supported by mlx-lm. Please file a feature request at https://github.com/ml-explore/mlx-lm`

### `README.md`
Add Troubleshooting section covering:
- **DFlash**: Qwen-only limitation (Rust backend, not extensible)
- **SpecPrefill**: mlx-lm dependency, known unsupported types, how to file upstream requests
- **Structured output**: `--with-grammar` reinstall note

## Testing

- [x] Syntax check: `python -m py_compile omlx/engine/batched.py` — OK
- [ ] CI: run `pytest tests/` (fast tests, no models needed for this change)
- [ ] Manual: set `specprefill_enabled: true` + `specprefill_draft_model` pointing to a `gemma4_assistant` model, verify warning appears before load error

## Related

- mlx-lm upstream tracking: https://github.com/ml-explore/mlx-lm (file issue for `gemma4_assistant` support)
- OMLX formula xgrammar fix: already handled in `Formula#post_install` (commit `3cebc69`)
