### PR TITLE
ci: add semantic release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[mcp]"
+          python -m pip install pytest pytest-asyncio
+
+      - name: Run unit tests
+        run: python -m pytest tests/ -m "not slow and not integration"
+
+  release:
+    runs-on: macos-14
+    needs: test
+    if: github.event_name == 'push' && github.event.repository.fork == false
+    permissions:
+      contents: write
+      id-token: write
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[mcp]"
+          python -m pip install python-semantic-release
+
+      - name: Run semantic release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semantic-release version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0.0",
     "mcp>=1.0.0",
+    "python-semantic-release>=10.0.0",
     "venvstacks>=0.7.0",
 ]
 # PEP 735 dependency groups — consumed by `uv sync --dev`.
@@ -155,6 +156,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0.0",
     "mcp>=1.0.0",
+    "python-semantic-release>=10.0.0",
     "venvstacks>=0.7.0",
 ]
 
@@ -204,3 +206,16 @@ ignore_missing_imports = true
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 asyncio_mode = "auto"
+
+[tool.semantic_release]
+version_variable = ["omlx/_version.py:__version__"]
+version_source = "variable"
+commit_parser = "conventional"
+parsers = [
+    "feat:minor",
+    "fix:patch",
+    "perf:patch",
+]
+upload_to_pypi = false
+upload_to_release = true
+build_command = false


### PR DESCRIPTION
Configures `python-semantic-release` with conventional commit parsing. Version source is `omlx/_version.py`. The release job runs after tests pass on push to `main`, gated to skip on forks.

Holding as draft — not requested for merge yet per https://github.com/jundot/omlx/pull/1396#issuecomment-4552457241.