### PR TITLE
fix(mtp): guard _reconcile_mtp_to_standard against unbounded re-prefill

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -77,6 +77,8 @@ from typing import Any, Deque, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
+_RECONCILE_MAX_TOKENS = 16384
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -481,6 +483,16 @@ def _reconcile_mtp_to_standard(gen_batch: Any, state: _MtpState) -> bool:
 
     tokens = gen_batch.tokens[0] if getattr(gen_batch, "tokens", None) else None
     if not tokens:
+        return False
+    n_tokens = len(tokens)
+    if n_tokens > _RECONCILE_MAX_TOKENS:
+        logger.warning(
+            "MTP reconcile skipped: token count %d exceeds safety limit %d "
+            "(uid=%s). Falling back to plain drop to avoid unbounded re-prefill.",
+            n_tokens,
+            _RECONCILE_MAX_TOKENS,
+            getattr(state, "uid", "?"),
+        )
         return False
     try:
         new_cache = _rebuild_singleton_cache(gen_batch.model)

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -645,6 +645,41 @@ class TestBatchGeneratorDispatch:
         # Nothing streamed yet -> cannot re-prefill; signal plain-drop fallback.
         assert bg._reconcile_mtp_to_standard(batch, state) is False
 
+    def test_reconcile_skips_when_token_count_exceeds_safety_limit(self, monkeypatch):
+        from omlx.patches.mlx_lm_mtp.batch_generator import _RECONCILE_MAX_TOKENS
+
+        bg, batch, state = self._make_reconcile_batch(
+            monkeypatch,
+            uid=7,
+            tokens=list(range(_RECONCILE_MAX_TOKENS + 1)),
+            queue_entries=[],
+        )
+        old_cache = batch.prompt_cache
+        backbone_called = []
+        real_backbone = bg._call_backbone
+        monkeypatch.setattr(
+            bg,
+            "_call_backbone",
+            lambda *a, **kw: backbone_called.append(1) or real_backbone(*a, **kw),
+        )
+
+        assert bg._reconcile_mtp_to_standard(batch, state) is False
+        assert batch.prompt_cache is old_cache
+        assert not backbone_called, "backbone should not be called for long sequences"
+
+    def test_reconcile_proceeds_at_safety_limit(self, monkeypatch):
+        from omlx.patches.mlx_lm_mtp.batch_generator import _RECONCILE_MAX_TOKENS
+
+        bg, batch, state = self._make_reconcile_batch(
+            monkeypatch,
+            uid=7,
+            tokens=list(range(_RECONCILE_MAX_TOKENS)),
+            queue_entries=[],
+        )
+
+        assert bg._reconcile_mtp_to_standard(batch, state) is True
+        assert batch.prompt_cache[0].offset == _RECONCILE_MAX_TOKENS
+
     def test_reconcile_fallback_on_rebuild_failure(self, monkeypatch):
         import mlx.core as mx
 


### PR DESCRIPTION
## Summary

`_reconcile_mtp_to_standard` re-prefills the entire token history through the backbone in a single `_call_backbone` call when transitioning from MTP to standard decode. At long contexts (70K+ tokens, reported on Qwen3.6-35B-A3B), this unbounded re-prefill triggers a Metal GPU abort (SIGABRT) that kills the server process — uncatchable by the existing try/except since SIGABRT fires on the Metal completion thread.

The crash surface requires stale SSD cache blocks from a prior model version (layer count mismatch after an upgrade like #1404), which cause repeated cache invalidations and allow context to grow without cache benefit.

## Changes

A module-level `_RECONCILE_MAX_TOKENS` constant (16384) caps how many tokens the reconcile function will attempt to re-prefill. When exceeded, the function returns False immediately — the caller (`patched_extend`) drops MTP state unconditionally regardless of the return value, so the batch falls back to standard decode with at most one stale token. This is the same degradation path as the existing empty-tokens and rebuild-failure cases.

The threshold is 8x the scheduler's `prefill_step_size` (2048) and ~4.3x below the observed crash point (70K), giving wide safety margin across model sizes.

## Test plan

- Two new tests: guard fires above the limit (backbone never called), reconcile proceeds normally at the limit.
- Full suite: 4585 passed, 19 skipped, 59 deselected.
- Verified on M5 Max 128GB — 100-token reconcile completes normally, 17K-token reconcile is blocked by guard with warning log.

Related to #1413