### PR TITLE
feat(cache): add ssd_write_drops counter for write-queue saturation

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -652,6 +652,7 @@ class PagedSSDCacheManager(CacheManager):
             "preload_calls": 0,
             "preload_blocks_loaded": 0,
             "preload_time_ms": 0.0,
+            "ssd_write_drops": 0,
         }
 
         # --- Hot cache (in-memory raw-bytes tier) ---
@@ -804,6 +805,7 @@ class PagedSSDCacheManager(CacheManager):
             )
             return True
         except queue.Full:
+            self._stats["ssd_write_drops"] += 1
             logger.warning(
                 f"SSD write queue full, dropping evicted block "
                 f"{block_hash.hex()[:16]}"
@@ -1140,6 +1142,7 @@ class PagedSSDCacheManager(CacheManager):
         # Check queue capacity before doing expensive GPU/disk work
         # (not needed for hot cache write-back mode)
         if not self._hot_cache_enabled and self._write_queue.full():
+            self._stats["ssd_write_drops"] += 1
             logger.warning(
                 f"SSD cache write queue full, skipping save for "
                 f"{block_hash.hex()[:16]}"
@@ -1377,6 +1380,7 @@ class PagedSSDCacheManager(CacheManager):
                     (block_hash, tensors_raw, metadata, file_path)
                 )
             except queue.Full:
+                self._stats["ssd_write_drops"] += 1
                 logger.warning(
                     f"SSD cache write queue full, dropping write for "
                     f"{block_hash.hex()[:16]}"
@@ -2282,6 +2286,7 @@ class PagedSSDCacheManager(CacheManager):
                 hot_cache_hits=self._stats["hot_cache_hits"],
                 hot_cache_evictions=self._stats["hot_cache_evictions"],
                 hot_cache_promotions=self._stats["hot_cache_promotions"],
+                ssd_write_drops=self._stats["ssd_write_drops"],
             )
 
     def get_stats_for_model(self, model_name: str) -> PagedSSDCacheStats:
@@ -2340,6 +2345,7 @@ class PagedSSDCacheManager(CacheManager):
                 hot_cache_hits=self._stats["hot_cache_hits"],
                 hot_cache_evictions=self._stats["hot_cache_evictions"],
                 hot_cache_promotions=self._stats["hot_cache_promotions"],
+                ssd_write_drops=self._stats["ssd_write_drops"],
             )
 
     def get_stats_dict(self) -> dict[str, Any]:

--- a/omlx/cache/stats.py
+++ b/omlx/cache/stats.py
@@ -187,9 +187,13 @@ class PagedSSDCacheStats(BaseCacheStats):
     Extends base stats with storage-specific and hot cache metrics.
     """
 
+    # Operation counters
     saves: int = 0
     loads: int = 0
     errors: int = 0
+    ssd_write_drops: int = 0
+
+    # Storage capacity
     total_size_bytes: int = 0
     max_size_bytes: int = 0
     configured_max_size_bytes: int = 0
@@ -230,6 +234,7 @@ class PagedSSDCacheStats(BaseCacheStats):
         self.saves = 0
         self.loads = 0
         self.errors = 0
+        self.ssd_write_drops = 0
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert stats to dictionary."""

