### PR TITLE
fix(server): populate total_time in non-streaming usage responses

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2042,8 +2042,10 @@ async def create_completion(
                 prompt_tokens_details=PromptTokensDetails(
                     cached_tokens=total_cached_tokens,
                 ),
+                model_load_duration=round(model_load_duration, 2) if model_load_duration > 1.0 else None,
+                total_time=round(elapsed, 2),
             ),
-        ).model_dump_json()
+        ).model_dump_json(exclude_none=True)
 
     return StreamingResponse(
         _with_json_keepalive(http_request, _build_completion()),
@@ -2399,8 +2401,10 @@ async def create_chat_completion(
                 prompt_tokens_details=PromptTokensDetails(
                     cached_tokens=output.cached_tokens,
                 ),
+                model_load_duration=round(model_load_duration, 2) if model_load_duration > 1.0 else None,
+                total_time=round(elapsed, 2),
             ),
-        ).model_dump_json()
+        ).model_dump_json(exclude_none=True)
 
     return StreamingResponse(
         _with_json_keepalive(http_request, _build_chat_completion()),

--- a/tests/test_stream_usage.py
+++ b/tests/test_stream_usage.py
@@ -139,6 +139,48 @@ class TestUsageChunkFormat:
         assert data["usage"]["generation_tokens_per_second"] == 36.23
         assert "model_load_duration" not in data["usage"]
 
+    def test_non_streaming_usage_only_total_time(self):
+        """Non-streaming responses know elapsed but not TTFT/decode split.
+
+        Usage should serialize total_time and drop fields that would require
+        per-token instrumentation (TTFT, prompt_eval_duration, generation_duration,
+        prompt_tokens_per_second, generation_tokens_per_second).
+        """
+        usage = Usage(
+            prompt_tokens=18,
+            completion_tokens=6,
+            total_tokens=24,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=0),
+            total_time=0.43,
+        )
+        dumped = json.loads(usage.model_dump_json(exclude_none=True))
+        assert dumped["total_time"] == 0.43
+        assert dumped["prompt_tokens"] == 18
+        assert dumped["completion_tokens"] == 6
+        for absent in (
+            "time_to_first_token",
+            "prompt_eval_duration",
+            "generation_duration",
+            "prompt_tokens_per_second",
+            "generation_tokens_per_second",
+            "model_load_duration",
+        ):
+            assert absent not in dumped, f"{absent} should be excluded when None"
+
+    def test_non_streaming_usage_with_model_load(self):
+        """model_load_duration appears only when > 1.0s (matches streaming gate)."""
+        usage = Usage(
+            prompt_tokens=18,
+            completion_tokens=6,
+            total_tokens=24,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=0),
+            model_load_duration=12.34,
+            total_time=15.67,
+        )
+        dumped = json.loads(usage.model_dump_json(exclude_none=True))
+        assert dumped["model_load_duration"] == 12.34
+        assert dumped["total_time"] == 15.67
+
     def test_usage_chunk_with_all_fields(self):
         chunk = ChatCompletionChunk(
             id="chatcmpl-test",


### PR DESCRIPTION
## Summary

- Non-streaming `/v1/chat/completions` and `/v1/completions` returned `null` for every Usage timing field (`total_time`, `model_load_duration`, `time_to_first_token`, etc.) even though the request's elapsed time was already computed and logged. This patch passes `total_time` (and `model_load_duration`, gated `> 1.0s` to match the streaming threshold at server.py:2735) into the `Usage` constructor.
- Both non-streaming serializations now use `.model_dump_json(exclude_none=True)`, matching the streaming chunk's `.model_dump(exclude_none=True)` (server.py:2742) and the existing `test_usage_none_fields_excluded` test's stated intent. Fields that genuinely require per-token instrumentation (TTFT, `prompt_eval_duration`, decode-only `generation_duration`, the `*_per_second` rates) stay `None` and are dropped from the response rather than serialized as `null`.
- Two unit tests added to `tests/test_stream_usage.py` pin the new serialization contract.

### Before
```json
"usage": {
  "prompt_tokens": 18, "completion_tokens": 6, "total_tokens": 24,
  "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": null},
  "model_load_duration": null, "time_to_first_token": null,
  "total_time": null, "prompt_eval_duration": null,
  "generation_duration": null, "prompt_tokens_per_second": null,
  "generation_tokens_per_second": null
}
```

### After
```json
"usage": {
  "prompt_tokens": 18, "completion_tokens": 6, "total_tokens": 24,
  "prompt_tokens_details": {"cached_tokens": 0},
  "total_time": 0.28
}
```

### Why not also populate generation_duration / generation_tokens_per_second?

In the streaming path, `generation_duration = end_time - first_token_time` (decode only), and `generation_tokens_per_second` is computed against that. In the non-streaming path `engine.chat()` is a single await covering prefill + decode, so the only honest scalar available is `total_time`. Setting `generation_duration = elapsed` would conflate prefill cost into the rate and report a misleadingly low tok/s. Recovering an accurate split requires engine-level TTFT instrumentation, which is out of scope for this change.

## Test plan

- [x] `pytest tests/test_stream_usage.py tests/test_server.py tests/test_server_metrics.py` (71 passed)
- [x] Live: `omlx serve --model-dir ~/models --port 8000` with `mlx-community/Qwen3-4B-Instruct-2507-4bit`, hit non-streaming `/v1/chat/completions` and `/v1/completions`. Both responses now carry `total_time` and no longer include the null timing fields.
- [x] Live: streaming `/v1/chat/completions` with `stream_options.include_usage=true` still emits the full timing block in its final chunk (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)