### PR TITLE
fix(scheduler): batch=1 ChunkedKVCache compat for Llama-4

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -187,6 +187,77 @@ except ImportError:
     pass
 
 
+# Monkey-patch ChunkedKVCache for Llama-4 (Scout / Maverick): mlx_lm's
+# ChunkedKVCache lacks the batch-aware methods (`merge`, `filter`, `extract`,
+# `size`, `extend`) that BatchGenerator's continuous-batching code path
+# expects, so any chat completion targeting a Llama-4 model raises
+# `Cache corruption not recoverable: <ChunkedKVCache> does not yet support
+# batching with history` and returns 500.
+#
+# Real continuous batching with chunked attention is unimplemented upstream;
+# this patch installs batch=1 pass-throughs so serialized requests work.
+# Run the server with `--max-concurrent-requests 1` to honor the assumption.
+try:
+    from mlx_lm.models.cache import ChunkedKVCache as _CKVCache
+
+    if not hasattr(_CKVCache, "merge"):
+        @classmethod
+        def _ckvcache_merge_passthrough(cls, caches):
+            if len(caches) == 1:
+                return caches[0]
+            raise NotImplementedError(
+                "ChunkedKVCache.merge for batch_size > 1 is not implemented. "
+                "Run with --max-concurrent-requests 1 when serving Llama-4."
+            )
+
+        _CKVCache.merge = _ckvcache_merge_passthrough
+
+    if not hasattr(_CKVCache, "filter"):
+        def _ckvcache_filter_passthrough(self, batch_indices):
+            try:
+                n = len(batch_indices)
+            except TypeError:
+                n = int(getattr(batch_indices, "shape", (0,))[0] or 0)
+            if n == 0:
+                self.keys = None
+                self.values = None
+                self.offset = 0
+                self.start_position = 0
+
+        _CKVCache.filter = _ckvcache_filter_passthrough
+
+    if not hasattr(_CKVCache, "extract"):
+        def _ckvcache_extract_passthrough(self, idx):
+            return self
+
+        _CKVCache.extract = _ckvcache_extract_passthrough
+
+    if not hasattr(_CKVCache, "size"):
+        def _ckvcache_size(self):
+            return max(0, self.offset - self.start_position)
+
+        _CKVCache.size = _ckvcache_size
+
+    if not hasattr(_CKVCache, "extend"):
+        def _ckvcache_extend_passthrough(self, other):
+            if other is None or other.empty():
+                return
+            if self.empty():
+                self.keys = other.keys
+                self.values = other.values
+                self.offset = other.offset
+                self.start_position = other.start_position
+                return
+            raise NotImplementedError(
+                "ChunkedKVCache.extend across non-empty caches is not "
+                "supported. Run with --max-concurrent-requests 1."
+            )
+
+        _CKVCache.extend = _ckvcache_extend_passthrough
+except ImportError:
+    pass
+
+
 # ---------------------------------------------------------------------------
 # Monkey-patch PromptProcessingBatch.prompt to set mRoPE deltas before the
 # prompt processing loop.  Without this, batched VLM prompt processing


### PR DESCRIPTION
## Symptom

Chat completions targeting Llama-4 models (Scout / Maverick — both `mlx-community/Llama-4-Scout-17B-16E-Instruct-4bit` via the VLM engine and `Llama-4-Scout-17B-16E-MLX-text-4bit` via the BatchedEngine) currently return `500: Cache corruption not recoverable: <ChunkedKVCache> does not yet support batching with history`. The scheduler retries 4× and gives up.

Reproduction (against `main`, even with `--max-concurrent-requests 1`):

```bash
omlx serve --base-path ~/.omlx --port 6789
curl -s -m 60 -X POST http://127.0.0.1:6789/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"Llama-4-Scout-17B-16E-Instruct-4bit","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":8}'
# → curl: (18) transfer closed with outstanding read data remaining
# → server.log: ERROR ChunkedKVCache does not yet support batching with history
```

