### PR TITLE
feat(audio): support max_tokens for /v1/audio/transcriptions

### DIFF
--- a/omlx/api/audio_models.py
+++ b/omlx/api/audio_models.py
@@ -13,13 +13,21 @@ from pydantic import BaseModel
 
 
 class AudioTranscriptionRequest(BaseModel):
-    """OpenAI-compatible audio transcription request."""
+    """OpenAI-compatible audio transcription request.
+
+    ``max_tokens`` is an oMLX extension (no equivalent in the OpenAI shape) that
+    raises the per-call output cap for STT models whose ``generate(..., max_tokens=...)``
+    default is too tight for long files — e.g. mlx-audio's VibeVoice-ASR caps at
+    8192 tokens (~24 min of audio) by default while the model itself supports
+    ~60 min / 64k context. When ``None``, the model's own default is used.
+    """
 
     model: str
     language: Optional[str] = None
     prompt: Optional[str] = None
     response_format: Optional[str] = "json"
     temperature: Optional[float] = 0.0
+    max_tokens: Optional[int] = None
 
 
 class AudioTranscriptionResponse(BaseModel):

--- a/omlx/api/audio_routes.py
+++ b/omlx/api/audio_routes.py
@@ -76,6 +76,19 @@ def _resolve_model(model_id: str) -> str:
     return resolve_model_id(model_id) or model_id
 
 
+def _get_settings_manager():
+    """Return the active ModelSettingsManager from server state, or None.
+
+    Lazy import + defensive guard so the audio router stays usable in tests
+    that don't bring up the full server state.
+    """
+    try:
+        from omlx.server import _server_state
+    except Exception:
+        return None
+    return getattr(_server_state, "settings_manager", None)
+
+
 def _record_audio_request(model_id: str) -> None:
     """Record audio request count without treating bytes/chars as tokens."""
     try:
@@ -363,11 +376,17 @@ async def create_transcription(
     language: Optional[str] = Form(None),
     response_format: str = Form("json"),
     temperature: float = Form(0.0),
+    max_tokens: Optional[int] = Form(None),
 ):
     """OpenAI-compatible audio transcription endpoint (Speech-to-Text).
 
     Note: ``response_format`` and ``temperature`` are accepted for OpenAI API
     compatibility but are not yet implemented — they are silently ignored.
+
+    ``max_tokens`` is an oMLX extension that raises the underlying model's
+    output cap. Useful for long audio with models like VibeVoice-ASR whose
+    mlx-audio default (8192) truncates ~24 min files. When omitted, the
+    model's own default applies.
     """
     from omlx.engine.stt import STTEngine
     from omlx.exceptions import ModelNotFoundError
@@ -406,7 +425,26 @@ async def create_transcription(
             tmp_path = tmp.name
             tmp.write(content)
 
-        result = await engine.transcribe(tmp_path, language=language)
+        # Effective max_tokens precedence: request > per-model setting (if any) >
+        # model's own ``generate(max_tokens=...)`` default. The per-model lookup
+        # mirrors how chat completions reads ModelSettings.max_tokens for LLMs;
+        # for STT, settings.json's ``max_tokens`` (e.g. raised to 65536 for
+        # VibeVoice-ASR) becomes the durable default for that model.
+        effective_max_tokens = max_tokens
+        if effective_max_tokens is None:
+            sm = _get_settings_manager()
+            if sm is not None:
+                try:
+                    ms = sm.get_settings(resolved_model)
+                    if ms is not None and getattr(ms, "max_tokens", None) is not None:
+                        effective_max_tokens = ms.max_tokens
+                except Exception:
+                    pass
+
+        transcribe_kwargs: dict = {"language": language}
+        if effective_max_tokens is not None:
+            transcribe_kwargs["max_tokens"] = effective_max_tokens
+        result = await engine.transcribe(tmp_path, **transcribe_kwargs)
     except HTTPException:
         raise
     except Exception as exc:

--- a/tests/test_audio_stt.py
+++ b/tests/test_audio_stt.py
@@ -190,6 +190,123 @@ class TestSTTEndpointBasic:
         )
         assert response.status_code == 200
 
