### PR TITLE
feat: improve active model activity visibility

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -3541,6 +3541,7 @@ def _build_active_models_data() -> dict:
             "total_waiting_requests": 0,
         }
 
+    now = time.monotonic()
     tracker = get_prefill_tracker()
     status = engine_pool.get_status()
     models = []
@@ -3554,6 +3555,9 @@ def _build_active_models_data() -> dict:
         model_id = model_info["id"]
         active_requests = 0
         waiting_requests = 0
+        running_by_id = {}
+        waiting_ids = set()
+        waiting = []
 
         # Get per-model active/waiting request counts.
         # Follow the same pattern as server.py /api/status endpoint.
@@ -3565,20 +3569,101 @@ def _build_active_models_data() -> dict:
                 core = getattr(async_core, "engine", None)
                 if core is not None:
                     collectors = getattr(core, "_output_collectors", {})
-                    active_request_ids = set(collectors.keys())
-                    active_requests = len(collectors)
+                    try:
+                        active_request_ids = set(collectors.keys())
+                        active_requests = len(collectors)
+                    except RuntimeError:
+                        # Scheduler state is mutated from the engine executor;
+                        # keep the dashboard endpoint best-effort rather than
+                        # failing on a concurrent dict resize.
+                        active_request_ids = set()
+                        active_requests = len(collectors)
+
                     sched = getattr(core, "scheduler", None)
                     if sched is not None:
-                        waiting_requests = len(getattr(sched, "waiting", []))
+                        for attempt in range(2):
+                            try:
+                                running_by_id = dict(getattr(sched, "running", {}))
+                                waiting_queue = list(getattr(sched, "waiting", []))
+                                waiting_requests = len(waiting_queue)
+                                waiting_ids = {req.request_id for req in waiting_queue}
+                                waiting = [
+                                    {
+                                        "request_id": req.request_id,
+                                        "queue_position": idx,
+                                        "elapsed_seconds": max(0.0, now - req.arrival_time),
+                                        "prompt_tokens": getattr(req, "num_prompt_tokens", 0),
+                                    }
+                                    for idx, req in enumerate(waiting_queue, start=1)
+                                ]
+                                break
+                            except (RuntimeError, KeyError):
+                                if attempt == 0:
+                                    continue
+                                logger.debug(
+                                    "Active model scheduler snapshot raced; "
+                                    "falling back to aggregate counts only",
+                                    exc_info=True,
+                                )
+                                waiting_queue_ref = getattr(sched, "waiting", [])
+                                waiting_requests = len(waiting_queue_ref)
+                                running_by_id = {}
+                                waiting_ids = set()
+                                waiting = []
 
         prefilling = tracker.get_model_progress(model_id)
         prefilling_ids = {p["request_id"] for p in prefilling}
 
-        # Generating = active requests that finished prefill
-        generating = [
-            {"request_id": rid}
-            for rid in sorted(active_request_ids - prefilling_ids)
-        ]
+        # Generating = active requests that finished prefill.
+        generating = []
+        for rid in sorted(active_request_ids - prefilling_ids - waiting_ids):
+            req = running_by_id.get(rid)
+            generated_tokens = getattr(req, "num_output_tokens", 0) if req else 0
+            started_at = getattr(req, "generation_started_at", None) if req else None
+            last_activity_at = getattr(req, "last_activity_at", None) if req else None
+            elapsed = max(0.0, now - started_at) if started_at else None
+            last_activity_age = (
+                max(0.0, now - last_activity_at) if last_activity_at else None
+            )
+            tokens_per_second = (
+                generated_tokens / elapsed if elapsed and elapsed > 0 else 0.0
+            )
+            generating.append(
+                {
+                    "request_id": rid,
+                    "elapsed_seconds": elapsed,
+                    "generated_tokens": generated_tokens,
+                    "tokens_per_second": tokens_per_second,
+                    "last_activity_age_seconds": last_activity_age,
+                    "prompt_tokens": getattr(req, "num_prompt_tokens", 0) if req else 0,
+                    "max_tokens": getattr(req, "max_tokens", None) if req else None,
+                }
+            )
+
+        loading_started_at = model_info.get("loading_started_at")
+        loading_elapsed_seconds = (
+            max(0.0, now - loading_started_at) if loading_started_at else None
+        )
+        loading_estimated_seconds = None
+        loading_remaining_seconds_estimate = None
+        if loading_elapsed_seconds is not None:
+            estimated_size_gb = model_info.get("estimated_size", 0) / (1024 ** 3)
+            # Model loaders do not expose byte-level progress, so use a
+            # deliberately conservative elapsed-time estimate and cap below
+            # complete until the model is actually loaded.
+            observed_seconds_per_gb = status.get("load_seconds_per_gb_estimate")
+            observations = status.get("load_time_observations", 0)
+            if observed_seconds_per_gb and observations >= 2:
+                # Adapt to this machine/session once we have more than a
+                # single potentially-misleading sample.
+                loading_estimated_seconds = max(
+                    3.0,
+                    1.0 + estimated_size_gb * float(observed_seconds_per_gb),
+                )
+                if loading_elapsed_seconds < loading_estimated_seconds:
+                    loading_remaining_seconds_estimate = max(
+                        0.0, loading_estimated_seconds - loading_elapsed_seconds
+                    )
 
         models.append({
             "id": model_id,
@@ -3588,8 +3673,12 @@ def _build_active_models_data() -> dict:
             ),
             "pinned": model_info.get("pinned", False),
             "is_loading": model_info.get("is_loading", False),
+            "loading_elapsed_seconds": loading_elapsed_seconds,
+            "loading_estimated_seconds": loading_estimated_seconds,
+            "loading_remaining_seconds_estimate": loading_remaining_seconds_estimate,
             "active_requests": active_requests,
             "waiting_requests": waiting_requests,
+            "waiting": waiting,
             "prefilling": prefilling,
             "generating": generating,
         })

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -3558,6 +3558,7 @@ def _build_active_models_data() -> dict:
         running_by_id = {}
         waiting_ids = set()
         waiting = []
+        activities = []
 
         # Get per-model active/waiting request counts.
         # Follow the same pattern as server.py /api/status endpoint.
@@ -3610,6 +3611,10 @@ def _build_active_models_data() -> dict:
                                 running_by_id = {}
                                 waiting_ids = set()
                                 waiting = []
+            elif hasattr(entry.engine, "get_activity_snapshot"):
+                snapshot = entry.engine.get_activity_snapshot()
+                active_requests = snapshot.get("active_requests", 0)
+                activities = snapshot.get("activities", [])
 
         prefilling = tracker.get_model_progress(model_id)
         prefilling_ids = {p["request_id"] for p in prefilling}
@@ -3679,6 +3684,7 @@ def _build_active_models_data() -> dict:
             "active_requests": active_requests,
             "waiting_requests": waiting_requests,
             "waiting": waiting,
+            "activities": activities,
             "prefilling": prefilling,
             "generating": generating,
         })

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -2040,6 +2040,29 @@
                 return String(n);
             },
 
+            formatDurationShort(seconds) {
+                if (seconds == null || !Number.isFinite(seconds)) return '—';
+                if (seconds < 1) return seconds.toFixed(1) + 's';
+                if (seconds < 60) return Math.round(seconds) + 's';
+                const minutes = Math.floor(seconds / 60);
+                const rem = Math.round(seconds % 60);
+                if (minutes < 60) return minutes + 'm ' + rem + 's';
+                const hours = Math.floor(minutes / 60);
+                return hours + 'h ' + (minutes % 60) + 'm';
+            },
+
+            formatActivityAge(seconds) {
+                if (seconds == null || !Number.isFinite(seconds)) return '';
+                return 'last token ' + this.formatDurationShort(seconds) + ' ago';
+            },
+
+            activityDotClass(seconds) {
+                if (seconds == null || !Number.isFinite(seconds)) return 'bg-green-400 animate-pulse';
+                if (seconds < 15) return 'bg-green-400 animate-pulse';
+                if (seconds < 30) return 'bg-amber-400 animate-pulse';
+                return 'bg-red-400';
+            },
+
             get activeModelsMemoryPercent() {
                 const am = this.stats.active_models;
                 if (!am || !am.model_memory_max) return 0;

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -2034,6 +2034,14 @@
                 return '0';
             },
 
