### PR TITLE
fix(tests): add missing keys to MemorySettings test_to_dict expectation

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -676,7 +676,10 @@ class TestMemorySettings:
         d = settings.to_dict()
         assert d == {
             "max_process_memory": "75%",
+            "max_process_memory_is_explicit": False,
             "prefill_memory_guard": True,
+            "prefill_safe_zone_ratio": 0.8,
+            "prefill_min_chunk_tokens": 32,
             "soft_threshold": 0.85,
             "hard_threshold": 0.95,
         }


### PR DESCRIPTION
Fix this test:

```shell
pytest tests/test_settings.py
```