### PR TITLE
fix(scheduler): use async_eval for cache-store materialization

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -803,9 +803,16 @@ class Scheduler:
         """Run store_cache + paged_cache cleanup off the inference thread.
 
         Pre-conditions enforced by the caller (_cleanup_finished):
-        - All mx.array references in cache_to_store have already been
-          mx.eval()'d on the inference thread, so save_block's internal
-          mx.eval is a no-op.
+        - mx.async_eval() was called on the inference thread for all
+          KV cache arrays, dispatching materialization asynchronously
+          without blocking the inference thread. async_eval completes
+          Metal command enqueueing before returning, so all commands
+          are submitted by the time executor.submit() runs.
+        - This worker calls mx.synchronize() (global barrier — waits
+          all streams) to ensure materialization is complete before
+          extracting tensor bytes. Stream-scoped sync is not possible
+          here because generation_stream is thread-local to the
+          inference thread.
         - bfloat16 view+eval inside _extract_tensor_bytes runs on this
           worker's default mx stream, isolated from generation_stream;
           the underlying buffer is read-only at this point.
@@ -816,6 +823,8 @@ class Scheduler:
         threading.RLock so concurrent access from main and worker is safe.
         """
         try:
+            with self._phase_timer("store_cache_worker_sync"):
+                mx.synchronize()
             block_table = self.block_aware_cache.store_cache(
                 request_id,
                 token_sequence_to_store,
@@ -4094,14 +4103,13 @@ class Scheduler:
                             )
                             intermediate_snapshots = None
 
-                            # Boundary merge + a batched mx.eval all on the
-                            # inference thread. The eval forces every array
-                            # we hand to the worker into a materialized state
-                            # so the worker's _extract_tensor_bytes is a pure
-                            # memcpy (mx.eval inside save_block becomes a
-                            # no-op). bfloat16 view+eval inside the worker
-                            # then runs on its own default stream, isolated
-                            # from generation_stream.
+                            # Boundary merge + async_eval on the inference
+                            # thread. async_eval dispatches KV array
+                            # materialization without blocking, so the
+                            # inference thread can start the next request
+                            # immediately. The worker calls
+                            # mx.synchronize() to wait for completion
+                            # before extracting bytes.
                             with (
                                 self._phase_timer("store_cache_main_prep"),
                                 mx.stream(generation_stream),
@@ -4138,8 +4146,7 @@ class Scheduler:
                                     )
                                 )
                                 if pre_eval_arrays:
-                                    with self._phase_timer("store_cache_main_eval"):
-                                        mx.eval(*pre_eval_arrays)
+                                    mx.async_eval(*pre_eval_arrays)
 
                             if self._store_cache_executor is not None:
                                 store_future = self._store_cache_executor.submit(


### PR DESCRIPTION
## Summary

When the inference thread hands KV cache arrays to the store-cache worker, it currently calls `mx.eval(*pre_eval_arrays)` which blocks until every array is materialized. On long conversations the blocked time grows with cache size — the inference thread sits idle waiting for work that doesn't need to finish before the next request can start.

This replaces the blocking `mx.eval()` with `mx.async_eval()`, which dispatches Metal commands and returns after command enqueueing completes. The worker already runs on a ThreadPoolExecutor, so it can wait for materialization itself via `mx.synchronize()` while the inference thread moves on.

## Changes

The core change is a single line: `mx.eval(*pre_eval_arrays)` → `mx.async_eval(*pre_eval_arrays)` inside `_cleanup_finished`. `async_eval` enqueues the Metal commands synchronously (all commands are submitted before it returns), so by the time `executor.submit()` fires, the GPU work is in flight.

The worker's `_async_store_cache_worker` gains a `mx.synchronize()` call before `store_cache()` — a global barrier that waits all streams. Stream-scoped sync isn't possible here because `generation_stream` is thread-local to the inference thread and invisible to the worker. The global barrier is safe because the worker is the only consumer of these arrays at this point.

A `store_cache_worker_sync` phase timer wraps the synchronize call so the worker-side wait is observable in timing logs, replacing the visibility that `store_cache_main_eval` provided on the inference thread.

Docstrings and inline comments updated to document the async_eval enqueueing guarantee and global barrier rationale.

## Evidence

Server-side phase timers on a 30-turn conversation (Qwen3-0.6B-A0.3B-4bit, 256 max tokens/turn) show `store_cache_main_eval` accumulates ~40ms total across 30 turns. Replacing with async_eval eliminates this blocking time from the inference thread entirely.

On a Qwen3-Coder-Next (3B, Q6_K) 11-turn session with realistic 100-150 token responses, cumulative `store_cache_main_prep` dropped 23% (8.7ms → 6.7ms) because the prep phase no longer includes the synchronous eval stall. The per-turn improvement is small individually (~0.2ms) but compounds over long conversations and scales with model/cache size.

The benefit is architectural: the inference thread should not block for work that only the store-cache worker needs. Models with standard KV cache (transformers) see the full effect; hybrid architectures using ArraysCache (e.g. GatedDeltaNet) produce empty `pre_eval_arrays` and are unaffected.

## Test plan

- Full test suite passes (4147 passed, 34 pre-existing failures unrelated to this change)
- Multi-turn conversation benchmark (30 turns) confirms no regression in TTFT or cache integrity
- Phase timer logs verified: `store_cache_worker_sync` appears in worker timing, `store_cache_main_eval` no longer appears on inference thread