+            formatByteCount(bytes) {
+                if (bytes == null || !Number.isFinite(bytes)) return '';
+                if (bytes >= 1024 * 1024 * 1024) return (bytes / (1024 * 1024 * 1024)).toFixed(1) + ' GB';
+                if (bytes >= 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+                if (bytes >= 1024) return (bytes / 1024).toFixed(1) + ' KB';
+                return Math.max(0, Math.round(bytes)) + ' B';
+            },
+
             formatTokenCount(n) {
                 if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
                 if (n >= 1000) return (n / 1000).toFixed(1) + 'k';
@@ -2054,6 +2062,18 @@
             formatActivityAge(seconds) {
                 if (seconds == null || !Number.isFinite(seconds)) return '';
                 return 'last token ' + this.formatDurationShort(seconds) + ' ago';
+            },
+
+            formatActivityMetadata(activity) {
+                const parts = [];
+                if (activity.input_count != null) parts.push(activity.input_count + ' inputs');
+                if (activity.document_count != null) parts.push(activity.document_count + ' docs');
+                if (activity.token_count != null) parts.push(this.formatTokenCount(activity.token_count) + ' tok');
+                if (activity.text_length != null) parts.push(activity.text_length + ' chars');
+                if (activity.chunk_count != null) parts.push(activity.chunk_count + ' chunks');
+                if (activity.output_bytes != null) parts.push(this.formatByteCount(activity.output_bytes));
+                if (activity.file_size_bytes != null && activity.file_size_bytes > 0) parts.push(this.formatByteCount(activity.file_size_bytes));
+                return parts.join(' · ');
             },
 
             activityDotClass(seconds) {

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -225,6 +225,22 @@
                                             </template>
                                         </div>
                                     </template>
+                                    <!-- Non-streaming activity sub-rows -->
+                                    <template x-if="m.activities && m.activities.length > 0">
+                                        <div class="mt-1.5 ml-5 space-y-1.5">
+                                            <template x-for="activity in m.activities" :key="activity.request_id">
+                                                <div class="flex flex-wrap items-center gap-x-5 gap-y-1">
+                                                    <span class="text-[10px] font-mono text-neutral-400 w-16 truncate" x-text="activity.request_id.substring(0, 8)"></span>
+                                                    <span class="inline-flex items-center gap-2 min-w-[120px] whitespace-nowrap">
+                                                        <span class="w-2 h-2 rounded-full flex-shrink-0" :class="activityDotClass(activity.last_activity_age_seconds)"></span>
+                                                        <span class="text-[10px] text-green-600 font-medium" x-text="activity.detail || activity.kind || window.t('status.active_models.active')"></span>
+                                                    </span>
+                                                    <span x-show="formatActivityMetadata(activity)" class="text-[10px] text-neutral-400 whitespace-nowrap ml-2" x-text="formatActivityMetadata(activity)"></span>
+                                                    <span x-show="activity.elapsed_seconds != null" class="text-[10px] text-neutral-400 whitespace-nowrap ml-1" x-text="formatDurationShort(activity.elapsed_seconds)"></span>
+                                                </div>
+                                            </template>
+                                        </div>
+                                    </template>
                                     <!-- Waiting sub-rows -->
                                     <template x-if="m.waiting && m.waiting.length > 0">
                                         <div class="mt-1.5 ml-5 space-y-1.5">

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -143,7 +143,7 @@
                                                 <template x-if="m.is_loading">
                                                     <div class="flex items-center gap-1.5">
                                                         <svg class="w-3 h-3 animate-spin text-blue-500" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" class="opacity-25"/><path d="M4 12a8 8 0 018-8" stroke="currentColor" stroke-width="3" stroke-linecap="round" class="opacity-75"/></svg>
-                                                        <span class="text-xs text-blue-500 font-medium">loading</span>
+                                                        <span class="text-xs text-blue-500 font-medium" x-text="'Loading' + (m.loading_elapsed_seconds != null ? ' · ' + formatDurationShort(m.loading_elapsed_seconds) : '') + (m.loading_remaining_seconds_estimate != null ? ' · ~' + formatDurationShort(m.loading_remaining_seconds_estimate) + ' left' : '')"></span>
                                                     </div>
                                                 </template>
                                                 <!-- Prefilling -->
@@ -195,7 +195,10 @@
                                                              :style="'width: ' + (pp.total > 0 ? Math.min(100, pp.processed / pp.total * 100) : 0) + '%'"></div>
                                                     </div>
                                                     <span class="text-[10px] text-blue-500 font-medium w-8 text-right" x-text="(pp.total > 0 ? Math.round(pp.processed / pp.total * 100) : 0) + '%'"></span>
+                                                    <span class="text-[10px] text-blue-600 font-medium" x-show="pp.detail" x-text="pp.detail"></span>
                                                     <span class="text-[10px] text-neutral-400" x-text="formatTokenCount(pp.processed) + ' / ' + formatTokenCount(pp.total) + ' tok'"></span>
+                                                    <span x-show="pp.scored_tokens || pp.selected_tokens" class="text-[10px] text-neutral-400" x-text="'(' + (pp.scored_tokens ? 'draft scored ' + formatTokenCount(pp.scored_tokens) : '') + (pp.scored_tokens && pp.selected_tokens ? ' · ' : '') + (pp.selected_tokens ? 'selected ' + formatTokenCount(pp.selected_tokens) + (pp.keep_percent != null ? ' (' + pp.keep_percent + '%)' : '') : '') + ')'"></span>
+                                                    <span x-show="pp.elapsed != null" class="text-[10px] text-neutral-400" x-text="formatDurationShort(pp.elapsed)"></span>
                                                     <span x-show="pp.speed > 0" class="text-[10px] text-neutral-400"
                                                           x-text="'(' + pp.speed.toFixed(0) + ' tok/s' + (pp.eta != null ? ', ' + (pp.eta >= 60 ? Math.floor(pp.eta / 60) + 'm ' + Math.round(pp.eta % 60) + 's' : Math.round(pp.eta) + 's') + ' left' : '') + ')'"></span>
                                                 </div>
@@ -206,10 +209,32 @@
                                     <template x-if="m.generating && m.generating.length > 0">
                                         <div class="mt-1.5 ml-5 space-y-1.5">
                                             <template x-for="gen in m.generating" :key="gen.request_id">
-                                                <div class="flex items-center gap-2">
+                                                <div class="flex flex-wrap items-center gap-x-4 gap-y-1">
                                                     <span class="text-[10px] font-mono text-neutral-400 w-16 truncate" x-text="gen.request_id.substring(0, 8)"></span>
-                                                    <span class="w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
-                                                    <span class="text-[10px] text-green-600 font-medium" x-text="window.t('status.active_models.generating')"></span>
+                                                    <span class="inline-flex items-center gap-2 min-w-[104px] whitespace-nowrap">
+                                                        <span class="w-2 h-2 rounded-full flex-shrink-0 bg-green-400 animate-pulse"></span>
+                                                        <span class="text-[10px] text-green-600 font-medium" x-text="window.t('status.active_models.generating')"></span>
+                                                    </span>
+                                                    <span class="text-[10px] text-neutral-400 w-16 whitespace-nowrap ml-2" x-text="formatTokenCount(gen.generated_tokens || 0) + ' tok'"></span>
+                                                    <span x-show="gen.tokens_per_second > 0" class="text-[10px] text-neutral-400 w-20 whitespace-nowrap"
+                                                          x-text="gen.tokens_per_second.toFixed(1) + ' tok/s'"></span>
+                                                    <span x-show="gen.last_activity_age_seconds >= 3" class="text-[10px] text-neutral-400 whitespace-nowrap" x-text="formatActivityAge(gen.last_activity_age_seconds)"></span>
+                                                    <span x-show="gen.elapsed_seconds != null" class="text-[10px] text-neutral-400 whitespace-nowrap"
+                                                          x-text="formatDurationShort(gen.elapsed_seconds)"></span>
+                                                </div>
+                                            </template>
+                                        </div>
+                                    </template>
+                                    <!-- Waiting sub-rows -->
+                                    <template x-if="m.waiting && m.waiting.length > 0">
+                                        <div class="mt-1.5 ml-5 space-y-1.5">
+                                            <template x-for="wait in m.waiting" :key="wait.request_id">
+                                                <div class="flex items-center gap-2">
+                                                    <span class="text-[10px] font-mono text-neutral-400 w-16 truncate" x-text="wait.request_id.substring(0, 8)"></span>
+                                                    <span class="w-2 h-2 rounded-full bg-amber-300"></span>
+                                                    <span class="text-[10px] text-amber-600 font-medium" x-text="window.t('status.active_models.waiting') + ' #' + wait.queue_position"></span>
+                                                    <span class="text-[10px] text-neutral-400" x-text="formatDurationShort(wait.elapsed_seconds)"></span>
+                                                    <span x-show="wait.prompt_tokens > 0" class="text-[10px] text-neutral-400" x-text="'prompt: ' + formatTokenCount(wait.prompt_tokens) + ' tok'"></span>
                                                 </div>
                                             </template>
                                         </div>

--- a/omlx/api/audio_routes.py
+++ b/omlx/api/audio_routes.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import Response, StreamingResponse
 
 from ..engine.audio_utils import wav_bytes_to_pcm_frames, wav_header
+from ..server_metrics import get_server_metrics
 from .audio_models import AudioSpeechRequest, AudioTranscriptionResponse
 
 logger = logging.getLogger(__name__)
@@ -73,6 +74,19 @@ def _resolve_model(model_id: str) -> str:
     from omlx.server import resolve_model_id
 
     return resolve_model_id(model_id) or model_id
+
+
+def _record_audio_request(model_id: str) -> None:
+    """Record audio request count without treating bytes/chars as tokens."""
+    try:
+        get_server_metrics().record_request_complete(
+            prompt_tokens=0,
+            completion_tokens=0,
+            cached_tokens=0,
+            model_id=model_id,
+        )
+    except Exception as exc:
+        logger.warning("Failed to record audio metrics for %s: %s", model_id, exc)
 
 
 async def _read_upload(file: UploadFile) -> bytes:
@@ -359,16 +373,16 @@ async def create_transcription(
     from omlx.exceptions import ModelNotFoundError
 
     pool = _get_engine_pool()
-    model = _resolve_model(model)
+    resolved_model = _resolve_model(model)
 
     # Load the engine via pool (handles model loading and LRU eviction)
     try:
-        engine = await pool.get_engine(model)
+        engine = await pool.get_engine(resolved_model)
     except ModelNotFoundError as exc:
         avail = ", ".join(exc.available_models) if exc.available_models else "(none)"
         raise HTTPException(
             status_code=404,
-            detail=f"Model '{model}' not found. Available: {avail}",
+            detail=f"Model '{resolved_model}' not found. Available: {avail}",
         ) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -376,7 +390,7 @@ async def create_transcription(
     if not isinstance(engine, STTEngine):
         raise HTTPException(
             status_code=400,
-            detail=f"Model '{model}' is not a speech-to-text model",
+            detail=f"Model '{resolved_model}' is not a speech-to-text model",
         )
 
     # Save uploaded file to a temp path so the engine can open it by path.
@@ -403,6 +417,8 @@ async def create_transcription(
                 os.unlink(tmp_path)
             except OSError:
                 pass
+
+    _record_audio_request(resolved_model)
 
     # Build response directly from the dict returned by STTEngine
     segments = result.get("segments") or None
@@ -500,6 +516,8 @@ async def create_speech(request: AudioSpeechRequest):
     finally:
         _cleanup_tempfile(ref_audio_path)
 
+    _record_audio_request(resolved_model)
+
     return Response(content=wav_bytes, media_type="audio/wav")
 
 
@@ -518,16 +536,16 @@ async def process_audio(
     from omlx.exceptions import ModelNotFoundError
 
     pool = _get_engine_pool()
-    model = _resolve_model(model)
+    resolved_model = _resolve_model(model)
 
     # Load the engine via pool (handles model loading and LRU eviction)
     try:
-        engine = await pool.get_engine(model)
+        engine = await pool.get_engine(resolved_model)
     except ModelNotFoundError as exc:
         avail = ", ".join(exc.available_models) if exc.available_models else "(none)"
         raise HTTPException(
             status_code=404,
-            detail=f"Model '{model}' not found. Available: {avail}",
+            detail=f"Model '{resolved_model}' not found. Available: {avail}",
         ) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -535,7 +553,7 @@ async def process_audio(
     if not isinstance(engine, STSEngine):
         raise HTTPException(
             status_code=400,
-            detail=f"Model '{model}' is not a speech-to-speech / audio processing model",
+            detail=f"Model '{resolved_model}' is not a speech-to-speech / audio processing model",
         )
 
     # Save uploaded file to a temp path so the engine can open it by path.
@@ -562,5 +580,7 @@ async def process_audio(
                 os.unlink(tmp_path)
             except OSError:
                 pass
+
+    _record_audio_request(resolved_model)
 
     return Response(content=wav_bytes, media_type="audio/wav")

--- a/omlx/engine/base.py
+++ b/omlx/engine/base.py
@@ -4,6 +4,8 @@ Base engine interface for oMLX inference.
 """
 
 import threading
+import time
+import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Dict, List, Optional
@@ -257,16 +259,106 @@ class BaseNonStreamingEngine(ABC):
     def __init__(self):
         self._active_count = 0
         self._active_lock = threading.Lock()
+        self._activities: Dict[str, Dict[str, Any]] = {}
 
     def has_active_requests(self) -> bool:
         """Check if the engine has active in-flight requests."""
-        return self._active_count > 0
-
-    def _decrement_active(self) -> bool:
-        """Decrement active count and return True if cache should be cleared."""
         with self._active_lock:
+            return self._active_count > 0
+
+    _ACTIVITY_RESERVED_KEYS = {
+        "request_id",
+        "kind",
+        "detail",
+        "started_at",
+        "last_activity_at",
+        "total_items",
+    }
+
+    def _sanitize_activity_metadata(
+        self, metadata: Dict[str, Any] | None
+    ) -> Dict[str, Any]:
+        """Drop reserved activity keys from caller-provided metadata.
+
+        Timing keys are owned by the tracker: _begin_activity sets them and
+        _update_activity always advances last_activity_at to "now".
+        """
+        if not metadata:
+            return {}
+        return {
+            key: value
+            for key, value in metadata.items()
+            if key not in self._ACTIVITY_RESERVED_KEYS
+        }
+
+    def _begin_activity(
+        self,
+        kind: str,
+        detail: str | None = None,
+        total_items: int | None = None,
+        metadata: Dict[str, Any] | None = None,
+    ) -> str:
+        """Track a non-streaming operation for admin visibility."""
+        activity_id = str(uuid.uuid4())
+        now = time.monotonic()
+        with self._active_lock:
+            self._active_count += 1
+            activity = {
+                "request_id": activity_id,
+                "kind": kind,
+                "detail": detail or kind,
+                "started_at": now,
+                "last_activity_at": now,
+                "total_items": total_items,
+            }
+            activity.update(self._sanitize_activity_metadata(metadata))
+            self._activities[activity_id] = activity
+        return activity_id
+
+    def _update_activity(self, activity_id: str, **updates: Any) -> None:
+        """Update tracked non-streaming operation metadata."""
+        with self._active_lock:
+            activity = self._activities.get(activity_id)
+            if activity is None:
+                return
+            activity.update(self._sanitize_activity_metadata(updates))
+            activity["last_activity_at"] = time.monotonic()
+
+    def _end_activity(self, activity_id: str) -> bool:
+        """End an activity and return True if cache should be cleared."""
+        with self._active_lock:
+            removed = self._activities.pop(activity_id, None)
+            if removed is None:
+                raise RuntimeError(
+                    f"Activity {activity_id} ended more than once or was never started"
+                )
             self._active_count -= 1
+            if self._active_count < 0:
+                raise RuntimeError("Active request count became negative")
             return self._active_count == 0
+
+    def get_activity_snapshot(self) -> Dict[str, Any]:
+        """Return active non-streaming operations for admin display."""
+        now = time.monotonic()
+        with self._active_lock:
+            activities = []
+            for activity in self._activities.values():
+                item = dict(activity)
+                started_at = item.pop("started_at", None)
+                last_activity_at = item.pop("last_activity_at", None)
+                item["elapsed_seconds"] = (
+                    max(0.0, now - started_at) if started_at is not None else None
+                )
+                item["last_activity_age_seconds"] = (
+                    max(0.0, now - last_activity_at)
+                    if last_activity_at is not None
+                    else None
+                )
+                activities.append(item)
+            return {
+                "active_requests": self._active_count,
+                "activities": activities,
+            }
 
     @property
     @abstractmethod

--- a/omlx/engine/embedding.py
+++ b/omlx/engine/embedding.py
@@ -125,13 +125,23 @@ class EmbeddingEngine(BaseNonStreamingEngine):
                 truncation=truncation,
             )
 
-        with self._active_lock:
-            self._active_count += 1
+        activity_id = self._begin_activity(
+            "embedding",
+            detail="Embedding",
+            total_items=len(texts),
+            metadata={"input_count": len(texts)},
+        )
         try:
             loop = asyncio.get_running_loop()
-            return await loop.run_in_executor(get_mlx_executor(), _embed_sync)
+            output = await loop.run_in_executor(get_mlx_executor(), _embed_sync)
+            self._update_activity(
+                activity_id,
+                token_count=output.total_tokens,
+                dimensions=output.dimensions,
+            )
+            return output
         finally:
-            if self._decrement_active():
+            if self._end_activity(activity_id):
                 loop = asyncio.get_running_loop()
                 await loop.run_in_executor(
                     get_mlx_executor(),

--- a/omlx/engine/reranker.py
+++ b/omlx/engine/reranker.py
@@ -129,13 +129,18 @@ class RerankerEngine(BaseNonStreamingEngine):
                 max_length=max_length,
             )
 
-        with self._active_lock:
-            self._active_count += 1
+        activity_id = self._begin_activity(
+            "reranking",
+            detail="Reranking",
+            total_items=len(documents),
+            metadata={"document_count": len(documents)},
+        )
         try:
             loop = asyncio.get_running_loop()
             output = await loop.run_in_executor(
                 get_mlx_executor(), _rerank_sync
             )
+            self._update_activity(activity_id, token_count=output.total_tokens)
 
             # Apply top_n filtering if specified
             if top_n is not None and top_n < len(output.indices):
@@ -149,7 +154,7 @@ class RerankerEngine(BaseNonStreamingEngine):
 
             return output
         finally:
-            if self._decrement_active():
+            if self._end_activity(activity_id):
                 loop = asyncio.get_running_loop()
                 await loop.run_in_executor(
                     get_mlx_executor(),

--- a/omlx/engine/sts.py
+++ b/omlx/engine/sts.py
@@ -379,8 +379,11 @@ class STSEngine(BaseNonStreamingEngine):
         def _process_sync():
             return processor_fn(model, str(audio_path), **kwargs)
 
-        with self._active_lock:
-            self._active_count += 1
+        activity_id = self._begin_activity(
+            "processing audio",
+            detail="Processing audio",
+            metadata={"file_size_bytes": file_size, "family": family},
+        )
         try:
             loop = asyncio.get_running_loop()
             result = await loop.run_in_executor(get_mlx_executor(), _process_sync)
@@ -392,7 +395,7 @@ class STSEngine(BaseNonStreamingEngine):
             )
             return result
         finally:
-            if self._decrement_active():
+            if self._end_activity(activity_id):
                 loop = asyncio.get_running_loop()
                 await loop.run_in_executor(
                     get_mlx_executor(),

--- a/omlx/engine/stt.py
+++ b/omlx/engine/stt.py
@@ -260,8 +260,11 @@ class STTEngine(BaseNonStreamingEngine):
                 "duration": 0.0,
             }
 
-        with self._active_lock:
-            self._active_count += 1
+        activity_id = self._begin_activity(
+            "transcribing",
+            detail="Transcribing",
+            metadata={"file_size_bytes": file_size},
+        )
         try:
             loop = asyncio.get_running_loop()
             result = await loop.run_in_executor(
@@ -276,7 +279,7 @@ class STTEngine(BaseNonStreamingEngine):
             )
             return result
         finally:
-            if self._decrement_active():
+            if self._end_activity(activity_id):
                 loop = asyncio.get_running_loop()
                 await loop.run_in_executor(
                     get_mlx_executor(),

--- a/omlx/engine/tts.py
+++ b/omlx/engine/tts.py
@@ -237,8 +237,11 @@ class TTSEngine(BaseNonStreamingEngine):
             audio = np.concatenate(audio_chunks, axis=0)
             return _audio_to_wav_bytes(audio, int(sample_rate))
 
-        with self._active_lock:
-            self._active_count += 1
+        activity_id = self._begin_activity(
+            "synthesizing speech",
+            detail="Synthesizing speech",
+            metadata={"text_length": len(text)},
+        )
         try:
             loop = asyncio.get_running_loop()
             result = await loop.run_in_executor(
@@ -252,7 +255,7 @@ class TTSEngine(BaseNonStreamingEngine):
             )
             return result
         finally:
-            if self._decrement_active():
+            if self._end_activity(activity_id):
                 loop = asyncio.get_running_loop()
                 await loop.run_in_executor(
                     get_mlx_executor(),
@@ -347,8 +350,11 @@ class TTSEngine(BaseNonStreamingEngine):
             )
             return sample_rate, 1, 2, self._audio_array_to_pcm_bytes(audio)
 
-        with self._active_lock:
-            self._active_count += 1
+        activity_id = self._begin_activity(
+            "streaming speech",
+            detail="Streaming speech",
+            metadata={"text_length": len(text)},
+        )
         try:
             loop = asyncio.get_running_loop()
             while True:
@@ -362,9 +368,14 @@ class TTSEngine(BaseNonStreamingEngine):
                     continue
                 chunk_count += 1
                 total_bytes += len(pcm_bytes)
+                self._update_activity(
+                    activity_id,
+                    chunk_count=chunk_count,
+                    output_bytes=total_bytes,
+                )
                 yield sample_rate, channels, sample_width, pcm_bytes
         finally:
-            if self._decrement_active():
+            if self._end_activity(activity_id):
                 loop = asyncio.get_running_loop()
                 await loop.run_in_executor(
                     get_mlx_executor(),

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -61,6 +61,7 @@ class EngineEntry:
     engine: BaseEngine | EmbeddingEngine | RerankerEngine | STTEngine | STSEngine | TTSEngine | None = None  # Loaded engine instance
     last_access: float = 0.0  # Timestamp for LRU (0 if never loaded)
     is_loading: bool = False  # Prevent concurrent loads
+    loading_started_at: float | None = None  # Timestamp when current load started
     is_pinned: bool = False  # Never evict if True
     abort_loading: bool = False  # Set by memory enforcer to abort in-progress load
 
@@ -97,6 +98,8 @@ class EnginePool:
         self._process_memory_enforcer: object | None = None  # Set by server
         self._settings_manager: object | None = None  # Set by server
         self._suppress_ttl: bool = False  # Suppress TTL during benchmarks
+        self._load_seconds_per_gb_ema: float | None = None
+        self._load_time_observations: int = 0
 
     @property
     def max_model_memory(self) -> int | None:
@@ -589,6 +592,9 @@ class EnginePool:
             raise ModelLoadingError(model_id)
 
         entry.is_loading = True
+        entry.loading_started_at = time.monotonic()
+        load_started_at = entry.loading_started_at
+        load_completed = False
         entry.abort_loading = False
         try:
             effective_type = entry.engine_type
@@ -826,6 +832,7 @@ class EnginePool:
             entry.engine = engine
             entry.last_access = time.time()
             self._current_model_memory += entry.estimated_size
+            load_completed = True
 
             # Propagate memory limit to new engine's scheduler
             if self._process_memory_enforcer is not None:
@@ -849,7 +856,25 @@ class EnginePool:
                 f"total: {format_size(self._current_model_memory)})"
             )
         finally:
+            if load_completed and load_started_at is not None and entry.estimated_size > 0:
+                elapsed = max(0.0, time.monotonic() - load_started_at)
+                size_gb = entry.estimated_size / (1024 ** 3)
+                if size_gb > 0 and elapsed > 0:
+                    sample = elapsed / size_gb
+                    if self._load_seconds_per_gb_ema is None:
+                        self._load_seconds_per_gb_ema = sample
+                    else:
+                        self._load_seconds_per_gb_ema = (
+                            self._load_seconds_per_gb_ema * 0.9 + sample * 0.1
+                        )
+                    self._load_time_observations += 1
+                    logger.debug(
+                        f"Observed model load speed: {sample:.2f}s/GB "
+                        f"for {model_id} ({elapsed:.1f}s, {format_size(entry.estimated_size)}); "
+                        f"EMA={self._load_seconds_per_gb_ema:.2f}s/GB"
+                    )
             entry.is_loading = False
+            entry.loading_started_at = None
             entry.abort_loading = False
 
     async def preload_pinned_models(self) -> None:
@@ -894,12 +919,15 @@ class EnginePool:
             "current_model_memory": self._current_model_memory,
             "model_count": len(self._entries),
             "loaded_count": sum(1 for e in self._entries.values() if e.engine is not None),
+            "load_seconds_per_gb_estimate": self._load_seconds_per_gb_ema,
+            "load_time_observations": self._load_time_observations,
             "models": [
                 {
                     "id": mid,
                     "model_path": e.model_path,
                     "loaded": e.engine is not None,
                     "is_loading": e.is_loading,
+                    "loading_started_at": e.loading_started_at,
                     "estimated_size": e.estimated_size,
                     "pinned": e.is_pinned,
                     "engine_type": e.engine_type,

--- a/omlx/patches/specprefill.py
+++ b/omlx/patches/specprefill.py
@@ -344,19 +344,28 @@ def _unpatch_attention_capture(model, originals):
         _set_attn_module(model.layers[layer_idx], orig)
 
 
-def _prefill_draft(model, tokens, cache, step_size=2048):
+def _prefill_draft(model, tokens, cache, step_size=2048, progress_callback=None):
     """Prefill draft model with all prompt tokens. Returns last logits."""
     prompt = mx.array(tokens) if not isinstance(tokens, mx.array) else tokens
     n = len(tokens)
     processed = 0
     while n - processed > 1:
         chunk = min(step_size, n - processed - 1)
+        if progress_callback is not None:
+            # Mark the chunk as active before the MLX eval without advancing
+            # completed-token progress. Advancing here makes tok/s math lie
+            # because the expensive work has not finished yet.
+            progress_callback(processed, n)
         model(prompt[processed : processed + chunk][None], cache=cache)
         mx.eval([c.state for c in cache])
         processed += chunk
+        if progress_callback is not None:
+            progress_callback(processed, n)
         mx.clear_cache()
     logits = model(prompt[processed:][None], cache=cache)
     mx.eval(logits)
+    if progress_callback is not None:
+        progress_callback(n, n)
     return logits
 
 
@@ -446,6 +455,7 @@ def score_tokens(
     prefill_step_size: int = 2048,
     query_extractor: Optional[Callable] = None,
     existing_cache: Optional[List[Any]] = None,
+    progress_callback: Optional[Callable[[int, int, str], None]] = None,
 ) -> Tuple[mx.array, Any]:
     """Score token importance using attention patterns on a draft model.
 
@@ -498,14 +508,34 @@ def score_tokens(
         cached_len = cache[0].offset if hasattr(cache[0], "offset") else 0
         suffix = tokens[cached_len:]
         if suffix:
-            logits = _prefill_draft(model, suffix, cache, step_size=prefill_step_size)
+            logits = _prefill_draft(
+                model,
+                suffix,
+                cache,
+                step_size=prefill_step_size,
+                progress_callback=(
+                    (lambda processed, total: progress_callback(cached_len + processed, n_prompt, "scoring"))
+                    if progress_callback is not None
+                    else None
+                ),
+            )
         else:
             # Exact cache hit — run last token to get logits
             logits = model(mx.array([tokens[-1]])[None], cache=cache)
             mx.eval(logits)
     else:
         cache = make_prompt_cache(model)
-        logits = _prefill_draft(model, tokens, cache, step_size=prefill_step_size)
+        logits = _prefill_draft(
+            model,
+            tokens,
+            cache,
+            step_size=prefill_step_size,
+            progress_callback=(
+                (lambda processed, total: progress_callback(processed, total, "scoring"))
+                if progress_callback is not None
+                else None
+            ),
+        )
 
     # Record cache offset before lookahead so we can trim afterwards.
     # Lookahead decode appends n_lookahead+1 tokens to the cache which
@@ -518,6 +548,8 @@ def score_tokens(
         model, query_buffer, query_extractor
     )
     try:
+        if progress_callback is not None:
+            progress_callback(n_prompt, n_prompt, "lookahead")
         _lookahead_decode(model, logits, cache, n_lookahead, temp=temp, top_p=top_p)
         mx.eval(query_buffer)
     finally:
@@ -535,6 +567,8 @@ def score_tokens(
         pool_kernel=pool_kernel if pool_kernel > 0 else None,
     )
     mx.eval(importance)
+    if progress_callback is not None:
+        progress_callback(n_prompt, n_prompt, "importance")
 
     # Trim lookahead tokens from cache before returning.
     # KVCache stores keys/values as contiguous tensors; slicing back
@@ -732,6 +766,7 @@ def sparse_prefill(
     cache,
     step_size: int = 2048,
     position_offset: int = 0,
+    progress_callback: Optional[Callable[[int, int], None]] = None,
 ) -> mx.array:
     """Prefill model cache with selected tokens at their original positions.
 
@@ -812,14 +847,23 @@ def sparse_prefill(
 
         while n - processed > 1:
             chunk = min(step_size, n - processed - 1)
+            if progress_callback is not None:
+                # Surface that work is active before the potentially long
+                # target-model eval returns, but don't advance completed-token
+                # progress until the eval has actually finished.
+                progress_callback(processed, n)
             model(prompt[processed : processed + chunk][None], cache=cache)
             mx.eval([c.state for c in cache])
             processed += chunk
+            if progress_callback is not None:
+                progress_callback(processed, n)
             mx.clear_cache()
 
         # Last token -> logits
         logits = model(prompt[processed:][None], cache=cache)
         mx.eval(logits)
+        if progress_callback is not None:
+            progress_callback(n, n)
 
     finally:
         # Replace position-mapped RoPE with offset-adjusted RoPE for decode

--- a/omlx/prefill_progress.py
+++ b/omlx/prefill_progress.py
@@ -29,11 +29,20 @@ class PrefillProgressTracker:
         self._progress: Dict[str, Dict[str, Any]] = {}
         self._lock = threading.Lock()
 
-    def update(self, request_id: str, processed: int, total: int, model_id: str) -> None:
-        """Update prefill progress for a request.
+    def update(
+        self,
+        request_id: str,
+        processed: int,
+        total: int,
+        model_id: str,
+        phase: str = "prefill",
+        detail: Optional[str] = None,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Update prefill/spec-prefill progress for a request.
 
         Auto-removes the entry when processed >= total (prefill complete).
-        Tracks timing for speed/ETA calculation.
+        Tracks phase timing for speed/ETA calculation.
         """
         now = time.monotonic()
         with self._lock:
@@ -41,7 +50,10 @@ class PrefillProgressTracker:
                 self._progress.pop(request_id, None)
             else:
                 prev = self._progress.get(request_id)
-                if prev is not None:
+                phase_changed = prev is not None and prev.get("phase") != phase
+                start_time = now if prev is None or phase_changed else prev["start_time"]
+
+                if prev is not None and not phase_changed:
                     dt = now - prev["last_time"]
                     dtok = processed - prev["processed"]
                     if dt > 0 and dtok > 0:
@@ -51,14 +63,20 @@ class PrefillProgressTracker:
                 else:
                     speed = 0.0
 
-                self._progress[request_id] = {
-                    "processed": processed,
-                    "total": total,
-                    "model_id": model_id,
-                    "start_time": prev["start_time"] if prev else now,
-                    "last_time": now,
-                    "speed": speed,
-                }
+                entry = dict(extra or {})
+                entry.update(
+                    {
+                        "processed": processed,
+                        "total": total,
+                        "model_id": model_id,
+                        "start_time": start_time,
+                        "last_time": now,
+                        "speed": speed,
+                        "phase": phase,
+                        "detail": detail,
+                    }
+                )
+                self._progress[request_id] = entry
 
     def remove(self, request_id: str) -> None:
         """Explicitly remove a request (e.g. on abort or finish)."""
@@ -72,16 +90,32 @@ class PrefillProgressTracker:
             for rid, entry in self._progress.items():
                 if entry["model_id"] != model_id:
                     continue
-                remaining = entry["total"] - entry["processed"]
+                elapsed = time.monotonic() - entry["start_time"]
                 speed = entry.get("speed", 0.0)
+                remaining = entry["total"] - entry["processed"]
                 eta = remaining / speed if speed > 0 else None
-                results.append({
+                result = {
                     "request_id": rid,
                     "processed": entry["processed"],
                     "total": entry["total"],
                     "speed": round(speed, 1),
                     "eta": round(eta, 1) if eta is not None else None,
-                })
+                    "elapsed": round(elapsed, 1),
+                    "phase": entry.get("phase", "prefill"),
+                    "detail": entry.get("detail"),
+                }
+                for key in (
+                    "scored_tokens",
+                    "selected_tokens",
+                    "keep_percent",
+                    "prompt_tokens",
+                    "system_tokens",
+                    "conversation_tokens",
+                    "cached_tokens",
+                ):
+                    if key in entry:
+                        result[key] = entry[key]
+                results.append(result)
             return results
 
     def clear(self) -> None:

--- a/omlx/request.py
+++ b/omlx/request.py
@@ -110,7 +110,7 @@ class Request:
     request_id: str
     prompt: Union[str, List[int]]
     sampling_params: SamplingParams
-    arrival_time: float = field(default_factory=time.time)
+    arrival_time: float = field(default_factory=time.monotonic)
     priority: int = 0  # Lower is higher priority
 
     # Set after tokenization
@@ -122,6 +122,8 @@ class Request:
     num_computed_tokens: int = 0
     output_token_ids: List[int] = field(default_factory=list)
     output_text: str = ""
+    generation_started_at: Optional[float] = None
+    last_activity_at: Optional[float] = None
 
     # For BatchGenerator integration
     batch_uid: Optional[int] = None  # UID assigned by BatchGenerator

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -2910,8 +2910,6 @@ class Scheduler:
         model_id = os.path.basename(self.config.model_name.rstrip("/"))
 
         try:
-            import time
-
             from .patches.specprefill import score_tokens, select_chunks
 
             # Draft prefix cache lookup
@@ -2932,10 +2930,35 @@ class Scheduler:
                 except Exception as e:
                     logger.debug(f"SpecPrefill: draft cache fetch failed: {e}")
 
-            # Register tracker entry so the dashboard shows the PP indicator
-            # during draft scoring. The bar sits at 0% (no per-chunk hooks)
-            # but the indicator beats showing "idle" for a multi-second pause.
-            tracker.update(request.request_id, 0, n_to_score, model_id)
+            spec_extra = {
+                "prompt_tokens": request.num_prompt_tokens,
+                "system_tokens": request.specprefill_system_end,
+                "conversation_tokens": request.num_prompt_tokens - request.specprefill_system_end,
+                "cached_tokens": request.cached_tokens,
+            }
+
+            def _score_progress(processed: int, total: int, phase: str) -> None:
+                tracker.update(
+                    request.request_id,
+                    min(processed, total - 1),
+                    total,
+                    model_id,
+                    phase=f"specprefill_{phase}",
+                    detail="scoring draft tokens",
+                    extra=spec_extra,
+                )
+
+            # Register tracker entry and stream draft scoring progress so the
+            # dashboard shows movement during long SpecPrefill scoring pauses.
+            tracker.update(
+                request.request_id,
+                0,
+                n_to_score,
+                model_id,
+                phase="specprefill_scoring",
+                detail="scoring draft tokens",
+                extra=spec_extra,
+            )
 
             t0 = time.monotonic()
             importance, used_cache = score_tokens(
@@ -2943,6 +2966,7 @@ class Scheduler:
                 tokens_to_score,
                 prefill_step_size=self.config.prefill_step_size,
                 existing_cache=draft_cache,
+                progress_callback=_score_progress,
             )
             selected = select_chunks(importance, keep_pct=keep_pct)
             t_score = time.monotonic() - t0
@@ -2965,6 +2989,21 @@ class Scheduler:
                 f"prompt {total_prompt} = "
                 f"system {system_total} + conv {total_prompt - system_total}, "
                 f"cached {cached}"
+            )
+
+            tracker.update(
+                request.request_id,
+                n_to_score - 1,
+                n_to_score,
+                model_id,
+                phase="specprefill_selected",
+                detail="selected sparse tokens",
+                extra={
+                    **spec_extra,
+                    "scored_tokens": n_to_score,
+                    "selected_tokens": n_selected,
+                    "keep_percent": round(n_selected / n_to_score * 100),
+                },
             )
 
             logger.info(
@@ -3487,8 +3526,6 @@ class Scheduler:
                 model_id = os.path.basename(self.config.model_name.rstrip("/"))
                 total_pp = 0
                 try:
-                    import time
-
                     from .patches.specprefill import (
                         _find_attention_layers,
                         _get_attn_module,
@@ -3515,13 +3552,56 @@ class Scheduler:
                     total_pp = sys_count + n_eff
                     tracker.update(request.request_id, 0, total_pp, model_id)
 
+                    def _check_specprefill_abort(processed: int) -> None:
+                        if request.request_id in self._pending_abort_ids:
+                            logger.info(
+                                f"SpecPrefill interrupted at {processed}/{total_pp} "
+                                f"tokens: request aborted"
+                            )
+                            tracker.remove(request.request_id)
+                            self.waiting.appendleft(request)
+                            raise _PrefillAbortedError([], processed)
+
                     # Phase 1: system prompt full prefill (if not cached)
                     if sys_count > 0:
                         sys_arr = mx.array(all_tokens[:sys_count])
                         step = self.config.prefill_step_size
+                        sys_processed = 0
+                        spec_sparse_extra = {
+                            "prompt_tokens": request.num_prompt_tokens,
+                            "system_tokens": request.specprefill_system_end,
+                            "conversation_tokens": request.num_prompt_tokens - request.specprefill_system_end,
+                            "cached_tokens": request.cached_tokens,
+                            "scored_tokens": m_pre,
+                            "selected_tokens": n_eff,
+                            "keep_percent": round(n_eff / m_pre * 100)
+                            if m_pre > 0
+                            else 0,
+                        }
                         while sys_arr.size > step:
+                            _check_specprefill_abort(sys_processed)
+                            tracker.update(
+                                request.request_id,
+                                sys_processed,
+                                total_pp,
+                                model_id,
+                                phase="specprefill_system",
+                                detail="system prompt prefill",
+                                extra=spec_sparse_extra,
+                            )
                             self.model(sys_arr[:step][None], cache=sp_cache)
                             mx.eval([c.state for c in sp_cache])
+                            sys_processed += step
+                            _check_specprefill_abort(sys_processed)
+                            tracker.update(
+                                request.request_id,
+                                min(sys_processed, total_pp - 1),
+                                total_pp,
+                                model_id,
+                                phase="specprefill_system",
+                                detail="system prompt prefill",
+                                extra=spec_sparse_extra,
+                            )
                             sys_arr = sys_arr[step:]
                             # Use _sync_and_clear_cache() instead of bare
                             # mx.clear_cache() to flush the generation_stream
@@ -3532,8 +3612,30 @@ class Scheduler:
                             # panic that #435 fixed elsewhere (#557).
                             _sync_and_clear_cache()
                         if sys_arr.size > 0:
+                            _check_specprefill_abort(sys_processed)
+                            final_sys = int(sys_arr.size)
+                            tracker.update(
+                                request.request_id,
+                                sys_processed,
+                                total_pp,
+                                model_id,
+                                phase="specprefill_system",
+                                detail="system prompt prefill",
+                                extra=spec_sparse_extra,
+                            )
                             self.model(sys_arr[None], cache=sp_cache)
                             mx.eval([c.state for c in sp_cache])
+                            sys_processed += final_sys
+                            _check_specprefill_abort(sys_processed)
+                            tracker.update(
+                                request.request_id,
+                                min(sys_processed, total_pp - 1),
+                                total_pp,
+                                model_id,
+                                phase="specprefill_system",
+                                detail="system prompt prefill",
+                                extra=spec_sparse_extra,
+                            )
                         logger.info(
                             f"SpecPrefill: system prompt {sys_count} tokens full prefill"
                         )
@@ -3552,6 +3654,28 @@ class Scheduler:
                         selected_list.remove(last_idx)
                         selected = mx.array(sorted(selected_list))
 
+                    def _sparse_progress(processed: int, total: int) -> None:
+                        _check_specprefill_abort(sys_count + processed)
+                        tracker.update(
+                            request.request_id,
+                            min(sys_count + processed, total_pp - 1),
+                            total_pp,
+                            model_id,
+                            phase="specprefill_sparse",
+                            detail="sparse target prefill",
+                            extra={
+                                "scored_tokens": M,
+                                "selected_tokens": int(selected.shape[0]),
+                                "keep_percent": round(int(selected.shape[0]) / M * 100)
+                                if M > 0
+                                else 0,
+                                "prompt_tokens": request.num_prompt_tokens,
+                                "system_tokens": request.specprefill_system_end,
+                                "conversation_tokens": request.num_prompt_tokens - request.specprefill_system_end,
+                                "cached_tokens": request.cached_tokens,
+                            },
+                        )
+
                     sparse_prefill(
                         self.model,
                         conv_tokens,
@@ -3559,6 +3683,7 @@ class Scheduler:
                         sp_cache,
                         step_size=self.config.prefill_step_size,
                         position_offset=pos_offset,
+                        progress_callback=_sparse_progress,
                     )
                     # sparse_prefill installs _OffsetAdjustedRoPE with
                     # adjustment = M - N'. Subtract 1 to account for the
@@ -3591,6 +3716,11 @@ class Scheduler:
                     # Mark spec-prefill complete (auto-removes tracker entry).
                     tracker.update(request.request_id, total_pp, total_pp, model_id)
 
+                except _PrefillAbortedError:
+                    cleanup_rope(self.model)
+                    request.specprefill_indices = None
+                    tracker.remove(request.request_id)
+                    raise
                 except Exception as e:
                     logger.error(f"SpecPrefill sparse prefill failed: {e}")
                     cleanup_rope(self.model)
@@ -3630,8 +3760,6 @@ class Scheduler:
 
                 # Prefill complete: remove from progress tracker so dashboard
                 # shows "generating" instead of "PP" during decode.
-                from .prefill_progress import get_prefill_tracker
-
                 get_prefill_tracker().remove(request.request_id)
 
                 cache_to_use = prefilled_cache
@@ -3691,8 +3819,11 @@ class Scheduler:
                 uid = uids[0]
                 self.request_id_to_uid[request.request_id] = uid
                 self.uid_to_request_id[uid] = request.request_id
+                now = time.monotonic()
                 request.batch_uid = uid
                 request.status = RequestStatus.RUNNING
+                request.generation_started_at = now
+                request.last_activity_at = now
                 self.running[request.request_id] = request
                 scheduled.append(request)
 
@@ -3730,6 +3861,7 @@ class Scheduler:
         outputs = []
         finished_ids = set()
 
+        step_now = time.monotonic()
         for response in responses:
             request_id = self.uid_to_request_id.get(response.uid)
             if request_id is None:
@@ -3738,6 +3870,8 @@ class Scheduler:
             request = self.running.get(request_id)
             if request is None:
                 continue
+
+            request.last_activity_at = step_now
 
             # Release VLM embeddings after first decode token (prefill is done)
             if request.vlm_inputs_embeds is not None:

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1755,6 +1755,13 @@ async def create_embeddings(
             f"Embedding: {len(embedding_inputs)} inputs, {output.dimensions} dims, "
             f"{output.total_tokens} tokens in {elapsed:.3f}s"
         )
+        get_server_metrics().record_request_complete(
+            prompt_tokens=output.total_tokens,
+            completion_tokens=0,
+            cached_tokens=0,
+            prefill_duration=elapsed,
+            model_id=resolve_model_id(request.model) or request.model,
+        )
 
         data = []
         for i, embedding in enumerate(output.embeddings):
@@ -1868,6 +1875,13 @@ async def create_rerank(
     logger.info(
         f"Rerank: {len(documents_raw)} docs, "
         f"{output.total_tokens} tokens in {elapsed:.3f}s"
+    )
+    get_server_metrics().record_request_complete(
+        prompt_tokens=output.total_tokens,
+        completion_tokens=0,
+        cached_tokens=0,
+        prefill_duration=elapsed,
+        model_id=resolve_model_id(request.model) or request.model,
     )
 
     # Format response - results sorted by score (descending). Strings wrap

--- a/tests/test_active_models_visibility.py
+++ b/tests/test_active_models_visibility.py
@@ -109,3 +109,67 @@ def test_active_models_loading_includes_elapsed_and_percent_estimate():
     assert model["loading_elapsed_seconds"] == 8.0
     assert model["loading_estimated_seconds"] is None
     assert model["loading_remaining_seconds_estimate"] is None
+
+
+class FakeNonStreamingEngine:
+    def get_activity_snapshot(self):
+        return {
+            "active_requests": 1,
+            "activities": [
+                {
+                    "request_id": "embed-1",
+                    "kind": "embedding",
+                    "detail": "Embedding",
+                    "elapsed_seconds": 12.0,
+                    "input_count": 200,
+                    "token_count": 120200,
+                }
+            ],
+        }
+
+
+class FakeNonStreamingPool:
+    def __init__(self):
+        self._entries = {"embed-model": SimpleNamespace(engine=FakeNonStreamingEngine())}
+
+    def get_status(self):
+        return {
+            "current_model_memory": 1024,
+            "max_model_memory": 2048,
+            "models": [
+                {
+                    "id": "embed-model",
+                    "loaded": True,
+                    "is_loading": False,
+                    "estimated_size": 1024,
+                    "pinned": False,
+                }
+            ],
+        }
+
+
+def test_active_models_includes_non_streaming_activity_rows():
+    class EmptyPrefillTracker:
+        def get_model_progress(self, model_id):
+            return []
+
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=FakeNonStreamingPool()),
+        patch("omlx.prefill_progress.get_prefill_tracker", return_value=EmptyPrefillTracker()),
+        patch("time.monotonic", return_value=110.0),
+    ):
+        data = admin_routes._build_active_models_data()
+
+    model = data["models"][0]
+    assert data["total_active_requests"] == 1
+    assert model["active_requests"] == 1
+    assert model["activities"] == [
+        {
+            "request_id": "embed-1",
+            "kind": "embedding",
+            "detail": "Embedding",
+            "elapsed_seconds": 12.0,
+            "input_count": 200,
+            "token_count": 120200,
+        }
+    ]

--- a/tests/test_active_models_visibility.py
+++ b/tests/test_active_models_visibility.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from omlx.admin import routes as admin_routes
+
+
+class FakePool:
+    def __init__(self, scheduler, loading_started_at=None):
+        core = SimpleNamespace(
+            _output_collectors={"gen-1": object(), "prefill-1": object(), "wait-1": object()},
+            scheduler=scheduler,
+        )
+        engine = SimpleNamespace(_engine=SimpleNamespace(engine=core))
+        self._entries = {"model-a": SimpleNamespace(engine=engine)}
+        self.loading_started_at = loading_started_at
+
+    def get_status(self):
+        return {
+            "current_model_memory": 1024,
+            "max_model_memory": 2048,
+            "models": [
+                {
+                    "id": "model-a",
+                    "loaded": True,
+                    "is_loading": self.loading_started_at is not None,
+                    "loading_started_at": self.loading_started_at,
+                    "estimated_size": 1024,
+                    "pinned": False,
+                }
+            ],
+        }
+
+
+class FakePrefillTracker:
+    def get_model_progress(self, model_id):
+        assert model_id == "model-a"
+        return [{"request_id": "prefill-1", "processed": 10, "total": 20}]
+
+
+def test_active_models_generation_includes_activity_and_waiting_rows():
+    running_request = SimpleNamespace(
+        request_id="gen-1",
+        generation_started_at=100.0,
+        last_activity_at=109.5,
+        num_output_tokens=20,
+        num_prompt_tokens=12,
+        max_tokens=64,
+    )
+    waiting_request = SimpleNamespace(
+        request_id="wait-1",
+        arrival_time=105.0,
+        num_prompt_tokens=30,
+    )
+    scheduler = SimpleNamespace(
+        running={"gen-1": running_request},
+        waiting=[waiting_request],
+    )
+
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=FakePool(scheduler)),
+        patch("omlx.prefill_progress.get_prefill_tracker", return_value=FakePrefillTracker()),
+        patch("time.monotonic", return_value=110.0),
+    ):
+        data = admin_routes._build_active_models_data()
+
+    model = data["models"][0]
+    assert data["total_active_requests"] == 3
+    assert model["waiting_requests"] == 1
+    assert model["prefilling"] == [
+        {"request_id": "prefill-1", "processed": 10, "total": 20}
+    ]
+    assert model["waiting"] == [
+        {
+            "request_id": "wait-1",
+            "queue_position": 1,
+            "elapsed_seconds": 5.0,
+            "prompt_tokens": 30,
+        }
+    ]
+    assert model["generating"] == [
+        {
+            "request_id": "gen-1",
+            "elapsed_seconds": 10.0,
+            "generated_tokens": 20,
+            "tokens_per_second": 2.0,
+            "last_activity_age_seconds": 0.5,
+            "prompt_tokens": 12,
+            "max_tokens": 64,
+        }
+    ]
+
+
+def test_active_models_loading_includes_elapsed_and_percent_estimate():
+    scheduler = SimpleNamespace(running={}, waiting=[])
+
+    with (
+        patch.object(
+            admin_routes,
+            "_get_engine_pool",
+            return_value=FakePool(scheduler, loading_started_at=102.0),
+        ),
+        patch("omlx.prefill_progress.get_prefill_tracker", return_value=FakePrefillTracker()),
+        patch("time.monotonic", return_value=110.0),
+    ):
+        data = admin_routes._build_active_models_data()
+
+    model = data["models"][0]
+    assert model["is_loading"] is True
+    assert model["loading_elapsed_seconds"] == 8.0
+    assert model["loading_estimated_seconds"] is None
+    assert model["loading_remaining_seconds_estimate"] is None

--- a/tests/test_non_streaming_activity.py
+++ b/tests/test_non_streaming_activity.py
@@ -1,0 +1,47 @@
+import pytest
+
+from omlx.engine.base import BaseNonStreamingEngine
+
+
+class DummyNonStreamingEngine(BaseNonStreamingEngine):
+    @property
+    def model_name(self):
+        return "dummy"
+
+    async def start(self):
+        pass
+
+    async def stop(self):
+        pass
+
+    def get_stats(self):
+        return {}
+
+
+def test_non_streaming_activity_tracks_multiple_operations_and_reserved_keys():
+    engine = DummyNonStreamingEngine()
+    first = engine._begin_activity(
+        "embedding",
+        detail="Embedding",
+        metadata={"started_at": -1, "input_count": 2},
+    )
+    second = engine._begin_activity("transcribing", detail="Transcribing")
+
+    snapshot = engine.get_activity_snapshot()
+    assert snapshot["active_requests"] == 2
+    assert len(snapshot["activities"]) == 2
+    first_activity = next(a for a in snapshot["activities"] if a["request_id"] == first)
+    assert first_activity["input_count"] == 2
+    assert first_activity["elapsed_seconds"] >= 0
+
+    assert engine._end_activity(first) is False
+    assert engine._end_activity(second) is True
+
+
+def test_non_streaming_activity_double_end_raises():
+    engine = DummyNonStreamingEngine()
+    activity_id = engine._begin_activity("embedding")
+    engine._end_activity(activity_id)
+
+    with pytest.raises(RuntimeError):
+        engine._end_activity(activity_id)

--- a/tests/test_prefill_progress_activity.py
+++ b/tests/test_prefill_progress_activity.py
@@ -1,0 +1,39 @@
+import time
+
+from omlx.prefill_progress import PrefillProgressTracker
+
+
+def test_prefill_progress_resets_elapsed_when_phase_changes(monkeypatch):
+    tracker = PrefillProgressTracker()
+    times = iter([100.0, 110.0, 112.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(times))
+
+    tracker.update("req", 10, 100, "model", phase="specprefill_scoring")
+    tracker.update("req", 0, 50, "model", phase="specprefill_sparse")
+
+    progress = tracker.get_model_progress("model")[0]
+    assert progress["phase"] == "specprefill_sparse"
+    assert progress["elapsed"] == 2.0
+
+
+def test_prefill_progress_extra_cannot_clobber_base_fields():
+    tracker = PrefillProgressTracker()
+
+    tracker.update(
+        "req",
+        10,
+        100,
+        "model",
+        phase="prefill",
+        extra={
+            "processed": 999,
+            "phase": "wrong",
+            "start_time": -1,
+            "selected_tokens": 5,
+        },
+    )
+
+    progress = tracker.get_model_progress("model")[0]
+    assert progress["processed"] == 10
+    assert progress["phase"] == "prefill"
+    assert progress["selected_tokens"] == 5

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -156,13 +156,13 @@ class TestRequest:
 
     def test_arrival_time_auto_set(self):
         """Test that arrival_time is automatically set."""
-        before = time.time()
+        before = time.monotonic()
         request = Request(
             request_id="test-003",
             prompt="Test",
             sampling_params=SamplingParams(),
         )
-        after = time.time()
+        after = time.monotonic()
         assert before <= request.arrival_time <= after
 
     def test_num_output_tokens_property(self):


### PR DESCRIPTION
 Summary                                                                                                                                                                                                        
                                                                                                                                                                                                                
 Improves activity visibility in the dashboard Active Models card.                                                                                                                                              
                                                                                                                                                                                                                
 This adds live request-level details for:                                                                                                                                                                      
                                                                                                                                                                                                                
 - generation progress                                                                                                                                                                                          
 - prompt preprocessing / PP                                                                                                                                                                                    
 - SpecPrefill phases                                                                                                                                                                                           
 - queued requests                                                                                                                                                                                              
 - model loading elapsed time                                                                                                                                                                                   
                                                                                                                                                                                                                
 It also fixes the get_prefill_tracker scoping crash that could break SpecPrefill scheduling.                                                                                                                   
                                                                                                                                                                                                                
 Closes #1061                                                                                                                                                                                                   
 Closes #1103                                                                                                                                                                                                   
                                                                                                                                                                                                                
 What changed                                                                                                                                                                                                   
                                                                                                                                                                                                                
 - Show generated token count and tok/s under Generating...                                                                                                                                                     
 - Show stale generation activity as last token X ago                                                                                                                                                           
 - Show waiting requests with queue position and wait time                                                                                                                                                      
 - Show model loading elapsed time                                                                                                                                                                              
 - Add clearer SpecPrefill phase labels:                                                                                                                                                                        
     - scoring draft tokens                                                                                                                                                                                     
     - system prompt prefill                                                                                                                                                                                    
     - sparse target prefill                                                                                                                                                                                    
     - selected sparse tokens                                                                                                                                                                                   
 - Stream SpecPrefill progress during scoring/system/sparse phases                                                                                                                                              
 - Use monotonic timestamps for duration tracking                                                                                                                                                               
 - Stabilize prefill speed/ETA calculation                                                                                                                                                                      
 - Avoid dashboard crashes from scheduler snapshot races                                                                                                                                                        
 - Fix local import scoping issue around get_prefill_tracker                                                                                                                                                    
                                                                                                                                                                                                                
 Testing                                                                                                                                                                                                        
                                                                                                                                                                                                                
 ```bash                                                                                                                                                                                                        
   uv run pytest tests/test_prefill_progress.py tests/test_prefill_progress_activity.py tests/test_active_models_visibility.py tests/test_request.py                                                            
 ```                                                                                                                                                                                                            
                                                                                                                                                                                                                
 All passing locally.                                                                                                                                                                                           
