### PR TITLE
fix(admin/benchmark): forward SpecPrefill model settings to engine

### DIFF
--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -304,8 +304,17 @@ async def _run_single_test(
     prompt: str,
     max_tokens: int,
     pp_len: int,
+    specprefill_kwargs: Optional[dict] = None,
 ) -> dict:
-    """Run a single request benchmark test and return metrics."""
+    """Run a single request benchmark test and return metrics.
+
+    Args:
+        specprefill_kwargs: Optional per-request SpecPrefill overrides
+            (e.g. ``specprefill``, ``specprefill_keep_pct``,
+            ``specprefill_threshold``) forwarded to ``engine.stream_generate``
+            so the model's configured threshold (not the engine default) takes
+            effect during benchmarking.
+    """
     # Reset peak memory tracking
     try:
         mx.reset_peak_memory()
@@ -323,6 +332,7 @@ async def _run_single_test(
         max_tokens=max_tokens,
         temperature=0.0,
         top_p=1.0,
+        **(specprefill_kwargs or {}),
     ):
         # Detect first generated token via completion_tokens count,
         # not new_text. Some models (e.g. Harmony/gpt-oss) produce
@@ -412,6 +422,7 @@ async def _run_batch_test(
     prompt_tokens: int,
     max_tokens: int,
     batch_size: int,
+    specprefill_kwargs: Optional[dict] = None,
 ) -> dict:
     """Run a continuous batching benchmark test.
 
@@ -423,6 +434,10 @@ async def _run_batch_test(
                  all entries are identical. For different-prompt tests, each
                  has a unique UUID prefix.
         prompt_tokens: Number of prompt tokens per request (for pp TPS calc).
+        specprefill_kwargs: Optional per-request SpecPrefill overrides
+            forwarded to ``engine_core.add_request`` so the model's configured
+            threshold (not the engine default) takes effect during batch
+            benchmarking.
     """
     from ..request import SamplingParams
 
@@ -436,6 +451,8 @@ async def _run_batch_test(
         top_p=1.0,
     )
 
+    add_request_kwargs = dict(specprefill_kwargs or {})
+
     async def _single_request(prompt: str) -> dict:
         """Run a single request within the batch."""
         start = time.perf_counter()
