### PR TITLE
fix(anthropic_models): relax role field and fix line-length formatting

### DIFF
--- a/omlx/api/anthropic_models.py
+++ b/omlx/api/anthropic_models.py
@@ -30,7 +30,9 @@ class ContentBlockImage(BaseModel):
     """Image content block with source data."""
 
     type: Literal["image"] = "image"
-    source: dict[str, Any]  # {"type": "base64"|"url", "media_type": "...", "data"|"url": "..."}
+    source: dict[
+        str, Any
+    ]  # {"type": "base64"|"url", "media_type": "...", "data"|"url": "..."}
 
 
 class ContentBlockToolUse(BaseModel):
@@ -63,7 +65,9 @@ class ContentBlockDocument(BaseModel):
     """Document content block (PDF, plain text)."""
 
     type: Literal["document"] = "document"
-    source: dict[str, Any]  # {"type": "base64", "media_type": "application/pdf", "data": "..."}
+    source: dict[
+        str, Any
+    ]  # {"type": "base64", "media_type": "application/pdf", "data": "..."}
     title: str | None = None
     context: str | None = None
     citations: dict[str, Any] | None = None
@@ -102,7 +106,7 @@ class SystemContent(BaseModel):
 class AnthropicMessage(BaseModel):
     """A message in an Anthropic conversation."""
 
-    role: Literal["user", "assistant"]
+    role: str
     content: str | list[ContentBlock]
 
 
@@ -231,7 +235,9 @@ class MessagesResponse(BaseModel):
     role: Literal["assistant"] = "assistant"
     model: str
     content: list[ContentBlockText | ContentBlockToolUse | ContentBlockThinking]
-    stop_reason: Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"] | None = None
+    stop_reason: (
+        Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"] | None
+    ) = None
     stop_sequence: str | None = None
     usage: AnthropicUsage = Field(default_factory=AnthropicUsage)
 


### PR DESCRIPTION
## Summary

- Relax `role` field in `AnthropicMessage` from `Literal["user", "assistant"]` to `str` to accommodate roles beyond the two hardcoded values (e.g. tool results or future role types)
- Reformat long `source` type annotations in `ContentBlockImage`, `ContentBlockDocument`, and `stop_reason` in `MessagesResponse` to fit within line-length limits

## Test plan

- [ ] Verify existing Anthropic message parsing still works for `user` and `assistant` roles
- [ ] Confirm messages with non-standard roles no longer raise validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)