### PR TITLE
fix(metrics): record non-streaming prefill timing

### DIFF
--- a/omlx/engine/base.py
+++ b/omlx/engine/base.py
@@ -35,6 +35,9 @@ class GenerationOutput:
     tool_calls: Optional[List[Dict[str, Any]]] = None
     # Prefix cache stats
     cached_tokens: int = 0
+    # Timing
+    prefill_duration: float = 0.0
+    generation_duration: float = 0.0
 
 
 class BaseEngine(ABC):

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -513,6 +513,8 @@ class BatchedEngine(BaseEngine):
             finish_reason=output.finish_reason,
             tool_calls=output.tool_calls,
             cached_tokens=output.cached_tokens,
+            prefill_duration=output.prefill_duration,
+            generation_duration=output.generation_duration,
         )
 
     async def stream_generate(
@@ -613,6 +615,8 @@ class BatchedEngine(BaseEngine):
                     finish_reason=output.finish_reason,
                     tool_calls=output.tool_calls,
                     cached_tokens=output.cached_tokens,
+                    prefill_duration=output.prefill_duration,
+                    generation_duration=output.generation_duration,
                 )
         except GeneratorExit:
             # Client disconnected

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -15,6 +15,7 @@ import gc
 import json
 import logging
 import threading
+import time
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -833,11 +834,13 @@ class DFlashEngine(BaseEngine):
 
         loop = asyncio.get_running_loop()
         stop_event = threading.Event()
+        request_start = time.perf_counter()
 
         def _run():
             from dflash_mlx.engine.events import SummaryEvent, TokenEvent
 
             event_iter = None
+            first_token_time = None
             # Per-request parser session (gemma4 channel markers, harmony
             # channels). Lives only inside the executor thread so the parser
             # state cannot leak across requests.
@@ -859,6 +862,8 @@ class DFlashEngine(BaseEngine):
                         logger.info("DFlash generation aborted by client")
                         break
                     if isinstance(event, TokenEvent):
+                        if first_token_time is None:
+                            first_token_time = time.perf_counter()
                         token_id = int(event.token_id)
                         if token_id in stop_ids:
                             continue
@@ -873,7 +878,13 @@ class DFlashEngine(BaseEngine):
                     final = parser_session.finalize()
                     if final.visible_text:
                         parsed_visible_parts.append(final.visible_text)
-                return summary, tokens, parser_session, parsed_visible_parts
+                return (
+                    summary,
+                    tokens,
+                    parser_session,
+                    parsed_visible_parts,
+                    first_token_time,
+                )
             finally:
                 if event_iter is not None:
                     close = getattr(event_iter, "close", None)
@@ -887,9 +898,13 @@ class DFlashEngine(BaseEngine):
         self._active_request = True
         future = loop.run_in_executor(get_mlx_executor(), _run)
         try:
-            summary, generated, parser_session, parsed_visible_parts = (
-                await asyncio.shield(asyncio.wrap_future(future))
-            )
+            (
+                summary,
+                generated,
+                parser_session,
+                parsed_visible_parts,
+                first_token_time,
+            ) = await asyncio.shield(asyncio.wrap_future(future))
         except asyncio.CancelledError:
             stop_event.set()
             logger.info("DFlash generate cancelled, waiting for executor to drain")
@@ -929,12 +944,21 @@ class DFlashEngine(BaseEngine):
         completion_token_count = (
             int(summary.generation_tokens) if summary is not None else len(generated)
         )
