### PR TITLE
fix(tests): repair pre-existing upstream test failures and import guards

### DIFF
--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from omlx.api.responses_utils import ResponseStore
+from omlx.engine.base import BaseEngine
 from omlx.engine.embedding import EmbeddingEngine
 from omlx.engine.reranker import RerankerEngine
 
@@ -143,7 +144,7 @@ class MockTokenizer:
         return "\n".join(parts)
 
 
-class MockBaseEngine:
+class MockBaseEngine(BaseEngine):
     """Mock LLM engine for testing."""
 
     def __init__(self, model_name: str = "test-llm-model"):
@@ -170,6 +171,9 @@ class MockBaseEngine:
     async def start(self) -> None:
         pass
 
+    async def stop(self) -> None:
+        pass
+
     async def generate(self, prompt: str, **kwargs) -> MockGenerationOutput:
         return MockGenerationOutput(text="Generated response.")
 
@@ -186,7 +190,7 @@ class MockBaseEngine:
             finish_reason="stop",
         )
 
-    def count_chat_tokens(self, messages: List[Dict], tools=None, chat_template_kwargs=None) -> int:
+    def count_chat_tokens(self, messages: List[Dict], tools=None, chat_template_kwargs=None, **kwargs) -> int:
         prompt = self._tokenizer.apply_chat_template(messages, tokenize=False)
         return len(self._tokenizer.encode(prompt))
 
@@ -205,6 +209,12 @@ class MockBaseEngine:
             finished=True,
             finish_reason="stop",
         )
+
+    def get_stats(self) -> Dict[str, Any]:
+        return {}
+
+    def get_cache_stats(self):
+        return None
 
 
 class RecordingResponsesEngine(MockBaseEngine):

--- a/tests/test_accuracy_benchmark.py
+++ b/tests/test_accuracy_benchmark.py
@@ -58,7 +58,7 @@ class TestAccuracyBenchmarkRequest:
             model_id="test-model",
             benchmarks={b: 100 for b in VALID_BENCHMARKS},
         )
