### PR TITLE
feat(specprefill): draft-model-free self-scoring for single-request TTFT

### DIFF
--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -289,6 +289,7 @@ class EngineCore:
         specprefill_keep_pct: Optional[float] = None,
         specprefill_threshold: Optional[int] = None,
         specprefill_system_end: Optional[int] = None,
+        specprefill_self_score: Optional[bool] = None,
     ) -> str:
         """
         Add a request for processing.
@@ -305,6 +306,8 @@ class EngineCore:
             specprefill: Per-request SpecPrefill override (True/False/None)
             specprefill_keep_pct: Per-request keep rate override
             specprefill_threshold: Per-request threshold override (min tokens)
+            specprefill_self_score: Use target model self-scoring (no draft model
+                required).  Auto-enables SpecPrefill for this request.
 
         Returns:
             The request ID
@@ -341,6 +344,9 @@ class EngineCore:
             request._specprefill_threshold = specprefill_threshold
         if specprefill_system_end is not None and specprefill_system_end > 0:
             request.specprefill_system_end = specprefill_system_end
+        if specprefill_self_score:
+            request._specprefill_self_score = True
+            request._specprefill_enabled = True  # no draft model needed
 
         # Setup output collector with stream_interval from config
         self._output_collectors[request_id] = RequestOutputCollector(aggregate=True)

--- a/omlx/patches/specprefill.py
+++ b/omlx/patches/specprefill.py
@@ -319,14 +319,23 @@ def _detect_query_extractor(attn_obj) -> Callable:
 # ---------------------------------------------------------------------------
 
 
-def _patch_attention_for_capture(model, query_buffer, query_extractor):
+def _patch_attention_for_capture(model, query_buffer, query_extractor,
+                                  layers_to_patch=None):
     """Replace attention modules with capture wrappers.
