### PR TITLE
feat(audio): expose word_timestamps on /v1/audio/transcriptions

### DIFF
--- a/omlx/api/audio_routes.py
+++ b/omlx/api/audio_routes.py
@@ -377,6 +377,7 @@ async def create_transcription(
     response_format: str = Form("json"),
     temperature: float = Form(0.0),
     max_tokens: Optional[int] = Form(None),
+    word_timestamps: bool = Form(False),
 ):
     """OpenAI-compatible audio transcription endpoint (Speech-to-Text).
 
@@ -387,6 +388,12 @@ async def create_transcription(
     output cap. Useful for long audio with models like VibeVoice-ASR whose
     mlx-audio default (8192) truncates ~24 min files. When omitted, the
     model's own default applies.
+
+    ``word_timestamps`` is an oMLX extension that exposes mlx-audio's native
+    word-level alignment for Whisper models. When True, each segment in the
+    response includes a ``words`` array of
+    ``{word, start, end, probability}`` objects. Default False preserves the
+    existing response shape for every current caller.
     """
     from omlx.engine.stt import STTEngine
     from omlx.exceptions import ModelNotFoundError
@@ -444,6 +451,8 @@ async def create_transcription(
         transcribe_kwargs: dict = {"language": language}
         if effective_max_tokens is not None:
             transcribe_kwargs["max_tokens"] = effective_max_tokens
+        if word_timestamps:
+            transcribe_kwargs["word_timestamps"] = True
         result = await engine.transcribe(tmp_path, **transcribe_kwargs)
     except HTTPException:
         raise


### PR DESCRIPTION
## Summary

`mlx-audio` Whisper supports word-level timestamps natively (`word_timestamps=True` passed to `model.generate`). `STTEngine.transcribe` already forwards `**kwargs` straight through to that call. The FastAPI route was the only layer dropping the parameter, so callers could not opt in.

This adds `word_timestamps: bool = Form(False)` to `create_transcription` and appends it to `transcribe_kwargs` when set. Mirrors the pattern PR #1163 used for `max_tokens` (also a "route layer was the gap" parameter pass-through). Same code shape, same default-off behavior, same backwards-compat guarantee.

## Behavior

Default `False` keeps the response identical for every existing caller.

When `True`, each segment in the response includes a `words` array of `{word, start, end, probability}` objects (whatever `mlx-audio` attaches for the model). For Whisper:

```json
{
  "text": " The patch landed cleanly.",
  "segments": [
    {
      "start": 0.0, "end": 1.32, "text": " The patch landed cleanly.",
      "words": [
        {"word": " The",      "start": 0.00, "end": 0.10, "probability": 0.917},
        {"word": " patch",    "start": 0.10, "end": 0.38, "probability": 0.990},
        {"word": " landed",   "start": 0.38, "end": 0.78, "probability": 0.999},
        {"word": " cleanly.", "start": 0.78, "end": 1.32, "probability": 0.999}
      ]
    }
  ]
}
```

`_normalize_segment` already preserves arbitrary dict fields, so the words array flows straight through with no further changes.

## Verification

Tested locally on `0.3.8` (with this patch applied on top) against `whisper-large-v3-turbo`:

```bash
say "the patch landed cleanly" -o /tmp/smoke.aiff
afconvert /tmp/smoke.aiff /tmp/smoke.wav -d LEI16 -f WAVE

# Backwards-compat: no opt-in, identical response shape
curl -s -X POST http://127.0.0.1:8800/v1/audio/transcriptions \
  -H "Authorization: Bearer $KEY" \
  -F "file=@/tmp/smoke.wav" \
  -F "model=whisper-large-v3-turbo" \
  | jq '.segments[0] | keys'
# -> ["avg_logprob","compression_ratio","end","id","no_speech_prob","seek","start","temperature","text","tokens"]

# Opt-in
curl -s -X POST http://127.0.0.1:8800/v1/audio/transcriptions \
  -H "Authorization: Bearer $KEY" \
  -F "file=@/tmp/smoke.wav" \
  -F "model=whisper-large-v3-turbo" \
  -F "word_timestamps=true" \
  | jq '.segments[0].words'
# -> [{word, start, end, probability}, ...]
```

Performance: when `word_timestamps=True`, `mlx-audio`'s alignment pass adds roughly 1.5-2x to transcription time (only for the request that asked for it). Negligible memory bump per request.

## Why this is small

The actual diff is the Form parameter, three lines of `transcribe_kwargs` mutation, and a docstring paragraph. Eight lines including the docstring. Same risk profile as #1163.

Happy to add a unit test if you want one to match style; `tests/test_audio_stt.py` looked like the right home but wasn't sure if you preferred end-to-end via FastAPI's TestClient or unit-level on the route function. Let me know.