### PR TITLE
fix(serve): fail fast on occupied port before preload

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -165,112 +165,123 @@ def serve_command(args):
     _crash_file = open(crash_log_path, "a")
     faulthandler.enable(file=_crash_file, all_threads=True)
 
-    # Import server and config
-    from .server import app, init_server
-    from .config import parse_size
-
-    model_dirs = settings.model.get_model_dirs(settings.base_path)
-    print(f"Base path: {settings.base_path}")
-    print(f"Model directories: {', '.join(str(d) for d in model_dirs)}")
-    print(f"Memory guard tier: {settings.memory.memory_guard_tier}")
-
-    # Store MCP config path for FastAPI startup
-    # Priority: CLI arg > settings.json
-    mcp_config = args.mcp_config or settings.mcp.config_path
-    if mcp_config:
-        print(f"MCP config: {mcp_config}")
-        os.environ["OMLX_MCP_CONFIG"] = mcp_config
-
-    # Determine paged SSD cache directory
-    # Priority: --no-cache > CLI arg > settings file
-    if args.no_cache:
-        paged_ssd_cache_dir = None
-    elif args.paged_ssd_cache_dir:
-        # CLI argument takes precedence
-        paged_ssd_cache_dir = args.paged_ssd_cache_dir
-    elif settings.cache.enabled:
-        # Use settings file value (resolved path or default)
-        paged_ssd_cache_dir = str(settings.cache.get_ssd_cache_dir(settings.base_path))
-    else:
-        # Cache explicitly disabled in settings
-        paged_ssd_cache_dir = None
-
-    # Build scheduler config for BatchedEngine
-    scheduler_config = settings.to_scheduler_config()
-    # Set paged SSD cache options
-    scheduler_config.paged_ssd_cache_dir = paged_ssd_cache_dir
-    # Determine cache max size: CLI arg > settings (with auto resolution)
-    if paged_ssd_cache_dir:
-        if args.paged_ssd_cache_max_size:
-            # CLI argument specified explicitly
-            cache_max_size_bytes = parse_size(args.paged_ssd_cache_max_size)
-        else:
-            # Use settings value (handles "auto" -> 10% of SSD capacity)
-            cache_max_size_bytes = settings.cache.get_ssd_cache_max_size_bytes(settings.base_path)
-        scheduler_config.paged_ssd_cache_max_size = cache_max_size_bytes
-    else:
-        scheduler_config.paged_ssd_cache_max_size = 0
-        cache_max_size_bytes = 0
-
-    # Hot cache: CLI arg > settings
-    if paged_ssd_cache_dir:
-        if args.hot_cache_max_size:
-            hot_cache_max_bytes = parse_size(args.hot_cache_max_size)
-        else:
-            hot_cache_max_bytes = settings.cache.get_hot_cache_max_size_bytes()
-        scheduler_config.hot_cache_max_size = hot_cache_max_bytes
-    else:
-        scheduler_config.hot_cache_max_size = 0
-
-    if args.no_cache:
-        print("Mode: Multi-model serving (no oMLX cache, mlx-lm BatchGenerator only)")
-    elif paged_ssd_cache_dir:
-        print("Mode: Multi-model serving (continuous batching + paged SSD cache)")
-        # Format cache size for display
-        cache_max_size_display = f"{cache_max_size_bytes / (1024**3):.1f}GB"
-        print(f"paged SSD cache: {paged_ssd_cache_dir} (max: {cache_max_size_display})")
-        if scheduler_config.hot_cache_max_size > 0:
-            hot_display = f"{scheduler_config.hot_cache_max_size / (1024**3):.1f}GB"
-            print(f"Hot cache: {hot_display} (in-memory)")
-    else:
-        print("Mode: Multi-model serving (continuous batching, no cache)")
-
-    # Set MLX buffer cache limit high to prevent the allocator from
-    # immediately releasing Metal buffers when the cache is full.
-    # Without this, allocator::free() can call buf->release() while the
-    # GPU is still using the buffer, causing kernel panics on M4.
-    # With a large cache limit, freed buffers always stay in the pool
-    # and are only released via mx.clear_cache() (which we protect
-    # with mx.synchronize()). See issue #300.
-    import mlx.core as mx
-    total_mem = mx.device_info().get("memory_size", 0)
-    if total_mem > 0:
-        mx.set_cache_limit(total_mem)
-
-    # Initialize server
-    # Note: pinned_models and default_model are managed via admin page (model_settings.json)
-    # Sampling parameters (max_tokens, temperature, etc.) are per-model settings
-    init_server(
-        model_dirs=[str(d) for d in model_dirs],
-        scheduler_config=scheduler_config,
-        api_key=settings.auth.api_key,
-        global_settings=settings,
-    )
-
-    # Start server
-    print(f"Starting server at http://{settings.server.host}:{settings.server.port}")
+    # Bind the socket before importing/initializing the server. Uvicorn's
+    # normal startup runs ASGI lifespan before binding host/port, which means
+    # pinned models can be preloaded before a port conflict is detected.
+    print(f"Binding server at http://{settings.server.host}:{settings.server.port}")
     # uvicorn does not support "trace" — map to "debug" for its internal logging
     uvicorn_level = "debug" if settings.server.log_level == "trace" else settings.server.log_level
     # Only show access logs at trace level
     show_access_log = settings.server.log_level == "trace"
