### PR TITLE
feat(tool_calling): parse Llama-3-style {"name","parameters"} JSON content

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -1267,6 +1267,38 @@ def _parse_tool_calls_impl(
     if "[Calling tool:" in cleaned_text or "[Tool call:" in cleaned_text:
         return _parse_bracket_tool_calls(cleaned_text)
 
+    # Fallback: Llama-3-style JSON tool calls emitted as plain content.
+    # Llama-4-Scout-Instruct's official chat template instructs the model to
+    # respond with `{"name": "<func>", "parameters": {...}}` instead of using
+    # a marker tag. Promote only when the function name matches a provided
+    # tool, to avoid mis-parsing arbitrary user-content JSON as a tool call.
+    if tools and "{" in cleaned_text and '"name"' in cleaned_text:
+        valid_names = _extract_tool_names(tools)
+        for m in re.finditer(
+            r"\{\s*\"name\"\s*:\s*\"([A-Za-z_][\w.-]*)\"\s*,"
+            r"\s*\"(?:parameters|arguments)\"\s*:\s*(\{(?:[^{}]|\{[^{}]*\})*\})\s*\}",
+            cleaned_text,
+            flags=re.DOTALL,
+        ):
+            name = m.group(1)
+            if name not in valid_names:
+                continue
+            args_str = m.group(2)
+            try:
+                args = json.loads(args_str)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            tc = ToolCall(
+                id=f"call_{uuid.uuid4().hex[:8]}",
+                type="function",
+                function=FunctionCall(
+                    name=name,
+                    arguments=_serialize_tool_call_arguments(args),
+                ),
+            )
+            cleaned = (cleaned_text[:m.start()] + cleaned_text[m.end():]).strip()
+            return cleaned, [tc]
+
     # All parsing attempts exhausted. Strip known tool-call markers so raw
     # control markup never leaks into the API response.  Models whose markers
     # overlap with the generic ``<tool_call>`` tag already returned above via

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -1268,25 +1268,43 @@ def _parse_tool_calls_impl(
         return _parse_bracket_tool_calls(cleaned_text)
 
     # Fallback: Llama-3-style JSON tool calls emitted as plain content.
-    # Llama-4-Scout-Instruct's official chat template instructs the model to
-    # respond with `{"name": "<func>", "parameters": {...}}` instead of using
-    # a marker tag. Promote only when the function name matches a provided
-    # tool, to avoid mis-parsing arbitrary user-content JSON as a tool call.
+    # Some chat templates (notably Llama-4-Scout-Instruct's) instruct the
+    # model to respond with `{"name": "<func>", "parameters": {...}}`
+    # instead of a marker tag, and the `parameters` value can be nested
+    # arbitrarily deep. Use `JSONDecoder.raw_decode` to scan candidate `{`
+    # positions so we accept any valid JSON depth (the earlier regex only
+    # handled one level of nested braces). Promote only when the function
+    # name matches a provided tool, to avoid mis-parsing arbitrary
+    # user-content JSON as a tool call.
     if tools and "{" in cleaned_text and '"name"' in cleaned_text:
         valid_names = _extract_tool_names(tools)
-        for m in re.finditer(
-            r"\{\s*\"name\"\s*:\s*\"([A-Za-z_][\w.-]*)\"\s*,"
-            r"\s*\"(?:parameters|arguments)\"\s*:\s*(\{(?:[^{}]|\{[^{}]*\})*\})\s*\}",
-            cleaned_text,
-            flags=re.DOTALL,
-        ):
-            name = m.group(1)
-            if name not in valid_names:
-                continue
-            args_str = m.group(2)
+        decoder = json.JSONDecoder()
+        idx = 0
+        while True:
+            start = cleaned_text.find("{", idx)
+            if start == -1:
+                break
             try:
-                args = json.loads(args_str)
+                obj, end = decoder.raw_decode(cleaned_text, start)
             except (json.JSONDecodeError, ValueError):
+                idx = start + 1
+                continue
+            if not isinstance(obj, dict):
+                idx = end
+                continue
+            name = obj.get("name")
+            args = obj.get("parameters", obj.get("arguments"))
+            if not isinstance(name, str) or not isinstance(args, dict):
+                idx = end
+                continue
+            if name not in valid_names:
+                logger.debug(
+                    "Llama-3 JSON fallback: skipping object with name=%r "
+                    "(not in tools list %r)",
+                    name,
+                    sorted(valid_names),
+                )
+                idx = end
                 continue
             tc = ToolCall(
                 id=f"call_{uuid.uuid4().hex[:8]}",
@@ -1296,7 +1314,7 @@ def _parse_tool_calls_impl(
                     arguments=_serialize_tool_call_arguments(args),
                 ),
             )
-            cleaned = (cleaned_text[:m.start()] + cleaned_text[m.end():]).strip()
+            cleaned = (cleaned_text[:start] + cleaned_text[end:]).strip()
             return cleaned, [tc]
 
     # All parsing attempts exhausted. Strip known tool-call markers so raw

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -2939,3 +2939,105 @@ class TestToolCallStreamFilterGemma4StrayClose:
         result = f.feed('<|tool_call>call()<tool_call|> extra<tool_call|>')
         result += f.finish()
         assert result == " extra"
+
+
+class TestParseToolCallsLlama3JsonContent:
+    """Tests for the Llama-3-style {"name", "parameters"} JSON content fallback.
+
+    Llama-4-Scout-Instruct's official chat template instructs the model to
+    respond with ``{"name": "<func>", "parameters": {...}}`` instead of using
+    a marker tag, so this format must be promoted to ``tool_calls`` when the
+    function name matches a provided tool.
+    """
+
+    _WEATHER_TOOLS = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+
+    def test_llama3_json_content_extracts_tool_call(self):
+        """Plain-content {"name","parameters":{...}} is promoted to tool_calls."""
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = False
+
+        text = '{"name": "get_weather", "parameters": {"location": "Paris"}}'
+        cleaned, tool_calls = parse_tool_calls(text, tok, tools=self._WEATHER_TOOLS)
+
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "get_weather"
+        assert json.loads(tool_calls[0].function.arguments) == {"location": "Paris"}
+        assert cleaned == ""
+
+    def test_llama3_json_arguments_synonym(self):
+        """``arguments`` should be accepted as a synonym for ``parameters``."""
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = False
+
+        text = '{"name": "get_weather", "arguments": {"location": "Tokyo"}}'
+        cleaned, tool_calls = parse_tool_calls(text, tok, tools=self._WEATHER_TOOLS)
+
+        assert tool_calls is not None
+        assert tool_calls[0].function.name == "get_weather"
+        assert json.loads(tool_calls[0].function.arguments) == {"location": "Tokyo"}
+
+    def test_llama3_json_content_strips_match_from_cleaned_text(self):
+        """Surrounding prose should survive; only the JSON block is removed."""
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = False
+
+        text = (
+            'Sure, calling now: '
+            '{"name": "get_weather", "parameters": {"location": "Paris"}}'
+            ' done.'
+        )
+        cleaned, tool_calls = parse_tool_calls(text, tok, tools=self._WEATHER_TOOLS)
+
+        assert tool_calls is not None and len(tool_calls) == 1
+        assert "get_weather" not in cleaned
+        assert "Sure, calling now:" in cleaned
+        assert "done." in cleaned
+
+    def test_llama3_json_content_rejects_unknown_function(self):
+        """Function names outside the tools list must NOT be promoted."""
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = False
+
+        text = '{"name": "rm_rf", "parameters": {"path": "/"}}'
+        cleaned, tool_calls = parse_tool_calls(text, tok, tools=self._WEATHER_TOOLS)
+
+        assert tool_calls is None
+        assert cleaned == text
+
+    def test_llama3_json_content_no_tools_no_promotion(self):
+        """Without a tools list, JSON content must not be classified as a call."""
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = False
+
+        text = '{"name": "get_weather", "parameters": {"location": "Paris"}}'
+        cleaned, tool_calls = parse_tool_calls(text, tok, tools=None)
+
+        assert tool_calls is None
+        assert cleaned == text
+
+    def test_llama3_json_content_invalid_json_skipped(self):
+        """Malformed parameter JSON must not raise; falls through cleanly."""
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = False
+
+        text = '{"name": "get_weather", "parameters": {malformed}}'
+        cleaned, tool_calls = parse_tool_calls(text, tok, tools=self._WEATHER_TOOLS)
+
+        # Either no match (regex picky on inner braces) or failed json.loads -
+        # both must result in no tool_calls and no exception.
+        assert tool_calls is None

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -3038,6 +3038,44 @@ class TestParseToolCallsLlama3JsonContent:
         text = '{"name": "get_weather", "parameters": {malformed}}'
         cleaned, tool_calls = parse_tool_calls(text, tok, tools=self._WEATHER_TOOLS)
 
-        # Either no match (regex picky on inner braces) or failed json.loads -
-        # both must result in no tool_calls and no exception.
+        # raw_decode rejects the malformed inner object — no tool_calls,
+        # no exception.
         assert tool_calls is None
+
+    def test_llama3_json_content_handles_deeply_nested_parameters(self):
+        """Parameters with nested objects >1 level deep must still match.
+
+        The earlier brace-balance regex only handled one level of nesting;
+        real tool schemas (e.g. filter expressions with nested predicates)
+        routinely exceed that. Switching to ``json.JSONDecoder.raw_decode``
+        accepts any valid JSON depth.
+        """
+        nested_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search_events",
+                    "description": "Search events with nested filters",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"filter": {"type": "object"}},
+                        "required": ["filter"],
+                    },
+                },
+            }
+        ]
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = False
+
+        text = (
+            '{"name": "search_events", "parameters": '
+            '{"filter": {"date": {"gte": "2026-01-01", "lt": "2027-01-01"}}}}'
+        )
+        cleaned, tool_calls = parse_tool_calls(text, tok, tools=nested_tools)
+
+        assert tool_calls is not None and len(tool_calls) == 1
+        assert tool_calls[0].function.name == "search_events"
+        assert json.loads(tool_calls[0].function.arguments) == {
+            "filter": {"date": {"gte": "2026-01-01", "lt": "2027-01-01"}}
+        }
+        assert cleaned == ""


