### PR TITLE
fix(tests): update Scheduler/Memory to_dict expectations for new fields

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -273,6 +273,7 @@ class TestSchedulerSettings:
         result = settings.to_dict()
         assert result == {
             "max_concurrent_requests": 8,
+            "chunked_prefill": False,
         }
 
     def test_from_dict(self):
@@ -673,7 +674,12 @@ class TestMemorySettings:
         """Test serialization."""
         settings = MemorySettings(max_process_memory="75%")
         d = settings.to_dict()
-        assert d == {"max_process_memory": "75%", "prefill_memory_guard": True}
+        assert d == {
+            "max_process_memory": "75%",
+            "prefill_memory_guard": True,
+            "soft_threshold": 0.85,
+            "hard_threshold": 0.95,
+        }
 
     def test_to_dict_guard_disabled(self):
         """Test serialization with prefill guard disabled."""


### PR DESCRIPTION
## Summary

`SchedulerSettings.to_dict()` and `MemorySettings.to_dict()` emit several fields (`chunked_prefill`, `soft_threshold`, `hard_threshold`) that their corresponding tests in `tests/test_settings.py` didn't include in the expected dict. The tests fail locally against current defaults. Updates the expected dicts to match the implementation.

## Why this matters

#1259 surfaced the staleness in passing. Test failures in this area mask any real regression in the settings serialization path.

## Changes

- `tests/test_settings.py` - update `to_dict` expectations for SchedulerSettings and MemorySettings to include the missing fields.

## Testing

Tests pass locally after the update; no other test changes needed.

Fixes #1259
