### PR TITLE
test(mtp): drop monkeypatch of removed _get_generation_stream

### DIFF
--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -573,7 +573,10 @@ class TestBatchGeneratorDispatch:
 
         monkeypatch.setattr(batch_generator, "_rebuild_singleton_cache", fake_rebuild)
         monkeypatch.setattr(batch_generator, "_call_backbone", fake_backbone)
-        monkeypatch.setattr(batch_generator, "_get_generation_stream", lambda: mx.cpu)
+        # ``_get_generation_stream`` was removed in #1304 when the patch
+        # moved stream selection to the enclosing BatchGenerator context.
+        # The fake_backbone / fake_rebuild monkeypatches above bypass the
+        # actual MLX dispatch, so no stream override is needed.
 
         def greedy(lp_2d):
             return mx.argmax(lp_2d, axis=-1).astype(mx.uint32)


### PR DESCRIPTION
## Summary

#1304 (`fix(engine): per-engine threads to eliminate cross-engine stream contamination`) refactored the patched `BatchGenerator` to inherit its execution stream from the enclosing engine context, and removed the module-level `_get_generation_stream` helper as part of that.

`TestBatchGeneratorDispatch._make_reconcile_batch` still tried to monkeypatch that name and failed at every test that used the fixture with:

```
AttributeError: module 'omlx.patches.mlx_lm_mtp.batch_generator' has no attribute '_get_generation_stream'
```

— taking down 4 reconcile-path tests on every CI run.

The override is no longer needed: the surrounding fixture replaces `_rebuild_singleton_cache` and `_call_backbone` with fakes that do their work via `np.array` / `mx.array` directly, so neither MLX dispatch nor stream selection is reached.

## Test plan

- [x] `pytest tests/test_mlx_lm_mtp_patch.py::TestBatchGeneratorDispatch` — 11/11 pass (was 7/11 with these 4 failing on `main`):
  - `test_reconcile_uses_queue_front_as_next_token`
  - `test_reconcile_empty_queue_samples_from_logits`
  - `test_reconcile_returns_false_on_empty_tokens`
  - `test_reconcile_fallback_on_rebuild_failure`