### PR TITLE
fix(oq): pass text_only to _build_model_sanitizer to preserve MTP tensors

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -1505,18 +1505,22 @@ def _should_quantize_tensor(name: str, shape: tuple) -> bool:
     return True
 
 
-def _build_model_sanitizer(config: dict):
+def _build_model_sanitizer(config: dict, text_only: bool = False):
     """Build a sanitize function from the model class.
 
     For VLM models, uses mlx-vlm's model class (preserves vision weights).
     For LLM models, uses mlx-lm's model class.
+    When text_only is True, always uses the LLM path even for VLM
+    architectures so that mlx_lm_mtp patches (which handle MTP sanitize
+    for both dense and MoE) are used instead of the VLM path whose
+    _Proxy-based sanitize drops the MTP head.
 
     Returns:
         A function that takes a dict of weights and returns sanitized weights,
         or None if the model class can't be loaded.
     """
     architectures = config.get("architectures", [])
-    is_vlm = any("ForConditionalGeneration" in a for a in architectures)
+    is_vlm = any("ForConditionalGeneration" in a for a in architectures) and not text_only
 
     if is_vlm:
         try:
@@ -2064,7 +2068,7 @@ def quantize_oq_streaming(
 
     cb("loading", 12.0)
 
-    sanitize_fn = _build_model_sanitizer(config)
+    sanitize_fn = _build_model_sanitizer(config, text_only=text_only)
     # When preserve_mtp is True, the patched sanitize functions
     # (mlx_lm_mtp/qwen35_model.py and mlx_vlm_mtp/qwen35_vlm_model.py)
     # keep mtp.* in the output and apply the +1 RMSNorm shift to MTP

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -1291,4 +1291,77 @@ class TestDiscoverSanitizePlan:
 
 
 # =============================================================================
+# Test _build_model_sanitizer text_only VLM bypass
+# =============================================================================
+
+
+class TestBuildModelSanitizerTextOnly:
+    """When text_only=True, _build_model_sanitizer must use the mlx-lm (LLM)
+    sanitize path — never the mlx-vlm (VLM) path — even when the model config
+    lists a ForConditionalGeneration architecture.
+
+    Without this, VLM sanitize uses a _Proxy that lacks self.mtp, silently
+    stripping all mtp.* tensors from the oQ output despite preserve_mtp=True.
+    """
+
+    VLM_CONFIG = {
+        "architectures": ["Qwen2_5_VLForConditionalGeneration"],
+        "model_type": "qwen3_5",
+        "num_hidden_layers": 28,
+        "hidden_size": 3584,
+    }
+
+    LLM_CONFIG = {
+        "architectures": ["Qwen2ForCausalLM"],
+        "model_type": "qwen3_5",
+        "num_hidden_layers": 28,
+        "hidden_size": 3584,
+    }
+
+    def test_vlm_config_without_text_only_attempts_vlm_path(self):
+        """Baseline: VLM config without text_only should try the VLM path."""
+        from unittest.mock import patch
+
+        from omlx.oq import _build_model_sanitizer
+
+        with patch("omlx.oq.logger") as mock_logger:
+            _build_model_sanitizer(self.VLM_CONFIG, text_only=False)
+
+        debug_messages = [str(c) for c in mock_logger.debug.call_args_list]
+        info_messages = [str(c) for c in mock_logger.info.call_args_list]
+        all_messages = " ".join(debug_messages + info_messages)
+        assert "mlx-vlm" in all_messages or "mlx-lm" in all_messages
+
+    def test_vlm_config_with_text_only_skips_vlm_path(self):
+        """With text_only=True, the VLM path must be skipped entirely."""
+        from unittest.mock import patch
+
+        from omlx.oq import _build_model_sanitizer
+
+        with patch("omlx.oq.logger") as mock_logger:
+            _build_model_sanitizer(self.VLM_CONFIG, text_only=True)
+
+        debug_messages = [str(c) for c in mock_logger.debug.call_args_list]
+        info_messages = [str(c) for c in mock_logger.info.call_args_list]
+        all_messages = " ".join(debug_messages + info_messages)
+        assert "mlx-vlm full sanitize" not in all_messages
+
+    def test_llm_config_unaffected_by_text_only(self):
+        """LLM configs (no ForConditionalGeneration) should always use the
+        mlx-lm path regardless of text_only."""
+        from unittest.mock import patch
+
+        from omlx.oq import _build_model_sanitizer
+
+        for text_only in (True, False):
+            with patch("omlx.oq.logger") as mock_logger:
+                _build_model_sanitizer(self.LLM_CONFIG, text_only=text_only)
+
+            debug_messages = [str(c) for c in mock_logger.debug.call_args_list]
+            info_messages = [str(c) for c in mock_logger.info.call_args_list]
+            all_messages = " ".join(debug_messages + info_messages)
+            assert "mlx-vlm full sanitize" not in all_messages
+
+
+# =============================================================================
 # Test GPTQ quantization


### PR DESCRIPTION
## Summary

When `text_only=True` is passed to `quantize_oq_streaming`, the caller wants a text-only quantization — no vision weights, just the language model. However, `_build_model_sanitizer` never received this flag and unconditionally chose the VLM sanitize path for any model whose config lists a `ForConditionalGeneration` architecture.

This affects all Qwen3.5 and Qwen3.6 checkpoints, which register `Qwen2_5_VLForConditionalGeneration` even though the underlying text model has MTP heads.

The VLM sanitize path uses mlx-vlm's `_Proxy`-based model loading, which never attaches `self.mtp`. As a result, the sanitize function silently drops every `mtp.*` tensor from the output — even when `preserve_mtp=True`. The quantized model ships with 0 MTP tensors and falls back to single-token decoding at inference time.

## Root cause

`_build_model_sanitizer(config)` checked `config["architectures"]` for `"ForConditionalGeneration"` but had no knowledge of whether the caller intended a text-only quantization. The `text_only` parameter was only used later in the tensor write loop to skip vision weights — by that point, MTP tensors had already been stripped by the wrong sanitizer.

## Changes

- Add a `text_only: bool = False` parameter to `_build_model_sanitizer`.
- When `text_only` is `True`, skip VLM detection so the LLM sanitize path is always used. The `mlx_lm_mtp` patches handle MTP sanitize correctly for both dense and MoE architectures.
- Thread `text_only` from `quantize_oq_streaming` through to the call site.

## Reproduction

1. Start oMLX with any Qwen3.5 or Qwen3.6 model.
2. Run oQ quantization via the admin API with `preserve_mtp: true` and `text_only: true`.
3. Check the output for `mtp.*` tensors.

**Before fix:** 0 MTP tensors in output.
**After fix:** 39 MTP tensors preserved (verified on Qwen3.6-35B-A3B oQ8).

## Test plan

- [x] Verified on Qwen3.6-35B-A3B: oQ8 with `text_only=true` and `preserve_mtp=true` produces 39 MTP tensors in output (0 before fix).
- [x] All existing tests pass (`uv run pytest tests/ -x` — 1 pre-existing failure in `test_response_endpoint_recovers_tool_call_from_thinking` unrelated to this change).

Related: #1109, #1099, #1094, #1092