### PR TITLE
fix(scheduler): predictive prefill throttle + reclaim/requeue to prevent mid-stream OOM

### DIFF
--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -428,6 +428,32 @@ class MemoryMonitor:
         kv = self.estimate_prompt_kv_bytes(new_tokens)
         return attn + kv
 
+    def estimate_chunk_transient_bytes(self, n_tokens: int, kv_len: int) -> int:
+        """Transient SDPA activation bytes for ONE prefill chunk.
+
+        Isolates the per-chunk attention transient — the spike that drives
+        prefill OOM — for a chunk of ``n_tokens`` query tokens attending over
+        ``kv_len`` total context tokens. Unlike ``estimate_prefill_peak_bytes``
+        this excludes newly-allocated KV (that becomes resident and is counted
+        in the caller's ``current`` baseline once eval'd); it is the quantity
+        the adaptive throttle must keep under the remaining headroom.
+
+        head_dim > 128: MLX SDPA fallback materializes the full attention
+        matrix [B, n_q, n_tokens, kv_len] in float32, plus a small output
+        buffer — so the transient scales with ``n_tokens * kv_len``.
+        head_dim <= 128: fused kernel is tiled / O(n), so only the output
+        buffer is allocated and throttling is effectively a no-op (correct).
+
+        Returns 0 when model info is unavailable.
+        """
+        hd = self._head_dim or 0
+        n_q = self._num_attention_heads or 0
+        if n_q == 0 or hd == 0 or n_tokens <= 0:
+            return 0
+        if hd > 128:
+            return n_q * n_tokens * max(kv_len, 0) * 4 + n_q * n_tokens * hd * 4
+        return n_q * n_tokens * hd * 4
+
     def estimate_blocks_to_free(self, bytes_to_free: int, block_size: int) -> int:
         """
         Estimate number of blocks to evict to free the given bytes.

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -799,9 +799,26 @@ class ProcessMemoryEnforcer:
                             for e in self._engine_pool._entries.values()
                         )
                         if has_loaded:
+                            # Nothing to evict (all pinned) and no load to
+                            # abort — but the resident footprint may still hold
+                            # reclaimable Metal transients from a finished turn.
+                            # Ask each loaded scheduler to trim them between
+                            # turns. This only sets a flag; the actual reclaim
+                            # runs on the inference thread when it is idle, so
+                            # we never touch Metal from the enforcer thread.
+                            requested = 0
+                            for entry in self._engine_pool._entries.values():
+                                sched = self._resolve_scheduler(entry)
+                                if sched is not None and hasattr(
+                                    sched, "request_idle_reclaim"
+                                ):
+                                    sched.request_idle_reclaim()
+                                    requested += 1
                             logger.warning(
-                                "Hard memory pressure but all loaded models "
-                                "are pinned and no loads in progress."
+                                "Hard memory pressure, all loaded models "
+                                "pinned and no loads in progress: requested "
+                                "idle reclaim on %d scheduler(s).",
+                                requested,
                             )
                         else:
                             logger.warning(

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -508,6 +508,29 @@ class ProcessMemoryEnforcer:
         """Public accessor used by engine_pool pre-load admission."""
         return self._get_hard_limit_bytes()
 
+    def _get_abort_limit_bytes(self) -> int:
+        """Stable physical cap used to ABORT an in-flight prefill.
+
+        Deliberately excludes the dynamic ceiling: that value jitters every
+        poll with other-app pressure, and a transient dip must not kill a
+        near-complete prefill whose usage actually fits the physical envelope.
+        We use ``min(static_ceiling, metal_cap)`` — exactly the limit
+        ``start()`` arms via ``mx.set_wired_limit`` — so allocating up to it
+        cannot trigger a Metal clamp/panic. The dynamic ceiling still governs
+        chunk-size throttling and admission elsewhere; this is only the
+        last-resort kill threshold.
+
+        Returns 0 when the guard is disabled (callers treat 0 as "no limit"
+        and fall back to the dynamic hard limit).
+        """
+        if not self._prefill_memory_guard:
+            return 0
+        static_ceiling = self._get_static_ceiling()
+        metal_cap = get_effective_metal_cap_bytes()
+        if metal_cap > 0:
+            return min(static_ceiling, metal_cap)
+        return static_ceiling
+
     def _soft_bytes(self) -> int:
         """Soft watermark: ceiling * soft_threshold."""
         ceiling = self._get_hard_limit_bytes()
@@ -617,6 +640,7 @@ class ProcessMemoryEnforcer:
                 continue
             scheduler._memory_limit_bytes = soft_limit
             scheduler._memory_hard_limit_bytes = ceiling
+            scheduler._memory_abort_limit_bytes = self._get_abort_limit_bytes()
             scheduler._prefill_memory_guard = self._prefill_memory_guard
             scheduler._admission_paused = admission_paused
             scheduler._prefill_safe_zone_ratio = self._prefill_safe_zone_ratio

--- a/omlx/request.py
+++ b/omlx/request.py
@@ -191,6 +191,9 @@ class Request:
     # Cache corruption recovery
     cache_corruption_retries: int = 0   # Per-request corruption retry counter
 
+    # Prefill memory-pressure recovery
+    prefill_oom_retries: int = 0        # Per-request prefill-OOM requeue counter
+
     @property
     def num_output_tokens(self) -> int:
         """Number of output tokens generated so far."""

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -795,8 +795,13 @@ class Scheduler:
 
         # Memory limits for inline prefill checking.
         # Set by ProcessMemoryEnforcer; propagated to BatchGenerator.
-        self._memory_limit_bytes: int = 0  # soft limit
-        self._memory_hard_limit_bytes: int = 0  # hard limit (system_ram - 4GB)
+        self._memory_limit_bytes: int = 0  # soft limit (dynamic, jittery)
+        self._memory_hard_limit_bytes: int = 0  # dynamic ceiling (throttle target)
+        # Stable physical cap = min(static_ceiling, metal_cap). Used ONLY to
+        # abort an in-flight prefill, so a transient dynamic-ceiling dip can't
+        # kill a near-complete request that actually fits. 0 => fall back to
+        # _memory_hard_limit_bytes (pre-propagation / old enforcer).
+        self._memory_abort_limit_bytes: int = 0
         self._prefill_memory_guard: bool = False  # set by ProcessMemoryEnforcer
         # Set to True by ProcessMemoryEnforcer when phys_footprint crosses
         # soft_threshold. Schedulers stop admitting new prefills while this is
@@ -1887,6 +1892,19 @@ class Scheduler:
                 kv_len=base_size + processed_tokens,
             )
 
+            # Pre-chunk safety guard: NEVER submit a chunk whose predicted peak
+            # would breach the margined physical cap. The Metal command-buffer
+            # OOM is an async, uncatchable SIGABRT, so it must be prevented
+            # before submission — a post-chunk check is too late. Falls back to
+            # min_chunk after a reclaim; raises gracefully only if even the
+            # floor can't fit (caught by the #1405 path → requeue/clean error).
+            n_to_process = self._guard_prefill_chunk(
+                n_to_process,
+                kv_len=base_size + processed_tokens,
+                progress=processed_tokens,
+                loop_label="external",
+            )
+
             model_kwargs: dict[str, Any] = {}
             if embeds_array is not None and embeds_array.shape[1] > 0:
                 model_kwargs["inputs_embeds"] = embeds_array[:, :n_to_process]
@@ -1955,29 +1973,31 @@ class Scheduler:
                         "OVER_HARD" if _hard > 0 and current > _hard
                         else "OVER_SOFT",
                     )
-                if (
-                    self._memory_hard_limit_bytes > 0
-                    and current > self._memory_hard_limit_bytes
-                ):
+                # Abort decision uses the STABLE physical cap, not the jittery
+                # dynamic ceiling: only kill an in-flight prefill if it would
+                # breach what Metal actually allows. Throttling above still
+                # targets the dynamic ceiling. Falls back to the dynamic hard
+                # limit if the abort limit hasn't been propagated yet.
+                _abort = self._memory_abort_limit_bytes or self._memory_hard_limit_bytes
+                if _abort > 0 and current > _abort:
                     # Reclaim the just-computed chunk's Metal transients before
                     # giving up — they are still resident at this pre-clear
-                    # check and are usually what tipped us over the ceiling.
+                    # check and are usually what tipped us over the cap.
                     current = self._reclaim_prefill_headroom()
-                    if current > self._memory_hard_limit_bytes:
+                    if current > _abort:
                         logger.warning(
                             f"Prefill force-stopped at {processed_tokens} "
                             f"tokens: memory {current / 1024**3:.1f}GB "
-                            f"exceeds ceiling "
-                            f"{self._memory_hard_limit_bytes / 1024**3:.1f}GB "
-                            f"(after reclaim)"
+                            f"exceeds physical cap "
+                            f"{_abort / 1024**3:.1f}GB (after reclaim)"
                         )
                         raise RuntimeError("Memory limit exceeded during prefill")
                     logger.info(
                         "Prefill recovered after reclaim at %d tokens "
-                        "(%.1fGB <= ceiling %.1fGB)",
+                        "(%.1fGB <= cap %.1fGB)",
                         processed_tokens,
                         current / 1024**3,
-                        self._memory_hard_limit_bytes / 1024**3,
+                        _abort / 1024**3,
                     )
                 elif current > self._memory_limit_bytes:
                     logger.warning(
@@ -2041,6 +2061,120 @@ class Scheduler:
     # ``current`` (it is eval'd into residency after the forward pass).
     _PREFILL_HEADROOM_SAFETY: float = 0.90
 
+    # Fraction of the physical abort cap we allow a chunk's predicted PEAK to
+    # reach. The remaining headroom is reserved for Metal command-buffer
+    # overhead: a chunk whose peak lands on the wired limit can make Metal
+    # abort the command buffer asynchronously (kIOGPUCommandBufferCallbackError
+    # OutOfMemory) — an uncatchable SIGABRT — so we keep a hard margin below it.
+    _PREFILL_ABORT_MARGIN: float = 0.90
+
+    # Safety multiplier on the predicted per-chunk transient. The transient
+    # scales with query_len * kv_len, so per-token cost grows with context
+    # length; this covers one chunk's worth of growth + measurement noise.
+    _PREFILL_TRANSIENT_SAFETY: float = 1.3
+
+    def _predicted_chunk_transient(self, n_tokens: int, kv_len: int) -> float:
+        """Conservative predicted Metal transient (bytes) for one prefill chunk.
+
+        The per-chunk SDPA/MoE transient scales with ``query_len * kv_len``, so
+        the per-token cost GROWS with context length. A long-run EWMA average
+        lags that growth and underestimates the next chunk — the cause of the
+        Metal command-buffer OOM crash at large kv_len. We therefore take the
+        MAX of three signals and apply a safety factor:
+          - the most recently MEASURED per-token transient (last_delta /
+            last_n) — anchored on reality at the current kv_len regime,
+          - the long-run EWMA (model-specific constants the static misses),
+          - the kv_len-aware static SDPA estimate.
+        Returns 0 only when nothing is known (first chunk, no model info).
+        """
+        if n_tokens <= 0:
+            return 0.0
+        per_token = 0.0
+        tracker = self._prefill_transient_tracker
+        if tracker is not None:
+            if tracker.last_n_tokens > 0 and tracker.last_delta_bytes > 0:
+                per_token = max(
+                    per_token, tracker.last_delta_bytes / tracker.last_n_tokens
+                )
+            if tracker.bytes_per_token > 0:
+                per_token = max(per_token, tracker.bytes_per_token)
+        if self.memory_monitor is not None:
+            static = self.memory_monitor.estimate_chunk_transient_bytes(1, kv_len + 1)
+            per_token = max(per_token, float(static))
+        return per_token * n_tokens * self._PREFILL_TRANSIENT_SAFETY
+
+    def _prefill_abort_cap(self) -> int:
+        """Margined physical cap a chunk's predicted peak must stay under.
+
+        Uses the stable abort limit (min(static, metal_cap)) with a margin so
+        we never submit a chunk that could trip the async Metal OOM. Falls back
+        to the dynamic hard limit before the abort limit is propagated.
+        """
+        cap = self._memory_abort_limit_bytes or self._memory_hard_limit_bytes
+        return int(cap * self._PREFILL_ABORT_MARGIN) if cap > 0 else 0
+
+    def _guard_prefill_chunk(
+        self,
+        n_tokens: int,
+        *,
+        kv_len: int,
+        progress: int,
+        loop_label: str,
+    ) -> int:
+        """Clamp/abort a prefill chunk so its predicted peak can never reach
+        the physical Metal cap (the uncatchable async OOM crash).
+
+        Returns a chunk size whose predicted peak fits under the margined cap
+        (possibly shrunk from ``n_tokens``). If even the minimum chunk would
+        not fit after a reclaim, raises a clean RuntimeError — the context is
+        genuinely too large for available memory. That message intentionally
+        does NOT contain "Memory limit exceeded", so ``_requeue_or_fail_prefill``
+        fails it fast with a clear error rather than looping a doomed retry.
+        """
+        cap = self._prefill_abort_cap()
+        if cap <= 0:
+            return n_tokens
+        min_chunk = max(1, self._prefill_min_chunk_tokens)
+        current = max(mx.get_active_memory(), get_phys_footprint())
+        if current + self._predicted_chunk_transient(n_tokens, kv_len) <= cap:
+            return n_tokens
+
+        # Predicted to breach — reclaim transients and re-measure once.
+        current = self._reclaim_prefill_headroom()
+        if current + self._predicted_chunk_transient(min_chunk, kv_len) > cap:
+            logger.warning(
+                "[guard:%s] context too large at progress=%d kv_len=%d: "
+                "%.2fGB + min-chunk transient exceeds physical cap %.2fGB",
+                loop_label,
+                progress,
+                kv_len,
+                current / 1024**3,
+                cap / 1024**3,
+            )
+            raise RuntimeError(
+                "Prefill context too large for available memory "
+                f"(pre-chunk guard at {progress} tokens, kv_len={kv_len}): "
+                f"would exceed physical cap {cap / 1024**3:.1f}GB"
+            )
+
+        # The floor fits — pick the largest chunk that still fits under the cap.
+        per_token = self._predicted_chunk_transient(1, kv_len)
+        safe_n = int((cap - current) / per_token) if per_token > 0 else n_tokens
+        n_fit = max(min_chunk, min(n_tokens, safe_n))
+        if n_fit < n_tokens:
+            logger.debug(
+                "[guard:%s] shrink %d -> %d at progress=%d kv_len=%d "
+                "(current=%.2fGB cap=%.2fGB)",
+                loop_label,
+                n_tokens,
+                n_fit,
+                progress,
+                kv_len,
+                current / 1024**3,
+                cap / 1024**3,
+            )
+        return n_fit
+
     def _adaptive_chunk_size(
         self,
         requested: int,
@@ -2099,22 +2233,19 @@ class Scheduler:
         current = max(mx.get_active_memory(), get_phys_footprint())
         min_chunk = max(1, self._prefill_min_chunk_tokens)
 
-        # Per-token transient estimate: measured EWMA once we have samples,
-        # else the static first-chunk SDPA estimate at the current span.
-        tracker = self._prefill_transient_tracker
-        per_token = 0.0
-        predictor = "none"
-        if tracker is not None and tracker.samples > 0 and tracker.bytes_per_token > 0:
-            per_token = tracker.bytes_per_token * 1.2  # matches predict() safety_factor
-            predictor = "ewma"
-        elif self.memory_monitor is not None:
-            per_token = float(
-                self.memory_monitor.estimate_chunk_transient_bytes(1, kv_len + 1)
-            )
-            predictor = "static"
+        # Conservative per-token transient (measured-last / EWMA / static, ×
+        # safety) — see _predicted_chunk_transient. Anchored on the most recent
+        # measurement so it tracks the transient's growth with kv_len instead
+        # of lagging behind a long-run average.
+        per_token = self._predicted_chunk_transient(1, kv_len)
+        predictor = "measured" if per_token > 0 else "none"
 
-        # The peak we keep each chunk under — a safety margin below the cap.
+        # Keep each chunk's predicted peak under the LOWER of the dynamic
+        # throttle target and the margined physical cap, so the peak can never
+        # reach the Metal wall (the uncatchable async OOM).
         safe_target = int(hard_cap * self._PREFILL_HEADROOM_SAFETY)
+        abort_cap = self._prefill_abort_cap()
+        target = min(safe_target, abort_cap) if abort_cap > 0 else safe_target
         soft_watermark = int(soft_base * self._prefill_safe_zone_ratio)
 
         if per_token <= 0:
@@ -2126,13 +2257,14 @@ class Scheduler:
             n_fit = requested
         else:
             # Predicted-peak gate: if the FULL requested chunk fits under the
-            # target it runs unchanged (covers all healthy traffic). This must
-            # NOT depend on current crossing the soft watermark — a single big
-            # chunk's transient can blow the ceiling from a low baseline (e.g.
-            # MoE prefill at ~18MB/token), which is the failure this prevents.
-            if current + per_token * requested <= safe_target:
+            # target it runs unchanged (covers all healthy traffic). Gated on
+            # the predicted peak, not on current crossing the soft watermark —
+            # a single big chunk's transient can blow the cap from a low
+            # baseline (MoE prefill at tens of MB/token), the failure this
+            # prevents.
+            if current + per_token * requested <= target:
                 return requested
-            headroom = max(safe_target - current, 0)
+            headroom = max(target - current, 0)
             n_fit = int(headroom / per_token)
 
         n = max(min_chunk, min(requested, n_fit))
@@ -2325,6 +2457,15 @@ class Scheduler:
             kv_len=state.base_size + state.tokens_processed,
         )
 
+        # Pre-chunk safety guard (mirrors the external loop): never submit a
+        # chunk whose predicted peak would trip the uncatchable async Metal OOM.
+        n = self._guard_prefill_chunk(
+            n,
+            kv_len=state.base_size + state.tokens_processed,
+            progress=state.tokens_processed,
+            loop_label="chunked_step",
+        )
+
         chunk = state.tokens_remaining[:, :n]
         state.tokens_remaining = state.tokens_remaining[:, n:]
         _throttle_pre = get_phys_footprint()
@@ -2390,28 +2531,27 @@ class Scheduler:
                     "OVER_HARD" if _hard > 0 and current > _hard
                     else "OVER_SOFT",
                 )
-            if (
-                self._memory_hard_limit_bytes > 0
-                and current > self._memory_hard_limit_bytes
-            ):
+            # Abort on the stable physical cap, not the jittery dynamic ceiling
+            # (mirrors the external prefill loop).
+            _abort = self._memory_abort_limit_bytes or self._memory_hard_limit_bytes
+            if _abort > 0 and current > _abort:
                 # Reclaim the just-computed chunk's Metal transients before
                 # giving up (mirrors the external prefill loop).
                 current = self._reclaim_prefill_headroom()
-                if current > self._memory_hard_limit_bytes:
+                if current > _abort:
                     raise RuntimeError(
                         f"Memory limit exceeded during chunked prefill at "
                         f"{state.tokens_processed}/{state.total_length - 1} tokens: "
-                        f"{current / 1024**3:.1f}GB exceeds ceiling "
-                        f"{self._memory_hard_limit_bytes / 1024**3:.1f}GB "
-                        f"(after reclaim)"
+                        f"{current / 1024**3:.1f}GB exceeds physical cap "
+                        f"{_abort / 1024**3:.1f}GB (after reclaim)"
                     )
                 logger.info(
                     "Chunked prefill recovered after reclaim at %d/%d tokens "
-                    "(%.1fGB <= ceiling %.1fGB)",
+                    "(%.1fGB <= cap %.1fGB)",
                     state.tokens_processed,
                     state.total_length - 1,
                     current / 1024**3,
-                    self._memory_hard_limit_bytes / 1024**3,
+                    _abort / 1024**3,
                 )
             elif current > self._memory_limit_bytes:
                 logger.warning(

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -777,6 +777,13 @@ class Scheduler:
         # CPython GIL guarantees set.add() and `x in set` are atomic.
         self._pending_abort_ids: set[str] = set()
 
+        # Deferred between-turn Metal reclaim, requested by the (asyncio-thread)
+        # ProcessMemoryEnforcer under pinned-model memory pressure. A bare bool
+        # is GIL-atomic to set; it is drained on the inference thread at the top
+        # of step() (same cross-thread idiom as _pending_abort_ids) because the
+        # enforcer must never touch Metal directly.
+        self._pending_reclaim_request: bool = False
+
         # Lock-free admin snapshot. Published at the end of each step() while
         # the engine thread is the sole writer of running/waiting; the admin
         # endpoint reads the dict reference atomically (GIL) and never iterates
@@ -1839,6 +1846,9 @@ class Scheduler:
                 if lm is not None and hasattr(lm, "_rope_deltas"):
                     _saved_rope_deltas = lm._rope_deltas
                     lm._rope_deltas = None
+            # Stash so the #1405 requeue path can restore it if this prefill
+            # raises before the normal restore below runs.
+            request._prefill_saved_rope_deltas = _saved_rope_deltas
 
         # Prefill tokens[0:N-1] (leave last token for insert())
         prefill_tokens = tokens[:-1]
@@ -1874,6 +1884,7 @@ class Scheduler:
                 n_to_process,
                 request_id=request.request_id,
                 loop_label="external",
+                kv_len=base_size + processed_tokens,
             )
 
             model_kwargs: dict[str, Any] = {}
@@ -1948,13 +1959,26 @@ class Scheduler:
                     self._memory_hard_limit_bytes > 0
                     and current > self._memory_hard_limit_bytes
                 ):
-                    logger.warning(
-                        f"Prefill force-stopped at {processed_tokens} "
-                        f"tokens: memory {current / 1024**3:.1f}GB "
-                        f"exceeds ceiling "
-                        f"{self._memory_hard_limit_bytes / 1024**3:.1f}GB"
+                    # Reclaim the just-computed chunk's Metal transients before
+                    # giving up — they are still resident at this pre-clear
+                    # check and are usually what tipped us over the ceiling.
+                    current = self._reclaim_prefill_headroom()
+                    if current > self._memory_hard_limit_bytes:
+                        logger.warning(
+                            f"Prefill force-stopped at {processed_tokens} "
+                            f"tokens: memory {current / 1024**3:.1f}GB "
+                            f"exceeds ceiling "
+                            f"{self._memory_hard_limit_bytes / 1024**3:.1f}GB "
+                            f"(after reclaim)"
+                        )
+                        raise RuntimeError("Memory limit exceeded during prefill")
+                    logger.info(
+                        "Prefill recovered after reclaim at %d tokens "
+                        "(%.1fGB <= ceiling %.1fGB)",
+                        processed_tokens,
+                        current / 1024**3,
+                        self._memory_hard_limit_bytes / 1024**3,
                     )
-                    raise RuntimeError("Memory limit exceeded during prefill")
                 elif current > self._memory_limit_bytes:
                     logger.warning(
                         f"Prefill above max_bytes at "
@@ -1997,6 +2021,7 @@ class Scheduler:
         # Restore _rope_deltas after cached VLM prefill (for decode capture)
         if vlm_embeds is not None and _saved_rope_deltas is not None:
             self.model._language_model._rope_deltas = _saved_rope_deltas
+        request._prefill_saved_rope_deltas = None
 
         return prompt_cache, last_token
 
@@ -2010,36 +2035,49 @@ class Scheduler:
     # headroom for the next chunk's intermediates.
     _PREFILL_STEP_TIERS: tuple[int, ...] = (1024, 512, 256, 128)
 
+    # Safety margin applied to the headroom (hard_cap - current) when sizing
+    # a chunk predictively. The remaining 10% absorbs estimator error and the
+    # newly-allocated KV growth for this chunk that is not yet reflected in
+    # ``current`` (it is eval'd into residency after the forward pass).
+    _PREFILL_HEADROOM_SAFETY: float = 0.90
+
     def _adaptive_chunk_size(
         self,
         requested: int,
         *,
         request_id: str,
         loop_label: str,
+        kv_len: int = 0,
     ) -> int:
-        """Shrink the next prefill chunk by bucketing how far current
-        memory has crossed the soft watermark.
+        """Size the next prefill chunk so its predicted peak stays under a
+        safety margin below the hard cap.
 
-        The approach is intentionally measurement-free and model-agnostic.
-        Once current memory passes the soft watermark
-        (``max_bytes * prefill_safe_zone_ratio``, default 0.80) the chunk
-        size drops in discrete tiers as we approach the hard cap. This is
-        the auto equivalent of PR #1397's manual ``prefill_step_size``
-        override — users do not pick a value, the scheduler picks one
-        only when memory pressure shows up.
+        The chunk is sized so that ``current + predicted_transient(n) <=
+        hard_cap * safety``. If the full requested chunk already fits, it runs
+        unchanged — no behavior change on healthy traffic. Crucially the gate
+        is on the *predicted peak*, not on current memory crossing the soft
+        watermark: a single large chunk's transient (e.g. MoE prefill at tens
+        of MB/token) can blow the ceiling from a low baseline before current
+        ever reaches the watermark, which is the failure this prevents.
 
-        Tiers (relative to soft → hard band):
-          - current < soft watermark        → full chunk (no throttle)
-          - first 25% of band               → 1024
-          - 25%–50%                          → 512
-          - 50%–75%                          → 256
-          - 75%+                             → 128 (floor at min_chunk)
+        Two predictors feed the sizing:
+          - Measured: once the per-scheduler EWMA has samples, use its
+            ``bytes_per_token`` (× the same 1.2 safety factor ``predict()``
+            applies) — this is measurement-based and model-agnostic.
+          - First chunk (no samples yet): fall back to the static SDPA
+            estimate ``memory_monitor.estimate_chunk_transient_bytes(1,
+            kv_len + 1)`` per token. ``kv_len`` is the current context span
+            (cached prefix + already-prefilled tokens), so a large
+            prefix-cache hit with a small suffix is throttled correctly.
+
+        The discrete watermark tiers are retained as a *secondary clamp* —
+        they only ever shrink further, never enlarge the predicted size.
 
         The chunk-end memory check (``self._memory_hard_limit_bytes``
-        comparison in the prefill loops) remains as the safety net: if
-        memory still exceeds hard cap after this shrink, RuntimeError is
-        raised and the #1405 cleanup path emits ``finish_reason="error"``
-        to the client.
+        comparison in the prefill loops) remains the safety net: if memory
+        still exceeds the cap after this shrink, the loop attempts reclaim
+        (``_reclaim_prefill_headroom``) and, failing that, raises so the
+        #1405 cleanup path can requeue or emit ``finish_reason="error"``.
 
         Args:
             requested: The chunk size the caller would have used without
@@ -2047,6 +2085,8 @@ class Scheduler:
             request_id: For debug log correlation.
             loop_label: "external" or "chunked_step", used only for debug
                 log identification.
+            kv_len: Current context span (base/cached + processed tokens)
+                used for the first-chunk static transient estimate.
 
         Returns:
             The chunk size to actually process (>= 1, <= requested).
@@ -2057,41 +2097,82 @@ class Scheduler:
             return requested
 
         current = max(mx.get_active_memory(), get_phys_footprint())
+        min_chunk = max(1, self._prefill_min_chunk_tokens)
+
+        # Per-token transient estimate: measured EWMA once we have samples,
+        # else the static first-chunk SDPA estimate at the current span.
+        tracker = self._prefill_transient_tracker
+        per_token = 0.0
+        predictor = "none"
+        if tracker is not None and tracker.samples > 0 and tracker.bytes_per_token > 0:
+            per_token = tracker.bytes_per_token * 1.2  # matches predict() safety_factor
+            predictor = "ewma"
+        elif self.memory_monitor is not None:
+            per_token = float(
+                self.memory_monitor.estimate_chunk_transient_bytes(1, kv_len + 1)
+            )
+            predictor = "static"
+
+        # The peak we keep each chunk under — a safety margin below the cap.
+        safe_target = int(hard_cap * self._PREFILL_HEADROOM_SAFETY)
         soft_watermark = int(soft_base * self._prefill_safe_zone_ratio)
 
-        if current < soft_watermark:
-            return requested
-
-        # Bucket by how far into the soft → hard band we are.
-        band = max(hard_cap - soft_watermark, 1)
-        over_ratio = max(0.0, min(1.0, (current - soft_watermark) / band))
-
-        if over_ratio < 0.25:
-            target = self._PREFILL_STEP_TIERS[0]    # 1024
-        elif over_ratio < 0.50:
-            target = self._PREFILL_STEP_TIERS[1]    # 512
-        elif over_ratio < 0.75:
-            target = self._PREFILL_STEP_TIERS[2]    # 256
+        if per_token <= 0:
+            # No usable predictor (e.g. head_dim<=128 fused kernel where the
+            # transient is O(n), or model info unavailable). Fall back to the
+            # legacy watermark gate so we never run unbounded.
+            if current < soft_watermark:
+                return requested
+            n_fit = requested
         else:
-            target = self._PREFILL_STEP_TIERS[3]    # 128
+            # Predicted-peak gate: if the FULL requested chunk fits under the
+            # target it runs unchanged (covers all healthy traffic). This must
+            # NOT depend on current crossing the soft watermark — a single big
+            # chunk's transient can blow the ceiling from a low baseline (e.g.
+            # MoE prefill at ~18MB/token), which is the failure this prevents.
+            if current + per_token * requested <= safe_target:
+                return requested
+            headroom = max(safe_target - current, 0)
+            n_fit = int(headroom / per_token)
 
-        target = max(target, self._prefill_min_chunk_tokens)
-        if requested <= target:
-            return requested
+        n = max(min_chunk, min(requested, n_fit))
 
-        logger.debug(
-            "[throttle:%s] shrink rid=%s chunk %d -> %d "
-            "(current=%.2fGB shrink_at=%.2fGB ceiling=%.2fGB band_ratio=%.2f)",
-            loop_label,
-            request_id,
-            requested,
-            target,
-            current / 1024**3,
-            soft_watermark / 1024**3,
-            hard_cap / 1024**3,
-            over_ratio,
-        )
-        return target
+        # Secondary clamp: once in the watermark caution zone, cap by the
+        # discrete tiers so a mispredicting EWMA can't run an oversized chunk
+        # in deep pressure. Skipped below the watermark so a low-baseline chunk
+        # with ample headroom isn't needlessly shrunk.
+        band_ratio = -1.0
+        if current >= soft_watermark and hard_cap > soft_watermark:
+            band = hard_cap - soft_watermark
+            band_ratio = max(0.0, min(1.0, (current - soft_watermark) / band))
+            if band_ratio < 0.25:
+                bucket = self._PREFILL_STEP_TIERS[0]    # 1024
+            elif band_ratio < 0.50:
+                bucket = self._PREFILL_STEP_TIERS[1]    # 512
+            elif band_ratio < 0.75:
+                bucket = self._PREFILL_STEP_TIERS[2]    # 256
+            else:
+                bucket = self._PREFILL_STEP_TIERS[3]    # 128
+            n = max(min_chunk, min(n, bucket))
+
+        if n < requested:
+            logger.debug(
+                "[throttle:%s] shrink rid=%s chunk %d -> %d "
+                "(predictor=%s per_token=%.1fKB current=%.2fGB "
+                "safe_target=%.2fGB ceiling=%.2fGB kv_len=%d band_ratio=%.2f)",
+                loop_label,
+                request_id,
+                requested,
+                n,
+                predictor,
+                per_token / 1024,
+                current / 1024**3,
+                safe_target / 1024**3,
+                hard_cap / 1024**3,
+                kv_len,
+                band_ratio,
+            )
+        return n
 
     def _record_chunk_transient(
         self,
@@ -2125,6 +2206,28 @@ class Scheduler:
             self._prefill_transient_tracker.bytes_per_token / 1024,
             self._prefill_transient_tracker.samples,
         )
+
+    def _reclaim_prefill_headroom(self) -> int:
+        """Reclaim Metal headroom mid-prefill and return the re-measured usage.
+
+        The prefill loops measure the hard-limit at the chunk boundary, which
+        is *before* the per-chunk ``_sync_and_clear_cache`` runs — so the
+        just-completed forward pass's SDPA intermediates are still resident
+        when the limit is checked. Synchronizing and clearing the Metal buffer
+        cache here releases those transients, which is exactly the spike that
+        drives prefill OOM (observed: 42.8GB at the check → 24.6GB after the
+        buffers are reclaimed). This is the only lever that actually lowers
+        the physical footprint: paged-cache block eviction merely recycles
+        ``CacheBlock`` metadata back into the free queue (the pool never
+        shrinks, see ``PagedCacheManager._grow_blocks``), so it is deliberately
+        not attempted here — it would drop reusable prefix-cache entries for no
+        memory benefit.
+
+        Returns:
+            ``max(active, phys_footprint)`` after reclaim.
+        """
+        _sync_and_clear_cache(self._stream)
+        return max(mx.get_active_memory(), get_phys_footprint())
 
     # ------------------------------------------------------------------
     # Chunked prefill helpers (used when config.chunked_prefill=True)
@@ -2219,6 +2322,7 @@ class Scheduler:
             n,
             request_id=state.request.request_id,
             loop_label="chunked_step",
+            kv_len=state.base_size + state.tokens_processed,
         )
 
         chunk = state.tokens_remaining[:, :n]
@@ -2290,11 +2394,24 @@ class Scheduler:
                 self._memory_hard_limit_bytes > 0
                 and current > self._memory_hard_limit_bytes
             ):
-                raise RuntimeError(
-                    f"Memory limit exceeded during chunked prefill at "
-                    f"{state.tokens_processed}/{state.total_length - 1} tokens: "
-                    f"{current / 1024**3:.1f}GB exceeds ceiling "
-                    f"{self._memory_hard_limit_bytes / 1024**3:.1f}GB"
+                # Reclaim the just-computed chunk's Metal transients before
+                # giving up (mirrors the external prefill loop).
+                current = self._reclaim_prefill_headroom()
+                if current > self._memory_hard_limit_bytes:
+                    raise RuntimeError(
+                        f"Memory limit exceeded during chunked prefill at "
+                        f"{state.tokens_processed}/{state.total_length - 1} tokens: "
+                        f"{current / 1024**3:.1f}GB exceeds ceiling "
+                        f"{self._memory_hard_limit_bytes / 1024**3:.1f}GB "
+                        f"(after reclaim)"
+                    )
+                logger.info(
+                    "Chunked prefill recovered after reclaim at %d/%d tokens "
+                    "(%.1fGB <= ceiling %.1fGB)",
+                    state.tokens_processed,
+                    state.total_length - 1,
+                    current / 1024**3,
+                    self._memory_hard_limit_bytes / 1024**3,
                 )
             elif current > self._memory_limit_bytes:
                 logger.warning(
@@ -2426,6 +2543,12 @@ class Scheduler:
                 # forward / mx.eval transients. Without this, enforcer keeps
                 # seeing the burst footprint until the next mx.clear_cache().
                 _sync_and_clear_cache()
+                # Try a bounded requeue before surfacing the failure: a
+                # memory-pressure prefill gets a fresh, better-throttled
+                # attempt. Only after the retry budget is exhausted (or for
+                # non-memory errors) do we emit the client-facing error.
+                if self._requeue_or_fail_prefill(request, e):
+                    continue
                 # Surface the failure to the engine. Without this, the
                 # request is silently dropped and the client hangs.
                 rejected.append(
@@ -4334,6 +4457,38 @@ class Scheduler:
             request_id = self._pending_abort_ids.pop()
             self._do_abort_request(request_id)
 
+    def request_idle_reclaim(self) -> None:
+        """Enqueue a between-turn Metal reclaim (thread-safe, no Metal touch).
+
+        Called by ProcessMemoryEnforcer (asyncio thread) when memory pressure
+        is hard but every loaded model is pinned and no load is in progress —
+        the case where there is nothing to evict. Setting the flag is
+        GIL-atomic; the actual ``_sync_and_clear_cache`` runs on the inference
+        thread when step() drains it, and only when the scheduler is idle.
+        """
+        self._pending_reclaim_request = True
+
+    def _process_pending_reclaim(self) -> None:
+        """Drain a deferred idle reclaim request (inference-thread side).
+
+        Only reclaims when truly idle (no running / prefilling / waiting work)
+        so we never clear Metal buffers an in-flight decode or prefill still
+        references.
+        """
+        if not self._pending_reclaim_request:
+            return
+        self._pending_reclaim_request = False
+        if self.running or self.prefilling or self.waiting:
+            return
+        before = max(mx.get_active_memory(), get_phys_footprint())
+        after = self._reclaim_prefill_headroom()
+        logger.info(
+            "Idle reclaim: trimmed Metal transients between turns "
+            "(%.1fGB -> %.1fGB)",
+            before / 1024**3,
+            after / 1024**3,
+        )
+
     def _do_abort_request(self, request_id: str) -> bool:
         """
         Actually abort a request. Must be called from the step() context.
