### PR TITLE
fix(downloader): remove stale symlink targets

### DIFF
--- a/omlx/admin/hf_downloader.py
+++ b/omlx/admin/hf_downloader.py
@@ -610,6 +610,7 @@ class HFDownloader:
                 # Derive model name from repo_id (last part)
                 model_name = task.repo_id.split("/")[-1]
                 target_dir = self._model_dir / model_name
+                self._prepare_download_target(target_dir)
 
                 api, endpoint = _get_hf_api()
 
@@ -836,6 +837,20 @@ class HFDownloader:
         except OSError:
             pass
         return total
+
+    @staticmethod
+    def _prepare_download_target(target_dir: Path) -> None:
+        """Prepare a local_dir path for Hugging Face downloads."""
+        if target_dir.is_symlink() and not target_dir.exists():
+            target_dir.unlink()
+            logger.info(f"Removed stale download symlink: {target_dir}")
+
+        if target_dir.exists() and not target_dir.is_dir():
+            raise FileExistsError(
+                f"Download target exists and is not a directory: {target_dir}"
+            )
+
+        target_dir.parent.mkdir(parents=True, exist_ok=True)
 
     def _cleanup_partial(self, task: DownloadTask) -> None:
         """Remove partially downloaded model directory."""

--- a/tests/test_hf_downloader.py
+++ b/tests/test_hf_downloader.py
@@ -195,6 +195,45 @@ class TestHFDownloader:
             await downloader.shutdown()
 
     @pytest.mark.asyncio
+    async def test_download_removes_stale_symlink_target(self, model_dir):
+        model_dir.mkdir(parents=True, exist_ok=True)
+        downloader = HFDownloader(model_dir=str(model_dir))
+
+        target_dir = model_dir / "model"
+        target_dir.symlink_to(model_dir / "missing-cache-entry")
+
+        def fake_snapshot_download(**kwargs):
+            if kwargs.get("dry_run"):
+                return []
+            local_dir = Path(kwargs["local_dir"])
+            local_dir.mkdir(parents=True, exist_ok=True)
+            (local_dir / "config.json").write_text("{}")
+            return str(local_dir)
+
+        with patch(
+            "omlx.admin.hf_downloader.HfApi"
+        ) as mock_api_cls, patch(
+            "omlx.admin.hf_downloader.snapshot_download",
+            side_effect=fake_snapshot_download,
+        ):
+            mock_api = MagicMock()
+            mock_info = MagicMock()
+            mock_info.siblings = []
+            mock_api.model_info.return_value = mock_info
+            mock_api_cls.return_value = mock_api
+
+            task = await downloader.start_download("owner/model")
+
+            await asyncio.sleep(0.5)
+
+            assert task.status == DownloadStatus.COMPLETED
+            assert target_dir.is_dir()
+            assert not target_dir.is_symlink()
+            assert (target_dir / "config.json").exists()
+
+            await downloader.shutdown()
+
+    @pytest.mark.asyncio
     async def test_download_failure_sets_error(self, model_dir):
         model_dir.mkdir(parents=True, exist_ok=True)
         downloader = HFDownloader(model_dir=str(model_dir))


### PR DESCRIPTION
## Summary
- remove broken symlink placeholders before starting a Hugging Face download
- preserve valid directories/symlinks so partial downloads can still resume
- add regression coverage for the dashboard failure shape: `[Errno 17] File exists: .../.omlx/models/<model>`

## Tests
- `.venv/bin/python -m pytest tests/test_hf_downloader.py` (80 passed)
- `python3 -m py_compile omlx/admin/hf_downloader.py tests/test_hf_downloader.py`
- `git diff --check`