### PR TITLE
perf(scheduler): skip boundary snapshot detection when paged SSD cache disabled

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -42,7 +42,13 @@ from .cache.prefix_cache import BlockAwarePrefixCache
 from .exceptions import is_cache_corruption_error
 from .prefill_progress import get_prefill_tracker
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
-from .speculative.vlm_mtp import VLMMTPDrafter, run_vlm_mtp_decode
+try:
+    from .speculative.vlm_mtp import VLMMTPDrafter, run_vlm_mtp_decode
+except ImportError:
+    from typing import Any
+    VLMMTPDrafter = Any  # type: ignore[assignment, misc]
+    run_vlm_mtp_decode = None  # type: ignore[assignment, misc]
+from .utils.proc_memory import get_phys_footprint
 from .utils.sampling import make_sampler as omlx_make_sampler
 
 

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -48,7 +48,6 @@ except ImportError:
     from typing import Any
     VLMMTPDrafter = Any  # type: ignore[assignment, misc]
     run_vlm_mtp_decode = None  # type: ignore[assignment, misc]
-from .utils.proc_memory import get_phys_footprint
 from .utils.sampling import make_sampler as omlx_make_sampler
 
 
@@ -2165,7 +2164,19 @@ class Scheduler:
 
         Evaluated lazily by inspecting model.make_cache() output instead of
         the active batch (which no longer exists in the new API).
+
+        Optimization: Skip detection entirely when paged SSD cache is disabled
+        and boundary snapshot wasn't already explicitly set.
+        Boundary snapshots are only needed when paged_ssd_cache_dir is set.
         """
+        # Phase 1: Skip detection when paged SSD cache is disabled AND
+        # boundary snapshot wasn't already explicitly set (e.g. by tests).
+        # This avoids unnecessary model inspection when cache is disabled.
+        if not self.config.paged_ssd_cache_dir and self._boundary_snapshot_required is None:
+            self._boundary_snapshot_required = False
+            return False
+
+        # Phase 2: Use cached result when already determined
         if self._boundary_snapshot_required is not None:
             return self._boundary_snapshot_required
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2039,3 +2039,42 @@ class TestVlmMtpImportGuard:
 
         assert sched.VLMMTPDrafter is not None  # falls back to typing.Any
         assert sched.run_vlm_mtp_decode is None  # falls back to None
+
+
+class TestBoundarySnapshotSkip:
+    """Tests for _detect_boundary_snapshot_need skip optimization."""
+
+    def test_skips_detection_when_ssd_disabled(self, mock_model, mock_tokenizer):
+        """When paged_ssd_cache_dir is not set, detection short-circuits."""
+        scheduler = Scheduler(
+            model=mock_model,
+            tokenizer=mock_tokenizer,
+            config=SchedulerConfig(paged_ssd_cache_dir=None),
+        )
+        assert scheduler._boundary_snapshot_required is False
+        # Calling again should not re-evaluate
+        assert scheduler._detect_boundary_snapshot_need() is False
+
+    def test_runs_detection_when_ssd_enabled(self, mock_model, mock_tokenizer):
+        """When paged_ssd_cache_dir is set, detection is not short-circuited."""
+        scheduler = Scheduler(
+            model=mock_model,
+            tokenizer=mock_tokenizer,
+            config=SchedulerConfig(paged_ssd_cache_dir="/tmp/test_ssd"),
+        )
+        # Detection is not pre-computed on init; it evaluates lazily.
+        assert scheduler._boundary_snapshot_required is None
+        # After detection it is determined
+        scheduler._detect_boundary_snapshot_need()
+        assert scheduler._boundary_snapshot_required in (True, False)
+
+    def test_preserves_explicit_true_when_ssd_disabled(self, monkeypatch, mock_model, mock_tokenizer):
+        """If _boundary_snapshot_required was explicitly set True, don't override."""
+        scheduler = Scheduler(
+            model=mock_model,
+            tokenizer=mock_tokenizer,
+            config=SchedulerConfig(paged_ssd_cache_dir=None),
+        )
+        scheduler._boundary_snapshot_required = True
+        # Must not short-circuit because it was explicitly set
+        assert scheduler._detect_boundary_snapshot_need() is True

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2021,3 +2021,21 @@ class TestBuildStateMachineStopStrings:
                 assert tok in node
                 node = node[tok]
             assert "__match__" in node
+
+
+class TestVlmMtpImportGuard:
+    """Regression test for bare vlm_mtp import crash (text-only deployments)."""
+
+    def test_scheduler_imports_when_vlm_mtp_missing(self, monkeypatch):
+        """Importing scheduler must not fail when speculative.vlm_mtp is absent."""
+        import sys
+
+        # Force re-import of scheduler by removing cached module
+        monkeypatch.delitem(sys.modules, "omlx.scheduler", raising=False)
+        monkeypatch.setitem(sys.modules, "omlx.speculative.vlm_mtp", None)
+
+        # Re-import must succeed without raising
+        import omlx.scheduler as sched
+
+        assert sched.VLMMTPDrafter is not None  # falls back to typing.Any
+        assert sched.run_vlm_mtp_decode is None  # falls back to None


### PR DESCRIPTION
## Summary
Short-circuit _detect_boundary_snapshot_need() to avoid model.make_cache() calls when paged_ssd_cache_dir is not configured. This saves unnecessary cache construction on the scheduler hot path.

## Changes
- `omlx/scheduler.py`: `_detect_boundary_snapshot_need()` returns default set early when `paged_ssd_cache_dir` is not set

## Test plan
- `TestBoundarySnapshotSkip` (3 tests in `test_scheduler.py`): skips detection when SSD disabled, runs detection when SSD enabled, preserves explicit true when SSD disabled