+
+    Args:
+        layers_to_patch: optional set of layer indices to patch.  When
+            provided, only those layers receive capture wrappers; all others
+            are left untouched.  Callers that omit this argument get the
+            original behaviour (all attention layers are patched).
 
     Returns (originals, attn_layer_indices) for cleanup.
     """
     originals = []
     attn_indices = []
     for layer_idx, layer in _find_attention_layers(model):
+        if layers_to_patch is not None and layer_idx not in layers_to_patch:
+            continue
         buf_idx = len(attn_indices)
         attn_indices.append(layer_idx)
         orig = _get_attn_module(layer)
@@ -737,6 +746,31 @@ class _OffsetAdjustedRoPE:
         return self._original(x, offset=offset + self._adjustment)
 
 
+class _ScoringComplete(BaseException):
+    """Sentinel: raised to abort a forward pass after the last scored layer.
+
+    Inherits BaseException (not Exception) so bare ``except Exception`` handlers
+    inside model code do not accidentally swallow it.  Caught only by
+    ``score_tokens_self()``.
+    """
+
+
+class _EarlyExitAttn:
+    """Replaces an attention module to abort the forward pass immediately.
+
+    Install on the first attention layer that should NOT be scored.
+    When called it raises ``_ScoringComplete`` before any Q/K/V work is done,
+    which stops Python graph construction for all subsequent layers.
+    MLX will only execute Metal ops for the layers that ran before this stub.
+    """
+
+    def __call__(self, x, mask=None, cache=None, **kwargs):
+        raise _ScoringComplete()
+
+    def __getattr__(self, name: str):
+        raise AttributeError(name)
+
+
 def _get_dims(rope_module):
     """Extract rotary dimensions from any RoPE variant."""
     for attr in ("_dims", "dim", "dims"):
@@ -752,6 +786,153 @@ def _get_pre_scale(rope_module):
     if hasattr(rope_module, "_scale") and hasattr(rope_module, "dim"):
         return rope_module._scale
     return 1.0
+
+
+def score_tokens_self(
+    model,
+    tokens,
+    n_score_layers: int = 4,
+    n_tail_queries: int = 8,
+    pool_kernel: int = 13,
+    prefill_step_size: int = 2048,
+    progress_callback: Optional[Callable[[int, int, str], None]] = None,
+) -> mx.array:
+    """Score token importance using the first n_score_layers of the target model.
+
+    No draft model required.  Runs a partial forward pass (first
+    ``n_score_layers`` attention layers) using an early-exit exception to
+    stop Python graph construction before the remaining layers are built.
+    MLX therefore executes Metal ops only for those first N layers.
+
+    Q vectors from the last ``n_tail_queries`` prompt positions are used as a
+    proxy for future-generation queries (analogous to the lookahead-decode
+    queries in ``score_tokens``), scoring which earlier tokens each of those
+    final positions attends to.
+
+    Args:
+        model: Target language model (the same model that will be passed to
+            ``sparse_prefill`` afterwards).
+        tokens: list or mx.array of token IDs for the prompt to score.
+        n_score_layers: number of attention layers to run (default 4).
+        n_tail_queries: Q vectors from the last N prompt positions used for
+            scoring (default 8).
+        pool_kernel: smoothing kernel size for importance (default 13, 0=off).
+        prefill_step_size: chunk size for the scoring pass (default 2048).
+        progress_callback: optional callable(processed, total, phase).
+
+    Returns:
+        importance (M,) array — same format as ``score_tokens()``; no cache
+        is returned because the truncated-pass cache is not worth persisting.
+    """
+    from mlx_lm.models.cache import make_prompt_cache
+
+    if isinstance(tokens, mx.array):
+        tokens = tokens.tolist()
+    n_prompt = len(tokens)
+    n_tail_queries = min(n_tail_queries, max(1, n_prompt - 1))
+
+    # Full-size cache — no layer truncation; _build_layer_to_cache_map and
+    # make_prompt_cache use the real model structure (safe for Gemma4, etc.)
+    cache = make_prompt_cache(model)
+
+    attn_layers = _find_attention_layers(model)
+    n_all_attn = len(attn_layers)
+    n_score = min(n_score_layers, n_all_attn)
+
+    attn_obj = _get_attn_module(attn_layers[0][1])
+    n_attn_heads = getattr(
+        attn_obj,
+        "num_attention_heads",
+        getattr(attn_obj, "n_heads", getattr(attn_obj, "num_heads", None)),
+    )
+    n_kv_heads = getattr(
+        attn_obj, "num_key_value_heads", getattr(attn_obj, "n_kv_heads", None)
+    )
+    query_extractor = _detect_query_extractor(attn_obj)
+
+    layer_to_cache = _build_layer_to_cache_map(model)
+    score_layer_indices = {idx for idx, _ in attn_layers[:n_score]}
+    score_cache_list = [
+        cache[layer_to_cache[i]]
+        for i, _ in attn_layers[:n_score]
+        if i in layer_to_cache
+    ]
+
+    # Patch only the first n_score attention layers for Q capture.
+    # The next attention layer (index n_score) receives _EarlyExitAttn, which
+    # is installed separately so cleanup ordering is unambiguous.
+    query_buffer: list = [[] for _ in range(n_all_attn)]
+    patches, attn_indices = _patch_attention_for_capture(
+        model, query_buffer, query_extractor,
+        layers_to_patch=score_layer_indices,
+    )
+
+    early_exit_patch = None
+    if n_score < n_all_attn:
+        _, exit_layer = attn_layers[n_score]
+        orig_exit_attn = _get_attn_module(exit_layer)
+        _set_attn_module(exit_layer, _EarlyExitAttn())
+        early_exit_patch = (exit_layer, orig_exit_attn)
+
+    try:
+        prompt = mx.array(tokens)
+        processed = 0
+
+        while processed < n_prompt:
+            chunk = min(prefill_step_size, n_prompt - processed)
+            if progress_callback is not None:
+                progress_callback(processed, n_prompt, "self_scoring")
+            try:
+                model(prompt[processed : processed + chunk][None], cache=cache)
+            except _ScoringComplete:
+                pass
+            # Evaluate only the scored layers' cache states; layers beyond
+            # n_score were never added to the compute graph this iteration.
+            mx.eval([c.state for c in score_cache_list])
+            processed += chunk
+
+        if progress_callback is not None:
+            progress_callback(n_prompt, n_prompt, "self_scoring")
+
+    finally:
+        _unpatch_attention_capture(model, patches)
+        if early_exit_patch is not None:
+            _set_attn_module(early_exit_patch[0], early_exit_patch[1])
+
+    # Build trimmed query buffer: one entry per scored layer containing only
+    # Q vectors from the last n_tail_queries prompt positions.
+    trimmed_buffer = []
+    for i, _ in attn_layers[:n_score]:
+        if i not in attn_indices:
+            trimmed_buffer.append([])
+            continue
+        buf_slot = attn_indices.index(i)
+        captures = query_buffer[buf_slot]
+        if not captures:
+            trimmed_buffer.append([])
+            continue
+        full_q = mx.concatenate(captures, axis=2)           # (1, heads, n_prompt, d)
+        trimmed_buffer.append([full_q[:, :, -n_tail_queries:, :]])
+
+    score_caches = [
+        cache[layer_to_cache[i]]
+        for i, _ in attn_layers[:n_score]
+        if i in layer_to_cache
+    ]
+
+    importance = _compute_importance(
+        trimmed_buffer,
+        score_caches,
+        n_prompt,
+        n_attn_heads,
+        n_kv_heads,
+        pool_kernel=pool_kernel if pool_kernel > 0 else None,
+    )
+    mx.eval(importance)
+
+    del cache, query_buffer, trimmed_buffer
+    mx.clear_cache()
+    return importance
 
 
 # ===========================================================================

--- a/omlx/request.py
+++ b/omlx/request.py
@@ -187,6 +187,7 @@ class Request:
     specprefill_total_tokens: int = 0  # Original total token count (M)
     specprefill_position_offset: int = 0  # RoPE offset = M - N
     specprefill_system_end: int = 0  # Token index where system prompt ends
+    _specprefill_self_score: bool = False  # Use target model self-scoring (no draft)
 
     # Cache corruption recovery
     cache_corruption_retries: int = 0   # Per-request corruption retry counter

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -530,6 +530,9 @@ class SchedulerConfig:
     gc_cleanup_interval: int = 0  # Steps between gc.collect() calls (0=disabled)
     mlx_cache_cleanup_interval: int = 512  # Steps between mx.clear_cache() calls
 
+    # Self-scoring SpecPrefill (no draft model required)
+    specprefill_self_score_layers: int = 4  # Attention layers used for the scoring pass
+
 
 @dataclass
 class SchedulerOutput:
@@ -3384,10 +3387,11 @@ class Scheduler:
         was already scored in a previous turn, the draft cache is restored
         and only the new suffix is prefilled through the draft model.
         """
