### PR TITLE
Feat/dashboard idle ttl

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -3908,6 +3908,32 @@ def _build_active_models_data() -> dict:
                         0.0, loading_estimated_seconds - loading_elapsed_seconds
                     )
 
+        # Compute idle time and TTL remaining for loaded models.
+        is_loaded = model_info.get("loaded") and entry is not None and entry.engine is not None
+        last_access = model_info.get("last_access")
+        idle_seconds: float | None = None
+        ttl_remaining_seconds: float | None = None
+
+        if is_loaded and last_access is not None and last_access > 0:
+            idle_seconds = max(0.0, time.time() - last_access)
+
+        # Determine effective TTL: per-model ttl_seconds first, then global idle_timeout.
+        effective_ttl: int | None = None
+        settings_manager = _get_settings_manager()
+        if is_loaded and settings_manager is not None:
+            model_settings = settings_manager.get_settings(model_id)
+            if model_settings is not None and getattr(model_settings, "ttl_seconds", None) is not None:
+                effective_ttl = model_settings.ttl_seconds
+        if effective_ttl is None:
+            global_settings = _get_global_settings()
+            if global_settings is not None:
+                gt = getattr(global_settings, "idle_timeout", None)
+                if gt is not None:
+                    effective_ttl = getattr(gt, "idle_timeout_seconds", None)
+
+        if is_loaded and effective_ttl is not None and idle_seconds is not None:
+            ttl_remaining_seconds = max(0.0, effective_ttl - idle_seconds)
+
         models.append({
             "id": model_id,
             "estimated_size": model_info.get("estimated_size", 0),
@@ -3931,6 +3957,8 @@ def _build_active_models_data() -> dict:
             "activities": activities,
             "prefilling": prefilling,
             "generating": generating,
+            "idle_seconds": idle_seconds,
+            "ttl_remaining_seconds": ttl_remaining_seconds,
         })
 
         total_active += active_requests

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -3908,6 +3908,30 @@ def _build_active_models_data() -> dict:
                         0.0, loading_estimated_seconds - loading_elapsed_seconds
                     )
 
+        # Compute idle time and TTL remaining for loaded models.
+        entry = engine_pool._entries.get(model_id)
+        is_loaded = model_info.get("loaded") and entry.engine is not None if entry else False
+        last_access = model_info.get("last_access")
+        idle_seconds: float | None = None
+        ttl_remaining_seconds: float | None = None
+
+        if is_loaded and last_access is not None and last_access > 0:
+            idle_seconds = max(0.0, time.time() - last_access)
+
+        # Determine effective TTL: per-model ttl_seconds first, then global idle_timeout.
+        effective_ttl: int | None = None
+        if is_loaded and settings_manager is not None:
+            model_settings = settings_manager.get_setting(model_id)
+            if model_settings is not None and getattr(model_settings, "ttl_seconds", None) is not None:
+                effective_ttl = model_settings.ttl_seconds
+        if effective_ttl is None and global_settings is not None:
+            gt = getattr(global_settings, "idle_timeout", None)
+            if gt is not None:
+                effective_ttl = getattr(gt, "idle_timeout_seconds", None)
+
+        if is_loaded and effective_ttl is not None and idle_seconds is not None:
+            ttl_remaining_seconds = max(0.0, effective_ttl - idle_seconds)
+
         models.append({
             "id": model_id,
             "estimated_size": model_info.get("estimated_size", 0),
@@ -3931,6 +3955,8 @@ def _build_active_models_data() -> dict:
             "activities": activities,
             "prefilling": prefilling,
             "generating": generating,
+            "idle_seconds": idle_seconds,
+            "ttl_remaining_seconds": ttl_remaining_seconds,
         })
 
         total_active += active_requests

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -174,7 +174,7 @@
                                                             <span class="text-[10px] text-neutral-400" x-text="formatDurationShort(m.idle_seconds)"></span>
                                                         </template>
                                                         <template x-if="m.ttl_remaining_seconds != null">
