### PR TITLE
feat(launch): add clnkr integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Requires macOS 15.0+ (Sequoia), Python 3.10+, and Apple Silicon (M1/M2/M3/M4).
 
 ### macOS App
 
-Launch oMLX from your Applications folder. The Welcome screen guides you through three steps - model directory, server start, and first model download. That's it. To connect OpenClaw, OpenCode, Codex, Hermes Agent, or Copilot, see [Integrations](#integrations).
+Launch oMLX from your Applications folder. The Welcome screen guides you through three steps - model directory, server start, and first model download. That's it. To connect OpenClaw, OpenCode, Codex, Hermes Agent, Copilot, clnkr, or Pi, see [Integrations](#integrations).
 
 <p align="center">
   <img src="docs/images/Screenshot 2026-02-10 at 00.36.32.png" alt="oMLX Welcome Screen" width="360">
@@ -194,7 +194,7 @@ Search and download MLX models from HuggingFace directly in the admin dashboard.
 
 ### Integrations
 
-Set up OpenClaw, OpenCode, Codex, Hermes Agent, Copilot, and Pi directly from the admin dashboard with a single click. No manual config editing required.
+Set up OpenClaw, OpenCode, Codex, Hermes Agent, Copilot, clnkr, and Pi directly from the admin dashboard with a single click. No manual config editing required.
 
 <p align="center">
   <img src="docs/images/omlx_integrations.png" alt="oMLX Integrations" width="720">

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -263,6 +263,7 @@ class GlobalSettingsRequest(BaseModel):
     integrations_openclaw_model: str | None = None
     integrations_hermes_model: str | None = None
     integrations_pi_model: str | None = None
+    integrations_clnkr_model: str | None = None
     integrations_openclaw_tools_profile: Literal["minimal", "coding", "messaging", "full"] | None = None
 
     # UI settings
@@ -2760,6 +2761,7 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
             "hermes_model": global_settings.integrations.hermes_model,
             "pi_model": global_settings.integrations.pi_model,
             "copilot_model": global_settings.integrations.copilot_model,
+            "clnkr_model": global_settings.integrations.clnkr_model,
             "openclaw_tools_profile": global_settings.integrations.openclaw_tools_profile,
         },
         "system": {
@@ -3166,6 +3168,9 @@ async def update_global_settings(
     if "integrations_pi_model" in request.model_fields_set:
         global_settings.integrations.pi_model = request.integrations_pi_model
         integrations_changed = True
+    if "integrations_clnkr_model" in request.model_fields_set:
+        global_settings.integrations.clnkr_model = request.integrations_clnkr_model
+        integrations_changed = True
     if "integrations_openclaw_tools_profile" in request.model_fields_set:
         global_settings.integrations.openclaw_tools_profile = (
             request.integrations_openclaw_tools_profile
@@ -3181,7 +3186,8 @@ async def update_global_settings(
             f"opencode={global_settings.integrations.opencode_model}, "
             f"openclaw={global_settings.integrations.openclaw_model}, "
             f"hermes={global_settings.integrations.hermes_model}, "
-            f"pi={global_settings.integrations.pi_model}"
+            f"pi={global_settings.integrations.pi_model}, "
+            f"clnkr={global_settings.integrations.clnkr_model}"
         )
 
     # Apply UI settings

--- a/omlx/admin/static/img/integrations/clnkr.svg
+++ b/omlx/admin/static/img/integrations/clnkr.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="clnkr">
+  <rect width="64" height="64" rx="14" fill="#111827"/>
+  <path d="M18 34c0-9 6-16 15-16 5 0 9 2 12 5l-5 5c-2-2-4-3-7-3-5 0-8 4-8 9s3 9 8 9c3 0 5-1 7-3l5 5c-3 3-7 5-12 5-9 0-15-7-15-16Z" fill="#F9FAFB"/>
+  <path d="M44 17h7v30h-7z" fill="#38BDF8"/>
+</svg>

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -2091,6 +2091,10 @@
                 return this._launchCmd('copilot');
             },
 
+            get clnkrCommand() {
+                return this._launchCmd('clnkr');
+            },
+
             get opencodeCommand() {
                 return this._launchCmd('opencode');
             },
@@ -2120,6 +2124,7 @@
                             integrations_openclaw_model: this.globalSettings.integrations.openclaw_model,
                             integrations_hermes_model: this.globalSettings.integrations.hermes_model,
                             integrations_pi_model: this.globalSettings.integrations.pi_model,
+                            integrations_clnkr_model: this.globalSettings.integrations.clnkr_model,
                             integrations_openclaw_tools_profile: this.globalSettings.integrations.openclaw_tools_profile,
                         }),
                     });

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -684,6 +684,25 @@
                                 </button>
                             </div>
 