+        end_time = time.perf_counter()
+        ttft = (
+            first_token_time - request_start
+            if first_token_time is not None
+            else end_time - request_start
+        )
+        generation_duration = end_time - (first_token_time or request_start)
         return GenerationOutput(
             text=text,
             tokens=generated,
             prompt_tokens=prompt_token_count,
             completion_tokens=completion_token_count,
             finish_reason="stop",
+            prefill_duration=ttft,
+            generation_duration=generation_duration,
         )
 
     async def stream_generate(
@@ -1019,10 +1043,15 @@ class DFlashEngine(BaseEngine):
         total_text = ""
         total_completion = 0
         finished_normally = False
+        start_time = time.perf_counter()
+        first_token_time = None
 
         try:
             while True:
                 new_text, new_tokens, finished, metrics = await queue.get()
+
+                if first_token_time is None and new_text:
+                    first_token_time = time.perf_counter()
 
                 if think_prefix_pending and new_text:
                     new_text = self._think_prefix_text() + new_text
@@ -1046,6 +1075,14 @@ class DFlashEngine(BaseEngine):
                     completion_tokens=total_completion,
                     finished=finished,
                     finish_reason=finish_reason,
+                    prefill_duration=(
+                        first_token_time - start_time
+                        if first_token_time is not None
+                        else 0.0
+                    ),
+                    generation_duration=(
+                        time.perf_counter() - (first_token_time or start_time)
+                    ),
                 )
 
                 if finished:

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1663,6 +1663,8 @@ class VLMBatchedEngine(BaseEngine):
             finish_reason=output.finish_reason,
             tool_calls=output.tool_calls,
             cached_tokens=output.cached_tokens,
+            prefill_duration=output.prefill_duration,
+            generation_duration=output.generation_duration,
         )
 
     async def stream_generate(
@@ -1760,6 +1762,8 @@ class VLMBatchedEngine(BaseEngine):
                     finish_reason=output.finish_reason,
                     tool_calls=output.tool_calls,
                     cached_tokens=output.cached_tokens,
+                    prefill_duration=output.prefill_duration,
+                    generation_duration=output.generation_duration,
                 )
         except GeneratorExit:
             logger.info(f"[vlm_stream_generate] GeneratorExit for request {request_id}")

--- a/omlx/output_collector.py
+++ b/omlx/output_collector.py
@@ -146,6 +146,8 @@ class RequestOutputCollector:
             finish_reason=new.finish_reason,
             prompt_tokens=new.prompt_tokens,
             completion_tokens=new.completion_tokens,
+            prefill_duration=new.prefill_duration or existing.prefill_duration,
+            generation_duration=new.generation_duration,
             tool_calls=new.tool_calls,  # Preserve tool_calls for Harmony models
             cached_tokens=new.cached_tokens,
             error=new.error or existing.error,

--- a/omlx/request.py
+++ b/omlx/request.py
@@ -123,6 +123,8 @@ class Request:
     output_token_ids: List[int] = field(default_factory=list)
     output_text: str = ""
     generation_started_at: Optional[float] = None
+    prefill_started_at: Optional[float] = None
+    first_token_at: Optional[float] = None
     last_activity_at: Optional[float] = None
 
     # For BatchGenerator integration
@@ -262,6 +264,8 @@ class RequestOutput:
     # Timing
     prompt_tokens: int = 0
     completion_tokens: int = 0
+    prefill_duration: float = 0.0
+    generation_duration: float = 0.0
 
     # Tool calls (for Harmony and other models with tool calling support)
     tool_calls: Optional[List[Dict[str, str]]] = None

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -4705,6 +4705,9 @@ class Scheduler:
                 )
                 break
 
+            if request.prefill_started_at is None:
+                request.prefill_started_at = time.monotonic()
+
             # Mark as Harmony model if applicable (before think detection)
             if self._is_harmony_model:
                 request.is_harmony_model = True
@@ -5213,6 +5216,13 @@ class Scheduler:
                 continue
 
             request.last_activity_at = step_now
+            if request.first_token_at is None:
+                request.first_token_at = step_now
+
+            prefill_started_at = request.prefill_started_at or request.arrival_time
+            prefill_duration = max(0.0, request.first_token_at - prefill_started_at)
+            generation_started_at = request.generation_started_at or request.first_token_at
+            generation_duration = max(0.0, step_now - generation_started_at)
 
             # Release VLM embeddings after first decode token (prefill is done)
             if request.vlm_inputs_embeds is not None:
@@ -5312,6 +5322,8 @@ class Scheduler:
                 output_token_ids=list(request.output_token_ids),
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
+                prefill_duration=prefill_duration,
+                generation_duration=generation_duration,
                 cached_tokens=request.cached_tokens,
             )
 
@@ -5778,6 +5790,9 @@ class Scheduler:
             # Reset scheduling state
             request.status = RequestStatus.WAITING
             request.batch_uid = None
