### PR TITLE
Improve DFlash prefix cache accounting and restore observability

### DIFF
--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -121,6 +121,8 @@ class BlockAwarePrefixCache(CacheManager):
         self._tokens_requested_total = 0
         self._last_partial_tokens_skipped = 0
         self._last_tokens_to_next_block = 0
+        self._retained_restore_walkbacks = 0
+        self._placeholder_full_rejects = 0
 
     def _get_model_num_layers(self, model: Any) -> int:
         """
@@ -1601,6 +1603,7 @@ class BlockAwarePrefixCache(CacheManager):
                         if bid in self.paged_cache.allocated_blocks
                     )
                     block_table.num_tokens = valid_token_count
+                    self._retained_restore_walkbacks += 1
 
                     # Update meta_states to the truncation-point block
                     if trunc_idx < len(all_block_meta_states):
@@ -1646,6 +1649,7 @@ class BlockAwarePrefixCache(CacheManager):
                             f"CacheList layer {layer_idx}: partial prefix match "
                             f"detected (placeholder). Rejecting cache."
                         )
+                        self._placeholder_full_rejects += 1
                         return None
 
                     # Each sub_state in block_data may be either:
@@ -1967,6 +1971,7 @@ class BlockAwarePrefixCache(CacheManager):
                                 f"block). Rejecting cache to prevent stale "
                                 f"sliding-window state."
                             )
+                            self._placeholder_full_rejects += 1
                             return None
 
                         latest_state = {
@@ -1990,6 +1995,7 @@ class BlockAwarePrefixCache(CacheManager):
                                 f"block). Rejecting cache to prevent stale GDN "
                                 f"state. Request will reprocess from scratch."
                             )
+                            self._placeholder_full_rejects += 1
                             return None
 
                         # Exact match: last block has full state
@@ -2406,6 +2412,8 @@ class BlockAwarePrefixCache(CacheManager):
             last_tokens_to_next_block=self._last_tokens_to_next_block,
             tokens_matched_total=self._tokens_matched_total,
             tokens_requested_total=self._tokens_requested_total,
+            retained_restore_walkbacks=self._retained_restore_walkbacks,
+            placeholder_full_rejects=self._placeholder_full_rejects,
         )
 
     def get_stats_dict(self) -> dict[str, Any]:
@@ -2434,6 +2442,8 @@ class BlockAwarePrefixCache(CacheManager):
             "last_tokens_to_next_block": self._last_tokens_to_next_block,
             "tokens_matched_total": self._tokens_matched_total,
             "tokens_requested_total": self._tokens_requested_total,
+            "retained_restore_walkbacks": self._retained_restore_walkbacks,
+            "placeholder_full_rejects": self._placeholder_full_rejects,
             "active_requests": len(self._request_tables),
             **paged_stats,
         }
@@ -2449,6 +2459,8 @@ class BlockAwarePrefixCache(CacheManager):
         self._tokens_requested_total = 0
         self._last_partial_tokens_skipped = 0
         self._last_tokens_to_next_block = 0
+        self._retained_restore_walkbacks = 0
+        self._placeholder_full_rejects = 0
         self.paged_cache.reset_stats()
 
     def clear(self) -> int:

--- a/omlx/cache/stats.py
+++ b/omlx/cache/stats.py
@@ -90,6 +90,8 @@ class PrefixCacheStats(BaseCacheStats):
     last_tokens_to_next_block: int = 0
     tokens_matched_total: int = 0
     tokens_requested_total: int = 0
+    retained_restore_walkbacks: int = 0
+    placeholder_full_rejects: int = 0
     _total_queries: int = field(default=0, repr=False)
 
     @property
@@ -115,6 +117,8 @@ class PrefixCacheStats(BaseCacheStats):
         self.last_tokens_to_next_block = 0
         self.tokens_matched_total = 0
         self.tokens_requested_total = 0
+        self.retained_restore_walkbacks = 0
+        self.placeholder_full_rejects = 0
         self._total_queries = 0
 
 

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -17,6 +17,7 @@ import logging
 import threading
 from collections.abc import AsyncIterator
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import mlx.core as mx
@@ -607,6 +608,8 @@ class DFlashEngine(BaseEngine):
         self,
         prompt_tokens: list[int],
         max_tokens: int,
+        prefix_cache_request: Any | None = None,
+        prefix_cache_chat_template_kwargs: dict[str, Any] | None = None,
     ):
         """Build the dflash event iterator with prefix cache plumbed in."""
         from dflash_mlx.runtime import get_stop_token_ids, stream_dflash_generate
@@ -618,18 +621,20 @@ class DFlashEngine(BaseEngine):
         # ``model_key`` is consumed as a tuple where index 0 = target id and
         # index 2 = draft id; the middle slot is unused on the dflash side.
         # ``tokenizer`` and ``cli_args`` are required since dflash-mlx 1ba6713 —
-        # build_prefix_key hashes the chat template / policy. cli_args=None
-        # makes chat_template_args fall back to {}.
+        # build_prefix_key hashes the chat template / policy.
         class _ModelProviderShim:
             model_key = (self._model_name, None, self._draft_model_path)
             tokenizer = self._executor_tokenizer
-            cli_args = None
+            cli_args = SimpleNamespace(
+                chat_template_args=prefix_cache_chat_template_kwargs or {}
+            )
 
         prefix_flow = PrefixCacheFlow.for_request(
             model_provider=_ModelProviderShim(),
             draft_model=self._draft_model,
             tokenizer=self._executor_tokenizer,
             prompt=prompt_tokens,
+            request=prefix_cache_request,
             runtime_context=self._runtime_context,
         )
 
@@ -660,6 +665,8 @@ class DFlashEngine(BaseEngine):
         queue: asyncio.Queue,
         loop: asyncio.AbstractEventLoop,
         stop_event: threading.Event,
+        prefix_cache_request: Any | None = None,
+        prefix_cache_chat_template_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """Run dflash generation with streaming on MLX executor thread.
 
