### PR TITLE
feat(chat): enable chat multi-tasking and fix chat response appear to follow bug

### DIFF
--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -1030,17 +1030,18 @@
                 </template>
 
                 <!-- Streaming Message -->
-                <div x-show="isStreaming" class="assistant-message message-fade-in">
+                <div x-show="isCurrentChatStreaming()" class="assistant-message message-fade-in">
                     <div class="message-header">
                         <div class="flex items-center gap-2 text-sm font-medium" style="color: var(--text-primary);">
                             <i data-lucide="cpu" class="w-4 h-4" style="color: var(--text-tertiary);"></i>
-                            <span x-text="currentModel || window.t('chat.assistant_label')"></span>
+                            <span
+                                x-text="currentStream()?.sourceModel || currentModel || window.t('chat.assistant_label')"></span>
                         </div>
                         <div class="flex gap-1">
                             <!-- Timeline toggle for streaming -->
-                            <button @click="statusTimelineVisible = !statusTimelineVisible"
+                            <button @click="toggleCurrentStreamTimeline()"
                                 class="w-7 h-7 flex items-center justify-center rounded-md bg-transparent cursor-pointer transition-all hover:bg-surface-alt"
-                                :style="statusTimelineVisible ? 'color:var(--text-primary);' : 'color:var(--text-tertiary);'"
+                                :style="currentStream()?.statusTimelineVisible ? 'color:var(--text-primary);' : 'color:var(--text-tertiary);'"
                                 title="Toggle timeline">
                                 <i data-lucide="activity" class="w-4 h-4"></i>
                             </button>
@@ -1053,8 +1054,9 @@
                     </div>
                     <div class="message-body">
                         <!-- Accumulated timeline entries — only shown when toggled open -->
-                        <div x-show="statusTimelineVisible && statusLog.length > 0" class="space-y-0.5 mb-1 mt-0.5">
-                            <template x-for="(entry, idx) in statusLog" :key="idx">
+                        <div x-show="currentStream()?.statusTimelineVisible && currentStream()?.statusLog?.length > 0"
+                            class="space-y-0.5 mb-1 mt-0.5">
+                            <template x-for="(entry, idx) in (currentStream()?.statusLog || [])" :key="idx">
                                 <div class="flex items-center gap-2 text-xs font-mono"
                                     style="color:var(--text-tertiary);">
                                     <span x-text="entry.t" style="min-width:6ch;flex-shrink:0;opacity:0.5;"></span>
@@ -1087,16 +1089,17 @@
                             </template>
                         </div>
                         <!-- Live status line — always visible while streaming, hidden once final content arrives -->
-                        <div x-show="!finalContent" class="flex items-center gap-2 text-xs font-mono py-1"
-                            style="color:var(--text-tertiary);">
-                            <span x-show="engineStatus?.icon === 'wrench'" style="flex-shrink:0;display:inline-flex;">
+                        <div x-show="!currentStream()?.finalContent"
+                            class="flex items-center gap-2 text-xs font-mono py-1" style="color:var(--text-tertiary);">
+                            <span x-show="currentStream()?.engineStatus?.icon === 'wrench'"
+                                style="flex-shrink:0;display:inline-flex;">
                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                                     stroke-width="2">
                                     <path
                                         d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
                                 </svg>
                             </span>
-                            <span x-text="engineStatus?.text || 'Starting'"></span>
+                            <span x-text="currentStream()?.engineStatus?.text || 'Starting'"></span>
                             <span class="loading-dots" style="display:inline-flex;gap:2px;margin:0;">
                                 <span class="loading-dot" style="width:4px;height:4px;"></span>
                                 <span class="loading-dot" style="width:4px;height:4px;"></span>
@@ -1105,25 +1108,27 @@
                         </div>
                         <!-- Streaming content (thinking block + final answer) -->
                         <!-- Live thinking bubble — shown while reasoning_content is arriving -->
-                        <div x-show="streamingThinking" class="thinking-container mb-2">
-                            <div class="thinking-header" @click="streamingThinkingOpen = !streamingThinkingOpen">
+                        <div x-show="currentStream()?.streamingThinking" class="thinking-container mb-2">
+                            <div class="thinking-header" @click="toggleCurrentStreamThinking()">
                                 <svg class="thinking-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                                     stroke-width="2">
                                     <circle cx="12" cy="12" r="10" />
                                     <path d="M12 8v4M12 16h.01" />
                                 </svg>
-                                <span class="thinking-text" x-text="finalContent ? 'Thinking' : 'Thinking...'"></span>
-                                <svg class="thinking-toggle" :class="{ collapsed: !streamingThinkingOpen }"
-                                    viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <span class="thinking-text"
+                                    x-text="currentStream()?.finalContent ? 'Thinking' : 'Thinking...' "></span>
+                                <svg class="thinking-toggle"
+                                    :class="{ collapsed: !currentStream()?.streamingThinkingOpen }" viewBox="0 0 24 24"
+                                    fill="none" stroke="currentColor" stroke-width="2">
                                     <polyline points="18 15 12 9 6 15" />
                                 </svg>
                             </div>
                             <div class="thinking-content markdown-content thinking-markdown"
-                                :class="{ collapsed: !streamingThinkingOpen }" data-math-pending="true"
-                                :data-math-version="String(streamingThinking.length)"
-                                x-html="renderMarkdown(streamingThinking)"></div>
+                                :class="{ collapsed: !currentStream()?.streamingThinkingOpen }" data-math-pending="true"
+                                :data-math-version="String((currentStream()?.streamingThinking || '').length)"
+                                x-html="renderMarkdown(currentStream()?.streamingThinking || '')"></div>
                         </div>
-                        <div x-show="streamingContent" class="markdown-content" x-ref="streamingOutput"
+                        <div x-show="currentStream()?.streamingContent" class="markdown-content" x-ref="streamingOutput"
                             x-effect="updateStreamingDOM()"></div>
                     </div>
                 </div>
@@ -1156,7 +1161,7 @@
                     <div class="flex items-end">
                         <!-- Image upload button (only for VLM models) -->
                         <button x-show="hasVisionSupport()" @click="$refs.imageInput.click()"
-                            :disabled="!apiKeySet || !currentModel || isStreaming || uploadImages.length >= 10"
+                            :disabled="!apiKeySet || !currentModel || isCurrentChatStreaming() || uploadImages.length >= 10"
                             class="p-3 shrink-0 transition-colors text-fg-tertiary hover:text-fg-secondary disabled:opacity-50 disabled:cursor-not-allowed"
                             :title="window.t('chat.upload_image')">
                             <i data-lucide="image" class="w-5 h-5"></i>
