### PR TITLE
fix(engine_pool): surface original load error when fallback also fails

### DIFF
--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -737,7 +737,13 @@ class EnginePool:
                             scheduler_config=self._scheduler_config,
                             model_settings=model_settings,
                         )
-                    await engine.start()
+                    try:
+                        await engine.start()
+                    except Exception as fallback_error:
+                        raise RuntimeError(
+                            f"DFlash load failed: {start_error}; "
+                            f"{effective_type} fallback also failed: {fallback_error}"
+                        ) from start_error
                     logger.info(
                         f"Successfully loaded {model_id} as {effective_type} "
                         f"(fallback from DFlash)"
@@ -768,7 +774,13 @@ class EnginePool:
                         scheduler_config=self._scheduler_config,
                         model_settings=model_settings,
                     )
-                    await engine.start()
+                    try:
+                        await engine.start()
+                    except Exception as fallback_error:
+                        raise RuntimeError(
+                            f"LM load failed (force_lm=True): {start_error}; "
+                            f"VLM fallback also failed: {fallback_error}"
+                        ) from start_error
 
                     logger.info(
                         f"Successfully loaded {model_id} as VLM "
@@ -797,7 +809,13 @@ class EnginePool:
                         scheduler_config=self._scheduler_config,
                         model_settings=model_settings,
                     )
-                    await engine.start()
+                    try:
+                        await engine.start()
+                    except Exception as fallback_error:
+                        raise RuntimeError(
+                            f"VLM load failed: {start_error}; "
+                            f"LLM fallback also failed: {fallback_error}"
+                        ) from start_error
 
                     entry.model_type = "llm"
                     entry.engine_type = "batched"


### PR DESCRIPTION
## Problem

`EnginePool._load_model` catches engine-start failures and retries with an alternate engine type. When the alternate also raises, the HTTP 500 carries only the alternate's error: the original failure lands at WARNING level in `server.log` and never reaches the ERROR-level exception log in `server.py` (`unhandled_exception_handler`). This PR logs the original failure alongside the alternate's.

A concrete trace: a long-running oMLX daemon started before I installed `torch`, so `transformers.utils.import_utils.is_torch_available` cached `False` at startup (via `@lru_cache`). Loading `LFM2-VL-3B-bf16` raised `Lfm2VlImageProcessor requires the PyTorch library but it was not found in your environment.` at the VLM engine start. The VLM→Batched fallback then raised `Model type lfm2_vl not supported.` (mlx-lm has no `lfm2_vl` registration). The client received `Internal server error`; the 500 traceback showed only `Model type lfm2_vl not supported.`, hiding the real cause.

## Fix

Wrap the inner `await engine.start()` in each fallback branch (`DFlash → natural`, `force_lm → VLM`, `VLM → LLM`) in a `try`/`except`. On fallback failure, raise `RuntimeError(...) from start_error` so the original failure becomes the explicit `__cause__` in formatted tracebacks. The new message embeds `str(fallback_error)`, so the catch-all's single `%s` log line carries both errors.

## Verification

Reproducing the trace above with this branch, the unhandled-exception logger now records `VLM load failed: Lfm2VlImageProcessor requires the PyTorch library …; LLM fallback also failed: Model type lfm2_vl not supported.` — instead of the bare `Model type lfm2_vl not supported.`. To reproduce, start the daemon in an env without `torch`, then install `torch` later (the `@lru_cache` result for `is_torch_available` stays `False` for the life of the process).

Successful loads of `LFM2-VL-450M-bf16`, `LFM2-VL-1.6B-bf16`, and `LFM2-VL-3B-bf16` (after a torch-aware restart) still initialize and serve requests.

## Scope and risk

- Files: `omlx/engine_pool.py` (+21/−3 lines).
- Risk: very low. The change touches only the exception raised when both engines fail to start; successful loads and successful fallbacks are unaffected.
- No HTTP API contract change. The internal exception type becomes `RuntimeError` only on dual failure (primary load and fallback load both raise).