@@ -675,6 +682,8 @@ class DFlashEngine(BaseEngine):
             event_iter, prefix_flow, stop_ids = self._stream_dflash_events(
                 prompt_tokens=prompt_tokens,
                 max_tokens=max_tokens,
+                prefix_cache_request=prefix_cache_request,
+                prefix_cache_chat_template_kwargs=prefix_cache_chat_template_kwargs,
             )
             prefix_hit_tokens = int(getattr(prefix_flow, "hit_tokens", 0) or 0)
 
@@ -803,6 +812,10 @@ class DFlashEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        prefix_cache_request = kwargs.pop("prefix_cache_request", None)
+        prefix_cache_chat_template_kwargs = kwargs.pop(
+            "prefix_cache_chat_template_kwargs", None
+        )
         prompt_tokens = self._tokenizer_obj.encode(prompt)
 
         # Fallback: evict dflash models, start LLM/VLM engine
@@ -852,6 +865,8 @@ class DFlashEngine(BaseEngine):
                 event_iter, prefix_flow, stop_ids = self._stream_dflash_events(
                     prompt_tokens=prompt_tokens,
                     max_tokens=max_tokens,
+                    prefix_cache_request=prefix_cache_request,
+                    prefix_cache_chat_template_kwargs=prefix_cache_chat_template_kwargs,
                 )
                 prefix_hit_tokens = int(getattr(prefix_flow, "hit_tokens", 0) or 0)
                 tokens: list[int] = []
@@ -957,6 +972,10 @@ class DFlashEngine(BaseEngine):
         if not self._loaded:
             await self.start()
 
+        prefix_cache_request = kwargs.pop("prefix_cache_request", None)
+        prefix_cache_chat_template_kwargs = kwargs.pop(
+            "prefix_cache_chat_template_kwargs", None
+        )
         prompt_tokens = self._tokenizer_obj.encode(prompt)
 
         # Fallback: evict dflash models, start LLM/VLM engine
@@ -1018,6 +1037,8 @@ class DFlashEngine(BaseEngine):
             queue,
             loop,
             stop_event,
