### PR TITLE
feat(prefill): interleaved chunked prefill + decode

### DIFF
--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -322,6 +322,8 @@
   "settings.resource.prefill_memory_guard_description": "Estimate memory before prefill and defer scheduling under memory pressure to prevent Metal allocation failures.",
   "settings.resource.max_concurrent_requests": "Max Concurrent Requests",
   "settings.resource.max_concurrent_requests_hint": "Maximum number of requests processed simultaneously. Higher values increase throughput but use more memory.",
+  "settings.resource.chunked_prefill": "Chunked Prefill",
+  "settings.resource.chunked_prefill_description": "Interleave prefill chunks with decode steps. Reduces time-to-first-token for concurrent requests by processing one prefill chunk per step instead of blocking decode.",
   "settings.resource.restart_badge": "Restart needed",
   "settings.cache.section_label": "Cache",
   "settings.cache.enabled": "Cache Enabled",

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -21,9 +21,9 @@ import sys
 import time
 from collections import deque
 from dataclasses import asdict, is_dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Dict, Optional, List, Literal
+from typing import Any, Literal
 
 import requests
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
@@ -31,6 +31,9 @@ from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Redirect
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
+from ..model_profiles import EXCLUDED_FROM_PROFILES
+from ..settings import SubKeyEntry
+from ..utils.release_check import select_latest_stable_release
 from .auth import (
     REMEMBER_ME_MAX_AGE,
     SESSION_MAX_AGE,
@@ -40,9 +43,6 @@ from .auth import (
     verify_api_key,
     verify_session,
 )
-from ..settings import SubKeyEntry
-from ..model_profiles import EXCLUDED_FROM_PROFILES
-from ..utils.release_check import select_latest_stable_release
 
 logger = logging.getLogger(__name__)
 
@@ -92,83 +92,83 @@ class CacheProbeRequest(BaseModel):
     """
 
     model_id: str
-    messages: List[Dict[str, Any]]
-    tools: Optional[List[Dict[str, Any]]] = None
-    chat_template_kwargs: Optional[Dict[str, Any]] = None
+    messages: list[dict[str, Any]]
+    tools: list[dict[str, Any]] | None = None
+    chat_template_kwargs: dict[str, Any] | None = None
 
 
 class ModelSettingsRequest(BaseModel):
     """Request model for updating per-model settings."""
 
-    model_alias: Optional[str] = None
-    model_type_override: Optional[str] = None
-    max_context_window: Optional[int] = None
-    max_tokens: Optional[int] = None
-    temperature: Optional[float] = None
-    top_p: Optional[float] = None
-    top_k: Optional[int] = None
-    repetition_penalty: Optional[float] = None
-    min_p: Optional[float] = None
-    presence_penalty: Optional[float] = None
-    force_sampling: Optional[bool] = None
-    max_tool_result_tokens: Optional[int] = None
-    chat_template_kwargs: Optional[Dict[str, Any]] = None
-    forced_ct_kwargs: Optional[list[str]] = None
-    ttl_seconds: Optional[int] = None
-    index_cache_freq: Optional[int] = None
-    enable_thinking: Optional[bool] = None
-    thinking_budget_enabled: Optional[bool] = None
-    thinking_budget_tokens: Optional[int] = None
+    model_alias: str | None = None
+    model_type_override: str | None = None
+    max_context_window: int | None = None
+    max_tokens: int | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    repetition_penalty: float | None = None
+    min_p: float | None = None
+    presence_penalty: float | None = None
+    force_sampling: bool | None = None
+    max_tool_result_tokens: int | None = None
+    chat_template_kwargs: dict[str, Any] | None = None
+    forced_ct_kwargs: list[str] | None = None
+    ttl_seconds: int | None = None
+    index_cache_freq: int | None = None
+    enable_thinking: bool | None = None
+    thinking_budget_enabled: bool | None = None
+    thinking_budget_tokens: int | None = None
     # TurboQuant KV cache (mlx-vlm backend)
-    turboquant_kv_enabled: Optional[bool] = None
-    turboquant_kv_bits: Optional[float] = None
+    turboquant_kv_enabled: bool | None = None
+    turboquant_kv_bits: float | None = None
     # SpecPrefill (experimental)
-    specprefill_enabled: Optional[bool] = None
-    specprefill_draft_model: Optional[str] = None
-    specprefill_keep_pct: Optional[float] = None
-    specprefill_threshold: Optional[int] = None
+    specprefill_enabled: bool | None = None
+    specprefill_draft_model: str | None = None
+    specprefill_keep_pct: float | None = None
+    specprefill_threshold: int | None = None
     # DFlash (block diffusion speculative decoding)
-    dflash_enabled: Optional[bool] = None
-    dflash_draft_model: Optional[str] = None
-    dflash_draft_quant_enabled: Optional[bool] = None
-    dflash_draft_quant_weight_bits: Optional[int] = None
-    dflash_draft_quant_activation_bits: Optional[int] = None
-    dflash_draft_quant_group_size: Optional[int] = None
-    dflash_max_ctx: Optional[int] = None
-    dflash_in_memory_cache: Optional[bool] = None
-    dflash_in_memory_cache_max_entries: Optional[int] = None
-    dflash_in_memory_cache_max_bytes: Optional[int] = None
-    dflash_ssd_cache: Optional[bool] = None
+    dflash_enabled: bool | None = None
+    dflash_draft_model: str | None = None
+    dflash_draft_quant_enabled: bool | None = None
+    dflash_draft_quant_weight_bits: int | None = None
+    dflash_draft_quant_activation_bits: int | None = None
+    dflash_draft_quant_group_size: int | None = None
+    dflash_max_ctx: int | None = None
+    dflash_in_memory_cache: bool | None = None
+    dflash_in_memory_cache_max_entries: int | None = None
+    dflash_in_memory_cache_max_bytes: int | None = None
+    dflash_ssd_cache: bool | None = None
     # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch)
-    mtp_enabled: Optional[bool] = None
+    mtp_enabled: bool | None = None
     # VLM MTP speculative decoding via external assistant drafter (mlx-vlm 191d7c8+)
-    vlm_mtp_enabled: Optional[bool] = None
-    vlm_mtp_draft_model: Optional[str] = None
-    vlm_mtp_draft_block_size: Optional[int] = None
-    reasoning_parser: Optional[str] = None
-    is_pinned: Optional[bool] = None
-    is_default: Optional[bool] = None
+    vlm_mtp_enabled: bool | None = None
+    vlm_mtp_draft_model: str | None = None
+    vlm_mtp_draft_block_size: int | None = None
+    reasoning_parser: str | None = None
+    is_pinned: bool | None = None
+    is_default: bool | None = None
     # Security: per-model opt-in for trust_remote_code (issue #926)
-    trust_remote_code: Optional[bool] = None
+    trust_remote_code: bool | None = None
 
 
 class CreateProfileRequest(BaseModel):
     """Request body for creating a per-model profile."""
     name: str
     display_name: str
-    description: Optional[str] = None
-    settings: Dict[str, Any] = Field(default_factory=dict)
+    description: str | None = None
+    settings: dict[str, Any] = Field(default_factory=dict)
     also_save_as_template: bool = False
-    source_template: Optional[str] = None
+    source_template: str | None = None
 
 
 class UpdateProfileRequest(BaseModel):
     """Request body for updating/renaming a per-model profile."""
-    new_name: Optional[str] = None
-    display_name: Optional[str] = None
-    description: Optional[str] = None
-    settings: Optional[Dict[str, Any]] = None
-    source_template: Optional[str] = None
+    new_name: str | None = None
+    display_name: str | None = None
+    description: str | None = None
+    settings: dict[str, Any] | None = None
+    source_template: str | None = None
     also_save_as_template: bool = False
 
 
@@ -176,97 +176,98 @@ class CreateTemplateRequest(BaseModel):
     """Request body for creating a global template."""
     name: str
     display_name: str
-    description: Optional[str] = None
-    settings: Dict[str, Any] = Field(default_factory=dict)
+    description: str | None = None
+    settings: dict[str, Any] = Field(default_factory=dict)
 
 
 class UpdateTemplateRequest(BaseModel):
     """Request body for updating/renaming a global template."""
-    new_name: Optional[str] = None
-    display_name: Optional[str] = None
-    description: Optional[str] = None
-    settings: Optional[Dict[str, Any]] = None
+    new_name: str | None = None
+    display_name: str | None = None
+    description: str | None = None
+    settings: dict[str, Any] | None = None
 
 
 class GlobalSettingsRequest(BaseModel):
     """Request model for updating global server settings."""
 
     # Server settings
-    host: Optional[str] = None
-    port: Optional[int] = None
-    log_level: Optional[str] = None
-    server_aliases: Optional[List[str]] = None
-    sse_keepalive_mode: Optional[str] = None
+    host: str | None = None
+    port: int | None = None
+    log_level: str | None = None
+    server_aliases: list[str] | None = None
+    sse_keepalive_mode: str | None = None
 
     # Model settings
-    model_dirs: Optional[List[str]] = None
-    model_dir: Optional[str] = None  # Deprecated: kept for backward compatibility
-    max_model_memory: Optional[str] = None
-    model_fallback: Optional[bool] = None
+    model_dirs: list[str] | None = None
+    model_dir: str | None = None  # Deprecated: kept for backward compatibility
+    max_model_memory: str | None = None
+    model_fallback: bool | None = None
 
     # Memory enforcement
-    max_process_memory: Optional[str] = None  # "auto", "disabled", or "XX%"
-    memory_prefill_memory_guard: Optional[bool] = None
+    max_process_memory: str | None = None  # "auto", "disabled", or "XX%"
+    memory_prefill_memory_guard: bool | None = None
 
     # Scheduler settings
-    max_concurrent_requests: Optional[int] = None
+    max_concurrent_requests: int | None = None
+    chunked_prefill: bool | None = None
 
     # Cache settings
-    cache_enabled: Optional[bool] = None
-    ssd_cache_dir: Optional[str] = None
-    ssd_cache_max_size: Optional[str] = None
-    hot_cache_only: Optional[bool] = None
-    hot_cache_max_size: Optional[str] = None  # "0" = disabled, "8GB", etc.
-    initial_cache_blocks: Optional[int] = None  # Starting blocks (requires restart)
+    cache_enabled: bool | None = None
+    ssd_cache_dir: str | None = None
+    ssd_cache_max_size: str | None = None
+    hot_cache_only: bool | None = None
+    hot_cache_max_size: str | None = None  # "0" = disabled, "8GB", etc.
+    initial_cache_blocks: int | None = None  # Starting blocks (requires restart)
 
     # MCP settings
-    mcp_config: Optional[str] = None
+    mcp_config: str | None = None
 
     # HuggingFace settings
-    hf_endpoint: Optional[str] = None
+    hf_endpoint: str | None = None
 
     # ModelScope settings
-    ms_endpoint: Optional[str] = None
+    ms_endpoint: str | None = None
 
     # Network settings
-    network_http_proxy: Optional[str] = None
-    network_https_proxy: Optional[str] = None
-    network_no_proxy: Optional[str] = None
-    network_ca_bundle: Optional[str] = None
+    network_http_proxy: str | None = None
+    network_https_proxy: str | None = None
+    network_no_proxy: str | None = None
+    network_ca_bundle: str | None = None
 
     # Sampling defaults
-    sampling_max_context_window: Optional[int] = None
-    sampling_max_tokens: Optional[int] = None
-    sampling_temperature: Optional[float] = None
-    sampling_top_p: Optional[float] = None
-    sampling_top_k: Optional[int] = None
-    sampling_repetition_penalty: Optional[float] = None
+    sampling_max_context_window: int | None = None
+    sampling_max_tokens: int | None = None
+    sampling_temperature: float | None = None
+    sampling_top_p: float | None = None
+    sampling_top_k: int | None = None
+    sampling_repetition_penalty: float | None = None
 
     # Claude Code settings
-    claude_code_context_scaling_enabled: Optional[bool] = None
-    claude_code_target_context_size: Optional[int] = None
-    claude_code_mode: Optional[str] = None
-    claude_code_opus_model: Optional[str] = None
-    claude_code_sonnet_model: Optional[str] = None
-    claude_code_haiku_model: Optional[str] = None
+    claude_code_context_scaling_enabled: bool | None = None
+    claude_code_target_context_size: int | None = None
+    claude_code_mode: str | None = None
+    claude_code_opus_model: str | None = None
+    claude_code_sonnet_model: str | None = None
+    claude_code_haiku_model: str | None = None
 
     # Other integrations settings
-    integrations_copilot_model: Optional[str] = None
-    integrations_codex_model: Optional[str] = None
-    integrations_opencode_model: Optional[str] = None
-    integrations_openclaw_model: Optional[str] = None
-    integrations_pi_model: Optional[str] = None
-    integrations_openclaw_tools_profile: Optional[Literal["minimal", "coding", "messaging", "full"]] = None
+    integrations_copilot_model: str | None = None
+    integrations_codex_model: str | None = None
+    integrations_opencode_model: str | None = None
+    integrations_openclaw_model: str | None = None
+    integrations_pi_model: str | None = None
+    integrations_openclaw_tools_profile: Literal["minimal", "coding", "messaging", "full"] | None = None
 
     # UI settings
-    ui_language: Optional[str] = None
+    ui_language: str | None = None
 
     # Idle timeout settings. null disables the global fallback.
-    idle_timeout_seconds: Optional[int] = Field(default=None, ge=60)
+    idle_timeout_seconds: int | None = Field(default=None, ge=60)
 
     # Auth settings
-    api_key: Optional[str] = None
-    skip_api_key_verification: Optional[bool] = None
+    api_key: str | None = None
+    skip_api_key_verification: bool | None = None
 
 
 class HFDownloadRequest(BaseModel):
@@ -532,6 +533,7 @@ async def _apply_model_dirs_runtime(model_dirs: list[str]) -> tuple[bool, str]:
         Tuple of (success, message)
     """
     from pathlib import Path
+
     from ..server import _server_state
 
     if _server_state.engine_pool is None:
@@ -643,8 +645,8 @@ async def _apply_max_model_memory_runtime(
     Returns:
         Tuple of (success, message)
     """
-    from ..server import _server_state
     from ..model_discovery import format_size
+    from ..server import _server_state
 
     if _server_state.engine_pool is None:
         return False, "Engine pool not initialized"
@@ -745,11 +747,11 @@ async def _apply_max_process_memory_runtime(
 
 
 async def _apply_cache_settings_runtime(
-    enabled: Optional[bool],
-    ssd_cache_dir: Optional[str],
-    ssd_cache_max_size: Optional[str],
+    enabled: bool | None,
+    ssd_cache_dir: str | None,
+    ssd_cache_max_size: str | None,
     global_settings,
-    hot_cache_max_size: Optional[str] = None,
+    hot_cache_max_size: str | None = None,
 ) -> tuple[bool, str]:
     """
     Apply cache settings at runtime.
@@ -760,8 +762,8 @@ async def _apply_cache_settings_runtime(
     Returns:
         Tuple of (success, message)
     """
-    from ..server import _server_state
     from ..config import parse_size
+    from ..server import _server_state
 
     if _server_state.engine_pool is None:
         return False, "Engine pool not initialized"
@@ -829,12 +831,12 @@ async def _apply_cache_settings_runtime(
 
 
 def _apply_sampling_settings_runtime(
-    max_context_window: Optional[int],
-    max_tokens: Optional[int],
-    temperature: Optional[float],
-    top_p: Optional[float],
-    top_k: Optional[int],
-    repetition_penalty: Optional[float] = None,
+    max_context_window: int | None,
+    max_tokens: int | None,
+    temperature: float | None,
+    top_p: float | None,
+    top_k: int | None,
+    repetition_penalty: float | None = None,
 ) -> tuple[bool, str]:
     """
     Apply sampling default settings at runtime.
@@ -898,6 +900,7 @@ def _static_version(path: str) -> str:
 templates.env.globals["static"] = _static_version
 
 from omlx._version import __version__ as _omlx_version
+
 templates.env.globals["version"] = _omlx_version
 
 # i18n defaults (English) — overridden once set_admin_getters is called
@@ -1431,7 +1434,7 @@ async def create_sub_key(
     entry = SubKeyEntry(
         key=request.key,
         name=request.name or "",
-        created_at=datetime.now(timezone.utc).isoformat(),
+        created_at=datetime.now(UTC).isoformat(),
     )
     global_settings.auth.sub_keys.append(entry)
 
@@ -1494,7 +1497,7 @@ _SUPPORTED_MODELS_DOC_RE = re.compile(
 )
 
 
-def _models_from_docstring(fn) -> List[str]:
+def _models_from_docstring(fn) -> list[str]:
     """Extract the ``Supported models:`` bullet list from an xgrammar 0.1.34+
     structural-tag function's docstring. Returns ``[]`` if the section is
     absent or unparseable."""
@@ -1806,7 +1809,6 @@ async def update_model_settings(
         raise HTTPException(status_code=404, detail=f"Model not found: {model_id}")
 
     # Get current settings
-    from ..model_settings import ModelSettings
     current_settings = settings_manager.get_settings(model_id)
 
     # Apply updates — use model_fields_set to distinguish "sent as null"
@@ -1994,9 +1996,10 @@ async def update_model_settings(
             # files must actually contain mtp.* tensors. The last check is
             # the one that catches mlx-community converted weights where the
             # default sanitize path stripped the MTP heads.
-            from ..utils.model_loading import _is_mtp_compatible
             import json
             from pathlib import Path
+
+            from ..utils.model_loading import _is_mtp_compatible
 
             cfg_path = Path(entry.model_path) / "config.json"
             if not cfg_path.exists():
@@ -2358,8 +2361,8 @@ async def apply_model_profile(
 @router.get("/api/profile-fields")
 async def get_profile_fields(is_admin: bool = Depends(require_admin)):
     from ..model_profiles import (
-        UNIVERSAL_PROFILE_FIELDS,
         MODEL_SPECIFIC_PROFILE_FIELDS,
+        UNIVERSAL_PROFILE_FIELDS,
     )
 
     return {
@@ -2502,7 +2505,7 @@ async def get_generation_config(
     gen_config_path = model_path / "generation_config.json"
     if gen_config_path.exists():
         try:
-            with open(gen_config_path, "r", encoding="utf-8") as f:
+            with open(gen_config_path, encoding="utf-8") as f:
                 gen_config = json_module.load(f)
 
             # Temperature: if do_sample is false, effective temperature is 0
@@ -2526,7 +2529,7 @@ async def get_generation_config(
     config_path = model_path / "config.json"
     if config_path.exists():
         try:
-            with open(config_path, "r", encoding="utf-8") as f:
+            with open(config_path, encoding="utf-8") as f:
                 model_config = json_module.load(f)
 
             max_pos = (
@@ -2712,6 +2715,7 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
         },
         "scheduler": {
             "max_concurrent_requests": global_settings.scheduler.max_concurrent_requests,
+            "chunked_prefill": global_settings.scheduler.chunked_prefill,
         },
         "cache": {
             "enabled": global_settings.cache.enabled,
@@ -2815,7 +2819,7 @@ async def update_global_settings(
         raise HTTPException(status_code=503, detail="Server not initialized")
 
     # Track which settings were applied at runtime
-    runtime_applied: List[str] = []
+    runtime_applied: list[str] = []
 
     # Apply server settings
     if request.host is not None:
@@ -2943,6 +2947,26 @@ async def update_global_settings(
     if request.max_concurrent_requests is not None:
         global_settings.scheduler.max_concurrent_requests = (
             request.max_concurrent_requests
+        )
+
+    # Apply chunked prefill setting (Live)
+    if request.chunked_prefill is not None:
+        global_settings.scheduler.chunked_prefill = request.chunked_prefill
+        from ..server import _server_state
+
+        pool = _server_state.engine_pool
+        if pool is not None:
+            for mid, entry in pool._entries.items():
+                if entry is None or entry.engine is None:
+                    continue
+                async_core = getattr(entry.engine, "_engine", None)
+                core = getattr(async_core, "engine", None) if async_core is not None else None
+                scheduler = getattr(core, "scheduler", None) if core is not None else None
+                if scheduler is not None and hasattr(scheduler, "config"):
+                    scheduler.config.chunked_prefill = request.chunked_prefill
+        runtime_applied.append("chunked_prefill")
+        logger.info(
+            f"Chunked prefill {'enabled' if request.chunked_prefill else 'disabled'}"
         )
 
     # Apply cache settings
@@ -3248,7 +3272,7 @@ def _tail_file(file_path: Path, num_lines: int) -> tuple[str, int]:
     lines = deque(maxlen=num_lines)
     total_lines = 0
 
-    with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+    with open(file_path, encoding="utf-8", errors="replace") as f:
         for line in f:
             lines.append(line)
             total_lines += 1
@@ -3256,7 +3280,7 @@ def _tail_file(file_path: Path, num_lines: int) -> tuple[str, int]:
     return "".join(lines), total_lines
 
 
-def _get_available_log_files(log_dir: Path) -> List[str]:
+def _get_available_log_files(log_dir: Path) -> list[str]:
     """
     Get list of available log files sorted by modification time.
 
@@ -3283,7 +3307,7 @@ def _get_available_log_files(log_dir: Path) -> List[str]:
 @router.get("/api/logs")
 async def get_logs(
     lines: int = 100,
-    file: Optional[str] = None,
+    file: str | None = None,
     is_admin: bool = Depends(require_admin),
 ):
     """
@@ -3679,8 +3703,6 @@ async def get_server_stats(
     port = global_settings.server.port if global_settings else 8000
     api_key = global_settings.auth.api_key if global_settings else ""
 
-    from ..model_discovery import format_size
-    from ..prefill_progress import get_prefill_tracker
     from ..utils.install import get_cli_prefix
 
     # Build active_models data for the dashboard card.
@@ -4240,7 +4262,7 @@ async def get_recommended_models(
             max_memory_bytes=max_memory, result_limit=50, mlx_only=mlx_only
         )
         return result
-    except asyncio.TimeoutError:
+    except TimeoutError:
         raise HTTPException(
             status_code=504,
             detail="HuggingFace API request timed out. The service may be temporarily unavailable.",
@@ -4271,7 +4293,7 @@ async def search_hf_models(
             mlx_only=mlx_only,
         )
         return result
-    except asyncio.TimeoutError:
+    except TimeoutError:
         raise HTTPException(
             status_code=504,
             detail="HuggingFace API request timed out. The service may be temporarily unavailable.",
@@ -4291,14 +4313,14 @@ async def get_hf_model_info(
             status_code=400, detail="Query parameter 'repo_id' is required"
         )
 
-    from .hf_downloader import HFDownloader
-
     from huggingface_hub.utils import RepositoryNotFoundError
+
+    from .hf_downloader import HFDownloader
 
     try:
         result = await HFDownloader.get_model_info(repo_id=repo_id.strip())
         return result
-    except asyncio.TimeoutError:
+    except TimeoutError:
         raise HTTPException(
             status_code=504,
             detail="HuggingFace API request timed out. The service may be temporarily unavailable.",
@@ -4597,7 +4619,7 @@ async def get_ms_recommended_models(
             max_memory_bytes=max_memory, result_limit=50, mlx_only=mlx_only
         )
         return result
-    except asyncio.TimeoutError:
+    except TimeoutError:
         raise HTTPException(
             status_code=504,
             detail="ModelScope API request timed out. The service may be temporarily unavailable.",
@@ -4628,7 +4650,7 @@ async def search_ms_models(
             mlx_only=mlx_only,
         )
         return result
-    except asyncio.TimeoutError:
+    except TimeoutError:
         raise HTTPException(
             status_code=504,
             detail="ModelScope API request timed out. The service may be temporarily unavailable.",
@@ -4653,7 +4675,7 @@ async def get_ms_model_info(
     try:
         result = await MSDownloader.get_model_info(model_id=model_id.strip())
         return result
-    except asyncio.TimeoutError:
+    except TimeoutError:
         raise HTTPException(
             status_code=504,
             detail="ModelScope API request timed out. The service may be temporarily unavailable.",
@@ -4805,7 +4827,7 @@ async def stream_accuracy_benchmark(
             while True:
                 try:
                     event = await asyncio.wait_for(run.queue.get(), timeout=60.0)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     yield ": keepalive\n\n"
                     continue
 
@@ -4913,7 +4935,7 @@ async def stream_benchmark(
             while True:
                 try:
                     event = await asyncio.wait_for(run.queue.get(), timeout=60.0)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     # Send keepalive
                     yield ": keepalive\n\n"
                     continue
@@ -5019,7 +5041,7 @@ async def get_device_info(
 # Update Check
 # =============================================================================
 
-_update_cache: Optional[Dict[str, Any]] = None
+_update_cache: dict[str, Any] | None = None
 _update_cache_time: float = 0.0
 _UPDATE_CACHE_TTL = 3600  # 1 hour
 

--- a/omlx/admin/templates/dashboard/_settings.html
+++ b/omlx/admin/templates/dashboard/_settings.html
@@ -532,6 +532,20 @@
                                            min="1"
                                            class="w-full sm:w-48 px-3 py-2 text-sm text-right border border-neutral-200 rounded-lg focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
                                 </div>
+                                <!-- Chunked Prefill -->
+                                <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 sm:px-6 py-4">
+                                    <div>
+                                        <label class="text-sm text-neutral-700">{{ t('settings.resource.chunked_prefill') }}</label>
+                                        <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.resource.chunked_prefill_description') }}</p>
+                                    </div>
+                                    <button type="button"
+                                            @click="globalSettings.scheduler.chunked_prefill = !globalSettings.scheduler.chunked_prefill"
+                                            :class="globalSettings.scheduler.chunked_prefill ? 'bg-black' : 'bg-neutral-200'"
+                                            class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
+                                        <span :class="globalSettings.scheduler.chunked_prefill ? 'translate-x-5' : 'translate-x-0'"
+                                              class="block w-5 h-5 bg-white rounded-full shadow-sm transform transition-transform duration-300 absolute top-0.5 left-0.5"></span>
+                                    </button>
+                                </div>
                                 <!-- Idle Timeout -->
                                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 sm:px-6 py-4">
                                     <div>

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -197,6 +197,31 @@ class _PrefillAbortedError(Exception):
         )
 
 
+@dataclass
+class _PrefillState:
+    """Intermediate state for a request undergoing chunked prefill.
+
+    When chunked_prefill=True, a long prefill is spread across multiple
+    step() calls (one prefill_step_size chunk per step). This dataclass
+    holds all the state needed to resume prefill between steps.
+    """
+
+    request: Any
+    cache: list  # Accumulated prompt_cache (mutated in-place by each chunk)
+    tokens_remaining: Any  # mx.array shape (1, N) — tokens not yet prefilled
+    last_token: list  # tokens[-1:] — passed to batch_generator.insert()
+    tokens_processed: int  # Cumulative count for boundary snapshot math
+    base_size: int  # Prefix cache offset at prefill start (for alignment)
+    emitted_boundaries: dict  # {request_id: int} — last emitted boundary count
+    boundary_enabled: bool  # Whether boundary snapshots are active
+    block_size: int  # Copied from config.paged_cache_block_size
+    total_length: int  # len(original tokens) for completeness
+    # Pre-built insert-time params (set by _schedule_waiting before enqueuing)
+    sampler: Any = None
+    sm: Any = None
+    per_row_lps: Any = None
+
+
 # ---------------------------------------------------------------------------
 # Monkey-patch GenerationBatch._step to call grammar accept_token() after
 # sampling.  In the pipelined _step(), logits processors fill the bitmask
@@ -503,6 +528,10 @@ class SchedulerConfig:
     # BatchGenerator settings (passed directly to mlx-lm)
     completion_batch_size: int = 32
     prefill_step_size: int = 2048
+    # When True, long prefills are processed one chunk per step() call,
+    # interleaved with decode steps for already-running requests. This
+    # reduces TTFT for concurrent requests but adds per-step overhead.
+    chunked_prefill: bool = False
 
     # Paged cache settings (internal defaults)
     paged_cache_block_size: int = 256  # Tokens per block
@@ -665,6 +694,10 @@ class Scheduler:
         # Request management - following vLLM's design
         self.waiting: deque[Request] = deque()  # Waiting queue (FCFS)
         self.running: dict[str, Request] = {}  # Running requests by ID
+        # Chunked prefill queue: requests whose prefill spans multiple steps.
+        # Populated when chunked_prefill=True and prompt exceeds prefill_step_size.
+        self.prefilling: deque[Request] = deque()
+        self._prefill_states: dict[str, _PrefillState] = {}
         self.requests: dict[str, Request] = {}  # All requests by ID
         self.finished_req_ids: set[str] = set()  # Recently finished
 
@@ -1823,6 +1856,262 @@ class Scheduler:
             self.model._language_model._rope_deltas = _saved_rope_deltas
 
         return prompt_cache, last_token
+
+    # ------------------------------------------------------------------
+    # Chunked prefill helpers (used when config.chunked_prefill=True)
+    # ------------------------------------------------------------------
+
+    def _begin_prefill(
+        self,
+        request: "Request",
+        tokens: list[int],
+        existing_cache: "list[Any] | None",
+    ) -> _PrefillState:
+        """Initialise a _PrefillState for a non-VLM request.
+
+        Performs all once-per-request setup (cache creation, boundary config,
+        token splitting) without running any model forward passes.
+        """
+        if hasattr(self.model, "clear_vlm_position_state"):
+            self.model.clear_vlm_position_state()
+
+        prompt_cache = existing_cache if existing_cache is not None else make_prompt_cache(self.model)
+
+        block_size = self.config.paged_cache_block_size
+        boundary_enabled = (
+            block_size > 0
+            and self.block_aware_cache is not None
+            and _prompt_cache_needs_snapshots(prompt_cache)
+        )
+        base_size = _cache_base_sizes(prompt_cache) if boundary_enabled else 0
+        if (
+            boundary_enabled
+            and hasattr(request, "cached_tokens")
+            and request.cached_tokens > 0
+            and base_size != request.cached_tokens
+        ):
+            logger.debug(
+                "Cache base_size mismatch: computed %d, expected %d "
+                "(cached_tokens). Using cached_tokens for boundary alignment.",
+                base_size,
+                request.cached_tokens,
+            )
+            base_size = request.cached_tokens
+
+        prefill_tokens = tokens[:-1]
+        last_token = tokens[-1:]
+        input_arr = mx.array(prefill_tokens)[None]  # (1, N-1)
+
+        return _PrefillState(
+            request=request,
+            cache=prompt_cache,
+            tokens_remaining=input_arr,
+            last_token=last_token,
+            tokens_processed=0,
+            base_size=base_size,
+            emitted_boundaries={},
+            boundary_enabled=boundary_enabled,
+            block_size=block_size,
+            total_length=len(tokens),
+        )
+
+    def _step_prefill_chunk(self, state: _PrefillState) -> bool:
+        """Process one prefill chunk from *state*.
+
+        Runs the model on at most prefill_step_size tokens, evals the cache,
+        emits any due boundary snapshot, checks for abort, and clears Metal
+        intermediates.
+
+        Returns:
+            True when all tokens_remaining have been consumed (prefill done).
+
+        Raises:
+            _PrefillAbortedError: If the request is aborted between chunks.
+            RuntimeError: If the hard memory limit is exceeded.
+        """
+        if state.tokens_remaining.shape[1] == 0:
+            return True
+
+        n = min(self.config.prefill_step_size, state.tokens_remaining.shape[1])
+
+        # Clamp to the next block boundary so boundary snapshots fire exactly.
+        if state.boundary_enabled and state.block_size > 0:
+            current_total = state.base_size + state.tokens_processed
+            next_boundary = ((current_total // state.block_size) + 1) * state.block_size
+            delta = (next_boundary - state.base_size) - state.tokens_processed
+            if delta > 0:
+                n = min(n, delta)
+            n = max(1, n)
+
+        chunk = state.tokens_remaining[:, :n]
+        state.tokens_remaining = state.tokens_remaining[:, n:]
+        self.model(chunk, cache=state.cache)
+        mx.eval([c.state for c in state.cache])
+        state.tokens_processed += n
+
+        # Boundary snapshot
+        if state.boundary_enabled:
+            total_tokens = state.base_size + state.tokens_processed
+            rid = state.request.request_id
+            if (
+                total_tokens > 0
+                and total_tokens % state.block_size == 0
+                and state.emitted_boundaries.get(rid, -1) < total_tokens
+            ):
+                self._emit_prefill_boundary_snapshot(state.request, state.cache, total_tokens)
+                state.emitted_boundaries[rid] = total_tokens
+
+        # Hard memory limit
+        if self._memory_hard_limit_bytes > 0:
+            active = mx.get_active_memory()
+            if active > self._memory_hard_limit_bytes:
+                raise RuntimeError(
+                    f"Memory limit exceeded during chunked prefill at "
+                    f"{state.tokens_processed}/{state.total_length - 1} tokens"
+                )
+
+        # Abort check (direct request_id lookup — no temp uid in chunked path)
+        if state.request.request_id in self._pending_abort_ids:
+            raise _PrefillAbortedError([], state.tokens_processed)
+
+        _sync_and_clear_cache()
+        return state.tokens_remaining.shape[1] == 0
+
+    def _emit_final_boundary_if_needed(self, state: _PrefillState) -> None:
+        """Emit a final boundary snapshot if the prefill landed on a boundary."""
+        if not state.boundary_enabled:
+            return
+        total_tokens = state.base_size + state.tokens_processed
+        rid = state.request.request_id
+        if (
+            total_tokens > 0
+            and total_tokens % state.block_size == 0
+            and state.emitted_boundaries.get(rid, -1) < total_tokens
+        ):
+            self._emit_prefill_boundary_snapshot(state.request, state.cache, total_tokens)
+
+    def _insert_prefilled_request(
+        self,
+        request: "Request",
+        state: _PrefillState,
+        scheduled: "list[Request]",
+    ) -> None:
+        """Insert a fully-prefilled request into BatchGenerator.
+
+        Handles the batch_generator.insert() call, uid bookkeeping, and moving
+        the request to self.running. Called from both the inline chunked path
+        (first chunk completed immediately) and _advance_chunked_prefills()
+        (last chunk completed across steps).
+
+        Precondition: state.sampler, state.sm, state.per_row_lps are set.
+        """
+        if request.sampling_params.seed is not None:
+            mx.random.seed(request.sampling_params.seed)
+
+        per_row_lps = state.per_row_lps if state.per_row_lps is not None else []
+        uids = self.batch_generator.insert(
+            [state.last_token],
+            max_tokens=[request.sampling_params.max_tokens],
+            caches=[state.cache] if state.cache else None,
+            samplers=[state.sampler],
+            logits_processors=[per_row_lps],
+            state_machines=[state.sm],
+        )
+
+        if uids:
+            uid = uids[0]
+            self.request_id_to_uid[request.request_id] = uid
+            self.uid_to_request_id[uid] = request.request_id
+            now = time.monotonic()
+            request.batch_uid = uid
+            request.status = RequestStatus.RUNNING
+            request.generation_started_at = now
+            request.last_activity_at = now
+            self.running[request.request_id] = request
+            scheduled.append(request)
+
+            if hasattr(self.model, "register_rope_delta"):
+                self.model.register_rope_delta(uid, request.rope_deltas)
+
+            self.total_prompt_tokens += request.num_prompt_tokens
+            cache_info = (
+                f", {request.cached_tokens} cached" if request.cached_tokens > 0 else ""
+            )
+            logger.debug(
+                "Scheduled chunked-prefill request %s (uid=%d) "
+                "with %d tokens (%d total)%s",
+                request.request_id, uid,
+                len(state.last_token), request.num_prompt_tokens, cache_info,
+            )
+
+    def _advance_chunked_prefills(self, scheduled: "list[Request]") -> None:
+        """Process one prefill chunk per in-flight chunked-prefill request.
+
+        Called at the start of each step() before _schedule_waiting(). Each
+        call advances every request in self.prefilling by one prefill_step_size
+        chunk. When a request's prefill completes it is inserted into
+        BatchGenerator and moved to self.running.
+
+        Args:
+            scheduled: The step's running list of newly-scheduled requests;
+                completed chunked-prefill requests are appended here.
+        """
+        if not self.prefilling:
+            return
+
+        still_prefilling: deque[Request] = deque()
+
+        for request in self.prefilling:
+            rid = request.request_id
+            state = self._prefill_states.get(rid)
+
+            # State missing means the request was aborted and cleaned up by
+            # _do_abort_request() between steps — just skip it.
+            if state is None:
+                continue
+
+            try:
+                done = self._step_prefill_chunk(state)
+            except _PrefillAbortedError:
+                # Request aborted mid-chunk. Discard state; the abort will
+                # be fully processed by _process_pending_aborts() next step.
+                self._prefill_states.pop(rid, None)
+                continue
+            except RuntimeError as e:
+                logger.error("Chunked prefill failed for %s: %s", rid, e)
+                self._prefill_states.pop(rid, None)
+                # Remove from requests so the engine can report an error.
+                self.requests.pop(rid, None)
+                continue
+
+            if not done:
+                still_prefilling.append(request)
+                continue
+
+            # Prefill complete — emit final boundary snapshot and insert.
+            self._prefill_states.pop(rid, None)
+            self._emit_final_boundary_if_needed(state)
+            _sync_and_clear_cache()
+
+            # Ensure a BatchGenerator exists (may not if all requests were
+            # previously in chunked prefill with no running decode).
+            self._ensure_batch_generator(request.sampling_params)
+            if self.batch_generator is None:
+                # Unlikely, but if BG creation fails put request back.
+                logger.error(
+                    "BatchGenerator unavailable at chunked-prefill completion "
+                    "for %s; requeueing.", rid
+                )
+                still_prefilling.append(request)
+                self._prefill_states[rid] = state
+                continue
+
+            # Clean up the prefill-progress tracker entry.
+            get_prefill_tracker().remove(rid)
+
+            self._insert_prefilled_request(request, state, scheduled)
+
+        self.prefilling = still_prefilling
 
     def _build_state_machine(self, request: "Request") -> SequenceStateMachine:
         """Build a SequenceStateMachine for per-request stop tokens.
@@ -3682,6 +3971,13 @@ class Scheduler:
             except ValueError:
                 pass
 
+        # Remove from chunked-prefill queue (if mid-prefill)
+        if request_id in self._prefill_states:
+            self._prefill_states.pop(request_id, None)
+            self.prefilling = deque(
+                r for r in self.prefilling if r.request_id != request_id
+            )
+
         # Remove from running (BatchGenerator)
         if request.request_id in self.request_id_to_uid:
             uid = self.request_id_to_uid[request.request_id]
@@ -3763,7 +4059,7 @@ class Scheduler:
         Without this, an idle server would never reach the target step and
         stale buffers would accumulate indefinitely.
         """
-        return bool(self.waiting or self.running or self._deferred_clear_at is not None)
+        return bool(self.waiting or self.prefilling or self.running or self._deferred_clear_at is not None)
 
     def fail_all_requests(self) -> list[str]:
         """Remove all running and waiting requests after unrecoverable error.
@@ -3786,6 +4082,14 @@ class Scheduler:
                 req._extracted_cache = None
                 req.prompt_cache = None
         self.running.clear()
+        for request in list(self.prefilling):
+            failed_ids.append(request.request_id)
+            req = self.requests.pop(request.request_id, None)
+            if req is not None:
+                req._extracted_cache = None
+                req.prompt_cache = None
+        self.prefilling.clear()
+        self._prefill_states.clear()
         for request in list(self.waiting):
             failed_ids.append(request.request_id)
             req = self.requests.pop(request.request_id, None)
@@ -4256,13 +4560,6 @@ class Scheduler:
             # Only the last token goes to insert() for the first decode step.
             # SpecPrefill already handled its own prefill above, so skip for those.
             if request.specprefill_indices is None and len(tokens_to_process) > 1:
-                # Assign UID early so progress callbacks can map uid->request_id
-                # during external prefill. Use a temporary UID that will be replaced
-                # by the real one from insert().
-                temp_uid = id(request)  # unique, won't collide with BatchGenerator UIDs
-                self.request_id_to_uid[request.request_id] = temp_uid
-                self.uid_to_request_id[temp_uid] = request.request_id
-
                 vlm_embeds = None
                 if request.vlm_inputs_embeds is not None:
                     vlm_embeds = (
@@ -4270,6 +4567,44 @@ class Scheduler:
                         request.vlm_extra_kwargs or {},
                         request.cached_tokens,
                     )
+
+                # Chunked prefill: non-VLM prompts longer than one step are
+                # spread across multiple step() calls. The first chunk is run
+                # here; subsequent chunks run in _advance_chunked_prefills().
+                if (
+                    self.config.chunked_prefill
+                    and vlm_embeds is None
+                    and len(tokens_to_process) > self.config.prefill_step_size + 1
+                ):
+                    sm = self._build_state_machine(request)
+                    per_row_lps = list(logits_processors) if logits_processors else []
+                    state = self._begin_prefill(request, tokens_to_process, cache_to_use)
+                    state.sampler = sampler
+                    state.sm = sm
+                    state.per_row_lps = per_row_lps
+
+                    try:
+                        done = self._step_prefill_chunk(state)
+                    except _PrefillAbortedError:
+                        raise
+
+                    if done:
+                        self._emit_final_boundary_if_needed(state)
+                        _sync_and_clear_cache()
+                        get_prefill_tracker().remove(request.request_id)
+                        self._insert_prefilled_request(request, state, scheduled)
+                    else:
+                        self.prefilling.append(request)
+                        self._prefill_states[request.request_id] = state
+                    continue  # Skip normal prefill + insert path
+
+                # Normal (non-chunked) full prefill path.
+                # Assign a temporary UID so progress callbacks can map
+                # uid→request_id during external prefill. Replaced by the
+                # real UID returned from insert().
+                temp_uid = id(request)  # unique, won't collide with BatchGenerator UIDs
+                self.request_id_to_uid[request.request_id] = temp_uid
+                self.uid_to_request_id[temp_uid] = request.request_id
 
                 prefilled_cache, last_token = self._do_external_prefill(
                     request,
@@ -5014,8 +5349,18 @@ class Scheduler:
             self._check_memory_pressure()
 
         try:
+            # Advance in-flight chunked prefills (one chunk per request).
+            # Must run before _schedule_waiting() so that completing prefills
+            # are inserted into BatchGenerator before the decode step.
+            chunked_scheduled: list[Request] = []
+            if self.prefilling:
+                self._advance_chunked_prefills(chunked_scheduled)
+
             # Schedule waiting requests
             scheduled, rejected = self._schedule_waiting()
+            # Merge chunked-prefill completions into the scheduled list.
+            if chunked_scheduled:
+                scheduled = chunked_scheduled + scheduled
             output.scheduled_request_ids = [r.request_id for r in scheduled]
             output.num_scheduled_tokens = sum(r.num_prompt_tokens for r in scheduled)
             if rejected:
@@ -5180,6 +5525,7 @@ class Scheduler:
         """Get scheduler statistics."""
         stats = {
             "num_waiting": len(self.waiting),
+            "num_prefilling": len(self.prefilling),
             "num_running": len(self.running),
             "num_requests_processed": self.num_requests_processed,
             "total_prompt_tokens": self.total_prompt_tokens,
@@ -5206,6 +5552,8 @@ class Scheduler:
             self._do_abort_request(request_id)
 
         self.waiting.clear()
+        self.prefilling.clear()
+        self._prefill_states.clear()
         self.running.clear()
         self.requests.clear()
         self.finished_req_ids.clear()

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -217,6 +217,9 @@ class SchedulerSettings:
     """Scheduler configuration settings."""
 
     max_concurrent_requests: int = 8
+    # When True, long prefills are interleaved with decode steps.
+    # Reduces TTFT for concurrent requests at the cost of per-step overhead.
+    chunked_prefill: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
@@ -233,7 +236,10 @@ class SchedulerSettings:
             value = data.get("completion_batch_size")
         if value is None:
             value = 8
-        return cls(max_concurrent_requests=value)
+        return cls(
+            max_concurrent_requests=value,
+            chunked_prefill=bool(data.get("chunked_prefill", False)),
+        )
 
 
 @dataclass
@@ -369,7 +375,7 @@ class ModelIdleTimeoutSettings:
         return {"idle_timeout_seconds": self.idle_timeout_seconds}
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "ModelIdleTimeoutSettings":
+    def from_dict(cls, data: dict[str, Any]) -> ModelIdleTimeoutSettings:
         """Create from dictionary."""
         return cls(
             idle_timeout_seconds=data.get("idle_timeout_seconds"),
@@ -460,7 +466,7 @@ class HuggingFaceSettings:
         return {"endpoint": self.endpoint}
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "HuggingFaceSettings":
+    def from_dict(cls, data: dict[str, Any]) -> HuggingFaceSettings:
         """Create from dictionary."""
         return cls(endpoint=data.get("endpoint", ""))
 
@@ -476,7 +482,7 @@ class ModelScopeSettings:
         return {"endpoint": self.endpoint}
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "ModelScopeSettings":
+    def from_dict(cls, data: dict[str, Any]) -> ModelScopeSettings:
         """Create from dictionary."""
         return cls(endpoint=data.get("endpoint", ""))
 
@@ -500,7 +506,7 @@ class NetworkSettings:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "NetworkSettings":
+    def from_dict(cls, data: dict[str, Any]) -> NetworkSettings:
         """Create from dictionary."""
         return cls(
             http_proxy=data.get("http_proxy", ""),
@@ -593,7 +599,7 @@ class UISettings:
         return {"language": self.language}
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "UISettings":
+    def from_dict(cls, data: dict[str, Any]) -> UISettings:
         """Create from dictionary."""
         return cls(language=data.get("language", "en"))
 
@@ -629,9 +635,9 @@ class ClaudeCodeSettings:
             context_scaling_enabled=data.get("context_scaling_enabled", False),
             target_context_size=data.get("target_context_size", 200000),
             mode=data.get("mode", "cloud"),
-            opus_model=data.get("opus_model", None),
-            sonnet_model=data.get("sonnet_model", None),
-            haiku_model=data.get("haiku_model", None),
+            opus_model=data.get("opus_model"),
+            sonnet_model=data.get("sonnet_model"),
+            haiku_model=data.get("haiku_model"),
         )
 
 
@@ -661,11 +667,11 @@ class IntegrationSettings:
     def from_dict(cls, data: dict[str, Any]) -> IntegrationSettings:
         """Create from dictionary."""
         return cls(
-            codex_model=data.get("codex_model", None),
-            opencode_model=data.get("opencode_model", None),
-            openclaw_model=data.get("openclaw_model", None),
-            pi_model=data.get("pi_model", None),
-            copilot_model=data.get("copilot_model", None),
+            codex_model=data.get("codex_model"),
+            opencode_model=data.get("opencode_model"),
+            openclaw_model=data.get("openclaw_model"),
+            pi_model=data.get("pi_model"),
+            copilot_model=data.get("copilot_model"),
             openclaw_tools_profile=data.get("openclaw_tools_profile", "coding"),
         )
 
@@ -1201,6 +1207,7 @@ class GlobalSettings:
         return SchedulerConfig(
             max_num_seqs=self.scheduler.max_concurrent_requests,
             completion_batch_size=self.scheduler.max_concurrent_requests,
+            chunked_prefill=self.scheduler.chunked_prefill,
             initial_cache_blocks=self.cache.initial_cache_blocks,
             paged_ssd_cache_dir=str(ssd_dir) if ssd_dir else None,
             hot_cache_only=self.cache.hot_cache_only,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "LLM inference server, optimized for your Mac"
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [
     {name = "omlx contributors"}
 ]

--- a/tests/test_scheduler_chunked_prefill.py
+++ b/tests/test_scheduler_chunked_prefill.py
@@ -1,0 +1,436 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tests for interleaved chunked prefill + decode (SchedulerConfig.chunked_prefill).
+
+Strategy: keep tests fast by mocking MLX model calls and cache operations.
+_begin_prefill() and _step_prefill_chunk() are tested by patching
+make_prompt_cache and mx.eval; the scheduler-level flow is tested by
+patching _step_prefill_chunk directly.
+"""
+
+from collections import deque
+from unittest.mock import MagicMock, patch
+
+from omlx.request import Request, RequestStatus, SamplingParams
+from omlx.scheduler import (
+    Scheduler,
+    SchedulerConfig,
+    _PrefillState,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_scheduler(chunked_prefill: bool = True, step_size: int = 4) -> Scheduler:
+    """Return a Scheduler with a mock model/tokenizer and chunked_prefill config."""
+    model = MagicMock()
+    model.layers = []  # No attention layers — keeps _build_state_machine simple
+
+    tokenizer = MagicMock()
+    tokenizer.eos_token_id = 2
+
+    config = SchedulerConfig(
+        max_num_seqs=8,
+        prefill_step_size=step_size,
+        chunked_prefill=chunked_prefill,
+        paged_cache_block_size=0,  # Disable boundary snapshots
+    )
+
+    scheduler = Scheduler(model=model, tokenizer=tokenizer, config=config)
+
+    # Replace the real batch_generator factory so insert() returns a uid.
+    mock_bg = MagicMock()
+    mock_bg.insert.return_value = [42]
+    mock_bg.next_generated.return_value = iter([])
+    scheduler.batch_generator = mock_bg
+    scheduler._current_sampler_params = ()
+
+    return scheduler
+
+
+def _make_request(request_id: str = "req-1", n_tokens: int = 10) -> Request:
+    """Return a pre-tokenized request with *n_tokens* prompt tokens."""
+    req = Request(
+        request_id=request_id,
+        prompt=list(range(n_tokens)),
+        sampling_params=SamplingParams(max_tokens=32),
+    )
+    req.prompt_token_ids = list(range(n_tokens))
+    req.num_prompt_tokens = n_tokens
+    req.remaining_tokens = list(range(n_tokens))
+    return req
+
+
+def _make_prefill_state(scheduler: Scheduler, request: Request, n_remaining: int = 20) -> _PrefillState:
+    """Build a minimal _PrefillState for direct testing."""
+    import mlx.core as mx
+
+    tokens_remaining = mx.zeros((1, n_remaining), dtype=mx.int32)
+    state = _PrefillState(
+        request=request,
+        cache=[],
+        tokens_remaining=tokens_remaining,
+        last_token=[99],
+        tokens_processed=0,
+        base_size=0,
+        emitted_boundaries={},
+        boundary_enabled=False,
+        block_size=0,
+        total_length=n_remaining + 1,
+        sampler=MagicMock(),
+        sm=MagicMock(),
+        per_row_lps=[],
+    )
+    return state
+
+
+# ---------------------------------------------------------------------------
+# SchedulerConfig
+# ---------------------------------------------------------------------------
+
+class TestSchedulerConfigChunkedPrefill:
+    def test_default_is_false(self):
+        config = SchedulerConfig()
+        assert config.chunked_prefill is False
+
+    def test_can_be_enabled(self):
+        config = SchedulerConfig(chunked_prefill=True)
+        assert config.chunked_prefill is True
+
+
+# ---------------------------------------------------------------------------
+# _PrefillState
+# ---------------------------------------------------------------------------
+
+class TestPrefillState:
+    def test_fields_accessible(self):
+        import mlx.core as mx
+
+        state = _PrefillState(
+            request=MagicMock(),
+            cache=[],
+            tokens_remaining=mx.zeros((1, 5), dtype=mx.int32),
+            last_token=[7],
+            tokens_processed=0,
+            base_size=0,
+            emitted_boundaries={},
+            boundary_enabled=False,
+            block_size=256,
+            total_length=6,
+        )
+        assert state.tokens_processed == 0
+        assert state.sampler is None
+        assert state.per_row_lps is None
+
+    def test_insert_params_settable(self):
+        import mlx.core as mx
+
+        state = _PrefillState(
+            request=MagicMock(),
+            cache=[],
+            tokens_remaining=mx.zeros((1, 3), dtype=mx.int32),
+            last_token=[1],
+            tokens_processed=0,
+            base_size=0,
+            emitted_boundaries={},
+            boundary_enabled=False,
+            block_size=256,
+            total_length=4,
+        )
+        state.sampler = "s"
+        state.sm = "sm"
+        state.per_row_lps = []
+        assert state.sampler == "s"
+
+
+# ---------------------------------------------------------------------------
+# Scheduler queues initialised
+# ---------------------------------------------------------------------------
+
+class TestSchedulerQueues:
+    def test_prefilling_queue_exists(self):
+        sched = _make_scheduler()
+        assert hasattr(sched, "prefilling")
+        assert isinstance(sched.prefilling, deque)
+        assert len(sched.prefilling) == 0
+
+    def test_prefill_states_dict_exists(self):
+        sched = _make_scheduler()
+        assert hasattr(sched, "_prefill_states")
+        assert isinstance(sched._prefill_states, dict)
+
+
+# ---------------------------------------------------------------------------
+# has_requests includes prefilling
+# ---------------------------------------------------------------------------
+
+class TestHasRequests:
+    def test_false_when_all_empty(self):
+        sched = _make_scheduler()
+        assert not sched.has_requests()
+
+    def test_true_when_prefilling(self):
+        sched = _make_scheduler()
+        req = _make_request()
+        sched.prefilling.append(req)
+        assert sched.has_requests()
+
+    def test_still_true_with_waiting_only(self):
+        sched = _make_scheduler()
+        req = _make_request()
+        sched.waiting.append(req)
+        assert sched.has_requests()
+
+
+# ---------------------------------------------------------------------------
+# get_stats includes num_prefilling
+# ---------------------------------------------------------------------------
+
+class TestGetStats:
+    def test_num_prefilling_in_stats(self):
+        sched = _make_scheduler()
+        stats = sched.get_stats()
+        assert "num_prefilling" in stats
+        assert stats["num_prefilling"] == 0
+
+    def test_num_prefilling_counts_correctly(self):
+        sched = _make_scheduler()
+        sched.prefilling.append(_make_request("r1"))
+        sched.prefilling.append(_make_request("r2"))
+        assert sched.get_stats()["num_prefilling"] == 2
+
+
+# ---------------------------------------------------------------------------
+# reset() clears prefilling
+# ---------------------------------------------------------------------------
+
+class TestReset:
+    def test_reset_clears_prefilling(self):
+        sched = _make_scheduler()
+        req = _make_request()
+        sched.prefilling.append(req)
+        sched._prefill_states[req.request_id] = MagicMock()
+        sched.requests[req.request_id] = req
+
+        sched.reset()
+
+        assert len(sched.prefilling) == 0
+        assert len(sched._prefill_states) == 0
+
+
+# ---------------------------------------------------------------------------
+# fail_all_requests() includes prefilling
+# ---------------------------------------------------------------------------
+
+class TestFailAllRequests:
+    def test_fail_all_includes_prefilling(self):
+        sched = _make_scheduler()
+        req = _make_request("pf-req")
+        sched.prefilling.append(req)
+        sched._prefill_states[req.request_id] = MagicMock()
+        sched.requests[req.request_id] = req
+
+        failed = sched.fail_all_requests()
+
+        assert "pf-req" in failed
+        assert len(sched.prefilling) == 0
+        assert len(sched._prefill_states) == 0
+
+
+# ---------------------------------------------------------------------------
+# _do_abort_request() cleans up prefilling
+# ---------------------------------------------------------------------------
+
+class TestAbortPrefilling:
+    def test_abort_removes_from_prefilling(self):
+        sched = _make_scheduler()
+        req = _make_request("abort-me")
+        req.status = RequestStatus.WAITING
+        sched.prefilling.append(req)
+        sched._prefill_states[req.request_id] = MagicMock()
+        sched.requests[req.request_id] = req
+
+        sched._do_abort_request(req.request_id)
+
+        assert req.request_id not in sched._prefill_states
+        assert all(r.request_id != req.request_id for r in sched.prefilling)
+
+
+# ---------------------------------------------------------------------------
+# _advance_chunked_prefills(): core logic
+# ---------------------------------------------------------------------------
+
+class TestAdvanceChunkedPrefills:
+    def test_no_op_when_queue_empty(self):
+        sched = _make_scheduler()
+        scheduled = []
+        # Should not raise
+        sched._advance_chunked_prefills(scheduled)
+        assert scheduled == []
+
+    def test_advances_chunk_when_not_done(self):
+        """Requests that still have tokens stay in prefilling queue."""
+        sched = _make_scheduler()
+        req = _make_request("r1")
+        sched.requests[req.request_id] = req
+        state = _make_prefill_state(sched, req, n_remaining=20)
+        sched.prefilling.append(req)
+        sched._prefill_states[req.request_id] = state
+
+        with patch.object(sched, "_step_prefill_chunk", return_value=False) as mock_step:
+            scheduled = []
+            sched._advance_chunked_prefills(scheduled)
+
+        mock_step.assert_called_once_with(state)
+        # Not done → stays in prefilling, not moved to running
+        assert req in sched.prefilling
+        assert scheduled == []
+        assert req.request_id not in sched.running
+
+    def test_inserts_when_done(self):
+        """Completed prefill is inserted into BatchGenerator and moved to running."""
+        sched = _make_scheduler()
+        req = _make_request("r1")
+        sched.requests[req.request_id] = req
+        state = _make_prefill_state(sched, req, n_remaining=1)
+        state.sampler = MagicMock()
+        state.sm = MagicMock()
+        state.per_row_lps = []
+        sched.prefilling.append(req)
+        sched._prefill_states[req.request_id] = state
+
+        with patch.object(sched, "_step_prefill_chunk", return_value=True):
+            with patch.object(sched, "_emit_final_boundary_if_needed"):
+                scheduled = []
+                sched._advance_chunked_prefills(scheduled)
+
+        # Moved to running, removed from prefilling
+        assert req not in sched.prefilling
+        assert req.request_id not in sched._prefill_states
+        assert req.request_id in sched.running
+        assert req in scheduled
+        assert req.status == RequestStatus.RUNNING
+
+    def test_skips_aborted_request(self):
+        """Request whose state was cleared by abort is silently skipped."""
+        sched = _make_scheduler()
+        req = _make_request("gone")
+        # State NOT added to _prefill_states (simulates post-abort cleanup)
+        sched.prefilling.append(req)
+
+        scheduled = []
+        sched._advance_chunked_prefills(scheduled)  # Must not raise
+
+        assert scheduled == []
+        assert len(sched.prefilling) == 0
+
+    def test_abort_during_chunk_discards_state(self):
+        """_PrefillAbortedError from _step_prefill_chunk is swallowed cleanly."""
+        from omlx.scheduler import _PrefillAbortedError
+
+        sched = _make_scheduler()
+        req = _make_request("r1")
+        sched.requests[req.request_id] = req
+        state = _make_prefill_state(sched, req)
+        sched.prefilling.append(req)
+        sched._prefill_states[req.request_id] = state
+
+        with patch.object(
+            sched, "_step_prefill_chunk",
+            side_effect=_PrefillAbortedError([], 4)
+        ):
+            scheduled = []
+            sched._advance_chunked_prefills(scheduled)  # Must not raise
+
+        assert req.request_id not in sched._prefill_states
+        assert req not in sched.prefilling
+        assert scheduled == []
+
+    def test_multiple_requests_all_advanced(self):
+        """All requests in prefilling get one chunk advanced per call."""
+        sched = _make_scheduler()
+        reqs = [_make_request(f"r{i}") for i in range(3)]
+        for req in reqs:
+            sched.requests[req.request_id] = req
+            state = _make_prefill_state(sched, req, n_remaining=20)
+            state.sampler = MagicMock()
+            state.sm = MagicMock()
+            state.per_row_lps = []
+            sched.prefilling.append(req)
+            sched._prefill_states[req.request_id] = state
+
+        call_count = 0
+        def fake_step(state):
+            nonlocal call_count
+            call_count += 1
+            return False  # All still in-progress
+
+        with patch.object(sched, "_step_prefill_chunk", side_effect=fake_step):
+            sched._advance_chunked_prefills([])
+
+        assert call_count == 3  # One chunk per request
+
+
+# ---------------------------------------------------------------------------
+# _schedule_waiting(): chunked fork is taken for long prompts
+# ---------------------------------------------------------------------------
+
+class TestScheduleWaitingChunkedFork:
+    def _setup(self, n_tokens: int, chunked: bool = True, step_size: int = 4):
+        sched = _make_scheduler(chunked_prefill=chunked, step_size=step_size)
+        req = _make_request("r1", n_tokens=n_tokens)
+        sched.add_request(req)
+        return sched, req
+
+    def test_short_prompt_stays_on_normal_path(self):
+        """Prompts that fit in one chunk use the normal prefill path."""
+        # step_size=4, prompt=3 tokens → not long enough to trigger chunked fork
+        sched, req = self._setup(n_tokens=3, step_size=4)
+
+        with patch.object(sched, "_do_external_prefill", return_value=([], [0])) as mock_ep:
+            with patch.object(sched, "_begin_prefill") as mock_bp:
+                sched._schedule_waiting()
+
+        mock_ep.assert_called_once()
+        mock_bp.assert_not_called()
+
+    def test_long_prompt_enters_prefilling_queue(self):
+        """Prompts longer than step_size+1 enter the chunked prefill queue."""
+        # step_size=4, 10 tokens → triggers chunked path
+        sched, req = self._setup(n_tokens=10, step_size=4)
+
+        with patch.object(sched, "_begin_prefill", return_value=_make_prefill_state(sched, req)) as mock_bp:
+            with patch.object(sched, "_step_prefill_chunk", return_value=False):
+                sched._schedule_waiting()
+
+        mock_bp.assert_called_once()
+        assert req.request_id in sched._prefill_states
+        assert req in sched.prefilling
+        assert req.request_id not in sched.running
+
+    def test_long_prompt_completes_in_first_chunk_goes_to_running(self):
+        """If the first chunk happens to finish the prefill, request goes to running."""
+        sched, req = self._setup(n_tokens=10, step_size=4)
+        fake_state = _make_prefill_state(sched, req, n_remaining=1)
+
+        with patch.object(sched, "_begin_prefill", return_value=fake_state):
+            with patch.object(sched, "_step_prefill_chunk", return_value=True):
+                with patch.object(sched, "_emit_final_boundary_if_needed"):
+                    with patch("omlx.scheduler._sync_and_clear_cache"):
+                        sched._schedule_waiting()
+
+        assert req.request_id not in sched._prefill_states
+        assert req not in sched.prefilling
+        assert req.request_id in sched.running
+
+    def test_chunked_disabled_uses_normal_path(self):
+        """chunked_prefill=False always uses the full-prefill path."""
+        sched, req = self._setup(n_tokens=100, chunked=False, step_size=4)
+
+        with patch.object(sched, "_do_external_prefill", return_value=([], [0])) as mock_ep:
+            with patch.object(sched, "_begin_prefill") as mock_bp:
+                sched._schedule_waiting()
+
+        mock_ep.assert_called_once()
+        mock_bp.assert_not_called()


### PR DESCRIPTION
## Problem

On oMLX, a long-context request blocks decode for all concurrent requests until its entire prefill completes. For a 100K-token prompt at `prefill_step_size=2048`, that's ~50 sequential model calls with no decode output in between — causing TTFT spikes and throughput loss for concurrent users. The gap was already acknowledged in a comment at `scheduler.py`.

## Solution

Process **one prefill chunk per `step()`** for in-progress requests, then run the normal decode step. Already-running requests keep streaming tokens; new long requests see their first token sooner on average.

The feature is opt-in (`chunked_prefill: false` by default) and can be toggled live from the admin UI without restarting.

## Implementation

**Scheduler (`omlx/scheduler.py`)**
- `_PrefillState` dataclass — carries mid-prefill state (cache, remaining tokens, boundary tracking, sampler params) across step boundaries
- `self.prefilling` / `self._prefill_states` — new queue + state dict for in-flight chunked prefills
- `_begin_prefill()` — initialises `_PrefillState` from a request; no model calls
- `_step_prefill_chunk()` — processes one `prefill_step_size` chunk: model forward pass, boundary snapshot check, abort check, cache clear
- `_advance_chunked_prefills()` — called at the top of `step()`; advances each in-flight prefill by one chunk, inserts completed requests into `BatchGenerator`
- `_schedule_waiting()` — forks to chunked path when `chunked_prefill=True`, prompt exceeds `prefill_step_size + 1` tokens, and request is not a VLM (VLM deferred to follow-up)
- Lifecycle methods updated: `has_requests()`, `fail_all_requests()`, `reset()`, `get_stats()`, `_do_abort_request()`

**Settings**
- `SchedulerConfig.chunked_prefill: bool = False`
- `SchedulerSettings.chunked_prefill: bool = False` with `from_dict` / `to_scheduler_config` wiring
- Admin API: `GET /settings` returns `scheduler.chunked_prefill`; `POST /settings` applies it live to all loaded schedulers
- Admin UI: toggle switch added to the Resources section

**Tests (`tests/test_scheduler_chunked_prefill.py`)**

24 unit tests covering: config defaults, `_PrefillState` fields, queue initialisation, `has_requests`, `get_stats`, `reset`, `fail_all_requests`, abort cleanup, `_advance_chunked_prefills` (no-op, in-progress, completion, skip-aborted, `_PrefillAbortedError`, multi-request), and the `_schedule_waiting` fork (short/long prompt, first-chunk completion, disabled mode).

## Scope exclusions (deferred)

- **VLM requests**: embedding slices need per-chunk offset tracking into `embeds_array` — fall back to full prefill via `vlm_embeds is None` guard
- **SpecPrefill requests**: already bypass `_do_external_prefill` entirely; no changes needed

## Test plan

- [x] `uv run pytest tests/test_scheduler.py tests/test_scheduler_chunked_prefill.py` — 115 tests, all passing
- [x] Enable `chunked_prefill: true` in settings, send a 50K-token prompt alongside a short concurrent request — short request should start generating before the long prefill finishes
- [x] Verify `GET /v1/admin/settings` returns `scheduler.chunked_prefill`
- [x] Toggle in admin UI saves and reflects immediately without restart
