### PR TITLE
feat(mtp): allow sidecar style mtp.safetensors from MLX OptiQ models

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -438,57 +438,15 @@ def _mtp_compat_for_model(model_info: dict) -> tuple[bool, str]:
             f"model_type={model_type!r} is not on the MTP whitelist "
             "(supported: qwen3_5*, qwen3_6*, deepseek_v4*)"
         )
-    if not _model_has_mtp_weight_tensors(Path(model_path)):
+    from ..utils.model_loading import _checkpoint_has_mtp_weights
+
+    if not _checkpoint_has_mtp_weights(model_path):
         return False, (
             "Config declares MTP layers but the converted weights are missing "
-            "mtp.* tensors. Re-convert from HF with a converter that preserves "
-            "MTP weights."
+            "mtp.* tensors (including mtp.safetensors sidecars). Re-convert "
+            "from HF with a converter that preserves MTP weights."
         )
     return True, ""
-
-
-def _model_has_mtp_weight_tensors(model_dir) -> bool:
-    """Return True iff the model directory's weight files contain ``mtp.*`` keys.
-
-    Uses ``model.safetensors.index.json`` when present (cheap — only reads
-    the weight_map). Falls back to opening each ``*.safetensors`` and
-    checking its keys when no index is present (single-shard models).
-    Returns False on any error (we treat the model as incompatible rather
-    than risking a confusing load failure mid-inference).
-    """
-    import json
-    from pathlib import Path
-
-    try:
-        from safetensors import safe_open
-    except ImportError:
-        # Library should be installed via mlx-lm deps; if it's not we can't
-        # peek the weights. Stay conservative and assume incompatible.
-        return False
-
-    model_dir = Path(model_dir)
-
-    # Preferred path: read the index file's weight_map (no tensor data loaded).
-    index_path = model_dir / "model.safetensors.index.json"
-    if index_path.exists():
-        try:
-            index = json.loads(index_path.read_text())
-            weight_map = index.get("weight_map", {})
-            return any("mtp." in key for key in weight_map.keys())
-        except Exception:
-            return False
-
-    # Single-shard fallback: enumerate keys via safe_open metadata. We
-    # short-circuit on the first ``mtp.*`` key.
-    for path in model_dir.glob("*.safetensors"):
-        try:
-            with safe_open(str(path), framework="numpy") as f:  # type: ignore[arg-type]
-                for key in f.keys():
-                    if "mtp." in key:
-                        return True
-        except Exception:
-            continue
-    return False
 
 
 def _apply_log_level_runtime(level: str) -> None:
@@ -2023,14 +1981,15 @@ async def update_model_settings(
                         "Native MTP requires Qwen3.5/3.6 or DeepSeek-V4 with MTP heads."
                     ),
                 )
-            if not _model_has_mtp_weight_tensors(Path(entry.model_path)):
+            from ..utils.model_loading import _checkpoint_has_mtp_weights
+
+            if not _checkpoint_has_mtp_weights(entry.model_path):
                 raise HTTPException(
                     status_code=400,
                     detail=(
                         "Config declares MTP layers but the converted weights are "
-                        "missing mtp.* tensors. Re-convert from HF with a converter "
-                        "that preserves MTP weights. The default "
-                        "mlx-lm sanitize() path strips them."
+                        "missing mtp.* tensors (including mtp.safetensors sidecars). "
+                        "Re-convert from HF with a converter that preserves MTP weights."
                     ),
                 )
             # Mutual exclusion with DFlash / TurboQuant — ModelSettings.__post_init__

