### PR TITLE
feat(dflash): add configurable prefix cache max_entries setting

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -132,6 +132,7 @@ class ModelSettingsRequest(BaseModel):
     dflash_draft_quant_bits: Optional[int] = None
     dflash_max_ctx: Optional[int] = None
     dflash_in_memory_cache: Optional[bool] = None
+    dflash_in_memory_cache_max_entries: Optional[int] = None
     dflash_in_memory_cache_max_bytes: Optional[int] = None
     dflash_ssd_cache: Optional[bool] = None
     # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch)
@@ -1606,6 +1607,7 @@ async def list_models(is_admin: bool = Depends(require_admin)):
                 "dflash_draft_quant_bits": settings.dflash_draft_quant_bits,
                 "dflash_max_ctx": settings.dflash_max_ctx,
                 "dflash_in_memory_cache": settings.dflash_in_memory_cache,
+                "dflash_in_memory_cache_max_entries": settings.dflash_in_memory_cache_max_entries,
                 "dflash_in_memory_cache_max_bytes": settings.dflash_in_memory_cache_max_bytes,
                 "dflash_ssd_cache": settings.dflash_ssd_cache,
                 "mtp_enabled": settings.mtp_enabled,
@@ -1881,6 +1883,11 @@ async def update_model_settings(
         current_settings.dflash_max_ctx = value if value and value > 0 else None
     if "dflash_in_memory_cache" in sent:
         current_settings.dflash_in_memory_cache = bool(request.dflash_in_memory_cache)
+    if "dflash_in_memory_cache_max_entries" in sent:
+        value = request.dflash_in_memory_cache_max_entries
+        current_settings.dflash_in_memory_cache_max_entries = (
+            int(value) if value and value > 0 else 4
+        )
     if "dflash_in_memory_cache_max_bytes" in sent and request.dflash_in_memory_cache_max_bytes:
         current_settings.dflash_in_memory_cache_max_bytes = int(
             request.dflash_in_memory_cache_max_bytes
@@ -2058,6 +2065,7 @@ async def update_model_settings(
             or "dflash_draft_quant_bits" in sent
             or "dflash_max_ctx" in sent
             or "dflash_in_memory_cache" in sent
+            or "dflash_in_memory_cache_max_entries" in sent
             or "dflash_in_memory_cache_max_bytes" in sent
             or "dflash_ssd_cache" in sent
             # trust_remote_code is plumbed at model load time; toggling it on

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1555,6 +1555,7 @@
                     dflash_draft_quant_bits: settings.dflash_draft_quant_bits ? String(settings.dflash_draft_quant_bits) : '',
                     dflash_max_ctx: settings.dflash_max_ctx ?? null,
                     dflash_in_memory_cache: settings.dflash_in_memory_cache !== false,
+                    dflash_in_memory_cache_max_entries: settings.dflash_in_memory_cache_max_entries || 4,
                     dflash_in_memory_cache_max_gib: settings.dflash_in_memory_cache_max_bytes
                         ? Math.round(settings.dflash_in_memory_cache_max_bytes / (1024 ** 3))
                         : 8,
@@ -1652,6 +1653,9 @@
                                 dflash_in_memory_cache: this.modelSettings.dflash_enabled
                                     ? !!this.modelSettings.dflash_in_memory_cache
                                     : true,
+                                dflash_in_memory_cache_max_entries: this.modelSettings.dflash_enabled
+                                    ? (parseInt(this.modelSettings.dflash_in_memory_cache_max_entries) || 4)
+                                    : 4,
                                 dflash_in_memory_cache_max_bytes: this.modelSettings.dflash_enabled
                                     ? Math.max(1, parseInt(this.modelSettings.dflash_in_memory_cache_max_gib) || 8) * (1024 ** 3)
                                     : 8 * (1024 ** 3),
@@ -1731,6 +1735,7 @@
                         this.modelSettings.dflash_draft_quant_bits = null;
                         this.modelSettings.dflash_max_ctx = null;
                         this.modelSettings.dflash_in_memory_cache = true;
+                        this.modelSettings.dflash_in_memory_cache_max_entries = 4;
                         this.modelSettings.dflash_in_memory_cache_max_gib = 8;
                         this.modelSettings.dflash_ssd_cache = false;
                         this.modelSettings.mtp_enabled = false;

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -737,6 +737,12 @@
                                             </button>
                                         </div>
                                         <div x-show="modelSettings.dflash_in_memory_cache" x-transition>
+                                            <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">In-memory cache max entries</label>
+                                            <input type="number" x-model.number="modelSettings.dflash_in_memory_cache_max_entries" min="1" max="128" step="1" placeholder="4"
+                                                   class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
+                                            <p class="text-xs text-neutral-400 mt-1">Maximum number of prefix snapshots kept in L1 cache. Each entry stores KV + draft GDN state for one conversation prefix.</p>
+                                        </div>
+                                        <div x-show="modelSettings.dflash_in_memory_cache" x-transition>
                                             <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">In-memory cache size (GiB)</label>
                                             <input type="number" x-model.number="modelSettings.dflash_in_memory_cache_max_gib" min="1" max="256" step="1" placeholder="8"
                                                    class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -108,6 +108,11 @@ class DFlashEngine(BaseEngine):
             if model_settings
             else True
         )
+        self._in_memory_cache_max_entries = int(
+            getattr(model_settings, "dflash_in_memory_cache_max_entries", 4)
+            if model_settings
+            else 4
+        )
         self._in_memory_cache_max_bytes = int(
             getattr(model_settings, "dflash_in_memory_cache_max_bytes", 8 * 1024**3)
             if model_settings
@@ -170,6 +175,7 @@ class DFlashEngine(BaseEngine):
         cfg = runtime_config_from_profile(
             profile="balanced",
             prefix_cache=self._in_memory_cache_enabled,
+            prefix_cache_max_entries=self._in_memory_cache_max_entries,
             prefix_cache_max_bytes=self._in_memory_cache_max_bytes,
             prefix_cache_l2=l2_enabled,
             prefix_cache_l2_dir=str(l2_dir) if l2_dir else "",

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -65,6 +65,7 @@ class ModelSettings:
         dflash_draft_quant_bits: Draft model quantization bits.
         dflash_max_ctx: Token threshold to fall back to BatchedEngine (None = unlimited).
         dflash_in_memory_cache: Enable DFlash L1 (RAM) prefix cache.
+        dflash_in_memory_cache_max_entries: L1 cache max entries (None = use dflash profile default, e.g. 4).
         dflash_in_memory_cache_max_bytes: L1 cache byte budget.
         dflash_ssd_cache: Enable DFlash L2 (SSD) prefix cache spill (uses omlx SSD cache dir).
         mtp_enabled: Enable native multi-token prediction (mlx-lm PR 990 / PR 15 monkey-patch).
@@ -121,6 +122,7 @@ class ModelSettings:
     # DFlash prefix cache (private to dflash; separate from omlx tiered cache because
     # snapshots include draft model GDN state and target hidden chunks omlx never tracks)
     dflash_in_memory_cache: bool = True
+    dflash_in_memory_cache_max_entries: int = 4  # Default 4 entries (dflash profile default is 4)
     dflash_in_memory_cache_max_bytes: int = 8 * 1024 * 1024 * 1024  # 8 GiB (balanced profile default)
     dflash_ssd_cache: bool = False  # Requires in-memory cache and an omlx paged SSD cache dir
 


### PR DESCRIPTION
## Summary

The DFlash prefix cache `max_entries` was previously hardcoded to the dflash-mlx "balanced" profile default of **4**, with no way to override it from oMLX. This meant users couldn't increase the number of cached prefix snapshots even when they had sufficient memory budget.

This PR adds a new per-model setting `dflash_in_memory_cache_max_entries` (default: **4**, matching the dflash-mlx balanced profile) that is passed directly to `runtime_config_from_profile(prefix_cache_max_entries=...)`, giving users explicit control over how many prefix snapshots are retained in L1.

## Changes

| File | Change |
|------|--------|
| `omlx/model_settings.py` | Add `dflash_in_memory_cache_max_entries: int = 4` field |
| `omlx/engine/dflash.py` | Read the setting and pass `prefix_cache_max_entries` to `runtime_config_from_profile()` |
| `omlx/admin/routes.py` | Expose in API request model, response payload, update handler, and reload trigger |
| `omlx/admin/static/js/dashboard.js` | Wire up JS model init, save payload, and reset defaults |
| `omlx/admin/templates/dashboard/_modal_model_settings.html` | Add number input field in the DFlash cache section |

## Behavior

- Default is 4 entries (matches dflash-mlx balanced profile)
- Configurable per-model via admin API (`PUT /admin/api/models/{id}/settings`) or the dashboard UI
- Changing the value on a loaded model triggers automatic unload + reload
- Setting to 0 or null resets to default (4)

## UI

A new "In-memory cache max entries" input appears in the DFlash section of the model settings modal (visible when in-memory cache is enabled), right above the existing cache size (GiB) field.