### PR TITLE
Fix #1249: Handle unexpected 'strict' kwarg in mlx_lm load()

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -237,10 +237,26 @@ class BatchedEngine(BaseEngine):
                 model, processor = custom_loaded
                 return model, getattr(processor, "tokenizer", processor)
 
-            return load(
-                self._model_name,
-                tokenizer_config=tokenizer_config,
-            )
+            try:
+                return load(
+                    self._model_name,
+                    tokenizer_config=tokenizer_config,
+                )
+            except ValueError as e:
+                if "parameters not in model" in str(e):
+                    import inspect
+
+                    load_sig = inspect.signature(load)
+                    if "strict" in load_sig.parameters:
+                        logger.warning(
+                            f"Caught parameter mismatch error. Retrying load with strict=False. Details: {e}"
+                        )
+                        return load(
+                            self._model_name,
+                            tokenizer_config=tokenizer_config,
+                            strict=False,
+                        )
+                raise
 
         loop = asyncio.get_running_loop()
         self._model, self._tokenizer = await loop.run_in_executor(

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -614,9 +614,25 @@ class VLMBatchedEngine(BaseEngine):
                     model, processor = custom_loaded
                     return model, processor
 
-                return vlm_load(
-                    self._model_name, trust_remote_code=self._trust_remote_code
-                )
+                try:
+                    return vlm_load(
+                        self._model_name, trust_remote_code=self._trust_remote_code
+                    )
+                except ValueError as e:
+                    if "parameters not in model" in str(e):
+                        import inspect
+
+                        load_sig = inspect.signature(vlm_load)
+                        if "strict" in load_sig.parameters:
+                            logger.warning(
+                                f"Caught parameter mismatch error. Retrying vlm_load with strict=False. Details: {e}"
+                            )
+                            return vlm_load(
+                                self._model_name,
+                                trust_remote_code=self._trust_remote_code,
+                                strict=False,
+                            )
+                    raise
 
         loop = asyncio.get_running_loop()
         self._vlm_model, self._processor = await loop.run_in_executor(


### PR DESCRIPTION
**Fixes #1249**

**Motivation:**
In `v0.3.9.dev2`, `omlx/engine/batched.py` attempts to pass `strict=False` to `mlx_lm.load()` to tolerate extra weights from converted/abliterated models. However, the upstream `mlx_lm.load()` function does not currently accept a `strict` argument. This results in a 500 error: `load() got an unexpected keyword argument 'strict'`.

**Solution:**
This PR uses `inspect.signature` to dynamically check if the installed version of `mlx_lm` supports the `strict` argument before passing it. This ensures compatibility with both older versions of `mlx_lm` and future versions where the argument is exposed (e.g., via the upstream PR I've opened on [ml-explore/mlx-lm](https://github.com/ml-explore/mlx-lm/pull/1284)).