+            request.prefill_started_at = None
+            request.generation_started_at = None
+            request.first_token_at = None
 
             # Reset cache state
             request.prompt_cache = None

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -233,6 +233,24 @@ class ServerState:
 _server_state: ServerState = ServerState()
 
 
+def _output_timing(output: object, field: str) -> float:
+    """Return a non-negative timing value from an engine output."""
+    value = getattr(output, field, 0.0) or 0.0
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _generation_duration_for_metrics(output: object, elapsed: float) -> float:
+    """Prefer engine timing, falling back to elapsed minus TTFT."""
+    generation_duration = _output_timing(output, "generation_duration")
+    if generation_duration > 0:
+        return generation_duration
+    prefill_duration = _output_timing(output, "prefill_duration")
+    return max(0.0, elapsed - prefill_duration)
+
+
 def get_server_state() -> ServerState:
     """Get the global server state."""
     return _server_state
@@ -1992,6 +2010,8 @@ async def create_completion(
         total_completion_tokens = 0
         total_prompt_tokens = 0
         total_cached_tokens = 0
+        total_prefill_duration = 0.0
+        total_generation_duration = 0.0
 
         temperature, top_p, top_k, repetition_penalty, min_p, presence_penalty, frequency_penalty, max_tokens, xtc_probability, xtc_threshold = get_sampling_params(
             request.temperature, request.top_p, request.model,
@@ -2028,8 +2048,12 @@ async def create_completion(
             total_completion_tokens += output.completion_tokens
             total_prompt_tokens += output.prompt_tokens
             total_cached_tokens += output.cached_tokens
+            total_prefill_duration += _output_timing(output, "prefill_duration")
+            total_generation_duration += _output_timing(output, "generation_duration")
 
         elapsed = time.perf_counter() - start_time
+        if total_generation_duration <= 0:
+            total_generation_duration = max(0.0, elapsed - total_prefill_duration)
         tokens_per_sec = total_completion_tokens / elapsed if elapsed > 0 else 0
         logger.info(f"Completion: {total_completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s), prompt: {total_prompt_tokens}")
 
@@ -2037,7 +2061,8 @@ async def create_completion(
             prompt_tokens=total_prompt_tokens,
             completion_tokens=total_completion_tokens,
             cached_tokens=total_cached_tokens,
-            generation_duration=elapsed,
+            prefill_duration=total_prefill_duration,
+            generation_duration=total_generation_duration,
             model_id=resolve_model_id(request.model) or request.model,
         )
 
@@ -2337,7 +2362,8 @@ async def create_chat_completion(
             prompt_tokens=output.prompt_tokens,
             completion_tokens=output.completion_tokens,
             cached_tokens=output.cached_tokens,
-            generation_duration=elapsed,
+            prefill_duration=_output_timing(output, "prefill_duration"),
+            generation_duration=_generation_duration_for_metrics(output, elapsed),
             model_id=resolved_model,
         )
 
@@ -3644,7 +3670,8 @@ async def create_anthropic_message(
             prompt_tokens=output.prompt_tokens,
             completion_tokens=output.completion_tokens,
             cached_tokens=output.cached_tokens,
-            generation_duration=elapsed,
+            prefill_duration=_output_timing(output, "prefill_duration"),
+            generation_duration=_generation_duration_for_metrics(output, elapsed),
             model_id=resolved_model,
         )
 
@@ -4054,7 +4081,8 @@ async def create_response(
             prompt_tokens=output.prompt_tokens,
             completion_tokens=output.completion_tokens,
             cached_tokens=output.cached_tokens,
-            generation_duration=elapsed,
+            prefill_duration=_output_timing(output, "prefill_duration"),
+            generation_duration=_generation_duration_for_metrics(output, elapsed),
             model_id=resolved_model,
         )
 

--- a/tests/integration/test_e2e_streaming.py
+++ b/tests/integration/test_e2e_streaming.py
@@ -26,6 +26,8 @@ class MockGenerationOutput:
     finished: bool = False
     tool_calls: Optional[List[Dict[str, Any]]] = None
     cached_tokens: int = 0
+    prefill_duration: float = 0.0
+    generation_duration: float = 0.0
 
 
 class MockTokenizer:

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -54,6 +54,8 @@ class MockGenerationOutput:
     finished: bool = True
     tool_calls: Optional[List[Dict[str, Any]]] = None
     cached_tokens: int = 0
+    prefill_duration: float = 0.0
+    generation_duration: float = 0.0
 
 
 class MockEmbeddingEngineImpl(EmbeddingEngine):
@@ -559,6 +561,38 @@ class TestResponsesEndpoint:
             _server_state.default_model = original_default
             _server_state.responses_store = original_store
 
+    def test_responses_records_prefill_metrics(self, client, mock_llm_engine):
+        """Non-streaming Responses API requests should record engine TTFT."""
+        from omlx.server_metrics import get_server_metrics, reset_server_metrics
+
+        reset_server_metrics()
+        try:
+            mock_llm_engine.chat = AsyncMock(return_value=MockGenerationOutput(
+                text="Responses API response.",
+                prompt_tokens=100,
+                completion_tokens=20,
+                cached_tokens=25,
+                prefill_duration=0.5,
+                generation_duration=1.0,
+                finish_reason="stop",
+                finished=True,
+            ))
+
+            response = client.post(
+                "/v1/responses",
+                json={
+                    "model": "test-model",
+                    "input": "Metric prompt",
+                },
+            )
+
+            assert response.status_code == 200
+            snapshot = get_server_metrics().get_snapshot(model_id="test-model")
+            assert snapshot["avg_prefill_tps"] == pytest.approx(150.0)
+            assert snapshot["avg_generation_tps"] == pytest.approx(20.0)
+        finally:
+            reset_server_metrics()
+
 
 class TestModelsStatusEndpoint:
     """Tests for the /v1/models/status endpoint."""
@@ -644,6 +678,36 @@ class TestCompletionEndpoint:
         data = response.json()
         assert data["usage"]["prompt_tokens_details"]["cached_tokens"] == 2048
 
+    def test_completion_records_prefill_metrics(self, client, mock_llm_engine):
+        """Non-streaming completions should contribute engine TTFT to server metrics."""
+        from omlx.server_metrics import get_server_metrics, reset_server_metrics
+
+        reset_server_metrics()
+        try:
+            mock_llm_engine.generate = AsyncMock(return_value=MockGenerationOutput(
+                text="Generated response.",
+                prompt_tokens=80,
+                completion_tokens=10,
+                cached_tokens=20,
+                prefill_duration=0.5,
+                generation_duration=1.0,
+            ))
+
+            response = client.post(
+                "/v1/completions",
+                json={
+                    "model": "test-model",
+                    "prompt": "Metric prompt",
+                },
+            )
+
+            assert response.status_code == 200
+            snapshot = get_server_metrics().get_snapshot(model_id="test-model")
+            assert snapshot["avg_prefill_tps"] == pytest.approx(120.0)
+            assert snapshot["avg_generation_tps"] == pytest.approx(10.0)
+        finally:
+            reset_server_metrics()
+
 
 class TestChatCompletionEndpoint:
     """Tests for the /v1/chat/completions endpoint."""
@@ -721,6 +785,38 @@ class TestChatCompletionEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert data["usage"]["prompt_tokens_details"]["cached_tokens"] == 2048
+
+    def test_chat_completion_records_prefill_metrics(self, client, mock_llm_engine):
+        """Non-streaming chat should contribute engine TTFT to server metrics."""
+        from omlx.server_metrics import get_server_metrics, reset_server_metrics
+
+        reset_server_metrics()
+        try:
+            mock_llm_engine.chat = AsyncMock(return_value=MockGenerationOutput(
+                text="Chat response.",
+                prompt_tokens=100,
+                completion_tokens=20,
+                cached_tokens=25,
+                prefill_duration=0.5,
+                generation_duration=1.0,
+                finish_reason="stop",
+                finished=True,
+            ))
+
+            response = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "Metric prompt"}],
+                },
+            )
+
+            assert response.status_code == 200
+            snapshot = get_server_metrics().get_snapshot(model_id="test-model")
+            assert snapshot["avg_prefill_tps"] == pytest.approx(150.0)
+            assert snapshot["avg_generation_tps"] == pytest.approx(20.0)
+        finally:
+            reset_server_metrics()
 
     def test_chat_completion_sanitizes_reasoning_tool_call_markup(self, client, mock_llm_engine):
         """Thinking-only tool calls should become structured tool_calls without leaked markup."""