-                                                            <span class="text-[10px]" :class="m.ttl_remaining_seconds > 0 ? 'text-neutral-400' : 'text-red-500 font-medium'" x-text="m.ttl_remaining_seconds > 0 ? '~' + formatDurationShort(m.ttl_remaining_seconds) + ' left' : 'EXPIRED'"></span>
+                                                            <span class="text-[10px] text-neutral-400" x-text="'~' + formatDurationShort(m.ttl_remaining_seconds) + ' left'"></span>
                                                         </template>
                                                     </div>
                                                 </template>

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -167,9 +167,15 @@
                                                 </template>
                                                 <!-- Idle -->
                                                 <template x-if="!m.is_loading && (!m.prefilling || m.prefilling.length === 0) && m.active_requests === 0">
-                                                    <div class="flex items-center gap-1.5">
+                                                    <div class="flex items-center gap-1.5 flex-wrap">
                                                         <span class="w-2 h-2 rounded-full bg-neutral-300"></span>
                                                         <span class="text-xs text-neutral-400">idle</span>
+                                                        <template x-if="m.idle_seconds != null">
+                                                            <span class="text-[10px] text-neutral-400" x-text="formatDurationShort(m.idle_seconds)"></span>
+                                                        </template>
+                                                        <template x-if="m.ttl_remaining_seconds != null">
+                                                            <span class="text-[10px]" :class="m.ttl_remaining_seconds > 0 ? 'text-neutral-400' : 'text-red-500 font-medium'" x-text="m.ttl_remaining_seconds > 0 ? '~' + formatDurationShort(m.ttl_remaining_seconds) + ' left' : 'EXPIRED'"></span>
+                                                        </template>
                                                     </div>
                                                 </template>
                                             </div>

--- a/tests/test_active_models_visibility.py
+++ b/tests/test_active_models_visibility.py
@@ -177,3 +177,220 @@ def test_active_models_includes_non_streaming_activity_rows():
             "token_count": 120200,
         }
     ]
