### PR TITLE
fix(admin/chat): keep mobile input bar on-screen by dropping min-height: 100vh

### DIFF
--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -72,8 +72,8 @@
     }
 
     .chat-shell {
+        height: 100vh; /* fallback for browsers without dvh support */
         height: 100dvh;
-        min-height: 100vh;
     }
 
     /* Scrollbar */


### PR DESCRIPTION
## Summary

On mobile browsers (reproduced on Chrome / Pixel 8) the chat input bar at the bottom of `/chat` is invisible — pushed behind the browser's collapsing address bar.

Root cause is the `.chat-shell` rule in `omlx/admin/templates/chat.html`:

```css
.chat-shell {
    height: 100dvh;
    min-height: 100vh;   /* the culprit */
}
```

`100vh` is the *large* viewport height (as if the address bar were retracted). On a phone where the address bar is visible, `min-height: 100vh` forces the flex column taller than the actually-visible area. The input bar is the last `flex-shrink-0` child of that column, so it ends up below the fold.

This PR replaces the rule with a progressive-enhancement cascade:

```css
.chat-shell {
    height: 100vh; /* fallback for browsers without dvh support */
    height: 100dvh;
}
```

- Browsers without `dvh` support ignore the second line and fall back to `100vh`.
- Browsers with `dvh` support (modern Chrome / Safari / Firefox, including Chrome on Pixel 8) use `100dvh`, which tracks the *dynamic* viewport and grows/shrinks alongside the browser chrome.

Removing `min-height: 100vh` is the actual fix; the `100vh` line is kept only as a fallback.

`.chat-shell` is not referenced anywhere else in the repo (only the rule definition and the single class usage in the same template), so no other layout is affected.

## Test plan

- [ ] Open `/chat` in desktop Chrome / Firefox — input bar visible, layout unchanged.
- [ ] Open `/chat` in Chrome DevTools device-mode (Pixel 8) or a real mobile browser — input bar stays pinned to the bottom of the visible viewport whether the address bar is expanded or collapsed.
- [ ] Scroll the chat history on mobile — input bar stays anchored.