### PR TITLE
feat(oq): load presaved oQ sensitivity map from the source model folder

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -2244,76 +2244,82 @@ def quantize_oq_streaming(
         f"{len(weight_files)} shards"
     )
 
-    from omlx.settings import get_system_memory as _get_system_memory
-    _model_bytes = all_weights.nbytes()
-    _system_ram = _get_system_memory()
-    _model_exceeds_ram = _model_bytes > int(_system_ram * _MAX_MODEL_RAM_FRACTION)
-    if _model_exceeds_ram:
-        logger.info(
-            f"oQ{oq_level:g}: model size ({_model_bytes / 1e9:.1f} GB) exceeds "
-            f"80% of system RAM ({_system_ram / 1e9:.1f} GB), "
-            "OOM-prone paths will be skipped"
-        )
+    sensitivity_map_path = Path(model_path, "oq_sensitivity_map.json")
 
-    cb("loading", 12.0)
-
-    # --- Sensitivity measurement (before sanitize-plan discovery) ---------
-    # Must run before _build_model_sanitizer + _discover_sanitize_plan,
-    # because the discovery pass feeds _TrackedTensor proxies through
-    # Model.sanitize which corrupts mutable state in the MTP sanitize
-    # patch (weights.pop on tracked objects). Running sensitivity first
-    # ensures vlm_load_model sees a pristine patch chain.
-    if sensitivity_model_path:
-        logger.info(f"oQ{oq_level:g}: measuring sensitivity via proxy model")
-        sensitivity_map = _measure_sensitivity_from_quantized_model(
-            sensitivity_model_path, config, oq_level,
-            num_samples=128, seq_length=256,
-        )
-    elif _model_exceeds_ram and auto_proxy_sensitivity:
-        logger.warning(
-            f"oQ{oq_level:g}: model size ({_model_bytes/1e9:.1f} GB) exceeds "
-            f"{int(_MAX_MODEL_RAM_FRACTION*100)}% of system RAM "
-            f"({_system_ram/1e9:.1f} GB). Auto-building a uniform "
-            f"{_PROXY_QUANT_BITS}-bit proxy on disk so sensitivity "
-            "measurement stays data-driven."
-        )
-        _proxy_dir: Path | None = None
-        try:
-            _proxy_dir = _build_proxy_for_sensitivity(
-                model_path, dtype=dtype, working_dir=str(output.parent),
-            )
+    if sensitivity_map_path.exists():
+        sensitivity_map = json.loads(sensitivity_map_path.read_text(encoding="utf-8"))
+        logger.info(f"{sensitivity_map_path} found, skipping measuring.")
+    else:
+        from omlx.settings import get_system_memory as _get_system_memory
+        _model_bytes = all_weights.nbytes()
+        _system_ram = _get_system_memory()
+        _model_exceeds_ram = _model_bytes > int(_system_ram * _MAX_MODEL_RAM_FRACTION)
+        if _model_exceeds_ram:
             logger.info(
-                f"oQ{oq_level:g}: proxy ready at {_proxy_dir}, measuring sensitivity"
+                f"oQ{oq_level:g}: model size ({_model_bytes / 1e9:.1f} GB) exceeds "
+                f"80% of system RAM ({_system_ram / 1e9:.1f} GB), "
+                "OOM-prone paths will be skipped"
             )
+
+        cb("loading", 12.0)
+
+        # --- Sensitivity measurement (before sanitize-plan discovery) ---------
+        # Must run before _build_model_sanitizer + _discover_sanitize_plan,
+        # because the discovery pass feeds _TrackedTensor proxies through
+        # Model.sanitize which corrupts mutable state in the MTP sanitize
+        # patch (weights.pop on tracked objects). Running sensitivity first
+        # ensures vlm_load_model sees a pristine patch chain.
+        if sensitivity_model_path:
+            logger.info(f"oQ{oq_level:g}: measuring sensitivity via proxy model")
             sensitivity_map = _measure_sensitivity_from_quantized_model(
-                str(_proxy_dir), config, oq_level,
+                sensitivity_model_path, config, oq_level,
                 num_samples=128, seq_length=256,
             )