--- a/tests/test_hot_cache.py
+++ b/tests/test_hot_cache.py
@@ -1045,3 +1045,200 @@ class TestPendingWriteBuffer:
             assert len(loaded_ssd) == 2
         finally:
             mgr.close()
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestSSDWriteDrops:
+    """ssd_write_drops counter increments at queue-saturation drop sites."""
+
+    # Mirrors TestPendingWriteBuffer._make_cache_data — small dimensions
+    # so the per-entry footprint is small and predictable for queue tests.
+    def _make_cache_data(self, num_layers=2, seq_len=16, heads=2, head_dim=16):
+        return [
+            (
+                mx.zeros((1, heads, seq_len, head_dim)),
+                mx.zeros((1, heads, seq_len, head_dim)),
+            )
+            for _ in range(num_layers)
+        ]
+
+    # Mirrors TestPendingWriteBuffer._save_block — uses 2 layers, token_count=16
+    # so the entry_size formula `2 * 2 * 1 * 2 * 16 * 16 * 4` calibrates Test A.
+    def _save_block(self, manager, block_hash, model="test-model"):
+        cache_data = self._make_cache_data()
+        return manager.save_block(
+            block_hash=block_hash,
+            cache_data=cache_data,
+            token_count=16,
+            model_name=model,
+            layer_cache_types=["KVCache"] * 2,
+        )
+
+    def test_paged_ssd_cache_stats_default_and_reset(self):
+        """Dataclass: ssd_write_drops defaults to 0 and is zeroed by reset()."""
+        from omlx.cache.stats import PagedSSDCacheStats
+
+        # Default is zero.
+        stats = PagedSSDCacheStats()
+        assert stats.ssd_write_drops == 0
+
+        # reset() returns it to zero from a non-zero state.
+        stats = PagedSSDCacheStats(ssd_write_drops=5, saves=2, loads=3)
+        stats.reset()
+        assert stats.ssd_write_drops == 0
+        # Verify reset() didn't break the existing fields it already handled.
+        assert stats.saves == 0
+        assert stats.loads == 0
+
+    def test_ssd_write_drops_field_round_trips_through_get_stats(self, tmp_path):
+        """The _stats dict value flows through get_stats() AND get_stats_for_model().
+
+        Force a non-zero value into _stats so a missing pass-through in either
+        accessor would leave the dataclass at the default 0 and fail this test.
+        The default-0 case is covered by the dataclass-level test in Task 1;
+        this test exercises the wiring specifically.
+        """
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "wiring_test",
+            max_size_bytes=100 * 1024**2,
+        )
+        try:
+            # Directly poke a non-zero value to test the accessor pass-through
+            # specifically. The real increment sites have their own tests
+            # further down in this class; this test would catch a regression
+            # where a future refactor drops the field from get_stats() or
+            # get_stats_for_model() but leaves the _stats dict key alone.
+            mgr._stats["ssd_write_drops"] = 7
+
+            # Global stats accessor.
+            stats = mgr.get_stats()
+            assert stats.ssd_write_drops == 7, (
+                "get_stats() must pass _stats['ssd_write_drops'] through "
+                "to the dataclass field"
+            )
+
+            # Per-model stats accessor — same wiring, separate code path.
+            # Use any model name; the field is global on the manager.
+            model_stats = mgr.get_stats_for_model("any-model-name")
+            assert model_stats.ssd_write_drops == 7, (
+                "get_stats_for_model() must pass _stats['ssd_write_drops'] "
+                "through to the dataclass field"
+            )
+        finally:
+            mgr.close()
+
+    def test_ssd_write_drops_increments_on_hot_eviction_queue_full(self, tmp_path):
+        """Site 1: hot-cache eviction → put_nowait raises queue.Full → drop += 1.
+
+        Patches the real queue's put_nowait to always raise queue.Full,
+        guaranteeing the drop path fires on the first eviction without any
+        dependency on the writer thread's drain rate.
+        """
+        import queue as _queue
+        from unittest.mock import patch
+
+        # entry_size matches the small-dimension helpers above (num_layers=2,
+        # K+V=2 tensors, batch=1, heads=2, seq=16, head_dim=16, float32=4).
+        entry_size = 2 * 2 * 1 * 2 * 16 * 16 * 4
+        max_bytes = entry_size * 2 + 100  # holds exactly 2 entries
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "drops_hot_eviction_test",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=max_bytes,
+        )
+        try:
+            with patch.object(
+                mgr._write_queue, "put_nowait", side_effect=_queue.Full
+            ):
+                self._save_block(mgr, b"qf_drop_block_00")
+                self._save_block(mgr, b"qf_drop_block_01")
+                # save_02 evicts block 00 → _enqueue_ssd_write → put_nowait
+                # raises queue.Full → drop fires, cleanup runs.
+                self._save_block(mgr, b"qf_drop_block_02")
+
+            stats = mgr.get_stats()
+            assert stats.ssd_write_drops == 1
+            assert stats.errors == 0  # drops are distinct from errors
+
+            # Block 00 was the one being enqueued when put_nowait raised.
+            # Cleanup must have removed it from both pending structures.
+            with mgr._pending_write_hashes_lock:
+                assert b"qf_drop_block_00" not in mgr._pending_write_buffers
+                assert b"qf_drop_block_00" not in mgr._pending_write_hashes
+        finally:
+            mgr.close()
+
+    def test_ssd_write_drops_increments_on_cold_store_preflight(self, tmp_path):
+        """Site 2: save_block preflight _write_queue.full() guard.
+
+        Hot cache disabled. Patches the queue's `full()` method to return
+        True so the preflight short-circuits on the first save. No real
+        queue manipulation, no writer-thread race, no risk of crashing the
+        writer with a malformed sentinel.
+        """
+        from unittest.mock import patch
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "drops_cold_preflight_test",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=0,  # hot cache disabled → cold-store path
+        )
+        try:
+            with patch.object(mgr._write_queue, "full", return_value=True):
+                cache_data = self._make_cache_data()
+                ok = mgr.save_block(
+                    block_hash=b"cold_preflight_drop_00",
+                    cache_data=cache_data,
+                    token_count=16,
+                    model_name="test-model",
+                    layer_cache_types=["KVCache"] * 2,
+                )
+                assert ok is False
+
+            stats = mgr.get_stats()
+            assert stats.ssd_write_drops == 1
+            assert stats.errors == 0
+            # Site 2 is a preflight rejection — no index/buffer state was
+            # created, so nothing to assert on cleanup.
+        finally:
+            mgr.close()
+
+    def test_ssd_write_drops_increments_on_cold_store_late_exception(self, tmp_path):
+        """Site 3: save_block put_nowait raises queue.Full after preflight passes.
+
+        Hot cache disabled. put_nowait is patched to raise queue.Full even
+        though _write_queue.full() reports False — forces the late-exception
+        path inside save_block. Cleanup must remove index + pending hashes.
+        """
+        import queue as _queue
+        from unittest.mock import patch
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "drops_cold_late_exception_test",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=0,
+        )
+        try:
+            cache_data = self._make_cache_data()
+            block_hash = b"cold_late_drop_00"
+            with patch.object(
+                mgr._write_queue, "put_nowait", side_effect=_queue.Full
+            ):
+                ok = mgr.save_block(
+                    block_hash=block_hash,
+                    cache_data=cache_data,
+                    token_count=16,
+                    model_name="test-model",
+                    layer_cache_types=["KVCache"] * 2,
+                )
+                assert ok is False
+
+            stats = mgr.get_stats()
+            assert stats.ssd_write_drops == 1
+            # Site 3 cleanup: removed from index and pending hashes.
+            assert not mgr._index.contains(block_hash)
+            with mgr._pending_write_hashes_lock:
+                assert block_hash not in mgr._pending_write_hashes
+        finally:
+            mgr.close()