@@ -819,6 +915,39 @@ class TestAnthropicMessagesEndpoint:
         )
 
         assert response.status_code == 200
+
+    def test_anthropic_messages_records_prefill_metrics(self, client, mock_llm_engine):
+        """Non-streaming Anthropic messages should record engine TTFT."""
+        from omlx.server_metrics import get_server_metrics, reset_server_metrics
+
+        reset_server_metrics()
+        try:
+            mock_llm_engine.chat = AsyncMock(return_value=MockGenerationOutput(
+                text="Anthropic response.",
+                prompt_tokens=90,
+                completion_tokens=15,
+                cached_tokens=30,
+                prefill_duration=0.5,
+                generation_duration=1.0,
+                finish_reason="stop",
+                finished=True,
+            ))
+
+            response = client.post(
+                "/v1/messages",
+                json={
+                    "model": "test-model",
+                    "max_tokens": 1024,
+                    "messages": [{"role": "user", "content": "Metric prompt"}],
+                },
+            )
+
+            assert response.status_code == 200
+            snapshot = get_server_metrics().get_snapshot(model_id="test-model")
+            assert snapshot["avg_prefill_tps"] == pytest.approx(120.0)
+            assert snapshot["avg_generation_tps"] == pytest.approx(15.0)
+        finally:
+            reset_server_metrics()
 
     def test_anthropic_messages_sanitize_thinking_tool_call_markup(self, client, mock_llm_engine):
         """Anthropic thinking blocks should not expose raw tool-call markup."""

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -42,6 +42,8 @@ class FakeStreamingCore:
             finish_reason=None,
             tool_calls=None,
             cached_tokens=0,