-        if self._specprefill_draft_model is None:
+        specprefill_enabled = getattr(request, "_specprefill_enabled", False)
+        self_score_requested = getattr(request, "_specprefill_self_score", False)
+        if self._specprefill_draft_model is None and not self_score_requested:
             return
 
-        specprefill_enabled = getattr(request, "_specprefill_enabled", False)
         if not specprefill_enabled:
             return
 
@@ -3429,12 +3433,20 @@ class Scheduler:
         model_id = os.path.basename(self.config.model_name.rstrip("/"))
 
         try:
-            from .patches.specprefill import score_tokens, select_chunks
+            from .patches.specprefill import select_chunks
 
-            # Draft prefix cache lookup
+            use_self_score = (
+                self._specprefill_draft_model is None
+                and getattr(request, "_specprefill_self_score", False)
+            )
+
+            if self._specprefill_draft_model is None and not use_self_score:
+                return
+
+            # Draft prefix cache lookup (only relevant when draft model is present)
             draft_cache = None
             draft_cached_tokens = 0
-            if self._draft_prefix_cache is not None:
+            if self._draft_prefix_cache is not None and not use_self_score:
                 try:
                     block_table, draft_remaining = self._draft_prefix_cache.fetch_cache(
                         request.request_id, tokens_to_score
@@ -3480,13 +3492,25 @@ class Scheduler:
             )
 
             t0 = time.monotonic()
