### PR TITLE
fix(scheduler): import guard for vlm_mtp when mlx_vlm absent

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -43,7 +43,12 @@ from .cache.prefix_cache import BlockAwarePrefixCache
 from .exceptions import is_cache_corruption_error
 from .prefill_progress import get_prefill_tracker
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
-from .speculative.vlm_mtp import VLMMTPDrafter, run_vlm_mtp_decode
+try:
+    from .speculative.vlm_mtp import VLMMTPDrafter, run_vlm_mtp_decode
+except ImportError:
+    from typing import Any
+    VLMMTPDrafter = Any  # type: ignore[assignment, misc]
+    run_vlm_mtp_decode = None  # type: ignore[assignment, misc]
 from .utils.proc_memory import get_phys_footprint
 from .utils.sampling import make_sampler as omlx_make_sampler
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2102,3 +2102,21 @@ class TestBuildStateMachineStopStrings:
                 assert tok in node
                 node = node[tok]
             assert "__match__" in node
+
+
+class TestVlmMtpImportGuard:
+    """Regression test for bare vlm_mtp import crash (text-only deployments)."""
+
+    def test_scheduler_imports_when_vlm_mtp_missing(self, monkeypatch):
+        """Importing scheduler must not fail when speculative.vlm_mtp is absent."""
+        import sys
+
+        # Force re-import of scheduler by removing cached module
+        monkeypatch.delitem(sys.modules, "omlx.scheduler", raising=False)
+        monkeypatch.setitem(sys.modules, "omlx.speculative.vlm_mtp", None)
+
+        # Re-import must succeed without raising
+        import omlx.scheduler as sched
+
+        assert sched.VLMMTPDrafter is not None  # falls back to typing.Any
+        assert sched.run_vlm_mtp_decode is None  # falls back to None


### PR DESCRIPTION
## Problem

Importing `omlx.scheduler` crashes with `ModuleNotFoundError: No module named 'mlx_vlm.speculative.utils'` when the installed `mlx-vlm` version does not contain the `speculative.utils` submodule that `omlx/speculative/vlm_mtp.py` expects.

This can occur when `mlx-vlm` is installed but from an older commit (before the speculative utils were moved), or if `mlx_vlm` fails to import for any other reason. Since `scheduler.py` is a core module loaded by the engine and server, this import-time failure cascades into a startup crash regardless of whether VLM features are actually used.

**Reproduction (before fix):**

```python
>>> import omlx.scheduler
Traceback (most recent call last):
  File ".../omlx/scheduler.py", line 46, in <module>
    from .speculative.vlm_mtp import VLMMTPDrafter, run_vlm_mtp_decode
  File ".../omlx/speculative/vlm_mtp.py", line 48, in <module>
    from mlx_vlm.speculative.utils import _mtp_rounds, _mtp_rounds_batch
ModuleNotFoundError: No module named 'mlx_vlm.speculative.utils'
```

## Root cause

`omlx/scheduler.py` unconditionally imports at module top-level:

```python
from .speculative.vlm_mtp import VLMMTPDrafter, run_vlm_mtp_decode
```

`omlx/speculative/vlm_mtp.py` itself imports from `mlx_vlm.speculative` (lines 43-48). If the installed `mlx-vlm` is missing `speculative.utils` or raises `ImportError` for any other reason, the scheduler crashes at module load time, even though the VLM MTP path is only meaningful when a VLM MTP drafter is explicitly configured.

## Fix

Wrap the `vlm_mtp` import in `scheduler.py` in a `try/except ImportError` guard with fallback types, matching the established pattern already used by 6+ other optional imports in the same file (lines 149-191):

```python
try:
    from .speculative.vlm_mtp import VLMMTPDrafter, run_vlm_mtp_decode
except ImportError:
    from typing import Any
    VLMMTPDrafter = Any           # type: ignore[assignment, misc]
    run_vlm_mtp_decode = None     # type: ignore[assignment, misc]
```

**Why this is safe:**
- `VLMMTPDrafter` is only used as a type annotation (`self._vlm_mtp_drafter: VLMMTPDrafter | None`) and as a parameter type in `set_vlm_mtp_drafter()`. `typing.Any` is a safe runtime fallback that satisfies type checkers.
- `run_vlm_mtp_decode` is only called inside `_route_to_vlm_mtp()`, which has an early guard `if drafter is None: return None` (line 3490). Since `self._vlm_mtp_drafter` is initialized to `None` when no drafter is set, the execution path never reaches the `None` fallback for `run_vlm_mtp_decode`.

## Test plan

- [x] New regression test `TestVlmMtpImportGuard` in `tests/test_scheduler.py` simulates a missing `vlm_mtp` module via `monkeypatch` on `sys.modules` and verifies the scheduler imports successfully with correct fallbacks.
- [x] Verified RED by removing the fix --- `pytest` fails with `ImportError`.
- [x] Full `pytest tests/test_scheduler.py::TestVlmMtpImportGuard -v` --- 1 passed.

## Scope and risk

- **Files changed:** `omlx/scheduler.py` (+7 / -1), `tests/test_scheduler.py` (+18).
- **Risk:** negligible. The fix follows an established pattern (lines 149-191 already use 5 identical `try/except ImportError` guards in the same file). No behavioral change when the import succeeds; the scheduler becomes resilient if the import fails.
- **No public API changes;** no schema changes; no new dependencies.

## Related work

- This is a defensive import-guard fix for the broader optional-dependency pattern already established in `omlx/scheduler.py` (tiered cache, hybrid cache, streaming detokenizer, output parser, etc.).