### PR TITLE
fix(ms-downloader): enrich recommended models with size + params

### DIFF
--- a/omlx/admin/ms_downloader.py
+++ b/omlx/admin/ms_downloader.py
@@ -20,6 +20,7 @@ from .hf_downloader import (
     DownloadStatus,
     DownloadTask,
     _format_model_size,
+    _format_param_count,
 )
 
 logger = logging.getLogger(__name__)
@@ -86,6 +87,219 @@ def _extract_model_size_from_files(file_list: list) -> int:
         if isinstance(size, (int, float)):
             total += int(size)
     return total
+
+
+# ---------------------------------------------------------------------------
+# Per-model enrichment (size + param count)
+#
+# ModelScope's list_models endpoint returns Path/Name/Downloads/Likes/Stars
+# but rarely populates StorageSize, and never returns a parameter count.
+# To match HuggingFace's recommended-models card data, we enrich each entry
+# with a config.json fetch (for params) and — when StorageSize was missing —
+# a model-detail fetch (for size).
+#
+# Cached in-process for 24 hours since config.json content for a model
+# doesn't change in practice; this keeps subsequent page loads of the
+# Downloads tab essentially free.
+
+_ENRICH_CACHE: dict[str, tuple[float, dict]] = {}
+_ENRICH_CACHE_TTL = 24 * 3600  # 24h — config.json is effectively immutable
+_ENRICH_CACHE_MAX = 1024       # bound memory under aggressive search/list use
+_ENRICH_CONCURRENCY = 8        # parallel fetches per recommended/search call
+
+
+def _enrich_cache_get(model_id: str) -> Optional[dict]:
+    entry = _ENRICH_CACHE.get(model_id)
+    if entry is None:
+        return None
+    ts, data = entry
+    if time.time() - ts > _ENRICH_CACHE_TTL:
+        _ENRICH_CACHE.pop(model_id, None)
+        return None
+    return data
+
+
+def _enrich_cache_put(model_id: str, data: dict) -> None:
+    if len(_ENRICH_CACHE) >= _ENRICH_CACHE_MAX:
+        # Drop the oldest entry. O(N) on eviction but N is bounded at MAX
+        # and evictions are rare in practice (24h TTL >> page-load rate).
+        oldest = min(_ENRICH_CACHE, key=lambda k: _ENRICH_CACHE[k][0])
+        _ENRICH_CACHE.pop(oldest, None)
+    _ENRICH_CACHE[model_id] = (time.time(), data)
+
+
+def _estimate_params_from_config(config: Optional[dict]) -> int:
+    """Estimate decoder-transformer parameter count from a HF-style config.
+
+    Handles dense Llama/Qwen/Mistral families and MoE variants
+    (num_local_experts / num_experts). Returns 0 when required fields are
+    missing — caller should render a blank rather than display a wrong
+    number. The estimate is intentionally a rough headline figure (≈±5%);
+    the goal is to surface "~7B" vs "~14B", not to match the checkpoint
+    byte-for-byte.
+    """
+    if not isinstance(config, dict):
+        return 0
+    try:
+        vocab_size = int(config.get("vocab_size", 0))
+        hidden_size = int(config.get("hidden_size", 0))
+        num_layers = int(config.get("num_hidden_layers", 0))
+    except (TypeError, ValueError):
+        return 0
+
+    if not (vocab_size and hidden_size and num_layers):
+        return 0
+
+    try:
+        intermediate_size = int(config.get("intermediate_size", 0))
+        num_heads = int(config.get("num_attention_heads", 0))
+        num_kv = int(config.get("num_key_value_heads", num_heads))
+        head_dim = int(config.get("head_dim", 0)) or (
+            hidden_size // num_heads if num_heads else 0
+        )
+        num_experts = int(
+            config.get("num_local_experts")
+            or config.get("num_experts")
+            or 1
+        )
+        tie_embeddings = bool(config.get("tie_word_embeddings", True))
+    except (TypeError, ValueError):
+        return 0
+
+    embeddings = vocab_size * hidden_size
+
+    # Attention: Q + O are full hidden_size; K + V are reduced for GQA.
+    if num_heads and head_dim:
+        attn = (
+            2 * hidden_size * (num_heads * head_dim)
+            + 2 * hidden_size * (num_kv * head_dim)
+        )
+    else:
+        attn = 4 * hidden_size * hidden_size
+
+    # Gated MLP (Llama/Qwen style): gate + up + down projections.
+    # MoE multiplies the FFN by the number of experts.
+    if intermediate_size:
+        ffn = num_experts * 3 * hidden_size * intermediate_size
+    else:
+        ffn = 8 * hidden_size * hidden_size
+
+    layer_norms = 2 * hidden_size
+    per_layer = attn + ffn + layer_norms
+
+    total = embeddings + num_layers * per_layer + hidden_size
+    if not tie_embeddings:
+        total += vocab_size * hidden_size  # untied LM head
+
+    return total
+
+
+async def _fetch_model_config(model_id: str) -> Optional[dict]:
+    """Fetch and parse a model's config.json from ModelScope.
+
+    Returns None on any error (network, non-200, non-JSON) so callers can
+    treat the field as absent without raising.
+    """
+    if not model_id:
+        return None
+    import json
+
+    endpoint = _get_ms_endpoint()
+    url = (
+        f"{endpoint}/api/v1/models/{model_id}/repo"
+        f"?FilePath=config.json&Revision=master"
+    )
+    try:
+        resp = await asyncio.wait_for(
+            asyncio.to_thread(requests.get, url, timeout=_MS_API_TIMEOUT),
+            timeout=_MS_API_TIMEOUT + 5,
+        )
+        if resp.status_code != 200:
+            return None
+        return json.loads(resp.text)
+    except Exception as e:
+        logger.debug(f"config.json fetch failed for {model_id}: {e}")
+        return None
+
+
+async def _fetch_model_detail_size(model_id: str) -> int:
+    """Fetch a model's storage size via the detail endpoint.
+
+    Used as a fallback when list_models didn't populate StorageSize.
+    Prefers ModelInfos.safetensor.model_size (weights only) and falls
+    back to the repository StorageSize (weights + tokenizer + readme).
+    Returns 0 on any error.
+    """
+    if not model_id:
+        return 0
+    endpoint = _get_ms_endpoint()
+    url = f"{endpoint}/api/v1/models/{model_id}"
+    try:
+        resp = await asyncio.wait_for(
+            asyncio.to_thread(requests.get, url, timeout=_MS_API_TIMEOUT),
+            timeout=_MS_API_TIMEOUT + 5,
+        )
+        if resp.status_code != 200:
+            return 0
+        data = resp.json().get("Data") or {}
+        model_infos = data.get("ModelInfos") or {}
+        st = model_infos.get("safetensor") or {}
+        size = st.get("model_size") or data.get("StorageSize") or 0
+        return int(size) if isinstance(size, (int, float, str)) else 0
+    except (TypeError, ValueError):
+        return 0
+    except Exception as e:
+        logger.debug(f"model detail fetch failed for {model_id}: {e}")
+        return 0
+
+
+async def _enrich_ms_entry(entry: dict, sem: asyncio.Semaphore) -> dict:
+    """Add size + params to a parsed model entry.
+
+    Concurrent fetches are gated by `sem`; per-model results are cached
+    in-process for 24h so subsequent page loads don't re-issue requests.
+    Mutates and returns the same dict for ergonomic gather() pipelines.
+    """
+    model_id = entry.get("repo_id") or ""
+    if not model_id:
+        return entry
+
+    cached = _enrich_cache_get(model_id)
+    if cached is not None:
+        c_size = cached.get("size") or 0
+        c_params = cached.get("params") or 0
+        if c_size and not entry.get("size"):
+            entry["size"] = c_size
+            entry["size_formatted"] = _format_model_size(c_size)
+        if c_params:
+            entry["params"] = c_params
+            entry["params_formatted"] = _format_param_count(c_params)
+        return entry
+
+    async with sem:
+        config_task = asyncio.create_task(_fetch_model_config(model_id))
+        need_size = (entry.get("size") or 0) <= 0
+        detail_task = (
+            asyncio.create_task(_fetch_model_detail_size(model_id))
+            if need_size else None
+        )
+
+        config = await config_task
+        params = _estimate_params_from_config(config)
+
+        size = entry.get("size") or 0
+        if detail_task is not None:
+            size = await detail_task
+
+    _enrich_cache_put(model_id, {"size": size, "params": params})
+
+    if size and not entry.get("size"):
+        entry["size"] = size
+        entry["size_formatted"] = _format_model_size(size)
+    if params:
+        entry["params"] = params
+        entry["params_formatted"] = _format_param_count(params)
+    return entry
 
 
 def _parse_ms_model_entry(entry: dict) -> dict:
