### PR TITLE
fix(scheduler): release paged cache refs on prefill rejection paths

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -2422,6 +2422,7 @@ class Scheduler:
             except RuntimeError as e:
                 logger.error("Chunked prefill failed for %s: %s", rid, e)
                 self._prefill_states.pop(rid, None)
+                self._release_paged_cache_for_request(rid)
                 self.requests.pop(rid, None)
                 get_prefill_tracker().remove(rid)
                 # Drop Metal cache pool buffers held by the aborted chunk's
@@ -5034,6 +5035,7 @@ class Scheduler:
                             request.request_id,
                             e,
                         )
+                        self._release_paged_cache_for_request(request.request_id)
                         self.requests.pop(request.request_id, None)
                         get_prefill_tracker().remove(request.request_id)
                         # Drop Metal cache pool buffers held by the aborted
@@ -5085,6 +5087,7 @@ class Scheduler:
                     logger.error("Prefill failed for %s: %s", request.request_id, e)
                     self.uid_to_request_id.pop(temp_uid, None)
                     self.request_id_to_uid.pop(request.request_id, None)
+                    self._release_paged_cache_for_request(request.request_id)
                     self.requests.pop(request.request_id, None)
                     get_prefill_tracker().remove(request.request_id)
                     # Drop Metal cache pool buffers held by the aborted
@@ -5447,6 +5450,24 @@ class Scheduler:
             outputs.append(output)
 
         return outputs, finished_ids
+
+    def _release_paged_cache_for_request(self, request_id: str) -> None:
+        """Drop a request's paged-cache footprint on rejection paths.
+
+        ``add_request`` routes through ``block_aware_cache.fetch_cache``
+        which records the request in ``_request_tables`` and increments
+        ref counts on every prefix-matched paged-cache block. The normal
+        completion path releases that state in ``_cleanup_finished``;
+        the prefill-rejection paths in ``_advance_chunked_prefills`` /
+        ``_schedule_waiting`` must do the same or rejected requests
+        leak block refs (pinning the paged cache and compounding the
+        very memory pressure that triggered the rejection) and orphan
+        ``_request_tables`` entries.
+        """
+        if self.block_aware_cache is not None:
+            self.block_aware_cache.release_cache(request_id)
+        elif self.paged_cache_manager is not None:
+            self.paged_cache_manager.delete_block_table(request_id)
 
     def _cleanup_finished(self, finished_ids: set[str]) -> None:
         """Clean up finished requests and store caches for reuse."""

--- a/tests/test_scheduler_chunked_prefill.py
+++ b/tests/test_scheduler_chunked_prefill.py
@@ -649,3 +649,125 @@ class TestScheduleWaitingChunkedFork:
             assert "Memory limit" in out.error
         finally:
             tracker.clear()
