### PR TITLE
fix(cache): pass full entry to _hot_cache_entry_size in get_stats_for_model

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -2110,7 +2110,7 @@ class PagedSSDCacheManager(CacheManager):
                     if blk_meta is None or not _matches(blk_meta.model_name):
                         continue
                     hot_entries.append(entry)
-                    hot_size += self._hot_cache_entry_size(entry["tensors_raw"])
+                    hot_size += self._hot_cache_entry_size(entry)
 
             return PagedSSDCacheStats(
                 hits=self._stats["hits"],

--- a/tests/test_hot_cache.py
+++ b/tests/test_hot_cache.py
@@ -549,6 +549,59 @@ class TestHotCacheStatsAccuracy:
         finally:
             mgr.close()
 
+    def test_get_stats_for_model_reports_hot_cache_size(self, tmp_path):
+        """get_stats_for_model() should report non-zero hot_cache_size_bytes."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "model_stats_test",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=10 * 1024**2,
+        )
+        try:
+            cache_data = [
+                (mx.zeros((1, 2, 16, 16)), mx.zeros((1, 2, 16, 16)))
+                for _ in range(2)
+            ]
+            mgr.save_block(
+                block_hash=b"model_stats_test",
+                cache_data=cache_data,
+                token_count=16,
+                model_name="test-model",
+                layer_cache_types=["KVCache"] * 2,
+            )
+
+            global_stats = mgr.get_stats()
+            model_stats = mgr.get_stats_for_model("test-model")
+
+            assert global_stats.hot_cache_size_bytes > 0
+            assert model_stats.hot_cache_size_bytes > 0
+            assert model_stats.hot_cache_size_bytes == global_stats.hot_cache_size_bytes
+            assert model_stats.hot_cache_entries == 1
+
+            mgr.save_block(
+                block_hash=b"other_model_test",
+                cache_data=cache_data,
+                token_count=16,
+                model_name="other-model",
+                layer_cache_types=["KVCache"] * 2,
+            )
+
+            global_stats = mgr.get_stats()
+            model_stats = mgr.get_stats_for_model("test-model")
+            other_stats = mgr.get_stats_for_model("other-model")
+
+            assert global_stats.hot_cache_entries == 2
+            assert model_stats.hot_cache_entries == 1
+            assert other_stats.hot_cache_entries == 1
+            assert model_stats.hot_cache_size_bytes > 0
+            assert other_stats.hot_cache_size_bytes > 0
+            assert model_stats.hot_cache_size_bytes < global_stats.hot_cache_size_bytes
+            assert (
+                model_stats.hot_cache_size_bytes + other_stats.hot_cache_size_bytes
+                == global_stats.hot_cache_size_bytes
+            )
+        finally:
+            mgr.close()
+
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
 class TestHotCacheWriteBack:


### PR DESCRIPTION
## Summary

`get_stats_for_model()` passes `entry["tensors_raw"]` to `_hot_cache_entry_size()`, but the method expects the full entry dict — it looks for `"tensors_raw"` or `"arrays"` as top-level keys. Passing the inner `tensors_raw` dict means neither key is found, so it returns 0. The result is that `hot_cache_size_bytes` is always 0 in the per-model stats returned by the admin dashboard.

The global `get_stats()` path is unaffected because it reads the pre-tracked `_hot_cache_total_bytes` field directly. Every other call site in the file already passes the full entry.

## Changes

One-line fix: `entry["tensors_raw"]` → `entry` in `get_stats_for_model()`.

## Test plan

Regression test covers both single-model and multi-model cases: saves blocks under two different model names, verifies each model reports its own non-zero size, and confirms per-model sizes sum to the global total.

Verified running two models simultaneously (Qwen3.6-35B-A3B-oQ4-mtp and Qwen3.6-27B-oQ6-mtp). Before the fix, `/admin/api/stats` reported `hot_cache_size_bytes: 0` with 20 entries in cache. After, the 35B model reported 1.7 GB across 16 entries and the 27B model reported 2.3 GB across 8 entries — per-model sizes sum to the global total as expected.