### PR TITLE
feat(eval): add uniform stratified sampling for MMLU benchmarks

### DIFF
--- a/omlx/eval/__init__.py
+++ b/omlx/eval/__init__.py
@@ -20,12 +20,24 @@ from .mathqa import MathQABenchmark
 from .mbpp import MBPPBenchmark
 from .mmlu import MMLUBenchmark
 from .mmlu_pro import MMLUProBenchmark
+from .hellaswag_uniform import HellaSwagUniformBenchmark
+from .mmlu_uniform import MMLUUniformBenchmark
+from .mmlu_pro_uniform import MMLUProUniformBenchmark
+from .cmmlu_uniform import CMMLUUniformBenchmark
+from .kmmlu_uniform import KMMLUUniformBenchmark
+from .jmmlu_uniform import JMMLUUniformBenchmark
 from .safetybench import SafetyBenchBenchmark
 from .truthfulqa import TruthfulQABenchmark
 from .winogrande import WinograndeBenchmark
 
 BENCHMARKS: dict[str, type[BaseBenchmark]] = {
+    "hellaswag_uniform": HellaSwagUniformBenchmark,
     "mmlu": MMLUBenchmark,
+    "mmlu_uniform": MMLUUniformBenchmark,
+    "mmlu_pro_uniform": MMLUProUniformBenchmark,
+    "cmmlu_uniform": CMMLUUniformBenchmark,
+    "kmmlu_uniform": KMMLUUniformBenchmark,
+    "jmmlu_uniform": JMMLUUniformBenchmark,
     "mmlu_pro": MMLUProBenchmark,
     "kmmlu": KMMLUBenchmark,
     "cmmlu": CMMLUBenchmark,

--- a/omlx/eval/cmmlu_uniform.py
+++ b/omlx/eval/cmmlu_uniform.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CMMLU with Uniform Category Sampling."""
+
+from pathlib import Path
+from .datasets import load_jsonl
+from .cmmlu import CMMLUBenchmark
+from .sampling import uniform_stratified_sample
+
+
+class CMMLUUniformBenchmark(CMMLUBenchmark):
+    """CMMLU with Uniform Stratified Sampling."""
+
+    name = "cmmlu_uniform"
+
+    async def load_dataset(self, sample_size: int = 0) -> list[dict]:
+        """Load CMMLU dataset and sample uniformly per category."""
+        all_items = await super().load_dataset(sample_size=0)
+        if sample_size == 0:
+            return all_items
+        return uniform_stratified_sample(all_items, sample_size, key="subject")

--- a/omlx/eval/hellaswag_uniform.py
+++ b/omlx/eval/hellaswag_uniform.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HellaSwag with Uniform Activity Sampling."""
+
+from pathlib import Path
+from .datasets import load_jsonl
+from .hellaswag import HellaSwagBenchmark
+from .sampling import uniform_stratified_sample
+
+
+class HellaSwagUniformBenchmark(HellaSwagBenchmark):
+    """HellaSwag with Uniform Stratified Sampling by activity_label."""
+
+    name = "hellaswag_uniform"
+
+    async def load_dataset(self, sample_size: int = 0) -> list[dict]:
+        """Load HellaSwag dataset and sample uniformly per activity."""
+        # HellaSwag uses activity_label as category
+        # We need to replicate normalization or call super
+        
+        # Calling super().load_dataset(0) might not work if parent logic 
+        # requires specific normalization steps that are hardcoded.
+        # Looking at parent HellaSwagBenchmark:
+        # It normalizes `label` to `answer` (int) and maps `ctx`, `endings`.
+        # We should replicate this logic to be safe, then sample.
+        
+        items = load_jsonl(Path(__file__).parent / "data" / "hellaswag_val.jsonl")
+        normalized = []
+        for item in items:
+            label = item.get("label", "0")
+            normalized.append({
+                "id": item.get("ind", ""),
+                "context": item.get("ctx", ""),
+                "endings": item.get("endings", []),
+                "answer": int(label) if isinstance(label, (int, float)) else int(label),
+                "activity_label": item.get("activity_label", ""),
+            })
+            
+        if sample_size == 0:
+            return normalized
+            
+        return uniform_stratified_sample(normalized, sample_size, key="activity_label")

--- a/omlx/eval/jmmlu_uniform.py
+++ b/omlx/eval/jmmlu_uniform.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+"""JMMLU with Uniform Category Sampling."""
+
+from pathlib import Path
+from .datasets import load_jsonl
+from .jmmlu import JMMLUBenchmark
+from .sampling import uniform_stratified_sample
+
+
+class JMMLUUniformBenchmark(JMMLUBenchmark):
+    """JMMLU with Uniform Stratified Sampling."""
+
+    name = "jmmlu_uniform"
+
+    async def load_dataset(self, sample_size: int = 0) -> list[dict]:
+        """Load JMMLU dataset and sample uniformly per category."""
+        all_items = await super().load_dataset(sample_size=0)
+        if sample_size == 0:
+            return all_items
+        return uniform_stratified_sample(all_items, sample_size, key="subject")

--- a/omlx/eval/kmmlu_uniform.py
+++ b/omlx/eval/kmmlu_uniform.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KMMLU with Uniform Category Sampling."""
+
+from pathlib import Path
+from .datasets import load_jsonl
+from .kmmlu import KMMLUBenchmark
+from .sampling import uniform_stratified_sample
+
+
+class KMMLUUniformBenchmark(KMMLUBenchmark):
+    """KMMLU with Uniform Stratified Sampling."""
+
+    name = "kmmlu_uniform"
+
+    async def load_dataset(self, sample_size: int = 0) -> list[dict]:
+        """Load KMMLU dataset and sample uniformly per category."""
+        all_items = await super().load_dataset(sample_size=0)
+        if sample_size == 0:
+            return all_items
+        return uniform_stratified_sample(all_items, sample_size, key="subject")

--- a/omlx/eval/mmlu_pro_uniform.py
+++ b/omlx/eval/mmlu_pro_uniform.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MMLU-Pro with Uniform Category Sampling."""
+
+from pathlib import Path
+from .datasets import load_jsonl
+from .mmlu_pro import MMLUProBenchmark
+from .sampling import uniform_stratified_sample
+
+
+class MMLUProUniformBenchmark(MMLUProBenchmark):
+    """MMLU-Pro with Uniform Stratified Sampling."""
+
+    name = "mmlu_pro_uniform"
+
+    async def load_dataset(self, sample_size: int = 0) -> list[dict]:
+        """Load MMLU-Pro dataset and sample uniformly per category."""
+        all_items = await super().load_dataset(sample_size=0)
+        if sample_size == 0:
+            return all_items
+        return uniform_stratified_sample(all_items, sample_size, key="subject")

--- a/omlx/eval/mmlu_uniform.py
+++ b/omlx/eval/mmlu_uniform.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MMLU with Uniform Category Sampling."""
+
+from pathlib import Path
+from .datasets import load_jsonl
+from .mmlu import MMLUBenchmark
+from .sampling import uniform_stratified_sample
+
+
+class MMLUUniformBenchmark(MMLUBenchmark):
+    """MMLU with Uniform Stratified Sampling.
+    
+    Ensures each subject has equal representation in the sample,
+    unlike the default proportional sampling.
+    """
+    
+    name = "mmlu_uniform"
+    
+    async def load_dataset(self, sample_size: int = 0) -> list[dict]:
+        """Load MMLU dataset and sample uniformly per category."""
+        # 1. Load base data (reusing parent logic to parse choices/answers)
+        test_items = load_jsonl(Path(__file__).parent / "data" / "mmlu_test.jsonl")
+        all_items = []
+        
+        # We need to replicate the item parsing from MMLUBenchmark.load_dataset
+        # because that method returns a list[dict] with parsed answers.
+        # Alternatively, we could call super().load_dataset(0) if it returns the full list.
+        # Looking at the parent class, load_dataset(0) returns the full list of items.
+        # However, the parent class logic includes loading few-shot examples from dev_items.
+        # The safest way is to call the parent implementation and then re-sample.
+        
+        # Note: MMLUBenchmark.load_dataset handles both loading and sampling.
+        # If sample_size == 0, it returns all items.
+        # But we also need the few-shot examples to be loaded for self._few_shot_examples.
+        
+        # To ensure self._few_shot_examples is populated correctly, we must run the parent logic.
+        # We can trick the parent by calling it with 0, then re-sampling the result.
+        
+        all_items = await super().load_dataset(sample_size=0)
+        
+        if sample_size == 0:
+            return all_items
+
+        # 2. Apply uniform stratified sampling
+        return uniform_stratified_sample(all_items, sample_size, key="subject")

--- a/omlx/eval/sampling.py
+++ b/omlx/eval/sampling.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Dataset sampling utilities with deterministic results.
+
+Provides uniform and proportional stratified sampling strategies
+to ensure fair representation across categories (e.g., subjects).
+"""
+
+import random
+from .datasets import SAMPLE_SEED
+
+def uniform_stratified_sample(
+    items: list[dict], n: int, key: str, min_per_cat: int = 1
+) -> list[dict]:
+    """Uniform stratified sampling: equal representation from each category.
+    
+    Uses a fixed seed so the same questions are always selected.
+    Ensures every category has at least `min_per_cat` items.
+
+    Args:
+        items: Full dataset.
+        n: Target sample size.
+        key: Dict key for the category field (e.g., 'subject').
+        min_per_cat: Minimum number of items per category.
+
+    Returns:
+        Stratified sample of size <= n.
+    """
+    if not items:
+        return []
+    
+    # Group by category
+    groups: dict[str, list[dict]] = {}
+    for item in items:
+        cat = item.get(key, "unknown")
+        groups.setdefault(cat, []).append(item)
+        
+    num_cats = len(groups)
+    rng = random.Random(SAMPLE_SEED)
+    
+    # Edge Case Guard: If we can't satisfy the minimum constraint,
+    # return all items to avoid sampling bias or crashes.
+    if n < num_cats * min_per_cat:
+        return items
+
+    if n >= len(items):
+        return items
+
+    # Calculate base allocation
+    base_count = max(min_per_cat, n // num_cats)
+    remainder = n - (base_count * num_cats)
+    
+    sampled = []
+    # Sort keys to ensure deterministic assignment of remainder
+    sorted_cats = sorted(groups.keys())
+    
+    for i, cat in enumerate(sorted_cats):
+        group = groups[cat]
+        # First 'remainder' categories get one extra item
+        count = base_count + (1 if i < remainder else 0)
+        count = min(count, len(group))
+        
+        sampled.extend(rng.sample(group, count))
+        
+    return sampled
+
+def proportional_stratified_sample(
+    items: list[dict], n: int, key: str
+) -> list[dict]:
+    """Proportional stratified sampling (original oMLX behavior).
+    
+    Allocates samples based on category size.
+    """
+    if n >= len(items):
+        return items
+
+    rng = random.Random(SAMPLE_SEED)
+    groups: dict[str, list[dict]] = {}
+    for item in items:
+        cat = item.get(key, "unknown")
+        groups.setdefault(cat, []).append(item)
+
+    total = len(items)
+    sampled = []
+    remaining = n
+    sorted_cats = sorted(groups.keys())
+
+    for i, cat in enumerate(sorted_cats):
+        group = groups[cat]
+        if i == len(sorted_cats) - 1:
+            count = remaining
+        else:
+            count = max(1, round(len(group) / total * n))
+            count = min(count, remaining, len(group))
+
+        sampled.extend(rng.sample(group, min(count, len(group))))
+        remaining -= len([x for x in sampled if x.get(key) == cat])
+        if remaining <= 0:
+            break
+            
+    return sampled


### PR DESCRIPTION
## Summary
This PR introduces a **Global Uniform Stratified Sampling** system for oMLX benchmarks.
The current proportional sampling over-samples large categories (e.g., \`professional_law\` in MMLU) and under-samples small ones, making it harder to detect specific model weaknesses in smaller domains.

## Changes
1. **\`omlx/eval/sampling.py\`**: New module with \`uniform_stratified_sample\`.
   - Deterministic seeding (\`SAMPLE_SEED\`).
   - Edge case protection when sample size < number of categories.
2. **New Uniform Benchmark Classes**:
   - \`MMLUUniformBenchmark\`
   - \`MMLUProUniformBenchmark\`
   - \`CMMLUUniformBenchmark\` (Chinese)
   - \`KMMLUUniformBenchmark\` (Korean)
   - \`JMMLUUniformBenchmark\` (Japanese)
3. **\`omlx/eval/__init__.py\`**: Registers all new benchmarks so they appear in the Admin UI.

## Testing
- Verified syntax validity of all new modules.
- Checked AST structure to ensure correct inheritance.
- Verified registration in \`BENCHMARKS\` dict.