### PR TITLE
Fix Anthropic stream block indices for thinking tool calls

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3313,9 +3313,9 @@ async def stream_anthropic_messages(
 
     # 4. Close open blocks
     if thinking_block_started and not text_block_started:
-        # Only thinking was emitted, close it
+        # Only thinking was emitted. Keep block_index on the just-closed
+        # block so following tool_use blocks start at the next contiguous index.
         yield create_content_block_stop_event(index=block_index)
-        block_index += 1
     if text_block_started:
         yield create_content_block_stop_event(index=block_index)
     elif not thinking_block_started and not tool_calls:

--- a/tests/integration/test_e2e_streaming.py
+++ b/tests/integration/test_e2e_streaming.py
@@ -919,6 +919,7 @@ class TestStreamingHelperFunctions:
 
         thinking_deltas = []
         tool_use_blocks = []
+        block_start_indices = []
         stop_reasons = []
         for event in parsed_events:
             if event.get("type") == "content_block_delta":
@@ -926,6 +927,7 @@ class TestStreamingHelperFunctions:
                 if delta.get("type") == "thinking_delta":
                     thinking_deltas.append(delta["thinking"])
             elif event.get("type") == "content_block_start":
+                block_start_indices.append(event["index"])
                 content_block = event.get("content_block", {})
                 if content_block.get("type") == "tool_use":
                     tool_use_blocks.append(content_block)
@@ -939,6 +941,7 @@ class TestStreamingHelperFunctions:
         assert "</tool_call>" not in streamed_thinking
         assert "Need to inspect first." in streamed_thinking
         assert "Then continue." in streamed_thinking
+        assert block_start_indices == list(range(len(block_start_indices)))
         assert len(tool_use_blocks) == 1
         assert tool_use_blocks[0]["name"] == "get_weather"
         assert "tool_use" in stop_reasons


### PR DESCRIPTION
Fixes #1353.

## Problem
Anthropic streaming clients expect `content_block_start` indices to be contiguous and zero-based. When oMLX streamed a response with a thinking block followed directly by a tool_use block, the emitted indices skipped from `0` to `2`. The official Anthropic SDK accumulates content blocks in a list and then indexes by `event.index`, so the gap can raise `IndexError: list index out of range`.

## Root cause
`stream_anthropic_messages()` closed the thinking block and incremented `block_index`. Later, the tool_use start index was calculated as `block_index + 1`, which added one more step and produced the gap.

## Fix
- keep `block_index` on the just-closed thinking block
- let the existing tool block start calculation advance to the next contiguous index
- add a regression assertion for thinking + tool_use streaming so `content_block_start` indices remain consecutive

## Tests
- `.venv/bin/pytest tests/integration/test_e2e_streaming.py::TestStreamingHelperFunctions::test_stream_anthropic_messages_sanitizes_tool_call_markup_inside_thinking -q`
- `.venv/bin/pytest tests/integration/test_e2e_streaming.py::TestStreamingHelperFunctions -q`
- `.venv/bin/pytest tests/test_anthropic_adapter.py tests/test_api_utils.py::TestSSEEventFormatters -q`
- `.venv/bin/pytest tests/integration/test_e2e_streaming.py -q`