+
+
+# ---------------------------------------------------------------------------
+# Prefill-rejection paged-cache cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestPrefillRejectionReleasesPagedCache:
+    """Rejection paths must release block_aware_cache refs / paged_cache
+    block_table entries that ``add_request`` populated via ``fetch_cache``.
+
+    Without this, every rejected request leaks an entry in
+    ``BlockAwarePrefixCache._request_tables`` plus the ref counts on its
+    prefix-matched blocks — pinning the paged cache and compounding the
+    very memory pressure that triggered the rejection. The existing
+    ``self.requests.pop(...)`` and ``get_prefill_tracker().remove(...)``
+    cleanups handle scheduler-side state but never reach into the
+    paged-cache layer.
+    """
+
+    def test_helper_calls_block_aware_cache_release(self):
+        """The helper delegates to block_aware_cache.release_cache when one
+        is attached — the normal production wiring."""
+        sched = _make_scheduler()
+        sched.block_aware_cache = MagicMock()
+        sched.paged_cache_manager = MagicMock()
+
+        sched._release_paged_cache_for_request("rid-1")
+
+        sched.block_aware_cache.release_cache.assert_called_once_with("rid-1")
+        # release_cache delegates to delete_block_table internally; the
+        # helper must NOT also call it directly (double-delete).
+        sched.paged_cache_manager.delete_block_table.assert_not_called()
+
+    def test_helper_falls_back_to_paged_cache_manager(self):
+        """Without a BlockAwarePrefixCache, fall back to deleting the block
+        table directly on the paged cache manager."""
+        sched = _make_scheduler()
+        sched.block_aware_cache = None
+        sched.paged_cache_manager = MagicMock()
+
+        sched._release_paged_cache_for_request("rid-2")
+
+        sched.paged_cache_manager.delete_block_table.assert_called_once_with("rid-2")
+
+    def test_helper_is_noop_without_any_paged_cache(self):
+        """No paged-cache layer attached → silent no-op."""
+        sched = _make_scheduler()
+        sched.block_aware_cache = None
+        sched.paged_cache_manager = None
+
+        # Should not raise.
+        sched._release_paged_cache_for_request("rid-3")
+
+    def test_advance_chunked_prefills_releases_on_runtime_error(self):
+        """_advance_chunked_prefills' RuntimeError handler must call
+        release_cache so the paged-cache block refs from the request's
+        prefix-cache lookup don't leak."""
+        sched = _make_scheduler()
+        sched.block_aware_cache = MagicMock()
+        req = _make_request("oom-chunked")
+        sched.requests[req.request_id] = req
+        state = _make_prefill_state(sched, req)
+        sched.prefilling.append(req)
+        sched._prefill_states[req.request_id] = state
+
+        with patch.object(
+            sched, "_step_prefill_chunk",
+            side_effect=RuntimeError("Memory limit exceeded"),
+        ):
+            sched._advance_chunked_prefills([], [])
+
+        sched.block_aware_cache.release_cache.assert_called_once_with(
+            "oom-chunked"
+        )
+
+    def test_schedule_waiting_non_chunked_releases_on_runtime_error(self):
+        """The non-chunked _do_external_prefill rejection path must release
+        the paged-cache footprint before popping self.requests."""
+        sched = _make_scheduler(step_size=4)
+        sched.block_aware_cache = MagicMock()
+        # No prefix-cache hit: fetch_cache returns (None, prompt_tokens) so
+        # add_request falls through to the waiting queue without trying to
+        # preload/reconstruct.
+        sched.block_aware_cache.fetch_cache.return_value = (None, [0, 1, 2])
+        req = _make_request("oom-direct", n_tokens=3)
+        sched.add_request(req)
+        sched.block_aware_cache.reset_mock()
+
+        with patch.object(
+            sched, "_do_external_prefill",
+            side_effect=RuntimeError("Memory limit exceeded during prefill"),
+        ):
+            sched._schedule_waiting()
+
+        sched.block_aware_cache.release_cache.assert_called_once_with(
+            "oom-direct"
+        )
+
+    def test_schedule_waiting_chunked_first_chunk_releases_on_runtime_error(self):
+        """The chunked first-chunk rejection path must release the
+        paged-cache footprint before popping self.requests."""
+        sched = _make_scheduler(step_size=4)
+        sched.block_aware_cache = MagicMock()
+        sched.block_aware_cache.fetch_cache.return_value = (None, list(range(10)))
+        req = _make_request("oom-first-chunk", n_tokens=10)
+        sched.add_request(req)
+        sched.block_aware_cache.reset_mock()
+
+        with patch.object(
+            sched, "_begin_prefill",
+            return_value=_make_prefill_state(sched, req),
+        ):
+            with patch.object(
+                sched, "_step_prefill_chunk",
+                side_effect=RuntimeError("Memory limit exceeded"),
+            ):
+                sched._schedule_waiting()
+
+        sched.block_aware_cache.release_cache.assert_called_once_with(
+            "oom-first-chunk"
+        )


### PR DESCRIPTION
## Summary

`add_request` routes through `block_aware_cache.fetch_cache` which records the request in `_request_tables` and increments ref counts on every prefix-matched paged-cache block. The normal completion path releases that state in `_cleanup_finished`; the prefill-rejection paths in `_advance_chunked_prefills` / `_schedule_waiting` (added in #1405) pop `self.requests` and remove the prefill-tracker entry but **never call `release_cache(request_id)`** — so rejected requests leak `_request_tables` entries and pin block refs in the paged-cache pool, compounding the very memory pressure that triggered the rejection.

Fix: add a small `_release_paged_cache_for_request` helper and call it from all three rejection sites. The helper delegates to `block_aware_cache.release_cache` (which pops the request table AND deletes the paged block_table) when a prefix cache is configured; otherwise it falls back to `paged_cache_manager.delete_block_table` for the no-prefix-cache configuration.

## Test plan

- [x] `pytest tests/test_scheduler_chunked_prefill.py::TestPrefillRejectionReleasesPagedCache` — 6 passed
  - helper delegates to block_aware_cache.release_cache when one is attached; doesn't double-call delete_block_table
  - helper falls back to paged_cache_manager.delete_block_table when no prefix cache
  - helper is a no-op without any paged-cache layer (defensive)
  - `_advance_chunked_prefills` releases on RuntimeError
  - `_schedule_waiting` non-chunked path releases on RuntimeError
  - `_schedule_waiting` chunked first-chunk path releases on RuntimeError