## Root cause

`mlx_lm.models.cache.ChunkedKVCache` (used by Llama-4 for chunked attention — see `make_cache` in `mlx_lm/models/llama4.py:322`) doesn't implement the batch-aware methods that `BatchGenerator._merge_caches()` calls — `merge`, `filter`, `extract`, `size`, `extend`. The `to_batch_cache` helper in `mlx_lm/generate.py` also has no `ChunkedKVCache` branch (it raises `does not yet support batching`). Real continuous batching with chunked attention is unimplemented upstream in `mlx_lm`.

## Fix

This patches `mlx_lm.models.cache.ChunkedKVCache` from `omlx/scheduler.py` with batch=1 pass-throughs, sitting alongside the existing `TurboQuantKVCache.merge` monkey-patch (~line 178), so serialized requests succeed:

| Method | Behavior |
|---|---|
| `merge(caches)` | Returns `caches[0]` if `len == 1`. Raises `NotImplementedError` for batch > 1 (no silent corruption). |
| `filter(batch_indices)` | No-op for keep-the-only-one (`len(idx) > 0`); clears the cache when filtering to empty (`len(idx) == 0`). |
| `extract(idx)` | Returns `self` (only one batch element exists). |
| `size()` | Returns `offset - start_position`. |
| `extend(other)` | Allows extend from an empty cache; raises for non-empty merges (would corrupt chunked attention). |

All methods are guarded with `if not hasattr(_CKVCache, ...)` so a future upstream `mlx_lm` implementation will take precedence. The whole block is wrapped in `try/except ImportError` matching the `TurboQuant` patch above it.

## Operator impact

The patch assumes serialized requests, so the server needs `--max-concurrent-requests 1` when serving Llama-4 models — multi-request batching with chunked attention would still hit the existing `ChunkedKVCache` semantics. The `NotImplementedError` raises in `merge`/`extend` make this a loud failure rather than silent corruption if concurrency is misconfigured. The same scheduler.py file already documents a similar single-request constraint for TurboQuantKV around line 1419.

## Verification

Local fleet on M3 Ultra, base-path `~/.omlx`:

| Model | chat | coding | tool_call | tok/s |
|---|---|---|---|---|
| `Llama-4-Scout-17B-16E-Instruct-4bit` (VLM engine; previously 500'd) | ✓ | ✓ | ✓ | 39.6 |
| `Mistral-Medium-3.5-128B-4bit` | ✓ | ✓ | ✓ | 5.7 |
| `mlx-community/gemma-4-26B-A4B-it-OptiQ-4bit` | ✓ | ✓ | ✓ | 94.6 |
| `mlx-community/gemma-4-31B-it-OptiQ-4bit` | ✓ | ✓ | ✓ | 22.7 |

`pytest -m "not slow"` for `tests/test_scheduler.py`, `tests/test_cache_type_handlers.py`, `tests/test_chat_tool_call.py`: **194 passed**, no regressions.

## Notes

This is a stop-gap rather than a complete fix — the proper home is upstream in `mlx_lm` (a `BatchChunkedKVCache` parallel to `BatchKVCache`, with `to_batch_cache` registration). Glad to follow up there if you'd prefer that route; this PR just unblocks Llama-4 serving today without touching `mlx_lm`.

I didn't add an automated test for the patch itself — exercising `_merge_caches` on `ChunkedKVCache` needs a real Llama-4 checkpoint, which seemed too heavy for CI. Surface area is small (`hasattr` guards + pass-throughs) and it no-ops when `mlx_lm` is unavailable. Happy to add one if a fixture pattern fits the existing `tests/test_scheduler.py` conventions.

Thanks for building oMLX — paged SSD caching has been the difference between local Apple Silicon agents being a fun experiment and being usable. Hope this is helpful, and looking forward to where the project goes next.