### PR DESCRIPTION
## Symptom

`mlx-community/Llama-4-Scout-17B-16E-Instruct-4bit` returns its tool calls as plain content rather than as structured `tool_calls`:

```json
{
  "role": "assistant",
  "content": "{\"name\": \"get_weather\", \"parameters\": {\"location\": \"Paris\"}}",
  "tool_calls": null,
  "finish_reason": "stop"
}
```

OpenAI-compatible clients see an empty `message.tool_calls` and miss the call. The model is doing exactly what its chat template asks of it.

## Root cause

The model's chat template (Meta's official Llama-4 template, `chat_template.json`) explicitly instructs:

> Respond in the format `{"name": function name, "parameters": dictionary of argument name and its value}`. Do not use variables.

So Llama-4-Scout-Instruct emits the call as a JSON object inside `content`, not wrapped in `<tool_call>...</tool_call>` or any tokenizer marker. omlx's `parse_tool_calls` tries, in order:

1. Native parser via `tokenizer.tool_parser` — skipped (no `tool_call_start`).
2. `<tool_call>` XML tags — not present.
3. `<ns:tool_call>` namespaced tags — not present.
4. `[Calling tool: …]` bracket format — not present.
5. Marker-stripping fallback — does nothing for content without markers.

The Llama-3-style JSON format had no extractor, so the call ends up in `content` and is lost.