+                            <!-- clnkr -->
+                            <div class="flex items-center gap-4 px-6 py-4 group">
+                                <div class="w-9 h-9 rounded-lg overflow-hidden flex-shrink-0">
+                                    <img src="/admin/static/img/integrations/clnkr.svg" alt="clnkr" class="w-full h-full object-cover">
+                                </div>
+                                <div class="flex-1 min-w-0">
+                                    <div class="text-sm font-semibold text-neutral-800">clnkr</div>
+                                    <code class="text-xs text-neutral-500 font-mono" x-text="clnkrCommand"></code>
+                                </div>
+                                <button x-data="{ copied: false }"
+                                        @click="copyToClipboard(clnkrCommand); copied = true; setTimeout(() => copied = false, 2000)"
+                                        class="p-2 rounded-lg transition-all opacity-0 group-hover:opacity-100 flex-shrink-0"
+                                        :class="copied ? 'text-green-500 opacity-100' : 'text-neutral-400 hover:text-neutral-700 hover:bg-neutral-100'"
+                                        :title="window.t('status.integrations.copy_command_tooltip')">
+                                    <svg x-show="!copied" class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+                                    <svg x-show="copied" x-cloak class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+                                </button>
+                            </div>
+
                             <!-- OpenCode -->
                             <div class="flex items-center gap-4 px-6 py-4 group">
                                 <div class="w-9 h-9 rounded-lg overflow-hidden flex-shrink-0">

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -676,13 +676,13 @@ Example directory structure:
     launch_parser = subparsers.add_parser(
         "launch",
         help="Launch an external tool with oMLX integration",
-        description="Configure and launch external coding tools (Claude Code, Copilot, Codex, OpenCode, OpenClaw, Hermes Agent, Pi) "
+        description="Configure and launch external coding tools (Claude Code, Copilot, Codex, OpenCode, OpenClaw, Hermes Agent, Pi, clnkr) "
         "to use the running oMLX server.",
     )
     launch_parser.add_argument(
         "tool",
         type=str,
-        help="Tool to launch: claude, copilot, codex, opencode, openclaw, hermes, pi, or 'list' to show available",
+        help="Tool to launch: claude, copilot, codex, opencode, openclaw, hermes, pi, clnkr, or 'list' to show available",
     )
     launch_parser.add_argument(
         "--model",

--- a/omlx/integrations/__init__.py
+++ b/omlx/integrations/__init__.py
@@ -2,6 +2,7 @@
 
 from omlx.integrations.base import Integration
 from omlx.integrations.claude import ClaudeCodeIntegration
+from omlx.integrations.clnkr import ClnkrIntegration
 from omlx.integrations.codex import CodexIntegration
 from omlx.integrations.copilot import CopilotIntegration
 from omlx.integrations.hermes import HermesIntegration
@@ -11,6 +12,7 @@ from omlx.integrations.pi import PiIntegration
 
 INTEGRATIONS: dict[str, Integration] = {
     "claude": ClaudeCodeIntegration(),
+    "clnkr": ClnkrIntegration(),
     "codex": CodexIntegration(),
     "opencode": OpenCodeIntegration(),
     "openclaw": OpenClawIntegration(),
@@ -33,6 +35,7 @@ def list_integrations() -> list[Integration]:
 __all__ = [
     "Integration",
     "ClaudeCodeIntegration",
+    "ClnkrIntegration",
     "CopilotIntegration",
     "HermesIntegration",
     "INTEGRATIONS",

--- a/omlx/integrations/clnkr.py
+++ b/omlx/integrations/clnkr.py
@@ -1,0 +1,50 @@
+"""clnkr integration."""
+
+from __future__ import annotations
+
+import os
+
+from omlx.integrations.base import Integration
+from omlx.utils.install import get_cli_prefix
+
+
+class ClnkrIntegration(Integration):
+    """clnkr integration using OpenAI-compatible environment variables."""
+
+    def __init__(self):
+        super().__init__(
+            name="clnkr",
+            display_name="clnkr",
+            type="env_var",
+            install_check="clnkr",
+            install_hint="See https://clnkr.ai/",
+        )
+
+    def get_command(
+        self, port: int, api_key: str, model: str, host: str = "127.0.0.1"
+    ) -> str:
+        return f"{get_cli_prefix()} launch clnkr --model {model or 'select-a-model'}"
+
+    def launch(
+        self,
+        port: int,
+        api_key: str,
+        model: str,
+        host: str = "127.0.0.1",
+        extra_args: list[str] | None = None,
+        **kwargs,
+    ) -> None:
+        env = self._scrubbed_env()
+        env["CLNKR_API_KEY"] = api_key or "omlx"
+        env["CLNKR_BASE_URL"] = f"http://{host}:{port}/v1"
+        env["CLNKR_PROVIDER"] = "openai"
+        env["CLNKR_PROVIDER_API"] = "openai-chat-completions"
+
+        if model:
+            env["CLNKR_MODEL"] = model
+
+        args = ["clnkr"]
+        args.extend(extra_args or [])
+
+        print(f"Launching clnkr with model {model}...")
+        os.execvpe("clnkr", args, env)

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -651,7 +651,7 @@ class ClaudeCodeSettings:
 
 @dataclass
 class IntegrationSettings:
-    """Other integrations settings (Codex, OpenCode, OpenClaw, Hermes, Pi, Copilot)."""
+    """Other integrations settings (Codex, OpenCode, OpenClaw, Hermes, Pi, Copilot, clnkr)."""
 
     codex_model: str | None = None
     opencode_model: str | None = None
@@ -659,6 +659,7 @@ class IntegrationSettings:
     hermes_model: str | None = None
     pi_model: str | None = None
     copilot_model: str | None = None
+    clnkr_model: str | None = None
     openclaw_tools_profile: str = "coding"
 
     def to_dict(self) -> dict[str, Any]:
@@ -670,6 +671,7 @@ class IntegrationSettings:
             "hermes_model": self.hermes_model,
             "pi_model": self.pi_model,
             "copilot_model": self.copilot_model,
+            "clnkr_model": self.clnkr_model,
             "openclaw_tools_profile": self.openclaw_tools_profile,
         }
 
@@ -683,6 +685,7 @@ class IntegrationSettings:
             hermes_model=data.get("hermes_model"),
             pi_model=data.get("pi_model"),
             copilot_model=data.get("copilot_model"),
+            clnkr_model=data.get("clnkr_model"),
             openclaw_tools_profile=data.get("openclaw_tools_profile", "coding"),
         )
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -10,6 +10,7 @@ import yaml
 
 from omlx.integrations import get_integration, list_integrations
 from omlx.integrations.claude import ClaudeCodeIntegration
+from omlx.integrations.clnkr import ClnkrIntegration
 from omlx.integrations.codex import CodexIntegration
 from omlx.integrations.copilot import CopilotIntegration
 from omlx.integrations.hermes import HermesIntegration
@@ -21,10 +22,11 @@ from omlx.integrations.pi import PiIntegration, _get_agent_dir
 class TestIntegrationRegistry:
     def test_list_integrations(self):
         integrations = list_integrations()
-        assert len(integrations) == 7
+        assert len(integrations) == 8
         names = {i.name for i in integrations}
         assert names == {
             "claude",
+            "clnkr",
             "copilot",
             "codex",
             "opencode",
@@ -35,6 +37,7 @@ class TestIntegrationRegistry:
 
     def test_get_integration(self):
         assert get_integration("claude") is not None
+        assert get_integration("clnkr") is not None
         assert get_integration("copilot") is not None
         assert get_integration("codex") is not None
         assert get_integration("opencode") is not None
@@ -1181,6 +1184,96 @@ class TestCopilotIntegration:
         assert "COPILOT_PROVIDER_MAX_OUTPUT_TOKENS" not in env
 
 
+class TestClnkrIntegration:
+    def test_get_command(self):
+        clnkr = ClnkrIntegration()
+        cmd = clnkr.get_command(port=8000, api_key="key", model="qwen3.5")
+        assert "omlx launch clnkr" in cmd
+        assert "--model qwen3.5" in cmd
+
+    def test_get_command_no_model(self):
+        clnkr = ClnkrIntegration()
+        cmd = clnkr.get_command(port=8000, api_key="", model="")
+        assert "select-a-model" in cmd
+
+    def test_type(self):
+        clnkr = ClnkrIntegration()
+        assert clnkr.type == "env_var"
+        assert clnkr.display_name == "clnkr"
+        assert clnkr.install_check == "clnkr"
+
+    def test_launch_sets_clnkr_env(self):
+        clnkr = ClnkrIntegration()
+        captured = {}
+
+        def fake_execvpe(binary, argv, env):
+            captured["binary"] = binary
+            captured["argv"] = argv
+            captured["env"] = env
+
+        base_env = {
+            "PATH": "/usr/bin",
+            "PYTHONHOME": "/bundle/python",
+            "PYTHONPATH": "/bundle/lib",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+        with (
+            patch("omlx.integrations.clnkr.os.environ", base_env),
+            patch("omlx.integrations.clnkr.os.execvpe", side_effect=fake_execvpe),
+        ):
+            clnkr.launch(port=8000, api_key="secret", model="qwen3.5")
+
+        env = captured["env"]
+        assert captured["binary"] == "clnkr"
+        assert captured["argv"] == ["clnkr"]
+        assert env["CLNKR_API_KEY"] == "secret"
+        assert env["CLNKR_BASE_URL"] == "http://127.0.0.1:8000/v1"
+        assert env["CLNKR_MODEL"] == "qwen3.5"
+        assert env["CLNKR_PROVIDER"] == "openai"
+        assert env["CLNKR_PROVIDER_API"] == "openai-chat-completions"
+        assert "PYTHONHOME" not in env
+        assert "PYTHONPATH" not in env
+        assert "PYTHONDONTWRITEBYTECODE" not in env
+
+    def test_launch_open_server_uses_omlx_token(self):
+        clnkr = ClnkrIntegration()
+        captured = {}
+
+        def fake_execvpe(binary, argv, env):
+            captured["env"] = env
+
+        with (
+            patch("omlx.integrations.clnkr.os.environ", {"PATH": "/usr/bin"}),
+            patch("omlx.integrations.clnkr.os.execvpe", side_effect=fake_execvpe),
+        ):
+            clnkr.launch(port=8000, api_key="", model="qwen3.5")
+
+        assert captured["env"]["CLNKR_API_KEY"] == "omlx"
+
+    def test_launch_custom_host_and_extra_args(self):
+        clnkr = ClnkrIntegration()
+        captured = {}
+
+        def fake_execvpe(binary, argv, env):
+            captured["argv"] = argv
+            captured["env"] = env
+
+        with (
+            patch("omlx.integrations.clnkr.os.environ", {"PATH": "/usr/bin"}),
+            patch("omlx.integrations.clnkr.os.execvpe", side_effect=fake_execvpe),
+        ):
+            clnkr.launch(
+                port=9000,
+                api_key="key",
+                model="qwen3.5",
+                host="192.168.1.100",
+                extra_args=["--full-send", "--max-steps", "3"],
+            )
+
+        assert captured["argv"] == ["clnkr", "--full-send", "--max-steps", "3"]
+        assert captured["env"]["CLNKR_BASE_URL"] == "http://192.168.1.100:9000/v1"
+
+
 class TestIntegrationSettings:
     def test_settings_dataclass(self):
         from omlx.settings import IntegrationSettings
@@ -1192,6 +1285,7 @@ class TestIntegrationSettings:
         assert settings.openclaw_model is None
         assert settings.hermes_model is None
         assert settings.pi_model is None
+        assert settings.clnkr_model is None
         assert settings.openclaw_tools_profile == "coding"
 
     def test_to_dict(self):
@@ -1204,6 +1298,7 @@ class TestIntegrationSettings:
         assert d["opencode_model"] is None
         assert d["hermes_model"] is None
         assert d["pi_model"] is None
+        assert d["clnkr_model"] is None
         assert d["openclaw_tools_profile"] == "coding"
 
     def test_from_dict(self):
@@ -1215,6 +1310,7 @@ class TestIntegrationSettings:
                 "codex_model": "llama",
                 "opencode_model": "qwen",
                 "hermes_model": "hermes-qwen",
+                "clnkr_model": "clnkr-qwen",
             }
         )
         assert settings.copilot_model == "gpt-oss"
@@ -1223,9 +1319,11 @@ class TestIntegrationSettings:
         assert settings.openclaw_model is None
         assert settings.hermes_model == "hermes-qwen"
         assert settings.pi_model is None
+        assert settings.clnkr_model == "clnkr-qwen"
 
     def test_from_dict_empty(self):
         from omlx.settings import IntegrationSettings
 
         settings = IntegrationSettings.from_dict({})
         assert settings.codex_model is None
+        assert settings.clnkr_model is None


### PR DESCRIPTION
## Summary

Adds `clnkr` as an `omlx launch` target.

clnkr is a command-line coding agent with OpenAI-compatible endpoint support. It has a published Terminal-Bench 2.0 result: 66.2% +/- 2.5 with GPT-5.5 on clnkr 0.3.11. Debian already carries it in testing.

References:
- Terminal-Bench 2.0 clnkr result: https://www.tbench.ai/leaderboard/terminal-bench/2.0/clnkr/0.3.11/gpt-5.5%40openai
- Debian manpage: https://manpages.debian.org/testing/clnkr/clnkr.1.en.html
- Debian package bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1135616

`omlx launch clnkr --model <model>` now points clnkr at the local oMLX OpenAI-compatible server, sets the CLNKR provider environment, and execs `clnkr`.

## Changes

- Registers `clnkr` in `omlx launch list`
- Sets `CLNKR_API_KEY`, `CLNKR_BASE_URL`, `CLNKR_MODEL`, `CLNKR_PROVIDER`, and `CLNKR_PROVIDER_API`
- Uses the chat completions path, which is the oMLX-compatible path verified locally
- Forwards extra launch args through to `clnkr`
- Adds `clnkr_model` to settings and admin settings plumbing
- Adds a dashboard row, icon, and README mention

## Test plan

- `uv run --extra dev pytest tests/test_integrations.py -q`
- `uv run --extra dev pytest tests/test_cli.py tests/test_integrations.py tests/test_settings.py -q`
- `uv run --extra dev python -m omlx.cli launch list`