### PR TITLE
fix(server): gate Anthropic usage partition on cache_control, not engine prefix cache

### DIFF
--- a/omlx/api/anthropic_utils.py
+++ b/omlx/api/anthropic_utils.py
@@ -28,6 +28,38 @@ _PRESERVE_ROLE_BOUNDARY = "_preserve_role_boundary"
 logger = logging.getLogger(__name__)
 
 
+def request_has_cache_control(request: MessagesRequest) -> bool:
+    """True if any system / tool / message block carries ``cache_control``.
+
+    Anthropic's three input-side usage fields (``input_tokens``,
+    ``cache_creation_input_tokens``, ``cache_read_input_tokens``) form a
+    *disjoint* partition of the prompt only when the client explicitly
+    marks a region with ``cache_control``. Without that signal the cache
+    fields must stay at 0 and ``input_tokens`` carries the whole prompt
+    count — independent of whether the oMLX engine happens to run
+    automatic prefix caching internally.
+    """
+    sys = request.system
+    if isinstance(sys, list):
+        for blk in sys:
+            if getattr(blk, "cache_control", None):
+                return True
+
+    for tool in request.tools or []:
+        if getattr(tool, "cache_control", None):
+            return True
+
+    for msg in request.messages:
+        content = msg.content
+        if not isinstance(content, list):
+            continue
+        for blk in content:
+            if getattr(blk, "cache_control", None):
+                return True
+
+    return False
+
+
 def _decode_document_block(block_dict: dict[str, Any]) -> str:
     """Decode an Anthropic document content block to text.
 
@@ -806,16 +838,19 @@ def convert_internal_to_anthropic_response(
     tool_calls: list[ToolCall] | None = None,
     thinking: str | None = None,
     cached_tokens: int = 0,
-    prefix_cache_enabled: bool = False,
+    request_uses_cache_control: bool = False,
 ) -> MessagesResponse:
     """
     Convert internal output to Anthropic MessagesResponse.
 
-    When ``prefix_cache_enabled`` is True the prompt count is split into
-    Anthropic's disjoint usage fields so that
-    input_tokens + cache_creation_input_tokens + cache_read_input_tokens
-    equals prompt_tokens. Otherwise the response keeps the legacy shape
-    (input_tokens = prompt_tokens, cache fields = 0).
+    When the request carries ``cache_control`` breakpoints (signalled by
+    ``request_uses_cache_control``) the prompt count is split into
+    Anthropic's disjoint usage triple so that
+    ``input_tokens + cache_creation_input_tokens + cache_read_input_tokens
+    == prompt_tokens``. Otherwise the response keeps the legacy shape
+    (``input_tokens = prompt_tokens``, both cache fields = 0) — even when
+    the engine's automatic prefix cache happened to hit, since Anthropic
+    only surfaces the cache triple when the client opted in.
 
     Args:
         text: Generated text content
