### PR TITLE
feat: Qwen3.6 nested-visual patch, native reasoning, and Responses API reasoning items

### DIFF
--- a/omlx/api/responses_models.py
+++ b/omlx/api/responses_models.py
@@ -140,13 +140,20 @@ class OutputContent(BaseModel):
     annotations: List[Any] = Field(default_factory=list)
 
 
+class ReasoningSummaryPart(BaseModel):
+    """A single part of a reasoning summary."""
+
+    type: str = "summary_text"
+    text: str = ""
+
+
 class OutputItem(BaseModel):
     """A single item in the response output array.
 
-    Can be a message or a function_call.
+    Can be a message, function_call, or reasoning.
     """
 
-    type: str  # "message" or "function_call"
+    type: str  # "message" or "function_call" or "reasoning"
     id: str
     status: str = "completed"
     # message fields
@@ -156,6 +163,8 @@ class OutputItem(BaseModel):
     call_id: Optional[str] = None
     name: Optional[str] = None
     arguments: Optional[str] = None
+    # reasoning fields
+    summary: Optional[List[ReasoningSummaryPart]] = None
 
 
 class InputTokensDetails(BaseModel):

--- a/omlx/api/responses_utils.py
+++ b/omlx/api/responses_utils.py
@@ -139,6 +139,8 @@ def convert_responses_input_to_messages(
     # Process input items
     # Track pending tool calls for grouping into a single assistant message
     pending_tool_calls: List[Dict[str, Any]] = []
+    # Track reasoning content to attach to the next assistant message
+    pending_reasoning: str = ""
 
     for item in input_data:
         # Resolve effective type: EasyInputMessage has no type field
@@ -192,7 +194,26 @@ def convert_responses_input_to_messages(
             if role == "system":
                 system_parts.append(content or "")
             else:
-                messages.append({"role": role, "content": content or ""})
+                msg_dict: Dict[str, Any] = {"role": role, "content": content or ""}
+                if role == "assistant" and pending_reasoning:
+                    msg_dict["reasoning_content"] = pending_reasoning
+                    pending_reasoning = ""
+                messages.append(msg_dict)
+
+        elif item_type == "reasoning":
+            # Collect reasoning summary text to attach to the next
+            # assistant message as reasoning_content.
+            summary = getattr(item, "summary", None) or (
+                (item.model_extra or {}).get("summary") if hasattr(item, "model_extra") else None
+            )
+            if summary:
+                parts = []
+                for s in summary:
+                    if isinstance(s, dict):
+                        parts.append(s.get("text", ""))
+                    else:
+                        parts.append(getattr(s, "text", ""))
+                pending_reasoning = "\n".join(p for p in parts if p)
 
         elif item.type == "function_call":
             # Assistant's tool call — accumulate for grouping
@@ -303,15 +324,38 @@ def build_function_call_output_item(
     )
 
 
+def build_reasoning_output_item(
+    reasoning_text: str,
+    item_id: Optional[str] = None,
+    status: str = "completed",
+) -> OutputItem:
+    """Build a reasoning-type OutputItem with full CoT in summary[0].text."""
+    from .responses_models import ReasoningSummaryPart
+
+    summary = [ReasoningSummaryPart(text=reasoning_text)] if reasoning_text else []
+    return OutputItem(
+        type="reasoning",
+        id=item_id or generate_id(IDPrefix.REASONING),
+        status=status,
+        summary=summary,
+    )
+
+
 def build_response_usage(
-    input_tokens: int, output_tokens: int, cached_tokens: int = 0
+    input_tokens: int,
+    output_tokens: int,
+    reasoning_tokens: int = 0,
+    cached_tokens: int = 0,
 ) -> ResponseUsage:
     """Build ResponseUsage from token counts."""
+    from .responses_models import OutputTokensDetails
+
     return ResponseUsage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=input_tokens + output_tokens,
         input_tokens_details=InputTokensDetails(cached_tokens=cached_tokens),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=reasoning_tokens),
     )
 
 
