### PR TITLE
refactor(bench): replay-on-subscribe SSE delivery + multi-tab coherence

### DIFF
--- a/omlx/admin/accuracy_benchmark.py
+++ b/omlx/admin/accuracy_benchmark.py
@@ -72,16 +72,28 @@ class AccuracyBenchmarkRequest(BaseModel):
 
 @dataclass
 class AccuracyBenchmarkRun:
-    """Tracks the state of a running accuracy benchmark."""
+    """Tracks the state of a running accuracy benchmark.
+
+    SSE delivery model mirrors `BenchmarkRun`: append-only `events`
+    log + `cond` for live notification + `terminal` flag set on the
+    final event. See benchmark.py for the rationale.
+    """
 
     bench_id: str
     request: AccuracyBenchmarkRequest
     status: str = "running"  # running, completed, cancelled, error
-    queue: asyncio.Queue = field(default_factory=asyncio.Queue)
+    events: list[dict] = field(default_factory=list)
+    cond: asyncio.Condition = field(default_factory=asyncio.Condition)
+    terminal: bool = False
     task: Optional[asyncio.Task] = None
     results: list[dict] = field(default_factory=list)
     error_message: str = ""
     last_progress: Optional[dict] = None  # last progress event for reconnect
+
+
+# Accuracy stream closes on `done` (run finished) or `error`. Unlike the
+# throughput bench there's no separate upload phase to ride out.
+_ACCURACY_TERMINAL_TYPES = frozenset({"done", "error"})
 
 
 # --- Run management ---
@@ -251,13 +263,18 @@ async def cancel_queue() -> None:
 
 
 async def _send_event(run: AccuracyBenchmarkRun, event: dict) -> None:
-    """Send an SSE event to the client."""
+    """Append an event to the run's log and wake subscribers.
+
+    Updates `last_progress` (used by the REST `queue/status` endpoint
+    for reconnect hints) and sets `run.terminal` on the final event.
+    """
     if event.get("type") == "progress":
         run.last_progress = event
-    try:
-        await run.queue.put(event)
-    except Exception:
-        pass
+    async with run.cond:
+        run.events.append(event)
+        if event.get("type") in _ACCURACY_TERMINAL_TYPES:
+            run.terminal = True
+        run.cond.notify_all()
 
 
 # --- Benchmark execution ---

--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -103,6 +103,20 @@ def get_run(bench_id: str) -> Optional[BenchmarkRun]:
     return _benchmark_runs.get(bench_id)
 
 
+def get_active_run() -> Optional[BenchmarkRun]:
+    """Return the currently-running throughput benchmark, if any.
+
+    Discovery surface for clients that need to attach to an in-progress
+    run without knowing the bench_id upfront (page refresh, second tab).
+    Returns the first run with status == "running"; throughput benches
+    are 1-at-a-time so there's never more than one.
+    """
+    for run in _benchmark_runs.values():
+        if run.status == "running":
+            return run
+    return None
+
+
 def create_run(request: BenchmarkRequest) -> BenchmarkRun:
     """Create and register a new benchmark run."""
     bench_id = f"bench-{uuid.uuid4().hex[:12]}"

--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -68,12 +68,21 @@ class BenchmarkRequest(BaseModel):
 
 @dataclass
 class BenchmarkRun:
-    """Tracks the state of a running benchmark."""
+    """Tracks the state of a running benchmark.
+
+    SSE delivery model: events are appended to `events` (append-only
+    log) under `cond`. Subscribers replay `events` from offset 0 then
+    wait on `cond` for new entries. `terminal` is set once the final
+    event (`upload_done` / `error`) has been published so subscribers
+    know to close their stream rather than wait for a follow-up.
+    """
 
     bench_id: str
     request: BenchmarkRequest
     status: str = "running"  # running, completed, cancelled, error
-    queue: asyncio.Queue = field(default_factory=asyncio.Queue)
+    events: list[dict] = field(default_factory=list)
+    cond: asyncio.Condition = field(default_factory=asyncio.Condition)
+    terminal: bool = False
     task: Optional[asyncio.Task] = None
     results: list[dict] = field(default_factory=list)
     error_message: str = ""
@@ -81,6 +90,12 @@ class BenchmarkRun:
     # the run's results are not uploaded to omlx.ai community benchmarks
     # because experimental features skew the numbers.
     experimental_features: list[str] = field(default_factory=list)
+
+
+# Event types that close the SSE stream for a bench run. `done` is NOT
+# terminal — it marks "tests finished, upload starting"; the real end of
+# stream is `upload_done` (or `error`).
+_BENCH_TERMINAL_TYPES = frozenset({"upload_done", "error"})
 
 
 def get_run(bench_id: str) -> Optional[BenchmarkRun]:
