### PR TITLE
chore(deps): bump mlx-embeddings, uvicorn, fastapi floors

### DIFF
--- a/packaging/venvstacks.toml
+++ b/packaging/venvstacks.toml
@@ -19,11 +19,11 @@ requirements = [
     "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@ed1fca4cef15a824c5f1702c80f70b4cffc8e4dd",
     # regex for mlx-lm's Gemma 4 tool parser (uses recursive patterns)
     "regex",
-    # mlx-embeddings from latest commit (32981fa) - aligned with pyproject.toml
-    "mlx-embeddings @ git+https://github.com/Blaizzy/mlx-embeddings@32981fa4e8064ed664b52071789dd18271fe4206",
+    # mlx-embeddings from latest commit (ea6d739c) - aligned with pyproject.toml
+    "mlx-embeddings @ git+https://github.com/Blaizzy/mlx-embeddings@ea6d739c73efe991239bc8596ebdfb7060ad209d",
     # Server dependencies
-    "fastapi>=0.100.0",
-    "uvicorn>=0.23.0",
+    "fastapi>=0.136.0",
+    "uvicorn>=0.46.0",
     # Tokenizers and transformers (aligned with pyproject.toml)
     # mlx-vlm custom processors bypass HF AutoProcessor, so torch is not required
     "transformers>=5.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
     "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@ed1fca4cef15a824c5f1702c80f70b4cffc8e4dd",
     # regex for mlx-lm's Gemma 4 tool parser (uses recursive patterns)
     "regex",
-    # mlx-embeddings from latest commit (32981fa)
-    "mlx-embeddings @ git+https://github.com/Blaizzy/mlx-embeddings@32981fa4e8064ed664b52071789dd18271fe4206",
+    # mlx-embeddings from latest commit (ea6d739c)
+    "mlx-embeddings @ git+https://github.com/Blaizzy/mlx-embeddings@ea6d739c73efe991239bc8596ebdfb7060ad209d",
     # mlx-vlm custom processors bypass HF AutoProcessor, so torch is not required
     "transformers>=5.0.0",
     # transformers 5.x's tokenization_mistral_common module imports
@@ -63,8 +63,8 @@ dependencies = [
     # Resource monitoring
     "psutil>=5.9.0",
     # Server
-    "fastapi>=0.108.0",
-    "uvicorn>=0.23.0",
+    "fastapi>=0.136.0",
+    "uvicorn>=0.46.0",
     # JSON Schema validation for structured output
     "jsonschema>=4.0.0",
     # Harmony format parser for gpt-oss models


### PR DESCRIPTION
## Summary
- `mlx-embeddings`: `32981fa` → `ea6d739c`
- `fastapi`: `>=0.108` → `>=0.136`
- `uvicorn`: `>=0.23` → `>=0.46`

Updated in both `pyproject.toml` and `packaging/venvstacks.toml`.

## Test plan
- [x] Full test suite passes (4193 passed, 0 failed)
- [x] Verify `uv sync --all-extras` resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)