+            prefix_cache_request,
+            prefix_cache_chat_template_kwargs,
         )
 
         total_text = ""
@@ -1121,11 +1142,15 @@ class DFlashEngine(BaseEngine):
             chat_template_kwargs=ct_kwargs, is_partial=is_partial,
         )
 
+        prefix_cache_request = SimpleNamespace(request_type="chat", messages=messages)
         return await self.generate(
             prompt=prompt, max_tokens=max_tokens, temperature=temperature,
             top_p=top_p, top_k=top_k, min_p=min_p,
             repetition_penalty=repetition_penalty,
-            presence_penalty=presence_penalty, **kwargs,
+            presence_penalty=presence_penalty,
+            prefix_cache_request=prefix_cache_request,
+            prefix_cache_chat_template_kwargs=ct_kwargs,
+            **kwargs,
         )
 
     async def stream_chat(
@@ -1179,11 +1204,15 @@ class DFlashEngine(BaseEngine):
             chat_template_kwargs=ct_kwargs, is_partial=is_partial,
         )
 
+        prefix_cache_request = SimpleNamespace(request_type="chat", messages=messages)
         async for output in self.stream_generate(
             prompt=prompt, max_tokens=max_tokens, temperature=temperature,
             top_p=top_p, top_k=top_k, min_p=min_p,
             repetition_penalty=repetition_penalty,
-            presence_penalty=presence_penalty, **kwargs,
+            presence_penalty=presence_penalty,
+            prefix_cache_request=prefix_cache_request,
+            prefix_cache_chat_template_kwargs=ct_kwargs,
+            **kwargs,
         ):
             yield output
 

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -676,6 +676,7 @@ class DFlashEngine(BaseEngine):
                 prompt_tokens=prompt_tokens,
                 max_tokens=max_tokens,
             )
+            prefix_hit_tokens = int(getattr(prefix_flow, "hit_tokens", 0) or 0)
 
             # Protocol-specific parser (gemma4 channel markers → <think> tags,
             # harmony channels → <think>/visible split). When active it owns
@@ -753,6 +754,7 @@ class DFlashEngine(BaseEngine):
                         "completion_tokens": gen_tokens,
                         "acceptance_ratio": accept_ratio,
                         "cycles_completed": cycles,
+                        "cached_tokens": prefix_hit_tokens,
                     }
                     asyncio.run_coroutine_threadsafe(
                         queue.put(("", [], True, metrics)), loop
@@ -851,6 +853,7 @@ class DFlashEngine(BaseEngine):
                     prompt_tokens=prompt_tokens,
                     max_tokens=max_tokens,
                 )
+                prefix_hit_tokens = int(getattr(prefix_flow, "hit_tokens", 0) or 0)
                 tokens: list[int] = []
                 parsed_visible_parts: list[str] = []
                 summary: SummaryEvent | None = None
@@ -873,7 +876,7 @@ class DFlashEngine(BaseEngine):
                     final = parser_session.finalize()
                     if final.visible_text:
                         parsed_visible_parts.append(final.visible_text)
-                return summary, tokens, parser_session, parsed_visible_parts
+                return summary, tokens, parser_session, parsed_visible_parts, prefix_hit_tokens
             finally:
                 if event_iter is not None:
                     close = getattr(event_iter, "close", None)
@@ -887,7 +890,7 @@ class DFlashEngine(BaseEngine):
         self._active_request = True
         future = loop.run_in_executor(get_mlx_executor(), _run)
         try:
