### PR TITLE
fix(cache): pending write buffer for hot cache eviction race

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -668,6 +668,12 @@ class PagedSSDCacheManager(CacheManager):
         # Track which block hashes are queued for background write
         self._pending_write_hashes: set = set()
         self._pending_write_hashes_lock = threading.Lock()
+        # Lock ordering invariant: _hot_cache_lock -> _pending_write_hashes_lock.
+        # Never acquire in reverse. Load path: _hot_cache_get (holds _hot_cache_lock,
+        # releases), then _pending_write_buffer_get (holds _pending_write_hashes_lock).
+        # Eviction path: _hot_cache_put (holds _hot_cache_lock, releases), then
+        # _enqueue_ssd_write (holds _pending_write_hashes_lock).
+        self._pending_write_buffers: dict[bytes, dict] = {}
         self._writer_shutdown = threading.Event()
         # Writer thread is only needed when writing to SSD.
         self._writer_thread = None
@@ -769,13 +775,19 @@ class PagedSSDCacheManager(CacheManager):
             return False
         metadata = entry["file_metadata"]
 
-        # Add to SSD index now that block is being written to SSD
+        # 1. Buffer first — instant read-back for concurrent loads (CPD K1).
+        #    Must precede _index.add so load_block never sees an index hit
+        #    for a block that has no file and no buffer entry yet.
+        with self._pending_write_hashes_lock:
+            self._pending_write_buffers[block_hash] = entry
+            self._pending_write_hashes.add(block_hash)
+
+        # 2. Index second — makes the block discoverable in has_block/contains.
         if not self._index.contains(block_hash):
             self._enforce_size_limit_for_new_block()
             self._index.add(blk_meta)
 
-        with self._pending_write_hashes_lock:
-            self._pending_write_hashes.add(block_hash)
+        # 3. Queue third — enqueue for background writer.
         try:
             item = (block_hash, tensors_raw, metadata, file_path)
             if blocking:
@@ -795,6 +807,7 @@ class PagedSSDCacheManager(CacheManager):
             self._index.remove(block_hash)
             with self._pending_write_hashes_lock:
                 self._pending_write_hashes.discard(block_hash)
+                self._pending_write_buffers.pop(block_hash, None)
             return False
 
     def _hot_cache_get(self, block_hash: bytes) -> dict | None:
@@ -804,6 +817,11 @@ class PagedSSDCacheManager(CacheManager):
                 self._hot_cache.move_to_end(block_hash)
                 return self._hot_cache[block_hash]
             return None
+
+    def _pending_write_buffer_get(self, block_hash: bytes) -> dict | None:
+        """Get entry from pending-write buffer. Returns None on miss."""
+        with self._pending_write_hashes_lock:
+            return self._pending_write_buffers.get(block_hash)
 
     def _hot_cache_remove(self, block_hash: bytes) -> None:
         """Remove entry from hot cache if present."""
@@ -1063,6 +1081,7 @@ class PagedSSDCacheManager(CacheManager):
                 # Remove from pending write tracking
                 with self._pending_write_hashes_lock:
                     self._pending_write_hashes.discard(block_hash)
+                    self._pending_write_buffers.pop(block_hash, None)
                 # When hot cache is disabled, remove temporary read buffer entry
                 if not self._hot_cache_enabled:
                     self._hot_cache_remove(block_hash)
@@ -1632,6 +1651,29 @@ class PagedSSDCacheManager(CacheManager):
                 logger.debug(f"Loaded block from hot cache: {block_hash.hex()[:16]}...")
             return cache_data
 
