### PR TITLE
refactor(packaging): rename mlx-framework venvstacks layer to mlx-base

### DIFF
--- a/apps/omlx-mac/Scripts/build.sh
+++ b/apps/omlx-mac/Scripts/build.sh
@@ -244,15 +244,15 @@ mkdir -p "$FRAMEWORKS_DIR" "$RESOURCES_DIR"
 resolve_donor_layers
 log "Using donor: $DONOR_SOURCE"
 [ -d "$DONOR_LAYERS/cpython-3.11" ] || die "Donor missing cpython-3.11 at $DONOR_LAYERS"
-[ -d "$DONOR_LAYERS/framework-mlx-framework" ] || die "Donor missing framework-mlx-framework at $DONOR_LAYERS"
+[ -d "$DONOR_LAYERS/framework-mlx-base" ] || die "Donor missing framework-mlx-base at $DONOR_LAYERS"
 
 log "Copying cpython-3.11 from donor…"
 ditto "$DONOR_LAYERS/cpython-3.11" "$FRAMEWORKS_DIR/cpython-3.11"
 ok "  + cpython-3.11"
 
-log "Copying framework-mlx-framework from donor (~1 GB)…"
-ditto "$DONOR_LAYERS/framework-mlx-framework" "$FRAMEWORKS_DIR/framework-mlx-framework"
-ok "  + framework-mlx-framework"
+log "Copying framework-mlx-base from donor (~1 GB)…"
+ditto "$DONOR_LAYERS/framework-mlx-base" "$FRAMEWORKS_DIR/framework-mlx-base"
+ok "  + framework-mlx-base"
 
 if [ -d "$DONOR_LAYERS/__venvstacks__" ]; then
     ditto "$DONOR_LAYERS/__venvstacks__" "$FRAMEWORKS_DIR/__venvstacks__"

--- a/apps/omlx-mac/Sources/Server/PythonRuntime.swift
+++ b/apps/omlx-mac/Sources/Server/PythonRuntime.swift
@@ -11,7 +11,7 @@
 //   PYTHONHOME = Contents/Frameworks/cpython-3.11
 //     so the relocated interpreter finds its stdlib without grepping the
 //     host system's /usr/lib.
-//   PYTHONPATH = Contents/Resources : framework-mlx-framework/site-packages
+//   PYTHONPATH = Contents/Resources : framework-mlx-base/site-packages
 //     : __venvstacks__/site-customize
 //     so `python -m omlx.cli` resolves both the omlx package (shipped as a
 //     pure source tree in Resources/omlx/, matching today's Python build)
