### PR TITLE
Re-check for updates from periodic health timer

### DIFF
--- a/packaging/omlx_app/app.py
+++ b/packaging/omlx_app/app.py
@@ -1847,6 +1847,9 @@ class OMLXAppDelegate(NSObject):
         # Always refresh icon in case theme changed
         self._update_menubar_icon()
 
+        # Check once per day; self-gates on a 24h timestamp cache.
+        self._check_for_updates()
+
     # --- Menu actions ---
 
     def _handle_port_conflict(self, conflict: PortConflict) -> None:


### PR DESCRIPTION
Hooks `_check_for_updates()` into the existing `healthCheck_` timer so the app passively checks for new releases in the background. The check self-gates on a 24h timestamp cache, so it only hits the network once per day regardless of how frequently the timer fires.