@@ -1166,12 +1171,12 @@
                             @keydown.enter="if (!isMobile && !$event.shiftKey && !$event.isComposing && $event.keyCode !== 229) { $event.preventDefault(); sendMessage(); }"
                             @input="autoResize($event.target)" @paste="handlePaste($event)"
                             :placeholder="isMobile ? window.t('chat.input_placeholder_mobile') : window.t('chat.input_placeholder')"
-                            :disabled="!apiKeySet || !currentModel || isStreaming" rows="1"
+                            :disabled="!apiKeySet || !currentModel || isCurrentChatStreaming()" rows="1"
                             class="flex-1 px-4 py-3 bg-transparent resize-none outline-none text-sm max-h-32"
                             style="color: var(--text-primary);"></textarea>
                         <div class="relative flex-shrink-0">
                             <button @click="sendMessage()"
-                                :disabled="(!inputMessage.trim() && uploadImages.length === 0) || !apiKeySet || !currentModel || isStreaming"
+                                :disabled="(!inputMessage.trim() && uploadImages.length === 0) || !apiKeySet || !currentModel || isCurrentChatStreaming()"
                                 class="w-10 h-10 m-1 bg-accent hover:bg-accent-hover disabled:bg-surface-muted rounded-full transition-colors flex items-center justify-center">
                                 <i data-lucide="arrow-up" class="w-4 h-4 text-accent-fg"></i>
                             </button>
@@ -1216,10 +1221,8 @@
                 class="w-full px-4 py-3 border border-line rounded-xl mb-4 focus:outline-none focus:border-line-strong resize-y"
                 style="background: var(--bg-primary); color: var(--text-primary);"></textarea>
             <div class="flex items-center justify-between">
-                <button
-                    @click="systemPromptDraft = ''; systemPrompt = ''; localStorage.removeItem('omlx_chat_system_prompt'); showSystemPromptModal = false"
-                    class="text-sm px-3 py-2 hover:bg-surface-muted rounded-lg" style="color: var(--text-tertiary);"
-                    x-show="systemPrompt.trim()">
+                <button @click="clearSystemPrompt()" class="text-sm px-3 py-2 hover:bg-surface-muted rounded-lg"
+                    style="color: var(--text-tertiary);" x-show="systemPrompt.trim()">
                     {{ t('chat.system_prompt.clear') }}
                 </button>
                 <div class="flex items-center gap-2 ml-auto">
@@ -1227,8 +1230,7 @@
                         class="px-4 py-2 text-sm rounded-xl hover:bg-surface-muted" style="color: var(--text-primary);">
                         {{ t('chat.system_prompt.cancel') }}
                     </button>
-                    <button
-                        @click="systemPrompt = systemPromptDraft; localStorage.setItem('omlx_chat_system_prompt', systemPrompt); showSystemPromptModal = false"
+                    <button @click="saveSystemPrompt()"
                         class="px-4 py-2 text-sm bg-accent text-accent-fg rounded-xl hover:bg-accent-hover">
                         {{ t('chat.system_prompt.save') }}
                     </button>
@@ -1273,6 +1275,7 @@
             // Chat State
             currentChatId: null,
             chatHistory: [],
+            chatSessions: {},
             messages: [],
             inputMessage: '',
 
@@ -1281,26 +1284,7 @@
             currentModel: null,
 
             // Streaming State
-            isStreaming: false,
-            streamingContent: '',
-            abortController: null,
-
-            // Thinking streaming state
-            thinkingState: {
-                isInThinking: false,
-                thinkingIndex: 0,
-                thinkingContent: '',
-                regularContent: '',
-                thinkingStartTime: null
-            },
-
-            // Live thinking bubble state (shown during streaming)
-            streamingThinking: '',          // accumulated reasoning_content for current stream
-            streamingThinkingOpen: false,   // whether the live thinking bubble is expanded
-            streamRenderState: {
-                stableIndex: 0,
-                stableText: ''
-            },
+            streamSessions: {},
 
             // Scroll state
             autoScrollEnabled: true,
@@ -1338,17 +1322,135 @@
             MAX_TOOL_DEPTH: 10,          // Max recursive streamResponse calls for tool loops
             TOOL_TIMEOUT_MS: 30000,      // Per-tool execution timeout (ms)
 
-            // Engine status & timing
-            engineStatus: null,          // { text, icon? } shown while streaming; null when idle
-            statusLog: [],               // [{ t, text, icon }] full timeline for current prompt
-            finalContent: false,         // true once delta.content arrives — hides timeline
-            statusTimelineVisible: false, // whether the streaming timeline panel is expanded
-            _statusStart: 0,             // Date.now() at depth-0 stream start
-            _toolTimers: {},             // { toolName: Date.now() } per-tool execution start
-
             // MCP tools & prefill polling
             mcpTools: [],                // OpenAI-format tool definitions loaded from /v1/mcp/tools