+        # Check pending-write buffer (evicted from hot cache, SSD write in progress)
+        entry = self._pending_write_buffer_get(block_hash)
+        if entry is not None:
+            arrays = entry.get("arrays") or self._arrays_from_tensors_raw(
+                entry["tensors_raw"]
+            )
+            cache_data = self._reconstruct_cache_data(
+                arrays,
+                entry["file_metadata"],
+                entry["num_layers"],
+                entry["layer_cache_types"],
+            )
+            if cache_data is not None:
+                self._index.touch(block_hash)
+                self._stats["loads"] += 1
+                self._stats["hits"] += 1
+                self._stats["hot_cache_hits"] += 1
+                logger.debug(
+                    f"Loaded block from pending write buffer: "
+                    f"{block_hash.hex()[:16]}..."
+                )
+            return cache_data
+
         # Check index
         metadata = self._index.get(block_hash)
         if metadata is None:
@@ -1775,6 +1817,40 @@ class PagedSSDCacheManager(CacheManager):
             )
             return cache_data, metadata_dict
 
+        # Check pending-write buffer (evicted from hot cache, SSD write in progress)
+        entry = self._pending_write_buffer_get(block_hash)
+        if entry is not None:
+            blk_meta = entry["block_metadata"]
+            arrays = entry.get("arrays") or self._arrays_from_tensors_raw(
+                entry["tensors_raw"]
+            )
+            cache_data = self._reconstruct_cache_data(
+                arrays,
+                entry["file_metadata"],
+                entry["num_layers"],
+                entry["layer_cache_types"],
+            )
+            if cache_data is None:
+                return None, None
+
+            metadata_dict = {
+                "num_layers": entry["num_layers"],
+                "token_count": blk_meta.token_count,
+                "model_name": blk_meta.model_name,
+                "layer_cache_types": entry["layer_cache_types"],
+                "layer_meta_states": blk_meta.layer_meta_states,
+            }
+
+            self._index.touch(block_hash)
+            self._stats["loads"] += 1
+            self._stats["hits"] += 1
+            self._stats["hot_cache_hits"] += 1
+            logger.debug(
+                f"Loaded block with metadata from pending write buffer: "
+                f"{block_hash.hex()[:16]}..."
+            )
+            return cache_data, metadata_dict
+
         # Check index
         block_metadata = self._index.get(block_hash)
         if block_metadata is None:
@@ -1885,19 +1961,25 @@ class PagedSSDCacheManager(CacheManager):
 
     def has_block(self, block_hash: bytes) -> bool:
         """
-        Check if a block exists in cache (hot cache or SSD storage).
+        Check if a block exists in cache (hot cache, pending writes, or SSD storage).
 
         Args:
             block_hash: Content hash for the block.
 
         Returns:
-            True if block exists in hot cache or SSD index.
+            True if block exists in hot cache, pending write buffer, or SSD index.
         """
         if self._index.contains(block_hash):
             return True
         # Block may have been evicted from SSD index but still in hot cache
         with self._hot_cache_lock:
