### PR TITLE
fix(bench): sanitize upload error so CF challenge HTML doesn't leak to UI

### DIFF
--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -378,6 +378,51 @@ def _clean_model_name(model_id: str, quantization: str) -> str:
     return name.strip("-_ ")
 
 
+def _sanitize_upload_error(resp: Any) -> str:
+    """Extract a user-presentable error string from a failed upload response.
+
+    Avoids dumping raw HTML bodies (e.g. Cloudflare's "Just a moment..."
+    challenge interstitial) into the dashboard's red-x error column.
+    Detects CF mitigation specifically so users get actionable context
+    instead of a 5KB markup blob.
+
+    Resolution order:
+    1. Cloudflare challenge — header ``cf-mitigated: challenge`` is
+       authoritative; a body sniff for "just a moment" / "cf-chl" covers
+       edge transports that strip the header.
+    2. JSON envelope — the omlx.ai API's normal error shape; extract
+       ``error`` / ``detail`` / ``message`` if present, truncated.
+    3. Plain-text body — short responses only; HTML-looking bodies are
+       collapsed to a one-line "non-JSON response (N bytes)" hint.
+    4. Fallback to the bare HTTP status code.
+    """
+    headers = getattr(resp, "headers", {}) or {}
+    cf_mitigated = str(headers.get("cf-mitigated", "")).lower()
+    body = getattr(resp, "text", "") or ""
+    status = getattr(resp, "status_code", "?")
+
+    body_head = body[:512].lower()
+    if cf_mitigated == "challenge" or "just a moment" in body_head or "cf-chl" in body_head:
+        return (
+            f"Upload blocked by Cloudflare (HTTP {status}). "
+            f"This is a server-side issue with omlx.ai — retry later or "
+            f"report it to the maintainer."
+        )
+
+    try:
+        data = resp.json()
+        msg = data.get("error") or data.get("detail") or data.get("message")
+        if msg:
+            return str(msg)[:300]
+    except Exception:
+        pass
+
+    text = body.strip()
+    if "<" in text and ">" in text:
+        return f"HTTP {status} — unexpected non-JSON response ({len(body)} bytes)"
+    return text[:300] or f"HTTP {status}"
+
+
 async def _upload_to_omlx_ai(run: BenchmarkRun, engine_pool: Any) -> None:
     """Upload benchmark results to omlx.ai community benchmarks.
 
@@ -537,11 +582,7 @@ async def _upload_to_omlx_ai(run: BenchmarkRun, engine_pool: Any) -> None:
                 })
             else:
                 failed_count += 1
-                error_msg = ""
-                try:
-                    error_msg = resp.json().get("error", resp.text)
-                except Exception:
-                    error_msg = resp.text
+                error_msg = _sanitize_upload_error(resp)
                 await _send_event(run, {
                     "type": "upload",
                     "data": {
@@ -549,10 +590,18 @@ async def _upload_to_omlx_ai(run: BenchmarkRun, engine_pool: Any) -> None:
                         "error": error_msg,
                     },
                 })
+                # Surface the sanitized message to ops; the full body
+                # (truncated) goes to debug so it can still be retrieved
+                # from the log file if needed.
                 logger.warning(
                     f"Benchmark upload failed for pp{context_length}: "
                     f"{resp.status_code} {error_msg}"
                 )
+                if (resp.text or "")[:1] not in ("{", "["):
+                    logger.debug(
+                        "Benchmark upload non-JSON body (truncated): %r",
+                        (resp.text or "")[:500],
+                    )
 
         except Exception as e:
             failed_count += 1

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -552,3 +552,95 @@ class TestUploadToOmlxAi:
 
         # No HTTP call was made
         mock_to_thread.assert_not_called()
+
+
+_CF_INTERSTITIAL = (
+    '<!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title>'
+    '<meta http-equiv="refresh" content="360"></head><body><div class="main-wrapper">'
+    + ("x" * 5000)
+    + "</div></body></html>"
+)
+
+
+class TestSanitizeUploadError:
+    """The Cloudflare interstitial pollutes the dashboard upload panel when
+    omlx.ai's API endpoint is gated behind a managed challenge. The
+    sanitizer must detect that case and surface an actionable message
+    without dumping the full 5KB HTML body."""
+
+    def _resp(self, status=403, headers=None, text="", json_raises=True, json_data=None):
+        from unittest.mock import MagicMock
+        resp = MagicMock()
+        resp.status_code = status
+        resp.headers = headers or {}
+        resp.text = text
+        if json_raises:
+            resp.json.side_effect = ValueError("not JSON")
+        else:
+            resp.json.return_value = json_data or {}
+        return resp
+
+    def test_cloudflare_challenge_via_header(self):
+        from omlx.admin.benchmark import _sanitize_upload_error
+        resp = self._resp(
+            status=403,
+            headers={"cf-mitigated": "challenge"},
+            text=_CF_INTERSTITIAL,
+        )
+        msg = _sanitize_upload_error(resp)
+        assert "Cloudflare" in msg
+        assert "403" in msg
+        # The raw HTML body must NOT appear in the error message.
+        assert "<!DOCTYPE" not in msg
+        assert "Just a moment" not in msg
+        assert len(msg) < 300
+
+    def test_cloudflare_challenge_via_body_sniff(self):
+        """Header missing but body still contains the interstitial — covers
+        edge transports / proxies that strip cf-mitigated."""
+        from omlx.admin.benchmark import _sanitize_upload_error
+        resp = self._resp(status=403, headers={}, text=_CF_INTERSTITIAL)
+        msg = _sanitize_upload_error(resp)
+        assert "Cloudflare" in msg
+        assert "<!DOCTYPE" not in msg
+
+    def test_json_error_field_extracted(self):
+        from omlx.admin.benchmark import _sanitize_upload_error
+        resp = self._resp(
+            status=400,
+            json_raises=False,
+            json_data={"error": "Invalid model_name"},
+            text='{"error": "Invalid model_name"}',
+        )
+        assert _sanitize_upload_error(resp) == "Invalid model_name"
+
+    def test_json_detail_field_extracted(self):
+        from omlx.admin.benchmark import _sanitize_upload_error
+        resp = self._resp(
+            status=422,
+            json_raises=False,
+            json_data={"detail": "context_length out of range"},
+            text='{"detail": "context_length out of range"}',
+        )
+        assert _sanitize_upload_error(resp) == "context_length out of range"
+
+    def test_html_body_without_cf_signals_collapses_to_hint(self):
+        """Non-CF HTML body (e.g. nginx 502 page) should not be dumped raw."""
+        from omlx.admin.benchmark import _sanitize_upload_error
+        resp = self._resp(
+            status=502,
+            text="<html><body>502 Bad Gateway</body></html>",
+        )
+        msg = _sanitize_upload_error(resp)
+        assert "<html>" not in msg
+        assert "502" in msg
+
+    def test_plain_text_short_body_passes_through(self):
+        from omlx.admin.benchmark import _sanitize_upload_error
+        resp = self._resp(status=500, text="upstream connection refused")
+        assert _sanitize_upload_error(resp) == "upstream connection refused"
+
+    def test_empty_body_falls_back_to_status(self):
+        from omlx.admin.benchmark import _sanitize_upload_error
+        resp = self._resp(status=503, text="")
+        assert _sanitize_upload_error(resp) == "HTTP 503"


### PR DESCRIPTION
## Summary

The Community Benchmark Upload panel on the Throughput Benchmark tab has been rendering the entire Cloudflare "Just a moment..." HTML challenge interstitial as the error message for every prompt-length row, for at least the past several weeks. Reproduced against `omlx.ai/api/benchmarks` from a clean network — every POST returns:

```
HTTP/2 403
cf-mitigated: challenge
content-type: text/html; charset=UTF-8
content-length: 5290
...
<!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title>...
```

The current error path in `_upload_to_omlx_ai` (`omlx/admin/benchmark.py:540-555`) falls back to `resp.text` when `resp.json()` raises, and sends the entire body to the dashboard via SSE. `_bench.html:321` renders that string via `x-text` — Alpine treats it as a text node, so the literal HTML markup ends up in the red-x cell next to each `pp{N}` row.

This PR does **not** fix the upload itself — that's an omlx.ai server-side configuration issue (filed separately as an issue). It fixes the UI so the panel surfaces a single actionable line instead of a 5KB markup blob.

## What changed

New helper `_sanitize_upload_error(resp)` in `omlx/admin/benchmark.py` with this resolution order:

1. **Cloudflare challenge** — header `cf-mitigated: challenge` is authoritative; a body sniff for `"just a moment"` / `"cf-chl"` covers edge transports / proxies that strip the header. Returns: `"Upload blocked by Cloudflare (HTTP {status}). This is a server-side issue with omlx.ai — retry later or report it to the maintainer."`
2. **JSON envelope** — the normal API error shape. Extracts `error` / `detail` / `message` if present, truncated to 300 chars.
3. **Plain-text body** — short responses pass through (capped at 300 chars). HTML-shaped bodies collapse to a one-line hint: `"HTTP {status} — unexpected non-JSON response (N bytes)"`.
4. **Empty body** — falls back to the bare HTTP status string (`"HTTP {status}"`).

Full response body (truncated to 500 chars) is logged at DEBUG level so it remains available for offline analysis, but never reaches the dashboard.

## Test plan

- [x] 7 new tests in `TestSanitizeUploadError` cover each branch: CF-via-header, CF-via-body-sniff, JSON error, JSON detail, generic HTML 5xx, short plain text, empty body.
- [x] `pytest tests/test_benchmark.py` — 47 passed (was 40, added 7).
- [x] Manually verified against the live endpoint: `curl -X POST https://omlx.ai/api/benchmarks -d '{}'` returns 403 + CF interstitial; sanitizer maps that to a one-line message in the dashboard.

## Why this is a partial fix

The underlying upload-failure is a server-side issue. Cloudflare is challenging all non-browser POSTs to `/api/benchmarks` — UA spoofing (Safari, Chrome, python-requests) all return identical 403 + challenge responses. The actual fix is on the omlx.ai side: allow API traffic, add API-key auth, or configure Bot Fight Mode exceptions for the benchmark endpoint. This PR just stops the failure from being unreadable in the meantime.