### PR TITLE
fix(hf): follow cross-origin permanent redirects on configured endpoint

### DIFF
--- a/omlx/admin/hf_downloader.py
+++ b/omlx/admin/hf_downloader.py
@@ -14,6 +14,7 @@ import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Optional
+from urllib.parse import urlparse
 
 from huggingface_hub import HfApi, hf_hub_download, snapshot_download
 from huggingface_hub.utils import (
@@ -31,21 +32,101 @@ _HF_API_TIMEOUT = 10
 # Seconds with no download progress before considering the download stalled.
 _STALL_TIMEOUT = 300
 
+# Cache of (configured_endpoint -> resolved_endpoint) so we only probe each
+# endpoint once per process lifetime. Mirrors like hf-mirror.com permanently
+# 308-redirect to huggingface.co when accessed from IPs outside their region;
+# huggingface_hub does NOT follow those cross-origin 308s during HEAD probes,
+# so downloads fail. We resolve the redirect chain upfront and pin HfApi to
+# the final origin.
+_endpoint_resolution_cache: dict[str, str] = {}
+
+
+def _resolve_endpoint(endpoint: str) -> str:
+    """Follow permanent (301/308) cross-origin redirects on `endpoint`.
+
+    Returns the final origin (scheme://host[:port]) the endpoint resolves to.
+    Used to work around `huggingface_hub`'s inability to follow cross-origin
+    308 redirects during file-download HEAD probes.
+
+    Probes a known-stable HF API path (`/api/models/gpt2`) with HEAD; if the
+    server returns a 301/308 with a Location pointing at a different host,
+    the redirected origin is returned (and cached). Network errors fall back
+    to the original endpoint.
+    """
+    endpoint = endpoint.rstrip("/")
+    if endpoint in _endpoint_resolution_cache:
+        return _endpoint_resolution_cache[endpoint]
+
+    try:
+        import httpx
+    except ImportError:
+        return endpoint
+
+    probe = f"{endpoint}/api/models/gpt2"
+    original_host = urlparse(endpoint).netloc
+    resolved = endpoint
+    try:
+        with httpx.Client(follow_redirects=False, timeout=5.0) as client:
+            r = client.head(probe)
+            # Walk up to 3 permanent hops; stop on first non-permanent status.
+            hops = 0
+            current_url = probe
+            while r.status_code in (301, 308) and "location" in r.headers:
+                hops += 1
+                if hops > 3:
+                    break
+                location = r.headers["location"]
+                if location.startswith("/"):
+                    # Relative redirect — same origin, no rewrite needed.
+                    break
+                target = urlparse(location)
+                if not target.netloc:
+                    break
+                if target.netloc != original_host:
+                    # Cross-origin permanent redirect: rewrite the endpoint.
+                    port = f":{target.port}" if target.port else ""
+                    resolved = f"{target.scheme}://{target.hostname}{port}"
+                    original_host = target.netloc
+                current_url = location
+                r = client.head(current_url)
+    except Exception as e:  # noqa: BLE001 — probe is best-effort
+        logger.debug(f"HF endpoint probe failed for {endpoint}: {e}")
+        return endpoint
+
+    if resolved != endpoint:
+        logger.info(
+            f"HuggingFace endpoint {endpoint} permanently redirects to "
+            f"{resolved}; using resolved origin for downloads."
+        )
+    _endpoint_resolution_cache[endpoint] = resolved
+    return resolved
+
 
 def _get_hf_api() -> tuple[HfApi, str | None]:
     """Create HfApi instance with configured endpoint.
 
+    Only the admin UI's `huggingface.endpoint` setting is honored here.
+    When that's empty, return `HfApi()` with no explicit endpoint so
+    `huggingface_hub` falls back to its own resolution (which already
+    honors the `HF_ENDPOINT` env var). The configured endpoint, when
+    present, is run through `_resolve_endpoint()` to follow permanent
+    cross-origin redirects (e.g. hf-mirror.com → huggingface.co from
+    non-CN IPs) so downstream HF library code sees a stable origin.
+
     Returns:
         Tuple of (HfApi instance, endpoint URL or None).
     """
+    endpoint: str | None = None
     try:
         from ..settings import get_settings
 
-        endpoint = get_settings().huggingface.endpoint
-        if endpoint:
-            return HfApi(endpoint=endpoint), endpoint
+        endpoint = get_settings().huggingface.endpoint or None
     except (RuntimeError, AttributeError):
-        pass
+        endpoint = None
+
+    if endpoint:
+        resolved = _resolve_endpoint(endpoint)
+        return HfApi(endpoint=resolved), resolved
     return HfApi(), None
 
 

--- a/tests/test_hf_downloader.py
+++ b/tests/test_hf_downloader.py
@@ -2293,3 +2293,144 @@ class TestEtagTimeout:
             assert call_kwargs["etag_timeout"] == 30
 
             await downloader.shutdown()
+
+
+# =============================================================================
+# Endpoint resolution (_resolve_endpoint)
+# =============================================================================
+#
+# Background: `huggingface_hub` does not follow cross-origin permanent
+# redirects during the HEAD probe it issues at the start of a download
+# (e.g. hf-mirror.com permanently 308s to huggingface.co when accessed
+# from non-CN IPs). The result is a silent download failure with a
+# misleading error. `_resolve_endpoint` probes the configured endpoint
+# upfront, walks the redirect chain, and pins HfApi to the final origin.
+#
+# These tests pin that behavior so a future refactor doesn't regress it.
+
+
+class TestResolveEndpoint:
+    """Pin the cross-origin redirect resolution for HF_ENDPOINT."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        # Cache is module-global; clear before/after every test so cases
+        # don't bleed into each other.
+        from omlx.admin.hf_downloader import _endpoint_resolution_cache
+        _endpoint_resolution_cache.clear()
+        yield
+        _endpoint_resolution_cache.clear()
+
+    @staticmethod
+    def _response(status_code: int, location: str | None = None) -> MagicMock:
+        r = MagicMock()
+        r.status_code = status_code
+        r.headers = {"location": location} if location else {}
+        return r
+
+    def _patch_httpx(self, responses: list):
+        """Patch httpx.Client.head to walk through `responses` in order."""
+        mock_client_cls = MagicMock()
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.head = MagicMock(side_effect=responses)
+        mock_client_cls.return_value = mock_client
+        return patch("httpx.Client", mock_client_cls), mock_client
+
+    def test_no_redirect_returns_endpoint_unchanged(self):
+        from omlx.admin.hf_downloader import _resolve_endpoint
+        ctx, _ = self._patch_httpx([self._response(200)])
+        with ctx:
+            assert _resolve_endpoint("https://huggingface.co") == "https://huggingface.co"
+
+    def test_cross_origin_308_returns_redirected_origin(self):
+        # The bug this whole module exists to fix: hf-mirror permanently
+        # 308s to huggingface.co; downloads must resolve to the final origin.
+        from omlx.admin.hf_downloader import _resolve_endpoint
+        ctx, _ = self._patch_httpx([
+            self._response(308, "https://huggingface.co/api/models/gpt2"),
+            self._response(200),  # probe at resolved origin
+        ])
+        with ctx:
+            assert _resolve_endpoint("https://hf-mirror.com") == "https://huggingface.co"
+
+    def test_cross_origin_301_also_handled(self):
+        # 301 (Moved Permanently) gets the same treatment as 308.
+        from omlx.admin.hf_downloader import _resolve_endpoint
+        ctx, _ = self._patch_httpx([
+            self._response(301, "https://huggingface.co/api/models/gpt2"),
+            self._response(200),
+        ])
+        with ctx:
+            assert _resolve_endpoint("https://hf-mirror.com") == "https://huggingface.co"
+
+    def test_same_origin_redirect_does_not_rewrite(self):
+        # If the server returns a relative Location (`/foo`) we must not
+        # try to rewrite the endpoint — same origin, same hostname.
+        from omlx.admin.hf_downloader import _resolve_endpoint
+        ctx, _ = self._patch_httpx([
+            self._response(308, "/api/models/gpt2"),
+        ])
+        with ctx:
+            assert _resolve_endpoint("https://hf-mirror.com") == "https://hf-mirror.com"
+
+    def test_chained_redirects_walk_up_to_3_hops(self):
+        # A → B → C all cross-origin permanent. Final hop wins.
+        from omlx.admin.hf_downloader import _resolve_endpoint
+        ctx, _ = self._patch_httpx([
+            self._response(308, "https://hop2.example/api/models/gpt2"),
+            self._response(308, "https://huggingface.co/api/models/gpt2"),
+            self._response(200),
+        ])
+        with ctx:
+            assert _resolve_endpoint("https://hop1.example") == "https://huggingface.co"
+
+    def test_temporary_redirect_is_not_followed(self):
+        # 302 / 307 are NOT permanent — leave the endpoint alone so the HF
+        # client can handle them per-request.
+        from omlx.admin.hf_downloader import _resolve_endpoint
+        ctx, _ = self._patch_httpx([
+            self._response(302, "https://huggingface.co/api/models/gpt2"),
+        ])
+        with ctx:
+            assert _resolve_endpoint("https://hf-mirror.com") == "https://hf-mirror.com"
+
+    def test_network_error_falls_back_to_original_endpoint(self):
+        # Best-effort probe: any httpx exception leaves the endpoint as-is.
+        from omlx.admin.hf_downloader import _resolve_endpoint
+        mock_client_cls = MagicMock()
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.head = MagicMock(side_effect=OSError("network unreachable"))
+        mock_client_cls.return_value = mock_client
+        with patch("httpx.Client", mock_client_cls):
+            assert _resolve_endpoint("https://hf-mirror.com") == "https://hf-mirror.com"
+
+    def test_result_is_cached_per_endpoint(self):
+        # Second call for the same endpoint must not re-probe.
+        from omlx.admin.hf_downloader import _resolve_endpoint
+        ctx, mock_client = self._patch_httpx([
+            self._response(308, "https://huggingface.co/api/models/gpt2"),
+            self._response(200),
+        ])
+        with ctx:
+            _resolve_endpoint("https://hf-mirror.com")
+            _resolve_endpoint("https://hf-mirror.com")
+        assert mock_client.head.call_count == 2  # one probe + one resolved probe
+
+    def test_trailing_slash_normalized(self):
+        # `https://hf-mirror.com/` and `https://hf-mirror.com` are the same
+        # endpoint and must share the cache.
+        from omlx.admin.hf_downloader import _resolve_endpoint
+        ctx, mock_client = self._patch_httpx([
+            self._response(308, "https://huggingface.co/api/models/gpt2"),
+            self._response(200),
+        ])
+        with ctx:
+            r1 = _resolve_endpoint("https://hf-mirror.com")
+            r2 = _resolve_endpoint("https://hf-mirror.com/")
+        assert r1 == r2 == "https://huggingface.co"
+        # Second call was a cache hit — head() count unchanged from first probe.
+        assert mock_client.head.call_count == 2


### PR DESCRIPTION
## Summary

`huggingface_hub` doesn't follow cross-origin 301/308 redirects during its HEAD probes, so a downloader configured to use a mirror that redirects (e.g. `hf-mirror.com` → `huggingface.co` from non-CN IPs) silently fails with a misleading error.

This change resolves the configured endpoint upfront — walks up to 3 permanent hops, returns the final origin — and pins `HfApi` to it so downloads target a stable host.

This is the first of the prep PRs split out of the Swift macOS app rewrite (`feature/native-app-swift-rewrite`); files as a standalone fix because it benefits HTML dashboard users too.

## Scope

- Only the admin UI's `huggingface.endpoint` setting is run through the new probe. The `HF_ENDPOINT` env var resolution stays inside `huggingface_hub` (we pass `endpoint=None` when no admin setting is configured), matching the existing `test_snapshot_download_endpoint_none_without_mirror` contract.
- Best-effort probe: network errors leave the endpoint unchanged. Per-process cache so the resolve only fires once per endpoint.

## Test plan

- [x] 9 new tests in `TestResolveEndpoint` cover: no-redirect, 308, 301, relative Location, 3-hop chain, 302/307 ignored, network error fallback, cache hit, trailing-slash normalization.
- [x] Verified RED by reverting `hf_downloader.py` to `origin/main` — all 9 fail with `ImportError`.
- [x] Full `tests/test_hf_downloader.py` — 99 passed.

## Local reproduction

```bash
git checkout fix/hf-mirror-cross-origin-redirect
uv run pytest tests/test_hf_downloader.py::TestResolveEndpoint -v
# Expect: 9 passed
```

To prove the tests catch the bug, temporarily revert the fix:

```bash
git show origin/main:omlx/admin/hf_downloader.py > omlx/admin/hf_downloader.py
uv run pytest tests/test_hf_downloader.py::TestResolveEndpoint -v
# Expect: 9 errors (ImportError on _resolve_endpoint)
git checkout HEAD -- omlx/admin/hf_downloader.py
```