@@ -170,8 +185,16 @@ def _compute_single_metrics(
 
 
 async def _send_event(run: BenchmarkRun, event: dict) -> None:
-    """Send an SSE event to the run's queue."""
-    await run.queue.put(event)
+    """Append an event to the run's log and wake any subscribers.
+
+    Sets `run.terminal` when the event ends the stream so subscribers
+    can return rather than wait for an event that will never come.
+    """
+    async with run.cond:
+        run.events.append(event)
+        if event.get("type") in _BENCH_TERMINAL_TYPES:
+            run.terminal = True
+        run.cond.notify_all()
 
 
 async def _run_single_test(

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -5007,6 +5007,27 @@ async def stream_accuracy_benchmark(
 # =============================================================================
 
 
+@router.get("/api/bench/active")
+async def get_active_benchmark(is_admin: bool = Depends(require_admin)):
+    """Return the currently-running throughput benchmark, if any.
+
+    Symmetric to `/api/bench/accuracy/queue/status` — lets a fresh page
+    load or a second tab discover an in-flight run so it can attach to
+    the SSE stream. Combined with the replay-on-subscribe stream this
+    is what makes the multi-tab + page-refresh story actually work.
+    """
+    from .benchmark import get_active_run
+
+    run = get_active_run()
+    if run is None:
+        return {"running": False, "bench_id": None, "model_id": None}
+    return {
+        "running": True,
+        "bench_id": run.bench_id,
+        "model_id": run.request.model_id,
+    }
+
+
 @router.post("/api/bench/start")
 async def start_benchmark(
     request: Request,

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -5036,18 +5036,33 @@ async def start_benchmark(
     """Start a benchmark run.
 
     Validates the model, creates a benchmark run, and starts it
-    as an asyncio background task.
+    as an asyncio background task. Rejects with 409 if another
+    throughput bench is already running — two concurrent runs on
+    the same engine produce mutually-corrupted measurements.
     """
     from .benchmark import (
         BenchmarkRequest,
         cleanup_old_runs,
         create_run,
+        get_active_run,
         run_benchmark,
     )
 
     engine_pool = _get_engine_pool()
     if engine_pool is None:
         raise HTTPException(status_code=503, detail="Engine pool not initialized")
+
+    # One throughput bench at a time. The replay-on-subscribe stream lets
+    # clients attach to the already-running one if that's what they want.
+    active = get_active_run()
+    if active is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"A throughput benchmark is already running "
+                f"(bench_id={active.bench_id}, model_id={active.request.model_id})."
+            ),
+        )
 
     body = await request.json()
     try:

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -4965,17 +4965,28 @@ async def stream_accuracy_benchmark(
         )
 
     async def event_generator():
+        # Replay-then-attach: every subscriber starts at offset 0 of the
+        # run's event log and follows along live. Lets the HTML dashboard
+        # recover its view on page refresh and lets multiple consumers
+        # (e.g. browser + Swift app) share the same run.
+        seen = 0
         try:
             while True:
-                try:
-                    event = await asyncio.wait_for(run.queue.get(), timeout=60.0)
-                except TimeoutError:
+                async with run.cond:
+                    while seen >= len(run.events) and not run.terminal:
+                        try:
+                            await asyncio.wait_for(run.cond.wait(), timeout=60.0)
+                        except TimeoutError:
+                            break
+                    new = list(run.events[seen:])
+                    seen = len(run.events)
+                    done = run.terminal
+
+                for ev in new:
+                    yield f"data: {json.dumps(ev)}\n\n"
+                if not new and not done:
                     yield ": keepalive\n\n"
-                    continue
-
-                yield f"data: {json.dumps(event)}\n\n"
-
-                if event.get("type") in ("done", "error"):
+                if done:
                     break
         except asyncio.CancelledError:
             pass
@@ -5073,19 +5084,28 @@ async def stream_benchmark(
         raise HTTPException(status_code=404, detail=f"Benchmark not found: {bench_id}")
 
     async def event_generator():
+        # Replay-then-attach: see /api/bench/accuracy/{id}/stream for the
+        # full rationale. The bench stream's terminal events are
+        # `upload_done` and `error` — `done` only marks the boundary
+        # between tests and upload.
+        seen = 0
         try:
             while True:
-                try:
-                    event = await asyncio.wait_for(run.queue.get(), timeout=60.0)
-                except TimeoutError:
-                    # Send keepalive
+                async with run.cond:
+                    while seen >= len(run.events) and not run.terminal:
+                        try:
+                            await asyncio.wait_for(run.cond.wait(), timeout=60.0)
+                        except TimeoutError:
+                            break
+                    new = list(run.events[seen:])
+                    seen = len(run.events)
+                    done = run.terminal
+
+                for ev in new:
+                    yield f"data: {json.dumps(ev)}\n\n"
+                if not new and not done:
                     yield ": keepalive\n\n"
-                    continue
-
-                yield f"data: {json.dumps(event)}\n\n"
-
-                # Stop streaming on terminal events
-                if event.get("type") in ("upload_done", "error"):
+                if done:
                     break
         except asyncio.CancelledError:
             pass

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -387,6 +387,11 @@
             benchUploadDone: null,
             benchUploading: false,
             benchUploadSkipped: null,  // { features: [...] } when upload was skipped due to experimental features
+            // { bench_id, model_id } when the server reports a running bench
+            // that is NOT the one this tab is displaying. Drives the "another
+            // bench is running" banner + disables Start so the user doesn't
+            // race a 409 on the server.
+            benchOtherActive: null,
 
             // Bench sub-tab & dropdown
             benchTab: 'throughput',
@@ -473,6 +478,17 @@
                 // Watch for main tab changes to manage refresh timers
                 this.$watch('mainTab', (value) => {
                     this.handleMainTabChange(value);
+                });
+
+                // When the user returns to this browser tab after looking
+                // elsewhere, re-check whether a different bench just started
+                // in another tab. Fires the banner without requiring an
+                // in-app tab switch.
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState !== 'visible') return;
+                    if (this.mainTab === 'bench' && this.benchTab === 'throughput') {
+                        this.loadBenchState();
+                    }
                 });
 
                 this.$watch('hfMlxOnly', () => {
@@ -2739,19 +2755,82 @@
                 // Discover an in-progress throughput run on tab/page load so
                 // a second tab (or a refresh) can attach to its SSE stream
                 // and replay the run's full event history.
+                //
+                // Three cases:
+                //   1. No active run → clear any stale banner state.
+                //   2. Active run, this tab is already attached → no-op.
+                //   3. Active run, this tab is fresh → auto-attach.
+                //   4. Active run, this tab is displaying a *different*
+                //      completed bench → show banner; let the user decide
+                //      whether to clobber their result view.
                 try {
                     const resp = await fetch('/admin/api/bench/active');
                     if (!resp.ok) return;
                     const data = await resp.json();
-                    if (data.running && data.bench_id) {
-                        this.benchBenchId = data.bench_id;
-                        this.benchModelId = data.model_id;
-                        this.benchRunning = true;
-                        this.connectBenchSSE(data.bench_id);
+
+                    if (!data.running || !data.bench_id) {
+                        this.benchOtherActive = null;
+                        return;
                     }
+
+                    // Already attached to this bench — nothing to do.
+                    if (this.benchBenchId === data.bench_id && this.benchEventSource) {
+                        return;
+                    }
+
+                    // We have completed results from a DIFFERENT bench on
+                    // screen — don't silently swap them out. Show a banner
+                    // so the user can explicitly accept the new bench.
+                    const hasStaleResults = !this.benchRunning
+                        && this.benchBenchId
+                        && this.benchBenchId !== data.bench_id
+                        && (this.benchSingleResults.length > 0
+                            || this.benchBatchResults.length > 0);
+                    if (hasStaleResults) {
+                        this.benchOtherActive = {
+                            bench_id: data.bench_id,
+                            model_id: data.model_id,
+                        };
+                        return;
+                    }
+
+                    // Fresh slate: attach.
+                    this.benchBenchId = data.bench_id;
+                    this.benchModelId = data.model_id;
+                    this.benchRunning = true;
+                    this.benchOtherActive = null;
+                    this.connectBenchSSE(data.bench_id);
                 } catch (err) {
                     console.error('Failed to load bench state:', err);
                 }
+            },
+
+            // User clicked "View live" on the banner — clear the stale
+            // result display, attach to the active run. The replay-on-
+            // subscribe stream re-delivers every event so the new bench
+            // populates its table from the start.
+            acceptOtherBench() {
+                if (!this.benchOtherActive) return;
+                const other = this.benchOtherActive;
+                this.benchOtherActive = null;
+                this.benchBenchId = other.bench_id;
+                this.benchModelId = other.model_id;
+                this.benchRunning = true;
+                this.benchSingleResults = [];
+                this.benchBatchResults = [];
+                this.benchUploadResults = [];
+                this.benchUploadDone = null;
+                this.benchUploadSkipped = null;
+                this.benchProgress = null;
+                this.benchError = '';
+                this.connectBenchSSE(other.bench_id);
+            },
+
+            dismissOtherBench() {
+                // Hide for now; the banner reappears next loadBenchState if
+                // the run is still active. Use case: user wants to keep
+                // reviewing their previous result for a moment.
+                this.benchOtherActive = null;
             },
 
             // Bench sub-tab

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -553,6 +553,7 @@
                 }
                 if (value === 'bench') {
                     if (!this.benchDeviceInfo) await this.loadBenchDeviceInfo();
+                    await this.loadBenchState();
                     await this.loadAccState();
                 }
             },
@@ -2734,6 +2735,25 @@
                 }
             },
 
