### PR TITLE
fix(model_discovery): classify Mistral-based CausalLM rerankers

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -123,6 +123,7 @@ SUPPORTED_RERANKER_ARCHITECTURES = {
 # Detected by architecture + heuristic (model name or tokenizer hints).
 CAUSAL_LM_RERANKER_ARCHITECTURES = {
     "Qwen3ForCausalLM",
+    "MistralForCausalLM",  # e.g. ContextualAI/reranker_v2_6b (dir-name gated)
 }
 
 # CausalLM-based embedding architectures.


### PR DESCRIPTION

## Summary

One-line classifier addition that recognizes Mistral-based CausalLM rerankers (Contextual AI Reranker v2 family) as rerankers instead of plain LLMs.

Pre-fix symptom: `ContextualAI/reranker_v2_6b` (and quantized variants such as `ctxl-rerank-v2-6b-bf16`) classifies as `llm`. The model carries no chat_template, so chat-mode loading produces a 500; loading it as a SentenceTransformer-style reranker fails because the on-disk arch is `MistralForCausalLM`, not `*ForSequenceClassification`. oMLX already supports CausalLM-style reranking through `CAUSAL_LM_RERANKER_ARCHITECTURES` — the set just omits `MistralForCausalLM`.

## Fix

`omlx/model_discovery.py`. One-line addition: `MistralForCausalLM` joins `CAUSAL_LM_RERANKER_ARCHITECTURES`.

Detection still requires the existing basename heuristic (`_is_causal_lm_reranker`, matching `"rerank"`/`"reranker"` in `model_path.name`), so plain Mistral chat models keep classifying as `llm` — only directories named like rerankers (e.g., `ctxl-rerank-v2-6b-bf16`, `*-Reranker-*`) trigger reranker classification. This mirrors the existing pattern already in the set for `Qwen3ForCausalLM`.

## Verification

`ContextualAI/reranker_v2_6b` (Contextual AI Reranker v2 6B, `MistralForCausalLM`, dir `ctxl-rerank-v2-6b-bf16`) classifies as `reranker` after this fix and serves correctly via the `/v1/rerank` endpoint. Plain Mistral chat models (no `rerank` in the basename) keep classifying as `llm`.

## Scope and risk

- Files: `omlx/model_discovery.py` (≈ +1 / −0).
- Risk: minimal. Additive entry in an existing set, gated by an existing basename heuristic. No public API changes; no schema changes; no new dependencies.
- The companion PR (VLM classifier + adapter layers fallback) is independent and lives separately.
