### PR TITLE
fix(engine): keep streaming abort engine reference

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -561,7 +561,8 @@ class BatchedEngine(BaseEngine):
                 "specprefill_system_end"
             )
 
-        request_id = await self._engine.add_request(
+        engine = self._engine
+        request_id = await engine.add_request(
             prompt=prompt,
             sampling_params=sampling_params,
             **specprefill_kwargs,
@@ -569,7 +570,7 @@ class BatchedEngine(BaseEngine):
 
         finished_normally = False
         try:
-            async for output in self._engine.stream_outputs(request_id):
+            async for output in engine.stream_outputs(request_id):
                 text = clean_special_tokens(output.output_text)
 
                 # Set finished_normally BEFORE yield, because the consumer
@@ -600,7 +601,7 @@ class BatchedEngine(BaseEngine):
                 logger.info(
                     f"[stream_generate] Aborting request {request_id} (finished_normally={finished_normally})"
                 )
-                await self._engine.abort_request(request_id)
+                await engine.abort_request(request_id)
             else:
                 logger.debug(
                     f"[stream_generate] Request {request_id} finished normally"

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1362,7 +1362,8 @@ class VLMBatchedEngine(BaseEngine):
         if kwargs.get("specprefill_system_end") is not None:
             specprefill_kwargs["specprefill_system_end"] = kwargs.pop("specprefill_system_end")
 
-        request_id = await self._engine.add_request(
+        engine = self._engine
+        request_id = await engine.add_request(
             prompt=prompt,
             sampling_params=sampling_params,
             vlm_inputs_embeds=vlm_inputs_embeds,
@@ -1375,7 +1376,7 @@ class VLMBatchedEngine(BaseEngine):
 
         finished_normally = False
         try:
-            async for output in self._engine.stream_outputs(request_id):
+            async for output in engine.stream_outputs(request_id):
                 text = clean_special_tokens(output.output_text)
 
                 if output.finished:
@@ -1396,7 +1397,7 @@ class VLMBatchedEngine(BaseEngine):
         finally:
             if not finished_normally:
                 logger.info(f"[vlm_stream_generate] Aborting request {request_id}")
-                await self._engine.abort_request(request_id)
+                await engine.abort_request(request_id)
 
     async def chat(
         self,

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -14,12 +14,38 @@ Note: mlx_lm.load() is mocked to avoid loading real models.
 """
 
 from abc import ABC
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, patch, AsyncMock
 
 import pytest
 
 from omlx.engine.base import BaseEngine, BaseNonStreamingEngine, GenerationOutput
+
+
+class FakeStreamingCore:
+    """Minimal async engine core for stream cleanup tests."""
+
+    def __init__(self):
+        self.aborted_request_id = None
+
+    async def add_request(self, **kwargs):
+        return "request-1"
+
+    async def stream_outputs(self, request_id):
+        yield SimpleNamespace(
+            output_text="partial",
+            new_text="partial",
+            prompt_tokens=1,
+            completion_tokens=1,
+            finished=False,
+            finish_reason=None,
+            tool_calls=None,
+            cached_tokens=0,
+        )
+
+    async def abort_request(self, request_id):
+        self.aborted_request_id = request_id
 
 
 class TestGenerationOutput:
@@ -267,6 +293,29 @@ class TestBatchedEngineInitialization:
         engine = BatchedEngine(model_name="test-model")
 
         assert engine.model_type is None
+
+
+class TestBatchedEngineStreamingCleanup:
+    """Tests for streaming generator cleanup paths."""
+
+    @pytest.mark.asyncio
+    async def test_stream_abort_uses_captured_engine_if_engine_cleared(self):
+        """Generator finalization aborts on the original engine reference."""
+        from omlx.engine.batched import BatchedEngine
+
+        fake_engine = FakeStreamingCore()
+        engine = BatchedEngine(model_name="test-model")
+        engine._loaded = True
+        engine._engine = fake_engine
+
+        stream = engine.stream_generate("hello")
+        first = await stream.__anext__()
+        assert first.text == "partial"
+
+        engine._engine = None
+        await stream.aclose()
+
+        assert fake_engine.aborted_request_id == "request-1"
 
 
 class TestBatchedEngineApplyChatTemplate:

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -11,6 +11,7 @@ Tests cover:
 """
 
 import copy
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -87,6 +88,56 @@ def _make_loaded_engine(model_type=None, tokenizer=None, **overrides):
     engine._engine = MagicMock()
 
     return engine
+
+
+class FakeStreamingCore:
+    """Minimal async engine core for VLM stream cleanup tests."""
+
+    def __init__(self):
+        self.aborted_request_id = None
+
+    async def add_request(self, **kwargs):
+        return "vlm-request-1"
+
+    async def stream_outputs(self, request_id):
+        yield SimpleNamespace(
+            output_text="partial",
+            new_text="partial",
+            prompt_tokens=1,
+            completion_tokens=1,
+            finished=False,
+            finish_reason=None,
+            tool_calls=None,
+            cached_tokens=0,
+        )
+
+    async def abort_request(self, request_id):
+        self.aborted_request_id = request_id
+
+
+# ---------------------------------------------------------------------------
+# Test stream cleanup
+# ---------------------------------------------------------------------------
+
+class TestVLMStreamingCleanup:
+    """Tests for streaming generator cleanup paths."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(not HAS_MLX, reason="mlx is required to import VLMBatchedEngine")
+    async def test_stream_abort_uses_captured_engine_if_engine_cleared(self):
+        """Generator finalization aborts on the original engine reference."""
+        fake_engine = FakeStreamingCore()
+        engine = _make_loaded_engine(model_type="test-vlm")
+        engine._engine = fake_engine
+
+        stream = engine.stream_generate("hello")
+        first = await stream.__anext__()
+        assert first.text == "partial"
+
+        engine._engine = None
+        await stream.aclose()
+
+        assert fake_engine.aborted_request_id == "vlm-request-1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- capture the active async engine at the start of streaming generation
- use the captured engine for request creation, output streaming, and abort cleanup
- avoid `NoneType.abort_request` when shutdown/unload clears `self._engine` while an async stream generator is finalizing
- add focused regression coverage for text and VLM streaming cleanup paths

Fixes #1167.

## Test plan
- `python -m py_compile omlx/engine/batched.py omlx/engine/vlm.py tests/test_batched_engine.py tests/test_vlm_engine.py`
- `git diff --check`

Note: full pytest collection could not run in this Linux environment because `mlx` is unavailable (`ModuleNotFoundError: No module named 'mlx'`). The added tests are focused on mocked streaming cleanup and are intended to run in the project MLX environment.