+            async loadBenchState() {
+                // Discover an in-progress throughput run on tab/page load so
+                // a second tab (or a refresh) can attach to its SSE stream
+                // and replay the run's full event history.
+                try {
+                    const resp = await fetch('/admin/api/bench/active');
+                    if (!resp.ok) return;
+                    const data = await resp.json();
+                    if (data.running && data.bench_id) {
+                        this.benchBenchId = data.bench_id;
+                        this.benchModelId = data.model_id;
+                        this.benchRunning = true;
+                        this.connectBenchSSE(data.bench_id);
+                    }
+                } catch (err) {
+                    console.error('Failed to load bench state:', err);
+                }
+            },
+
             // Bench sub-tab
             setBenchTab(tab) {
                 if (!DASHBOARD_BENCH_TABS.has(tab)) return;
@@ -2742,6 +2762,7 @@
                 this.syncTabStateToUrl();
                 if (tab === 'throughput') {
                     this.loadBenchDeviceInfo();
+                    this.loadBenchState();
                 }
             },
 

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -2527,10 +2527,24 @@
                                 total: data.total,
                             };
                         } else if (data.type === 'result') {
+                            // SSE replay-on-subscribe re-delivers every event on
+                            // every reconnect (incl. page refresh), so append-only
+                            // arrays must dedupe. Single rows are keyed by
+                            // (pp, tg); batch rows by batch_size.
                             if (data.data.test_type === 'single') {
-                                this.benchSingleResults = [...this.benchSingleResults, data.data];
+                                const exists = this.benchSingleResults.some(
+                                    r => r.pp === data.data.pp && r.tg === data.data.tg
+                                );
+                                if (!exists) {
+                                    this.benchSingleResults = [...this.benchSingleResults, data.data];
+                                }
                             } else if (data.data.test_type === 'batch') {
-                                this.benchBatchResults = [...this.benchBatchResults, data.data];
+                                const exists = this.benchBatchResults.some(
+                                    r => r.batch_size === data.data.batch_size
+                                );
+                                if (!exists) {
+                                    this.benchBatchResults = [...this.benchBatchResults, data.data];
+                                }
                             }
                         } else if (data.type === 'done') {
                             // Benchmark tests done, uploading starts
@@ -2543,7 +2557,13 @@
                             };
                             this.loadModels();
                         } else if (data.type === 'upload') {
-                            this.benchUploadResults = [...this.benchUploadResults, data.data];
+                            // Dedupe on replay: upload entries are unique by context_length.
+                            const exists = this.benchUploadResults.some(
+                                r => r.context_length === data.data.context_length
+                            );
+                            if (!exists) {
+                                this.benchUploadResults = [...this.benchUploadResults, data.data];
+                            }
                         } else if (data.type === 'upload_done') {
                             this.benchUploadDone = data.data;
                             this.benchUploading = false;
@@ -2837,8 +2857,18 @@
                                 this.accCurrentModel = data.model_id || this.accCurrentModel;
                                 break;
                             case 'result':
-                                data.data._showCategories = false;
-                                this.accAllResults.push(data.data);
+                                // Dedupe on replay: accuracy results are unique by
+                                // (model_id, benchmark).
+                                {
+                                    const exists = this.accAllResults.some(
+                                        r => r.model_id === data.data.model_id
+                                          && r.benchmark === data.data.benchmark
+                                    );
+                                    if (!exists) {
+                                        data.data._showCategories = false;
+                                        this.accAllResults.push(data.data);
+                                    }
+                                }
                                 break;
                             case 'done':
                                 this.accProgress = null;

--- a/omlx/admin/templates/dashboard/_bench.html
+++ b/omlx/admin/templates/dashboard/_bench.html
@@ -52,6 +52,33 @@
                         <p class="text-sm text-neutral-500 mt-2">{{ t('bench.description') }}</p>
                     </div>
 
+                    <!-- "Another bench is running" banner. Shown when the
+                         server reports a running run that this tab isn't
+                         attached to (e.g. another tab started one while this
+                         one was viewing a previous result). Lets the user
+                         keep their previous result on screen until they
+                         explicitly choose to view the new run. -->
+                    <div x-show="benchOtherActive" x-cloak
+                         class="bg-amber-50 border border-amber-200 rounded-2xl px-5 py-4 mb-6 flex items-center justify-between gap-4">
+                        <div class="flex items-center gap-3">
+                            <i data-lucide="info" class="w-5 h-5 text-amber-600 flex-shrink-0"></i>
+                            <div class="text-sm text-amber-900">
+                                Another throughput benchmark is running on
+                                <span class="font-medium" x-text="benchOtherActive?.model_id"></span>.
+                            </div>
+                        </div>
+                        <div class="flex items-center gap-2 flex-shrink-0">
+                            <button @click="acceptOtherBench()"
+                                    class="px-3 py-1.5 bg-amber-600 text-white text-xs font-medium rounded-lg hover:bg-amber-700 transition-all">
+                                View live
+                            </button>
+                            <button @click="dismissOtherBench()"
+                                    class="px-3 py-1.5 text-amber-700 text-xs font-medium hover:text-amber-900 transition-all">
+                                Dismiss
+                            </button>
+                        </div>
+                    </div>
+
                     <!-- Configuration Card -->
                     <div class="bg-white rounded-2xl border border-neutral-200 overflow-hidden mb-6">
                         <div class="flex items-center justify-between px-6 py-4 bg-neutral-100 border-b border-neutral-200">
@@ -113,7 +140,8 @@
                             <div class="flex items-center gap-3 pt-2">
                                 <button x-show="!benchRunning"
                                         @click="startBenchmark()"
-                                        :disabled="!benchModelId || Object.values(benchPromptLengths).every(v => !v)"
+                                        :disabled="!benchModelId || Object.values(benchPromptLengths).every(v => !v) || benchOtherActive !== null"
+                                        :title="benchOtherActive ? 'Another throughput benchmark is already running in this server.' : ''"
                                         class="px-6 py-2.5 bg-neutral-900 text-white text-sm font-medium rounded-lg hover:bg-neutral-800 transition-all disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-2">
                                     <i data-lucide="play" class="w-4 h-4"></i>
                                     {{ t('bench.config.run_button') }}

--- a/tests/test_accuracy_benchmark.py
+++ b/tests/test_accuracy_benchmark.py
@@ -201,10 +201,8 @@ class TestRunAccuracyBenchmark:
         with patch.dict("omlx.eval.BENCHMARKS", {"mmlu": mock_bench_cls}, clear=True):
             await run_accuracy_benchmark(run, mock_pool)
 
-        # Collect all events
-        events = []
-        while not run.queue.empty():
-            events.append(await run.queue.get())
+        # Collect all events from the replay log.
+        events = list(run.events)
 
         event_types = [e["type"] for e in events]
         assert "done" in event_types

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -258,7 +258,9 @@ class TestSSEEventFormat:
             "total": 3,
         })
 
