### PR TITLE
fix(server): advertise model-config context length instead of 32K global default

### DIFF
--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -381,6 +381,10 @@ class ModelInfo(BaseModel):
     object: str = "model"
     created: int = Field(default_factory=get_unix_timestamp)
     owned_by: str = "omlx"
+    # vLLM-compatible extension: lets OpenAI-style clients discover the
+    # effective context window from the listing without a separate call
+    # to /v1/models/status (see #1308).
+    max_model_len: int | None = None
 
 
 class ModelsResponse(BaseModel):

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -60,6 +60,7 @@ class EngineEntry:
     config_model_type: str = ""  # Raw model_type from config.json (e.g., "deepseekocr_2")
     thinking_default: bool | None = None  # True if model thinks by default, False if not, None if unknown
     preserve_thinking_default: bool | None = None  # True when template supports preserve_thinking (Qwen 3.6+)
+    model_context_length: int | None = None  # Declared context length from config.json (None if unknown)
     engine: BaseEngine | EmbeddingEngine | RerankerEngine | STTEngine | STSEngine | TTSEngine | None = None  # Loaded engine instance
     last_access: float = 0.0  # Timestamp for LRU (0 if never loaded)
     is_loading: bool = False  # Prevent concurrent loads
@@ -189,6 +190,7 @@ class EnginePool:
                     config_model_type=getattr(info, "config_model_type", ""),
                     thinking_default=getattr(info, "thinking_default", None),
                     preserve_thinking_default=getattr(info, "preserve_thinking_default", None),
+                    model_context_length=getattr(info, "model_context_length", None),
                     is_pinned=model_id in pinned_set,
                 )
 

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -277,6 +277,7 @@ class DiscoveredModel:
     config_model_type: str = ""  # Raw model_type from config.json (e.g., "deepseekocr_2")
     thinking_default: bool | None = None  # True if model thinks by default, False if not, None if unknown
     preserve_thinking_default: bool | None = None  # True when template supports preserve_thinking (Qwen 3.6+)
+    model_context_length: int | None = None  # Declared context length from config.json (None if unknown)
 
 
 def _is_unsupported_model(model_path: Path) -> bool:
@@ -599,6 +600,81 @@ def detect_thinking_default(model_path: Path) -> bool | None:
     return None
 
 
+# Context-length keys, in priority order. Order mirrors HuggingFace
+# Transformers conventions: ``max_position_embeddings`` is the canonical
+# field for decoder-only LLMs; ``max_seq_len`` / ``seq_length`` show up on
+# Llama / Mistral / Qwen forks; ``n_positions`` is the GPT-2 lineage.
+_CONTEXT_LENGTH_KEYS = (
+    "max_position_embeddings",
+    "max_seq_len",
+    "max_seq_length",
+    "seq_length",
+    "n_positions",
+)
+
+# tokenizer_config.json's ``model_max_length`` is Transformers' fallback
+# field. Transformers seeds it with ``int(1e30)`` when the tokenizer has
+# no real cap, and downstream code distinguishes that sentinel from a
+# real long context. Anything above ~1e18 is treated as the sentinel.
+_TOKENIZER_MAX_LENGTH_SENTINEL = 10**18
+
+
+def _read_model_context_length(model_path: Path) -> int | None:
+    """Discover the declared context length from a model's config files.
+
+    Resolution order:
+
+    1. Top-level ``config.json`` keys (``max_position_embeddings`` first,
+       then the rest of :data:`_CONTEXT_LENGTH_KEYS`).
+    2. Nested ``text_config`` / ``language_config`` keys (used by VLM
+       wrappers and Qwen-style MoE configs that put the language head in
+       a sub-object).
+    3. ``tokenizer_config.json``'s ``model_max_length`` — but only when
+       it is a finite positive integer, since Transformers seeds it with
+       ``int(1e30)`` as a "no cap" sentinel.
+
+    Returns:
+        Positive integer context length, or ``None`` when no usable
+        value was found in any of the above.
+    """
+    config_path = model_path / "config.json"
+    if config_path.exists():
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                model_config = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.debug(f"Failed to read config.json for {model_path}: {e}")
+            model_config = {}
+
+        for key in _CONTEXT_LENGTH_KEYS:
+            value = model_config.get(key)
+            if isinstance(value, int) and value > 0:
+                return value
+
+        for nest_key in ("text_config", "language_config"):
+            nested = model_config.get(nest_key)
+            if isinstance(nested, dict):
+                for key in _CONTEXT_LENGTH_KEYS:
+                    value = nested.get(key)
+                    if isinstance(value, int) and value > 0:
+                        return value
+
+    tc_path = model_path / "tokenizer_config.json"
+    if tc_path.exists():
+        try:
+            with open(tc_path, encoding="utf-8") as f:
+                tc = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.debug(f"Failed to read tokenizer_config.json for {model_path}: {e}")
+            tc = {}
+
+        value = tc.get("model_max_length")
+        if isinstance(value, int) and 0 < value < _TOKENIZER_MAX_LENGTH_SENTINEL:
+            return value
+
+    return None
+
+
 def detect_preserve_thinking(model_path: Path) -> bool | None:
     """Detect whether a model's chat template supports ``preserve_thinking``.
 
@@ -748,6 +824,7 @@ def _register_model(
 
         thinking_default = detect_thinking_default(model_dir)
         preserve_thinking_default = detect_preserve_thinking(model_dir)
+        model_context_length = _read_model_context_length(model_dir)
 
         models[model_id] = DiscoveredModel(
             model_id=model_id,
@@ -758,6 +835,7 @@ def _register_model(
             config_model_type=config_model_type,
             thinking_default=thinking_default,
             preserve_thinking_default=preserve_thinking_default,
+            model_context_length=model_context_length,
         )
 
         size_gb = estimated_size / (1024**3)

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1041,10 +1041,19 @@ def get_max_context_window(model_id: str | None = None) -> int | None:
     """
     Get effective max context window limit.
 
