### PR TITLE
fix(mtp): skip MoE expert stacking when MTP layer is dense (MTPLX)

### DIFF
--- a/omlx/patches/mlx_lm_mtp/qwen35_model.py
+++ b/omlx/patches/mlx_lm_mtp/qwen35_model.py
@@ -691,10 +691,14 @@ def _patch_qwen3_5_moe() -> None:
                 # MTPLX (lightning-mlx convert) layout: MTP layer is dense
                 # — no per-expert tensors to stack/unfuse. The router/gate
                 # and shared_expert weights are passed through unchanged.
-                has_experts = any(
-                    k.startswith(f"{prefix}.experts.") for k in new_weights
+                # Probe by layout sentinel (O(1)) rather than scanning all
+                # weight keys — matters on multi-thousand-tensor checkpoints.
+                sentinel = (
+                    f"{prefix}.experts.gate_up_proj"
+                    if mtp_is_fused
+                    else f"{prefix}.experts.0.gate_proj.weight"
                 )
-                if not has_experts:
+                if sentinel not in new_weights:
                     continue
                 if mtp_is_fused:
                     _unfuse_experts(new_weights, prefix)

--- a/omlx/patches/mlx_lm_mtp/qwen35_model.py
+++ b/omlx/patches/mlx_lm_mtp/qwen35_model.py
@@ -671,7 +671,7 @@ def _patch_qwen3_5_moe() -> None:
         for l in range(self.language_model.args.num_hidden_layers):
             _unfuse_experts(new_weights, f"language_model.model.layers.{l}.mlp")
 
-        # MTP layers: fused (Qwen3.6) or per-expert (Qwen3.5). Detect once.
+        # MTP layers: fused (Qwen3.6), per-expert (Qwen3.5), or dense (MTPLX).
         mtp_num = int(
             getattr(self.language_model.args, "mtp_num_hidden_layers", 0) or 0
         )
@@ -687,6 +687,14 @@ def _patch_qwen3_5_moe() -> None:
                 # form (mlx-vlm sanitize patch unfuses MTP experts before
                 # quantization). Skip the load-time unfuse/stack in that case.
                 if f"{prefix}.switch_mlp.gate_proj.weight" in new_weights:
+                    continue
+                # MTPLX (lightning-mlx convert) layout: MTP layer is dense
+                # — no per-expert tensors to stack/unfuse. The router/gate
+                # and shared_expert weights are passed through unchanged.
+                has_experts = any(
+                    k.startswith(f"{prefix}.experts.") for k in new_weights
+                )
+                if not has_experts:
                     continue
                 if mtp_is_fused:
                     _unfuse_experts(new_weights, prefix)

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -161,6 +161,109 @@ class TestQwen35Model:
         assert hasattr(Model, "_omlx_mtp_patched")
 
 
+class TestQwen35MoeSanitize:
+    """Cover qwen3_5_moe.Model.sanitize for the three MTP weight layouts:
+    fused (Qwen3.6), per-expert (Qwen3.5), and dense (MTPLX). The dense
+    case is the regression guard for the Ornstein3.6 SABER-MTPLX KeyError.
+    """
+
+    @staticmethod
+    def _fake_self(num_hidden_layers=0, mtp_num=1, num_experts=2):
+        """Stand-in for qwen3_5_moe.Model. Sanitize only reads
+        ``self.language_model.args.{num_hidden_layers,mtp_num_hidden_layers,
+        num_experts}`` and tail-calls ``self.language_model.sanitize``."""
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            language_model=SimpleNamespace(
+                args=SimpleNamespace(
+                    num_hidden_layers=num_hidden_layers,
+                    mtp_num_hidden_layers=mtp_num,
+                    num_experts=num_experts,
+                ),
+                # Identity tail-call so the test inspects the post-MoE
+                # weight dict directly.
+                sanitize=lambda w: w,
+            )
+        )
+
+    def test_dense_mtp_passes_through_without_keyerror(self):
+        """MTPLX-format checkpoints ship a dense MLP at the MTP layer
+        (no ``experts.*`` keys). Sanitize must short-circuit, not attempt
+        to stack non-existent per-expert tensors.
+        """
+        from omlx.patches.mlx_lm_mtp import apply_mlx_lm_mtp_patch
+
+        assert apply_mlx_lm_mtp_patch() is True
+        try:
+            from mlx_lm.models import qwen3_5_moe as moe
+        except ImportError:
+            pytest.skip("mlx_lm.models.qwen3_5_moe not importable")
+
+        # Mirrors samuelfaj/Ornstein3.6-35B-A3B-SABER-6bit-MTPLX-Optimized-Speed
+        # mtp.safetensors key list (dense MLP at the MTP layer).
+        weights = {
+            "mtp.layers.0.mlp.gate_proj.weight": "g",
+            "mtp.layers.0.mlp.up_proj.weight": "u",
+            "mtp.layers.0.mlp.down_proj.weight": "d",
+            "mtp.layers.0.mlp.gate.weight": "router",
+            "mtp.layers.0.mlp.shared_expert.gate_proj.weight": "sg",
+            "mtp.layers.0.mlp.shared_expert.up_proj.weight": "su",
+            "mtp.layers.0.mlp.shared_expert.down_proj.weight": "sd",
+            "mtp.layers.0.mlp.shared_expert_gate.weight": "seg",
+        }
+
+        out = moe.Model.sanitize(self._fake_self(), weights)
+
+        # Dense MTP keys survive untouched (with the ``language_model.``
+        # prefix sanitize prepends to bare keys).
+        assert "language_model.mtp.layers.0.mlp.gate_proj.weight" in out
+        assert (
+            "language_model.mtp.layers.0.mlp.shared_expert.gate_proj.weight"
+            in out
+        )
+        # No bogus switch_mlp keys synthesized for the dense layer.
+        assert (
+            "language_model.mtp.layers.0.mlp.switch_mlp.gate_proj.weight"
+            not in out
+        )
+
+    def test_per_expert_mtp_gets_stacked(self):
+        """Qwen3.5-style per-expert MTP weights must be stacked into the
+        unified ``switch_mlp.{gate,up,down}_proj.weight`` layout.
+        """
+        import mlx.core as mx
+
+        from omlx.patches.mlx_lm_mtp import apply_mlx_lm_mtp_patch
+
+        assert apply_mlx_lm_mtp_patch() is True
+        try:
+            from mlx_lm.models import qwen3_5_moe as moe
+        except ImportError:
+            pytest.skip("mlx_lm.models.qwen3_5_moe not importable")
+
+        # Two experts, three projections each — minimal but exercises stack.
+        weights = {}
+        for e in (0, 1):
+            for n in ("gate_proj", "up_proj", "down_proj"):
+                weights[f"mtp.layers.0.mlp.experts.{e}.{n}.weight"] = mx.zeros(
+                    (4, 8)
+                )
+
+        out = moe.Model.sanitize(self._fake_self(num_experts=2), weights)
+
+        # Per-expert keys consumed.
+        assert (
+            "language_model.mtp.layers.0.mlp.experts.0.gate_proj.weight"
+            not in out
+        )
+        # Unified switch_mlp keys synthesized with experts dim stacked.
+        for n in ("gate_proj", "up_proj", "down_proj"):
+            key = f"language_model.mtp.layers.0.mlp.switch_mlp.{n}.weight"
+            assert key in out
+            assert out[key].shape == (2, 4, 8)
+
+
 class TestDeepseekV4Model:
     def test_skip_when_base_patch_not_applied(self, monkeypatch):
         """deepseek_v4 MTP patch must skip cleanly if the base


### PR DESCRIPTION
## Summary

Fix `KeyError: 'language_model.mtp.layers.0.mlp.experts.0.gate_proj.weight'` when loading MTPLX-format MoE checkpoints (e.g. [`samuelfaj/Ornstein3.6-35B-A3B-SABER-6bit-MTPLX-Optimized-Speed`](https://huggingface.co/samuelfaj/Ornstein3.6-35B-A3B-SABER-6bit-MTPLX-Optimized-Speed)) under the batched LLM engine.

The `_patch_qwen3_5_moe` sanitize assumed every MTP layer carries MoE expert tensors in one of two layouts: fused (`experts.gate_up_proj`) or per-expert (`experts.{e}.{n}.weight`). MTPLX checkpoints (produced by `lightning-mlx convert-mtplx tensor-layout gate`) ship the MTP layer as a single dense MLP — the router/gate and `shared_expert` weights are present, but there are no per-expert tensors. The old code fell through to `_stack_per_expert`, which crashed.

Add a `has_experts` short-circuit: if the MTP layer has no `experts.*` keys, pass the dense weights through untouched. Backbone MoE unfusing is unaffected.

## Repro

Pre-fix:
```
omlx.engine_pool - INFO - Loading model: Ornstein3.6-35B-A3B-SABER-6bit-MTPLX-Optimized-Speed
omlx.admin.benchmark - ERROR - Benchmark error: 'language_model.mtp.layers.0.mlp.experts.0.gate_proj.weight'
...
File "omlx/patches/mlx_lm_mtp/qwen35_model.py", line 654, in <listcomp>
    weights.pop(f"{prefix}.experts.{e}.{n}.weight")
KeyError: 'language_model.mtp.layers.0.mlp.experts.0.gate_proj.weight'
```

Post-fix: model loads and benchmarks run cleanly.

## Why latent until now

Surfaced by [`6fe6d70`](../commit/6fe6d70) (`fix(mtp): MoE oQ-mtp variants for Qwen3.5 A3B and DeepSeek-V4`), which switched the patch's idempotency check from `hasattr(cls, "_omlx_mtp_patched")` to `"_omlx_mtp_patched" in cls.__dict__`. Before that change the MoE sub-patch was silently skipped on `qwen3_5_moe.Model` because its parent `qwen3_5.Model` already carried the marker (via inheritance) — so stock mlx_lm sanitize ran instead, which ignores MTP layers entirely. After `6fe6d70` the sub-patch installs as intended, exposing the dense-MTP gap.

## Test plan

- [x] `samuelfaj/Ornstein3.6-35B-A3B-SABER-6bit-MTPLX-Optimized-Speed` loads cleanly and runs benchmarks (`mtp_enabled=False`).
- [x] No regression for per-expert MoE MTP models (Qwen3.5 A3B / DeepSeek-V4) which exercise the same `_stack_per_expert` path when expert tensors are present.
- [x] Existing test suite passes (113 passed; the unrelated `test_all_valid_benchmarks` failure on `main` is independent).