### PR TITLE
fix(memory): warn once per engine type when scheduler unresolvable

### DIFF
--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -340,6 +340,11 @@ class ProcessMemoryEnforcer:
         # or the call failed). Used by the admin dashboard to surface a
         # warning when the kernel iogpu.wired_limit_mb is below this.
         self._metal_wired_limit_request: int = 0
+        # Engine types we've already complained about in
+        # ``_propagate_memory_limit``'s "scheduler unreachable" path.
+        # Prevents the per-poll warning from spamming logs while keeping
+        # the first occurrence loud enough to alert CI / oncall.
+        self._scheduler_resolve_warned: set[str] = set()
 
     @staticmethod
     def _normalize_tier(tier: str) -> str:
@@ -582,17 +587,37 @@ class ProcessMemoryEnforcer:
         admission_paused = self._pressure_level != "ok"
         for entry in self._engine_pool._entries.values():
             scheduler = self._resolve_scheduler(entry)
-            if scheduler is not None:
-                scheduler._memory_limit_bytes = soft_limit
-                scheduler._memory_hard_limit_bytes = ceiling
-                scheduler._prefill_memory_guard = self._prefill_memory_guard
-                scheduler._admission_paused = admission_paused
-                scheduler._prefill_safe_zone_ratio = self._prefill_safe_zone_ratio
-                scheduler._prefill_min_chunk_tokens = self._prefill_min_chunk_tokens
-                bg = getattr(scheduler, "batch_generator", None)
-                if bg is not None and hasattr(bg, "_memory_limit_bytes"):
-                    bg._memory_limit_bytes = soft_limit
-                    bg._memory_hard_limit_bytes = ceiling
+            if scheduler is None:
+                # Silent no-op was the failure mode that originally hid
+                # the dead memory guard: a wrapper-chain change made
+                # ``_resolve_scheduler()`` return None and the loop kept
+                # iterating without complaining. Surface it now — once
+                # per engine type per enforcer lifetime so the regression
+                # is loud in CI / oncall but a misconfigured engine
+                # polled every second doesn't spam.
+                engine = getattr(entry, "engine", None)
+                engine_type = type(engine).__name__ if engine is not None else "None"
+                if engine_type not in self._scheduler_resolve_warned:
+                    self._scheduler_resolve_warned.add(engine_type)
+                    logger.warning(
+                        "ProcessMemoryEnforcer: could not resolve "
+                        "scheduler for engine type %s — prefill memory "
+                        "guard will not propagate to this engine. "
+                        "Verify the wrapper chain "
+                        "(engine._engine.engine.scheduler) still holds.",
+                        engine_type,
+                    )
+                continue
+            scheduler._memory_limit_bytes = soft_limit
+            scheduler._memory_hard_limit_bytes = ceiling
+            scheduler._prefill_memory_guard = self._prefill_memory_guard
+            scheduler._admission_paused = admission_paused
+            scheduler._prefill_safe_zone_ratio = self._prefill_safe_zone_ratio
+            scheduler._prefill_min_chunk_tokens = self._prefill_min_chunk_tokens
+            bg = getattr(scheduler, "batch_generator", None)
+            if bg is not None and hasattr(bg, "_memory_limit_bytes"):
+                bg._memory_limit_bytes = soft_limit
+                bg._memory_hard_limit_bytes = ceiling
 
     def _walk_store_cache_caps(self) -> None:
         """Walk each scheduler's store-cache gate one step per poll (#1383).

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -898,6 +898,74 @@ class TestMemoryLimitPropagation:
             assert scheduler._memory_limit_bytes == 10 * 1024**3
 
 
+class TestUnresolvableSchedulerWarning:
+    """``_propagate_memory_limit`` must complain when a wrapper-chain
+    change makes the scheduler unreachable via ``_resolve_scheduler``.
+
+    Silent no-op was the failure mode that originally hid the
+    dead-memory-guard bug for months — surfacing it as a per-engine-type
+    rate-limited warning closes that gap without spamming logs at
+    request rate.
+    """
+
+    def test_warns_once_per_engine_type(self, enforcer, caplog):
+        """Three propagation calls with an unreachable scheduler emit
+        exactly one WARNING (not three)."""
+        # Engine wrapper with no resolvable scheduler chain: spec=[]
+        # blocks both ``.scheduler`` and ``._engine`` lookups so
+        # ``_resolve_scheduler`` returns None.
+        engine = MagicMock(spec=[])
+        entry = _make_entry("model-broken", engine=engine)
+        enforcer._engine_pool._entries = {"model-broken": entry}
+
+        with caplog.at_level(
+            "WARNING", logger="omlx.process_memory_enforcer"
+        ):
+            enforcer._propagate_memory_limit()
+            enforcer._propagate_memory_limit()
+            enforcer._propagate_memory_limit()
+
+        warnings = [
+            r for r in caplog.records
+            if "could not resolve scheduler" in r.getMessage()
+        ]
+        assert len(warnings) == 1, (
+            f"Expected exactly one warning per engine type per lifetime, "
+            f"got {len(warnings)}"
+        )
+
+    def test_unresolvable_does_not_block_other_engines(self, enforcer):
+        """If engine A is unresolvable but engine B has a real scheduler,
+        B must still receive the propagation."""
+        # A: unresolvable (no .scheduler / no ._engine).
+        engine_a = MagicMock(spec=[])
+        entry_a = _make_entry("model-a", engine=engine_a)
+
+        # B: real scheduler chain.
+        scheduler_b = MagicMock(spec=[])
+        scheduler_b._memory_limit_bytes = 0
+        scheduler_b._memory_hard_limit_bytes = 0
+        scheduler_b._prefill_memory_guard = False
+        scheduler_b._admission_paused = False
+        scheduler_b._prefill_safe_zone_ratio = 0.0
+        scheduler_b._prefill_min_chunk_tokens = 0
+        scheduler_b.batch_generator = None
+        engine_b = MagicMock(spec=[])
+        engine_b.scheduler = scheduler_b
+        entry_b = _make_entry("model-b", engine=engine_b)
+
+        enforcer._engine_pool._entries = {
+            "model-a": entry_a,
+            "model-b": entry_b,
+        }
+
+        enforcer._propagate_memory_limit()
+
+        # B got it; A's resolve-failure didn't poison the loop.
+        assert scheduler_b._memory_limit_bytes == 10 * 1024**3
+        assert scheduler_b._prefill_memory_guard is True
+
+
 class TestStoreCacheCapWalk:
     """Tests for _walk_store_cache_caps — store-cache gate adjustment (#1383)."""
 


### PR DESCRIPTION
## Summary

`_propagate_memory_limit` skips engines whose `_resolve_scheduler` returns None, but until now the skip was silent. That same silent no-op is what originally hid the dead-memory-guard bug for months — the docstring on `_resolve_scheduler` itself acknowledges it. If a future wrapper change (BatchedEngine refactor, new engine type) breaks the `engine._engine.engine.scheduler` traversal, the guard will silently stop propagating again.

Fix: log a WARNING when `_resolve_scheduler` returns None, naming the engine type. Rate-limited per type per enforcer lifetime (`_scheduler_resolve_warned: set[str]`) so a misconfigured engine polled every second doesn't spam, but the first occurrence is loud enough to alert CI / oncall.

## Test plan

- [x] `pytest tests/test_process_memory_enforcer.py::TestUnresolvableSchedulerWarning` — 2 passed
  - three propagation calls with an unreachable scheduler emit exactly one WARNING (not three)
  - when one engine is unresolvable but another resolves, the unresolvable one's failure doesn't prevent propagation reaching the resolvable one