### PR TITLE
feat(responses): native reasoning support for Responses API

### DIFF
--- a/omlx/api/responses_models.py
+++ b/omlx/api/responses_models.py
@@ -140,13 +140,20 @@ class OutputContent(BaseModel):
     annotations: List[Any] = Field(default_factory=list)
 
 
+class ReasoningSummaryPart(BaseModel):
+    """A single part of a reasoning summary."""
+
+    type: str = "summary_text"
+    text: str = ""
+
+
 class OutputItem(BaseModel):
     """A single item in the response output array.
 
-    Can be a message or a function_call.
+    Can be a message, function_call, or reasoning.
     """
 
-    type: str  # "message" or "function_call"
+    type: str  # "message" or "function_call" or "reasoning"
     id: str
     status: str = "completed"
     # message fields
@@ -156,6 +163,8 @@ class OutputItem(BaseModel):
     call_id: Optional[str] = None
     name: Optional[str] = None
     arguments: Optional[str] = None
+    # reasoning fields
+    summary: Optional[List[ReasoningSummaryPart]] = None
 
 
 class InputTokensDetails(BaseModel):

--- a/omlx/api/responses_utils.py
+++ b/omlx/api/responses_utils.py
@@ -139,6 +139,8 @@ def convert_responses_input_to_messages(
     # Process input items
     # Track pending tool calls for grouping into a single assistant message
     pending_tool_calls: List[Dict[str, Any]] = []
+    # Track reasoning content to attach to the next assistant message
+    pending_reasoning: str = ""
 
     for item in input_data:
         # Resolve effective type: EasyInputMessage has no type field
@@ -192,7 +194,26 @@ def convert_responses_input_to_messages(
             if role == "system":
                 system_parts.append(content or "")
             else:
-                messages.append({"role": role, "content": content or ""})
+                msg_dict: Dict[str, Any] = {"role": role, "content": content or ""}
+                if role == "assistant" and pending_reasoning:
+                    msg_dict["reasoning_content"] = pending_reasoning
+                    pending_reasoning = ""
+                messages.append(msg_dict)
+
+        elif item_type == "reasoning":
+            # Collect reasoning summary text to attach to the next
+            # assistant message as reasoning_content.
+            summary = getattr(item, "summary", None) or (
+                (item.model_extra or {}).get("summary") if hasattr(item, "model_extra") else None
+            )
+            if summary:
+                parts = []
+                for s in summary:
+                    if isinstance(s, dict):
+                        parts.append(s.get("text", ""))
+                    else:
+                        parts.append(getattr(s, "text", ""))
+                pending_reasoning = "\n".join(p for p in parts if p)
 
         elif item.type == "function_call":
             # Assistant's tool call — accumulate for grouping
@@ -303,15 +324,38 @@ def build_function_call_output_item(
     )
 
 
+def build_reasoning_output_item(
+    reasoning_text: str,
+    item_id: Optional[str] = None,
+    status: str = "completed",
+) -> OutputItem:
+    """Build a reasoning-type OutputItem with full CoT in summary[0].text."""
+    from .responses_models import ReasoningSummaryPart
+
+    summary = [ReasoningSummaryPart(text=reasoning_text)] if reasoning_text else []
+    return OutputItem(
+        type="reasoning",
+        id=item_id or generate_id(IDPrefix.REASONING),
+        status=status,
+        summary=summary,
+    )
+
+
 def build_response_usage(
-    input_tokens: int, output_tokens: int, cached_tokens: int = 0
+    input_tokens: int,
+    output_tokens: int,
+    reasoning_tokens: int = 0,
+    cached_tokens: int = 0,
 ) -> ResponseUsage:
     """Build ResponseUsage from token counts."""
+    from .responses_models import OutputTokensDetails
+
     return ResponseUsage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=input_tokens + output_tokens,
         input_tokens_details=InputTokensDetails(cached_tokens=cached_tokens),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=reasoning_tokens),
     )
 
 
