### PR TITLE
Cache SpecPrefill token selections

### DIFF
--- a/omlx/cache/specprefill_selection.py
+++ b/omlx/cache/specprefill_selection.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class SpecPrefillSelectionKey:
+    token_digest: str
+    token_count: int
+    draft_model_name: str
+    keep_pct: float
+    chunk_size: int
+    prefill_step_size: int
+
+
+class SpecPrefillSelectionCache:
+    def __init__(self, max_entries: int = 128):
+        self.max_entries = max(0, max_entries)
+        self._entries: OrderedDict[SpecPrefillSelectionKey, tuple[int, ...]] = OrderedDict()
+        self.hits = 0
+        self.misses = 0
+        self.evictions = 0
+
+    @staticmethod
+    def digest_tokens(tokens: Iterable[int]) -> tuple[str, int]:
+        digest = hashlib.blake2b(digest_size=16)
+        count = 0
+        for token in tokens:
+            digest.update(int(token).to_bytes(8, byteorder="little", signed=True))
+            count += 1
+        return digest.hexdigest(), count
+
+    @classmethod
+    def make_key(
+        cls,
+        tokens: Iterable[int],
+        *,
+        draft_model_name: str,
+        keep_pct: float,
+        chunk_size: int,
+        prefill_step_size: int,
+    ) -> SpecPrefillSelectionKey:
+        token_digest, token_count = cls.digest_tokens(tokens)
+        return SpecPrefillSelectionKey(
+            token_digest=token_digest,
+            token_count=token_count,
+            draft_model_name=draft_model_name,
+            keep_pct=float(keep_pct),
+            chunk_size=int(chunk_size),
+            prefill_step_size=int(prefill_step_size),
+        )
+
+    def get(self, key: SpecPrefillSelectionKey) -> tuple[int, ...] | None:
+        selected = self._entries.get(key)
+        if selected is None:
+            self.misses += 1
+            return None
+        self.hits += 1
+        self._entries.move_to_end(key)
+        return selected
+
+    def put(self, key: SpecPrefillSelectionKey, selected: Iterable[int]) -> None:
+        if self.max_entries <= 0:
+            return
+        values = tuple(int(i) for i in selected)
+        if key in self._entries:
+            self._entries.move_to_end(key)
+        self._entries[key] = values
+        while len(self._entries) > self.max_entries:
+            self._entries.popitem(last=False)
+            self.evictions += 1
+
+    def clear(self) -> None:
+        self._entries.clear()
+        self.hits = 0
+        self.misses = 0
+        self.evictions = 0
+
+    def stats(self) -> dict[str, int]:
+        return {
+            "entries": len(self._entries),
+            "hits": self.hits,
+            "misses": self.misses,
+            "evictions": self.evictions,
+        }

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -40,6 +40,7 @@ from mlx_lm.sample_utils import make_logits_processors
 from .cache.observability import CacheRateTracker
 from .cache.paged_cache import PagedCacheManager
 from .cache.prefix_cache import BlockAwarePrefixCache
+from .cache.specprefill_selection import SpecPrefillSelectionCache
 from .exceptions import is_cache_corruption_error
 from .prefill_progress import get_prefill_tracker
 from .prefill_transient_tracker import PrefillTransientTracker
@@ -813,6 +814,8 @@ class Scheduler:
 
         # SpecPrefill: draft model for attention-based sparse prefill
         self._specprefill_draft_model: Any | None = None
+        self._specprefill_draft_model_name = "specprefill-draft"
+        self._specprefill_selection_cache = SpecPrefillSelectionCache()
         # Track active specprefill request for RoPE cleanup
         self._specprefill_active_request_id: str | None = None
 
