### PR TITLE
feat(server): secure default CORS + VLM tool parser whitelist

### DIFF
--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -2878,7 +2878,7 @@
                     return { auto: false, percent: Math.min(99, Math.max(1, percent)) };
                 }
                 // Handle percent format (e.g., "69%")
-                const percent = parseInt(value.replace('%', ''));
+                const percent = parseInt(value.replace(/%/g, ''));
                 if (isNaN(percent)) return { auto: false, percent: 90 };
                 return { auto: false, percent: Math.min(99, Math.max(0, percent)) };
             },

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -606,6 +606,13 @@ class VLMBatchedEngine(BaseEngine):
             tool_parser_type = _mlx_lm_infer(chat_template)
             if tool_parser_type is None:
                 return
+            
+            # Validation whitelist for dynamic loading
+            allowed_parsers = {"gemma", "llama", "mistral", "hermes", "phi", "qwen"}
+            if tool_parser_type not in allowed_parsers:
+                logger.warning(f"Unauthorized VLM tool parser type: {tool_parser_type}")
+                return
+
             try:
                 tool_module = importlib.import_module(
                     f"mlx_lm.tool_parsers.{tool_parser_type}"

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1125,7 +1125,7 @@ def init_server(
         init_auth(global_settings.auth.secret_key, lambda: _server_state.global_settings)
 
     # Configure CORS middleware from settings
-    cors_origins = global_settings.server.cors_origins if global_settings else ["*"]
+    cors_origins = global_settings.server.cors_origins if global_settings else ["http://localhost:*", "http://127.0.0.1:*"]
     app.add_middleware(
         CORSMiddleware,
         allow_origins=cors_origins,


### PR DESCRIPTION
## Summary

Restricts the default CORS policy to local origins and introduces a validation whitelist for VLM tool calling parsers. Also fixes a string sanitization bug in the dashboard percentage input.

## Architecture

The VLM tool calling logic uses dynamic imports based on a parser type inferred from the chat template. Previously, any inferred type was passed directly to `importlib.import_module`, which I noticed could lead to failures or unauthorized module loading if a model template contains an unexpected parser identifier. 

This PR adds an explicit `allowed_parsers` whitelist before the import to ensure only supported `mlx_lm.tool_parsers` are loaded.

For CORS, the server now defaults to `localhost` and `127.0.0.1` origins when settings are uninitialized, preventing accidental external exposure in local-only deployments.

## Changes

| File | What | LOC |
|---|---|---|
| `omlx/server.py` | Change default CORS origins from `*` to `localhost`/`127.0.0.1` | +1 |
| `omlx/engine/vlm.py` | Add `allowed_parsers` whitelist for dynamic tool parser loading | +7 |
| `omlx/admin/static/js/dashboard.js` | Switch to global regex for percent string sanitization | +1 |

## Test Plan

- [x] Verified CORS restriction doesn't break the local dashboard.
- [x] Tested model loading with various template types to confirm whitelist behavior (invalid types are now safely ignored with a warning).
- [x] Smoke tested the dashboard percentage input with multiple `%` signs.
- [x] `node --check omlx/admin/static/js/dashboard.js` clean.

## What this doesn't do

- Does not prevent users from explicitly setting `cors_origins: ["*"]` in their configuration if they require it.
- Does not add new parser types; it only secures the loading of existing ones.