### PR TITLE
fix(model-discovery): disambiguate LFM model types

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -59,6 +59,7 @@ VLM_MODEL_TYPES = {
     "phi4_siglip",
     "phi4mm",
     "youtu_vl",
+    "lfm2_vl",
 }
 
 # Known VLM architectures
@@ -79,6 +80,7 @@ VLM_ARCHITECTURES = {
     "Molmo2ForConditionalGeneration",
     "LlavaQwen2ForCausalLM",  # apple/FastVLM (all sizes)
     "Florence2ForConditionalGeneration",
+    "Lfm2VlForConditionalGeneration",
 }
 
 # Known embedding model types from mlx-embeddings
@@ -90,7 +92,6 @@ EMBEDDING_MODEL_TYPES = {
     "siglip",
     "colqwen2_5",
     "colqwen2-5",
-    "lfm2",
 }
 
 # Model types that have both embedding and LLM variants.
@@ -99,6 +100,7 @@ AMBIGUOUS_EMBEDDING_MODEL_TYPES = {
     "qwen3",
     "gemma3-text",
     "gemma3_text",
+    "lfm2",
 }
 
 # Known embedding architectures
@@ -134,6 +136,7 @@ CAUSAL_LM_RERANKER_ARCHITECTURES = {
 # (no lm_head weights). Detected by architecture + directory name heuristic.
 CAUSAL_LM_EMBEDDING_ARCHITECTURES = {
     "Qwen3ForCausalLM",  # Qwen3-Embedding uses CausalLM arch without lm_head
+    "Lfm2ForCausalLM",  # LFM2 embedding variants share the base text arch
 }
 
 # Multimodal (VLM-based) reranker architectures.
@@ -262,6 +265,7 @@ AUDIO_STS_ARCHITECTURES = {
     "MossFormer2SEModel",
     "SAMAudio",
     "LFM2AudioModel",
+    "Lfm2AudioForConditionalGeneration",
 }
 
 
@@ -545,9 +549,6 @@ def detect_model_type(model_path: Path) -> ModelType:
     if normalized_type in AUDIO_STT_MODEL_TYPES or model_type in AUDIO_STT_MODEL_TYPES:
         return "audio_stt"
     if normalized_type in AUDIO_STS_MODEL_TYPES or model_type in AUDIO_STS_MODEL_TYPES:
-        return "audio_sts"
-    # LFM2 audio: model_type starts with "lfm" and is not an embedding
-    if normalized_type.startswith("lfm") and normalized_type not in EMBEDDING_MODEL_TYPES:
         return "audio_sts"
 
     return "llm"

--- a/tests/test_audio_discovery.py
+++ b/tests/test_audio_discovery.py
@@ -389,6 +389,14 @@ class TestDetectSTSModelType:
         })
         assert detect_model_type(tmp_path) == "audio_sts"
 
+    def test_lfm2_audio_for_conditional_generation_returns_audio_sts(self, tmp_path):
+        """Real LFM2.5-Audio configs use Lfm2AudioForConditionalGeneration."""
+        _write_config(tmp_path, {
+            "model_type": "lfm_audio",
+            "architectures": ["Lfm2AudioForConditionalGeneration"],
+        })
+        assert detect_model_type(tmp_path) == "audio_sts"
+
     def test_sts_model_types_set_contains_expected_entries(self):
         """AUDIO_STS_MODEL_TYPES contains the expected STS model families."""
         # When mlx-audio is installed these come from directory scanning;

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -410,6 +410,50 @@ class TestDetectModelType:
         (tmp_path / "config.json").write_text(json.dumps(config))
         assert detect_model_type(tmp_path) == "llm"
 
+    def test_detect_lfm2_text_model_is_llm(self, tmp_path):
+        """LiquidAI LFM2 text models use model_type='lfm2' and should not be embeddings."""
+        model_dir = tmp_path / "LFM2.5-1.2B-Instruct"
+        model_dir.mkdir()
+        config = {
+            "model_type": "lfm2",
+            "architectures": ["Lfm2ForCausalLM"],
+        }
+        (model_dir / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(model_dir) == "llm"
+
+    def test_detect_lfm2_moe_text_model_is_llm(self, tmp_path):
+        """LiquidAI LFM2 MoE text models should not fall through to audio_sts."""
+        model_dir = tmp_path / "LFM2.5-8B-A1B-MLX-8bit"
+        model_dir.mkdir()
+        config = {
+            "model_type": "lfm2_moe",
+            "architectures": ["Lfm2MoeForCausalLM"],
+        }
+        (model_dir / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(model_dir) == "llm"
+
+    def test_detect_lfm2_embedding_model_by_name(self, tmp_path):
+        """LFM2 embedding variants can still opt into embedding routing by name."""
+        embed_dir = tmp_path / "LFM2-Embedding-4bit"
+        embed_dir.mkdir()
+        config = {
+            "model_type": "lfm2",
+            "architectures": ["Lfm2ForCausalLM"],
+        }
+        (embed_dir / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(embed_dir) == "embedding"
+
+    def test_detect_lfm2_vl_model_is_vlm(self, tmp_path):
+        """LiquidAI LFM2-VL models should route through the VLM engine."""
+        config = {
+            "model_type": "lfm2_vl",
+            "architectures": ["Lfm2VlForConditionalGeneration"],
+            "vision_config": {"hidden_size": 1024},
+            "text_config": {"model_type": "lfm2"},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "vlm"
+
 
 class TestEstimateModelSize:
     """Tests for estimate_model_size function."""


### PR DESCRIPTION
Fixes #1501.

## Summary

- classify LFM2/LFM2-MoE causal LM configs as `llm`
- keep LFM2 embedding variants routable by the existing embedding name heuristic
- add explicit LFM2-VL and LFM2-Audio architecture/model-type coverage
- remove the broad `lfm*` audio fallback that caught text models

## Testing

- `uv run pytest tests/test_model_discovery.py tests/test_audio_discovery.py`
- manual local config check:
  - `LiquidAI/LFM2.5-8B-A1B-MLX-8bit` -> `llm`
  - `LiquidAI/LFM2.5-1.2B-Instruct` -> `llm`
  - `LiquidAI/LFM2.5-VL-1.6B` -> `vlm`
  - `mlx-community/LFM2.5-Audio-1.5B-6bit` -> `audio_sts`
