### PR TITLE
feat:(ui): Add observable memory bar to the dashboard.

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -1613,6 +1613,12 @@ async def list_models(is_admin: bool = Depends(require_admin)):
             "is_loading": model_info.get("is_loading", False),
             "estimated_size": model_info.get("estimated_size", 0),
             "estimated_size_formatted": format_size(model_info.get("estimated_size", 0)),
+            "actual_size": model_info.get("actual_size") or 0,
+            "actual_size_formatted": (
+                format_size(model_info.get("actual_size", 0))
+                if model_info.get("actual_size")
+                else None
+            ),
             "pinned": model_info.get("pinned", False),
             "is_default": server_state.default_model == model_id if server_state else False,
             "engine_type": model_info.get("engine_type", "batched"),
@@ -3734,11 +3740,23 @@ def _build_active_models_data() -> dict:
     from ..prefill_progress import get_prefill_tracker
 
     engine_pool = _get_engine_pool()
+    server_state = _get_server_state()
     if engine_pool is None:
         return {
             "models": [],
             "model_memory_used": 0,
             "model_memory_max": 0,
+            "model_memory_used_actual": 0,
+            "memory_pressure": {
+                "enabled": False,
+                "current_bytes": 0,
+                "soft_bytes": 0,
+                "hard_bytes": 0,
+                "current_formatted": "0.0GB",
+                "soft_formatted": "0.0GB",
+                "hard_formatted": "0.0GB",
+                "pressure_level": "ok",
+            },
             "total_active_requests": 0,
             "total_waiting_requests": 0,
         }
@@ -3746,6 +3764,12 @@ def _build_active_models_data() -> dict:
     now = time.monotonic()
     tracker = get_prefill_tracker()
     status = engine_pool.get_status()
+    enforcer = (
+        getattr(server_state, "process_memory_enforcer", None)
+        if server_state is not None
+        else None
+    )
+    enforcer_status = enforcer.get_status() if enforcer is not None else None
     models = []
     total_active = 0
     total_waiting = 0
@@ -3863,6 +3887,12 @@ def _build_active_models_data() -> dict:
             "estimated_size_formatted": format_size(
                 model_info.get("estimated_size", 0)
             ),
+            "actual_size": model_info.get("actual_size") or 0,
+            "actual_size_formatted": (
+                format_size(model_info.get("actual_size", 0))
+                if model_info.get("actual_size")
+                else None
+            ),
             "pinned": model_info.get("pinned", False),
             "is_loading": model_info.get("is_loading", False),
             "loading_elapsed_seconds": loading_elapsed_seconds,
@@ -3883,6 +3913,45 @@ def _build_active_models_data() -> dict:
         "models": models,
         "model_memory_used": status.get("current_model_memory", 0),
         "model_memory_max": status.get("max_model_memory", 0),
+        "model_memory_used_actual": status.get("current_model_memory_actual", 0),
+        "memory_pressure": {
+            "enabled": bool(enforcer_status and enforcer_status.get("enabled")),
+            "current_bytes": (
+                enforcer_status.get("current_bytes", 0)
+                if enforcer_status is not None
+                else 0
+            ),
+            "soft_bytes": (
+                enforcer_status.get("soft_bytes", 0)
+                if enforcer_status is not None
+                else 0
+            ),
+            "hard_bytes": (
+                enforcer_status.get("hard_bytes", 0)
+                if enforcer_status is not None
+                else 0
+            ),
+            "current_formatted": (
+                enforcer_status.get("current_formatted", "0.0GB")
+                if enforcer_status is not None
+                else "0.0GB"
+            ),
+            "soft_formatted": (
+                enforcer_status.get("soft_formatted", "0.0GB")
+                if enforcer_status is not None
+                else "0.0GB"
+            ),
+            "hard_formatted": (
+                enforcer_status.get("hard_formatted", "0.0GB")
+                if enforcer_status is not None
+                else "0.0GB"
+            ),
+            "pressure_level": (
+                enforcer_status.get("pressure_level", "ok")
+                if enforcer_status is not None
+                else "ok"
+            ),
+        },
         "total_active_requests": total_active,
         "total_waiting_requests": total_waiting,
     }

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -149,6 +149,14 @@
                     models: [],
                     model_memory_used: 0,
                     model_memory_max: 0,
+                    model_memory_used_actual: 0,
+                    memory_pressure: {
+                        enabled: false,
+                        current_bytes: 0,
+                        soft_bytes: 0,
+                        hard_bytes: 0,
+                        pressure_level: 'ok',
+                    },
                     total_active_requests: 0,
                     total_waiting_requests: 0,
                 },
@@ -2113,7 +2121,7 @@
                 }
             },
 