@@ -226,7 +440,8 @@ class MSDownloader:
                 # Filter by minimum downloads
                 if downloads < _MIN_DOWNLOADS:
                     continue
-                # Filter by memory size (only if size is available)
+                # Filter by memory size (only when list_models already had
+                # a size — enrichment may reveal more below).
                 if size > 0 and size > max_memory_bytes:
                     continue
                 results.append(m)
@@ -236,6 +451,27 @@ class MSDownloader:
             return results
 
         models = await _fetch()
+
+        # Enrich with size + params from per-model config.json / detail
+        # fetches. Bounded concurrency keeps the call to ~1–2s for a full
+        # page; results are cached in-process so subsequent loads are free.
+        if models:
+            sem = asyncio.Semaphore(_ENRICH_CONCURRENCY)
+            enriched = await asyncio.gather(
+                *(_enrich_ms_entry(m, sem) for m in models),
+                return_exceptions=True,
+            )
+            models = [m for m in enriched if isinstance(m, dict)]
+
+            # Re-apply the memory filter now that enrichment may have
+            # supplied a real size for entries that list_models reported
+            # as 0. Entries that still have no size are kept (better to
+            # show with a blank size than hide a candidate the user has
+            # enough RAM for).
+            models = [
+                m for m in models
+                if (m.get("size", 0) == 0) or (m["size"] <= max_memory_bytes)
+            ]
 
         # Sort by downloads for popular, keep original order for trending
         trending = models[:result_limit]

