### PR TITLE
fix(chat): Fix aliased model handling in admin chat

### DIFF
--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -1282,6 +1282,7 @@
             // Model State
             availableModels: [],
             currentModel: null,
+            modelDisplayIdMap: {},       // { canonicalModelId: displayIdFromV1Models }
 
             // Streaming State
             streamSessions: {},
@@ -1313,6 +1314,7 @@
 
             // VLM Detection State
             modelTypeMap: {},            // { modelId: "llm"|"vlm"|"embedding"|"reranker" }
+            modelStatusModels: [],        // Canonical model metadata from /v1/models/status
 
             // System Prompt
             systemPrompt: localStorage.getItem('omlx_chat_system_prompt') || '',
@@ -1485,14 +1487,31 @@
             });
             if (!resp.ok) return;
             const data = await resp.json();
+            this.modelStatusModels = data.models || [];
             const map = {};
-            for (const m of (data.models || [])) {
+            for (const m of this.modelStatusModels) {
                 map[m.id] = m.model_type || 'llm';
             }
             this.modelTypeMap = map;
         } catch (e) {
             // Model status endpoint unavailable
         }
+    },
+
+    syncDisplayModelMetadata(displayModels) {
+        this.modelTypeMap = { ...this.modelTypeMap };
+        this.modelDisplayIdMap = {};
+        displayModels.forEach((displayModel, index) => {
+            const statusModel = this.modelStatusModels[index];
+            if (!statusModel) return;
+            this.modelTypeMap[displayModel.id] = statusModel.model_type || 'llm';
+            this.modelDisplayIdMap[statusModel.id] = displayModel.id;
+            this.modelDisplayIdMap[displayModel.id] = displayModel.id;
+        });
+    },
+
+    resolveDisplayModelId(modelId) {
+        return this.modelDisplayIdMap[modelId] || modelId;
     },
 
     hasVisionSupport() {
@@ -1770,6 +1789,7 @@
 
             // Fetch model types first (needed for filtering and VLM detection)
             await this.fetchModelTypes();
+            this.syncDisplayModelMetadata(allModels);
 
             // Filter out audio/embedding/reranker — chat only works with LLM/VLM
             this.availableModels = allModels.filter(m => {
@@ -1785,8 +1805,9 @@
 
             // Auto-select default model if set, otherwise first model
             if (!this.currentModel && this.availableModels.length > 0) {
-                if (defaultModel && this.availableModels.some(m => m.id === defaultModel)) {
-                    this.currentModel = defaultModel;
+                const defaultDisplayModel = defaultModel ? this.resolveDisplayModelId(defaultModel) : null;
+                if (defaultDisplayModel && this.availableModels.some(m => m.id === defaultDisplayModel)) {
+                    this.currentModel = defaultDisplayModel;
                 } else {
                     this.currentModel = this.availableModels[0].id;
                 }

--- a/tests/test_admin_chat.py
+++ b/tests/test_admin_chat.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for built-in admin chat UI behavior."""
+
+from pathlib import Path
+
+
+CHAT_TEMPLATE = (
+    Path(__file__).parent.parent / "omlx" / "admin" / "templates" / "chat.html"
+)
+
+
+class TestChatModelAliasHandling:
+    """Built-in chat should handle display ids from /v1/models."""
+
+    def test_model_type_map_includes_display_ids_for_vision_gate(self):
+        """Aliased VLMs should still show image upload controls in chat."""
+        template = CHAT_TEMPLATE.read_text()
+
+        assert "syncDisplayModelMetadata(displayModels)" in template
+        assert "this.modelTypeMap[displayModel.id] = statusModel.model_type || 'llm';" in template
+        assert "this.modelDisplayIdMap[statusModel.id] = displayModel.id;" in template
+
+    def test_default_model_is_resolved_to_display_id(self):
+        """The chat default model can be canonical while /v1/models uses aliases."""
+        template = CHAT_TEMPLATE.read_text()
+
+        assert "resolveDisplayModelId(modelId)" in template
+        assert "const defaultDisplayModel = defaultModel ? this.resolveDisplayModelId(defaultModel) : null;" in template
+        assert "this.currentModel = defaultDisplayModel;" in template


### PR DESCRIPTION
## Summary

Fixes admin chat behavior when a model has an alias configured.

The built-in chat receives display model IDs from `/v1/models`, which may be aliases set in "Model Settings", while `/v1/models/status` and `/health.default_model` use canonical model directory IDs. Because the chat UI compared these IDs directly, aliased models could lose VLM capability detection and the default model could fail to auto-select.

This change keeps the server API unchanged and resolves the mismatch inside the admin chat UI.

## What changed

- Correlate `/v1/models` display IDs with `/v1/models/status` canonical model metadata in admin chat.
- Map `model_type` onto display IDs so aliased VLMs still show image upload controls.
- Resolve `/health.default_model` from canonical ID to display ID before auto-selecting the default model.
- Add fast admin chat tests for alias-aware VLM gating and default model selection.

## Related issues

Fixes #983 
Fixes #1411

## Tests Performed

```bash
uv run pytest tests/test_admin_chat.py tests/test_chat_image_upload.py
uv run pytest -m "not slow"
```

## AI assistance

This PR was prepared with AI assistance and reviewed by a human before submission.