### PR TITLE
chore: git ignore uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ omlx/admin/tailwindcss-*
 
 # Git worktrees
 .worktrees/
+
+# UV lockfile
+uv.lock


### PR DESCRIPTION
I, likely among other contributors, use [UV](https://docs.astral.sh/uv/) Python package manager to handle venv and dependencies with `uv sync`.

I propose that we just git-ignore the lockfile so that it doesn't get commited accidentally one day.

It doesn't oblige you to change your way of dealing with Python, just for overall convenience.