@@ -525,20 +569,29 @@ def normalize_response_output_to_messages(
     """Convert response output items to assistant/tool-call history messages."""
     messages: List[Dict[str, Any]] = []
     pending_tool_calls: List[Dict[str, Any]] = []
+    pending_reasoning: str = ""
 
     for item in output_items:
         item_type = item.get("type")
-        if item_type == "message":
+        if item_type == "reasoning":
+            summary = item.get("summary", [])
+            parts = [s.get("text", "") for s in summary if isinstance(s, dict)]
+            pending_reasoning = "\n".join(p for p in parts if p)
+        elif item_type == "message":
             _flush_pending_tool_calls(messages, pending_tool_calls)
             content_blocks = item.get("content", [])
             text_parts = []
             for block in content_blocks:
                 if block.get("type") == "output_text":
                     text_parts.append(block.get("text", ""))
-            messages.append({
+            msg_dict: Dict[str, Any] = {
                 "role": item.get("role", "assistant"),
                 "content": "\n".join(text_parts),
-            })
+            }
+            if pending_reasoning:
+                msg_dict["reasoning_content"] = pending_reasoning
+                pending_reasoning = ""
+            messages.append(msg_dict)
         elif item_type == "function_call":
             call_id = item.get("call_id", f"call_{uuid.uuid4().hex[:8]}")
             pending_tool_calls.append({

--- a/omlx/api/shared_models.py
+++ b/omlx/api/shared_models.py
@@ -18,6 +18,7 @@ class IDPrefix(str, Enum):
     RERANK = "rerank"
     RESPONSE = "resp"
     FUNCTION_CALL = "fc"
+    REASONING = "rs"
 
 
 def generate_id(prefix: IDPrefix, length: int = 8) -> str:
@@ -37,6 +38,8 @@ def generate_id(prefix: IDPrefix, length: int = 8) -> str:
         return f"resp_{uuid.uuid4().hex[:24]}"
     if prefix == IDPrefix.FUNCTION_CALL:
         return f"fc_{uuid.uuid4().hex[:8]}"
+    if prefix == IDPrefix.REASONING:
+        return f"rs_{uuid.uuid4().hex[:24]}"
     return f"{prefix.value}-{uuid.uuid4().hex[:length]}"
 
 

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -26,7 +26,9 @@ _THINKING_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
 _THINKING_TAIL_PATTERN = re.compile(r'^(.*?)</think>', re.DOTALL)
 
 
-def extract_thinking(text: str) -> Tuple[str, str]:
+def extract_thinking(
+    text: str, start_in_thinking: bool = False
+) -> Tuple[str, str]:
     """Extract thinking and content from complete text.
 
     Handles:
@@ -40,9 +42,14 @@ def extract_thinking(text: str) -> Tuple[str, str]:
       occasionally skip the ``</think>`` boundary token. Without this
       fallback the entire body would be classified as thinking and the
       visible answer would be empty.
+    - Native reasoning (``start_in_thinking=True``): when the prompt
+      pre-opened ``<think>`` and generation contains no tags at all,
+      the entire output is treated as thinking with empty content.
 
     Args:
         text: Complete model output text.
+        start_in_thinking: If True, treat tag-free text as thinking
+            (native-reasoning mode where the prompt pre-opens <think>).
 
     Returns:
         Tuple of (thinking_content, regular_content).
@@ -81,6 +88,11 @@ def extract_thinking(text: str) -> Tuple[str, str]:
         after = text[idx + _OPEN_LEN:]
         return ("", (before + after).strip())
 
+    # Native-reasoning fallback: prompt pre-opened <think>, generation
+    # contains no tags at all — treat the whole output as thinking.
+    if start_in_thinking and '<think>' not in text and '</think>' not in text:
+        return (text.strip(), "")
+
     return ("", text)
 
 
@@ -106,8 +118,8 @@ class ThinkingParser:
         t, c = parser.finish()
     """
 
-    def __init__(self):
-        self._in_thinking: bool = False
+    def __init__(self, start_in_thinking: bool = False):
+        self._in_thinking: bool = start_in_thinking
         self._buffer: str = ""  # Buffer for potential partial tags
         # Recovery state for malformed thinking: when the prompt prepends
         # ``<think>`` and the model never emits ``</think>`` before EOS,

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -133,6 +133,7 @@ from .api.responses_utils import (
     ResponseStateNotFoundError,
     build_function_call_output_item,
     build_message_output_item,
+    build_reasoning_output_item,
     build_response_store_record,
     build_response_usage,
     convert_responses_input_to_messages,
@@ -3971,9 +3972,9 @@ async def create_response(
     # for it (Qwen 3.6+). Gated on detection so other templates don't
     # receive an unknown kwarg.
     _entry = get_engine_pool().get_entry(resolved_model)
+    native_reasoning = bool(_entry and _entry.preserve_thinking_default is True)
     if (
-        _entry is not None
-        and _entry.preserve_thinking_default is True
+        native_reasoning
         and merged_ct_kwargs.get("enable_thinking") is not False
         and "preserve_thinking" not in merged_ct_kwargs
     ):
@@ -4007,6 +4008,7 @@ async def create_response(
                     model_load_duration=model_load_duration,
                     resolved_model=resolved_model,
                     response_format=response_format,
+                    native_reasoning=native_reasoning,
                     **chat_kwargs,
                 ),
                 http_request=http_request,
@@ -4038,7 +4040,9 @@ async def create_response(
 
         # Process output text
         raw_text = clean_special_tokens(output.text) if output.text else ""
-        thinking_content, regular_content = extract_thinking(raw_text)
+        thinking_content, regular_content = extract_thinking(
+            raw_text, start_in_thinking=native_reasoning
+        )
 
         # Parse tool calls
         if engine.model_type == "gpt_oss" and output.tool_calls:
@@ -4079,6 +4083,9 @@ async def create_response(
 
         # Build output items
         output_items: list[OutputItem] = []
+        reasoning_text = (thinking_content or "").strip()
+        if native_reasoning and reasoning_text:
+            output_items.append(build_reasoning_output_item(reasoning_text))
         output_items.append(
             build_message_output_item(cleaned_text.strip() if cleaned_text else "")
         )
@@ -4144,6 +4151,7 @@ async def stream_responses_api(
     model_load_duration: float = 0.0,
     resolved_model: Optional[str] = None,
     response_format=None,
+    native_reasoning: bool = False,
     **kwargs,
 ) -> AsyncIterator[str]:
     """Stream Responses API events (SSE with named event types)."""
@@ -4153,12 +4161,20 @@ async def stream_responses_api(
     first_token_time = None
     last_output = None
     accumulated_text = ""
+    accumulated_reasoning = ""
     has_tools = bool(kwargs.get("tools"))
-    thinking_parser = ThinkingParser()
+    thinking_parser = ThinkingParser(start_in_thinking=native_reasoning)
     seq = 0
 
     response_id = generate_id(IDPrefix.RESPONSE)
     msg_id = generate_id(IDPrefix.MESSAGE)
+    reasoning_id = generate_id(IDPrefix.REASONING)
+
+    # Lazy item emission state — items are opened on first token
+    reasoning_opened = False
+    reasoning_closed = False
+    message_opened = False
+    next_output_index = 0
 
     # Build initial response object (in_progress, empty output)
     initial_response = ResponseObject(
@@ -4191,35 +4207,114 @@ async def stream_responses_api(
         "sequence_number": seq,
     })
 
-    # 3. response.output_item.added (message)
-    msg_item = {
-        "type": "message",
-        "id": msg_id,
-        "status": "in_progress",
-        "role": "assistant",
-        "content": [],
-    }
-    seq += 1
-    yield format_sse_event("response.output_item.added", {
-        "type": "response.output_item.added",
-        "output_index": 0,
-        "item": msg_item,
-        "sequence_number": seq,
-    })
+    # --- helper closures for lazy item emission ----------------------
+    def _open_reasoning():
+        nonlocal seq, reasoning_opened, next_output_index
+        if reasoning_opened:
+            return []
+        reasoning_opened = True
+        events = []
+        seq += 1
+        events.append(format_sse_event("response.output_item.added", {
+            "type": "response.output_item.added",
+            "output_index": next_output_index,
+            "item": {
+                "type": "reasoning",
+                "id": reasoning_id,
+                "status": "in_progress",
+                "summary": [],
+            },
+            "sequence_number": seq,
+        }))
+        seq += 1
+        events.append(format_sse_event("response.reasoning_summary_part.added", {
+            "type": "response.reasoning_summary_part.added",
+            "item_id": reasoning_id,
+            "output_index": next_output_index,
+            "summary_index": 0,
+            "part": {"type": "summary_text", "text": ""},
+            "sequence_number": seq,
+        }))
+        return events
 
-    # 4. response.content_part.added
-    content_part = {"type": "output_text", "text": "", "annotations": []}
-    seq += 1
-    yield format_sse_event("response.content_part.added", {
-        "type": "response.content_part.added",
-        "item_id": msg_id,
-        "output_index": 0,
-        "content_index": 0,
-        "part": content_part,
-        "sequence_number": seq,
-    })
+    def _close_reasoning():
+        nonlocal seq, reasoning_closed, next_output_index
+        if reasoning_closed or not reasoning_opened:
+            return []
+        reasoning_closed = True
+        reasoning_output_index = next_output_index
+        next_output_index += 1
+        events = []
+        seq += 1
+        events.append(format_sse_event("response.reasoning_summary_text.done", {
+            "type": "response.reasoning_summary_text.done",
+            "item_id": reasoning_id,
+            "output_index": reasoning_output_index,
+            "summary_index": 0,
+            "text": accumulated_reasoning,
+            "sequence_number": seq,
+        }))
+        seq += 1
+        events.append(format_sse_event("response.reasoning_summary_part.done", {
+            "type": "response.reasoning_summary_part.done",
+            "item_id": reasoning_id,
+            "output_index": reasoning_output_index,
+            "summary_index": 0,
+            "part": {"type": "summary_text", "text": accumulated_reasoning},
+            "sequence_number": seq,
+        }))
+        seq += 1
+        events.append(format_sse_event("response.output_item.done", {
+            "type": "response.output_item.done",
+            "output_index": reasoning_output_index,
+            "item": {
+                "type": "reasoning",
+                "id": reasoning_id,
+                "status": "completed",
+                "summary": [{"type": "summary_text", "text": accumulated_reasoning}],
+            },
+            "sequence_number": seq,
+        }))
+        return events
 
-    # 5. Stream tokens
+    def _open_message():
+        nonlocal seq, message_opened, next_output_index
+        if message_opened:
+            return []
+        message_opened = True
+        msg_output_index = next_output_index
+        events = []
+        seq += 1
+        events.append(format_sse_event("response.output_item.added", {
+            "type": "response.output_item.added",
+            "output_index": msg_output_index,
+            "item": {
+                "type": "message",
+                "id": msg_id,
+                "status": "in_progress",
+                "role": "assistant",
+                "content": [],
+            },
+            "sequence_number": seq,
+        }))
+        seq += 1
+        events.append(format_sse_event("response.content_part.added", {
+            "type": "response.content_part.added",
+            "item_id": msg_id,
+            "output_index": msg_output_index,
+            "content_index": 0,
+            "part": {"type": "output_text", "text": "", "annotations": []},
+            "sequence_number": seq,
+        }))
+        return events
+    # -----------------------------------------------------------------
+
+    # If not native reasoning, open message immediately (legacy behavior)
+    if not native_reasoning:
+        for ev in _open_message():
+            yield ev
+
+    # Stream tokens
     tool_filter = None
     stream_content = True
     if has_tools:
@@ -4228,6 +4323,8 @@ async def stream_responses_api(
             tool_filter = _f
         else:
             stream_content = False
+
+    msg_output_index = None  # will be set when message opens
 
     try:
         async for output in engine.stream_chat(messages=messages, **kwargs):
@@ -4238,8 +4335,30 @@ async def stream_responses_api(
                 accumulated_text += output.new_text
 
             if stream_content and output.new_text:
-                _thinking, content_delta = thinking_parser.feed(output.new_text)
+                thinking_delta, content_delta = thinking_parser.feed(output.new_text)
+
+                if thinking_delta and native_reasoning:
+                    accumulated_reasoning += thinking_delta
+                    for ev in _open_reasoning():
+                        yield ev
+                    seq += 1
+                    yield format_sse_event("response.reasoning_summary_text.delta", {
+                        "type": "response.reasoning_summary_text.delta",
+                        "item_id": reasoning_id,
+                        "output_index": 0 if not reasoning_closed else next_output_index - 1,
+                        "summary_index": 0,
+                        "delta": thinking_delta,
+                        "sequence_number": seq,
+                    })
+
                 if content_delta:
+                    if native_reasoning and reasoning_opened and not reasoning_closed:
+                        for ev in _close_reasoning():
+                            yield ev
+                    for ev in _open_message():
+                        yield ev
+                    if msg_output_index is None:
+                        msg_output_index = next_output_index
                     if tool_filter:
                         content_delta = tool_filter.feed(content_delta)
                     if content_delta:
@@ -4247,7 +4366,7 @@ async def stream_responses_api(
                         yield format_sse_event("response.output_text.delta", {
                             "type": "response.output_text.delta",
                             "item_id": msg_id,
-                            "output_index": 0,
+                            "output_index": msg_output_index,
                             "content_index": 0,
                             "delta": content_delta,
                             "sequence_number": seq,
@@ -4262,9 +4381,22 @@ async def stream_responses_api(
         })
         return
 
+    # Close reasoning if still open
+    if native_reasoning and reasoning_opened and not reasoning_closed:
+        for ev in _close_reasoning():
+            yield ev
+
+    # Ensure message item is opened (even if no content was streamed)
+    for ev in _open_message():
+        yield ev
+    if msg_output_index is None:
+        msg_output_index = next_output_index
+
     # Flush remaining content from parsers
     if stream_content:
-        _thinking, content_delta = thinking_parser.finish()
+        thinking_delta, content_delta = thinking_parser.finish()
+        if thinking_delta and native_reasoning:
+            accumulated_reasoning += thinking_delta
         if content_delta:
             if tool_filter:
                 content_delta = tool_filter.feed(content_delta)
@@ -4273,7 +4405,7 @@ async def stream_responses_api(
                 yield format_sse_event("response.output_text.delta", {
                     "type": "response.output_text.delta",
                     "item_id": msg_id,
-                    "output_index": 0,
+                    "output_index": msg_output_index,
                     "content_index": 0,
                     "delta": content_delta,
                     "sequence_number": seq,
@@ -4285,7 +4417,7 @@ async def stream_responses_api(
                 yield format_sse_event("response.output_text.delta", {
                     "type": "response.output_text.delta",
                     "item_id": msg_id,
-                    "output_index": 0,
+                    "output_index": msg_output_index,
                     "content_index": 0,
                     "delta": remaining,
                     "sequence_number": seq,
@@ -4298,7 +4430,9 @@ async def stream_responses_api(
         tool_calls = last_output.tool_calls
         cleaned_text = ""
     elif has_tools and accumulated_text:
-        thinking_content, regular_content = extract_thinking(accumulated_text)
+        thinking_content, regular_content = extract_thinking(
+            accumulated_text, start_in_thinking=native_reasoning
+        )
         extraction = extract_tool_calls_with_thinking(
             thinking_content,
             regular_content,
@@ -4312,14 +4446,16 @@ async def stream_responses_api(
             yield format_sse_event("response.output_text.delta", {
                 "type": "response.output_text.delta",
                 "item_id": msg_id,
-                "output_index": 0,
+                "output_index": msg_output_index,
                 "content_index": 0,
                 "delta": cleaned_text,
                 "sequence_number": seq,
             })
     else:
         # No tools — use raw accumulated text minus thinking
-        thinking_content, regular_content = extract_thinking(accumulated_text)
+        thinking_content, regular_content = extract_thinking(
+            accumulated_text, start_in_thinking=native_reasoning
+        )
         cleaned_text = clean_special_tokens(regular_content) if regular_content else ""
 
     # Reverse Gemma 4 parameter renaming
@@ -4346,33 +4482,33 @@ async def stream_responses_api(
         if not is_valid:
             logger.warning(f"JSON validation failed: {error}")
 
-    # 6. response.output_text.done
+    # response.output_text.done
     seq += 1
     yield format_sse_event("response.output_text.done", {
         "type": "response.output_text.done",
         "item_id": msg_id,
-        "output_index": 0,
+        "output_index": msg_output_index,
         "content_index": 0,
         "text": final_text,
         "sequence_number": seq,
     })
 
-    # 7. response.content_part.done
+    # response.content_part.done
     seq += 1
     yield format_sse_event("response.content_part.done", {
         "type": "response.content_part.done",
         "item_id": msg_id,
-        "output_index": 0,
+        "output_index": msg_output_index,
         "content_index": 0,
         "part": {"type": "output_text", "text": final_text, "annotations": []},
         "sequence_number": seq,
     })
 
-    # 8. response.output_item.done (message)
+    # response.output_item.done (message)
     seq += 1
     yield format_sse_event("response.output_item.done", {
         "type": "response.output_item.done",
-        "output_index": 0,
+        "output_index": msg_output_index,
         "item": {
             "type": "message",
             "id": msg_id,
@@ -4384,19 +4520,25 @@ async def stream_responses_api(
     })
 
     # Build output items for final response
-    output_items = [
-        {
-            "type": "message",
-            "id": msg_id,
+    output_items = []
+    if native_reasoning and accumulated_reasoning:
+        output_items.append({
+            "type": "reasoning",
+            "id": reasoning_id,
             "status": "completed",
-            "role": "assistant",
-            "content": [{"type": "output_text", "text": final_text, "annotations": []}],
-        }
-    ]
+            "summary": [{"type": "summary_text", "text": accumulated_reasoning}],
+        })
+    output_items.append({
+        "type": "message",
+        "id": msg_id,
+        "status": "completed",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": final_text, "annotations": []}],
+    })
 
-    # 9-12. Emit function call items if present
+    # Emit function call items if present
     if tool_calls:
-        output_index = 1
+        output_index = next_output_index + 1
         for tc in tool_calls:
             if hasattr(tc, "function"):
                 call_id = tc.id


### PR DESCRIPTION
## Summary
- **thinking.py**: Add `start_in_thinking` parameter for native-reasoning models (e.g. Qwen3.6) where the prompt pre-opens `<think>` — complements existing malformed-tag recovery
- **responses_models.py**: `IDPrefix.REASONING` and `ReasoningSummaryPart` Pydantic model
- **responses_utils.py**: `build_reasoning_output_item()` helper with lazy item emission in streaming — reasoning opens on first `thinking_delta`, message opens on first `content_delta`
- **server.py**: `response.reasoning_summary_text.delta` SSE events, `pending_reasoning` tracking in input/output message conversion, `native_reasoning` detection from `preserve_thinking_default`

This implements the Responses API contract for reasoning output items so native-reasoning models emit structured `reasoning` items instead of folding thinking tokens into the message body.

Follow-up to [#1158 review feedback](https://github.com/jundot/omlx/pull/1158#issuecomment-2866949248) where @jundot noted these "look reasonable" as a separate follow-up.

## Test plan
- [x] Responses API streaming with native-reasoning model emits reasoning items
- [x] Non-streaming Responses API includes reasoning output item
- [x] Non-reasoning models unaffected (no reasoning items emitted)
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)