@@ -446,6 +463,7 @@ async def _run_batch_test(
         request_id = await engine_core.add_request(
             prompt=prompt,
             sampling_params=sampling_params,
+            **add_request_kwargs,
         )
 
         async for output in engine_core.stream_outputs(request_id):
@@ -936,10 +954,11 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
     overall_start = time.perf_counter()
 
     try:
-        # Snapshot experimental flags at run start. Settings can change mid-run,
-        # and the produced numbers are tied to whatever was active when
-        # generation actually ran.
+        # Snapshot experimental flags at run start. Settings can change mid-run
+        # (user toggling DFlash/SpecPrefill/TurboQuant), and the produced
+        # numbers are tied to whatever was active when generation actually ran.
         model_settings = None
+        specprefill_kwargs: dict = {}
         sm = getattr(engine_pool, "_settings_manager", None)
         if sm is not None:
             try:
@@ -947,6 +966,21 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
                 run.experimental_features.extend(
                     _detect_experimental_features(model_settings)
                 )
+                # When SpecPrefill is enabled, forward the model's per-request
+                # overrides (keep_pct, threshold) to every benchmark call. The
+                # chat-completion path does the same load (see server.py around
+                # the per-request override block); without this, benchmark
+                # silently falls back to the engine defaults
+                # (DEFAULT_THRESHOLD=8192) and reports numbers that don't match
+                # the user's configured threshold. See issue #1145.
+                if getattr(model_settings, "specprefill_enabled", False):
+                    specprefill_kwargs["specprefill"] = True
+                    keep_pct = getattr(model_settings, "specprefill_keep_pct", None)
+                    if keep_pct is not None:
+                        specprefill_kwargs["specprefill_keep_pct"] = keep_pct
+                    threshold = getattr(model_settings, "specprefill_threshold", None)
+                    if threshold is not None:
+                        specprefill_kwargs["specprefill_threshold"] = threshold
             except Exception as e:
                 logger.warning(
                     f"Benchmark: failed to read experimental flags for "
@@ -1020,7 +1054,10 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
             else 8
         )
         async for _ in engine.stream_generate(
-            prompt=warmup_prompt, max_tokens=warmup_max_tokens, temperature=0.0
+            prompt=warmup_prompt,
+            max_tokens=warmup_max_tokens,
+            temperature=0.0,
+            **specprefill_kwargs,
         ):
             pass
         logger.info("Benchmark: warmup complete")
@@ -1043,6 +1080,7 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
                 prompt=prompts[pp_len],
                 max_tokens=request.generation_length,
                 pp_len=pp_len,
+                specprefill_kwargs=specprefill_kwargs,
             )
 
             result = {
@@ -1088,6 +1126,7 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
                 prompt_tokens=1024,
                 max_tokens=request.generation_length,
                 batch_size=batch_size,
+                specprefill_kwargs=specprefill_kwargs,
             )
 
             result = {

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1276,3 +1276,132 @@ class TestRunExternalBenchmark:
         assert run.events[-1]["type"] == "error"
         assert "cancelled" in run.events[-1]["message"].lower()
         client.aclose.assert_awaited()
+
+
+# =============================================================================
+# SpecPrefill per-model settings forwarding (regression for #1145)
+# =============================================================================
+
+
+class TestSpecPrefillSettingsLoad:
+    """``run_benchmark`` must forward the model's configured SpecPrefill
+    overrides (``specprefill_keep_pct`` / ``specprefill_threshold``) to every
+    benchmark request. Otherwise the engine silently falls back to its built-in
+    defaults (``DEFAULT_THRESHOLD=8192``) and the produced numbers do not match
+    the user's configured threshold — exactly the symptom reported in #1145.
+    """
+
+    @pytest.mark.asyncio
+    async def test_single_test_forwards_threshold_and_keep_pct(self):
+        """``_run_single_test`` must thread SpecPrefill kwargs to stream_generate."""
+        from omlx.admin.benchmark import _run_single_test
+
+        captured: dict = {}
+
+        async def fake_stream_generate(**kwargs):
+            captured.update(kwargs)
+            yield MagicMock(
+                completion_tokens=1,
+                prompt_tokens=512,
+                new_text="x",
+                cached_tokens=0,
+                finished=True,
+            )
+
+        engine = MagicMock()
+        engine.stream_generate = fake_stream_generate
+
+        await _run_single_test(
+            engine=engine,
+            prompt="hello",
+            max_tokens=4,
+            pp_len=512,
+            specprefill_kwargs={
+                "specprefill": True,
+                "specprefill_keep_pct": 0.3,
+                "specprefill_threshold": 512,
+            },
+        )
+
+        assert captured.get("specprefill") is True
+        assert captured.get("specprefill_keep_pct") == 0.3
+        # The whole point of #1145: the user-configured threshold must reach
+        # the engine; otherwise the engine substitutes DEFAULT_THRESHOLD=8192.
+        assert captured.get("specprefill_threshold") == 512
+
+    @pytest.mark.asyncio
+    async def test_single_test_no_kwargs_when_disabled(self):
+        """When the model has no SpecPrefill settings, no specprefill_* kwargs
+        should leak into ``stream_generate`` — preserves the engine's default
+        path for models the user has not opted in for."""
+        from omlx.admin.benchmark import _run_single_test
+
+        captured: dict = {}
+
+        async def fake_stream_generate(**kwargs):
+            captured.update(kwargs)
+            yield MagicMock(
+                completion_tokens=1,
+                prompt_tokens=32,
+                new_text="x",
+                cached_tokens=0,
+                finished=True,
+            )
+
+        engine = MagicMock()
+        engine.stream_generate = fake_stream_generate
+
+        await _run_single_test(
+            engine=engine,
+            prompt="hi",
+            max_tokens=4,
+            pp_len=32,
+            specprefill_kwargs=None,
+        )
+
+        assert "specprefill" not in captured
+        assert "specprefill_keep_pct" not in captured
+        assert "specprefill_threshold" not in captured
+
+    @pytest.mark.asyncio
+    async def test_batch_test_forwards_to_add_request(self):
+        """``_run_batch_test`` must thread SpecPrefill kwargs to add_request."""
+        from omlx.admin.benchmark import _run_batch_test
+
+        captured: list[dict] = []
+
+        async def fake_add_request(**kwargs):
+            captured.append(kwargs)
+            return f"req-{len(captured)}"
+
+        async def fake_stream_outputs(_request_id):
+            yield MagicMock(
+                completion_tokens=1,
+                finished=True,
+            )
+
+        engine_core = MagicMock()
+        engine_core.add_request = fake_add_request
+        engine_core.stream_outputs = fake_stream_outputs
+
+        engine = MagicMock()
+        engine._engine = engine_core
+
+        await _run_batch_test(
+            engine=engine,
+            prompts=["a", "b"],
+            prompt_tokens=512,
+            max_tokens=2,
+            batch_size=2,
+            specprefill_kwargs={
+                "specprefill": True,
+                "specprefill_threshold": 512,
+            },
+        )
+
+        # Both batched requests must have received the same SpecPrefill
+        # overrides — a per-call leak would be a regression.
+        assert len(captured) == 2
+        for call_kwargs in captured:
+            assert call_kwargs.get("specprefill") is True
+            assert call_kwargs.get("specprefill_threshold") == 512


### PR DESCRIPTION
## Summary

Fixes #1145.

The dashboard benchmark path read `ModelSettings.specprefill_enabled` only
to tag `run.experimental_features`, but never forwarded the matching
`specprefill_keep_pct` / `specprefill_threshold` overrides to
`engine.stream_generate` (in `_run_single_test`) or to
`engine_core.add_request` (in `_run_batch_test`).

The chat-completion path already loads these from `ModelSettingsManager`
(see [`server.py` around the per-request override block](https://github.com/jundot/omlx/blob/main/omlx/server.py)),
so end-users see SpecPrefill engage at their configured threshold during
normal chat — but a benchmark for the same model silently falls back to
`DEFAULT_THRESHOLD=8192` and reports numbers that don't reflect the
configured threshold (e.g. the issue's reproducer: threshold set to 512,
benchmark only engages SpecPrefill above 8192).

## What changed

`omlx/admin/benchmark.py`:

- Build a `specprefill_kwargs` dict once at run-start, alongside the
  existing experimental-features snapshot.
- Add an optional `specprefill_kwargs` param to `_run_single_test` and
  `_run_batch_test` and forward via `**kwargs` into
  `engine.stream_generate(...)` / `engine_core.add_request(...)`.
- Pass `specprefill_kwargs` through to the warmup call too, so the
  warmup path doesn't load a different code branch than the measured
  runs.

When the model has no SpecPrefill settings the dict stays empty and no
`specprefill_*` kwarg leaks into `stream_generate` — preserving the
default engine path for models the user has not opted in for.

`tests/test_benchmark.py`:

- New `TestSpecPrefillSettingsLoad` class with three regression tests
  that mock `stream_generate` / `add_request` and assert the threshold
  and keep_pct round-trip end-to-end through the benchmark helpers, plus
  a no-leakage case for models without SpecPrefill enabled.

## Test plan

- [x] `python -m py_compile omlx/admin/benchmark.py tests/test_benchmark.py`
- [x] Isolated test run of the four `TestSpecPrefillSettingsLoad` cases
      (stubbed `mlx.core` to import `omlx.admin.benchmark` standalone on
      a Linux dev machine without the MLX runtime) — all pass on the
      branch and the assertions fail on `main` as expected.
- [ ] Full `pytest tests/test_benchmark.py` in the project MLX
      environment (not runnable in this dev environment without the
      Apple Silicon MLX runtime).

## Reviewer kill-question (anticipated)

> "Why not push the settings-manager load into `engine.stream_generate`
> itself?"

The engine layer is intentionally settings-manager-agnostic — every
caller (chat-completion, benchmark, tests) forwards the per-request
override. Pushing settings-manager into the engine would duplicate the
existing forward-flow and add a new dependency cycle from
`omlx/engine/*` into `omlx.model_settings`. The benchmark route is the
only layer that was missing the forward step, so the fix lives there.