@@ -71,7 +71,7 @@ struct PythonRuntime {
         if FileManager.default.isExecutableFile(atPath: bundled.path) {
             let resources = bundleRoot.appendingPathComponent("Contents/Resources")
             let mlxFramework = frameworks
-                .appendingPathComponent("framework-mlx-framework/lib/python3.11/site-packages")
+                .appendingPathComponent("framework-mlx-base/lib/python3.11/site-packages")
             return PythonRuntime(
                 executable: bundled,
                 homebrewPaths: defaultHomebrewPaths,

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -50,7 +50,7 @@ packaging/
 | Layer | Contents |
 |-------|----------|
 | Runtime (`cpython-3.11`) | Python 3.11 |
-| Framework (`mlx-framework`) | MLX, mlx-lm, mlx-vlm, FastAPI, transformers, mlx-audio, paroquant, spaCy |
+| Framework (`mlx-base`) | MLX, mlx-lm, mlx-vlm, FastAPI, transformers, mlx-audio, paroquant, spaCy |
 
 No application layer — the Swift app is the application surface.
 

--- a/packaging/build.py
+++ b/packaging/build.py
@@ -108,8 +108,8 @@ def _resolve_mlx_version(toml_path: Path) -> str:
     req_file = (
         SCRIPT_DIR
         / "requirements"
-        / "framework-mlx-framework"
-        / "requirements-framework-mlx-framework-macosx_arm64.txt"
+        / "framework-mlx-base"
+        / "requirements-framework-mlx-base-macosx_arm64.txt"
     )
     if req_file.exists():
         import re as _re
@@ -143,7 +143,7 @@ def swap_platform_wheels(
 
     site_packages = (
         export_dir
-        / "framework-mlx-framework"
+        / "framework-mlx-base"
         / "lib"
         / f"python{python_version}"
         / "site-packages"
@@ -442,7 +442,7 @@ def _write_engine_commits(omlx_pkg_dir: Path):
 # normalized). [bundle] last means a bundle-specific [audio]-extra entry
 # wins over [project]'s plain entry for the same package.
 _LAYER_REQUIREMENTS_SOURCES = {
-    "mlx-framework": ["project", "bundle"],
+    "mlx-base": ["project", "bundle"],
 }
 
 
@@ -746,7 +746,7 @@ def _install_mlx_audio(export_dir: Path):
     # Install into framework site-packages
     fw_site = (
         export_dir
-        / "framework-mlx-framework"
+        / "framework-mlx-base"
         / "lib"
         / "python3.11"
         / "site-packages"
@@ -785,7 +785,7 @@ def _install_paroquant(export_dir: Path):
 
     fw_site = (
         export_dir
-        / "framework-mlx-framework"
+        / "framework-mlx-base"
         / "lib"
         / "python3.11"
         / "site-packages"
@@ -822,7 +822,7 @@ def _install_spacy_model(export_dir: Path):
 
     fw_site = (
         export_dir
-        / "framework-mlx-framework"
+        / "framework-mlx-base"
         / "lib"
         / "python3.11"
         / "site-packages"
@@ -872,7 +872,7 @@ def _strip_unused_packages(export_dir: Path):
     """Remove large packages not needed for inference from exported framework."""
     fw_site = (
         export_dir
-        / "framework-mlx-framework"
+        / "framework-mlx-base"
         / "lib"
         / "python3.11"
         / "site-packages"

--- a/packaging/venvstacks.toml
+++ b/packaging/venvstacks.toml
@@ -1,7 +1,7 @@
 # oMLX venvstacks layer template
 #
 # Layer structure + runtime pin + uv resolver settings live here. The
-# actual `requirements = [...]` for the mlx-framework layer is generated
+# actual `requirements = [...]` for the mlx-base layer is generated
 # at build time by packaging/build.py:_generate_venvstacks_toml() from
 # pyproject.toml's [project] dependencies + [bundle] optional extra, so
 # this file does not list package versions. Single source of truth for
@@ -19,7 +19,7 @@ platforms = [
 ]
 
 [[frameworks]]
-name = "mlx-framework"
+name = "mlx-base"
 runtime = "cpython-3.11"
 # Populated by _generate_venvstacks_toml() — do not hand-edit.
 requirements = []


### PR DESCRIPTION
## Summary

- Rename the venvstacks `[[frameworks]]` layer from `mlx-framework` → `mlx-base`. venvstacks auto-prefixes framework layers with `framework-`, so the old name produced the tautological directory `Contents/Frameworks/framework-mlx-framework/`. The new name yields `framework-mlx-base/` — keeps the venvstacks convention, drops the redundancy, and leaves room for future layers (e.g. `framework-mlx-extras`).
- Touches 5 files: `packaging/venvstacks.toml` (layer name + comment), `packaging/build.py` (path strings, `_LAYER_REQUIREMENTS_SOURCES` key, resolved-requirements filename), `apps/omlx-mac/Scripts/build.sh` (donor copy paths), `apps/omlx-mac/Sources/Server/PythonRuntime.swift` (bundled `PYTHONPATH` entry), `packaging/README.md` (layer table). No API surface change — strictly an internal rename.
- Reviewers should also delete their stale `packaging/_export/` and `packaging/requirements/framework-mlx-framework/` before rebuilding so venvstacks emits the new layout.

## Test plan

- [x] `grep -rn "mlx-framework\|mlx_framework"` across `apps/`, `packaging/`, `omlx/`, `docs/` is clean
- [x] Wipe `packaging/_export/` + `packaging/requirements/framework-mlx-framework/` and run `apps/omlx-mac/Scripts/build.sh release`
- [x] `packaging/_export/framework-mlx-base/` is produced by venvstacks
- [x] `packaging/requirements/framework-mlx-base/requirements-framework-mlx-base-macosx_arm64.{in,txt,txt.json}` regenerated
- [x] `apps/omlx-mac/build/Stage/oMLX.app/Contents/Frameworks/framework-mlx-base/` is present
- [x] Launch the staged bundle — Python runtime resolves `PYTHONPATH` via the new path
- [ ] Reviewer rebuilds locally after wiping stale artifacts