### PR TITLE
feat(downloads): model card sheet with metadata, files, tags

### DIFF
--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -1695,6 +1695,18 @@
         }
       }
     },
+    "downloads.button.show_card" : {
+      "comment" : "Tooltip on the info button that opens a model's README sheet",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View model card"
+          }
+        }
+      }
+    },
     "downloads.cancel.help" : {
       "comment" : "Tooltip on the X button that cancels or removes a download task",
       "extractionState" : "manual",
@@ -1703,6 +1715,162 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "downloads.card.close" : {
+      "comment" : "Tooltip on the model card sheet's close button",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        }
+      }
+    },
+    "downloads.card.download" : {
+      "comment" : "Primary button in the model card sheet that starts downloading the displayed model",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download"
+          }
+        }
+      }
+    },
+    "downloads.card.empty" : {
+      "comment" : "Empty state shown when the upstream repo has no model card",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This model doesn't ship a README."
+          }
+        }
+      }
+    },
+    "downloads.card.files.empty" : {
+      "comment" : "Empty state in the Files tab when the upstream API doesn't list any files",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No files reported."
+          }
+        }
+      }
+    },
+    "downloads.card.error" : {
+      "comment" : "Title shown in the model card sheet when the fetch failed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't load model card"
+          }
+        }
+      }
+    },
+    "downloads.card.loading" : {
+      "comment" : "Status text shown while the model README is being fetched",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading model card…"
+          }
+        }
+      }
+    },
+    "downloads.card.lora_warning" : {
+      "comment" : "Warning banner shown in the model card sheet when the repo is an adapter rather than a full model",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This is a LoRA adapter. It needs a compatible base model to run — downloading on its own won't load in oMLX."
+          }
+        }
+      }
+    },
+    "downloads.card.retry" : {
+      "comment" : "Retry button shown after the model card fetch failed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
+          }
+        }
+      }
+    },
+    "downloads.card.tab.card" : {
+      "comment" : "Tab label in the model card sheet for the README content",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Model Card"
+          }
+        }
+      }
+    },
+    "downloads.card.tab.files" : {
+      "comment" : "Tab label in the model card sheet for the repo file list",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Files"
+          }
+        }
+      }
+    },
+    "downloads.card.tab.tags" : {
+      "comment" : "Tab label in the model card sheet for the repo tag list",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tags"
+          }
+        }
+      }
+    },
+    "downloads.card.tags.empty" : {
+      "comment" : "Empty state in the Tags tab when the upstream API doesn't list any tags",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No tags."
+          }
+        }
+      }
+    },
+    "downloads.card.view_upstream" : {
+      "comment" : "Link button in the model card sheet that opens the upstream model page; placeholder is 'Hugging Face' or 'ModelScope'",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View on %@"
           }
         }
       }

