### PR TITLE
fix(dflash): detect multimodal content and trigger VLM fallback

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -114,6 +114,7 @@ class DFlashEngine(BaseEngine):
         self._model_type_str = None
         self._fallback_engine: BaseEngine | None = None
         self._in_fallback_mode = False
+        self._fallback_lock = asyncio.Lock()
         self._runtime_context: Any | None = None
         self._dflash_prefix_cache: Any | None = None
         # Protocol-specific output parser factory (gemma4 / harmony).
@@ -497,6 +498,22 @@ class DFlashEngine(BaseEngine):
         )
         return len(self._tokenizer_obj.encode(prompt))
 
+    @property
+    def supports_multimodal_fallback(self) -> bool:
+        return self._fallback_engine_type == "vlm"
+
+    _MULTIMODAL_TYPES = frozenset({"image", "image_url", "input_image"})
+
+    @staticmethod
+    def _has_multimodal_content(messages: list[dict]) -> bool:
+        for msg in messages:
+            content = msg.get("content")
+            if isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") in DFlashEngine._MULTIMODAL_TYPES:
+                        return True
+        return False
+
     def _should_fallback(self, prompt_tokens: list[int]) -> bool:
         if self._max_dflash_ctx is None:
             return False
@@ -764,12 +781,13 @@ class DFlashEngine(BaseEngine):
 
         # Fallback: evict dflash models, start LLM/VLM engine
         if self._should_fallback(prompt_tokens):
