### PR TITLE
fix(admin): left panel icon toggling improvement

### DIFF
--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -420,9 +420,6 @@
                     <img x-show="activeTheme === 'dark'" src="/admin/static/navbar-logo-dark.svg" alt="oMLX" class="w-[30px] h-[30px]" x-cloak>
                     <span class="font-semibold">{{ t('chat.brand') }}</span>
                 </a>
-                <button @click="sidebarOpen = false" class="p-1.5 hover:bg-surface-muted rounded-md" style="color: var(--text-primary);">
-                    <i data-lucide="panel-left-close" class="w-4 h-4"></i>
-                </button>
             </div>
         </div>
 
@@ -494,7 +491,8 @@
                 <i data-lucide="menu" class="w-5 h-5"></i>
             </button>
             <button @click="sidebarOpen = !sidebarOpen" class="p-2 hover:bg-surface-muted rounded-lg hidden md:block" style="color: var(--text-primary);">
-                <i data-lucide="panel-left" class="w-5 h-5"></i>
+                <i data-lucide="panel-left-open" class="w-5 h-5" x-show="!sidebarOpen"></i>
+                <i data-lucide="panel-left-close" class="w-5 h-5" x-show="sidebarOpen"></i>
             </button>
 
             <!-- Model Selector -->


### PR DESCRIPTION
- Removing redundant panel icon toggle from the side bar
- Conditionally showing panel icon on `sideBarOpen` flag

| State | **Closed** | **Opened** |
|---|---|---|
| **AFTER** | <img width="233" alt="Closed After" src="https://github.com/user-attachments/assets/7a5f0845-e3b5-4b78-a69f-fbd0f32b84e5" /> | <img width="373" alt="Open After" src="https://github.com/user-attachments/assets/530d6da3-fc24-41c0-be65-81e88464e0bd" /> |
| **BEFORE** | <img width="270" alt="Closed Before" src="https://github.com/user-attachments/assets/6474920d-9066-409a-b775-05316d447719" /> | <img width="366" alt="Open Before" src="https://github.com/user-attachments/assets/f487ffa6-b1f0-40f5-bfb7-d5d6fef37d59" /> |

