### PR TITLE
fix(model_discovery, models/vlm): VLM classifier coverage + adapter layers fallback

### DIFF
--- a/omlx/admin/oq_manager.py
+++ b/omlx/admin/oq_manager.py
@@ -195,6 +195,7 @@ class OQManager:
                                 or int(tc.get("mtp_num_hidden_layers", 0) or 0) > 0
                                 or int(tc.get("num_nextn_predict_layers", 0) or 0) > 0
                             )
+                            from ..model_discovery import _has_vision_subconfig
                             info = {
                                 "name": path.name,
                                 "path": str(path),
@@ -202,7 +203,10 @@ class OQManager:
                                 "size_formatted": _format_size(size),
                                 "model_type": config.get("model_type", "") or tc.get("model_type", ""),
                                 "is_quantized": "quantization" in config,
-                                "is_vlm": "vision_config" in config,
+                                # Treat vision_config / vit_config / mm_vision_tower as VLM
+                                # evidence (Molmo / Molmo2 use vit_config; FastVLM uses
+                                # mm_vision_tower). Same predicate as model_discovery.
+                                "is_vlm": _has_vision_subconfig(config),
                                 "has_mtp_heads": has_mtp,
                             }
                             all_models.append(info)

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -46,6 +46,7 @@ VLM_MODEL_TYPES = {
     "mistral3",
     "pixtral",
     "molmo",
+    "molmo2",
     "bunny_llama",
     "multi_modality",
     "florence2",
@@ -74,6 +75,7 @@ VLM_ARCHITECTURES = {
     "Phi3VForCausalLM",
     "Pixtral",
     "MolmoForCausalLM",
+    "Molmo2ForConditionalGeneration",
     "Florence2ForConditionalGeneration",
 }
 
@@ -461,13 +463,20 @@ def detect_model_type(model_path: Path) -> ModelType:
     # Check for VLM: architectures field
     # Some text-only quants (e.g., unsloth/gemma-4-31b-it-MLX-8bit) keep the VLM
     # architecture name but strip vision_config and vision weights.
-    # For model families known to have text-only variants, require vision_config.
+    # For model families known to have text-only variants, require evidence
+    # of a vision sub-config. The Molmo / Molmo2 family stores its vision
+    # sub-config under ``vit_config`` rather than ``vision_config``; accept
+    # either as evidence the model retains its vision tower.
     for arch in architectures:
         if arch in VLM_ARCHITECTURES:
-            if normalized_type in VLM_MODEL_TYPES and "vision_config" not in config:
+            has_vision_subconfig = (
+                "vision_config" in config or "vit_config" in config
+            )
+            if normalized_type in VLM_MODEL_TYPES and not has_vision_subconfig:
                 logger.info(
-                    f"Architecture '{arch}' is a VLM architecture but no vision_config "
-                    "found — treating as LLM (text-only quant)"
+                    f"Architecture '{arch}' is a VLM architecture but no "
+                    "vision_config / vit_config found — "
+                    "treating as LLM (text-only quant)"
                 )
                 break
             return "vlm"

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -372,6 +372,29 @@ def _has_sentence_transformers_embedding_pipeline(model_path: Path) -> bool:
     )
 
 