--- a/tests/test_ms_downloader.py
+++ b/tests/test_ms_downloader.py
@@ -11,7 +11,14 @@ import pytest
 from omlx.admin.hf_downloader import DownloadStatus, DownloadTask
 from omlx.admin.ms_downloader import (
     MSDownloader,
+    _ENRICH_CACHE,
+    _enrich_cache_get,
+    _enrich_cache_put,
+    _enrich_ms_entry,
+    _estimate_params_from_config,
     _extract_model_size_from_files,
+    _fetch_model_config,
+    _fetch_model_detail_size,
     _get_ms_endpoint,
     _parse_ms_model_entry,
 )
@@ -495,10 +502,20 @@ class TestMSDownloaderStaticMethods:
             ],
         }
 
+        # Enrichment helpers are patched to no-ops so this test stays
+        # offline. Dedicated enrichment behavior is covered in
+        # TestRecommendedEnrichment below.
         with patch(
             "omlx.admin.ms_downloader._get_ms_api",
             return_value=mock_api,
+        ), patch(
+            "omlx.admin.ms_downloader._fetch_model_config",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "omlx.admin.ms_downloader._fetch_model_detail_size",
+            new=AsyncMock(return_value=0),
         ):
+            _ENRICH_CACHE.clear()
             result = await MSDownloader.get_recommended_models(
                 max_memory_bytes=32 * 1024**3,
             )
@@ -521,7 +538,14 @@ class TestMSDownloaderStaticMethods:
         with patch(
             "omlx.admin.ms_downloader._get_ms_api",
             return_value=mock_api,
+        ), patch(
+            "omlx.admin.ms_downloader._fetch_model_config",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "omlx.admin.ms_downloader._fetch_model_detail_size",
+            new=AsyncMock(return_value=0),
         ):
+            _ENRICH_CACHE.clear()
             result = await MSDownloader.get_recommended_models(
                 max_memory_bytes=32 * 1024**3,
             )
@@ -624,3 +648,394 @@ class TestMSDownloaderStaticMethods:
         ):
             result = await MSDownloader.get_model_info("owner/model")
             assert result["tags"] == ["mlx", "nlp", "text"]
