### PR TITLE
Fix HTTP request hang when engine loop raises during scheduling

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -4171,7 +4171,18 @@ class Scheduler:
         # in self.requests (and the engine_core collector / finished_event
         # for its id is still waiting). Without this pass, fail_all_requests
         # returns an incomplete list and the HTTP request hangs forever.
+        #
+        # Exclude finished requests still awaiting async cache-store cleanup
+        # (those have an entry in ``_inflight_store_futures`` — see
+        # ``_cleanup_finished`` line ~5267). They have already emitted a
+        # ``finished=True`` output to their collector; ``_drain_pending_async_removes``
+        # pops them from ``self.requests`` after the store future completes.
+        # Failing them here would append an error output that wins over the
+        # success for non-streaming ``generate()`` callers (engine_core
+        # returns the last queued output).
         for request_id in list(self.requests):
+            if request_id in self._inflight_store_futures:
+                continue
             failed_ids.append(request_id)
             req = self.requests.pop(request_id, None)
             if req is not None:

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -4164,6 +4164,19 @@ class Scheduler:
                 req._extracted_cache = None
                 req.prompt_cache = None
         self.waiting.clear()
+        # Catch in-flight orphans: a request popped from self.waiting but
+        # not yet added to self.running (or self.prefilling) sits as a
+        # local in _schedule_waiting. If _do_external_prefill raises, the
+        # request is unreachable through the three queues but still lives
+        # in self.requests (and the engine_core collector / finished_event
+        # for its id is still waiting). Without this pass, fail_all_requests
+        # returns an incomplete list and the HTTP request hangs forever.
+        for request_id in list(self.requests):
+            failed_ids.append(request_id)
+            req = self.requests.pop(request_id, None)
+            if req is not None:
+                req._extracted_cache = None
+                req.prompt_cache = None
         # Reset batch generator only (cache is not corrupted)
         self.batch_generator = None
         self._current_sampler_params = None

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1700,6 +1700,40 @@ class TestCacheCorruptionRecovery:
         assert "req-orphan" in failed_ids
         assert "req-orphan" not in scheduler.requests
 
+    def test_fail_all_requests_excludes_async_cleanup_in_flight(
+        self, mock_model, mock_tokenizer
+    ):
+        """Finished requests awaiting async cache-store cleanup must not be failed.
+
+        ``_cleanup_finished`` keeps a finished request in ``self.requests``
+        and registers its store future in ``_inflight_store_futures`` until
+        ``_drain_pending_async_removes`` finalizes the cleanup. That request
+        has already emitted ``finished=True`` to its collector; if
+        ``fail_all_requests`` runs during this window, appending an error
+        output via the orphan sweep would override the success for
+        non-streaming ``generate()`` (engine_core returns the last queued
+        output). The sweep must skip ids present in
+        ``_inflight_store_futures`` and leave them for the async drain.
+        """
+        scheduler = self._make_scheduler(mock_model, mock_tokenizer)
+        finished_pending_cleanup = Request(
+            request_id="req-async-cleanup",
+            prompt="finished",
+            sampling_params=SamplingParams(),
+            prompt_token_ids=[8, 9],
+            num_prompt_tokens=2,
+        )
+        # Simulate _cleanup_finished's terminal state: request lives in
+        # self.requests + _inflight_store_futures, absent from all three queues.
+        scheduler.requests[finished_pending_cleanup.request_id] = finished_pending_cleanup
+        scheduler._inflight_store_futures[finished_pending_cleanup.request_id] = MagicMock()
+
+        failed_ids = scheduler.fail_all_requests()
+
+        assert "req-async-cleanup" not in failed_ids
+        assert "req-async-cleanup" in scheduler.requests
+        assert "req-async-cleanup" in scheduler._inflight_store_futures
+
 
 class TestDetectNeedsThinkPrefix:
     """Tests for _detect_needs_think_prefix() method.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1669,6 +1669,37 @@ class TestCacheCorruptionRecovery:
         # Cache should NOT be cleared (not a corruption error)
         scheduler.block_aware_cache.clear.assert_not_called()
 
+    def test_fail_all_requests_includes_in_flight_orphans(
+        self, mock_model, mock_tokenizer
+    ):
+        """Catch requests popped from self.waiting but not yet in self.running.
+
+        Regression test for the hang triggered when ``_do_external_prefill``
+        raises inside ``_schedule_waiting``: the request has already been
+        popped from ``self.waiting`` and has not yet been inserted into
+        ``self.running``, so the three-queue sweep misses it. The orphan
+        still lives in ``self.requests`` and the HTTP collector for its id
+        keeps awaiting a result that never arrives.
+        """
+        scheduler = self._make_scheduler(mock_model, mock_tokenizer)
+        orphan = Request(
+            request_id="req-orphan",
+            prompt="orphan",
+            sampling_params=SamplingParams(),
+            prompt_token_ids=[6, 7],
+            num_prompt_tokens=2,
+        )
+        # Orphan only: present in self.requests, absent from all three queues.
+        scheduler.requests[orphan.request_id] = orphan
+        assert orphan.request_id not in scheduler.waiting
+        assert orphan.request_id not in scheduler.running
+        assert orphan.request_id not in scheduler.prefilling
+
+        failed_ids = scheduler.fail_all_requests()
+
+        assert "req-orphan" in failed_ids
+        assert "req-orphan" not in scheduler.requests
+
 
 class TestDetectNeedsThinkPrefix:
     """Tests for _detect_needs_think_prefix() method.