-            async loadStats() {
+            async loadStats(includeAlltime = true) {
                 try {
                     const params = new URLSearchParams();
                     if (this.selectedStatsModel) {
@@ -2126,6 +2134,10 @@
                         this.stats = { ...this.stats, ...data };
                     } else if (response.status === 401) {
                         window.location.href = '/admin';
+                    }
+
+                    if (!includeAlltime) {
+                        return;
                     }
 
                     // Load all-time stats
@@ -2192,9 +2204,10 @@
 
             startStatsRefresh() {
                 this.stopStatsRefresh();
+                this.loadStats();
                 this._statsRefreshTimer = setInterval(() => {
-                    this.loadStats();
-                }, 1000);
+                    this.loadStats(false);
+                }, 500);
             },
 
             stopStatsRefresh() {
@@ -2313,10 +2326,61 @@
                 return Math.min(100, (rc.total_size_bytes / rc.disk_max_bytes) * 100);
             },
 
-            get activeModelsMemoryPercent() {
-                const am = this.stats.active_models;
-                if (!am || !am.model_memory_max) return 0;
-                return Math.min(100, (am.model_memory_used / am.model_memory_max) * 100);
+            get activeModelsPressurePercent() {
+                const mp = this.stats.active_models?.memory_pressure;
+                if (!mp || !mp.hard_bytes) return 0;
+                return Math.min(100, (mp.current_bytes / mp.hard_bytes) * 100);
+            },
+
+            get activeModelsSoftPercent() {
+                const mp = this.stats.active_models?.memory_pressure;
+                if (!mp || !mp.hard_bytes || !mp.soft_bytes) return 0;
+                return Math.min(100, (mp.soft_bytes / mp.hard_bytes) * 100);
+            },
+
+            get activeModelsPressureBarColor() {
+                const pct = this.activeModelsPressurePercent;
+                if (pct >= 90) return '#ef4444';
+                if (pct >= 80) return '#f97316';
+                if (pct >= 70) return '#f59e0b';
+                if (pct >= 60) return '#facc15';
+                return '#22c55e';
+            },
+
+            get activeModelsPressureBarStyle() {
+                return `width: ${this.activeModelsPressurePercent}%; height: 100%; display: block; background-color: ${this.activeModelsPressureBarColor};`;
+            },
+
+            get activeModelsSoftMarkerStyle() {
+                return `left: ${this.activeModelsSoftPercent}%; width: 1px; background-color: rgba(64, 64, 64, 0.6);`;
+            },
+
+            activeModelsPressureLabel() {
+                const mp = this.stats.active_models?.memory_pressure;
+                if (!mp || !mp.enabled || !mp.hard_bytes) {
+                    return 'Enforcer disabled';
+                }
+                return `${this.formatSizeBytes(mp.current_bytes)} / ${this.formatSizeBytes(mp.soft_bytes)} soft / ${this.formatSizeBytes(mp.hard_bytes)} hard`;
+            },
+
+            modelSizeLabel(model) {
+                if (!model) return '-';
+                const estimated = model.estimated_size_formatted || '-';
+                if (model.is_loading) {
+                    return estimated;
+                }
+                const actual = model.actual_size_formatted;
+                if (!actual) {
+                    return estimated;
+                }
+                if (!estimated || estimated === actual) {
+                    return `${actual}`;
+                }
+                return `${actual} / ${estimated} est`;
+            },
+
+            activeModelSizeLabel(model) {
+                return this.modelSizeLabel(model);
             },
 
             copyToClipboard(text) {

--- a/omlx/admin/templates/dashboard/_settings.html
+++ b/omlx/admin/templates/dashboard/_settings.html
@@ -967,8 +967,8 @@
                                         </div>
 
                                         <!-- Size -->
-                                        <div class="hidden sm:block w-20 text-center flex-shrink-0">
-                                            <span class="text-sm text-neutral-600" x-text="model.estimated_size_formatted || '-'"></span>
+                                        <div class="hidden sm:block w-60 text-center flex-shrink-0">
+                                            <span class="text-sm text-neutral-600" x-text="modelSizeLabel(model)"></span>
                                         </div>
 
                                         <!-- Status -->

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -110,12 +110,18 @@
                             <div class="flex items-center gap-3">
                                 <!-- Memory progress bar -->
                                 <div class="flex items-center gap-2">
-                                    <div class="w-24 h-2 bg-neutral-200 rounded-full overflow-hidden">
-                                        <div class="h-full bg-neutral-700 rounded-full transition-all duration-500"
-                                             :style="'width: ' + activeModelsMemoryPercent + '%'"></div>
+                                     <div class="bg-neutral-200 rounded-full overflow-hidden relative shrink-0"
+                                         style="width: 9rem; height: 0.625rem;">
+                                        <div class="rounded-full transition-all duration-300"
+                                            :style="activeModelsPressureBarStyle"></div>
+                                        <div x-show="stats.active_models.memory_pressure && stats.active_models.memory_pressure.enabled && activeModelsSoftPercent > 0"
+                                             x-cloak
+                                            class="absolute inset-y-0"
+                                            :style="activeModelsSoftMarkerStyle">
+                                        </div>
                                     </div>
                                     <span class="text-xs font-medium text-neutral-500 whitespace-nowrap"
-                                          x-text="formatSizeBytes(stats.active_models.model_memory_used) + ' / ' + formatSizeBytes(stats.active_models.model_memory_max)"></span>
+                                          x-text="activeModelsPressureLabel()"></span>
                                 </div>
                             </div>
                         </div>
@@ -169,7 +175,7 @@
                                                 </template>
                                             </div>
                                             <!-- Memory size -->
-                                            <span class="text-xs text-neutral-400 font-mono w-16 text-right" x-text="m.estimated_size_formatted"></span>
+                                                <span class="text-xs text-neutral-400 font-mono w-60 text-right" x-text="activeModelSizeLabel(m)"></span>
                                             <!-- Unload button -->
                                             <div x-show="!m.is_loading" class="relative opacity-0 group-hover:opacity-100 transition-all"
                                                  x-data="{ showTip: false }"

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -56,6 +56,7 @@ class EngineEntry:
     model_type: Literal["llm", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", "audio_sts"]  # Model type
     engine_type: Literal["batched", "simple", "embedding", "reranker", "vlm", "audio_stt", "audio_tts", "audio_sts"]  # Engine type to use
     estimated_size: int  # Pre-calculated from safetensors (bytes)
+    actual_size: int | None = None  # Observed process-memory delta after load settles
     config_model_type: str = ""  # Raw model_type from config.json (e.g., "deepseekocr_2")
     thinking_default: bool | None = None  # True if model thinks by default, False if not, None if unknown
     preserve_thinking_default: bool | None = None  # True when template supports preserve_thinking (Qwen 3.6+)
@@ -499,6 +500,7 @@ class EnginePool:
         # Clear engine reference before settle barrier
         entry.engine = None
         entry.last_access = 0.0
+        entry.actual_size = None
 
         # Force garbage collection to release memory.
         # Run mx.clear_cache on the global MLX executor to avoid concurrent
@@ -599,6 +601,7 @@ class EnginePool:
         load_started_at = entry.loading_started_at
         load_completed = False
         entry.abort_loading = False
+        pre_load_memory = max(mx.get_active_memory(), get_phys_footprint())
         try:
             effective_type = entry.engine_type
             if force_lm and effective_type == "vlm":
@@ -909,9 +912,14 @@ class EnginePool:
                 lambda: (mx.synchronize(), mx.clear_cache()),
             )
 
+            post_load_memory = max(mx.get_active_memory(), get_phys_footprint())
+            observed_delta = max(0, post_load_memory - pre_load_memory)
+            entry.actual_size = observed_delta or entry.estimated_size
+
             logger.info(
                 f"Loaded model: {model_id} "
-                f"(estimated: {format_size(entry.estimated_size)}, "
+                f"(actual: {format_size(entry.actual_size)}, "
+                f"estimated: {format_size(entry.estimated_size)}, "
                 f"total: {format_size(self._current_model_memory)})"
             )
         finally:
@@ -976,6 +984,11 @@ class EnginePool:
         return {
             "max_model_memory": self._max_model_memory,
             "current_model_memory": self._current_model_memory,
+            "current_model_memory_actual": sum(
+                (e.actual_size or e.estimated_size)
+                for e in self._entries.values()
+                if e.engine is not None
+            ),
             "model_count": len(self._entries),
             "loaded_count": sum(1 for e in self._entries.values() if e.engine is not None),
             "load_seconds_per_gb_estimate": self._load_seconds_per_gb_ema,
@@ -988,6 +1001,7 @@ class EnginePool:
                     "is_loading": e.is_loading,
                     "loading_started_at": e.loading_started_at,
                     "estimated_size": e.estimated_size,
+                    "actual_size": e.actual_size,
                     "pinned": e.is_pinned,
                     "engine_type": e.engine_type,
                     "model_type": e.model_type,

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -404,8 +404,15 @@ class ProcessMemoryEnforcer:
             "enabled": self._running,
             "max_bytes": self._max_bytes,
             "max_formatted": _format_gb(self._max_bytes),
+            "soft_threshold": self._soft_threshold,
+            "hard_threshold": self._hard_threshold,
+            "soft_bytes": self._soft_bytes,
+            "soft_formatted": _format_gb(self._soft_bytes),
+            "hard_bytes": self._hard_bytes,
+            "hard_formatted": _format_gb(self._hard_bytes),
             "current_bytes": current,
             "current_formatted": _format_gb(current),
+            "pressure_level": self._pressure_level if self._running else "ok",
             "utilization": (
                 current / self._max_bytes if self._max_bytes > 0 else 0.0
             ),


### PR DESCRIPTION
* Pull number from the memory enforcer
* Update at 500ms
* Display at the dashboard
* Per active model use delta between not load and loaded state to determine real memory usage, some model use a lot less than estimate.

<img width="1333" height="236" alt="Screenshot 2569-05-16 at 17 16 26" src="https://github.com/user-attachments/assets/e8a9e2b3-7c5c-405b-9d6b-a3e73a2b816a" />
<img width="1339" height="177" alt="Screenshot 2569-05-16 at 17 16 36" src="https://github.com/user-attachments/assets/05eee513-7937-4784-9aff-9da7bca91629" />
<img width="1342" height="273" alt="Screenshot 2569-05-16 at 17 17 19" src="https://github.com/user-attachments/assets/23d68a52-c2e2-4328-a2a3-2f0833d21ddd" />
