### PR TITLE
fix(load): skip VLM MTP runtime when checkpoint lacks weights

### DIFF
--- a/omlx/patches/mlx_lm_mtp/__init__.py
+++ b/omlx/patches/mlx_lm_mtp/__init__.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 # right before ``mlx_lm.load()`` runs based on ``model_settings.mtp_enabled``.
 # Default False keeps newly-loaded models MTP-free unless explicitly opted in.
 _MTP_ACTIVE = False
+_MTP_WEIGHT_BINDING_ACTIVE = False
 
 
 def set_mtp_active(active: bool) -> None:
@@ -53,6 +54,24 @@ def set_mtp_active(active: bool) -> None:
 
 def is_mtp_active() -> bool:
     return _MTP_ACTIVE
+
+
+def set_mtp_weight_binding_active(active: bool) -> None:
+    """Toggle whether VLM loads should attach an MTP module for weights.
+
+    VLM checkpoints can need ``self.mtp`` present even when speculative
+    decoding is disabled, because persisted ``mtp.*`` tensors still need a
+    destination during strict weight loading. This flag is separate from
+    ``is_mtp_active()`` so mtp_enabled=False can still bind real MTP weights,
+    while checkpoints that only declare MTP in config but have no MTP tensors
+    load as normal VLMs.
+    """
+    global _MTP_WEIGHT_BINDING_ACTIVE
+    _MTP_WEIGHT_BINDING_ACTIVE = bool(active)
+
+
+def is_mtp_weight_binding_active() -> bool:
+    return _MTP_WEIGHT_BINDING_ACTIVE
 
 
 def apply_mlx_lm_mtp_patch() -> bool:

--- a/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py
@@ -205,13 +205,14 @@ def _patch_vlm_language_model(q35moe_lang: Any) -> None:
 
     def __init__(self, args, config=None):
         original_init(self, args, config)
-        # Always attach MTPModule when the config declares MTP heads, so
-        # mlx-vlm's load_weights (which skips Model.sanitize for is_mlx_format
-        # checkpoints) can place the persisted mtp.* tensors. MTP speculative
-        # decode invocation is gated downstream by
-        # ``mlx_lm_mtp.batch_generator._is_mtp_eligible`` via ``is_mtp_active``.
+        # Attach MTPModule only when this load has real MTP tensors to bind.
+        # Some quantized VLM checkpoints keep mtp_num_hidden_layers in config
+        # but were exported without mtp.* weights; attaching a module there
+        # makes strict load fail with missing language_model.mtp.* parameters.
         n_mtp = int(getattr(args, "mtp_num_hidden_layers", 0) or 0)
-        if n_mtp > 0:
+        from ..mlx_lm_mtp import is_mtp_weight_binding_active
+
+        if n_mtp > 0 and is_mtp_weight_binding_active():
             self.mtp = q35moe_lang.MTPModule(args)
 
     def __call__(self, inputs, inputs_embeds=None, mask=None, cache=None, **kwargs):

--- a/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
@@ -192,18 +192,14 @@ def _patch_vlm_language_model(q35_lang: Any) -> None:
 
     def __init__(self, args, config=None):
         original_init(self, args, config)
-        # Always attach MTPModule when the config declares MTP heads, so
-        # mlx-vlm's load_weights (which skips Model.sanitize for is_mlx_format
-        # checkpoints) can place the persisted mtp.* tensors. Whether MTP
-        # speculative decode is actually invoked at inference time is gated
-        # downstream by ``mlx_lm_mtp.batch_generator._is_mtp_eligible``,
-        # which checks the process-wide ``is_mtp_active`` flag.
-        # Without this unconditional attach, mtp_enabled=False would fail
-        # VLM load with "Received N parameters not in model" and the engine
-        # pool would permanently downgrade the entry to BatchedEngine —
-        # losing vision support.
+        # Attach MTPModule only when this load has real MTP tensors to bind.
+        # This preserves the mtp_enabled=False binding fix for true MTP
+        # checkpoints without forcing no-MTP exports to expect missing
+        # language_model.mtp.* parameters.
         n_mtp = int(getattr(args, "mtp_num_hidden_layers", 0) or 0)
-        if n_mtp > 0:
+        from ..mlx_lm_mtp import is_mtp_weight_binding_active
+
+        if n_mtp > 0 and is_mtp_weight_binding_active():
             self.mtp = q35_lang.MTPModule(args)
 
     def __call__(self, inputs, inputs_embeds=None, mask=None, cache=None, **kwargs):

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -14,6 +14,12 @@ _VLM_TEXT_PREFIX = "language_model."
 
 _MLX_LM_LOAD_CONFIG_PATCHED = False
 