@@ -826,7 +861,8 @@ def convert_internal_to_anthropic_response(
         tool_calls: List of internal ToolCall objects
         thinking: Reasoning/thinking content from <think> blocks
         cached_tokens: Prompt tokens served from the prefix cache
-        prefix_cache_enabled: Whether the engine runs automatic prefix caching
+        request_uses_cache_control: Whether the originating request carried
+            ``cache_control`` on any system / tool / message block.
 
     Returns:
         Anthropic MessagesResponse
@@ -877,9 +913,11 @@ def convert_internal_to_anthropic_response(
     # Map finish reason to stop reason
     stop_reason = map_finish_reason_to_stop_reason(finish_reason, bool(tool_calls))
 
-    # When prefix caching is on, split prompt_tokens into the Anthropic
-    # disjoint triple (input + creation + read == prompt_tokens).
-    if prefix_cache_enabled:
+    # Anthropic's three input-side fields are a disjoint partition of the
+    # prompt and only carry non-zero values when the request opted into
+    # caching via cache_control. Without that signal the cache fields stay
+    # at 0 regardless of any internal prefix-cache hits in the engine.
+    if request_uses_cache_control:
         cache_read = max(0, min(cached_tokens, prompt_tokens))
         cache_creation = prompt_tokens - cache_read
         input_display = 0
@@ -1065,17 +1103,20 @@ def create_message_delta_event(
     stop_sequence: str | None = None,
     input_tokens: int | None = None,
     cached_tokens: int = 0,
-    prefix_cache_enabled: bool = False,
+    request_uses_cache_control: bool = False,
 ) -> str:
     """Create message_delta SSE event.
 
-    When ``prefix_cache_enabled`` is True and ``input_tokens`` is given, the
-    count is split into Anthropic's disjoint triple (input stays 0, creation
-    and read carry the remainder). Otherwise the legacy shape is preserved.
+    When ``request_uses_cache_control`` is True and ``input_tokens`` is
+    given, the count is split into Anthropic's disjoint triple (input
+    stays 0, creation and read carry the remainder). Without that signal
+    the cache fields are omitted entirely — Anthropic only surfaces them
+    when the client opted in via a ``cache_control`` breakpoint, even if
+    the engine's automatic prefix cache happened to hit.
     """
     usage: dict[str, int] = {"output_tokens": output_tokens}
 
-    if prefix_cache_enabled and input_tokens is not None:
+    if request_uses_cache_control and input_tokens is not None:
         cache_read = max(0, min(cached_tokens, input_tokens))
         usage["input_tokens"] = 0
         usage["cache_creation_input_tokens"] = input_tokens - cache_read

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -81,6 +81,7 @@ from .api.anthropic_utils import (
     create_text_delta_event,
     create_thinking_delta_event,
     map_finish_reason_to_stop_reason,
+    request_has_cache_control,
 )
 
 # Import from new modular API
@@ -3174,6 +3175,13 @@ async def stream_anthropic_messages(
             tool_filter = _content_filter
             thinking_filter = _thinking_filter
 
+    # Does the client opt into Anthropic's cache_control accounting?
+    # When yes, message_start.input_tokens reports the post-partition value
+    # (0 here, since we approximate the whole prompt as belonging to the
+    # cache_control region — the final message_delta refines with the real
+    # cache hit count). When no, input_tokens carries the full prompt count.
+    uses_cache_control = request_has_cache_control(request)
+
     # Calculate input tokens before streaming starts
     # This is needed for message_start event
     estimated_input_tokens = 0
@@ -3196,7 +3204,11 @@ async def stream_anthropic_messages(
     yield create_message_start_event(
         message_id=message_id,
         model=request.model,
-        input_tokens=scale_anthropic_tokens(estimated_input_tokens, request.model),
+        input_tokens=(
+            0
+            if uses_cache_control
+            else scale_anthropic_tokens(estimated_input_tokens, request.model)
+        ),
     )
 
     # 3. Stream content with thinking/content separation
@@ -3439,7 +3451,7 @@ async def stream_anthropic_messages(
         output_tokens=actual_output_tokens,
         input_tokens=actual_input_tokens,
         cached_tokens=actual_cached_tokens,
-        prefix_cache_enabled=engine.prefix_cache_enabled,
+        request_uses_cache_control=uses_cache_control,
     )
 
     # Record metrics
@@ -3748,7 +3760,7 @@ async def create_anthropic_message(
             tool_calls=tool_calls,
             thinking=cleaned_thinking if cleaned_thinking else None,
             cached_tokens=scale_anthropic_tokens(output.cached_tokens, request.model),
-            prefix_cache_enabled=engine.prefix_cache_enabled,
+            request_uses_cache_control=request_has_cache_control(request),
         )
 
         return response.model_dump_json()

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -38,6 +38,7 @@ from omlx.api.anthropic_utils import (
     create_text_delta_event,
     format_sse_event,
     map_finish_reason_to_stop_reason,
+    request_has_cache_control,
 )
 from omlx.api.openai_models import ContentPart, FunctionCall, Message, ToolCall
 from omlx.api.anthropic_models import (
@@ -1445,8 +1446,13 @@ class TestConvertInternalToAnthropicResponse:
         # Should have at least one content block
         assert len(result.content) >= 1
 
-    def test_prefix_cache_disabled_legacy_shape(self):
-        """Caching off: usage keeps the legacy shape (input=prompt, cache=0)."""
+    def test_no_cache_control_legacy_shape(self):
+        """No cache_control: usage keeps the legacy shape (input=prompt, cache=0).
+
+        Engine-internal prefix cache hits MUST NOT leak into the Anthropic
+        cache fields when the client did not opt in via cache_control — that
+        would violate the spec contract for input_tokens (#1487).
+        """
         result = convert_internal_to_anthropic_response(
             text="hi",
             model="claude-3",
@@ -1454,15 +1460,31 @@ class TestConvertInternalToAnthropicResponse:
             completion_tokens=5,
             finish_reason="stop",
             cached_tokens=40,
-            prefix_cache_enabled=False,
+            request_uses_cache_control=False,
         )
 
         assert result.usage.input_tokens == 100
         assert result.usage.cache_creation_input_tokens == 0
         assert result.usage.cache_read_input_tokens == 0
 
-    def test_prefix_cache_enabled_splits_prompt(self):
-        """Caching on: prompt splits into input(0) + creation + read."""
+    def test_cache_control_cold_partitions_to_creation(self):
+        """cache_control + cold prefix cache: input=0, cw=prompt, cr=0."""
+        result = convert_internal_to_anthropic_response(
+            text="hi",
+            model="claude-3",
+            prompt_tokens=100,
+            completion_tokens=5,
+            finish_reason="stop",
+            cached_tokens=0,
+            request_uses_cache_control=True,
+        )
+
+        assert result.usage.input_tokens == 0
+        assert result.usage.cache_creation_input_tokens == 100
+        assert result.usage.cache_read_input_tokens == 0
+
+    def test_cache_control_warm_partitions_to_read(self):
+        """cache_control + warm prefix hit: input=0, cw=tail, cr=hit."""
         result = convert_internal_to_anthropic_response(
             text="hi",
             model="claude-3",
@@ -1470,12 +1492,93 @@ class TestConvertInternalToAnthropicResponse:
             completion_tokens=5,
             finish_reason="stop",
             cached_tokens=20,
-            prefix_cache_enabled=True,
+            request_uses_cache_control=True,
         )
 
         assert result.usage.input_tokens == 0
         assert result.usage.cache_creation_input_tokens == 80
         assert result.usage.cache_read_input_tokens == 20
+
+    def test_usage_triple_is_disjoint_partition(self):
+        """input + cw + cr must equal prompt_tokens in every accounting mode (#1487)."""
+        for uses_cc in (True, False):
+            for cached in (0, 25, 100, 200):
+                result = convert_internal_to_anthropic_response(
+                    text="hi",
+                    model="claude-3",
+                    prompt_tokens=100,
+                    completion_tokens=5,
+                    finish_reason="stop",
+                    cached_tokens=cached,
+                    request_uses_cache_control=uses_cc,
+                )
+                u = result.usage
+                assert u.input_tokens + u.cache_creation_input_tokens + u.cache_read_input_tokens == 100, (
+                    f"partition broken at uses_cc={uses_cc}, cached={cached}: "
+                    f"{u.input_tokens} + {u.cache_creation_input_tokens} + "
+                    f"{u.cache_read_input_tokens} != 100"
+                )
+                # cached_tokens > prompt_tokens must clamp, never under-report.
+                assert u.cache_read_input_tokens <= 100
+
+
+class TestRequestHasCacheControl:
+    """Tests for request_has_cache_control — the gate for the Anthropic
+    cache-usage partition (#1487)."""
+
+    @staticmethod
+    def _req(**overrides):
+        kwargs = dict(
+            model="claude-3",
+            max_tokens=10,
+            messages=[AnthropicMessage(role="user", content="hi")],
+        )
+        kwargs.update(overrides)
+        return MessagesRequest(**kwargs)
+
+    def test_no_cache_control_anywhere(self):
+        assert request_has_cache_control(self._req()) is False
+
+    def test_plain_string_system_never_signals(self):
+        """system as a plain string can't carry cache_control."""
+        req = self._req(system="You are helpful.")
+        assert request_has_cache_control(req) is False
+
+    def test_system_block_with_cache_control(self):
+        req = self._req(
+            system=[SystemContent(type="text", text="ctx", cache_control={"type": "ephemeral"})]
+        )
+        assert request_has_cache_control(req) is True
+
+    def test_system_block_without_cache_control(self):
+        req = self._req(system=[SystemContent(type="text", text="ctx")])
+        assert request_has_cache_control(req) is False
+
+    def test_tool_with_cache_control(self):
+        req = self._req(
+            tools=[
+                AnthropicTool(
+                    name="get_weather",
+                    input_schema={"type": "object"},
+                    cache_control={"type": "ephemeral"},
+                )
+            ]
+        )
+        assert request_has_cache_control(req) is True
+
+    def test_document_block_with_cache_control(self):
+        doc = ContentBlockDocument(
+            type="document",
+            source={"type": "base64", "media_type": "text/plain", "data": ""},
+            cache_control={"type": "ephemeral"},
+        )
+        req = self._req(messages=[AnthropicMessage(role="user", content=[doc])])
+        assert request_has_cache_control(req) is True
+
+    def test_string_content_message_never_signals(self):
+        """Plain-string message content can't carry cache_control."""
+        req = self._req(messages=[AnthropicMessage(role="user", content="just text")])
+        assert request_has_cache_control(req) is False
 
 
 class TestMapFinishReasonToStopReason:
@@ -1583,19 +1686,34 @@ class TestSSEEventFormatters:
 
         assert '"input_tokens": 100' in result
 
-    def test_create_message_delta_event_prefix_cache_enabled(self):
-        """With caching active, usage splits into disjoint cache fields."""
+    def test_create_message_delta_event_cache_control_splits(self):
+        """With cache_control present, usage splits into disjoint cache fields."""
         result = create_message_delta_event(
             "end_turn",
             10,
             input_tokens=100,
             cached_tokens=30,
-            prefix_cache_enabled=True,
+            request_uses_cache_control=True,
         )
 
         assert '"input_tokens": 0' in result
         assert '"cache_creation_input_tokens": 70' in result
         assert '"cache_read_input_tokens": 30' in result
+
+    def test_create_message_delta_event_no_cache_control_omits_cache_fields(self):
+        """Without cache_control the cache fields stay absent — even if the
+        engine's internal prefix cache hit (#1487)."""
+        result = create_message_delta_event(
+            "end_turn",
+            10,
+            input_tokens=100,
+            cached_tokens=30,
+            request_uses_cache_control=False,
+        )
+
+        assert '"input_tokens": 100' in result
+        assert "cache_creation_input_tokens" not in result
+        assert "cache_read_input_tokens" not in result
 
     def test_create_message_stop_event(self):
         """Test creating message_stop event."""


### PR DESCRIPTION
## Summary

Fixes #1487. The Anthropic `/v1/messages` partition logic was keyed on the engine-level `engine.prefix_cache_enabled` flag, but per Anthropic's spec the disjoint triple

```
input_tokens + cache_creation_input_tokens + cache_read_input_tokens == prompt_tokens
```

only carries meaning when the **request** opted in via a `cache_control` breakpoint. Two symptoms fell out of the wrong gate:

1. **With `cache_control`**: the non-streaming response set `input_tokens` to the full prompt count *and* populated `cache_creation_input_tokens` with the same number, so downstream agent harnesses (Claude Code, Claude Agent SDK, third-party wrappers) computing `total = input + cw + cr` over-reported by exactly `cw + cr` per turn. A 100K-token conversation looked like 200K.
2. **Without `cache_control`**: the engine's automatic prefix-cache hits still leaked into the cache fields even though Anthropic only surfaces them when the client opted in.

This PR adds `request_has_cache_control(request)` — scans `system` / `tools` / message blocks for any `cache_control` field — and renames the partition gate on `convert_internal_to_anthropic_response()` and `create_message_delta_event()` from `prefix_cache_enabled` to `request_uses_cache_control`. The three server-side call sites (streaming `message_start`, streaming `message_delta`, non-streaming response builder) now pass the per-request signal instead of the engine flag.

### Behaviour after the fix

| Scenario | `input_tokens` | `cache_creation_input_tokens` | `cache_read_input_tokens` |
|---|---:|---:|---:|
| No `cache_control` | `prompt_tokens` | 0 | 0 |
| `cache_control`, cold | 0 | `prompt_tokens` | 0 |
| `cache_control`, warm | 0 | `prompt − hit` | `hit` |

### Before

```bash
curl -s -X POST http://127.0.0.1:8000/v1/messages \
  -d '{"model":"...","max_tokens":4,
       "system":[{"type":"text","text":"<1615 tokens>","cache_control":{"type":"ephemeral"}}],
       "messages":[{"role":"user","content":"hi"}]}'
```
```json
"usage": {
  "input_tokens": 1615,
  "cache_creation_input_tokens": 1615,
  "cache_read_input_tokens": 0,
  "output_tokens": 4
}
```
`input_tokens == cw + cr`, partition sums to 3230 (double-count).

### After

```json
"usage": {
  "input_tokens": 0,
  "cache_creation_input_tokens": 1615,
  "cache_read_input_tokens": 0,
  "output_tokens": 4
}
```
Partition sums to 1615. Identical to the spec example in #1487.

### Why is `input_tokens` always 0 when `cache_control` is present (and not, say, the tail of the prompt below the breakpoint)?

A strictly accurate partition would tokenize each block separately and split at the cache_control breakpoint position (e.g. system 1615 + user 1 → `cw=1615, input=1`). That requires per-block tokenization in the prompt builder. The issue reporter's "expected response" example uses the same approximation (`input=0` even though the prompt also has a one-token `"hi"`), so this PR ships the simple version and leaves per-block tokenization as a follow-up if anyone cares about that last token.

## Test plan

- [x] `pytest tests/test_api_utils.py tests/test_anthropic_adapter.py tests/test_anthropic_models.py tests/test_server.py tests/test_server_metrics.py tests/test_stream_usage.py` — **366 passed**.
- [x] Full unit suite: **4668 passed, 36 skipped, 59 deselected** (no regressions in non-Anthropic paths).
- [x] Live: `omlx serve --model-dir <gemma-4-e4b> --paged-ssd-cache-dir /tmp/ssd` against the curl examples from #1487. All three scenarios produce the spec-correct partition:

  | Test | Request | `input_tokens` | `cw` | `cr` | Sum |
  |---|---|---:|---:|---:|---:|
  | A | no cache_control | **10** | 0 | 0 | 10 |
  | B | cache_control, cold | **0** | **1615** | 0 | 1615 |
  | C | cache_control, warm | **0** | 79 | **1536** | 1615 |

  (The 79 in `cw` on the warm call is paged-cache block alignment — the prefix tail that doesn't fill a complete block — not a bug.)

### New / changed tests

- Rewrote `test_prefix_cache_disabled_legacy_shape` → `test_no_cache_control_legacy_shape` and `test_prefix_cache_enabled_splits_prompt` → `test_cache_control_cold_partitions_to_creation` + `test_cache_control_warm_partitions_to_read` against the spec contract.
- Added `test_usage_triple_is_disjoint_partition` — pins `input + cw + cr == prompt_tokens` across the `(uses_cc × cached_tokens)` matrix, including the `cached > prompt` clamp.
- Added `test_create_message_delta_event_no_cache_control_omits_cache_fields` — streaming SSE doesn't include the cache fields when the client didn't opt in.
- New `TestRequestHasCacheControl` class — 7 tests covering plain-string system, list system ±cc, tools ±cc, document content blocks ±cc, plain-string message content.