--- a/omlx/patches/mlx_lm_mtp/__init__.py
+++ b/omlx/patches/mlx_lm_mtp/__init__.py
@@ -74,7 +74,15 @@ def apply_mlx_lm_mtp_patch() -> bool:
         True if the patch is now active. False if a sub-step refused
         to apply (mlx-lm not importable, missing prerequisite patch).
     """
-    from . import batch_generator, cache_rollback, deepseek_v4_model, qwen35_model
+    from . import (
+        batch_generator,
+        cache_rollback,
+        deepseek_v4_model,
+        load_sidecar,
+        qwen35_model,
+    )
+
+    load_sidecar.apply()
 
     if not cache_rollback.apply():
         return False

--- a/omlx/patches/mlx_lm_mtp/load_sidecar.py
+++ b/omlx/patches/mlx_lm_mtp/load_sidecar.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Merge Hugging Face-style ``mtp.safetensors`` sidecars during ``mlx_lm.load``.
+
+Official Qwen3.5/3.6 checkpoints (and some third-party quant exports such as
+OptiQ) store MTP head weights in ``mtp.safetensors`` while the main index only
+references ``model-*.safetensors``. Stock mlx-lm loads ``model*.safetensors``
+only, so the MTP module stays at random init unless the sidecar is merged.
+
+This patch wraps ``mlx_lm.utils.load_model`` and, when ``mtp.safetensors``
+exists, temporarily extends ``glob.glob`` so the sidecar is loaded with the
+main shards *before* ``sanitize`` / ``nn.quantize`` / ``load_weights``. That
+matters for quantized checkpoints: ``class_predicate`` only quantizes layers
+whose ``.scales`` tensors appear in the weight dict at quantize time.
+"""
+
+from __future__ import annotations
+
+import glob as glob_module
+import logging
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+from ...utils.model_loading import _mtp_sidecar_path
+
+logger = logging.getLogger(__name__)
+
+_PATCHED = False
+
+
+@contextmanager
+def _glob_includes_mtp_sidecar(sidecar: Path) -> Iterator[None]:
+    """Append ``mtp.safetensors`` to mlx-lm's ``model*.safetensors`` glob."""
+    real_glob = glob_module.glob
+    sidecar_str = str(sidecar)
+
+    def patched_glob(pattern: str, *args, **kwargs):
+        files = real_glob(pattern, *args, **kwargs)
+        if sidecar_str in files:
+            return files
+        normalized = pattern.replace("\\", "/")
+        if normalized.endswith("model*.safetensors"):
+            return sorted(files) + [sidecar_str]
+        return files
+
+    glob_module.glob = patched_glob
+    try:
+        yield
+    finally:
+        glob_module.glob = real_glob
+
+
+def apply() -> bool:
+    """Wrap ``mlx_lm.utils.load_model`` to load ``mtp.safetensors`` sidecars."""
+    global _PATCHED
+    if _PATCHED:
+        return True
+
+    try:
+        import mlx_lm.utils as mlx_utils
+    except ImportError:
+        logger.debug("mlx_lm.utils not importable; skipping mtp sidecar load patch")
+        return False
+
+    if getattr(mlx_utils, "_omlx_mtp_load_patched", False):
+        _PATCHED = True
+        return True
+
+    original: Callable[..., Any] = mlx_utils.load_model
+
+    def patched_load_model(
+        model_path: Path,
+        lazy: bool = False,
+        strict: bool = True,
+        model_config: dict | None = None,
+        get_model_classes: Callable | None = None,
+    ):
+        kwargs: dict[str, Any] = {
+            "lazy": lazy,
+            "strict": strict,
+            "model_config": model_config,
+        }
+        if get_model_classes is not None:
+            kwargs["get_model_classes"] = get_model_classes
+
+        model_path = Path(model_path)
+        sidecar = _mtp_sidecar_path(model_path)
+        if sidecar is not None:
+            with _glob_includes_mtp_sidecar(sidecar):
+                model, config = original(model_path, **kwargs)
+            logger.info("Loaded MTP weights from %s", sidecar.name)
+            return model, config
+
+        return original(model_path, **kwargs)
+
+    patched_load_model._omlx_mtp_load_patched = True  # type: ignore[attr-defined]
+    mlx_utils.load_model = patched_load_model
+    mlx_utils._omlx_mtp_load_patched = True
+
+    _propagate_load_model_binding(mlx_utils, patched_load_model, original)
+
+    _PATCHED = True
+    logger.debug("mlx_lm.utils.load_model wrapped for mtp.safetensors sidecars")
+    return True
+
+
+def _propagate_load_model_binding(
+    mlx_utils: Any, patched: Callable[..., Any], original: Callable[..., Any]
+) -> None:
+    """Point stale ``mlx_lm.*`` imports at the new ``load_model``."""
+    import sys
+
+    for mod_name, mod in list(sys.modules.items()):
+        if mod is None or not mod_name.startswith("mlx_lm"):
+            continue
+        if mod_name == "mlx_lm.utils":
+            continue
+        existing = getattr(mod, "load_model", None)
+        if existing is not None and existing in (original, patched):
+            try:
+                mod.load_model = patched
+            except Exception:
+                pass

