### PR TITLE
fix(oq): patch mlx-lm during auto-building a sensitivity proxy

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -3063,23 +3063,43 @@ def _build_proxy_for_sensitivity(
 
     The caller is responsible for deleting the returned directory.
     """
-    from mlx_lm import convert
+    try:
+        from omlx.patches.mlx_lm_mtp import (
+            apply_mlx_lm_mtp_patch,
+            is_mtp_active,
+            set_mtp_active,
+        )
+        _have_lm_patch = apply_mlx_lm_mtp_patch()
+    except Exception:
+        _have_lm_patch = False
+        is_mtp_active = None
+        set_mtp_active = None
 
-    # mlx-lm's convert() refuses to write into a pre-existing directory,
-    # so reserve a unique temp name and let convert() create it.
-    proxy_dir = Path(tempfile.mkdtemp(prefix="omlx_oq_proxy_", dir=working_dir))
-    shutil.rmtree(proxy_dir)
-    convert(
-        hf_path=model_path,
-        mlx_path=str(proxy_dir),
-        quantize=True,
-        q_bits=_PROXY_QUANT_BITS,
-        q_group_size=_PROXY_QUANT_GROUP_SIZE,
-        q_mode="affine",
-        dtype=dtype,
-        trust_remote_code=trust_remote_code,
-    )
-    return proxy_dir
+    prev_active = is_mtp_active() if _have_lm_patch else False
+    try:
+        if _have_lm_patch:
+            set_mtp_active(True)
+
+        from mlx_lm import convert
+
+        # mlx-lm's convert() refuses to write into a pre-existing directory,
+        # so reserve a unique temp name and let convert() create it.
+        proxy_dir = Path(tempfile.mkdtemp(prefix="omlx_oq_proxy_", dir=working_dir))
+        shutil.rmtree(proxy_dir)
+        convert(
+            hf_path=model_path,
+            mlx_path=str(proxy_dir),
+            quantize=True,
+            q_bits=_PROXY_QUANT_BITS,
+            q_group_size=_PROXY_QUANT_GROUP_SIZE,
+            q_mode="affine",
+            dtype=dtype,
+            trust_remote_code=trust_remote_code,
+        )
+        return proxy_dir
+    finally:
+        if _have_lm_patch:
+            set_mtp_active(prev_active)
 
 
 def _measure_sensitivity_from_quantized_model(

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -2063,4 +2063,101 @@ class TestBuildModelSanitizerTextOnly:
 
 
 # =============================================================================
-# Test GPTQ quantization
+# Test _build_proxy_for_sensitivity MTP patch integration
+# =============================================================================
+
+
+class TestBuildProxyForSensitivityMtpPatch:
+    """Tests for the MTP patch gating in _build_proxy_for_sensitivity.
+
+    The function must temporarily activate the MTP patch during
+    ``mlx_lm.convert()`` so that MTP-bearing models (Qwen3.5, DeepSeek-V4)
+    are converted correctly. After conversion the previous MTP state must
+    be restored regardless of success or failure.
+    """
+
+    def _make_mocks(self, patch_return=True, is_active=False, convert_side_effect=None):
+        mock_apply = MagicMock(return_value=patch_return)
+        mock_is_active = MagicMock(return_value=is_active)
+        mock_set_active = MagicMock()
+        mock_convert = MagicMock(side_effect=convert_side_effect)
+        return (
+            MagicMock(
+                apply_mlx_lm_mtp_patch=mock_apply,
+                is_mtp_active=mock_is_active,
+                set_mtp_active=mock_set_active,
+            ),
+            mock_apply, mock_is_active, mock_set_active, mock_convert,
+        )
+
+    def _patch(self, monkeypatch, mtp_mod, mock_convert):
+        monkeypatch.setitem(sys.modules, "omlx.patches.mlx_lm_mtp", mtp_mod)
+        monkeypatch.setitem(sys.modules, "mlx_lm", MagicMock(convert=mock_convert))
+
+    def test_happy_path_with_active_patch(self, tmp_path, monkeypatch):
+        """MTP patch applied → state toggled → convert called with correct kwargs → state restored."""
+        mtp_mod, mock_apply, mock_is_active, mock_set_active, mock_convert = self._make_mocks()
+        self._patch(monkeypatch, mtp_mod, mock_convert)
+
+        result = _build_proxy_for_sensitivity(
+            "/my/model", dtype="bfloat16", working_dir=str(tmp_path), trust_remote_code=True,
+        )
+
+        assert isinstance(result, Path)
+        assert result.name.startswith("omlx_oq_proxy_")
+        assert result.parent == tmp_path
+
+        mock_apply.assert_called_once()
+        assert mock_set_active.call_count == 2
+        assert mock_set_active.call_args_list[0] == ((True,),)
+        assert mock_set_active.call_args_list[-1] == ((False,),)
+
+        kw = mock_convert.call_args.kwargs
+        assert kw["hf_path"] == "/my/model"
+        assert kw["quantize"] is True
+        assert kw["q_bits"] == _PROXY_QUANT_BITS
+        assert kw["q_group_size"] == _PROXY_QUANT_GROUP_SIZE
+        assert kw["q_mode"] == "affine"
+        assert kw["dtype"] == "bfloat16"
+        assert kw["trust_remote_code"] is True
+
+    @pytest.mark.parametrize("prev_state", [False, True])
+    def test_state_restored_on_error(self, tmp_path, monkeypatch, prev_state):
+        """Convert error → finally block restores previous MTP state."""
+        mtp_mod, _, _, mock_set_active, mock_convert = self._make_mocks(
+            convert_side_effect=RuntimeError("boom"), is_active=prev_state,
+        )
+        self._patch(monkeypatch, mtp_mod, mock_convert)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            _build_proxy_for_sensitivity(
+                "/fake/model", dtype="float16", working_dir=str(tmp_path),
+            )
+
+        assert mock_set_active.call_count == 2
+        assert mock_set_active.call_args_list[-1] == ((prev_state,),)
+
+    def test_patch_returns_false_no_toggle(self, tmp_path, monkeypatch):
+        """apply_mlx_lm_mtp_patch returns False → no MTP toggle, convert is still called."""
+        mtp_mod, _, _, mock_set_active, mock_convert = self._make_mocks(patch_return=False)
+        self._patch(monkeypatch, mtp_mod, mock_convert)
+
+        _build_proxy_for_sensitivity(
+            "/fake/model", dtype="float16", working_dir=str(tmp_path),
+        )
+
+        mock_set_active.assert_not_called()
+        mock_convert.assert_called_once()
+
+    def test_import_fails_graceful_degradation(self, tmp_path, monkeypatch):
+        """MTP patch import raises → function proceeds without MTP gating."""
+        mock_convert = MagicMock()
+        monkeypatch.setitem(sys.modules, "omlx.patches.mlx_lm_mtp", None)
+        monkeypatch.setitem(sys.modules, "mlx_lm", MagicMock(convert=mock_convert))
+
+        result = _build_proxy_for_sensitivity(
+            "/fake/model", dtype="float16", working_dir=str(tmp_path),
+        )
+
+        assert isinstance(result, Path)
+        mock_convert.assert_called_once()


### PR DESCRIPTION
Fixes #1199.

## Issue

The unpatched version of `mlx_lm.convert()` was used, leading to:

```
2026-05-12 12:20:21,427 - omlx.oq - ERROR - Sensitivity proxy load failed (Native MTP is enabled for this model but the converted weights are missing the mtp.* tensors. Default mlx-lm converters strip them; you need a converter that preserves MTP weights (or a Qwen3.6 / DeepSeek-V4 checkpoint that already preserves them). To recover without re-converting, open the model's settings in the oMLX admin UI and toggle 'Native MTP' off, then retry.)
2026-05-12 12:20:21,431 - omlx.admin.oq_manager - ERROR - oQ quantization failed: Qwen3.6-35B-A3B -> oQ5: sensitivity measurement produced no scores. Check the preceding log lines for the root cause (model load, calibration data, or layer discovery), and either fix it or pass an explicit sensitivity_model_path.
```

Because the auto-built affine 4-bit sensitivity model comes out with stripped out `mtp.*` tensors.

## Fix

Wrap `_build_proxy_for_sensitivity` with `apply_mlx_lm_mtp_patch` monkey-patching similarly to many other oQ helpers.

## Test

- `test_happy_path_with_active_patch` – Full happy path: patch applied, MTP toggled True→False, all kwargs forwarded, correct return value and working_dir.
 - `test_state_restored_on_error` – Parametrized (False/True) to verify that `finally` restores the exact prior state on exception.                   
 - `test_patch_returns_false_no_toggle` – Patch returns `False`, no toggle, convert() still runs.
 - `test_import_fails_graceful_degradation` – Patch import fails, proceeds without MTP gating, convert() still runs.

Probably way too verbose, the last 2 tests could be removed if you like.

## Also

My concerns from [here](https://github.com/jundot/omlx/pull/1136#issuecomment-4429008784):

>A question: is 4-bit affine "fallback" enough for the sensitivity model role? In my understanding it could potentially lead to a different dynamic bits allocation since we are going to apply a quantization on top of another quantization, and only then calculate how much it hurts? I've always quantized oQ using affine Q8 sensitivity model with such assumption in mind.

Come true. I have different .safetensors with using affine 4-bit and 8-bit sensitivity models, meaning some bits allocation made different choices.