### PR TITLE
feat(server): log streaming chat completion summary

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2284,7 +2284,7 @@ async def create_chat_completion(
 
         elapsed = time.perf_counter() - start_time
         tokens_per_sec = output.completion_tokens / elapsed if elapsed > 0 else 0
-        logger.info(f"Chat completion: {output.completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s)")
+        logger.info(f"Chat completion: {output.completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s), prompt: {output.prompt_tokens}")
 
         get_server_metrics().record_request_complete(
             prompt_tokens=output.prompt_tokens,
@@ -2989,6 +2989,8 @@ async def stream_chat_completion(
             generation_duration=gen_duration,
             model_id=resolved_model or request.model,
         )
+        tokens_per_sec = last_output.completion_tokens / gen_duration if gen_duration > 0 else 0
+        logger.info(f"Chat completion: {last_output.completion_tokens} tokens in {end_time - start_time:.2f}s ({tokens_per_sec:.1f} tok/s), prompt: {last_output.prompt_tokens}")
 
         # Emit usage chunk if requested
         if request.stream_options and request.stream_options.include_usage:


### PR DESCRIPTION
## Problem

The non-streaming chat path logs a completion summary:

```
Chat completion: 42 tokens in 3.21s (13.1 tok/s)
```

The streaming path logs nothing. This makes it difficult to monitor per-request throughput when clients use streaming (which is the common case for interactive use).

Additionally, neither path includes prompt token count, which is useful for understanding context utilisation.

## Changes

`omlx/server.py` — 3 line change:

1. **Non-streaming** (`create_chat_completion`): append `, prompt: N` to the existing log line.
2. **Streaming** (`stream_chat_completion`): add an equivalent log line after `record_request_complete()`, inside the `if last_output and last_output.finished:` guard.

**After:**
```
Chat completion: 42 tokens in 3.21s (13.1 tok/s), prompt: 512   # non-streaming
Chat completion: 42 tokens in 3.21s (13.1 tok/s), prompt: 512   # streaming (new)
```

The streaming tok/s uses `gen_duration` (generation time, excluding prefill) to reflect actual decode speed. Total wall-clock time is used for the "in Xs" field to match the non-streaming convention.

## Testing

Pre-existing test failures on `main` (unrelated to this change): 22. After this patch: 21. Zero new failures introduced.