### PR TITLE
fix(oq): strip _vision suffix from VisionConfig.model_type for VLM loads

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -1609,6 +1609,12 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
             vision_config = model_config.vision_config
             if isinstance(vision_config, dict):
                 vision_config = model_module.VisionConfig.from_dict(vision_config)
+            if hasattr(vision_config, "model_type") and isinstance(
+                vision_config.model_type, str
+            ) and vision_config.model_type.endswith("_vision"):
+                vision_config.model_type = vision_config.model_type.removesuffix(
+                    "_vision"
+                )
             text_config = model_config.text_config
             if isinstance(text_config, dict):
                 text_config = model_module.TextConfig.from_dict(text_config)

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -16,6 +16,46 @@ logger = logging.getLogger(__name__)
 _VLM_TEXT_PREFIX = "language_model."
 
 _MLX_LM_LOAD_CONFIG_PATCHED = False
+_VLM_VISION_CONFIG_MT_PATCHED = False
+
+
+def _patch_vlm_vision_config_model_type() -> None:
+    """Strip ``_vision`` suffix from ``VisionConfig.model_type``.
+
+    HuggingFace transformers auto-generates ``vision_config.model_type`` by
+    appending ``_vision`` to the base model type (e.g. ``qwen3_5_moe_vision``).
+    mlx-vlm's ``VisionModel.__init__`` has a hardcoded allowlist that only
+    accepts the base name. Normalise here so VLM checkpoints with the HF
+    convention load without error.
+
+    Patched at the ``BaseModelConfig`` level so every VisionConfig subclass
+    (qwen3_vl, qwen3_5_moe, future families) inherits the fix automatically.
+    """
+    global _VLM_VISION_CONFIG_MT_PATCHED
+    if _VLM_VISION_CONFIG_MT_PATCHED:
+        return
+
+    try:
+        from mlx_vlm.models.base import BaseModelConfig
+    except ImportError:
+        return
+
+    if getattr(BaseModelConfig, "_omlx_vision_mt_patched", False):
+        _VLM_VISION_CONFIG_MT_PATCHED = True
+        return
+
+    original = BaseModelConfig.from_dict.__func__
+
+    def patched(cls, params):
+        if params and isinstance(params, dict):
+            mt = params.get("model_type", "")
+            if isinstance(mt, str) and mt.endswith("_vision"):
+                params = {**params, "model_type": mt.removesuffix("_vision")}
+        return original(cls, params)
+
+    BaseModelConfig.from_dict = classmethod(patched)
+    BaseModelConfig._omlx_vision_mt_patched = True
+    _VLM_VISION_CONFIG_MT_PATCHED = True
 
 
 def expand_per_layer_quant_keys(cfg: dict) -> dict:
@@ -112,6 +152,7 @@ def maybe_apply_pre_load_patches(
     set_mtp_active(False)
 
     _patch_mlx_lm_load_config()
+    _patch_vlm_vision_config_model_type()
 
     config_path = Path(model_name) / "config.json"
     if not config_path.exists():


### PR DESCRIPTION
## Summary
- HuggingFace transformers appends `_vision` to vision sub-config `model_type` (e.g. `qwen3_5_moe_vision`), but mlx-vlm's `VisionModel.__init__` only accepts the base name.
- This broke both oQ sensitivity measurement (instant "produced no scores" failure) and sanitize-plan discovery (output kept HF-format keys, causing "2052 parameters not in model" on load).
- Two fix sites: `BaseModelConfig.from_dict` monkey-patch for VLM model loads, and `_build_model_sanitizer` normalization for the `_maybe_deserialize_config` bypass path.

## Test plan
- Run oQ quantization on a Qwen3.6 VLM model and verify sensitivity measurement completes
- Verify sanitized weights load without "parameters not in model" errors
- Confirm non-VLM quantization is unaffected