### PR DESCRIPTION

## Summary

An exception inside `_do_external_prefill` — or anywhere between popping a request from `self.waiting` and inserting it into `self.running` — hangs the HTTP request forever. The engine logs the error and calls `fail_all_requests`, but the failing request sits in none of the three queues that sweep covers. The fix adds a final pass over any ids still in `self.requests` after the queue sweeps.

## Reproduction

Trigger with `mlx-community/MiniCPM-V-4.6-8bit` before `Blaizzy/mlx-vlm#1201` lands — the upstream bug crashes in qwen3_5's `get_rope_index`:

```bash
curl -m 30 -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -X POST http://127.0.0.1:8100/v1/chat/completions \
  -d '{"model":"MiniCPM-V-4.6-8bit","messages":[{"role":"user","content":"hi"}],"max_tokens":10}'
```

Observed:

- The request hangs the full 30 s timeout. No 5xx. No response body.
- `~/.omlx/logs/server.log` records `omlx.engine_core - ERROR - Engine loop error: 'VisionConfig' object has no attribute 'spatial_merge_size'` with a traceback.
- Subsequent requests hitting the same prefill exception also hang. Live testing wedged the model for the failing prompt; the source proves every new request hitting that exception sees the same orphaned-event behavior.
- Unloading the model via `/admin/api/models/{id}/unload` succeeds, but the hung request never terminates — the client must be killed.

The MiniCPM-V case is the easiest live trigger right now; the included synthetic test constructs the orphan state directly.

## Root cause

The scheduler lifecycle under `_schedule_waiting`:

1. `add_request()` registers the request in `self.requests` (master registry) and appends it to `self.waiting`.
2. `_schedule_waiting()` calls `request = self.waiting.popleft()` (`scheduler.py:4309`). The request is now a local variable, no longer in any queue.
3. The full-prefill path runs `prefilled_cache, last_token = self._do_external_prefill(request, …)` (`scheduler.py:4700`).
4. On success, the request enters `self.running` (`scheduler.py:4762` or `4803`).

If the model's forward pass raises in step 3 — `self.model(input_arr[:, :n_to_process], cache=prompt_cache, **model_kwargs)` at `scheduler.py:1779` — the exception bubbles up through `_schedule_waiting` → `step()` → `engine_core._engine_loop`'s `try` block at `engine_core.py:205`. The `except Exception` handler (`engine_core.py:252–273`) then runs:

```python
failed_ids = await loop.run_in_executor(
    self._mlx_executor, self.scheduler.fail_all_requests
)
for rid in failed_ids:
    collector = self._output_collectors.get(rid)
    if collector is not None:
        collector.put(RequestOutput(request_id=rid, finished=True, finish_reason="error", error=str(e)))
    event = self._finished_events.get(rid)
    if event:
        event.set()
```