-    Priority: model setting > global setting.
+    Priority (#1308):
+        1. Explicit per-model setting (admin UI / settings.json override).
+        2. Context length discovered from the model's ``config.json`` at
+           server startup (``max_position_embeddings`` etc.); without
+           this tier the server would advertise the 32 K global default
+           even for models that declare 256 K+ natively.
+        3. Global default from ``SamplingConfig`` — last-resort fallback
+           for models whose config files don't expose a context length.
 
     Returns:
-        Max context window token count, or None if not set.
+        Max context window token count, or ``None`` if no tier resolves
+        (only possible when neither the model nor the global default
+        provides a value, which shouldn't happen in practice).
     """
     # Resolve alias so per-model settings are found by real model ID
     model_id = resolve_model_id(model_id)
@@ -1055,6 +1064,12 @@ def get_max_context_window(model_id: str | None = None) -> int | None:
 
     if model_settings and model_settings.max_context_window is not None:
         return model_settings.max_context_window
+
+    pool = _server_state.engine_pool
+    if model_id and pool is not None:
+        entry = pool.get_entry(model_id)
+        if entry is not None and entry.model_context_length is not None:
+            return entry.model_context_length
 
     return _server_state.sampling.max_context_window
 
@@ -1693,6 +1708,7 @@ async def list_models(_: bool = Depends(verify_api_key)) -> ModelsResponse:
                 ModelInfo(
                     id=display_id,
                     owned_by="omlx",
+                    max_model_len=get_max_context_window(model_id),
                 )
             )
 

--- a/tests/test_context_window.py
+++ b/tests/test_context_window.py
@@ -19,6 +19,10 @@ class TestGetMaxContextWindow:
         state = MagicMock()
         state.sampling = SamplingDefaults(max_context_window=global_max_ctx)
         state.settings_manager = None
+        # Discovery-tier (#1308) lookups are exercised in TestGetMaxContextWindow
+        # in test_server.py; nulling the pool here keeps these focused on the
+        # per-model-setting → global fallback path.
+        state.engine_pool = None
         return state
 
     def test_returns_global_default(self):

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -11,6 +11,7 @@ from omlx.model_discovery import (
     DiscoveredModel,
     _is_adapter_dir,
     _is_unsupported_model,
+    _read_model_context_length,
     _resolve_hf_cache_entry,
     detect_model_type,
     discover_models,
@@ -778,6 +779,76 @@ class TestDiscoveredModel:
 
         assert model.model_type == "embedding"
         assert model.engine_type == "embedding"
+
+
+class TestReadModelContextLength:
+    """Tests for _read_model_context_length — the discovery-time
+    config.json reader that backs #1308's API exposure fix."""
+
+    def _write(self, tmp_path, config=None, tokenizer_config=None):
+        if config is not None:
+            (tmp_path / "config.json").write_text(json.dumps(config))
+        if tokenizer_config is not None:
+            (tmp_path / "tokenizer_config.json").write_text(json.dumps(tokenizer_config))
+
+    def test_max_position_embeddings_wins(self, tmp_path):
+        self._write(tmp_path, config={"max_position_embeddings": 262144})
+        assert _read_model_context_length(tmp_path) == 262144
+
+    def test_alternate_keys(self, tmp_path):
+        for key in ("max_seq_len", "max_seq_length", "seq_length", "n_positions"):
+            sub = tmp_path / key
+            sub.mkdir()
+            self._write(sub, config={key: 8192})
+            assert _read_model_context_length(sub) == 8192, key
+
+    def test_top_level_takes_precedence_over_nested(self, tmp_path):
+        self._write(tmp_path, config={
+            "max_position_embeddings": 200000,
+            "text_config": {"max_position_embeddings": 32768},
+        })
+        assert _read_model_context_length(tmp_path) == 200000
+
+    def test_text_config_fallback(self, tmp_path):
+        """VLM wrappers stash the language head's ctx in text_config."""
+        self._write(tmp_path, config={"text_config": {"max_position_embeddings": 131072}})
+        assert _read_model_context_length(tmp_path) == 131072
+
+    def test_language_config_fallback(self, tmp_path):
+        """Some Qwen-style configs use language_config instead."""
+        self._write(tmp_path, config={"language_config": {"max_position_embeddings": 65536}})
+        assert _read_model_context_length(tmp_path) == 65536
+
+    def test_tokenizer_max_length_fallback(self, tmp_path):
+        """When config.json doesn't expose a length, tokenizer_config wins."""
+        self._write(tmp_path, config={"model_type": "llama"}, tokenizer_config={"model_max_length": 4096})
+        assert _read_model_context_length(tmp_path) == 4096
+
+    def test_tokenizer_sentinel_rejected(self, tmp_path):
+        """Transformers' int(1e30) "no cap" sentinel must NOT leak through."""
+        self._write(
+            tmp_path,
+            config={"model_type": "llama"},
+            tokenizer_config={"model_max_length": int(1e30)},
+        )
+        assert _read_model_context_length(tmp_path) is None
+
+    def test_no_config_returns_none(self, tmp_path):
+        assert _read_model_context_length(tmp_path) is None
+
+    def test_invalid_types_rejected(self, tmp_path):
+        """A string or zero in the config must not be returned as a length."""
+        self._write(tmp_path, config={"max_position_embeddings": "long"})
+        assert _read_model_context_length(tmp_path) is None
+        sub = tmp_path / "zero"
+        sub.mkdir()
+        self._write(sub, config={"max_position_embeddings": 0})
+        assert _read_model_context_length(sub) is None
+
+    def test_malformed_config_is_silent(self, tmp_path):
+        """A broken config.json must not raise — discovery should keep going."""
+        (tmp_path / "config.json").write_text("{not valid json")
+        assert _read_model_context_length(tmp_path) is None
 
 
 class TestTwoLevelDiscovery:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,9 +7,18 @@ import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
+from omlx.engine_pool import EngineEntry
 from omlx.exceptions import ModelNotFoundError
 from omlx.model_settings import ModelSettings, ModelSettingsManager
-from omlx.server import EngineType, SamplingDefaults, ServerState, app, get_engine, get_sampling_params
+from omlx.server import (
+    EngineType,
+    SamplingDefaults,
+    ServerState,
+    app,
+    get_engine,
+    get_max_context_window,
+    get_sampling_params,
+)
 from omlx.settings import GlobalSettings, ModelSettings as GlobalModelSettings
 
 
@@ -423,3 +432,75 @@ class TestGetEngineLLMTypeValidation:
 
         engine = await get_engine("llama-3", EngineType.LLM)
         assert engine is llm
+
+
+class TestGetMaxContextWindow:
+    """Tests for get_max_context_window precedence rule (#1308).
+
+    Resolution order:
+        1. Explicit per-model setting (admin / settings.json).
+        2. Context length discovered from the model's config.json at
+           startup (EngineEntry.model_context_length).
+        3. Global SamplingDefaults.max_context_window (32K).
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_server_state(self):
+        state = ServerState()
+        with patch("omlx.server._server_state", state):
+            self._state = state
+            yield
+
+    @staticmethod
+    def _entry(model_id: str, ctx_length: int | None) -> EngineEntry:
+        return EngineEntry(
+            model_id=model_id,
+            model_path=f"/fake/{model_id}",
+            model_type="llm",
+            engine_type="batched",
+            estimated_size=0,
+            model_context_length=ctx_length,
+        )
+
+    def _mount_pool(self, entries: dict):
+        pool = MagicMock()
+        pool.resolve_model_id.side_effect = lambda mid, _sm: mid
+        pool.get_entry.side_effect = lambda mid: entries.get(mid)
+        self._state.engine_pool = pool
+
+    def _mount_settings(self, overrides: dict):
+        """Mount a settings_manager that returns the given per-model overrides."""
+        manager = MagicMock()
+        manager.get_settings.side_effect = lambda mid: overrides.get(mid)
+        self._state.settings_manager = manager
+
+    def test_global_default_when_nothing_discovered(self):
+        """No model context, no per-model override → global default."""
+        self._mount_pool({"llama-3": self._entry("llama-3", None)})
+        assert get_max_context_window("llama-3") == 32768
+
+    def test_discovered_context_returned_when_no_override(self):
+        """Model config declares 262144 → /v1/models reports 262144, not 32K (#1308)."""
+        self._mount_pool({"qwen3-coder": self._entry("qwen3-coder", 262144)})
+        assert get_max_context_window("qwen3-coder") == 262144
+
+    def test_per_model_override_wins_over_discovery(self):
+        """Admin set 16384 → that wins over the model's declared 262144."""
+        self._mount_pool({"qwen3-coder": self._entry("qwen3-coder", 262144)})
+        self._mount_settings({"qwen3-coder": ModelSettings(max_context_window=16384)})
+        assert get_max_context_window("qwen3-coder") == 16384
+
+    def test_per_model_override_wins_over_global(self):
+        """Override of 8192 wins even when the model didn't declare a value."""
+        self._mount_pool({"llama-3": self._entry("llama-3", None)})
+        self._mount_settings({"llama-3": ModelSettings(max_context_window=8192)})
+        assert get_max_context_window("llama-3") == 8192
+
+    def test_no_model_id_returns_global_default(self):
+        """A bare /v1/messages-style call with no model id falls to the default."""
+        assert get_max_context_window(None) == 32768
+
+    def test_unknown_model_id_returns_global_default(self):
+        """An unknown model id doesn't crash — falls through to the default."""
+        self._mount_pool({})
+        assert get_max_context_window("ghost-model") == 32768


### PR DESCRIPTION
## Summary

Fixes #1308. `/v1/models` and `/v1/models/status` reported the global 32 K default for every model, even ones whose `config.json` declared 256 K or more. Clients that read the listing to size their context budgets (vLLM-compatible OpenAI consumers, monitoring dashboards) configured themselves at the wrong limit unless an operator manually set a per-model override.

### Resolution order (#1308)

```
1. Explicit per-model setting (admin UI / settings.json override).
2. EngineEntry.model_context_length — discovered from config.json at startup.
3. SamplingDefaults.max_context_window — last-resort global default.
```

The discovery-time helper `_read_model_context_length(model_path)` walks the standard set of config-length fields once at startup, so per-request resolution stays cheap:

```
config.json:
  max_position_embeddings, max_seq_len, max_seq_length,
  seq_length, n_positions
config.json -> text_config / language_config:   (VLM, MoE wrappers)
  same set of keys
tokenizer_config.json:
  model_max_length, with Transformers' int(1e30) sentinel rejected
```

The resolved length lives on `DiscoveredModel` and propagates to `EngineEntry.model_context_length`. `get_max_context_window()` reads it as the middle tier.

### `/v1/models` response shape

`ModelInfo` gains an optional `max_model_len` field (vLLM convention), letting OpenAI-style clients read the effective context window from the listing without a separate `/v1/models/status` call:

```json
{
  "object": "list",
  "data": [
    {
      "id": "gemma-4-e4b",
      "object": "model",
      "owned_by": "omlx",
      "max_model_len": 131072
    }
  ]
}
```

`/v1/models/status`'s existing `max_context_window` field picks up the discovery tier automatically since it already goes through `get_max_context_window()`.

## Test plan

- [x] `pytest tests/test_model_discovery.py tests/test_server.py tests/test_engine_pool.py tests/test_context_window.py` — **224 passed**.
- [x] Full unit suite: **4762 passed, 37 skipped, 59 deselected** (no regressions; one pre-existing test in `test_context_window.py` updated to null `state.engine_pool` so its focus remains on the per-model → global fallback path that pre-dates this PR).
- [x] Live: `omlx serve --model-dir <gemma-4-E4B-it-MLX-4bit>` — this model has `text_config.max_position_embeddings = 131072` plus a `tokenizer_config.json` `model_max_length = int(1e30)` sentinel (a nice double-check of the nested-config path *and* the sentinel filter).

  | Endpoint | Before | After |
  |---|---|---|
  | `/v1/models -> data[0].max_model_len` | (absent) | `131072` |
  | `/v1/models/status -> models[0].max_context_window` | `32768` | `131072` |

### New / changed tests

- **`tests/test_model_discovery.py::TestReadModelContextLength`** — 10 tests covering every config field, top-level vs nested precedence, `text_config` and `language_config` fallback, `tokenizer_config.json` fallback, the `int(1e30)` sentinel rejection, missing config files, malformed JSON, and invalid types (string, zero).
- **`tests/test_server.py::TestGetMaxContextWindow`** — 6 tests pinning the three-tier precedence: global default when no discovery, discovery tier when no override, override wins over discovery, override wins over global, `model_id=None`, unknown model id.
- **`tests/test_context_window.py::TestGetMaxContextWindow`** — its `_make_server_state` now nulls `state.engine_pool` so the discovery tier short-circuits cleanly. Without that, the `MagicMock` returned a truthy `entry.model_context_length` and broke `test_falls_back_to_global_when_model_not_set`. The pre-existing tests still cover the per-model → global fallback path; the discovery tier is covered in the new `test_server.py` class.