### PR TITLE
fix(deps): bump dflash-mlx to fix act_bits=32 crash (DFlash w8a32)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,8 @@ dependencies = [
     # mlx-vlm from commit (f96138e) - Gemma4 MTP server batching (PR #1166), speculative utils refactor (PR #1169), Qwen native MTP drafter, MiniCPM-V 4.6
     "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@f96138eef1f5ce7fb5d97f8dd41a664a195b5659",
     "Pillow>=9.0.0",
-    # dflash-mlx v0.1.5.1 (20d68db) — original bstnxbt repo. Gemma4 support, runtime package refactor, stable prefix snapshot reuse
-    "dflash-mlx @ git+https://github.com/bstnxbt/dflash-mlx@20d68db3b3c0ae3dd6d3a2f0d3c10b2344ee514e",
+    # dflash-mlx (6761883) — fix _cast_to_f32 signature in load_draft_bundle (act_bits=32 crash on MLX apply)
+    "dflash-mlx @ git+https://github.com/bstnxbt/dflash-mlx@67618834f994c97f4358b9fdb331699d7dddbd27",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- **Root cause**: `_cast_to_f32` in `dflash_mlx.runtime.loading.load_draft_bundle` was defined as `(_, x: mx.array)` but `model.apply()` passes a single argument — calling `_cast_to_f32(array)` fails with `TypeError: missing 1 required positional argument: 'x'`
- **Trigger**: Only activates when DFlash quantization uses `act_bits=32` (i.e. `w8a32` config). With `act_bits=16` the code path is never reached, so the bug was invisible until users enabled 32-bit activations for better coding accuracy
- **Effect**: `DFlashEngine.start()` raises, caught by `engine_pool` which silently falls back to `BatchedEngine` — no visible error, just unexpectedly low throughput (~96 tok/s instead of ~250+ tok/s)
- **Fix**: Already merged upstream in `bstnxbt/dflash-mlx@1dac0a8` ("Fix MLX apply draft cast callbacks"). This PR bumps the pin to `6761883` (current HEAD)

## Test plan

- [ ] Start oMLX with a model that has DFlash enabled and `act_bits=32` (w8a32 config)
- [ ] Verify server log shows `DFlashEngine loaded` instead of `DFlash start failed`
- [ ] Verify throughput is ~250+ tok/s at pp1024 (not ~96 tok/s fallback)