### PR TITLE
fix(packaging): reuse Session for health checks to prevent port exhaustion

### DIFF
--- a/packaging/omlx_app/server_manager.py
+++ b/packaging/omlx_app/server_manager.py
@@ -73,6 +73,13 @@ class ServerManager:
         self._stop_health_check = threading.Event()
         self._adopted = False
 
+        # Persistent session for health checks. Reused across every poll so
+        # the underlying TCP connection is kept alive instead of opening a
+        # fresh socket per check (which lands in TIME_WAIT and, under server
+        # slowdown, can exhaust the host's ephemeral port range).
+        self._health_session = requests.Session()
+        self._health_session.trust_env = False
+
         # Health check failure tracking
         self._consecutive_health_failures: int = 0
         self._max_health_failures: int = 3  # 3 consecutive failures → UNRESPONSIVE
@@ -115,9 +122,7 @@ class ServerManager:
 
     def check_health(self) -> bool:
         try:
-            session = requests.Session()
-            session.trust_env = False
-            response = session.get(self._get_health_url(), timeout=2)
+            response = self._health_session.get(self._get_health_url(), timeout=2)
             return response.status_code == 200
         except requests.RequestException:
             return False

--- a/tests/test_omlx_app.py
+++ b/tests/test_omlx_app.py
@@ -756,7 +756,7 @@ class TestServerManager:
         assert manager.is_running() is False
 
     @patch("omlx_app.server_manager.requests.Session")
-    def test_check_health_success(self, mock_session_cls, manager: ServerManager):
+    def test_check_health_success(self, mock_session_cls, config: ServerConfig):
         """Test successful health check."""
         mock_session = Mock()
         mock_response = Mock()
@@ -764,12 +764,14 @@ class TestServerManager:
         mock_session.get.return_value = mock_response
         mock_session_cls.return_value = mock_session
 
+        manager = ServerManager(config)
+
         assert manager.check_health() is True
         mock_session.get.assert_called_once_with("http://127.0.0.1:8765/health", timeout=2)
         assert mock_session.trust_env is False
 
     @patch("omlx_app.server_manager.requests.Session")
-    def test_check_health_failure(self, mock_session_cls, manager: ServerManager):
+    def test_check_health_failure(self, mock_session_cls, config: ServerConfig):
         """Test failed health check (non-200 status)."""
         mock_session = Mock()
         mock_response = Mock()
@@ -777,17 +779,42 @@ class TestServerManager:
         mock_session.get.return_value = mock_response
         mock_session_cls.return_value = mock_session
 
+        manager = ServerManager(config)
+
         assert manager.check_health() is False
 
     @patch("omlx_app.server_manager.requests.Session")
-    def test_check_health_connection_error(self, mock_session_cls, manager: ServerManager):
+    def test_check_health_connection_error(self, mock_session_cls, config: ServerConfig):
         """Test health check with connection error."""
         import requests
         mock_session = Mock()
         mock_session.get.side_effect = requests.RequestException("Connection refused")
         mock_session_cls.return_value = mock_session
 
+        manager = ServerManager(config)
+
         assert manager.check_health() is False
+
+    @patch("omlx_app.server_manager.requests.Session")
+    def test_check_health_reuses_session(self, mock_session_cls, config: ServerConfig):
+        """Session is created once and reused across health checks.
+
+        Without reuse, every poll opens a fresh TCP connection that lands
+        in TIME_WAIT. The background loop polls every 5s; under server
+        slowdown this can exhaust the host's ephemeral port range and
+        wedge unrelated outbound TCP.
+        """
+        mock_session = Mock()
+        mock_session.get.return_value = Mock(status_code=200)
+        mock_session_cls.return_value = mock_session
+
+        manager = ServerManager(config)
+        manager.check_health()
+        manager.check_health()
+        manager.check_health()
+
+        assert mock_session_cls.call_count == 1
+        assert mock_session.get.call_count == 3
 
     def test_start_already_running(self, manager: ServerManager):
         """Test start returns False when already running."""


### PR DESCRIPTION
### Evidence

  Observed on a Mac running oMLX:
  - 14,126 sockets in TIME_WAIT to `127.0.0.1:8888` (the oMLX backend),
    out of 17,546 total on the host
  - `lsof` showed the menubar app (`oMLX`) and the backend (`python3`)
    connecting on a fresh source port each poll, confirming no shared
    connection
  - Outbound TCP from other apps on the same Mac failed until reboot

  ### Fix

  Create one `Session` in `__init__` and reuse it on every health
  check. A single TCP connection stays open instead of one being
  created and discarded each time.

  ### Tests

  Added `test_check_health_reuses_session` in `tests/test_omlx_app.py`
  that fails on the previous code and passes on the new code. The three
  existing `test_check_health_*` tests were updated to construct the
  manager inside the patched scope (since the `Session` is now created
  in `__init__`).

  ### Out of scope (noted for follow-up)

  The same function-local-Session pattern appears in
  `packaging/omlx_app/config.py` (two places: lines 173 and 303). Those
  call sites are not on a polling hot path, so I left them for a
  separate change to keep this PR small and focused.

  ### Note on local testing

  `uv sync --dev` fails on this repo because `paroquant==0.1.14`
  requires Python `>=3.11` but `[project].requires-python` is `>=3.10`.
  I bumped `requires-python` locally to `>=3.11` to run the tests, then
  reverted before committing. Worth a separate fix.