### PR TITLE
Fix admin chat preserve_thinking history serialization

### DIFF
--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -2042,6 +2042,10 @@
             .filter(msg => ['user', 'assistant', 'tool', 'system'].includes(msg.role))
             .map(msg => {
                 const m = { role: msg.role, content: msg.content ?? null };
+                if (msg.reasoning_content) m.reasoning_content = msg.reasoning_content;
+                if (!m.reasoning_content && msg.role === 'assistant' && msg._thinking) {
+                    m.reasoning_content = msg._thinking;
+                }
                 if (msg.tool_calls) m.tool_calls = msg.tool_calls;
                 if (msg.tool_call_id) m.tool_call_id = msg.tool_call_id;
                 return m;
@@ -2218,6 +2222,7 @@
                 chatSession.messages.push({
                     role: 'assistant',
                     content: stream.streamingContent || null,
+                    reasoning_content: stream.streamingThinking || null,
                     model: context.model,
                     tool_calls: toolCalls,
                     _ui: false,
@@ -2293,6 +2298,7 @@
             chatSession.messages.push({
                 role: 'assistant',
                 content: stream.streamingContent || '',
+                reasoning_content: stream.streamingThinking || null,
                 model: context.model,
                 _perfVisible: false,
                 _thinking: stream.streamingThinking || null,
@@ -2317,6 +2323,7 @@
                     chatSession.messages.push({
                         role: 'assistant',
                         content: stream.streamingContent,
+                        reasoning_content: stream.streamingThinking || null,
                         model: context.model,
                         _perfVisible: false,
                         _thinking: stream.streamingThinking || null,


### PR DESCRIPTION
## Summary

Fixes `preserve_thinking` in the built-in admin chat UI.

The raw `/v1/chat/completions` API preserves historical reasoning correctly when prior assistant messages include `reasoning_content`. However, the admin chat UI was storing streamed reasoning only in the UI-private `_thinking` field and then dropping it when serializing conversation history for the next request.

This made `preserve_thinking` work with raw API calls but fail inside the built-in chat.

## Changes

- Include `reasoning_content` when building `messagesForApi`
- Fall back to `_thinking` so existing localStorage conversations continue to work
- Store streamed thinking as both:
  - `reasoning_content`, for API history replay
  - `_thinking`, for existing UI rendering
- Preserve reasoning on normal assistant messages, aborted streams, and assistant tool-call turns

## Manual test

Tested locally with `Qwen3.6-35B-A3B-oQ8-mtp`.

Prompt 1:

> Generate two random 20-digit numbers, validate that both are 20 digits, do not use tools, and only give me one of the two.

Prompt 2:

> Now give me the second number only.

Before this fix, the built-in chat could not retrieve the hidden second number because prior reasoning was not sent back. After this fix, the built-in chat returns the second number from preserved reasoning history.
