### PR TITLE
fix(ssd-cache): inline LRU unlinks so eviction frees queue capacity

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -71,6 +71,17 @@ def _compute_max_pending_writes() -> int:
 
 _MAX_PENDING_WRITES = _compute_max_pending_writes()
 
+# Cap on the number of LRU blocks ``_enforce_size_limit_for_new_block`` is
+# allowed to unlink in one inline burst. Eviction normally returns ~1
+# entry; the cap exists for the ENOSPC-recovery path where the disk-usage
+# cache invalidates and the next ``_get_effective_max_size`` call can
+# shrink sharply — ``evict_until_size`` would then return hundreds of
+# entries at once and stall the inference thread on a syscall storm.
+# Deferred-but-not-unlinked entries are reinserted into the index so
+# subsequent saves drain the remainder; bounds per-call latency at the
+# cost of taking multiple saves to fully reconverge.
+_MAX_INLINE_UNLINKS_PER_SAVE = 32
+
 
 # Cache format version. Bump when on-disk layout or RotatingKVCache meta_state
 # semantics change in a way that older blocks become unsafe to load.
@@ -749,6 +760,7 @@ class PagedSSDCacheManager(CacheManager):
             "hits": 0,
             "misses": 0,
             "evictions": 0,
+            "evict_unlink_failures": 0,
             "errors": 0,
             "hot_cache_hits": 0,
             "hot_cache_evictions": 0,
@@ -1206,23 +1218,6 @@ class PagedSSDCacheManager(CacheManager):
 
             if item is None:  # Sentinel for shutdown
                 break
-
-            # Unlink task: tuple ('unlink', file_path). Used to defer LRU file
-            # deletion off the inference thread (see _enforce_size_limit_for_new_block).
-            # Sequential queue processing prevents race with subsequent writes
-            # to the same block_hash (write tasks always queued after unlink).
-            if isinstance(item[0], str) and item[0] == "unlink":
-                _, unlink_path = item
-                try:
-                    if unlink_path.exists():
-                        unlink_path.unlink()
-                        self._stats["evictions"] += 1
-                        logger.debug(f"Evicted SSD cache file (async): {unlink_path}")
-                except FileNotFoundError:
-                    pass
-                except Exception as e:
-                    logger.warning(f"Failed to delete evicted file {unlink_path}: {e}")
-                continue
 
             block_hash, tensors_raw, metadata, file_path = item
             temp_path = None
@@ -2366,24 +2361,61 @@ class PagedSSDCacheManager(CacheManager):
 
         if self._index.total_size > target_size:
             evicted = self._index.evict_until_size(target_size)
-            # Defer file unlink to the writer thread to avoid blocking the
-            # inference thread with N file delete syscalls. Sequential queue
-            # processing keeps unlink ordered before any later write of the
-            # same block_hash. Hot cache is NOT touched here — see
-            # original comment about delete_block() being the only path that
-            # clears both tiers.
-            for metadata in evicted:
+            # Inline unlinks on the calling thread. Eviction typically returns
+            # a single entry per save (the ``evict_until_size`` loop stops as
+            # soon as ``total_size <= target``), so this is one syscall per
+            # save in steady state. The previous design enqueued evicted
+            # paths as ``("unlink", path)`` items onto ``_write_queue`` — the
+            # same bounded queue that carries pending writes — so eviction
+            # could never free queue capacity, only add more work to it.
+            # Combined with the pre-eviction ``_write_queue.full()`` short-
+            # circuit at the top of ``save_block``, that interaction kept the
+            # cache permanently full once the queue saturated. Inline removes
+            # the bounded-queue contention entirely. Hot cache is NOT touched
+            # here — ``delete_block()`` is the only path that clears both
+            # tiers.
+            #
+            # Bounded inline burst. The ENOSPC-recovery path invalidates the
+            # 30 s disk-usage cache, which can shrink the next
+            # ``_get_effective_max_size`` call sharply — ``evict_until_size``
+            # may then return hundreds of entries at once and the inline
+            # loop would stall the inference thread on a syscall storm. Cap
+            # the burst at ``_MAX_INLINE_UNLINKS_PER_SAVE`` and reinsert the
+            # deferred metadata into the index so subsequent saves drain
+            # the remainder. Bounds per-call latency at the cost of taking
+            # multiple saves to fully reconverge.
+            unlinked_count = 0
+            for metadata in evicted[:_MAX_INLINE_UNLINKS_PER_SAVE]:
                 try:
