### PR TITLE
fix(cache): use blocking put during shutdown flush to prevent dropped blocks

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -745,11 +745,17 @@ class PagedSSDCacheManager(CacheManager):
         for evicted_hash, evicted in evicted_entries:
             self._enqueue_ssd_write(evicted_hash, evicted)
 
-    def _enqueue_ssd_write(self, block_hash: bytes, entry: dict) -> bool:
+    def _enqueue_ssd_write(
+        self, block_hash: bytes, entry: dict, *, blocking: bool = False,
+    ) -> bool:
         """Enqueue a hot cache entry for SSD background write.
 
         Used when evicting from hot cache or flushing on shutdown.
         Adds block to SSD index before enqueueing write.
+
+        When *blocking* is True, waits briefly for queue space instead of
+        dropping the block immediately.  This is used during shutdown to
+        let the writer thread drain between submissions.
         """
         if self._hot_cache_only:
             return False
@@ -771,7 +777,11 @@ class PagedSSDCacheManager(CacheManager):
         with self._pending_write_hashes_lock:
             self._pending_write_hashes.add(block_hash)
         try:
-            self._write_queue.put_nowait((block_hash, tensors_raw, metadata, file_path))
+            item = (block_hash, tensors_raw, metadata, file_path)
+            if blocking:
+                self._write_queue.put(item, timeout=0.5)
+            else:
+                self._write_queue.put_nowait(item)
             logger.debug(
                 f"Evicted hot cache block to SSD write queue: "
                 f"{block_hash.hex()[:16]}..."
@@ -2169,20 +2179,33 @@ class PagedSSDCacheManager(CacheManager):
         """Close the SSD cache manager, flushing hot cache and pending writes."""
         logger.info("Shutting down PagedSSDCacheManager...")
 
-        # Flush hot cache entries to SSD before shutdown
+        # Flush hot cache entries to SSD before shutdown.
+        # Use blocking=True so the flush waits for the writer thread to
+        # drain queue space rather than dropping blocks via put_nowait().
         if self._hot_cache_enabled:
             with self._hot_cache_lock:
                 entries_to_flush = list(self._hot_cache.items())
             flushed = 0
+            dropped = 0
             for block_hash, entry in entries_to_flush:
-                # Skip blocks already written to SSD
+                if self._writer_thread and not self._writer_thread.is_alive():
+                    logger.warning(
+                        "Writer thread died during shutdown flush, "
+                        f"aborting ({flushed} flushed, "
+                        f"{len(entries_to_flush) - flushed - dropped} remaining)"
+                    )
+                    break
                 blk_meta = entry.get("block_metadata")
                 if blk_meta and blk_meta.file_path.exists():
                     continue
-                if self._enqueue_ssd_write(block_hash, entry):
+                if self._enqueue_ssd_write(block_hash, entry, blocking=True):
                     flushed += 1
+                else:
+                    dropped += 1
             if flushed:
                 logger.info(f"Flushed {flushed} hot cache blocks to SSD write queue")
+            if dropped:
+                logger.warning(f"Dropped {dropped} hot cache blocks during flush")
 
         # Signal writer thread to stop (after processing remaining queue)
         if self._writer_thread:

--- a/tests/test_hot_cache.py
+++ b/tests/test_hot_cache.py
@@ -5,6 +5,7 @@ import threading
 import time
 from pathlib import Path
 from typing import List
+from unittest.mock import patch
 
 import pytest
 
@@ -670,4 +671,46 @@ class TestHotCacheWriteBack:
         ssd_files = list((tmp_path / "wb_flush_test").rglob("*.safetensors"))
         assert len(ssd_files) == 3, (
             f"Expected 3 SSD files after flush, got {len(ssd_files)}"
+        )
+
+    def test_close_flushes_all_blocks_with_small_queue(self, tmp_path):
+        """close() must flush all hot cache blocks even when more blocks
+        exist than the write queue depth.
+
+        Regression test for #1070: put_nowait() in the shutdown flush loop
+        drops blocks when the bounded write queue fills up faster than the
+        writer thread can drain it.
+        """
+        queue_depth = 4
+        block_count = 12  # 3x the queue depth
+
+        with patch("omlx.cache.paged_ssd_cache._MAX_PENDING_WRITES", queue_depth):
+            mgr = PagedSSDCacheManager(
+                cache_dir=tmp_path / "wb_queue_full_test",
+                max_size_bytes=100 * 1024**2,
+                hot_cache_max_bytes=10 * 1024**2,
+            )
+
+        for i in range(block_count):
+            block_hash = f"wb_qfull_blk_{i:02d}".encode()
+            cache_data = self._make_cache_data()
+            mgr.save_block(
+                block_hash=block_hash,
+                cache_data=cache_data,
+                token_count=16,
+                model_name="test",
+                layer_cache_types=["KVCache"] * 2,
+            )
+
+        # All blocks in hot cache, no SSD files yet
+        time.sleep(0.3)
+        ssd_files = list((tmp_path / "wb_queue_full_test").rglob("*.safetensors"))
+        assert len(ssd_files) == 0
+
+        mgr.close()
+
+        ssd_files = list((tmp_path / "wb_queue_full_test").rglob("*.safetensors"))
+        assert len(ssd_files) == block_count, (
+            f"Expected {block_count} SSD files after flush, got {len(ssd_files)}. "
+            f"Blocks were likely dropped due to write queue overflow during shutdown."
         )


### PR DESCRIPTION
## Summary

When `PagedSSDCacheManager.close()` flushes hot cache entries to SSD, it iterates all entries and calls `_enqueue_ssd_write()` which uses `put_nowait()` on the bounded write queue. The flush loop runs in microseconds while the writer thread drains at NVMe speed (~1ms/block), so the queue fills almost immediately and subsequent blocks are silently dropped.

On a 128GB machine (`_MAX_PENDING_WRITES=64`), flushing ~111 hot cache blocks drops ~46 of them — the most recently active prefixes — causing cold misses on the next startup.

## Changes

- Add a `blocking` keyword argument to `_enqueue_ssd_write()`. When `True`, uses `put(timeout=0.5)` instead of `put_nowait()`, giving the writer thread time to drain between submissions.
- `close()` passes `blocking=True`; all other callers remain non-blocking (inference-time eviction can still drop a single block without harm).
- `close()` checks `_writer_thread.is_alive()` before each blocking put to bail early if the consumer is dead, avoiding a stall on a dead thread.
- Dropped blocks during shutdown are now counted and logged as a warning.

## Test plan

- [x] Added regression test `test_close_flushes_all_blocks_with_small_queue`: patches `_MAX_PENDING_WRITES` to 4, creates 12 hot cache blocks (3x queue depth), calls `close()`, and verifies all 12 are persisted to SSD.
- [x] All 95 existing tests pass (`uv run pytest tests/ -x`).
- [x] Verified on 128GB M-series Mac with production-sized hot cache (~111 blocks): 0 dropped blocks after fix vs. ~46 dropped before.

Related: #1070