+    def test_max_tokens_forwarded_to_engine(self, server_audio_client):
+        """max_tokens= form field is passed through to engine.transcribe()."""
+        client, mock_pool = server_audio_client
+        engine = mock_pool.get_engine.return_value
+
+        captured: dict = {}
+
+        async def capture(path, **kwargs):
+            captured.update(kwargs)
+            return {"text": "ok", "language": "en", "segments": [], "duration": 0.0}
+
+        engine.transcribe = AsyncMock(side_effect=capture)
+
+        response = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("audio.wav", TINY_WAV, "audio/wav")},
+            data={"model": "whisper-tiny", "max_tokens": "32768"},
+        )
+
+        assert response.status_code == 200
+        assert captured.get("max_tokens") == 32768
+
+    def test_max_tokens_omitted_when_not_set_and_no_setting(self, server_audio_client):
+        """max_tokens is not passed when neither request nor per-model setting set it."""
+        from unittest.mock import patch
+
+        client, mock_pool = server_audio_client
+        engine = mock_pool.get_engine.return_value
+
+        captured: dict = {}
+
+        async def capture(path, **kwargs):
+            captured.update(kwargs)
+            return {"text": "ok", "language": "en", "segments": [], "duration": 0.0}
+
+        engine.transcribe = AsyncMock(side_effect=capture)
+
+        # No settings manager => model's own default applies; nothing forwarded.
+        with patch(
+            "omlx.api.audio_routes._get_settings_manager",
+            return_value=None,
+        ):
+            response = client.post(
+                "/v1/audio/transcriptions",
+                files={"file": ("audio.wav", TINY_WAV, "audio/wav")},
+                data={"model": "whisper-tiny"},
+            )
+
+        assert response.status_code == 200
+        assert "max_tokens" not in captured
+
+    def test_max_tokens_falls_back_to_per_model_setting(self, server_audio_client):
+        """When request omits max_tokens, ModelSettings.max_tokens is used."""
+        from unittest.mock import MagicMock, patch
+
+        client, mock_pool = server_audio_client
+        engine = mock_pool.get_engine.return_value
+
+        captured: dict = {}
+
+        async def capture(path, **kwargs):
+            captured.update(kwargs)
+            return {"text": "ok", "language": "en", "segments": [], "duration": 0.0}
+
+        engine.transcribe = AsyncMock(side_effect=capture)
+
+        # Stand in for ModelSettingsManager that returns max_tokens=65536
+        # for any model id.
+        fake_settings = MagicMock(max_tokens=65536)
+        fake_manager = MagicMock()
+        fake_manager.get_settings.return_value = fake_settings
+
+        with patch(
+            "omlx.api.audio_routes._get_settings_manager",
+            return_value=fake_manager,
+        ):
+            response = client.post(
+                "/v1/audio/transcriptions",
+                files={"file": ("audio.wav", TINY_WAV, "audio/wav")},
+                data={"model": "whisper-tiny"},
+            )
+
+        assert response.status_code == 200
+        assert captured.get("max_tokens") == 65536
+
+    def test_max_tokens_request_overrides_per_model_setting(self, server_audio_client):
+        """An explicit request max_tokens beats the per-model setting."""
+        from unittest.mock import MagicMock, patch
+
+        client, mock_pool = server_audio_client
+        engine = mock_pool.get_engine.return_value
+
+        captured: dict = {}
+
+        async def capture(path, **kwargs):
+            captured.update(kwargs)
+            return {"text": "ok", "language": "en", "segments": [], "duration": 0.0}
+
+        engine.transcribe = AsyncMock(side_effect=capture)
+
+        fake_settings = MagicMock(max_tokens=65536)
+        fake_manager = MagicMock()
+        fake_manager.get_settings.return_value = fake_settings
+
+        with patch(
+            "omlx.api.audio_routes._get_settings_manager",
+            return_value=fake_manager,
+        ):
+            response = client.post(
+                "/v1/audio/transcriptions",
+                files={"file": ("audio.wav", TINY_WAV, "audio/wav")},
+                data={"model": "whisper-tiny", "max_tokens": "4096"},
+            )
+
+        assert response.status_code == 200
+        assert captured.get("max_tokens") == 4096
+
 
 # ---------------------------------------------------------------------------
 # TestSTTEndpointResponseFormat


### PR DESCRIPTION
## Problem

`/v1/audio/transcriptions` has no way to raise the per-call output token cap. mlx-audio's STT models each set their own default in `generate(...)`:

| Model | `max_tokens` default |
|---|---|
| VibeVoice-ASR | 8192 |
| canary | 200 |
| granite_speech | 4096 |
| whisper / sensevoice / fireredasr2 | accept `**kwargs` |

For `VibeVoice-ASR-8bit` specifically, an 8192 cap means a 60-min file truncates at ~24 min of transcript even though the model itself advertises ~60 min audio + 64k context. Confirmed locally — issue #1127 is the same shape on the LLM side.

oMLX already has the right infrastructure for this: `ModelSettings.max_tokens` exists and chat completions reads from it (`omlx/server.py:917-927`). Audio just doesn't.

## Change

Mirror the chat-completions precedence on the STT path, with one new field:

```
request.max_tokens > ModelSettings.max_tokens > model's own generate() default
```

- `AudioTranscriptionRequest`: new `max_tokens: Optional[int] = None` (oMLX extension; documented).
- `POST /v1/audio/transcriptions`: new `max_tokens: Optional[int] = Form(None)`. When omitted, the route reads `_server_state.settings_manager.get_settings(model_id).max_tokens`. When that's also `None`, nothing is forwarded and the model's own default applies — fully backward-compatible.
- `STTEngine.transcribe(..., **kwargs)` already forwards to `model.generate`, so no engine change. Quick audit confirmed every mlx-audio STT model in tree either accepts `max_tokens=` or has a `**kwargs` catch-all.

After this, a user can set
```json
"VibeVoice-ASR-8bit": { "max_tokens": 65536 }
```
in `~/.omlx/model_settings.json` and stop hitting the 24-min ceiling, without changing any client code.

## Tests

Four new tests in `tests/test_audio_stt.py`:

- `test_max_tokens_forwarded_to_engine` — explicit form field flows to `engine.transcribe(..., max_tokens=...)`.
- `test_max_tokens_omitted_when_not_set_and_no_setting` — neither source set ⇒ kwarg not passed (model default wins).
- `test_max_tokens_falls_back_to_per_model_setting` — request omits, `ModelSettings.max_tokens=65536` ⇒ 65536 forwarded.
- `test_max_tokens_request_overrides_per_model_setting` — request value wins over settings value.

Full `tests/test_audio_stt.py` passes (the 5 deselected failures pre-date this change — `mx.new_thread_local_stream` mlx-version mismatch in dev `.venv`, unrelated to audio routing).

## Backward compatibility

- OpenAI clients sending the old transcription request shape: unchanged behaviour, `max_tokens` defaults to `None`.
- Models that don't accept `max_tokens` keyword: not currently a concern (every STT model in `mlx_audio/stt/models/` either takes it explicitly or has `**kwargs`), but since the kwarg is only added when an explicit value exists, even a future strict-signature model only fails on clients who opted in.