### PR TITLE
fix(deps): add python_version marker to paroquant optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ paroquant = [
     # with --no-deps semantics here because the official [mlx] extra pulls
     # torchvision, which the load path doesn't actually use (verified end
     # to end on 0.1.14). The DMG build installs the same pin via build.py.
-    "paroquant==0.1.14",
+    "paroquant==0.1.14; python_version >= '3.11'",
 ]
 dev = [
     "pytest>=7.0.0",


### PR DESCRIPTION
## Summary

`paroquant==0.1.14` declares `requires-python >= 3.11` on PyPI, but the project's `requires-python` is `>= 3.10`. Dependency resolvers that evaluate all supported Python versions — `uv lock`, `uv sync`, and pip's backtracking resolver — fail because no valid solution exists for the Python 3.10 split.

## Changes

Add a `python_version >= '3.11'` environment marker to the paroquant optional dependency so the resolver skips it when targeting Python < 3.11. The marker matches paroquant's own `requires-python` declaration.

## Test plan

- `uv lock` resolves successfully (201 packages, was failing before)
- Full test suite: 4276 passed, 31 failed (all pre-existing), 19 skipped