-            summary, generated, parser_session, parsed_visible_parts = (
+            summary, generated, parser_session, parsed_visible_parts, prefix_hit_tokens = (
                 await asyncio.shield(asyncio.wrap_future(future))
             )
         except asyncio.CancelledError:
@@ -935,6 +938,7 @@ class DFlashEngine(BaseEngine):
             prompt_tokens=prompt_token_count,
             completion_tokens=completion_token_count,
             finish_reason="stop",
+            cached_tokens=prefix_hit_tokens,
         )
 
     async def stream_generate(
@@ -1038,6 +1042,7 @@ class DFlashEngine(BaseEngine):
                         finish_reason = "error"
                     finished_normally = True
 
+                cached_tokens = int(metrics.get("cached_tokens", 0)) if metrics else 0
                 yield GenerationOutput(
                     text=total_text,
                     new_text=new_text,
@@ -1046,6 +1051,7 @@ class DFlashEngine(BaseEngine):
                     completion_tokens=total_completion,
                     finished=finished,
                     finish_reason=finish_reason,
+                    cached_tokens=cached_tokens,
                 )
 
                 if finished:

--- a/tests/test_dflash_prefix_accounting.py
+++ b/tests/test_dflash_prefix_accounting.py
@@ -40,6 +40,9 @@ class _FakeTokenizer:
     def decode(self, tokens, skip_special_tokens=True):
         return "decoded"
 
+    def apply_chat_template(self, messages, **kwargs):
+        return "templated prompt"
+
 
 class _FakePrefixFlow:
     hit_tokens = 3
@@ -129,7 +132,7 @@ def _make_engine(dflash_module):
     engine._detect_needs_think_prefix = lambda prompt_tokens: False
     engine._think_prefix_text = lambda: "<think>\n"
 
-    def fake_stream(prompt_tokens, max_tokens):
+    def fake_stream(prompt_tokens, max_tokens, **kwargs):
         events = iter(
             [
                 TokenEvent(
@@ -167,3 +170,68 @@ def test_dflash_stream_generate_surfaces_prefix_flow_hit_tokens(dflash_module):
 
     assert outputs[-1].finished is True
     assert outputs[-1].cached_tokens == 3
+
+
+def test_dflash_generate_forwards_prefix_cache_metadata_to_flow(dflash_module):
+    engine = _make_engine(dflash_module)
+    captured = {}
+    request = types.SimpleNamespace(request_type="chat", messages=[])
+    chat_template_kwargs = {"enable_thinking": False}
+
+    def fake_stream(prompt_tokens, max_tokens, **kwargs):
+        captured.update(kwargs)
+        events = iter(
+            [
+                TokenEvent(
+                    token_id=10,
+                    generated_tokens=1,
+                    acceptance_ratio=1.0,
+                    cycles_completed=1,
+                ),
+                _summary_event(),
+            ]
+        )
+        return events, _FakePrefixFlow(), {0}
+
+    engine._stream_dflash_events = fake_stream
+
+    asyncio.run(
+        engine.generate(
+            "prompt",
+            max_tokens=1,
+            prefix_cache_request=request,
+            prefix_cache_chat_template_kwargs=chat_template_kwargs,
+        )
+    )
+
+    assert captured["prefix_cache_request"] is request
+    assert captured["prefix_cache_chat_template_kwargs"] == chat_template_kwargs
+
+
+def test_dflash_chat_forwards_prefix_cache_policy_metadata(dflash_module):
+    engine = _make_engine(dflash_module)
+    captured = {}
+
+    async def fake_generate(prompt, **kwargs):
+        captured["prompt"] = prompt
+        captured["kwargs"] = kwargs
+        return _GenerationOutput(text="ok")
+
+    engine.generate = fake_generate
+    messages = [{"role": "user", "content": "hello"}]
+    chat_template_kwargs = {"enable_thinking": False}
+
+    asyncio.run(
+        engine.chat(
+            messages=messages,
+            max_tokens=1,
+            chat_template_kwargs=chat_template_kwargs,
+            is_partial=False,
+        )
+    )
+
+    assert captured["prompt"] == "templated prompt"
+    request = captured["kwargs"]["prefix_cache_request"]
+    assert request.request_type == "chat"
+    assert request.messages == messages
+    assert captured["kwargs"]["prefix_cache_chat_template_kwargs"] == chat_template_kwargs

--- a/tests/test_dflash_prefix_accounting.py
+++ b/tests/test_dflash_prefix_accounting.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import importlib.util
+import sys
+import types
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from dflash_mlx.engine.events import SummaryEvent, TokenEvent
+
+
+@dataclass
+class _GenerationOutput:
+    text: str
+    tokens: List[int] = field(default_factory=list)
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    finish_reason: Optional[str] = "stop"
+    new_text: str = ""
+    finished: bool = True
+    tool_calls: Optional[List[Dict[str, Any]]] = None
+    cached_tokens: int = 0
+
+
+class _BaseEngine:
+    pass
+
+
+class _FakeTokenizer:
+    clean_up_tokenization_spaces = False
+
+    def encode(self, prompt):
+        return [1, 2, 3, 4]
+
+    def decode(self, tokens, skip_special_tokens=True):
+        return "decoded"
+
+
+class _FakePrefixFlow:
+    hit_tokens = 3
+
+
+@pytest.fixture
+def dflash_module(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[1]
+    executor = ThreadPoolExecutor(max_workers=1)
+
+    omlx = types.ModuleType("omlx")
+    omlx.__path__ = [str(repo_root / "omlx")]
+    monkeypatch.setitem(sys.modules, "omlx", omlx)
+
+    engine_pkg = types.ModuleType("omlx.engine")
+    engine_pkg.__path__ = [str(repo_root / "omlx" / "engine")]
+    monkeypatch.setitem(sys.modules, "omlx.engine", engine_pkg)
+
+    base = types.ModuleType("omlx.engine.base")
+    base.GenerationOutput = _GenerationOutput
+    base.BaseEngine = _BaseEngine
+    monkeypatch.setitem(sys.modules, "omlx.engine.base", base)
+
+    adapter_pkg = types.ModuleType("omlx.adapter")
+    adapter = types.ModuleType("omlx.adapter.output_parser")
+    adapter.detect_output_parser = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "omlx.adapter", adapter_pkg)
+    monkeypatch.setitem(sys.modules, "omlx.adapter.output_parser", adapter)
+
+    api_pkg = types.ModuleType("omlx.api")
+    api_tool = types.ModuleType("omlx.api.tool_calling")
+    api_tool.convert_tools_for_template = lambda tools: tools
+    api_utils = types.ModuleType("omlx.api.utils")
+    api_utils.clean_special_tokens = lambda text: text
+    api_utils.detect_and_strip_partial = lambda messages: False
+    monkeypatch.setitem(sys.modules, "omlx.api", api_pkg)
+    monkeypatch.setitem(sys.modules, "omlx.api.tool_calling", api_tool)
+    monkeypatch.setitem(sys.modules, "omlx.api.utils", api_utils)
+
+    utils_pkg = types.ModuleType("omlx.utils")
+    utils_model = types.ModuleType("omlx.utils.model_loading")
+    utils_model.maybe_apply_pre_load_patches = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "omlx.utils", utils_pkg)
+    monkeypatch.setitem(sys.modules, "omlx.utils.model_loading", utils_model)
+
+    engine_core = types.ModuleType("omlx.engine_core")
+    engine_core.get_mlx_executor = lambda: executor
+    monkeypatch.setitem(sys.modules, "omlx.engine_core", engine_core)
+
+    spec = importlib.util.spec_from_file_location(
+        "omlx.engine.dflash",
+        repo_root / "omlx" / "engine" / "dflash.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "omlx.engine.dflash", module)
+    spec.loader.exec_module(module)
+    try:
+        yield module
+    finally:
+        executor.shutdown(wait=True)
+
+
+def _summary_event():
+    return SummaryEvent(
+        elapsed_us=1000,
+        prompt_token_count=4,
+        generated_token_ids=(10,),
+        generation_tokens=1,
+        accepted_from_draft=1,
+        acceptance_ratio=1.0,
+        cycles_completed=1,
+        phase_timings_us={},
+    )
+
+
+def _make_engine(dflash_module):
+    engine = dflash_module.DFlashEngine.__new__(dflash_module.DFlashEngine)
+    engine._loaded = True
+    engine._tokenizer_obj = _FakeTokenizer()
+    engine._executor_tokenizer = _FakeTokenizer()
+    engine._in_fallback_mode = False
+    engine._fallback_engine = None
+    engine._fallback_engine_type = "batched"
+    engine._output_parser_factory = None
+    engine._active_request = False
+    engine._should_fallback = lambda prompt_tokens: False
+    engine._detect_needs_think_prefix = lambda prompt_tokens: False
+    engine._think_prefix_text = lambda: "<think>\n"
+
+    def fake_stream(prompt_tokens, max_tokens):
+        events = iter(
+            [
+                TokenEvent(
+                    token_id=10,
+                    generated_tokens=1,
+                    acceptance_ratio=1.0,
+                    cycles_completed=1,
+                ),
+                _summary_event(),
+            ]
+        )
+        return events, _FakePrefixFlow(), {0}
+
+    engine._stream_dflash_events = fake_stream
+    return engine
+
+
+def test_dflash_generate_surfaces_prefix_flow_hit_tokens(dflash_module):
+    engine = _make_engine(dflash_module)
+
+    output = asyncio.run(engine.generate("prompt", max_tokens=1))
+
+    assert output.cached_tokens == 3
+
+
+def test_dflash_stream_generate_surfaces_prefix_flow_hit_tokens(dflash_module):
+    engine = _make_engine(dflash_module)
+
+    async def collect_outputs():
+        return [
+            output async for output in engine.stream_generate("prompt", max_tokens=1)
+        ]
+
+    outputs = asyncio.run(collect_outputs())
+
+    assert outputs[-1].finished is True
+    assert outputs[-1].cached_tokens == 3

--- a/tests/test_hybrid_cache.py
+++ b/tests/test_hybrid_cache.py
@@ -928,6 +928,54 @@ class TestReconstructCachePartialRestore:
         result = prefix_cache.reconstruct_cache(block_table)
 
         assert result is None
+        assert prefix_cache.get_stats().placeholder_full_rejects == 1
+
+    def test_walk_back_truncates_to_latest_valid_rotating_block(
+        self, paged_cache, mock_ssd_cache
+    ):
+        model = MockModel(num_layers=2)
+        prefix_cache = BlockAwarePrefixCache(
+            model=model,
+            paged_cache_manager=paged_cache,
+            paged_ssd_cache_manager=mock_ssd_cache,
+        )
+
+        block1 = paged_cache.allocate_block()
+        block1.block_hash = b"block1_hash"
+        block1.token_count = 256
+        block2 = paged_cache.allocate_block()
+        block2.block_hash = b"block2_hash"
+        block2.token_count = 256
+
+        block_table = paged_cache.create_block_table("req-walkback")
+        block_table.block_ids = [block1.block_id, block2.block_id]
+        block_table.num_tokens = 512
+
+        kv_keys = mx.zeros((1, 8, 256, 64))
+        kv_values = mx.zeros((1, 8, 256, 64))
+        rot_keys = mx.ones((1, 8, 1024, 64))
+        rot_values = mx.ones((1, 8, 1024, 64))
+        placeholder = mx.zeros((1,))
+        metadata = {
+            'layer_cache_types': ['KVCache', 'RotatingKVCache'],
+            'layer_meta_states': [
+                (256,),
+                (4, 1024, 500, 100),
+            ],
+            'model_name': 'test-model',
+            'num_layers': 2,
+        }
+        mock_ssd_cache.load_block_with_metadata.side_effect = [
+            ([(kv_keys, kv_values), (rot_keys, rot_values)], metadata),
+            ([(kv_keys, kv_values), (placeholder, placeholder)], metadata),
+        ]
+
+        result = prefix_cache.reconstruct_cache(block_table)
+
+        assert result is not None
+        assert block_table.block_ids == [block1.block_id]
+        assert block_table.num_tokens == 256
+        assert prefix_cache.get_stats().retained_restore_walkbacks == 1
 
     def test_full_restore_reconstructs_rotating_state(
         self, paged_cache, mock_ssd_cache


### PR DESCRIPTION
## Summary
- Propagate DFlash `prefix_flow.hit_tokens` into `GenerationOutput.cached_tokens` for both non-streaming and streaming generation paths.
- Forward chat request metadata and per-request `chat_template_kwargs` into the dflash-mlx prefix-cache flow so stable-prefix boundary decisions and prompt-policy hashing use the same request/policy context that produced the prompt tokens.
- Add focused regression tests that stub the DFlash event stream and verify cached-token accounting plus prefix-cache metadata plumbing.
- Add observability for block-aware retained restore behavior: retained restore walk-backs and full placeholder rejects are now visible in prefix-cache stats.
- Add a regression covering walk-back truncation to the latest block whose non-sliceable RotatingKVCache state is valid.

## Environment
- macOS Darwin 25.4.0 arm64
- Apple M1 Max, 32 GB unified memory
- Local MLX-capable Python environment on Apple Silicon

## Validation
DFlash accounting / metadata:

```bash
PYTHONPATH=<omlx>:<dflash-mlx> python -m pytest tests/test_dflash_prefix_accounting.py -q
```

Result: 4 passed

Hybrid / retained restore:

```bash
PYTHONPATH=<omlx> python -m pytest tests/test_hybrid_cache.py -q
```

Result: 47 passed

Paged SSD cache compatibility:

```bash
PYTHONPATH=<omlx> python -m pytest tests/test_paged_ssd_cache.py -q
```

Result: 87 passed

## Real-weight DFlash runs

This PR is accounting and prefix-cache identity plumbing: it reports existing DFlash hit tokens and forwards request/policy metadata to dflash-mlx. It does not alter target/draft kernels. The real-weight runs below validate the DFlash path and provide context for the observability fields.

### Smoke baseline vs DFlash

Command shape: `dflash_mlx.benchmark --suite smoke --model Qwen/Qwen3.5-4B --draft z-lab/Qwen3.5-4B-DFlash --max-tokens 32 --repeat 1 --cooldown 0 --no-eos`.

| Metric | Baseline MLX | DFlash |
| --- | ---: | ---: |
| Generation TPS median | 35.77 tok/s | 32.78 tok/s |
| Prefill TPS median | 34.20 tok/s | 60.86 tok/s physical / 60.86 apparent |
| Acceptance median | n/a | 0.875 |
| Peak memory median | 8.49 GB | 9.68 GB |
| End physical footprint | 8.77 GB | 10.03 GB |

### Long-context DFlash-only run

Command shape: `dflash_mlx.benchmark --suite longctx --ctx-tokens 50000 --model Qwen/Qwen3.5-4B --draft z-lab/Qwen3.5-4B-DFlash --max-tokens 5000 --repeat 1 --cooldown 0 --no-eos --only-dflash`.

| Metric | DFlash |
| --- | ---: |
| Logical context tokens | 54,579 |
| Generated tokens | 5,000 |
| TTFT | 92.56s |
| Generation TPS | 36.63 tok/s |
| Prefill TPS | 590.16 tok/s physical / 590.16 apparent |
| Acceptance ratio | 0.7926 |
| Accepted from draft | 3,963 tokens |
| Cycles | 1,037 |
| Peak memory | 15.64 GB |
| End physical footprint | 13.86 GB |

No speedup claim is made from this oMLX PR itself: measurable target/draft TTFT changes depend on dflash-mlx snapshot lookup/publish internals. The regression target here is correctness of cached-token accounting, request/policy identity propagation, and retained-restore observability.

## DFlash key / canonicalization review
The sibling dflash-mlx prefix-cache code already keys snapshots by target model id, draft model id, captured target layer ids, draft sink/window sizes, target FA window, chat template hash, and prompt-policy hash.

This oMLX change fixes the integration gap on the caller side: oMLX now passes the chat request object and `chat_template_kwargs` into `PrefixCacheFlow.for_request()`. That lets dflash-mlx compute the stable prefix boundary from the actual last chat role and include per-request template/policy options in the key hash instead of silently defaulting to `{}`.

The change deliberately does not mix oMLX scheduler KV payloads with DFlash snapshot payloads. DFlash lookup/publish remains owned by dflash-mlx; this PR only fixes accounting, request/policy metadata plumbing, and retained-restore observability.