### PR TITLE
Forward STT language to mlx-audio

### DIFF
--- a/omlx/engine/stt.py
+++ b/omlx/engine/stt.py
@@ -11,7 +11,7 @@ when mlx-audio is not installed.
 import asyncio
 import gc
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
 import mlx.core as mx
 
@@ -19,6 +19,33 @@ from ..engine_core import get_mlx_executor
 from .base import BaseNonStreamingEngine
 
 logger = logging.getLogger(__name__)
+
+
+_ISO_TO_QWEN3_ASR_LANG: dict[str, str] = {
+    "zh": "Chinese",
+    "yue": "Cantonese",
+    "en": "English",
+    "de": "German",
+    "es": "Spanish",
+    "fr": "French",
+    "it": "Italian",
+    "pt": "Portuguese",
+    "ru": "Russian",
+    "ko": "Korean",
+    "ja": "Japanese",
+}
+
+
+def _normalize_stt_generate_language(language: str | None) -> str | None:
+    """Map OpenAI-style ISO codes to language names accepted by mlx-audio."""
+    if language is None:
+        return None
+
+    normalized = language.strip()
+    if not normalized:
+        return None
+
+    return _ISO_TO_QWEN3_ASR_LANG.get(normalized.lower(), normalized)
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +99,7 @@ def _validate_stt_processor(model_name: str, model: Any) -> None:
     # to None when WhisperProcessor.from_pretrained() failed on load.
     if not hasattr(model, "_processor"):
         return
-    if getattr(model, "_processor") is not None:
+    if model._processor is not None:
         return
     raise RuntimeError(_missing_processor_hint(model_name))
 
@@ -171,9 +198,9 @@ class STTEngine(BaseNonStreamingEngine):
     async def transcribe(
         self,
         audio_path: str,
-        language: Optional[str] = None,
+        language: str | None = None,
         **kwargs,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Transcribe an audio file.
 
@@ -228,7 +255,12 @@ class STTEngine(BaseNonStreamingEngine):
         def _transcribe_sync():
             # Call model.generate() directly instead of
             # generate_transcription() which writes files to disk.
-            result = model.generate(audio_path, **kwargs)
+            gen_kwargs = dict(kwargs)
+            generate_language = _normalize_stt_generate_language(language)
+            if generate_language is not None:
+                gen_kwargs["language"] = generate_language
+
+            result = model.generate(audio_path, **gen_kwargs)
 
             # result is typically an STTOutput dataclass with:
             # text, segments, language, total_time, etc.
@@ -286,7 +318,7 @@ class STTEngine(BaseNonStreamingEngine):
                     lambda: (mx.synchronize(), mx.clear_cache()),
                 )
 
-    def get_stats(self) -> Dict[str, Any]:
+    def get_stats(self) -> dict[str, Any]:
         """Get engine statistics."""
         return {
             "model_name": self._model_name,

--- a/tests/test_audio_stt.py
+++ b/tests/test_audio_stt.py
@@ -10,11 +10,11 @@ required. Integration tests (marked @pytest.mark.slow) need a real model.
 
 import io
 import wave
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-
 
 # ---------------------------------------------------------------------------
 # WAV fixture helpers
@@ -78,17 +78,20 @@ def _make_mock_pool(stt_engine=None, model_id: str = "whisper-tiny") -> MagicMoc
 @pytest.fixture
 def audio_client():
     """TestClient for the audio router with a mocked STT engine."""
+    from fastapi import FastAPI
+
     from omlx.api.audio_routes import router
 
-    from fastapi import FastAPI
     app = FastAPI()
     app.include_router(router)
 
     mock_pool = _make_mock_pool()
 
-    with patch("omlx.api.audio_routes._get_engine_pool", return_value=mock_pool):
-        with TestClient(app, raise_server_exceptions=False) as client:
-            yield client, mock_pool
+    with (
+        patch("omlx.api.audio_routes._get_engine_pool", return_value=mock_pool),
+        TestClient(app, raise_server_exceptions=False) as client,
+    ):
+        yield client, mock_pool
 
 
 def _ensure_audio_routes(app):
@@ -99,6 +102,74 @@ def _ensure_audio_routes(app):
     existing = {getattr(r, "path", "") for r in app.routes}
     if not audio_paths & existing:
         app.include_router(audio_router)
+
+
+class TestSTTEngineLanguageForwarding:
+    """Unit tests for STTEngine language handling."""
+
+    @pytest.mark.asyncio
+    async def test_transcribe_maps_iso_language_and_forwards_kwargs(self, tmp_path):
+        """OpenAI ISO language codes reach mlx-audio as supported names."""
+        from omlx.engine.stt import STTEngine
+
+        generate_call = {}
+
+        class FakeModel:
+            def generate(self, audio_path, **kwargs):
+                generate_call["audio_path"] = audio_path
+                generate_call["kwargs"] = kwargs
+                return SimpleNamespace(
+                    text="hello",
+                    language=None,
+                    segments=[],
+                    total_time=0.1,
+                )
+
+        audio_path = tmp_path / "sample.wav"
+        audio_path.write_bytes(TINY_WAV)
+
+        engine = STTEngine("qwen3-asr")
+        engine._model = FakeModel()
+
+        result = await engine.transcribe(
+            str(audio_path),
+            language="zh",
+            temperature=0.0,
+        )
+
+        assert generate_call["audio_path"] == str(audio_path)
+        assert generate_call["kwargs"] == {
+            "language": "Chinese",
+            "temperature": 0.0,
+        }
+        assert result["language"] == "zh"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_omits_empty_language(self, tmp_path):
+        """Empty language values keep mlx-audio in its default mode."""
+        from omlx.engine.stt import STTEngine
+
+        generate_kwargs = {}
+
+        class FakeModel:
+            def generate(self, audio_path, **kwargs):
+                generate_kwargs.update(kwargs)
+                return SimpleNamespace(
+                    text="hello",
+                    language=None,
+                    segments=[],
+                    total_time=0.1,
+                )
+
+        audio_path = tmp_path / "sample.wav"
+        audio_path.write_bytes(TINY_WAV)
+
+        engine = STTEngine("qwen3-asr")
+        engine._model = FakeModel()
+
+        await engine.transcribe(str(audio_path), language=" ")
+
+        assert "language" not in generate_kwargs
 
 
 @pytest.fixture
@@ -419,8 +490,6 @@ class TestSTTProcessorErrors:
         """``load_model`` raising ``Can't load feature extractor`` becomes a
         clear message pointing at ``preprocessor_config.json``."""
         import asyncio
-
-        from omlx.engine import stt as stt_mod
 
         def _failing_load(*args, **kwargs):
             raise OSError(


### PR DESCRIPTION
## Summary
- normalize OpenAI-style ISO language codes before passing them to mlx-audio STT models
- forward `language` to `model.generate()` only when a non-empty value is provided, preserving auto-detect for blank values
- add STTEngine regression coverage for ISO mapping and empty language handling

Fixes #1117

## Testing
- python -m ruff check omlx/engine/stt.py tests/test_audio_stt.py
- python -m compileall -q omlx/engine/stt.py tests/test_audio_stt.py
- focused local STTEngine harness with a stubbed MLX core/executor

Note: full pytest was not run locally because this Windows workspace does not have Apple MLX/MLX-LM installed.