+def _has_vision_subconfig(config: dict) -> bool:
+    """
+    Return True if ``config`` carries evidence of a vision sub-config.
+
+    Three keys cover the conventions in the wild:
+
+    - ``vision_config`` — most VLMs (Qwen2-VL, Gemma3, LLaVA-Next, ...).
+    - ``vit_config`` — Molmo / Molmo2 family.
+    - ``mm_vision_tower`` — older LLaVA family including FastVLM's
+      ``llava_qwen2``. The check is non-empty-only: a config-stub text-only
+      quant could in principle declare a tower path it doesn't ship weights
+      for, but in practice bf16 FastVLM ships a real path string.
+
+    Used by the VLM classifier in :func:`detect_model_type` and by other
+    paths (``oq``, admin model info) that need to ask "is this a VLM?".
+    """
+    return (
+        "vision_config" in config
+        or "vit_config" in config
+        or bool(config.get("mm_vision_tower"))
+    )
+
+
 def detect_model_type(model_path: Path) -> ModelType:
     """
     Detect model type from config.json.
@@ -382,7 +405,9 @@ def detect_model_type(model_path: Path) -> ModelType:
     3. sentence-transformers pipeline detection via modules.json
     4. architectures field for embedding-specific classes
     5. model_type field against known embedding types (unambiguous only)
-    6. VLM detection via architectures, model_type, or vision_config presence
+    6. VLM detection via architectures, model_type, or vision sub-config
+       presence (``vision_config`` / ``vit_config`` / non-empty
+       ``mm_vision_tower`` — see :func:`_has_vision_subconfig`)
     7. Audio model detection (STT/TTS/STS)
 
     Args:
@@ -466,21 +491,12 @@ def detect_model_type(model_path: Path) -> ModelType:
     # Some text-only quants (e.g., unsloth/gemma-4-31b-it-MLX-8bit) keep the VLM
     # architecture name but strip vision_config and vision weights.
     # For model families known to have text-only variants, require evidence
-    # of a vision sub-config. Three keys cover the conventions in the wild:
-    # ``vision_config`` (most VLMs), ``vit_config`` (Molmo / Molmo2), and
-    # ``mm_vision_tower`` (older LLaVA family incl. FastVLM's
-    # ``llava_qwen2``). The ``mm_vision_tower`` check is non-empty-only: a
-    # config-stub text-only quant could in principle declare a tower path
-    # it doesn't ship weights for, but in practice bf16 FastVLM ships a
-    # real path string.
+    # of a vision sub-config — see :func:`_has_vision_subconfig` for the
+    # three keys we accept (``vision_config``, ``vit_config``,
+    # ``mm_vision_tower``).
     for arch in architectures:
         if arch in VLM_ARCHITECTURES:
-            has_vision_subconfig = (
-                "vision_config" in config
-                or "vit_config" in config
-                or bool(config.get("mm_vision_tower"))
-            )
-            if normalized_type in VLM_MODEL_TYPES and not has_vision_subconfig:
+            if normalized_type in VLM_MODEL_TYPES and not _has_vision_subconfig(config):
                 logger.info(
                     f"Architecture '{arch}' is a VLM architecture but no "
                     "vision_config / vit_config / mm_vision_tower found — "
@@ -491,18 +507,19 @@ def detect_model_type(model_path: Path) -> ModelType:
 
     # Check for VLM: model_type field (only if vision capabilities are present)
     # Some model families (e.g., qwen3_5_moe) have both VLM and text-only variants.
-    # Text-only quants won't have vision_config in their config.json.
+    # Text-only quants won't carry a vision sub-config.
     if normalized_type in VLM_MODEL_TYPES:
-        if "vision_config" in config:
+        if _has_vision_subconfig(config):
             return "vlm"
         logger.info(
-            f"Model type '{model_type}' is in VLM_MODEL_TYPES but no vision_config found — "
+            f"Model type '{model_type}' is in VLM_MODEL_TYPES but no "
+            "vision_config / vit_config / mm_vision_tower found — "
             "treating as LLM (text-only quant)"
         )
 
-    # Check for VLM: presence of vision_config (fallback heuristic)
+    # Check for VLM: presence of a vision sub-config (fallback heuristic).
     # Catch-all for VLMs that aren't yet listed in VLM_MODEL_TYPES.
-    if "vision_config" in config:
+    if _has_vision_subconfig(config):
         return "vlm"
 
     # Check for audio models — architectures take priority over model_type.

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -38,6 +38,7 @@ VLM_MODEL_TYPES = {
     "llava",
     "llava_next",
     "llava-qwen2",
+    "llava_qwen2",  # underscore form — matches FastVLM checkpoints on disk
     "mllama",
     "idefics3",
     "internvl_chat",
@@ -76,6 +77,7 @@ VLM_ARCHITECTURES = {
     "Pixtral",
     "MolmoForCausalLM",
     "Molmo2ForConditionalGeneration",
+    "LlavaQwen2ForCausalLM",  # apple/FastVLM (all sizes)
     "Florence2ForConditionalGeneration",
 }
 
@@ -464,18 +466,24 @@ def detect_model_type(model_path: Path) -> ModelType:
     # Some text-only quants (e.g., unsloth/gemma-4-31b-it-MLX-8bit) keep the VLM
     # architecture name but strip vision_config and vision weights.
     # For model families known to have text-only variants, require evidence
-    # of a vision sub-config. The Molmo / Molmo2 family stores its vision
-    # sub-config under ``vit_config`` rather than ``vision_config``; accept
-    # either as evidence the model retains its vision tower.
+    # of a vision sub-config. Three keys cover the conventions in the wild:
+    # ``vision_config`` (most VLMs), ``vit_config`` (Molmo / Molmo2), and
+    # ``mm_vision_tower`` (older LLaVA family incl. FastVLM's
+    # ``llava_qwen2``). The ``mm_vision_tower`` check is non-empty-only: a
+    # config-stub text-only quant could in principle declare a tower path
+    # it doesn't ship weights for, but in practice bf16 FastVLM ships a
+    # real path string.
     for arch in architectures:
         if arch in VLM_ARCHITECTURES:
             has_vision_subconfig = (
-                "vision_config" in config or "vit_config" in config
+                "vision_config" in config
+                or "vit_config" in config
+                or bool(config.get("mm_vision_tower"))
             )
             if normalized_type in VLM_MODEL_TYPES and not has_vision_subconfig:
                 logger.info(
                     f"Architecture '{arch}' is a VLM architecture but no "
-                    "vision_config / vit_config found — "
+                    "vision_config / vit_config / mm_vision_tower found — "
                     "treating as LLM (text-only quant)"
                 )
                 break

--- a/omlx/models/vlm.py
+++ b/omlx/models/vlm.py
@@ -71,8 +71,23 @@ class VLMModelAdapter(nn.Module):
 
     @property
     def layers(self):
-        """Expose language model layers for cache creation."""
-        return self._language_model.model.layers
+        """Expose language model layers for cache creation.
+
+        Tries, in order: nested ``model.layers`` (Qwen2VL etc.), nested
+        ``model.blocks`` (Molmo / Molmo2 / molmo_point / Moondream3), flat
+        ``layers``, flat ``blocks``. Covers all four mlx-vlm conventions.
+        """
+        lm = self._language_model
+        for parent in (getattr(lm, "model", None), lm):
+            if parent is None:
+                continue
+            for attr in ("layers", "blocks"):
+                v = getattr(parent, attr, None)
+                if v is not None:
+                    return v
+        raise AttributeError(
+            f"{type(lm).__name__} has no .layers/.blocks (flat or nested)"
+        )
 
     @property
     def model_type(self) -> str:

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -3058,6 +3058,7 @@ def _measure_sensitivity(
     num_samples=32, seq_length=256,
 ):
     """Measure sensitivity by loading model temporarily. Used by streaming path."""
+    from omlx.model_discovery import _has_vision_subconfig
     from omlx.utils.model_loading import (
         _has_mtp_heads,
         maybe_apply_pre_load_patches,
@@ -3068,7 +3069,10 @@ def _measure_sensitivity(
     # applied exactly as in the production load path.
     maybe_apply_pre_load_patches(model_path)
 
-    is_vlm = "vision_config" in config
+    # Treat any model with a vision sub-config (vision_config / vit_config /
+    # mm_vision_tower) as a VLM for the MTP attach decision. The classifier
+    # in model_discovery._has_vision_subconfig owns the canonical predicate.
+    is_vlm = _has_vision_subconfig(config)
 
     # maybe_apply_pre_load_patches leaves mtp_active False, which is correct
     # for the text path: the patched qwen35_model.sanitize self-consistently

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -368,6 +368,48 @@ class TestDetectModelType:
         (tmp_path / "config.json").write_text(json.dumps(config))
         assert detect_model_type(tmp_path) == "llm"
 
+    def test_detect_vlm_molmo2_via_vit_config(self, tmp_path):
+        """Molmo2 bf16 ships ``vit_config`` (not ``vision_config``) — must classify as VLM."""
+        config = {
+            "model_type": "molmo2",
+            "architectures": ["Molmo2ForConditionalGeneration"],
+            "vit_config": {"hidden_size": 1024, "num_layers": 24},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "vlm"
+
+    def test_detect_vlm_fastvlm_via_mm_vision_tower(self, tmp_path):
+        """FastVLM bf16 ships ``mm_vision_tower`` (older LLaVA style) — must classify as VLM."""
+        config = {
+            "model_type": "llava_qwen2",
+            "architectures": ["LlavaQwen2ForCausalLM"],
+            "mm_vision_tower": "openai/clip-vit-large-patch14-336",
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "vlm"
+
+    def test_detect_text_only_quant_with_empty_mm_vision_tower_as_llm(self, tmp_path):
+        """``mm_vision_tower`` evidence check is non-empty-only — empty string falls back to LLM."""
+        config = {
+            "model_type": "llava_qwen2",
+            "architectures": ["LlavaQwen2ForCausalLM"],
+            "mm_vision_tower": "",
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "llm"
+
+    def test_detect_text_only_quant_no_vision_evidence_as_llm(self, tmp_path):
+        """A VLM_ARCHITECTURE match without any vision sub-config evidence is a text-only quant."""
+        config = {
+            # qwen3_5_moe is in VLM_MODEL_TYPES, and the unsloth Qwen3.5-122B
+            # text-only quant ships only the chat backbone arch.
+            "model_type": "qwen3_5_moe",
+            "architectures": ["Qwen3_5_MoEForCausalLM"],
+            # No vision_config / vit_config / mm_vision_tower.
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "llm"
+
 
 class TestEstimateModelSize:
     """Tests for estimate_model_size function."""


### PR DESCRIPTION

## Summary

Four independent oMLX-layer fixes from a VLM regression sweep on Apple Silicon:

1. `VLMModelAdapter.layers` falls back to `.blocks` for Molmo, Molmo2, molmo_point, and Moondream3 — four mlx-vlm language modules that expose their decoder stack as `.blocks` rather than `.layers`.
2. Molmo2 classifies as VLM via architecture + model_type + `vit_config` evidence.
3. FastVLM (`llava_qwen2`) classifies as VLM via architecture + model_type + non-empty `mm_vision_tower` evidence.
4. Extract `_has_vision_subconfig()` helper in `model_discovery.py` and reuse it in `oq.py` and `admin/oq_manager.py`, so OQ's MTP gate and the Admin API's `is_vlm` field treat Molmo2 / FastVLM as VLMs consistently with the classifier.

## What this PR fixes

| Family | Symptom | Files touched |
|---|---|---|
| Molmo2 (bf16 plus 8bit/mxfp8 checkpoints) | bf16 variant classifies as LLM → 500 with `Model type molmo2 not supported`; quantized variants hang mid-request on `'Molmo2Transformer' object has no attribute 'layers'` | `omlx/model_discovery.py`, `omlx/models/vlm.py` |
| FastVLM bf16 (0.5B, 1.5B, 7B) | classifies as LLM → no chat works, no vision works | `omlx/model_discovery.py` |
| Molmo, Molmo-Point, Moondream3 (and Molmo2 quants) | `make_cache()` raises `AttributeError: 'XTransformer' object has no attribute 'layers'` | `omlx/models/vlm.py` |

## Fix 1 — `VLMModelAdapter.layers`: fall back to `.blocks` for Molmo-family and Moondream3

`omlx/models/vlm.py:72-89`. The property was hardcoded to `self._language_model.model.layers`. That works for the mlx-vlm language modules that use `self.layers`, but **four use `self.blocks` instead**: `molmo`, `molmo2`, `molmo_point`, `moondream3`. On any of those, `len(self.layers)` in `make_cache()` raises `AttributeError` inside the engine loop after the 200 OK header has gone out — clients see a stalled stream, not an error.

The fix walks four positions in the attribute tree: (nested × flat) × (`.layers` × `.blocks`). First hit wins. Existing `.layers`-based models keep their fast path; `.blocks`-based models work without per-model special-casing.

```python
@property
def layers(self):
    lm = self._language_model
    for parent in (getattr(lm, "model", None), lm):
        if parent is None:
            continue
        for attr in ("layers", "blocks"):
            v = getattr(parent, attr, None)
            if v is not None:
                return v
    raise AttributeError(
        f"{type(lm).__name__} has no .layers/.blocks (flat or nested)"
    )
```

Verified: `mlx-community/Molmo2-8B-mxfp8`, `Molmo2-8B-8bit`, and `Molmo2-8B-bf16` all serve text + image cleanly. Molmo, Molmo-Point, and Moondream3 share the same code path; not live-tested but the change applies symmetrically across all four.

## Fix 2 — `model_discovery`: classify Molmo2 as VLM

`omlx/model_discovery.py`. Three coordinated edits:

- Add `Molmo2ForConditionalGeneration` to `VLM_ARCHITECTURES`.
- Add `molmo2` to `VLM_MODEL_TYPES`.
- Extend the "text-only quant" guard to accept either `vision_config` *or* `vit_config` as evidence the model retains its vision tower (Molmo-family stores vision config under `vit_config`, not `vision_config`).

Pre-fix, the bf16 variant carried no top-level `vision_config` placeholder (only the quantized variants do), so it fell through every check and landed under `llm`. The other Molmo2 variants squeaked through on the `if "vision_config" in config: return "vlm"` fallback because their configs ship the empty `vision_config: {}` placeholder.

Verified: Molmo2 bf16, 8bit, and mxfp8 classify as `vlm`.

## Fix 3 — `model_discovery`: classify FastVLM (`llava_qwen2`) as VLM

`omlx/model_discovery.py`. Same pattern as Fix 2, different evidence key:

- Add `LlavaQwen2ForCausalLM` to `VLM_ARCHITECTURES`.
- Add `llava_qwen2` (underscore form, matching disk configs) to `VLM_MODEL_TYPES`. The existing entry `"llava-qwen2"` (hyphen) never matched because the classifier normalizes the *input* model_type to underscores but leaves the *set entries* unchanged.
- Extend the "text-only quant" guard to also accept a non-empty `mm_vision_tower` as VLM evidence (FastVLM uses the older LLaVA-style flat `mm_*` keys, not `vision_config` / `vit_config`). The non-empty check is deliberate: it adds a new evidence key without broadening the existing empty-`vision_config` misclassification path tracked in `jundot/omlx#483` (the Qwen3_5_MoE config carries neither `vit_config` nor `mm_vision_tower`). The check is config evidence, not a guarantee that vision weights are present.

Pre-fix, `llava_qwen2` (underscore) failed to match the hyphenated set entry; bf16 FastVLM configs ship no `vision_config` placeholder, so they fell through to `llm`. The 8bit/quantized variants happen to ship `vision_config: {}` and squeaked through the fallback.

Verified: `FastVLM-0.5B-bf16`, `FastVLM-1.5B-bf16`, `FastVLM-7B-bf16` all classify as `vlm`. Note: FastVLM-7B requires `Blaizzy/mlx-vlm#1193` (open draft) for *coherent output*; this PR only fixes classification.

## Fix 4 — extract `_has_vision_subconfig()` helper, reuse across oMLX

`omlx/model_discovery.py`, `omlx/oq.py`, `omlx/admin/oq_manager.py`. Adversarial review surfaced three other call sites that still hardcoded `"vision_config" in config`:

- `omlx/oq.py:3071` — OQ's per-load `is_vlm` gate for MTP head attachment.
- `omlx/admin/oq_manager.py:205` — Admin API's per-model `is_vlm` field returned to UI / consumers.
- `omlx/model_discovery.py:495` and `:505` — the model_type-only path and the catch-all fallback in `detect_model_type` itself.

Without this fix, Molmo2 (which uses `vit_config`) and FastVLM (which uses `mm_vision_tower`) would be correctly routed through the VLM engine by `detect_model_type`'s arch-based check, but then reported as non-VLM by the Admin API and skipped by OQ's VLM-specific MTP handling — an internal inconsistency.

Extract `_has_vision_subconfig(config: dict) -> bool` as the single source of truth for the predicate (`vision_config` OR `vit_config` OR non-empty `mm_vision_tower`), and have all four sites call it.

Regression tests in `tests/test_model_discovery.py::TestDetectModelType`: Molmo2 via `vit_config` → `vlm`; FastVLM via non-empty `mm_vision_tower` → `vlm`; empty `mm_vision_tower` string → `llm` (anti-regression for config-stub text-only quants); VLM arch with no vision evidence at all → `llm` (anti-regression for the `#483` pattern).

## Scope and risk

- Files: `omlx/model_discovery.py` (≈ +35 / −15), `omlx/models/vlm.py` (≈ +15 / −2), `omlx/oq.py` (+5), `omlx/admin/oq_manager.py` (+5), `tests/test_model_discovery.py` (+42).
- Risk: low. Each fix is additive (new architecture in a set, new attribute name in a fallback chain) and gated by existing heuristics (multi-path for the adapter). The helper preserves the same predicate semantics as the previous inline checks in `detect_model_type`; the oq.py and oq_manager.py changes broaden their previously-too-narrow checks to match.
- The `mm_vision_tower` evidence check is non-empty-only, so this PR adds no new empty-key VLM fallback. The existing empty-`vision_config` path tracked in `#483` is unchanged.
- No public API changes; no schema changes; no new dependencies.

## Related work

- `jundot/omlx#1283` — engine_pool fallback error surfacing (**merged 2026-05-17**). Its chained-error log format diagnosed the bf16 misclassifications above in a single log line.
- `jundot/omlx#1036` — `unstoppablesssss` LFM2 classifier fix (**open**). Independent; not duplicated here.
- `jundot/omlx#881` — `_rope_deltas` non-mRoPE guard (**merged 2026-04-21**). Already lands the same symptom my carry `7623064` addresses, via `hasattr`.
- `jundot/omlx#483` — Qwen3.5-122B-A10B-4bit misclassified as VLM via empty `vision_config` (**open**). Opposite direction from this PR's bf16 fixes; this PR does not fix #483, but its `mm_vision_tower` evidence check is non-empty-only so it does not add an analogous empty-key path.
- `jundot/omlx#1313` — Mistral-based CausalLM reranker classifier (**open draft**). Filed as a companion PR to keep VLM and reranker concerns separated.