-            importance, used_cache = score_tokens(
-                self._specprefill_draft_model,
-                tokens_to_score,
-                prefill_step_size=self.config.prefill_step_size,
-                existing_cache=draft_cache,
-                progress_callback=_score_progress,
-            )
+            used_cache = None
+            if use_self_score:
+                from .patches.specprefill import score_tokens_self
+                importance = score_tokens_self(
+                    self.model,
+                    tokens_to_score,
+                    n_score_layers=self.config.specprefill_self_score_layers,
+                    prefill_step_size=self.config.prefill_step_size,
+                    progress_callback=_score_progress,
+                )
+            else:
+                from .patches.specprefill import score_tokens
+                importance, used_cache = score_tokens(
+                    self._specprefill_draft_model,
+                    tokens_to_score,
+                    prefill_step_size=self.config.prefill_step_size,
+                    existing_cache=draft_cache,
+                    progress_callback=_score_progress,
+                )
             selected = select_chunks(importance, keep_pct=keep_pct)
             t_score = time.monotonic() - t0
 
@@ -3531,7 +3555,7 @@ class Scheduler:
                 f"(keep={n_selected/n_to_score*100:.0f}%, {', '.join(extras)})"
             )
 
-            # Save draft cache for next turn
+            # Save draft cache for next turn (skip for self-score: no cache to persist)
             if self._draft_prefix_cache is not None and used_cache is not None:
                 try:
                     extracted, mcc = self._extract_cache_states(used_cache)
@@ -3549,7 +3573,8 @@ class Scheduler:
             # the generation_stream is drained before Metal buffers are
             # returned to the pool — a bare mx.clear_cache() here can race
             # with in-flight async evals and trigger a kernel panic (#557).
-            del used_cache
+            if used_cache is not None:
+                del used_cache
             _sync_and_clear_cache()
 
             # Mark scoring complete (auto-removes tracker entry).

--- a/tests/test_specprefill.py
+++ b/tests/test_specprefill.py
@@ -608,3 +608,259 @@ class TestEngineCorePropagation:
         req = core.scheduler.add_request.call_args[0][0]
         assert not hasattr(req, "_specprefill_threshold")
         assert not hasattr(req, "_specprefill_keep_pct")