--- a/omlx/patches/mlx_lm_mtp/load_sidecar.py
+++ b/omlx/patches/mlx_lm_mtp/load_sidecar.py
@@ -7,10 +7,10 @@ references ``model-*.safetensors``. Stock mlx-lm loads ``model*.safetensors``
 only, so the MTP module stays at random init unless the sidecar is merged.
 
 This patch wraps ``mlx_lm.utils.load_model`` and, when ``mtp.safetensors``
-exists, temporarily extends ``glob.glob`` so the sidecar is loaded with the
-main shards *before* ``sanitize`` / ``nn.quantize`` / ``load_weights``. That
-matters for quantized checkpoints: ``class_predicate`` only quantizes layers
-whose ``.scales`` tensors appear in the weight dict at quantize time.
+is needed (no inlined ``mtp.*`` in the main shards/index), temporarily extends
+``glob.glob`` so the sidecar is loaded with the main shards *before*
+``sanitize`` / ``nn.quantize`` / ``load_weights``. Inlined oQ exports are
+left to stock mlx-lm loading even if a leftover sidecar file is present.
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Iterator
 
-from ...utils.model_loading import _mtp_sidecar_path
+from ...utils.model_loading import mtp_sidecar_path_for_load
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +84,7 @@ def apply() -> bool:
             kwargs["get_model_classes"] = get_model_classes
 
         model_path = Path(model_path)
-        sidecar = _mtp_sidecar_path(model_path)
+        sidecar = mtp_sidecar_path_for_load(model_path)
         if sidecar is not None:
             with _glob_includes_mtp_sidecar(sidecar):
                 model, config = original(model_path, **kwargs)

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -373,33 +373,15 @@ def _safetensors_has_mtp_keys(path: Path) -> bool:
     return False
 
 
-def _checkpoint_has_mtp_weights(model_path: str | Path) -> bool:
-    """True iff the checkpoint at *model_path* ships any ``mtp.*`` weight tensor.
+def _checkpoint_has_inlined_mtp_weights(model_path: str | Path) -> bool:
+    """True iff ``mtp.*`` tensors live in the main checkpoint (index or model shards).
 