-            return block_hash in self._hot_cache
+            if block_hash in self._hot_cache:
+                return True
+        # Block may be evicted from hot cache and awaiting SSD write
+        with self._pending_write_hashes_lock:
+            if block_hash in self._pending_write_buffers:
+                return True
+        return False
 
     def delete_block(self, block_hash: bytes) -> bool:
         """
@@ -1912,6 +1994,11 @@ class PagedSSDCacheManager(CacheManager):
         with self._lock:
             # Also remove from hot cache
             self._hot_cache_remove(block_hash)
+
+            # Also remove from pending write buffer
+            with self._pending_write_hashes_lock:
+                self._pending_write_buffers.pop(block_hash, None)
+                self._pending_write_hashes.discard(block_hash)
 
             metadata = self._index.remove(block_hash)
             if metadata is None:
@@ -2223,10 +2310,13 @@ class PagedSSDCacheManager(CacheManager):
                     f"SSD cache writer thread did not stop within {timeout}s"
                 )
 
-        # Clear hot cache
+        # Clear hot cache and pending write buffer
         with self._hot_cache_lock:
             self._hot_cache.clear()
             self._hot_cache_total_bytes = 0
+        with self._pending_write_hashes_lock:
+            self._pending_write_buffers.clear()
+            self._pending_write_hashes.clear()
 
         logger.debug("PagedSSDCacheManager closed")
 

--- a/tests/test_hot_cache.py
+++ b/tests/test_hot_cache.py
@@ -806,3 +806,242 @@ class TestHotCacheWriteBack:
             f"Expected {block_count} SSD files after flush, got {len(ssd_files)}. "
             f"Blocks were likely dropped due to write queue overflow during shutdown."
         )
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestPendingWriteBuffer:
+    """Tests for the pending-write buffer that bridges hot cache eviction to SSD write."""
+
+    def _make_cache_data(self, num_layers=2, seq_len=16, heads=2, head_dim=16):
+        return [
+            (
+                mx.zeros((1, heads, seq_len, head_dim)),
+                mx.zeros((1, heads, seq_len, head_dim)),
+            )
+            for _ in range(num_layers)
+        ]
+
+    def _save_block(self, manager, block_hash, model="test-model"):
+        cache_data = self._make_cache_data()
+        return manager.save_block(
+            block_hash=block_hash,
+            cache_data=cache_data,
+            token_count=16,
+            model_name=model,
+            layer_cache_types=["KVCache"] * 2,
+        )
+
+    def test_evicted_block_readable_from_pending_buffer(self, tmp_path):
+        """A block evicted from hot cache is still loadable while SSD write is pending."""
+        entry_size = 2 * 2 * 1 * 2 * 16 * 16 * 4
+        max_bytes = entry_size * 2 + 100
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "pending_buf_test",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=max_bytes,
+        )
+        try:
+            # Save 2 blocks (fills hot cache)
+            self._save_block(mgr, b"pending_buf_blk0")
+            self._save_block(mgr, b"pending_buf_blk1")
+
+            # Save 3rd block → evicts block 0
+            self._save_block(mgr, b"pending_buf_blk2")
+
+            # Block 0 should still be loadable (from pending buffer, not SSD)
+            with mgr._hot_cache_lock:
+                assert b"pending_buf_blk0" not in mgr._hot_cache, (
+                    "Block 0 should have been evicted from hot cache"
+                )
+            loaded = mgr.load_block(b"pending_buf_blk0")
+            assert loaded is not None, (
+                "Evicted block should be readable from pending write buffer"
+            )
+            assert len(loaded) == 2
+        finally:
+            mgr.close()
+
+    def test_writer_cleanup_empties_buffer(self, tmp_path):
+        """After background writer completes, pending buffer entry is removed."""
+        entry_size = 2 * 2 * 1 * 2 * 16 * 16 * 4
+        max_bytes = entry_size * 2 + 100
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "writer_cleanup_test",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=max_bytes,
+        )
+        try:
+            self._save_block(mgr, b"cleanup_test_blk0")
+            self._save_block(mgr, b"cleanup_test_blk1")
+            # Evict block 0
+            self._save_block(mgr, b"cleanup_test_blk2")
+
+            # Block 0 should be in pending buffer
+            with mgr._pending_write_hashes_lock:
+                assert b"cleanup_test_blk0" in mgr._pending_write_buffers
+
+            # Wait for writer to finish
+            time.sleep(1.0)
+
+            # Buffer should be empty after writer cleanup
+            with mgr._pending_write_hashes_lock:
+                assert b"cleanup_test_blk0" not in mgr._pending_write_buffers
+                assert b"cleanup_test_blk0" not in mgr._pending_write_hashes
+        finally:
+            mgr.close()
+
+    def test_has_block_sees_pending_entries(self, tmp_path):
+        """has_block() returns True for blocks in the pending write buffer."""
+        entry_size = 2 * 2 * 1 * 2 * 16 * 16 * 4
+        max_bytes = entry_size * 2 + 100
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "has_block_test",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=max_bytes,
+        )
+        try:
+            self._save_block(mgr, b"has_block_test_b0")
+            self._save_block(mgr, b"has_block_test_b1")
+            # Evict block 0
+            self._save_block(mgr, b"has_block_test_b2")
+
+            with mgr._hot_cache_lock:
+                assert b"has_block_test_b0" not in mgr._hot_cache
+
+            assert mgr.has_block(b"has_block_test_b0") is True, (
+                "has_block should find blocks in the pending write buffer"
+            )
+        finally:
+            mgr.close()
+
+    def test_delete_block_clears_pending_buffer(self, tmp_path):
+        """delete_block() removes the entry from pending write buffer."""
+        entry_size = 2 * 2 * 1 * 2 * 16 * 16 * 4
+        max_bytes = entry_size * 2 + 100
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "delete_pending_test",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=max_bytes,
+        )
+        try:
+            self._save_block(mgr, b"del_pending_blk_0")
+            self._save_block(mgr, b"del_pending_blk_1")
+            # Evict block 0
+            self._save_block(mgr, b"del_pending_blk_2")
+
+            # Block 0 is in pending buffer
+            with mgr._pending_write_hashes_lock:
+                assert b"del_pending_blk_0" in mgr._pending_write_buffers
+
+            # Delete it
+            mgr.delete_block(b"del_pending_blk_0")
+
+            # Should no longer be loadable
+            loaded = mgr.load_block(b"del_pending_blk_0")
+            assert loaded is None, (
+                "Deleted block should not be readable from pending buffer"
+            )
+        finally:
+            mgr.close()
+
+    def test_queue_full_cleans_pending_buffer(self, tmp_path):
+        """When write queue is full, dropped block is removed from pending buffer."""
+        entry_size = 2 * 2 * 1 * 2 * 16 * 16 * 4
+        max_bytes = entry_size * 2 + 100
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "queue_full_test",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=max_bytes,
+        )
+        try:
+            # Pause the writer by filling the queue with sentinel-free blocks
+            # Use a tiny queue to make overflow easy
+            original_maxsize = mgr._write_queue.maxsize
+            mgr._write_queue = __import__("queue").Queue(maxsize=1)
+
+            # Save blocks to fill queue via eviction
+            self._save_block(mgr, b"qf_test_block_00")
+            self._save_block(mgr, b"qf_test_block_01")
+            # This evicts block 0 → fills queue (size 1)
+            self._save_block(mgr, b"qf_test_block_02")
+            # This evicts block 1 → queue full → should drop AND clean buffer
+            self._save_block(mgr, b"qf_test_block_03")
+
+            # Block 1 was dropped — should NOT be in pending buffer
+            with mgr._pending_write_hashes_lock:
+                assert b"qf_test_block_01" not in mgr._pending_write_buffers, (
+                    "Dropped block should be removed from pending buffer on queue full"
+                )
+                assert b"qf_test_block_01" not in mgr._pending_write_hashes, (
+                    "Dropped block should be removed from pending hashes on queue full"
+                )
+        finally:
+            mgr._write_queue = __import__("queue").Queue(maxsize=original_maxsize)
+            mgr.close()
+
+    def test_evicted_block_loadable_with_metadata(self, tmp_path):
+        """load_block_with_metadata returns data for pending-buffer blocks."""
+        entry_size = 2 * 2 * 1 * 2 * 16 * 16 * 4
+        max_bytes = entry_size * 2 + 100
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "meta_load_test",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=max_bytes,
+        )
+        try:
+            self._save_block(mgr, b"meta_load_blk_00")
+            self._save_block(mgr, b"meta_load_blk_01")
+            # Evict block 0
+            self._save_block(mgr, b"meta_load_blk_02")
+
+            cache_data, metadata = mgr.load_block_with_metadata(b"meta_load_blk_00")
+            assert cache_data is not None, (
+                "load_block_with_metadata should serve evicted block from pending buffer"
+            )
+            assert metadata is not None
+            assert metadata["num_layers"] == 2
+            assert metadata["token_count"] == 16
+            assert metadata["model_name"] == "test-model"
+        finally:
+            mgr.close()
+
+    def test_end_to_end_lifecycle(self, tmp_path):
+        """Full lifecycle: save → evict → pending hit → writer completes → SSD hit."""
+        entry_size = 2 * 2 * 1 * 2 * 16 * 16 * 4
+        max_bytes = entry_size * 2 + 100
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "lifecycle_test",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=max_bytes,
+        )
+        try:
+            self._save_block(mgr, b"lifecycle_blk_00")
+            self._save_block(mgr, b"lifecycle_blk_01")
+            # Evict block 0
+            self._save_block(mgr, b"lifecycle_blk_02")
+
+            # Phase 1: pending buffer hit (before writer completes)
+            loaded = mgr.load_block(b"lifecycle_blk_00")
+            assert loaded is not None, "Should load from pending buffer"
+            assert mgr._stats["hot_cache_hits"] >= 1
+
+            # Phase 2: wait for writer to complete
+            time.sleep(1.0)
+
+            # Buffer should be empty
+            with mgr._pending_write_hashes_lock:
+                assert b"lifecycle_blk_00" not in mgr._pending_write_buffers
+
+            # Phase 3: SSD hit (block now on disk)
+            loaded_ssd = mgr.load_block(b"lifecycle_blk_00")
+            assert loaded_ssd is not None, "Should load from SSD after writer completes"
+            assert len(loaded_ssd) == 2
+        finally:
+            mgr.close()


### PR DESCRIPTION
## Summary

When hot cache is enabled, blocks evicted from the hot cache become unreachable during the window between eviction and SSD write completion. `load_block()` hits the SSD index, finds no file on disk (write still pending), removes the index entry, and returns `None` — forcing a full reprefill that shouldn't be necessary.

This adds a `_pending_write_buffers` dict that holds evicted entries until the background writer completes. The pattern matches what `boundary_snapshot_store.py` already does with its `_pending_writes` dict.

## Root Cause

The race sequence:
1. `_hot_cache_put()` evicts LRU entry from `_hot_cache`
2. `_enqueue_ssd_write()` adds block to SSD index and write queue
3. Block data now lives only in the write queue tuple — not in hot cache, not on disk
4. Concurrent `load_block()`: hot cache miss → SSD index hit → `file_path.exists()` false → removes from index, returns `None`

## Changes

**Write path** — `_enqueue_ssd_write()` reordered to buffer → index → queue. The buffer is populated before the index entry, so a concurrent load never sees an index hit for a block with no backing data. Queue-full rollback cleans all three.

**Read path** — Both `load_block()` and `load_block_with_metadata()` check the pending buffer after a hot cache miss, before the SSD index/file check. Hits are zero-I/O and counted as `hot_cache_hits`.

**`has_block()`** — Now checks the pending buffer, so callers in `scheduler.py` and `tiered_manager.py` don't miss blocks awaiting write.

**`delete_block()`** — Cleans pending buffer entries so deleted blocks aren't served during the write window.

**Writer cleanup** — `_writer_loop()` finally block removes buffer entries alongside `_pending_write_hashes`. `close()` clears the buffer defensively in case the writer times out.

## Test plan

7 new tests in `TestPendingWriteBuffer`:
- Evicted block readable from pending buffer (both `load_block` and `load_block_with_metadata`)
- Writer cleanup empties buffer after write completion
- `has_block()` sees pending entries
- `delete_block()` clears pending buffer
- Queue-full handler removes dropped block from buffer
- End-to-end lifecycle: save → evict → pending hit → writer completes → SSD hit

29/29 hot cache tests pass. 2 pre-existing failures in unrelated test files (`test_admin_profiles_api`, `test_mlx_lm_mtp_patch`).

Closes #1232