-            _prefillInterval: null,      // setInterval handle for pre-generation polling
+
+            cloneData(value) {
+                return value == null ? value : JSON.parse(JSON.stringify(value));
+            },
+
+            createThinkingState() {
+                return {
+                    isInThinking: false,
+                    thinkingIndex: 0,
+                    thinkingContent: '',
+                    regularContent: '',
+                    thinkingStartTime: null
+                };
+            },
+
+            createStreamSession(chatId = null) {
+                return {
+                    chatId,
+                    sourceModel: null,
+                    sourceSystemPrompt: '',
+                    isStreaming: false,
+                    streamingContent: '',
+                    abortController: null,
+                    thinkingState: this.createThinkingState(),
+                    streamingThinking: '',
+                    streamingThinkingOpen: false,
+                    streamRenderState: {
+                        stableIndex: 0,
+                        stableText: ''
+                    },
+                    engineStatus: null,
+                    statusLog: [],
+                    finalContent: false,
+                    statusTimelineVisible: false,
+                    _statusStart: 0,
+                    _toolTimers: {},
+                    _prefillInterval: null,
+                };
+            },
+
+            getChatSession(chatId = this.currentChatId, create = false) {
+                if (!chatId) return null;
+                if (!this.chatSessions[chatId] && create) {
+                    const historyChat = this.chatHistory.find(c => c.id === chatId);
+                    this.chatSessions[chatId] = {
+                        messages: this.cloneData(historyChat?.messages || (this.currentChatId === chatId ? this.messages : [])) || [],
+                        model: historyChat?.model || (this.currentChatId === chatId ? this.currentModel : null),
+                        systemPrompt: historyChat?.systemPrompt ?? (this.currentChatId === chatId
+                            ? this.systemPrompt
+                            : (localStorage.getItem('omlx_chat_system_prompt') || ''))
+                    };
+                }
+                return this.chatSessions[chatId] || null;
+            },
+
+            getCurrentChatSession() {
+                return this.getChatSession(this.currentChatId, false);
+            },
+
+            getStreamSession(chatId = this.currentChatId, create = false) {
+                if (!chatId) return null;
+                if (!this.streamSessions[chatId] && create) {
+                    this.streamSessions[chatId] = this.createStreamSession(chatId);
+                }
+                return this.streamSessions[chatId] || null;
+            },
+
+            currentStream() {
+                return this.getStreamSession(this.currentChatId, false);
+            },
+
+            isChatStreaming(chatId = this.currentChatId) {
+                return Boolean(this.getStreamSession(chatId, false)?.isStreaming);
+            },
+
+            isCurrentChatStreaming() {
+                return this.isChatStreaming(this.currentChatId);
+            },
+
+            toggleCurrentStreamTimeline() {
+                const stream = this.currentStream();
+                if (stream) {
+                    stream.statusTimelineVisible = !stream.statusTimelineVisible;
+                }
+            },
+
+            toggleCurrentStreamThinking() {
+                const stream = this.currentStream();
+                if (stream) {
+                    stream.streamingThinkingOpen = !stream.streamingThinkingOpen;
+                }
+            },
+
+            resetStreamSession(stream, { preserveStatusLog = false, preserveFinalContent = false } = {}) {
+                if (!stream) return;
+                if (stream._prefillInterval) {
+                    clearInterval(stream._prefillInterval);
+                    stream._prefillInterval = null;
+                }
+                stream.isStreaming = false;
+                stream.streamingContent = '';
+                stream.abortController = null;
+                stream.thinkingState = this.createThinkingState();
+                stream.streamingThinking = '';
+                stream.streamingThinkingOpen = false;
+                stream.streamRenderState = {
+                    stableIndex: 0,
+                    stableText: ''
+                };
+                stream.engineStatus = null;
+                if (!preserveStatusLog) {
+                    stream.statusLog = [];
+                    stream.statusTimelineVisible = false;
+                    stream._statusStart = 0;
+                }
+                if (!preserveFinalContent) {
+                    stream.finalContent = false;
+                }
+                stream._toolTimers = {};
+            },
+
+            stopAllStreams() {
+                Object.values(this.streamSessions).forEach((stream) => {
+                    stream.abortController?.abort();
+                    this.resetStreamSession(stream);
+                });
+            },
 
             async init() {
 
@@ -1419,54 +1521,59 @@
 
     // ===== Engine Status =====
 
-    setEngineStatus(status, { log = true } = {}) {
-        this.engineStatus = status;
+    setEngineStatus(chatId, status, { log = true } = {}) {
+        const stream = this.getStreamSession(chatId, true);
+        stream.engineStatus = status;
         if (log && status) {
-            const elapsed = ((Date.now() - this._statusStart) / 1000).toFixed(1);
-            const last = this.statusLog[this.statusLog.length - 1];
+            const elapsed = ((Date.now() - stream._statusStart) / 1000).toFixed(1);
+            const last = stream.statusLog[stream.statusLog.length - 1];
             if (!last || last.text !== status.text || last.icon !== (status.icon || null)) {
-                this.statusLog.push({ t: `+${elapsed}s`, text: status.text, icon: status.icon || null });
+                stream.statusLog.push({ t: `+${elapsed}s`, text: status.text, icon: status.icon || null });
             }
         }
     },
 
-    startPrefillPolling() {
-        this.stopPrefillPolling();
-        this._prefillInterval = setInterval(() => this._pollPrefill(), 500);
+    startPrefillPolling(chatId, modelId) {
+        const stream = this.getStreamSession(chatId, true);
+        this.stopPrefillPolling(chatId);
+        stream._prefillInterval = setInterval(() => this._pollPrefill(chatId, modelId), 500);
     },
 
-    stopPrefillPolling() {
-        if (this._prefillInterval) {
-            clearInterval(this._prefillInterval);
-            this._prefillInterval = null;
+    stopPrefillPolling(chatId) {
+        const stream = this.getStreamSession(chatId, false);
+        if (stream?._prefillInterval) {
+            clearInterval(stream._prefillInterval);
+            stream._prefillInterval = null;
         }
     },
 
-            async _pollPrefill() {
+            async _pollPrefill(chatId, modelId) {
+        const stream = this.getStreamSession(chatId, false);
+        if (!stream?.isStreaming) return;
         try {
             const resp = await fetch('/admin/api/stats', { credentials: 'same-origin' });
             if (!resp.ok) return;
             const data = await resp.json();
             const models = data.active_models?.models || [];
-            const model = models.find(m => m.id === this.currentModel);
-            if (this.engineStatus?.icon === 'wrench') return; // don't overwrite tool status
+            const model = models.find(m => m.id === modelId);
+            if (stream.engineStatus?.icon === 'wrench') return; // don't overwrite tool status
             if (model?.is_loading || (!model && models.some(m => m.is_loading))) {
-                this.setEngineStatus({ text: 'Loading model' });
+                this.setEngineStatus(chatId, { text: 'Loading model' });
             } else if (model?.prefilling?.length > 0) {
                 const p = model.prefilling[0];
                 if (p.total > 0) {
                     const pct = Math.round(p.processed / p.total * 100);
                     if (pct >= 100) {
-                        this.engineStatus = { text: 'Generating' }; // prefill done, now generating
+                        stream.engineStatus = { text: 'Generating' }; // prefill done, now generating
                     } else {
                         const speed = p.speed > 0 ? ` · ${Math.round(p.speed)} tok/s` : '';
-                        this.engineStatus = { text: `Prefilling ${pct}%${speed}` };
+                        stream.engineStatus = { text: `Prefilling ${pct}%${speed}` };
                     }
                 } else {
-                    this.engineStatus = { text: 'Prefilling' };
+                    stream.engineStatus = { text: 'Prefilling' };
                 }
             } else if (model?.generating?.length > 0) {
-                this.setEngineStatus({ text: 'Generating' });
+                this.setEngineStatus(chatId, { text: 'Generating' });
             }
         } catch (e) { /* ignore poll errors */ }
     },
@@ -1620,8 +1727,11 @@
 
     clearApiKey() {
         if (confirm(window.t('chat.confirm_change_api_key'))) {
+            this.stopAllStreams();
             localStorage.removeItem('omlx_chat_api_key');
             this.apiKeySet = false;
+            this.chatSessions = {};
+            this.streamSessions = {};
             this.messages = [];
             this.currentChatId = null;
         }
@@ -1688,6 +1798,10 @@
 
     selectModel(modelId) {
         this.currentModel = modelId;
+        const session = this.getChatSession(this.currentChatId, true);
+        if (session) {
+            session.model = modelId;
+        }
     },
 
     loadChatHistory() {
@@ -1706,23 +1820,30 @@
     },
 
     startNewChat() {
-        this.currentChatId = 'chat_' + Date.now();
-        this.messages = [];
+        const chatId = 'chat_' + Date.now();
+        const systemPrompt = localStorage.getItem('omlx_chat_system_prompt') || '';
+        this.currentChatId = chatId;
         this.uploadImages = [];
-        this.systemPrompt = localStorage.getItem('omlx_chat_system_prompt') || '';
+        this.systemPrompt = systemPrompt;
         this.isMobile = window.innerWidth < 768;
         this.sidebarOpen = window.innerWidth >= 768;
-        this.resetStreamRenderState();
+        this.chatSessions[chatId] = {
+            messages: [],
+            model: this.currentModel,
+            systemPrompt
+        };
+        this.messages = this.chatSessions[chatId].messages;
+        this.resetStreamSession(this.getStreamSession(chatId, true));
     },
 
     loadChat(chatId) {
-        const chat = this.chatHistory.find(c => c.id === chatId);
-        if (chat) {
+        const session = this.getChatSession(chatId, true);
+        if (session) {
             this.currentChatId = chatId;
-            this.messages = chat.messages || [];
-            this.systemPrompt = chat.systemPrompt || '';
-            if (chat.model) {
-                this.currentModel = chat.model;
+            this.messages = session.messages;
+            this.systemPrompt = session.systemPrompt || '';
+            if (session.model) {
+                this.currentModel = session.model;
             }
             this.scheduleEnhanceMessages();
         }
@@ -1730,14 +1851,16 @@
         this.sidebarOpen = window.innerWidth >= 768;
     },
 
-    saveCurrentChat() {
-        if (!this.currentChatId || this.messages.length === 0) return;
+    saveCurrentChat(chatId = this.currentChatId, messages = null, model = null, systemPrompt = null) {
+        const session = this.getChatSession(chatId, false);
+        const messagesToSave = messages || session?.messages || (chatId === this.currentChatId ? this.messages : []);
+        if (!chatId || messagesToSave.length === 0) return;
 
-        const existingIndex = this.chatHistory.findIndex(c => c.id === this.currentChatId);
+        const existingIndex = this.chatHistory.findIndex(c => c.id === chatId);
         const existingChat = existingIndex >= 0 ? this.chatHistory[existingIndex] : null;
 
         // Strip base64 image data from content arrays to avoid localStorage quota issues
-        const messagesForStorage = this.messages.map(msg => {
+        const messagesForStorage = messagesToSave.map(msg => {
             if (!Array.isArray(msg.content)) return msg;
             return {
                 ...msg,
@@ -1752,18 +1875,27 @@
 
         const title = existingChat?.manualTitle
             ? (existingChat.title || window.t('chat.new_chat_title'))
-            : (this.getTextContent(this.messages[0]?.content)?.slice(0, 50)
+            : (this.getTextContent(messagesToSave[0]?.content)?.slice(0, 50)
                 || window.t('chat.new_chat_title'));
 
+        const chatModel = model ?? session?.model ?? (chatId === this.currentChatId ? this.currentModel : null);
+        const chatSystemPrompt = systemPrompt ?? session?.systemPrompt ?? (chatId === this.currentChatId ? this.systemPrompt : '');
+
         const chatData = {
-            id: this.currentChatId,
+            id: chatId,
             title,
             manualTitle: existingChat?.manualTitle || false,
             messages: messagesForStorage,
-            model: this.currentModel,
-            systemPrompt: this.systemPrompt,
+            model: chatModel,
+            systemPrompt: chatSystemPrompt,
             updatedAt: new Date().toISOString()
         };
+
+        if (session) {
+            session.messages = messagesToSave;
+            session.model = chatModel;
+            session.systemPrompt = chatSystemPrompt;
+        }
 
         if (existingIndex >= 0) {
             this.chatHistory[existingIndex] = chatData;
@@ -1797,12 +1929,33 @@
         this.cancelRenamingChat();
     },
 
+    clearSystemPrompt() {
+        this.systemPromptDraft = '';
+        this.systemPrompt = '';
+        localStorage.removeItem('omlx_chat_system_prompt');
+        const session = this.getChatSession(this.currentChatId, true);
+        if (session) {
+            session.systemPrompt = '';
+        }
+        this.showSystemPromptModal = false;
+    },
+
+    saveSystemPrompt() {
+        this.systemPrompt = this.systemPromptDraft;
+        localStorage.setItem('omlx_chat_system_prompt', this.systemPrompt);
+        const session = this.getChatSession(this.currentChatId, true);
+        if (session) {
+            session.systemPrompt = this.systemPrompt;
+        }
+        this.showSystemPromptModal = false;
+    },
+
             async sendMessage() {
         const userText = this.inputMessage.trim();
         const images = [...this.uploadImages];
 
         if (!userText && images.length === 0) return;
-        if (!this.currentModel || this.isStreaming) return;
+        if (!this.currentModel || this.isCurrentChatStreaming()) return;
 
         // Clear input state
         this.inputMessage = '';
@@ -1814,8 +1967,15 @@
         });
 
         if (!this.currentChatId) {
-            this.currentChatId = 'chat_' + Date.now();
+            this.startNewChat();
         }
+
+        const chatId = this.currentChatId;
+        const sourceModel = this.currentModel;
+        const sourceSystemPrompt = this.systemPrompt;
+        const chatSession = this.getChatSession(chatId, true);
+        chatSession.model = sourceModel;
+        chatSession.systemPrompt = sourceSystemPrompt;
 
         // Build message content (OpenAI content array for images, string for text-only)
         let content;
@@ -1831,47 +1991,54 @@
             content = userText;
         }
 
-        this.messages.push({ role: 'user', content });
+        chatSession.messages.push({ role: 'user', content });
+        this.messages = chatSession.messages;
         this.forceScrollToBottom();
-        await this.streamResponse();
+        await this.streamResponse({ chatId, model: sourceModel, systemPrompt: sourceSystemPrompt }, 0);
     },
 
-            async streamResponse(depth = 0) {
+            async streamResponse(streamContext = null, depth = 0) {
+        const context = {
+            chatId: streamContext?.chatId || this.currentChatId,
+            model: streamContext?.model || this.currentModel,
+            systemPrompt: streamContext?.systemPrompt ?? this.systemPrompt
+        };
+        const chatSession = this.getChatSession(context.chatId, true);
+        const stream = this.getStreamSession(context.chatId, true);
+        context.model = context.model || chatSession?.model || this.currentModel;
+        context.systemPrompt = context.systemPrompt ?? chatSession?.systemPrompt ?? '';
+        chatSession.model = context.model;
+        chatSession.systemPrompt = context.systemPrompt;
+
         if (depth > this.MAX_TOOL_DEPTH) {
-            this.messages.push({
+            chatSession.messages.push({
                 role: 'assistant',
                 content: `Error: Maximum tool call depth (${this.MAX_TOOL_DEPTH}) exceeded. The model may be stuck in a loop.`,
-                model: this.currentModel,
+                model: context.model,
                 _perfVisible: false,
             });
-            this.saveCurrentChat();
-            this.isStreaming = false;
-            this.streamingContent = '';
-            this.engineStatus = null;
-            this.stopPrefillPolling();
-            this.abortController = null;
+            this.saveCurrentChat(context.chatId, chatSession.messages, context.model, context.systemPrompt);
+            this.resetStreamSession(stream);
             return;
         }
         // Initialise timing and status log once, at the top of a new prompt
         if (depth === 0) {
-            this.statusLog = [];
-            this._statusStart = Date.now();
-            this._toolTimers = {};
-            this.finalContent = false;
-            this.statusTimelineVisible = false;
-            this.streamingThinking = '';
-            this.streamingThinkingOpen = false;
-            this.resetStreamRenderState();
+            this.resetStreamSession(stream);
+            stream._statusStart = Date.now();
+            stream.sourceModel = context.model;
+            stream.sourceSystemPrompt = context.systemPrompt;
         }
-        this.isStreaming = true;
-        this.streamingContent = '';
-        this.abortController = new AbortController();
+        stream.isStreaming = true;
+        stream.sourceModel = context.model;
+        stream.sourceSystemPrompt = context.systemPrompt;
+        stream.streamingContent = '';
+        stream.abortController = new AbortController();
         this.autoScrollEnabled = true;
-        this.setEngineStatus({ text: 'Starting' });
-        this.startPrefillPolling();
+        this.setEngineStatus(context.chatId, { text: 'Starting' });
+        this.startPrefillPolling(context.chatId, context.model);
 
         // Build messages for API - pass through tool_calls/tool_call_id for MCP loop
-        const messagesForApi = this.messages
+        const messagesForApi = chatSession.messages
             .filter(msg => ['user', 'assistant', 'tool', 'system'].includes(msg.role))
             .map(msg => {
                 const m = { role: msg.role, content: msg.content ?? null };
@@ -1880,10 +2047,10 @@
                 return m;
             });
         // Prepend system prompt if set
-        if (this.systemPrompt.trim()) {
+        if (context.systemPrompt.trim()) {
             messagesForApi.unshift({
                 role: 'system',
-                content: this.systemPrompt.trim()
+                content: context.systemPrompt.trim()
             });
         }
 
@@ -1895,13 +2062,13 @@
                     'Authorization': `Bearer ${this.getApiKey()}`
                 },
                 body: JSON.stringify({
-                    model: this.currentModel,
+                    model: context.model,
                     messages: messagesForApi,
                     stream: true,
                     stream_options: { include_usage: true },
                     ...(this.mcpTools.length > 0 && { tools: this.mcpTools })
                 }),
-                signal: this.abortController.signal
+                signal: stream.abortController.signal
             });
 
             if (!response.ok) {
@@ -1943,7 +2110,10 @@
 
                             // Accumulate streaming tool_call chunks
                             if (delta?.tool_calls) {
-                                if (!firstToken) { firstToken = true; this.stopPrefillPolling(); }
+                                if (!firstToken) {
+                                    firstToken = true;
+                                    this.stopPrefillPolling(context.chatId);
+                                }
                                 for (const tc of delta.tool_calls) {
                                     const i = tc.index ?? 0;
                                     if (!toolCallsMap[i]) toolCallsMap[i] = { id: '', type: 'function', function: { name: '', arguments: '' } };
@@ -1953,10 +2123,10 @@
                                 }
                                 // Clear any thinking content so it doesn't show as response text
                                 // Also reset thinking state so the close tag isn't appended later
-                                if (this.streamingContent) {
-                                    this.streamingContent = '';
-                                    this.thinkingState.isInThinking = false;
-                                    this.thinkingState.thinkingStartTime = null;
+                                if (stream.streamingContent) {
+                                    stream.streamingContent = '';
+                                    stream.thinkingState.isInThinking = false;
+                                    stream.thinkingState.thinkingStartTime = null;
                                 }
                                 // Update live status
                                 const names = Object.values(toolCallsMap).map(t => t.function.name).filter(Boolean);
@@ -1965,40 +2135,45 @@
                                     const liveLabel = names.length > 3
                                         ? `Calling ${unique.slice(0, 2).join(', ')} +${names.length - 2} more`
                                         : `Calling ${names.join(', ')}`;
-                                    this.engineStatus = { text: liveLabel, icon: 'wrench' };
+                                    stream.engineStatus = { text: liveLabel, icon: 'wrench' };
                                 }
                             }
 
                             if (delta?.reasoning_content) {
-                                if (!firstToken) { firstToken = true; this.stopPrefillPolling(); }
-                                if (!this.thinkingState.isInThinking) {
-                                    this.thinkingState.isInThinking = true;
-                                    this.thinkingState.thinkingStartTime = Date.now();
-                                    this.setEngineStatus({ text: 'Thinking' });
+                                if (!firstToken) {
+                                    firstToken = true;
+                                    this.stopPrefillPolling(context.chatId);
+                                }
+                                if (!stream.thinkingState.isInThinking) {
+                                    stream.thinkingState.isInThinking = true;
+                                    stream.thinkingState.thinkingStartTime = Date.now();
+                                    this.setEngineStatus(context.chatId, { text: 'Thinking' });
                                 }
                                 // Accumulate into live thinking bubble
-                                this.streamingThinking += delta.reasoning_content;
+                                stream.streamingThinking += delta.reasoning_content;
                             }
 
                             if (delta?.content) {
                                 if (!firstToken) {
                                     firstToken = true;
-                                    this.stopPrefillPolling();
+                                    this.stopPrefillPolling(context.chatId);
                                 }
                                 // Log thinking duration to timeline when content starts
-                                if (this.thinkingState.isInThinking) {
-                                    const thinkSecs = ((Date.now() - this.thinkingState.thinkingStartTime) / 1000).toFixed(1);
-                                    this.setEngineStatus({ text: `Thought for ${thinkSecs}s` });
-                                    this.thinkingState.isInThinking = false;
-                                    this.thinkingState.thinkingStartTime = null;
+                                if (stream.thinkingState.isInThinking) {
+                                    const thinkSecs = ((Date.now() - stream.thinkingState.thinkingStartTime) / 1000).toFixed(1);
+                                    this.setEngineStatus(context.chatId, { text: `Thought for ${thinkSecs}s` });
+                                    stream.thinkingState.isInThinking = false;
+                                    stream.thinkingState.thinkingStartTime = null;
                                 }
                                 // Only set finalContent on non-whitespace content
-                                if (!this.finalContent && delta.content.trim()) {
-                                    this.finalContent = true;
-                                    this.engineStatus = null;
+                                if (!stream.finalContent && delta.content.trim()) {
+                                    stream.finalContent = true;
+                                    stream.engineStatus = null;
                                 }
-                                this.streamingContent += delta.content;
-                                this.scrollToBottom();
+                                stream.streamingContent += delta.content;
+                                if (this.currentChatId === context.chatId) {
+                                    this.scrollToBottom();
+                                }
                             }
                         } catch (e) {
                             console.error('Error parsing SSE:', e);
@@ -2008,11 +2183,11 @@
             }
 
             // If model ended while still thinking (tool-call turn), log elapsed and reset
-            if (this.thinkingState.isInThinking) {
-                const thinkSecs = ((Date.now() - this.thinkingState.thinkingStartTime) / 1000).toFixed(1);
-                this.setEngineStatus({ text: `Thought for ${thinkSecs}s` });
-                this.thinkingState.isInThinking = false;
-                this.thinkingState.thinkingStartTime = null;
+            if (stream.thinkingState.isInThinking) {
+                const thinkSecs = ((Date.now() - stream.thinkingState.thinkingStartTime) / 1000).toFixed(1);
+                this.setEngineStatus(context.chatId, { text: `Thought for ${thinkSecs}s` });
+                stream.thinkingState.isInThinking = false;
+                stream.thinkingState.thinkingStartTime = null;
             }
 
             // Log usage metrics as a single compact entry
@@ -2026,7 +2201,7 @@
                 if (ptps != null) parts.push(`prefill ${Math.round(ptps)} tok/s`);
                 if (gtps != null) parts.push(`gen ${Math.round(gtps)} tok/s`);
                 if (ttft != null) parts.push(`ttft ${ttft}s`);
-                if (parts.length) this.setEngineStatus({ text: parts.join(' · ') });
+                if (parts.length) this.setEngineStatus(context.chatId, { text: parts.join(' · ') });
             }
 
             const toolCalls = Object.values(toolCallsMap);
@@ -2037,19 +2212,19 @@
                 const label = toolCalls.length > 3
                     ? `Calling ${uniqueNames.slice(0, 2).join(', ')} +${toolCalls.length - 2} more`
                     : `Calling ${names.join(', ')}`;
-                if (names.length) this.setEngineStatus({ text: label, icon: 'wrench' });
+                if (names.length) this.setEngineStatus(context.chatId, { text: label, icon: 'wrench' });
 
                 // Store the assistant tool_calls turn (hidden from chat UI)
-                this.messages.push({
+                chatSession.messages.push({
                     role: 'assistant',
-                    content: this.streamingContent || null,
-                    model: this.currentModel,
+                    content: stream.streamingContent || null,
+                    model: context.model,
                     tool_calls: toolCalls,
                     _ui: false,
                 });
 
                 // Record per-tool start times for elapsed tracking
-                toolCalls.forEach((tc) => { this._toolTimers[tc.function.name] = Date.now(); });
+                toolCalls.forEach((tc) => { stream._toolTimers[tc.function.name] = Date.now(); });
 
                 // Execute all tools in parallel
                 const results = await Promise.all(toolCalls.map(async (tc, i) => {
@@ -2058,16 +2233,16 @@
                     try { args = JSON.parse(tc.function.arguments || '{}'); } catch (e) { }
                     try {
                         const timeoutSignal = AbortSignal.timeout?.(this.TOOL_TIMEOUT_MS);
-                        const combinedSignal = this.abortController?.signal && timeoutSignal
-                            ? AbortSignal.any([this.abortController.signal, timeoutSignal])
-                            : (timeoutSignal || this.abortController?.signal);
+                        const combinedSignal = stream.abortController?.signal && timeoutSignal
+                            ? AbortSignal.any([stream.abortController.signal, timeoutSignal])
+                            : (timeoutSignal || stream.abortController?.signal);
                         const execResp = await fetch('/v1/mcp/execute', {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${this.getApiKey()}` },
                             body: JSON.stringify({ tool_name: toolName, arguments: args }),
                             signal: combinedSignal,
                         });
-                        const elapsed = ((Date.now() - (this._toolTimers[toolName] || Date.now())) / 1000).toFixed(2);
+                        const elapsed = ((Date.now() - (stream._toolTimers[toolName] || Date.now())) / 1000).toFixed(2);
                         if (!execResp.ok) {
                             return { content: `Error: HTTP ${execResp.status}`, error: true, toolName, elapsed };
                         }
@@ -2077,7 +2252,7 @@
                             : JSON.stringify(execData.content ?? execData);
                         return { content, error: false, toolName, elapsed };
                     } catch (e) {
-                        const elapsed = ((Date.now() - (this._toolTimers[toolName] || Date.now())) / 1000).toFixed(2);
+                        const elapsed = ((Date.now() - (stream._toolTimers[toolName] || Date.now())) / 1000).toFixed(2);
                         const isTimeout = e.name === 'TimeoutError';
                         const msg = isTimeout ? `Error: Tool timed out after ${this.TOOL_TIMEOUT_MS / 1000}s` : `Error: ${e.message}`;
                         return { content: msg, error: true, toolName, elapsed };
@@ -2087,27 +2262,27 @@
                 // Log each tool outcome to the status timeline
                 results.forEach((result) => {
                     if (result.error) {
-                        this.setEngineStatus({ text: `${result.toolName} failed`, icon: 'error' });
+                        this.setEngineStatus(context.chatId, { text: `${result.toolName} failed`, icon: 'error' });
                     } else {
-                        this.setEngineStatus({ text: `${result.toolName} done in ${result.elapsed}s`, icon: 'check' });
+                        this.setEngineStatus(context.chatId, { text: `${result.toolName} done in ${result.elapsed}s`, icon: 'check' });
                     }
                 });
 
                 // Push hidden tool result messages
                 toolCalls.forEach((tc, i) => {
-                    this.messages.push({ role: 'tool', tool_call_id: tc.id, content: results[i].content, _ui: false });
+                    chatSession.messages.push({ role: 'tool', tool_call_id: tc.id, content: results[i].content, _ui: false });
                 });
 
-                this.saveCurrentChat();
-                if (this.abortController?.signal.aborted) {
+                this.saveCurrentChat(context.chatId, chatSession.messages, context.model, context.systemPrompt);
+                if (stream.abortController?.signal.aborted) {
                     return;
                 }
 
-                this.streamingContent = '';
-                this.resetStreamRenderState();
+                stream.streamingContent = '';
+                this.resetStreamRenderState(stream);
 
                 // Recurse — model synthesises final answer using tool results
-                await this.streamResponse(depth + 1);
+                await this.streamResponse(context, depth + 1);
                 return;
             }
             // --- end MCP tool call loop ---
@@ -2115,85 +2290,85 @@
             // Always push the completed assistant message — even if content is empty.
             // This prevents the streaming box from disappearing with no replacement
             // when the model emits only whitespace, only reasoning tokens, or nothing at all.
-            this.messages.push({
+            chatSession.messages.push({
                 role: 'assistant',
-                content: this.streamingContent || '',
-                model: this.currentModel,
+                content: stream.streamingContent || '',
+                model: context.model,
                 _perfVisible: false,
-                _thinking: this.streamingThinking || null,
+                _thinking: stream.streamingThinking || null,
                 _thinkingOpen: false,
             });
-            this.saveCurrentChat();
-            this.scheduleEnhanceMessages();
+            this.saveCurrentChat(context.chatId, chatSession.messages, context.model, context.systemPrompt);
+            if (this.currentChatId === context.chatId) {
+                this.scheduleEnhanceMessages();
+            }
 
         } catch (error) {
             console.log('[streamResponse] catch error:', error.name, error.message);
             if (error.name === 'AbortError') {
                 console.log('[streamResponse] AbortError caught - stream stopped by user');
                 // Reset thinking state (reasoning now lives in streamingThinking, not streamingContent)
-                if (this.thinkingState.isInThinking) {
-                    this.thinkingState.isInThinking = false;
-                    this.thinkingState.thinkingStartTime = null;
+                if (stream.thinkingState.isInThinking) {
+                    stream.thinkingState.isInThinking = false;
+                    stream.thinkingState.thinkingStartTime = null;
                 }
                 // Stream was stopped by user — push whatever was accumulated
-                if (this.streamingContent || this.streamingThinking) {
-                    this.messages.push({
+                if (stream.streamingContent || stream.streamingThinking) {
+                    chatSession.messages.push({
                         role: 'assistant',
-                        content: this.streamingContent,
-                        model: this.currentModel,
+                        content: stream.streamingContent,
+                        model: context.model,
                         _perfVisible: false,
-                        _thinking: this.streamingThinking || null,
+                        _thinking: stream.streamingThinking || null,
                         _thinkingOpen: false,
                     });
-                    this.saveCurrentChat();
-                    this.scheduleEnhanceMessages();
+                    this.saveCurrentChat(context.chatId, chatSession.messages, context.model, context.systemPrompt);
+                    if (this.currentChatId === context.chatId) {
+                        this.scheduleEnhanceMessages();
+                    }
                 }
             } else {
                 console.error('Streaming error:', error);
-                this.messages.push({
+                chatSession.messages.push({
                     role: 'assistant',
                     content: `Error: ${error.message}`,
-                    model: this.currentModel,
+                    model: context.model,
                     _perfVisible: false,
                 });
-                this.scheduleEnhanceMessages();
+                this.saveCurrentChat(context.chatId, chatSession.messages, context.model, context.systemPrompt);
+                if (this.currentChatId === context.chatId) {
+                    this.scheduleEnhanceMessages();
+                }
             }
         } finally {
             // Attach performance timeline and thinking to the final assistant message, once per prompt
             if (depth === 0) {
-                for (let i = this.messages.length - 1; i >= 0; i--) {
-                    const msg = this.messages[i];
+                for (let i = chatSession.messages.length - 1; i >= 0; i--) {
+                    const msg = chatSession.messages[i];
                     if (msg.role === 'assistant' && msg._ui !== false) {
-                        if (this.statusLog.length > 0) {
-                            const totalTime = ((Date.now() - this._statusStart) / 1000).toFixed(2) + 's total';
-                            msg._perfLog = [...this.statusLog];
+                        if (stream.statusLog.length > 0) {
+                            const totalTime = ((Date.now() - stream._statusStart) / 1000).toFixed(2) + 's total';
+                            msg._perfLog = [...stream.statusLog];
                             msg._perfTotal = totalTime;
                         }
-                        if (this.streamingThinking) {
-                            msg._thinking = this.streamingThinking;
+                        if (stream.streamingThinking) {
+                            msg._thinking = stream.streamingThinking;
                         }
                         break;
                     }
                 }
             }
-            this.isStreaming = false;
-            this.streamingContent = '';
-            this.resetStreamRenderState();
-            this.engineStatus = null;
-            // Don't reset finalContent here — keeps the status block hidden after completion
-            // It gets reset at the start of the next depth=0 streamResponse call
-            this._toolTimers = {};
-            this.stopPrefillPolling();
-            this.abortController = null;
+            this.resetStreamSession(stream, { preserveFinalContent: true });
             this.thinkingAutoScroll = true;
         }
     },
 
     stopStreaming() {
-        console.log('[stopStreaming] called, abortController:', this.abortController);
-        if (this.abortController) {
+        const stream = this.currentStream();
+        console.log('[stopStreaming] called, abortController:', stream?.abortController || null);
+        if (stream?.abortController) {
             console.log('[stopStreaming] calling abort()');
-            this.abortController.abort();
+            stream.abortController.abort();
             console.log('[stopStreaming] abort() called');
         } else {
             console.log('[stopStreaming] abortController is null');
@@ -2201,14 +2376,22 @@
     },
 
             async regenerateMessage(index) {
-        if (this.isStreaming) return;
+        if (this.isCurrentChatStreaming()) return;
+
+        const session = this.getChatSession(this.currentChatId, true);
+        if (!session) return;
 
         // Find the user message before this assistant message
-        const messagesToKeep = this.messages.slice(0, index);
-        this.messages = messagesToKeep;
+        const messagesToKeep = session.messages.slice(0, index);
+        session.messages = messagesToKeep;
+        this.messages = session.messages;
         this.scheduleEnhanceMessages();
 
-        await this.streamResponse();
+        await this.streamResponse({
+            chatId: this.currentChatId,
+            model: session.model || this.currentModel,
+            systemPrompt: session.systemPrompt ?? this.systemPrompt
+        }, 0);
     },
 
     _copyFallback(text) {
@@ -2246,7 +2429,7 @@
 
     // Edit functions
     startEdit(index) {
-        if (this.isStreaming || this.editingIndex !== null) return;
+        if (this.isCurrentChatStreaming() || this.editingIndex !== null) return;
         this.editingIndex = index;
         this.editContent = this.getTextContent(this.messages[index].content);
         // Preserve images from the original message
@@ -2260,12 +2443,16 @@
     },
 
             async saveEdit(index) {
-        if (!this.editContent.trim() || this.isStreaming) return;
+        if (!this.editContent.trim() || this.isCurrentChatStreaming()) return;
+
+        const session = this.getChatSession(this.currentChatId, true);
+        if (!session) return;
 
         const newContent = this.editContent.trim();
 
         // Remove all messages from this index onwards
-        this.messages = this.messages.slice(0, index);
+        session.messages = session.messages.slice(0, index);
+        this.messages = session.messages;
         this.scheduleEnhanceMessages();
 
         // Build message content, preserving images
@@ -2281,7 +2468,7 @@
         }
 
         // Add edited user message
-        this.messages.push({
+        session.messages.push({
             role: 'user',
             content
         });
@@ -2293,12 +2480,20 @@
 
         // Scroll and get new response
         this.scrollToBottom();
-        await this.streamResponse();
+        await this.streamResponse({
+            chatId: this.currentChatId,
+            model: session.model || this.currentModel,
+            systemPrompt: session.systemPrompt ?? this.systemPrompt
+        }, 0);
     },
 
     // Delete chat
     deleteChat(chatId) {
         if (!confirm(window.t('chat.confirm_delete_chat'))) return;
+
+        this.getStreamSession(chatId, false)?.abortController?.abort();
+        delete this.streamSessions[chatId];
+        delete this.chatSessions[chatId];
 
         this.chatHistory = this.chatHistory.filter(c => c.id !== chatId);
         this.saveChatHistory();
@@ -2314,7 +2509,10 @@
     clearAllHistory() {
         if (!confirm(window.t('chat.confirm_clear_all'))) return;
 
+        this.stopAllStreams();
         this.chatHistory = [];
+        this.chatSessions = {};
+        this.streamSessions = {};
         this.saveChatHistory();
         this.startNewChat();
 
@@ -2465,15 +2663,16 @@
     // Efficiently update streaming DOM without destroying thinking container
     updateStreamingDOM() {
         const container = this.$refs.streamingOutput;
+        const stream = this.currentStream();
         if (!container) return;
 
-        if (!this.streamingContent) {
+        if (!stream?.streamingContent) {
             container.innerHTML = '';
-            this.resetStreamRenderState();
+            this.resetStreamRenderState(stream);
             return;
         }
 
-        const text = this.streamingContent;
+        const text = stream.streamingContent;
 
         if (text.includes('<think>')) {
             container.innerHTML = this.renderStreamingMarkdown(text);
@@ -2488,19 +2687,19 @@
 
         const { stableRoot, tailRoot } = this.ensureStreamingRoots(container);
         const cutoff = this.findStableRenderCutoff(text);
-        const safeCutoff = Math.max(cutoff, this.streamRenderState.stableIndex);
+        const safeCutoff = Math.max(cutoff, stream.streamRenderState.stableIndex);
 
-        if (safeCutoff > this.streamRenderState.stableIndex) {
-            this.streamRenderState.stableText = text.slice(0, safeCutoff);
-            stableRoot.innerHTML = this.streamRenderState.stableText
-                ? DOMPurify.sanitize(marked.parse(this.streamRenderState.stableText))
+        if (safeCutoff > stream.streamRenderState.stableIndex) {
+            stream.streamRenderState.stableText = text.slice(0, safeCutoff);
+            stableRoot.innerHTML = stream.streamRenderState.stableText
+                ? DOMPurify.sanitize(marked.parse(stream.streamRenderState.stableText))
                 : '';
             this.addCodeCopyButtons(stableRoot);
             this.renderMathInRoot(stableRoot);
-            this.streamRenderState.stableIndex = safeCutoff;
+            stream.streamRenderState.stableIndex = safeCutoff;
         }
 
-        const tailText = text.slice(this.streamRenderState.stableIndex);
+        const tailText = text.slice(stream.streamRenderState.stableIndex);
         tailRoot.innerHTML = tailText ? DOMPurify.sanitize(marked.parse(tailText)) : '';
 
         this.$nextTick(() => {
@@ -2524,12 +2723,13 @@
                     <div data-streaming-stable-root="true"></div>
                     <div data-streaming-tail-root="true"></div>
                 `;
-        this.resetStreamRenderState();
+        this.resetStreamRenderState(this.currentStream());
     },
 
-    resetStreamRenderState() {
-        this.streamRenderState.stableIndex = 0;
-        this.streamRenderState.stableText = '';
+    resetStreamRenderState(stream = this.currentStream()) {
+        if (!stream) return;
+        stream.streamRenderState.stableIndex = 0;
+        stream.streamRenderState.stableText = '';
     },
 
     addCodeCopyButtons(root = null) {


### PR DESCRIPTION
**PROBLEM**
- Currently you cannot do chat multitask. The chat in-progess response appear to follow you everywhere when you click on other chat tab. And even do a persist a save on whatever tab you currently navigated to, not the one suppose to generate response.

**SOLUTION**
- To fully enable chat multitask, this require quite a lot of fixes. The root problem was that streaming state was stored at the page level instead of the chat level. Things like the live assistant bubble, thinking panel, status timeline, abort controller, and input lock were all shared across the whole page. When you switched chats, the UI changed which message list was visible, but the active stream state stayed global, so the newly selected chat could start showing the other chat’s in-flight generation.
- This change moves streaming state to per-chat sessions. Each chat now owns its own stream lifecycle, including partial content, reasoning text, timeline visibility, engine status, abort controller, render state, and progress polling. The live streaming bubble only renders for the currently selected chat if that specific chat is actually streaming.
- It also fixes a request-context bug where parts of the streaming flow could still read the currently selected model after a tab switch. The full request lifecycle now stays bound to the originating chat, including the source chat ID, model, and system prompt. That context is preserved through follow-up tool-call recursion as well, so background generations continue using the correct chat configuration even if the user navigates elsewhere.
- Before this change, the UI behaved as if the whole page was busy whenever any stream was active. Now sending, editing, regenerating, and input disabling are all checked against the currently selected chat only, so one busy chat no longer blocks work in another.
- Chat saves are written back to the chat that actually owns the updated message list. saveCurrentChat() now derives the title from the messages being saved rather than implicitly from whatever chat is currently visible, which prevents sidebar metadata drift during background updates.

---

After fix, chat can now multitask, as long as chat page remains open and HTTP stay connected.

<img width="753" height="337" alt="Screenshot 2569-05-13 at 21 04 51" src="https://github.com/user-attachments/assets/a719237d-5a21-415e-9da9-df3f8e637322" />