### PR TITLE
fix(app): persist DMG model directory changes

### DIFF
--- a/packaging/omlx_app/config.py
+++ b/packaging/omlx_app/config.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -169,11 +169,14 @@ class ServerConfig:
         try:
             with open(settings_file) as f:
                 data = json.load(f)
+            model_settings = data.get("model", {})
+            model_dirs = model_settings.get("model_dirs") or []
+            model_dir = model_dirs[0] if model_dirs else model_settings.get("model_dir")
             return {
-                "model_dir": data.get("model", {}).get("model_dir"),
+                "model_dir": model_dir,
                 "port": data.get("server", {}).get("port", 8000),
             }
-        except (json.JSONDecodeError, OSError) as e:
+        except (json.JSONDecodeError, OSError):
             return {}
 
     def sync_from_server_settings(self):
@@ -189,14 +192,14 @@ class ServerConfig:
         if "model_dir" in server_settings and server_settings["model_dir"]:
             self.model_dir = server_settings["model_dir"]
 
-    def sync_model_dir_to_server_settings(self):
-        """Write app's model_dir to server's settings.json if model_dirs not already set.
+    def sync_model_dir_to_server_settings(self, overwrite: bool = False):
+        """Write app's model directory to server settings.json.
 
-        Called after the welcome screen sets a model directory, so the server
-        picks it up from settings.json instead of a CLI flag.
+        The welcome screen uses the default conservative behavior so existing
+        multi-directory settings from the web admin are preserved. Preferences
+        saves pass overwrite=True because the user explicitly selected the app's
+        single model directory setting there.
         """
-        if not self.model_dir:
-            return
         settings_file = Path(self.base_path).expanduser() / "settings.json"
         data = {}
         if settings_file.exists():
@@ -207,13 +210,52 @@ class ServerConfig:
                 pass
         if "model" not in data:
             data["model"] = {}
-        existing_dirs = data["model"].get("model_dirs", [])
-        if not existing_dirs:
-            data["model"]["model_dirs"] = [self.model_dir]
-            data["model"]["model_dir"] = self.model_dir
-            settings_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(settings_file, "w") as f:
-                json.dump(data, f, indent=2)
+
+        existing_dirs = data["model"].get("model_dirs") or []
+        existing_dir = data["model"].get("model_dir")
+        if not overwrite and (existing_dirs or existing_dir):
+            return
+
+        model_dir = self.get_effective_model_dir()
+        data["model"]["model_dirs"] = [model_dir]
+        data["model"]["model_dir"] = model_dir
+        settings_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(settings_file, "w") as f:
+            json.dump(data, f, indent=2)
+
+    def update_model_dir_runtime(self, model_dir: str) -> bool:
+        """Update model directory on a running server via admin API.
+
+        The admin API updates the in-memory server state and persists the same
+        value to settings.json. Returns False if the server is unreachable or
+        authentication fails.
+        """
+        base_url = f"http://127.0.0.1:{self.port}"
+        current_key = self.get_server_api_key()
+
+        try:
+            session = requests.Session()
+            session.trust_env = False
+
+            if current_key:
+                login_resp = session.post(
+                    f"{base_url}/admin/api/login",
+                    json={"api_key": current_key},
+                    timeout=2,
+                )
+                if login_resp.status_code != 200:
+                    return False
+
+            resp = session.post(
+                f"{base_url}/admin/api/global-settings",
+                json={"model_dirs": [model_dir]},
+                timeout=2,
+            )
+            return resp.status_code == 200
+
+        except requests.RequestException as e:
+            logger.debug(f"Failed to update model directory on running server: {e}")
+            return False
 
     def sync_port_to_server_settings(self):
         """Write app's port to server's settings.json so `omlx launch` and other

--- a/packaging/omlx_app/preferences.py
+++ b/packaging/omlx_app/preferences.py
@@ -508,10 +508,10 @@ class PreferencesWindowController(NSObject):
         self.config.start_server_on_launch = bool(self.auto_start_checkbox.state())
         self.config.save()
 