## Fix

Adds a final fallback in `parse_tool_calls` (right before the marker-stripping pass) that:

- Matches `{"name": "<func>", "parameters": {...}}` (with `arguments` accepted as a synonym for OpenAI parity) via a brace-aware regex.
- Validates `<func>` against the request's `tools` list using the existing `_extract_tool_names` helper — this is what prevents arbitrary user JSON like `{"name": "...", "parameters": {...}}` in unrelated contexts from being mis-classified as tool calls.
- Serializes captured arguments through `_serialize_tool_call_arguments` for the same OpenAI-shaped output other extractors produce.
- Strips the matched span from `cleaned_text` so the JSON doesn't leak alongside `tool_calls`.

The fallback is gated on `tools` being present — a tool-less request never goes near it.

## Verification

- 6 new unit tests in `tests/test_tool_calling.py::TestParseToolCallsLlama3JsonContent`:
  - happy path → `tool_calls` populated, `content` cleared
  - `arguments` synonym accepted
  - surrounding prose preserved (not over-stripped)
  - unknown function name → no promotion (security guard)
  - no `tools` list → no promotion
  - malformed parameter JSON → safe fall-through (no exception)
- Full `pytest tests/test_tool_calling.py -m "not slow"`: **159 passed**, no regressions.
- Live integration: `Llama-4-Scout-17B-16E-Instruct-4bit` chat completion with a `get_weather` tool now returns:

  ```json
  {
    "role": "assistant",
    "content": null,
    "tool_calls": [{
      "id": "call_84918517",
      "type": "function",
      "function": {
        "name": "get_weather",
        "arguments": "{\"location\": \"Paris\"}"
      }
    }]
  }
  ```

## Trade-offs / scope

- The fallback only activates when no other parser claimed the response — same priority as `_parse_bracket_tool_calls`. No behavior change for any model that already has a marker.
- Doesn't try to handle every possible Llama-3-derivative format (e.g. multi-call responses, `<|python_tag|>{"name":...}` framing). One call per response, gated on tools, matches the canonical Meta template wording. Glad to extend if you have repro cases.
- Pairs naturally with the Llama-4 `ChunkedKVCache` patch but is independent — this one is useful for any future model that follows the same Llama-3 chat-template pattern.

Thanks for the work that's gone into oMLX's tool-calling layer — the parser registry and the `tool_call_start` / `tool_call_end` abstraction made this fallback easy to slot in cleanly. Hope the project keeps growing.

(Reposted from #1151 with corrected commit authorship.)