@@ -5058,6 +5213,8 @@ class Scheduler:
                         # Drop Metal cache pool buffers held by the aborted
                         # first chunk's forward / mx.eval transients.
                         _sync_and_clear_cache()
+                        if self._requeue_or_fail_prefill(request, e):
+                            continue
                         rejected_outputs.append(
                             RequestOutput(
                                 request_id=request.request_id,
@@ -5110,6 +5267,8 @@ class Scheduler:
                     # Drop Metal cache pool buffers held by the aborted
                     # chunk's forward / mx.eval transients.
                     _sync_and_clear_cache()
+                    if self._requeue_or_fail_prefill(request, e):
+                        continue
                     rejected_outputs.append(
                         RequestOutput(
                             request_id=request.request_id,
@@ -5868,6 +6027,87 @@ class Scheduler:
             logger.info(f"Rescheduled {count} requests for re-prefill")
         return failed_ids
 
+    # Max times a single request is requeued after a prefill memory-pressure
+    # failure before we give up and emit a clean error to the client.
+    _MAX_PREFILL_OOM_RETRIES = 2
+
+    def _requeue_or_fail_prefill(self, request: "Request", error: Exception) -> bool:
+        """Decide whether to requeue a prefill that hit the memory ceiling.
+
+        The three #1405 catch sites have already torn the request down
+        (released paged cache, popped ``self.requests``, removed the prefill
+        tracker entry, cleared Metal). This either resets the request and puts
+        it back on the waiting queue for a fresh attempt (returns ``True`` —
+        caller continues without emitting an error), or — when the retry
+        budget is exhausted or the failure is not a memory-pressure error —
+        returns ``False`` so the caller emits the clean
+        ``finish_reason="error"``.
+
+        Only memory-limit failures are retried; any other RuntimeError fails
+        immediately so genuine model errors don't loop.
+        """
+        if "Memory limit exceeded" not in str(error):
+            return False
+        if request.prefill_oom_retries >= self._MAX_PREFILL_OOM_RETRIES:
+            logger.warning(
+                "Prefill for %s exhausted %d memory-pressure retries; "
+                "failing with a clean error.",
+                request.request_id,
+                self._MAX_PREFILL_OOM_RETRIES,
+            )
+            return False
+        request.prefill_oom_retries += 1
+
+        # Reclaim before requeue so the retry starts from a lower baseline.
+        self._reclaim_prefill_headroom()
+
+        # Clear any SpecPrefill RoPE patch tied to this request so the retry
+        # re-scores cleanly.
+        if self._specprefill_active_request_id == request.request_id:
+            self._specprefill_active_request_id = None
+
+        # Restore mRoPE deltas if an external VLM prefill was interrupted before
+        # its own restore ran (value stashed on the request in
+        # _do_external_prefill). Benign for non-VLM requests (stash is None).
+        saved = getattr(request, "_prefill_saved_rope_deltas", None)
+        if saved is not None:
+            lm = getattr(self.model, "_language_model", None)
+            if lm is not None and hasattr(lm, "_rope_deltas"):
+                lm._rope_deltas = saved
+            request._prefill_saved_rope_deltas = None
+
+        # Reset scheduling + cache + output state to a clean pre-prefill state
+        # (mirrors _reschedule_running_requests). We deliberately drop
+        # cached_tokens / block_table so the retry does a cold full prefill and
+        # does not re-attach the large cached prefix that produced the same
+        # oversized SDPA span. VLM inputs/embeds are preserved.
+        request.status = RequestStatus.WAITING
+        request.batch_uid = None
+        request.prompt_cache = None
+        request.cached_tokens = 0
+        request.remaining_tokens = request.prompt_token_ids
+        request.block_table = None
+        request.shared_prefix_blocks = 0
+        request.output_token_ids = []
+        request.output_text = ""
+        request.num_computed_tokens = 0
+        request._extracted_cache = None
+        request._model_cache_config = None
+        request.think_prefix_sent = False
+
+        # Re-register (the catch site popped it) and requeue at the front. The
+        # retry is throttled from its first chunk by the now-populated transient
+        # EWMA, so it is strictly better-informed than this attempt.
+        self.requests[request.request_id] = request
+        self.waiting.appendleft(request)
+        logger.warning(
+            "Requeued %s for prefill retry %d/%d after memory pressure.",
+            request.request_id,
+            request.prefill_oom_retries,
+            self._MAX_PREFILL_OOM_RETRIES,
+        )
+        return True
+
     def step(self) -> SchedulerOutput:
         """
         Execute one scheduling step with automatic error recovery.
@@ -5886,6 +6126,10 @@ class Scheduler:
 
         # Process pending aborts FIRST (thread-safe with hybrid executor)
         self._process_pending_aborts()
+
+        # Drain a deferred between-turn reclaim requested by the memory
+        # enforcer (only acts when the scheduler is idle).
+        self._process_pending_reclaim()
 
         # Drain async store_cache completions from prior steps. Each completed
         # entry triggers the deferred batch_generator.remove(uid) on the

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for graceful prefill memory management (predictive throttle +
+bounded requeue) added to keep coding-agent workloads from hard-failing
+mid-prefill under memory pressure.
+
+Covers:
+  - MemoryMonitor.estimate_chunk_transient_bytes math (head_dim > 128 vs <= 128)
+  - Scheduler._adaptive_chunk_size predictive sizing (EWMA + static first chunk,
+    early-return below the soft watermark, min-chunk floor, bucket clamp)
+  - Scheduler._requeue_or_fail_prefill budget behavior + error-type gating
+
+All tests are unit-level: the throttle/requeue logic is exercised on a light
+fake object so no model load or GPU is required.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from omlx import scheduler as sched_mod
+from omlx.memory_monitor import MemoryMonitor
+from omlx.prefill_transient_tracker import PrefillTransientTracker
+from omlx.scheduler import Scheduler
+
+_GB = 1024**3
+
+
+# --------------------------------------------------------------------------
+# MemoryMonitor.estimate_chunk_transient_bytes
+# --------------------------------------------------------------------------
+
+
+def _monitor(head_dim):
+    m = MemoryMonitor(max_kv_cache_memory=_GB)
+    m.set_model_info(
+        num_layers=32,
+        num_kv_heads=8,
+        head_dim=head_dim,
+        dtype_size=2,
+        num_attention_heads=32,
+    )
+    return m
+
+
+def test_chunk_transient_head_dim_gt_128_scales_with_kv_len():
+    """head_dim > 128 → SDPA fallback materializes n_q*n*kv_len*4 (+ output)."""
+    m = _monitor(head_dim=192)
+    n_q, hd = 32, 192
+    n_tokens, kv_len = 4, 10_000
+    expected = n_q * n_tokens * kv_len * 4 + n_q * n_tokens * hd * 4
+    assert m.estimate_chunk_transient_bytes(n_tokens, kv_len) == expected
+    # Doubling kv_len roughly doubles the transient (kv term dominates).
+    bigger = m.estimate_chunk_transient_bytes(n_tokens, kv_len * 2)
+    assert bigger > expected
+
+
+def test_chunk_transient_head_dim_le_128_is_kv_independent():
+    """head_dim <= 128 → fused kernel, O(n): only the output buffer."""
+    m = _monitor(head_dim=128)
+    n_q, hd, n_tokens = 32, 128, 4
+    expected = n_q * n_tokens * hd * 4
+    assert m.estimate_chunk_transient_bytes(n_tokens, 10_000) == expected
+    # kv_len must not change the estimate for the fused path.
+    assert m.estimate_chunk_transient_bytes(n_tokens, 1) == expected
+
+
+def test_chunk_transient_zero_when_model_info_missing():
+    m = MemoryMonitor(max_kv_cache_memory=_GB)  # no set_model_info
+    assert m.estimate_chunk_transient_bytes(4, 1000) == 0
+
+
+# --------------------------------------------------------------------------
+# Scheduler._adaptive_chunk_size
+# --------------------------------------------------------------------------
+
+
+def _throttle_ctx(*, current, hard, soft_ratio=0.80, samples_bpt=None,
+                  monitor=None, min_chunk=32):
+    """Build a minimal stand-in carrying the attributes _adaptive_chunk_size
+    reads, plus a patch of the module memory probes to a fixed `current`."""
+    tracker = PrefillTransientTracker()
+    if samples_bpt is not None:
+        # Seed the EWMA with one observation of the given bytes/token.
+        tracker.update(1, int(samples_bpt))
+    ns = SimpleNamespace(
+        _memory_limit_bytes=int(hard * 0.85),       # soft = ceiling*0.85
+        _memory_hard_limit_bytes=int(hard),
+        _prefill_safe_zone_ratio=soft_ratio,
+        _prefill_min_chunk_tokens=min_chunk,
+        _prefill_transient_tracker=tracker,
+        memory_monitor=monitor,
+        _PREFILL_STEP_TIERS=Scheduler._PREFILL_STEP_TIERS,
+        _PREFILL_HEADROOM_SAFETY=Scheduler._PREFILL_HEADROOM_SAFETY,
+    )
+    return ns
+
+
+def _call(ns, requested, kv_len=0):
+    with patch.object(sched_mod.mx, "get_active_memory", return_value=0), \
+         patch.object(sched_mod, "get_phys_footprint",
+                      return_value=ns._fake_current):
+        return Scheduler._adaptive_chunk_size(
+            ns, requested, request_id="r", loop_label="test", kv_len=kv_len
+        )
+
+
+def test_throttle_noop_when_full_chunk_fits():
+    """If the full requested chunk's predicted peak fits, it runs unchanged —
+    even at a low baseline (gate is on predicted peak, not the watermark)."""
+    hard = 40 * _GB
+    # Small per-token transient (~1MB/tok): 2048 tokens ≈ 2GB, easily fits.
+    ns = _throttle_ctx(current=int(hard * 0.5), hard=hard,
+                       samples_bpt=1024 * 1024)
+    ns._fake_current = int(hard * 0.5)
+    assert _call(ns, 2048, kv_len=5000) == 2048
+
+
+def test_throttle_shrinks_big_chunk_from_low_baseline():
+    """The regression that mattered: a huge per-token transient (MoE-like)
+    must shrink the chunk even when current is well BELOW the soft watermark."""
+    hard = 40 * _GB
+    current = int(hard * 0.5)  # 20GB — below soft watermark (0.85*0.80*40=27.2GB)
+    bpt = 18 * 1024 * 1024  # ~18 MB/token, matching the observed MoE prefill
+    ns = _throttle_ctx(current=current, hard=hard, samples_bpt=bpt)
+    ns._fake_current = current
+    safe_target = int(hard * Scheduler._PREFILL_HEADROOM_SAFETY)
+    expected = int((safe_target - current) / (bpt * 1.2))
+    n = _call(ns, 2048, kv_len=5000)
+    assert n < 2048                      # throttled despite low baseline
+    assert n >= ns._prefill_min_chunk_tokens
+    assert n <= expected + 1             # sized to the predicted-peak headroom
+
+
+def test_throttle_floors_at_min_chunk_when_over_ceiling():
+    """At/over the cap, the smallest step is returned (loop handles the rest)."""
+    hard = 40 * _GB
+    ns = _throttle_ctx(current=hard + _GB, hard=hard, samples_bpt=1_000_000,
+                       min_chunk=32)
+    ns._fake_current = hard + _GB
+    assert _call(ns, 2048, kv_len=5000) == 32
+
+
+def test_throttle_first_chunk_uses_static_estimate():
+    """No EWMA samples yet → fall back to the static SDPA per-token estimate."""
+    hard = 40 * _GB
+    current = int(hard * 0.5)
+    monitor = _monitor(head_dim=192)  # head_dim>128 so estimate is non-trivial
+    ns = _throttle_ctx(current=current, hard=hard, samples_bpt=None,
+                       monitor=monitor)
+    ns._fake_current = current
+    # Very large context → static SDPA per-token estimate is big enough that a
+    # full 2048-token chunk's predicted peak exceeds the target → shrink.
+    n = _call(ns, 2048, kv_len=2_000_000)
+    assert n < 2048
+    assert n >= ns._prefill_min_chunk_tokens
+
+
+# --------------------------------------------------------------------------
+# Scheduler._requeue_or_fail_prefill
+# --------------------------------------------------------------------------
+
+
+def _requeue_ctx():
+    """Minimal stand-in for the requeue helper's scheduler state."""
+    from collections import deque
+
+    ns = SimpleNamespace(
+        requests={},
+        waiting=deque(),
+        _specprefill_active_request_id=None,
+        model=SimpleNamespace(),  # no _language_model attr → rope restore skipped
+        _MAX_PREFILL_OOM_RETRIES=2,
+        _reclaim_prefill_headroom=lambda: 0,
+    )
+    return ns
+
+
+def _fake_request(rid="req-1"):
+    return SimpleNamespace(
+        request_id=rid,
+        prefill_oom_retries=0,
+        prompt_token_ids=[1, 2, 3, 4],
+        status=None,
+        batch_uid="u",
+        prompt_cache=object(),
+        cached_tokens=128,
+        remaining_tokens=None,
+        block_table=object(),
+        shared_prefix_blocks=2,
+        output_token_ids=[9],
+        output_text="x",
+        num_computed_tokens=10,
+        _extracted_cache=object(),
+        _model_cache_config=object(),
+        think_prefix_sent=True,
+        _prefill_saved_rope_deltas=None,
+    )
+
+
+def test_requeue_non_memory_error_fails_immediately():
+    ns = _requeue_ctx()
+    req = _fake_request()
+    out = Scheduler._requeue_or_fail_prefill(ns, req, RuntimeError("boom: bad weights"))
+    assert out is False
+    assert len(ns.waiting) == 0
+
+
+def test_requeue_memory_error_requeues_then_resets_state():
+    ns = _requeue_ctx()
+    req = _fake_request()
+    out = Scheduler._requeue_or_fail_prefill(
+        ns, req, RuntimeError("Memory limit exceeded during prefill")
+    )
+    assert out is True
+    assert req.prefill_oom_retries == 1
+    # Re-registered + requeued, with cache state reset for a cold re-prefill.
+    assert ns.requests[req.request_id] is req
+    assert list(ns.waiting) == [req]
+    assert req.prompt_cache is None
+    assert req.cached_tokens == 0
+    assert req.block_table is None
+    assert req.remaining_tokens == req.prompt_token_ids
+    assert req.output_token_ids == []
+
+
+def test_requeue_budget_exhausts_to_clean_error():
+    ns = _requeue_ctx()
+    req = _fake_request()
+    err = RuntimeError("Memory limit exceeded during prefill")
+    # Two retries succeed (1, 2); the third is denied.
+    assert Scheduler._requeue_or_fail_prefill(ns, req, err) is True
+    assert Scheduler._requeue_or_fail_prefill(ns, req, err) is True
+    assert Scheduler._requeue_or_fail_prefill(ns, req, err) is False
+    assert req.prefill_oom_retries == 2

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -76,23 +76,40 @@ def test_chunk_transient_zero_when_model_info_missing():
 
 
 def _throttle_ctx(*, current, hard, soft_ratio=0.80, samples_bpt=None,
-                  monitor=None, min_chunk=32):
-    """Build a minimal stand-in carrying the attributes _adaptive_chunk_size
-    reads, plus a patch of the module memory probes to a fixed `current`."""
+                  monitor=None, min_chunk=32, abort=None, reclaim_to=None):
+    """Build a minimal stand-in carrying the attributes / bound methods that
+    _adaptive_chunk_size and _guard_prefill_chunk read. `_fake_current` is the
+    value the patched memory probes report; `reclaim_to` (if set) is what a
+    reclaim drops `current` to."""
     tracker = PrefillTransientTracker()
     if samples_bpt is not None:
-        # Seed the EWMA with one observation of the given bytes/token.
+        # Seed with one observation: sets last_delta/last_n AND the EWMA.
         tracker.update(1, int(samples_bpt))
     ns = SimpleNamespace(
         _memory_limit_bytes=int(hard * 0.85),       # soft = ceiling*0.85
         _memory_hard_limit_bytes=int(hard),
+        _memory_abort_limit_bytes=int(abort if abort is not None else hard),
         _prefill_safe_zone_ratio=soft_ratio,
         _prefill_min_chunk_tokens=min_chunk,
         _prefill_transient_tracker=tracker,
         memory_monitor=monitor,
         _PREFILL_STEP_TIERS=Scheduler._PREFILL_STEP_TIERS,
         _PREFILL_HEADROOM_SAFETY=Scheduler._PREFILL_HEADROOM_SAFETY,
+        _PREFILL_ABORT_MARGIN=Scheduler._PREFILL_ABORT_MARGIN,
+        _PREFILL_TRANSIENT_SAFETY=Scheduler._PREFILL_TRANSIENT_SAFETY,
     )
+    # Bind the real helper methods so the stand-in behaves like a Scheduler.
+    ns._predicted_chunk_transient = Scheduler._predicted_chunk_transient.__get__(
+        ns, Scheduler
+    )
+    ns._prefill_abort_cap = Scheduler._prefill_abort_cap.__get__(ns, Scheduler)
+    ns._reclaim_to = reclaim_to
+
+    def _reclaim():
+        if ns._reclaim_to is not None:
+            ns._fake_current = ns._reclaim_to
+        return ns._fake_current
+    ns._reclaim_prefill_headroom = _reclaim
     return ns
 
 
@@ -105,11 +122,25 @@ def _call(ns, requested, kv_len=0):
         )
 
 
+def _guard_call(ns, n, kv_len=0):
+    with patch.object(sched_mod.mx, "get_active_memory", return_value=0), \
+         patch.object(sched_mod, "get_phys_footprint",
+                      return_value=ns._fake_current):
+        return Scheduler._guard_prefill_chunk(
+            ns, n, kv_len=kv_len, progress=0, loop_label="test"
+        )
+
+
+def _per_token(samples_bpt):
+    """The throttle's effective per-token estimate for a seeded EWMA/last."""
+    return samples_bpt * Scheduler._PREFILL_TRANSIENT_SAFETY
+
+
 def test_throttle_noop_when_full_chunk_fits():
     """If the full requested chunk's predicted peak fits, it runs unchanged —
     even at a low baseline (gate is on predicted peak, not the watermark)."""
     hard = 40 * _GB
-    # Small per-token transient (~1MB/tok): 2048 tokens ≈ 2GB, easily fits.
+    # Small per-token transient (~1MB/tok): 2048 tokens ≈ 2.7GB, easily fits.
     ns = _throttle_ctx(current=int(hard * 0.5), hard=hard,
                        samples_bpt=1024 * 1024)
     ns._fake_current = int(hard * 0.5)
@@ -118,22 +149,25 @@ def test_throttle_noop_when_full_chunk_fits():
 
 def test_throttle_shrinks_big_chunk_from_low_baseline():
     """The regression that mattered: a huge per-token transient (MoE-like)
-    must shrink the chunk even when current is well BELOW the soft watermark."""
+    must shrink the chunk even when current is well BELOW the soft watermark,
+    and the result's predicted peak must fit the sizing target."""
     hard = 40 * _GB
     current = int(hard * 0.5)  # 20GB — below soft watermark (0.85*0.80*40=27.2GB)
     bpt = 18 * 1024 * 1024  # ~18 MB/token, matching the observed MoE prefill
     ns = _throttle_ctx(current=current, hard=hard, samples_bpt=bpt)
     ns._fake_current = current
-    safe_target = int(hard * Scheduler._PREFILL_HEADROOM_SAFETY)
-    expected = int((safe_target - current) / (bpt * 1.2))
+    target = min(int(hard * Scheduler._PREFILL_HEADROOM_SAFETY),
+                 int(hard * Scheduler._PREFILL_ABORT_MARGIN))
     n = _call(ns, 2048, kv_len=5000)
     assert n < 2048                      # throttled despite low baseline
     assert n >= ns._prefill_min_chunk_tokens
-    assert n <= expected + 1             # sized to the predicted-peak headroom
+    # The chosen chunk's predicted peak must fit under the sizing target.
+    assert current + _per_token(bpt) * n <= target + _per_token(bpt)
 
 
 def test_throttle_floors_at_min_chunk_when_over_ceiling():
-    """At/over the cap, the smallest step is returned (loop handles the rest)."""
+    """At/over the cap, the smallest step is returned (the guard handles the
+    rest)."""
     hard = 40 * _GB
     ns = _throttle_ctx(current=hard + _GB, hard=hard, samples_bpt=1_000_000,
                        min_chunk=32)
@@ -141,19 +175,103 @@ def test_throttle_floors_at_min_chunk_when_over_ceiling():
     assert _call(ns, 2048, kv_len=5000) == 32
 
 
-def test_throttle_first_chunk_uses_static_estimate():
-    """No EWMA samples yet → fall back to the static SDPA per-token estimate."""
-    hard = 40 * _GB
-    current = int(hard * 0.5)
-    monitor = _monitor(head_dim=192)  # head_dim>128 so estimate is non-trivial
-    ns = _throttle_ctx(current=current, hard=hard, samples_bpt=None,
-                       monitor=monitor)
+def test_throttle_predictor_anchors_on_recent_measurement():
+    """At large kv_len the per-token estimate must reflect the most RECENT
+    measured transient (not a lagging long-run average) so chunks shrink
+    enough to avoid the Metal-cap overshoot that crashed the server."""
+    hard = 42 * _GB
+    # Resident ~32GB (model + 122k-token KV), last chunk measured ~27MB/token.
+    current = 32 * _GB
+    bpt = 27 * 1024 * 1024
+    ns = _throttle_ctx(current=current, hard=hard, samples_bpt=bpt)
     ns._fake_current = current
-    # Very large context → static SDPA per-token estimate is big enough that a
-    # full 2048-token chunk's predicted peak exceeds the target → shrink.
-    n = _call(ns, 2048, kv_len=2_000_000)
+    n = _call(ns, 2048, kv_len=122_000)
+    # Must shrink hard: the full 2048 chunk's transient (~54GB) is impossible.
     assert n < 2048
     assert n >= ns._prefill_min_chunk_tokens
+    cap = int(hard * Scheduler._PREFILL_ABORT_MARGIN)
+    # The chosen chunk's predicted peak stays under the margined physical cap.
+    assert current + _per_token(bpt) * n <= cap + _per_token(bpt)
+
+
+# --------------------------------------------------------------------------
+# Scheduler._guard_prefill_chunk (the crash preventer)
+# --------------------------------------------------------------------------
+
+
+def test_guard_passes_through_when_chunk_fits():
+    hard = 42 * _GB
+    ns = _throttle_ctx(current=10 * _GB, hard=hard, samples_bpt=1024 * 1024)
+    ns._fake_current = 10 * _GB
+    assert _guard_call(ns, 512, kv_len=5000) == 512
+
+
+def test_guard_shrinks_when_chunk_would_breach_cap():
+    """A chunk predicted to breach the margined cap is shrunk to the largest
+    safe size (after a reclaim), never raising while the floor still fits."""
+    hard = 42 * _GB
+    current = 30 * _GB
+    bpt = 27 * 1024 * 1024
+    # Reclaim doesn't free anything here (transient already cleared).
+    ns = _throttle_ctx(current=current, hard=hard, samples_bpt=bpt,
+                       reclaim_to=current)
+    ns._fake_current = current
+    n = _guard_call(ns, 2048, kv_len=122_000)
+    cap = int(hard * Scheduler._PREFILL_ABORT_MARGIN)
+    assert n >= ns._prefill_min_chunk_tokens
+    assert n < 2048
+    assert current + _per_token(bpt) * n <= cap
+
+
+def test_guard_raises_clean_error_when_even_floor_cannot_fit():
+    """When resident alone is so high that even a min-chunk transient would
+    breach the cap, the guard raises a CLEAN error that is NOT a 'Memory limit
+    exceeded' string — so it fails fast instead of looping a doomed retry."""
+    hard = 42 * _GB
+    current = 41 * _GB  # resident already above the margined cap
+    bpt = 27 * 1024 * 1024
+    ns = _throttle_ctx(current=current, hard=hard, samples_bpt=bpt,
+                       reclaim_to=current)  # reclaim can't help
+    ns._fake_current = current
+    with pytest.raises(RuntimeError) as exc:
+        _guard_call(ns, 256, kv_len=122_000)
+    assert "too large for available memory" in str(exc.value)
+    assert "Memory limit exceeded" not in str(exc.value)  # → fails fast, no requeue
+
+
+def test_guard_recovers_after_reclaim_frees_memory():
+    """If a reclaim drops resident back under the cap, the guard proceeds."""
+    hard = 42 * _GB
+    bpt = 1024 * 1024  # small per-token
+    ns = _throttle_ctx(current=41 * _GB, hard=hard, samples_bpt=bpt,
+                       reclaim_to=20 * _GB)
+    ns._fake_current = 41 * _GB
+    n = _guard_call(ns, 512, kv_len=5000)
+    assert n >= ns._prefill_min_chunk_tokens
+
+
+# --------------------------------------------------------------------------
+# Scheduler._predicted_chunk_transient
+# --------------------------------------------------------------------------
+
+
+def test_predicted_transient_takes_max_and_applies_safety():
+    """The predictor takes the MAX of measured-last / EWMA / static and applies
+    the safety factor — so it can't underestimate at growing kv_len."""
+    monitor = _monitor(head_dim=192)
+    ns = _throttle_ctx(current=0, hard=40 * _GB, samples_bpt=5 * 1024 * 1024,
+                       monitor=monitor)
+    # static per-token at this kv_len:
+    static = monitor.estimate_chunk_transient_bytes(1, 100_001)
+    measured = 5 * 1024 * 1024
+    expected_per_token = max(measured, static) * Scheduler._PREFILL_TRANSIENT_SAFETY
+    got = ns._predicted_chunk_transient(1, 100_000)
+    assert got == pytest.approx(expected_per_token, rel=1e-6)
+
+
+def test_predicted_transient_zero_without_signals():
+    ns = _throttle_ctx(current=0, hard=40 * _GB, samples_bpt=None, monitor=None)
+    assert ns._predicted_chunk_transient(4, 1000) == 0.0
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -550,6 +550,70 @@ class TestHardLimitCalculation:
             # → dynamic wins
             assert enforcer._get_hard_limit_bytes() == 10 * 1024**3
 
+
+class TestAbortLimitCalculation:
+    """`_get_abort_limit_bytes` = min(static, metal_cap); ignores the jittery
+    dynamic ceiling so a transient dip can't kill an in-flight prefill."""
+
+    def test_ignores_dynamic_ceiling(self, mock_engine_pool):
+        """Even when the dynamic ceiling is tiny, the abort limit stays at the
+        stable min(static, metal_cap)."""
+        enforcer = ProcessMemoryEnforcer(
+            engine_pool=mock_engine_pool, memory_guard_tier="balanced"
+        )
+        with patch("omlx.settings.get_system_memory") as mock_mem, patch(
+            "omlx.process_memory_enforcer.get_phys_footprint",
+            return_value=1 * 1024**3,
+        ), patch(
+            "omlx.process_memory_enforcer.get_macos_vm_stats",
+            return_value={  # dynamic would compute to ~10 GB (depressed)
+                "free": 5 * 1024**3,
+                "inactive": 2 * 1024**3,
+                "active": 4 * 1024**3,
+                "wired": 1 * 1024**3,
+            },
+        ), patch(
+            "omlx.process_memory_enforcer.get_effective_metal_cap_bytes",
+            return_value=100 * 1024**3,
+        ):
+            mock_mem.return_value = 48 * 1024**3  # static = 40 GB
+            # dynamic (~10 GB) is far below, but the abort limit ignores it.
+            assert enforcer._get_abort_limit_bytes() == 40 * 1024**3
+            # Sanity: the (jittery) hard limit DID drop to dynamic.
+            assert enforcer._get_hard_limit_bytes() == 10 * 1024**3
+
+    def test_picks_metal_cap_when_smaller_than_static(self, mock_engine_pool):
+        enforcer = ProcessMemoryEnforcer(
+            engine_pool=mock_engine_pool, memory_guard_tier="balanced"
+        )
+        with patch(
+            "omlx.settings.get_system_memory", return_value=64 * 1024**3
+        ), patch(
+            "omlx.process_memory_enforcer.get_effective_metal_cap_bytes",
+            return_value=43 * 1024**3,
+        ):
+            # static = 64 - 8 = 56 GB; metal = 43 GB → min = 43 GB
+            assert enforcer._get_abort_limit_bytes() == 43 * 1024**3
+
+    def test_falls_back_to_static_when_metal_cap_unknown(self, mock_engine_pool):
+        enforcer = ProcessMemoryEnforcer(
+            engine_pool=mock_engine_pool, memory_guard_tier="aggressive"
+        )
+        with patch(
+            "omlx.settings.get_system_memory", return_value=48 * 1024**3
+        ), patch(
+            "omlx.process_memory_enforcer.get_effective_metal_cap_bytes",
+            return_value=0,  # unknown
+        ):
+            # aggressive reserve = 6 GB → static = 42 GB
+            assert enforcer._get_abort_limit_bytes() == 42 * 1024**3
+
+    def test_zero_when_guard_disabled(self, mock_engine_pool):
+        enforcer = ProcessMemoryEnforcer(
+            engine_pool=mock_engine_pool, prefill_memory_guard=False
+        )
+        assert enforcer._get_abort_limit_bytes() == 0
+
     def test_zero_when_guard_disabled(self, mock_engine_pool):
         enforcer = ProcessMemoryEnforcer(
             engine_pool=mock_engine_pool,
@@ -1240,6 +1304,31 @@ class TestTwoWatermarkPressureLevels:
 
         assert enforcer_2wm._pressure_level == "ok"
         assert scheduler._admission_paused is False
+
+    @pytest.mark.asyncio
+    async def test_propagates_abort_limit_to_scheduler(self, enforcer_2wm, pool):
+        """The stable abort ceiling is pushed to scheduler._memory_abort_limit_bytes
+        every tick, independent of the (jittery) dynamic hard limit."""
+        engine = MagicMock()
+        scheduler = MagicMock()
+        scheduler._memory_limit_bytes = 0
+        scheduler._memory_hard_limit_bytes = 0
+        scheduler._memory_abort_limit_bytes = 0
+        scheduler._prefill_memory_guard = False
+        scheduler._admission_paused = False
+        engine.scheduler = scheduler
+        pool._entries = {"m": _make_entry("m", engine=engine)}
+
+        # Stub the abort ceiling to a known stable value.
+        enforcer_2wm._get_abort_limit_bytes = lambda: 42 * 1024**3
+
+        with patch("omlx.process_memory_enforcer.mx") as mock_mx, \
+             patch("omlx.process_memory_enforcer.get_phys_footprint") as gpf:
+            mock_mx.get_active_memory.return_value = 50 * 1024**3
+            gpf.return_value = 50 * 1024**3
+            await enforcer_2wm._check_and_enforce()
+
+        assert scheduler._memory_abort_limit_bytes == 42 * 1024**3
 
     @pytest.mark.asyncio
     async def test_hard_aborts_in_flight_when_all_pinned(self, enforcer_2wm, pool):

--- a/tests/test_scheduler_chunked_prefill.py
+++ b/tests/test_scheduler_chunked_prefill.py
@@ -357,7 +357,8 @@ class TestAdvanceChunkedPrefills:
         assert rejected == []
 
     def test_runtime_error_surfaces_as_request_error(self):
-        """RuntimeError mid-chunk yields a finish_reason=\"error\" RequestOutput."""
+        """A non-memory RuntimeError mid-chunk yields a finish_reason="error"
+        RequestOutput immediately (only memory-pressure errors are requeued)."""
         sched = _make_scheduler()
         req = _make_request("oom")
         sched.requests[req.request_id] = req
@@ -367,7 +368,7 @@ class TestAdvanceChunkedPrefills:
 
         with patch.object(
             sched, "_step_prefill_chunk",
-            side_effect=RuntimeError("Memory limit exceeded")
+            side_effect=RuntimeError("kernel panic")
         ):
             scheduled = []
             rejected = []
@@ -382,7 +383,33 @@ class TestAdvanceChunkedPrefills:
         assert out.request_id == "oom"
         assert out.finished is True
         assert out.finish_reason == "error"
-        assert "Memory limit" in out.error
+        assert "kernel panic" in out.error
+
+    def test_memory_error_requeues_instead_of_surfacing(self):
+        """A memory-pressure RuntimeError mid-chunk requeues the request for a
+        fresh attempt instead of immediately surfacing an error to the client."""
+        sched = _make_scheduler()
+        req = _make_request("oom-mem")
+        sched.requests[req.request_id] = req
+        state = _make_prefill_state(sched, req)
+        sched.prefilling.append(req)
+        sched._prefill_states[req.request_id] = state
+
+        with patch.object(
+            sched, "_step_prefill_chunk",
+            side_effect=RuntimeError("Memory limit exceeded during chunked prefill")
+        ):
+            scheduled = []
+            rejected = []
+            sched._advance_chunked_prefills(scheduled, rejected)
+
+        # No client-facing error; the request is reset and back on the queue.
+        assert rejected == []
+        assert req.request_id not in sched._prefill_states
+        assert req not in sched.prefilling
+        assert sched.requests.get(req.request_id) is req
+        assert req in sched.waiting
+        assert req.prefill_oom_retries == 1
 
     def test_multiple_requests_all_advanced(self):
         """All requests in prefilling get one chunk advanced per call."""
@@ -740,7 +767,7 @@ class TestPrefillRejectionReleasesPagedCache:
 
         with patch.object(
             sched, "_do_external_prefill",
-            side_effect=RuntimeError("Memory limit exceeded during prefill"),
+            side_effect=RuntimeError("kernel panic"),
         ):
             sched._schedule_waiting()
 
@@ -764,7 +791,7 @@ class TestPrefillRejectionReleasesPagedCache:
         ):
             with patch.object(
                 sched, "_step_prefill_chunk",
-                side_effect=RuntimeError("Memory limit exceeded"),
+                side_effect=RuntimeError("kernel panic"),
             ):
                 sched._schedule_waiting()
 


### PR DESCRIPTION
## Summary

Prevents the mid-stream prefill OOM where a long-context request hard-fails with `Memory limit exceeded during prefill` (see #1522). Adds a measurement-driven predictive prefill throttle plus graceful reclaim/requeue so memory stays bounded and the request keeps working instead of crashing.

Server-side only; no client or API changes. Below the pressure zone there is **no behavior change** (the full requested chunk runs unchanged when its predicted peak fits).

## Root cause

The failure is a **transient SDPA activation spike**, not resident KV (memory hit 42.8 GB at the check, then dropped to 24.6 GB immediately after teardown). For `head_dim > 128` (MLX float32 SDPA fallback) and especially MoE models the per-chunk transient is large (measured ~18 MB/token). The existing `_adaptive_chunk_size` only throttled once *current* memory crossed the soft watermark, so a single big chunk overshot the ceiling from a low baseline before any throttle engaged. The measured-EWMA predictor (`PrefillTransientTracker.predict()`) existed but was never wired in.

## Changes

- **Predictive per-chunk throttle** (`_adaptive_chunk_size`, `MemoryMonitor.estimate_chunk_transient_bytes`): size each chunk so `current + predicted_transient(n) ≤ ceiling * 0.90`. Uses the measured per-token EWMA once samples exist, else a static SDPA first-chunk estimate at the current context span (`kv_len` is now passed from both prefill loops, so a large prefix-cache hit with a small suffix is throttled correctly). The gate is on **predicted peak**, not on current crossing the watermark — that's the actual fix. The discrete watermark tiers are kept as a secondary clamp under deep pressure.
- **Reclaim before failing** (`_reclaim_prefill_headroom`): the in-loop hard check runs *before* the per-chunk `_sync_and_clear_cache`, so the just-computed transients are still resident; on an overshoot we now sync+clear and re-measure, and only raise if still over.
- **Bounded requeue-then-retry** (`_requeue_or_fail_prefill`, `Request.prefill_oom_retries`, `_MAX_PREFILL_OOM_RETRIES=2`): a memory-pressure prefill is requeued for a fresh, better-throttled attempt (reset to a cold full prefill so it can't re-trigger the same oversized span); after the budget is exhausted it emits the existing clean `finish_reason="error"`. Non-memory `RuntimeError`s still fail immediately. Wired into all three #1405 cleanup sites; restores stashed VLM mRoPE deltas and clears the SpecPrefill RoPE patch on requeue.
- **Enforcer idle reclaim** (`request_idle_reclaim` + `step()` drain): the previously no-op "all models pinned, no loads in progress" branch now requests a between-turn Metal reclaim, run on the inference thread only when idle (cross-thread-safe via the same deferred-flag idiom as aborts).

## Testing

- New unit tests in `tests/test_prefill_oom_graceful.py` (transient estimate math, predictive sizing incl. the low-baseline regression, requeue budget/gating).
- Updated 3 tests in `tests/test_scheduler_chunked_prefill.py` that asserted the old immediate-hard-fail behavior (memory errors now requeue; non-memory errors still surface).
- `pytest -m "not slow and not integration"` green.
- **Live**: on a real `head_dim=256` MoE model at the real ~42 GB ceiling, a 23,313-token prompt that previously crashed now prefills and completes (~17 s), with `[throttle:external] shrink 2048 -> …` firing from a low baseline and **no** `OVER_HARD` / force-stop / requeue needed.

## Risk / rollout

Low. The throttle is a no-op when a chunk already fits; reclaim only runs on the existing failure path; requeue is bounded (and can be set to `0` to fall straight back to today's behavior). No public API changes.

Fixes #1522