-    uvicorn.run(
-        app,
+    uvicorn_config = uvicorn.Config(
+        "omlx.server:app",
         host=settings.server.host,
         port=settings.server.port,
         log_level=uvicorn_level,
         access_log=show_access_log,
     )
+    serve_socket = uvicorn_config.bind_socket()
 
+    try:
+        # Import server and config after the port is known to be available.
+        from .server import init_server
+        from .config import parse_size
+
+        model_dirs = settings.model.get_model_dirs(settings.base_path)
+        print(f"Base path: {settings.base_path}")
+        print(f"Model directories: {', '.join(str(d) for d in model_dirs)}")
+        print(f"Memory guard tier: {settings.memory.memory_guard_tier}")
+
+        # Store MCP config path for FastAPI startup
+        # Priority: CLI arg > settings.json
+        mcp_config = args.mcp_config or settings.mcp.config_path
+        if mcp_config:
+            print(f"MCP config: {mcp_config}")
+            os.environ["OMLX_MCP_CONFIG"] = mcp_config
+
+        # Determine paged SSD cache directory
+        # Priority: --no-cache > CLI arg > settings file
+        if args.no_cache:
+            paged_ssd_cache_dir = None
+        elif args.paged_ssd_cache_dir:
+            # CLI argument takes precedence
+            paged_ssd_cache_dir = args.paged_ssd_cache_dir
+        elif settings.cache.enabled:
+            # Use settings file value (resolved path or default)
+            paged_ssd_cache_dir = str(settings.cache.get_ssd_cache_dir(settings.base_path))
+        else:
+            # Cache explicitly disabled in settings
+            paged_ssd_cache_dir = None
+
+        # Build scheduler config for BatchedEngine
+        scheduler_config = settings.to_scheduler_config()
+        # Set paged SSD cache options
+        scheduler_config.paged_ssd_cache_dir = paged_ssd_cache_dir
+        # Determine cache max size: CLI arg > settings (with auto resolution)
+        if paged_ssd_cache_dir:
+            if args.paged_ssd_cache_max_size:
+                # CLI argument specified explicitly
+                cache_max_size_bytes = parse_size(args.paged_ssd_cache_max_size)
+            else:
+                # Use settings value (handles "auto" -> 10% of SSD capacity)
+                cache_max_size_bytes = settings.cache.get_ssd_cache_max_size_bytes(settings.base_path)
+            scheduler_config.paged_ssd_cache_max_size = cache_max_size_bytes
+        else:
+            scheduler_config.paged_ssd_cache_max_size = 0
+            cache_max_size_bytes = 0
+
+        # Hot cache: CLI arg > settings
+        if paged_ssd_cache_dir:
+            if args.hot_cache_max_size:
+                hot_cache_max_bytes = parse_size(args.hot_cache_max_size)
+            else:
+                hot_cache_max_bytes = settings.cache.get_hot_cache_max_size_bytes()
+            scheduler_config.hot_cache_max_size = hot_cache_max_bytes
+        else:
+            scheduler_config.hot_cache_max_size = 0
+
+        if args.no_cache:
+            print("Mode: Multi-model serving (no oMLX cache, mlx-lm BatchGenerator only)")
+        elif paged_ssd_cache_dir:
+            print("Mode: Multi-model serving (continuous batching + paged SSD cache)")
+            # Format cache size for display
+            cache_max_size_display = f"{cache_max_size_bytes / (1024**3):.1f}GB"
+            print(f"paged SSD cache: {paged_ssd_cache_dir} (max: {cache_max_size_display})")
+            if scheduler_config.hot_cache_max_size > 0:
+                hot_display = f"{scheduler_config.hot_cache_max_size / (1024**3):.1f}GB"
+                print(f"Hot cache: {hot_display} (in-memory)")
+        else:
+            print("Mode: Multi-model serving (continuous batching, no cache)")
+
+        # Set MLX buffer cache limit high to prevent the allocator from
+        # immediately releasing Metal buffers when the cache is full.
+        # Without this, allocator::free() can call buf->release() while the
+        # GPU is still using the buffer, causing kernel panics on M4.
+        # With a large cache limit, freed buffers always stay in the pool
+        # and are only released via mx.clear_cache() (which we protect
+        # with mx.synchronize()). See issue #300.
+        import mlx.core as mx
+
+        total_mem = mx.device_info().get("memory_size", 0)
+        if total_mem > 0:
+            mx.set_cache_limit(total_mem)
+
+        # Initialize server
+        # Note: pinned_models and default_model are managed via admin page (model_settings.json)
+        # Sampling parameters (max_tokens, temperature, etc.) are per-model settings
+        init_server(
+            model_dirs=[str(d) for d in model_dirs],
+            scheduler_config=scheduler_config,
+            api_key=settings.auth.api_key,
+            global_settings=settings,
+        )
+
+        print(f"Starting server at http://{settings.server.host}:{settings.server.port}")
+        uvicorn.Server(uvicorn_config).run(sockets=[serve_socket])
+    finally:
+        # Uvicorn closes sockets during normal shutdown; this covers failures
+        # after bind succeeds but before the server takes ownership.
+        serve_socket.close()
 
 
 def launch_command(args, extra_args: list[str] | None = None):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,8 +7,10 @@ Note: Configuration validation tests are in test_config.py.
 """
 
 import argparse
+import socket
 import subprocess
 import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -379,6 +381,82 @@ class TestLaunchArgvParsing:
 class TestServeCommandFunctions:
     """Tests for serve command function."""
 
+    @staticmethod
+    def _make_serve_args(tmp_path, host="127.0.0.1", port=8000, **overrides):
+        defaults = {
+            "model_dir": None,
+            "host": host,
+            "port": port,
+            "log_level": None,
+            "sse_keepalive_mode": None,
+            "max_concurrent_requests": None,
+            "embedding_batch_size": None,
+            "paged_ssd_cache_dir": None,
+            "paged_ssd_cache_max_size": None,
+            "hot_cache_max_size": None,
+            "no_cache": True,
+            "initial_cache_blocks": None,
+            "mcp_config": None,
+            "hf_endpoint": None,
+            "ms_endpoint": None,
+            "http_proxy": None,
+            "https_proxy": None,
+            "no_proxy": None,
+            "ca_bundle": None,
+            "base_path": str(tmp_path),
+            "api_key": None,
+        }
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    @staticmethod
+    def _make_settings(tmp_path, host="127.0.0.1", port=8000):
+        log_dir = tmp_path / "logs"
+        settings = SimpleNamespace()
+        settings.base_path = tmp_path
+        settings.server = SimpleNamespace(host=host, port=port, log_level="info")
+        settings.huggingface = SimpleNamespace(endpoint=None)
+        settings.modelscope = SimpleNamespace(endpoint=None)
+        settings.network = SimpleNamespace(
+            http_proxy=None,
+            https_proxy=None,
+            no_proxy=None,
+            ca_bundle=None,
+        )
+        settings.logging = SimpleNamespace(
+            retention_days=7,
+            get_log_dir=lambda base_path: log_dir,
+        )
+        settings.model = SimpleNamespace(
+            get_model_dirs=lambda base_path: [tmp_path / "models"],
+        )
+        settings.memory = SimpleNamespace(memory_guard_tier="balanced")
+        settings.mcp = SimpleNamespace(config_path=None)
+        settings.cache = SimpleNamespace(
+            enabled=False,
+            get_ssd_cache_dir=lambda base_path: tmp_path / "cache",
+            get_ssd_cache_max_size_bytes=lambda base_path: 0,
+            get_hot_cache_max_size_bytes=lambda: 0,
+        )
+        settings.auth = SimpleNamespace(api_key=None)
+        settings.ensure_directories = lambda: log_dir.mkdir(parents=True, exist_ok=True)
+        settings.validate = lambda: []
+        settings.save = MagicMock()
+        settings.to_scheduler_config = lambda: SimpleNamespace(
+            paged_ssd_cache_dir=None,
+            paged_ssd_cache_max_size=0,
+            hot_cache_max_size=0,
+        )
+        return settings
+
+    @staticmethod
+    def _reserve_port(host="127.0.0.1"):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, 0))
+        sock.listen(1)
+        return sock
+
     def test_serve_command_exists(self):
         """Test that serve_command function exists."""
         from omlx.cli import serve_command
@@ -419,6 +497,109 @@ class TestServeCommandFunctions:
         assert "embedding_batch_size" in result.stdout
         assert not (tmp_path / "settings.json").exists()
 
+    def test_serve_exits_on_port_conflict_before_importing_server(
+        self, tmp_path, monkeypatch
+    ):
+        """Port conflicts should fail before server import can preload pinned models."""
+        import uvicorn
+
+        from omlx.cli import serve_command
+
+        listener = self._reserve_port()
+        host, port = listener.getsockname()
+        settings = self._make_settings(tmp_path, host=host, port=port)
+        args = self._make_serve_args(tmp_path, host=host, port=port)
+        previous_server = sys.modules.pop("omlx.server", None)
+        events = []
+
+        original_bind_socket = uvicorn.Config.bind_socket
+
+        def tracking_bind_socket(config):
+            events.append("bind")
+            return original_bind_socket(config)
+
+        monkeypatch.setattr("omlx.settings.init_settings", lambda **kwargs: settings)
+        monkeypatch.setattr(
+            "omlx.logging_config.configure_file_logging",
+            lambda **kwargs: None,
+        )
+        monkeypatch.setattr("faulthandler.enable", lambda *args, **kwargs: None)
+        monkeypatch.setattr("uvicorn.Config.bind_socket", tracking_bind_socket)
+        try:
+            with pytest.raises(SystemExit) as exc:
+                serve_command(args)
+
+            assert exc.value.code != 0
+            assert events == ["bind"]
+            assert "omlx.server" not in sys.modules
+        finally:
+            listener.close()
+            if previous_server is not None:
+                sys.modules["omlx.server"] = previous_server
+
+    def test_serve_hands_prebound_socket_to_uvicorn(self, tmp_path, monkeypatch):
+        """Successful serve startup should pass the pre-bound socket into uvicorn."""
+        import omlx
+        import uvicorn
+
+        from omlx.cli import serve_command
+
+        host, port = "127.0.0.1", 0
+        settings = self._make_settings(tmp_path, host=host, port=port)
+        args = self._make_serve_args(tmp_path, host=host, port=port)
+        events = []
+
+        fake_server = ModuleType("omlx.server")
+
+        async def app(scope, receive, send):
+            return None
+
+        def fake_init_server(**kwargs):
+            events.append("init")
+
+        fake_server.app = app
+        fake_server.init_server = MagicMock(side_effect=fake_init_server)
+        monkeypatch.setitem(sys.modules, "omlx.server", fake_server)
+        monkeypatch.setattr(omlx, "server", fake_server, raising=False)
+
+        fake_mlx = ModuleType("mlx")
+        fake_mlx_core = ModuleType("mlx.core")
+        fake_mlx_core.device_info = lambda: {"memory_size": 0}
+        fake_mlx_core.set_cache_limit = MagicMock()
+        fake_mlx.core = fake_mlx_core
+        monkeypatch.setitem(sys.modules, "mlx", fake_mlx)
+        monkeypatch.setitem(sys.modules, "mlx.core", fake_mlx_core)
+
+        monkeypatch.setattr("omlx.settings.init_settings", lambda **kwargs: settings)
+        monkeypatch.setattr(
+            "omlx.logging_config.configure_file_logging",
+            lambda **kwargs: None,
+        )
+        monkeypatch.setattr("faulthandler.enable", lambda *args, **kwargs: None)
+        captured = {}
+        original_bind_socket = uvicorn.Config.bind_socket
+
+        def tracking_bind_socket(config):
+            sock = original_bind_socket(config)
+            events.append("bind")
+            return sock
+
+        def fake_run(self, sockets=None):
+            self.config.load()
+            events.append("run")
+            captured["socket_name"] = sockets[0].getsockname()
+            captured["socket_count"] = len(sockets)
+
+        monkeypatch.setattr("uvicorn.Config.bind_socket", tracking_bind_socket)
+        monkeypatch.setattr("uvicorn.Server.run", fake_run)
+
+        serve_command(args)
+
+        fake_server.init_server.assert_called_once()
+        assert events == ["bind", "init", "run"]
+        assert captured["socket_count"] == 1
+        assert captured["socket_name"][0] == host
+        assert captured["socket_name"][1] > 0
 
 
 class TestHasCliOverrides:


### PR DESCRIPTION
Fixes #1524.

## Summary

- bind the uvicorn serve socket before importing/initializing the server
- fail occupied host/port startup before ASGI lifespan and pinned model preload
- pass the pre-bound socket into `uvicorn.Server(...).run(sockets=[...])`
- close the socket if server initialization fails before uvicorn takes ownership

## Problem

`omlx serve` preloads pinned models during FastAPI lifespan startup. Uvicorn's normal startup path runs lifespan before binding the host/port, so a second process on the same port can still load and unload pinned models before exiting with `EADDRINUSE`.

Under a restart supervisor, that can turn a simple port conflict into repeated expensive model load/unload cycles.

## Approach

Use `uvicorn.Config.bind_socket()` before importing `omlx.server` or calling `init_server(...)`. If the bind fails, the process exits before server setup. If it succeeds, the existing setup path runs and uvicorn receives the already-bound socket.

This keeps the change scoped to the `omlx serve` CLI path.

## Tests

- `uv run pytest tests/test_cli.py -q`
- `uv run python -m compileall -q omlx/cli.py tests/test_cli.py`
- `git diff --check`
