### PR TITLE
fix(menubar): show live server port after restart, not stale config snapshot

### DIFF
--- a/apps/omlx-mac/Sources/Menubar/MenubarController.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarController.swift
@@ -291,9 +291,10 @@ final class MenubarController: NSObject {
                 .systemBlue
             )
         case .running(let pid):
+            let port = MenubarController.displayPort(server: server, fallback: config.port)
             return (
                 String(localized: "menubar.header.running",
-                       defaultValue: "Server: running · pid \(String(pid)) · :\(String(config.port))",
+                       defaultValue: "Server: running · pid \(String(pid)) · :\(String(port))",
                        comment: "Menubar status header when the server is running; placeholders are PID and port (rendered as plain integers, no grouping)"),
                 .systemGreen
             )
@@ -478,8 +479,9 @@ final class MenubarController: NSObject {
     private func presentPortConflictAlert(_ conflict: PortConflict) {
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
+        let port = MenubarController.displayPort(server: server, fallback: config.port)
         alert.messageText = String(localized: "menubar.alert.port_in_use.title",
-                                   defaultValue: "Port \(String(config.port)) is in use.",
+                                   defaultValue: "Port \(String(port)) is in use.",
                                    comment: "Title of the port-conflict alert; placeholder is the port number (plain integer, no grouping)")
         let pidStr = conflict.pid.map {
             String(localized: "menubar.alert.pid_known",
@@ -493,7 +495,7 @@ final class MenubarController: NSObject {
                      defaultValue: "Another oMLX server is already running on this port (\(pidStr)). Stop it before starting a new instance, or change the port in Settings.",
                      comment: "Port-conflict alert body when the conflicting process is another oMLX instance")
             : String(localized: "menubar.alert.port_in_use.other",
-                     defaultValue: "Another process (\(pidStr)) is listening on port \(String(config.port)). Choose a different port in Settings or terminate that process.",
+                     defaultValue: "Another process (\(pidStr)) is listening on port \(String(port)). Choose a different port in Settings or terminate that process.",
                      comment: "Port-conflict alert body when an unrelated process owns the port")
         alert.addButton(withTitle: String(localized: "menubar.alert.ok",
                                           defaultValue: "OK",
@@ -510,7 +512,9 @@ final class MenubarController: NSObject {
     }
 
     @objc private func openChat() {
-        guard let url = URL(string: "http://\(config.host):\(config.port)/admin/chat") else { return }
+        let host = MenubarController.displayHost(server: server, fallback: config.host)
+        let port = MenubarController.displayPort(server: server, fallback: config.port)
+        guard let url = URL(string: "http://\(host):\(port)/admin/chat") else { return }
         NSWorkspace.shared.open(url)
     }
 
@@ -557,6 +561,30 @@ final class MenubarController: NSObject {
     private func tps(_ value: Double?) -> String {
         guard let v = value else { return "—" }
         return String(format: "%.1f tok/s", v)
+    }
+}
+
+// MARK: - Live endpoint resolution
+
+extension MenubarController {
+    /// Source-of-truth port for any menubar item that renders the
+    /// current bind port (status header, port-conflict alert, Chat URL).
+    /// The running server is authoritative — `config` here is just the
+    /// snapshot we were constructed with and goes stale after the user
+    /// changes the port via Server screen's Apply, which calls
+    /// `server.reconfigure(port:)` and updates `AppServices.config` but
+    /// not the menubar's local `config` copy.
+    ///
+    /// Internal access (not private) so `MenubarControllerPortTests`
+    /// can exercise it without instantiating the full controller (which
+    /// requires a live `NSStatusBar`).
+    static func displayPort(server: ServerProcess?, fallback: Int) -> Int {
+        server?.port ?? fallback
+    }
+
+    /// Companion to `displayPort(server:fallback:)` — same rationale.
+    static func displayHost(server: ServerProcess?, fallback: String) -> String {
+        server?.host ?? fallback
     }
 }
 

--- a/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
@@ -1,0 +1,99 @@
+// Regression coverage for the menubar-shows-stale-port bug.
+//
+// Before the fix, MenubarController captured `config: AppConfig` by value
+// at init and rendered `config.port` in the running-status header / port
+// alert / Chat URL. The user-facing flow:
+//   1. ServerScreen's Apply commits a new port via
+//      `AppServices.applyServerEndpoint(port:)`.
+//   2. AppServices calls `server.reconfigure(port:)` and restarts the
+//      ServerProcess on the new port.
+//   3. The server transitions to `.running(newPid)`; the menubar's
+//      stateDidChange observer fires `refreshMenuState()`.
+//   4. `refreshMenuState()` rebuilds the header — and read the OLD port
+//      from the stale `config` snapshot. The user saw `:8080` after
+//      changing to `:8964`.
+//
+// Fix: `MenubarController.displayPort(server:fallback:)` sources from
+// the live server (which `reconfigure(port:)` updates), falling back to
+// the captured config snapshot only when there is no server (bootstrap
+// failed). These tests exercise the helper directly — instantiating the
+// full controller in a unit test would require a live `NSStatusBar`.
+
+import Foundation
+import XCTest
+@testable import oMLX
+
+@MainActor
+final class MenubarControllerPortTests: XCTestCase {
+
+    /// Test-only PythonRuntime. ServerProcess holds it but doesn't
+    /// dereference until `start()` — these tests never start, they just
+    /// read `.port` / `.host` after `reconfigure`.
+    private func makeRuntime() -> PythonRuntime {
+        PythonRuntime(
+            executable: URL(fileURLWithPath: "/usr/bin/true"),
+            homebrewPaths: [],
+            pythonPath: [],
+            pythonHome: nil,
+            isBundled: false
+        )
+    }
+
+    // MARK: - displayPort
+
+    func testDisplayPortFallsBackToConfigWhenNoServer() {
+        XCTAssertEqual(
+            MenubarController.displayPort(server: nil, fallback: 8080),
+            8080,
+            "With no server (bootstrap failed), the displayed port must come from the AppConfig snapshot."
+        )
+    }
+
+    func testDisplayPortPrefersLiveServer() {
+        let server = ServerProcess(runtime: makeRuntime(), port: 8888)
+        XCTAssertEqual(
+            MenubarController.displayPort(server: server, fallback: 8080),
+            8888,
+            "When a server is present, its `port` is authoritative — `fallback` is only for the no-server case."
+        )
+    }
+
+    func testDisplayPortFollowsReconfigure() throws {
+        // The original bug: menubar's `config.port` snapshot never sees
+        // this change, so the running-header text keeps showing 8080.
+        let server = ServerProcess(runtime: makeRuntime(), port: 8080)
+        try server.reconfigure(port: 8964)
+        XCTAssertEqual(
+            MenubarController.displayPort(server: server, fallback: 8080),
+            8964,
+            "After Server screen's Apply commits a new port (which calls server.reconfigure(port:)), the menubar must source from the live server."
+        )
+    }
+
+    // MARK: - displayHost
+
+    func testDisplayHostFallsBackToConfigWhenNoServer() {
+        XCTAssertEqual(
+            MenubarController.displayHost(server: nil, fallback: "127.0.0.1"),
+            "127.0.0.1"
+        )
+    }
+
+    func testDisplayHostPrefersLiveServer() {
+        let server = ServerProcess(runtime: makeRuntime(), host: "0.0.0.0", port: 8080)
+        XCTAssertEqual(
+            MenubarController.displayHost(server: server, fallback: "127.0.0.1"),
+            "0.0.0.0"
+        )
+    }
+
+    func testDisplayHostFollowsReconfigure() throws {
+        let server = ServerProcess(runtime: makeRuntime(), host: "127.0.0.1", port: 8080)
+        try server.reconfigure(host: "0.0.0.0")
+        XCTAssertEqual(
+            MenubarController.displayHost(server: server, fallback: "127.0.0.1"),
+            "0.0.0.0",
+            "Listen Address changes propagate to the server via saveHost → applyServerEndpoint → server.reconfigure(host:); the menubar must reflect that."
+        )
+    }
+}

--- a/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
+++ b/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		DBB00000000000000000000D /* DTOFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000D /* DTOFixtureTests.swift */; };
 		DBB00000000000000000000E /* ServerProcessIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */; };
 		DBB00000000000000000000F /* LocalizationSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000F /* LocalizationSmokeTests.swift */; };
+		DBB000000000000000000100 /* MenubarControllerPortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000100 /* MenubarControllerPortTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -191,6 +192,7 @@
 		DCC00000000000000000000D /* DTOFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTOFixtureTests.swift; sourceTree = "<group>"; };
 		DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerProcessIntegrationTests.swift; sourceTree = "<group>"; };
 		DCC00000000000000000000F /* LocalizationSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationSmokeTests.swift; sourceTree = "<group>"; };
+		DCC000000000000000000100 /* MenubarControllerPortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarControllerPortTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000010 /* oMLXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = oMLXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -248,6 +250,7 @@
 				DCC00000000000000000000D /* DTOFixtureTests.swift */,
 				DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */,
 				DCC00000000000000000000F /* LocalizationSmokeTests.swift */,
+				DCC000000000000000000100 /* MenubarControllerPortTests.swift */,
 			);
 			path = oMLXTests;
 			sourceTree = "<group>";
@@ -627,6 +630,7 @@
 				DBB00000000000000000000D /* DTOFixtureTests.swift in Sources */,
 				DBB00000000000000000000E /* ServerProcessIntegrationTests.swift in Sources */,
 				DBB00000000000000000000F /* LocalizationSmokeTests.swift in Sources */,
+				DBB000000000000000000100 /* MenubarControllerPortTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary

After changing the server port via Server screen's Apply and letting the server restart, the menubar status header kept showing the *original* port (`:8080`) instead of the new one (`:8964`). Same stale-snapshot bug also affected the port-in-use alert and the Chat menu item's URL.

## Root cause

`MenubarController.config` is captured by value at init (`private let config: AppConfig`). When `AppServices.applyServerEndpoint(port:)`:

1. mutates `AppServices.config.port`
2. calls `server.reconfigure(port:)` so the running `ServerProcess` knows the new port
3. restarts the process — `ServerProcess.stateDidChangeNotification` fires
4. menubar's observer calls `refreshMenuState()` → `headerDisplay(.running(pid))` → reads `config.port`

…step 4 reads from the captured snapshot, which never saw step 1. So `:8080` stuck.

## Fix

Source the displayed port (and host) from the live `ServerProcess` — which `reconfigure(host:port:)` keeps current — falling back to the captured config only when there is no server (bootstrap failed).

Two `static` helpers on `MenubarController` so they can be unit-tested without instantiating the full controller (which needs a live `NSStatusBar`):

```swift
static func displayPort(server: ServerProcess?, fallback: Int) -> Int {
    server?.port ?? fallback
}
static func displayHost(server: ServerProcess?, fallback: String) -> String {
    server?.host ?? fallback
}
```

Updated 4 user-facing sites:
- `.running(pid)` header (`menubar.header.running`)
- Port-in-use alert title (`menubar.alert.port_in_use.title`)
- Port-in-use alert body (`menubar.alert.port_in_use.other`)
- Chat menu URL

Listen Address picker already commits via `AppServices.applyServerEndpoint(host:)` → `server.reconfigure(host:)`, so the same fix also covers the parallel "menubar shows stale host" path.

## Test plan

New `MenubarControllerPortTests` (6 cases, all pass):

- [x] `displayPort(server: nil, fallback:)` returns the fallback
- [x] `displayPort(server: realServer, fallback:)` prefers the server's port
- [x] After `server.reconfigure(port:)`, `displayPort` follows — **the regression case**
- [x] Same three for `displayHost`

```
Executed 6 tests, with 0 failures (0 unexpected) in 0.004 seconds
** TEST SUCCEEDED **
```

Manual verification deferred to the reviewer's full Release stage: change port in Server tab → click Apply → server restarts → open menubar → header shows new port.

## Notes

- New test file's Xcode project slot is `100` (not `010`, which collides with the existing `oMLXTests.xctest` product reference — Xcode silently drops the dupe and the test class never reaches the bundle).
- Diff: 3 files, +135/−4 (the +135 is the test file's body).