### PR TITLE
feat: specprefill model compat + xgrammar troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,38 @@ FastAPI Server (OpenAI / Anthropic API)
 
 </details>
 
+## Troubleshooting
+
+### Speculative Decoding
+
+#### DFlash
+
+DFlash is a Rust-based block-diffusion drafter that works with Qwen models only. This is
+a hard limitation of the [dflash-mlx](https://github.com/bstnxbt/dflash-mlx) Rust backend.
+DFlash is not available for Gemma, Llama, or other architectures.
+
+#### SpecPrefill
+
+SpecPrefill uses `mlx_lm.load()` to load the draft model. Any model type supported by
+[mlx-lm](https://github.com/ml-explore/mlx-lm) can be used as a draft. If your draft model
+fails to load with an error like "Model type X not supported", this means mlx-lm does not
+yet have a model loader for that architecture.
+
+Known unsupported draft model types:
+- `gemma4_assistant` — See [mlx-lm#XXXX](https://github.com/ml-explore/mlx-lm/issues)
+
+To request support for a new model type, please open an issue at
+https://github.com/ml-explore/mlx-lm with the model architecture details.
+
+### Structured Output
+
+Structured output requires the `--with-grammar` install flag which includes xgrammar. If
+you installed without this flag and need structured output, reinstall with:
+
+```bash
+brew reinstall jundot/omlx/omlx --with-grammar
+```
+
 ## Development
 
 ### CLI Server

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -7,8 +7,10 @@ for better throughput when serving multiple concurrent requests.
 """
 
 import copy
+import json
 import logging
 from collections.abc import AsyncIterator
+from pathlib import Path
 from typing import Any
 
 from ..api.tool_calling import convert_tools_for_template
@@ -27,6 +29,48 @@ try:
 except ImportError:
     HAS_HARMONY_ADAPTER = False
     preprocess_harmony_messages = None  # type: ignore
+
+
+# Known model types that mlx_lm cannot load. mlx_lm uses
+# ``importlib.import_module(f"mlx_lm.models.{model_type}")`` which fails for
+# unsupported architectures. Track upstream mlx-lm issues at:
+#   https://github.com/ml-explore/mlx-lm/issues
+_KNOWN_UNSUPPORTED_DRAFT_TYPES = {
+    "gemma4_assistant": (
+        "gemma4_assistant is not supported by mlx-lm. "
+        "This model type requires support in Apple's mlx-lm library. "
+        "Please file a feature request at https://github.com/ml-explore/mlx-lm"
+    ),
+}
+
+
+def _is_specprefill_compatible(model_path: str) -> tuple[bool, str]:
+    """Check if a model is likely loadable by mlx_lm.load() as a specprefill draft.
+
+    Returns (compatible: bool, hint: str).
+    If compatible=False, hint explains why and links to upstream.
+
+    This is a best-effort pre-check based on config.json model_type.
+    HF repos without a local config.json are assumed compatible
+    (mlx_lm will handle download and type detection).
+    """
+    cfg_path = Path(model_path) / "config.json"
+    if not cfg_path.exists():
+        # HF repo path — mlx_lm handles it
+        return True, ""
+
+    try:
+        with open(cfg_path) as f:
+            cfg = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        # Can't read config — defer to mlx_lm.load() which will surface the error
+        return True, ""
+
+    model_type = cfg.get("model_type", "")
+    hint = _KNOWN_UNSUPPORTED_DRAFT_TYPES.get(model_type, "")
+    if hint:
+        return False, hint
+    return True, ""
 
 
 class BatchedEngine(BaseEngine):
@@ -273,6 +317,12 @@ class BatchedEngine(BaseEngine):
             specprefill_draft = getattr(self._model_settings, "specprefill_draft_model", None)
             specprefill_enabled = getattr(self._model_settings, "specprefill_enabled", False)
             if specprefill_enabled and specprefill_draft:
+                # Pre-check: surface known incompatibilities before mlx_lm.load() fails
+                compatible, hint = _is_specprefill_compatible(specprefill_draft)
+                if not compatible:
+                    logger.warning(
+                        f"SpecPrefill: draft model may not be loadable — {hint}"
+                    )
                 try:
                     def _load_draft():
                         draft_model, _ = load(specprefill_draft)


### PR DESCRIPTION
## Summary

Two user-facing improvements:

### 1. SpecPrefill Draft Model Compatibility Check
Adds a pre-check in  that catches unsupported draft model architectures *before*  fails. Currently, trying to use a Gemma 4 Assistant model as a SpecPrefill draft produces an opaque runtime error from mlx-lm. This surfaces an actionable message pointing users to the mlx-lm issue tracker.

### 2. xgrammar Troubleshooting Documentation + Fix Script
Structured output (grammar-constrained generation) requires the  install flag, but users routinely hit cryptic errors even after reinstalling with  because the formula's  hook silently fails in some environments. This adds:

- **README**: Full troubleshooting section with error table, step-by-step manual fix (RECORD file, rpaths, codesign), and a note about Cellar persistence after upgrades
- ****: A version-agnostic Python helper that automates all four fix steps — detects OMLX version/path, creates RECORD, adds rpaths, re-signs dylibs, patches , and verifies with a single command

## Changes

| File | Change |
|------|--------|
| `omlx/engine/batched.py` | `_is_specprefill_compatible()` + pre-check in SpecPrefill init |
| `README.md` | Troubleshooting section: SpecPrefill compat table + xgrammar manual fix |
| `scripts/fix-xgrammar.py` | New: automated fix script |

## Testing

- `python3 scripts/fix-xgrammar.py` → `xgrammar OK -- structured output ready`
- SpecPrefill with `gemma4_assistant` draft → raises `SpecPrefillCompatibilityError` with link to mlx-lm issue tracker
- SpecPrefill with `Qwen3-14B` draft → loads normally