### PR TITLE
fix(eval): correct KMMLU answer mapping

### DIFF
--- a/omlx/eval/kmmlu.py
+++ b/omlx/eval/kmmlu.py
@@ -17,7 +17,7 @@ from .datasets import load_jsonl, stratified_sample
 logger = logging.getLogger(__name__)
 
 DATA_DIR = Path(__file__).parent / "data"
-ANSWER_MAP = {0: "A", 1: "B", 2: "C", 3: "D"}
+ANSWER_MAP = {1: "A", 2: "B", 3: "C", 4: "D"}
 
 
 def _format_subject_name(subject: str) -> str:
@@ -28,7 +28,7 @@ def _format_question(item: dict) -> str:
     question = item["question"]
     choices = item["choices"]
     parts = [question]
-    for i, choice in enumerate(choices):
+    for i, choice in enumerate(choices, start=1):
         parts.append(f"{ANSWER_MAP[i]}. {choice}")
     return "\n".join(parts)
 


### PR DESCRIPTION
## Summary
- Fix KMMLU answer normalization to map the bundled 1-indexed labels (`1`-`4`) to `A`-`D`.
- Keep KMMLU prompt choice labels aligned with that mapping.

## Why
The bundled KMMLU files store answers as `1`, `2`, `3`, and `4`, but `KMMLUBenchmark` treated them as zero-indexed labels. That shifted answers by one letter, and raw answer `4` became the string `"4"`, which could never match extracted model answers (`A`-`D`).

This caused KMMLU accuracy to be severely underreported across models.

## Evidence
The bundled KMMLU answer distribution is 1-indexed:

```text
kmmlu_test.jsonl: {1: 3458, 2: 10418, 3: 10477, 4: 10677}
kmmlu_dev.jsonl:  {1: 8,    2: 5,     3: 7,     4: 5}
```

The first five loaded KMMLU answers normalize to:

```text
B, A, A, D, C
```

## Validation

Before the fix, KMMLU scored abnormally low:

```text
Model: Qwen3.6-35B-A3B
Benchmark: KMMLU
Mode: Thinking
Correct: 11 / 300
Accuracy: 3.7%
Time: 2278.2s
```

After restarting the server with the fix loaded and rerunning KMMLU:

```text
Model: Qwen3.6-35B-A3B
Benchmark: KMMLU
Mode: Thinking
Correct: 41 / 50
Accuracy: 82.0%
Time: 406.5s
```