### PR TITLE
fix(mtp): guard MoE sanitize against missing MTP expert weights

### DIFF
--- a/omlx/patches/mlx_lm_mtp/qwen35_model.py
+++ b/omlx/patches/mlx_lm_mtp/qwen35_model.py
@@ -676,22 +676,35 @@ def _patch_qwen3_5_moe() -> None:
             getattr(self.language_model.args, "mtp_num_hidden_layers", 0) or 0
         )
         if mtp_num > 0:
-            num_experts = self.language_model.args.num_experts
-            mtp_is_fused = (
-                "language_model.mtp.layers.0.mlp.experts.gate_up_proj"
-                in new_weights
+            has_any_mtp = any(
+                k.startswith("language_model.mtp.") for k in new_weights
             )
-            for layer_idx in range(mtp_num):
-                prefix = f"language_model.mtp.layers.{layer_idx}.mlp"
-                # Idempotent: oQ outputs already store experts in switch_mlp
-                # form (mlx-vlm sanitize patch unfuses MTP experts before
-                # quantization). Skip the load-time unfuse/stack in that case.
-                if f"{prefix}.switch_mlp.gate_proj.weight" in new_weights:
-                    continue
-                if mtp_is_fused:
-                    _unfuse_experts(new_weights, prefix)
-                else:
-                    _stack_per_expert(new_weights, prefix, num_experts)
+            if not has_any_mtp:
+                logger.debug(
+                    "mtp_num_hidden_layers=%d but no MTP weights found; "
+                    "model may have been quantized without preserve_mtp",
+                    mtp_num,
+                )
+            else:
+                num_experts = self.language_model.args.num_experts
+                mtp_is_fused = (
+                    "language_model.mtp.layers.0.mlp.experts.gate_up_proj"
+                    in new_weights
+                )
+                for layer_idx in range(mtp_num):
+                    prefix = f"language_model.mtp.layers.{layer_idx}.mlp"
+                    # Idempotent: oQ outputs already store experts in
+                    # switch_mlp form (mlx-vlm sanitize patch unfuses MTP
+                    # experts before quantization). Skip the load-time
+                    # unfuse/stack in that case.
+                    if f"{prefix}.switch_mlp.gate_proj.weight" in new_weights:
+                        continue
+                    if mtp_is_fused:
+                        if f"{prefix}.experts.gate_up_proj" in new_weights:
+                            _unfuse_experts(new_weights, prefix)
+                    else:
+                        if f"{prefix}.experts.0.gate_proj.weight" in new_weights:
+                            _stack_per_expert(new_weights, prefix, num_experts)
 
         return self.language_model.sanitize(new_weights)
 

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -161,6 +161,91 @@ class TestQwen35Model:
         assert hasattr(Model, "_omlx_mtp_patched")
 
 
+class TestQwen35MoeSanitize:
+    """Regression tests for the MoE MTP sanitize patch (qwen3_5_moe.Model)."""
+
+    @pytest.fixture(autouse=True)
+    def _apply(self):
+        try:
+            from omlx.patches.mlx_lm_mtp import qwen35_model
+        except ImportError:
+            pytest.skip("omlx.patches.mlx_lm_mtp not importable")
+        if not qwen35_model.apply():
+            pytest.skip("qwen35_model patch refused to apply")
+        from omlx.patches.mlx_lm_mtp.qwen35_model import _patch_qwen3_5_moe
+        _patch_qwen3_5_moe()
+
+    @pytest.fixture()
+    def moe_model(self):
+        from types import SimpleNamespace
+        from mlx_lm.models import qwen3_5_moe as moe
+
+        args = SimpleNamespace(
+            num_hidden_layers=2,
+            mtp_num_hidden_layers=1,
+            num_experts=4,
+        )
+        inner = SimpleNamespace(args=args, sanitize=lambda w: w)
+        model = moe.Model.__new__(moe.Model)
+        model.language_model = inner
+        return model
+
+    def _backbone_weights(self):
+        import mlx.core as mx
+
+        weights = {}
+        for layer in range(2):
+            pfx = f"language_model.model.layers.{layer}.mlp"
+            weights[f"{pfx}.experts.gate_up_proj"] = mx.zeros((4, 128, 64))
+            weights[f"{pfx}.experts.down_proj"] = mx.zeros((4, 64, 128))
+        weights["language_model.model.embed_tokens.weight"] = mx.zeros((256, 64))
+        return weights
+
+    def test_sanitize_no_mtp_weights(self, moe_model, caplog):
+        """Config declares mtp_num_hidden_layers=1 but no MTP weights exist
+        (model quantized without preserve_mtp). Must not crash."""
+        import logging
+
+        with caplog.at_level(logging.DEBUG):
+            result = moe_model.sanitize(self._backbone_weights())
+        assert not any("mtp" in k for k in result)
+        assert any("no MTP weights found" in r.getMessage() for r in caplog.records)
+
+    def test_sanitize_switch_mlp_form(self, moe_model):
+        """oQ outputs store MTP experts in switch_mlp form — sanitize skips."""
+        import mlx.core as mx
+
+        weights = self._backbone_weights()
+        pfx = "language_model.mtp.layers.0.mlp"
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            weights[f"{pfx}.switch_mlp.{proj}.weight"] = mx.zeros((4, 64, 128))
+        result = moe_model.sanitize(weights)
+        assert f"{pfx}.switch_mlp.gate_proj.weight" in result
+
+    def test_sanitize_per_expert_form(self, moe_model):
+        """Raw HF Qwen3.5 per-expert tensors stacked into switch_mlp."""
+        import mlx.core as mx
+
+        weights = self._backbone_weights()
+        pfx = "language_model.mtp.layers.0.mlp"
+        for e in range(4):
+            for proj in ("gate_proj", "up_proj", "down_proj"):
+                weights[f"{pfx}.experts.{e}.{proj}.weight"] = mx.zeros((64, 128))
+        result = moe_model.sanitize(weights)
+        assert f"{pfx}.switch_mlp.gate_proj.weight" in result
+
+    def test_sanitize_fused_form(self, moe_model):
+        """Qwen3.6 fused gate_up_proj unfused into switch_mlp."""
+        import mlx.core as mx
+
+        weights = self._backbone_weights()
+        pfx = "language_model.mtp.layers.0.mlp"
+        weights[f"{pfx}.experts.gate_up_proj"] = mx.zeros((4, 128, 64))
+        weights[f"{pfx}.experts.down_proj"] = mx.zeros((4, 64, 128))
+        result = moe_model.sanitize(weights)
+        assert f"{pfx}.switch_mlp.gate_proj.weight" in result
+
+
 class TestDeepseekV4Model:
     def test_skip_when_base_patch_not_applied(self, monkeypatch):
         """deepseek_v4 MTP patch must skip cleanly if the base


### PR DESCRIPTION
## Summary

When loading an oQ-quantized Qwen 3.5/3.6 MoE model that was quantized without `preserve_mtp`, the MTP sanitize path crashes with a `KeyError` inside `_stack_per_expert`. The config still declares `mtp_num_hidden_layers > 0`, so the sanitize loop tries to reshape expert weights that don't exist.

## Root Cause

`sanitize` iterates over `range(mtp_num)` and attempts to unfuse or stack MTP expert weights. It checks the weight format (switch_mlp, fused gate_up_proj, or per-expert tensors) but never checks whether MTP weights exist *at all*. When they're absent — the common case for oQ checkpoints quantized without `preserve_mtp` — the per-expert fallback runs `_stack_per_expert`, which pops keys that aren't in the dict.

## Fix

Before entering the MTP expert loop, check whether any `language_model.mtp.*` key exists in the weight dict. If none are found, short-circuit with a debug log explaining the mismatch between config and weights. The existing format-specific guards (`switch_mlp`, fused, per-expert) are also tightened with key-existence checks so each branch only runs when its expected keys are present.

The switch_mlp idempotency guard is preserved: oQ outputs already store experts in switch_mlp form (the mlx-vlm sanitize patch unfuses MTP experts before quantization), so the load-time unfuse/stack is correctly skipped in that case.

## Test plan

Four regression tests in `TestQwen35MoeSanitize`:

- `test_sanitize_no_mtp_weights` — the crash scenario: `mtp_num_hidden_layers=1` but no MTP keys in weights. Verifies no crash and a debug log message.
- `test_sanitize_switch_mlp_form` — oQ output format (already in switch_mlp layout). Verifies idempotent pass-through.
- `test_sanitize_per_expert_form` — Qwen 3.5 per-expert tensors. Verifies stacking into switch_mlp layout.
- `test_sanitize_fused_form` — Qwen 3.6 fused gate_up_proj. Verifies unfusing into switch_mlp layout.

All 40 MTP patch tests pass. 13 pre-existing failures in unrelated areas (server endpoints, grammar, update check, gated delta).

Closes #1138