-            if not self._in_fallback_mode:
-                logger.info(
-                    f"DFlash context fallback: {len(prompt_tokens)} >= {self._max_dflash_ctx}, "
-                    f"evicting dflash models and switching to {self._fallback_engine_type} engine"
-                )
-                await self._evict_dflash_and_start_fallback()
+            async with self._fallback_lock:
+                if not self._in_fallback_mode:
+                    logger.info(
+                        f"DFlash context fallback: {len(prompt_tokens)} >= {self._max_dflash_ctx}, "
+                        f"evicting dflash models and switching to {self._fallback_engine_type} engine"
+                    )
+                    await self._evict_dflash_and_start_fallback()
             return await self._fallback_engine.generate(
                 prompt=prompt, max_tokens=max_tokens, temperature=temperature,
                 top_p=top_p, top_k=top_k, min_p=min_p,
@@ -915,12 +933,13 @@ class DFlashEngine(BaseEngine):
 
         # Fallback: evict dflash models, start LLM/VLM engine
         if self._should_fallback(prompt_tokens):
-            if not self._in_fallback_mode:
-                logger.info(
-                    f"DFlash context fallback: {len(prompt_tokens)} >= {self._max_dflash_ctx}, "
-                    f"evicting dflash models and switching to {self._fallback_engine_type} engine"
-                )
-                await self._evict_dflash_and_start_fallback()
+            async with self._fallback_lock:
+                if not self._in_fallback_mode:
+                    logger.info(
+                        f"DFlash context fallback: {len(prompt_tokens)} >= {self._max_dflash_ctx}, "
+                        f"evicting dflash models and switching to {self._fallback_engine_type} engine"
+                    )
+                    await self._evict_dflash_and_start_fallback()
             async for output in self._fallback_engine.stream_generate(
                 prompt=prompt, max_tokens=max_tokens, temperature=temperature,
                 top_p=top_p, top_k=top_k, min_p=min_p,
@@ -1041,6 +1060,29 @@ class DFlashEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        if self._in_fallback_mode:
+            return await self._fallback_engine.chat(
+                messages, max_tokens=max_tokens, temperature=temperature,
+                top_p=top_p, top_k=top_k, min_p=min_p,
+                repetition_penalty=repetition_penalty,
+                presence_penalty=presence_penalty, tools=tools, **kwargs,
+            )
+
+        if self._fallback_engine_type == "vlm" and self._has_multimodal_content(messages):
+            async with self._fallback_lock:
+                if not self._in_fallback_mode:
+                    logger.info(
+                        "DFlash multimodal fallback: image content detected, "
+                        "switching to VLM engine"
+                    )
+                    await self._evict_dflash_and_start_fallback()
+            return await self._fallback_engine.chat(
+                messages, max_tokens=max_tokens, temperature=temperature,
+                top_p=top_p, top_k=top_k, min_p=min_p,
+                repetition_penalty=repetition_penalty,
+                presence_penalty=presence_penalty, tools=tools, **kwargs,
+            )
+
         template_tools = convert_tools_for_template(tools) if tools else None
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
         is_partial = kwargs.pop("is_partial", None)
@@ -1071,6 +1113,33 @@ class DFlashEngine(BaseEngine):
     ) -> AsyncIterator[GenerationOutput]:
         if not self._loaded:
             await self.start()
+
+        if self._in_fallback_mode:
+            async for output in self._fallback_engine.stream_chat(
+                messages, max_tokens=max_tokens, temperature=temperature,
+                top_p=top_p, top_k=top_k, min_p=min_p,
+                repetition_penalty=repetition_penalty,
+                presence_penalty=presence_penalty, tools=tools, **kwargs,
+            ):
+                yield output
+            return
+
+        if self._fallback_engine_type == "vlm" and self._has_multimodal_content(messages):
+            async with self._fallback_lock:
+                if not self._in_fallback_mode:
+                    logger.info(
+                        "DFlash multimodal fallback: image content detected, "
+                        "switching to VLM engine"
+                    )
+                    await self._evict_dflash_and_start_fallback()
+            async for output in self._fallback_engine.stream_chat(
+                messages, max_tokens=max_tokens, temperature=temperature,
+                top_p=top_p, top_k=top_k, min_p=min_p,
+                repetition_penalty=repetition_penalty,
+                presence_penalty=presence_penalty, tools=tools, **kwargs,
+            ):
+                yield output
+            return
 
         template_tools = convert_tools_for_template(tools) if tools else None
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2133,11 +2133,15 @@ async def create_chat_completion(
     _entry = get_engine_pool().get_entry(resolved_model)
     native_reasoning = bool(_entry and _entry.preserve_thinking_default is True)
     is_vlm = isinstance(engine, VLMBatchedEngine)
+    is_dflash_vlm = (
+        not is_vlm
+        and getattr(engine, "supports_multimodal_fallback", False)
+    )
     extractor = getattr(engine, "message_extractor", None)
     if extractor is not None:
         messages = extractor(request.messages, max_tool_result_tokens, engine.tokenizer)
-    elif is_vlm:
-        # VLM: preserve image_url content parts for vision processing
+    elif is_vlm or is_dflash_vlm:
+        # VLM or DFlash with VLM fallback: preserve image_url content parts
         messages = extract_multimodal_content(
             request.messages,
             max_tool_result_tokens,
@@ -3482,6 +3486,10 @@ async def create_anthropic_message(
     # Convert Anthropic format to internal format
     # Harmony models need special handling to preserve tool format
     is_vlm = isinstance(engine, VLMBatchedEngine)
+    is_dflash_vlm = (
+        not is_vlm
+        and getattr(engine, "supports_multimodal_fallback", False)
+    )
     _entry = get_engine_pool().get_entry(resolved_model)
     native_reasoning = bool(_entry and _entry.preserve_thinking_default is True)
     if engine.model_type == "gpt_oss":
@@ -3491,7 +3499,7 @@ async def create_anthropic_message(
     else:
         messages = convert_anthropic_to_internal(
             request, max_tool_result_tokens, engine.tokenizer,
-            preserve_images=is_vlm,
+            preserve_images=is_vlm or is_dflash_vlm,
             native_reasoning_content=native_reasoning,
         )
 

--- a/tests/test_dflash_multimodal_fallback.py
+++ b/tests/test_dflash_multimodal_fallback.py
@@ -1,0 +1,413 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for DFlash multimodal VLM fallback (issue #1342).
+
+Before this fix:
+- DFlash with VLM fallback was treated as a plain text engine by server.py
+- Images were silently stripped by extract_text_content() before reaching the engine
+- chat()/stream_chat() had no multimodal detection — images that survived
+  extraction would still be flattened by _apply_chat_template()
+
+After this fix:
+- server.py detects DFlash engines with VLM fallback via supports_multimodal_fallback
+- Image content is preserved through extract_multimodal_content()
+- chat()/stream_chat() detect multimodal messages and trigger VLM fallback
+  BEFORE applying text-only chat template
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omlx.engine.dflash import DFlashEngine
+
+# -- Helpers ------------------------------------------------------------------
+
+def _text_only_messages():
+    return [{"role": "user", "content": "What is 2+2?"}]
+
+
+def _image_url_messages():
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this image"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ],
+        }
+    ]
+
+
+def _image_type_messages():
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What do you see?"},
+                {"type": "image", "source": {"type": "base64", "data": "abc"}},
+            ],
+        }
+    ]
+
+
+def _input_image_messages():
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Analyze"},
+                {"type": "input_image", "image_url": {"url": "data:image/jpeg;base64,xyz"}},
+            ],
+        }
+    ]
+
+
+def _mixed_history_messages():
+    """Image in earlier turn, text-only in latest — still multimodal."""
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Look at this"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            ],
+        },
+        {"role": "assistant", "content": "I see a cat."},
+        {"role": "user", "content": "What breed?"},
+    ]
+
+
+# -- supports_multimodal_fallback property ------------------------------------
+
+class TestSupportsMultimodalFallback:
+    def test_vlm_fallback_returns_true(self):
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            fallback_engine_type="vlm",
+        )
+        assert engine.supports_multimodal_fallback is True
+
+    def test_batched_fallback_returns_false(self):
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            fallback_engine_type="batched",
+        )
+        assert engine.supports_multimodal_fallback is False
+
+    def test_default_fallback_returns_false(self):
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+        )
+        assert engine.supports_multimodal_fallback is False
+
+
+# -- _has_multimodal_content detection ----------------------------------------
+
+class TestHasMultimodalContent:
+    """Before: DFlash had no way to detect image content in messages.
+    After: _has_multimodal_content() scans for all three image part types."""
+
+    def test_text_only_returns_false(self):
+        assert DFlashEngine._has_multimodal_content(_text_only_messages()) is False
+
+    def test_image_url_detected(self):
+        assert DFlashEngine._has_multimodal_content(_image_url_messages()) is True
+
+    def test_image_type_detected(self):
+        assert DFlashEngine._has_multimodal_content(_image_type_messages()) is True
+
+    def test_input_image_detected(self):
+        assert DFlashEngine._has_multimodal_content(_input_image_messages()) is True
+
+    def test_mixed_history_detected(self):
+        assert DFlashEngine._has_multimodal_content(_mixed_history_messages()) is True
+
+    def test_string_content_ignored(self):
+        msgs = [{"role": "user", "content": "plain string"}]
+        assert DFlashEngine._has_multimodal_content(msgs) is False
+
+    def test_empty_messages(self):
+        assert DFlashEngine._has_multimodal_content([]) is False
+
+    def test_no_content_key(self):
+        msgs = [{"role": "system"}]
+        assert DFlashEngine._has_multimodal_content(msgs) is False
+
+
+# -- chat()/stream_chat() multimodal fallback ---------------------------------
+
+class TestChatMultimodalFallback:
+    """Before: chat() always applied text-only _apply_chat_template(), which
+    flattened multimodal content to plain text. Images were lost.
+    After: chat() detects multimodal messages in VLM-fallback DFlash engines
+    and delegates to the VLM fallback engine, which handles images natively."""
+
+    @pytest.fixture
+    def vlm_dflash_engine(self):
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            fallback_engine_type="vlm",
+        )
+        engine._loaded = True
+        engine._tokenizer_obj = MagicMock()
+        return engine
+
+    @pytest.fixture
+    def batched_dflash_engine(self):
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            fallback_engine_type="batched",
+        )
+        engine._loaded = True
+        engine._tokenizer_obj = MagicMock()
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_chat_triggers_vlm_fallback_on_images(self, vlm_dflash_engine):
+        mock_output = MagicMock()
+        mock_fallback = AsyncMock()
+        mock_fallback.chat = AsyncMock(return_value=mock_output)
+
+        with patch.object(vlm_dflash_engine, "_evict_dflash_and_start_fallback") as mock_evict:
+            mock_evict.side_effect = lambda: setattr(vlm_dflash_engine, "_fallback_engine", mock_fallback) or setattr(vlm_dflash_engine, "_in_fallback_mode", True)
+
+            result = await vlm_dflash_engine.chat(_image_url_messages())
+
+        mock_evict.assert_called_once()
+        mock_fallback.chat.assert_called_once()
+        call_msgs = mock_fallback.chat.call_args[0][0]
+        assert any(
+            isinstance(part, dict) and part.get("type") == "image_url"
+            for msg in call_msgs
+            if isinstance(msg.get("content"), list)
+            for part in msg["content"]
+        )
+        assert result is mock_output
+
+    @pytest.mark.asyncio
+    async def test_chat_text_only_uses_normal_dflash_path(self, vlm_dflash_engine):
+        vlm_dflash_engine._apply_chat_template = MagicMock(return_value="formatted prompt")
+        vlm_dflash_engine.generate = AsyncMock(return_value=MagicMock())
+
+        await vlm_dflash_engine.chat(_text_only_messages())
+
+        vlm_dflash_engine._apply_chat_template.assert_called_once()
+        vlm_dflash_engine.generate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_chat_batched_fallback_ignores_images(self, batched_dflash_engine):
+        """DFlash with batched (non-VLM) fallback has no multimodal support.
+        Images in messages proceed through the normal text path (existing behavior)."""
+        batched_dflash_engine._apply_chat_template = MagicMock(return_value="formatted")
+        batched_dflash_engine.generate = AsyncMock(return_value=MagicMock())
+
+        await batched_dflash_engine.chat(_image_url_messages())
+
+        batched_dflash_engine._apply_chat_template.assert_called_once()
+        batched_dflash_engine.generate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_chat_already_in_fallback_forwards_directly(self, vlm_dflash_engine):
+        mock_fallback = AsyncMock()
+        mock_fallback.chat = AsyncMock(return_value=MagicMock())
+        vlm_dflash_engine._in_fallback_mode = True
+        vlm_dflash_engine._fallback_engine = mock_fallback
+
+        await vlm_dflash_engine.chat(_image_url_messages())
+
+        mock_fallback.chat.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_chat_already_in_fallback_text_still_forwards(self, vlm_dflash_engine):
+        """Once in fallback mode, even text-only messages go through the
+        fallback engine (sticky fallback — no reload)."""
+        mock_fallback = AsyncMock()
+        mock_fallback.chat = AsyncMock(return_value=MagicMock())
+        vlm_dflash_engine._in_fallback_mode = True
+        vlm_dflash_engine._fallback_engine = mock_fallback
+
+        await vlm_dflash_engine.chat(_text_only_messages())
+
+        mock_fallback.chat.assert_called_once()
+
+
+class TestStreamChatMultimodalFallback:
+    """Same before/after as chat(), but for the streaming path."""
+
+    @pytest.fixture
+    def vlm_dflash_engine(self):
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            fallback_engine_type="vlm",
+        )
+        engine._loaded = True
+        engine._tokenizer_obj = MagicMock()
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_triggers_vlm_fallback_on_images(self, vlm_dflash_engine):
+        mock_output = MagicMock()
+
+        async def mock_stream(*args, **kwargs):
+            yield mock_output
+
+        mock_fallback = AsyncMock()
+        mock_fallback.stream_chat = mock_stream
+
+        with patch.object(vlm_dflash_engine, "_evict_dflash_and_start_fallback") as mock_evict:
+            mock_evict.side_effect = lambda: setattr(vlm_dflash_engine, "_fallback_engine", mock_fallback) or setattr(vlm_dflash_engine, "_in_fallback_mode", True)
+
+            outputs = []
+            async for out in vlm_dflash_engine.stream_chat(_image_url_messages()):
+                outputs.append(out)
+
+        mock_evict.assert_called_once()
+        assert len(outputs) == 1
+        assert outputs[0] is mock_output
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_already_in_fallback_forwards(self, vlm_dflash_engine):
+        mock_output = MagicMock()
+
+        async def mock_stream(*args, **kwargs):
+            yield mock_output
+
+        mock_fallback = AsyncMock()
+        mock_fallback.stream_chat = mock_stream
+        vlm_dflash_engine._in_fallback_mode = True
+        vlm_dflash_engine._fallback_engine = mock_fallback
+
+        outputs = []
+        async for out in vlm_dflash_engine.stream_chat(_image_url_messages()):
+            outputs.append(out)
+
+        assert len(outputs) == 1
+
+
+# -- Concurrent fallback (lock correctness) -----------------------------------
+
+class TestFallbackLockSafety:
+    """Verify _fallback_lock prevents double eviction from concurrent requests."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_image_requests_evict_once(self):
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            fallback_engine_type="vlm",
+        )
+        engine._loaded = True
+        engine._tokenizer_obj = MagicMock()
+
+        evict_count = 0
+
+        async def mock_evict():
+            nonlocal evict_count
+            evict_count += 1
+            await asyncio.sleep(0.05)
+            engine._fallback_engine = AsyncMock()
+            engine._fallback_engine.chat = AsyncMock(return_value=MagicMock())
+            engine._in_fallback_mode = True
+
+        with patch.object(engine, "_evict_dflash_and_start_fallback", side_effect=mock_evict):
+            results = await asyncio.gather(
+                engine.chat(_image_url_messages()),
+                engine.chat(_image_url_messages()),
+                engine.chat(_image_url_messages()),
+            )
+
+        assert evict_count == 1
+        assert len(results) == 3
+
+
+# -- Server-side extraction routing (before/after) ----------------------------
+
+class TestServerExtractionRouting:
+    """Before: server.py checked `isinstance(engine, VLMBatchedEngine)` only.
+    DFlash engines always took the text-only extraction path, stripping images.
+
+    After: server.py also checks `engine.supports_multimodal_fallback` for
+    DFlash engines, routing them through multimodal extraction when True."""
+
+    def test_extract_text_content_drops_images(self):
+        """BEFORE behavior: extract_text_content silently drops image parts."""
+        from omlx.api.utils import extract_text_content
+
+        messages = [
+            MagicMock(
+                role="user",
+                content=[
+                    MagicMock(
+                        model_dump=lambda: {"type": "text", "text": "Describe this"},
+                    ),
+                    MagicMock(
+                        model_dump=lambda: {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,abc"},
+                        },
+                    ),
+                ],
+                tool_call_id=None,
+            )
+        ]
+        result = extract_text_content(messages, None, None)
+        for msg in result:
+            content = msg.get("content", "")
+            if isinstance(content, str):
+                assert "image" not in content.lower()
+            elif isinstance(content, list):
+                for part in content:
+                    assert part.get("type") != "image_url"
+
+    def test_extract_multimodal_content_preserves_images(self):
+        """AFTER behavior: extract_multimodal_content keeps image_url parts."""
+        from omlx.api.utils import extract_multimodal_content
+
+        messages = [
+            MagicMock(
+                role="user",
+                content=[
+                    MagicMock(
+                        model_dump=lambda: {"type": "text", "text": "Describe this"},
+                    ),
+                    MagicMock(
+                        model_dump=lambda: {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,abc"},
+                        },
+                    ),
+                ],
+                tool_call_id=None,
+            )
+        ]
+        result = extract_multimodal_content(messages, None, None)
+        has_image = False
+        for msg in result:
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "image_url":
+                        has_image = True
+        assert has_image, "extract_multimodal_content must preserve image_url parts"
+
+    def test_dflash_vlm_detected_via_getattr(self):
+        """server.py uses getattr(engine, 'supports_multimodal_fallback', False)
+        to avoid importing DFlashEngine directly."""
+        engine_vlm = DFlashEngine(
+            model_name="test", draft_model_path="test", fallback_engine_type="vlm",
+        )
+        engine_batched = DFlashEngine(
+            model_name="test", draft_model_path="test", fallback_engine_type="batched",
+        )
+        assert getattr(engine_vlm, "supports_multimodal_fallback", False) is True
+        assert getattr(engine_batched, "supports_multimodal_fallback", False) is False
+
+        plain_engine = MagicMock(spec=[])
+        assert getattr(plain_engine, "supports_multimodal_fallback", False) is False


### PR DESCRIPTION
## Summary

DFlash engines silently drop images when VLM fallback is configured. Requests with image content get their images stripped during text-only template flattening, producing hallucinated responses instead of triggering the VLM fallback path.

Closes #1342

## Root Cause

Two-part bug:

1. **Server-side** (`server.py`): The extraction path checks `isinstance(engine, VLMBatchedEngine)` to decide whether to preserve images. DFlash wraps a VLM fallback but isn't itself a VLM instance, so images are stripped before the engine ever sees them.

2. **Engine-side** (`dflash.py`): Even if images survived extraction, DFlash's `chat()` and `stream_chat()` have no multimodal detection — they'd feed image tokens into the text-only draft model, producing garbage.

## Changes

**`omlx/engine/dflash.py`:**
- Add `supports_multimodal_fallback` property — returns `True` when fallback engine type is `"vlm"`
- Add `_has_multimodal_content()` static method — scans messages for `image`, `image_url`, `input_image` content parts
- Add multimodal detection in `chat()` and `stream_chat()` — when image content is detected and VLM fallback is configured, trigger eviction + fallback before processing
- Add `asyncio.Lock` around all fallback transitions (multimodal + existing max_ctx) to prevent concurrent eviction races

**`omlx/server.py`:**
- Add `is_dflash_vlm` detection via `getattr(engine, "supports_multimodal_fallback", False)` in both OpenAI and Anthropic extraction paths
- Preserve images through extraction when DFlash has VLM fallback configured

**`tests/test_dflash_multimodal_fallback.py`:**
- 22 tests covering property detection, content scanning, chat/stream fallback triggering, lock safety under concurrency, and server extraction routing

> **Note:** There is a pre-existing concurrency gap where text-only requests arriving during the eviction transition window could fail. This affects the existing max_ctx fallback path equally — not specific to this change. Worth a separate ticket if addressed.

## Test plan

- [x] `pytest tests/test_dflash_multimodal_fallback.py` — 22/22 pass
- [x] `pytest tests/ -x --timeout=60 -q` — full suite passes (pre-existing failures on main excluded)
- [x] Verified: image requests to DFlash+VLM trigger fallback instead of silent stripping
- [x] Verified: text-only requests still use normal DFlash path (no regression)
- [x] Verified: concurrent image requests produce single eviction (lock safety)