### PR TITLE
fix(ui): align headers in model settings table

### DIFF
--- a/omlx/admin/templates/dashboard/_settings.html
+++ b/omlx/admin/templates/dashboard/_settings.html
@@ -887,7 +887,7 @@
                                 {{ t('settings.models.table.type') }}
                                 <span x-show="sortBy === 'type'" x-text="sortOrder === 'asc' ? '▲' : '▼'" class="text-[10px]"></span>
                             </div>
-                            <div class="hidden sm:flex w-20 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('size')">
+                            <div class="hidden sm:flex w-60 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('size')">
                                 {{ t('settings.models.table.size') }}
                                 <span x-show="sortBy === 'size'" x-text="sortOrder === 'asc' ? '▲' : '▼'" class="text-[10px]"></span>
                             </div>


### PR DESCRIPTION
This is annoying 🙂


Before:
<img width="1344" height="423" alt="Снимок экрана — 2026-05-30 в 14 05 05" src="https://github.com/user-attachments/assets/b67b1025-8ed6-4abb-bc21-0458cf46de59" />

After:
<img width="1285" height="414" alt="Снимок экрана — 2026-05-30 в 14 04 24" src="https://github.com/user-attachments/assets/b85043b1-7868-4975-8c6b-9f5fe3603ca1" />
