### PR TITLE
[codex] Fix hot cache byte accounting

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -800,9 +800,7 @@ class PagedSSDCacheManager(CacheManager):
         with self._hot_cache_lock:
             old = self._hot_cache.pop(block_hash, None)
             if old:
-                self._hot_cache_total_bytes -= self._hot_cache_entry_size(
-                    old["tensors_raw"]
-                )
+                self._hot_cache_total_bytes -= self._hot_cache_entry_size(old)
 
     def _promote_to_hot_cache(
         self,
@@ -2110,7 +2108,7 @@ class PagedSSDCacheManager(CacheManager):
                     if blk_meta is None or not _matches(blk_meta.model_name):
                         continue
                     hot_entries.append(entry)
-                    hot_size += self._hot_cache_entry_size(entry["tensors_raw"])
+                    hot_size += self._hot_cache_entry_size(entry)
 
             return PagedSSDCacheStats(
                 hits=self._stats["hits"],

--- a/tests/test_hot_cache.py
+++ b/tests/test_hot_cache.py
@@ -9,10 +9,10 @@ from typing import List
 import pytest
 
 from omlx.cache.paged_ssd_cache import (
+    PagedSSDBlockMetadata,
     PagedSSDCacheManager,
     _extract_tensor_bytes,
 )
-
 
 try:
     import mlx.core as mx
@@ -491,6 +491,98 @@ class TestHotCacheConcurrency:
         mgr.close()
 
         assert len(errors) == 0, f"Concurrent errors: {errors}"
+
+
+class TestHotCacheByteAccounting:
+    """Regression tests for raw-byte hot cache size accounting."""
+
+    def _make_raw_entry(
+        self,
+        tmp_path: Path,
+        block_hash: bytes,
+        model_name: str = "test-model",
+        key_size: int = 128,
+        value_size: int = 256,
+    ):
+        metadata = PagedSSDBlockMetadata(
+            block_hash=block_hash,
+            file_path=tmp_path / f"{block_hash.hex()}.safetensors",
+            file_size=key_size + value_size,
+            token_count=16,
+            created_at=time.time(),
+            last_access=time.time(),
+            num_layers=1,
+            model_name=model_name,
+            layer_cache_types=["KVCache"],
+        )
+        entry = {
+            "tensors_raw": {
+                "layer_0_keys": (bytes(key_size), "float32", [1, 1, 1, key_size // 4]),
+                "layer_0_values": (
+                    bytes(value_size),
+                    "float32",
+                    [1, 1, 1, value_size // 4],
+                ),
+            },
+            "file_metadata": {},
+            "num_layers": 1,
+            "layer_cache_types": ["KVCache"],
+            "block_metadata": metadata,
+        }
+        return entry, key_size + value_size
+
+    def test_hot_cache_remove_decrements_raw_entry_bytes(self, tmp_path):
+        """Removing a tensors_raw entry should subtract its bytes from the counter."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "remove_accounting",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=1024**2,
+            hot_cache_only=True,
+        )
+
+        try:
+            block_hash = b"remove_bytes_test"
+            entry, expected_size = self._make_raw_entry(tmp_path, block_hash)
+
+            mgr._hot_cache_put(block_hash, entry)
+            assert mgr._hot_cache_total_bytes == expected_size
+
+            mgr._hot_cache_remove(block_hash)
+
+            assert mgr._hot_cache_get(block_hash) is None
+            assert mgr._hot_cache_total_bytes == 0
+            assert mgr.get_stats().hot_cache_size_bytes == 0
+        finally:
+            mgr.close()
+
+    def test_get_stats_for_model_reports_raw_hot_cache_bytes(self, tmp_path):
+        """Per-model stats should count tensors_raw entries in the hot cache."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "model_accounting",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=1024**2,
+            hot_cache_only=True,
+        )
+
+        try:
+            model_a_hash = b"model_a_hot_bytes"
+            model_b_hash = b"model_b_hot_bytes"
+            model_a_entry, model_a_size = self._make_raw_entry(
+                tmp_path, model_a_hash, model_name="model-a"
+            )
+            model_b_entry, _ = self._make_raw_entry(
+                tmp_path, model_b_hash, model_name="model-b"
+            )
+
+            mgr._hot_cache_put(model_a_hash, model_a_entry)
+            mgr._hot_cache_put(model_b_hash, model_b_entry)
+
+            stats = mgr.get_stats_for_model("model-a")
+
+            assert stats.hot_cache_entries == 1
+            assert stats.hot_cache_size_bytes == model_a_size
+        finally:
+            mgr.close()
 
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")


### PR DESCRIPTION
## Summary
- Fix hot cache byte accounting when removing raw-byte entries.
- Fix per-model hot cache stats so tensors_raw entries contribute to hot_cache_size_bytes.
- Add focused regression coverage for raw-byte hot cache removal and per-model stats.

## Root cause
_hot_cache_remove and get_stats_for_model passed entry["tensors_raw"] into _hot_cache_entry_size(), but that helper expects the full hot cache entry and looks for top-level arrays or tensors_raw keys. Passing the nested raw tensor dict made the helper return 0.

## Impact
Before this change, explicit hot cache removal failed to decrement _hot_cache_total_bytes for tensors_raw entries, and model-scoped stats under-reported hot cache bytes. Once the counter drifted high enough, the hot cache could stop admitting new entries even after removals.

## Validation
- uv run -p 3.13 --extra dev python -m pytest tests/test_hot_cache.py -q
- git diff --check