### PR TITLE
feat(pi): enhance agent directory configuration with environment vari…

### DIFF
--- a/omlx/integrations/pi.py
+++ b/omlx/integrations/pi.py
@@ -10,11 +10,19 @@ from omlx.integrations.base import Integration
 from omlx.utils.install import get_cli_prefix
 
 
-class PiIntegration(Integration):
-    """Pi integration that configures ~/.pi/agent/models.json and settings.json."""
+def _get_agent_dir() -> Path:
+    """Get the pi agent config directory, respecting PI_CODING_AGENT_DIR."""
+    env_dir = os.environ.get("PI_CODING_AGENT_DIR")
+    if env_dir:
+        return Path(env_dir).expanduser()
+    return Path.home() / ".pi" / "agent"
 
-    MODELS_PATH = Path.home() / ".pi" / "agent" / "models.json"
-    SETTINGS_PATH = Path.home() / ".pi" / "agent" / "settings.json"
+class PiIntegration(Integration):
+    """Pi integration that configures the pi agent config directory."""
+
+    AGENT_DIR = _get_agent_dir()
+    MODELS_PATH = AGENT_DIR / "models.json"
+    SETTINGS_PATH = AGENT_DIR / "settings.json"
 
     def __init__(self):
         super().__init__(

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -13,7 +13,7 @@ from omlx.integrations.codex import CodexIntegration
 from omlx.integrations.copilot import CopilotIntegration
 from omlx.integrations.opencode import OpenCodeIntegration
 from omlx.integrations.openclaw import OpenClawIntegration
-from omlx.integrations.pi import PiIntegration
+from omlx.integrations.pi import PiIntegration, _get_agent_dir
 
 
 class TestIntegrationRegistry:
@@ -415,6 +415,24 @@ class TestOpenClawIntegration:
 
 
 class TestPiIntegration:
+    def test_get_agent_dir_default(self, tmp_path, monkeypatch):
+        """Default agent dir is ~/.pi/agent when env var is not set."""
+        monkeypatch.delenv("PI_CODING_AGENT_DIR", raising=False)
+        result = _get_agent_dir()
+        assert result == Path.home() / ".pi" / "agent"
+
+    def test_get_agent_dir_custom_env(self, tmp_path, monkeypatch):
+        """PI_CODING_AGENT_DIR env var overrides the default path."""
+        monkeypatch.setenv("PI_CODING_AGENT_DIR", str(tmp_path / "custom_pi"))
+        result = _get_agent_dir()
+        assert result == tmp_path / "custom_pi"
+
+    def test_get_agent_dir_expands_user(self, tmp_path, monkeypatch):
+        """PI_CODING_AGENT_DIR ~ is expanded to the home directory."""
+        monkeypatch.setenv("PI_CODING_AGENT_DIR", "~/my-agent")
+        result = _get_agent_dir()
+        assert result == Path.home() / "my-agent"
+
     def test_get_command(self):
         pi = PiIntegration()
         cmd = pi.get_command(port=8000, api_key="key", model="qwen3.5")


### PR DESCRIPTION
This adds Pi Coding Agent's "PI_CODING_AGENT_DIR" variable to Pi Integration (omlx/integrations/pi.py) so oMLX can use the variable to setup the model integration for settings.json and models.json.

adds tests to the tests/test_integrations.py.

Reference in the Pi Docs for PI_CODING_AGENT_DIR - Under Environment Variables
https://pi.dev/docs/latest/usage#:~:text=code%22-,Environment%20Variables

AI SUMMARY
This pull request improves the configuration flexibility of the `PiIntegration` class by allowing the pi agent's config directory to be set via an environment variable, and adds corresponding tests to ensure correct behavior. The main focus is on making the agent directory location configurable and testable.

Configuration improvements for `PiIntegration`:

* Added a `_get_agent_dir` helper function in `omlx/integrations/pi.py` to determine the pi agent config directory, prioritizing the `PI_CODING_AGENT_DIR` environment variable and falling back to the default `~/.pi/agent` path. (`[omlx/integrations/pi.pyR13-R25](diffhunk://#diff-75caab1d3aee2e6c3ebb1047fe824b7428a3f485eb342ddf291a62b4ea339c92R13-R25)`)
* Updated `PiIntegration` to use the new `_get_agent_dir` function for its `MODELS_PATH` and `SETTINGS_PATH` attributes, making the config directory location dynamic. (`[omlx/integrations/pi.pyR13-R25](diffhunk://#diff-75caab1d3aee2e6c3ebb1047fe824b7428a3f485eb342ddf291a62b4ea339c92R13-R25)`)

Testing enhancements:

* Imported `_get_agent_dir` in `tests/test_integrations.py` to allow direct testing of the helper function. (`[tests/test_integrations.pyL16-R16](diffhunk://#diff-32998b183a0ea425281f7287e50c0212757b185e44c143aea1732d88923ffabbL16-R16)`)
* Added tests to verify that `_get_agent_dir` correctly handles the default path, environment variable override, and user directory expansion. (`[tests/test_integrations.pyR418-R435](diffhunk://#diff-32998b183a0ea425281f7287e50c0212757b185e44c143aea1732d88923ffabbR418-R435)`)…able support and add tests