### PR TITLE
fix(embedding): bound per-request embedding batch size

### DIFF
--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -3582,6 +3582,18 @@
         }
       }
     },
+    "performance.error.embedding_batch_size_invalid" : {
+      "comment" : "Performance screen error when embedding batch size input is invalid",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Embedding Batch Size must be a positive integer."
+          }
+        }
+      }
+    },
     "performance.error.idle_timeout_invalid" : {
       "comment" : "Performance screen error when idle timeout input is below 60 seconds",
       "extractionState" : "manual",
@@ -3782,6 +3794,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Split long prompts across scheduler ticks so other requests can interleave."
+          }
+        }
+      }
+    },
+    "performance.scheduler.embedding_batch_size" : {
+      "comment" : "Row label for embedding batch size",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Embedding Batch Size"
+          }
+        }
+      }
+    },
+    "performance.scheduler.embedding_batch_size.sub" : {
+      "comment" : "Sublabel for embedding batch size",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Max input texts per embedding forward pass."
           }
         }
       }

--- a/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
@@ -319,7 +319,7 @@ private struct CacheSection: View {
 final class PerformanceScreenVM: ObservableObject {
     // Scheduler
     @Published var maxConcurrentText: String = "8"
-    @Published var embeddingBatchSizeText: String = "8"
+    @Published var embeddingBatchSizeText: String = "32"
     @Published var chunkedPrefill: Bool = false
 
     // Memory & Lifecycle
@@ -339,7 +339,7 @@ final class PerformanceScreenVM: ObservableObject {
 
     // Loaded baselines (everything that drives Apply's enabled state)
     @Published private(set) var loadedMaxConcurrent: Int = 8
-    @Published private(set) var loadedEmbeddingBatchSize: Int = 8
+    @Published private(set) var loadedEmbeddingBatchSize: Int = 32
     @Published private(set) var loadedChunkedPrefill: Bool = false
     @Published private(set) var loadedMaxProcessMemory: String = ""
     @Published private(set) var loadedMaxModelMemory: String = ""
@@ -379,7 +379,7 @@ final class PerformanceScreenVM: ObservableObject {
             if let sched = s.scheduler {
                 self.maxConcurrentText = String(sched.maxConcurrentRequests)
                 self.loadedMaxConcurrent = sched.maxConcurrentRequests
-                let embeddingBatchSize = sched.embeddingBatchSize ?? 8
+                let embeddingBatchSize = sched.embeddingBatchSize ?? 32
                 self.embeddingBatchSizeText = String(embeddingBatchSize)
                 self.loadedEmbeddingBatchSize = embeddingBatchSize
                 self.chunkedPrefill = sched.chunkedPrefill ?? false

--- a/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
@@ -2,14 +2,14 @@
 //
 // One tab for every "how the engine runs" knob. Three sections:
 //   • Scheduler — max_concurrent_requests (moved from ServerScreen for
-//     scheduler coherence) + chunked_prefill.
+//     scheduler coherence), embedding_batch_size, and chunked_prefill.
 //   • Memory & Lifecycle — process / model memory limits, prefill memory
 //     guard, server-wide idle timeout, model fallback routing.
 //   • Cache — master enable toggle gates a hot-cache toggle + size, a
 //     cold-cache directory + size, and an advanced initial-blocks tuning
 //     knob (requires restart).
 //
-// All twelve fields are server-side already (`omlx/admin/routes.py:191-272`)
+// All thirteen fields are server-side already (`omlx/admin/routes.py:191-272`)
 // — Phase 3 is pure UI. Single Apply button at the bottom, Storage /
 // Network pattern: disabled until at least one trimmed draft diverges
 // from its loaded value, and only changed fields are sent in the PATCH
@@ -77,6 +77,16 @@ private struct SchedulerSection: View {
                                  comment: "Sublabel for max concurrent requests")
             ) {
                 TextInput(text: $vm.maxConcurrentText, mono: true, width: 90)
+            }
+            Row(
+                label: String(localized: "performance.scheduler.embedding_batch_size",
+                              defaultValue: "Embedding Batch Size",
+                              comment: "Row label for embedding batch size"),
+                sublabel: String(localized: "performance.scheduler.embedding_batch_size.sub",
+                                 defaultValue: "Max input texts per embedding forward pass.",
+                                 comment: "Sublabel for embedding batch size")
+            ) {
+                TextInput(text: $vm.embeddingBatchSizeText, mono: true, width: 90)
             }
             Row(
                 label: String(localized: "performance.scheduler.chunked_prefill",
@@ -309,6 +319,7 @@ private struct CacheSection: View {
 final class PerformanceScreenVM: ObservableObject {
     // Scheduler
     @Published var maxConcurrentText: String = "8"
+    @Published var embeddingBatchSizeText: String = "8"
     @Published var chunkedPrefill: Bool = false
 
     // Memory & Lifecycle
@@ -328,6 +339,7 @@ final class PerformanceScreenVM: ObservableObject {
 
     // Loaded baselines (everything that drives Apply's enabled state)
     @Published private(set) var loadedMaxConcurrent: Int = 8
+    @Published private(set) var loadedEmbeddingBatchSize: Int = 8
     @Published private(set) var loadedChunkedPrefill: Bool = false
     @Published private(set) var loadedMaxProcessMemory: String = ""
     @Published private(set) var loadedMaxModelMemory: String = ""
@@ -346,6 +358,7 @@ final class PerformanceScreenVM: ObservableObject {
 
     var hasPendingChanges: Bool {
         parsedMaxConcurrent != loadedMaxConcurrent
+            || parsedEmbeddingBatchSize != loadedEmbeddingBatchSize
             || chunkedPrefill != loadedChunkedPrefill
             || trim(maxProcessMemory) != loadedMaxProcessMemory
             || trim(maxModelMemory) != loadedMaxModelMemory
@@ -366,6 +379,9 @@ final class PerformanceScreenVM: ObservableObject {
             if let sched = s.scheduler {
                 self.maxConcurrentText = String(sched.maxConcurrentRequests)
                 self.loadedMaxConcurrent = sched.maxConcurrentRequests
+                let embeddingBatchSize = sched.embeddingBatchSize ?? 8
+                self.embeddingBatchSizeText = String(embeddingBatchSize)
+                self.loadedEmbeddingBatchSize = embeddingBatchSize
                 self.chunkedPrefill = sched.chunkedPrefill ?? false
                 self.loadedChunkedPrefill = sched.chunkedPrefill ?? false
             }
@@ -414,6 +430,12 @@ final class PerformanceScreenVM: ObservableObject {
                                     comment: "Performance screen error when max concurrent input is invalid")
             return
         }
+        guard let embeddingBatchSize = parsedEmbeddingBatchSize, embeddingBatchSize > 0 else {
+            self.lastError = String(localized: "performance.error.embedding_batch_size_invalid",
+                                    defaultValue: "Embedding Batch Size must be a positive integer.",
+                                    comment: "Performance screen error when embedding batch size input is invalid")
+            return
+        }
         // Idle timeout: empty = leave alone (no patch field for null). Non-
         // empty must be a positive integer; server enforces >= 60 itself.
         let idleTrimmed = idleTimeoutText.trimmingCharacters(in: .whitespaces)
@@ -443,6 +465,9 @@ final class PerformanceScreenVM: ObservableObject {
         var patch = GlobalSettingsPatch()
         // Scheduler
         if mc != loadedMaxConcurrent { patch.maxConcurrentRequests = mc }
+        if embeddingBatchSize != loadedEmbeddingBatchSize {
+            patch.embeddingBatchSize = embeddingBatchSize
+        }
         if chunkedPrefill != loadedChunkedPrefill { patch.chunkedPrefill = chunkedPrefill }
         // Memory & lifecycle
         let mpm = trim(maxProcessMemory)
@@ -475,6 +500,7 @@ final class PerformanceScreenVM: ObservableObject {
             _ = try await client.updateGlobalSettings(patch)
             // Converge baselines on success.
             self.loadedMaxConcurrent = mc
+            self.loadedEmbeddingBatchSize = embeddingBatchSize
             self.loadedChunkedPrefill = chunkedPrefill
             self.loadedMaxProcessMemory = mpm
             self.loadedMaxModelMemory = mmm
@@ -497,6 +523,10 @@ final class PerformanceScreenVM: ObservableObject {
 
     private var parsedMaxConcurrent: Int? {
         Int(maxConcurrentText.trimmingCharacters(in: .whitespaces))
+    }
+
+    private var parsedEmbeddingBatchSize: Int? {
+        Int(embeddingBatchSizeText.trimmingCharacters(in: .whitespaces))
     }
 
     private var parsedIdleTimeout: Int? {

--- a/apps/omlx-mac/Sources/Net/DTO/GlobalSettingsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/GlobalSettingsDTO.swift
@@ -48,6 +48,7 @@ struct GlobalSettingsDTO: Codable, Equatable, Sendable {
 
     struct SchedulerSettings: Codable, Equatable, Sendable {
         let maxConcurrentRequests: Int
+        let embeddingBatchSize: Int?
         let chunkedPrefill: Bool?
     }
 
@@ -160,6 +161,7 @@ struct GlobalSettingsPatch: Encodable, Equatable, Sendable {
     var port: Int? = nil
     var logLevel: String? = nil
     var maxConcurrentRequests: Int? = nil
+    var embeddingBatchSize: Int? = nil
 
     // Server — Advanced (Phase 4).
     /// Extra host names the server identifies as for cookie/host-header

--- a/apps/omlx-mac/Tests/oMLXTests/DTOFixtureTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/DTOFixtureTests.swift
@@ -81,7 +81,7 @@ final class DTOFixtureTests: XCTestCase {
         XCTAssertNotNil(settings.auth,          "auth block missing")
         XCTAssertNotNil(settings.claudeCode,    "claude_code block missing")
         XCTAssertNotNil(settings.integrations,  "integrations block missing")
-        XCTAssertEqual(settings.scheduler?.embeddingBatchSize, 8)
+        XCTAssertEqual(settings.scheduler?.embeddingBatchSize, 32)
     }
 
     // MARK: - Models list

--- a/apps/omlx-mac/Tests/oMLXTests/DTOFixtureTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/DTOFixtureTests.swift
@@ -81,6 +81,7 @@ final class DTOFixtureTests: XCTestCase {
         XCTAssertNotNil(settings.auth,          "auth block missing")
         XCTAssertNotNil(settings.claudeCode,    "claude_code block missing")
         XCTAssertNotNil(settings.integrations,  "integrations block missing")
+        XCTAssertEqual(settings.scheduler?.embeddingBatchSize, 8)
     }
 
     // MARK: - Models list

--- a/apps/omlx-mac/Tests/oMLXTests/Fixtures/global-settings.json
+++ b/apps/omlx-mac/Tests/oMLXTests/Fixtures/global-settings.json
@@ -31,7 +31,7 @@
     },
     "scheduler": {
         "max_concurrent_requests": 8,
-        "embedding_batch_size": 8,
+        "embedding_batch_size": 32,
         "chunked_prefill": true
     },
     "cache": {

--- a/apps/omlx-mac/Tests/oMLXTests/Fixtures/global-settings.json
+++ b/apps/omlx-mac/Tests/oMLXTests/Fixtures/global-settings.json
@@ -31,6 +31,7 @@
     },
     "scheduler": {
         "max_concurrent_requests": 8,
+        "embedding_batch_size": 8,
         "chunked_prefill": true
     },
     "cache": {

--- a/apps/omlx-mac/Tests/oMLXTests/GlobalSettingsSamplingTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/GlobalSettingsSamplingTests.swift
@@ -76,6 +76,18 @@ final class GlobalSettingsSamplingTests: XCTestCase {
 
     // MARK: - Patch encode
 
+    func testPatchEncodesEmbeddingBatchSizeAsSnakeCaseFlatKey() throws {
+        // Scheduler writes use the flat GlobalSettingsRequest shape, so the
+        // Swift camelCase property must encode to embedding_batch_size.
+        var patch = GlobalSettingsPatch()
+        patch.embeddingBatchSize = 8
+
+        let data = try encoder.encode(patch)
+        let str = String(data: data, encoding: .utf8) ?? ""
+
+        XCTAssertTrue(str.contains("\"embedding_batch_size\":8"), "got: \(str)")
+    }
+
     func testPatchEncodesSamplingFieldsAsSnakeCaseFlatKeys() throws {
         // The Python `GlobalSettingsRequest` accepts the sampling defaults
         // as flat `sampling_*` keys (omlx/admin/routes.py:229-234), not

--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -342,6 +342,8 @@
   "settings.resource.prefill_memory_guard_description": "Pause prefill scheduling and evict LRU models when memory pressure approaches the ceiling derived from the reserve level on the right.",
   "settings.resource.max_concurrent_requests": "Max Concurrent Requests",
   "settings.resource.max_concurrent_requests_hint": "Maximum number of requests processed simultaneously. Higher values increase throughput but use more memory.",
+  "settings.resource.embedding_batch_size": "Embedding Batch Size",
+  "settings.resource.embedding_batch_size_hint": "Maximum number of input texts embedded in one forward pass. Higher values increase throughput but use more memory.",
   "settings.resource.chunked_prefill": "Chunked Prefill",
   "settings.resource.chunked_prefill_description": "Interleave prefill chunks with decode steps. Reduces time-to-first-token for concurrent requests by processing one prefill chunk per step instead of blocking decode.",
   "settings.resource.restart_badge": "Restart needed",

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -342,6 +342,8 @@
   "settings.resource.prefill_memory_guard_description": "Estima la memoria antes del prefill y difiere la planificación bajo presión de memoria para evitar fallos de asignación de Metal.",
   "settings.resource.max_concurrent_requests": "Máximo de Solicitudes Concurrentes",
   "settings.resource.max_concurrent_requests_hint": "Número máximo de solicitudes procesadas simultáneamente. Valores más altos aumentan el throughput pero usan más memoria.",
+  "settings.resource.embedding_batch_size": "Tamaño de lote de embeddings",
+  "settings.resource.embedding_batch_size_hint": "Número máximo de textos de entrada procesados en una pasada forward. Valores más altos aumentan el throughput pero usan más memoria.",
   "settings.resource.chunked_prefill": "Chunked Prefill",
   "settings.resource.chunked_prefill_description": "Interleave prefill chunks with decode steps. Reduces time-to-first-token for concurrent requests by processing one prefill chunk per step instead of blocking decode.",
   "settings.resource.restart_badge": "Reinicio necesario",

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -342,6 +342,8 @@
   "settings.resource.prefill_memory_guard_description": "Estimez la mémoire avant le pré-remplissage et reportez la planification sous pression mémoire pour éviter les défaillances d'allocation Metal.",
   "settings.resource.max_concurrent_requests": "Nombre max de requêtes simultanées",
   "settings.resource.max_concurrent_requests_hint": "Nombre maximal de requêtes traitées simultanément. Les valeurs plus élevées augmentent le débit mais utilisent plus de mémoire.",
+  "settings.resource.embedding_batch_size": "Taille de lot des embeddings",
+  "settings.resource.embedding_batch_size_hint": "Nombre maximal de textes incorporés en une passe avant. Les valeurs plus élevées augmentent le débit mais utilisent plus de mémoire.",
   "settings.resource.chunked_prefill": "Chunked Prefill",
   "settings.resource.chunked_prefill_description": "Interleave prefill chunks with decode steps. Reduces time-to-first-token for concurrent requests by processing one prefill chunk per step instead of blocking decode.",
   "settings.resource.restart_badge": "Redémarrage nécessaire",

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -342,6 +342,8 @@
   "settings.resource.prefill_memory_guard_description": "プリフィル前にメモリを推定し、メモリ圧力時にスケジューリングを遅延してMetal割り当てエラーを防止します。",
   "settings.resource.max_concurrent_requests": "最大同時リクエスト数",
   "settings.resource.max_concurrent_requests_hint": "同時に処理するリクエストの最大数。値が大きいほどスループットは向上しますが、メモリ使用量も増加します。",
+  "settings.resource.embedding_batch_size": "Embedding バッチサイズ",
+  "settings.resource.embedding_batch_size_hint": "1 回のフォワードパスで埋め込む入力テキストの最大数。値が大きいほどスループットは向上しますが、メモリ使用量も増加します。",
   "settings.resource.chunked_prefill": "Chunked Prefill",
   "settings.resource.chunked_prefill_description": "Interleave prefill chunks with decode steps. Reduces time-to-first-token for concurrent requests by processing one prefill chunk per step instead of blocking decode.",
   "settings.resource.restart_badge": "再起動が必要",

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -342,6 +342,8 @@
   "settings.resource.prefill_memory_guard_description": "프리필 전 메모리를 추정하고, 메모리 압력 시 스케줄링을 지연하여 Metal 할당 오류를 방지합니다.",
   "settings.resource.max_concurrent_requests": "최대 동시 요청",
   "settings.resource.max_concurrent_requests_hint": "동시에 처리할 수 있는 최대 요청 수. 높을수록 처리량이 증가하지만 메모리 사용량도 늘어납니다.",
+  "settings.resource.embedding_batch_size": "임베딩 배치 크기",
+  "settings.resource.embedding_batch_size_hint": "한 번의 forward pass에서 임베딩할 입력 텍스트의 최대 개수입니다. 값이 클수록 처리량이 증가하지만 메모리 사용량도 늘어납니다.",
   "settings.resource.chunked_prefill": "Chunked Prefill",
   "settings.resource.chunked_prefill_description": "Interleave prefill chunks with decode steps. Reduces time-to-first-token for concurrent requests by processing one prefill chunk per step instead of blocking decode.",
   "settings.resource.restart_badge": "재시작 필요",

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -342,6 +342,8 @@
   "settings.resource.prefill_memory_guard_description": "Оценивайте расход памяти перед prefill и откладывайте выполнение при дефиците памяти, чтобы избежать ошибок выделения Metal.",
   "settings.resource.max_concurrent_requests": "Максимум одновременных запросов",
   "settings.resource.max_concurrent_requests_hint": "Максимальное число запросов, обрабатываемых одновременно. Более высокие значения увеличивают пропускную способность, но используют больше памяти.",
+  "settings.resource.embedding_batch_size": "Размер пакета эмбеддингов",
+  "settings.resource.embedding_batch_size_hint": "Максимальное число входных текстов для эмбеддингов за один прямой проход. Более высокие значения увеличивают пропускную способность, но используют больше памяти.",
   "settings.resource.chunked_prefill": "Chunked Prefill",
   "settings.resource.chunked_prefill_description": "Interleave prefill chunks with decode steps. Reduces time-to-first-token for concurrent requests by processing one prefill chunk per step instead of blocking decode.",
   "settings.resource.restart_badge": "Требует перезапуска",

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -342,6 +342,8 @@
   "settings.resource.prefill_memory_guard_description": "在預填充前估算記憶體，記憶體壓力時延遲調度以防止Metal分配失敗。",
   "settings.resource.max_concurrent_requests": "最大並發請求",
   "settings.resource.max_concurrent_requests_hint": "同時處理的最大請求數。數值越大吞吐量越高，但記憶體使用也越多。",
+  "settings.resource.embedding_batch_size": "Embedding 批次大小",
+  "settings.resource.embedding_batch_size_hint": "單次前向計算處理的最大 embedding 輸入文字數。數值越大吞吐量越高，但記憶體使用也越多。",
   "settings.resource.chunked_prefill": "Chunked Prefill",
   "settings.resource.chunked_prefill_description": "Interleave prefill chunks with decode steps. Reduces time-to-first-token for concurrent requests by processing one prefill chunk per step instead of blocking decode.",
   "settings.resource.restart_badge": "需要重新啟動",

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -342,6 +342,8 @@
   "settings.resource.prefill_memory_guard_description": "在预填充前估算内存，内存压力时延迟调度以防止Metal分配失败。",
   "settings.resource.max_concurrent_requests": "最大并发请求",
   "settings.resource.max_concurrent_requests_hint": "同时处理的最大请求数。值越大吞吐量越高，但内存使用也越多。",
+  "settings.resource.embedding_batch_size": "Embedding 批大小",
+  "settings.resource.embedding_batch_size_hint": "单次前向计算处理的最大 embedding 输入文本数。值越大吞吐量越高，但内存使用也越多。",
   "settings.resource.chunked_prefill": "Chunked Prefill",
   "settings.resource.chunked_prefill_description": "Interleave prefill chunks with decode steps. Reduces time-to-first-token for concurrent requests by processing one prefill chunk per step instead of blocking decode.",
   "settings.resource.restart_badge": "需要重启",

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -215,6 +215,7 @@ class GlobalSettingsRequest(BaseModel):
 
     # Scheduler settings
     max_concurrent_requests: int | None = None
+    embedding_batch_size: int | None = None
     chunked_prefill: bool | None = None
 
     # Cache settings
@@ -2700,6 +2701,7 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
         },
         "scheduler": {
             "max_concurrent_requests": global_settings.scheduler.max_concurrent_requests,
+            "embedding_batch_size": global_settings.scheduler.embedding_batch_size,
             "chunked_prefill": global_settings.scheduler.chunked_prefill,
         },
         "cache": {
@@ -2815,6 +2817,8 @@ async def update_global_settings(
 
     # Track which settings were applied at runtime
     runtime_applied: list[str] = []
+    pending_embedding_batch_size: int | None = None
+    previous_embedding_batch_size: int | None = None
 
     # Apply server settings
     if request.host is not None:
@@ -2935,6 +2939,15 @@ async def update_global_settings(
         global_settings.scheduler.max_concurrent_requests = (
             request.max_concurrent_requests
         )
+
+    # Apply embedding batch size setting (Live for loaded embedding engines)
+    if request.embedding_batch_size is not None:
+        if request.embedding_batch_size <= 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid embedding_batch_size: must be > 0",
+            )
+        pending_embedding_batch_size = request.embedding_batch_size
 
     # Apply chunked prefill setting (Live)
     if request.chunked_prefill is not None:
@@ -3217,16 +3230,33 @@ async def update_global_settings(
         global_settings.auth.skip_api_key_verification = request.skip_api_key_verification
         runtime_applied.append("skip_api_key_verification")
 
+    if pending_embedding_batch_size is not None:
+        previous_embedding_batch_size = global_settings.scheduler.embedding_batch_size
+        global_settings.scheduler.embedding_batch_size = pending_embedding_batch_size
+
     # Validate settings
     errors = global_settings.validate()
     if errors:
+        if previous_embedding_batch_size is not None:
+            global_settings.scheduler.embedding_batch_size = previous_embedding_batch_size
         raise HTTPException(status_code=400, detail=errors)
 
     # Persist to file
     try:
         global_settings.save()
     except Exception as e:
+        if previous_embedding_batch_size is not None:
+            global_settings.scheduler.embedding_batch_size = previous_embedding_batch_size
         raise HTTPException(status_code=500, detail=f"Failed to save settings: {e}")
+
+    if pending_embedding_batch_size is not None:
+        from ..server import _server_state
+
+        pool = _server_state.engine_pool
+        if pool is not None:
+            await pool.apply_embedding_batch_size(pending_embedding_batch_size)
+        runtime_applied.append("embedding_batch_size")
+        logger.info(f"Embedding batch size set to {pending_embedding_batch_size}")
 
     # Build response message
     message = "Settings saved successfully."

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -33,7 +33,7 @@
                 server: { host: '127.0.0.1', port: 8000, log_level: 'info', sse_keepalive_mode: 'chunk' },
                 model: { model_dirs: [''] },
                 memory: { prefill_memory_guard: true, memory_guard_tier: 'balanced', memory_guard_custom_ceiling_gb: 0 },
-                scheduler: { max_concurrent_requests: 8 },
+                scheduler: { max_concurrent_requests: 8, embedding_batch_size: 8, chunked_prefill: false },
                 cache: { enabled: true, ssd_cache_dir: '', ssd_cache_max_size: 'auto', hot_cache_max_size: '0', initial_cache_blocks: 256, hot_cache_only: false },
                 sampling: { max_context_window: 32768, max_tokens: 32768, temperature: 1.0, top_p: 0.95, top_k: 0, repetition_penalty: 1.0 },
                 mcp: { config_path: '' },
@@ -731,6 +731,7 @@
                 if (!s.server.port) errors.push('Port');
                 if (!s.model.model_dirs || !s.model.model_dirs.some(d => d.trim())) errors.push('Model Directory');
                 if (!s.scheduler.max_concurrent_requests) errors.push('Max Concurrent Requests');
+                if (!s.scheduler.embedding_batch_size) errors.push('Embedding Batch Size');
                 if (!s.cache.ssd_cache_max_size) errors.push('Max Cache Size');
                 if (!s.sampling.max_context_window) errors.push('Max Context Window');
                 if (!s.sampling.max_tokens) errors.push('Max Tokens');
@@ -770,6 +771,7 @@
                             memory_guard_tier: this.globalSettings.memory.memory_guard_tier,
                             memory_guard_custom_ceiling_gb: this.globalSettings.memory.memory_guard_custom_ceiling_gb,
                             max_concurrent_requests: this.globalSettings.scheduler.max_concurrent_requests,
+                            embedding_batch_size: this.globalSettings.scheduler.embedding_batch_size,
                             chunked_prefill: this.globalSettings.scheduler.chunked_prefill,
                             cache_enabled: this.globalSettings.cache.enabled,
                             ssd_cache_dir: this.globalSettings.cache.ssd_cache_dir,

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -33,7 +33,7 @@
                 server: { host: '127.0.0.1', port: 8000, log_level: 'info', sse_keepalive_mode: 'chunk' },
                 model: { model_dirs: [''] },
                 memory: { prefill_memory_guard: true, memory_guard_tier: 'balanced', memory_guard_custom_ceiling_gb: 0 },
-                scheduler: { max_concurrent_requests: 8, embedding_batch_size: 8, chunked_prefill: false },
+                scheduler: { max_concurrent_requests: 8, embedding_batch_size: 32, chunked_prefill: false },
                 cache: { enabled: true, ssd_cache_dir: '', ssd_cache_max_size: 'auto', hot_cache_max_size: '0', initial_cache_blocks: 256, hot_cache_only: false },
                 sampling: { max_context_window: 32768, max_tokens: 32768, temperature: 1.0, top_p: 0.95, top_k: 0, repetition_penalty: 1.0 },
                 mcp: { config_path: '' },

--- a/omlx/admin/templates/dashboard/_settings.html
+++ b/omlx/admin/templates/dashboard/_settings.html
@@ -463,6 +463,16 @@
                                            min="1"
                                            class="w-full sm:w-48 px-3 py-2 text-sm text-right border border-neutral-200 rounded-lg focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
                                 </div>
+                                <!-- Embedding Batch Size -->
+                                <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 sm:px-6 py-4">
+                                    <div>
+                                        <label class="text-sm text-neutral-700">{{ t('settings.resource.embedding_batch_size') }}</label>
+                                        <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.resource.embedding_batch_size_hint') }}</p>
+                                    </div>
+                                    <input type="number" x-model.number="globalSettings.scheduler.embedding_batch_size"
+                                           min="1"
+                                           class="w-full sm:w-48 px-3 py-2 text-sm text-right border border-neutral-200 rounded-lg focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
+                                </div>
                                 <!-- Chunked Prefill -->
                                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 sm:px-6 py-4">
                                     <div>

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -561,7 +561,7 @@ Example directory structure:
         "--embedding-batch-size",
         type=int,
         default=None,
-        help="Max embedding inputs processed in one forward pass. Higher values increase throughput but use more memory. (default: 8)",
+        help="Max embedding inputs processed in one forward pass. Higher values increase throughput but use more memory. (default: 32)",
     )
 
     # paged SSD cache options

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -33,6 +33,8 @@ def _has_cli_overrides(args) -> bool:
         return True
     if hasattr(args, "log_level") and args.log_level is not None:
         return True
+    if hasattr(args, "embedding_batch_size") and args.embedding_batch_size is not None:
+        return True
     if hasattr(args, "mcp_config") and args.mcp_config is not None:
         return True
     if hasattr(args, "hf_endpoint") and args.hf_endpoint is not None:
@@ -128,6 +130,14 @@ def serve_command(args):
         os.environ["REQUESTS_CA_BUNDLE"] = settings.network.ca_bundle
         os.environ["SSL_CERT_FILE"] = settings.network.ca_bundle
 
+    # Validate before persisting CLI overrides, so invalid flags never poison
+    # settings.json.
+    errors = settings.validate()
+    if errors:
+        for error in errors:
+            print(f"Configuration error: {error}")
+        sys.exit(1)
+
     # Save CLI args to settings.json if non-default values provided
     if _has_cli_overrides(args):
         try:
@@ -152,13 +162,6 @@ def serve_command(args):
     crash_log_path = log_dir / "crash.log"
     _crash_file = open(crash_log_path, "a")
     faulthandler.enable(file=_crash_file, all_threads=True)
-
-    # Validate settings
-    errors = settings.validate()
-    if errors:
-        for error in errors:
-            print(f"Configuration error: {error}")
-        sys.exit(1)
 
     # Import server and config
     from .server import app, init_server
@@ -553,6 +556,12 @@ Example directory structure:
         type=int,
         default=None,
         help="Max requests processed simultaneously. Higher values increase throughput but use more memory. (default: 8)",
+    )
+    serve_parser.add_argument(
+        "--embedding-batch-size",
+        type=int,
+        default=None,
+        help="Max embedding inputs processed in one forward pass. Higher values increase throughput but use more memory. (default: 8)",
     )
 
     # paged SSD cache options

--- a/omlx/config.py
+++ b/omlx/config.py
@@ -88,6 +88,7 @@ class SchedulerConfig:
 
     max_num_seqs: int = 8
     completion_batch_size: int = 8
+    embedding_batch_size: int = 8
     stream_interval: int = 1
     enable_thinking: Optional[bool] = None
 

--- a/omlx/config.py
+++ b/omlx/config.py
@@ -88,7 +88,7 @@ class SchedulerConfig:
 
     max_num_seqs: int = 8
     completion_batch_size: int = 8
-    embedding_batch_size: int = 8
+    embedding_batch_size: int = 32
     stream_interval: int = 1
     enable_thinking: Optional[bool] = None
 

--- a/omlx/engine/embedding.py
+++ b/omlx/engine/embedding.py
@@ -32,7 +32,12 @@ class EmbeddingEngine(BaseNonStreamingEngine):
     since embeddings are computed in a single forward pass.
     """
 
-    def __init__(self, model_name: str, trust_remote_code: bool = False):
+    def __init__(
+        self,
+        model_name: str,
+        trust_remote_code: bool = False,
+        batch_size: int = 8,
+    ):
         """
         Initialize the embedding engine.
 
@@ -44,6 +49,7 @@ class EmbeddingEngine(BaseNonStreamingEngine):
         super().__init__()
         self._model_name = model_name
         self._trust_remote_code = trust_remote_code
+        self._batch_size = max(1, int(batch_size))
         self._model: Optional[MLXEmbeddingModel] = None
 
     @property
@@ -116,24 +122,55 @@ class EmbeddingEngine(BaseNonStreamingEngine):
             raise RuntimeError("Engine not started. Call start() first.")
 
         model = self._model
+        input_items = [texts] if isinstance(texts, str) else list(texts)
 
-        def _embed_sync():
-            return model.embed(
-                inputs=texts,
-                max_length=max_length,
-                padding=padding,
-                truncation=truncation,
-            )
+        if not input_items:
+            return EmbeddingOutput(embeddings=[], total_tokens=0, dimensions=0)
 
         activity_id = self._begin_activity(
             "embedding",
             detail="Embedding",
-            total_items=len(texts),
-            metadata={"input_count": len(texts)},
+            total_items=len(input_items),
+            metadata={"input_count": len(input_items), "batch_size": self._batch_size},
         )
         try:
             loop = asyncio.get_running_loop()
-            output = await loop.run_in_executor(get_mlx_executor(), _embed_sync)
+            embeddings: List[List[float]] = []
+            total_tokens = 0
+            dimensions = 0
+
+            for start in range(0, len(input_items), self._batch_size):
+                batch = input_items[start:start + self._batch_size]
+
+                def _embed_sync():
+                    try:
+                        return model.embed(
+                            inputs=batch,
+                            max_length=max_length,
+                            padding=padding,
+                            truncation=truncation,
+                        )
+                    finally:
+                        mx.synchronize()
+                        mx.clear_cache()
+
+                output = await loop.run_in_executor(get_mlx_executor(), _embed_sync)
+                embeddings.extend(output.embeddings)
+                total_tokens += output.total_tokens
+                if output.dimensions:
+                    dimensions = output.dimensions
+                self._update_activity(
+                    activity_id,
+                    completed_items=min(start + len(batch), len(input_items)),
+                    token_count=total_tokens,
+                    dimensions=dimensions,
+                )
+
+            output = EmbeddingOutput(
+                embeddings=embeddings,
+                total_tokens=total_tokens,
+                dimensions=dimensions,
+            )
             self._update_activity(
                 activity_id,
                 token_count=output.total_tokens,
@@ -141,7 +178,7 @@ class EmbeddingEngine(BaseNonStreamingEngine):
             )
             return output
         finally:
-            await self._finish_activity(activity_id)
+            self._end_activity(activity_id)
 
     def get_stats(self) -> Dict[str, Any]:
         """Get engine statistics."""
@@ -149,6 +186,7 @@ class EmbeddingEngine(BaseNonStreamingEngine):
             "model_name": self._model_name,
             "loaded": self._model is not None,
             "hidden_size": self.hidden_size,
+            "batch_size": self._batch_size,
         }
 
     def get_model_info(self) -> Dict[str, Any]:

--- a/omlx/engine/embedding.py
+++ b/omlx/engine/embedding.py
@@ -56,9 +56,9 @@ class EmbeddingEngine(BaseNonStreamingEngine):
         self._trust_remote_code = trust_remote_code
         if batch_size is None:
             batch_size = (
-                getattr(scheduler_config, "embedding_batch_size", 8)
+                getattr(scheduler_config, "embedding_batch_size", 32)
                 if scheduler_config is not None
-                else 8
+                else 32
             )
         self._batch_size = max(1, int(batch_size))
         self._model: Optional[MLXEmbeddingModel] = None

--- a/omlx/engine/embedding.py
+++ b/omlx/engine/embedding.py
@@ -36,7 +36,9 @@ class EmbeddingEngine(BaseNonStreamingEngine):
         self,
         model_name: str,
         trust_remote_code: bool = False,
-        batch_size: int = 8,
+        batch_size: int | None = None,
+        *,
+        scheduler_config: Any | None = None,
     ):
         """
         Initialize the embedding engine.
@@ -45,10 +47,19 @@ class EmbeddingEngine(BaseNonStreamingEngine):
             model_name: HuggingFace model name or local path
             trust_remote_code: Allow loaders to execute custom Python shipped
                 with the model repo. Off by default for security (issue #926).
+            batch_size: Explicit per-forward input chunk size override.
+            scheduler_config: Shared scheduler configuration. Embedding uses
+                completion_batch_size as its per-forward input chunk size.
         """
         super().__init__()
         self._model_name = model_name
         self._trust_remote_code = trust_remote_code
+        if batch_size is None:
+            batch_size = (
+                getattr(scheduler_config, "completion_batch_size", 8)
+                if scheduler_config is not None
+                else 8
+            )
         self._batch_size = max(1, int(batch_size))
         self._model: Optional[MLXEmbeddingModel] = None
 

--- a/omlx/engine/embedding.py
+++ b/omlx/engine/embedding.py
@@ -49,14 +49,14 @@ class EmbeddingEngine(BaseNonStreamingEngine):
                 with the model repo. Off by default for security (issue #926).
             batch_size: Explicit per-forward input chunk size override.
             scheduler_config: Shared scheduler configuration. Embedding uses
-                completion_batch_size as its per-forward input chunk size.
+                embedding_batch_size as its per-forward input chunk size.
         """
         super().__init__()
         self._model_name = model_name
         self._trust_remote_code = trust_remote_code
         if batch_size is None:
             batch_size = (
-                getattr(scheduler_config, "completion_batch_size", 8)
+                getattr(scheduler_config, "embedding_batch_size", 8)
                 if scheduler_config is not None
                 else 8
             )
@@ -138,11 +138,12 @@ class EmbeddingEngine(BaseNonStreamingEngine):
         if not input_items:
             return EmbeddingOutput(embeddings=[], total_tokens=0, dimensions=0)
 
+        batch_size = self._batch_size
         activity_id = self._begin_activity(
             "embedding",
             detail="Embedding",
             total_items=len(input_items),
-            metadata={"input_count": len(input_items), "batch_size": self._batch_size},
+            metadata={"input_count": len(input_items), "batch_size": batch_size},
         )
         try:
             loop = asyncio.get_running_loop()
@@ -150,8 +151,8 @@ class EmbeddingEngine(BaseNonStreamingEngine):
             total_tokens = 0
             dimensions = 0
 
-            for start in range(0, len(input_items), self._batch_size):
-                batch = input_items[start:start + self._batch_size]
+            for start in range(0, len(input_items), batch_size):
+                batch = input_items[start:start + batch_size]
 
                 def _embed_sync():
                     try:

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -134,6 +134,19 @@ class EnginePool:
         """Number of currently loaded models."""
         return sum(1 for e in self._entries.values() if e.engine is not None)
 
+    async def apply_embedding_batch_size(self, batch_size: int) -> None:
+        """Apply embedding batch size to future and currently loaded embedding engines."""
+        batch_size = int(batch_size)
+        if batch_size <= 0:
+            raise ValueError("embedding batch size must be > 0")
+
+        async with self._lock:
+            self._scheduler_config.embedding_batch_size = batch_size
+            for entry in list(self._entries.values()):
+                engine = entry.engine if entry is not None else None
+                if isinstance(engine, EmbeddingEngine):
+                    engine._batch_size = batch_size
+
     def discover_models(
         self, model_dirs: str | list[str], pinned_models: list[str] | None = None
     ) -> None:

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -97,6 +97,7 @@ class EnginePool:
         self._entries: dict[str, EngineEntry] = {}
         self._lock = asyncio.Lock()
         self._current_model_memory = 0
+        self._scheduler_config_provided = scheduler_config is not None
         self._scheduler_config = scheduler_config or SchedulerConfig()
         self._process_memory_enforcer: object | None = None  # Set by server
         self._get_final_ceiling: object | None = None  # Set by server
@@ -624,10 +625,13 @@ class EnginePool:
             # Create engine based on engine type (if DFlash not active)
             if engine is None:
                 if effective_type == "embedding":
-                    engine = EmbeddingEngine(
-                        model_name=entry.model_path,
-                        trust_remote_code=trc,
-                    )
+                    embedding_kwargs = {
+                        "model_name": entry.model_path,
+                        "trust_remote_code": trc,
+                    }
+                    if self._scheduler_config_provided:
+                        embedding_kwargs["scheduler_config"] = self._scheduler_config
+                    engine = EmbeddingEngine(**embedding_kwargs)
                 elif effective_type == "reranker":
                     engine = RerankerEngine(
                         model_name=entry.model_path,

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -97,7 +97,6 @@ class EnginePool:
         self._entries: dict[str, EngineEntry] = {}
         self._lock = asyncio.Lock()
         self._current_model_memory = 0
-        self._scheduler_config_provided = scheduler_config is not None
         self._scheduler_config = scheduler_config or SchedulerConfig()
         self._process_memory_enforcer: object | None = None  # Set by server
         self._get_final_ceiling: object | None = None  # Set by server
@@ -625,13 +624,11 @@ class EnginePool:
             # Create engine based on engine type (if DFlash not active)
             if engine is None:
                 if effective_type == "embedding":
-                    embedding_kwargs = {
-                        "model_name": entry.model_path,
-                        "trust_remote_code": trc,
-                    }
-                    if self._scheduler_config_provided:
-                        embedding_kwargs["scheduler_config"] = self._scheduler_config
-                    engine = EmbeddingEngine(**embedding_kwargs)
+                    engine = EmbeddingEngine(
+                        model_name=entry.model_path,
+                        trust_remote_code=trc,
+                        scheduler_config=self._scheduler_config,
+                    )
                 elif effective_type == "reranker":
                     engine = RerankerEngine(
                         model_name=entry.model_path,

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -596,6 +596,8 @@ class SchedulerConfig:
     policy: SchedulingPolicy = SchedulingPolicy.FCFS
     # BatchGenerator settings (passed directly to mlx-lm)
     completion_batch_size: int = 32
+    # Per-forward embedding input chunk size
+    embedding_batch_size: int = 8
     prefill_step_size: int = 2048
     # When True, long prefills are processed one chunk per step() call,
     # interleaved with decode steps for already-running requests. This

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -597,7 +597,7 @@ class SchedulerConfig:
     # BatchGenerator settings (passed directly to mlx-lm)
     completion_batch_size: int = 32
     # Per-forward embedding input chunk size
-    embedding_batch_size: int = 8
+    embedding_batch_size: int = 32
     prefill_step_size: int = 2048
     # When True, long prefills are processed one chunk per step() call,
     # interleaved with decode steps for already-running requests. This

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -189,7 +189,7 @@ class SchedulerSettings:
     """Scheduler configuration settings."""
 
     max_concurrent_requests: int = 8
-    embedding_batch_size: int = 8
+    embedding_batch_size: int = 32
     # When True, long prefills are interleaved with decode steps.
     # Reduces TTFT for concurrent requests at the cost of per-step overhead.
     chunked_prefill: bool = False
@@ -209,7 +209,7 @@ class SchedulerSettings:
             value = data.get("completion_batch_size")
         if value is None:
             value = 8
-        embedding_batch_size = data.get("embedding_batch_size", 8)
+        embedding_batch_size = data.get("embedding_batch_size", 32)
         return cls(
             max_concurrent_requests=value,
             embedding_batch_size=embedding_batch_size,

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -189,6 +189,7 @@ class SchedulerSettings:
     """Scheduler configuration settings."""
 
     max_concurrent_requests: int = 8
+    embedding_batch_size: int = 8
     # When True, long prefills are interleaved with decode steps.
     # Reduces TTFT for concurrent requests at the cost of per-step overhead.
     chunked_prefill: bool = False
@@ -208,8 +209,10 @@ class SchedulerSettings:
             value = data.get("completion_batch_size")
         if value is None:
             value = 8
+        embedding_batch_size = data.get("embedding_batch_size", 8)
         return cls(
             max_concurrent_requests=value,
+            embedding_batch_size=embedding_batch_size,
             chunked_prefill=bool(data.get("chunked_prefill", False)),
         )
 
@@ -817,6 +820,13 @@ class GlobalSettings:
                 logger.warning(
                     f"Invalid OMLX_MAX_CONCURRENT_REQUESTS value: {max_concurrent}"
                 )
+        if embedding_batch_size := os.getenv("OMLX_EMBEDDING_BATCH_SIZE"):
+            try:
+                self.scheduler.embedding_batch_size = int(embedding_batch_size)
+            except ValueError:
+                logger.warning(
+                    f"Invalid OMLX_EMBEDDING_BATCH_SIZE value: {embedding_batch_size}"
+                )
 
         # Cache settings
         if cache_enabled := os.getenv("OMLX_CACHE_ENABLED"):
@@ -898,6 +908,11 @@ class GlobalSettings:
             and args.max_concurrent_requests is not None
         ):
             self.scheduler.max_concurrent_requests = args.max_concurrent_requests
+        if (
+            hasattr(args, "embedding_batch_size")
+            and args.embedding_batch_size is not None
+        ):
+            self.scheduler.embedding_batch_size = args.embedding_batch_size
 
         # Cache settings
         if hasattr(args, "cache_enabled") and args.cache_enabled is not None:
@@ -1071,6 +1086,11 @@ class GlobalSettings:
                 f"Invalid max_concurrent_requests: "
                 f"{self.scheduler.max_concurrent_requests} (must be > 0)"
             )
+        if self.scheduler.embedding_batch_size <= 0:
+            errors.append(
+                f"Invalid embedding_batch_size: "
+                f"{self.scheduler.embedding_batch_size} (must be > 0)"
+            )
 
         # Cache validation
         if self.cache.ssd_cache_max_size.lower() != "auto":
@@ -1172,6 +1192,7 @@ class GlobalSettings:
         return SchedulerConfig(
             max_num_seqs=self.scheduler.max_concurrent_requests,
             completion_batch_size=self.scheduler.max_concurrent_requests,
+            embedding_batch_size=self.scheduler.embedding_batch_size,
             chunked_prefill=self.scheduler.chunked_prefill,
             initial_cache_blocks=self.cache.initial_cache_blocks,
             paged_ssd_cache_dir=str(ssd_dir) if ssd_dir else None,

--- a/tests/test_admin_server_aliases.py
+++ b/tests/test_admin_server_aliases.py
@@ -4,7 +4,8 @@
 
 import asyncio
 from contextlib import contextmanager
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -258,3 +259,127 @@ class TestUpdateGlobalSettingsAliases:
             )
 
         assert gs.server.server_aliases == []
+
+
+class TestUpdateGlobalSettingsEmbeddingBatchSize:
+    """update_global_settings: saving and hot-applying embedding batch size."""
+
+    def _make_scheduler_settings(self):
+        return SimpleNamespace(
+            max_concurrent_requests=8,
+            embedding_batch_size=8,
+            chunked_prefill=False,
+        )
+
+    def test_saves_and_hot_applies_embedding_batch_size(self):
+        gs = MagicMock()
+        gs.scheduler = self._make_scheduler_settings()
+        gs.validate.return_value = []
+        gs.save.return_value = None
+
+        pool = SimpleNamespace(apply_embedding_batch_size=AsyncMock())
+        server_state = SimpleNamespace(engine_pool=pool)
+        request = GlobalSettingsRequest(embedding_batch_size=5)
+
+        with _patched_global_settings(gs), patch.object(
+            omlx.server,
+            "_server_state",
+            server_state,
+        ):
+            result = asyncio.run(
+                admin_routes.update_global_settings(request=request, is_admin=True)
+            )
+
+        assert result["success"] is True
+        assert "embedding_batch_size" in result["runtime_applied"]
+        assert gs.scheduler.embedding_batch_size == 5
+        pool.apply_embedding_batch_size.assert_awaited_once_with(5)
+        gs.save.assert_called_once()
+
+    def test_rejects_invalid_embedding_batch_size(self):
+        gs = MagicMock()
+        gs.scheduler = self._make_scheduler_settings()
+        gs.validate.return_value = []
+        gs.save.return_value = None
+        request = GlobalSettingsRequest(embedding_batch_size=0)
+
+        with _patched_global_settings(gs):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "embedding_batch_size" in exc_info.value.detail
+        gs.save.assert_not_called()
+
+    def test_does_not_hot_apply_embedding_batch_size_when_validation_fails(self):
+        gs = MagicMock()
+        gs.scheduler = self._make_scheduler_settings()
+        gs.validate.return_value = ["invalid unrelated setting"]
+        gs.save.return_value = None
+        pool = SimpleNamespace(apply_embedding_batch_size=AsyncMock())
+        server_state = SimpleNamespace(engine_pool=pool)
+        request = GlobalSettingsRequest(embedding_batch_size=5)
+
+        with _patched_global_settings(gs), patch.object(
+            omlx.server,
+            "_server_state",
+            server_state,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 400
+        pool.apply_embedding_batch_size.assert_not_awaited()
+        assert gs.scheduler.embedding_batch_size == 8
+        gs.save.assert_not_called()
+
+    def test_does_not_mutate_embedding_batch_size_when_api_key_is_invalid(self):
+        gs = MagicMock()
+        gs.scheduler = self._make_scheduler_settings()
+        gs.validate.return_value = []
+        gs.save.return_value = None
+        pool = SimpleNamespace(apply_embedding_batch_size=AsyncMock())
+        server_state = SimpleNamespace(engine_pool=pool)
+        request = GlobalSettingsRequest(embedding_batch_size=5, api_key="abc")
+
+        with _patched_global_settings(gs), patch.object(
+            omlx.server,
+            "_server_state",
+            server_state,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 400
+        pool.apply_embedding_batch_size.assert_not_awaited()
+        assert gs.scheduler.embedding_batch_size == 8
+        gs.save.assert_not_called()
+
+    def test_does_not_hot_apply_embedding_batch_size_when_save_fails(self):
+        gs = MagicMock()
+        gs.scheduler = self._make_scheduler_settings()
+        gs.validate.return_value = []
+        gs.save.side_effect = OSError("disk full")
+        pool = SimpleNamespace(apply_embedding_batch_size=AsyncMock())
+        server_state = SimpleNamespace(engine_pool=pool)
+        request = GlobalSettingsRequest(embedding_batch_size=5)
+
+        with _patched_global_settings(gs), patch.object(
+            omlx.server,
+            "_server_state",
+            server_state,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 500
+        pool.apply_embedding_batch_size.assert_not_awaited()
+        assert gs.scheduler.embedding_batch_size == 8

--- a/tests/test_admin_server_aliases.py
+++ b/tests/test_admin_server_aliases.py
@@ -267,7 +267,7 @@ class TestUpdateGlobalSettingsEmbeddingBatchSize:
     def _make_scheduler_settings(self):
         return SimpleNamespace(
             max_concurrent_requests=8,
-            embedding_batch_size=8,
+            embedding_batch_size=32,
             chunked_prefill=False,
         )
 
@@ -334,7 +334,7 @@ class TestUpdateGlobalSettingsEmbeddingBatchSize:
 
         assert exc_info.value.status_code == 400
         pool.apply_embedding_batch_size.assert_not_awaited()
-        assert gs.scheduler.embedding_batch_size == 8
+        assert gs.scheduler.embedding_batch_size == 32
         gs.save.assert_not_called()
 
     def test_does_not_mutate_embedding_batch_size_when_api_key_is_invalid(self):
@@ -358,7 +358,7 @@ class TestUpdateGlobalSettingsEmbeddingBatchSize:
 
         assert exc_info.value.status_code == 400
         pool.apply_embedding_batch_size.assert_not_awaited()
-        assert gs.scheduler.embedding_batch_size == 8
+        assert gs.scheduler.embedding_batch_size == 32
         gs.save.assert_not_called()
 
     def test_does_not_hot_apply_embedding_batch_size_when_save_fails(self):
@@ -382,4 +382,4 @@ class TestUpdateGlobalSettingsEmbeddingBatchSize:
 
         assert exc_info.value.status_code == 500
         pool.apply_embedding_batch_size.assert_not_awaited()
-        assert gs.scheduler.embedding_batch_size == 8
+        assert gs.scheduler.embedding_batch_size == 32

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,6 +160,7 @@ class TestServeCommandOptions:
             timeout=10,
         )
         assert "--max-concurrent-requests" in result.stdout
+        assert "--embedding-batch-size" in result.stdout
 
     def test_serve_has_cache_options(self):
         """Test that serve command has cache options."""
@@ -382,6 +383,28 @@ class TestServeCommandFunctions:
         # Help text should mention ~/.omlx/models or similar
         assert ".omlx" in result.stdout or "model" in result.stdout.lower()
 
+    def test_invalid_embedding_batch_size_is_not_persisted(self, tmp_path):
+        """Invalid CLI scheduler values should fail before saving settings.json."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "omlx.cli",
+                "serve",
+                "--base-path",
+                str(tmp_path),
+                "--embedding-batch-size",
+                "0",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        assert result.returncode != 0
+        assert "embedding_batch_size" in result.stdout
+        assert not (tmp_path / "settings.json").exists()
+
 
 
 class TestHasCliOverrides:
@@ -395,6 +418,7 @@ class TestHasCliOverrides:
             "port": None,
             "host": None,
             "log_level": None,
+            "embedding_batch_size": None,
         }
         defaults.update(kwargs)
         return argparse.Namespace(**defaults)
@@ -422,6 +446,10 @@ class TestHasCliOverrides:
         from omlx.cli import _has_cli_overrides
         assert _has_cli_overrides(self._make_args(log_level="info")) is True
         assert _has_cli_overrides(self._make_args(log_level="debug")) is True
+
+    def test_embedding_batch_size_explicit(self):
+        from omlx.cli import _has_cli_overrides
+        assert _has_cli_overrides(self._make_args(embedding_batch_size=4)) is True
 
     def test_multiple_overrides(self):
         from omlx.cli import _has_cli_overrides

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -164,6 +164,7 @@ class TestSchedulerConfig:
         config = SchedulerConfig()
         assert config.max_num_seqs == 8
         assert config.completion_batch_size == 8
+        assert config.embedding_batch_size == 8
         assert config.stream_interval == 1
         assert config.enable_thinking is None
 
@@ -172,11 +173,13 @@ class TestSchedulerConfig:
         config = SchedulerConfig(
             max_num_seqs=128,
             completion_batch_size=16,
+            embedding_batch_size=12,
             stream_interval=2,
             enable_thinking=True,
         )
         assert config.max_num_seqs == 128
         assert config.completion_batch_size == 16
+        assert config.embedding_batch_size == 12
         assert config.stream_interval == 2
         assert config.enable_thinking is True
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -164,7 +164,7 @@ class TestSchedulerConfig:
         config = SchedulerConfig()
         assert config.max_num_seqs == 8
         assert config.completion_batch_size == 8
-        assert config.embedding_batch_size == 8
+        assert config.embedding_batch_size == 32
         assert config.stream_interval == 1
         assert config.enable_thinking is None
 

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -8,6 +8,8 @@ import math
 import numpy as np
 import struct
 import tempfile
+import threading
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -803,7 +805,7 @@ class TestEmbeddingEngine:
         engine = EmbeddingEngine("test-model")
 
         with patch("omlx.engine.embedding.MLXEmbeddingModel") as MockModel, \
-             patch("omlx.engine.base.mx") as mock_mx:
+             patch("omlx.engine.embedding.mx") as mock_mx:
             mock_model = MagicMock()
             mock_model.embed.return_value = EmbeddingOutput(
                 embeddings=[[0.1, 0.2]],
@@ -829,7 +831,7 @@ class TestEmbeddingEngine:
         concurrency = 4
 
         with patch("omlx.engine.embedding.MLXEmbeddingModel") as MockModel, \
-             patch("omlx.engine.base.mx") as mock_mx:
+             patch("omlx.engine.embedding.mx") as mock_mx:
             mock_model = MagicMock()
             mock_model.embed.return_value = EmbeddingOutput(
                 embeddings=[[0.1, 0.2]],
@@ -848,6 +850,81 @@ class TestEmbeddingEngine:
 
             assert mock_mx.synchronize.call_count == concurrency
             assert mock_mx.clear_cache.call_count == concurrency
+
+    def test_engine_chunks_large_embedding_requests_and_clears_each_chunk(self):
+        """Large embedding requests should not hold the whole batch in MLX memory."""
+        engine = EmbeddingEngine("test-model", batch_size=2)
+
+        def embed_side_effect(inputs, **kwargs):
+            return EmbeddingOutput(
+                embeddings=[[float(text.rsplit("-", 1)[-1])] for text in inputs],
+                total_tokens=len(inputs),
+                dimensions=1,
+            )
+
+        with patch("omlx.engine.embedding.MLXEmbeddingModel") as MockModel, \
+             patch("omlx.engine.embedding.mx") as mock_mx:
+            mock_model = MagicMock()
+            mock_model.embed.side_effect = embed_side_effect
+            MockModel.return_value = mock_model
+
+            asyncio.run(engine.start())
+            result = asyncio.run(
+                engine.embed([f"text-{i}" for i in range(5)])
+            )
+
+            assert result.embeddings == [[0.0], [1.0], [2.0], [3.0], [4.0]]
+            assert result.total_tokens == 5
+            assert result.dimensions == 1
+            assert [
+                call.kwargs["inputs"] for call in mock_model.embed.call_args_list
+            ] == [
+                ["text-0", "text-1"],
+                ["text-2", "text-3"],
+                ["text-4"],
+            ]
+            assert mock_mx.synchronize.call_count == 3
+            assert mock_mx.clear_cache.call_count == 3
+
+    def test_concurrent_large_embedding_requests_interleave_between_chunks(self):
+        """One large embedding request should not monopolize the MLX executor."""
+        engine = EmbeddingEngine("test-model", batch_size=2)
+        observed_chunks = []
+        observed_lock = threading.Lock()
+
+        def embed_side_effect(inputs, **kwargs):
+            time.sleep(0.01)
+            with observed_lock:
+                observed_chunks.append(tuple(inputs))
+            return EmbeddingOutput(
+                embeddings=[[float(text.rsplit("-", 1)[-1])] for text in inputs],
+                total_tokens=len(inputs),
+                dimensions=1,
+            )
+
+        with patch("omlx.engine.embedding.MLXEmbeddingModel") as MockModel, \
+             patch("omlx.engine.embedding.mx"):
+            mock_model = MagicMock()
+            mock_model.embed.side_effect = embed_side_effect
+            MockModel.return_value = mock_model
+
+            async def run_concurrent():
+                await engine.start()
+                return await asyncio.gather(
+                    engine.embed([f"a-{i}" for i in range(4)]),
+                    engine.embed([f"b-{i}" for i in range(4)]),
+                )
+
+            first, second = asyncio.run(run_concurrent())
+
+            assert [row[0] for row in first.embeddings] == [0.0, 1.0, 2.0, 3.0]
+            assert [row[0] for row in second.embeddings] == [0.0, 1.0, 2.0, 3.0]
+            assert observed_chunks == [
+                ("a-0", "a-1"),
+                ("b-0", "b-1"),
+                ("a-2", "a-3"),
+                ("b-2", "b-3"),
+            ]
 
 
 class TestEmbeddingModelsPydantic:

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -782,7 +782,7 @@ class TestEmbeddingEngine:
             scheduler_config=SchedulerConfig(completion_batch_size=6),
         )
 
-        assert engine.get_stats()["batch_size"] == 8
+        assert engine.get_stats()["batch_size"] == 32
 
     def test_engine_preserves_positional_batch_size_argument(self):
         """Keep EmbeddingEngine(model, trust_remote_code, batch_size) working."""

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -757,6 +757,26 @@ class TestEmbeddingEngine:
         assert stats["model_name"] == "test-model"
         assert stats["loaded"] is False
 
+    def test_engine_uses_scheduler_completion_batch_size(self):
+        """Embedding chunk size should follow shared scheduler config."""
+        from omlx.engine.embedding import EmbeddingEngine
+        from omlx.scheduler import SchedulerConfig
+
+        engine = EmbeddingEngine(
+            "test-model",
+            scheduler_config=SchedulerConfig(completion_batch_size=6),
+        )
+
+        assert engine.get_stats()["batch_size"] == 6
+
+    def test_engine_preserves_positional_batch_size_argument(self):
+        """Keep EmbeddingEngine(model, trust_remote_code, batch_size) working."""
+        from omlx.engine.embedding import EmbeddingEngine
+
+        engine = EmbeddingEngine("test-model", False, 3)
+
+        assert engine.get_stats()["batch_size"] == 3
+
     def test_engine_get_model_info_not_loaded(self):
         """Test get_model_info when model is not loaded."""
         from omlx.engine.embedding import EmbeddingEngine

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -757,8 +757,23 @@ class TestEmbeddingEngine:
         assert stats["model_name"] == "test-model"
         assert stats["loaded"] is False
 
-    def test_engine_uses_scheduler_completion_batch_size(self):
+    def test_engine_uses_scheduler_embedding_batch_size(self):
         """Embedding chunk size should follow shared scheduler config."""
+        from omlx.engine.embedding import EmbeddingEngine
+        from omlx.scheduler import SchedulerConfig
+
+        engine = EmbeddingEngine(
+            "test-model",
+            scheduler_config=SchedulerConfig(
+                completion_batch_size=6,
+                embedding_batch_size=4,
+            ),
+        )
+
+        assert engine.get_stats()["batch_size"] == 4
+
+    def test_engine_ignores_scheduler_completion_batch_size(self):
+        """Completion batching should not affect embedding forward chunks."""
         from omlx.engine.embedding import EmbeddingEngine
         from omlx.scheduler import SchedulerConfig
 
@@ -767,7 +782,7 @@ class TestEmbeddingEngine:
             scheduler_config=SchedulerConfig(completion_batch_size=6),
         )
 
-        assert engine.get_stats()["batch_size"] == 6
+        assert engine.get_stats()["batch_size"] == 8
 
     def test_engine_preserves_positional_batch_size_argument(self):
         """Keep EmbeddingEngine(model, trust_remote_code, batch_size) working."""
@@ -905,6 +920,39 @@ class TestEmbeddingEngine:
             ]
             assert mock_mx.synchronize.call_count == 3
             assert mock_mx.clear_cache.call_count == 3
+
+    def test_engine_snapshots_batch_size_per_request(self):
+        """Live batch-size updates must not skip or duplicate active request inputs."""
+        engine = EmbeddingEngine("test-model", batch_size=2)
+        observed_batches = []
+
+        def embed_side_effect(inputs, **kwargs):
+            observed_batches.append(list(inputs))
+            if len(observed_batches) == 1:
+                engine._batch_size = 1
+            return EmbeddingOutput(
+                embeddings=[[float(text.rsplit("-", 1)[-1])] for text in inputs],
+                total_tokens=len(inputs),
+                dimensions=1,
+            )
+
+        with patch("omlx.engine.embedding.MLXEmbeddingModel") as MockModel, \
+             patch("omlx.engine.embedding.mx"):
+            mock_model = MagicMock()
+            mock_model.embed.side_effect = embed_side_effect
+            MockModel.return_value = mock_model
+
+            asyncio.run(engine.start())
+            result = asyncio.run(
+                engine.embed([f"text-{i}" for i in range(5)])
+            )
+
+            assert result.embeddings == [[0.0], [1.0], [2.0], [3.0], [4.0]]
+            assert observed_batches == [
+                ["text-0", "text-1"],
+                ["text-2", "text-3"],
+                ["text-4"],
+            ]
 
     def test_concurrent_large_embedding_requests_interleave_between_chunks(self):
         """One large embedding request should not monopolize the MLX executor."""

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -699,6 +699,71 @@ class TestEnginePoolAsync:
         assert pool.current_model_memory > 0
 
     @pytest.mark.asyncio
+    async def test_embedding_engine_receives_scheduler_config(self, tmp_path):
+        """Embedding chunk sizing should come from the shared scheduler config."""
+        from omlx.scheduler import SchedulerConfig
+
+        model_path = tmp_path / "embed-model"
+        model_path.mkdir()
+        scheduler_config = SchedulerConfig(completion_batch_size=6)
+        pool = _make_pool(
+            ceiling=10 * 1024**3,
+            scheduler_config=scheduler_config,
+        )
+        pool._entries["embed-model"] = EngineEntry(
+            model_id="embed-model",
+            model_path=str(model_path),
+            model_type="embedding",
+            engine_type="embedding",
+            estimated_size=1024,
+        )
+
+        mock_engine = MagicMock()
+        mock_engine.start = AsyncMock()
+
+        with patch(
+            "omlx.engine_pool.EmbeddingEngine",
+            return_value=mock_engine,
+        ) as MockEmbeddingEngine:
+            engine = await pool.get_engine("embed-model")
+
+        assert engine is mock_engine
+        MockEmbeddingEngine.assert_called_once_with(
+            model_name=str(model_path),
+            trust_remote_code=False,
+            scheduler_config=scheduler_config,
+        )
+
+    @pytest.mark.asyncio
+    async def test_embedding_engine_keeps_default_without_scheduler_config(self, tmp_path):
+        """A bare EnginePool should not inflate EmbeddingEngine's default chunk size."""
+        model_path = tmp_path / "embed-model"
+        model_path.mkdir()
+        pool = _make_pool(ceiling=10 * 1024**3)
+        pool._entries["embed-model"] = EngineEntry(
+            model_id="embed-model",
+            model_path=str(model_path),
+            model_type="embedding",
+            engine_type="embedding",
+            estimated_size=1024,
+        )
+
+        mock_engine = MagicMock()
+        mock_engine.start = AsyncMock()
+
+        with patch(
+            "omlx.engine_pool.EmbeddingEngine",
+            return_value=mock_engine,
+        ) as MockEmbeddingEngine:
+            engine = await pool.get_engine("embed-model")
+
+        assert engine is mock_engine
+        MockEmbeddingEngine.assert_called_once_with(
+            model_name=str(model_path),
+            trust_remote_code=False,
+        )
+
+    @pytest.mark.asyncio
     async def test_get_engine_returns_cached(self, pool_with_mock_engines):
         """Test that get_engine returns cached engine on second call."""
         pool = pool_with_mock_engines

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -735,8 +735,8 @@ class TestEnginePoolAsync:
         )
 
     @pytest.mark.asyncio
-    async def test_embedding_engine_keeps_default_without_scheduler_config(self, tmp_path):
-        """A bare EnginePool should not inflate EmbeddingEngine's default chunk size."""
+    async def test_embedding_engine_receives_fallback_scheduler_config(self, tmp_path):
+        """A bare EnginePool should pass its fallback scheduler config consistently."""
         model_path = tmp_path / "embed-model"
         model_path.mkdir()
         pool = _make_pool(ceiling=10 * 1024**3)
@@ -761,6 +761,7 @@ class TestEnginePoolAsync:
         MockEmbeddingEngine.assert_called_once_with(
             model_name=str(model_path),
             trust_remote_code=False,
+            scheduler_config=pool._scheduler_config,
         )
 
     @pytest.mark.asyncio

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -705,7 +705,10 @@ class TestEnginePoolAsync:
 
         model_path = tmp_path / "embed-model"
         model_path.mkdir()
-        scheduler_config = SchedulerConfig(completion_batch_size=6)
+        scheduler_config = SchedulerConfig(
+            completion_batch_size=6,
+            embedding_batch_size=4,
+        )
         pool = _make_pool(
             ceiling=10 * 1024**3,
             scheduler_config=scheduler_config,
@@ -763,6 +766,31 @@ class TestEnginePoolAsync:
             trust_remote_code=False,
             scheduler_config=pool._scheduler_config,
         )
+
+    @pytest.mark.asyncio
+    async def test_apply_embedding_batch_size_updates_loaded_embedding_engines(self):
+        """Runtime setting changes should update pool config and loaded embedding engines."""
+        from omlx.engine.embedding import EmbeddingEngine
+        from omlx.scheduler import SchedulerConfig
+
+        engine = EmbeddingEngine("embed-model", batch_size=8)
+        pool = _make_pool(
+            ceiling=10 * 1024**3,
+            scheduler_config=SchedulerConfig(embedding_batch_size=8),
+        )
+        pool._entries["embed-model"] = EngineEntry(
+            model_id="embed-model",
+            model_path="/tmp/embed-model",
+            model_type="embedding",
+            engine_type="embedding",
+            estimated_size=1024,
+            engine=engine,
+        )
+
+        await pool.apply_embedding_batch_size(5)
+
+        assert pool._scheduler_config.embedding_batch_size == 5
+        assert engine.get_stats()["batch_size"] == 5
 
     @pytest.mark.asyncio
     async def test_get_engine_returns_cached(self, pool_with_mock_engines):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -36,7 +36,7 @@ class TestSchedulerConfig:
         assert config.max_num_batched_tokens == 8192
         assert config.policy == SchedulingPolicy.FCFS
         assert config.completion_batch_size == 32
-        assert config.embedding_batch_size == 8
+        assert config.embedding_batch_size == 32
         assert config.prefill_step_size == 2048
         assert config.paged_cache_block_size == 256
         assert config.max_cache_blocks is None

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -36,6 +36,7 @@ class TestSchedulerConfig:
         assert config.max_num_batched_tokens == 8192
         assert config.policy == SchedulingPolicy.FCFS
         assert config.completion_batch_size == 32
+        assert config.embedding_batch_size == 8
         assert config.prefill_step_size == 2048
         assert config.paged_cache_block_size == 256
         assert config.max_cache_blocks is None
@@ -53,6 +54,7 @@ class TestSchedulerConfig:
             max_num_batched_tokens=4096,
             policy=SchedulingPolicy.PRIORITY,
             completion_batch_size=16,
+            embedding_batch_size=12,
             prefill_step_size=1024,
             paged_cache_block_size=128,
             max_cache_blocks=500,
@@ -68,6 +70,7 @@ class TestSchedulerConfig:
         assert config.max_num_batched_tokens == 4096
         assert config.policy == SchedulingPolicy.PRIORITY
         assert config.completion_batch_size == 16
+        assert config.embedding_batch_size == 12
         assert config.prefill_step_size == 1024
         assert config.paged_cache_block_size == 128
         assert config.max_cache_blocks == 500

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -217,11 +217,13 @@ class TestSchedulerSettings:
         """Test default values."""
         settings = SchedulerSettings()
         assert settings.max_concurrent_requests == 8
+        assert settings.embedding_batch_size == 8
 
     def test_custom_values(self):
         """Test custom values."""
-        settings = SchedulerSettings(max_concurrent_requests=128)
+        settings = SchedulerSettings(max_concurrent_requests=128, embedding_batch_size=16)
         assert settings.max_concurrent_requests == 128
+        assert settings.embedding_batch_size == 16
 
     def test_to_dict(self):
         """Test conversion to dictionary."""
@@ -229,6 +231,7 @@ class TestSchedulerSettings:
         result = settings.to_dict()
         assert result == {
             "max_concurrent_requests": 8,
+            "embedding_batch_size": 8,
             "chunked_prefill": False,
         }
 
@@ -237,6 +240,12 @@ class TestSchedulerSettings:
         data = {"max_concurrent_requests": 512}
         settings = SchedulerSettings.from_dict(data)
         assert settings.max_concurrent_requests == 512
+        assert settings.embedding_batch_size == 8
+
+        data = {"max_concurrent_requests": 512, "embedding_batch_size": 24}
+        settings = SchedulerSettings.from_dict(data)
+        assert settings.max_concurrent_requests == 512
+        assert settings.embedding_batch_size == 24
 
     def test_from_dict_backwards_compat(self):
         """Test creation from dictionary with old keys."""
@@ -644,6 +653,7 @@ class TestGlobalSettings:
             assert settings.server.port == 8000
             assert settings.memory.memory_guard_tier == "balanced"
             assert settings.scheduler.max_concurrent_requests == 8
+            assert settings.scheduler.embedding_batch_size == 8
             assert settings.cache.enabled is True
             assert settings.auth.api_key is None
             assert settings.mcp.config_path is None
@@ -680,6 +690,7 @@ class TestGlobalSettings:
                         "memory": {"memory_guard_tier": "safe"},
                         "scheduler": {
                             "max_concurrent_requests": 128,
+                            "embedding_batch_size": 24,
                         },
                         "cache": {
                             "enabled": False,
@@ -700,6 +711,7 @@ class TestGlobalSettings:
             assert settings.model.model_dir == "/models"  # Backward compat field
             assert settings.memory.memory_guard_tier == "safe"
             assert settings.scheduler.max_concurrent_requests == 128
+            assert settings.scheduler.embedding_batch_size == 24
             assert settings.cache.enabled is False
             assert settings.cache.ssd_cache_dir == "/cache"
             assert settings.auth.api_key == "secret"
@@ -917,6 +929,11 @@ class TestGlobalSettings:
         errors = settings.validate()
         assert any("max_concurrent_requests" in e.lower() for e in errors)
 
+        settings = GlobalSettings()
+        settings.scheduler.embedding_batch_size = 0
+        errors = settings.validate()
+        assert any("embedding_batch_size" in e.lower() for e in errors)
+
     def test_validate_invalid_cache_size(self):
         """Test validation catches invalid cache size."""
         settings = GlobalSettings()
@@ -1006,6 +1023,17 @@ class TestGlobalSettings:
             ):
                 settings = GlobalSettings.load(base_path=tmpdir)
                 assert settings.scheduler.max_concurrent_requests == 512
+
+    def test_env_override_embedding_batch_size(self):
+        """Test environment variable override for embedding batch size."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(
+                os.environ,
+                {"OMLX_EMBEDDING_BATCH_SIZE": "24"},
+                clear=False,
+            ):
+                settings = GlobalSettings.load(base_path=tmpdir)
+                assert settings.scheduler.embedding_batch_size == 24
 
     def test_env_override_scheduler_legacy_fallback(self):
         """Test legacy OMLX_MAX_NUM_SEQS env var is accepted as fallback."""
@@ -1160,9 +1188,10 @@ class TestGlobalSettings:
     def test_cli_override_scheduler(self):
         """Test CLI override for scheduler settings."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            args = Namespace(max_concurrent_requests=64)
+            args = Namespace(max_concurrent_requests=64, embedding_batch_size=12)
             settings = GlobalSettings.load(base_path=tmpdir, cli_args=args)
             assert settings.scheduler.max_concurrent_requests == 64
+            assert settings.scheduler.embedding_batch_size == 12
 
     def test_cli_override_cache(self):
         """Test CLI override for cache settings."""
@@ -1271,10 +1300,12 @@ class TestGlobalSettings:
         """Test conversion to SchedulerConfig."""
         settings = GlobalSettings()
         settings.scheduler.max_concurrent_requests = 128
+        settings.scheduler.embedding_batch_size = 12
 
         scheduler_config = settings.to_scheduler_config()
         assert scheduler_config.max_num_seqs == 128
         assert scheduler_config.completion_batch_size == 128
+        assert scheduler_config.embedding_batch_size == 12
         assert scheduler_config.initial_cache_blocks == 256  # default
 
     def test_to_scheduler_config_initial_cache_blocks(self):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -217,7 +217,7 @@ class TestSchedulerSettings:
         """Test default values."""
         settings = SchedulerSettings()
         assert settings.max_concurrent_requests == 8
-        assert settings.embedding_batch_size == 8
+        assert settings.embedding_batch_size == 32
 
     def test_custom_values(self):
         """Test custom values."""
@@ -231,7 +231,7 @@ class TestSchedulerSettings:
         result = settings.to_dict()
         assert result == {
             "max_concurrent_requests": 8,
-            "embedding_batch_size": 8,
+            "embedding_batch_size": 32,
             "chunked_prefill": False,
         }
 
@@ -240,7 +240,7 @@ class TestSchedulerSettings:
         data = {"max_concurrent_requests": 512}
         settings = SchedulerSettings.from_dict(data)
         assert settings.max_concurrent_requests == 512
-        assert settings.embedding_batch_size == 8
+        assert settings.embedding_batch_size == 32
 
         data = {"max_concurrent_requests": 512, "embedding_batch_size": 24}
         settings = SchedulerSettings.from_dict(data)
@@ -653,7 +653,7 @@ class TestGlobalSettings:
             assert settings.server.port == 8000
             assert settings.memory.memory_guard_tier == "balanced"
             assert settings.scheduler.max_concurrent_requests == 8
-            assert settings.scheduler.embedding_batch_size == 8
+            assert settings.scheduler.embedding_batch_size == 32
             assert settings.cache.enabled is True
             assert settings.auth.api_key is None
             assert settings.mcp.config_path is None


### PR DESCRIPTION
## Summary

Fixes the embedding memory spike caused by unbounded per-request embedding batches.

The root problem was that `/v1/embeddings` treated the whole `input` array as one model forward. `max_concurrent_requests` only limits how many requests run at once; it did not limit how many texts a single embedding request could pass into `model.embed(...)`.

That meant a request with 1,000 input texts was still one request, but all 1,000 texts could be embedded in one forward pass.

This PR adds a dedicated `embedding_batch_size` setting so each embedding request is internally chunked:

- Adds `scheduler.embedding_batch_size`
- Defaults embedding batch size to `32`
- Applies it in `EmbeddingEngine.embed()`
- Preserves output ordering and API response shape
- Supports runtime updates for loaded embedding engines
- Exposes the setting in Web Admin and macOS Performance settings
- Adds CLI/env/settings support

## Why this is separate from Max Concurrent Requests

`max_concurrent_requests` controls request-level concurrency for completion/chat scheduling.

Embedding needs a different limit: how many input texts from one request are sent through one embedding forward pass. Without this limit, a single request can still create an oversized batch even when request concurrency is low.

## Validation

- `446 passed, 1 deselected`

```bash
env UV_CACHE_DIR=/tmp/uv-cache uv run pytest \
  tests/test_settings.py \
  tests/test_embedding.py \
  tests/test_scheduler.py \
  tests/test_config.py \
  tests/test_admin_server_aliases.py \
  tests/test_cli.py \
  -q