+
+
+# ---------------------------------------------------------------------------
+# Synthetic helpers shared by TestScoreTokensSelf
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_kvcache(n_tokens, n_heads, head_dim):
+    """Return a minimal KVCache-like object with pre-filled keys/values."""
+
+    class _FakeKVCache:
+        def __init__(self):
+            # Keys/values shaped (1, n_heads, n_tokens, head_dim)
+            self.keys = mx.ones((1, n_heads, n_tokens, head_dim)) * 0.1
+            self.values = mx.zeros((1, n_heads, n_tokens, head_dim))
+            self.offset = n_tokens
+
+        @property
+        def state(self):
+            return (self.keys, self.values)
+
+    return _FakeKVCache()
+
+
+def _make_fake_model(n_layers=8, n_heads=4, head_dim=16, vocab=256):
+    """Build a minimal model stub compatible with score_tokens_self.
+
+    Each layer has a ``self_attn`` that:
+      - stores fixed keys in cache (so _compute_importance can read them)
+      - returns queries shaped (1, n_heads, seq_len, head_dim) when the
+        ``_llama_extract_queries`` extractor is invoked
+      - passes hidden state through unchanged
+
+    The model exposes ``make_cache()`` (used by ``make_prompt_cache`` fallback)
+    and a ``__call__`` that iterates layers exactly as a real transformer would.
+    """
+    hidden = n_heads * head_dim
+
+    class FakeAttn:
+        def __init__(self, layer_idx, n_heads, head_dim):
+            self._idx = layer_idx
+            self.n_heads = n_heads
+            self.num_attention_heads = n_heads
+            self.num_key_value_heads = n_heads
+            self.head_dim = head_dim
+            # rope attribute marks this as a standard Llama-style attention
+            self.rope = lambda q, offset=0: q
+
+        def q_proj(self, x):
+            B, L, D = x.shape
+            return mx.ones((B, L, self.n_heads * self.head_dim))
+
+        def __call__(self, x, mask=None, cache=None, **kwargs):
+            B, L, D = x.shape
+            if cache is not None:
+                # Write dummy keys/values so _compute_importance can read them
+                new_k = mx.ones((B, self.n_heads, L, self.head_dim)) * (self._idx + 1) * 0.1
+                new_v = mx.zeros((B, self.n_heads, L, self.head_dim))
+                if hasattr(cache, "keys") and cache.keys is not None:
+                    cache.keys = mx.concatenate([cache.keys, new_k], axis=2)
+                    cache.values = mx.concatenate([cache.values, new_v], axis=2)
+                else:
+                    cache.keys = new_k
+                    cache.values = new_v
+                cache.offset = cache.offset + L if hasattr(cache, "offset") else L
+            return x  # identity — hidden state passes through
+
+    class FakeLayer:
+        def __init__(self, layer_idx, n_heads, head_dim):
+            self.self_attn = FakeAttn(layer_idx, n_heads, head_dim)
+
+        def __call__(self, x, mask=None, cache=None, **kwargs):
+            return self.self_attn(x, mask=mask, cache=cache, **kwargs)
+
+    class FakeKVCache:
+        def __init__(self):
+            self.keys = None
+            self.values = None
+            self.offset = 0
+
+        @property
+        def state(self):
+            if self.keys is None:
+                return mx.zeros((1,))
+            return (self.keys, self.values)
+
+    class FakeModel:
+        def __init__(self):
+            self.layers = [FakeLayer(i, n_heads, head_dim) for i in range(n_layers)]
+            self._n_layers = n_layers
+            self._n_heads = n_heads
+            self._head_dim = head_dim
+            self._vocab = vocab
+
+        def __call__(self, x, cache=None, **kwargs):
+            h = mx.ones((*x.shape, hidden))
+            for i, layer in enumerate(self.layers):
+                h = layer(h, cache=cache[i] if cache is not None else None)
+            # Return dummy logits — never evaluated by score_tokens_self
+            return mx.zeros((*x.shape, vocab))
+
+        def make_cache(self):
+            return [FakeKVCache() for _ in range(self._n_layers)]
+
+    return FakeModel()
+
+
+class TestScoreTokensSelf:
+    """Tests for score_tokens_self() — draft-model-free importance scoring."""
+
+    def test_output_shape_matches_token_count(self):
+        """importance vector length must equal the number of input tokens."""
+        from omlx.patches.specprefill import score_tokens_self
+
+        model = _make_fake_model(n_layers=8, n_heads=4, head_dim=16)
+        tokens = list(range(64))
+        importance = score_tokens_self(model, tokens, n_score_layers=2,
+                                       n_tail_queries=4, pool_kernel=0)
+        assert importance.shape == (64,)
+
+    def test_importance_is_finite_and_nonnegative(self):
+        """All importance scores must be finite and ≥ 0."""
+        from omlx.patches.specprefill import score_tokens_self
+
+        model = _make_fake_model(n_layers=8, n_heads=4, head_dim=16)
+        importance = score_tokens_self(model, list(range(32)), n_score_layers=2,
+                                       n_tail_queries=4, pool_kernel=0)
+        assert mx.all(mx.isfinite(importance)).item()
+        assert mx.all(importance >= 0).item()
+
+    def test_attention_modules_restored_after_scoring(self):
+        """All self_attn modules must be back to their originals after the call."""
+        from omlx.patches.specprefill import score_tokens_self
+
+        model = _make_fake_model(n_layers=6, n_heads=2, head_dim=8)
+        originals = [layer.self_attn for layer in model.layers]
+
+        score_tokens_self(model, list(range(20)), n_score_layers=3,
+                          n_tail_queries=2, pool_kernel=0)
+
+        for i, layer in enumerate(model.layers):
+            assert layer.self_attn is originals[i], (
+                f"Layer {i} self_attn was not restored"
+            )
+
+    def test_attention_modules_restored_after_exception(self):
+        """Modules must be restored even if scoring raises mid-way."""
+        from omlx.patches.specprefill import _ScoringComplete, score_tokens_self
+
+        model = _make_fake_model(n_layers=6, n_heads=2, head_dim=8)
+        originals = [layer.self_attn for layer in model.layers]
+
+        # Patch layer 1's self_attn to raise during its own __call__ so we
+        # exercise the exception path inside the prefill loop.
+        real_attn_1 = model.layers[1].self_attn
+
+        class _BombAttn:
+            def __call__(self, *a, **kw):
+                raise RuntimeError("boom")
+
+            def __getattr__(self, name):
+                return getattr(real_attn_1, name)
+
+        model.layers[1].self_attn = _BombAttn()
+        originals[1] = model.layers[1].self_attn  # update expected
+
+        try:
+            score_tokens_self(model, list(range(20)), n_score_layers=3,
+                               n_tail_queries=2, pool_kernel=0)
+        except Exception:
+            pass  # scoring may fail — we only care about cleanup
+
+        for i, layer in enumerate(model.layers):
+            assert layer.self_attn is originals[i], (
+                f"Layer {i} self_attn not restored after exception"
+            )
+
+    def test_n_score_layers_clamped_to_model_depth(self):
+        """Requesting more score layers than the model has must not crash."""
+        from omlx.patches.specprefill import score_tokens_self
+
+        model = _make_fake_model(n_layers=4, n_heads=2, head_dim=8)
+        # n_score_layers=99 > n_layers=4 — should clamp silently
+        importance = score_tokens_self(model, list(range(16)), n_score_layers=99,
+                                       n_tail_queries=2, pool_kernel=0)
+        assert importance.shape == (16,)
+
+    def test_n_tail_queries_clamped_to_prompt_length(self):
+        """n_tail_queries > n_prompt-1 must not crash."""
+        from omlx.patches.specprefill import score_tokens_self
+
+        model = _make_fake_model(n_layers=4, n_heads=2, head_dim=8)
+        importance = score_tokens_self(model, list(range(5)), n_score_layers=2,
+                                       n_tail_queries=100, pool_kernel=0)
+        assert importance.shape == (5,)
+
+    def test_mx_array_tokens_accepted(self):
+        """Passing tokens as an mx.array (not a list) must work."""
+        from omlx.patches.specprefill import score_tokens_self
+
+        model = _make_fake_model(n_layers=4, n_heads=2, head_dim=8)
+        tokens = mx.array(list(range(16)))
+        importance = score_tokens_self(model, tokens, n_score_layers=2,
+                                       n_tail_queries=4, pool_kernel=0)
+        assert importance.shape == (16,)
+
+    def test_progress_callback_called(self):
+        """progress_callback must be invoked at least once during scoring."""
+        from omlx.patches.specprefill import score_tokens_self
+
+        model = _make_fake_model(n_layers=6, n_heads=2, head_dim=8)
+        calls = []
+
+        def cb(processed, total, phase):
+            calls.append((processed, total, phase))
+
+        score_tokens_self(model, list(range(32)), n_score_layers=2,
+                          n_tail_queries=4, pool_kernel=0,
+                          progress_callback=cb)
+        assert len(calls) > 0
+        # Final call must report completion
+        assert calls[-1][0] == calls[-1][1]
+
+    @pytest.mark.asyncio
+    async def test_engine_core_self_score_flag_propagates(self):
+        """specprefill_self_score=True must set the request fields correctly."""
+        from unittest.mock import MagicMock
+
+        from omlx.engine_core import EngineCore
+        from omlx.request import SamplingParams
+
+        core = object.__new__(EngineCore)
+        core._output_collectors = {}
+        core._active_requests = {}
+        core._stream_states = {}
+        core._finished_events = {}
+        core._mlx_executor = None  # use default thread pool for run_in_executor
+
+        mock_scheduler = MagicMock(spec=[])
+        mock_scheduler._specprefill_draft_model = None
+        mock_scheduler.add_request = MagicMock()
+        core.scheduler = mock_scheduler
+
+        mock_config = MagicMock(spec=[])
+        mock_config.stream_interval = 0
+        core.config = mock_config
+
+        await core.add_request(
+            prompt=[1, 2, 3],
+            sampling_params=SamplingParams(),
+            specprefill_self_score=True,
+        )
+
+        req = mock_scheduler.add_request.call_args[0][0]
+        assert req._specprefill_self_score is True
+        assert req._specprefill_enabled is True


