### PR TITLE
fix: guard late aborts after engine close

### DIFF
--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -372,7 +372,15 @@ class EngineCore:
         finally block, NOT here -- calling _cleanup_request() immediately
         after put() would clear the output before the consumer can drain it.
         """
-        result = self.scheduler.abort_request(request_id)
+        scheduler = getattr(self, "scheduler", None)
+        if getattr(self, "_closed", False) or scheduler is None:
+            logger.debug(
+                "Skipping abort for request %s because engine is already closed",
+                request_id,
+            )
+            return False
+
+        result = scheduler.abort_request(request_id)
 
         # Signal consumer with abort error so any waiting
         # stream_outputs() / generate() can exit gracefully.
@@ -744,7 +752,7 @@ class AsyncEngineCore:
         return self
 
     async def __aexit__(self, *args) -> None:
-        await self.engine.stop()
+        await self.stop()
 
     def start(self) -> None:
         """Start engine (creates task in current loop)."""
@@ -752,7 +760,10 @@ class AsyncEngineCore:
 
     async def stop(self) -> None:
         """Stop the engine."""
-        await self.engine.stop()
+        engine = getattr(self, "engine", None)
+        if engine is None:
+            return
+        await engine.stop()
 
     async def add_request(
         self,
@@ -771,11 +782,21 @@ class AsyncEngineCore:
 
     async def abort_request(self, request_id: str) -> bool:
         """Abort a request."""
-        return await self.engine.abort_request(request_id)
+        engine = getattr(self, "engine", None)
+        if engine is None:
+            logger.debug(
+                "Skipping abort for request %s because async engine is closed",
+                request_id,
+            )
+            return False
+        return await engine.abort_request(request_id)
 
     async def abort_all_requests(self) -> int:
         """Abort all active requests without stopping the engine."""
-        return await self.engine.abort_all_requests()
+        engine = getattr(self, "engine", None)
+        if engine is None:
+            return 0
+        return await engine.abort_all_requests()
 
     async def stream_outputs(
         self,

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -292,6 +292,19 @@ class TestEngineCoreAbortRequest:
     """Tests for EngineCore.abort_request()."""
 
     @pytest.mark.asyncio
+    async def test_abort_request_after_close_returns_false(self):
+        """Late aborts after close should not touch a cleared scheduler."""
+        engine = EngineCore.__new__(EngineCore)
+        engine._closed = True
+        engine.scheduler = None
+        engine._output_collectors = {}
+        engine._finished_events = {}
+
+        result = await engine.abort_request("request-after-close")
+
+        assert result is False
+
+    @pytest.mark.asyncio
     async def test_abort_request(self, mock_model, mock_tokenizer):
         """Test abort_request() returns True for existing request."""
         with patch("omlx.engine_core.get_registry") as mock_registry:
@@ -800,6 +813,40 @@ class TestAsyncEngineCore:
                 result = await engine.abort_request(request_id)
 
                 assert result is True
+
+    @pytest.mark.asyncio
+    async def test_abort_request_after_close_returns_false(self):
+        """Late stream cleanup should no-op if unload already closed the core.
+
+        Streaming generators keep an AsyncEngineCore reference. A concurrent
+        unload can close that wrapper before the generator's finally block
+        calls abort_request(), clearing ``engine`` to None. The wrapper must
+        not raise AttributeError in that late-cleanup path.
+        """
+        async_engine = AsyncEngineCore.__new__(AsyncEngineCore)
+        setattr(async_engine, "engine", None)
+
+        result = await async_engine.abort_request("request-after-close")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_context_manager_exit_after_close_does_not_raise(self):
+        """Context-manager cleanup should tolerate an already-closed wrapper."""
+        async_engine = AsyncEngineCore.__new__(AsyncEngineCore)
+        setattr(async_engine, "engine", None)
+
+        await async_engine.__aexit__(None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_abort_all_requests_after_close_returns_zero(self):
+        """Bulk abort should no-op if the async wrapper is already closed."""
+        async_engine = AsyncEngineCore.__new__(AsyncEngineCore)
+        setattr(async_engine, "engine", None)
+
+        count = await async_engine.abort_all_requests()
+
+        assert count == 0
 
     @pytest.mark.asyncio
     async def test_get_stats(self, mock_model, mock_tokenizer):


### PR DESCRIPTION
## Summary
- Guard late `EngineCore.abort_request()` calls after `EngineCore.close()` has cleared scheduler state.
- Guard `AsyncEngineCore` stop/abort/bulk-abort paths when the async wrapper is already closed.
- Add regression tests for late abort, context-manager exit, and bulk abort after close.

## Why
A streaming response can race with model unload: the stream generator reaches its cleanup `finally` after unload has already stopped/closed the engine. In that path a late abort should be a no-op, not an `AttributeError` that surfaces as a server streaming error.

## Test plan
- [x] RED: new close-race tests failed before the fix with `AttributeError`.
- [x] Focused regression tests: `3 passed` for the new close-race cases.
- [x] Related engine tests: `194 passed` for `test_engine_core.py`, `test_batched_engine.py`, `test_vlm_engine.py`, `test_engine_pool.py`.
- [x] Full default pytest: `4589 passed, 36 skipped, 59 deselected`.
- [x] `git diff --check` clean.
- [x] Live patched-source port 8000 smoke: strong stream + forced unload saw a real `gemma-4-e4b-it-4bit` content chunk, unload returned HTTP 200, abort signature delta stayed `0`, final `loaded_count=0`.

## Live verification artifact
Local run artifact: `/Users/dracoglasser/.hermes/runs/omlx-stream-unload-fix-20260524/stream-forced-unload-strong-final.json`
