### PR TITLE
fix(scheduler): enforce thinking budgets for Gemma 4 and Harmony models

### DIFF
--- a/omlx/adapter/harmony.py
+++ b/omlx/adapter/harmony.py
@@ -221,6 +221,7 @@ class HarmonyStreamingParser:
         # Check if this is a special token (should not be streamed)
         is_special_token = token_id in self._special_tokens
         is_stop = token_id in self._stop_tokens
+        was_analysis = self._prev_channel == "analysis"
 
         # Passthrough: parser crashed earlier, buffer all tokens silently.
         # Tokens are still tracked by the scheduler for non-streaming tool
@@ -243,6 +244,12 @@ class HarmonyStreamingParser:
 
         channel = self._parser.current_channel
         control_text = ""
+
+        # Harmony uses the same end token for analysis, final, and tool/action
+        # messages. Ending analysis should let generation continue into the
+        # final channel; ending other channels should stop the request.
+        if was_analysis and is_stop:
+            is_stop = False
 
         # Handle channel transitions for <think> tags
         if channel != self._prev_channel:
@@ -372,11 +379,13 @@ def parse_tool_calls_from_tokens(
     try:
         encoding = load_harmony_encoding("HarmonyGptOss")
 
-        # The model's chat template includes "<|start|>assistant" in the prompt,
-        # so the model generates starting from "<|channel|>".
-        # We need to prepend "<|start|>assistant" for proper parsing.
-        if prepend_start:
-            start_tokens = encoding.encode("<|start|>assistant", allowed_special="all")
+        start_tokens = encoding.encode("<|start|>assistant", allowed_special="all")
+        has_start = list(token_ids[: len(start_tokens)]) == start_tokens
+
+        # The normal chat template includes "<|start|>assistant" in the prompt,
+        # so completions start from "<|channel|>" and need the prefix restored.
+        # Budget-forced or recovered Harmony completions may already include it.
+        if prepend_start and not has_start:
             full_token_ids = start_tokens + list(token_ids)
         else:
             full_token_ids = list(token_ids)

--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -59,6 +59,8 @@ class OutputParserFactory:
     kind: str
     create_session: Callable[[Any], OutputParserSession]
     stop_token_ids: set[int] = field(default_factory=set)
+    thinking_end_text: str | None = None
+    thinking_end_trailing_text: str | None = None
 
 
 class HarmonyOutputParserSession:
@@ -155,6 +157,8 @@ def detect_output_parser(
             kind="harmony",
             create_session=HarmonyOutputParserSession,
             stop_token_ids=temp_parser.get_stop_token_ids(),
+            thinking_end_text="<|end|>",
+            thinking_end_trailing_text="<|start|>assistant<|channel|>final<|message|>",
         )
 
     if is_gemma4_model(model_name, model_config):
@@ -164,6 +168,7 @@ def detect_output_parser(
             kind="gemma4",
             create_session=Gemma4OutputParserSession,
             stop_token_ids=set(),
+            thinking_end_text="<channel|>",
         )
 
     return None

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -10,6 +10,7 @@ their chain-of-thought reasoning in <think>...</think> tags.
 """
 
 import re
+from collections.abc import Callable
 from typing import List, Optional, Tuple
 
 
@@ -278,6 +279,7 @@ class ThinkingBudgetProcessor:
         think_start_token_id: Optional[int] = None,
         leading_token_ids: Optional[List[int]] = None,
         trailing_token_ids: Optional[List[int]] = None,
+        token_to_piece: Optional[Callable[[int], str | bytes | None]] = None,
     ):
         self._think_end_ids = think_end_token_ids
         # Full force sequence: \n + </think> + \n\n (matches training pattern)
@@ -288,31 +290,24 @@ class ThinkingBudgetProcessor:
         )
         self._budget = budget
         self._think_start_id = think_start_token_id
+        self._token_to_piece = token_to_piece
 
         # State
         self._thinking_tokens: int = 0
         self._in_thinking: bool = True  # Starts True (prompt ends with <think>)
         self._forcing: bool = False
+        self._waiting_utf8: bool = False
         self._force_idx: int = 0
         self._done: bool = False
         self._first_call: bool = True
-        # After forced sequence, suppress duplicate </think> tokens
-        self._suppress_end: bool = False
         # Sliding window for multi-token end detection
         self._recent_tokens: List[int] = []
-        # Flat set for fast single-token suppression check
-        self._end_id_set = set(think_end_token_ids)
+        self._last_token_utf8_complete: bool = True
+        self._pending_utf8: bytes = b""
 
     def __call__(self, tokens, logits):
         """mlx-lm logits processor: (tokens, logits) -> logits."""
         import mlx.core as mx
-
-        if self._done:
-            return logits
-
-        # Post-forcing phase: suppress duplicate </think> tokens
-        if self._suppress_end:
-            return self._suppress_end_tokens(logits, mx)
 
         # In new mlx-lm API, tokens is the full history list.
         # Accept each genuinely generated token exactly once (see grammar.py).
@@ -327,31 +322,44 @@ class ThinkingBudgetProcessor:
         # If state changed by _update_state, handle immediately
         if self._done:
             return logits
-        if self._suppress_end:
-            return self._suppress_end_tokens(logits, mx)
 
         if self._forcing:
             return self._force_next_token(logits, mx)
 
+        if self._waiting_utf8:
+            return logits
+
         if self._in_thinking:
             self._thinking_tokens += 1
             if self._thinking_tokens >= self._budget:
-                self._forcing = True
-                self._force_idx = 0
-                return self._force_next_token(logits, mx)
+                if self._last_token_utf8_complete:
+                    self._forcing = True
+                    self._force_idx = 0
+                    self._recent_tokens = []
+                    return self._force_next_token(logits, mx)
+                self._waiting_utf8 = True
+                self._recent_tokens = []
 
         return logits
 
     def _update_state(self, token_id: int) -> None:
         """Update thinking state based on the last generated token."""
+        self._last_token_utf8_complete = self._is_utf8_complete(token_id)
+
+        if self._done:
+            if self._think_start_id and token_id == self._think_start_id:
+                self._in_thinking = True
+                self._done = False
+                self._thinking_tokens = 0
+                self._recent_tokens = []
+            return
+
         if self._forcing:
             self._force_idx += 1
             if self._force_idx >= len(self._force_sequence):
                 self._in_thinking = False
                 self._forcing = False
-                # Don't set _done — enter suppression mode to prevent
-                # the model from generating a duplicate </think>.
-                self._suppress_end = True
+                self._done = True
             return
 
         # Detect natural close-think via sliding window
@@ -369,9 +377,46 @@ class ThinkingBudgetProcessor:
                 self._done = True
                 return
 
+        if self._waiting_utf8:
+            if self._last_token_utf8_complete:
+                self._waiting_utf8 = False
+                self._forcing = True
+                self._force_idx = 0
+                self._recent_tokens = []
+            return
+
         # Detect re-entry into thinking (rare but possible)
         if not self._in_thinking and self._think_start_id and token_id == self._think_start_id:
             self._in_thinking = True
+            self._done = False
+            self._thinking_tokens = 0
+            self._recent_tokens = []
+
+    def _is_utf8_complete(self, token_id: int) -> bool:
+        """Best-effort UTF-8 boundary check for accepted token bytes."""
+        if self._token_to_piece is None:
+            return True
+        try:
+            piece = self._token_to_piece(token_id)
+        except Exception:
+            return True
+        if piece is None:
+            return True
+        if isinstance(piece, str):
+            self._pending_utf8 = b""
+            return True
+        self._pending_utf8 += piece
+        try:
+            self._pending_utf8.decode("utf-8")
+            self._pending_utf8 = b""
+            return True
+        except UnicodeDecodeError as exc:
+            if exc.reason == "unexpected end of data" or exc.end == len(
+                self._pending_utf8
+            ):
+                return False
+            self._pending_utf8 = b""
+            return True
 
     def _force_next_token(self, logits, mx):
         """Force the next token in the close-think + trailing sequence."""
@@ -379,11 +424,3 @@ class ThinkingBudgetProcessor:
         forced = mx.full(logits.shape, float("-inf"))
         forced[..., target_id] = 0.0
         return forced
-
-    def _suppress_end_tokens(self, logits, mx):
-        """Suppress duplicate </think> tokens after forced close."""
-        # Set logits of all end-token IDs to -inf so the model
-        # cannot produce another </think>.
-        for tid in self._end_id_set:
-            logits[..., tid] = float("-inf")
-        return logits

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -2901,6 +2901,7 @@ class Scheduler:
                     think_start_token_id=think_start_id,
                     leading_token_ids=leading_ids,
                     trailing_token_ids=trailing_ids,
+                    token_to_piece=self._thinking_budget_token_to_piece,
                 )
                 logits_processors.append(processor)
 
@@ -2970,6 +2971,46 @@ class Scheduler:
 
         if ids:
             return list(ids)
+        return None
+
+    def _thinking_budget_token_to_piece(self, token_id: int) -> str | bytes | None:
+        """Best-effort token piece lookup for UTF-8-safe budget forcing."""
+        try:
+            token = self.tokenizer.convert_ids_to_tokens(token_id)
+            if token is not None:
+                byte_piece = self._token_piece_to_bytes(token)
+                return byte_piece if byte_piece is not None else token
+        except (AttributeError, KeyError, TypeError, ValueError):
+            pass
+
+        try:
+            return self.tokenizer.decode([token_id], skip_special_tokens=False)
+        except TypeError:
+            try:
+                return self.tokenizer.decode([token_id])
+            except Exception:
+                return None
+        except Exception:
+            return None
+
+    def _token_piece_to_bytes(self, token: str) -> bytes | None:
+        """Convert byte-fallback tokenizer pieces to raw bytes when possible."""
+        import re
+
+        byte_fallback = re.fullmatch(r"(?:<0x[0-9A-Fa-f]{2}>)+", token)
+        if byte_fallback is not None:
+            return bytes(
+                int(match.group(1), 16)
+                for match in re.finditer(r"<0x([0-9A-Fa-f]{2})>", token)
+            )
+
+        byte_decoder = getattr(self.tokenizer, "byte_decoder", None)
+        if isinstance(byte_decoder, dict) and token:
+            try:
+                return bytes(byte_decoder[ch] for ch in token)
+            except (KeyError, TypeError, ValueError):
+                pass
+
         return None
 
     def _resolve_output_parser_thinking_trailing_ids(self) -> list[int] | None:
@@ -6003,13 +6044,7 @@ class Scheduler:
                                     if pre_eval_arrays:
                                         mx.async_eval(*pre_eval_arrays)
 
-                            parser_backed_output = (
-                                self._output_parser_factory is not None
-                            )
-                            if (
-                                self._store_cache_executor is not None
-                                and not parser_backed_output
-                            ):
+                            if self._store_cache_executor is not None:
                                 # Hand the store-cache write to the background
                                 # executor without ever blocking the generation
                                 # step. The gate only counts in-flight writes;

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1521,9 +1521,9 @@ class Scheduler:
         if self._generation_config_eos is not None:
             stop_tokens.update(self._generation_config_eos)
 
-        # Add protocol-specific stop tokens (e.g. Harmony action stops)
-        if self._output_parser_factory is not None:
-            stop_tokens.update(self._output_parser_factory.stop_token_ids)
+        # Protocol parsers need to observe their own stop tokens so they can
+        # apply channel-aware handling (for example, Harmony analysis end
+        # should continue into the final channel).
 
         return stop_tokens
 
@@ -2879,15 +2879,22 @@ class Scheduler:
         if (
             sampling_params.thinking_budget is not None
             and request is not None
-            and getattr(request, "needs_think_prefix", False)
-            and not getattr(request, "is_harmony_model", False)
+            and (
+                getattr(request, "needs_think_prefix", False)
+                or self._get_output_parser_thinking_end_text() is not None
+            )
         ):
             think_end_ids = self._resolve_think_end_token_ids()
             if think_end_ids:
                 from .api.thinking import ThinkingBudgetProcessor
 
                 think_start_id = self._get_think_token_id("think_start_id")
-                leading_ids, trailing_ids = self._resolve_think_close_pattern()
+                leading_ids, trailing_ids = self._resolve_think_close_pattern(
+                    self._get_output_parser_thinking_end_text()
+                )
+                parser_trailing_ids = self._resolve_output_parser_thinking_trailing_ids()
+                if parser_trailing_ids is not None:
+                    trailing_ids = parser_trailing_ids
                 processor = ThinkingBudgetProcessor(
                     think_end_token_ids=think_end_ids,
                     budget=sampling_params.thinking_budget,
@@ -2942,12 +2949,51 @@ class Scheduler:
         except (ValueError, TypeError):
             return None
 
+    def _get_output_parser_thinking_end_text(self) -> str | None:
+        """Return parser-provided thinking close text, if the parser has one."""
+        factory = getattr(self, "_output_parser_factory", None)
+        if factory is None:
+            return None
+        return getattr(factory, "thinking_end_text", None)
+
+    def _encode_thinking_marker(self, text: str) -> list[int] | None:
+        """Encode a parser/tokenizer thinking marker into token IDs."""
+        try:
+            ids = self.tokenizer.encode(text, add_special_tokens=False)
+        except TypeError:
+            try:
+                ids = self.tokenizer.encode(text)
+            except Exception:
+                return None
+        except Exception:
+            return None
+
+        if ids:
+            return list(ids)
+        return None
+
+    def _resolve_output_parser_thinking_trailing_ids(self) -> list[int] | None:
+        """Resolve parser-provided tokens that should follow a forced close."""
+        factory = getattr(self, "_output_parser_factory", None)
+        if factory is None:
+            return None
+
+        trailing_text = getattr(factory, "thinking_end_trailing_text", None)
+        if not trailing_text:
+            return None
+
+        return self._encode_thinking_marker(trailing_text)
+
     def _resolve_think_end_token_ids(self) -> list[int] | None:
         """Resolve token ID(s) for the close-think tag.
 
         Uses mlx-lm's built-in think_end_id which supports both
         </think> and </longcat_think> automatically.
         """
+        parser_think_end = self._get_output_parser_thinking_end_text()
+        if parser_think_end is not None:
+            return self._encode_thinking_marker(parser_think_end)
+
         # Tier 1: mlx-lm tokenizer attribute (covers all known think variants)
         think_end_id = self._get_think_token_id("think_end_id")
         if think_end_id is not None:
@@ -2972,7 +3018,9 @@ class Scheduler:
 
         return None
 
-    def _resolve_think_close_pattern(self) -> tuple[list[int] | None, list[int] | None]:
+    def _resolve_think_close_pattern(
+        self, think_end_str: str | None = None
+    ) -> tuple[list[int] | None, list[int] | None]:
         """Detect leading/trailing tokens around </think> from the chat template.
 
         Different models use different patterns:
@@ -2985,7 +3033,8 @@ class Scheduler:
         """
         import re
 
-        think_end_str = getattr(self.tokenizer, "think_end", "</think>")
+        if think_end_str is None:
+            think_end_str = getattr(self.tokenizer, "think_end", None) or "</think>"
 
         # Try to get the chat template text
         template_text = self._get_chat_template_text()
@@ -5652,6 +5701,7 @@ class Scheduler:
                 if parser_result.is_stop and not is_finished:
                     is_finished = True
                     is_stop = True
+                    response.finish_reason = "stop"
 
                 should_record_token = (
                     parser_result.record_token
@@ -5953,7 +6003,13 @@ class Scheduler:
                                     if pre_eval_arrays:
                                         mx.async_eval(*pre_eval_arrays)
 
-                            if self._store_cache_executor is not None:
+                            parser_backed_output = (
+                                self._output_parser_factory is not None
+                            )
+                            if (
+                                self._store_cache_executor is not None
+                                and not parser_backed_output
+                            ):
                                 # Hand the store-cache write to the background
                                 # executor without ever blocking the generation
                                 # step. The gate only counts in-flight writes;

--- a/tests/test_harmony.py
+++ b/tests/test_harmony.py
@@ -210,6 +210,26 @@ class TestPassthroughMode:
         _, _, _, is_stop = parser.process_token(stop_token)
         assert is_stop is True
 
+    def test_analysis_end_does_not_stop_generation(self, tokenizer, encoding):
+        """Ending analysis closes thinking but lets the final channel continue."""
+        parser = HarmonyStreamingParser(tokenizer=tokenizer)
+
+        tokens = encoding.encode(
+            "<|channel|>analysis<|message|>thinking<|end|>",
+            allowed_special="all",
+        )
+
+        result = None
+        for token_id in tokens:
+            result = parser.process_token(token_id)
+
+        assert result is not None
+        control_text, stream_token, visible_token, is_stop = result
+        assert "</think>\n" in control_text
+        assert stream_token is None
+        assert visible_token is None
+        assert is_stop is False
+
     def test_passthrough_closes_think_tag(self, tokenizer, encoding):
         """Passthrough activation while in analysis channel closes think tag."""
         parser = HarmonyStreamingParser(tokenizer=tokenizer)
@@ -311,3 +331,16 @@ class TestParseToolCallsFromTokens:
         )
         assert analysis_text == ""
         assert "Hello world" in output_text
+
+    def test_does_not_prepend_duplicate_start_header(self, encoding):
+        """Budget-forced Harmony completions may already include the start header."""
+        tokens = encoding.encode(
+            "<|start|>assistant<|channel|>analysis<|message|>thinking<|end|>",
+            allowed_special="all",
+        )
+        output_text, analysis_text, tool_calls = parse_tool_calls_from_tokens(
+            tokens, prepend_start=True
+        )
+        assert output_text == ""
+        assert "thinking" in analysis_text
+        assert tool_calls == []

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -25,6 +25,32 @@ from omlx.request import Request, RequestOutput, RequestStatus, SamplingParams
 from omlx.scheduler import Scheduler, SchedulerConfig, SchedulerOutput, SchedulingPolicy
 
 
+class _ParserStopFactory:
+    kind = "test"
+    stop_token_ids = set()
+    thinking_end_text = None
+
+    def create_session(self, tokenizer):
+        return _ParserStopSession()
+
+
+class _ParserStopSession:
+    def process_token(self, token_id):
+        from omlx.adapter.output_parser import OutputParserTokenResult
+
+        return OutputParserTokenResult(
+            stream_text="",
+            visible_text="",
+            is_stop=True,
+            record_token=False,
+        )
+
+    def finalize(self):
+        from omlx.adapter.output_parser import OutputParserFinalizeResult
+
+        return OutputParserFinalizeResult()
+
+
 class TestSchedulerConfig:
     """Tests for SchedulerConfig dataclass."""
 
@@ -2218,6 +2244,39 @@ class TestOutputParserSmoke:
         assert "<|channel>" not in full_stream
         assert "<channel|>" not in full_stream
         assert full_stream == "<think>\nreasoning</think>\nanswer"
+
+    def test_parser_stop_sets_finish_reason(self, mock_model):
+        tokenizer = self._GemmaTokenizer({11: "<|return|>"})
+        scheduler = Scheduler(
+            model=mock_model,
+            tokenizer=tokenizer,
+            config=SchedulerConfig(model_name="test-model"),
+        )
+        scheduler._output_parser_factory = _ParserStopFactory()
+
+        request = Request(
+            request_id="parser-stop-req",
+            prompt="prompt",
+            sampling_params=SamplingParams(max_tokens=5),
+            prompt_token_ids=[1, 2, 3],
+            num_prompt_tokens=3,
+            status=RequestStatus.RUNNING,
+            batch_uid=99,
+        )
+        scheduler.running[request.request_id] = request
+        scheduler.requests[request.request_id] = request
+        scheduler.uid_to_request_id[99] = request.request_id
+        scheduler.request_id_to_uid[request.request_id] = 99
+
+        responses = [
+            type("Resp", (), {"uid": 99, "token": 11, "finish_reason": None})(),
+        ]
+
+        outputs, finished_ids = scheduler._process_batch_responses(responses)
+
+        assert finished_ids == {"parser-stop-req"}
+        assert outputs[-1].finished is True
+        assert outputs[-1].finish_reason == "stop"
 
 
 class TestVLMPositionStateClearing:

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for ThinkingBudgetProcessor logits processor."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -13,8 +13,11 @@ try:
 except ImportError:
     HAS_MLX = False
 
+from omlx.adapter.output_parser import OutputParserFactory
 from omlx.api.thinking import ThinkingBudgetProcessor
 from omlx.model_settings import ModelSettings
+from omlx.request import Request, SamplingParams
+from omlx.scheduler import Scheduler
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +242,126 @@ class TestModelSettingsThinkingBudget:
         settings = ModelSettings()
         d = settings.to_dict()
         assert "thinking_budget_tokens" not in d
+
+
+class TestParserBackedThinkingBudgetWiring:
+    """Scheduler wiring for parsers that own reasoning protocol markers."""
+
+    def _make_scheduler(self, factory, encode_map):
+        scheduler = MagicMock(spec=Scheduler)
+        scheduler._output_parser_factory = factory
+        scheduler._xtc_special_tokens = set()
+        scheduler._get_think_token_id = Scheduler._get_think_token_id.__get__(
+            scheduler, Scheduler
+        )
+        scheduler._get_output_parser_thinking_end_text = (
+            Scheduler._get_output_parser_thinking_end_text.__get__(scheduler, Scheduler)
+        )
+        scheduler._encode_thinking_marker = Scheduler._encode_thinking_marker.__get__(
+            scheduler, Scheduler
+        )
+        scheduler._resolve_output_parser_thinking_trailing_ids = (
+            Scheduler._resolve_output_parser_thinking_trailing_ids.__get__(
+                scheduler, Scheduler
+            )
+        )
+        scheduler._resolve_think_end_token_ids = (
+            Scheduler._resolve_think_end_token_ids.__get__(scheduler, Scheduler)
+        )
+        scheduler._resolve_think_close_pattern = MagicMock(return_value=(None, None))
+        scheduler._build_sampler_and_processors = (
+            Scheduler._build_sampler_and_processors.__get__(scheduler, Scheduler)
+        )
+
+        tokenizer = MagicMock()
+        tokenizer.encode.side_effect = lambda text, add_special_tokens=False: encode_map[
+            text
+        ]
+        scheduler.tokenizer = tokenizer
+        return scheduler
+
+    def _make_request(self):
+        request = Request(
+            request_id="parser-thinking-budget",
+            prompt="test",
+            sampling_params=SamplingParams(thinking_budget=512),
+            prompt_token_ids=[1, 2, 3],
+            num_prompt_tokens=3,
+        )
+        request.needs_think_prefix = False
+        return request
+
+    def test_gemma4_uses_parser_thinking_close_marker(self):
+        factory = OutputParserFactory(
+            kind="gemma4",
+            create_session=MagicMock(),
+            thinking_end_text="<channel|>",
+        )
+        scheduler = self._make_scheduler(factory, {"<channel|>": [101]})
+        request = self._make_request()
+
+        _, processors = scheduler._build_sampler_and_processors(
+            request.sampling_params, request
+        )
+
+        budget_processors = [
+            p for p in processors if isinstance(p, ThinkingBudgetProcessor)
+        ]
+        assert len(budget_processors) == 1
+        assert budget_processors[0]._think_end_ids == [101]
+
+    def test_parser_marker_ignores_none_tokenizer_think_end(self):
+        factory = OutputParserFactory(
+            kind="gemma4",
+            create_session=MagicMock(),
+            thinking_end_text="<channel|>",
+        )
+        scheduler = self._make_scheduler(factory, {"<channel|>": [101]})
+        scheduler._resolve_think_close_pattern = (
+            Scheduler._resolve_think_close_pattern.__get__(scheduler, Scheduler)
+        )
+        scheduler.tokenizer.think_end = None
+        scheduler._get_chat_template_text = MagicMock(return_value="no close marker")
+        request = self._make_request()
+
+        _, processors = scheduler._build_sampler_and_processors(
+            request.sampling_params, request
+        )
+
+        budget_processors = [
+            p for p in processors if isinstance(p, ThinkingBudgetProcessor)
+        ]
+        assert len(budget_processors) == 1
+        assert budget_processors[0]._think_end_ids == [101]
+
+    def test_harmony_uses_parser_thinking_close_and_final_header(self):
+        final_header = "<|start|>assistant<|channel|>final<|message|>"
+        factory = OutputParserFactory(
+            kind="harmony",
+            create_session=MagicMock(),
+            thinking_end_text="<|end|>",
+            thinking_end_trailing_text=final_header,
+        )
+        scheduler = self._make_scheduler(
+            factory,
+            {
+                "<|end|>": [200],
+                final_header: [201, 202, 203, 204, 205],
+            },
+        )
+        request = self._make_request()
+        request.is_harmony_model = True
+
+        _, processors = scheduler._build_sampler_and_processors(
+            request.sampling_params, request
+        )
+
+        budget_processors = [
+            p for p in processors if isinstance(p, ThinkingBudgetProcessor)
+        ]
+        assert len(budget_processors) == 1
+        assert budget_processors[0]._think_end_ids == [200]
+        assert budget_processors[0]._force_sequence == [200, 201, 202, 203, 204, 205]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -81,8 +81,8 @@ class TestThinkingBudgetProcessor:
         assert target_logit == 0.0
         assert other_logit == float("-inf")
 
-    def test_enters_suppression_after_forcing(self):
-        """After forcing </think>, processor should suppress duplicate end tokens."""
+    def test_done_after_forced_sequence(self):
+        """After forcing the close sequence, processor should become a no-op."""
         proc = self._make_processor(budget=1)
 
         # Call 1 (first_call): budget=1, forcing starts → forces THINK_END_ID
@@ -90,13 +90,11 @@ class TestThinkingBudgetProcessor:
         assert proc._forcing
         assert forced_logits[0, self.THINK_END_ID].item() == 0.0
 
-        # Call 2: force_sequence has only [THINK_END_ID] (no trailing), so
-        # _force_idx advances to 1 == len([42]) → enters suppression
+        # Call 2: force_sequence has only [THINK_END_ID], so the processor is done.
         logits = proc(_make_tokens(10, self.THINK_END_ID), _make_logits())
-        assert proc._suppress_end
-        assert not proc._done
-        # The end token should be suppressed (-inf)
-        assert logits[0, self.THINK_END_ID].item() == float("-inf")
+        assert proc._done
+        assert not proc._forcing
+        assert mx.array_equal(logits, _make_logits())
 
     def test_trailing_tokens_forced_after_end(self):
         """Trailing tokens (e.g. \\n) should be forced after </think>."""
@@ -113,10 +111,10 @@ class TestThinkingBudgetProcessor:
         assert proc._forcing
         assert logits1[0, self.NEWLINE_ID].item() == 0.0
 
-        # Call 3: _force_idx advances to 2 == len([42, 99]) → suppression
+        # Call 3: _force_idx advances to 2 == len([42, 99]) → done
         logits2 = proc(_make_tokens(10, self.THINK_END_ID, self.NEWLINE_ID), _make_logits())
-        assert proc._suppress_end
-        assert logits2[0, self.THINK_END_ID].item() == float("-inf")
+        assert proc._done
+        assert mx.array_equal(logits2, _make_logits())
 
     def test_natural_end_before_budget(self):
         """If model produces </think> naturally, processor becomes no-op."""
@@ -167,13 +165,40 @@ class TestThinkingBudgetProcessor:
         assert proc._forcing
         assert logits2[0, 52].item() == 0.0
 
-        # Call 4: _force_idx advances to 3 == len(end_ids), enters suppression
+        # Call 4: _force_idx advances to 3 == len(end_ids), then becomes done.
         logits3 = proc(_make_tokens(10, 50, 51, 52), _make_logits())
-        assert proc._suppress_end
-        assert not proc._done
-        # All end tokens suppressed
-        for tid in end_ids:
-            assert logits3[0, tid].item() == float("-inf")
+        assert proc._done
+        assert not proc._forcing
+        assert mx.array_equal(logits3, _make_logits())
+
+    def test_waits_for_utf8_completion_before_forcing(self):
+        """Budget exhaustion waits until the current token piece is UTF-8 complete."""
+        pieces = {
+            20: b"\xe2",
+            21: b"\x82",
+            22: b"\xac",
+        }
+        proc = ThinkingBudgetProcessor(
+            think_end_token_ids=[self.THINK_END_ID],
+            budget=2,
+            think_start_token_id=self.THINK_START_ID,
+            token_to_piece=lambda token_id: pieces.get(token_id, "x"),
+        )
+
+        proc(_make_tokens(10), _make_logits())
+        logits = proc(_make_tokens(10, 20), _make_logits())
+        assert proc._waiting_utf8
+        assert not proc._forcing
+        assert mx.array_equal(logits, _make_logits())
+
+        logits = proc(_make_tokens(10, 20, 21), _make_logits())
+        assert proc._waiting_utf8
+        assert not proc._forcing
+        assert mx.array_equal(logits, _make_logits())
+
+        logits = proc(_make_tokens(10, 20, 21, 22), _make_logits())
+        assert proc._forcing
+        assert logits[0, self.THINK_END_ID].item() == 0.0
 
     def test_multi_token_natural_detection(self):
         """Sliding window should detect multi-token </think> naturally."""
@@ -260,6 +285,9 @@ class TestParserBackedThinkingBudgetWiring:
         scheduler._encode_thinking_marker = Scheduler._encode_thinking_marker.__get__(
             scheduler, Scheduler
         )
+        scheduler._token_piece_to_bytes = Scheduler._token_piece_to_bytes.__get__(
+            scheduler, Scheduler
+        )
         scheduler._resolve_output_parser_thinking_trailing_ids = (
             Scheduler._resolve_output_parser_thinking_trailing_ids.__get__(
                 scheduler, Scheduler
@@ -333,6 +361,10 @@ class TestParserBackedThinkingBudgetWiring:
         ]
         assert len(budget_processors) == 1
         assert budget_processors[0]._think_end_ids == [101]
+
+    def test_token_piece_to_bytes_handles_sentencepiece_byte_fallback(self):
+        scheduler = self._make_scheduler(None, {})
+        assert scheduler._token_piece_to_bytes("<0xE2><0x82><0xAC>") == "€".encode()
 
     def test_harmony_uses_parser_thinking_close_and_final_header(self):
         final_header = "<|start|>assistant<|channel|>final<|message|>"


### PR DESCRIPTION
## Summary

- Add parser-provided thinking budget markers for Gemma 4 and Harmony output parsers
- Enforce thinking budgets for parser-backed reasoning models even when the prompt does not end with `<think>`
- Use Gemma 4’s native `<channel|>` thought close marker instead of tokenizer `</think>` fallback
- Force Harmony from analysis into final channel after budget exhaustion
- Let Harmony parser observe protocol stop tokens so analysis `<|end|>` does not prematurely stop generation
- Avoid duplicate Harmony `<|start|>assistant` prefix during final tool-call parsing
- Ensure parser-defined stop tokens set `finish_reason="stop"`
- Keep parser-backed cache storage on the synchronous path to avoid cross-thread MLX stream crashes

## Why

Gemma 4 thinking budget was not enforced because the scheduler only attached `ThinkingBudgetProcessor` when prompt-tail `<think>` detection succeeded. Gemma 4 uses parser/channel markers instead, so the budget processor never ran or used the wrong end marker.

Harmony also needs parser-aware budget handling: closing analysis requires protocol-specific transition into the final channel.

## Testing

```bash
uv run pytest tests/test_scheduler.py::TestOutputParserSmoke tests/test_harmony.py::TestParseToolCallsFromTokens tests/test_harmony.py::TestPassthroughMode::test_analysis_end_does_not_stop_generation tests/test_thinking_budget.py::TestParserBackedThinkingBudgetWiring tests/test_output_parser.py::TestOutputParserFactory -q
uv run pytest -m "not slow" 
```
I have also done manual tests on Qwen3.6-35B-A3B, Gemma4-26B-A4B, and GPT-OSS-20B quantized models. I am not sure if I can run the tests requiring model loading. 