The propagation logic in `engine_core` is correct, but it depends on the scheduler returning a complete list of affected ids. `fail_all_requests` sweeps only `self.running`, `self.prefilling`, and `self.waiting`. The orphan — popped from waiting in step 2, not yet inserted in step 4 — appears in none of them. It still sits in `self.requests`, and its collector and finished_event still live in `engine_core`. So `failed_ids` skips it, and the HTTP handler waits on a finished_event that never fires.

## Fix

In `omlx/scheduler.py`, in `fail_all_requests`: after the three sweeps drain `self.running` / `self.prefilling` / `self.waiting`, add a final pass that drains any ids still in `self.requests`, skipping ids present in `self._inflight_store_futures` (those are finished requests awaiting async cache-store cleanup; `_drain_pending_async_removes` will finalize them once the store future completes). The target case is the in-flight orphan above; the queue sweeps already cover the queued / running / prefilling cases, so the new pass is a no-op there (`test_fail_all_requests_clears_everything` verifies this). The async-cleanup exclusion is required to avoid converting a successful response into an error for non-streaming `generate()` callers — they drain all queued outputs and return the last one, so appending an error after the existing `finished=True` output would override the success.

```diff
         for request in list(self.waiting):
             failed_ids.append(request.request_id)
             req = self.requests.pop(request.request_id, None)
             if req is not None:
                 req._extracted_cache = None
                 req.prompt_cache = None
         self.waiting.clear()
+        # Catch in-flight orphans: a request popped from self.waiting but
+        # not yet added to self.running (or self.prefilling) sits as a
+        # local in _schedule_waiting. If _do_external_prefill raises, the
+        # request is unreachable through the three queues but still lives
+        # in self.requests …
+        #
+        # Exclude finished requests still awaiting async cache-store
+        # cleanup (those have an entry in _inflight_store_futures — see
+        # _cleanup_finished). They have already emitted finished=True;
+        # _drain_pending_async_removes finalizes them once the store
+        # future completes. Failing them here would append an error
+        # output that overrides the success for non-streaming generate().
+        for request_id in list(self.requests):
+            if request_id in self._inflight_store_futures:
+                continue
+            failed_ids.append(request_id)
+            req = self.requests.pop(request_id, None)
+            if req is not None:
+                req._extracted_cache = None
+                req.prompt_cache = None
         # Reset batch generator only (cache is not corrupted)
```

## Verification

- New unit test `test_fail_all_requests_includes_in_flight_orphans` constructs the orphan state directly (entry in `self.requests`, absent from all three queues), then asserts the id appears in `failed_ids` and is gone from `self.requests` after the call.
- New unit test `test_fail_all_requests_excludes_async_cleanup_in_flight` constructs the finished-pending-async-cleanup state (entry in `self.requests` + `_inflight_store_futures`, absent from all three queues), then asserts the id is NOT in `failed_ids` and remains in both `self.requests` and `_inflight_store_futures` for `_drain_pending_async_removes` to finalize.
- The orphan-inclusion test fails on unpatched main (`assert 'req-orphan' in ['req-0', 'req-1', 'req-2']`) and passes after the fix.
- Existing tests `test_fail_all_requests_clears_everything` and `test_fail_all_requests_preserves_cache` still pass; the orphan-cleanup pass is a no-op once the three queue sweeps drain `self.requests`.

## Scope and risk

- Files: `omlx/scheduler.py` (+21 / −0 in `fail_all_requests`), `tests/test_scheduler.py` (+68 / −0 for the two regression tests).
- Risk: low. For the queued / running / prefilling cases, the three earlier sweeps drain `self.requests` and the new loop is a no-op. For the finished-pending-async-cleanup case, the loop skips via the `_inflight_store_futures` check so success outputs are not overridden by error outputs.
- No public API change, no schema change, no new dependencies.

## Related work

- `jundot/omlx#1283` — engine_pool fallback error surfacing (**merged**). Surfaces errors during model *load*. This PR is the inference-time counterpart: errors during *prefill*.
- `Blaizzy/mlx-vlm#1201` — qwen3_5 `get_rope_index` crash on MiniCPM-V 4.6 (**open draft**). Removes the easiest live trigger but leaves the underlying orphan-propagation gap.