### PR DESCRIPTION
## Summary

- Adds `score_tokens_self()` — a SpecPrefill scoring path that works without a draft model, using only the first `n_score_layers` (default 4) of the target model itself
- Uses an early-exit exception (`_ScoringComplete`) to stop MLX graph construction after layer N, so Metal only executes ops for those layers (~12.5% of dense prefill cost for a 32-layer model)
- Q vectors from the last `n_tail_queries` prompt positions act as a proxy for future-generation queries, feeding into the existing `_compute_importance → select_chunks → sparse_prefill` pipeline unchanged
- Total cost: ~42% of dense prefill (12.5% scoring + 30% sparse prefill at 0.3 keep rate), no second model in RAM required

## Motivation

IDE workflows (opencode, Continue, Cursor) suffer a full re-prefill penalty whenever an in-context file changes — the prefix cache ends at `[system+tools]` and everything after must be re-prefilled densely every turn. Previously, `SpecPrefill` required a configured draft model (additional 4–8 GB RAM), making it inaccessible to most single-server deployments. This change makes the speedup available to everyone with a single flag.

## Architecture safety

No truncation of `model.layers` is used. `make_prompt_cache(model)` and `_build_layer_to_cache_map()` operate on the real model structure throughout, so the following special cases are handled correctly without any extra code:
- **Gemma4** (`previous_kvs` shared-KV cache routing)
- **Nemotron-H** (`block_type` sparse attention, compacted layer-to-cache mapping)
- **VLM wrappers** (`VLMModelAdapter.layers` property delegation)
- **RotatingKVCache** (already skipped by `_compute_importance`)