-                    self._write_queue.put_nowait(("unlink", metadata.file_path))
-                except queue.Full:
-                    # Queue saturated — fall back to inline unlink so size
-                    # accounting stays consistent. Rare path.
-                    try:
-                        if metadata.file_path.exists():
-                            metadata.file_path.unlink()
-                            self._stats["evictions"] += 1
-                    except Exception as e:
-                        logger.warning(f"Failed to delete evicted file: {e}")
+                    if metadata.file_path.exists():
+                        metadata.file_path.unlink()
+                    self._stats["evictions"] += 1
+                    unlinked_count += 1
+                except FileNotFoundError:
+                    # Concurrent writer/cleanup beat us to it. Still counts
+                    # as an eviction from the index's perspective.
+                    self._stats["evictions"] += 1
+                    unlinked_count += 1
+                except OSError as e:
+                    # The block has already been removed from the index by
+                    # ``evict_until_size``; surfacing the unlink failure as
+                    # a counter keeps the size accounting honest (an on-disk
+                    # file outside the index can still occupy bytes the
+                    # next ``_get_effective_max_size`` call doesn't see).
+                    self._stats["evict_unlink_failures"] += 1
+                    logger.warning(
+                        f"Failed to delete evicted file {metadata.file_path}: {e}"
+                    )
+            # Reinsert anything we deferred so size accounting reflects the
+            # on-disk reality. Next save will retry.
+            for metadata in evicted[_MAX_INLINE_UNLINKS_PER_SAVE:]:
+                self._index.add(metadata)
+            if unlinked_count < len(evicted):
+                logger.debug(
+                    f"Inline eviction capped at {_MAX_INLINE_UNLINKS_PER_SAVE} "
+                    f"of {len(evicted)} entries; {len(evicted) - unlinked_count} "
+                    f"reinserted for subsequent saves to drain"
+                )
 
     def enforce_size_limit(self) -> int:
         """

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -2340,3 +2340,187 @@ class TestPreloadBlocks:
             assert ssd_manager2._hot_cache_get(bh) is not None
 
         ssd_manager2.close()
+
+
+class TestInlineLRUUnlinks:
+    """LRU eviction must unlink inline on the calling thread, not enqueue
+    ``("unlink", path)`` tasks onto ``_write_queue``.
+
+    The original async-queued design routed eviction unlinks through the
+    same bounded queue that carries pending writes. Under sustained save
+    pressure, the queue saturated, ``save_block``'s pre-eviction
+    ``_write_queue.full()`` short-circuit fired before eviction could
+    run, and the cache stayed permanently full once the queue saturated.
+    Inlining removes the bounded-queue contention.
+    """
+
+    @pytest.fixture
+    def mx(self):
+        try:
+            import mlx.core as mx
+
+            return mx
+        except ImportError:
+            pytest.skip("MLX not available")
+
+    def _entry_size(self, num_layers=2, seq_len=16, heads=2, head_dim=16):
+        # 2 tensors (K+V) per layer, batch=1, float32=4
+        return num_layers * 2 * 1 * heads * seq_len * head_dim * 4
+
+    def _save_block(self, mgr, mx, block_hash, num_layers=2):
+        cache_data = [
+            (mx.zeros((1, 2, 16, 16)), mx.zeros((1, 2, 16, 16)))
+            for _ in range(num_layers)
+        ]
+        return mgr.save_block(
+            block_hash=block_hash,
+            cache_data=cache_data,
+            token_count=16,
+            model_name="test-model",
+            layer_cache_types=["KVCache"] * num_layers,
+        )
+
+    def test_eviction_does_not_enqueue_unlink_tasks(self, tmp_path, mx):
+        """Force eviction; assert no ``("unlink", ...)`` items ever enter
+        ``_write_queue``. Regression for the original async-queued
+        design."""
+        entry_size = self._entry_size()
+        # Room for ~2 entries; the third save forces eviction of the first.
+        max_bytes = entry_size * 2 + 100
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "inline_eviction",
+            max_size_bytes=max_bytes,
+        )
+
+        # Sentinel: intercept put_nowait and reject any unlink-shaped tuple.
+        original_put_nowait = mgr._write_queue.put_nowait
+        unlink_attempts: list = []
+
+        def guard_put_nowait(item):
+            if isinstance(item, tuple) and item and item[0] == "unlink":
+                unlink_attempts.append(item)
+            return original_put_nowait(item)
+
+        mgr._write_queue.put_nowait = guard_put_nowait  # type: ignore[assignment]
+
+        try:
+            for i in range(5):
+                self._save_block(mgr, mx, f"inline_evict_{i:04d}".encode())
+
+            assert unlink_attempts == [], (
+                "Eviction must unlink inline, not enqueue. Found queued "
+                f"unlink attempts: {unlink_attempts!r}"
+            )
+        finally:
+            mgr.close()
+
+    def test_eviction_frees_capacity_under_pressure(self, tmp_path, mx):
+        """Even when the writer thread is paused (mimicking the
+        saturation scenario), eviction must keep the index size within
+        the configured cap."""
+        entry_size = self._entry_size()
+        max_bytes = entry_size * 2 + 100  # holds exactly 2 entries
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "inline_pressure",
+            max_size_bytes=max_bytes,
+        )
+        try:
+            # Save more entries than the cap allows; eviction must keep
+            # the index within ``max_bytes``.
+            for i in range(8):
+                self._save_block(mgr, mx, f"pressure_{i:04d}".encode())
+
+            # Wait briefly for in-flight writes to settle so the index
+            # accounting reflects post-eviction state.
+            time.sleep(0.05)
+
+            assert mgr._index.total_size <= max_bytes + entry_size, (
+                f"Eviction failed to keep total_size ({mgr._index.total_size}) "
+                f"near cap ({max_bytes})"
+            )
+        finally:
+            mgr.close()
+
+    def test_inline_eviction_burst_is_capped(self, tmp_path, mx):
+        """A large forced eviction is bounded by
+        ``_MAX_INLINE_UNLINKS_PER_SAVE``; deferred entries reinsert into
+        the index so subsequent saves drain the remainder."""
+        from omlx.cache.paged_ssd_cache import _MAX_INLINE_UNLINKS_PER_SAVE
+
+        # Use a large cap initially, then shrink to force a mass-eviction.
+        entry_size = self._entry_size()
+        n_entries = _MAX_INLINE_UNLINKS_PER_SAVE + 16
+        initial_max = entry_size * (n_entries + 2)
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "inline_burst",
+            max_size_bytes=initial_max,
+        )
+        try:
+            for i in range(n_entries):
+                self._save_block(mgr, mx, f"burst_{i:04d}".encode())
+
+            # Wait for writes to flush so file_size in the index matches
+            # what's on disk.
+            time.sleep(0.05)
+            count_before = mgr._index.count
+
+            # Shrink the effective cap dramatically. Next eviction must
+            # cap its inline burst at _MAX_INLINE_UNLINKS_PER_SAVE.
+            mgr._max_size = entry_size  # cap at 1 entry
+
+            # Trigger eviction via a fresh save.
+            self._save_block(mgr, mx, b"burst_trigger___")
+
+            # After one save, the index should have shed at most
+            # _MAX_INLINE_UNLINKS_PER_SAVE entries. The rest must have
+            # been reinserted so subsequent saves can drain them.
+            time.sleep(0.05)
+            count_after = mgr._index.count
+            removed = count_before + 1 - count_after  # +1 for the new save
+            assert removed <= _MAX_INLINE_UNLINKS_PER_SAVE, (
+                f"Inline burst removed {removed} entries (cap "
+                f"{_MAX_INLINE_UNLINKS_PER_SAVE}); ENOSPC-storm protection "
+                f"is not in effect"
+            )
+            assert removed > 0, (
+                "No entries were evicted despite the new save crossing "
+                "the (shrunken) cap"
+            )
+        finally:
+            mgr.close()
+
+    def test_unlink_failure_increments_counter(self, tmp_path, mx):
+        """When ``Path.unlink`` raises ``OSError``, the eviction loop
+        records the failure in ``evict_unlink_failures`` instead of
+        silently dropping the signal."""
+        entry_size = self._entry_size()
+        max_bytes = entry_size + 100
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "unlink_fail",
+            max_size_bytes=max_bytes,
+        )
+        try:
+            self._save_block(mgr, mx, b"unlink_fail_0001")
+            time.sleep(0.05)
+
+            # Patch unlink to raise OSError on the next eviction attempt.
+            from pathlib import Path as _Path
+
+            original_unlink = _Path.unlink
+
+            def boom_unlink(self, *args, **kwargs):
+                raise OSError("simulated unlink failure")
+
+            with patch.object(_Path, "unlink", boom_unlink):
+                # Save a second block; eviction of the first triggers the
+                # patched unlink.
+                self._save_block(mgr, mx, b"unlink_fail_0002")
+                time.sleep(0.05)
+
+            assert mgr._stats["evict_unlink_failures"] >= 1
+        finally:
+            mgr.close()


### PR DESCRIPTION
## Summary

`_enforce_size_limit_for_new_block` enqueues evicted file unlinks as `("unlink", path)` items onto `_write_queue` — the same bounded queue that carries pending writes. Combined with the pre-eviction `_write_queue.full()` short-circuit at the top of `save_block`, this creates a deadlock under sustained save pressure:

1. Writer is saturated → `_write_queue` is full.
2. `save_block`'s pre-eviction check sees `full()` → returns False immediately, **before** calling `_enforce_size_limit_for_new_block`.
3. Eviction never runs → cache stays at the size cap.
4. Every subsequent save drops; `ssd_write_drops` climbs forever while `_total_size` sits pinned at the cap.

Fix: inline the unlinks on the eviction-calling thread instead. Eviction typically removes a single block per save (`evict_until_size` stops as soon as `total_size <= target`), so this is one syscall per save in steady state. The deferred-unlink justification ("avoid blocking the inference thread with N file delete syscalls") doesn't materialise under normal load, and inlining removes the bounded-queue contention entirely.

**Bounded inline burst.** The ENOSPC-recovery path invalidates the 30 s disk-usage cache, which can shrink `_get_effective_max_size` sharply — `evict_until_size` would then return hundreds of entries at once and the inline-unlink loop would stall the inference thread on a syscall storm. Cap the burst at `_MAX_INLINE_UNLINKS_PER_SAVE = 32` and reinsert the deferred metadata into the index so subsequent saves drain the remainder.

Also adds an `evict_unlink_failures` stats counter (eviction now decrements the index before the on-disk unlink; if `Path.unlink` raises `OSError`, surfacing the counter lets operators see when on-disk size has drifted above what the index reports).

The dead writer-thread `("unlink", file_path)` dispatch branch is removed since no path enqueues such tuples anymore.

## Test plan

- [x] `pytest tests/test_paged_ssd_cache.py::TestInlineLRUUnlinks` — 4 passed
- [x] `pytest tests/test_paged_ssd_cache.py tests/test_hot_cache.py` — 125 passed (4 new + 121 existing)