### PR TITLE
fix: cache size validation and SSD cache auto settings

### DIFF
--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -3505,7 +3505,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "RAM ceiling for hot cache. \"0\" disables, \"8GB\" or \"auto\" accepted."
+            "value" : "RAM ceiling for hot cache. \"0\" disables; positive sizes like \"8GB\" enable it."
           }
         }
       }

--- a/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
@@ -243,14 +243,12 @@ private struct CacheSection: View {
                               defaultValue: "Hot Cache Size",
                               comment: "Row label for the hot cache size field"),
                 sublabel: String(localized: "performance.cache.hot_size.sub",
-                                 defaultValue: "RAM ceiling for hot cache. \"0\" disables, \"8GB\" or \"auto\" accepted.",
+                                 defaultValue: "RAM ceiling for hot cache. \"0\" disables; positive sizes like \"8GB\" enable it.",
                                  comment: "Sublabel describing accepted hot cache size values")
             ) {
                 TextInput(
                     text: $vm.hotCacheMaxSize,
-                    placeholder: String(localized: "performance.memory.placeholder_auto",
-                                        defaultValue: "auto",
-                                        comment: "Memory field placeholder meaning automatic"),
+                    placeholder: "0",
                     mono: true,
                     width: 140
                 )
@@ -367,9 +365,9 @@ final class PerformanceScreenVM: ObservableObject {
             || modelFallback != loadedModelFallback
             || cacheEnabled != loadedCacheEnabled
             || hotCacheOnly != loadedHotCacheOnly
-            || trim(hotCacheMaxSize) != loadedHotCacheMaxSize
+            || normalizedHotCacheMaxSize != loadedHotCacheMaxSize
             || trim(ssdCacheDir) != loadedSsdCacheDir
-            || trim(ssdCacheMaxSize) != loadedSsdCacheMaxSize
+            || normalizedSsdCacheMaxSize != loadedSsdCacheMaxSize
             || parsedInitialCacheBlocks != loadedInitialCacheBlocks
     }
 
@@ -484,11 +482,11 @@ final class PerformanceScreenVM: ObservableObject {
         // Cache
         if cacheEnabled != loadedCacheEnabled { patch.cacheEnabled = cacheEnabled }
         if hotCacheOnly != loadedHotCacheOnly { patch.hotCacheOnly = hotCacheOnly }
-        let hcm = trim(hotCacheMaxSize)
+        let hcm = normalizedHotCacheMaxSize
         if hcm != loadedHotCacheMaxSize { patch.hotCacheMaxSize = hcm }
         let scd = trim(ssdCacheDir)
         if scd != loadedSsdCacheDir { patch.ssdCacheDir = scd }
-        let scm = trim(ssdCacheMaxSize)
+        let scm = normalizedSsdCacheMaxSize
         if scm != loadedSsdCacheMaxSize { patch.ssdCacheMaxSize = scm }
         if initBlocks != loadedInitialCacheBlocks, let n = initBlocks {
             patch.initialCacheBlocks = n
@@ -537,6 +535,16 @@ final class PerformanceScreenVM: ObservableObject {
     private var parsedInitialCacheBlocks: Int? {
         let t = initialCacheBlocksText.trimmingCharacters(in: .whitespaces)
         return t.isEmpty ? nil : Int(t)
+    }
+
+    private var normalizedHotCacheMaxSize: String {
+        let trimmed = trim(hotCacheMaxSize)
+        return trimmed.isEmpty ? "0" : trimmed
+    }
+
+    private var normalizedSsdCacheMaxSize: String {
+        let trimmed = trim(ssdCacheMaxSize)
+        return trimmed.isEmpty ? "auto" : trimmed
     }
 
     private func trim(_ s: String) -> String {

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -9,6 +9,7 @@ This module provides HTTP routes for the admin panel including:
 """
 
 import asyncio
+import copy
 import inspect
 import json
 import logging
@@ -33,7 +34,11 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
 from ..model_profiles import EXCLUDED_FROM_PROFILES
-from ..settings import SubKeyEntry
+from ..settings import (
+    SubKeyEntry,
+    normalize_hot_cache_max_size,
+    normalize_ssd_cache_max_size,
+)
 from ..utils.release_check import select_latest_stable_release
 from .auth import (
     REMEMBER_ME_MAX_AGE,
@@ -603,6 +608,24 @@ async def _apply_model_dirs_runtime(model_dirs: list[str]) -> tuple[bool, str]:
     )
 
 
+def _validate_model_dirs_for_runtime(model_dirs: list[str]) -> None:
+    """Validate model directories before persisting a runtime change."""
+    for model_dir in model_dirs:
+        model_path = Path(model_dir).expanduser().resolve()
+        if not model_path.exists():
+            raise HTTPException(
+                status_code=400,
+                detail=f"Failed to change model directories: "
+                f"Model directory does not exist: {model_dir}",
+            )
+        if not model_path.is_dir():
+            raise HTTPException(
+                status_code=400,
+                detail=f"Failed to change model directories: "
+                f"Path is not a directory: {model_dir}",
+            )
+
+
 async def _reload_models() -> tuple[bool, str]:
     """
     Reload models: re-read model_settings.json, re-scan dirs, re-apply overrides,
@@ -693,6 +716,7 @@ async def _apply_cache_settings_runtime(
     ssd_cache_dir: str | None,
     ssd_cache_max_size: str | None,
     global_settings,
+    hot_cache_only: bool | None = None,
     hot_cache_max_size: str | None = None,
 ) -> tuple[bool, str]:
     """
@@ -712,6 +736,20 @@ async def _apply_cache_settings_runtime(
 
     pool = _server_state.engine_pool
 
+    effective_hot_cache_only = (
+        hot_cache_only
+        if hot_cache_only is not None
+        else global_settings.cache.hot_cache_only
+    )
+    old_hot_cache_only = getattr(pool._scheduler_config, "hot_cache_only", False)
+    pool._scheduler_config.hot_cache_only = effective_hot_cache_only
+    if effective_hot_cache_only != old_hot_cache_only:
+        logger.info(
+            "Hot-cache-only mode changed: %s -> %s",
+            old_hot_cache_only,
+            effective_hot_cache_only,
+        )
+
     # Update scheduler config based on cache settings
     if enabled is False or (enabled is None and not global_settings.cache.enabled):
         pool._scheduler_config.paged_ssd_cache_dir = None
@@ -729,6 +767,7 @@ async def _apply_cache_settings_runtime(
             )
 
         if ssd_cache_max_size is not None:
+            ssd_cache_max_size = normalize_ssd_cache_max_size(ssd_cache_max_size)
             # Handle "auto" value
             if ssd_cache_max_size.lower() == "auto":
                 pool._scheduler_config.paged_ssd_cache_max_size = (
@@ -2786,6 +2825,223 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
     }
 
 
+def _raise_global_settings_errors(errors: list[str]) -> None:
+    if errors:
+        raise HTTPException(
+            status_code=400,
+            detail=errors[0] if len(errors) == 1 else errors,
+        )
+
+
+def _restore_global_settings_data(settings, snapshot) -> None:
+    """Restore settings data after a failed transactional update."""
+    for name, value in snapshot.__dict__.items():
+        setattr(settings, name, copy.deepcopy(value))
+
+
+def _clean_server_aliases(server_aliases: list[str]) -> list[str]:
+    from ..utils.network import is_valid_alias
+
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for alias in server_aliases:
+        if not isinstance(alias, str):
+            raise ValueError("Invalid server alias: each alias must be a string")
+        value = alias.strip()
+        if not value or value in seen:
+            continue
+        if not is_valid_alias(value):
+            raise ValueError(
+                f"Invalid server alias: {value!r} (must be a hostname or IP address)"
+            )
+        seen.add(value)
+        cleaned.append(value)
+    return cleaned
+
+
+def _apply_global_settings_data_patch(
+    settings,
+    request: GlobalSettingsRequest,
+    *,
+    server_aliases: list[str] | None,
+    ssd_cache_max_size: str | None,
+    hot_cache_max_size: str | None,
+) -> None:
+    """Apply the pure data portion of a global-settings patch."""
+    if request.host is not None:
+        settings.server.host = request.host
+    if request.port is not None:
+        settings.server.port = request.port
+    if request.log_level is not None:
+        settings.server.log_level = request.log_level
+    if request.sse_keepalive_mode is not None:
+        settings.server.sse_keepalive_mode = request.sse_keepalive_mode
+    if request.server_aliases is not None:
+        settings.server.server_aliases = server_aliases
+
+    if request.model_dirs is not None:
+        new_dirs = [d for d in request.model_dirs if d.strip()]
+        settings.model.model_dirs = new_dirs
+        settings.model.model_dir = new_dirs[0] if new_dirs else None
+    elif request.model_dir is not None:
+        settings.model.model_dirs = [request.model_dir]
+        settings.model.model_dir = request.model_dir
+    if request.model_fallback is not None:
+        settings.model.model_fallback = request.model_fallback
+
+    if request.memory_guard_tier is not None:
+        settings.memory.memory_guard_tier = request.memory_guard_tier
+    if request.memory_guard_custom_ceiling_gb is not None:
+        settings.memory.memory_guard_custom_ceiling_gb = float(
+            request.memory_guard_custom_ceiling_gb
+        )
+    if request.memory_prefill_memory_guard is not None:
+        settings.memory.prefill_memory_guard = request.memory_prefill_memory_guard
+
+    if request.max_concurrent_requests is not None:
+        settings.scheduler.max_concurrent_requests = request.max_concurrent_requests
+    if request.embedding_batch_size is not None:
+        settings.scheduler.embedding_batch_size = request.embedding_batch_size
+    if request.chunked_prefill is not None:
+        settings.scheduler.chunked_prefill = request.chunked_prefill
+
+    if request.cache_enabled is not None:
+        settings.cache.enabled = request.cache_enabled
+    if request.ssd_cache_dir is not None:
+        settings.cache.ssd_cache_dir = request.ssd_cache_dir
+    if request.ssd_cache_max_size is not None and ssd_cache_max_size is not None:
+        settings.cache.ssd_cache_max_size = ssd_cache_max_size
+    if request.hot_cache_only is not None:
+        settings.cache.hot_cache_only = request.hot_cache_only
+    if request.hot_cache_max_size is not None and hot_cache_max_size is not None:
+        settings.cache.hot_cache_max_size = hot_cache_max_size
+    if request.initial_cache_blocks is not None:
+        settings.cache.initial_cache_blocks = request.initial_cache_blocks
+
+    if request.mcp_config is not None:
+        settings.mcp.config_path = request.mcp_config if request.mcp_config else None
+    if request.hf_endpoint is not None:
+        settings.huggingface.endpoint = request.hf_endpoint
+    if request.ms_endpoint is not None:
+        settings.modelscope.endpoint = request.ms_endpoint
+    if request.network_http_proxy is not None:
+        settings.network.http_proxy = request.network_http_proxy
+    if request.network_https_proxy is not None:
+        settings.network.https_proxy = request.network_https_proxy
+    if request.network_no_proxy is not None:
+        settings.network.no_proxy = request.network_no_proxy
+    if request.network_ca_bundle is not None:
+        settings.network.ca_bundle = request.network_ca_bundle
+
+    if request.sampling_max_context_window is not None:
+        settings.sampling.max_context_window = request.sampling_max_context_window
+    if request.sampling_max_tokens is not None:
+        settings.sampling.max_tokens = request.sampling_max_tokens
+    if request.sampling_temperature is not None:
+        settings.sampling.temperature = request.sampling_temperature
+    if request.sampling_top_p is not None:
+        settings.sampling.top_p = request.sampling_top_p
+    if request.sampling_top_k is not None:
+        settings.sampling.top_k = request.sampling_top_k
+    if request.sampling_repetition_penalty is not None:
+        settings.sampling.repetition_penalty = request.sampling_repetition_penalty
+
+    if request.claude_code_context_scaling_enabled is not None:
+        settings.claude_code.context_scaling_enabled = (
+            request.claude_code_context_scaling_enabled
+        )
+    if request.claude_code_target_context_size is not None:
+        settings.claude_code.target_context_size = (
+            request.claude_code_target_context_size
+        )
+    if request.claude_code_mode is not None:
+        settings.claude_code.mode = request.claude_code_mode
+    if "claude_code_opus_model" in request.model_fields_set:
+        settings.claude_code.opus_model = request.claude_code_opus_model
+    if "claude_code_sonnet_model" in request.model_fields_set:
+        settings.claude_code.sonnet_model = request.claude_code_sonnet_model
+    if "claude_code_haiku_model" in request.model_fields_set:
+        settings.claude_code.haiku_model = request.claude_code_haiku_model
+
+    if "integrations_copilot_model" in request.model_fields_set:
+        settings.integrations.copilot_model = request.integrations_copilot_model
+    if "integrations_codex_model" in request.model_fields_set:
+        settings.integrations.codex_model = request.integrations_codex_model
+    if "integrations_opencode_model" in request.model_fields_set:
+        settings.integrations.opencode_model = request.integrations_opencode_model
+    if "integrations_openclaw_model" in request.model_fields_set:
+        settings.integrations.openclaw_model = request.integrations_openclaw_model
+    if "integrations_hermes_model" in request.model_fields_set:
+        settings.integrations.hermes_model = request.integrations_hermes_model
+    if "integrations_pi_model" in request.model_fields_set:
+        settings.integrations.pi_model = request.integrations_pi_model
+    if "integrations_openclaw_tools_profile" in request.model_fields_set:
+        settings.integrations.openclaw_tools_profile = (
+            request.integrations_openclaw_tools_profile
+        )
+
+    if request.ui_language is not None:
+        settings.ui.language = request.ui_language
+    if "idle_timeout_seconds" in request.model_fields_set:
+        settings.idle_timeout.idle_timeout_seconds = request.idle_timeout_seconds
+    if request.skip_api_key_verification is not None:
+        settings.auth.skip_api_key_verification = request.skip_api_key_verification
+    if request.api_key is not None:
+        settings.auth.api_key = request.api_key
+
+
+def _preflight_global_settings_request(
+    global_settings,
+    request: GlobalSettingsRequest,
+) -> tuple[list[str] | None, str | None, str | None]:
+    """Validate a candidate settings object before mutating live state."""
+    errors: list[str] = []
+    cleaned_server_aliases: list[str] | None = None
+    if request.server_aliases is not None:
+        try:
+            cleaned_server_aliases = _clean_server_aliases(request.server_aliases)
+        except ValueError as e:
+            errors.append(str(e))
+
+    normalized_ssd_cache_max_size: str | None = None
+    if request.ssd_cache_max_size is not None:
+        try:
+            normalized_ssd_cache_max_size = normalize_ssd_cache_max_size(
+                request.ssd_cache_max_size
+            )
+        except ValueError as e:
+            errors.append(str(e))
+
+    normalized_hot_cache_max_size: str | None = None
+    if request.hot_cache_max_size is not None:
+        try:
+            normalized_hot_cache_max_size = normalize_hot_cache_max_size(
+                request.hot_cache_max_size
+            )
+        except ValueError as e:
+            errors.append(str(e))
+
+    candidate = copy.deepcopy(global_settings)
+    _apply_global_settings_data_patch(
+        candidate,
+        request,
+        server_aliases=cleaned_server_aliases,
+        ssd_cache_max_size=normalized_ssd_cache_max_size,
+        hot_cache_max_size=normalized_hot_cache_max_size,
+    )
+    errors.extend(candidate.validate())
+    if request.api_key is not None:
+        is_valid, error_msg = validate_api_key(request.api_key)
+        if not is_valid:
+            errors.append(error_msg)
+    _raise_global_settings_errors(errors)
+    return (
+        cleaned_server_aliases,
+        normalized_ssd_cache_max_size,
+        normalized_hot_cache_max_size,
+    )
+
+
 @router.post("/api/global-settings")
 async def update_global_settings(
     request: GlobalSettingsRequest,
@@ -2808,102 +3064,74 @@ async def update_global_settings(
         HTTPException: 401 if not authenticated, 503 if server not initialized,
                       400 if validation fails.
     """
-    from ..config import parse_size
-
     global_settings = _get_global_settings()
 
     if global_settings is None:
         raise HTTPException(status_code=503, detail="Server not initialized")
 
-    # Track which settings were applied at runtime
+    (
+        cleaned_server_aliases,
+        normalized_ssd_cache_max_size,
+        normalized_hot_cache_max_size,
+    ) = _preflight_global_settings_request(global_settings, request)
+    settings_snapshot = copy.deepcopy(global_settings)
+
     runtime_applied: list[str] = []
-    pending_embedding_batch_size: int | None = None
-    previous_embedding_batch_size: int | None = None
 
-    # Apply server settings
-    if request.host is not None:
-        global_settings.server.host = request.host
-    if request.port is not None:
-        global_settings.server.port = request.port
-    if request.log_level is not None:
-        global_settings.server.log_level = request.log_level
-        # Apply log level at runtime
-        _apply_log_level_runtime(request.log_level)
-        runtime_applied.append("log_level")
-    if request.sse_keepalive_mode is not None:
-        valid_modes = {"chunk", "comment", "off"}
-        if request.sse_keepalive_mode not in valid_modes:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Invalid sse_keepalive_mode: {request.sse_keepalive_mode} "
-                f"(must be one of {sorted(valid_modes)})",
-            )
-        global_settings.server.sse_keepalive_mode = request.sse_keepalive_mode
-        runtime_applied.append("sse_keepalive_mode")
-
-    if request.server_aliases is not None:
-        from ..utils.network import is_valid_alias
-
-        cleaned: list[str] = []
-        seen: set[str] = set()
-        for alias in request.server_aliases:
-            if not isinstance(alias, str):
-                raise HTTPException(
-                    status_code=400,
-                    detail="Invalid server alias: each alias must be a string",
-                )
-            value = alias.strip()
-            if not value or value in seen:
-                continue
-            if not is_valid_alias(value):
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Invalid server alias: {value!r} (must be a hostname or IP address)",
-                )
-            seen.add(value)
-            cleaned.append(value)
-        global_settings.server.server_aliases = cleaned
-        runtime_applied.append("server_aliases")
-
-    # Apply model settings
     new_dirs = None
     if request.model_dirs is not None:
         new_dirs = [d for d in request.model_dirs if d.strip()]
     elif request.model_dir is not None:
         new_dirs = [request.model_dir]
+    old_dirs = list(global_settings.model.model_dirs)
+    if new_dirs is not None and new_dirs != old_dirs:
+        _validate_model_dirs_for_runtime(new_dirs)
 
-    if new_dirs is not None:
-        old_dirs = global_settings.model.model_dirs
-        if new_dirs != old_dirs:
-            success, msg = await _apply_model_dirs_runtime(new_dirs)
-            if success:
-                global_settings.model.model_dirs = new_dirs
-                global_settings.model.model_dir = new_dirs[0] if new_dirs else None
-                runtime_applied.append("model_dirs")
-                logger.info(msg)
-            else:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Failed to change model directories: {msg}"
-                )
+    _apply_global_settings_data_patch(
+        global_settings,
+        request,
+        server_aliases=cleaned_server_aliases,
+        ssd_cache_max_size=normalized_ssd_cache_max_size,
+        hot_cache_max_size=normalized_hot_cache_max_size,
+    )
+
+    # Validate settings
+    errors = global_settings.validate()
+    if errors:
+        _restore_global_settings_data(global_settings, settings_snapshot)
+        raise HTTPException(status_code=400, detail=errors)
+
+    # Persist to file
+    try:
+        global_settings.save()
+    except Exception as e:
+        _restore_global_settings_data(global_settings, settings_snapshot)
+        raise HTTPException(status_code=500, detail=f"Failed to save settings: {e}")
+
+    # Apply runtime effects only after persistence succeeds.
+    if request.log_level is not None:
+        _apply_log_level_runtime(global_settings.server.log_level)
+        runtime_applied.append("log_level")
+    if request.sse_keepalive_mode is not None:
+        runtime_applied.append("sse_keepalive_mode")
+    if request.server_aliases is not None:
+        runtime_applied.append("server_aliases")
+
+    if new_dirs is not None and new_dirs != old_dirs:
+        success, msg = await _apply_model_dirs_runtime(new_dirs)
+        if success:
+            runtime_applied.append("model_dirs")
+            logger.info(msg)
+        else:
+            logger.warning(f"Failed to apply model directories runtime: {msg}")
 
     if request.model_fallback is not None:
-        global_settings.model.model_fallback = request.model_fallback
         runtime_applied.append("model_fallback")
 
-    # Apply memory guard tier + custom ceiling change (Live)
     if (
         request.memory_guard_tier is not None
         or request.memory_guard_custom_ceiling_gb is not None
     ):
-        if request.memory_guard_tier is not None:
-            global_settings.memory.memory_guard_tier = (
-                request.memory_guard_tier
-            )
-        if request.memory_guard_custom_ceiling_gb is not None:
-            global_settings.memory.memory_guard_custom_ceiling_gb = float(
-                request.memory_guard_custom_ceiling_gb
-            )
         try:
             success, msg = await _apply_memory_guard_tier_runtime(
                 tier=request.memory_guard_tier,
@@ -2917,84 +3145,58 @@ async def update_global_settings(
         except Exception as e:
             logger.warning(f"Error applying memory_guard_tier: {e}")
 
-    # Apply prefill memory guard setting (Live)
     if request.memory_prefill_memory_guard is not None:
-        global_settings.memory.prefill_memory_guard = (
-            request.memory_prefill_memory_guard
-        )
         from ..server import _server_state
 
         if _server_state.process_memory_enforcer is not None:
             _server_state.process_memory_enforcer.prefill_memory_guard = (
-                request.memory_prefill_memory_guard
+                global_settings.memory.prefill_memory_guard
             )
         runtime_applied.append("prefill_memory_guard")
         logger.info(
             f"Prefill memory guard "
-            f"{'enabled' if request.memory_prefill_memory_guard else 'disabled'}"
+            f"{'enabled' if global_settings.memory.prefill_memory_guard else 'disabled'}"
         )
 
-    # Apply scheduler settings (restart required)
-    if request.max_concurrent_requests is not None:
-        global_settings.scheduler.max_concurrent_requests = (
-            request.max_concurrent_requests
-        )
-
-    # Apply embedding batch size setting (Live for loaded embedding engines)
-    if request.embedding_batch_size is not None:
-        if request.embedding_batch_size <= 0:
-            raise HTTPException(
-                status_code=400,
-                detail="Invalid embedding_batch_size: must be > 0",
-            )
-        pending_embedding_batch_size = request.embedding_batch_size
-
-    # Apply chunked prefill setting (Live)
     if request.chunked_prefill is not None:
-        global_settings.scheduler.chunked_prefill = request.chunked_prefill
         from ..server import _server_state
 
         pool = _server_state.engine_pool
         if pool is not None:
-            for mid, entry in pool._entries.items():
+            for _mid, entry in pool._entries.items():
                 if entry is None or entry.engine is None:
                     continue
                 async_core = getattr(entry.engine, "_engine", None)
-                core = getattr(async_core, "engine", None) if async_core is not None else None
-                scheduler = getattr(core, "scheduler", None) if core is not None else None
+                core = getattr(async_core, "engine", None) if async_core else None
+                scheduler = getattr(core, "scheduler", None) if core else None
                 if scheduler is not None and hasattr(scheduler, "config"):
-                    scheduler.config.chunked_prefill = request.chunked_prefill
+                    scheduler.config.chunked_prefill = (
+                        global_settings.scheduler.chunked_prefill
+                    )
         runtime_applied.append("chunked_prefill")
         logger.info(
-            f"Chunked prefill {'enabled' if request.chunked_prefill else 'disabled'}"
+            "Chunked prefill %s",
+            "enabled" if global_settings.scheduler.chunked_prefill else "disabled",
         )
 
-    # Apply cache settings
-    cache_changed = False
-    if request.cache_enabled is not None:
-        global_settings.cache.enabled = request.cache_enabled
-        cache_changed = True
-    if request.ssd_cache_dir is not None:
-        global_settings.cache.ssd_cache_dir = request.ssd_cache_dir
-        cache_changed = True
-    if request.ssd_cache_max_size is not None:
-        global_settings.cache.ssd_cache_max_size = request.ssd_cache_max_size
-        cache_changed = True
-    if request.hot_cache_only is not None:
-        global_settings.cache.hot_cache_only = request.hot_cache_only
-    if request.hot_cache_max_size is not None:
-        global_settings.cache.hot_cache_max_size = request.hot_cache_max_size
-        cache_changed = True
-    if request.initial_cache_blocks is not None:
-        global_settings.cache.initial_cache_blocks = request.initial_cache_blocks
-
+    cache_changed = any(
+        value is not None
+        for value in (
+            request.cache_enabled,
+            request.ssd_cache_dir,
+            request.ssd_cache_max_size,
+            request.hot_cache_only,
+            request.hot_cache_max_size,
+        )
+    )
     if cache_changed:
         success, msg = await _apply_cache_settings_runtime(
             request.cache_enabled,
             request.ssd_cache_dir,
-            request.ssd_cache_max_size,
+            normalized_ssd_cache_max_size,
             global_settings,
-            hot_cache_max_size=request.hot_cache_max_size,
+            hot_cache_only=request.hot_cache_only,
+            hot_cache_max_size=normalized_hot_cache_max_size,
         )
         if success:
             runtime_applied.append("cache")
@@ -3002,103 +3204,76 @@ async def update_global_settings(
         else:
             logger.warning(f"Failed to apply cache settings runtime: {msg}")
 
-    # Apply MCP settings (restart required)
-    if request.mcp_config is not None:
-        global_settings.mcp.config_path = request.mcp_config if request.mcp_config else None
-
-    # Apply HuggingFace settings (Live - immediately applied via env var)
     if request.hf_endpoint is not None:
-        global_settings.huggingface.endpoint = request.hf_endpoint
-        if request.hf_endpoint:
-            os.environ["HF_ENDPOINT"] = request.hf_endpoint
-        elif "HF_ENDPOINT" in os.environ:
-            del os.environ["HF_ENDPOINT"]
+        if global_settings.huggingface.endpoint:
+            os.environ["HF_ENDPOINT"] = global_settings.huggingface.endpoint
+        else:
+            os.environ.pop("HF_ENDPOINT", None)
         runtime_applied.append("hf_endpoint")
         logger.info(
-            f"HuggingFace endpoint updated to: "
-            f"{request.hf_endpoint or '(default)'}"
+            "HuggingFace endpoint updated to: %s",
+            global_settings.huggingface.endpoint or "(default)",
         )
 
-    # Apply ModelScope settings (Live - immediately applied via env var)
     if request.ms_endpoint is not None:
-        global_settings.modelscope.endpoint = request.ms_endpoint
-        if request.ms_endpoint:
-            os.environ["MODELSCOPE_DOMAIN"] = request.ms_endpoint
-        elif "MODELSCOPE_DOMAIN" in os.environ:
-            del os.environ["MODELSCOPE_DOMAIN"]
+        if global_settings.modelscope.endpoint:
+            os.environ["MODELSCOPE_DOMAIN"] = global_settings.modelscope.endpoint
+        else:
+            os.environ.pop("MODELSCOPE_DOMAIN", None)
         runtime_applied.append("ms_endpoint")
         logger.info(
-            f"ModelScope endpoint updated to: "
-            f"{request.ms_endpoint or '(default)'}"
+            "ModelScope endpoint updated to: %s",
+            global_settings.modelscope.endpoint or "(default)",
         )
 
-    # Apply network settings (Live - immediately applied via env vars)
-    network_changed = False
-    if request.network_http_proxy is not None:
-        global_settings.network.http_proxy = request.network_http_proxy
-        if request.network_http_proxy:
-            os.environ["HTTP_PROXY"] = request.network_http_proxy
-            os.environ["http_proxy"] = request.network_http_proxy
+    network_changed = any(
+        value is not None
+        for value in (
+            request.network_http_proxy,
+            request.network_https_proxy,
+            request.network_no_proxy,
+            request.network_ca_bundle,
+        )
+    )
+    if network_changed:
+        if global_settings.network.http_proxy:
+            os.environ["HTTP_PROXY"] = global_settings.network.http_proxy
+            os.environ["http_proxy"] = global_settings.network.http_proxy
         else:
             os.environ.pop("HTTP_PROXY", None)
             os.environ.pop("http_proxy", None)
-        network_changed = True
-
-    if request.network_https_proxy is not None:
-        global_settings.network.https_proxy = request.network_https_proxy
-        if request.network_https_proxy:
-            os.environ["HTTPS_PROXY"] = request.network_https_proxy
-            os.environ["https_proxy"] = request.network_https_proxy
+        if global_settings.network.https_proxy:
+            os.environ["HTTPS_PROXY"] = global_settings.network.https_proxy
+            os.environ["https_proxy"] = global_settings.network.https_proxy
         else:
             os.environ.pop("HTTPS_PROXY", None)
             os.environ.pop("https_proxy", None)
-        network_changed = True
-
-    if request.network_no_proxy is not None:
-        global_settings.network.no_proxy = request.network_no_proxy
-        if request.network_no_proxy:
-            os.environ["NO_PROXY"] = request.network_no_proxy
-            os.environ["no_proxy"] = request.network_no_proxy
+        if global_settings.network.no_proxy:
+            os.environ["NO_PROXY"] = global_settings.network.no_proxy
+            os.environ["no_proxy"] = global_settings.network.no_proxy
         else:
             os.environ.pop("NO_PROXY", None)
             os.environ.pop("no_proxy", None)
-        network_changed = True
-
-    if request.network_ca_bundle is not None:
-        global_settings.network.ca_bundle = request.network_ca_bundle
-        if request.network_ca_bundle:
-            os.environ["REQUESTS_CA_BUNDLE"] = request.network_ca_bundle
-            os.environ["SSL_CERT_FILE"] = request.network_ca_bundle
+        if global_settings.network.ca_bundle:
+            os.environ["REQUESTS_CA_BUNDLE"] = global_settings.network.ca_bundle
+            os.environ["SSL_CERT_FILE"] = global_settings.network.ca_bundle
         else:
             os.environ.pop("REQUESTS_CA_BUNDLE", None)
             os.environ.pop("SSL_CERT_FILE", None)
-        network_changed = True
-
-    if network_changed:
         runtime_applied.append("network")
         logger.info("Network settings updated")
 
-    # Apply sampling settings (Live - immediately applied)
-    sampling_changed = False
-    if request.sampling_max_context_window is not None:
-        global_settings.sampling.max_context_window = request.sampling_max_context_window
-        sampling_changed = True
-    if request.sampling_max_tokens is not None:
-        global_settings.sampling.max_tokens = request.sampling_max_tokens
-        sampling_changed = True
-    if request.sampling_temperature is not None:
-        global_settings.sampling.temperature = request.sampling_temperature
-        sampling_changed = True
-    if request.sampling_top_p is not None:
-        global_settings.sampling.top_p = request.sampling_top_p
-        sampling_changed = True
-    if request.sampling_top_k is not None:
-        global_settings.sampling.top_k = request.sampling_top_k
-        sampling_changed = True
-    if request.sampling_repetition_penalty is not None:
-        global_settings.sampling.repetition_penalty = request.sampling_repetition_penalty
-        sampling_changed = True
-
+    sampling_changed = any(
+        value is not None
+        for value in (
+            request.sampling_max_context_window,
+            request.sampling_max_tokens,
+            request.sampling_temperature,
+            request.sampling_top_p,
+            request.sampling_top_k,
+            request.sampling_repetition_penalty,
+        )
+    )
     if sampling_changed:
         success, msg = _apply_sampling_settings_runtime(
             request.sampling_max_context_window,
@@ -3112,35 +3287,17 @@ async def update_global_settings(
             runtime_applied.append("sampling")
             logger.info(msg)
 
-    # Apply Claude Code settings (Live - immediately applied)
-    claude_code_changed = False
-    if request.claude_code_context_scaling_enabled is not None:
-        global_settings.claude_code.context_scaling_enabled = (
-            request.claude_code_context_scaling_enabled
+    claude_code_changed = any(
+        field in request.model_fields_set
+        for field in (
+            "claude_code_context_scaling_enabled",
+            "claude_code_target_context_size",
+            "claude_code_mode",
+            "claude_code_opus_model",
+            "claude_code_sonnet_model",
+            "claude_code_haiku_model",
         )
-        claude_code_changed = True
-    if request.claude_code_target_context_size is not None:
-        global_settings.claude_code.target_context_size = (
-            request.claude_code_target_context_size
-        )
-        claude_code_changed = True
-    # mode: standard is-not-None check is correct — mode must never be null
-    if request.claude_code_mode is not None:
-        global_settings.claude_code.mode = request.claude_code_mode
-        claude_code_changed = True
-    # model fields: use model_fields_set to distinguish "field absent from POST body"
-    # from "field explicitly sent as null" — null must clear the field to None.
-    # DO NOT use `is not None` here: that would prevent clearing a model field to null.
-    if "claude_code_opus_model" in request.model_fields_set:
-        global_settings.claude_code.opus_model = request.claude_code_opus_model
-        claude_code_changed = True
-    if "claude_code_sonnet_model" in request.model_fields_set:
-        global_settings.claude_code.sonnet_model = request.claude_code_sonnet_model
-        claude_code_changed = True
-    if "claude_code_haiku_model" in request.model_fields_set:
-        global_settings.claude_code.haiku_model = request.claude_code_haiku_model
-        claude_code_changed = True
-
+    )
     if claude_code_changed:
         runtime_applied.append("claude_code")
         logger.info(
@@ -3153,36 +3310,18 @@ async def update_global_settings(
             f"haiku={global_settings.claude_code.haiku_model}"
         )
 
-    # Apply integrations settings (Live - immediately applied)
-    integrations_changed = False
-    if "integrations_copilot_model" in request.model_fields_set:
-        global_settings.integrations.copilot_model = request.integrations_copilot_model
-        integrations_changed = True
-    if "integrations_codex_model" in request.model_fields_set:
-        global_settings.integrations.codex_model = request.integrations_codex_model
-        integrations_changed = True
-    if "integrations_opencode_model" in request.model_fields_set:
-        global_settings.integrations.opencode_model = (
-            request.integrations_opencode_model
+    integrations_changed = any(
+        field in request.model_fields_set
+        for field in (
+            "integrations_copilot_model",
+            "integrations_codex_model",
+            "integrations_opencode_model",
+            "integrations_openclaw_model",
+            "integrations_hermes_model",
+            "integrations_pi_model",
+            "integrations_openclaw_tools_profile",
         )
-        integrations_changed = True
-    if "integrations_openclaw_model" in request.model_fields_set:
-        global_settings.integrations.openclaw_model = (
-            request.integrations_openclaw_model
-        )
-        integrations_changed = True
-    if "integrations_hermes_model" in request.model_fields_set:
-        global_settings.integrations.hermes_model = request.integrations_hermes_model
-        integrations_changed = True
-    if "integrations_pi_model" in request.model_fields_set:
-        global_settings.integrations.pi_model = request.integrations_pi_model
-        integrations_changed = True
-    if "integrations_openclaw_tools_profile" in request.model_fields_set:
-        global_settings.integrations.openclaw_tools_profile = (
-            request.integrations_openclaw_tools_profile
-        )
-        integrations_changed = True
-
+    )
     if integrations_changed:
         runtime_applied.append("integrations")
         logger.info(
@@ -3195,68 +3334,44 @@ async def update_global_settings(
             f"pi={global_settings.integrations.pi_model}"
         )
 
-    # Apply UI settings
     if request.ui_language is not None:
-        global_settings.ui.language = request.ui_language
         runtime_applied.append("ui_language")
         _refresh_i18n_globals()
-        logger.info(f"UI language changed to: {request.ui_language}")
+        logger.info(f"UI language changed to: {global_settings.ui.language}")
 
-    # Apply idle timeout settings (Live)
-    # Use model_fields_set to distinguish "explicitly sent as null" (disable)
-    # from "not sent" (don't touch).
     if "idle_timeout_seconds" in request.model_fields_set:
-        global_settings.idle_timeout.idle_timeout_seconds = request.idle_timeout_seconds
         runtime_applied.append("idle_timeout_seconds")
-        if request.idle_timeout_seconds:
-            logger.info(f"Idle timeout set to: {request.idle_timeout_seconds}s")
+        if global_settings.idle_timeout.idle_timeout_seconds:
+            logger.info(
+                "Idle timeout set to: %ss",
+                global_settings.idle_timeout.idle_timeout_seconds,
+            )
         else:
             logger.info("Idle timeout disabled")
 
-    # Apply auth settings (API key change)
     if request.api_key is not None:
         from ..server import _server_state
 
-        is_valid, error_msg = validate_api_key(request.api_key)
-        if not is_valid:
-            raise HTTPException(status_code=400, detail=error_msg)
-
-        global_settings.auth.api_key = request.api_key
-        _server_state.api_key = request.api_key
+        _server_state.api_key = global_settings.auth.api_key
         runtime_applied.append("api_key")
         logger.info("API key updated via admin settings")
 
     if request.skip_api_key_verification is not None:
-        global_settings.auth.skip_api_key_verification = request.skip_api_key_verification
         runtime_applied.append("skip_api_key_verification")
 
-    if pending_embedding_batch_size is not None:
-        previous_embedding_batch_size = global_settings.scheduler.embedding_batch_size
-        global_settings.scheduler.embedding_batch_size = pending_embedding_batch_size
-
-    # Validate settings
-    errors = global_settings.validate()
-    if errors:
-        if previous_embedding_batch_size is not None:
-            global_settings.scheduler.embedding_batch_size = previous_embedding_batch_size
-        raise HTTPException(status_code=400, detail=errors)
-
-    # Persist to file
-    try:
-        global_settings.save()
-    except Exception as e:
-        if previous_embedding_batch_size is not None:
-            global_settings.scheduler.embedding_batch_size = previous_embedding_batch_size
-        raise HTTPException(status_code=500, detail=f"Failed to save settings: {e}")
-
-    if pending_embedding_batch_size is not None:
+    if request.embedding_batch_size is not None:
         from ..server import _server_state
 
         pool = _server_state.engine_pool
         if pool is not None:
-            await pool.apply_embedding_batch_size(pending_embedding_batch_size)
+            await pool.apply_embedding_batch_size(
+                global_settings.scheduler.embedding_batch_size
+            )
         runtime_applied.append("embedding_batch_size")
-        logger.info(f"Embedding batch size set to {pending_embedding_batch_size}")
+        logger.info(
+            f"Embedding batch size set to "
+            f"{global_settings.scheduler.embedding_batch_size}"
+        )
 
     # Build response message
     message = "Settings saved successfully."

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2716,6 +2716,9 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
         global_settings.cache.get_ssd_cache_dir(global_settings.base_path)
     )
     disk_info = get_ssd_disk_info(cache_dir)
+    ssd_cache_max_size_resolved = _format_cache_size(
+        global_settings.cache.get_ssd_cache_max_size_bytes(global_settings.base_path)
+    )
 
     return {
         "base_path": str(global_settings.base_path),
@@ -2746,10 +2749,8 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
         "cache": {
             "enabled": global_settings.cache.enabled,
             "ssd_cache_dir": cache_dir,
-            # Resolve "auto" to actual value (10% of SSD capacity)
-            "ssd_cache_max_size": _format_cache_size(
-                global_settings.cache.get_ssd_cache_max_size_bytes(global_settings.base_path)
-            ),
+            "ssd_cache_max_size": global_settings.cache.ssd_cache_max_size,
+            "ssd_cache_max_size_resolved": ssd_cache_max_size_resolved,
             "hot_cache_only": global_settings.cache.hot_cache_only,
             "hot_cache_max_size": global_settings.cache.hot_cache_max_size,
             "initial_cache_blocks": global_settings.cache.initial_cache_blocks,

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -3318,7 +3318,7 @@
             percentToCacheString(percent, totalBytes) {
                 if (!totalBytes || totalBytes === 0) return 'auto';
                 const bytes = Math.floor((percent / 100) * totalBytes);
-                const gb = Math.floor(bytes / (1024 * 1024 * 1024));
+                const gb = Math.max(1, Math.floor(bytes / (1024 * 1024 * 1024)));
                 return `${gb}GB`;
             },
 
@@ -3542,7 +3542,7 @@
 
             // Update cache from manual GB input
             updateCacheFromInput(gbValue) {
-                const gb = parseInt(gbValue) || 0;
+                const gb = Math.max(1, parseInt(gbValue) || 1);
                 this.globalSettings.cache.ssd_cache_max_size = `${gb}GB`;
 
                 // Update percent slider

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -703,8 +703,6 @@
                             this.globalSettings.cache.ssd_cache_max_size,
                             this.globalSettings.system.ssd_total_bytes
                         );
-                        // Sync the cache string value from percent
-                        this.updateCacheFromSlider();
 
                         // Calculate hot cache percent from stored value
                         this.hotCachePercent = this.parseHotCacheToPercent(
@@ -3310,8 +3308,8 @@
                 else if (unit === 'GB') bytes *= 1024 * 1024 * 1024;
                 else if (unit === 'MB') bytes *= 1024 * 1024;
 
-                const percent = Math.round((bytes / totalBytes) * 100);
-                return Math.min(100, percent);
+                const percent = Math.round((bytes / totalBytes) * 10000) / 100;
+                return Math.min(100, Math.max(0.01, percent));
             },
 
             // Convert percent to cache size string
@@ -3549,7 +3547,8 @@
                 const totalBytes = this.globalSettings.system?.ssd_total_bytes || 0;
                 if (totalBytes > 0) {
                     const bytes = gb * 1024 * 1024 * 1024;
-                    this.cachePercent = Math.min(100, Math.round((bytes / totalBytes) * 100));
+                    const percent = Math.round((bytes / totalBytes) * 10000) / 100;
+                    this.cachePercent = Math.min(100, Math.max(0.01, percent));
                 }
             },
 

--- a/omlx/admin/templates/dashboard/_settings.html
+++ b/omlx/admin/templates/dashboard/_settings.html
@@ -425,7 +425,7 @@
                                         </p>
                                     </div>
                                     <div class="flex flex-wrap items-center gap-2 sm:gap-3">
-                                        <input type="range" min="0" max="100" step="1"
+                                        <input type="range" min="1" max="100" step="1"
                                                x-model.number="cachePercent"
                                                @input="updateCacheFromSlider()"
                                                class="w-32 h-1.5 bg-neutral-200 rounded-full appearance-none cursor-pointer
@@ -443,7 +443,7 @@
                                                    @keydown.escape="editingCache = false"
                                                    x-init="if (editingCache) { $nextTick(() => $el.focus()) }"
                                                    class="w-12 px-1 text-sm text-right border border-neutral-900 rounded focus:outline-none"
-                                                   min="0"
+                                                   min="1"
                                                    step="1"><span class="text-neutral-400">GB)</span>
                                         </span>
                                     </div>

--- a/omlx/admin/templates/dashboard/_settings.html
+++ b/omlx/admin/templates/dashboard/_settings.html
@@ -425,7 +425,7 @@
                                         </p>
                                     </div>
                                     <div class="flex flex-wrap items-center gap-2 sm:gap-3">
-                                        <input type="range" min="1" max="100" step="1"
+                                        <input type="range" min="0.01" max="100" step="0.01"
                                                x-model.number="cachePercent"
                                                @input="updateCacheFromSlider()"
                                                class="w-32 h-1.5 bg-neutral-200 rounded-full appearance-none cursor-pointer

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -54,6 +54,31 @@ def _has_cli_overrides(args) -> bool:
     return False
 
 
+def _resolve_ssd_cache_max_size_bytes(size: str, cache_dir: str) -> int:
+    """Resolve a CLI SSD cache size through the central settings validator."""
+    from pathlib import Path
+
+    from .config import parse_size
+    from .settings import (
+        SSD_CACHE_SIZE_AUTO,
+        get_ssd_capacity,
+        normalize_ssd_cache_max_size,
+    )
+
+    normalized = normalize_ssd_cache_max_size(size)
+    if normalized == SSD_CACHE_SIZE_AUTO:
+        return int(get_ssd_capacity(Path(cache_dir)) * 0.1)
+    return parse_size(normalized)
+
+
+def _resolve_hot_cache_max_size_bytes(size: str) -> int:
+    """Resolve a CLI hot-cache size through the central settings validator."""
+    from .config import parse_size
+    from .settings import normalize_hot_cache_max_size
+
+    return parse_size(normalize_hot_cache_max_size(size))
+
+
 def serve_command(args):
     """Start the OpenAI-compatible multi-model server."""
     import logging
@@ -167,7 +192,6 @@ def serve_command(args):
 
     # Import server and config
     from .server import app, init_server
-    from .config import parse_size
 
     model_dirs = settings.model.get_model_dirs(settings.base_path)
     print(f"Base path: {settings.base_path}")
@@ -202,8 +226,14 @@ def serve_command(args):
     # Determine cache max size: CLI arg > settings (with auto resolution)
     if paged_ssd_cache_dir:
         if args.paged_ssd_cache_max_size:
-            # CLI argument specified explicitly
-            cache_max_size_bytes = parse_size(args.paged_ssd_cache_max_size)
+            try:
+                cache_max_size_bytes = _resolve_ssd_cache_max_size_bytes(
+                    args.paged_ssd_cache_max_size,
+                    paged_ssd_cache_dir,
+                )
+            except ValueError as e:
+                print(f"Configuration error: {e}")
+                sys.exit(1)
         else:
             # Use settings value (handles "auto" -> 10% of SSD capacity)
             cache_max_size_bytes = settings.cache.get_ssd_cache_max_size_bytes(settings.base_path)
@@ -215,7 +245,13 @@ def serve_command(args):
     # Hot cache: CLI arg > settings
     if paged_ssd_cache_dir:
         if args.hot_cache_max_size:
-            hot_cache_max_bytes = parse_size(args.hot_cache_max_size)
+            try:
+                hot_cache_max_bytes = _resolve_hot_cache_max_size_bytes(
+                    args.hot_cache_max_size
+                )
+            except ValueError as e:
+                print(f"Configuration error: {e}")
+                sys.exit(1)
         else:
             hot_cache_max_bytes = settings.cache.get_hot_cache_max_size_bytes()
         scheduler_config.hot_cache_max_size = hot_cache_max_bytes

--- a/omlx/config.py
+++ b/omlx/config.py
@@ -9,6 +9,7 @@ This module provides unified configuration management with:
 - Default values with sensible defaults
 """
 
+import math
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -39,8 +40,10 @@ def parse_size(size_str: str) -> int:
         if size_str.endswith(unit):
             try:
                 value = float(size_str[: -len(unit)])
+                if not math.isfinite(value):
+                    raise ValueError
                 return int(value * multiplier)
-            except ValueError:
+            except (OverflowError, ValueError):
                 pass
 
     # Try parsing as plain number (bytes)
@@ -113,13 +116,26 @@ class PagedSSDCacheConfig:
 
     @property
     def max_size_bytes(self) -> int:
-        """Get max size in bytes."""
-        return parse_size(self.max_size)
+        """Get max size in bytes using the central settings semantics."""
+        from .settings import (
+            DEFAULT_BASE_PATH,
+            SSD_CACHE_SIZE_AUTO,
+            get_ssd_capacity,
+            normalize_ssd_cache_max_size,
+        )
+
+        normalized = normalize_ssd_cache_max_size(self.max_size)
+        if normalized == SSD_CACHE_SIZE_AUTO:
+            cache_dir = self.cache_dir or (DEFAULT_BASE_PATH / "cache")
+            return int(get_ssd_capacity(cache_dir) * 0.1)
+        return parse_size(normalized)
 
     @property
     def hot_cache_max_size_bytes(self) -> int:
         """Get hot cache max size in bytes. 0 means disabled."""
-        return parse_size(self.hot_cache_max_size)
+        from .settings import normalize_hot_cache_max_size
+
+        return parse_size(normalize_hot_cache_max_size(self.hot_cache_max_size))
 
 
 @dataclass

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -39,6 +39,63 @@ logger = logging.getLogger(__name__)
 # Settings file version for future migrations
 SETTINGS_VERSION = "1.0"
 
+SSD_CACHE_SIZE_AUTO = "auto"
+
+
+def normalize_ssd_cache_max_size(
+    value: str | None,
+    *,
+    legacy_zero_to_auto: bool = False,
+) -> str:
+    """Normalize and validate the SSD cache size setting.
+
+    ``ssd_cache_max_size`` is a capacity limit. Unlike ``hot_cache_max_size``,
+    zero is not a disable sentinel; disabling SSD spillover is represented by
+    ``cache.enabled=False`` or ``hot_cache_only=True``.
+    """
+    size = SSD_CACHE_SIZE_AUTO if value is None else str(value).strip()
+    if not size:
+        raise ValueError("ssd_cache_max_size must be 'auto' or a positive size")
+    if size.lower() == SSD_CACHE_SIZE_AUTO:
+        return SSD_CACHE_SIZE_AUTO
+
+    try:
+        size_bytes = parse_size(size)
+    except ValueError as e:
+        raise ValueError(f"Invalid ssd_cache_max_size: {e}") from e
+    if size_bytes <= 0:
+        if size_bytes == 0 and legacy_zero_to_auto:
+            return SSD_CACHE_SIZE_AUTO
+        raise ValueError("ssd_cache_max_size must be positive")
+    return size
+
+
+def normalize_hot_cache_max_size(
+    value: str | None,
+    *,
+    legacy_auto_to_disabled: bool = False,
+) -> str:
+    """Normalize and validate the in-memory hot cache size setting.
+
+    Hot cache uses ``0`` as its explicit disabled value. Other values must be
+    positive byte sizes accepted by ``parse_size``.
+    """
+    size = "0" if value is None else str(value).strip()
+    if not size:
+        raise ValueError("hot_cache_max_size must be 0 or a positive size")
+    if size.lower() == SSD_CACHE_SIZE_AUTO and legacy_auto_to_disabled:
+        return "0"
+
+    try:
+        size_bytes = parse_size(size)
+    except ValueError as e:
+        raise ValueError(f"Invalid hot_cache_max_size: {e}") from e
+    if size_bytes < 0:
+        raise ValueError("hot_cache_max_size must be 0 or a positive size")
+    if size_bytes == 0:
+        return "0"
+    return size
+
 # Default base path
 DEFAULT_BASE_PATH = Path.home() / ".omlx"
 
@@ -252,14 +309,15 @@ class CacheSettings:
         Returns:
             Max SSD cache size in bytes (10% of SSD if "auto").
         """
-        if self.ssd_cache_max_size.lower() == "auto":
+        ssd_cache_max_size = normalize_ssd_cache_max_size(self.ssd_cache_max_size)
+        if ssd_cache_max_size == SSD_CACHE_SIZE_AUTO:
             cache_dir = self.get_ssd_cache_dir(base_path)
             return int(get_ssd_capacity(cache_dir) * 0.1)
-        return parse_size(self.ssd_cache_max_size)
+        return parse_size(ssd_cache_max_size)
 
     def get_hot_cache_max_size_bytes(self) -> int:
         """Get hot cache max size in bytes. 0 means disabled."""
-        return parse_size(self.hot_cache_max_size)
+        return parse_size(normalize_hot_cache_max_size(self.hot_cache_max_size))
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
@@ -761,6 +819,38 @@ class GlobalSettings:
                 self.scheduler = SchedulerSettings.from_dict(data["scheduler"])
             if "cache" in data:
                 self.cache = CacheSettings.from_dict(data["cache"])
+                try:
+                    normalized_ssd = normalize_ssd_cache_max_size(
+                        self.cache.ssd_cache_max_size,
+                        legacy_zero_to_auto=True,
+                    )
+                except ValueError:
+                    # Keep non-legacy invalid values intact so startup validation
+                    # reports the actual bad setting instead of hiding it.
+                    pass
+                else:
+                    if normalized_ssd != self.cache.ssd_cache_max_size:
+                        logger.warning(
+                            "Recovered invalid persisted ssd_cache_max_size=%r "
+                            "to 'auto'",
+                            self.cache.ssd_cache_max_size,
+                        )
+                        self.cache.ssd_cache_max_size = normalized_ssd
+                try:
+                    normalized_hot = normalize_hot_cache_max_size(
+                        self.cache.hot_cache_max_size,
+                        legacy_auto_to_disabled=True,
+                    )
+                except ValueError:
+                    pass
+                else:
+                    if normalized_hot != self.cache.hot_cache_max_size:
+                        logger.warning(
+                            "Recovered invalid persisted hot_cache_max_size=%r "
+                            "to '0'",
+                            self.cache.hot_cache_max_size,
+                        )
+                        self.cache.hot_cache_max_size = normalized_hot
             if "auth" in data:
                 self.auth = AuthSettings.from_dict(data["auth"])
             if "mcp" in data:
@@ -1093,13 +1183,14 @@ class GlobalSettings:
             )
 
         # Cache validation
-        if self.cache.ssd_cache_max_size.lower() != "auto":
-            try:
-                size = parse_size(self.cache.ssd_cache_max_size)
-                if size <= 0:
-                    errors.append("ssd_cache_max_size must be positive")
-            except ValueError as e:
-                errors.append(f"Invalid ssd_cache_max_size: {e}")
+        try:
+            normalize_ssd_cache_max_size(self.cache.ssd_cache_max_size)
+        except ValueError as e:
+            errors.append(str(e))
+        try:
+            normalize_hot_cache_max_size(self.cache.hot_cache_max_size)
+        except ValueError as e:
+            errors.append(str(e))
 
         if self.cache.initial_cache_blocks <= 0:
             errors.append(

--- a/tests/test_admin_server_aliases.py
+++ b/tests/test_admin_server_aliases.py
@@ -4,6 +4,7 @@
 
 import asyncio
 from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -13,6 +14,7 @@ from fastapi import HTTPException
 import omlx.server  # noqa: F401 — ensure server module is imported first (triggers set_admin_getters)
 import omlx.admin.routes as admin_routes
 from omlx.admin.routes import GlobalSettingsRequest
+from omlx.settings import GlobalSettings
 from omlx.utils.network import (
     detect_server_aliases,
     is_valid_alias,
@@ -264,18 +266,13 @@ class TestUpdateGlobalSettingsAliases:
 class TestUpdateGlobalSettingsEmbeddingBatchSize:
     """update_global_settings: saving and hot-applying embedding batch size."""
 
-    def _make_scheduler_settings(self):
-        return SimpleNamespace(
-            max_concurrent_requests=8,
-            embedding_batch_size=32,
-            chunked_prefill=False,
-        )
+    def _make_settings(self):
+        gs = GlobalSettings(base_path=Path("/tmp/omlx"))
+        gs.save = MagicMock(return_value=None)
+        return gs
 
     def test_saves_and_hot_applies_embedding_batch_size(self):
-        gs = MagicMock()
-        gs.scheduler = self._make_scheduler_settings()
-        gs.validate.return_value = []
-        gs.save.return_value = None
+        gs = self._make_settings()
 
         pool = SimpleNamespace(apply_embedding_batch_size=AsyncMock())
         server_state = SimpleNamespace(engine_pool=pool)
@@ -297,10 +294,7 @@ class TestUpdateGlobalSettingsEmbeddingBatchSize:
         gs.save.assert_called_once()
 
     def test_rejects_invalid_embedding_batch_size(self):
-        gs = MagicMock()
-        gs.scheduler = self._make_scheduler_settings()
-        gs.validate.return_value = []
-        gs.save.return_value = None
+        gs = self._make_settings()
         request = GlobalSettingsRequest(embedding_batch_size=0)
 
         with _patched_global_settings(gs):
@@ -314,10 +308,8 @@ class TestUpdateGlobalSettingsEmbeddingBatchSize:
         gs.save.assert_not_called()
 
     def test_does_not_hot_apply_embedding_batch_size_when_validation_fails(self):
-        gs = MagicMock()
-        gs.scheduler = self._make_scheduler_settings()
-        gs.validate.return_value = ["invalid unrelated setting"]
-        gs.save.return_value = None
+        gs = self._make_settings()
+        gs.server.port = 0
         pool = SimpleNamespace(apply_embedding_batch_size=AsyncMock())
         server_state = SimpleNamespace(engine_pool=pool)
         request = GlobalSettingsRequest(embedding_batch_size=5)
@@ -338,10 +330,7 @@ class TestUpdateGlobalSettingsEmbeddingBatchSize:
         gs.save.assert_not_called()
 
     def test_does_not_mutate_embedding_batch_size_when_api_key_is_invalid(self):
-        gs = MagicMock()
-        gs.scheduler = self._make_scheduler_settings()
-        gs.validate.return_value = []
-        gs.save.return_value = None
+        gs = self._make_settings()
         pool = SimpleNamespace(apply_embedding_batch_size=AsyncMock())
         server_state = SimpleNamespace(engine_pool=pool)
         request = GlobalSettingsRequest(embedding_batch_size=5, api_key="abc")
@@ -362,9 +351,7 @@ class TestUpdateGlobalSettingsEmbeddingBatchSize:
         gs.save.assert_not_called()
 
     def test_does_not_hot_apply_embedding_batch_size_when_save_fails(self):
-        gs = MagicMock()
-        gs.scheduler = self._make_scheduler_settings()
-        gs.validate.return_value = []
+        gs = self._make_settings()
         gs.save.side_effect = OSError("disk full")
         pool = SimpleNamespace(apply_embedding_batch_size=AsyncMock())
         server_state = SimpleNamespace(engine_pool=pool)
@@ -383,3 +370,178 @@ class TestUpdateGlobalSettingsEmbeddingBatchSize:
         assert exc_info.value.status_code == 500
         pool.apply_embedding_batch_size.assert_not_awaited()
         assert gs.scheduler.embedding_batch_size == 32
+
+    def test_does_not_update_server_api_key_when_save_fails(self):
+        gs = self._make_settings()
+        gs.auth.api_key = "old-key"
+        gs.save.side_effect = OSError("disk full")
+        server_state = SimpleNamespace(api_key="old-key")
+        request = GlobalSettingsRequest(api_key="new-key")
+
+        with _patched_global_settings(gs), patch("omlx.server._server_state", server_state):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 500
+        assert server_state.api_key == "old-key"
+        assert gs.auth.api_key == "old-key"
+
+    def test_does_not_apply_model_dirs_runtime_when_save_fails(self, tmp_path):
+        gs = self._make_settings()
+        gs.model.model_dirs = ["/old/models"]
+        gs.model.model_dir = "/old/models"
+        gs.save.side_effect = OSError("disk full")
+        apply_model_dirs = AsyncMock(return_value=(True, "models updated"))
+        request = GlobalSettingsRequest(model_dirs=[str(tmp_path)])
+
+        with _patched_global_settings(gs), patch.object(
+            admin_routes,
+            "_apply_model_dirs_runtime",
+            apply_model_dirs,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 500
+        apply_model_dirs.assert_not_awaited()
+        assert gs.model.model_dirs == ["/old/models"]
+        assert gs.model.model_dir == "/old/models"
+
+
+class TestUpdateGlobalSettingsCacheSize:
+    """update_global_settings: SSD cache size validation and normalization."""
+
+    def _make_settings(self):
+        gs = GlobalSettings(base_path=Path("/tmp/omlx"))
+        gs.cache.ssd_cache_dir = "/tmp/omlx/cache"
+        gs.cache.ssd_cache_max_size = "50GB"
+        gs.save = MagicMock(return_value=None)
+        return gs
+
+    def test_rejects_zero_ssd_cache_size_without_mutating_settings(self):
+        gs = self._make_settings()
+        request = GlobalSettingsRequest(ssd_cache_max_size="0GB")
+        apply_cache = AsyncMock(return_value=(True, "cache updated"))
+
+        with _patched_global_settings(gs), patch.object(
+            admin_routes,
+            "_apply_cache_settings_runtime",
+            apply_cache,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "ssd_cache_max_size must be positive" in exc_info.value.detail
+        assert gs.cache.ssd_cache_max_size == "50GB"
+        apply_cache.assert_not_awaited()
+        gs.save.assert_not_called()
+
+    def test_trims_valid_ssd_cache_size_before_persisting(self):
+        gs = self._make_settings()
+        request = GlobalSettingsRequest(ssd_cache_max_size=" 20GB ")
+        apply_cache = AsyncMock(return_value=(True, "cache updated"))
+
+        with _patched_global_settings(gs), patch.object(
+            admin_routes,
+            "_apply_cache_settings_runtime",
+            apply_cache,
+        ):
+            result = asyncio.run(
+                admin_routes.update_global_settings(request=request, is_admin=True)
+            )
+
+        assert result["success"] is True
+        assert gs.cache.ssd_cache_max_size == "20GB"
+        apply_cache.assert_awaited_once()
+        gs.save.assert_called_once()
+
+    def test_hot_cache_only_updates_scheduler_runtime_config(self):
+        gs = self._make_settings()
+        request = GlobalSettingsRequest(hot_cache_only=True)
+        scheduler_config = SimpleNamespace(
+            paged_ssd_cache_dir=None,
+            paged_ssd_cache_max_size=0,
+            hot_cache_max_size=0,
+            hot_cache_only=False,
+        )
+        pool = SimpleNamespace(
+            _scheduler_config=scheduler_config,
+            get_loaded_model_ids=MagicMock(return_value=["model-a"]),
+            _unload_engine=AsyncMock(),
+        )
+        server_state = SimpleNamespace(engine_pool=pool)
+
+        with _patched_global_settings(gs), patch("omlx.server._server_state", server_state):
+            result = asyncio.run(
+                admin_routes.update_global_settings(request=request, is_admin=True)
+            )
+
+        assert result["success"] is True
+        assert "cache" in result["runtime_applied"]
+        assert gs.cache.hot_cache_only is True
+        assert scheduler_config.hot_cache_only is True
+        pool._unload_engine.assert_awaited_once_with("model-a")
+        gs.save.assert_called_once()
+
+    def test_does_not_apply_cache_runtime_when_save_fails(self):
+        gs = self._make_settings()
+        gs.save.side_effect = OSError("disk full")
+        request = GlobalSettingsRequest(ssd_cache_max_size="20GB")
+        apply_cache = AsyncMock(return_value=(True, "cache updated"))
+
+        with _patched_global_settings(gs), patch.object(
+            admin_routes,
+            "_apply_cache_settings_runtime",
+            apply_cache,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 500
+        apply_cache.assert_not_awaited()
+        assert gs.cache.ssd_cache_max_size == "50GB"
+
+    def test_rejects_invalid_hot_cache_size_without_mutating_settings(self):
+        gs = self._make_settings()
+        request = GlobalSettingsRequest(hot_cache_max_size="auto")
+        apply_cache = AsyncMock(return_value=(True, "cache updated"))
+
+        with _patched_global_settings(gs), patch.object(
+            admin_routes,
+            "_apply_cache_settings_runtime",
+            apply_cache,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "hot_cache_max_size" in exc_info.value.detail
+        assert gs.cache.hot_cache_max_size == "0"
+        apply_cache.assert_not_awaited()
+        gs.save.assert_not_called()
+
+    def test_rejects_invalid_port_without_mutating_settings(self):
+        gs = self._make_settings()
+        request = GlobalSettingsRequest(port=0)
+
+        with _patched_global_settings(gs):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "port" in exc_info.value.detail
+        assert gs.server.port == 8000
+        gs.save.assert_not_called()

--- a/tests/test_admin_server_aliases.py
+++ b/tests/test_admin_server_aliases.py
@@ -162,6 +162,77 @@ class TestServerInfoEndpoint:
         assert exc_info.value.status_code == 503
 
 
+class TestGetGlobalSettingsCache:
+    """get_global_settings: cache settings should expose raw save values."""
+
+    def _memory_info(self):
+        return {
+            "total_bytes": 64 * 1024**3,
+            "total_formatted": "64GB",
+            "auto_limit_formatted": "51GB",
+            "available_bytes": 32 * 1024**3,
+            "omlx_phys_footprint_bytes": 0,
+            "free_memory_bytes": 16 * 1024**3,
+            "inactive_memory_bytes": 8 * 1024**3,
+            "active_memory_bytes": 40 * 1024**3,
+            "iogpu_wired_limit_bytes": 0,
+            "omlx_wired_limit_request_bytes": 0,
+        }
+
+    def _disk_info(self):
+        return {
+            "total_bytes": 100 * 1024**3,
+            "total_formatted": "100GB",
+        }
+
+    def test_preserves_raw_auto_ssd_cache_size_in_settings_response(self):
+        gs = GlobalSettings(base_path=Path("/tmp/omlx"))
+        gs.cache.ssd_cache_dir = "/tmp/omlx/cache"
+        gs.cache.ssd_cache_max_size = "auto"
+
+        with (
+            _patched_global_settings(gs),
+            patch.object(
+                admin_routes,
+                "get_system_memory_info",
+                return_value=self._memory_info(),
+            ),
+            patch.object(
+                admin_routes,
+                "get_ssd_disk_info",
+                return_value=self._disk_info(),
+            ),
+            patch("omlx.settings.get_ssd_capacity", return_value=100 * 1024**3),
+        ):
+            result = asyncio.run(admin_routes.get_global_settings(is_admin=True))
+
+        assert result["cache"]["ssd_cache_max_size"] == "auto"
+        assert result["cache"]["ssd_cache_max_size_resolved"] == "10GB"
+
+    def test_returns_explicit_ssd_cache_size_in_settings_response(self):
+        gs = GlobalSettings(base_path=Path("/tmp/omlx"))
+        gs.cache.ssd_cache_dir = "/tmp/omlx/cache"
+        gs.cache.ssd_cache_max_size = "25GB"
+
+        with (
+            _patched_global_settings(gs),
+            patch.object(
+                admin_routes,
+                "get_system_memory_info",
+                return_value=self._memory_info(),
+            ),
+            patch.object(
+                admin_routes,
+                "get_ssd_disk_info",
+                return_value=self._disk_info(),
+            ),
+        ):
+            result = asyncio.run(admin_routes.get_global_settings(is_admin=True))
+
+        assert result["cache"]["ssd_cache_max_size"] == "25GB"
+        assert result["cache"]["ssd_cache_max_size_resolved"] == "25GB"
+
+
 # =============================================================================
 # /admin/api/global-settings save path for server_aliases
 # =============================================================================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -419,6 +419,22 @@ class TestServeCommandFunctions:
         assert "embedding_batch_size" in result.stdout
         assert not (tmp_path / "settings.json").exists()
 
+    def test_cli_ssd_cache_size_uses_settings_validator(self):
+        """One-shot CLI cache flags should share settings.py size semantics."""
+        from omlx.cli import _resolve_ssd_cache_max_size_bytes
+
+        with pytest.raises(ValueError, match="must be positive"):
+            _resolve_ssd_cache_max_size_bytes("0GB", "/tmp/omlx-cache")
+
+    def test_cli_hot_cache_size_uses_settings_validator(self):
+        """Hot-cache CLI values use 0 as disabled and reject auto."""
+        from omlx.cli import _resolve_hot_cache_max_size_bytes
+
+        assert _resolve_hot_cache_max_size_bytes("0GB") == 0
+        assert _resolve_hot_cache_max_size_bytes("0") == 0
+        with pytest.raises(ValueError, match="hot_cache_max_size"):
+            _resolve_hot_cache_max_size_bytes("auto")
+
 
 
 class TestHasCliOverrides:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,6 +79,13 @@ class TestParseSize:
         with pytest.raises(ValueError):
             parse_size("1XB")  # Invalid unit
 
+    def test_parse_non_finite_raises_error(self):
+        """Non-finite values should be rejected as invalid sizes."""
+        with pytest.raises(ValueError):
+            parse_size("infGB")
+        with pytest.raises(ValueError):
+            parse_size("1e309GB")
+
 
 class TestServerConfig:
     """Test cases for ServerConfig dataclass."""
@@ -215,6 +222,25 @@ class TestPagedSSDCacheConfig:
 
         config = PagedSSDCacheConfig(max_size="1TB")
         assert config.max_size_bytes == 1024**4
+
+    def test_max_size_bytes_uses_settings_semantics(self):
+        """SSD cache max size rejects zero and negative sizes."""
+        config = PagedSSDCacheConfig(max_size="0GB")
+        with pytest.raises(ValueError, match="must be positive"):
+            _ = config.max_size_bytes
+
+        config = PagedSSDCacheConfig(max_size="-1GB")
+        with pytest.raises(ValueError, match="must be positive"):
+            _ = config.max_size_bytes
+
+    def test_hot_cache_max_size_bytes_uses_settings_semantics(self):
+        """Hot cache accepts zero as disabled and rejects auto."""
+        config = PagedSSDCacheConfig(hot_cache_max_size="0GB")
+        assert config.hot_cache_max_size_bytes == 0
+
+        config = PagedSSDCacheConfig(hot_cache_max_size="auto")
+        with pytest.raises(ValueError, match="hot_cache_max_size"):
+            _ = config.hot_cache_max_size_bytes
 
 
 class TestMCPConfig:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -28,6 +28,8 @@ from omlx.settings import (
     get_ssd_capacity,
     get_system_memory,
     init_settings,
+    normalize_hot_cache_max_size,
+    normalize_ssd_cache_max_size,
     reset_settings,
 )
 
@@ -294,6 +296,51 @@ class TestCacheSettings:
         settings = CacheSettings(ssd_cache_max_size="100GB")
         base_path = Path("/tmp/omlx")
         assert settings.get_ssd_cache_max_size_bytes(base_path) == 100 * 1024**3
+
+    def test_normalize_ssd_cache_max_size_rejects_zero(self):
+        """Zero is not a disable sentinel for SSD cache size."""
+        with pytest.raises(ValueError, match="must be positive"):
+            normalize_ssd_cache_max_size("0GB")
+
+    def test_normalize_legacy_zero_ssd_cache_max_size_to_auto(self):
+        """Legacy persisted zero values recover to auto on load."""
+        assert (
+            normalize_ssd_cache_max_size("0GB", legacy_zero_to_auto=True)
+            == "auto"
+        )
+
+    def test_normalize_legacy_ssd_cache_max_size_rejects_negative(self):
+        """Only legacy zero values recover; negative sizes remain invalid."""
+        with pytest.raises(ValueError, match="must be positive"):
+            normalize_ssd_cache_max_size("-1GB", legacy_zero_to_auto=True)
+
+    def test_normalize_ssd_cache_max_size_rejects_non_finite(self):
+        """Non-finite sizes should surface as validation errors."""
+        with pytest.raises(ValueError, match="ssd_cache_max_size"):
+            normalize_ssd_cache_max_size("infGB")
+
+    def test_normalize_hot_cache_max_size_allows_zero(self):
+        """Hot cache uses zero as its disabled sentinel."""
+        assert normalize_hot_cache_max_size("0GB") == "0"
+        assert normalize_hot_cache_max_size("0") == "0"
+        assert normalize_hot_cache_max_size("8GB") == "8GB"
+
+    def test_normalize_hot_cache_max_size_rejects_auto(self):
+        """Hot cache auto is not a persisted size setting."""
+        with pytest.raises(ValueError, match="hot_cache_max_size"):
+            normalize_hot_cache_max_size("auto")
+
+    def test_normalize_hot_cache_max_size_rejects_non_finite(self):
+        """Non-finite hot cache sizes should surface as validation errors."""
+        with pytest.raises(ValueError, match="hot_cache_max_size"):
+            normalize_hot_cache_max_size("1e309GB")
+
+    def test_normalize_legacy_hot_cache_auto_to_disabled(self):
+        """Legacy hot cache auto values recover to the disabled sentinel."""
+        assert (
+            normalize_hot_cache_max_size("auto", legacy_auto_to_disabled=True)
+            == "0"
+        )
 
     def test_to_dict(self):
         """Test conversion to dictionary."""
@@ -717,6 +764,67 @@ class TestGlobalSettings:
             assert settings.auth.api_key == "secret"
             assert settings.mcp.config_path == "/mcp.json"
 
+    def test_load_legacy_zero_ssd_cache_max_size_recovers_to_auto(self):
+        """Startup should recover from old settings.json files with 0GB."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_file = Path(tmpdir) / "settings.json"
+            settings_file.write_text(
+                json.dumps(
+                    {
+                        "version": "1.0",
+                        "cache": {
+                            "enabled": True,
+                            "ssd_cache_max_size": "0GB",
+                        },
+                    }
+                )
+            )
+
+            settings = GlobalSettings.load(base_path=tmpdir)
+            assert settings.cache.ssd_cache_max_size == "auto"
+            assert settings.validate() == []
+
+    def test_load_negative_ssd_cache_max_size_stays_invalid(self):
+        """Startup recovery must not hide non-legacy invalid cache sizes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_file = Path(tmpdir) / "settings.json"
+            settings_file.write_text(
+                json.dumps(
+                    {
+                        "version": "1.0",
+                        "cache": {
+                            "enabled": True,
+                            "ssd_cache_max_size": "-1GB",
+                        },
+                    }
+                )
+            )
+
+            settings = GlobalSettings.load(base_path=tmpdir)
+            assert settings.cache.ssd_cache_max_size == "-1GB"
+            errors = settings.validate()
+            assert any("ssd_cache_max_size" in e.lower() for e in errors)
+
+    def test_load_legacy_hot_cache_auto_recovers_to_disabled(self):
+        """Startup should recover from old settings.json files with hot auto."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_file = Path(tmpdir) / "settings.json"
+            settings_file.write_text(
+                json.dumps(
+                    {
+                        "version": "1.0",
+                        "cache": {
+                            "enabled": True,
+                            "hot_cache_max_size": "auto",
+                        },
+                    }
+                )
+            )
+
+            settings = GlobalSettings.load(base_path=tmpdir)
+            assert settings.cache.hot_cache_max_size == "0"
+            assert settings.validate() == []
+
     def test_load_nonexistent_file_uses_defaults(self):
         """Test loading with no settings file uses defaults."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -940,6 +1048,16 @@ class TestGlobalSettings:
         settings.cache.ssd_cache_max_size = "not-a-size"
         errors = settings.validate()
         assert any("ssd_cache_max_size" in e.lower() for e in errors)
+
+        settings = GlobalSettings()
+        settings.cache.ssd_cache_max_size = "0GB"
+        errors = settings.validate()
+        assert any("ssd_cache_max_size" in e.lower() for e in errors)
+
+        settings = GlobalSettings()
+        settings.cache.hot_cache_max_size = "auto"
+        errors = settings.validate()
+        assert any("hot_cache_max_size" in e.lower() for e in errors)
 
     def test_validate_invalid_initial_cache_blocks(self):
         """Test validation catches invalid initial_cache_blocks."""


### PR DESCRIPTION
Fixes invalid cache size handling around SSD cold cache and hot RAM cache configuration.

This PR centralizes cache size validation so all entry points share the same rules:

- SSD cold cache accepts `auto` or a positive size such as `1GB`, `20GB`, `500GB`.
- SSD cold cache rejects `0`, because `0` is not a valid SSD cache size.
- Hot RAM cache accepts `0` as disabled, or a positive size such as `8GB`.
- Hot RAM cache rejects new `auto` values, because RAM auto-sizing is ambiguous and can conflict with runtime memory pressure.

It also fixes admin UI behavior so small positive SSD cache sizes are not inflated by the slider, and persisted `auto` settings are not silently converted into concrete GB values during unrelated saves.

## Problem

Issue #1492 exposed that `ssd_cache_max_size` could be saved as `0GB`.

That value is unsafe because the SSD cold cache runtime expects either:

- `auto`, which resolves to 10% of SSD capacity, or
- a positive size.

Unlike hot RAM cache, SSD cold cache does not use `0` as a disabled sentinel. Allowing `0GB` through the settings UI could persist a configuration that later caused startup/runtime failures.

There were also related consistency issues:

- Cache size rules were spread across settings, CLI, admin routes, legacy config helpers, web UI, and macOS UI.
- Admin save logic could mutate live settings or runtime state before persistence succeeded.
- The admin GET endpoint expanded `auto` into a concrete size, so opening the settings page and saving unrelated fields could silently persist `auto` as `NGB`.
- The web slider used integer percentages, which made small valid SSD cache sizes appear as `1%` and risked rewriting them to much larger values on large disks.

## Changes

### Centralized cache size validation

Added shared normalizers in `omlx/settings.py`:

- `normalize_ssd_cache_max_size`
- `normalize_hot_cache_max_size`

These functions are now the single source of truth for cache size semantics.

SSD cache behavior:

- `auto` is valid.
- Positive sizes are valid.
- `0`, `0GB`, negative sizes, invalid strings, and non-finite values are rejected.
- Legacy persisted `0GB` is recovered to `auto` during settings load.

Hot RAM cache behavior:

- `0` and `0GB` are valid and mean disabled.
- Positive sizes are valid.
- New `auto` values are rejected.
- Legacy persisted `auto` is recovered to `0` during settings load.

### Safer admin settings save flow

Updated `/admin/api/global-settings` so validation happens before live mutation and runtime application.

The save path now:

1. Normalizes incoming values.
2. Applies changes to a copied candidate settings object.
3. Runs global validation.
4. Mutates live settings only after preflight succeeds.
5. Saves to disk.
6. Applies runtime changes only after save succeeds.
7. Restores the live snapshot if persistence fails.

This prevents partial state drift where runtime settings change even though saving failed.

### Preserve SSD `auto` in admin API

The admin settings GET response now returns:

- `ssd_cache_max_size`: the raw persisted value, such as `auto`
- `ssd_cache_max_size_resolved`: the computed display value, such as `10GB`

This prevents unrelated admin saves from converting `auto` into a fixed GB value.

### Web dashboard slider fixes

Updated the SSD cache slider to support small positive cache sizes:

- Slider minimum changed from `1%` to `0.01%`.
- Slider step changed from `1` to `0.01`.
- Display parsing now preserves two decimal places.
- Loading settings no longer rewrites `ssd_cache_max_size`.
- Slider-generated values still clamp to at least `1GB`, so the UI cannot write `0GB`.

Manual GB input remains minimum `1GB`, because it edits the actual SSD cache size string.

### CLI and legacy config alignment

Updated CLI one-shot cache size resolution to reuse the shared settings validators.

Updated deprecated `PagedSSDCacheConfig` helpers so they also use the same validation semantics.

Also hardened `parse_size()` against non-finite and overflow values.

### macOS UI alignment

Updated the macOS performance settings UI so hot RAM cache no longer advertises `auto`.

Hot RAM cache empty input now normalizes to `0`, while SSD cache empty input normalizes to `auto`.