-    Some Qwen3.6 MoE VLM exports declare ``mtp_num_hidden_layers > 0`` in
-    ``config.json`` but strip the MTP weights during conversion (e.g.
-    ``unsloth/Qwen3.6-35B-A3B-UD-MLX-*bit``). Attaching ``MTPModule`` for
-    such a checkpoint causes mlx-vlm's strict ``load_weights`` to fail with
-    "Missing N parameters: language_model.mtp.*", the engine falls back to
-    LLM, and vision is silently dropped (issue #1426).
-
-    Detection order:
-
-    1. ``mtp.safetensors`` sidecar (official HF / OptiQ layout — keys are
-       often absent from ``model.safetensors.index.json``).
-    2. ``model.safetensors.index.json`` weight_map entries.
-    3. Any ``*.safetensors`` shard in the directory (header scan only).
-
-    Returns False when nothing resolves — callers treat that as "no MTP
-    weights" (the conservative choice: skip MTPModule attachment).
+    Does not consult ``mtp.safetensors``. Used to prefer inlined oQ / mlx-lm
+    exports over a leftover HF sidecar in the same directory.
     """
     p = Path(model_path)
     if not p.is_dir():
         return False
-
-    sidecar = _mtp_sidecar_path(p)
-    if sidecar is not None and _safetensors_has_mtp_keys(sidecar):
-        return True
 
     index_path = p / "model.safetensors.index.json"
     if index_path.exists():
@@ -419,6 +401,42 @@ def _checkpoint_has_mtp_weights(model_path: str | Path) -> bool:
         if _safetensors_has_mtp_keys(shard):
             return True
     return False
+
+
+def mtp_sidecar_path_for_load(model_path: str | Path) -> Path | None:
+    """Return ``mtp.safetensors`` only when MTP is not already in model shards.
+
+    Load path: inlined weights are picked up by stock ``model*.safetensors``
+    glob; the sidecar is merged only when the main checkpoint omitted them.
+    """
+    p = Path(model_path)
+    if _checkpoint_has_inlined_mtp_weights(p):
+        return None
+    return _mtp_sidecar_path(p)
+
+
+def _checkpoint_has_mtp_weights(model_path: str | Path) -> bool:
+    """True iff the checkpoint at *model_path* ships any ``mtp.*`` weight tensor.
+
+    Some Qwen3.6 MoE VLM exports declare ``mtp_num_hidden_layers > 0`` in
+    ``config.json`` but strip the MTP weights during conversion (e.g.
+    ``unsloth/Qwen3.6-35B-A3B-UD-MLX-*bit``). Attaching ``MTPModule`` for
+    such a checkpoint causes mlx-vlm's strict ``load_weights`` to fail with
+    "Missing N parameters: language_model.mtp.*", the engine falls back to
+    LLM, and vision is silently dropped (issue #1426).
+
+    Detection order:
+
+    1. ``model.safetensors.index.json`` or ``model-*.safetensors`` shards.
+    2. ``mtp.safetensors`` sidecar when step 1 found nothing (HF / OptiQ).
+
+    Returns False when neither resolves — callers treat that as "no MTP
+    weights" (the conservative choice: skip MTPModule attachment).
+    """
+    if _checkpoint_has_inlined_mtp_weights(model_path):
+        return True
+    sidecar = _mtp_sidecar_path(Path(model_path))
+    return sidecar is not None and _safetensors_has_mtp_keys(sidecar)
 
 
 def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -71,6 +71,24 @@ def _patch_mlx_lm_load_config() -> None:
     _MLX_LM_LOAD_CONFIG_PATCHED = True
 
 
+_MLX_LM_LOAD_MTP_SIDECAR_PATCHED = False
+
+
+def _patch_mlx_lm_load_mtp_sidecar() -> None:
+    """Wrap ``mlx_lm.utils.load_model`` to merge ``mtp.safetensors`` sidecars."""
+    global _MLX_LM_LOAD_MTP_SIDECAR_PATCHED
+    if _MLX_LM_LOAD_MTP_SIDECAR_PATCHED:
+        return
+
+    try:
+        from ..patches.mlx_lm_mtp import load_sidecar
+    except ImportError:
+        return
+
+    if load_sidecar.apply():
+        _MLX_LM_LOAD_MTP_SIDECAR_PATCHED = True
+
+
 def maybe_apply_pre_load_patches(
     model_name: str,
     model_settings: Any | None = None,
@@ -112,6 +130,7 @@ def maybe_apply_pre_load_patches(
     set_mtp_active(False)
 
     _patch_mlx_lm_load_config()
+    _patch_mlx_lm_load_mtp_sidecar()
 
     config_path = Path(model_name) / "config.json"
     if not config_path.exists():
@@ -325,6 +344,34 @@ _MTP_WEIGHT_PREFIXES = (
     "model.language_model.mtp.",
 )
 
+_MTP_SIDECAR_FILENAME = "mtp.safetensors"
+
+
+def _is_mtp_weight_key(key: str) -> bool:
+    return key.startswith(_MTP_WEIGHT_PREFIXES)
+
+
+def _mtp_sidecar_path(model_path: Path) -> Path | None:
+    """Return ``mtp.safetensors`` when the HF-style sidecar is present."""
+    sidecar = model_path / _MTP_SIDECAR_FILENAME
+    return sidecar if sidecar.is_file() else None
+
+
+def _safetensors_has_mtp_keys(path: Path) -> bool:
+    """True iff *path*'s safetensors header lists any MTP-prefixed tensor."""
+    try:
+        import safetensors
+    except ImportError:
+        return False
+    try:
+        with safetensors.safe_open(str(path), framework="numpy") as f:
+            for key in f.keys():
+                if _is_mtp_weight_key(key):
+                    return True
+    except Exception as e:
+        logger.debug("Failed to read %s for mtp weight scan: %s", path, e)
+    return False
+
 
 def _checkpoint_has_mtp_weights(model_path: str | Path) -> bool:
     """True iff the checkpoint at *model_path* ships any ``mtp.*`` weight tensor.
@@ -336,42 +383,41 @@ def _checkpoint_has_mtp_weights(model_path: str | Path) -> bool:
     "Missing N parameters: language_model.mtp.*", the engine falls back to
     LLM, and vision is silently dropped (issue #1426).
 
-    Reads ``model.safetensors.index.json`` when present (no shard I/O).
-    Falls back to the first safetensors shard's metadata header. Returns
-    False when neither resolves — callers treat that as "no MTP weights"
-    (the conservative choice: skip MTPModule attachment).
+    Detection order:
+
+    1. ``mtp.safetensors`` sidecar (official HF / OptiQ layout — keys are
+       often absent from ``model.safetensors.index.json``).
+    2. ``model.safetensors.index.json`` weight_map entries.
+    3. Any ``*.safetensors`` shard in the directory (header scan only).
+
+    Returns False when nothing resolves — callers treat that as "no MTP
+    weights" (the conservative choice: skip MTPModule attachment).
     """
     p = Path(model_path)
     if not p.is_dir():
         return False
+
+    sidecar = _mtp_sidecar_path(p)
+    if sidecar is not None and _safetensors_has_mtp_keys(sidecar):
+        return True
 
     index_path = p / "model.safetensors.index.json"
     if index_path.exists():
         try:
             data = json.loads(index_path.read_text())
             weight_map = data.get("weight_map") or {}
-            return any(
-                k.startswith(_MTP_WEIGHT_PREFIXES) for k in weight_map
-            )
+            if any(_is_mtp_weight_key(k) for k in weight_map):
+                return True
         except Exception as e:
             logger.debug(
                 "Failed to read %s for mtp weight scan: %s", index_path, e
             )
 
-    shards = sorted(p.glob("*.safetensors"))
-    if not shards:
-        return False
-    try:
-        import safetensors
-
-        with safetensors.safe_open(str(shards[0]), framework="numpy") as f:
-            for k in f.keys():
-                if k.startswith(_MTP_WEIGHT_PREFIXES):
-                    return True
-    except Exception as e:
-        logger.debug(
-            "Failed to read %s header for mtp weight scan: %s", shards[0], e
-        )
+    for shard in sorted(p.glob("*.safetensors")):
+        if shard.name == _MTP_SIDECAR_FILENAME:
+            continue
+        if _safetensors_has_mtp_keys(shard):
+            return True
     return False
 
 

--- a/tests/test_mlx_lm_mtp_load_sidecar.py
+++ b/tests/test_mlx_lm_mtp_load_sidecar.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for mtp.safetensors sidecar load + detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from omlx.utils.model_loading import _checkpoint_has_mtp_weights
+
+
+class TestLoadSidecarPatch:
+    def test_apply_idempotent(self):
+        from omlx.patches.mlx_lm_mtp import load_sidecar
+
+        assert load_sidecar.apply() in (True, False)
+        assert load_sidecar.apply() is True
+
+
+class TestCheckpointDetectsOptiQLayout:
+    def test_opti_q_style_index_without_mtp_keys(self, tmp_path):
+        import json
+
+        (tmp_path / "model.safetensors.index.json").write_text(
+            json.dumps(
+                {
+                    "weight_map": {
+                        "model.embed_tokens.weight": "model-00001-of-00006.safetensors",
+                    }
+                }
+            )
+        )
+        try:
+            import mlx.core as mx
+
+            mx.save_safetensors(
+                str(tmp_path / "mtp.safetensors"),
+                {"mtp.fc.weight": mx.zeros((2, 4))},
+            )
+        except ImportError:
+            pytest.skip("mlx not available")
+
+        assert _checkpoint_has_mtp_weights(tmp_path) is True

--- a/tests/test_mlx_lm_mtp_load_sidecar.py
+++ b/tests/test_mlx_lm_mtp_load_sidecar.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 
 import pytest
 
-from omlx.utils.model_loading import _checkpoint_has_mtp_weights
+from omlx.utils.model_loading import (
+    _checkpoint_has_inlined_mtp_weights,
+    _checkpoint_has_mtp_weights,
+    mtp_sidecar_path_for_load,
+)
 
 
 class TestLoadSidecarPatch:
@@ -39,4 +43,6 @@ class TestCheckpointDetectsOptiQLayout:
         except ImportError:
             pytest.skip("mlx not available")
 
+        assert _checkpoint_has_inlined_mtp_weights(tmp_path) is False
         assert _checkpoint_has_mtp_weights(tmp_path) is True
+        assert mtp_sidecar_path_for_load(tmp_path) == tmp_path / "mtp.safetensors"

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -422,6 +422,25 @@ class TestCheckpointHasMtpWeights:
             pytest.skip("mlx not available")
         assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is True
 
+    def test_inlined_mtp_skips_sidecar_for_load(self, tmp_path):
+        """When shards/index already have MTP, do not merge mtp.safetensors."""
+        self._write_index(
+            tmp_path,
+            {"language_model.mtp.fc.weight": "model.safetensors"},
+        )
+        try:
+            import mlx.core as mx
+
+            mx.save_safetensors(
+                str(tmp_path / "mtp.safetensors"),
+                {"mtp.fc.weight": mx.zeros((99, 99))},
+            )
+        except ImportError:
+            pytest.skip("mlx not available")
+        assert model_loading._checkpoint_has_inlined_mtp_weights(str(tmp_path)) is True
+        assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is True
+        assert model_loading.mtp_sidecar_path_for_load(str(tmp_path)) is None
+
     def test_returns_false_for_empty_dir(self, tmp_path):
         # No index, no shards — caller treats as "no MTP weights".
         assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is False

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -402,6 +402,26 @@ class TestCheckpointHasMtpWeights:
         )
         assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is False
 
+    def test_returns_true_when_sidecar_present_but_index_lacks_mtp(self, tmp_path):
+        """HF / OptiQ layout: MTP lives only in mtp.safetensors."""
+        self._write_index(
+            tmp_path,
+            {
+                "model.embed_tokens.weight": "model-00001-of-00001.safetensors",
+            },
+        )
+        sidecar = tmp_path / "mtp.safetensors"
+        try:
+            import mlx.core as mx
+
+            mx.save_safetensors(
+                str(sidecar),
+                {"mtp.fc.weight": mx.zeros((8, 16))},
+            )
+        except ImportError:
+            pytest.skip("mlx not available")
+        assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is True
+
     def test_returns_false_for_empty_dir(self, tmp_path):
         # No index, no shards — caller treats as "no MTP weights".
         assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is False


### PR DESCRIPTION
* Allow sidecar style MTP load, shipped with MLX OptiQ (mlx-community) - https://pypi.org/project/mlx-optiq/
* Delete duplicate fn _model_has_mtp_weight_tensors trying to do the same thing with _checkpoint_has_mtp_weights

* Test with 27B-OptiQ-4bit benchmark and it's increased by a lot 8k/128 - (26 t/s -> 34 t/s)