### PR TITLE
feat(dflash): log context size and warn on low acceptance ratio

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -605,14 +605,30 @@ class DFlashEngine(BaseEngine):
                     elapsed_s = elapsed_us / 1e6 if elapsed_us else 0
                     gen_tps = gen_tokens / elapsed_s if elapsed_s > 0 else 0
                     fallback = bool(event.fallback_ar)
+                    prompt_ctx = int(event.prompt_token_count)
                     logger.info(
                         f"DFlash generation complete: "
                         f"{gen_tokens} tokens, "
                         f"{gen_tps:.1f} tok/s, "
                         f"acceptance={accept_ratio:.1%}, "
-                        f"cycles={cycles}"
+                        f"cycles={cycles}, "
+                        f"ctx={prompt_ctx}"
                         f"{', fallback=AR' if fallback else ''}"
                     )
+                    if accept_ratio < 0.55:
+                        max_ctx = self._max_dflash_ctx
+                        near_limit = (
+                            max_ctx is not None and prompt_ctx >= int(max_ctx * 0.85)
+                        )
+                        limit_note = (
+                            f" (approaching fallback threshold {max_ctx})"
+                            if near_limit else ""
+                        )
+                        logger.warning(
+                            f"DFlash acceptance low: {accept_ratio:.1%} at "
+                            f"{prompt_ctx} context tokens{limit_note} — "
+                            "consider starting a new conversation soon"
+                        )
                     metrics = {
                         "prompt_tokens": int(event.prompt_token_count),
                         "completion_tokens": gen_tokens,


### PR DESCRIPTION
## Problem

When DFlash acceptance degrades in long conversations, users have no visibility into:
- **How many context tokens** were present when degradation occurred
- **A proactive warning** before DFlash permanently falls back to BatchedEngine

The current log only shows:
```
DFlash generation complete: 142 tokens, 3.1 tok/s, acceptance=49.3%, cycles=72
```

By the time acceptance is this low, the session is often only a few turns away from the permanent DFlash→BatchedEngine eviction — after which all subsequent requests (including new conversations) must go through SpecPrefill cold, causing 8–70 second stalls before the first token.

## Changes

- Add `ctx=N` to the existing `DFlash generation complete` log line (uses `event.prompt_token_count`, already available but unused in the log)
- Emit a `WARNING` when `acceptance_ratio < 0.55`, including the context token count and a note when within 85% of `dflash_max_ctx`

**After:**
```
DFlash generation complete: 142 tokens, 3.1 tok/s, acceptance=49.3%, cycles=72, ctx=62800
WARNING: DFlash acceptance low: 49.3% at 62800 context tokens (approaching fallback threshold 65536) — consider starting a new conversation soon
```

## Why 55%

From empirical observation on M4 Max 64GB with Qwen3.6-35B-A3B-TurboQuant-MLX-4bit + z-lab DFlash draft (w8a32):
- acceptance ≥ 65%: DFlash clearly faster than plain AR
- acceptance 55–65%: marginal gain, context approaching draft attention window limits  
- acceptance < 55%: DFlash is often slower than plain AR decoding

The 55% threshold is a conservative early warning, not a hard cutoff.

## Test plan

- [ ] Start a long conversation until acceptance drops below 55%
- [ ] Verify `ctx=N` appears in every `DFlash generation complete` log line
- [ ] Verify `WARNING: DFlash acceptance low` appears with correct context count and threshold note when within 85% of `dflash_max_ctx`
- [ ] Verify no warning is emitted when acceptance ≥ 55%
- [ ] Verify `ctx=` field is present even on healthy generations