### PR TITLE
deps: pin mistral-common>=1.10 to fix WhisperProcessor 'Processor not found'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,15 @@ dependencies = [
     "mlx-embeddings @ git+https://github.com/Blaizzy/mlx-embeddings@32981fa4e8064ed664b52071789dd18271fe4206",
     # mlx-vlm custom processors bypass HF AutoProcessor, so torch is not required
     "transformers>=5.0.0",
+    # transformers 5.x's tokenization_mistral_common module imports
+    # ReasoningEffort from mistral_common (added in 1.10). The audio extras
+    # transitively pull mistral-common via mlx-audio[stt], which historically
+    # resolved to 1.9.x and broke WhisperProcessor.from_pretrained() with a
+    # silent "Processor not found" on every Whisper model. Pinning the
+    # minimum here ensures resolution lands on a compatible version even
+    # without the audio extra installed.
+    # See pmarreck/omlx#1 for full repro and root cause.
+    "mistral-common>=1.10",
     "tokenizers>=0.19.0",
     "huggingface-hub>=0.23.0",
     "numpy>=1.24.0",


### PR DESCRIPTION
## Summary

`transformers 5.x`'s `tokenization_mistral_common` module imports `ReasoningEffort` from `mistral_common` (added in 1.10). The audio extras transitively pull `mistral-common` via `mlx-audio[stt]`, which historically resolved to 1.9.x — and that breaks `WhisperProcessor.from_pretrained()` with a silent fallback to `_processor=None`.

oMLX then misreports this as "missing `preprocessor_config.json`", even on Whisper models with a complete HF processor file set. Symptom: every `/v1/audio/transcriptions` request against any Whisper model returns `Processor not found. Make sure the model was loaded with a HuggingFace processor.` on oMLX 0.3.8.dev1+ / 0.3.8rc1.

## The fix

Add `mistral-common>=1.10` to the top-level `dependencies` list. pip's resolver then picks a compatible version regardless of whether the `[audio]` extra is installed, since direct deps win over transitives.

## Why I'm filing this

I'm a downstream user (ReClip+) who hit this and traced it to root cause. Full repro, debugging trail, and the local patch I currently apply to make my install work are all in **[pmarreck/omlx#1](https://github.com/pmarreck/omlx/issues/1)** on my fork. The local patch (modifying the bundled `tokenization_mistral_common.py` to make the `ReasoningEffort` import optional via try/except + stub class) works, but a direct dep bump here is the proper upstream fix.

## Test plan

- [x] Verify `pyproject.toml` parses cleanly (no syntax errors, comments preserved)
- [ ] Build oMLX with the new constraint and confirm `mistral-common>=1.10` is installed in the bundle
- [ ] `/v1/audio/transcriptions` against `whisper-large-v3-fp16` returns transcript instead of "Processor not found"
- [ ] No regression on chat-completion endpoints (which don't touch the mistral_common import path)