+        from .server_manager import ServerStatus
+
         # Save API key
         if api_key:
-            from .server_manager import ServerStatus
-
             if self.server_manager.status == ServerStatus.RUNNING:
                 # Update running server via admin API (also saves to settings.json)
                 if not self.config.update_server_api_key_runtime(api_key):
@@ -519,6 +519,17 @@ class PreferencesWindowController(NSObject):
                     self.config.set_server_api_key(api_key)
             else:
                 self.config.set_server_api_key(api_key)
+
+        # Keep the server settings in sync with the DMG app's single model
+        # directory preference. The server reads settings.json on startup and
+        # keeps an in-memory copy while running.
+        if self.server_manager.status == ServerStatus.RUNNING:
+            if not self.config.update_model_dir_runtime(
+                self.config.get_effective_model_dir()
+            ):
+                self.config.sync_model_dir_to_server_settings(overwrite=True)
+        else:
+            self.config.sync_model_dir_to_server_settings(overwrite=True)
 
         self._apply_launch_at_login(self.config.launch_at_login)
 

--- a/tests/test_omlx_app.py
+++ b/tests/test_omlx_app.py
@@ -22,7 +22,12 @@ import pytest
 
 # Import the modules under test
 sys.path.insert(0, str(Path(__file__).parent.parent / "packaging"))
-from omlx_app.config import ServerConfig, get_app_support_dir, get_config_path, get_log_path
+from omlx_app.config import (
+    ServerConfig,
+    get_app_support_dir,
+    get_config_path,
+    get_log_path,
+)
 from omlx_app.server_manager import PortConflict, ServerManager, ServerStatus
 
 
@@ -235,6 +240,26 @@ class TestServerConfig:
         assert result["model_dir"] == "/server/models"
         assert result["port"] == 9000
 
+    def test_load_server_settings_prefers_model_dirs(self, tmp_path: Path):
+        """Test loading primary model_dirs entry from server settings.json."""
+        config = ServerConfig(base_path=str(tmp_path))
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(
+            json.dumps(
+                {
+                    "model": {
+                        "model_dirs": ["/primary/models", "/secondary/models"],
+                        "model_dir": "/legacy/models",
+                    },
+                    "server": {"port": 9000},
+                }
+            )
+        )
+
+        result = config.load_server_settings()
+        assert result["model_dir"] == "/primary/models"
+        assert result["port"] == 9000
+
     def test_load_server_settings_missing_file(self, tmp_path: Path):
         """Test load_server_settings returns empty dict when no file."""
         config = ServerConfig(base_path=str(tmp_path))
@@ -316,6 +341,96 @@ class TestServerConfig:
             data = json.load(f)
         assert data["server"]["port"] == 7999
 
