### PR TITLE
fix(mtp): correct backbone and sampler time measurement

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -752,6 +752,9 @@ def _run_verify_cycle(gen_batch: Any, state: _MtpState) -> None:
         )
         verify_logits = logits[:, 0, :]
         bonus_logits = logits[:, 1, :]
+    # materialize logits now so that it doesn't count as
+    # sampler timing during mx.eval(verify_tok, bonus_tok)
+    mx.eval(logits)
     state.stats.backbone_ms += (time.perf_counter() - t0) * 1000
 
     t0 = time.perf_counter()


### PR DESCRIPTION
Related #1330, #1311, #1097.

A lot of people including me got confused with huge MTP sample timings. The actual problem is that due to mx.core lazy nature we've leaked massive logits computation to the sampler part until `mx.eval(verify_tok, bonus_tok)` or whatever first `.tolist()` happens.

This PR materializes it earlier so that it counts as `backbone_ms` properly:

```
INFO - MTP[0] finish=stop tokens=1886 cycles=973 accept=911/973 (93.6%) emits[init=2,draft=911,bonus=911,verify=62] timing[backbone=108907.4ms mtp=3935.5ms sample=401.0ms cache=54.1ms]
```