### PR TITLE
feat(responses): wire reasoning field to thinking control

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3870,6 +3870,12 @@ async def create_response(
         if ms.preserve_thinking is not None:
             merged_ct_kwargs["preserve_thinking"] = ms.preserve_thinking
 
+    # Wire request.reasoning → enable_thinking.
+    # reasoning.effort == "none" → disable; any other reasoning dict → enable.
+    if "enable_thinking" not in forced_keys and request.reasoning is not None:
+        disable = request.reasoning.get("effort") == "none"
+        merged_ct_kwargs["enable_thinking"] = not disable
+
     # Note: extract_text_content/extract_harmony_messages/extract_multimodal_content
     # are NOT called here because convert_responses_input_to_messages() already
     # returns plain dicts in {"role": str, "content": str} format.

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1095,3 +1095,31 @@ class TestResponsesRequest:
         assert len(req.tools) == 2
         assert req.tools[0].type == "local_shell"
         assert req.tools[1].name == "read_file"
+
+
+class TestResponsesRequestReasoning:
+    """reasoning field parsing on ResponsesRequest."""
+
+    def test_reasoning_none_by_default(self):
+        req = ResponsesRequest(model="test")
+        assert req.reasoning is None
+
+    def test_reasoning_effort_high(self):
+        req = ResponsesRequest(model="test", reasoning={"effort": "high"})
+        assert req.reasoning == {"effort": "high"}
+
+    def test_reasoning_summary_only(self):
+        req = ResponsesRequest(model="test", reasoning={"summary": "auto"})
+        assert req.reasoning == {"summary": "auto"}
+
+    def test_reasoning_empty_dict_is_not_none(self):
+        req = ResponsesRequest(model="test", reasoning={})
+        assert req.reasoning is not None
+
+    def test_reasoning_explicit_none(self):
+        req = ResponsesRequest(model="test", reasoning=None)
+        assert req.reasoning is None
+
+    def test_reasoning_effort_none_disables(self):
+        req = ResponsesRequest(model="test", reasoning={"effort": "none"})
+        assert req.reasoning.get("effort") == "none"


### PR DESCRIPTION
## Summary

- The Responses API (`/v1/responses`) accepts a `reasoning` dict on the request but previously ignored it entirely. This wires `reasoning.effort` to `enable_thinking` in the chat template kwargs.
- `{"effort": "high"}` (or any non-`"none"` value) enables thinking; `{"effort": "none"}` disables it; omitting the field leaves model settings / template defaults unchanged.
- Respects admin `forced_ct_kwargs` lock — if `enable_thinking` is forced in model settings, the per-request field is silently ignored.

## Test plan

- [x] Added `TestResponsesRequestReasoning` tests covering field parsing (None default, effort values, empty dict, explicit None)
- [x] All 88 tests in `tests/test_responses.py` pass
- [x] Manual: send Responses API request with `reasoning: {"effort": "none"}` to a thinking-capable model → verify no `<think>` output
- [x] Manual: send with `reasoning: {"effort": "high"}` → verify reasoning output is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)