+    def test_sync_model_dir_to_server_settings_new_file(self, tmp_path: Path):
+        """Test syncing model directory creates settings.json if missing."""
+        model_dir = str(tmp_path / "models")
+        config = ServerConfig(base_path=str(tmp_path), model_dir=model_dir)
+        config.sync_model_dir_to_server_settings()
+
+        settings_file = tmp_path / "settings.json"
+        assert settings_file.exists()
+        with open(settings_file) as f:
+            data = json.load(f)
+        assert data["model"]["model_dirs"] == [model_dir]
+        assert data["model"]["model_dir"] == model_dir
+
+    def test_sync_model_dir_to_server_settings_preserves_existing_by_default(
+        self, tmp_path: Path
+    ):
+        """Test conservative sync preserves existing server model directories."""
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(
+            json.dumps(
+                {
+                    "auth": {"api_key": "preserved"},
+                    "model": {
+                        "model_dirs": ["/keep/models", "/keep/other"],
+                        "model_dir": "/keep/models",
+                    },
+                }
+            )
+        )
+
+        config = ServerConfig(base_path=str(tmp_path), model_dir="/new/models")
+        config.sync_model_dir_to_server_settings()
+
+        with open(settings_file) as f:
+            data = json.load(f)
+        assert data["auth"]["api_key"] == "preserved"
+        assert data["model"]["model_dirs"] == ["/keep/models", "/keep/other"]
+        assert data["model"]["model_dir"] == "/keep/models"
+
+    def test_sync_model_dir_to_server_settings_overwrites_when_requested(
+        self, tmp_path: Path
+    ):
+        """Test Preferences-style sync overwrites stale server model directory."""
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(
+            json.dumps(
+                {
+                    "auth": {"api_key": "preserved"},
+                    "model": {
+                        "model_dirs": ["/old/models"],
+                        "model_dir": "/old/models",
+                    },
+                }
+            )
+        )
+
+        config = ServerConfig(base_path=str(tmp_path), model_dir="/new/models")
+        config.sync_model_dir_to_server_settings(overwrite=True)
+
+        with open(settings_file) as f:
+            data = json.load(f)
+        assert data["auth"]["api_key"] == "preserved"
+        assert data["model"]["model_dirs"] == ["/new/models"]
+        assert data["model"]["model_dir"] == "/new/models"
+
+    def test_sync_model_dir_to_server_settings_overwrites_with_default(
+        self, tmp_path: Path
+    ):
+        """Test overwrite sync persists the default base_path/models directory."""
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text(
+            json.dumps(
+                {
+                    "model": {
+                        "model_dirs": ["/old/models"],
+                        "model_dir": "/old/models",
+                    },
+                }
+            )
+        )
+
+        config = ServerConfig(base_path=str(tmp_path), model_dir="")
+        config.sync_model_dir_to_server_settings(overwrite=True)
+
+        default_model_dir = str(tmp_path / "models")
+        with open(settings_file) as f:
+            data = json.load(f)
+        assert data["model"]["model_dirs"] == [default_model_dir]
+        assert data["model"]["model_dir"] == default_model_dir
+
     def test_set_server_api_key_new_file(self, tmp_path: Path):
         """Test setting API key creates settings.json if not exists."""
         config = ServerConfig(base_path=str(tmp_path))
@@ -379,6 +494,43 @@ class TestServerConfig:
         mock_session.post.side_effect = req.ConnectionError("refused")
 
         result = config.update_server_api_key_runtime("new-key")
+        assert result is False
+
+    @patch("omlx_app.config.requests.Session")
+    def test_update_model_dir_runtime_success(self, mock_session_cls, tmp_path):
+        """Test runtime model directory update on running server."""
+        config = ServerConfig(base_path=str(tmp_path))
+        config.set_server_api_key("current-key")
+
+        mock_session = Mock()
+        mock_session_cls.return_value = mock_session
+        mock_session.post.side_effect = [
+            Mock(status_code=200),  # login
+            Mock(status_code=200),  # settings update
+        ]
+
+        result = config.update_model_dir_runtime("/new/models")
+        assert result is True
+        assert mock_session.post.call_count == 2
+        mock_session.post.assert_any_call(
+            "http://127.0.0.1:8000/admin/api/global-settings",
+            json={"model_dirs": ["/new/models"]},
+            timeout=2,
+        )
+
+    @patch("omlx_app.config.requests.Session")
+    def test_update_model_dir_runtime_server_down(self, mock_session_cls, tmp_path):
+        """Test runtime model directory update returns False when unreachable."""
+        import requests as req
+
+        config = ServerConfig(base_path=str(tmp_path))
+        config.set_server_api_key("current-key")
+
+        mock_session = Mock()
+        mock_session_cls.return_value = mock_session
+        mock_session.post.side_effect = req.ConnectionError("refused")
+
+        result = config.update_model_dir_runtime("/new/models")
         assert result is False
 
 


### PR DESCRIPTION
## Summary
- keep the macOS DMG app model directory preference in sync with the server settings file
- update a running server through the admin settings API so runtime state and disk state match
- preserve existing web-admin multi-directory settings during conservative first-run seeding, but overwrite stale values on explicit Preferences save

## Tests
- `uv run python -m pytest tests/test_omlx_app.py`
- `uv run python -m ruff check --select F841,I001 packaging/omlx_app/config.py tests/test_omlx_app.py`