### PR TITLE
feat: expose oMLX version via CLI

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -18,6 +18,8 @@ import argparse
 import faulthandler
 import sys
 
+from ._version import __version__
+
 
 def _has_cli_overrides(args) -> bool:
     """Check if CLI args contain non-default values that should be saved.
@@ -495,6 +497,12 @@ Examples:
   omlx serve mlx-community/Llama-3.2-3B-Instruct-4bit --port 8000
   omlx launch codex --model qwen3.5
         """,
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=__version__,
+        help="Print the oMLX version and exit",
     )
     subparsers = parser.add_subparsers(dest="command", help="Commands")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+from omlx._version import __version__
+
 
 class TestCLIModule:
     """Tests for CLI module existence and basic functionality."""
@@ -44,6 +46,18 @@ class TestCLIHelp:
         assert result.returncode == 0
         # Should show available commands
         assert "serve" in result.stdout.lower()
+
+    def test_main_version(self):
+        """Test main CLI version output."""
+        result = subprocess.run(
+            [sys.executable, "-m", "omlx.cli", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == __version__
+        assert result.stderr == ""
 
     def test_serve_help(self):
         """Test serve command help output."""


### PR DESCRIPTION
Adds a top-level `omlx --version` flag backed by the existing `omlx._version.__version__` source of truth.

## Changes

- Add `omlx --version`
- Add CLI test coverage for version output
- Leave existing server metadata behavior unchanged