+            prefill_duration=0.25,
+            generation_duration=0.5,
         )
 
     async def abort_request(self, request_id):
@@ -63,6 +65,8 @@ class TestGenerationOutput:
         assert output.new_text == ""
         assert output.finished is True
         assert output.tool_calls is None
+        assert output.prefill_duration == 0.0
+        assert output.generation_duration == 0.0
 
     def test_custom_values(self):
         """Test GenerationOutput with custom values."""
@@ -75,6 +79,8 @@ class TestGenerationOutput:
             new_text="partial",
             finished=False,
             tool_calls=[{"name": "test_tool", "arguments": "{}"}],
+            prefill_duration=0.25,
+            generation_duration=0.5,
         )
 
         assert output.text == "Generated text"
@@ -85,6 +91,8 @@ class TestGenerationOutput:
         assert output.new_text == "partial"
         assert output.finished is False
         assert output.tool_calls == [{"name": "test_tool", "arguments": "{}"}]
+        assert output.prefill_duration == 0.25
+        assert output.generation_duration == 0.5
 
     def test_streaming_output(self):
         """Test GenerationOutput for streaming use case."""

--- a/tests/test_output_collector.py
+++ b/tests/test_output_collector.py
@@ -368,6 +368,28 @@ class TestRequestOutputCollectorMergeOutputs:
         assert result.output_token_ids == [100, 101, 102]  # Uses latest
         assert result.completion_tokens == 3  # Uses latest
 
+    def test_merge_preserves_timing(self):
+        """Test _merge_outputs carries first TTFT and latest generation time."""
+        collector = RequestOutputCollector()
+
+        existing = RequestOutput(
+            request_id="test-001",
+            new_token_ids=[100],
+            prefill_duration=0.25,
+            generation_duration=0.1,
+        )
+        new = RequestOutput(
+            request_id="test-001",
+            new_token_ids=[101],
+            prefill_duration=0.25,
+            generation_duration=0.4,
+        )
+
+        result = collector._merge_outputs(existing, new)
+
+        assert result.prefill_duration == 0.25
+        assert result.generation_duration == 0.4
+
     def test_merge_preserves_finished_status(self):
         """Test _merge_outputs preserves finished status."""
         collector = RequestOutputCollector()

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -391,6 +391,8 @@ class TestRequestOutput:
         assert output.output_text == ""
         assert output.finished is False
         assert output.finish_reason is None