@@ -3727,6 +3730,7 @@ class Scheduler:
         in compute_block_hash() naturally isolates draft blocks from target.
         """
         self._specprefill_draft_model = draft_model
+        self._specprefill_draft_model_name = draft_model_name or "specprefill-draft"
         self._draft_prefix_cache: Any | None = None
 
         if (
@@ -3737,7 +3741,7 @@ class Scheduler:
                 from .cache.paged_cache import PagedCacheManager
                 from .cache.prefix_cache import BlockAwarePrefixCache
 
-                name = draft_model_name or "specprefill-draft"
+                name = self._specprefill_draft_model_name
                 draft_paged = PagedCacheManager(
                     block_size=self.config.paged_cache_block_size,
                     max_blocks=self.paged_cache_manager.max_blocks,
@@ -4100,6 +4104,29 @@ class Scheduler:
         if n_to_score <= threshold:
             return
 
+        selection_key = self._specprefill_selection_cache.make_key(
+            tokens_to_score,
+            draft_model_name=self._specprefill_draft_model_name,
+            keep_pct=keep_pct,
+            chunk_size=32,
+            prefill_step_size=self.config.prefill_step_size,
+        )
+        cached_selection = self._specprefill_selection_cache.get(selection_key)
+        if cached_selection is not None:
+            selected = mx.array(cached_selection, dtype=mx.int32)
+            n_selected = len(cached_selection)
+            request.specprefill_indices = selected
+            request.specprefill_total_tokens = n_to_score
+            request.specprefill_position_offset = (
+                request.cached_tokens + effective_system
+            )
+            request._specprefill_system_tokens = effective_system
+            logger.info(
+                f"SpecPrefill: reused selection cache for {n_selected}/{n_to_score} "
+                f"tokens (keep={n_selected/n_to_score*100:.0f}%)"
+            )
+            return
+
         tracker = get_prefill_tracker()
         model_id = os.path.basename(self.config.model_name.rstrip("/"))
 
@@ -4164,6 +4191,7 @@ class Scheduler:
                 progress_callback=_score_progress,
             )
             selected = select_chunks(importance, keep_pct=keep_pct)
+            self._specprefill_selection_cache.put(selection_key, selected.tolist())
             t_score = time.monotonic() - t0
 
             n_selected = selected.shape[0]
@@ -6078,6 +6106,7 @@ class Scheduler:
         # Include cache stats
         if self.block_aware_cache is not None:
             stats["ssd_cache"] = self.block_aware_cache.get_stats()
+        stats["specprefill_selection_cache"] = self._specprefill_selection_cache.stats()
         return stats
 
     def get_cache_stats(self) -> dict[str, Any] | None:
@@ -6119,6 +6148,7 @@ class Scheduler:
         if self.block_aware_cache is not None:
             self.block_aware_cache.clear()
         self._cache_rate_tracker.clear()
+        self._specprefill_selection_cache.clear()
 
         # Clear detokenizers
         self._request_detokenizers.clear()

--- a/tests/test_specprefill.py
+++ b/tests/test_specprefill.py
@@ -73,6 +73,100 @@ class TestSelectChunks:
         assert selected.shape[0] <= expected_tokens + 32
 
 
+class TestSelectionCache:
+    def test_key_changes_when_keep_pct_changes(self):
+        from omlx.cache.specprefill_selection import SpecPrefillSelectionCache
+
+        key_a = SpecPrefillSelectionCache.make_key(
+            [1, 2, 3],
+            draft_model_name="draft",
+            keep_pct=0.2,
+            chunk_size=32,
+            prefill_step_size=2048,
+        )
+        key_b = SpecPrefillSelectionCache.make_key(
+            [1, 2, 3],
+            draft_model_name="draft",
+            keep_pct=0.5,
+            chunk_size=32,
+            prefill_step_size=2048,
+        )
+
+        assert key_a != key_b
+
+    def test_lru_eviction_and_stats(self):
+        from omlx.cache.specprefill_selection import SpecPrefillSelectionCache
+
+        cache = SpecPrefillSelectionCache(max_entries=1)
+        key_a = cache.make_key(
+            [1, 2, 3],
+            draft_model_name="draft",
+            keep_pct=0.2,
+            chunk_size=32,
+            prefill_step_size=2048,
+        )
+        key_b = cache.make_key(
+            [4, 5, 6],
+            draft_model_name="draft",
+            keep_pct=0.2,
+            chunk_size=32,
+            prefill_step_size=2048,
+        )
+
+        cache.put(key_a, [0, 1])
+        assert cache.get(key_a) == (0, 1)
+        cache.put(key_b, [2, 3])
+        assert cache.get(key_a) is None
+        assert cache.get(key_b) == (2, 3)
+        assert cache.stats() == {"entries": 1, "hits": 2, "misses": 1, "evictions": 1}
+
+    def test_scheduler_reuses_selection_without_rescoring(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from omlx.cache.specprefill_selection import SpecPrefillSelectionCache
+        from omlx.scheduler import Scheduler, SchedulerConfig
+
+        calls = {"score": 0}
+
+        def fake_score_tokens(model, tokens, **kwargs):
+            calls["score"] += 1
+            return mx.arange(len(tokens), dtype=mx.float32), None
+
+        monkeypatch.setattr("omlx.patches.specprefill.score_tokens", fake_score_tokens)
+
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler._specprefill_draft_model = object()
+        scheduler._specprefill_draft_model_name = "draft"
+        scheduler._specprefill_selection_cache = SpecPrefillSelectionCache()
+        scheduler._draft_prefix_cache = None
+        scheduler.config = SchedulerConfig(prefill_step_size=128, model_name="target")
+        scheduler._stream = None
+
+        def make_request(request_id):
+            return SimpleNamespace(
+                request_id=request_id,
+                _specprefill_enabled=True,
+                _specprefill_threshold=4,
+                _specprefill_keep_pct=0.5,
+                vlm_inputs_embeds=None,
+                remaining_tokens=list(range(20)),
+                prompt_token_ids=list(range(20)),
+                specprefill_system_end=0,
+                cached_tokens=0,
+                num_prompt_tokens=20,
+            )
+
+        first = make_request("req-1")
+        second = make_request("req-2")
+
+        Scheduler._try_specprefill_scoring(scheduler, first)
+        Scheduler._try_specprefill_scoring(scheduler, second)
+
+        assert calls["score"] == 1
+        assert first.specprefill_indices.tolist() == second.specprefill_indices.tolist()
+        assert scheduler._specprefill_selection_cache.stats()["hits"] == 1
+
+
 class TestManualRoPE:
     """Tests for manual_rope() at arbitrary positions."""
 


### PR DESCRIPTION
## Summary
- Add an LRU cache for SpecPrefill token-selection results keyed by prompt digest and scoring parameters.
- Reuse cached sparse token selections for repeated long prompts instead of rescoring the same prompt with the draft model.
- Surface cache stats via scheduler stats and clear the cache on scheduler reset.

## Environment
- macOS Darwin 25.4.0 arm64
- Apple M1 Max, 32 GB unified memory
- MLX / oMLX local Python environment on Apple Silicon
- Target model: `mlx-community/Qwen3-0.6B-4bit`
- Draft model: `mlx-community/Qwen3-0.6B-4bit`

## Real-weight benchmark

Protocol: oMLX `BatchedEngine` with SpecPrefill enabled, repeated identical prompt, `specprefill_threshold=1024`, `keep_pct=0.2`, greedy generation. This compares upstream baseline (no selection memoization) against this PR. Both runs use 100K requested input tokens and 10K generated tokens. The tokenizer/chat-template path produced 90,001 prompt tokens for the benchmarked request.

| Branch | Repeat | Prompt tokens | Output tokens | TTFT | Total time | Peak memory | Selection cache |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| Upstream baseline | 1 | 90,001 | 10,000 | 234.63s | 446.41s | 18.96 GB | n/a |
| Upstream baseline | 2 | 90,001 | 10,000 | 209.47s | 419.70s | 18.63 GB | n/a |
| This PR | 1 | 90,001 | 10,000 | 252.72s | 465.39s | 18.75 GB | 1 miss, 0 hits |
| This PR | 2 | 90,001 | 10,000 | 12.84s | 224.31s | 7.43 GB | 1 miss, 1 hit |

For the repeated long prompt, the second request's TTFT improves from 209.47s on baseline to 12.84s with this PR, because sparse-token selection is reused instead of rescored. Total latency improves from 419.70s to 224.31s, and peak memory drops from 18.63 GB to 7.43 GB on the repeated request.

## Test plan
- `pytest tests/test_specprefill.py::TestSelectionCache -q`
- Real `mlx-community/Qwen3-0.6B-4bit` 100K/10K repeated-prompt SpecPrefill benchmark above

Note: a full `tests/test_specprefill.py` run in this local environment still needs the async pytest plugin; the targeted cache tests pass and the real engine benchmark above exercises the runtime path.