### PR TITLE
fix(scheduler): resolve UnboundLocalError in specprefill get_prefill_tracker path

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3318,6 +3318,8 @@ class Scheduler:
         scheduled = []
         rejected_outputs: list[RequestOutput] = []
 
+        from .prefill_progress import get_prefill_tracker
+
         # Track cache status of first scheduled request to ensure homogeneity
         # None = not determined yet, True = has cache, False = no cache
         batch_cache_status: bool | None = None


### PR DESCRIPTION
## Summary

Fixes `UnboundLocalError: cannot access local variable 'get_prefill_tracker' where it is not associated with a value` caused by Python lexical scoping in `_schedule_waiting()`.

## Root cause

The function `_schedule_waiting()` referenced `get_prefill_tracker()` at line 3486 for specprefill requests, but a `from .prefill_progress import get_prefill_tracker` at line 3633 (same function scope) caused Python to treat `get_prefill_tracker` as a **local variable** throughout the entire function. The module-level import (line 42) was shadowed. When a specprefill request hit line 3486 before the local import at 3633 executed, the name was unbound → crash.

## Fix

Add `from .prefill_progress import get_prefill_tracker` at function entry (after docstring, before first use), ensuring the name is bound before any code path.

## Test plan

- [x] SpecPrefill now works with draft model (Qwen3.5-0.8B) on target model (Qwen3.6-27B-oQ4-mtp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)