### PR TITLE
fix(tests): target omlx logger in caplog.at_level

### DIFF
--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -388,7 +388,7 @@ class TestQwen35MoeSanitize:
         (model quantized without preserve_mtp). Must not crash."""
         import logging
 
-        with caplog.at_level(logging.DEBUG):
+        with caplog.at_level(logging.DEBUG, logger="omlx"):
             result = moe_model.sanitize(self._backbone_weights())
         assert not any("mtp" in k for k in result)
         assert any("no MTP weights found" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
Without this fix a full `pytest` run currently errors like this:

```
tests/test_mlx_lm_mtp_patch.py:258: in test_sanitize_no_mtp_weights
    assert any("no MTP weights found" in r.getMessage() for r in caplog.records)
E   assert False
E    +  where False = any(<generator object TestQwen35MoeSanitize.test_sanitize_no_mtp_weights.<locals>.<genexpr> at 0x1180412a0>)
```

---

Analysis from my coding agent:

The `omlx` logger gets an explicit level set by earlier tests, preventing `caplog.at_level` from overriding it.
The chain of events
1. `test_cli.py` runs before `test_mlx_lm_mtp_patch.py` (alphabetical order). Inside `test_cli.py`, tests call `serve_command()` from `omlx/cli.py`, which executes:
- `logging.basicConfig(level=logging.INFO)` — sets root logger to `INFO`
- `logging.getLogger("omlx").setLevel(log_level)` — sets the omlx logger to INFO explicitly (`omlx/cli.py:100`)
1. Later, `test_sanitize_no_mtp_weights` uses `caplog.at_level(logging.DEBUG)` (without specifying a logger), which only sets the root logger to `DEBUG`.
2. The `omlx `logger still has its explicit INFO level. In Python's logging hierarchy, `omlx.patches.mlx_lm_mtp.qwen35_model` inherits INFO from `omlx`, so `logger.debug(...)` messages are filtered before they ever reach the root logger's `LogCaptureHandler`.
3. Result: `caplog.records` is empty → assertion fails.
Why it passes in isolation
When running only `test_mlx_lm_mtp_patch.py`, `test_cli.py` never runs, so `omlx` logger is never explicitly set. Its level stays `NOTSET`, inheriting from root — which `caplog.at_level(logging.DEBUG)` can override.

---