-        assert len(req.benchmarks) == 12
+        assert len(req.benchmarks) == len(VALID_BENCHMARKS)
 
     def test_enable_thinking_default_false(self):
         req = AccuracyBenchmarkRequest(

--- a/tests/test_admin_auth.py
+++ b/tests/test_admin_auth.py
@@ -444,10 +444,10 @@ class TestCheckUpdate:
         """Dev/pre-release GitHub releases should not trigger update notification."""
         fake_resp = _FakeResponse(
             200,
-            {
+            [{
                 "tag_name": "v99.0.0.dev1",
                 "html_url": "https://github.com/jundot/omlx/releases/tag/v99.0.0.dev1",
-            },
+            }],
         )
         with patch("omlx.admin.routes.asyncio") as mock_asyncio:
             mock_asyncio.to_thread = _make_async_return(fake_resp)
@@ -461,10 +461,10 @@ class TestCheckUpdate:
         """Stable GitHub releases should trigger update notification."""
         fake_resp = _FakeResponse(
             200,
-            {
+            [{
                 "tag_name": "v99.0.0",
                 "html_url": "https://github.com/jundot/omlx/releases/tag/v99.0.0",
-            },
+            }],
         )
         with patch("omlx.admin.routes.asyncio") as mock_asyncio:
             mock_asyncio.to_thread = _make_async_return(fake_resp)
@@ -478,10 +478,10 @@ class TestCheckUpdate:
         """RC releases should not trigger update notification."""
         fake_resp = _FakeResponse(
             200,
-            {
+            [{
                 "tag_name": "v99.0.0rc1",
                 "html_url": "https://github.com/jundot/omlx/releases/tag/v99.0.0rc1",
-            },
+            }],
         )
         with patch("omlx.admin.routes.asyncio") as mock_asyncio:
             mock_asyncio.to_thread = _make_async_return(fake_resp)

--- a/tests/test_admin_update_check.py
+++ b/tests/test_admin_update_check.py
@@ -14,7 +14,7 @@ class _FakeResponse:
 
     def __init__(self, status_code, data=None):
         self.status_code = status_code
-        self._data = data or {}
+        self._data = data if data is not None else []
 
     def json(self):
         return self._data
@@ -38,10 +38,10 @@ class TestCheckUpdate:
     @pytest.mark.asyncio
     async def test_update_available(self):
         """Should return update_available=True when newer version exists."""
-        fake_resp = _FakeResponse(200, {
+        fake_resp = _FakeResponse(200, [{
             "tag_name": "v99.0.0",
             "html_url": "https://github.com/jundot/omlx/releases/tag/v99.0.0",
-        })
+        }])
 
         with patch("omlx.admin.routes.asyncio") as mock_asyncio:
             mock_asyncio.to_thread = _make_async_return(fake_resp)
@@ -55,10 +55,10 @@ class TestCheckUpdate:
     @pytest.mark.asyncio
     async def test_no_update(self):
         """Should return update_available=False when current version is latest."""
-        fake_resp = _FakeResponse(200, {
+        fake_resp = _FakeResponse(200, [{
             "tag_name": "v0.0.1",
             "html_url": "https://github.com/jundot/omlx/releases/tag/v0.0.1",
-        })
+        }])
 
         with patch("omlx.admin.routes.asyncio") as mock_asyncio:
             mock_asyncio.to_thread = _make_async_return(fake_resp)
@@ -97,10 +97,10 @@ class TestCheckUpdate:
     @pytest.mark.asyncio
     async def test_cache_is_used(self):
         """Should not call GitHub API again within TTL window."""
-        fake_resp = _FakeResponse(200, {
+        fake_resp = _FakeResponse(200, [{
             "tag_name": "v99.0.0",
             "html_url": "https://github.com/jundot/omlx/releases/tag/v99.0.0",
-        })
+        }])
 
         call_count = 0
 
@@ -124,10 +124,10 @@ class TestCheckUpdate:
     @pytest.mark.asyncio
     async def test_cache_expires(self):
         """Should call GitHub API again after TTL expires."""
-        fake_resp = _FakeResponse(200, {
+        fake_resp = _FakeResponse(200, [{
             "tag_name": "v99.0.0",
             "html_url": "https://github.com/jundot/omlx/releases/tag/v99.0.0",
-        })
+        }])
 
         call_count = 0
 

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -20,6 +20,16 @@ import pytest
 
 from omlx.api.openai_models import StructuredOutputOptions
 
+try:
+    import xgrammar  # noqa: F401
+    HAS_XGRAMMAR = True
+except ImportError:
+    HAS_XGRAMMAR = False
+
+requires_xgrammar = pytest.mark.skipif(
+    not HAS_XGRAMMAR, reason="xgrammar not installed"
+)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -222,7 +232,8 @@ class TestCompileWithStructuralTag:
         from omlx.server import _compile_with_structural_tag
         return _compile_with_structural_tag(compiler, fmt, reasoning_parser, chat_template_kwargs)
 
-    @patch("omlx.server.xgr" if False else "xgrammar.get_builtin_structural_tag")
+    @requires_xgrammar
+    @patch("xgrammar.get_builtin_structural_tag")
     def test_calls_get_builtin_structural_tag(self, mock_get_tag):
         """Verifies xgrammar.get_builtin_structural_tag is called with correct args."""
         xgr = pytest.importorskip("xgrammar")
@@ -244,6 +255,7 @@ class TestCompileWithStructuralTag:
         compiler.compile_structural_tag.assert_called_once()
         assert result == "compiled"
 
+    @requires_xgrammar
     @patch("xgrammar.get_builtin_structural_tag")
     def test_reasoning_false_when_thinking_disabled(self, mock_get_tag):
         xgr = pytest.importorskip("xgrammar")
@@ -263,6 +275,7 @@ class TestCompileWithStructuralTag:
 
         mock_get_tag.assert_called_once_with("qwen", reasoning=False)
 
+    @requires_xgrammar
     @patch("xgrammar.get_builtin_structural_tag")
     def test_patches_user_grammar_into_tag(self, mock_get_tag):
         """The user's grammar should replace the any_text in the tag."""
@@ -399,6 +412,7 @@ class TestCompileGrammarForRequest:
         assert result == "compiled_builtin"
         compiler.compile_builtin_json_grammar.assert_called_once()
 
+    @requires_xgrammar
     @patch("xgrammar.get_builtin_structural_tag")
     def test_reasoning_parser_uses_structural_tag(self, mock_get_tag):
         """When reasoning_parser is set, compile_structural_tag is used."""
@@ -423,6 +437,7 @@ class TestCompileGrammarForRequest:
         compiler.compile_structural_tag.assert_called_once()
         mock_get_tag.assert_called_once_with("qwen", reasoning=True)
 
+    @requires_xgrammar
     @patch("xgrammar.get_builtin_structural_tag")
     def test_reasoning_parser_with_thinking_disabled(self, mock_get_tag):
         """enable_thinking=False → reasoning=False passed to get_builtin_structural_tag."""


### PR DESCRIPTION
## Summary
- Fix GitHub releases API response shape in update-check tests (`{...}` → `[{...}]`)
- Add xgrammar import guards to grammar tests (`@requires_xgrammar`)
- Update `MockBaseEngine` to satisfy `BaseEngine` ABC (`stop()`, `get_stats()`, `get_cache_stats()`)
- Use `len(VALID_BENCHMARKS)` instead of hardcoded count in accuracy benchmark test

## Test plan
- [x] `pytest tests/test_admin_auth.py tests/test_admin_update_check.py tests/test_grammar.py tests/test_accuracy_benchmark.py tests/integration/test_server_endpoints.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)