### PR TITLE
fix(tests): prevent engine loop from calling step() in abort/cancelation tests

### DIFF
--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -320,6 +320,7 @@ class TestEngineCoreAbortRequest:
 
             try:
                 await engine.start()
+                engine.scheduler.has_requests = lambda: False
 
                 request_id = await engine.add_request(prompt="Hello")
                 await engine.abort_request(request_id)
@@ -361,6 +362,7 @@ class TestEngineCoreAbortRequest:
 
             try:
                 await engine.start()
+                engine.scheduler.has_requests = lambda: False
 
                 request_id = await engine.add_request(prompt="Hello")
 
@@ -404,6 +406,7 @@ class TestEngineCoreAbortRequest:
 
             try:
                 await engine.start()
+                engine.scheduler.has_requests = lambda: False
 
                 request_id = await engine.add_request(prompt="Hello")
 
@@ -540,6 +543,7 @@ class TestEngineCoreGenerateCancellation:
 
             try:
                 await engine.start()
+                engine.scheduler.has_requests = lambda: False
 
                 # Create a task that calls generate - it will block on event.wait()
                 task = asyncio.create_task(
@@ -840,6 +844,7 @@ class TestEngineCoreAbortAllRequests:
 
             try:
                 await engine.start()
+                engine.scheduler.has_requests = lambda: False
 
                 # Add multiple requests
                 rid1 = await engine.add_request(prompt="Hello")
@@ -899,6 +904,7 @@ class TestEngineCoreAbortAllRequests:
 
             try:
                 await engine.start()
+                engine.scheduler.has_requests = lambda: False
 
                 rid = await engine.add_request(prompt="Hello")
                 await engine.abort_all_requests()


### PR DESCRIPTION
This fixes two new errors when running

```shell
pytest tests/test_engine_core.py
```

Please advise if this is the correct approach. For my still limited understanding about the codebase, it sounds plausible.

Below is the message from my coding agent:

---

`MockModel` lacks `.layers` attribute, causing `scheduler.step()` to fail with `AttributeError` from `make_prompt_cache`.  Adding `engine.scheduler.has_requests = lambda: False` prevents the engine loop from `running step()` in tests that test abort/cancellation logic without needing model inference.

Fixes `test_abort_request_wakes_blocked_stream_outputs` and `test_generate_cancel_aborts_request` which were failing because the engine loop error handler interfered with expected error messages and collector cleanup.

---

Update: I asked the agent:

Would it be a better approach add the new `.layers` attribute to the `MockModel` to fix the root cause of this problem, rather than preventing the symptoms? Or is that a worse approach? Please explain.

It didn't like this approach much:

---

Both approaches have trade-offs. Here's the analysis:

Approach A — Add `.layers` to `MockModel`: 

This fixes the `make_prompt_cache` crash at `cache.py:34` but doesn't stop there. The prefill pipeline immediately continues to create `mx.array(prefill_tokens)`, call `self.model(input_arr)` (which returns a `MagicMock`), then tries to extract logits, embeddings, etc. from that mock object. You'd need to mock ``.layers`, .get_input_embeddings, `the forward pass return type, and potentially more — it's a deep rabbit hole with fragile, high-maintenance mocks.

Approach B — `has_requests = lambda: False` (current fix): 

These tests test abort/cancellation logic, not token generation. Preventing `step()` from running is semantically correct — the engine loop shouldn't be trying to generate tokens with a mock model. The pattern is already established at `test_engine_core.py:586`, so it's consistent.

Approach B is better here because it's simple, targeted, and doesn't require building fragile mock infrastructure that would need ongoing maintenance as the prefill pipeline evolves.

