### PR TITLE
fix(specprefill): materialize draft model lazy state on loader thread

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -328,6 +328,16 @@ class BatchedEngine(BaseEngine):
                         set_mtp_active(False)
                         try:
                             draft_model, _ = load(specprefill_draft)
+                            # Materialize frozen buffers (RoPE freqs, etc.)
+                            # on the loader thread. mlx_lm.load only does
+                            # mx.eval(model.parameters()) and leaves siblings
+                            # lazy bound to this thread's stream. Without
+                            # this, the first score_tokens() call from
+                            # Scheduler.step on the per-engine executor
+                            # thread raises "no Stream(gpu, X) in current
+                            # thread". Same root cause and fix as e93c408
+                            # for the VLM MTP drafter.
+                            materialize_lazy_state(draft_model)
                             return draft_model
                         finally:
                             set_mtp_active(was_mtp)

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -811,6 +811,8 @@ class VLMBatchedEngine(BaseEngine):
                     def _load_draft():
                         from ..patches.mlx_lm_mtp import set_mtp_active
 
+                        from ..utils.model_loading import materialize_lazy_state
+
                         was_mtp = False
                         try:
                             from ..patches.mlx_lm_mtp import is_mtp_active
@@ -826,8 +828,18 @@ class VLMBatchedEngine(BaseEngine):
                             )
                             if custom_loaded is not None:
                                 draft_model, _ = custom_loaded
-                                return draft_model
-                            draft_model, _ = mlx_lm_load(specprefill_draft)
+                            else:
+                                draft_model, _ = mlx_lm_load(specprefill_draft)
+                            # Materialize frozen buffers (RoPE freqs, etc.)
+                            # on the loader thread. mlx_lm.load only does
+                            # mx.eval(model.parameters()) and leaves siblings
+                            # lazy bound to this thread's stream. Without
+                            # this, the first score_tokens() call from
+                            # Scheduler.step on the per-engine executor
+                            # thread raises "no Stream(gpu, X) in current
+                            # thread". Same root cause and fix as e93c408
+                            # for the VLM MTP drafter.
+                            materialize_lazy_state(draft_model)
                             return draft_model
                         finally:
                             set_mtp_active(was_mtp)


### PR DESCRIPTION
## Summary

Same root cause and fix as #1469 / `e93c408` for the VLM MTP drafter, applied to the **SpecPrefill draft load path** in both `BatchedEngine` (LLM) and `VLMBatchedEngine`. Two latent instances of the same `#1304` per-engine-threads bug class.

## The bug

`mlx_lm.load(specprefill_draft)` (and `maybe_load_custom_quantization`) materialize only `model.parameters()` via `mx.eval` and leave frozen buffers (RoPE freqs, masked_embedding tables, etc.) lazy, bound to the global mlx loader thread's stream.

The returned draft model is stored on `Scheduler._specprefill_draft_model` and later read from:

```python
# omlx/scheduler.py:4246-4252
importance, used_cache = score_tokens(
    self._specprefill_draft_model,
    ...
)
```

which runs on the **per-engine executor's worker thread** inside `Scheduler.step`. The first SpecPrefill-eligible prefill triggers `mx.async_eval` on the inference thread, which tries to materialize the leftover lazy ops against a stream that doesn't exist there → `no Stream(gpu, X) in current thread`.

Hasn't been hit yet because nobody appears to be running SpecPrefill on a per-engine-threaded session — but the load path was missed when the analogous fix for VLM MTP drafter (#1469 → `e93c408`) landed.

## The fix

Call `materialize_lazy_state(draft_model)` inside `_load_draft` (which runs on `get_mlx_executor()` — the loader thread) right before returning, so every leaf array is concrete before any inference thread reads it.

- `omlx/engine/batched.py` — one call site added; `materialize_lazy_state` already imported above (line 251).
- `omlx/engine/vlm.py` — added import inside `_load_draft`, refactored the dual-return (custom_loaded path + mlx_lm_load path) into a single materialize-then-return so both branches are covered.

## Related per-engine-threads fixes

Bug class introduced by #1304 (per-engine threads to eliminate cross-engine stream contamination). Three follow-up fixes already merged:

- `9d5bed8` — main VLM model
- `e93c408` — VLM MTP drafter (#1469)
- `9407468` — boundary snapshots dropped during prefill (closed as #1471, cherry-picked onto main)

This PR closes the SpecPrefill load paths, which the same audit pattern identified as the remaining clean miss of the same load-thread/inference-thread handoff. A code review of #1304's broader surface didn't surface any other high-confidence instances; a few medium-confidence ordering concerns (`apply_post_load_transforms` patch sequencing in LLM vs VLM, custom `make_cache` impls memoizing on `self`) are flagged but not in scope here.

## Test plan

- [x] Confirmed `_load_draft` runs on `get_mlx_executor()` (the loader thread) via `loop.run_in_executor`
- [x] Confirmed `materialize_lazy_state` is already a stable export from `omlx.utils.model_loading` used by the main model + VLM model + VLM MTP drafter init paths
- [x] Syntax check on both files
- [ ] Runtime verification: would require enabling `specprefill_enabled` + a `specprefill_draft_model` setting against a per-engine-configured session. Open to running this if you have a repro config in mind. Pattern match against `e93c408` is exact.