+        assert output.prefill_duration == 0.0
+        assert output.generation_duration == 0.0
 
     def test_with_tokens(self):
         """Test RequestOutput with tokens."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -697,6 +697,46 @@ class TestSchedulerStatistics:
         assert stats["num_running"] == 0
 
 
+class TestSchedulerResponseTiming:
+    """Tests for timing metadata on generated outputs."""
+
+    def test_process_batch_response_adds_timing(
+        self, mock_model, mock_tokenizer, monkeypatch
+    ):
+        """RequestOutput should expose TTFT and decode duration."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        monkeypatch.setattr("omlx.scheduler.time.monotonic", lambda: 12.5)
+        monkeypatch.setattr(scheduler, "_get_detokenizer", lambda _request_id: None)
+
+        request = Request(
+            request_id="req-timing",
+            prompt="Prompt",
+            sampling_params=SamplingParams(max_tokens=5),
+            prompt_token_ids=[1, 2, 3],
+            num_prompt_tokens=3,
+            status=RequestStatus.RUNNING,
+            batch_uid=99,
+            prefill_started_at=8.0,
+            generation_started_at=10.0,
+        )
+        scheduler.running[request.request_id] = request
+        scheduler.requests[request.request_id] = request
+        scheduler.uid_to_request_id[99] = request.request_id
+        scheduler.request_id_to_uid[request.request_id] = 99
+
+        response = type(
+            "Resp",
+            (),
+            {"uid": 99, "token": 42, "finish_reason": None},
+        )()
+
+        outputs, finished_ids = scheduler._process_batch_responses([response])
+
+        assert finished_ids == set()
+        assert outputs[0].prefill_duration == pytest.approx(4.5)
+        assert outputs[0].generation_duration == pytest.approx(2.5)
+
+
 class TestSchedulerReset:
     """Tests for Scheduler reset methods."""
 

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -109,6 +109,8 @@ class FakeStreamingCore:
             finish_reason=None,
             tool_calls=None,
             cached_tokens=0,
+            prefill_duration=0.25,
+            generation_duration=0.5,
         )
 
     async def abort_request(self, request_id):


### PR DESCRIPTION
Fixes #1432.

## Summary
- record prefill and generation timing on scheduler RequestOutput
- propagate timing through GenerationOutput for batched, VLM, and DFlash engines
- use engine-reported timing for non-streaming metrics across completions, chat, Anthropic messages, and Responses API
- add endpoint and scheduler coverage for non-streaming prefill TPS

## Problem
The server metrics dashboard could report avg_prefill_tps as 0 for non-streaming requests even when prompt tokens were processed. Streaming paths already measured TTFT at the server layer, but non-streaming responses only recorded total elapsed generation time and did not pass a prefill duration into record_request_complete.

## Approach
The scheduler now records when prefill begins and when the first decode token arrives, then includes those durations in RequestOutput. Engine wrappers preserve that timing when converting to GenerationOutput, and the API handlers prefer engine timing when recording server metrics.

This keeps the metrics calculation centralized in ServerMetrics while making non-streaming requests provide the same timing information streaming requests already had.

## Tests
- .venv/bin/python -m pytest tests/test_request.py tests/test_output_collector.py tests/test_scheduler.py tests/test_batched_engine.py tests/test_vlm_engine.py tests/test_server_metrics.py tests/integration/test_server_endpoints.py tests/integration/test_e2e_streaming.py -q
- .venv/bin/python -m ruff check --select F821 omlx/engine/base.py omlx/engine/batched.py omlx/engine/dflash.py omlx/engine/vlm.py omlx/output_collector.py omlx/request.py omlx/scheduler.py omlx/server.py tests/integration/test_e2e_streaming.py tests/integration/test_server_endpoints.py tests/test_batched_engine.py tests/test_output_collector.py tests/test_request.py tests/test_scheduler.py tests/test_vlm_engine.py
- git diff --check upstream/main...HEAD