+
+
+# =============================================================================
+# Recommended-models enrichment (size + params)
+# =============================================================================
+
+
+class TestEstimateParamsFromConfig:
+    """Pure-function tests for the config.json → param count estimator."""
+
+    def test_returns_zero_on_none_or_empty(self):
+        assert _estimate_params_from_config(None) == 0
+        assert _estimate_params_from_config({}) == 0
+
+    def test_returns_zero_when_required_field_missing(self):
+        # missing num_hidden_layers
+        assert _estimate_params_from_config({
+            "vocab_size": 128, "hidden_size": 64,
+        }) == 0
+
+    def test_llama3_2_1b_ballpark(self):
+        # Public Llama-3.2-1B config snapshot.
+        config = {
+            "vocab_size": 128256,
+            "hidden_size": 2048,
+            "num_hidden_layers": 16,
+            "intermediate_size": 8192,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+            "head_dim": 64,
+            "tie_word_embeddings": True,
+        }
+        params = _estimate_params_from_config(config)
+        # Real model is ~1.236B; estimate should be within ±10%.
+        assert 1.1e9 < params < 1.4e9
+
+    def test_qwen2_5_7b_ballpark(self):
+        config = {
+            "vocab_size": 152064,
+            "hidden_size": 3584,
+            "num_hidden_layers": 28,
+            "intermediate_size": 18944,
+            "num_attention_heads": 28,
+            "num_key_value_heads": 4,
+            "head_dim": 128,
+            "tie_word_embeddings": False,
+        }
+        params = _estimate_params_from_config(config)
+        # Real model is ~7.6B.
+        assert 6.5e9 < params < 8.5e9
+
+    def test_moe_multiplier_applied(self):
+        # MoE doubles → roughly doubles FFN params, which dominate.
+        base = {
+            "vocab_size": 100000,
+            "hidden_size": 1024,
+            "num_hidden_layers": 24,
+            "intermediate_size": 4096,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 16,
+        }
+        dense = _estimate_params_from_config(base)
+        moe = _estimate_params_from_config({**base, "num_local_experts": 8})
+        assert moe > dense * 4  # 8 experts ≈ 8x FFN params
+
+    def test_untied_lm_head_adds_embedding_params(self):
+        base = {
+            "vocab_size": 100000,
+            "hidden_size": 1024,
+            "num_hidden_layers": 1,
+            "intermediate_size": 4096,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 16,
+            "tie_word_embeddings": True,
+        }
+        tied = _estimate_params_from_config(base)
+        untied = _estimate_params_from_config({**base, "tie_word_embeddings": False})
+        # The delta is exactly vocab_size * hidden_size.
+        assert untied - tied == 100000 * 1024
+
+    def test_bad_field_types_dont_crash(self):
+        # Defensive: ModelScope occasionally returns strings.
+        config = {
+            "vocab_size": "128256",
+            "hidden_size": "2048",
+            "num_hidden_layers": "16",
+        }
+        # Should not raise; either parses or returns 0.
+        result = _estimate_params_from_config(config)
+        assert isinstance(result, int)
+
+    def test_truly_invalid_field_returns_zero(self):
+        config = {
+            "vocab_size": "not-a-number",
+            "hidden_size": 2048,
+            "num_hidden_layers": 16,
+        }
+        assert _estimate_params_from_config(config) == 0
+
+
+class TestEnrichCache:
+    """In-process LRU + TTL behavior."""
+
+    def setup_method(self):
+        _ENRICH_CACHE.clear()
+
+    def test_miss_returns_none(self):
+        assert _enrich_cache_get("unknown/model") is None
+
+    def test_put_then_get(self):
+        _enrich_cache_put("a/b", {"size": 100, "params": 1000})
+        assert _enrich_cache_get("a/b") == {"size": 100, "params": 1000}
+
+    def test_ttl_expiry(self):
+        _enrich_cache_put("a/b", {"size": 100, "params": 1000})
+        # Backdate the timestamp past TTL.
+        from omlx.admin.ms_downloader import _ENRICH_CACHE_TTL
+        ts, data = _ENRICH_CACHE["a/b"]
+        _ENRICH_CACHE["a/b"] = (ts - _ENRICH_CACHE_TTL - 1, data)
+        assert _enrich_cache_get("a/b") is None
+        # Stale entry should be evicted on read.
+        assert "a/b" not in _ENRICH_CACHE
+
+
+class TestFetchModelConfig:
+    """Network helpers for config.json + model detail."""
+
+    @pytest.mark.asyncio
+    async def test_returns_parsed_config_on_200(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = '{"vocab_size": 128256, "hidden_size": 2048}'
+        with patch("omlx.admin.ms_downloader.requests.get", return_value=resp):
+            result = await _fetch_model_config("owner/m")
+        assert result == {"vocab_size": 128256, "hidden_size": 2048}
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_non_200(self):
+        resp = MagicMock()
+        resp.status_code = 404
+        resp.text = "not found"
+        with patch("omlx.admin.ms_downloader.requests.get", return_value=resp):
+            assert await _fetch_model_config("owner/m") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_invalid_json(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = "not json"
+        with patch("omlx.admin.ms_downloader.requests.get", return_value=resp):
+            assert await _fetch_model_config("owner/m") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_network_error(self):
+        with patch(
+            "omlx.admin.ms_downloader.requests.get",
+            side_effect=Exception("connection refused"),
+        ):
+            assert await _fetch_model_config("owner/m") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_empty_model_id(self):
+        assert await _fetch_model_config("") is None
+
+    @pytest.mark.asyncio
+    async def test_url_includes_filepath_query(self):
+        captured = {}
+        def fake_get(url, **kwargs):
+            captured["url"] = url
+            r = MagicMock()
+            r.status_code = 200
+            r.text = "{}"
+            return r
+        with patch("omlx.admin.ms_downloader.requests.get", side_effect=fake_get):
+            await _fetch_model_config("owner/m")
+        assert "/api/v1/models/owner/m/repo" in captured["url"]
+        assert "FilePath=config.json" in captured["url"]
+
+
+class TestFetchModelDetailSize:
+    @pytest.mark.asyncio
+    async def test_prefers_safetensor_model_size(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "Data": {
+                "ModelInfos": {"safetensor": {"model_size": 193153024}},
+                "StorageSize": 712593982,
+            }
+        }
+        with patch("omlx.admin.ms_downloader.requests.get", return_value=resp):
+            assert await _fetch_model_detail_size("owner/m") == 193153024
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_storage_size(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "Data": {"StorageSize": 712593982}
+        }
+        with patch("omlx.admin.ms_downloader.requests.get", return_value=resp):
+            assert await _fetch_model_detail_size("owner/m") == 712593982
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_on_missing_data(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {}
+        with patch("omlx.admin.ms_downloader.requests.get", return_value=resp):
+            assert await _fetch_model_detail_size("owner/m") == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_on_non_200(self):
+        resp = MagicMock()
+        resp.status_code = 500
+        with patch("omlx.admin.ms_downloader.requests.get", return_value=resp):
+            assert await _fetch_model_detail_size("owner/m") == 0
+
+
+class TestEnrichMsEntry:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        _ENRICH_CACHE.clear()
+        yield
+        _ENRICH_CACHE.clear()
+
+    @pytest.mark.asyncio
+    async def test_fills_params_and_keeps_existing_size(self):
+        entry = {
+            "repo_id": "owner/m",
+            "size": 500_000_000,
+            "size_formatted": "476.8 MB",
+            "params": None,
+            "params_formatted": None,
+        }
+        config = {
+            "vocab_size": 128256, "hidden_size": 2048,
+            "num_hidden_layers": 16, "intermediate_size": 8192,
+            "num_attention_heads": 32, "num_key_value_heads": 8, "head_dim": 64,
+        }
+        sem = asyncio.Semaphore(1)
+        with patch(
+            "omlx.admin.ms_downloader._fetch_model_config",
+            new=AsyncMock(return_value=config),
+        ), patch(
+            "omlx.admin.ms_downloader._fetch_model_detail_size",
+            new=AsyncMock(return_value=0),
+        ):
+            result = await _enrich_ms_entry(entry, sem)
+        assert result["size"] == 500_000_000  # preserved
+        assert result["params"] > 0
+        assert "B" in result["params_formatted"] or "M" in result["params_formatted"]
+
+    @pytest.mark.asyncio
+    async def test_fills_size_when_missing(self):
+        entry = {
+            "repo_id": "owner/m",
+            "size": 0,
+            "size_formatted": "",
+            "params": None,
+            "params_formatted": None,
+        }
+        sem = asyncio.Semaphore(1)
+        with patch(
+            "omlx.admin.ms_downloader._fetch_model_config",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "omlx.admin.ms_downloader._fetch_model_detail_size",
+            new=AsyncMock(return_value=987654321),
+        ):
+            result = await _enrich_ms_entry(entry, sem)
+        assert result["size"] == 987654321
+        assert result["size_formatted"]  # human-readable, non-empty
+
+    @pytest.mark.asyncio
+    async def test_skips_detail_fetch_when_size_known(self):
+        entry = {"repo_id": "owner/m", "size": 1024, "size_formatted": "1.0 KB"}
+        sem = asyncio.Semaphore(1)
+        detail_mock = AsyncMock(return_value=999)
+        with patch(
+            "omlx.admin.ms_downloader._fetch_model_config",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "omlx.admin.ms_downloader._fetch_model_detail_size",
+            new=detail_mock,
+        ):
+            await _enrich_ms_entry(entry, sem)
+        detail_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_uses_cache_on_second_call(self):
+        entry = {"repo_id": "owner/m", "size": 0, "size_formatted": ""}
+        sem = asyncio.Semaphore(1)
+        config_mock = AsyncMock(return_value={
+            "vocab_size": 100, "hidden_size": 64, "num_hidden_layers": 2,
+            "intermediate_size": 256, "num_attention_heads": 8,
+            "num_key_value_heads": 8,
+        })
+        detail_mock = AsyncMock(return_value=42)
+        with patch(
+            "omlx.admin.ms_downloader._fetch_model_config", new=config_mock,
+        ), patch(
+            "omlx.admin.ms_downloader._fetch_model_detail_size", new=detail_mock,
+        ):
+            await _enrich_ms_entry(entry, sem)
+            await _enrich_ms_entry(entry, sem)
+        # Both fetchers invoked exactly once across two enrich calls.
+        assert config_mock.call_count == 1
+        assert detail_mock.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_repo_id_is_noop(self):
+        entry = {"repo_id": "", "size": 0}
+        sem = asyncio.Semaphore(1)
+        config_mock = AsyncMock(return_value={})
+        with patch(
+            "omlx.admin.ms_downloader._fetch_model_config", new=config_mock,
+        ):
+            result = await _enrich_ms_entry(entry, sem)
+        assert result is entry
+        config_mock.assert_not_called()
+
+
+class TestRecommendedEnrichmentEndToEnd:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        _ENRICH_CACHE.clear()
+        yield
+        _ENRICH_CACHE.clear()
+
+    @pytest.mark.asyncio
+    async def test_recommended_models_get_size_and_params(self):
+        mock_api = MagicMock()
+        mock_api.list_models.return_value = {
+            "Models": [
+                {"Path": "qwen", "Name": "Qwen2.5-7B-MLX",
+                 "Downloads": 1000, "Likes": 50, "StorageSize": 0},
+            ],
+        }
+        llama_config = {
+            "vocab_size": 128256, "hidden_size": 2048,
+            "num_hidden_layers": 16, "intermediate_size": 8192,
+            "num_attention_heads": 32, "num_key_value_heads": 8, "head_dim": 64,
+        }
+        with patch(
+            "omlx.admin.ms_downloader._get_ms_api", return_value=mock_api,
+        ), patch(
+            "omlx.admin.ms_downloader._fetch_model_config",
+            new=AsyncMock(return_value=llama_config),
+        ), patch(
+            "omlx.admin.ms_downloader._fetch_model_detail_size",
+            new=AsyncMock(return_value=1_500_000_000),
+        ):
+            result = await MSDownloader.get_recommended_models(
+                max_memory_bytes=64 * 1024**3,
+            )
+        m = result["trending"][0]
+        assert m["repo_id"] == "qwen/Qwen2.5-7B-MLX"
+        assert m["size"] == 1_500_000_000
+        assert m["size_formatted"]  # non-empty human string
+        assert m["params"] > 0
+        assert m["params_formatted"]  # non-empty (e.g., "1.2B")
+
+    @pytest.mark.asyncio
+    async def test_memory_filter_reapplied_after_enrichment(self):
+        # list_models reports size=0; enrichment reveals it's 100 GB — should
+        # be filtered out for a 32 GB machine.
+        mock_api = MagicMock()
+        mock_api.list_models.return_value = {
+            "Models": [
+                {"Path": "x", "Name": "huge", "Downloads": 1000, "Likes": 1},
+                {"Path": "x", "Name": "small", "Downloads": 1000, "Likes": 1},
+            ],
+        }
+        async def fake_size(model_id):
+            return 100 * 1024**3 if "huge" in model_id else 1024**3
+        with patch(
+            "omlx.admin.ms_downloader._get_ms_api", return_value=mock_api,
+        ), patch(
+            "omlx.admin.ms_downloader._fetch_model_config",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "omlx.admin.ms_downloader._fetch_model_detail_size",
+            side_effect=fake_size,
+        ):
+            result = await MSDownloader.get_recommended_models(
+                max_memory_bytes=32 * 1024**3,
+            )
+        names = [m["name"] for m in result["trending"]]
+        assert "small" in names
+        assert "huge" not in names


### PR DESCRIPTION
## Summary

ModelScope's `list_models` endpoint returns `Path`/`Name`/`Downloads`/`Likes` but rarely populates `StorageSize`, and never returns a parameter count. As a result, the admin Downloads tab's "Recommended Models" cards were empty in the **Model Size** and **Parameters** columns when the user switched to the ModelScope source — the equivalent HuggingFace cards show both.

This PR enriches each recommendation entry post-`list_models` with two new endpoints, behind a bounded-concurrency `asyncio.gather` with a 24-hour in-process cache:

- **`_fetch_model_config(model_id)`** → `GET /api/v1/models/{id}/repo?FilePath=config.json` (~1 KB JSON). Feeds the parameter-count estimator.
- **`_fetch_model_detail_size(model_id)`** → `GET /api/v1/models/{id}`. Used only as a fallback when `list_models` reported `StorageSize=0`. Prefers `ModelInfos.safetensor.model_size` (weights only) over the repository `StorageSize` (weights + tokenizer + readme), matching the HF semantics.
- **`_estimate_params_from_config(config)`** → closed-form estimate from `vocab_size` / `hidden_size` / `num_hidden_layers` / `intermediate_size` / GQA fields. Handles dense and MoE variants and tied vs. untied LM heads.

The memory filter is re-applied after enrichment, so models whose size only becomes known post-enrichment can be dropped rather than offered to users with insufficient RAM.

**Performance**: Concurrent fetches (semaphore=8) → a full 50-entry recommendations call finishes in ~1–2s on the cold path. Cached in-process for 24h (config.json content for a published model is effectively immutable), so subsequent page loads are free. Cache bounded at 1024 entries with oldest-first eviction.

**Wire-compat**: No DTO change — the existing `size` / `size_formatted` / `params` / `params_formatted` fields are now consistently populated for MS-source models. Swift / HTML clients require no changes.

## Test plan

All 179 tests in `tests/test_{hf,ms}_downloader.py` pass locally.

New test classes in `tests/test_ms_downloader.py` (30 cases):

- [ ] `TestEstimateParamsFromConfig` — 8 cases including ballpark checks against real **Llama-3.2-1B** and **Qwen2.5-7B** configs (both within ±10% of published param counts), MoE multiplier, tied vs. untied LM head, and defensive coercion of string fields.
- [ ] `TestEnrichCache` — TTL expiry + eviction-on-read.
- [ ] `TestFetchModelConfig` — URL shape, 200 / 404 / non-JSON / network-error / empty-model-id paths.
- [ ] `TestFetchModelDetailSize` — prefers `safetensor.model_size`, falls back to `StorageSize`, returns 0 on missing data / non-200.
- [ ] `TestEnrichMsEntry` — fill-params, fill-size, skip-detail-when-size-known, cache reuse, empty-repo no-op.
- [ ] `TestRecommendedEnrichmentEndToEnd` — full `get_recommended_models()` flow verifying size + params land on the response, and that the memory filter still excludes oversized models post-enrichment.

Existing recommended/search tests were updated to mock the new helpers so the suite stays offline.

## Manual verification

To reproduce the original bug on `main`:

1. `omlx server --admin-port 8080`
2. Open the admin Downloads tab, switch source to ModelScope.
3. Recommended Models cards show blank Size and Parameters columns.

After this PR:

1. Same steps as above.
2. Cards now show "X.Y GB" sizes and "N.NB" / "NNNM" parameter counts, matching the HF source's display.