### PR TITLE
feat: add AGENTS.md and SECURITY.md for project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,160 @@
+# AGENTS.md
+
+## Platform Scope (Read First)
+
+This project is ARM-first and ARM-only for Apple Silicon CPUs: **M1, M2, M3, M4, M5**.
+Assume macOS + Apple ARM architecture for runtime, performance tuning, and compatibility decisions.
+
+## Mission Context
+
+oMLX is a local-first, Apple Silicon–optimized multi-model inference platform.
+It serves OpenAI-compatible and Anthropic-compatible APIs with continuous batching,
+tiered KV caching (RAM + SSD), model lifecycle management, and an admin dashboard.
+
+Primary goals for changes:
+- Keep inference correctness and API compatibility stable.
+- Protect memory safety and graceful degradation under load.
+- Preserve low-latency streaming behavior.
+- Avoid regressions in cache coherence and model routing.
+
+## Tech Stack
+
+- Language: Python (project metadata requires `>=3.11`; classifiers include 3.10–3.13)
+- Server: FastAPI + Uvicorn
+- Core runtime: `mlx`, `mlx-lm`, `mlx-vlm`, `mlx-embeddings`, optional `mlx-audio`
+- Packaging: setuptools (`pyproject.toml`)
+- App wrapper: PyObjC menubar app under `packaging/omlx_app`
+- Tests: Pytest (unit + integration + slow/model tests)
+
+## Repo Map
+
+- `omlx/server.py`: FastAPI app, endpoint wiring, auth checks, streaming and lifecycle.
+- `omlx/cli.py`: `omlx serve` entrypoint, settings init, runtime env/bootstrap.
+- `omlx/settings.py`: hierarchical config and persistence (`CLI > env > file > defaults`).
+- `omlx/engine_core.py`, `omlx/scheduler.py`, `omlx/engine_pool.py`: request scheduling,
+  batching, model loading/eviction, execution orchestration.
+- `omlx/cache/`: paged/prefix/hybrid/SSD cache implementations + observability/stats.
+- `omlx/api/`: OpenAI/Anthropic models, adapters, response conversion, tool calling,
+  structured output, embeddings/rerank/audio/mcp routes.
+- `omlx/models/`: model wrappers and model-type abstractions.
+- `omlx/patches/`: model-family/runtime patches (DeepSeek/Qwen/Gemma/specprefill/etc).
+- `omlx/admin/`: dashboard routes, templates, static assets, auth/downloader tools.
+- `omlx/mcp/`: MCP client/manager/executor/types and tool bridge.
+- `omlx/integrations/`: setup helpers for Codex/Copilot/Claude/OpenCode/OpenClaw/etc.
+- `tests/`: broad unit/integration coverage.
+- `docs/`: contributor docs and feature docs.
+
+## Local Setup
+
+```bash
+git clone https://github.com/jundot/omlx.git
+cd omlx
+pip install -e ".[dev]"
+# Optional extras:
+# pip install -e ".[mcp]"
+# pip install -e ".[audio]"
+```
+
+## Common Commands
+
+```bash
+# Start server
+omlx serve --model-dir ~/models
+
+# Fast test loop
+pytest -m "not slow"
+
+# Single-file test
+pytest tests/test_config.py -v
+
+# Slow/model tests
+pytest -m slow
+
+# Integration tests
+pytest -m integration
+```
+
+## Coding Rules for Agents
+
+1. Keep API contracts stable unless explicitly changing versioned behavior.
+2. Preserve streaming semantics and usage accounting for chat/completions/responses.
+3. Any scheduler/cache/memory change must include focused tests.
+4. Prefer minimal, surgical edits over broad refactors.
+5. Follow existing style (Black/Ruff, line length 88, SPDX header on source files).
+6. Do not silently change default thresholds (memory/cache/concurrency) without tests and rationale.
+7. Maintain offline/admin-dashboard compatibility (vendored frontend deps).
+8. For model-family-specific changes, isolate logic in `omlx/patches` or adapter layers.
+
+## High-Risk Areas
+
+Treat these as sensitive and regression-prone:
+- `omlx/scheduler.py` (admission, chunked prefill, queue/full behavior)
+- `omlx/cache/*` (prefix sharing, block identity, persistence/recovery)
+- `omlx/engine_core.py` and `omlx/engine/batched.py` (streaming + batching)
+- `omlx/server.py` response streaming / API conversion / auth paths
+- `omlx/process_memory_enforcer.py` + memory monitor interactions
+- Tool-calling parsing (`omlx/api/tool_calling.py`, harmony/output parsers)
+
+For these areas, add or update targeted tests before concluding.
+
+## Test Strategy Expectations
+
+When touching code, choose the narrowest meaningful test subset first, then widen.
+
+Recommended mapping:
+- API schemas/serialization/adapters -> `tests/test_openai_models.py`,
+  `tests/test_anthropic_models.py`, `tests/test_responses.py`, `tests/test_*adapter*.py`
+- Scheduler/engine behavior -> `tests/test_scheduler*.py`, `tests/test_engine*.py`
+- Cache behavior -> `tests/test_cache_*.py`, `tests/test_prefix_cache*.py`,
+  `tests/test_paged_cache*.py`, `tests/test_hybrid_cache.py`
+- MCP/tooling -> `tests/test_mcp_*.py`, `tests/test_tool_calling.py`
+- Admin/auth/settings -> `tests/test_admin_*.py`, `tests/test_settings.py`
+
+Always run at least one relevant test for each modified subsystem.
+
+## Configuration & Persistence Notes
+
+- Runtime base path defaults to `~/.omlx`.
+- Important persisted artifacts include settings, cache, and logs.
+- Settings are initialized early and CLI overrides may be persisted.
+- Ensure config precedence remains: `CLI > env > settings file > defaults`.
+
+## Performance & Reliability Guardrails
+
+- Avoid adding per-token Python overhead in hot paths.
+- Keep allocations low in streaming loops.
+- Don’t block event loop with heavy sync work on request path.
+- Preserve graceful failures (`HTTPException`/typed errors) over crashes.
+- Keep memory guard behavior deterministic and observable via logs/metrics.
+
+## Integration Compatibility
+
+oMLX is used as a backend for coding agents and clients expecting OpenAI/Anthropic behavior.
+For changes in compatibility layers:
+- Validate endpoint payload shape and finish reasons.
+- Preserve handling for tool-call formats and structured output.
+- Keep `stream_options.include_usage` and SSE behavior consistent.
+
+## Definition of Done for Agent PRs
+
+1. Code compiles and imports cleanly.
+2. Relevant tests pass locally.
+3. New behavior is covered by tests or justified as no-test-needed.
+4. No unintended API/setting default drift.
+5. Logging/error messages remain actionable.
+6. Documentation/comments updated when behavior changes materially.
+
+## Quick File Targets
+
+- New endpoint behavior: start at `omlx/server.py` and `omlx/api/*`.
+- Model load/evict logic: `omlx/engine_pool.py`, `omlx/model_registry.py`.
+- Cache correctness: `omlx/cache/*` and matching cache tests.
+- Admin UX/API: `omlx/admin/routes.py`, `omlx/admin/templates/*`, static JS/CSS.
+- Packaging/app startup: `packaging/omlx_app/*`.
+
+## Non-Goals
+
+- Do not introduce non-macOS assumptions in core runtime paths.
+- Do not remove compatibility shims without migration path.
+- Do not bypass settings/auth checks for convenience during feature work.
+- Do not introduce support assumptions for non-ARM or non-Apple-Silicon CPU targets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v0.3.12] - 2026-05-26
+
+### Added
+- Document agent workflows, contributor guidance, and security reporting with new `AGENTS.md` and `SECURITY.md` files.
+- Enhance `README.md` with badges and community links for improved onboarding.
+
+### Changed
+- None
+
+### Deprecated
+- None
+
+### Removed
+- None
+
+### Fixed
+- None
+
+### Security
+- None
+
+---
+
+## Release Notes Guidelines
+
+- Add entries under `Unreleased` as part of each PR.
+- Keep entries user-facing and behavior-focused (not internal-only refactors unless impactful).
+- Group changes by category: `Added`, `Changed`, `Fixed`, `Security`, etc.
+- On release, move `Unreleased` entries to a new version section with date `YYYY-MM-DD`.
+- Prefer one concise bullet per logical change.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,23 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License">
-  <img src="https://img.shields.io/badge/python-3.10+-green" alt="Python 3.10+">
-  <img src="https://img.shields.io/badge/platform-Apple%20Silicon-black?logo=apple" alt="Apple Silicon">
+  <a href="https://github.com/jundot/omlx/releases">
+  </a>
+  <a>
+    <img src="https://img.shields.io/github/v/release/jundot/omlx?include_prereleases&style=for-the-badge" alt="GitHub Release">
+  </a>
+  <a href="LICENSE">
+    <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge" alt="Apache 2.0 License">
+  </a>
+  <a href="https://www.python.org/">
+    <img src="https://img.shields.io/badge/Python-3.10%2B-3776AB?logo=python&logoColor=white&style=for-the-badge" alt="Python 3.10+">
+  </a>
+  <a href="https://www.apple.com/apple-silicon/">
+    <img src="https://img.shields.io/badge/Apple%20Silicon-M1--M5-black?logo=apple&style=for-the-badge" alt="Apple Silicon M1-M5">
+  </a>
+  <a href="https://github.com/jundot/omlx/stargazers">
+    <img src="https://img.shields.io/github/stars/jundot/omlx?style=for-the-badge" alt="GitHub Stars">
+  </a>
 </p>
 
 <p align="center">
