### PR TITLE
ci: add git hooks for conventional commit enforcement

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# commit-msg hook — validates conventional commit format via gitlint.
+# Auto-installs itself by setting core.hooksPath if not configured.
+set -euo pipefail
+
+HOOKS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HOOKS_DIR/.." && git rev-parse --show-toplevel 2>/dev/null || echo "$HOOKS_DIR/..")"
+
+# Ensure core.hooksPath points to this directory so the hook stays active
+# after fresh clones.
+CURRENT_HOOKS_PATH="$(git config --get core.hooksPath 2>/dev/null || true)"
+if [ "$CURRENT_HOOKS_PATH" != "$HOOKS_DIR" ] && [ "$CURRENT_HOOKS_PATH" != ".githooks" ]; then
+    git config core.hooksPath "$HOOKS_DIR"
+fi
+
+# Gracefully skip if gitlint is not yet installed (fresh clone before dev deps).
+if ! command -v gitlint &>/dev/null; then
+    echo "gitlint not found — skipping commit message validation."
+    echo "Install dev deps to enable: pip install gitlint"
+    exit 0
+fi
+
+gitlint --msg-filename "$1"

--- a/.githooks/setup
+++ b/.githooks/setup
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# One-command bootstrap for git hooks and dev tooling.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOKS_DIR="$REPO_ROOT/.githooks"
+
+echo "Setting core.hooksPath to $HOOKS_DIR"
+git config core.hooksPath "$HOOKS_DIR"
+
+echo "Making hooks executable"
+chmod +x "$HOOKS_DIR"/*
+
+echo "Installing dev dependencies"
+pip install gitlint
+
+echo "Done. Commit messages will be validated via gitlint."

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,11 @@
+# gitlint configuration for conventional commit enforcement.
+# See https://jorisroovers.github.io/gitlint/configuration/ for options.
+
+[general]
+contrib = contrib-title-conventional-commits
+
+[title-match-regex]
+regex = ^(feat|fix|perf|refactor|docs|test|ci|build|chore|revert)(\(.+\))?!?: .{1,72}
+
+[body-max-line-length]
+line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0.0",
     "mcp>=1.0.0",
+    "gitlint>=0.19.1",
     "venvstacks>=0.7.0",
 ]
 # PEP 735 dependency groups — consumed by `uv sync --dev`.
@@ -155,6 +156,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0.0",
     "mcp>=1.0.0",
+    "gitlint>=0.19.1",
     "venvstacks>=0.7.0",
 ]
 


### PR DESCRIPTION
commit-msg hook validates messages via gitlint against conventional commit format. `.githooks/setup` is a one-command bootstrap. gitlint added as a dev dependency. Gracefully skips when gitlint is not installed (fresh clone before dev deps).

Holding as draft — not requested for merge yet per https://github.com/jundot/omlx/pull/1396#issuecomment-4552457241.