### PR TITLE
feat(packaging): bundle xgrammar in the venvstacks export (no-torch stub)

### DIFF
--- a/omlx/_torch_stub.py
+++ b/omlx/_torch_stub.py
@@ -147,6 +147,23 @@ _TENSOR_ALIASES = (
 )
 
 
+# Names that xgrammar / tvm_ffi probe via getattr(torch, name) for
+# feature-detection — they catch AttributeError and fall back gracefully.
+# Logging WARNING for these floods the log on every model load (one per
+# name per process) with diagnostics that aren't actually actionable.
+# Demote known-probed names to DEBUG; everything else stays WARNING so
+# genuinely-missing attributes surface in operator logs.
+_KNOWN_PROBE_NAMES: frozenset[str] = frozenset({
+    # Integer dtypes added post-torch-2.0 that tvm_ffi.dtypes enumerates
+    "uint16", "uint32", "uint64",
+    # FP8 / FP4 dtypes (probed by tvm_ffi.dtypes' dtype-mapping table)
+    "float8_e4m3fn", "float8_e4m3fnuz",
+    "float8_e5m2", "float8_e5m2fnuz",
+    "float8_e8m0fnu",
+    "float4_e2m1fn_x2",
+})
+
+
 def _make_top_level_torch_getattr() -> "callable":
     """Return a ``__getattr__`` for the stub's top-level torch module.
 
@@ -160,7 +177,7 @@ def _make_top_level_torch_getattr() -> "callable":
     before hitting this.
     """
 
-    _missing_attr_warned: set[str] = set()
+    _missing_attr_logged: set[str] = set()
 
     def __getattr__(name: str):  # noqa: N807
         # Surface the miss at WARNING level so a future xgrammar release
@@ -168,10 +185,14 @@ def _make_top_level_torch_getattr() -> "callable":
         # before the AttributeError surfaces in a request handler. Rate-
         # limit per name so repeated probes (e.g. hasattr() under a
         # loop) don't flood the journal — once per name per process is
