### PR TITLE
fix: replace Guard 1 heuristic with name-matching for thinking tool calls

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -621,19 +621,30 @@ def extract_tool_calls_with_thinking(
         _, tool_calls = parse_tool_calls(thinking_content, tokenizer, tools)
         tool_calls_from_thinking = bool(tool_calls)
 
-        # Guard 1: if model produced regular text, the tool call in thinking
-        # is just reasoning, not an actual invocation request.
-        if tool_calls and regular_content.strip():
-            tool_calls = None
-            tool_calls_from_thinking = False
-
-        # Guard 2: only keep tool calls whose name matches a provided tool.
-        if tool_calls and tools:
-            valid_names = _extract_tool_names(tools)
-            tool_calls = [tc for tc in tool_calls if tc.function.name in valid_names]
-            if not tool_calls:
-                tool_calls = None
-                tool_calls_from_thinking = False
+        # Guard: validate thinking-embedded tool calls.
+        #
+        # Three cases:
+        # 1. No tools list AND regular text exists → drop.  The call is
+        #    unvalidated and could be hallucinated reasoning about tools.
+        # 2. No tools list AND no regular text → keep.  The model clearly
+        #    intended a tool invocation (no competing prose).
+        # 3. Tools list provided → name matching is the sole discriminator.
+        #    If the call name matches a known tool, promote it regardless of
+        #    whether regular text was also produced.  The previous "regular
+        #    text means just reasoning" heuristic was wrong for models
+        #    (Qwen3-Coder) that genuinely place tool calls in thinking.
+        # See https://github.com/jundot/omlx/issues/1392
+        if tool_calls:
+            if not tools:
+                if regular_content.strip():
+                    tool_calls = None
+                    tool_calls_from_thinking = False
+            else:
+                valid_names = _extract_tool_names(tools)
+                tool_calls = [tc for tc in tool_calls if tc.function.name in valid_names]
+                if not tool_calls:
+                    tool_calls = None
+                    tool_calls_from_thinking = False
 
     return ToolCallExtraction(
         cleaned_text=cleaned_text,

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -1482,6 +1482,65 @@ class TestParseToolCallsWithThinkingFallback:
 
 
 # ---------------------------------------------------------------------------
+# Guard 1 regression: valid tool calls dropped with preamble (#1392)
+
+class TestThinkingFallbackGuardRegression:
+    """Guard 1 drops valid tool calls when the model emits a preamble.
+
+    Qwen3-Coder places real tool invocations inside thinking and adds a
+    short narrative preamble as regular content.  Guard 1 assumed regular
+    text means the thinking tool call is "just reasoning", but for these
+    models it's a genuine invocation.  Guard 2 (name matching) is the
+    correct discriminator.
+
+    See https://github.com/jundot/omlx/issues/1392
+    """
+
+    def _make_tokenizer(self):
+        tok = MagicMock(spec=[])
+        return tok
+
+    def test_known_tool_in_thinking_kept_with_preamble(self):
+        """A tool call matching a provided tool should survive even when
+        regular content is non-empty (short preamble).
+
+        Qwen3-Coder with thinking enabled places real tool calls inside
+        thinking and emits a preamble like "Let me create the file:" as
+        regular content. Guard 1 drops these; Guard 2 (name matching)
+        should preserve them.
+        """
+        thinking = (
+            'I need to write a file. '
+            '<tool_call>{"name": "write_file", "arguments": {"path": "/tmp/test.txt", "content": "hello"}}</tool_call>'
+        )
+        regular = "Let me create the file:"
+        tok = self._make_tokenizer()
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "write_file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "content": {"type": "string"},
+                    },
+                    "required": ["path", "content"],
+                },
+            },
+        }]
+
+        result = extract_tool_calls_with_thinking(
+            thinking, regular, tokenizer=tok, tools=tools,
+        )
+
+        assert result.tool_calls is not None
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "write_file"
+        assert result.tool_calls_from_thinking is True
+
+
+# ---------------------------------------------------------------------------
 # Gemma 4 robust fallback parser tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1392

## What changed

Replaced the blanket "regular text means just reasoning" guard in `extract_tool_calls_with_thinking()` with three-case logic:

| Case | Tools list | Regular text | Result |
|------|-----------|-------------|--------|
| 1 | No | Yes | Drop — unvalidated, could be reasoning |
| 2 | No | No | Keep — clear tool invocation |
| 3 | Yes | Any | Name matching decides |

Case 3 is the fix for #1392. Qwen3-Coder (and similar models) place real tool invocations inside thinking blocks and emit a short preamble as regular content. The old Guard 1 dropped these because it saw non-empty regular text. Now, when a tools list is provided, only name matching determines validity — if the call matches a known tool, it's promoted regardless of accompanying prose.

## Why not just swap guard order?

The old Guard 1 (regular text check) ran before Guard 2 (name matching). Swapping them doesn't help because Guard 1 would still kill valid calls after name matching passed. The regular-text heuristic is fundamentally the wrong discriminator when tools are provided — name matching already tells you whether the call is real.

## Test

New test: `TestThinkingFallbackGuardRegression::test_known_tool_in_thinking_kept_with_preamble` — verifies that a tool call matching a provided tool name survives even when regular content (a preamble) is present.

All 154 tests in `test_tool_calling.py` pass, including the existing guard tests which still validate the no-tools-list + regular-text case.

## Related

- #484 — introduced the original guards
- #812 — same symptom on Qwen3.6-35B
- #906 — feature request for `--tool-call-parser none` (workaround)