### PR TITLE
feat(oq): on-the-fly FP8/I8 dequant in _LazyTensorIndex + OOM guard

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -33,6 +33,8 @@ OQ_DTYPES: tuple[str, ...] = ("bfloat16", "float16")
 
 _OQ_DEFAULT_GROUP_SIZE = 64
 
+_MAX_MODEL_RAM_FRACTION = 0.8
+
 _LEVEL_BITS: dict[float, int] = {2: 2, 3: 3, 3.5: 3, 4: 4, 5: 5, 6: 6, 8: 8}
 
 _LEVEL_PROTECTION: dict[float, str] = {
@@ -773,32 +775,69 @@ class _TrackedTensor:
     def __truediv__(self, other):
         return self._clone(transform="div")
 
-    # Indexing: handle slice + None (broadcast) + tuple variants
+    @staticmethod
+    def _slice_length(dim, sl):
+        start, stop, step = sl.indices(dim)
+        return len(range(start, stop, step))
+
+    @staticmethod
+    def _detect_half_split(dim, sl):
+        start, stop, step = sl.indices(dim)
+        if step != 1 or dim <= 0 or dim % 2 != 0:
+            return None
+        length = len(range(start, stop, step))
+        if length != dim // 2:
+            return None
+        if start == 0:
+            return 0
+        if start == dim // 2:
+            return 1
+        return None
+
     def __getitem__(self, idx):
         new_shape = list(self.shape)
-        # Handle None-broadcasting like scale[:, None, :, None]
         if isinstance(idx, tuple):
+            if Ellipsis in idx:
+                raise NotImplementedError("Ellipsis indexing not supported in _TrackedTensor")
             result_shape = []
             axis = 0
+            split_info = None
             for part in idx:
                 if part is None:
                     result_shape.append(1)
                 elif isinstance(part, slice):
                     if axis < len(new_shape):
-                        result_shape.append(new_shape[axis])
+                        dim = new_shape[axis]
+                        length = self._slice_length(dim, part)
+                        result_shape.append(length)
+                        half = self._detect_half_split(dim, part)
+                        if half is not None:
+                            split_info = (axis, half, 2)
                         axis += 1
                     else:
                         result_shape.append(1)
                 else:
-                    # int index → dimension removed
                     if axis < len(new_shape):
                         axis += 1
             while axis < len(new_shape):
                 result_shape.append(new_shape[axis])
                 axis += 1
+            if split_info is not None:
+                ax, idx_n, total = split_info
+                return _TrackedTensor(result_shape, self.dtype, list(self.sources),
+                                     f"split_{idx_n}_{total}", axis=ax)
             return _TrackedTensor(result_shape, self.dtype, list(self.sources), "slice")
         if isinstance(idx, slice):
-            return self._clone(transform="slice")
+            dim = new_shape[0] if new_shape else 0
+            length = self._slice_length(dim, idx) if dim > 0 else 0
+            half = self._detect_half_split(dim, idx) if dim > 0 else None
+            if half is not None:
+                return _TrackedTensor([length] + new_shape[1:], self.dtype,
+                                     list(self.sources), f"split_{half}_2", axis=0)
+            result = list(new_shape)
+            if result:
+                result[0] = length
+            return _TrackedTensor(result, self.dtype, list(self.sources), "slice")
         # int or other
         if new_shape:
             return _TrackedTensor(new_shape[1:], self.dtype, list(self.sources), "slice")
@@ -828,6 +867,27 @@ class _TrackedTensor:
     def astype(self, dtype):
         return _TrackedTensor(self.shape, dtype, list(self.sources), "astype")
 
+    def moveaxis(self, src_ax, dst_ax):
+        src_ax = src_ax % self.ndim if src_ax < 0 else src_ax
+        dst_ax = dst_ax % self.ndim if dst_ax < 0 else dst_ax
+        dims = list(range(self.ndim))
+        dims.insert(dst_ax, dims.pop(src_ax))
+        new_shape = tuple(self.shape[d] for d in dims)
+        return _TrackedTensor(new_shape, self.dtype, list(self.sources),
+                              f"moveaxis_{src_ax}_{dst_ax}")
+
+    def transpose(self, *axes):
+        if not axes:
+            axes_list = list(reversed(range(self.ndim)))
+        elif len(axes) == 1 and isinstance(axes[0], (list, tuple)):
+            axes_list = list(axes[0])
+        else:
+            axes_list = list(axes)
+        axes_list = [a % self.ndim if a < 0 else a for a in axes_list]
+        new_shape = tuple(self.shape[a] for a in axes_list)
+        return _TrackedTensor(new_shape, self.dtype, list(self.sources),
+                              "transpose_" + "_".join(str(a) for a in axes_list))
+
     @property
     def T(self):
         return _TrackedTensor(tuple(reversed(self.shape)), self.dtype, list(self.sources), "transpose")
@@ -841,117 +901,50 @@ class _TrackedTensor:
 
 
 
-def _streaming_fp8_dequant(lazy_index, scratch_dir=None, shard_bytes=4_000_000_000):
-    """Streaming FP8 dequant with disk spill. For each (weight, weight_scale_inv)
-    pair, materialize both, run block-scaled dequant to bf16, append to a
-    scratch safetensors shard, and re-point the lazy index at it. Peak RAM
-    bounded to one weight + scale + current shard buffer."""
-    import tempfile, struct, json as _json
-    import numpy as _np
-    from pathlib import Path as _Path
+_FP8_WEIGHT_DTYPES = frozenset(("F8_E4M3", "F8_E5M2", "I8"))
 
-    scale_suffix = "_scale_inv"
-    scale_keys = [k for k in lazy_index._index if k.endswith(scale_suffix)]
-    if not scale_keys:
-        return 0
 
-    if scratch_dir is None:
-        scratch_dir = tempfile.mkdtemp(prefix="oq_fp8_dequant_")
-    scratch_dir = _Path(scratch_dir)
-    scratch_dir.mkdir(parents=True, exist_ok=True)
-    logger.info(f"FP8 dequant scratch dir: {scratch_dir}")
+def _block_dequant_fp8(weight_raw, scale_raw, w_dtype, s_dtype):
+    """Block-scaled dequant of a single FP8/I8 weight+scale pair to BF16."""
+    if s_dtype == "F8_E8M0":
+        scale = mx.power(mx.array(2.0), scale_raw.astype(mx.float32) - 127.0)
+    else:
+        scale = scale_raw
 
-    shard_idx = 0
-    shard_path = None
-    shard_fh = None
-    shard_header = {}
-    shard_data_bytes = 0
+    if w_dtype in ("F8_E4M3", "F8_E5M2"):
+        weight = mx.from_fp8(weight_raw, dtype=mx.bfloat16)
+    else:
+        weight = weight_raw.astype(mx.bfloat16)
 
-    def _flush_shard():
-        nonlocal shard_fh
-        if shard_fh is None:
-            return
-        shard_fh.close()
-        tmp_path = shard_path.with_suffix(".tmp")
-        hdr_bytes = _json.dumps(shard_header, separators=(",", ":")).encode("utf-8")
-        hlen = len(hdr_bytes)
-        with open(shard_path, "rb") as src, open(tmp_path, "wb") as dst:
-            dst.write(struct.pack("<Q", hlen))
-            dst.write(hdr_bytes)
-            dst.write(src.read())
-        tmp_path.replace(shard_path)
-        data_offset = 8 + hlen
-        for k, meta in shard_header.items():
-            start, end = meta["data_offsets"]
-            lazy_index._index[k] = (
-                str(shard_path), data_offset, start, end,
-                tuple(meta["shape"]), meta["dtype"],
-            )
-
-    def _open_new_shard():
-        nonlocal shard_idx, shard_path, shard_fh, shard_header, shard_data_bytes
-        shard_idx += 1
-        shard_path = scratch_dir / f"dequant-{shard_idx:04d}.safetensors"
-        shard_fh = open(shard_path, "wb")
-        shard_header = {}
-        shard_data_bytes = 0
-
-    _open_new_shard()
-    count = 0
-
-    for sk in scale_keys:
-        wk = sk.replace(scale_suffix, "")
-        if wk not in lazy_index._index:
-            continue
-        w_meta = lazy_index._index[wk]
-        s_meta = lazy_index._index[sk]
-        w_lt = _LazyTensor(w_meta[0], w_meta[1], w_meta[2], w_meta[3], w_meta[4], w_meta[5])
-        s_lt = _LazyTensor(s_meta[0], s_meta[1], s_meta[2], s_meta[3], s_meta[4], s_meta[5])
-        weight_u8 = w_lt[:]
-        scale_inv = s_lt[:]
-        mx.eval(weight_u8, scale_inv)
-
-        weight = mx.from_fp8(weight_u8, dtype=mx.bfloat16)
-        bs = 128
-        m, n = weight.shape
-        pad_bottom = (-m) % bs
-        pad_side = (-n) % bs
-        weight = mx.pad(weight, ((0, pad_bottom), (0, pad_side)))
-        weight = weight.reshape(
-            ((m + pad_bottom) // bs, bs, (n + pad_side) // bs, bs)
+    m, n = weight.shape
+    sm, sn = scale.shape
+    if sm == 0 or sn == 0:
+        raise ValueError(f"degenerate scale shape {scale.shape}")
+    if m % sm != 0 or n % sn != 0:
+        raise ValueError(
+            f"weight shape ({m},{n}) not divisible by scale shape ({sm},{sn})"
         )
-        weight = (weight * scale_inv[:, None, :, None]).reshape(
+    bs_row = m // sm
+    bs_col = n // sn
+
+    if bs_row > 1:
+        pad_bottom = (-m) % bs_row
+        pad_side = (-n) % bs_col
+        if pad_bottom or pad_side:
+            weight = mx.pad(weight, ((0, pad_bottom), (0, pad_side)))
+        weight = weight.reshape(sm, bs_row, sn, bs_col)
+        weight = (weight * scale[:, None, :, None]).reshape(
             m + pad_bottom, n + pad_side
         )
-        weight = weight[:m, :n].astype(mx.bfloat16)
-        mx.eval(weight)
+        if pad_bottom or pad_side:
+            weight = weight[:m, :n]
+    else:
+        weight = weight.reshape(m, sn, bs_col)
+        weight = (weight * scale[:, :, None]).reshape(m, n)
 
-        raw = bytes(_np.asarray(weight.view(mx.uint16)))
-        tensor_bytes = len(raw)
-        if shard_data_bytes > 0 and shard_data_bytes + tensor_bytes > shard_bytes:
-            _flush_shard()
-            _open_new_shard()
-
-        start = shard_data_bytes
-        end = start + tensor_bytes
-        shard_fh.write(raw)
-        shard_data_bytes = end
-        shard_header[wk] = {
-            "dtype": "BF16",
-            "shape": list(weight.shape),
-            "data_offsets": [start, end],
-        }
-        lazy_index._index.pop(wk, None)
-        lazy_index._index.pop(sk, None)
-        del weight_u8, scale_inv, weight, raw
-        mx.clear_cache()
-        count += 1
-        if count % 50 == 0:
-            logger.info(f"FP8 dequant: {count} tensors processed")
-
-    _flush_shard()
-    logger.info(f"FP8 dequant complete: {count} tensors spilled to {scratch_dir}")
-    return count
+    weight = weight.astype(mx.bfloat16)
+    mx.eval(weight)
+    return weight
 
 
 def _discover_sanitize_plan(sanitize_fn, lazy_index):
@@ -963,12 +956,18 @@ def _discover_sanitize_plan(sanitize_fn, lazy_index):
     """
     import mlx.core as mx
 
-    # Build tracked dict mirroring the lazy index
+    # Build tracked dict mirroring the lazy index (logical view hides scale
+    # keys and reports FP8 weights as BF16 so sanitize won't call from_fp8)
     tracked = {}
-    for k in lazy_index._index:
-        meta = lazy_index._index[k]
-        shape, dtype = meta[4], meta[5]
-        tracked[k] = _TrackedTensor(shape, dtype, sources=[k])
+    if hasattr(lazy_index, "logical_metadata"):
+        logical = lazy_index.logical_metadata()
+        for k, (shape, dtype) in logical.items():
+            tracked[k] = _TrackedTensor(shape, dtype, sources=[k])
+    else:
+        for k in lazy_index._index:
+            meta = lazy_index._index[k]
+            shape, dtype = meta[4], meta[5]
+            tracked[k] = _TrackedTensor(shape, dtype, sources=[k])
 
     # Monkey-patch mx ops to work on tracked tensors
     _orig = {
@@ -1030,18 +1029,23 @@ def _discover_sanitize_plan(sanitize_fn, lazy_index):
 
     def _fake_moveaxis(tensor, src_ax, dst_ax):
         if isinstance(tensor, _TrackedTensor):
+            src_ax = src_ax % tensor.ndim if src_ax < 0 else src_ax
+            dst_ax = dst_ax % tensor.ndim if dst_ax < 0 else dst_ax
             dims = list(range(tensor.ndim))
             dims.insert(dst_ax, dims.pop(src_ax))
             new_shape = tuple(tensor.shape[d] for d in dims)
-            return _TrackedTensor(new_shape, tensor.dtype, list(tensor.sources), "moveaxis")
+            return _TrackedTensor(new_shape, tensor.dtype, list(tensor.sources),
+                                  f"moveaxis_{src_ax}_{dst_ax}")
         return _orig["moveaxis"](tensor, src_ax, dst_ax)
 
     def _fake_transpose(tensor, axes=None):
         if isinstance(tensor, _TrackedTensor):
             if axes is None:
                 axes = list(reversed(range(tensor.ndim)))
+            axes = [a % tensor.ndim if a < 0 else a for a in axes]
             new_shape = tuple(tensor.shape[a] for a in axes)
-            return _TrackedTensor(new_shape, tensor.dtype, list(tensor.sources), "transpose")
+            return _TrackedTensor(new_shape, tensor.dtype, list(tensor.sources),
+                                  "transpose_" + "_".join(str(a) for a in axes))
         return _orig["transpose"](tensor, axes=axes)
 
     def _noop(*a, **kw): pass
@@ -1084,17 +1088,26 @@ def _discover_sanitize_plan(sanitize_fn, lazy_index):
             setattr(mx, name, fn)
 
     # Extract plan
+    _REPLAYABLE_PREFIXES = (
+        "passthrough", "literal", "stack", "concatenate", "add",
+        "transpose_", "moveaxis_", "split_",
+    )
     plan = {}
     for k, v in result.items():
         if isinstance(v, _TrackedTensor):
+            t = v.transform
+            if not any(t == p or t.startswith(p) for p in _REPLAYABLE_PREFIXES):
+                raise ValueError(
+                    f"non-replayable transform {t!r} for {k!r} — "
+                    "falling back to eager sanitize"
+                )
             plan[k] = {
                 "sources": v.sources,
-                "transform": v.transform,
+                "transform": t,
                 "shape": v.shape,
                 "axis": v.axis,
             }
         else:
-            # sanitize returned a real value (rare — e.g. a scalar override)
             plan[k] = {
                 "sources": [],
                 "transform": "literal",
@@ -1144,11 +1157,12 @@ class _DiscoveredPlan:
 
     def _materialize_source(self, src_key):
         """Load a single source tensor from the lazy index."""
+        if hasattr(self._lazy, '_fp8_pairs') and src_key in self._lazy._fp8_pairs:
+            return self._lazy._dequant_one(src_key)
         meta = self._lazy._index.get(src_key)
         if meta is None:
             raise KeyError(f"source tensor {src_key!r} not in lazy index")
         sf_path, data_offset, start, end, shape, dtype = meta
-        # Scalars (0-dim tensors) need special handling
         if len(shape) == 0:
             import numpy as _np
             with open(sf_path, "rb") as f:
@@ -1212,21 +1226,20 @@ class _DiscoveredPlan:
             mx.clear_cache()
             return result
 
-        # NOTE: discovery records transform TYPE but not parameters.
-        # These hardcoded values cover all current mlx-lm/mlx-vlm sanitize
-        # patterns. If a future model uses different parameters, discovery
-        # will fail and the eager sanitize fallback handles it safely.
         if transform == "add":
             arr = self._materialize_source(sources[0])
             return arr + 1.0  # norm weight += 1.0 pattern
 
-        if transform == "transpose":
+        if transform.startswith("transpose_"):
+            axes = [int(a) for a in transform.split("_")[1:]]
             arr = self._materialize_source(sources[0])
-            return mx.transpose(arr)  # full axis reverse
+            return mx.transpose(arr, axes=axes)
 
-        if transform == "moveaxis":
+        if transform.startswith("moveaxis_"):
+            parts = transform.split("_")
+            src_ax, dst_ax = int(parts[1]), int(parts[2])
             arr = self._materialize_source(sources[0])
-            return mx.moveaxis(arr, 2, 1)  # conv1d weight permute
+            return mx.moveaxis(arr, src_ax, dst_ax)
 
         if "split_" in transform:
             # split_N_M means take part N of M
@@ -1244,9 +1257,16 @@ class _DiscoveredPlan:
             # split_idx (index-based split) — less common
             return arr
 
-        # Fallback: just load first source
-        if sources:
+        if transform == "slice":
+            raise ValueError(
+                f"cannot replay arbitrary slice for {key!r} — "
+                "discovery should fall back to eager sanitize"
+            )
+
+        # Fallback: passthrough (identity) — load first source unchanged
+        if transform == "passthrough" and sources:
             return self._materialize_source(sources[0])
+
         raise ValueError(f"cannot materialize {key!r}: transform={transform}, no sources")
 
 
@@ -1768,7 +1788,7 @@ _LOAD_CHUNK_BYTES     = max(1 << 20, _METAL_MAX_BUFFER // 2)
 class _LazyTensorIndex:
     _DTYPE_BYTES = {"BF16":2,"F16":2,"F32":4,"F64":8,"I8":1,"U8":1,
                     "I16":2,"U16":2,"I32":4,"U32":4,"I64":8,"U64":8,"BOOL":1,
-                    "F8_E4M3":1,"F8_E5M2":1}
+                    "F8_E4M3":1,"F8_E5M2":1,"F8_E8M0":1}
 
     def __init__(self, weight_files):
         self._index = {}
@@ -1783,38 +1803,102 @@ class _LazyTensorIndex:
                     self._index[k] = (sf_path, data_offset,
                                       meta["data_offsets"][0], meta["data_offsets"][1],
                                       tuple(meta["shape"]), meta["dtype"])
+        self._fp8_pairs = {}
+        self._fp8_scale_keys = set()
+        self._discover_fp8_pairs()
+
+    def _discover_fp8_pairs(self):
+        seen = set()
+        for k in list(self._index):
+            if k.endswith("_scale_inv"):
+                wk = k[:-len("_scale_inv")]
+                if (wk in self._index and wk not in seen
+                        and self._index[wk][5] in _FP8_WEIGHT_DTYPES):
+                    self._fp8_pairs[wk] = k
+                    seen.add(wk)
+            elif k.endswith(".scale"):
+                wk = k[:-len(".scale")] + ".weight"
+                if (wk in self._index and wk not in seen
+                        and self._index[wk][5] in _FP8_WEIGHT_DTYPES):
+                    self._fp8_pairs[wk] = k
+                    seen.add(wk)
+        self._fp8_scale_keys = set(self._fp8_pairs.values())
+        if self._fp8_pairs:
+            logger.info(
+                f"FP8 on-the-fly dequant: {len(self._fp8_pairs)} weight+scale pairs detected"
+            )
+
+    def _dequant_one(self, wk):
+        sk = self._fp8_pairs[wk]
+        w_meta = self._index[wk]
+        s_meta = self._index[sk]
+        w_lt = _LazyTensor(w_meta[0], w_meta[1], w_meta[2], w_meta[3], w_meta[4], w_meta[5])
+        s_lt = _LazyTensor(s_meta[0], s_meta[1], s_meta[2], s_meta[3], s_meta[4], s_meta[5])
+        weight_raw = w_lt[:]
+        scale_raw = s_lt[:]
+        mx.eval(weight_raw, scale_raw)
+        weight = _block_dequant_fp8(weight_raw, scale_raw, w_meta[5], s_meta[5])
+        del weight_raw, scale_raw
+        mx.clear_cache()
+        return weight
+
+    def _is_visible(self, k):
+        return k not in self._fp8_scale_keys
+
+    def logical_metadata(self):
+        """Metadata for plan discovery: FP8 weights report as BF16, scale keys hidden."""
+        result = {}
+        for k, meta in self._index.items():
+            if k in self._fp8_scale_keys:
+                continue
+            shape, dtype = meta[4], meta[5]
+            if k in self._fp8_pairs:
+                dtype = "BF16"
+            result[k] = (shape, dtype)
+        return result
 
     def keys(self):
+        base = [k for k in self._index if self._is_visible(k)]
         if hasattr(self, "_overrides"):
-            return list(self._index.keys()) + list(self._overrides.keys())
-        return self._index.keys()
+            base.extend(self._overrides.keys())
+        return base
     def __len__(self):
-        n = len(self._index)
+        n = sum(1 for k in self._index if self._is_visible(k))
         if hasattr(self, "_overrides"): n += len(self._overrides)
         return n
     def __contains__(self, k):
-        if k in self._index: return True
+        if k in self._index and self._is_visible(k): return True
         return hasattr(self, "_overrides") and k in self._overrides
     def __iter__(self):
-        yield from self._index
+        for k in self._index:
+            if self._is_visible(k):
+                yield k
         if hasattr(self, "_overrides"):
             for k in self._overrides:
                 if k not in self._index:
                     yield k
-    def nbytes(self):         return sum(e - s for _,_,s,e,_,_ in self._index.values())
+    def nbytes(self):
+        return sum(e - s for k, (_,_,s,e,_,_) in self._index.items()
+                   if self._is_visible(k))
 
-    def __getitem__(self, key):
-        if key not in self._index:
-            raise KeyError(key)
+    def _load_raw(self, key):
         sf_path, data_offset, start, end, shape, dtype = self._index[key]
         lt = _LazyTensor(sf_path, data_offset, start, end, shape, dtype)
-        # Materialize as a real mx.array; _load_rows handles chunking internally.
-        arr = lt[:]
-        return arr
+        return lt[:]
+
+    def __getitem__(self, key):
+        if hasattr(self, "_overrides") and key in self._overrides:
+            return self._overrides[key]
+        if key not in self._index:
+            raise KeyError(key)
+        if key in self._fp8_pairs:
+            return self._dequant_one(key)
+        return self._load_raw(key)
 
     def items(self):
-        # Materialize tensors one at a time so sanitize sees real arrays.
         for k in list(self._index.keys()):
+            if not self._is_visible(k):
+                continue
             yield k, self[k]
             mx.clear_cache()
         if hasattr(self, "_overrides"):
@@ -1822,19 +1906,22 @@ class _LazyTensorIndex:
                 yield k, v
 
     def get(self, key, default=None):
-        if key in self._index:
+        if key in self:
             return self[key]
         return default
 
     def __setitem__(self, key, value):
-        # Sanitize may write back transformed tensors. Store as in-memory
-        # override; remove from lazy index so we don't re-load from disk.
         if not hasattr(self, "_overrides"):
             self._overrides = {}
         self._overrides[key] = value
         self._index.pop(key, None)
+        self._fp8_pairs.pop(key, None)
 
     def __delitem__(self, key):
+        if key in self._fp8_pairs:
+            sk = self._fp8_pairs.pop(key)
+            self._fp8_scale_keys.discard(sk)
+            self._index.pop(sk, None)
         self._index.pop(key, None)
         if hasattr(self, "_overrides"):
             self._overrides.pop(key, None)
@@ -1853,6 +1940,13 @@ class _LazyTensorIndex:
         if key not in self._index:
             if default: return default[0]
             raise KeyError(key)
+        if key in self._fp8_pairs:
+            result = self._dequant_one(key)
+            sk = self._fp8_pairs.pop(key)
+            self._fp8_scale_keys.discard(sk)
+            self._index.pop(key, None)
+            self._index.pop(sk, None)
+            return result
         sf_path, data_offset, start, end, shape, dtype = self._index.pop(key)
         lt = _LazyTensor(sf_path, data_offset, start, end, shape, dtype)
         arr = lt[:]
@@ -1885,17 +1979,31 @@ class _LazyTensor:
     def nbytes(self):
         return self._end - self._start
 
+    _SF_TO_MLX = {
+        "BF16": mx.bfloat16, "F16": mx.float16, "F32": mx.float32,
+        "I8": mx.int8, "U8": mx.uint8,
+        "I16": mx.int16, "U16": mx.uint16,
+        "I32": mx.int32, "U32": mx.uint32,
+        "I64": mx.int64, "U64": mx.uint64,
+        "F8_E4M3": mx.uint8, "F8_E5M2": mx.uint8, "F8_E8M0": mx.uint8,
+        "BOOL": mx.bool_,
+    }
+
+    _SF_TO_NP = {
+        "BF16": _np.uint16, "F16": _np.float16, "F32": _np.float32, "F64": _np.float64,
+        "I8": _np.int8, "U8": _np.uint8,
+        "I16": _np.int16, "U16": _np.uint16,
+        "I32": _np.int32, "U32": _np.uint32,
+        "I64": _np.int64, "U64": _np.uint64,
+        "F8_E4M3": _np.uint8, "F8_E5M2": _np.uint8, "F8_E8M0": _np.uint8,
+        "BOOL": _np.bool_,
+    }
+
     def _mlx_dtype(self):
-        # FP8 variants are loaded as uint8; sanitize calls mx.from_fp8 to convert
-        if self._dtype in ("F8_E4M3", "F8_E5M2"):
-            return mx.uint8
-        return {"BF16":mx.bfloat16,"F16":mx.float16,"F32":mx.float32}.get(self._dtype, mx.bfloat16)
+        return self._SF_TO_MLX.get(self._dtype, mx.bfloat16)
 
     def _np_view_dtype(self):
-        if self._dtype in ("F8_E4M3", "F8_E5M2"):
-            return _np.uint8
-        if self._bpe == 2: return _np.uint16
-        return _np.dtype({"F32":"<f4","F64":"<f8","I32":"<i4","I64":"<i8"}.get(self._dtype, "<u2"))
+        return self._SF_TO_NP.get(self._dtype, _np.uint16)
 
     def _load_rows(self, r0, r1):
         n = r1 - r0
@@ -2066,6 +2174,17 @@ def quantize_oq_streaming(
         f"{len(weight_files)} shards"
     )
 
+    from omlx.settings import get_system_memory as _get_system_memory
+    _model_bytes = all_weights.nbytes()
+    _system_ram = _get_system_memory()
+    _model_exceeds_ram = _model_bytes > int(_system_ram * _MAX_MODEL_RAM_FRACTION)
+    if _model_exceeds_ram:
+        logger.info(
+            f"oQ{oq_level:g}: model size ({_model_bytes / 1e9:.1f} GB) exceeds "
+            f"80% of system RAM ({_system_ram / 1e9:.1f} GB), "
+            "OOM-prone paths will be skipped"
+        )
+
     cb("loading", 12.0)
 
     sanitize_fn = _build_model_sanitizer(config, text_only=text_only)
@@ -2074,39 +2193,21 @@ def quantize_oq_streaming(
     # keep mtp.* in the output and apply the +1 RMSNorm shift to MTP
     # norms. No stash/merge wrapper needed — the patch covers both paths.
     if sanitize_fn is not None:
-        # Try discovery-based streaming sanitize first (works for any model,
-        # bounds peak memory by materializing one tensor at a time)
-        # Check if source contains FP8 weights — discovery can't capture the
-        # multi-op dequant chain (from_fp8 + pad + reshape + mul + slice + astype)
-        # as a single replayable transform. Fall back to eager sanitize for those.
-        has_fp8 = False
-        if hasattr(all_weights, "_index"):
-            for _k, _meta in all_weights._index.items():
-                if _meta[5] in ("F8_E4M3", "F8_E5M2"):
-                    has_fp8 = True
-                    break
-        if has_fp8:
+        try:
+            plan = _discover_sanitize_plan(sanitize_fn, all_weights)
+            all_weights = _DiscoveredPlan(plan, all_weights)
             logger.info(
-                f"oQ{oq_level:g}: FP8 source detected, streaming dequant to scratch shards"
+                f"oQ{oq_level:g}: discovered streaming sanitize plan, "
+                f"{len(all_weights)} output tensors"
             )
-            try:
-                n_deq = _streaming_fp8_dequant(all_weights)
-                logger.info(f"oQ{oq_level:g}: FP8 dequant complete ({n_deq} tensors)")
-                all_weights = sanitize_fn(all_weights)
-                logger.info(f"oQ{oq_level:g}: sanitize applied, {len(all_weights)} tensors")
-            except Exception as e:
-                import traceback; traceback.print_exc()
-                logger.warning(f"FP8 sanitize failed ({e}), aborting")
-                raise
-        else:
-            try:
-                plan = _discover_sanitize_plan(sanitize_fn, all_weights)
-                all_weights = _DiscoveredPlan(plan, all_weights)
-                logger.info(
-                    f"oQ{oq_level:g}: discovered streaming sanitize plan, "
-                    f"{len(all_weights)} output tensors"
+        except Exception as e:
+            if _model_exceeds_ram:
+                logger.error(
+                    f"Streaming discovery failed ({e}), skipping eager "
+                    "sanitize (model exceeds RAM). Output tensor names "
+                    "may not match inference expectations."
                 )
-            except Exception as e:
+            else:
                 logger.warning(
                     f"Streaming discovery failed ({e}), falling back to eager sanitize"
                 )
@@ -2127,11 +2228,18 @@ def quantize_oq_streaming(
             num_samples=128, seq_length=256,
         )
     else:
-        logger.info(f"oQ{oq_level:g}: measuring layer sensitivity for streaming path")
-        sensitivity_map = _measure_sensitivity(
-            model_path, config, oq_level,
-            num_samples=128, seq_length=256,
-        )
+        if _model_exceeds_ram:
+            logger.info(
+                f"oQ{oq_level:g}: skipping full-model sensitivity (model exceeds RAM), "
+                "using position-based sensitivity"
+            )
+            sensitivity_map = {}
+        else:
+            logger.info(f"oQ{oq_level:g}: measuring layer sensitivity for streaming path")
+            sensitivity_map = _measure_sensitivity(
+                model_path, config, oq_level,
+                num_samples=128, seq_length=256,
+            )
     if sensitivity_map:
         config["_oq_sensitivity_map"] = {
             str(k): v for k, v in sensitivity_map.items()

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -16,7 +16,9 @@ except ImportError:
 from omlx.oq import (
     OQ_LEVELS,
     _LEVEL_BITS,
+    _MAX_MODEL_RAM_FRACTION,
     _OQ_BPW_TARGETS,
+    _DiscoveredPlan,
     _TrackedTensor,
     _bpw_targets_for_level,
     _build_quant_plan,
@@ -34,6 +36,7 @@ from omlx.oq import (
     _should_quantize_tensor,
     estimate_memory,
     make_predicate,
+    quantize_oq_streaming,
     resolve_output_name,
     universal_quant_predicate,
     validate_quantizable,
@@ -1041,7 +1044,10 @@ class TestForwardLayer:
 
 
 def _write_safetensors(path, tensors):
-    """Write a minimal safetensors file from {name: np.ndarray} dict."""
+    """Write a minimal safetensors file from {name: np.ndarray} dict.
+
+    Values can be np.ndarray (auto-dtype) or (raw_bytes, shape, sf_dtype) tuples
+    for dtypes numpy doesn't support (F8_E4M3, F8_E8M0, I8)."""
     import json
     import struct
 
@@ -1049,12 +1055,16 @@ def _write_safetensors(path, tensors):
     data_parts = []
     offset = 0
     dtype_map = {np.float16: "F16", np.float32: "F32", np.dtype("<f2"): "F16"}
-    for name, arr in tensors.items():
-        raw = arr.tobytes()
-        sf_dtype = dtype_map.get(arr.dtype, "F16")
+    for name, val in tensors.items():
+        if isinstance(val, tuple):
+            raw, shape, sf_dtype = val
+        else:
+            raw = val.tobytes()
+            shape = list(val.shape)
+            sf_dtype = dtype_map.get(val.dtype, "F16")
         header[name] = {
             "dtype": sf_dtype,
-            "shape": list(arr.shape),
+            "shape": list(shape),
             "data_offsets": [offset, offset + len(raw)],
         }
         data_parts.append(raw)
@@ -1203,7 +1213,24 @@ class TestTrackedTensor:
     def test_getitem_slice(self):
         t = _TrackedTensor((4, 8), "F16", sources=["a"])
         r = t[1:3]
+        assert r.shape == (2, 8)
         assert r.transform == "slice"
+
+    def test_getitem_half_split(self):
+        t = _TrackedTensor((256, 2048, 384), "F16", sources=["gate_up"])
+        first = t[:, :1024, :]
+        assert first.shape == (256, 1024, 384)
+        assert first.transform == "split_0_2"
+        assert first.axis == 1
+        second = t[:, 1024:, :]
+        assert second.transform == "split_1_2"
+        # bare-slice path (axis 0)
+        t2 = _TrackedTensor((8, 4), "F16", sources=["a"])
+        assert t2[:4].transform == "split_0_2"
+
+    def test_getitem_non_half_stays_slice(self):
+        t = _TrackedTensor((256, 2048, 384), "F16", sources=["a"])
+        assert t[:, :512, :].transform == "slice"
 
     def test_getitem_none_broadcast(self):
         t = _TrackedTensor((4, 8), "F16", sources=["a"])
@@ -1226,6 +1253,25 @@ class TestTrackedTensor:
         t = _TrackedTensor((4, 8), "F16", sources=["a"])
         r = t.T
         assert r.shape == (8, 4)
+
+    def test_moveaxis_method(self):
+        t = _TrackedTensor((2, 3, 4), "F16", sources=["a"])
+        assert t.moveaxis(0, 2).shape == (3, 4, 2)
+        assert t.moveaxis(0, 2).transform == "moveaxis_0_2"
+        # negative axes normalized
+        assert t.moveaxis(-1, 0).transform == "moveaxis_2_0"
+
+    def test_transpose_method(self):
+        t = _TrackedTensor((2, 3, 4), "F16", sources=["a"])
+        assert t.transpose(2, 0, 1).shape == (4, 2, 3)
+        assert t.transpose(2, 0, 1).transform == "transpose_2_0_1"
+        # no-args reverses all axes
+        assert t.transpose().transform == "transpose_2_1_0"
+
+    def test_getitem_ellipsis_raises(self):
+        t = _TrackedTensor((2, 3, 4), "F16", sources=["a"])
+        with pytest.raises(NotImplementedError):
+            t[..., :2]
 
     def test_size_property(self):
         t = _TrackedTensor((4, 8), "F16", sources=["a"])
@@ -1288,6 +1334,477 @@ class TestDiscoverSanitizePlan:
         assert plan is not None
         assert "model.embed_tokens.weight" not in plan
         assert len(plan) == len(tensors) - 1
+
+    def test_non_replayable_slice_fails_discovery(self, sf_file):
+        path, tensors = sf_file
+        idx = _LazyTensorIndex([path])
+
+        def slice_sanitize(weights):
+            return {k: v[:, :3] for k, v in weights.items()}
+
+        with pytest.raises(ValueError, match="non-replayable"):
+            _discover_sanitize_plan(slice_sanitize, idx)
+
+
+# =============================================================================
+# Test _model_exceeds_ram guard
+# =============================================================================
+
+
+class TestModelExceedsRamGuard:
+    """Tests for the OOM guard that skips memory-intensive paths when a model
+    is larger than system RAM."""
+
+    @pytest.fixture
+    def sf_file(self, tmp_path):
+        if not HAS_MLX:
+            pytest.skip("mlx not available")
+        from safetensors.numpy import save_file as np_save
+
+        tensors = {
+            "weight_a": np.zeros((128, 256), dtype=np.float32),
+            "weight_b": np.zeros((64, 128), dtype=np.float32),
+        }
+        path = tmp_path / "test.safetensors"
+        np_save(tensors, str(path))
+        expected_bytes = (128 * 256 + 64 * 128) * 4
+        return path, expected_bytes
+
+    def test_lazy_index_nbytes_matches_tensor_sizes(self, sf_file):
+        path, expected_bytes = sf_file
+        idx = _LazyTensorIndex([path])
+        assert idx.nbytes() == expected_bytes
+
+    def test_guard_boundary(self, sf_file):
+        """Guard uses strict > with _MAX_MODEL_RAM_FRACTION of system RAM."""
+        path, expected_bytes = sf_file
+        idx = _LazyTensorIndex([path])
+        nbytes = idx.nbytes()
+        # Exceeds when "system RAM" is small enough
+        small_ram = int(nbytes / _MAX_MODEL_RAM_FRACTION) - 1
+        assert nbytes > int(small_ram * _MAX_MODEL_RAM_FRACTION)
+        # Does not exceed when system RAM is large
+        large_ram = int(nbytes / _MAX_MODEL_RAM_FRACTION) + 1
+        assert not (nbytes > int(large_ram * _MAX_MODEL_RAM_FRACTION))
+
+
+
+# =============================================================================
+# Test on-the-fly FP8 dequant in _LazyTensorIndex
+# =============================================================================
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestOnTheFlyFp8Dequant:
+    def test_vllm_scale_inv_convention(self, tmp_path):
+        """vLLM convention: weight (F8_E4M3) + weight_scale_inv (F32)."""
+        w = np.random.randint(0, 255, (128, 128), dtype=np.uint8)
+        s = np.ones((1, 1), dtype=np.float32)
+        path = str(tmp_path / "vllm.safetensors")
+        _write_safetensors(path, {
+            "layer.weight": (w.tobytes(), [128, 128], "F8_E4M3"),
+            "layer.weight_scale_inv": s,
+        })
+        idx = _LazyTensorIndex([path])
+        assert len(idx._fp8_pairs) == 1
+        assert "layer.weight" in idx
+        assert "layer.weight_scale_inv" not in idx
+        result = idx["layer.weight"]
+        assert result.dtype == mx.bfloat16
+
+    def test_mxfp_dot_scale_convention(self, tmp_path):
+        """MXFP convention: key.weight (F8_E4M3) + key.scale (F8_E8M0)."""
+        w = np.random.randint(0, 255, (128, 128), dtype=np.uint8)
+        s = np.full((1, 1), 127, dtype=np.uint8)  # E8M0 127 = 2^0 = 1.0
+        path = str(tmp_path / "mxfp.safetensors")
+        _write_safetensors(path, {
+            "layer.weight": (w.tobytes(), [128, 128], "F8_E4M3"),
+            "layer.scale": (s.tobytes(), [1, 1], "F8_E8M0"),
+        })
+        idx = _LazyTensorIndex([path])
+        assert "layer.weight" in idx
+        assert "layer.scale" not in idx
+        result = idx.pop("layer.weight")
+        assert result.dtype == mx.bfloat16
+        assert "layer.weight" not in idx._index
+
+    def test_i8_with_e8m0_scale(self, tmp_path):
+        """I8 expert weights with E8M0 microscaling (1x16 block)."""
+        w = np.random.randint(-128, 127, (32, 32), dtype=np.int8)
+        s = np.full((32, 2), 127, dtype=np.uint8)  # 1x16 blocking, scale=1.0
+        path = str(tmp_path / "i8.safetensors")
+        _write_safetensors(path, {
+            "expert.weight": (w.tobytes(), [32, 32], "I8"),
+            "expert.scale": (s.tobytes(), [32, 2], "F8_E8M0"),
+        })
+        idx = _LazyTensorIndex([path])
+        result = idx["expert.weight"]
+        expected = mx.array(w.astype(np.float32)).astype(mx.bfloat16)
+        assert mx.allclose(result, expected, atol=0.1).item()
+
+    def test_no_scale_keys_no_pairs(self, tmp_path):
+        path = str(tmp_path / "plain.safetensors")
+        _write_safetensors(path, {
+            "layer.weight": np.random.randn(4, 8).astype(np.float16),
+        })
+        idx = _LazyTensorIndex([path])
+        assert len(idx._fp8_pairs) == 0
+        assert len(idx) == 1
+
+
+# =============================================================================
+# End-to-end: quantize_oq_streaming with FP8 sources
+# =============================================================================
+
+
+def _make_fp8_model(model_dir, n_layers=2, hidden=128, n_experts=0,
+                    fp8_convention="mxfp"):
+    """Create a synthetic FP8 model directory for integration testing.
+
+    Returns the path and total raw bytes of FP8 weight data.
+    """
+    import json
+
+    config = {
+        "architectures": ["TestModelForCausalLM"],
+        "model_type": "test_fp8",
+        "num_hidden_layers": n_layers,
+        "hidden_size": hidden,
+        "vocab_size": 256,
+    }
+    if n_experts:
+        config["num_local_experts"] = n_experts
+
+    tensors = {}
+
+    # Embedding (plain F16 — not FP8)
+    tensors["model.embed_tokens.weight"] = np.random.randn(
+        256, hidden
+    ).astype(np.float16)
+
+    for i in range(n_layers):
+        pfx = f"model.layers.{i}"
+
+        # Attention weights (FP8 + scale)
+        for proj in ["q_proj", "k_proj", "v_proj", "o_proj"]:
+            w = np.random.randint(0, 255, (hidden, hidden), dtype=np.uint8)
+            if fp8_convention == "mxfp":
+                s = np.full((1, 1), 127, dtype=np.uint8)  # E8M0 scale=1.0
+                tensors[f"{pfx}.self_attn.{proj}.weight"] = (
+                    w.tobytes(), [hidden, hidden], "F8_E4M3"
+                )
+                tensors[f"{pfx}.self_attn.{proj}.scale"] = (
+                    s.tobytes(), [1, 1], "F8_E8M0"
+                )
+            else:  # vllm
+                s = np.ones((1, 1), dtype=np.float32)
+                tensors[f"{pfx}.self_attn.{proj}.weight"] = (
+                    w.tobytes(), [hidden, hidden], "F8_E4M3"
+                )
+                tensors[f"{pfx}.self_attn.{proj}.weight_scale_inv"] = s
+
+        # MLP weights (FP8 + scale)
+        for proj in ["gate_proj", "up_proj"]:
+            w = np.random.randint(0, 255, (hidden * 4, hidden), dtype=np.uint8)
+            if fp8_convention == "mxfp":
+                s = np.full((1, 1), 127, dtype=np.uint8)
+                tensors[f"{pfx}.mlp.{proj}.weight"] = (
+                    w.tobytes(), [hidden * 4, hidden], "F8_E4M3"
+                )
+                tensors[f"{pfx}.mlp.{proj}.scale"] = (
+                    s.tobytes(), [1, 1], "F8_E8M0"
+                )
+            else:
+                s = np.ones((1, 1), dtype=np.float32)
+                tensors[f"{pfx}.mlp.{proj}.weight"] = (
+                    w.tobytes(), [hidden * 4, hidden], "F8_E4M3"
+                )
+                tensors[f"{pfx}.mlp.{proj}.weight_scale_inv"] = s
+
+        # down_proj (FP8)
+        w = np.random.randint(0, 255, (hidden, hidden * 4), dtype=np.uint8)
+        if fp8_convention == "mxfp":
+            s = np.full((1, 1), 127, dtype=np.uint8)
+            tensors[f"{pfx}.mlp.down_proj.weight"] = (
+                w.tobytes(), [hidden, hidden * 4], "F8_E4M3"
+            )
+            tensors[f"{pfx}.mlp.down_proj.scale"] = (
+                s.tobytes(), [1, 1], "F8_E8M0"
+            )
+        else:
+            s = np.ones((1, 1), dtype=np.float32)
+            tensors[f"{pfx}.mlp.down_proj.weight"] = (
+                w.tobytes(), [hidden, hidden * 4], "F8_E4M3"
+            )
+            tensors[f"{pfx}.mlp.down_proj.weight_scale_inv"] = s
+
+        # Layer norms (plain F16)
+        tensors[f"{pfx}.input_layernorm.weight"] = np.ones(
+            hidden, dtype=np.float16
+        )
+        tensors[f"{pfx}.post_attention_layernorm.weight"] = np.ones(
+            hidden, dtype=np.float16
+        )
+
+    # LM head (plain F16)
+    tensors["lm_head.weight"] = np.random.randn(256, hidden).astype(np.float16)
+
+    sf_path = str(model_dir / "model.safetensors")
+    _write_safetensors(sf_path, tensors)
+
+    with open(model_dir / "config.json", "w") as f:
+        json.dump(config, f)
+
+    return model_dir
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestQuantizeOqStreamingFp8:
+    """End-to-end tests for quantize_oq_streaming with FP8 source models."""
+
+    def test_mxfp_source_produces_output(self, tmp_path):
+        """MXFP (.scale suffix) FP8 model quantizes without error."""
+        src = tmp_path / "src"
+        src.mkdir()
+        _make_fp8_model(src, fp8_convention="mxfp")
+        out = tmp_path / "out"
+
+        quantize_oq_streaming(str(src), str(out), oq_level=4)
+
+        assert (out / "config.json").exists()
+        out_shards = list(out.glob("*.safetensors"))
+        assert len(out_shards) > 0
+
+    def test_vllm_source_produces_output(self, tmp_path):
+        """vLLM (_scale_inv suffix) FP8 model quantizes without error."""
+        src = tmp_path / "src"
+        src.mkdir()
+        _make_fp8_model(src, fp8_convention="vllm")
+        out = tmp_path / "out"
+
+        quantize_oq_streaming(str(src), str(out), oq_level=4)
+
+        assert (out / "config.json").exists()
+        out_shards = list(out.glob("*.safetensors"))
+        assert len(out_shards) > 0
+
+    def test_no_scale_keys_in_output(self, tmp_path):
+        """Scale keys are consumed by dequant, never written to output."""
+        src = tmp_path / "src"
+        src.mkdir()
+        _make_fp8_model(src, fp8_convention="mxfp")
+        out = tmp_path / "out"
+
+        quantize_oq_streaming(str(src), str(out), oq_level=4)
+
+        from safetensors import safe_open
+        for sf in out.glob("*.safetensors"):
+            with safe_open(str(sf), framework="numpy") as f:
+                for k in f.keys():
+                    assert not k.endswith(".scale"), f"scale key leaked: {k}"
+                    assert not k.endswith("_scale_inv"), \
+                        f"scale_inv key leaked: {k}"
+
+    def test_output_tensors_are_bf16_or_quantized(self, tmp_path):
+        """All output tensors are either quantized (uint32) or bf16."""
+        src = tmp_path / "src"
+        src.mkdir()
+        _make_fp8_model(src, fp8_convention="mxfp")
+        out = tmp_path / "out"
+
+        quantize_oq_streaming(str(src), str(out), oq_level=4)
+
+        allowed = {mx.bfloat16, mx.float16, mx.float32, mx.uint32, mx.uint8}
+        for sf in out.glob("*.safetensors"):
+            tensors = mx.load(str(sf))
+            for k, t in tensors.items():
+                assert t.dtype in allowed, f"{k}: unexpected dtype {t.dtype}"
+
+    def test_exceeds_ram_skips_eager_sanitize(self, tmp_path):
+        """When model exceeds simulated RAM, eager sanitize is skipped."""
+        from unittest.mock import patch
+        src = tmp_path / "src"
+        src.mkdir()
+        _make_fp8_model(src, n_layers=2, hidden=128, fp8_convention="mxfp")
+        out = tmp_path / "out"
+
+        # Patch system RAM to 1 byte — any model exceeds it
+        with patch("omlx.settings.get_system_memory", return_value=1):
+            quantize_oq_streaming(str(src), str(out), oq_level=4)
+
+        assert (out / "config.json").exists()
+        out_shards = list(out.glob("*.safetensors"))
+        assert len(out_shards) > 0
+
+    def test_exceeds_ram_no_scratch_files(self, tmp_path):
+        """On-the-fly dequant produces zero scratch/temp shard files."""
+        from unittest.mock import patch
+        import tempfile
+        import os
+
+        src = tmp_path / "src"
+        src.mkdir()
+        _make_fp8_model(src, fp8_convention="mxfp")
+        out = tmp_path / "out"
+
+        # List temp files before
+        tmpdir = tempfile.gettempdir()
+        before = set(os.listdir(tmpdir))
+
+        with patch("omlx.settings.get_system_memory", return_value=1):
+            quantize_oq_streaming(str(src), str(out), oq_level=4)
+
+        # No new safetensors scratch files in tmp
+        after = set(os.listdir(tmpdir))
+        new_files = after - before
+        scratch = [f for f in new_files if "safetensors" in f or "dequant" in f]
+        assert scratch == [], f"scratch files created: {scratch}"
+
+    def test_fp8_dequant_with_sanitize_plan(self, tmp_path):
+        """When sanitize discovery succeeds, FP8 dequant works through
+        _DiscoveredPlan._materialize_source."""
+        src = tmp_path / "src"
+        src.mkdir()
+        _make_fp8_model(src, n_layers=1, hidden=128, fp8_convention="mxfp")
+
+        idx = _LazyTensorIndex([str(src / "model.safetensors")])
+        assert len(idx._fp8_pairs) > 0
+
+        def rename_sanitize(weights):
+            return {k.replace("model.", "m."): v for k, v in weights.items()}
+
+        plan = _discover_sanitize_plan(rename_sanitize, idx)
+        assert plan is not None
+
+        dp = _DiscoveredPlan(plan, idx)
+        # pop a renamed FP8 tensor — should dequant via _materialize_source
+        renamed_key = None
+        for k in dp.keys():
+            if "q_proj" in k:
+                renamed_key = k
+                break
+        assert renamed_key is not None
+        arr = dp.pop(renamed_key)
+        assert arr.dtype == mx.bfloat16
+        assert arr.shape == (128, 128)
+
+    def test_logical_metadata_hides_scales_reports_bf16(self, tmp_path):
+        """logical_metadata() hides scale keys and reports FP8 weights as BF16."""
+        src = tmp_path / "src"
+        src.mkdir()
+        _make_fp8_model(src, n_layers=1, hidden=64, fp8_convention="mxfp")
+        idx = _LazyTensorIndex([str(src / "model.safetensors")])
+
+        meta = idx.logical_metadata()
+        for k in meta:
+            assert not k.endswith(".scale"), f"scale key visible: {k}"
+        for k, (shape, dtype) in meta.items():
+            if "self_attn" in k or "mlp" in k:
+                if k.endswith(".weight"):
+                    assert dtype == "BF16", f"{k}: dtype={dtype}, expected BF16"
+
+    def test_mixed_fp8_and_plain_tensors(self, tmp_path):
+        """Model with both FP8 and plain (F16) tensors handles both correctly."""
+        src = tmp_path / "src"
+        src.mkdir()
+        _make_fp8_model(src, n_layers=1, hidden=128, fp8_convention="mxfp")
+        out = tmp_path / "out"
+
+        quantize_oq_streaming(str(src), str(out), oq_level=4)
+
+        from safetensors import safe_open
+        out_keys = set()
+        for sf in out.glob("*.safetensors"):
+            with safe_open(str(sf), framework="numpy") as f:
+                out_keys.update(f.keys())
+
+        # Embedding and norms should be present (not quantized, just passed through)
+        assert any("embed" in k for k in out_keys)
+        assert any("layernorm" in k for k in out_keys)
+        # Attention weights should be quantized (have .scales)
+        assert any("self_attn" in k and k.endswith(".scales") for k in out_keys)
+
+    def test_i8_expert_weights_with_mxfp_scale(self, tmp_path):
+        """I8 expert weights with E8M0 microscaling (1x16 block) dequant
+        correctly through the full quantize pipeline."""
+        import json
+
+        src = tmp_path / "src"
+        src.mkdir()
+
+        hidden = 64
+        tensors = {
+            "model.embed_tokens.weight": np.random.randn(
+                256, hidden
+            ).astype(np.float16),
+            "lm_head.weight": np.random.randn(256, hidden).astype(np.float16),
+            "model.layers.0.input_layernorm.weight": np.ones(
+                hidden, dtype=np.float16
+            ),
+        }
+        # I8 weight with 1x16 blocking
+        w_i8 = np.random.randint(-128, 127, (hidden, hidden), dtype=np.int8)
+        bs_col = 16
+        sn = hidden // bs_col
+        s_e8m0 = np.full((hidden, sn), 127, dtype=np.uint8)
+        tensors["model.layers.0.self_attn.q_proj.weight"] = (
+            w_i8.tobytes(), [hidden, hidden], "I8"
+        )
+        tensors["model.layers.0.self_attn.q_proj.scale"] = (
+            s_e8m0.tobytes(), [hidden, sn], "F8_E8M0"
+        )
+
+        _write_safetensors(str(src / "model.safetensors"), tensors)
+        config = {
+            "architectures": ["TestModelForCausalLM"],
+            "model_type": "test_i8",
+            "num_hidden_layers": 1,
+            "hidden_size": hidden,
+            "vocab_size": 256,
+        }
+        with open(src / "config.json", "w") as f:
+            json.dump(config, f)
+
+        out = tmp_path / "out"
+        quantize_oq_streaming(str(src), str(out), oq_level=4)
+
+        assert (out / "config.json").exists()
+        from safetensors import safe_open
+        out_keys = set()
+        for sf in out.glob("*.safetensors"):
+            with safe_open(str(sf), framework="numpy") as f:
+                out_keys.update(f.keys())
+        assert not any(k.endswith(".scale") for k in out_keys)
+
+    def test_bf16_weight_with_scale_key_not_paired(self, tmp_path):
+        """BF16 weight + .scale key must NOT be treated as FP8 pair."""
+        src = tmp_path / "src"
+        src.mkdir()
+        hidden = 64
+        tensors = {
+            "model.embed_tokens.weight": np.random.randn(256, hidden).astype(np.float16),
+            "lm_head.weight": np.random.randn(256, hidden).astype(np.float16),
+            "model.layers.0.input_layernorm.weight": np.ones(hidden, dtype=np.float16),
+            "model.layers.0.self_attn.q_proj.weight": np.random.randn(
+                hidden, hidden).astype(np.float16),
+            "model.layers.0.self_attn.q_proj.scale": np.ones(
+                (1, hidden), dtype=np.float32),
+        }
+        _write_safetensors(str(src / "model.safetensors"), tensors)
+        import json
+        config = {
+            "architectures": ["TestModelForCausalLM"],
+            "model_type": "test_bf16_scale",
+            "num_hidden_layers": 1,
+            "hidden_size": hidden,
+            "vocab_size": 256,
+        }
+        with open(src / "config.json", "w") as f:
+            json.dump(config, f)
+
+        idx = _LazyTensorIndex([str(src / "model.safetensors")])
+        assert len(idx._fp8_pairs) == 0, "BF16 weight should not pair with .scale"
+        assert "model.layers.0.self_attn.q_proj.scale" in idx, "scale key must remain visible"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- **On-the-fly FP8 dequant**: `_LazyTensorIndex` detects FP8/I8 weight+scale pairs at index construction (validated by weight dtype) and transparently dequants to BF16 when accessed. Scale keys hidden from the public API. Zero scratch disk.
- **Two scale conventions**: vLLM (`_scale_inv`, F32, 128-block) and MXFP (`key.scale`, E8M0 microscaling, variable block).
- **OOM guard**: When model size exceeds 80% of system RAM, skips eager sanitize fallback (with error-level logging) and sensitivity measurement.
- **`_TrackedTensor` improvements**: `moveaxis`, `transpose`, `_slice_length`, `_detect_half_split` for reliable sanitize plan discovery on conv1d and GQA patterns.
- **Replayable-transform validation**: Discovery rejects non-replayable transforms with a clear error instead of silently producing wrong weights.
- **Shared dequant helper**: `_block_dequant_fp8()` consolidates block-scaled dequant logic with shape divisibility and degenerate scale guards.
- **Removed dead code**: `_streaming_fp8_dequant` (no longer called after on-the-fly dequant replaced it).
- **Bug fix**: `_LazyTensorIndex.get()` now correctly returns override-only keys instead of `default`.

## Motivation

Related to #1094 — reduces peak memory during quantization by fixing `_TrackedTensor.moveaxis` (so discovery succeeds instead of falling back to eager sanitize) and adding an OOM guard for models exceeding system RAM. Does not address the underlying regression reported in that issue.

Related to #777 (streaming quant for limited memory) and #956 (E8M0 dtype support).

## Test plan

- [x] 23 new pytest tests (174 total, up from 151 upstream) covering both scale conventions, FP8-aware plan discovery, logical metadata, mixed tensors, I8+MXFP, simulated low-RAM paths, TrackedTensor shape tracking, and BF16+scale dtype guard
- [x] Live integration: Qwen3.6-27B oQ4 + oQ8, Qwen3.6-35B-A3B oQ8 with simulated 48GB RAM, Qwen3.5-122B-A10B oQ4 + oQ6 (real-world — model exceeds 128GB RAM unquantized) — all produce correct inference
- [x] DeepSeek V4 Flash oQ2: quantizes successfully (zero scratch), load fails due to upstream model class limitation (not this PR's scope)