### PR TITLE
fix(mtp): check real sampler temperature for greedy detection

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -354,10 +354,10 @@ def _resolve_sampler(gen_batch: Any):
     return gen_batch.fallback_sampler
 
 
-def _is_greedy(gen_batch: Any) -> bool:
-    """Heuristic mirroring PR 990's ``sampler is None``."""
-    if gen_batch.samplers and gen_batch.samplers[0] is not None:
-        return False
+def _is_greedy(gen_batch):
+    sampler = _resolve_sampler(gen_batch)
+    if sampler is not None:
+        return getattr(sampler, "temp", 0.0) == 0.0
     return True
 
 

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -566,3 +566,179 @@ class TestPreLoadPatchDispatch:
             json.dumps({"model_type": "qwen3_5", "mtp_num_hidden_layers": 1})
         )
         maybe_apply_pre_load_patches(str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# batch_generator — _resolve_sampler + _is_greedy
+# ---------------------------------------------------------------------------
+
+class TestResolveSampler:
+    """Tests for ``_resolve_sampler`` which mirrors GenerationBatch._step's
+    per-sequence sampler resolution (batch=1).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _apply(self):
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        applied = batch_generator.apply()
+        if not applied:
+            pytest.skip("batch_generator patch refused to apply (mlx_lm absent)")
+
+    def _make_batch(self, samplers=None, fallback_sampler=None):
+        return SimpleNamespace(
+            samplers=samplers,
+            fallback_sampler=fallback_sampler,
+        )
+
+    def test_returns_first_sampler_when_present(self):
+        from omlx.patches.mlx_lm_mtp.batch_generator import _resolve_sampler
+
+        sampler = object()
+        batch = self._make_batch(samplers=[sampler])
+        assert _resolve_sampler(batch) is sampler
+
+    def test_skips_none_sampler_and_uses_fallback(self):
+        from omlx.patches.mlx_lm_mtp.batch_generator import _resolve_sampler
+
+        fallback = object()
+        batch = self._make_batch(samplers=[None], fallback_sampler=fallback)
+        assert _resolve_sampler(batch) is fallback
+
+    def test_uses_fallback_when_samplers_empty(self):
+        from omlx.patches.mlx_lm_mtp.batch_generator import _resolve_sampler
+
+        fallback = object()
+        batch = self._make_batch(samplers=[], fallback_sampler=fallback)
+        assert _resolve_sampler(batch) is fallback
+
+    def test_uses_fallback_when_samplers_missing(self):
+        from omlx.patches.mlx_lm_mtp.batch_generator import _resolve_sampler
+
+        fallback = object()
+        batch = self._make_batch(samplers=None, fallback_sampler=fallback)
+        assert _resolve_sampler(batch) is fallback
+
+    def test_uses_fallback_when_samplers_is_none(self):
+        from omlx.patches.mlx_lm_mtp.batch_generator import _resolve_sampler
+
+        fallback = object()
+        batch = self._make_batch(samplers=None, fallback_sampler=fallback)
+        assert _resolve_sampler(batch) is fallback
+
+    def test_prefers_samplers_0_over_fallback(self):
+        """Even if fallback_sampler is set, samplers[0] takes priority."""
+        from omlx.patches.mlx_lm_mtp.batch_generator import _resolve_sampler
+
+        primary = object()
+        fallback = object()
+        batch = self._make_batch(samplers=[primary], fallback_sampler=fallback)
+        assert _resolve_sampler(batch) is primary
+
+
+class TestIsGreedy:
+    """Tests for ``_is_greedy`` which determines whether the active sampler
+    performs greedy decoding (temperature == 0).
+
+    Regression guard for the refactor that replaced the old
+    ``gen_batch.samplers and gen_batch.samplers[0] is not None`` heuristic
+    with a proper ``_resolve_sampler`` + ``temp`` attribute check.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _apply(self):
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        applied = batch_generator.apply()
+        if not applied:
+            pytest.skip("batch_generator patch refused to apply (mlx_lm absent)")
+
+    def _make_batch(self, samplers=None, fallback_sampler=None):
+        return SimpleNamespace(
+            samplers=samplers,
+            fallback_sampler=fallback_sampler,
+        )
+
+    def _make_sampler(self, temp=0.0):
+        return SimpleNamespace(temp=temp)
+
+    def _make_sampler_no_temp(self):
+        """Sampler without a ``temp`` attribute — defaults to 0.0."""
+        return SimpleNamespace()
+
+    def test_greedy_when_sampler_temp_is_zero(self):
+        from omlx.patches.mlx_lm_mtp.batch_generator import _is_greedy
+
+        batch = self._make_batch(samplers=[self._make_sampler(temp=0.0)])
+        assert _is_greedy(batch) is True
+
+    def test_not_greedy_when_sampler_temp_is_positive(self):
+        from omlx.patches.mlx_lm_mtp.batch_generator import _is_greedy
+
+        batch = self._make_batch(samplers=[self._make_sampler(temp=0.7)])
+        assert _is_greedy(batch) is False
+
+    def test_greedy_when_sampler_has_no_temp_attribute(self):
+        """Missing ``temp`` defaults to 0.0 → greedy."""
+        from omlx.patches.mlx_lm_mtp.batch_generator import _is_greedy
+
+        batch = self._make_batch(samplers=[self._make_sampler_no_temp()])
+        assert _is_greedy(batch) is True
+
+    def test_greedy_when_sampler_is_none(self):
+        """No sampler → falls back to fallback_sampler → greedy."""
+        from omlx.patches.mlx_lm_mtp.batch_generator import _is_greedy
+
+        batch = self._make_batch(samplers=[None], fallback_sampler=None)
+        assert _is_greedy(batch) is True
+
+    def test_greedy_when_samplers_empty(self):
+        """Empty samplers list → falls back to fallback_sampler → greedy."""
+        from omlx.patches.mlx_lm_mtp.batch_generator import _is_greedy
+
+        batch = self._make_batch(samplers=[], fallback_sampler=None)
+        assert _is_greedy(batch) is True
+
+    def test_greedy_when_samplers_missing(self):
+        """No samplers attribute → falls back to fallback_sampler → greedy."""
+        from omlx.patches.mlx_lm_mtp.batch_generator import _is_greedy
+
+        batch = self._make_batch(samplers=None, fallback_sampler=None)
+        assert _is_greedy(batch) is True
+
+    def test_not_greedy_via_fallback_sampler(self):
+        """When samplers[0] is None, the fallback sampler's temp is checked."""
+        from omlx.patches.mlx_lm_mtp.batch_generator import _is_greedy
+
+        batch = self._make_batch(
+            samplers=[None],
+            fallback_sampler=self._make_sampler(temp=0.8),
+        )
+        assert _is_greedy(batch) is False
+
+    def test_greedy_via_fallback_sampler(self):
+        """Fallback sampler with temp=0.0 → greedy."""
+        from omlx.patches.mlx_lm_mtp.batch_generator import _is_greedy
+
+        batch = self._make_batch(
+            samplers=[None],
+            fallback_sampler=self._make_sampler(temp=0.0),
+        )
+        assert _is_greedy(batch) is True
+
+    def test_greedy_fallback_no_temp_attribute(self):
+        """Fallback sampler without ``temp`` → defaults to 0.0 → greedy."""
+        from omlx.patches.mlx_lm_mtp.batch_generator import _is_greedy
+
+        batch = self._make_batch(
+            samplers=[None],
+            fallback_sampler=self._make_sampler_no_temp(),
+        )
+        assert _is_greedy(batch) is True
+
+    def test_greedy_when_fallback_is_none(self):
+        """Both samplers and fallback are None → greedy."""
+        from omlx.patches.mlx_lm_mtp.batch_generator import _is_greedy
+
+        batch = self._make_batch(samplers=None, fallback_sampler=None)
+        assert _is_greedy(batch) is True


### PR DESCRIPTION
Fixes #1330.

Seems like we've always had `is_greedy = False` because there was always a sampler. This PR fixes it by adding an explicit check for its temperature + reusing the already existing helper `_resolve_sampler`.

New tests added:

_resolve_sampler:                                                                                            
 - Returns samplers[0] when present and not None                                                                                                    
 - Falls back to fallback_sampler when samplers[0] is None                                                                                          
 - Falls back to fallback_sampler when samplers is empty                                                                                            
 - Falls back to fallback_sampler when samplers is None/missing                                                                                     
 - Prefers samplers[0] over fallback_sampler when both exist                                                                                        
                                                                                                                                                    
_is_greedy:                                                                                        
 - Returns True (greedy) when sampler.temp == 0.0                                                                                                   
 - Returns False (not greedy) when sampler.temp > 0.0                                                                                               
 - Returns True when sampler has no temp attribute (defaults to 0.0)                                                                                
 - Returns True when sampler is None (falls back to greedy)                                                                                         
 - Returns True when samplers is empty/missing                                                                                                      
 - Checks fallback_sampler.temp when samplers[0] is None                                                                                            
 - Handles fallback_sampler with no temp attribute (defaults to greedy) 