### PR DESCRIPTION
## Summary

Adds a runtime counter `ssd_write_drops` to `PagedSSDCacheManager` that increments at every site where the background writer queue is saturated and a cache write is dropped or skipped. The new metric pairs with the existing read-path counters (`hits`, `loads`, `hot_cache_hits`, etc.) in `PagedSSDCacheStats`, giving operators a first write-path health signal. WARN logs at these sites already exist; this PR makes the drops aggregable so they can be graphed, alerted on, or surfaced through the runtime cache observability surface added in #1183.

Purely additive: no change to drop behaviour, no change to any cache code path, no new dependency.

## Changes

- `omlx/cache/stats.py`: new `ssd_write_drops: int = 0` field on `PagedSSDCacheStats`, grouped with the other operation counters (`saves`, `loads`, `errors`); added to `reset()` for parity with the other runtime counters.
- `omlx/cache/paged_ssd_cache.py`: `"ssd_write_drops": 0` initialised in `_stats`; incremented at all three queue-saturation drop sites in this module — the hot-cache eviction path in `_enqueue_ssd_write`, the cold-store preflight `_write_queue.full()` guard, and the cold-store late `except queue.Full` fallback. Passed through in `get_stats()` and `get_stats_for_model()`. `get_stats_dict()` already spreads `**self._stats`, so no manual update needed there.
- `tests/test_hot_cache.py`: new `TestSSDWriteDrops` class with five tests — dataclass default + `reset()`, wiring round-trip through both stats accessors, and one test per drop site. The drop-site tests use `unittest.mock.patch.object` on the queue methods for deterministic firing rather than depending on writer-thread timing.

The bulk-eviction unlink path is intentionally excluded — that fallback runs an inline `unlink()` when the unlink queue saturates, but the file already exists on disk so no cache write is dropped. Counting it would conflate cleanup-queue backpressure with actual write loss.

## Test plan

- [x] `uv run pytest tests/ -x` — full suite passes
- [x] `uv run pytest tests/test_hot_cache.py::TestSSDWriteDrops -v` — 5/5 pass
- [ ] Optional manual verification: load a small model (e.g. `Qwen3-0.6B-4bit` or `Qwen3-Coder-Next-6bit` per the project's cache micro-benchmarking convention), reduce `_MAX_PENDING_WRITES` to force queue saturation under a write-heavy workload, confirm `ssd_write_drops` appears and increments in `/admin/api/stats`.