### PR TITLE
fix(packaging): point _install_xgrammar at framework-mlx-base after layer rename

### DIFF
--- a/packaging/build.py
+++ b/packaging/build.py
@@ -840,7 +840,7 @@ def _install_xgrammar(export_dir: Path):
     """
     fw_site = (
         export_dir
-        / "framework-mlx-framework"
+        / "framework-mlx-base"
         / "lib"
         / "python3.11"
         / "site-packages"


### PR DESCRIPTION
## Summary

Fixes #1530.

#1489 renamed the venvstacks layer from `mlx-framework` to `mlx-base` in `packaging/build.py`. `_install_mlx_audio`, `_install_paroquant`, and `_install_spacy_model` were updated; `_install_xgrammar` was missed and still writes to `framework-mlx-framework` — which the new export never creates.

```python
# packaging/build.py:841-847 (before)
fw_site = (
    export_dir
    / "framework-mlx-framework"   # ← stale
    / "lib"
    / "python3.11"
    / "site-packages"
)
```

The early-return at lines 759-760 (`site-packages not found`) then fires silently, the bundle ships without xgrammar / apache-tvm-ffi, and at runtime the engine wrapper logs:

> Structured output is not available in the DMG version (xgrammar requires torch which significantly increases app size). Use the pip or Homebrew version for structured output support.

— which misleads the user, both because this message predates the bundled-stub work from #1453 and because the actual cause is the stale layer path, not torch.

## The fix

One-line: `framework-mlx-framework` → `framework-mlx-base` to match the other install functions in the same file.

## Test plan

- [x] `grep -c framework-mlx-framework packaging/build.py` returns 0 (no stale references remain)
- [ ] Local bundle rebuild + verification that `_xgrammar_*.installed` sentinel lands in `framework-mlx-base/lib/python3.11/site-packages/` — kicking off now; will confirm once the build finishes.
- [ ] Runtime confirmation that structured output is available on the rebuilt bundle (no "Structured output is not available in the DMG version" log entry).

Will also leave a follow-up note on #1530 once the rebuilt bundle confirms the fix end-to-end. fry69 may want to re-test on their side too.

## Note on the misleading log message

Out of scope here, but worth flagging: the `if method == "dmg"` branch at `omlx/engine/batched.py:151` (and the matching site in `vlm.py`) still logs the pre-#1453 message about torch size, which doesn't reflect that xgrammar is now bundled with a torch stub. Even with this fix landed, any future failure of the stubbed-xgrammar path will surface that same outdated text. Happy to send a follow-up PR updating the message to match the new reality if you'd like.