-        event = run.queue.get_nowait()
+        # SSE delivery: events are appended to `run.events` (replay log).
+        assert len(run.events) == 1
+        event = run.events[0]
         assert event["type"] == "progress"
         assert event["phase"] == "single"
         assert event["current"] == 1
@@ -285,7 +287,8 @@ class TestSSEEventFormat:
         }
         await _send_event(run, {"type": "result", "data": result_data})
 
-        event = run.queue.get_nowait()
+        assert len(run.events) == 1
+        event = run.events[0]
         assert event["type"] == "result"
         assert event["data"]["test_type"] == "single"
         assert event["data"]["pp"] == 1024
@@ -430,10 +433,8 @@ class TestUploadToOmlxAi:
         with patch("asyncio.to_thread", mock_to_thread):
             await _upload_to_omlx_ai(run, mock_pool)
 
-        # Collect all events
-        events = []
-        while not run.queue.empty():
-            events.append(run.queue.get_nowait())
+        # Collect all events from the replay log.
+        events = list(run.events)
 
         # Should have: progress, upload, upload_done
         event_types = [e["type"] for e in events]
@@ -492,9 +493,7 @@ class TestUploadToOmlxAi:
         with patch("asyncio.to_thread", mock_to_thread):
             await _upload_to_omlx_ai(run, mock_pool)
 