+
+
+# ── idle / TTL countdown (#1307) ──────────────────────────────────────────
+
+
+def _make_global_settings(idle_timeout_seconds=None):
+    """Build a fake global_settings SimpleNamespace with optional idle_timeout."""
+    idle_timeout = SimpleNamespace(idle_timeout_seconds=idle_timeout_seconds)
+    return SimpleNamespace(idle_timeout=idle_timeout)
+
+
+def _make_settings_manager(ttl_seconds=None):
+    """Build a fake settings_manager whose get_settings() returns ttl_seconds."""
+    settings = SimpleNamespace(ttl_seconds=ttl_seconds)
+    return SimpleNamespace(get_settings=lambda _mid: settings)
+
+
+class FakeIdlePool:
+    """Pool with a single loaded idle model that has last_access set."""
+
+    def __init__(self, last_access=100.0):
+        self._entries = {
+            "model-a": SimpleNamespace(engine=object()),  # engine is not None → loaded
+        }
+        self._last_access = last_access
+
+    def get_status(self):
+        return {
+            "current_model_memory": 1024,
+            "max_model_memory": 2048,
+            "models": [
+                {
+                    "id": "model-a",
+                    "loaded": True,
+                    "is_loading": False,
+                    "loading_started_at": None,
+                    "estimated_size": 1024,
+                    "pinned": False,
+                    "last_access": self._last_access,
+                }
+            ],
+        }
+
+
+class EmptyPrefillTracker:
+    def get_model_progress(self, model_id):
+        return []
+
+
+def test_idle_seconds_computed_from_last_access():
+    """idle_seconds = time.time() - last_access for a loaded model."""
+    with (
+        patch("omlx.admin.routes._get_server_state", return_value=None),
+        patch.object(admin_routes, "_get_engine_pool", return_value=FakeIdlePool(last_access=100.0)),
+        patch.object(admin_routes, "_get_settings_manager", return_value=None),
+        patch.object(admin_routes, "_get_global_settings", return_value=None),
+        patch("omlx.prefill_progress.get_prefill_tracker", return_value=EmptyPrefillTracker()),
+        patch("time.time", return_value=115.0),
+        patch("time.monotonic", return_value=115.0),
+    ):
+        data = admin_routes._build_active_models_data()
+
+    model = data["models"][0]
+    assert model["idle_seconds"] == 15.0
+    assert model["ttl_remaining_seconds"] is None  # no TTL configured
+
+
+def test_idle_seconds_none_when_no_last_access():
+    """idle_seconds is None when last_access is missing or 0."""
+    with (
+        patch("omlx.admin.routes._get_server_state", return_value=None),
+        patch.object(admin_routes, "_get_engine_pool", return_value=FakeIdlePool(last_access=0)),
+        patch.object(admin_routes, "_get_settings_manager", return_value=None),
+        patch.object(admin_routes, "_get_global_settings", return_value=None),
+        patch("omlx.prefill_progress.get_prefill_tracker", return_value=EmptyPrefillTracker()),
+        patch("time.time", return_value=115.0),
+        patch("time.monotonic", return_value=115.0),
+    ):
+        data = admin_routes._build_active_models_data()
+
+    assert data["models"][0]["idle_seconds"] is None
+
+
+def test_ttl_remaining_from_per_model_setting():
+    """TTL countdown uses per-model ttl_seconds when available."""
+    with (
+        patch("omlx.admin.routes._get_server_state", return_value=None),
+        patch.object(admin_routes, "_get_engine_pool", return_value=FakeIdlePool(last_access=100.0)),
+        patch.object(
+            admin_routes,
+            "_get_settings_manager",
+            return_value=_make_settings_manager(ttl_seconds=30),
+        ),
+        patch.object(admin_routes, "_get_global_settings", return_value=None),
+        patch("omlx.prefill_progress.get_prefill_tracker", return_value=EmptyPrefillTracker()),
+        patch("time.time", return_value=115.0),
+        patch("time.monotonic", return_value=115.0),
+    ):
+        data = admin_routes._build_active_models_data()
+
+    model = data["models"][0]
+    assert model["idle_seconds"] == 15.0
+    # 30s TTL - 15s idle = 15s remaining
+    assert model["ttl_remaining_seconds"] == 15.0
+
+
+def test_ttl_remaining_falls_back_to_global_idle_timeout():
+    """When per-model ttl_seconds is None, global idle_timeout is used."""
+    with (
+        patch("omlx.admin.routes._get_server_state", return_value=None),
+        patch.object(admin_routes, "_get_engine_pool", return_value=FakeIdlePool(last_access=100.0)),
+        patch.object(
+            admin_routes,
+            "_get_settings_manager",
+            return_value=_make_settings_manager(ttl_seconds=None),
+        ),
+        patch.object(
+            admin_routes,
+            "_get_global_settings",
+            return_value=_make_global_settings(idle_timeout_seconds=60),
+        ),
+        patch("omlx.prefill_progress.get_prefill_tracker", return_value=EmptyPrefillTracker()),
+        patch("time.time", return_value=115.0),
+        patch("time.monotonic", return_value=115.0),
+    ):
+        data = admin_routes._build_active_models_data()
+
+    model = data["models"][0]
+    assert model["idle_seconds"] == 15.0
+    # 60s global TTL - 15s idle = 45s remaining
+    assert model["ttl_remaining_seconds"] == 45.0
+
+
+def test_ttl_remaining_per_model_takes_priority():
+    """Per-model ttl_seconds overrides global idle_timeout."""
+    with (
+        patch("omlx.admin.routes._get_server_state", return_value=None),
+        patch.object(admin_routes, "_get_engine_pool", return_value=FakeIdlePool(last_access=100.0)),
+        patch.object(
+            admin_routes,
+            "_get_settings_manager",
+            return_value=_make_settings_manager(ttl_seconds=20),
+        ),
+        patch.object(
+            admin_routes,
+            "_get_global_settings",
+            return_value=_make_global_settings(idle_timeout_seconds=300),
+        ),
+        patch("omlx.prefill_progress.get_prefill_tracker", return_value=EmptyPrefillTracker()),
+        patch("time.time", return_value=115.0),
+        patch("time.monotonic", return_value=115.0),
+    ):
+        data = admin_routes._build_active_models_data()
+
+    model = data["models"][0]
+    # per-model 20s wins over global 300s
+    assert model["ttl_remaining_seconds"] == 5.0  # 20 - 15
+
+
+def test_ttl_remaining_clamped_to_zero():
+    """ttl_remaining_seconds floors at 0 when TTL has expired."""
+    with (
+        patch("omlx.admin.routes._get_server_state", return_value=None),
+        patch.object(admin_routes, "_get_engine_pool", return_value=FakeIdlePool(last_access=100.0)),
+        patch.object(
+            admin_routes,
+            "_get_settings_manager",
+            return_value=_make_settings_manager(ttl_seconds=10),
+        ),
+        patch.object(admin_routes, "_get_global_settings", return_value=None),
+        patch("omlx.prefill_progress.get_prefill_tracker", return_value=EmptyPrefillTracker()),
+        patch("time.time", return_value=130.0),  # 30s idle, 10s TTL → expired
+        patch("time.monotonic", return_value=130.0),
+    ):
+        data = admin_routes._build_active_models_data()
+
+    assert data["models"][0]["ttl_remaining_seconds"] == 0.0
+
+
+def test_idle_and_ttl_not_computed_for_loading_model():
+    """Loading models have no idle/ttl fields set (both None)."""
+    class LoadingPool:
+        def __init__(self):
+            self._entries = {"model-a": SimpleNamespace(engine=None)}  # not loaded yet
+
+        def get_status(self):
+            return {
+                "current_model_memory": 0,
+                "max_model_memory": 0,
+                "models": [
+                    {
+                        "id": "model-a",
+                        "loaded": False,
+                        "is_loading": True,
+                        "loading_started_at": 100.0,
+                        "estimated_size": 1024,
+                        "pinned": False,
+                        "last_access": 0,
+                    }
+                ],
+            }
+
+    with (
+        patch("omlx.admin.routes._get_server_state", return_value=None),
+        patch.object(admin_routes, "_get_engine_pool", return_value=LoadingPool()),
+        patch.object(admin_routes, "_get_settings_manager", return_value=None),
+        patch.object(admin_routes, "_get_global_settings", return_value=None),
+        patch("omlx.prefill_progress.get_prefill_tracker", return_value=EmptyPrefillTracker()),
+        patch("time.time", return_value=115.0),
+        patch("time.monotonic", return_value=115.0),
+    ):
+        data = admin_routes._build_active_models_data()
+
+    model = data["models"][0]
+    assert model["is_loading"] is True
+    assert model["idle_seconds"] is None
+    assert model["ttl_remaining_seconds"] is None