+_MTP_WEIGHT_PREFIXES = (
+    "mtp.",
+    "language_model.mtp.",
+    "model.language_model.mtp.",
+)
+
 
 def expand_per_layer_quant_keys(cfg: dict) -> dict:
     """Add ``language_model.``-prefixed variants of per-layer quantization keys.
@@ -68,6 +74,56 @@ def _patch_mlx_lm_load_config() -> None:
     _MLX_LM_LOAD_CONFIG_PATCHED = True
 
 
+def _is_mtp_weight_key(key: str) -> bool:
+    return key.startswith(_MTP_WEIGHT_PREFIXES)
+
+
+def _checkpoint_has_mtp_weights(model_name: str) -> bool | None:
+    """Return whether a local checkpoint visibly contains MTP tensors.
+
+    ``None`` means the checkpoint layout could not be inspected cheaply, so
+    callers should preserve legacy behavior. Sharded MLX/HF exports normally
+    have a ``*.safetensors.index.json`` file, which lets us answer this
+    without opening the tensor files themselves.
+    """
+    model_path = Path(model_name)
+    index_paths = sorted(model_path.glob("*.safetensors.index.json"))
+    if index_paths:
+        for index_path in index_paths:
+            try:
+                index = json.loads(index_path.read_text())
+            except Exception as e:
+                logger.debug("Could not read %s for MTP key scan: %s", index_path, e)
+                return None
+            weight_map = index.get("weight_map")
+            if not isinstance(weight_map, dict):
+                return None
+            if any(_is_mtp_weight_key(key) for key in weight_map):
+                return True
+        return False
+
+    tensor_paths = sorted(model_path.glob("*.safetensors"))
+    if not tensor_paths:
+        return None
+
+    try:
+        from safetensors import safe_open
+    except Exception as e:
+        logger.debug("safetensors unavailable for MTP key scan: %s", e)
+        return None
+
+    try:
+        for tensor_path in tensor_paths:
+            with safe_open(tensor_path, framework="numpy") as handle:
+                if any(_is_mtp_weight_key(key) for key in handle.keys()):
+                    return True
+    except Exception as e:
+        logger.debug("Could not scan safetensors for MTP keys: %s", e)
+        return None
+
+    return False
+
+
 def maybe_apply_pre_load_patches(
     model_name: str,
     model_settings: Any | None = None,
@@ -104,9 +160,13 @@ def maybe_apply_pre_load_patches(
     # Reset the process-wide MTP flag so non-MTP-compatible models (or
     # models with mtp_enabled=False) are not polluted by a prior model
     # load that left the flag True.
-    from ..patches.mlx_lm_mtp import set_mtp_active
+    from ..patches.mlx_lm_mtp import (
+        set_mtp_active,
+        set_mtp_weight_binding_active,
+    )
 
     set_mtp_active(False)
+    set_mtp_weight_binding_active(False)
 
     _patch_mlx_lm_load_config()
 
@@ -144,10 +204,21 @@ def maybe_apply_pre_load_patches(
     # the resulting model is indistinguishable from a stock model that
     # never had MTP heads.
     if _is_mtp_compatible(config, model_type):
-        mtp_enabled = bool(
+        checkpoint_has_mtp_weights = _checkpoint_has_mtp_weights(model_name)
+        has_missing_mtp_weights = checkpoint_has_mtp_weights is False
+        requested_mtp_enabled = bool(
             model_settings is not None and getattr(model_settings, "mtp_enabled", False)
         )
+        mtp_enabled = requested_mtp_enabled and not has_missing_mtp_weights
         from ..patches.mlx_lm_mtp import apply_mlx_lm_mtp_patch, set_mtp_active
+
+        if has_missing_mtp_weights:
+            log = logger.warning if requested_mtp_enabled else logger.debug
+            log(
+                "%s declares MTP heads but no mtp.* weights were found; "
+                "loading without MTP",
+                model_name,
+            )
 
         if apply_mlx_lm_mtp_patch():
             set_mtp_active(mtp_enabled)
@@ -209,7 +280,18 @@ def maybe_apply_pre_load_patches(
                             "weights to bind)",
                             model_name,
                         )
-                if apply_mlx_vlm_mtp_runtime_patch():
+                if has_missing_mtp_weights:
+                    logger.debug(
+                        "Skipping mlx-vlm runtime MTP patch for %s "
+                        "(config declares MTP but checkpoint has no mtp.* weights)",
+                        model_name,
+                    )
+                else:
+                    set_mtp_weight_binding_active(True)
+                if (
+                    not has_missing_mtp_weights
+                    and apply_mlx_vlm_mtp_runtime_patch()
+                ):
                     if mtp_enabled:
                         logger.info(
                             "mlx-vlm runtime MTP patch applied for %s",

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -168,13 +168,16 @@ class TestVlmMtpPreLoadDispatch:
         calls: list[str] = []
         sanitize_mock = MagicMock(side_effect=lambda: calls.append("sanitize") or True)
         runtime_mock = MagicMock(side_effect=lambda: calls.append("runtime") or True)
+        set_mtp_active_mock = MagicMock()
+        set_mtp_weight_binding_active_mock = MagicMock()
         # Side-step the real mlx-lm load_config monkey-patch.
         monkeypatch.setattr(model_loading, "_patch_mlx_lm_load_config", lambda: None)
         monkeypatch.setitem(
             sys.modules,
             "omlx.patches.mlx_lm_mtp",
             MagicMock(
-                set_mtp_active=MagicMock(),
+                set_mtp_active=set_mtp_active_mock,
+                set_mtp_weight_binding_active=set_mtp_weight_binding_active_mock,
                 apply_mlx_lm_mtp_patch=MagicMock(return_value=True),
             ),
         )
@@ -186,12 +189,18 @@ class TestVlmMtpPreLoadDispatch:
                 apply_mlx_vlm_mtp_runtime_patch=runtime_mock,
             ),
         )
-        return calls, sanitize_mock, runtime_mock
+        return (
+            calls,
+            sanitize_mock,
+            runtime_mock,
+            set_mtp_active_mock,
+            set_mtp_weight_binding_active_mock,
+        )
 
     def test_sanitize_patch_runs_before_runtime_for_vlm_mtp(
         self, tmp_path, monkeypatch
     ):
-        calls, sanitize_mock, runtime_mock = self._stub_patches(monkeypatch)
+        calls, sanitize_mock, runtime_mock, _, _ = self._stub_patches(monkeypatch)
         # qwen3_5 (dense VLM) declaring an MTP head under text_config.
         path = _write_config(
             tmp_path,
@@ -214,7 +223,7 @@ class TestVlmMtpPreLoadDispatch:
         # even with mtp_enabled=False. Otherwise mlx-vlm's strict load_weights
         # fails with "parameters not in model" and the engine falls back to
         # LLM, silently dropping vision.
-        calls, sanitize_mock, runtime_mock = self._stub_patches(monkeypatch)
+        calls, sanitize_mock, runtime_mock, _, _ = self._stub_patches(monkeypatch)
         path = _write_config(
             tmp_path,
             '{"model_type": "qwen3_5", "vision_config": {}, '
@@ -233,7 +242,7 @@ class TestVlmMtpPreLoadDispatch:
         # mlx-vlm classes even when the model declares MTP heads. for_vlm
         # defaults to False so they pass through without invoking mlx-vlm
         # patches.
-        calls, sanitize_mock, runtime_mock = self._stub_patches(monkeypatch)
+        calls, sanitize_mock, runtime_mock, _, _ = self._stub_patches(monkeypatch)
         path = _write_config(
             tmp_path,
             '{"model_type": "qwen3_5", "vision_config": {}, '
@@ -251,7 +260,7 @@ class TestVlmMtpPreLoadDispatch:
         # mlx-lm Qwen3.6 MoE VLMs without MTP heads still need the mlx-vlm
         # sanitize replacement so pre-converted switch_mlp weights load.
         # Runtime MTP patch must NOT run — there is no mtp.* tree to bind.
-        calls, sanitize_mock, runtime_mock = self._stub_patches(monkeypatch)
+        calls, sanitize_mock, runtime_mock, _, _ = self._stub_patches(monkeypatch)
         path = _write_config(
             tmp_path,
             '{"model_type": "qwen3_5_moe", "vision_config": {}, '
@@ -268,7 +277,7 @@ class TestVlmMtpPreLoadDispatch:
     def test_qwen36_moe_vlm_sanitize_skipped_without_for_vlm(
         self, tmp_path, monkeypatch
     ):
-        calls, sanitize_mock, runtime_mock = self._stub_patches(monkeypatch)
+        calls, sanitize_mock, runtime_mock, _, _ = self._stub_patches(monkeypatch)
         path = _write_config(
             tmp_path,
             '{"model_type": "qwen3_5_moe", "vision_config": {}, '
@@ -281,3 +290,69 @@ class TestVlmMtpPreLoadDispatch:
         sanitize_mock.assert_not_called()
         runtime_mock.assert_not_called()
         assert calls == []
+
+    def test_vlm_mtp_runtime_skipped_when_config_declares_missing_mtp_weights(
+        self, tmp_path, monkeypatch
+    ):
+        # Regression for quantized VLM checkpoints that retain
+        # text_config.mtp_num_hidden_layers=1 but were exported without
+        # preserve_mtp. The sanitize patch is still useful, but attaching a
+        # runtime MTPModule would make strict load expect missing
+        # language_model.mtp.* parameters and trigger LLM fallback.
+        (
+            calls,
+            sanitize_mock,
+            runtime_mock,
+            set_mtp_active_mock,
+            set_mtp_weight_binding_active_mock,
+        ) = self._stub_patches(monkeypatch)
+        path = _write_config(
+            tmp_path,
+            '{"model_type": "qwen3_5_moe", "vision_config": {}, '
+            '"text_config": {"mtp_num_hidden_layers": 1}}',
+        )
+        (tmp_path / "model.safetensors.index.json").write_text(
+            '{"weight_map": {'
+            '"vision_tower.blocks.0.norm1.weight": "model-00001.safetensors", '
+            '"language_model.model.embed_tokens.weight": "model-00001.safetensors"'
+            "}}"
+        )
+        settings = types.SimpleNamespace(mtp_enabled=True)
+
+        maybe_apply_pre_load_patches(path, model_settings=settings, for_vlm=True)
+
+        sanitize_mock.assert_called_once()
+        runtime_mock.assert_not_called()
+        assert calls == ["sanitize"]
+        assert set_mtp_active_mock.call_args_list[-1].args == (False,)
+        assert set_mtp_weight_binding_active_mock.call_args_list[-1].args == (False,)
+
+    def test_vlm_mtp_runtime_kept_when_checkpoint_has_mtp_weights(
+        self, tmp_path, monkeypatch
+    ):
+        (
+            calls,
+            sanitize_mock,
+            runtime_mock,
+            set_mtp_active_mock,
+            set_mtp_weight_binding_active_mock,
+        ) = self._stub_patches(monkeypatch)
+        path = _write_config(
+            tmp_path,
+            '{"model_type": "qwen3_5_moe", "vision_config": {}, '
+            '"text_config": {"mtp_num_hidden_layers": 1}}',
+        )
+        (tmp_path / "model.safetensors.index.json").write_text(
+            '{"weight_map": {'
+            '"mtp.layers.0.input_layernorm.weight": "model-00001.safetensors"'
+            "}}"
+        )
+        settings = types.SimpleNamespace(mtp_enabled=False)
+
+        maybe_apply_pre_load_patches(path, model_settings=settings, for_vlm=True)
+
+        sanitize_mock.assert_called_once()
+        runtime_mock.assert_called_once()
+        assert calls == ["sanitize", "runtime"]
+        assert set_mtp_active_mock.call_args_list[-1].args == (False,)
+        assert set_mtp_weight_binding_active_mock.call_args_list[-1].args == (True,)


### PR DESCRIPTION
## Summary

- detect whether a local checkpoint actually contains MTP tensors before enabling VLM MTP weight binding
- keep the mlx-vlm sanitize patch active for Qwen3.6 VLM layout handling
- avoid attaching an MTP runtime module when `mtp_num_hidden_layers` is declared but no `mtp.*` weights exist

## Problem

Some Qwen3.6 VLM MLX checkpoints retain `text_config.mtp_num_hidden_layers > 0` in `config.json`, but were exported without preserved MTP tensors.

In that state, the VLM pre-load path treats the config declaration as enough to attach an MTP module. Strict weight loading then expects `language_model.mtp.*` parameters that are not present in the checkpoint. The model can fall back to the LLM engine, which silently drops vision support and shows up as image hallucination or "cannot see image" responses for image inputs.

Fixes the v0.3.11 vision regression in #1426.

## Approach

This change separates two related but different states:

- MTP declared in config
- MTP tensors actually present in the checkpoint

For sharded checkpoints, the loader checks the safetensors index for `mtp.*` keys. For single-file safetensors checkpoints, it checks the file header. If the checkpoint has no visible MTP tensors, the loader disables MTP activation and skips the VLM runtime MTP attachment, while still allowing the sanitize patch and Qwen3.6 VLM visual remapping path to run.

Checkpoints that do contain MTP tensors still get the VLM runtime binding path, including the existing `mtp_enabled=False` load fix where persisted MTP weights need a destination during strict load.

## Verification

- `env -u OMLX_API_KEY .venv/bin/python -m pytest -q`
  - `4656 passed, 36 skipped, 59 deselected`
- `.venv/bin/python -m ruff check --select F821 omlx/utils/model_loading.py omlx/patches/mlx_lm_mtp/__init__.py omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py tests/test_model_loading.py`
  - passed
- `git diff --check`
  - passed
- Manual before/after test with `unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit`
  - upstream `main`: VLM load falls back to LLM with missing `language_model.mtp.*` parameters; status becomes `model_type=llm`, `engine_type=batched`; image prompt is treated as text-only (`prompt_tokens=32`) and the model says it cannot see images
  - this branch: load stays on `VLMBatchedEngine`; status remains `model_type=vlm`, `engine_type=vlm`; image prompt includes vision tokens (`prompt_tokens=194`) and correctly answers `red square, blue circle, green triangle`