-        events = []
-        while not run.queue.empty():
-            events.append(run.queue.get_nowait())
+        events = list(run.events)
 
         upload_event = next(e for e in events if e["type"] == "upload")
         assert upload_event["data"]["duplicate"] is True
@@ -535,9 +534,7 @@ class TestUploadToOmlxAi:
         with patch("asyncio.to_thread", mock_to_thread):
             await _upload_to_omlx_ai(run, mock_pool)
 
-        events = []
-        while not run.queue.empty():
-            events.append(run.queue.get_nowait())
+        events = list(run.events)
 
         # Only an upload_skipped event is emitted, no progress / upload / upload_done
         event_types = [e["type"] for e in events]

--- a/tests/test_benchmark_sse_replay.py
+++ b/tests/test_benchmark_sse_replay.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the replay-on-subscribe SSE delivery model.
+
+These pin three behaviors the previous single-consumer `asyncio.Queue`
+implementation could not provide:
+
+1. **Replay**: a subscriber that connects after events were emitted
+   still sees the entire history.
+2. **Multi-consumer**: two subscribers both see every event in order.
+3. **Terminal close**: the stream closes cleanly after a terminal
+   event (`done` / `upload_done` / `error`) without blocking on a
+   timeout for a subsequent event that will never come.
+
+The reader helper mirrors the loop the SSE endpoint uses in
+`omlx/admin/routes.py`: snapshot events under the lock, release,
+yield, repeat.
+"""
+
+import asyncio
+from typing import Optional
+
+import pytest
+
+from omlx.admin.benchmark import (
+    BenchmarkRequest,
+    BenchmarkRun,
+    _send_event as bench_send_event,
+)
+from omlx.admin.accuracy_benchmark import (
+    AccuracyBenchmarkRequest,
+    AccuracyBenchmarkRun,
+    _send_event as acc_send_event,
+)
+
+
+# --- Test helpers -----------------------------------------------------------
+
+
+async def _drain(
+    run,
+    *,
+    max_events: Optional[int] = None,
+    timeout: float = 1.0,
+) -> list[dict]:
+    """Read the run's event log replay-then-attach style.
+
+    Matches the SSE endpoint loop: snapshot under `run.cond`, release,
+    yield, repeat. Returns once the run is terminal, `max_events` is
+    reached, or the wait times out.
+    """
+    seen = 0
+    out: list[dict] = []
+    while True:
+        async with run.cond:
+            while seen >= len(run.events) and not run.terminal:
+                try:
+                    await asyncio.wait_for(run.cond.wait(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    break
+            new = list(run.events[seen:])
+            seen = len(run.events)
+            done = run.terminal
+        out.extend(new)
+        if max_events is not None and len(out) >= max_events:
+            break
+        if done:
+            break
+        if not new:
+            # Timeout with no new events and not terminal — bail rather
+            # than spin.
+            break
+    return out
+
+
+def _bench_run() -> BenchmarkRun:
+    req = BenchmarkRequest(model_id="x", prompt_lengths=[1024])
+    return BenchmarkRun(bench_id="b-1", request=req)
+
+
+def _acc_run() -> AccuracyBenchmarkRun:
+    req = AccuracyBenchmarkRequest(model_id="x", benchmarks={"mmlu": 10})
+    return AccuracyBenchmarkRun(bench_id="a-1", request=req)
+
+
+# --- BenchmarkRun -----------------------------------------------------------
+
+
+class TestBenchmarkSSEReplay:
+    @pytest.mark.asyncio
+    async def test_replay_buffered_events_to_late_subscriber(self):
+        run = _bench_run()
+        await bench_send_event(run, {"type": "progress", "n": 1})
+        await bench_send_event(run, {"type": "progress", "n": 2})
+        await bench_send_event(run, {"type": "upload_done", "data": {}})
+        # Subscriber connects AFTER all events.
+        events = await _drain(run)
+        assert events == [
+            {"type": "progress", "n": 1},
+            {"type": "progress", "n": 2},
+            {"type": "upload_done", "data": {}},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_multiple_simultaneous_consumers(self):
+        run = _bench_run()
+
+        async def reader():
+            return await _drain(run, max_events=3)
+
+        async def producer():
+            # Give readers a tick to subscribe before sending.
+            await asyncio.sleep(0.01)
+            await bench_send_event(run, {"type": "progress", "n": 1})
+            await bench_send_event(run, {"type": "progress", "n": 2})
+            await bench_send_event(run, {"type": "upload_done", "data": {}})
+
+        r1, r2, _ = await asyncio.gather(reader(), reader(), producer())
+        expected = [
+            {"type": "progress", "n": 1},
+            {"type": "progress", "n": 2},
+            {"type": "upload_done", "data": {}},
+        ]
+        assert r1 == expected
+        assert r2 == expected
+
+    @pytest.mark.asyncio
+    async def test_terminal_event_closes_stream_without_extra_wait(self):
+        run = _bench_run()
+        await bench_send_event(run, {"type": "progress", "n": 1})
+        await bench_send_event(run, {"type": "upload_done", "data": {}})
+
+        # Should return immediately — no timeout — because the run is
+        # already terminal.
+        start = asyncio.get_event_loop().time()
+        events = await _drain(run, timeout=5.0)
+        elapsed = asyncio.get_event_loop().time() - start
+
+        assert events[-1]["type"] == "upload_done"
+        assert elapsed < 0.5, "stream blocked after terminal event"
+
+    @pytest.mark.asyncio
+    async def test_error_is_also_terminal(self):
+        run = _bench_run()
+        await bench_send_event(run, {"type": "error", "message": "boom"})
+        events = await _drain(run, timeout=5.0)
+        assert events == [{"type": "error", "message": "boom"}]
+        assert run.terminal is True
+
+    @pytest.mark.asyncio
+    async def test_late_subscriber_sees_replay_then_live_events(self):
+        run = _bench_run()
+        # Pre-existing buffered events
+        await bench_send_event(run, {"type": "progress", "n": 1})
+
+        async def producer():
+            # Subscriber will be mid-replay when this fires.
+            await asyncio.sleep(0.02)
+            await bench_send_event(run, {"type": "progress", "n": 2})
+            await bench_send_event(run, {"type": "upload_done", "data": {}})
+
+        async def subscriber():
+            return await _drain(run)
+
+        events, _ = await asyncio.gather(subscriber(), producer())
+        # No event lost between replay and live phases.
+        assert events == [
+            {"type": "progress", "n": 1},
+            {"type": "progress", "n": 2},
+            {"type": "upload_done", "data": {}},
+        ]
+
+
+# --- AccuracyBenchmarkRun ---------------------------------------------------
+
+
+class TestAccuracyBenchmarkSSEReplay:
+    """Same contract on the accuracy benchmark run dataclass."""
+
+    @pytest.mark.asyncio
+    async def test_replay_to_late_subscriber(self):
+        run = _acc_run()
+        await acc_send_event(run, {"type": "progress", "phase": "load"})
+        await acc_send_event(run, {"type": "result", "data": {"score": 0.5}})
+        await acc_send_event(run, {"type": "done"})
+        events = await _drain(run)
+        assert [e["type"] for e in events] == ["progress", "result", "done"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_consumers_see_same_events(self):
+        run = _acc_run()
+
+        async def reader():
+            return await _drain(run, max_events=2)
+
+        async def producer():
+            await asyncio.sleep(0.01)
+            await acc_send_event(run, {"type": "progress", "phase": "eval"})
+            await acc_send_event(run, {"type": "done"})
+
+        r1, r2, _ = await asyncio.gather(reader(), reader(), producer())
+        assert r1 == r2
+
+    @pytest.mark.asyncio
+    async def test_last_progress_still_tracked(self):
+        # The queue/status REST endpoint relies on `last_progress` for
+        # the reconnect hint. The SSE refactor must preserve that.
+        run = _acc_run()
+        await acc_send_event(run, {"type": "progress", "phase": "eval", "current": 5})
+        assert run.last_progress == {
+            "type": "progress",
+            "phase": "eval",
+            "current": 5,
+        }

--- a/tests/test_benchmark_sse_replay.py
+++ b/tests/test_benchmark_sse_replay.py
@@ -24,7 +24,9 @@ import pytest
 from omlx.admin.benchmark import (
     BenchmarkRequest,
     BenchmarkRun,
+    _benchmark_runs,
     _send_event as bench_send_event,
+    get_active_run,
 )
 from omlx.admin.accuracy_benchmark import (
     AccuracyBenchmarkRequest,
@@ -168,6 +170,59 @@ class TestBenchmarkSSEReplay:
             {"type": "progress", "n": 2},
             {"type": "upload_done", "data": {}},
         ]
+
+
+# --- Active-run discovery ---------------------------------------------------
+
+
+class TestGetActiveRun:
+    """A second subscriber (page refresh / new tab) needs a way to find
+    the currently-running bench so it can attach to the SSE stream.
+    `get_active_run()` is that discovery surface — it scans the run
+    registry and returns the first one whose status is "running"."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_registry(self):
+        # Test-level isolation: the module-level _benchmark_runs registry
+        # leaks between tests otherwise.
+        _benchmark_runs.clear()
+        yield
+        _benchmark_runs.clear()
+
+    def test_returns_none_when_no_runs(self):
+        assert get_active_run() is None
+
+    def test_returns_none_when_all_completed(self):
+        r = _bench_run()
+        r.status = "completed"
+        _benchmark_runs[r.bench_id] = r
+        assert get_active_run() is None
+
+    def test_returns_the_running_run(self):
+        finished = _bench_run()
+        finished.status = "completed"
+        _benchmark_runs[finished.bench_id] = finished
+
+        running = BenchmarkRun(
+            bench_id="b-2",
+            request=BenchmarkRequest(model_id="x", prompt_lengths=[1024]),
+        )
+        running.status = "running"
+        _benchmark_runs[running.bench_id] = running
+
+        found = get_active_run()
+        assert found is running
+        assert found.status == "running"
+
+    def test_only_returns_running_status_not_cancelled_or_error(self):
+        for state in ("cancelled", "error"):
+            r = BenchmarkRun(
+                bench_id=f"b-{state}",
+                request=BenchmarkRequest(model_id="x", prompt_lengths=[1024]),
+            )
+            r.status = state
+            _benchmark_runs[r.bench_id] = r
+        assert get_active_run() is None
 
 
 # --- AccuracyBenchmarkRun ---------------------------------------------------