-        except Exception as e:
+        elif _model_exceeds_ram and auto_proxy_sensitivity:
+            logger.warning(
+                f"oQ{oq_level:g}: model size ({_model_bytes/1e9:.1f} GB) exceeds "
+                f"{int(_MAX_MODEL_RAM_FRACTION*100)}% of system RAM "
+                f"({_system_ram/1e9:.1f} GB). Auto-building a uniform "
+                f"{_PROXY_QUANT_BITS}-bit proxy on disk so sensitivity "
+                "measurement stays data-driven."
+            )
+            _proxy_dir: Path | None = None
+            try:
+                _proxy_dir = _build_proxy_for_sensitivity(
+                    model_path, dtype=dtype, working_dir=str(output.parent),
+                )
+                logger.info(
+                    f"oQ{oq_level:g}: proxy ready at {_proxy_dir}, measuring sensitivity"
+                )
+                sensitivity_map = _measure_sensitivity_from_quantized_model(
+                    str(_proxy_dir), config, oq_level,
+                    num_samples=128, seq_length=256,
+                )
+            except Exception as e:
+                raise RuntimeError(
+                    f"oQ{oq_level:g}: auto-proxy sensitivity failed ({e}). "
+                    "Pass sensitivity_model_path with a pre-quantized version "
+                    "of this model, or run on a machine with enough RAM for "
+                    "full-fp16 sensitivity measurement."
+                ) from e
+            finally:
+                if _proxy_dir is not None and _proxy_dir.exists():
+                    shutil.rmtree(_proxy_dir, ignore_errors=True)
+                    logger.info(f"oQ{oq_level:g}: cleaned up proxy at {_proxy_dir}")
+        elif _model_exceeds_ram:
             raise RuntimeError(
-                f"oQ{oq_level:g}: auto-proxy sensitivity failed ({e}). "
-                "Pass sensitivity_model_path with a pre-quantized version "
-                "of this model, or run on a machine with enough RAM for "
-                "full-fp16 sensitivity measurement."
-            ) from e
-        finally:
-            if _proxy_dir is not None and _proxy_dir.exists():
-                shutil.rmtree(_proxy_dir, ignore_errors=True)
-                logger.info(f"oQ{oq_level:g}: cleaned up proxy at {_proxy_dir}")
-    elif _model_exceeds_ram:
-        raise RuntimeError(
-            f"oQ{oq_level:g}: model exceeds {int(_MAX_MODEL_RAM_FRACTION*100)}% "
-            "of system RAM and auto_proxy_sensitivity is disabled. "
-            "Enable auto_proxy_sensitivity, pass sensitivity_model_path "
-            "with a pre-quantized version of this model, or run on a "
-            "machine with enough RAM."
-        )
-    else:
-        logger.info(f"oQ{oq_level:g}: measuring layer sensitivity for streaming path")
-        sensitivity_map = _measure_sensitivity(
-            model_path, config, oq_level,
-            num_samples=128, seq_length=256,
-        )
+                f"oQ{oq_level:g}: model exceeds {int(_MAX_MODEL_RAM_FRACTION*100)}% "
+                "of system RAM and auto_proxy_sensitivity is disabled. "
+                "Enable auto_proxy_sensitivity, pass sensitivity_model_path "
+                "with a pre-quantized version of this model, or run on a "
+                "machine with enough RAM."
+            )
+        else:
+            logger.info(f"oQ{oq_level:g}: measuring layer sensitivity for streaming path")
+            sensitivity_map = _measure_sensitivity(
+                model_path, config, oq_level,
+                num_samples=128, seq_length=256,
+            )
 
     # Single enforcement point. Inner measurement helpers may return {} on
     # load / calibration / layer-discovery failure; treat that as a hard

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for oQ (oMLX Universal Dynamic Quantization)."""
 
+import json
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -2357,3 +2358,175 @@ class TestMeasureSensitivityVlmMtp:
 
         mock_apply_runtime.assert_not_called()
         mock_set_active.assert_not_called()
+
+
+# =============================================================================
+# Test pre-computed sensitivity map loading (oq_sensitivity_map.json)
+# =============================================================================
+
+
+class TestPrecomputedSensitivityMap:
+    """Tests for the oq_sensitivity_map.json disk cache feature.
+
+    When a pre-computed sensitivity map file exists at
+    ``{model_path}/oq_sensitivity_map.json``, quantize_oq_streaming loads it
+    directly and skips the entire sensitivity measurement pipeline
+    (proxy building, model loading, calibration, etc.).
+    """
+
+    def test_loads_existing_sensitivity_map_and_skips_measurement(
+        self, tmp_path, monkeypatch
+    ):
+        """When oq_sensitivity_map.json exists, it is loaded and measurement
+        functions are never called."""
+        if not HAS_MLX:
+            pytest.skip("mlx not available")
+        from safetensors.numpy import save_file as np_save
+
+        src = tmp_path / "src"
+        src.mkdir()
+        np_save(
+            {"w": np.zeros((128, 256), dtype=np.float32)},
+            str(src / "w.safetensors"),
+        )
+        (src / "config.json").write_text('{"model_type": "llama"}')
+
+        sensitivity_map = {"0": 0.05, "1": 0.03, "2": 0.01}
+        (src / "oq_sensitivity_map.json").write_text(
+            json.dumps(sensitivity_map), encoding="utf-8"
+        )
+
+        from omlx import oq as _oq
+
+        # Stub all measurement functions — they should NOT be called
+        monkeypatch.setattr(
+            _oq, "_measure_sensitivity", MagicMock(side_effect=RuntimeError("should not call"))
+        )
+        monkeypatch.setattr(
+            _oq, "_measure_sensitivity_from_quantized_model",
+            MagicMock(side_effect=RuntimeError("should not call")),
+        )
+        monkeypatch.setattr(
+            _oq, "_build_proxy_for_sensitivity",
+            MagicMock(side_effect=RuntimeError("should not call")),
+        )
+
+        out = tmp_path / "out"
+        quantize_oq_streaming(str(src), str(out), oq_level=4)
+
+        _oq._measure_sensitivity.assert_not_called()
+        _oq._measure_sensitivity_from_quantized_model.assert_not_called()
+        _oq._build_proxy_for_sensitivity.assert_not_called()
+
+    def test_sensitivity_map_used_in_quant_plan(
+        self, tmp_path, monkeypatch
+    ):
+        """The loaded sensitivity map is stored in config['_oq_sensitivity_map']
+        and flows into _build_quant_plan."""
+        if not HAS_MLX:
+            pytest.skip("mlx not available")
+        from safetensors.numpy import save_file as np_save
+
+        src = tmp_path / "src"
+        src.mkdir()
+        np_save(
+            {"w": np.zeros((128, 256), dtype=np.float32)},
+            str(src / "w.safetensors"),
+        )
+        (src / "config.json").write_text(
+            json.dumps({
+                "model_type": "llama",
+                "num_hidden_layers": 32,
+                "hidden_size": 128,
+                "intermediate_size": 256,
+                "num_attention_heads": 8,
+                "rms_norm_eps": 1e-5,
+                "vocab_size": 256,
+            })
+        )
+
+        sensitivity_map = {str(i): 0.1 / (i + 1) for i in range(32)}
+        (src / "oq_sensitivity_map.json").write_text(
+            json.dumps(sensitivity_map), encoding="utf-8"
+        )
+
+        from omlx import oq as _oq
+
+        # Capture the config that flows into _build_quant_plan
+        captured_configs = []
+        original_build_plan = _oq._build_quant_plan
+
+        def _capture_build_plan(named_shapes, config, oq_level, **kwargs):
+            captured_configs.append(dict(config))
+            return original_build_plan(named_shapes, config, oq_level, **kwargs)
+
+        monkeypatch.setattr(_oq, "_build_quant_plan", _capture_build_plan)
+
+        out = tmp_path / "out"
+        quantize_oq_streaming(str(src), str(out), oq_level=4)
+
+        assert len(captured_configs) == 1
+        config = captured_configs[0]
+        assert "_oq_sensitivity_map" in config
+        loaded_sens = config["_oq_sensitivity_map"]
+        assert loaded_sens == sensitivity_map
+
+    def test_no_sensitivity_map_falls_back_to_measurement(
+        self, tmp_path, monkeypatch
+    ):
+        """When oq_sensitivity_map.json does NOT exist, measurement runs."""
+        if not HAS_MLX:
+            pytest.skip("mlx not available")
+        from safetensors.numpy import save_file as np_save
+
+        src = tmp_path / "src"
+        src.mkdir()
+        np_save(
+            {"w": np.zeros((128, 256), dtype=np.float32)},
+            str(src / "w.safetensors"),
+        )
+        (src / "config.json").write_text('{"model_type": "llama"}')
+
+        from omlx import oq as _oq
+
+        monkeypatch.setattr(
+            _oq, "_measure_sensitivity",
+            MagicMock(return_value={"0": 0.05, "1": 0.03}),
+        )
+
+        out = tmp_path / "out"
+        quantize_oq_streaming(str(src), str(out), oq_level=4)
+
+        _oq._measure_sensitivity.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ("content,expected_exc,expected_match"),
+        [
+            ("{}", RuntimeError, "sensitivity measurement produced no scores"),
+            ("not valid json", ValueError, None),
+        ],
+    )
+    def test_sensitivity_map_file_errors(
+        self,
+        tmp_path,
+        monkeypatch,
+        content,
+        expected_exc,
+        expected_match,
+    ):
+        """Sensitivity map file issues (empty JSON or malformed JSON) should raise."""
+        if not HAS_MLX:
+            pytest.skip("mlx not available")
+        from safetensors.numpy import save_file as np_save
+
+        src = tmp_path / "src"
+        src.mkdir()
+        np_save(
+            {"w": np.zeros((128, 256), dtype=np.float32)},
+            str(src / "w.safetensors"),
+        )
+        (src / "config.json").write_text('{"model_type": "llama"}')
+        (src / "oq_sensitivity_map.json").write_text(content, encoding="utf-8")
+
+        with pytest.raises(expected_exc, match=expected_match or ".*"):
+            quantize_oq_streaming(str(src), str(tmp_path / "out"), oq_level=4)


### PR DESCRIPTION
Closes https://github.com/jundot/omlx/issues/972.

I quantize to oQ _a lot_ using the provided sensitivity model method, and it's been always doing the same calibration over and over again, given the fact that the sensitivity model is the same every time.

This PR introduces a small check for a special `oq_sensitivity_map.json` file in a source model directory before handling the provided sensitivity model path or building an auto-proxy.

The file contains manually presaved sensitivity map:

```json
{ 
  "0": 0.004673895891755819,
  "1": 0.001716080354526639,
  "2": 0.004504043143242598
}
```

oQ-level doesn't play any role in case of `_measure_sensitivity_from_quantized_model()`, so the data is pretty static. And thus it saves a ton of GPU time – further quantizations happen in seconds.

At this point it's more like a hidden hack for myself, but I'd be happy to help with further development if you approve the general idea. Maybe it could be useful to auto-save the file somewhere in oMLX cache directory after the first quantization using an auto-proxy to avoid the calibration process next time.