### PR TITLE
fix(load): apply mlx-vlm MoE sanitize for Qwen3.6 VLMs without MTP heads

### DIFF
--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -88,6 +88,13 @@ def maybe_apply_pre_load_patches(
       strict load fails on a Qwen3.6 *-mtp VLM and the engine falls back
       to LLM, losing vision). VLMBatchedEngine passes ``for_vlm=True``;
       BatchedEngine / DFlashEngine / LLM loaders keep the default.
+    - mlx-vlm MoE VLM sanitize patch when ``for_vlm`` is True and the
+      checkpoint is a Qwen3.6 MoE VLM without declared MTP heads.
+      Pre-converted mlx-lm exports ship ``switch_mlp`` weights; stock
+      mlx-vlm ``sanitize`` unconditionally pops ``experts.gate_up_proj``
+      and crashes with KeyError unless the mlx_vlm_mtp sanitize replacement
+      is installed first. ``for_vlm=True`` is only passed by
+      ``VLMBatchedEngine``, so no separate ``vision_config`` gate is needed.
 
     Both patches inject modules into ``sys.modules`` and replace mlx-lm
     internals; gating keeps non-affected models at zero cost.
@@ -223,6 +230,33 @@ def maybe_apply_pre_load_patches(
             model_type,
             _has_mtp_heads(config),
         )
+
+    # Pre-converted mlx-lm Qwen3.6 MoE VLMs (e.g. mlx-community mxfp4) ship
+    # switch_mlp weights under language_model.model.* and often declare
+    # mtp_num_hidden_layers=0. The mlx_vlm_mtp sanitize replacement skips
+    # unfuse when switch_mlp is already present; stock mlx-vlm sanitize
+    # unconditionally pops experts.gate_up_proj and VLM load fails with
+    # KeyError → LLM fallback (vision silently dropped, issue #1261). That
+    # sanitize patch was previously only wired through _is_mtp_compatible
+    # above; apply it here for non-MTP MoE VLMs. Runtime MTP patch stays in
+    # the branch above.
+    if (
+        for_vlm
+        and model_type
+        and model_type.startswith("qwen3_5_moe")
+        and not _is_mtp_compatible(config, model_type)
+    ):
+        try:
+            from ..patches.mlx_vlm_mtp import apply_mlx_vlm_mtp_patch
+        except Exception as e:
+            logger.debug("qwen3_6 MoE VLM sanitize patch import failed: %s", e)
+        else:
+            if apply_mlx_vlm_mtp_patch():
+                logger.debug(
+                    "mlx-vlm qwen3_6 MoE VLM sanitize patch applied for %s "
+                    "(no MTP heads; switch_mlp load correctness)",
+                    model_name,
+                )
 
     # qwen3_5_moe covers Qwen3.6 too (HF config sets model_type=qwen3_5_moe).
     # The nested-visual sanitize wrap remaps language_model.model.visual.*

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -155,7 +155,11 @@ class TestVlmMtpPreLoadDispatch:
     it relies on apply_mlx_vlm_mtp_patch having installed the mtp.*
     preservation first. If only the runtime patch runs, stock mlx-vlm
     sanitize strips every mtp.* key and the MTP head loads at random
-    init (PR #1320)."""
+    init (PR #1320).
+
+    MoE VLMs without declared MTP heads still need the sanitize replacement
+    so pre-converted switch_mlp weights load (issue #1261); runtime patch
+    must not run on that path."""
 
     def _stub_patches(self, monkeypatch):
         """Replace the patch modules with mocks that record call order.
@@ -236,6 +240,41 @@ class TestVlmMtpPreLoadDispatch:
             '"text_config": {"mtp_num_hidden_layers": 1}}',
         )
         settings = types.SimpleNamespace(mtp_enabled=True)
+
+        maybe_apply_pre_load_patches(path, model_settings=settings)
+
+        sanitize_mock.assert_not_called()
+        runtime_mock.assert_not_called()
+        assert calls == []
+
+    def test_qwen36_moe_vlm_sanitize_when_no_mtp_heads(self, tmp_path, monkeypatch):
+        # mlx-lm Qwen3.6 MoE VLMs without MTP heads still need the mlx-vlm
+        # sanitize replacement so pre-converted switch_mlp weights load.
+        # Runtime MTP patch must NOT run — there is no mtp.* tree to bind.
+        calls, sanitize_mock, runtime_mock = self._stub_patches(monkeypatch)
+        path = _write_config(
+            tmp_path,
+            '{"model_type": "qwen3_5_moe", "vision_config": {}, '
+            '"text_config": {"mtp_num_hidden_layers": 0}}',
+        )
+        settings = types.SimpleNamespace(mtp_enabled=False)
+
+        maybe_apply_pre_load_patches(path, model_settings=settings, for_vlm=True)
+
+        sanitize_mock.assert_called_once()
+        runtime_mock.assert_not_called()
+        assert calls == ["sanitize"]
+
+    def test_qwen36_moe_vlm_sanitize_skipped_without_for_vlm(
+        self, tmp_path, monkeypatch
+    ):
+        calls, sanitize_mock, runtime_mock = self._stub_patches(monkeypatch)
+        path = _write_config(
+            tmp_path,
+            '{"model_type": "qwen3_5_moe", "vision_config": {}, '
+            '"text_config": {"mtp_num_hidden_layers": 0}}',
+        )
+        settings = types.SimpleNamespace(mtp_enabled=False)
 
         maybe_apply_pre_load_patches(path, model_settings=settings)
 


### PR DESCRIPTION
## Summary

Pre-converted mlx-lm Qwen3.6 MoE VLM checkpoints (e.g. `mlx-community/Qwen3.6-35B-A3B-mxfp4`) ship `switch_mlp` weights under `language_model.model.*` and often declare `mtp_num_hidden_layers=0`. Stock mlx-vlm `Model.sanitize` unconditionally pops `experts.gate_up_proj`, so VLM load fails with `KeyError` and `VLMBatchedEngine` falls back to LLM, silently dropping vision.

The mlx_vlm_mtp sanitize replacement skips unfuse when `switch_mlp` is already present, but was only wired through the `_is_mtp_compatible` path (checkpoints that declare MTP heads). This applies sanitize-only for `for_vlm` + `qwen3_5_moe` loads that skip that branch. The runtime MTP patch stays gated in the existing branch.

Fixes #1261

## Changes

- `omlx/utils/model_loading.py`: apply `apply_mlx_vlm_mtp_patch()` when `for_vlm=True`, `model_type=qwen3_5_moe`, and the checkpoint is not MTP-compatible. Runtime MTP patch unchanged.
- `tests/test_model_loading.py`: cover sanitize-only dispatch for non-MTP MoE VLM loads and assert runtime patch is not invoked.

## Test plan

- [x] `pytest tests/test_model_loading.py::TestVlmMtpPreLoadDispatch -v` — 5/5 pass
- [ ] Manual: load `mlx-community/Qwen3.6-35B-A3B-mxfp4` via VLMBatchedEngine with MTP disabled; log shows `VLMBatchedEngine loaded` (not LLM fallback) and image input works