@@ -525,20 +569,29 @@ def normalize_response_output_to_messages(
     """Convert response output items to assistant/tool-call history messages."""
     messages: List[Dict[str, Any]] = []
     pending_tool_calls: List[Dict[str, Any]] = []
+    pending_reasoning: str = ""
 
     for item in output_items:
         item_type = item.get("type")
-        if item_type == "message":
+        if item_type == "reasoning":
+            summary = item.get("summary", [])
+            parts = [s.get("text", "") for s in summary if isinstance(s, dict)]
+            pending_reasoning = "\n".join(p for p in parts if p)
+        elif item_type == "message":
             _flush_pending_tool_calls(messages, pending_tool_calls)
             content_blocks = item.get("content", [])
             text_parts = []
             for block in content_blocks:
                 if block.get("type") == "output_text":
                     text_parts.append(block.get("text", ""))
-            messages.append({
+            msg_dict: Dict[str, Any] = {
                 "role": item.get("role", "assistant"),
                 "content": "\n".join(text_parts),
-            })
+            }
+            if pending_reasoning:
+                msg_dict["reasoning_content"] = pending_reasoning
+                pending_reasoning = ""
+            messages.append(msg_dict)
         elif item_type == "function_call":
             call_id = item.get("call_id", f"call_{uuid.uuid4().hex[:8]}")
             pending_tool_calls.append({

--- a/omlx/api/shared_models.py
+++ b/omlx/api/shared_models.py
@@ -18,6 +18,7 @@ class IDPrefix(str, Enum):
     RERANK = "rerank"
     RESPONSE = "resp"
     FUNCTION_CALL = "fc"
+    REASONING = "rs"
 
 
 def generate_id(prefix: IDPrefix, length: int = 8) -> str:
@@ -37,6 +38,8 @@ def generate_id(prefix: IDPrefix, length: int = 8) -> str:
         return f"resp_{uuid.uuid4().hex[:24]}"
     if prefix == IDPrefix.FUNCTION_CALL:
         return f"fc_{uuid.uuid4().hex[:8]}"
+    if prefix == IDPrefix.REASONING:
+        return f"rs_{uuid.uuid4().hex[:24]}"
     return f"{prefix.value}-{uuid.uuid4().hex[:length]}"
 
 

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -26,7 +26,9 @@ _THINKING_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
 _THINKING_TAIL_PATTERN = re.compile(r'^(.*?)</think>', re.DOTALL)
 
 
-def extract_thinking(text: str) -> Tuple[str, str]:
+def extract_thinking(
+    text: str, start_in_thinking: bool = False
+) -> Tuple[str, str]:
     """Extract thinking and content from complete text.
 
     Handles:
@@ -40,9 +42,14 @@ def extract_thinking(text: str) -> Tuple[str, str]:
       occasionally skip the ``</think>`` boundary token. Without this
       fallback the entire body would be classified as thinking and the
       visible answer would be empty.
+    - Native reasoning (``start_in_thinking=True``): when the prompt
+      pre-opened ``<think>`` and generation contains no tags at all,
+      the entire output is treated as thinking with empty content.
 
     Args:
         text: Complete model output text.
+        start_in_thinking: If True, treat tag-free text as thinking
+            (native-reasoning mode where the prompt pre-opens <think>).
 
     Returns:
         Tuple of (thinking_content, regular_content).
@@ -81,6 +88,11 @@ def extract_thinking(text: str) -> Tuple[str, str]:
         after = text[idx + _OPEN_LEN:]
         return ("", (before + after).strip())
 
+    # Native-reasoning fallback: prompt pre-opened <think>, generation
+    # contains no tags at all — treat the whole output as thinking.
+    if start_in_thinking and '<think>' not in text and '</think>' not in text:
+        return (text.strip(), "")
+
     return ("", text)
 
 
@@ -106,8 +118,8 @@ class ThinkingParser:
         t, c = parser.finish()
     """
 
-    def __init__(self):
-        self._in_thinking: bool = False
+    def __init__(self, start_in_thinking: bool = False):
+        self._in_thinking: bool = start_in_thinking
         self._buffer: str = ""  # Buffer for potential partial tags
         # Recovery state for malformed thinking: when the prompt prepends
         # ``<think>`` and the model never emits ``</think>`` before EOS,

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -39,6 +39,7 @@ from ..cache.vision_feature_cache import VisionFeatureSSDCache
 from ..models.vlm import VLMModelAdapter
 from ..patches.gated_delta_advance import apply_gated_delta_advance_patch
 from ..patches.qwen3_5_attention import apply_qwen3_5_attention_patch
+from ..patches.qwen3_6_nested_visual import apply_qwen3_6_nested_visual_patch
 from ..utils.image import (
     compute_image_hash,
     compute_per_image_hashes,
@@ -483,6 +484,9 @@ class VLMBatchedEngine(BaseEngine):
         # Patch mlx-vlm Qwen3_5Attention to use plain RoPE on text-only
         # inputs. Preserves mRoPE for genuine multimodal positions.
         apply_qwen3_5_attention_patch()
+        # Remap language_model.model.visual.* → vision_tower.* for
+        # Qwen3.6-35B-A3B's nested ViT layout.
+        apply_qwen3_6_nested_visual_patch()
 
         # Create scheduler config
         scheduler_config = (

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -1558,6 +1558,15 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
                 apply_mlx_vlm_mtp_patch()
             except Exception as patch_err:
                 logger.debug(f"mlx-vlm MTP patch not applied: {patch_err}")
+            try:
+                from omlx.patches.qwen3_6_nested_visual import (
+                    apply_qwen3_6_nested_visual_patch,
+                )
+                apply_qwen3_6_nested_visual_patch()
+            except Exception as patch_err:
+                logger.debug(
+                    f"Qwen3.6 nested-visual patch not applied: {patch_err}"
+                )
 
             model_module, _ = get_model_and_args(config)
             model_config_cls = model_module.ModelConfig

--- a/omlx/patches/qwen3_6_nested_visual.py
+++ b/omlx/patches/qwen3_6_nested_visual.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Patch mlx-vlm's qwen3_5_moe VLM sanitize for Qwen3.6's nested visual layout.
+
+Qwen3.6-35B-A3B's HF checkpoint nests the ViT weights inside the language
+model submodule: `model.language_model.visual.*` instead of the flat
+`model.visual.*` layout that other Qwen VLMs use. After mlx-vlm's default
+sanitize applies `model.language_model → language_model.model`, the visual
+keys land at `language_model.model.visual.*`, which the instantiated
+`Qwen3_5MoeForConditionalGeneration` model class does not have — the ViT
+lives at `self.vision_tower`. Result: 333 visual parameters are silently
+dropped on load and any image input produces garbage.
+
+This patch wraps `Model.sanitize` in mlx-vlm's `qwen3_5_moe` module to
+remap `language_model.model.visual.*` -> `vision_tower.*` after the
+original sanitize runs.
+
+Target commit: mlx-vlm 3472132... (pyproject pin). Should become a no-op
+once upstream mlx-vlm adds the rule itself; the patch auto-skips if it
+detects the rule is already there.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_NESTED_PREFIX = "language_model.model.visual."
+_TARGET_PREFIX = "vision_tower."
+
+_class_patch_applied = False
+
+
+def _rewrite_key(key: str) -> str:
+    if key.startswith(_NESTED_PREFIX):
+        return _TARGET_PREFIX + key[len(_NESTED_PREFIX) :]
+    return key
+
+
+def _make_patched_sanitize(original_sanitize):
+    # mlx-vlm's Model.sanitize is an instance method: def sanitize(self, weights).
+    # Preserve that signature so the bound-method call site keeps working.
+    def patched_sanitize(self, weights):
+        sanitized = original_sanitize(self, weights)
+        remapped = 0
+        out: dict = {}
+        for k, v in sanitized.items():
+            new_k = _rewrite_key(k)
+            if new_k != k:
+                remapped += 1
+            out[new_k] = v
+        if remapped:
+            logger.info(
+                "qwen3_6_nested_visual: remapped %d tensor keys "
+                "'language_model.model.visual.*' -> 'vision_tower.*'",
+                remapped,
+            )
+        return out
+
+    return patched_sanitize
+
+
+def apply_qwen3_6_nested_visual_patch() -> bool:
+    """Install the sanitize wrapper on mlx-vlm's Qwen3_5MoE VLM Model class.
+
+    Idempotent. Returns True on first successful application, False if the
+    module is unavailable or the patch was already applied.
+    """
+    global _class_patch_applied
+
+    if _class_patch_applied:
+        return False
+
+    try:
+        from mlx_vlm.models.qwen3_5_moe import qwen3_5_moe as qwen3_5_moe_module
+    except ImportError:
+        logger.debug("qwen3_6_nested_visual: mlx_vlm.models.qwen3_5_moe not available")
+        return False
+
+    model_cls = getattr(qwen3_5_moe_module, "Model", None)
+    if model_cls is None:
+        logger.debug("qwen3_6_nested_visual: Model class not found on module")
+        return False
+
+    original_sanitize = getattr(model_cls, "sanitize", None)
+    if original_sanitize is None:
+        logger.debug("qwen3_6_nested_visual: Model has no sanitize attr")
+        return False
+
+    try:
+        import inspect
+
+        source = inspect.getsource(original_sanitize)
+        if _NESTED_PREFIX in source or _TARGET_PREFIX in source:
+            logger.debug(
+                "qwen3_6_nested_visual: upstream sanitize already handles "
+                "nested visual; skipping"
+            )
+            _class_patch_applied = True
+            return False
+    except (OSError, TypeError):
+        pass
+
+    model_cls.sanitize = _make_patched_sanitize(original_sanitize)
+    _class_patch_applied = True
+    logger.info("qwen3_6_nested_visual: patched mlx_vlm.qwen3_5_moe Model.sanitize")
+    return True

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -133,6 +133,7 @@ from .api.responses_utils import (
     ResponseStateNotFoundError,
     build_function_call_output_item,
     build_message_output_item,
+    build_reasoning_output_item,
     build_response_store_record,
     build_response_usage,
     convert_responses_input_to_messages,
@@ -3907,9 +3908,9 @@ async def create_response(
     # for it (Qwen 3.6+). Gated on detection so other templates don't
     # receive an unknown kwarg.
     _entry = get_engine_pool().get_entry(resolved_model)
+    native_reasoning = bool(_entry and _entry.preserve_thinking_default is True)
     if (
-        _entry is not None
-        and _entry.preserve_thinking_default is True
+        native_reasoning
         and merged_ct_kwargs.get("enable_thinking") is not False
         and "preserve_thinking" not in merged_ct_kwargs
     ):
@@ -3943,6 +3944,7 @@ async def create_response(
                     model_load_duration=model_load_duration,
                     resolved_model=resolved_model,
                     response_format=response_format,
+                    native_reasoning=native_reasoning,
                     **chat_kwargs,
                 ),
                 http_request=http_request,
@@ -3974,7 +3976,9 @@ async def create_response(
 
         # Process output text
         raw_text = clean_special_tokens(output.text) if output.text else ""
-        thinking_content, regular_content = extract_thinking(raw_text)
+        thinking_content, regular_content = extract_thinking(
+            raw_text, start_in_thinking=native_reasoning
+        )
 
         # Parse tool calls
         if engine.model_type == "gpt_oss" and output.tool_calls:
@@ -4015,6 +4019,9 @@ async def create_response(
 
         # Build output items
         output_items: list[OutputItem] = []
+        reasoning_text = (thinking_content or "").strip()
+        if native_reasoning and reasoning_text:
+            output_items.append(build_reasoning_output_item(reasoning_text))
         output_items.append(
             build_message_output_item(cleaned_text.strip() if cleaned_text else "")
         )
@@ -4080,6 +4087,7 @@ async def stream_responses_api(
     model_load_duration: float = 0.0,
     resolved_model: Optional[str] = None,
     response_format=None,
+    native_reasoning: bool = False,
     **kwargs,
 ) -> AsyncIterator[str]:
     """Stream Responses API events (SSE with named event types)."""
@@ -4089,12 +4097,20 @@ async def stream_responses_api(
     first_token_time = None
     last_output = None
     accumulated_text = ""
+    accumulated_reasoning = ""
     has_tools = bool(kwargs.get("tools"))
-    thinking_parser = ThinkingParser()
+    thinking_parser = ThinkingParser(start_in_thinking=native_reasoning)
     seq = 0
 
     response_id = generate_id(IDPrefix.RESPONSE)
     msg_id = generate_id(IDPrefix.MESSAGE)
+    reasoning_id = generate_id(IDPrefix.REASONING)
+
+    # Lazy item emission state — items are opened on first token
+    reasoning_opened = False
+    reasoning_closed = False
+    message_opened = False
+    next_output_index = 0
 
     # Build initial response object (in_progress, empty output)
     initial_response = ResponseObject(
@@ -4127,35 +4143,114 @@ async def stream_responses_api(
         "sequence_number": seq,
     })
 
-    # 3. response.output_item.added (message)
-    msg_item = {
-        "type": "message",
-        "id": msg_id,
-        "status": "in_progress",
-        "role": "assistant",
-        "content": [],
-    }
-    seq += 1
-    yield format_sse_event("response.output_item.added", {
-        "type": "response.output_item.added",
-        "output_index": 0,
-        "item": msg_item,
-        "sequence_number": seq,
-    })
+    # --- helper closures for lazy item emission ----------------------
+    def _open_reasoning():
+        nonlocal seq, reasoning_opened, next_output_index
+        if reasoning_opened:
+            return []
+        reasoning_opened = True
+        events = []
+        seq += 1
+        events.append(format_sse_event("response.output_item.added", {
+            "type": "response.output_item.added",
+            "output_index": next_output_index,
+            "item": {
+                "type": "reasoning",
+                "id": reasoning_id,
+                "status": "in_progress",
+                "summary": [],
+            },
+            "sequence_number": seq,
+        }))
+        seq += 1
+        events.append(format_sse_event("response.reasoning_summary_part.added", {
+            "type": "response.reasoning_summary_part.added",
+            "item_id": reasoning_id,
+            "output_index": next_output_index,
+            "summary_index": 0,
+            "part": {"type": "summary_text", "text": ""},
+            "sequence_number": seq,
+        }))
+        return events
 
-    # 4. response.content_part.added
-    content_part = {"type": "output_text", "text": "", "annotations": []}
-    seq += 1
-    yield format_sse_event("response.content_part.added", {
-        "type": "response.content_part.added",
-        "item_id": msg_id,
-        "output_index": 0,
-        "content_index": 0,
-        "part": content_part,
-        "sequence_number": seq,
-    })
+    def _close_reasoning():
+        nonlocal seq, reasoning_closed, next_output_index
+        if reasoning_closed or not reasoning_opened:
+            return []
+        reasoning_closed = True
+        reasoning_output_index = next_output_index
+        next_output_index += 1
+        events = []
+        seq += 1
+        events.append(format_sse_event("response.reasoning_summary_text.done", {
+            "type": "response.reasoning_summary_text.done",
+            "item_id": reasoning_id,
+            "output_index": reasoning_output_index,
+            "summary_index": 0,
+            "text": accumulated_reasoning,
+            "sequence_number": seq,
+        }))
+        seq += 1
+        events.append(format_sse_event("response.reasoning_summary_part.done", {
+            "type": "response.reasoning_summary_part.done",
+            "item_id": reasoning_id,
+            "output_index": reasoning_output_index,
+            "summary_index": 0,
+            "part": {"type": "summary_text", "text": accumulated_reasoning},
+            "sequence_number": seq,
+        }))
+        seq += 1
+        events.append(format_sse_event("response.output_item.done", {
+            "type": "response.output_item.done",
+            "output_index": reasoning_output_index,
+            "item": {
+                "type": "reasoning",
+                "id": reasoning_id,
+                "status": "completed",
+                "summary": [{"type": "summary_text", "text": accumulated_reasoning}],
+            },
+            "sequence_number": seq,
+        }))
+        return events
 
-    # 5. Stream tokens
+    def _open_message():
+        nonlocal seq, message_opened, next_output_index
+        if message_opened:
+            return []
+        message_opened = True
+        msg_output_index = next_output_index
+        events = []
+        seq += 1
+        events.append(format_sse_event("response.output_item.added", {
+            "type": "response.output_item.added",
+            "output_index": msg_output_index,
+            "item": {
+                "type": "message",
+                "id": msg_id,
+                "status": "in_progress",
+                "role": "assistant",
+                "content": [],
+            },
+            "sequence_number": seq,
+        }))
+        seq += 1
+        events.append(format_sse_event("response.content_part.added", {
+            "type": "response.content_part.added",
+            "item_id": msg_id,
+            "output_index": msg_output_index,
+            "content_index": 0,
+            "part": {"type": "output_text", "text": "", "annotations": []},
+            "sequence_number": seq,
+        }))
+        return events
+    # -----------------------------------------------------------------
+
+    # If not native reasoning, open message immediately (legacy behavior)
+    if not native_reasoning:
+        for ev in _open_message():
+            yield ev
+
+    # Stream tokens
     tool_filter = None
     stream_content = True
     if has_tools:
@@ -4164,6 +4259,8 @@ async def stream_responses_api(
             tool_filter = _f
         else:
             stream_content = False
+
+    msg_output_index = None  # will be set when message opens
 
     try:
         async for output in engine.stream_chat(messages=messages, **kwargs):
@@ -4174,8 +4271,30 @@ async def stream_responses_api(
                 accumulated_text += output.new_text
 
             if stream_content and output.new_text:
-                _thinking, content_delta = thinking_parser.feed(output.new_text)
+                thinking_delta, content_delta = thinking_parser.feed(output.new_text)
+
+                if thinking_delta and native_reasoning:
+                    accumulated_reasoning += thinking_delta
+                    for ev in _open_reasoning():
+                        yield ev
+                    seq += 1
+                    yield format_sse_event("response.reasoning_summary_text.delta", {
+                        "type": "response.reasoning_summary_text.delta",
+                        "item_id": reasoning_id,
+                        "output_index": 0 if not reasoning_closed else next_output_index - 1,
+                        "summary_index": 0,
+                        "delta": thinking_delta,
+                        "sequence_number": seq,
+                    })
+
                 if content_delta:
+                    if native_reasoning and reasoning_opened and not reasoning_closed:
+                        for ev in _close_reasoning():
+                            yield ev
+                    for ev in _open_message():
+                        yield ev
+                    if msg_output_index is None:
+                        msg_output_index = next_output_index
                     if tool_filter:
                         content_delta = tool_filter.feed(content_delta)
                     if content_delta:
@@ -4183,7 +4302,7 @@ async def stream_responses_api(
                         yield format_sse_event("response.output_text.delta", {
                             "type": "response.output_text.delta",
                             "item_id": msg_id,
-                            "output_index": 0,
+                            "output_index": msg_output_index,
                             "content_index": 0,
                             "delta": content_delta,
                             "sequence_number": seq,
@@ -4198,9 +4317,22 @@ async def stream_responses_api(
         })
         return
 
+    # Close reasoning if still open
+    if native_reasoning and reasoning_opened and not reasoning_closed:
+        for ev in _close_reasoning():
+            yield ev
+
+    # Ensure message item is opened (even if no content was streamed)
+    for ev in _open_message():
+        yield ev
+    if msg_output_index is None:
+        msg_output_index = next_output_index
+
     # Flush remaining content from parsers
     if stream_content:
-        _thinking, content_delta = thinking_parser.finish()
+        thinking_delta, content_delta = thinking_parser.finish()
+        if thinking_delta and native_reasoning:
+            accumulated_reasoning += thinking_delta
         if content_delta:
             if tool_filter:
                 content_delta = tool_filter.feed(content_delta)
@@ -4209,7 +4341,7 @@ async def stream_responses_api(
                 yield format_sse_event("response.output_text.delta", {
                     "type": "response.output_text.delta",
                     "item_id": msg_id,
-                    "output_index": 0,
+                    "output_index": msg_output_index,
                     "content_index": 0,
                     "delta": content_delta,
                     "sequence_number": seq,
@@ -4221,7 +4353,7 @@ async def stream_responses_api(
                 yield format_sse_event("response.output_text.delta", {
                     "type": "response.output_text.delta",
                     "item_id": msg_id,
-                    "output_index": 0,
+                    "output_index": msg_output_index,
                     "content_index": 0,
                     "delta": remaining,
                     "sequence_number": seq,
@@ -4234,7 +4366,9 @@ async def stream_responses_api(
         tool_calls = last_output.tool_calls
         cleaned_text = ""
     elif has_tools and accumulated_text:
-        thinking_content, regular_content = extract_thinking(accumulated_text)
+        thinking_content, regular_content = extract_thinking(
+            accumulated_text, start_in_thinking=native_reasoning
+        )
         extraction = extract_tool_calls_with_thinking(
             thinking_content,
             regular_content,
@@ -4248,14 +4382,16 @@ async def stream_responses_api(
             yield format_sse_event("response.output_text.delta", {
                 "type": "response.output_text.delta",
                 "item_id": msg_id,
-                "output_index": 0,
+                "output_index": msg_output_index,
                 "content_index": 0,
                 "delta": cleaned_text,
                 "sequence_number": seq,
             })
     else:
         # No tools — use raw accumulated text minus thinking
-        thinking_content, regular_content = extract_thinking(accumulated_text)
+        thinking_content, regular_content = extract_thinking(
+            accumulated_text, start_in_thinking=native_reasoning
+        )
         cleaned_text = clean_special_tokens(regular_content) if regular_content else ""
 
     # Reverse Gemma 4 parameter renaming
@@ -4282,33 +4418,33 @@ async def stream_responses_api(
         if not is_valid:
             logger.warning(f"JSON validation failed: {error}")
 
-    # 6. response.output_text.done
+    # response.output_text.done
     seq += 1
     yield format_sse_event("response.output_text.done", {
         "type": "response.output_text.done",
         "item_id": msg_id,
-        "output_index": 0,
+        "output_index": msg_output_index,
         "content_index": 0,
         "text": final_text,
         "sequence_number": seq,
     })
 
-    # 7. response.content_part.done
+    # response.content_part.done
     seq += 1
     yield format_sse_event("response.content_part.done", {
         "type": "response.content_part.done",
         "item_id": msg_id,
-        "output_index": 0,
+        "output_index": msg_output_index,
         "content_index": 0,
         "part": {"type": "output_text", "text": final_text, "annotations": []},
         "sequence_number": seq,
     })
 
-    # 8. response.output_item.done (message)
+    # response.output_item.done (message)
     seq += 1
     yield format_sse_event("response.output_item.done", {
         "type": "response.output_item.done",
-        "output_index": 0,
+        "output_index": msg_output_index,
         "item": {
             "type": "message",
             "id": msg_id,
@@ -4320,19 +4456,25 @@ async def stream_responses_api(
     })
 
     # Build output items for final response
-    output_items = [
-        {
-            "type": "message",
-            "id": msg_id,
+    output_items = []
+    if native_reasoning and accumulated_reasoning:
+        output_items.append({
+            "type": "reasoning",
+            "id": reasoning_id,
             "status": "completed",
-            "role": "assistant",
-            "content": [{"type": "output_text", "text": final_text, "annotations": []}],
-        }
-    ]
+            "summary": [{"type": "summary_text", "text": accumulated_reasoning}],
+        })
+    output_items.append({
+        "type": "message",
+        "id": msg_id,
+        "status": "completed",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": final_text, "annotations": []}],
+    })
 
-    # 9-12. Emit function call items if present
+    # Emit function call items if present
     if tool_calls:
-        output_index = 1
+        output_index = next_output_index + 1
         for tc in tool_calls:
             if hasattr(tc, "function"):
                 call_id = tc.id


### PR DESCRIPTION
## Summary
- **Qwen3.6 nested-visual sanitize patch** (`omlx/patches/qwen3_6_nested_visual.py`): Monkey-patches mlx-vlm's `qwen3_5_moe.Model.sanitize` to remap `language_model.model.visual.*` → `vision_tower.*` for Qwen3.6-35B-A3B's nested ViT layout. Self-guarding: no-op when mlx-vlm already handles the remapping. Wired into both VLM engine load and oQ quantization paths.
- **thinking.py `start_in_thinking`**: Add parameter to `extract_thinking()` and `ThinkingParser` for native-reasoning models (e.g. Qwen3.6) where the prompt pre-opens `<think>`. Complements the existing malformed-tag recovery.
- **Responses API reasoning output items**: Full streaming + non-streaming support for reasoning output items:
  - `IDPrefix.REASONING` and `ReasoningSummaryPart` model
  - `build_reasoning_output_item()` helper
  - Lazy item emission in streaming: reasoning opens on first thinking_delta, message opens on first content_delta
  - `response.reasoning_summary_text.delta` SSE events
  - `pending_reasoning` tracking in input/output message conversion
  - `native_reasoning` detection from `preserve_thinking_default`

## Test plan
- [x] Full test suite passes (4193 passed, 0 failed)
- [x] Verify Qwen3.6-35B-A3B inference with nested ViT layout
- [x] Verify Responses API streaming with native-reasoning model emits reasoning items
- [x] Verify non-streaming Responses API includes reasoning output item

🤖 Generated with [Claude Code](https://claude.com/claude-code)