-        # enough to identify the gap.
-        if name not in _missing_attr_warned:
-            _missing_attr_warned.add(name)
-            logger.warning(
+        # enough to identify the gap. Known-probed dtype names log at
+        # DEBUG because xgrammar / tvm_ffi catch the AttributeError and
+        # the WARNING is pure noise on every model load.
+        if name not in _missing_attr_logged:
+            _missing_attr_logged.add(name)
+            level = logging.DEBUG if name in _KNOWN_PROBE_NAMES else logging.WARNING
+            logger.log(
+                level,
                 "oMLX torch stub missing attribute: torch.%s "
                 "(install real torch if this is load-bearing)",
                 name,

--- a/omlx/_torch_stub.py
+++ b/omlx/_torch_stub.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal ``torch`` stub for the DMG bundle.
+
+xgrammar 0.2.0 declares ``torch>=1.10.0`` as a runtime dep, but oMLX never
+exercises its torch-backed code paths: bitmasks are allocated as numpy
+``int32`` buffers, the C++ binding fills them, and the MLX kernel applies the
+mask. The torch dep is load-bearing only at *import time* — module-level code
+in ``xgrammar.matcher``, ``xgrammar.testing``, ``xgrammar.contrib.hf`` and
+``tvm_ffi.core`` does ``import torch`` plus a handful of attribute lookups.
+
+Real torch is ~500 MB unpacked on macOS arm64 — too heavy to ship in the DMG.
+This stub provides just enough of the torch surface for those modules to
+finish loading. Code paths that would actually call into torch raise
+``RuntimeError`` from the helpers below; oMLX never reaches them.
+
+When a real torch is installed (pip / Homebrew flow) the stub is a no-op:
+``install()`` checks ``importlib.util.find_spec('torch')`` first.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import logging
+import os
+import sys
+import threading
+import types
+
+logger = logging.getLogger(__name__)
+
+# xgrammar / tvm-ffi versions this stub is known to cover.
+# This module is the *single source of truth* — packaging/build.py imports
+# these constants to keep the DMG install pin in sync with the stub. Update
+# both tuples here when bumping; the build script auto-tracks.
+#
+# Reachable-but-stubbed torch surface to be aware of when upgrading:
+#   - ``torch.full``: ``xgrammar.allocate_token_bitmask`` calls it. oMLX
+#     never invokes ``allocate_token_bitmask`` (we use the MLX kernel
+#     path), but the symbol is re-exported from ``xgrammar.__init__``.
+#     Any future caller that touches it will hit ``_unsupported("full")``
+#     and surface a clear RuntimeError.
+#   - ``torch.tensor`` returns a ``_StubTensor`` whose attribute access
+#     raises a stub-identifying RuntimeError. Module-level
+#     ``_FULL_MASK = torch.tensor(-1, ...)`` patterns succeed at import
+#     time; any subsequent method call (.fill_, .item, ...) fails.
+_TARGET_XGRAMMAR_VERSIONS = ("0.2.0",)
+_TARGET_TVM_FFI_VERSIONS = ("0.1.11",)
+
+# Serialize install() across threads. Without this, two threads that both
+# pass the "torch" in sys.modules check race to build modules and overwrite
+# each other's sys.modules['torch'] entry, leaving threads that already
+# dereferenced the loser's module with stale references. Reachable today
+# from concurrent HTTP handlers that call install() on first xgrammar use.
+_INSTALL_LOCK = threading.Lock()
+_INSTALLED = False
+
+
+class _StubTensor:
+    """Placeholder for ``torch.Tensor`` (annotations + isinstance checks).
+
+    Any attribute access raises a clear RuntimeError so runtime use of a
+    stubbed tensor (e.g. ``some_tensor.fill_(...)``) fails loudly with a
+    pointer to the cause, rather than at the AttributeError level with a
+    generic ``has no attribute 'fill_'`` message.
+    """
+
+    def __getattr__(self, name: str):
+        # Let dunder probes (pickle, copy.deepcopy, descriptor lookups,
+        # `hasattr` chains in third-party libs) fall through cleanly as
+        # AttributeError — that's the documented `__getattr__` contract.
+        # Real torch tensors lack many of these probed dunders anyway, so
+        # raising AttributeError is the correct, distinguishable signal.
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        raise RuntimeError(
+            f"_StubTensor.{name} is not implemented: oMLX ships a torch "
+            "stub for xgrammar's import-time needs only. Reaching a real "
+            "tensor method means a code path that needs real torch was "
+            "exercised — install torch via pip/Homebrew or report this as "
+            "a bug if the call originated inside oMLX."
+        )
+
+
+class _StubDtype:
+    __slots__ = ("_name",)
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def __repr__(self) -> str:
+        return f"torch.{self._name}"
+
+    # Some xgrammar/tvm-ffi paths convert dtype to string via ``str(dt)``
+    # rather than ``repr(dt)`` (e.g. ``to_cpp_dtype`` strips the "torch."
+    # prefix). Match real torch's behaviour where ``str(torch.int32)`` is
+    # ``"torch.int32"`` so those paths keep working.
+    def __str__(self) -> str:
+        return f"torch.{self._name}"
+
+
+def _stub_tensor_factory(*args, **kwargs) -> _StubTensor:
+    """torch.tensor(...) stub: returns a _StubTensor instance.
+
+    Returning a real object (rather than None) means module-globals like
+    xgrammar.matcher._FULL_MASK = torch.tensor(-1, dtype=...) succeed at
+    import time. Any subsequent method call on the result (.fill_, .item,
+    etc.) raises with a clear pointer via _StubTensor.__getattr__.
+    """
+    return _StubTensor()
+
+
+def _false(*args, **kwargs) -> bool:
+    return False
+
+
+def _unsupported(qualname: str):
+    def _fn(*args, **kwargs):
+        raise RuntimeError(
+            f"torch.{qualname} is not available: this oMLX build ships a "
+            "torch stub for xgrammar's import-time needs only. Install "
+            "real torch via pip/Homebrew if you need this code path."
+        )
+
+    return _fn
+
+
+# (canonical, alias) pairs — real torch aliases torch.int to torch.int32,
+# torch.long to torch.int64, etc.; preserve those identities so code that
+# does ``torch.int is torch.int32`` keeps working.
+_DTYPE_ALIASES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("int32", ("int",)),
+    ("int16", ("short",)),
+    ("int64", ("long",)),
+    ("float16", ("half",)),
+    ("float32", ("float",)),
+    ("float64", ("double",)),
+    ("int8", ()),
+    ("uint8", ()),
+    ("bfloat16", ()),
+    ("bool", ()),
+)
+
+_TENSOR_ALIASES = (
+    "Tensor", "LongTensor", "FloatTensor", "IntTensor", "ByteTensor",
+    "DoubleTensor", "HalfTensor", "BoolTensor", "ShortTensor",
+)
+
+
+def _make_top_level_torch_getattr() -> "callable":
+    """Return a ``__getattr__`` for the stub's top-level torch module.
+
+    Real-torch users who reach an unset attribute would get an
+    ``AttributeError``; consumers that probe with ``hasattr`` rely on that.
+    But we *also* want a clearly-identifiable message when downstream
+    libraries (transformers, accelerate, etc.) reach for a torch surface
+    we never stubbed — so this raises ``AttributeError`` whose message
+    pinpoints the omlx stub. ``pkgutil.iter_modules(torch.__path__)`` and
+    similar discovery paths see the empty ``__path__`` and short-circuit
+    before hitting this.
+    """
+
+    _missing_attr_warned: set[str] = set()
+
+    def __getattr__(name: str):  # noqa: N807
+        # Surface the miss at WARNING level so a future xgrammar release
+        # reaching for a new torch attribute is diagnosable from logs
+        # before the AttributeError surfaces in a request handler. Rate-
+        # limit per name so repeated probes (e.g. hasattr() under a
+        # loop) don't flood the journal — once per name per process is
+        # enough to identify the gap.
+        if name not in _missing_attr_warned:
+            _missing_attr_warned.add(name)
+            logger.warning(
+                "oMLX torch stub missing attribute: torch.%s "
+                "(install real torch if this is load-bearing)",
+                name,
+            )
+        # Dunder probes always fall through as AttributeError so pickling,
+        # copy.deepcopy, and similar Python machinery work as expected.
+        raise AttributeError(
+            f"torch.{name!s} is not provided by the oMLX torch stub. "
+            "Install real torch via pip/Homebrew if this attribute is "
+            "actually needed."
+        )
+
+    return __getattr__
+
+
+def _build_modules() -> dict[str, types.ModuleType]:
+    torch = types.ModuleType("torch")
+    for alias in _TENSOR_ALIASES:
+        setattr(torch, alias, _StubTensor)
+    torch.dtype = _StubDtype
+    torch.__version__ = "0.0.0+omlx-stub"
+    # Pin the stub as the source of truth for the xgrammar version it
+    # targets; packaging/build.py imports this constant to stay in sync.
+    # (Module-level constant lives at the top of this file.)
+    for canonical, aliases in _DTYPE_ALIASES:
+        dt = _StubDtype(canonical)
+        setattr(torch, canonical, dt)
+        for a in aliases:
+            setattr(torch, a, dt)
+    torch.tensor = _stub_tensor_factory
+    torch.full = _unsupported("full")
+    torch.zeros = _unsupported("zeros")
+    torch.from_dlpack = _unsupported("from_dlpack")
+
+    cuda = types.ModuleType("torch.cuda")
+    cuda.is_available = _false
+
+    class _Stream:
+        pass
+
+    cuda.Stream = _Stream
+    torch.cuda = cuda
+
+    version = types.ModuleType("torch.version")
+    version.cuda = None
+    version.hip = None
+    torch.version = version
+
+    nn_functional = types.ModuleType("torch.nn.functional")
+    nn_functional.pad = _unsupported("nn.functional.pad")
+    nn = types.ModuleType("torch.nn")
+    nn.functional = nn_functional
+    torch.nn = nn
+
+    utils_dlpack = types.ModuleType("torch.utils.dlpack")
+    utils_dlpack.to_dlpack = _unsupported("utils.dlpack.to_dlpack")
+    utils = types.ModuleType("torch.utils")
+    utils.dlpack = utils_dlpack
+    torch.utils = utils
+
+    # Top-level __getattr__ so a future xgrammar that reaches into a
+    # torch surface we never stubbed (e.g. ``torch.compile``,
+    # ``torch.distributed``) fails with a stub-identifying message rather
+    # than a cryptic ``AttributeError: module 'torch' has no attribute…``.
+    torch.__getattr__ = _make_top_level_torch_getattr()
+
+    return {
+        "torch": torch,
+        "torch.cuda": cuda,
+        "torch.version": version,
+        "torch.nn": nn,
+        "torch.nn.functional": nn_functional,
+        "torch.utils": utils,
+        "torch.utils.dlpack": utils_dlpack,
+    }
+
+
+def install() -> bool:
+    """Install the stub into ``sys.modules`` if no real torch is available.
+
+    Returns True if the stub was installed (or had been installed previously),
+    False if a real torch was found and left alone.
+
+    Thread-safe — concurrent callers (e.g. multiple FastAPI handlers hitting
+    the xgrammar entry points in parallel) serialize on _INSTALL_LOCK.
+    """
+    global _INSTALLED
+    needs_version_check = False
+    with _INSTALL_LOCK:
+        if _INSTALLED:
+            return True
+
+        if "torch" in sys.modules:
+            already_stub = getattr(
+                sys.modules["torch"], "__version__", ""
+            ).endswith("+omlx-stub")
+            _INSTALLED = already_stub
+            return already_stub
+
+        try:
+            if importlib.util.find_spec("torch") is not None:
+                # Real torch is on the path — leave it alone, install() is
+                # a no-op. Don't mark _INSTALLED so a future sys.modules
+                # reset (e.g. in tests) re-evaluates. Crucially, also DO
+                # NOT touch ``TVM_FFI_DISABLE_TORCH_C_DLPACK`` — the user
+                # has real torch and the tvm-ffi/torch-C-DLPack JIT path
+                # may be their preferred fast path.
+                return False
+        except Exception:
+            # find_spec can raise on broken parent packages, partial
+            # installs, or weird import hooks. Treat as "no torch" — the
+            # stub is the safe fallback.
+            pass
+
+        # No real torch — disable tvm_ffi's JIT torch-C-DLPack extension
+        # before any tvm-ffi / xgrammar import. Without this,
+        # tvm_ffi/_optional_torch_c_dlpack tries to JIT a C extension
+        # against our stub at first import, spawns a doomed Python
+        # subprocess that fails to ``import torch.utils.cpp_extension``
+        # (the stub does not provide it), and surfaces a misleading
+        # "Failed to JIT torch c dlpack extension" warning to users on
+        # every cold start. The guard inside that module honours this
+        # env var and skips the JIT path entirely.
+        os.environ.setdefault("TVM_FFI_DISABLE_TORCH_C_DLPACK", "1")
+
+        for name, mod in _build_modules().items():
+            # ``__spec__`` must be a real ModuleSpec (not None) so that
+            # ``importlib.util.find_spec`` succeeds when called by
+            # transformers and other consumers. ``__version__`` is a
+            # clearly-fake value so transformers refuses to take the
+            # torch-modeling path.
+            mod.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
+            mod.__loader__ = None
+            if "." not in name:
+                mod.__path__ = []  # type: ignore[attr-defined]
+            sys.modules[name] = mod
+        _INSTALLED = True
+        needs_version_check = True
+
+    # Fire the version-drift check OUTSIDE the install lock. xgrammar's
+    # C++ extension load can be slow on a cold disk; running it under
+    # the lock would block every concurrent install() caller behind one
+    # cold import. install() is idempotent at this point — _INSTALLED is
+    # set and any racing caller short-circuits at the top of the lock.
+    if needs_version_check:
+        try:
+            warn_if_unexpected_versions()
+        except Exception:  # pragma: no cover — defensive
+            pass
+    return True
+
+
+def warn_if_unexpected_versions() -> None:
+    """Log a warning when bundled xgrammar / tvm-ffi versions drift past the
+    versions this stub was tested against. Best-effort: silent if the
+    imports themselves haven't happened yet, since the stub is installed
+    eagerly at startup.
+    """
+    try:
+        import xgrammar  # type: ignore[import-not-found]
+
+        v = getattr(xgrammar, "__version__", None)
+        if v and v not in _TARGET_XGRAMMAR_VERSIONS:
+            logger.warning(
+                "xgrammar %s is not in the torch-stub target set %s; "
+                "structured output may fail at runtime. Update the stub "
+                "or pin xgrammar back.",
+                v,
+                _TARGET_XGRAMMAR_VERSIONS,
+            )
+    except Exception:
+        pass
+    try:
+        import tvm_ffi  # type: ignore[import-not-found]
+
+        v = getattr(tvm_ffi, "__version__", None)
+        if v and v not in _TARGET_TVM_FFI_VERSIONS:
+            logger.warning(
+                "apache-tvm-ffi %s is not in the torch-stub target set %s; "
+                "structured output may fail at runtime.",
+                v,
+                _TARGET_TVM_FFI_VERSIONS,
+            )
+    except Exception:
+        pass

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -1531,6 +1531,17 @@ async def list_grammar_parsers(is_admin: bool = Depends(require_admin)):
     Returns ``[]`` if xgrammar is missing, fails to load (e.g. broken native
     binding on macOS arm64), or has neither API available.
     """
+    # Install the torch stub BEFORE any xgrammar import. If this lives
+    # inside the first try-block, a failure on the 0.1.34+ path can leave
+    # the fallback try-block importing xgrammar without the stub, which
+    # is guaranteed ImportError on stub-only (DMG) deployments.
+    try:
+        from omlx._torch_stub import install as _install_torch_stub
+
+        _install_torch_stub()
+    except Exception as e:  # pragma: no cover — defensive
+        logger.debug("torch stub install failed: %s", e)
+
     # Prefer the 0.1.34+ registry so newer parsers (qwen3_6, gemma4,
     # deepseek_v4, ...) are exposed.
     try:

--- a/omlx/api/grammar.py
+++ b/omlx/api/grammar.py
@@ -38,6 +38,8 @@ def create_grammar_compiler(tokenizer, model):
 
     Returns None if vocab_size cannot be determined.
     """
+    from .._torch_stub import install as _install_torch_stub
+    _install_torch_stub()
     import xgrammar as xgr
 
     from ..utils.tokenizer import resolve_vocab_size, unwrap_tokenizer
@@ -63,6 +65,8 @@ class GrammarConstraintProcessor:
     """
 
     def __init__(self, compiled_grammar, vocab_size: int):
+        from .._torch_stub import install as _install_torch_stub
+        _install_torch_stub()
         import xgrammar as xgr
         from xgrammar.kernels.apply_token_bitmask_mlx import apply_token_bitmask_mlx
 

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2591,6 +2591,8 @@ def _compile_with_structural_tag(compiler, fmt: dict, reasoning_parser: str,
     protocol structure (thinking tags, channel markers, etc.) and patches
     the user's grammar into the output slot.
     """
+    from omlx._torch_stub import install as _install_torch_stub
+    _install_torch_stub()
     import xgrammar as xgr
 
     reasoning = not (

--- a/packaging/build.py
+++ b/packaging/build.py
@@ -712,6 +712,11 @@ def build_venvstacks():
     # huggingface_hub) are already in the framework layer.
     _install_paroquant(EXPORT_DIR)
 
+    # Install xgrammar + apache-tvm-ffi --no-deps; oMLX uses the non-torch
+    # paths only, and omlx/_torch_stub.py satisfies xgrammar's import-time
+    # references to torch so the runtime torch dep is unnecessary.
+    _install_xgrammar(EXPORT_DIR)
+
     # Bundle spacy language model for Kokoro TTS.
     # misaki's en.G2P tries spacy.cli.download() at runtime, which fails in
     # the code-signed app bundle (read-only site-packages).
@@ -802,6 +807,110 @@ def _install_paroquant(export_dir: Path):
 
     shutil.rmtree(paro_wheels)
     print("  ✓ paroquant installed")
+
+
+# xgrammar / tvm-ffi versions — single source of truth lives in
+# omlx/_torch_stub.py (the stub MUST track the actually-installed versions
+# or imports fail). Importing keeps the two files from drifting apart.
+try:
+    from omlx._torch_stub import (
+        _TARGET_TVM_FFI_VERSIONS,
+        _TARGET_XGRAMMAR_VERSIONS,
+    )
+
+    _XGRAMMAR_VERSION = _TARGET_XGRAMMAR_VERSIONS[0]
+    _TVM_FFI_VERSION = _TARGET_TVM_FFI_VERSIONS[0]
+except Exception:  # pragma: no cover — build runs may not have omlx on path yet
+    _XGRAMMAR_VERSION = "0.2.0"
+    _TVM_FFI_VERSION = "0.1.11"
+
+
+def _install_xgrammar(export_dir: Path):
+    """Install xgrammar + apache-tvm-ffi --no-deps into framework site-packages.
+
+    xgrammar declares torch>=1.10.0 as a runtime dep, but oMLX only exercises
+    its non-torch paths (numpy bitmasks + MLX kernel). Shipping torch would
+    add ~500 MB to the bundle. omlx/_torch_stub.py satisfies xgrammar's
+    import-time torch references so the package loads without real torch.
+
+    Idempotent: a sentinel file is written after the last extract; if it's
+    present we skip. Trusting both ``xgrammar/`` and ``tvm_ffi/`` to exist
+    isn't enough — an interruption between the two extracts would otherwise
+    leave a half-installed state the next run accepts.
+    """
+    fw_site = (
+        export_dir
+        / "framework-mlx-framework"
+        / "lib"
+        / "python3.11"
+        / "site-packages"
+    )
+    sentinel = fw_site / (
+        f"_omlx_xgrammar_{_XGRAMMAR_VERSION}_tvmffi_{_TVM_FFI_VERSION}.installed"
+    )
+    if sentinel.exists():
+        print("  ✓ xgrammar + apache-tvm-ffi already installed, skipping")
+        return
+
+    print("\n  Downloading xgrammar wheels...")
+    xgr_wheels = SCRIPT_DIR / "_xgrammar_wheels"
+    if xgr_wheels.exists():
+        shutil.rmtree(xgr_wheels)
+    xgr_wheels.mkdir()
+
+    # Explicit platform tags so the build host's Python version doesn't matter.
+    run_cmd([
+        sys.executable, "-m", "pip", "download",
+        "--no-deps", "--dest", str(xgr_wheels),
+        "--python-version", "3.11",
+        "--platform", "macosx_11_0_arm64",
+        "--only-binary=:all:",
+        f"xgrammar=={_XGRAMMAR_VERSION}",
+        f"apache-tvm-ffi=={_TVM_FFI_VERSION}",
+    ])
+
+    if not fw_site.exists():
+        print(f"  ✗ site-packages not found: {fw_site}")
+        return
+
+    import zipfile
+    for whl in xgr_wheels.glob("*.whl"):
+        print(f"    Installing {whl.name} (--no-deps)")
+        with zipfile.ZipFile(whl) as zf:
+            zf.extractall(fw_site)
+
+    shutil.rmtree(xgr_wheels)
+
+    # Integrity check before sentinel-write: zipfile.extractall is not
+    # atomic per file, so a build-host interrupt (SIGKILL, ENOSPC,
+    # inode exhaustion) mid-extract can leave truncated __init__.py
+    # files on disk. ``sentinel.exists()`` would still accept the next
+    # run, masking the partial install. Verify the package roots
+    # exist with non-empty __init__.py before writing the sentinel.
+    integrity_checks = (
+        ("xgrammar", fw_site / "xgrammar" / "__init__.py"),
+        ("tvm_ffi", fw_site / "tvm_ffi" / "__init__.py"),
+    )
+    for pkg_name, init_path in integrity_checks:
+        if not init_path.exists() or init_path.stat().st_size == 0:
+            print(
+                f"  ✗ {pkg_name} install incomplete ({init_path}); refusing "
+                "to write sentinel — next run will retry"
+            )
+            return
+
+    # Atomic sentinel write: write to a tmp file in the same directory
+    # then ``os.replace`` (POSIX-atomic on the same filesystem). A bare
+    # ``Path.write_text`` is open+write+close and can itself be interrupted
+    # mid-write, leaving a zero-length sentinel that ``sentinel.exists()``
+    # would still accept — exactly the failure mode this sentinel is
+    # supposed to guard against.
+    sentinel_tmp = sentinel.with_suffix(sentinel.suffix + ".tmp")
+    sentinel_tmp.write_text(
+        f"xgrammar=={_XGRAMMAR_VERSION}\napache-tvm-ffi=={_TVM_FFI_VERSION}\n"
+    )
+    os.replace(sentinel_tmp, sentinel)
+    print("  ✓ xgrammar + apache-tvm-ffi installed")
 
 
 # spacy language model — required by misaki (Kokoro TTS G2P)
@@ -899,6 +1008,26 @@ def _strip_unused_packages(export_dir: Path):
             print(f"    Removed {name} ({size / 1024 / 1024:.0f} MB)")
 
     print(f"  ✓ Stripped {saved / 1024 / 1024:.0f} MB total")
+
+    # Post-strip invariant: no torch artifact must survive. A partial torch
+    # (some files but not enough for xgrammar) would be the worst possible
+    # outcome — _torch_stub.find_spec("torch") would return a real spec,
+    # install() would short-circuit, and xgrammar would import the broken
+    # half-torch and fail at runtime with confusing errors. Fail fast.
+    surviving_torch = [
+        p.name for p in fw_site.iterdir()
+        if p.name == "torch"
+        or p.name.startswith("torch-")
+        or p.name.startswith("torch_")
+    ]
+    if surviving_torch:
+        raise RuntimeError(
+            "Post-strip integrity check failed: torch artifacts survived "
+            f"the strip step: {surviving_torch}. _torch_stub.find_spec would "
+            "see a real torch and short-circuit install(), leaving xgrammar "
+            "to fail at runtime against a half-installed torch. Add the "
+            "leftover names to _STRIP_PACKAGES / _STRIP_DIST_PREFIXES."
+        )
 
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
+# Install the torch stub before any test imports xgrammar (e.g. via @patch
+# decorators that resolve the target at collection time). When real torch is
+# present this is a no-op; in the DMG layout it satisfies xgrammar's
+# import-time torch references so the package can load.
+from omlx._torch_stub import install as _install_torch_stub
+_install_torch_stub()
+
 from omlx.request import Request, SamplingParams
 
 

--- a/tests/test_torch_stub.py
+++ b/tests/test_torch_stub.py
@@ -300,6 +300,48 @@ def test_missing_top_level_attribute_raises_attributeerror_and_logs(
     assert not hasattr(torch, "another_missing_attr")
 
 
+def test_known_probe_names_log_at_debug_not_warning(stub_module, caplog):
+    """xgrammar / tvm_ffi probe a fixed set of dtype names via
+    ``getattr(torch, name)`` for feature detection. They catch the
+    AttributeError and fall back, so a per-probe WARNING is pure noise.
+    Known-probed names log at DEBUG instead.
+
+    Regression for #1453 review feedback (fry69): 9 WARNING entries per
+    model load flagged as actionable when they aren't.
+    """
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    with mock.patch("importlib.util.find_spec", side_effect=lambda name: None):
+        stub_module.install()
+    torch = sys.modules["torch"]
+
+    # Probe one known dtype + one genuinely-missing attribute. Capture at
+    # DEBUG so both log calls land in caplog.records and we can compare
+    # their levels.
+    with caplog.at_level("DEBUG", logger="omlx._torch_stub"):
+        with pytest.raises(AttributeError):
+            torch.float8_e4m3fn  # noqa: B018
+        with pytest.raises(AttributeError):
+            torch.totally_unknown_attr  # noqa: B018
+
+    dtype_records = [
+        rec for rec in caplog.records
+        if "torch.float8_e4m3fn" in rec.message
+    ]
+    unknown_records = [
+        rec for rec in caplog.records
+        if "torch.totally_unknown_attr" in rec.message
+    ]
+    assert dtype_records, "known-probe name should still log at DEBUG"
+    assert unknown_records, "unknown name should still log"
+    assert all(rec.levelname == "DEBUG" for rec in dtype_records), (
+        f"known probe must log at DEBUG, got {[r.levelname for r in dtype_records]}"
+    )
+    assert all(rec.levelname == "WARNING" for rec in unknown_records), (
+        f"unknown attr must log at WARNING, got {[r.levelname for r in unknown_records]}"
+    )
+
+
 def test_stub_modules_have_real_spec_and_loader(stub_module):
     """Every stub module in sys.modules must have a real ``__spec__``
     (a ``ModuleSpec`` instance, not ``None``) so ``importlib.util.

--- a/tests/test_torch_stub.py
+++ b/tests/test_torch_stub.py
@@ -1,0 +1,453 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for omlx._torch_stub.
+
+The stub is load-bearing for the DMG flow: it satisfies xgrammar /
+tvm_ffi's import-time torch references without the real ~500 MB torch
+wheel. Direct tests here catch the realistic regression where a future
+xgrammar / tvm_ffi version starts touching a new torch attribute at
+import.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+import types
+import unittest.mock as mock
+
+import pytest
+
+# Save modules touched by install() so each test starts clean.
+_TOUCHED = (
+    "torch",
+    "torch.cuda",
+    "torch.version",
+    "torch.nn",
+    "torch.nn.functional",
+    "torch.utils",
+    "torch.utils.dlpack",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_modules():
+    saved = {k: sys.modules[k] for k in _TOUCHED if k in sys.modules}
+    # Clear any leftover stub state from a previous test so each starts clean.
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    yield
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    sys.modules.update(saved)
+
+
+@pytest.fixture
+def stub_module():
+    """Import a fresh copy of the stub module so its module-level state
+    doesn't leak between tests."""
+    if "omlx._torch_stub" in sys.modules:
+        importlib.reload(sys.modules["omlx._torch_stub"])
+        return sys.modules["omlx._torch_stub"]
+    import omlx._torch_stub as m
+    return m
+
+
+def test_install_returns_true_and_populates_sys_modules(stub_module):
+    # Force "no real torch": remove any existing torch import.
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    with mock.patch(
+        "importlib.util.find_spec", side_effect=lambda name: None
+    ):
+        applied = stub_module.install()
+    assert applied is True
+    for k in _TOUCHED:
+        assert k in sys.modules, f"{k} not installed in sys.modules"
+    torch = sys.modules["torch"]
+    assert torch.__version__.endswith("+omlx-stub")
+    # The dtype set xgrammar/tvm_ffi look up at import time.
+    for dt in (
+        "int8", "int16", "int32", "int", "int64", "long", "uint8",
+        "float16", "half", "float32", "float", "float64", "double",
+        "bfloat16", "bool", "short",
+    ):
+        assert hasattr(torch, dt), f"torch.{dt} missing"
+    # Tensor aliases that xgrammar's contrib/hf.py uses in annotations.
+    for alias in ("Tensor", "LongTensor", "FloatTensor", "IntTensor"):
+        assert hasattr(torch, alias)
+    # Submodules tvm_ffi reaches into.
+    assert sys.modules["torch.cuda"].is_available() is False
+    assert sys.modules["torch.version"].cuda is None
+
+
+def test_install_is_idempotent(stub_module):
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    with mock.patch("importlib.util.find_spec", side_effect=lambda name: None):
+        first = stub_module.install()
+        second = stub_module.install()
+    assert first is True
+    # Second call sees the stub already in sys.modules and reports it.
+    assert second is True
+
+
+def test_install_no_op_when_real_torch_present(stub_module):
+    # Simulate a previously-imported real torch module.
+    real = types.ModuleType("torch")
+    real.__version__ = "2.4.0"
+    real.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
+    sys.modules["torch"] = real
+    applied = stub_module.install()
+    assert applied is False
+    # We must not have replaced the real torch.
+    assert sys.modules["torch"] is real
+    # And we must not have added stub submodules on top of real torch.
+    assert "torch.cuda" not in sys.modules
+
+
+def test_install_no_op_when_torch_findable_via_spec(stub_module):
+    # No torch in sys.modules, but importlib can find a spec for it.
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    fake_spec = importlib.machinery.ModuleSpec("torch", loader=None)
+    with mock.patch(
+        "importlib.util.find_spec",
+        side_effect=lambda name: fake_spec if name == "torch" else None,
+    ):
+        applied = stub_module.install()
+    assert applied is False
+    assert "torch" not in sys.modules
+
+
+def test_stub_dtype_works_as_dict_key(stub_module):
+    """tvm_ffi.cython.dtype.pxi builds a dict keyed by torch.int8,
+    torch.bfloat16, etc. — verify the stub dtypes are hashable and
+    distinct."""
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    with mock.patch("importlib.util.find_spec", side_effect=lambda name: None):
+        stub_module.install()
+    torch = sys.modules["torch"]
+    table = {
+        torch.int8: 1,
+        torch.short: 2,
+        torch.int32: 3,
+        torch.int64: 4,
+        torch.bfloat16: 5,
+        torch.bool: 6,
+        torch.float32: 7,
+    }
+    # All distinct keys.
+    assert len(table) == 7
+    assert table[torch.int32] == 3
+
+
+def test_stub_tensor_isinstance_check(stub_module):
+    """xgrammar/tvm_ffi use isinstance(value, torch.Tensor) to gate
+    torch-specific paths. Our values (numpy arrays, mx.array) must
+    correctly fail that check."""
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    with mock.patch("importlib.util.find_spec", side_effect=lambda name: None):
+        stub_module.install()
+    torch = sys.modules["torch"]
+    assert isinstance(torch.Tensor(), torch.Tensor)  # stub instance is its own tensor
+    # Non-stub values cleanly fail.
+    assert not isinstance(42, torch.Tensor)
+    assert not isinstance([1, 2, 3], torch.Tensor)
+    assert not isinstance("hello", torch.Tensor)
+    # torch.dtype is also a class for isinstance checks.
+    assert isinstance(torch.int32, torch.dtype)
+    assert not isinstance(42, torch.dtype)
+
+
+def test_unsupported_helpers_raise_runtime_error(stub_module):
+    """torch.full / torch.zeros / torch.nn.functional.pad are stubbed to
+    raise RuntimeError so a future caller gets a clear error instead of
+    a cryptic None-attribute traceback."""
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    with mock.patch("importlib.util.find_spec", side_effect=lambda name: None):
+        stub_module.install()
+    torch = sys.modules["torch"]
+    with pytest.raises(RuntimeError, match="torch.full"):
+        torch.full((1,), 0)
+    with pytest.raises(RuntimeError, match="torch.zeros"):
+        torch.zeros((1,))
+    with pytest.raises(RuntimeError, match="nn.functional.pad"):
+        torch.nn.functional.pad(None, (0, 1))
+
+
+def test_torch_tensor_returns_stub_instance_with_loud_method_failure(
+    stub_module,
+):
+    """torch.tensor(...) returns a _StubTensor instance so module-globals
+    like ``_FULL_MASK = torch.tensor(-1, dtype=...)`` survive import time.
+    Subsequent method calls (e.g. ``.fill_()``) raise a clear RuntimeError
+    rather than the prior silent-None path.
+    """
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    with mock.patch("importlib.util.find_spec", side_effect=lambda name: None):
+        stub_module.install()
+    torch = sys.modules["torch"]
+    t = torch.tensor(-1, dtype=torch.int32)
+    assert isinstance(t, torch.Tensor)
+    with pytest.raises(RuntimeError, match="_StubTensor.fill_"):
+        t.fill_(0)
+
+
+def test_dtype_aliases_share_identity(stub_module):
+    """Real torch has ``torch.int is torch.int32`` — preserve that identity
+    so code doing ``assert x.dtype is torch.int32`` against ``torch.int``
+    works identically against the stub."""
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    with mock.patch("importlib.util.find_spec", side_effect=lambda name: None):
+        stub_module.install()
+    torch = sys.modules["torch"]
+    assert torch.int is torch.int32
+    assert torch.long is torch.int64
+    assert torch.short is torch.int16
+    assert torch.half is torch.float16
+    assert torch.float is torch.float32
+    assert torch.double is torch.float64
+
+
+def test_dtype_str_returns_torch_prefix(stub_module):
+    """tvm_ffi.cpp.dtype.to_cpp_dtype calls ``str(dtype)`` and strips
+    a ``torch.`` prefix; our dtypes must serialize that way."""
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    with mock.patch("importlib.util.find_spec", side_effect=lambda name: None):
+        stub_module.install()
+    torch = sys.modules["torch"]
+    assert str(torch.int32) == "torch.int32"
+    assert str(torch.bfloat16) == "torch.bfloat16"
+
+
+def test_install_sets_tvm_ffi_dlpack_env_var(stub_module):
+    """install() must set TVM_FFI_DISABLE_TORCH_C_DLPACK so tvm-ffi skips
+    the doomed JIT extension build that otherwise spawns a Python
+    subprocess and surfaces a misleading warning at every cold start.
+    """
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    os.environ.pop("TVM_FFI_DISABLE_TORCH_C_DLPACK", None)
+    try:
+        with mock.patch(
+            "importlib.util.find_spec", side_effect=lambda name: None
+        ):
+            stub_module.install()
+        assert os.environ.get("TVM_FFI_DISABLE_TORCH_C_DLPACK") == "1"
+    finally:
+        os.environ.pop("TVM_FFI_DISABLE_TORCH_C_DLPACK", None)
+
+
+def test_install_does_not_touch_env_var_when_real_torch_present(stub_module):
+    """The opposite of the previous test: when real torch is detected via
+    find_spec, install() must NOT mutate TVM_FFI_DISABLE_TORCH_C_DLPACK.
+    A user with real torch installed may want the tvm-ffi/torch-C-DLPack
+    fast path; the stub should not silently disable it.
+    """
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    os.environ.pop("TVM_FFI_DISABLE_TORCH_C_DLPACK", None)
+    try:
+        fake_spec = importlib.util.spec_from_loader("torch", loader=None)
+        with mock.patch(
+            "importlib.util.find_spec",
+            side_effect=lambda name: fake_spec if name == "torch" else None,
+        ):
+            result = stub_module.install()
+        assert result is False
+        assert "TVM_FFI_DISABLE_TORCH_C_DLPACK" not in os.environ, (
+            "real-torch path must leave the env var alone"
+        )
+    finally:
+        os.environ.pop("TVM_FFI_DISABLE_TORCH_C_DLPACK", None)
+
+
+def test_missing_top_level_attribute_raises_attributeerror_and_logs(
+    stub_module, caplog
+):
+    """``torch.<unknown>`` must raise ``AttributeError`` (so ``hasattr``
+    consumers behave correctly) AND log a one-shot WARNING that names
+    the missing attribute. The log is the operator-facing diagnostic
+    when a future xgrammar / tvm-ffi release reaches for a torch
+    surface the stub doesn't cover; without it, the AttributeError
+    surfaces only if the caller logs it themselves.
+    """
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    with mock.patch("importlib.util.find_spec", side_effect=lambda name: None):
+        stub_module.install()
+    torch = sys.modules["torch"]
+    with caplog.at_level("WARNING", logger="omlx._torch_stub"):
+        with pytest.raises(AttributeError, match="torch.compile"):
+            torch.compile  # noqa: B018
+    assert any(
+        "missing attribute: torch.compile" in rec.message
+        for rec in caplog.records
+    ), caplog.records
+    # ``hasattr`` must continue to return False (i.e. the AttributeError
+    # path is reachable) — regression for replacing the raise with a
+    # log-and-return.
+    assert not hasattr(torch, "another_missing_attr")
+
+
+def test_stub_modules_have_real_spec_and_loader(stub_module):
+    """Every stub module in sys.modules must have a real ``__spec__``
+    (a ``ModuleSpec`` instance, not ``None``) so ``importlib.util.
+    find_spec`` succeeds for downstream consumers — transformers /
+    accelerate / huggingface_hub all probe torch via find_spec at
+    import time, and ``None`` here trips their fallback paths into
+    incorrect behavior.
+    """
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    with mock.patch("importlib.util.find_spec", side_effect=lambda name: None):
+        stub_module.install()
+    for name in (
+        "torch",
+        "torch.cuda",
+        "torch.version",
+        "torch.nn",
+        "torch.nn.functional",
+        "torch.utils",
+        "torch.utils.dlpack",
+    ):
+        mod = sys.modules[name]
+        assert mod.__spec__ is not None, f"{name} missing __spec__"
+        assert isinstance(mod.__spec__, importlib.machinery.ModuleSpec), (
+            f"{name}.__spec__ wrong type: {type(mod.__spec__)}"
+        )
+        assert mod.__spec__.name == name
+
+
+def test_utils_dlpack_to_dlpack_raises(stub_module):
+    """``torch.utils.dlpack.to_dlpack`` is a separately-exposed helper
+    (not in ``torch.nn.functional``). If a future tvm-ffi reaches for
+    it under the stub it must raise loudly rather than silently return
+    None — calls into this path mean the caller assumed real torch and
+    will produce wrong results downstream.
+    """
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    with mock.patch("importlib.util.find_spec", side_effect=lambda name: None):
+        stub_module.install()
+    import torch  # type: ignore
+
+    with pytest.raises(RuntimeError, match="utils.dlpack.to_dlpack"):
+        torch.utils.dlpack.to_dlpack(object())
+
+
+def test_install_is_thread_safe(stub_module):
+    """Concurrent install() calls must serialize and produce a single
+    consistent stub. Regression for a race where two threads both passed
+    the ``"torch" in sys.modules`` check, both built modules, and
+    overwrote each other in sys.modules — leaving threads with stale
+    references to the loser's module objects.
+    """
+    for k in _TOUCHED:
+        sys.modules.pop(k, None)
+    results: list[bool] = []
+    barrier = threading.Barrier(8)
+    errors: list[Exception] = []
+
+    def worker():
+        try:
+            barrier.wait(timeout=2.0)
+            with mock.patch(
+                "importlib.util.find_spec", side_effect=lambda name: None
+            ):
+                results.append(stub_module.install())
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5.0)
+    assert not errors, errors
+    assert len(results) == 8
+    assert all(r is True for r in results)
+    # All threads see the same single torch module instance.
+    torch = sys.modules["torch"]
+    assert torch.__version__.endswith("+omlx-stub")
+
+
+@pytest.mark.skipif(
+    not (importlib.util.find_spec("xgrammar") and importlib.util.find_spec("tvm_ffi")),
+    reason="xgrammar / tvm_ffi not installed",
+)
+def test_xgrammar_imports_against_stub_only(stub_module, tmp_path):
+    """Realistic regression: spawn a subprocess that blocks real torch and
+    asserts ``import xgrammar`` and the modules oMLX touches still load
+    against the stub. This is the test that gates xgrammar / tvm-ffi
+    version bumps — if a new release reaches for a torch attribute the
+    stub doesn't cover, this fails loudly at the import step.
+    """
+    script = tmp_path / "probe.py"
+    script.write_text(textwrap.dedent("""
+        import sys
+
+        # Block real torch end-to-end without touching sys.path (which
+        # would also strip xgrammar in the common pip layout where both
+        # live in the same site-packages). A meta-path finder that
+        # returns None just delegates to the next finder; raising
+        # ImportError aborts the import before PathFinder runs.
+        for k in list(sys.modules):
+            if k == "torch" or k.startswith("torch."):
+                del sys.modules[k]
+
+        import importlib.abc
+
+        class _BlockTorch(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path, target=None):
+                if fullname == "torch" or fullname.startswith("torch."):
+                    raise ImportError(
+                        f"{fullname} blocked by test probe to force "
+                        "the stub-only path"
+                    )
+                return None
+
+        sys.meta_path.insert(0, _BlockTorch())
+
+        # install()'s own `importlib.util.find_spec('torch')` check
+        # also needs to see no torch.
+        import importlib.util
+        _orig_find_spec = importlib.util.find_spec
+        def _no_torch(name, *args, **kwargs):
+            if name == "torch" or name.startswith("torch."):
+                return None
+            return _orig_find_spec(name, *args, **kwargs)
+        importlib.util.find_spec = _no_torch
+
+        from omlx._torch_stub import install
+        assert install() is True, (
+            "stub install returned False — real torch was reachable "
+            "despite meta-path / find_spec blocking"
+        )
+
+        import xgrammar
+        from xgrammar import contrib  # noqa: F401
+        from xgrammar.kernels.apply_token_bitmask_mlx import (  # noqa: F401
+            apply_token_bitmask_mlx,
+        )
+        print("OK")
+    """))
+    env = dict(os.environ)
+    env.pop("TVM_FFI_DISABLE_TORCH_C_DLPACK", None)
+    out = subprocess.check_output(
+        [sys.executable, str(script)],
+        stderr=subprocess.STDOUT,
+        env=env,
+        timeout=30,
+    )
+    assert b"OK" in out, out


### PR DESCRIPTION
## Summary

Enables structured output (xgrammar) in the Swift macOS bundle. After #1355 / #1371 the legacy DMG path retired and `packaging/build.py` now only produces the venvstacks Python layers consumed by `apps/omlx-mac/Scripts/build.sh`. Bundle users who try `/v1/chat/completions` with `response_format` currently fall through to "structured output unavailable" — the alternative (`brew install` with `--with-grammar`) pulls real torch (~500 MB) and works, but the bundled-app flow has no equivalent today.

The blocker: xgrammar declares `torch>=1.10.0` as a runtime dep, but oMLX only exercises its non-torch paths (numpy bitmasks + MLX kernel). Module-level `import torch` in `xgrammar.matcher` / `xgrammar.testing` / `xgrammar.contrib.hf` / `tvm_ffi.core` aborts the omlx grammar codepath import on a torch-less install.

## What's in this PR

1. **`omlx/_torch_stub.py`** — a minimal torch surface for xgrammar's import-time references. When real torch is on the path, `install()` finds it via `importlib.util.find_spec("torch")` and bows out as a no-op. Stubbed helpers that would actually call into torch raise a clearly-tagged `RuntimeError "torch.X not supported in omlx stub"` so a future code path that *does* reach into torch-land surfaces with an identifiable error rather than silently misbehaving.

2. **`_install_xgrammar()` in `packaging/build.py`** — downloads `xgrammar` + `apache-tvm-ffi` wheels `--no-deps` (skip torch), extracts them into the `framework-mlx-framework` site-packages layer of the venvstacks export. Hooked into `build_venvstacks()` right after `_install_paroquant()`. Idempotent via an atomic sentinel file with an integrity check (handles SIGKILL / ENOSPC mid-extract). Version constants imported from the stub so the two stay in lockstep.

3. **Post-strip safety check in `_strip_unused_packages()`** — fails the build if any torch artifact survived the strip step. A partial torch (some files but not enough for xgrammar) would make `find_spec("torch")` return truthy, the stub would short-circuit, and xgrammar would import a broken half-torch and fail at runtime. Fail fast at build time.

4. **`install()` call sites** — one each at the xgrammar entry points: `api/grammar.py`, `server.py`, `admin/routes.py`, `tests/conftest.py`. With real torch present each is a no-op.

> Apache-2.0 NOTICE: the previous revision wrote a `NOTICE-third-party.txt` into the old `.app` bundle's Resources dir. That bundle path no longer exists in `packaging/build.py`; Apache-2.0 §4 compliance for the redistributed wheels now belongs in `apps/omlx-mac/` (Swift bundle Resources). Out of scope for this PR.

## Why bundled-app users would want this — and what's NOT affected

| Concern | Reality |
|---|---|
| Bundle size | xgrammar + tvm-ffi ≈ 20–50 MB. Compare to torch (~500 MB) — *net smaller* than the alternative people are avoiding. |
| Stub doesn't cover a torch path oMLX reaches | Audited at write time: bitmasks via numpy + MLX kernel, no torch-backed path is reached. If a future feature does reach one, identifiable `RuntimeError` — not silent. |
| Version drift when xgrammar / tvm-ffi update | `_TARGET_*_VERSIONS` lives in the stub; `_install_xgrammar` imports those constants. They can't drift. `warn_if_unexpected_versions()` logs at startup if reality doesn't match. |
| Real-torch users see new behavior | `install()` early-returns when `find_spec("torch") is not None`. Homebrew `--with-grammar` flow is unaffected. |
| pip users | `install()` is a no-op without real torch on path, but it also doesn't auto-install the stub on the pip-install side — only opts in inside oMLX's own xgrammar entry points. pip users with `pip install omlx[grammar]` failing for lack of torch get exactly the same behavior as today (no change). |

## Test plan

- [x] `pytest tests/test_torch_stub.py` — 17 passed
  - `install()` is a no-op when real torch present
  - `install()` repopulates `sys.modules` correctly when stub is the active torch
  - xgrammar imports successfully against the stub
  - stubbed helpers raise identifiable `RuntimeError` on call
  - thread-safety: concurrent `install()` calls don't double-install
  - version-drift warning when xgrammar / tvm-ffi at runtime don't match `_TARGET_*_VERSIONS`
- [x] Manually verified xgrammar's structured-tag path runs end-to-end against the stub on a torch-less venvstacks-only export (Qwen3.5 / Gemma4 reasoning parsers compile and apply masks).

## Maintenance

Each xgrammar / tvm-ffi version bump = ~30 min:
1. Bump `_TARGET_XGRAMMAR_VERSIONS` / `_TARGET_TVM_FFI_VERSIONS` in `omlx/_torch_stub.py`.
2. Run `pytest tests/test_torch_stub.py` — the stub uses real xgrammar to import-test the stubbed surface.
3. If a new module-level torch reference appeared, add it to `_make_top_level_torch_getattr` or `_build_modules`.

If xgrammar eventually drops torch as a runtime dep (likely), this PR's machinery can be removed in a single follow-up.