### PR TITLE
docs(packaging): drop stale "DMG produced by the Swift build" claim

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -56,8 +56,16 @@ No application layer — the Swift app is the application surface.
 
 ## Installation
 
-1. Open the DMG produced by the Swift build.
-2. Drag `oMLX.app` to Applications.
-3. Launch the app (appears in the menubar).
-4. Walk through the first-run wizard (Storage + API key), then Start
+The Swift build (`build.sh release`) produces `build/Stage/oMLX.app`
+directly — no DMG step. To install:
+
+1. Drag `build/Stage/oMLX.app` to `/Applications`, or `open` it
+   in-place to launch from `build/Stage/`.
+2. Launch the app (appears in the menubar).
+3. Walk through the first-run wizard (Storage + API key), then Start
    Server.
+
+> The DMGs on the [Releases](https://github.com/jundot/omlx/releases)
+> page are produced by an off-tree maintainer pipeline, not by anything
+> in this repo. End users follow the Releases install path; this
+> section is for developers building from source.


### PR DESCRIPTION
## Summary

Closes #1456. (Supersedes #1457, which was auto-closed when I renamed the branch — content is identical.)

After #1355 retired `packaging/build.py`'s `.app` + DMG pipeline, nothing in the repo creates a `.dmg`:

- `apps/omlx-mac/Scripts/build.sh release` produces `oMLX.app` directly — `grep -rn "hdiutil\|create-dmg\|\.dmg" apps/omlx-mac/Scripts/` returns nothing
- No `.github/workflows/` entry produces one
- The Swift updater consumes DMGs from GitHub Releases but doesn't make them

Meanwhile `packaging/README.md` still told developers to "Open the DMG produced by the Swift build" — that DMG doesn't exist.

## What's in this PR

Just the README fix. The Installation section now reflects what actually happens:

1. Drag `build/Stage/oMLX.app` to `/Applications`, or `open` it in-place
2. (steps 2–3 unchanged)

Plus a note that the Releases DMGs come from an off-tree maintainer pipeline, so end users follow the Releases path and this section is explicitly scoped to developers building from source.

## Why no `hdiutil` step in `build.sh`?

An earlier revision of #1457 added an opt-in `--dmg` flag. Pulled it: a developer who built `oMLX.app` locally already has the artifact they need — dragging the `.app` to `/Applications` is the standard macOS install pattern. A DMG is a distribution wrapper, useful when shipping to users (single signed download, polished volume window); none of that helps the local-build flow.

The one niche where local DMG creation has value is dry-running the auto-updater download path — better served by hand-rolling a DMG once for that specific test than by paying a maintenance tax (and 5–10 s extra build time) on every release build.

If maintainers want the official Releases DMG pipeline brought in-tree (CI workflow, code-signing, notarization), that's a separate, larger discussion.

## Test plan

- [x] `cat packaging/README.md` — Installation section reads coherently and matches what `build.sh release` actually produces.