### PR TITLE
chore(packaging): pin venvstacks as dev dep + auto-detect driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ pytest -m "not slow"
 
 ### macOS App
 
-Requires Python 3.11+ and [venvstacks](https://venvstacks.lmstudio.ai) (`pip install venvstacks`).
+Requires Python 3.11+ and [venvstacks](https://venvstacks.lmstudio.ai). venvstacks is declared as a dev dependency, so `pip install -e ".[dev]"` (or `uv sync --dev`) brings the pinned version into your environment. `build.py` also falls back to `uvx venvstacks` or `pipx run venvstacks` if you prefer a host-global tool runner.
 
 ```bash
 cd packaging

--- a/packaging/build.py
+++ b/packaging/build.py
@@ -490,11 +490,45 @@ def _check_git_commit_sync():
         sys.exit(1)
 
 
+def _venvstacks_driver() -> list[str]:
+    """Pick an available venvstacks driver as a command prefix.
+
+    Resolution order (first that works wins):
+      1. `venvstacks` directly on PATH — installed via the dev extra in
+         pyproject.toml, fastest path with no extra startup overhead.
+      2. `uvx venvstacks` — uv's pipx-equivalent. Already available to
+         anyone using uv for development setup.
+      3. `pipx run venvstacks` — historical default; works if pipx is
+         installed on the host.
+
+    Aborts with a clear remediation message if none are available, so a
+    contributor with neither uv nor pipx nor a dev-installed venvstacks
+    gets actionable guidance instead of a cryptic "command not found".
+    """
+    if shutil.which("venvstacks") is not None:
+        return ["venvstacks"]
+    if shutil.which("uvx") is not None:
+        return ["uvx", "venvstacks"]
+    if shutil.which("pipx") is not None:
+        return ["pipx", "run", "venvstacks"]
+    print(
+        "  ✗ No venvstacks driver found. Install with one of:\n"
+        "      pip install -e \".[dev]\"     (pip-managed venv)\n"
+        "      uv sync --dev                (uv-managed venv)\n"
+        "      pipx install venvstacks       (host-global tool)",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
 def build_venvstacks():
     """Build venvstacks layers."""
     print("\n[1/4] Building venvstacks layers...")
 
     _check_git_commit_sync()
+
+    venvstacks_cmd = _venvstacks_driver()
+    print(f"  Using venvstacks driver: {' '.join(venvstacks_cmd)}")
 
     # Step 1: Build wheels from git-pinned packages
     version_map = build_local_wheels()
@@ -515,8 +549,8 @@ def build_venvstacks():
     # If lock fails due to sdist-only packages (no pre-built wheel on PyPI),
     # _lock_with_sdist_retry() builds them locally and retries automatically.
     print("\n  Locking environments...")
-    lock_cmd = [
-        "pipx", "run", "venvstacks", "lock",
+    lock_cmd = venvstacks_cmd + [
+        "lock",
         str(resolved_toml),
     ] + local_wheels_args
     if version_map:
@@ -528,8 +562,8 @@ def build_venvstacks():
 
     # Step 4: Build environments
     print("\n  Building environments (this may take a while)...")
-    run_cmd([
-        "pipx", "run", "venvstacks", "build",
+    run_cmd(venvstacks_cmd + [
+        "build",
         str(resolved_toml),
         "--no-lock",
     ] + local_wheels_args)
@@ -539,8 +573,8 @@ def build_venvstacks():
     if EXPORT_DIR.exists():
         shutil.rmtree(EXPORT_DIR)
 
-    run_cmd([
-        "pipx", "run", "venvstacks", "local-export",
+    run_cmd(venvstacks_cmd + [
+        "local-export",
         str(resolved_toml),
         "--output-dir", str(EXPORT_DIR),
     ])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0.0",
     "mcp>=1.0.0",
+    "venvstacks>=0.7.0",
 ]
 # PEP 735 dependency groups — consumed by `uv sync --dev`.
 # Keep in sync with [project.optional-dependencies] dev above
@@ -123,6 +124,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0.0",
     "mcp>=1.0.0",
+    "venvstacks>=0.7.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

This PR is raised for the reason someone wants to build App locally.

`packaging/build.py` currently invokes venvstacks via `pipx run venvstacks …` in three places. That works, but the version of venvstacks that produces the macOS app bundle is whatever PyPI release happens to be current on a given contributor's machine the day they build — there's no lockfile discipline on the tool that produces the artifact. Two of us can build "the same" commit and get subtly different output if venvstacks shipped a release in between.

This PR pins venvstacks the same way we pin every other dep that affects the bundle:

- **`pyproject.toml`**: `venvstacks>=0.7.0` added to both `[project.optional-dependencies].dev` (pip-managed venvs) and `[dependency-groups].dev` (PEP 735 / `uv sync --dev`), matching the existing pair-maintained pattern for pytest/black/ruff.
- **`packaging/build.py`**: a new `_venvstacks_driver()` helper auto-detects an available driver in priority order:
  1. `venvstacks` directly on PATH (installed via the dev extra — fastest path, no tool-runner startup overhead)
  2. `uvx venvstacks` (uv's `pipx run` equivalent)
  3. `pipx run venvstacks` (historical default — backwards compatible)
  
  Exits with an actionable remediation hint when none are present.
- **`README.md`**: updated the macOS build prerequisites paragraph to point at the dev extra as the canonical install path. Translated READMEs intentionally not touched — kept for the next translation-sync pass.

## Why this matters

The `.app` bundle ships to end users is the contract; venvstacks is what produces it. Making the producer reproducible is a small but load-bearing step toward the broader distribution story.

## Compatibility

- **pip-only workflows**: unchanged. `pip install -e ".[dev]"` brings venvstacks into the active venv, and the driver-detection helper finds it via the direct-on-PATH branch.
- **pipx-only workflows (status quo)**: still work via the third fallback — no behavior change for anyone who hasn't switched.
- **uv-only workflows**: `uv sync --dev` installs venvstacks; same direct-on-PATH branch picks it up. `uvx venvstacks` is also available as a fallback for cases where someone runs `build.py` outside an active venv.
- **End-user `.app`**: byte-identical. This is purely a build-time-reproducibility + host-dependency-footprint change.