## New API surface

| Symbol | Location | Notes |
|---|---|---|
| `score_tokens_self()` | `omlx/patches/specprefill.py` | Main new function |
| `_ScoringComplete` | `omlx/patches/specprefill.py` | `BaseException` sentinel |
| `_EarlyExitAttn` | `omlx/patches/specprefill.py` | Installed on layer N to abort graph |
| `_patch_attention_for_capture(..., layers_to_patch=None)` | `omlx/patches/specprefill.py` | Backward-compatible extension |
| `SchedulerConfig.specprefill_self_score_layers` | `omlx/scheduler.py` | Default `4` |
| `EngineCore.add_request(..., specprefill_self_score=True)` | `omlx/engine_core.py` | Auto-enables `_specprefill_enabled` |
| `Request._specprefill_self_score` | `omlx/request.py` | Per-request flag |

## Test plan

- [x] 9 new unit tests in `TestScoreTokensSelf` (shape, finiteness, module cleanup on normal + exception path, edge cases for clamped layer/query counts, `mx.array` input, progress callback, engine propagation)
- [x] All 43 existing `test_specprefill.py` tests pass
- [x] Full unit test suite: zero new failures (13 pre-existing failures on `main` unchanged)
- [x] End-to-end: start server, send request with `specprefill_self_score=True` and prompt >8192 tokens, verify SpecPrefill fires in dashboard and TTFT is reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)