--- a/tests/test_benchmark_sse_replay.py
+++ b/tests/test_benchmark_sse_replay.py
@@ -266,3 +266,119 @@ class TestAccuracyBenchmarkSSEReplay:
             "phase": "eval",
             "current": 5,
         }
+
+
+# --- Route-level: /api/bench/active + 409 on concurrent start ---------------
+
+
+class _FakeEntry:
+    def __init__(self):
+        self.engine_type = "batched"
+        self.model_type = "llm"
+        self.engine = None
+        self.is_pinned = False
+        self.is_loading = False
+        self.model_path = "/fake"
+
+
+class _FakePool:
+    def __init__(self):
+        self._entries = {"model-x": _FakeEntry()}
+
+    def get_entry(self, model_id):
+        return self._entries.get(model_id)
+
+
+@pytest.fixture
+def bench_client(monkeypatch):
+    """FastAPI TestClient with auth stubbed and a fake engine pool wired in."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from omlx.admin import routes as admin_routes
+
+    _benchmark_runs.clear()
+    admin_routes._get_engine_pool = lambda: _FakePool()
+
+    async def _fake_require_admin():
+        return True
+
+    app = FastAPI()
+    app.include_router(admin_routes.router)
+    app.dependency_overrides[admin_routes.require_admin] = _fake_require_admin
+    yield TestClient(app)
+    _benchmark_runs.clear()
+
+
+class TestActiveBenchEndpoint:
+    def test_returns_not_running_when_idle(self, bench_client):
+        r = bench_client.get("/admin/api/bench/active")
+        assert r.status_code == 200
+        assert r.json() == {"running": False, "bench_id": None, "model_id": None}
+
+    def test_returns_running_run_payload(self, bench_client):
+        run = BenchmarkRun(
+            bench_id="bench-abc",
+            request=BenchmarkRequest(model_id="model-x", prompt_lengths=[1024]),
+        )
+        run.status = "running"
+        _benchmark_runs[run.bench_id] = run
+
+        r = bench_client.get("/admin/api/bench/active")
+        assert r.status_code == 200
+        assert r.json() == {
+            "running": True,
+            "bench_id": "bench-abc",
+            "model_id": "model-x",
+        }
+
+
+class TestConcurrentStartRejection:
+    """Server refuses to start a second throughput bench while one is
+    running — two concurrent runs on the same engine produce mutually-
+    corrupted measurements, and there's no way to recover the data."""
+
+    def test_start_409_when_already_running(self, bench_client):
+        # Seed a running run in the registry.
+        existing = BenchmarkRun(
+            bench_id="bench-existing",
+            request=BenchmarkRequest(model_id="model-x", prompt_lengths=[1024]),
+        )
+        existing.status = "running"
+        _benchmark_runs[existing.bench_id] = existing
+
+        r = bench_client.post("/admin/api/bench/start", json={
+            "model_id": "model-x",
+            "prompt_lengths": [1024],
+        })
+        assert r.status_code == 409
+        body = r.json()
+        assert "already running" in body["detail"].lower()
+        assert "bench-existing" in body["detail"]
+        # Confirm the registry still has only the original run — no
+        # second one was spuriously created and abandoned.
+        assert len(_benchmark_runs) == 1
+
+    def test_start_allowed_when_previous_completed(self, bench_client, monkeypatch):
+        # A completed prior run must not block a fresh start.
+        finished = BenchmarkRun(
+            bench_id="bench-finished",
+            request=BenchmarkRequest(model_id="model-x", prompt_lengths=[1024]),
+        )
+        finished.status = "completed"
+        _benchmark_runs[finished.bench_id] = finished
+
+        # Stub out the async run_benchmark task so the request returns
+        # immediately without actually executing a bench.
+        from omlx.admin import benchmark as bench_module
+
+        async def _noop(run, pool):
+            return
+
+        monkeypatch.setattr(bench_module, "run_benchmark", _noop)
+
+        r = bench_client.post("/admin/api/bench/start", json={
+            "model_id": "model-x",
+            "prompt_lengths": [1024],
+        })
+        assert r.status_code == 200, r.text