### PR DESCRIPTION
feat(admin): show idle time and TTL countdown in Active Models dashboard
Add idle duration and TTL countdown display next to each loaded model's
status in the Admin Dashboard. Users can now see at a glance how long a
model has been idle and when it will be automatically evicted.
Backend (omlx/admin/routes.py):
- In _build_active_models_data(), compute idle_seconds from the model's
  last_access timestamp.
- Compute ttl_remaining_seconds using a two-tier priority:
  1. Per-model ttl_seconds (from model settings)
  2. Global idle_timeout_seconds (fallback)
- Both fields are None when the model is still loading.
Frontend (omlx/admin/templates/dashboard/_status.html):
- Show idle duration (e.g. "5m") next to the existing "idle" dot.
- Show TTL countdown (e.g. "~2m left") when a TTL is configured.
- Model is evicted on expiry, so no "EXPIRED" state is needed.
Tests (tests/test_active_models_visibility.py):
- test_idle_seconds_computed_from_last_access
- test_idle_seconds_none_when_no_last_access
- test_ttl_remaining_from_per_model_setting
- test_ttl_remaining_falls_back_to_global_idle_timeout
- test_ttl_remaining_per_model_takes_priority
- test_ttl_remaining_clamped_to_zero
- test_idle_and_ttl_not_computed_for_loading_model
Closes #1307 