### PR TITLE
fix(model_discovery): classify LFM text MoE as LLM, not mlx-audio STS

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -395,6 +395,16 @@ def _has_vision_subconfig(config: dict) -> bool:
     )
 
 
+def _architecture_indicates_causal_lm(architectures: list[str]) -> bool:
+    """True when ``architectures`` describe a text causal LM (not mlx-audio STS).
+
+    Liquid LFM text checkpoints (LFM2, LFM2.5 MoE, etc.) use ``lfm*`` model
+    types and ``*ForCausalLM`` classes. mlx-audio LFM STS uses ``LFM2AudioModel``
+    and is handled earlier via :data:`AUDIO_STS_ARCHITECTURES`.
+    """
+    return any("causallm" in arch.lower() for arch in architectures)
+
+
 def detect_model_type(model_path: Path) -> ModelType:
     """
     Detect model type from config.json.
@@ -546,8 +556,12 @@ def detect_model_type(model_path: Path) -> ModelType:
         return "audio_stt"
     if normalized_type in AUDIO_STS_MODEL_TYPES or model_type in AUDIO_STS_MODEL_TYPES:
         return "audio_sts"
-    # LFM2 audio: model_type starts with "lfm" and is not an embedding
+    # mlx-audio LFM STS may use an "lfm*" model_type without a known architecture
+    # string yet. Liquid LFM *text* checkpoints share that prefix — disambiguate
+    # with CausalLM architecture names (LFM2 / LFM2.5 MoE, future lfm* LMs).
     if normalized_type.startswith("lfm") and normalized_type not in EMBEDDING_MODEL_TYPES:
+        if _architecture_indicates_causal_lm(architectures):
+            return "llm"
         return "audio_sts"
 
     return "llm"

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -410,6 +410,51 @@ class TestDetectModelType:
         (tmp_path / "config.json").write_text(json.dumps(config))
         assert detect_model_type(tmp_path) == "llm"
 
+    def test_detect_lfm_text_moe_family_as_llm_not_audio_sts(self, tmp_path):
+        """LFM text MoE (lfm*_moe + *ForCausalLM) must not use mlx-audio STS."""
+        config = {
+            "model_type": "lfm2_moe",
+            "architectures": ["Lfm2MoeForCausalLM"],
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "llm"
+
+    def test_detect_lfm_future_moe_variant_as_llm_not_audio_sts(self, tmp_path):
+        """Any lfm*_moe text type with *ForCausalLM uses LLM, not mlx-audio STS."""
+        config = {
+            "model_type": "lfm2_5_moe",
+            "architectures": ["Lfm2MoeForCausalLM"],
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "llm"
+
+    def test_detect_lfm_audio_architecture_as_sts(self, tmp_path):
+        """mlx-audio LFM STS remains classified via LFM2AudioModel architecture."""
+        config = {
+            "model_type": "lfm_audio",
+            "architectures": ["LFM2AudioModel"],
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "audio_sts"
+
+    def test_detect_lfm_audio_model_type_as_sts(self, tmp_path):
+        """lfm_audio model_type is STS even without a recognized architecture."""
+        config = {
+            "model_type": "lfm_audio",
+            "architectures": [],
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "audio_sts"
+
+    def test_detect_unknown_lfm_prefix_without_causal_lm_as_sts(self, tmp_path):
+        """Unknown mlx-audio lfm* types without CausalLM still use prefix fallback."""
+        config = {
+            "model_type": "lfm_custom_audio",
+            "architectures": ["SomeLegacyLFMAudioWrapper"],
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "audio_sts"
+
 
 class TestEstimateModelSize:
     """Tests for estimate_model_size function."""


### PR DESCRIPTION
## Summary

- The `lfm*` `model_type` prefix fallback was meant for mlx-audio STS checkpoints, but it also matched Liquid LFM **text** exports (`lfm2_moe`, `lfm2_5_moe`, etc. with `*ForCausalLM`).
- Text LFM models are now classified as `llm` when architectures include CausalLM.
- Real LFM audio stays on existing paths: `LFM2AudioModel` (architecture) and `lfm_audio` (`AUDIO_STS_MODEL_TYPES`).

## Test plan

- [x] `pytest tests/test_model_discovery.py -k lfm` (5 cases: text MoE variants, audio arch, `lfm_audio` model_type-only, unknown mlx-audio prefix)
- [x] Full `tests/test_model_discovery.py` (107 passed)