--- a/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
@@ -55,7 +55,8 @@ struct DownloadsScreen: View {
                     onSaveMirror: { vm.saveMirror(client: services.client) },
                     onResetMirror: { vm.resetMirror(client: services.client) },
                     onPickResult: { vm.pickSearchResult($0) },
-                    onDismissSearch: { vm.dismissSearch() }
+                    onDismissSearch: { vm.dismissSearch() },
+                    onShowCard: { repo in vm.showModelCard(repoId: repo) }
                 )
                 .onChange(of: vm.repoText) { _, newValue in
                     vm.updateSearch(query: newValue, client: services.client)
@@ -76,7 +77,8 @@ struct DownloadsScreen: View {
                     onSaveMirror: { vm.saveMsMirror(client: services.client) },
                     onResetMirror: { vm.resetMsMirror(client: services.client) },
                     onPickResult: { vm.pickMsSearchResult($0) },
-                    onDismissSearch: { vm.dismissMsSearch() }
+                    onDismissSearch: { vm.dismissMsSearch() },
+                    onShowCard: { repo in vm.showModelCard(repoId: repo) }
                 )
                 .onChange(of: vm.msRepoText) { _, newValue in
                     vm.updateMsSearch(query: newValue, client: services.client)
@@ -92,7 +94,8 @@ struct DownloadsScreen: View {
             CompletedTasksSection(
                 tasks: vm.terminalTasks,
                 onRetry: { id in vm.retry(taskId: id, client: services.client) },
-                onRemove: { id in vm.remove(taskId: id, client: services.client) }
+                onRemove: { id in vm.remove(taskId: id, client: services.client) },
+                onShowCard: { repo in vm.showModelCard(repoId: repo) }
             )
 
             SuggestedSection(
@@ -100,7 +103,8 @@ struct DownloadsScreen: View {
                 sort: $vm.recommendedSort,
                 isLoading: vm.recommendedLoading,
                 onGet: { repo in vm.startDownload(repo: repo, client: services.client) },
-                onRefresh: { Task { await vm.loadRecommended(client: services.client) } }
+                onRefresh: { Task { await vm.loadRecommended(client: services.client) } },
+                onShowCard: { repo in vm.showModelCard(repoId: repo) }
             )
 
             if let error = vm.lastError {
@@ -113,6 +117,18 @@ struct DownloadsScreen: View {
         }
         .task { await vm.start(client: services.client) }
         .onDisappear { vm.stop() }
+        .sheet(item: $vm.modelCardTarget) { target in
+            ModelCardSheet(
+                target: target,
+                client: services.client,
+                onDownload: { repo in
+                    // Sheet dismisses itself before this fires; the
+                    // download lands in the Active section under
+                    // whichever source the sheet was opened from.
+                    vm.startDownload(repo: repo, client: services.client)
+                }
+            )
+        }
     }
 }
 
@@ -168,6 +184,7 @@ private struct AddFromHFSection: View {
     let onResetMirror: () -> Void
     let onPickResult: (HFModelInfo) -> Void
     let onDismissSearch: () -> Void
+    let onShowCard: (String) -> Void
 
     @Environment(\.omlxTheme) private var theme
     @FocusState private var mirrorFocused: Bool
@@ -214,7 +231,8 @@ private struct AddFromHFSection: View {
                             results: searchResults,
                             isLoading: searchLoading,
                             onPick: onPickResult,
-                            onDismiss: onDismissSearch
+                            onDismiss: onDismissSearch,
+                            onShowCard: onShowCard
                         )
                     }
                     if isEditingMirror {
@@ -322,6 +340,7 @@ private struct AddFromMSSection: View {
     let onResetMirror: () -> Void
     let onPickResult: (MSModelInfo) -> Void
     let onDismissSearch: () -> Void
+    let onShowCard: (String) -> Void
 
     @Environment(\.omlxTheme) private var theme
     @FocusState private var mirrorFocused: Bool
@@ -368,7 +387,8 @@ private struct AddFromMSSection: View {
                             results: searchResults,
                             isLoading: searchLoading,
                             onPick: onPickResult,
-                            onDismiss: onDismissSearch
+                            onDismiss: onDismissSearch,
+                            onShowCard: onShowCard
                         )
                     }
                     if isEditingMirror {
@@ -462,8 +482,16 @@ private struct SearchDropdown: View {
     let isLoading: Bool
     let onPick: (HFModelInfo) -> Void
     let onDismiss: () -> Void
+    /// Reveal a small `info.circle` action on the hovered row. Skipped
+    /// from the always-visible button family because each dropdown row
+    /// is itself a Button (`onPick`); a permanent trailing icon would
+    /// crowd the dense row and confuse "did the user mean to pick this
+    /// or open the card?". Finder-style hover reveal sidesteps both
+    /// problems.
+    let onShowCard: (String) -> Void
 
     @Environment(\.omlxTheme) private var theme
+    @State private var hoveredId: String?
 
     /// Cap visible rows at 8 — anything more is noise and the user can keep
     /// typing to narrow further. The HF API returns up to `limit` items
@@ -485,12 +513,42 @@ private struct SearchDropdown: View {
                 .padding(.vertical, 8)
             } else {
                 ForEach(Array(visible.enumerated()), id: \.element.repoId) { idx, m in
-                    Button {
-                        onPick(m)
-                    } label: {
-                        row(model: m)
+                    // Two distinct tap targets in a single HStack:
+                    //   1. row Button (left) — selects this result for download
+                    //   2. info Button (right, hover-only) — opens the model card
+                    // On hover we also hide the downloads count so the icon
+                    // slots into the trailing area cleanly instead of overlapping.
+                    HStack(spacing: 0) {
+                        Button {
+                            onPick(m)
+                        } label: {
+                            row(model: m, isHovered: hoveredId == m.repoId)
+                        }
+                        .buttonStyle(.plain)
+                        .frame(maxWidth: .infinity)
+                        if hoveredId == m.repoId {
+                            Button {
+                                onShowCard(m.repoId)
+                            } label: {
+                                Image(systemName: "info.circle")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(theme.textSecondary)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 6)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            .help(String(localized: "downloads.button.show_card",
+                                         defaultValue: "View model card",
+                                         comment: "Tooltip on the info button that opens a model's README sheet"))
+                            .transition(.opacity)
+                        }
                     }
-                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        withAnimation(.easeOut(duration: 0.1)) {
+                            hoveredId = hovering ? m.repoId : nil
+                        }
+                    }
                     if idx < visible.count - 1 {
                         Divider().opacity(0.4)
                     }
@@ -506,7 +564,7 @@ private struct SearchDropdown: View {
         .onExitCommand(perform: onDismiss)
     }
 
-    private func row(model m: HFModelInfo) -> some View {
+    private func row(model m: HFModelInfo, isHovered: Bool) -> some View {
         HStack(spacing: 8) {
             Image(systemName: "cube.transparent")
                 .font(.system(size: 11))
@@ -525,13 +583,17 @@ private struct SearchDropdown: View {
                 }
             }
             Spacer(minLength: 6)
-            if let downloads = m.downloads, downloads > 0 {
+            // Hide the downloads count on hover so the trailing slot is
+            // free for the info button (rendered as a sibling outside
+            // this row Button so its tap doesn't fall through to onPick).
+            if !isHovered, let downloads = m.downloads, downloads > 0 {
                 Text(formatNumber(downloads))
                     .font(.omlxMono(10.5))
                     .foregroundStyle(theme.textTertiary)
+                    .padding(.trailing, 12)
             }
         }
-        .padding(.horizontal, 12)
+        .padding(.leading, 12)
         .padding(.vertical, 6)
         .contentShape(Rectangle())
     }
@@ -689,6 +751,9 @@ private struct CompletedTasksSection: View {
     let tasks: [HFTaskDTO]
     let onRetry: (String) -> Void
     let onRemove: (String) -> Void
+    /// Open the model-card sheet for a row. Source is resolved by the VM
+    /// from the active downloader tab.
+    let onShowCard: (String) -> Void
 
     @Environment(\.omlxTheme) private var theme
 
@@ -718,6 +783,16 @@ private struct CompletedTasksSection: View {
                                     .buttonStyle(.omlx(.normal, size: .small))
                             }
                             Button {
+                                onShowCard(task.repoId)
+                            } label: {
+                                Image(systemName: "info.circle")
+                                    .font(.system(size: 11))
+                            }
+                            .buttonStyle(.omlx(.plain, size: .small))
+                            .help(String(localized: "downloads.button.show_card",
+                                         defaultValue: "View model card",
+                                         comment: "Tooltip on the info button that opens a model's README sheet"))
+                            Button {
                                 onRemove(task.taskId)
                             } label: {
                                 Image(systemName: "trash")
@@ -740,6 +815,9 @@ private struct SuggestedSection: View {
     let isLoading: Bool
     let onGet: (String) -> Void
     let onRefresh: () -> Void
+    /// Open the model-card sheet for a row. Same intent as the equivalent
+    /// callback on CompletedTasksSection.
+    let onShowCard: (String) -> Void
 
     @Environment(\.omlxTheme) private var theme
 
@@ -809,6 +887,16 @@ private struct SuggestedSection: View {
                                     .truncationMode(.middle)
                             }
                             Spacer(minLength: 8)
+                            Button {
+                                onShowCard(m.repoId)
+                            } label: {
+                                Image(systemName: "info.circle")
+                                    .font(.system(size: 11))
+                            }
+                            .buttonStyle(.omlx(.plain, size: .small))
+                            .help(String(localized: "downloads.button.show_card",
+                                         defaultValue: "View model card",
+                                         comment: "Tooltip on the info button that opens a model's README sheet"))
                             Button {
                                 onGet(m.repoId)
                             } label: {
@@ -930,6 +1018,19 @@ final class DownloadsScreenVM: ObservableObject {
     @Published private(set) var recommendedLoading: Bool = false
     @Published var recommendedSort: SuggestedSort = .downloads
     @Published var lastError: String?
+
+    /// Target for the model-card sheet. Non-nil while the sheet is open;
+    /// `ModelCardSheet` updates it back to nil on dismiss via `.sheet(item:)`.
+    /// Identifiable on `repoId+source`, so re-tapping the same row while a
+    /// sheet for a different row was open re-fires the fetch task.
+    @Published var modelCardTarget: ModelCardTarget?
+
+    /// Open the model-card sheet for a row. Source is resolved from the
+    /// active tab — `.hf` rows always belong to the HF tab and vice versa.
+    func showModelCard(repoId: String) {
+        let resolvedSource: ModelCardSource = (source == .hf) ? .huggingFace : .modelScope
+        modelCardTarget = ModelCardTarget(repoId: repoId, source: resolvedSource)
+    }
 
     /// Host the user sees on the Downloads screen. Strips scheme so the
     /// inline label reads like `huggingface.co` / `hf-mirror.com` per design.

--- a/apps/omlx-mac/Sources/AppView/Screens/ModelCardSheet.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelCardSheet.swift
@@ -1,0 +1,585 @@
+// PR — Downloads model card.
+//
+// Sheet that renders the upstream README for a model in the Downloads
+// screen. Wired to two API surfaces:
+//   • HF       → OMLXClient.getHFModelCard(repoId:)
+//   • MS       → OMLXClient.getMSModelCard(modelId:)
+//
+// Both surface the same shape (model card + metadata; YAML front-matter
+// stripped server-side, empty `model_card` when the upstream has no
+// README), so a single sheet handles both — the `target`'s source enum
+// just picks which client method to call and which upstream URL the
+// "View on …" link points at.
+//
+// Rendering uses `MarkdownUI` (swift-markdown-ui) for full block support
+// (headings, code blocks, tables, lists, images). Native
+// `AttributedString(markdown:)` only handles inline formatting which
+// would flatten the typical mlx-community README to plain text.
+
+import SwiftUI
+import AppKit
+import MarkdownUI
+
+// MARK: - Target / source
+
+/// What the sheet is showing. Identifiable so `.sheet(item:)` can
+/// drive presentation off the VM's `modelCardTarget` binding.
+struct ModelCardTarget: Identifiable, Equatable, Sendable {
+    let repoId: String
+    let source: ModelCardSource
+
+    /// `.sheet(item:)` uses this to decide when to re-present. Composing
+    /// source into the id means switching HF↔MS for the same string
+    /// re-fires the sheet's `.task(id:)` and refetches.
+    var id: String { "\(source.rawValue):\(repoId)" }
+}
+
+enum ModelCardSource: String, Sendable, Equatable {
+    case huggingFace = "hf"
+    case modelScope  = "ms"
+
+    var displayName: String {
+        switch self {
+        case .huggingFace: return "Hugging Face"
+        case .modelScope:  return "ModelScope"
+        }
+    }
+
+    /// Canonical upstream URL for the repo — used by the "View on …"
+    /// footer link. Always points at the canonical origin even when the
+    /// user has a mirror configured for downloads; the mirror is for
+    /// transport, not browsing.
+    func upstreamURL(repoId: String) -> URL? {
+        switch self {
+        case .huggingFace: return URL(string: "https://huggingface.co/\(repoId)")
+        case .modelScope:  return URL(string: "https://modelscope.cn/models/\(repoId)")
+        }
+    }
+}
+
+/// Tabs available inside the sheet. The Files tab is HF-only — matches
+/// the HTML admin which hides it for MS (MS file lists are usually
+/// opaque sharded blobs that don't help the user decide).
+enum ModelCardTab: Hashable, CaseIterable {
+    case card, files, tags
+
+    var label: String {
+        switch self {
+        case .card:
+            return String(localized: "downloads.card.tab.card",
+                          defaultValue: "Model Card",
+                          comment: "Tab label in the model card sheet for the README content")
+        case .files:
+            return String(localized: "downloads.card.tab.files",
+                          defaultValue: "Files",
+                          comment: "Tab label in the model card sheet for the repo file list")
+        case .tags:
+            return String(localized: "downloads.card.tab.tags",
+                          defaultValue: "Tags",
+                          comment: "Tab label in the model card sheet for the repo tag list")
+        }
+    }
+
+    static func available(for source: ModelCardSource) -> [ModelCardTab] {
+        switch source {
+        case .huggingFace: return [.card, .files, .tags]
+        case .modelScope:  return [.card, .tags]
+        }
+    }
+}
+
+// MARK: - Sheet
+
+@MainActor
+struct ModelCardSheet: View {
+    let target: ModelCardTarget
+    let client: OMLXClient
+    /// Triggered by the in-sheet Download button. The host wires this
+    /// to `vm.startDownload(repo:)` so the action plays nicely with
+    /// the existing source-routed downloader plumbing. Sheet dismisses
+    /// itself on tap so the user lands back on the row with the task
+    /// already moving in the Active section.
+    let onDownload: (String) -> Void
+
+    @State private var state: LoadState = .idle
+    /// Currently selected tab in the sheet. Reset to `.card` whenever
+    /// the target changes (different repo opened) so we never inherit
+    /// a stale Files/Tags selection from a previous model.
+    @State private var activeTab: ModelCardTab = .card
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.omlxTheme) private var theme
+
+    enum LoadState: Equatable {
+        case idle
+        case loading
+        case loaded(ModelCardDTO)
+        case failed(String)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            stateRegion
+        }
+        .frame(width: 720, height: 600)
+        .background(theme.windowBg)
+        .task(id: target.id) {
+            // Reset tab selection on every (re)open so a tab the
+            // previous repo had (e.g. Files on HF) doesn't stick when
+            // the user opens an MS card next.
+            activeTab = .card
+            await load()
+        }
+    }
+
+    // MARK: Header
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(target.repoId)
+                    .font(.omlxText(15, weight: .semibold))
+                    .foregroundStyle(theme.text)
+                    .textSelection(.enabled)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(target.source.displayName)
+                    .font(.omlxText(11, weight: .medium))
+                    .foregroundStyle(theme.textSecondary)
+                    .textCase(.uppercase)
+                    .kerning(0.6)
+            }
+            Spacer(minLength: 12)
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(theme.textSecondary)
+                    .padding(6)
+                    .background(theme.controlBg)
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+            .help(String(localized: "downloads.card.close",
+                         defaultValue: "Close",
+                         comment: "Tooltip on the model card sheet's close button"))
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
+
+    // MARK: State-dependent region
+
+    @ViewBuilder
+    private var stateRegion: some View {
+        switch state {
+        case .idle, .loading:
+            Divider().overlay(theme.groupBorder)
+            loadingView
+        case .failed(let message):
+            Divider().overlay(theme.groupBorder)
+            errorView(message: message)
+        case .loaded(let dto):
+            metadataRow(dto: dto)
+            if dto.isAdapter == true {
+                loraBanner
+            }
+            tabBar
+            Divider().overlay(theme.groupBorder)
+            tabBody(dto: dto)
+            footer(dto: dto)
+        }
+    }
+
+    // MARK: Tab bar
+
+    private var tabBar: some View {
+        let available = ModelCardTab.available(for: target.source)
+        return HStack(spacing: 6) {
+            ForEach(available, id: \.self) { tab in
+                tabButton(tab: tab, isSelected: activeTab == tab)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 20)
+        .padding(.bottom, 6)
+    }
+
+    private func tabButton(tab: ModelCardTab, isSelected: Bool) -> some View {
+        Button {
+            activeTab = tab
+        } label: {
+            Text(tab.label)
+                .font(.omlxText(11.5, weight: .semibold))
+                .foregroundStyle(isSelected ? theme.text : theme.textSecondary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(
+                    Capsule().fill(isSelected ? theme.controlBg : Color.clear)
+                )
+                .overlay(
+                    Capsule().strokeBorder(isSelected ? theme.inputBorder : Color.clear,
+                                           lineWidth: 0.5)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: Tab body switch
+
+    @ViewBuilder
+    private func tabBody(dto: ModelCardDTO) -> some View {
+        switch activeTab {
+        case .card:
+            cardBody(markdown: dto.modelCard)
+        case .files:
+            filesBody(files: dto.files ?? [])
+        case .tags:
+            tagsBody(tags: dto.tags ?? [])
+        }
+    }
+
+    // MARK: Metadata badges (gap #1)
+
+    @ViewBuilder
+    private func metadataRow(dto: ModelCardDTO) -> some View {
+        // Skip rendering the row entirely when none of the fields are
+        // populated — keeps the sheet from showing a hollow strip on
+        // metadata-poor repos.
+        let hasAnyMetadata = dto.paramsFormatted != nil
+            || dto.sizeFormatted != nil
+            || dto.pipelineTag != nil
+            || (dto.downloads ?? 0) > 0
+            || (dto.likes ?? 0) > 0
+        if hasAnyMetadata {
+            HStack(spacing: 8) {
+                if let p = dto.paramsFormatted, !p.isEmpty {
+                    metaChip(text: p, accent: false)
+                }
+                if let s = dto.sizeFormatted, !s.isEmpty {
+                    metaChip(text: s, accent: false)
+                }
+                if let tag = dto.pipelineTag, !tag.isEmpty {
+                    metaChip(text: tag, accent: true)
+                }
+                Spacer(minLength: 6)
+                if let d = dto.downloads, d > 0 {
+                    metaCounter(symbol: "arrow.down.circle", value: d)
+                }
+                if let l = dto.likes, l > 0 {
+                    metaCounter(symbol: "heart", value: l)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 12)
+        }
+    }
+
+    private func metaChip(text: String, accent: Bool) -> some View {
+        Text(text)
+            .font(.omlxText(10.5, weight: .heavy))
+            .kerning(0.4)
+            .textCase(.uppercase)
+            .foregroundStyle(accent ? theme.accent : theme.textSecondary)
+            .padding(.horizontal, 8)
+            .frame(height: 22)
+            .background(
+                Capsule().fill(accent ? theme.accent.opacity(0.12) : theme.codeBg)
+            )
+            .overlay(
+                Capsule().strokeBorder(accent ? theme.accent.opacity(0.25) : theme.inputBorder,
+                                       lineWidth: 0.5)
+            )
+    }
+
+    private func metaCounter(symbol: String, value: Int) -> some View {
+        HStack(spacing: 3) {
+            Image(systemName: symbol)
+                .font(.system(size: 10, weight: .medium))
+            Text(Self.compactCount(value))
+                .font(.omlxMono(11))
+        }
+        .foregroundStyle(theme.textSecondary)
+    }
+
+    // MARK: LoRA warning (gap #4)
+
+    private var loraBanner: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(theme.warningText)
+            Text(String(localized: "downloads.card.lora_warning",
+                        defaultValue: "This is a LoRA adapter. It needs a compatible base model to run — downloading on its own won't load in oMLX.",
+                        comment: "Warning banner shown in the model card sheet when the repo is an adapter rather than a full model"))
+                .font(.omlxText(11))
+                .foregroundStyle(theme.text)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(theme.warningBg)
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .strokeBorder(theme.warningText.opacity(0.25), lineWidth: 0.5)
+        )
+        .padding(.horizontal, 20)
+        .padding(.bottom, 10)
+    }
+
+    // MARK: Card body
+
+    @ViewBuilder
+    private func cardBody(markdown raw: String) -> some View {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            VStack(spacing: 10) {
+                Image(systemName: "doc.text.magnifyingglass")
+                    .font(.system(size: 32, weight: .light))
+                    .foregroundStyle(theme.textTertiary)
+                Text(String(localized: "downloads.card.empty",
+                            defaultValue: "This model doesn't ship a README.",
+                            comment: "Empty state shown when the upstream repo has no model card"))
+                    .font(.omlxText(13))
+                    .foregroundStyle(theme.textSecondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(24)
+        } else {
+            ScrollView {
+                Markdown(trimmed)
+                    .markdownTheme(.docC)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(20)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    // MARK: Files tab (gap #5)
+
+    @ViewBuilder
+    private func filesBody(files: [ModelCardFile]) -> some View {
+        if files.isEmpty {
+            emptyStateView(
+                symbol: "doc.text.below.ecg",
+                message: String(localized: "downloads.card.files.empty",
+                                defaultValue: "No files reported.",
+                                comment: "Empty state in the Files tab when the upstream API doesn't list any files")
+            )
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(files.enumerated()), id: \.element.id) { idx, file in
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Text(file.name)
+                                .font(.omlxMono(12))
+                                .foregroundStyle(theme.text)
+                                .textSelection(.enabled)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer(minLength: 8)
+                            if let s = file.sizeFormatted, !s.isEmpty {
+                                Text(s)
+                                    .font(.omlxMono(11))
+                                    .foregroundStyle(theme.textSecondary)
+                            }
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 8)
+                        if idx < files.count - 1 {
+                            Divider().opacity(0.4)
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    // MARK: Tags tab (gap #6)
+
+    @ViewBuilder
+    private func tagsBody(tags: [String]) -> some View {
+        if tags.isEmpty {
+            emptyStateView(
+                symbol: "tag",
+                message: String(localized: "downloads.card.tags.empty",
+                                defaultValue: "No tags.",
+                                comment: "Empty state in the Tags tab when the upstream API doesn't list any tags")
+            )
+        } else {
+            ScrollView {
+                FlowLayout(spacing: 6) {
+                    ForEach(tags, id: \.self) { tag in
+                        tagPill(tag)
+                    }
+                }
+                .padding(20)
+            }
+        }
+    }
+
+    private func tagPill(_ tag: String) -> some View {
+        Text(tag)
+            .font(.omlxMono(11))
+            .foregroundStyle(theme.textSecondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                Capsule().fill(theme.codeBg)
+            )
+            .overlay(
+                Capsule().strokeBorder(theme.inputBorder, lineWidth: 0.5)
+            )
+            .textSelection(.enabled)
+    }
+
+    private func emptyStateView(symbol: String, message: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: symbol)
+                .font(.system(size: 28, weight: .light))
+                .foregroundStyle(theme.textTertiary)
+            Text(message)
+                .font(.omlxText(13))
+                .foregroundStyle(theme.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(24)
+    }
+
+    // MARK: Footer (gaps #2 + #3)
+
+    @ViewBuilder
+    private func footer(dto: ModelCardDTO) -> some View {
+        Divider().overlay(theme.groupBorder)
+        HStack(spacing: 10) {
+            if let url = target.source.upstreamURL(repoId: target.repoId) {
+                Button {
+                    NSWorkspace.shared.open(url)
+                } label: {
+                    Label {
+                        Text(viewUpstreamLabel)
+                    } icon: {
+                        Image(systemName: "arrow.up.right.square")
+                            .font(.system(size: 11))
+                    }
+                    .font(.omlxText(11.5, weight: .medium))
+                    .foregroundStyle(theme.textSecondary)
+                }
+                .buttonStyle(.plain)
+            }
+            Spacer()
+            if dto.isAdapter != true {
+                // Adapters can't be downloaded as a runnable model;
+                // hide the action entirely so the user doesn't kick
+                // off a download that won't load.
+                Button {
+                    onDownload(target.repoId)
+                    dismiss()
+                } label: {
+                    Label(String(localized: "downloads.card.download",
+                                 defaultValue: "Download",
+                                 comment: "Primary button in the model card sheet that starts downloading the displayed model"),
+                          systemImage: "icloud.and.arrow.down")
+                        .labelStyle(.titleAndIcon)
+                }
+                .buttonStyle(.omlx(.primary))
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
+    }
+
+    /// Source-specific label for the "View on …" link. Localized via
+    /// inline interpolation of the source's display name.
+    private var viewUpstreamLabel: String {
+        String(localized: "downloads.card.view_upstream",
+               defaultValue: "View on \(target.source.displayName)",
+               comment: "Link button in the model card sheet that opens the upstream model page; placeholder is 'Hugging Face' or 'ModelScope'")
+    }
+
+    // MARK: Error / loading
+
+    private var loadingView: some View {
+        VStack(spacing: 10) {
+            ProgressView()
+            Text(String(localized: "downloads.card.loading",
+                        defaultValue: "Loading model card…",
+                        comment: "Status text shown while the model README is being fetched"))
+                .font(.omlxText(11))
+                .foregroundStyle(theme.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorView(message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 32, weight: .light))
+                .foregroundStyle(theme.redDot)
+            Text(String(localized: "downloads.card.error",
+                        defaultValue: "Couldn't load model card",
+                        comment: "Title shown in the model card sheet when the fetch failed"))
+                .font(.omlxText(13, weight: .semibold))
+                .foregroundStyle(theme.text)
+            Text(message)
+                .font(.omlxText(11))
+                .foregroundStyle(theme.textSecondary)
+                .multilineTextAlignment(.center)
+                .textSelection(.enabled)
+            Button(String(localized: "downloads.card.retry",
+                          defaultValue: "Retry",
+                          comment: "Retry button shown after the model card fetch failed")) {
+                Task { await load() }
+            }
+            .buttonStyle(.omlx(.primary))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(24)
+    }
+
+    // MARK: Fetch
+
+    private func load() async {
+        state = .loading
+        do {
+            let dto: ModelCardDTO
+            switch target.source {
+            case .huggingFace:
+                dto = try await client.getHFModelCard(repoId: target.repoId)
+            case .modelScope:
+                dto = try await client.getMSModelCard(modelId: target.repoId)
+            }
+            state = .loaded(dto)
+        } catch {
+            state = .failed(error.omlxDescription)
+        }
+    }
+
+    // MARK: Helpers
+
+    /// Compact-format a count for the metadata counters: 1234 → "1.2K",
+    /// 1_500_000 → "1.5M". Mirrors the HTML admin's display so the same
+    /// repos show the same numbers on both surfaces.
+    private static func compactCount(_ n: Int) -> String {
+        switch n {
+        case 1_000_000_000...:
+            return String(format: "%.1fB", Double(n) / 1_000_000_000)
+        case 1_000_000...:
+            return String(format: "%.1fM", Double(n) / 1_000_000)
+        case 1_000...:
+            return String(format: "%.1fK", Double(n) / 1_000)
+        default:
+            return String(n)
+        }
+    }
+}
+
+// `FlowLayout` (used by the Tags tab) lives in ProfileViews.swift —
+// reused here for consistency. If it ever needs to specialize for the
+// model-card sheet, prefer extending the shared type over forking.

--- a/apps/omlx-mac/Sources/Net/DTO/ModelCardDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/ModelCardDTO.swift
@@ -1,0 +1,63 @@
+// PR — Downloads model card. Decodes `/admin/api/hf/model-info` and
+// `/admin/api/ms/model-info`. Both endpoints share the same envelope
+// (modelo card + metadata) so a single DTO handles both.
+//
+// All metadata fields are optional because:
+//   • `model_card` is always present (server normalizes empty to "")
+//   • MS doesn't surface `params` (server returns null for it)
+//   • MS doesn't surface `is_adapter` at all (HF-only field)
+//   • Even on HF, some repos omit pipeline_tag or have zero downloads/likes
+//
+// Future tabs (Files, Tags) would decode `files` and `tags` here — left
+// out for now since v1 ships a single Card view.
+
+import Foundation
+
+struct ModelCardDTO: Decodable, Equatable, Sendable {
+    /// Raw Markdown body of the model's README. May be empty when the
+    /// upstream repo doesn't ship one.
+    let modelCard: String
+
+    /// HF-style pipeline tag, e.g. "text-generation", "automatic-speech-recognition".
+    /// Renders as a colored pill in the sheet's metadata row.
+    let pipelineTag: String?
+
+    /// Server-formatted parameter count, e.g. "7B", "13B". Already
+    /// display-ready — never reformat client-side.
+    let paramsFormatted: String?
+
+    /// Server-formatted total weight size on disk, e.g. "4.2 GB".
+    let sizeFormatted: String?
+
+    /// Lifetime download count from the upstream API.
+    let downloads: Int?
+
+    /// Lifetime like/star count from the upstream API.
+    let likes: Int?
+
+    /// HF-only: true when the repo is a LoRA / PEFT adapter rather than
+    /// a full model. The sheet renders a warning banner and hides the
+    /// Download button so the user doesn't accidentally pull an adapter
+    /// they can't run standalone.
+    let isAdapter: Bool?
+
+    /// Per-file listing — name + size in bytes + server-formatted size.
+    /// Drives the Files tab. Always present for HF; MS returns the same
+    /// shape but the sheet hides the Files tab for MS to match the HTML
+    /// admin's behavior (MS repos are usually opaque sharded blobs).
+    let files: [ModelCardFile]?
+
+    /// Free-form tag strings from the upstream API. Drives the Tags tab
+    /// for both sources.
+    let tags: [String]?
+}
+
+/// One entry in `ModelCardDTO.files`. `sizeFormatted` is already
+/// display-ready ("4.2 GB", "1.5 MB"); never reformat client-side.
+struct ModelCardFile: Decodable, Equatable, Sendable, Identifiable {
+    let name: String
+    let size: Int64
+    let sizeFormatted: String?
+
+    var id: String { name }
+}

--- a/apps/omlx-mac/Sources/Net/Endpoints.swift
+++ b/apps/omlx-mac/Sources/Net/Endpoints.swift
@@ -50,6 +50,7 @@ enum AdminAPI {
     static func hfTask(_ taskId: String) -> String   { "\(prefix)/hf/task/\(taskId)" }
     static let hfRecommended   = "\(prefix)/hf/recommended"
     static let hfSearch        = "\(prefix)/hf/search"
+    static let hfModelInfo     = "\(prefix)/hf/model-info"
     static func hfModel(_ name: String) -> String { "\(prefix)/hf/models/\(name)" }
 
     // Phase 2 — ModelScope downloader (mirrors the /hf/* surface 1:1, just
@@ -62,6 +63,7 @@ enum AdminAPI {
     static func msTask(_ taskId: String) -> String   { "\(prefix)/ms/task/\(taskId)" }
     static let msRecommended   = "\(prefix)/ms/recommended"
     static let msSearch        = "\(prefix)/ms/search"
+    static let msModelInfo     = "\(prefix)/ms/model-info"
 
     // PR 9
     static let setupApiKey     = "\(prefix)/setup-api-key"

--- a/apps/omlx-mac/Sources/Net/OMLXClient.swift
+++ b/apps/omlx-mac/Sources/Net/OMLXClient.swift
@@ -243,6 +243,18 @@ final class OMLXClient: ObservableObject {
         ])
     }
 
+    /// Fetch the README for a Hugging Face repo, the same payload the
+    /// browser admin renders in its model-card slide-over. Cache-aware
+    /// on the server (uses `hf_hub_download` under the hood), so post-
+    /// download lookups skip the network. Returns an empty
+    /// `modelCard` string when the upstream repo has no README — that
+    /// is a "no card" state, not an error.
+    func getHFModelCard(repoId: String) async throws -> ModelCardDTO {
+        try await get(AdminAPI.hfModelInfo, query: [
+            URLQueryItem(name: "repo_id", value: repoId),
+        ])
+    }
+
     // MARK: - ModelScope (Phase 2)
     //
     // 1:1 mirror of the /hf/* surface above, pointed at the parallel
@@ -300,6 +312,15 @@ final class OMLXClient: ObservableObject {
             URLQueryItem(name: "sort", value: sort),
             URLQueryItem(name: "limit", value: String(limit)),
             URLQueryItem(name: "mlx_only", value: mlxOnly ? "true" : "false"),
+        ])
+    }
+
+    /// ModelScope mirror of `getHFModelCard(repoId:)`. Returns the same
+    /// shape (`{model_card: "<markdown>"}`); empty string when the
+    /// upstream repo has no README.
+    func getMSModelCard(modelId: String) async throws -> ModelCardDTO {
+        try await get(AdminAPI.msModelInfo, query: [
+            URLQueryItem(name: "model_id", value: modelId),
         ])
     }
 

--- a/apps/omlx-mac/Tests/oMLXTests/ModelCardDTODecodeTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelCardDTODecodeTests.swift
@@ -1,0 +1,175 @@
+// Covers `ModelCardDTO`'s decode contract with both `/admin/api/hf/model-info`
+// and `/admin/api/ms/model-info`. The DTO is a single shared shape across
+// both surfaces because the server already strips YAML front-matter and
+// returns the same `{model_card: "<markdown>"}` envelope from either route
+// — so a decode regression here would silently break both Hugging Face and
+// ModelScope model-card sheets at once.
+
+import XCTest
+@testable import oMLX
+
+final class ModelCardDTODecodeTests: XCTestCase {
+
+    /// Mirrors the `OMLXClient` decoder configuration so snake_case
+    /// `model_card` maps to the camelCase `modelCard` property.
+    private let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }()
+
+    func testDecodeMarkdownBody() throws {
+        let json = """
+        {
+            "model_card": "# Model\\n\\nSome description.\\n\\n- bullet\\n"
+        }
+        """.data(using: .utf8)!
+
+        let dto = try decoder.decode(ModelCardDTO.self, from: json)
+        XCTAssertEqual(dto.modelCard, "# Model\n\nSome description.\n\n- bullet\n")
+    }
+
+    func testDecodeEmptyStringIsLegal() throws {
+        // The server signals "no README on the upstream repo" with an
+        // empty string rather than a 404 — the sheet's `.empty` branch
+        // distinguishes it from `.failed`. If we changed decoding to
+        // reject empty strings, every model without a README would
+        // surface as an error instead of the friendly empty state.
+        let json = #"{"model_card": ""}"#.data(using: .utf8)!
+
+        let dto = try decoder.decode(ModelCardDTO.self, from: json)
+        XCTAssertEqual(dto.modelCard, "")
+    }
+
+    func testIgnoresExtraFields() throws {
+        // Real responses include additional fields the DTO doesn't
+        // currently consume (e.g. `tags`, `files`, `description`,
+        // `created_at`). Swift's default Decodable behaviour ignores
+        // unknown keys; assert it here so a future migration to
+        // .failOnUnknownKey is caught.
+        let json = """
+        {
+            "model_card": "Hello",
+            "tags": ["text-generation", "mlx"],
+            "files": [{"name": "README.md", "size": 1234}],
+            "description": "A model",
+            "created_at": "2026-01-01T00:00:00Z"
+        }
+        """.data(using: .utf8)!
+
+        let dto = try decoder.decode(ModelCardDTO.self, from: json)
+        XCTAssertEqual(dto.modelCard, "Hello")
+        XCTAssertNil(dto.downloads)
+        XCTAssertNil(dto.likes)
+    }
+
+    func testDecodesFullHFMetadata() throws {
+        // Production-shaped HF response — every metadata field populated.
+        // Drives the sheet's badges (params/size/pipeline_tag), the
+        // downloads / likes counters, and the LoRA-adapter warning.
+        let json = """
+        {
+            "repo_id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            "name": "Llama 3.2",
+            "model_card": "# Llama 3.2 3B Instruct",
+            "pipeline_tag": "text-generation",
+            "params": 3000000000,
+            "params_formatted": "3B",
+            "size": 4500000000,
+            "size_formatted": "4.2 GB",
+            "downloads": 12500,
+            "likes": 234,
+            "is_adapter": false
+        }
+        """.data(using: .utf8)!
+
+        let dto = try decoder.decode(ModelCardDTO.self, from: json)
+        XCTAssertEqual(dto.pipelineTag, "text-generation")
+        XCTAssertEqual(dto.paramsFormatted, "3B")
+        XCTAssertEqual(dto.sizeFormatted, "4.2 GB")
+        XCTAssertEqual(dto.downloads, 12500)
+        XCTAssertEqual(dto.likes, 234)
+        XCTAssertEqual(dto.isAdapter, false)
+    }
+
+    func testDecodesMSResponseWithoutHFOnlyFields() throws {
+        // ModelScope returns the same envelope but omits `is_adapter`
+        // entirely and always leaves `params`/`params_formatted` null
+        // (see ms_downloader.py). Decoder must treat both as nil rather
+        // than throwing.
+        let json = """
+        {
+            "model_card": "## A ModelScope model",
+            "pipeline_tag": null,
+            "params": null,
+            "params_formatted": null,
+            "size_formatted": "8.1 GB",
+            "downloads": 4200,
+            "likes": 88
+        }
+        """.data(using: .utf8)!
+
+        let dto = try decoder.decode(ModelCardDTO.self, from: json)
+        XCTAssertNil(dto.pipelineTag)
+        XCTAssertNil(dto.paramsFormatted)
+        XCTAssertEqual(dto.sizeFormatted, "8.1 GB")
+        XCTAssertEqual(dto.downloads, 4200)
+        XCTAssertNil(dto.isAdapter,
+                     "MS responses omit is_adapter entirely; decoder must produce nil, not throw.")
+    }
+
+    func testDecodesLoraAdapter() throws {
+        // Adapter repos surface with `is_adapter: true` — the sheet's
+        // warning banner hinges on this. Test it as an isolated case
+        // so a server-side rename catches here, not via the larger
+        // metadata test.
+        let json = #"{"model_card": "...", "is_adapter": true}"#.data(using: .utf8)!
+        let dto = try decoder.decode(ModelCardDTO.self, from: json)
+        XCTAssertEqual(dto.isAdapter, true)
+    }
+
+    func testDecodesFilesList() throws {
+        // Files tab payload — server emits one object per repo file with
+        // `name`, raw `size` in bytes, and a `size_formatted` string we
+        // surface directly. `size_formatted` may be empty when the file
+        // size is unknown (server returns "" rather than null in that
+        // case — see hf_downloader.py:504).
+        let json = """
+        {
+            "model_card": "...",
+            "files": [
+                {"name": "README.md", "size": 12345, "size_formatted": "12 KB"},
+                {"name": "model.safetensors", "size": 4500000000, "size_formatted": "4.2 GB"},
+                {"name": "config.json", "size": 800, "size_formatted": ""}
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let dto = try decoder.decode(ModelCardDTO.self, from: json)
+        XCTAssertEqual(dto.files?.count, 3)
+        XCTAssertEqual(dto.files?[0].name, "README.md")
+        XCTAssertEqual(dto.files?[1].size, 4_500_000_000)
+        XCTAssertEqual(dto.files?[1].sizeFormatted, "4.2 GB")
+        XCTAssertEqual(dto.files?[2].sizeFormatted, "")
+    }
+
+    func testDecodesTagsList() throws {
+        // Tags tab payload — flat array of strings. MS encodes them as
+        // comma-separated server-side but converts before serializing,
+        // so the wire shape is identical to HF.
+        let json = #"{"model_card": "...", "tags": ["text-generation", "mlx", "license:apache-2.0"]}"#
+            .data(using: .utf8)!
+        let dto = try decoder.decode(ModelCardDTO.self, from: json)
+        XCTAssertEqual(dto.tags, ["text-generation", "mlx", "license:apache-2.0"])
+    }
+
+    func testMissingFieldThrows() throws {
+        // The contract requires `model_card` to be present, even if
+        // empty. If the server ever omits the field, we want a decode
+        // error surfaced as `.failed` in the sheet, not a silent empty
+        // body that masks a server-side regression.
+        let json = #"{"unrelated": "value"}"#.data(using: .utf8)!
+
+        XCTAssertThrowsError(try decoder.decode(ModelCardDTO.self, from: json))
+    }
+}

--- a/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
+++ b/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
@@ -67,6 +67,9 @@
 		8BB000000000000000000009 /* ProfileWorkingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC000000000000000000009 /* ProfileWorkingState.swift */; };
 		8BB00000000000000000000A /* MSTaskDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC00000000000000000000A /* MSTaskDTO.swift */; };
 		9BB000000000000000000005 /* PresetBundleDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000005 /* PresetBundleDTO.swift */; };
+		DBB000000000000000000101 /* ModelCardDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000101 /* ModelCardDTO.swift */; };
+		DBB000000000000000000102 /* ModelCardSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000102 /* ModelCardSheet.swift */; };
+		EBB000000000000000000001 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = ECC000000000000000000001 /* MarkdownUI */; };
 		9BB000000000000000000006 /* PresetBundleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000006 /* PresetBundleStore.swift */; };
 		9BB000000000000000000001 /* SubKeyDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000001 /* SubKeyDTO.swift */; };
 		9BB000000000000000000002 /* OQDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000002 /* OQDTO.swift */; };
@@ -92,6 +95,7 @@
 		DBB00000000000000000000E /* ServerProcessIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */; };
 		DBB00000000000000000000F /* LocalizationSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000F /* LocalizationSmokeTests.swift */; };
 		DBB000000000000000000100 /* MenubarControllerPortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000100 /* MenubarControllerPortTests.swift */; };
+		DBB000000000000000000103 /* ModelCardDTODecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000103 /* ModelCardDTODecodeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -168,6 +172,8 @@
 		8CC000000000000000000009 /* ProfileWorkingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileWorkingState.swift; sourceTree = "<group>"; };
 		8CC00000000000000000000A /* MSTaskDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSTaskDTO.swift; sourceTree = "<group>"; };
 		9CC000000000000000000005 /* PresetBundleDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetBundleDTO.swift; sourceTree = "<group>"; };
+		DCC000000000000000000101 /* ModelCardDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCardDTO.swift; sourceTree = "<group>"; };
+		DCC000000000000000000102 /* ModelCardSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCardSheet.swift; sourceTree = "<group>"; };
 		9CC000000000000000000006 /* PresetBundleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetBundleStore.swift; sourceTree = "<group>"; };
 		9CC000000000000000000001 /* SubKeyDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubKeyDTO.swift; sourceTree = "<group>"; };
 		9CC000000000000000000002 /* OQDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OQDTO.swift; sourceTree = "<group>"; };
@@ -193,6 +199,7 @@
 		DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerProcessIntegrationTests.swift; sourceTree = "<group>"; };
 		DCC00000000000000000000F /* LocalizationSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationSmokeTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000100 /* MenubarControllerPortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarControllerPortTests.swift; sourceTree = "<group>"; };
+		DCC000000000000000000103 /* ModelCardDTODecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCardDTODecodeTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000010 /* oMLXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = oMLXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -201,6 +208,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EBB000000000000000000001 /* MarkdownUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -251,6 +259,7 @@
 				DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */,
 				DCC00000000000000000000F /* LocalizationSmokeTests.swift */,
 				DCC000000000000000000100 /* MenubarControllerPortTests.swift */,
+				DCC000000000000000000103 /* ModelCardDTODecodeTests.swift */,
 			);
 			path = oMLXTests;
 			sourceTree = "<group>";
@@ -317,6 +326,7 @@
 				9CC000000000000000000003 /* HFUploadDTO.swift */,
 				9CC000000000000000000004 /* BenchDTO.swift */,
 				9CC000000000000000000005 /* PresetBundleDTO.swift */,
+				DCC000000000000000000101 /* ModelCardDTO.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -353,6 +363,7 @@
 				6CC00000000000000000000E /* AccuracyBenchScreen.swift */,
 				6CC00000000000000000000F /* NetworkScreen.swift */,
 				6CC000000000000000000010 /* PerformanceScreen.swift */,
+				DCC000000000000000000102 /* ModelCardSheet.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -462,6 +473,7 @@
 			);
 			name = "oMLX";
 			packageProductDependencies = (
+				ECC000000000000000000001 /* MarkdownUI */,
 			);
 			productName = "oMLX";
 			productReference = 1CCCCCCCCCCCCCCCCCCCCCC7 /* oMLX.app */;
@@ -513,6 +525,7 @@
 			);
 			mainGroup = 1BBBBBBBBBBBBBBBBBBBBBB1;
 			packageReferences = (
+				EDD000000000000000000001 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 			);
 			productRefGroup = 1BBBBBBBBBBBBBBBBBBBBBB6 /* Products */;
 			projectDirPath = "";
@@ -594,6 +607,8 @@
 				8BB000000000000000000003 /* HFTaskDTO.swift in Sources */,
 				8BB00000000000000000000A /* MSTaskDTO.swift in Sources */,
 				9BB000000000000000000005 /* PresetBundleDTO.swift in Sources */,
+				DBB000000000000000000101 /* ModelCardDTO.swift in Sources */,
+				DBB000000000000000000102 /* ModelCardSheet.swift in Sources */,
 				9BB000000000000000000006 /* PresetBundleStore.swift in Sources */,
 				8BB000000000000000000004 /* ModelSettingsScreen.swift in Sources */,
 				8BB000000000000000000005 /* ChatTemplateKwargs.swift in Sources */,
@@ -631,6 +646,7 @@
 				DBB00000000000000000000E /* ServerProcessIntegrationTests.swift in Sources */,
 				DBB00000000000000000000F /* LocalizationSmokeTests.swift in Sources */,
 				DBB000000000000000000100 /* MenubarControllerPortTests.swift in Sources */,
+				DBB000000000000000000103 /* ModelCardDTODecodeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -881,6 +897,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		EDD000000000000000000001 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		ECC000000000000000000001 /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EDD000000000000000000001 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 1AAAAAAAAAAAAAAAAAAAAAA1 /* Project object */;
 }


### PR DESCRIPTION
## Summary

Adds the model-card slide-over to the Swift Downloads screen — closes the parity gap with the HTML admin panel's model-card modal. The server endpoints (`/admin/api/hf/model-info` and `/admin/api/ms/model-info`) were already in place; this PR is entirely client-side.

## What you see

**Where the info button lives**

| Surface | Affordance |
|---|---|
| Completed Tasks rows | `info.circle` button between primary actions |
| Suggested Models rows | `info.circle` button before the Get button |
| HF / MS search dropdown rows | Hover-revealed `info.circle` at the trailing edge — replaces the downloads count while hovered so the icon has a clean slot and the row's `onPick` tap is unaffected |

**Sheet layout** (720×600)

- Header: model name + source badge ("Hugging Face" / "ModelScope")
- Metadata strip: params / size / pipeline_tag pills + downloads (↓) and likes (♥) counters in compact format (`1.2K`, `3.4M`)
- LoRA warning banner when `is_adapter == true` (HF only) — Download button is hidden in that case so users don't pull an adapter they can't run standalone
- Tab bar:
  - HF: `Model Card | Files | Tags`
  - MS: `Model Card | Tags` (Files hidden, matching the HTML admin)
- Tab body:
  - **Model Card** — Markdown rendered via `swift-markdown-ui`'s `.docC` theme (full block support — headings, code blocks, tables, images). Empty-string `model_card` shows a friendly "no README" state
  - **Files** — scrollable list with file name + server-formatted size
  - **Tags** — wrap-flow of pill chips (reuses the existing `FlowLayout` from `ProfileViews.swift`)
- Footer: "View on Hugging Face/ModelScope" external link + primary Download button (auto-dismisses sheet, kicks the download to the existing source-routed `startDownload` path)
- Loading / error / empty states with localized copy + Retry button on errors

## Why these UX choices

- **Info button (not click-on-name)**: macOS HIG canonical "more info" affordance, doesn't conflict with the row's primary "Download/Get" action, discoverable for a new feature. See discussion in the [audit thread](https://github.com/popfido/omlx/pull/1505) for the transactional-unit framing.
- **Hover-reveal for search dropdown**: the search-result row is already a single full-row `Button { onPick(m) }`; always-visible info icon would crowd and conflict. Finder-style hover swaps the count for the icon — same trailing slot, no overlap.
- **`swift-markdown-ui` over native `AttributedString(markdown:)`**: mlx-community READMEs typically have tables, code blocks, and heading hierarchy — native flattens all of those to plain text. The library is pure-SwiftUI, MIT, ~10K stars, actively maintained.
- **LoRA warning + hide Download**: prevents the most common "I downloaded the adapter and it doesn't load" support thread.

## Network

- `ModelCardDTO` decodes both endpoints (same envelope, optional fields tolerate HF/MS shape differences without per-source DTOs)
- `OMLXClient.getHFModelCard(repoId:)` / `getMSModelCard(modelId:)` use the existing GET helper

## Dependencies

First third-party SPM dep in the project. `project.pbxproj` gains the expected `XCRemoteSwiftPackageReference` + `XCSwiftPackageProductDependency` scaffolding and the framework is linked into oMLX's Frameworks build phase. `Package.resolved` stays ignored per the project's existing `.gitignore` convention; `minimumVersion = 2.4.0` + `upToNextMajorVersion` covers reproducibility.

| Package | Version | Source | Purpose |
|---|---|---|---|
| `swift-markdown-ui` | 2.4.1 (any 2.x) | github.com/gonzalezreal | Markdown rendering |
| `NetworkImage` | 6.0.1 | transitive | Image rendering in markdown |
| `swift-cmark` | 0.8.0 | transitive (from swiftlang) | Markdown parser |

## Test plan

`xcodebuild test` green — 132 tests, 1 integration skipped, 0 failures.

`ModelCardDTODecodeTests` (9 cases):
- [x] markdown body decoded
- [x] empty `model_card` is legal (no-README signal, not an error)
- [x] missing `model_card` field throws (server-side regression guard)
- [x] unknown fields ignored (forward-compat with new server fields)
- [x] full HF metadata (params/size/pipeline_tag/downloads/likes/is_adapter) decodes
- [x] MS shape (no is_adapter, null params) decodes without throwing
- [x] LoRA-adapter flag decodes in isolation
- [x] files list decodes (name/size/size_formatted including empty size_formatted)
- [x] tags list decodes

Manual (verified locally against a live server PATCH path):
- [x] Info button visible on Completed + Suggested rows
- [x] Info button hover-reveals on HF + MS search dropdown rows; clicking it doesn't fire `onPick`
- [x] Sheet renders Markdown with headings / code / tables / lists
- [x] Metadata badges render for HF; counters compact-format
- [x] Tabs switch correctly; tab selection resets to `Model Card` between repos
- [x] Files tab shows file list with sizes (HF)
- [x] Tags tab shows wrap-flow pills
- [x] LoRA banner appears for adapter repos; Download button hides
- [x] "View on Hugging Face/ModelScope" opens the canonical upstream URL
- [x] Download button kicks a fresh task into Active Downloads + dismisses the sheet
- [x] Close: ⎋ key + X button
- [x] Source switch (HF↔MS) re-fires the fetch via the sheet's `.task(id:)` keyed on `source+repoId`

## Notes

- The Tags tab uses the existing `FlowLayout` from `ProfileViews.swift` rather than introducing a duplicate; first attempt collided on the type name and was caught at build time.
- The HF Files / MS Files contrast matches the HTML admin's choice (MS file lists are usually sharded blobs that don't help the user decide).
- Future: a `Description` field is on the wire for both endpoints but not surfaced anywhere visible — could land as a one-line subtitle in the header in a follow-up if useful.