@@ -360,9 +374,28 @@ Contributions are welcome! See [Contributing Guide](docs/CONTRIBUTING.md) for de
 - Performance optimizations
 - Documentation improvements
 
-## License
+## Star History
 
-[Apache 2.0](LICENSE)
+<a href="https://www.star-history.com/?type=date&repos=jundot%2Fomlx">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=jundot/omlx&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=jundot/omlx&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=jundot/omlx&type=date&legend=top-left" />
+ </picture>
+</a>
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=jundot/omlx&style=landscape1&theme=dark" />
+  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=jundot/omlx&style=landscape1" />
+  <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=jundot/omlx&style=landscape1" />
+</picture>
+
+## Community
+
+- [GitHub Discussions](https://github.com/jundot/omlx/discussions)
+- [GitHub Issues](https://github.com/jundot/omlx/issues)
+- [Contributing Guide](docs/CONTRIBUTING.md)
+- [Security Policy](SECURITY.md)
 
 ## Acknowledgments
 
@@ -372,3 +405,7 @@ Contributions are welcome! See [Contributing Guide](docs/CONTRIBUTING.md) for de
 - [venvstacks](https://venvstacks.lmstudio.ai) - Portable Python environment layering for the macOS app bundle
 - [mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings) - Embedding model support for Apple Silicon
 - [dflash-mlx](https://github.com/bstnxbt/dflash-mlx) - Block diffusion speculative decoding on Apple Silicon
+
+## License
+
+[Apache 2.0](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security
+
+The oMLX maintainer team takes security seriously and will actively work to resolve security issues.
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability, please do not open a public issue. Instead, please report it by emailing `junkim.dot@gmail.com`.
+We ask that you give us sufficient time to investigate and address the vulnerability before disclosing it publicly.
+
+Please include the following details in your report:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Your assessment of the potential impact
+- Any possible mitigations
+
+## Security best practices
+
+While the maintainer team does its best to secure oMLX, users are encouraged to implement their own security best practices, such as:
+
+- Regularly updating to the latest version of oMLX
+- Securing access to hosted oMLX instances and admin endpoints
+- Monitoring systems for unusual activity
+
+## Contact
+
+For any other questions or concerns related to security, please contact us at `junkim.dot@gmail.com`.


### PR DESCRIPTION
## Summary
Adds project documentation and community guidance for the oMLX repository.

### What changed
- Added AGENTS.md to document agent workflows, platform scope, architecture, and contribution expectations.
- Added SECURITY.md for security reporting and responsible disclosure guidance.
- Enhanced README.md with badges and community links to improve discoverability and onboarding.

### Why
- Provides maintainers and contributors with clearer guidance around agent usage and project rules.
- Improves repository professionalism with standard security disclosure and community resources.
- Makes the project easier to evaluate and engage with from GitHub at a glance.