### PR TITLE
fix(server): chunk-form SSE keepalive shares the stream's completion id

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1359,6 +1359,26 @@ def _resolve_keepalive(protocol: str) -> Optional[str]:
     return None
 
 
+def _chat_keepalive_chunk(response_id: str) -> str:
+    """Keepalive frame that shares the stream's completion id.
+
+    The static ``_KEEPALIVE_CHAT_CHUNK`` carries a sentinel id
+    (``chatcmpl-keepalive``) that differs from the real completion chunks.
+    Strict OpenAI stream accumulators (e.g. the official ``openai-go`` SDK)
+    assume every chunk in one streamed completion shares a single ``id``: they
+    latch the first chunk's id and silently drop later chunks whose id differs,
+    discarding the real ``tool_calls``/``finish_reason``/``usage``. Emitting the
+    keepalive with the stream's own ``response_id`` makes it a true no-op for
+    those clients while remaining a parseable data event for clients that can't
+    handle SSE comment lines.
+    """
+    return (
+        'data: {"id":"' + response_id + '","object":"chat.completion.chunk",'
+        '"created":0,"model":"keepalive",'
+        '"choices":[{"index":0,"delta":{"content":""},"finish_reason":null}]}\n\n'
+    )
+
+
 async def _safe_anext(ait):
     """Wrapper for __anext__ that converts StopAsyncIteration to a sentinel.
 
@@ -2314,11 +2334,17 @@ async def create_chat_completion(
         chat_kwargs["stop"] = request.stop
 
     if request.stream:
+        # Pre-mint the completion id so the keepalive frame (emitted before the
+        # generator starts) can share it. See _chat_keepalive_chunk.
+        response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
+        keepalive = _resolve_keepalive("openai_chat")
+        if keepalive == _KEEPALIVE_CHAT_CHUNK:
+            keepalive = _chat_keepalive_chunk(response_id)
         return StreamingResponse(
             _with_sse_keepalive(
-                stream_chat_completion(engine, messages, request, model_load_duration=model_load_duration, resolved_model=resolved_model, **chat_kwargs),
+                stream_chat_completion(engine, messages, request, model_load_duration=model_load_duration, resolved_model=resolved_model, response_id=response_id, **chat_kwargs),
                 http_request=http_request,
-                keepalive_chunk=_resolve_keepalive("openai_chat"),
+                keepalive_chunk=keepalive,
             ),
             media_type="text/event-stream",
             headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"},
@@ -2770,6 +2796,7 @@ async def stream_chat_completion(
     request: ChatCompletionRequest,
     model_load_duration: float = 0.0,
     resolved_model: Optional[str] = None,
+    response_id: Optional[str] = None,
     **kwargs,
 ) -> AsyncIterator[str]:
     """Stream chat completion response.
@@ -2785,7 +2812,9 @@ async def stream_chat_completion(
     has_tools = bool(kwargs.get("tools"))
     thinking_parser = ThinkingParser()
 
-    response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
+    # Reuse the id pre-minted by the caller (so the keepalive frame can share
+    # it); otherwise mint one for direct/non-streaming callers.
+    response_id = response_id or f"chatcmpl-{uuid.uuid4().hex[:8]}"
 
     # First chunk with role
     first_chunk = ChatCompletionChunk(

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -153,6 +153,37 @@ class TestKeepaliveChunkFormats:
         assert items == ["data: real\n\n"]
 
 
+class TestChatKeepaliveSharesStreamId:
+    """The chunk-form chat keepalive must reuse the stream's completion id.
+
+    Strict OpenAI stream accumulators key on a single per-stream ``id`` and
+    drop chunks whose id differs from the first. A keepalive carrying the
+    sentinel ``chatcmpl-keepalive`` id therefore causes them to discard the
+    real tool_calls/usage chunks. _chat_keepalive_chunk reuses the stream id so
+    the frame is a true no-op for those clients.
+    """
+
+    def test_frame_uses_given_response_id(self):
+        from omlx.server import _chat_keepalive_chunk
+
+        frame = _chat_keepalive_chunk("chatcmpl-abc123")
+        assert frame.startswith("data: ")
+        assert frame.endswith("\n\n")
+        payload = json.loads(frame.removeprefix("data: ").strip())
+        assert payload["id"] == "chatcmpl-abc123"
+        assert payload["object"] == "chat.completion.chunk"
+        assert payload["choices"][0]["delta"]["content"] == ""
+        assert payload["choices"][0]["finish_reason"] is None
+
+    def test_frame_does_not_use_sentinel_id(self):
+        from omlx.server import _chat_keepalive_chunk
+
+        payload = json.loads(
+            _chat_keepalive_chunk("chatcmpl-real").removeprefix("data: ").strip()
+        )
+        assert payload["id"] != "chatcmpl-keepalive"
+
+
 class TestResolveKeepalive:
     """Tests for _resolve_keepalive helper that maps settings to wire format."""
 


### PR DESCRIPTION
## Problem

Since v0.3.9 the default SSE keepalive mode (`chunk`) emits a `chat.completion.chunk` whose `id` is the sentinel `chatcmpl-keepalive`, sent as the first frame of every stream. The real completion chunks then arrive under a different, freshly-minted id.

Strict OpenAI stream accumulators assume all chunks in one streamed completion share a single `id`. The official OpenAI Go SDK (`openai-go`) `ChatCompletionAccumulator` latches the first chunk's id and silently rejects every later chunk whose id differs:

```go
if len(cc.ID) == 0 {
    cc.ID = chunk.ID          // becomes "chatcmpl-keepalive"
} else if cc.ID != chunk.ID {
    return false              // every real chunk dropped
}
```

So the streamed `tool_calls`, `finish_reason`, and `usage` are all discarded, producing an empty assistant message on any tool-calling turn. (Plain `content` can survive if read from live deltas, which is why prose replies often look fine while tool-calling turns come back empty.)

Reported in #1478. This is a regression from the fix for #839, which switched the default keepalive from an SSE comment to this chunk form.

## Fix

Pre-mint `response_id` in `create_chat_completion` and reuse it for both the keepalive frame and `stream_chat_completion`. The keepalive (`_chat_keepalive_chunk`) now carries the stream's real id, so it is a true no-op for spec accumulators while remaining a parseable data event for the comment-intolerant clients chunk mode was added for (OpenClaw / WorkBuddy, #839/#1035). `comment` and `off` modes are unchanged.

## Verification

- New unit tests in `tests/test_sse_keepalive.py` assert the chat keepalive frame reuses the given id and never emits the sentinel.
- Validated end-to-end against a local build: with the patch the first keepalive frame's `id` matches the completion id, and an unmodified `openai-go` client that previously received empty tool-calling turns now gets the tool call + usage correctly.

## Notes

- Touches the same `create_chat_completion` streaming `return` as open PR #1452 (preflight guards) — only trivial line-context proximity, no logic overlap; may need a one-line rebase if both land.

Fixes #1478.
