### PR TITLE
fix(mtp): prevent process-wide _MTP_ACTIVE flag leaking across model loads

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -310,8 +310,21 @@ class BatchedEngine(BaseEngine):
                 try:
 
                     def _load_draft():
-                        draft_model, _ = load(specprefill_draft)
-                        return draft_model
+                        from ..patches.mlx_lm_mtp import set_mtp_active
+
+                        was_mtp = False
+                        try:
+                            from ..patches.mlx_lm_mtp import is_mtp_active
+
+                            was_mtp = is_mtp_active()
+                        except Exception:
+                            pass
+                        set_mtp_active(False)
+                        try:
+                            draft_model, _ = load(specprefill_draft)
+                            return draft_model
+                        finally:
+                            set_mtp_active(was_mtp)
 
                     draft_model = await loop.run_in_executor(
                         get_mlx_executor(), _load_draft

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -710,15 +710,28 @@ class VLMBatchedEngine(BaseEngine):
                     from ..utils.model_loading import maybe_load_custom_quantization
 
                     def _load_draft():
-                        custom_loaded = maybe_load_custom_quantization(
-                            specprefill_draft,
-                            is_vlm=False,
-                        )
-                        if custom_loaded is not None:
-                            draft_model, _ = custom_loaded
+                        from ..patches.mlx_lm_mtp import set_mtp_active
+
+                        was_mtp = False
+                        try:
+                            from ..patches.mlx_lm_mtp import is_mtp_active
+
+                            was_mtp = is_mtp_active()
+                        except Exception:
+                            pass
+                        set_mtp_active(False)
+                        try:
+                            custom_loaded = maybe_load_custom_quantization(
+                                specprefill_draft,
+                                is_vlm=False,
+                            )
+                            if custom_loaded is not None:
+                                draft_model, _ = custom_loaded
+                                return draft_model
+                            draft_model, _ = mlx_lm_load(specprefill_draft)
                             return draft_model
-                        draft_model, _ = mlx_lm_load(specprefill_draft)
-                        return draft_model
+                        finally:
+                            set_mtp_active(was_mtp)
                     draft_model = await loop.run_in_executor(get_mlx_executor(), _load_draft)
                     self._engine.engine.scheduler.set_specprefill_draft_model(
                         draft_model, draft_model_name=specprefill_draft

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -29,6 +29,13 @@ def maybe_apply_pre_load_patches(
 
     Safe to call repeatedly; the patches are idempotent.
     """
+    # Reset the process-wide MTP flag so non-MTP-compatible models (or
+    # models with mtp_enabled=False) are not polluted by a prior model
+    # load that left the flag True.
+    from ..patches.mlx_lm_mtp import set_mtp_active
+
+    set_mtp_active(False)
+
     config_path = Path(model_name) / "config.json"
     if not config_path.exists():
         return


### PR DESCRIPTION
## Summary

Fixes the process-wide `_MTP_ACTIVE` flag leaking from one model load to another, which caused SpecPrefill draft model loading to crash with "Native MTP is enabled but converted weights are missing mtp.* tensors".

## Root cause

`set_mtp_active()` is only called inside `_is_mtp_compatible()` branch in `maybe_apply_pre_load_patches()`. If the current model is **not** MTP-compatible, the flag is never reset. This means:

1. Load `Qwen3.6-27B-oQ4-mtp` with `mtp_enabled=True` → `_MTP_ACTIVE=True`
2. Switch to `Qwen3.6-35B-A3B-UD-MLX-4bit` (non-MTP) → flag stays `True`
3. SpecPrefill loads `Qwen3.5-0.8B-MLX-4bit` as draft → patched `__init__` sees `is_mtp_active()=True` → attaches MTP → crash

## Fix

- `maybe_apply_pre_load_patches()`: reset `_MTP_ACTIVE=False` at function entry so every model load starts clean
- `BatchedEngine._load_draft()`: snapshot/restore flag around draft model load
- `VLMBatchedEngine._load_draft()`: same snapshot/restore guard

## Test plan

- [x] Load MTP-enabled model, then switch to non-MTP model with SpecPrefill draft → no crash
- [x] Load non-MTP model directly with SpecPrefill draft → works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)