### PR DESCRIPTION
## Summary

This is also a prepare commit for the Swift Desktop App of oMLX.

Replaces the single-consumer `asyncio.Queue` event delivery on `BenchmarkRun` / `AccuracyBenchmarkRun` with an append-only event log + `asyncio.Condition`. SSE endpoints now snapshot the log, release, yield, repeat — every subscriber sees the run's full event history from the beginning and multiple subscribers can attach concurrently. Then layers the client-side surface needed to actually expose the new capability end-to-end.

Second of the prep PRs split out of the Swift macOS app rewrite per maintainer ask. The Swift app's REST polling mirrors (`upload_state`, `phase`) on `BenchmarkRun` go away in a follow-up PR after this one lands.

## What it fixes (latent HTML dashboard bugs)

- Two browser tabs on `/api/bench/{id}/stream` (or accuracy equivalent) no longer starve each other; both see every event.
- Reloading the page mid-run no longer loses the events delivered before the reload — the replay redelivers them.
- A second tab opened mid-run now actually attaches to the active bench (was silently never subscribing before today).
- Two tabs racing `Start` on the throughput bench no longer succeed independently and produce mutually-corrupted measurements; the second is rejected with 409.

## Commit-by-commit

| commit | What |
|---|---|
| `refactor(bench): replay-on-subscribe SSE delivery (multi-consumer)` | `BenchmarkRun.queue` / `AccuracyBenchmarkRun.queue` → `events: list[dict]` + `cond: Condition` + `terminal: bool`. `_send_event` becomes append-then-notify-all. SSE endpoints become replay-then-attach. Migrates 6 existing test callers from `run.queue.get_nowait()` to `list(run.events)`. |
| `test(bench): pin replay + multi-consumer + terminal-close contract` | New `tests/test_benchmark_sse_replay.py` with 5 SSE-replay cases + 3 accuracy-side cases. Verified RED on the pre-refactor commit. |
| `feat(bench): tab discovery so a second tab attaches to an active run` | `get_active_run()` helper + new `GET /api/bench/active` endpoint + dashboard JS `loadBenchState()` wired into bench-tab activation. Without this the replay capability has no client wired to use it. 4 new tests for `get_active_run`. |
| `feat(bench): one-bench-at-a-time guard + cross-tab awareness banner` | Server rejects concurrent throughput starts with 409 (engine contention would corrupt both measurements). Client gates the Start button on the same signal. Adds an amber banner on tab A when a different bench is running in another tab, with View live / Dismiss actions; `visibilitychange` listener so the banner appears when the user returns to the browser tab. 5 new route-level tests. |

