### PR TITLE
fix(ui): chat message render line break incorrectly, textarea inline edit

### DIFF
--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -157,11 +157,16 @@
         align-self: flex-end;
     }
 
+    .user-message.is-editing {
+        width: min(768px, 100%);
+    }
+
     .user-message-bubble {
         background: var(--bg-secondary);
         border-radius: 24px;
         padding: 8px 16px;
         font-size: 14px;
+        line-height: 1.6;
         color: var(--text-primary);
         max-width: 100%;
         min-width: 0;
@@ -171,7 +176,11 @@
 
     .user-message-bubble p {
         color: var(--text-primary) !important;
-        margin: 0;
+        margin: 0 0 1em;
+    }
+
+    .user-message-bubble p:last-child {
+        margin-bottom: 0;
     }
 
     .user-message-bubble * {
@@ -395,9 +404,9 @@
     .inline-edit-textarea {
         width: 100%;
         min-width: 280px;
-        max-width: 600px;
         min-height: 80px;
         max-height: 300px;
+        box-sizing: border-box;
         resize: vertical;
         padding: 12px 16px;
         border: 2px solid #2d3748;
@@ -862,7 +871,7 @@
                     <div class="message-fade-in">
                         <!-- User Message -->
                         <div x-show="msg.role === 'user'" class="flex justify-end">
-                            <div class="user-message">
+                            <div class="user-message" :class="{ 'is-editing': editingIndex === index }">
                                 <button @click="startEdit(index)" class="user-edit-btn"
                                     title="{{ t('chat.edit_tooltip') }}">
                                     <i data-lucide="pencil" class="w-4 h-4"></i>


### PR DESCRIPTION
1. Chat message rendered line break incorrectly.

<img width="1343" height="691" alt="Screenshot 2569-05-12 at 22 04 46" src="https://github.com/user-attachments/assets/cd35128d-772e-47c0-b70d-8e053439b0b2" />

<img width="1301" height="805" alt="Screenshot 2569-05-12 at 22 04 56" src="https://github.com/user-attachments/assets/c218adf8-24c2-42b9-aaad-25e76f026375" />

2. Textarea inline edit was contained to just min size (280px) not the real message bubble's width

<img width="1330" height="472" alt="Screenshot 2569-05-12 at 21 34 55" src="https://github.com/user-attachments/assets/1a580ca4-8ae0-4c87-bbda-4ed310a687d8" />

<img width="1325" height="385" alt="Screenshot 2569-05-12 at 22 05 49" src="https://github.com/user-attachments/assets/f0f28448-668f-4ad4-9799-c9915a9e7f7e" />
