### PR TITLE
fix(oq): copy processor_config.json to preserve VLM capability

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -2628,6 +2628,7 @@ def quantize_oq_streaming(
         "chat_template.json",
         "chat_template.jinja",
         "preprocessor_config.json",
+        "processor_config.json",
         "added_tokens.json",
         "merges.txt",
         "vocab.json",


### PR DESCRIPTION
## Summary
- oQ quantization was not copying `processor_config.json` (the mlx-vlm image/video processor config) to the output directory
- Without it, `VLMBatchedEngine.start()` fails and the engine pool silently falls back to a plain LLM — the quantized model loses vision capability and shows as type `llm` in the dashboard
- Adds `processor_config.json` to the file copy list alongside the existing `preprocessor_config.json`

## Test plan
- [ ] oQ-quantize a VLM (e.g. Qwen3.6-35B-A3B) and verify `processor_config.json` is present in the output directory
- [ ] Load the quantized model and confirm it detects as `vlm` (not `llm`) in the admin dashboard
- [ ] Verify vision/image inputs work end-to-end on the quantized model

🤖 Generated with [Claude Code](https://claude.com/claude-code)