## Wire format unchanged

Same JSON events as before. Since replay redelivers events on every reconnect (including page refresh), 4 append-only result handlers in `dashboard.js` were taught to dedupe before pushing:

- `result` events: keyed by `(pp, tg)` for single tests, `batch_size` for batch.
- `upload` events: keyed by `context_length`.
- Accuracy `result`: keyed by `(model_id, benchmark)`.

The other handlers (`progress`, `done`, `upload_done`, `upload_skipped`, `error`) overwrite state by reference and were already idempotent (audited).

## Test plan

```bash
uv run pytest tests/test_benchmark.py tests/test_accuracy_benchmark.py tests/test_benchmark_sse_replay.py -q
```

Expected: **79 passed**.

Breakdown of new + migrated tests in `tests/test_benchmark_sse_replay.py` (16 total):

| Class | Tests | What it covers |
|---|---|---|
| `TestBenchmarkSSEReplay` | 5 | Late-subscriber replay, multi-consumer parity, terminal-close timing, error-as-terminal, replay→live boundary |
| `TestGetActiveRun` | 4 | Discovery returns None / completed-only / picks running / excludes cancelled+error |
| `TestAccuracyBenchmarkSSEReplay` | 3 | Same replay / multi-consumer contract on accuracy side + `last_progress` preserved |
| `TestActiveBenchEndpoint` | 2 | `GET /api/bench/active` happy paths via FastAPI TestClient |
| `TestConcurrentStartRejection` | 2 | `POST /api/bench/start` returns 409 while a run is active; allows a fresh start after the previous completed |

Plus 6 migrated callers in `tests/test_benchmark.py` and 1 in `tests/test_accuracy_benchmark.py` switched from `run.queue.get_nowait()` to `list(run.events)`.

## Local repro

**Tests** (proves the contract):

```bash
# GREEN — full suite
uv run pytest tests/test_benchmark_sse_replay.py -v
# Expect: 16 passed

# RED proof — temporarily revert the dataclass changes
git show origin/main:omlx/admin/benchmark.py > omlx/admin/benchmark.py
git show origin/main:omlx/admin/accuracy_benchmark.py > omlx/admin/accuracy_benchmark.py
uv run pytest tests/test_benchmark_sse_replay.py::TestBenchmarkSSEReplay -v
# Expect: 4 of 5 fail with "AttributeError: 'BenchmarkRun' object has no attribute 'cond'"
git checkout HEAD -- omlx/admin/benchmark.py omlx/admin/accuracy_benchmark.py
```

**End-to-end UX** (hard-refresh the dashboard so the new JS loads):

| Scenario | Expected |
|---|---|
| Open `/admin/#/bench` in two tabs. Start a bench in tab A. | Both tabs render live progress for the same run. |
| Refresh tab A mid-run. | Table re-populates from replay; live updates continue. |
| Tab A running. Click Start in tab B. | Tab B shows error toast referencing the existing bench_id; no second run starts. |
| Tab A's bench finishes, result card on screen. Start a new bench in tab B. | Amber banner appears in tab A: "Another throughput benchmark is running on \<model\>" with `View live` / `Dismiss`. |
| Click `View live`. | Tab A's old rows clear, new bench's events stream in via replay. |
| Switch to another browser app and back to tab A. | If a new bench started in the meantime, the banner appears without needing an in-app tab switch. |

## Memory bound

`run.events` grows over a run's lifetime. The existing `cleanup_old_runs(max_runs=10)` already bounds total completed runs in `_benchmark_runs`. Worst case ≈ 10 runs × ~1000 events × ~500 bytes = ~5 MB. Acceptable for a desktop app.