### PR TITLE
fix(engine): keep per-engine MLX worker thread alive to fix DeepSeek V4 unload SIGSEGV (#1304 regression)

### DIFF
--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -31,6 +31,38 @@ logger = logging.getLogger(__name__)
 
 _global_mlx_executor: concurrent.futures.ThreadPoolExecutor | None = None
 
+# Module-global keep-alive registry for per-engine MLX streams (#1248).
+#
+# Background: prior to the per-engine executor/stream split (#1248), every
+# engine shared ONE process-global executor whose thread-local generation
+# stream was created once and lived for the entire process lifetime — an
+# IMMORTAL Metal command queue that was never destroyed or recycled.
+#
+# The #1248 split gave each EngineCore its own mx.Stream created at __init__.
+# That stream (and its underlying Metal command queue) is reaped when the
+# EngineCore is garbage-collected at unload, so the queue became MORTAL and
+# is RECYCLED on the next allocation. For DeepSeek-V4-Flash (the only model
+# with module-scope mx.fast.metal_kernel + persistent @mx.compile graphs)
+# this recycling deterministically triggers an asynchronous native Metal
+# SIGSEGV at unload (use-after-free on the recycled queue). The crash is
+# sync-immune: draining/flushing the stream before teardown only relocates
+# it. See deepseek-v4-benchmark-shutdown notes.
+#
+# Fix: keep a strong reference to every per-engine stream here so it is never
+# garbage-collected. This restores the proven-good IMMORTAL-queue invariant
+# (the Metal command queue lives for the process lifetime and is never
+# recycled) WITHOUT any synchronization, while preserving the #1248
+# per-engine executor concurrency for all models. Growth is bounded by the
+# number of engines ever created (O(engines), not O(load/unload cycles));
+# each entry is a tiny handle to a process-global device queue.
+#
+# Honest scope: this directly neutralizes the recycled-queue mechanism. If a
+# V4-internal Metal buffer double-free exists that is independent of queue
+# lifecycle, this MASKS it exactly as the good baseline did (by keeping the
+# queue alive so the corrupting timing never occurs) rather than root-causing
+# it. Do NOT remove entries from this list and do NOT add synchronization.
+_immortal_engine_streams: list = []
+
 
 def _init_mlx_thread() -> None:
     """Replace generation_stream with a thread-local stream on the executor thread.
@@ -137,6 +169,11 @@ class EngineCore:
         # Each EngineCore gets its own thread + GPU stream so different
         # models can run scheduler.step() concurrently.
         self._mlx_stream = mx.new_thread_local_stream(mx.default_device())
+        # Pin the stream immortal: hold a process-lifetime strong reference so
+        # GC never destroys it at unload and its Metal command queue is never
+        # recycled. Restores the proven-good immortal-queue invariant that the
+        # #1248 split removed (DeepSeek-V4 unload SIGSEGV). See registry note.
+        _immortal_engine_streams.append(self._mlx_stream)
         self._mlx_executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=1,
             thread_name_prefix=f"mlx-engine-{self._engine_id[:8]}",

--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -31,37 +31,37 @@ logger = logging.getLogger(__name__)
 
 _global_mlx_executor: concurrent.futures.ThreadPoolExecutor | None = None
 
-# Module-global keep-alive registry for per-engine MLX streams (#1248).
+# Module-global keep-alive registries for per-engine MLX resources (#1248).
 #
-# Background: prior to the per-engine executor/stream split (#1248), every
-# engine shared ONE process-global executor whose thread-local generation
-# stream was created once and lived for the entire process lifetime — an
-# IMMORTAL Metal command queue that was never destroyed or recycled.
+# PROVEN ROOT CAUSE (native crash frame, 2026-05-30): MLX's @mx.compile graph
+# cache — mlx::core::detail::CompilerCache — is a C++ `thread_local`. Every
+# thread that runs compiled functions gets its own CompilerCache holding the
+# compiled graphs, which reference Python objects (captured constants/arrays).
 #
-# The #1248 split gave each EngineCore its own mx.Stream created at __init__.
-# That stream (and its underlying Metal command queue) is reaped when the
-# EngineCore is garbage-collected at unload, so the queue became MORTAL and
-# is RECYCLED on the next allocation. For DeepSeek-V4-Flash (the only model
-# with module-scope mx.fast.metal_kernel + persistent @mx.compile graphs)
-# this recycling deterministically triggers an asynchronous native Metal
-# SIGSEGV at unload (use-after-free on the recycled queue). The crash is
-# sync-immune: draining/flushing the stream before teardown only relocates
-# it. See deepseek-v4-benchmark-shutdown notes.
+# Before #1248, all engines shared ONE process-global executor whose worker
+# thread NEVER exits mid-process, so its thread_local CompilerCache is never
+# destructed while the server runs. #1248 gave each EngineCore its own
+# ThreadPoolExecutor, and EngineCore.close() called executor.shutdown(wait=True)
+# — which EXITS that worker thread. On thread exit, dyld runs the thread_local
+# destructor ~CompilerCache(), which frees the cached graphs' Python tuples
+# from a thread-exit handler (no GIL held, and after deep_reset/gc already
+# released those objects) -> use-after-free -> asynchronous native SIGSEGV.
+# Crash frame: _pthread_exit -> dyld finalizeList -> ~CompilerCache ->
+# tupledealloc (KERN_INVALID_ADDRESS). It is DeepSeek-V4-only because V4 is the
+# only model with module-scope @mx.compile graphs (deepseek_v4_model.py /
+# hyper_connection.py) that populate the per-engine thread's cache. It is
+# sync-immune (a C++ thread-exit destructor, nothing to do with GPU streams) —
+# which is why every prior synchronize/flush/stream fix only relocated it.
 #
-# Fix: keep a strong reference to every per-engine stream here so it is never
-# garbage-collected. This restores the proven-good IMMORTAL-queue invariant
-# (the Metal command queue lives for the process lifetime and is never
-# recycled) WITHOUT any synchronization, while preserving the #1248
-# per-engine executor concurrency for all models. Growth is bounded by the
-# number of engines ever created (O(engines), not O(load/unload cycles));
-# each entry is a tiny handle to a process-global device queue.
-#
-# Honest scope: this directly neutralizes the recycled-queue mechanism. If a
-# V4-internal Metal buffer double-free exists that is independent of queue
-# lifecycle, this MASKS it exactly as the good baseline did (by keeping the
-# queue alive so the corrupting timing never occurs) rather than root-causing
-# it. Do NOT remove entries from this list and do NOT add synchronization.
+# FIX: never let a per-engine worker thread exit mid-process. Hold a strong
+# reference to every per-engine executor (and its stream) here so the thread —
+# and its thread_local CompilerCache — lives for the process lifetime,
+# restoring the good-baseline invariant. No synchronization (sync-immune).
+# Growth is O(engines ever created): one idle thread + two small handles per
+# model load, reclaimed at process exit — negligible for a model server.
+# Do NOT shut these down and do NOT add synchronization.
 _immortal_engine_streams: list = []
+_immortal_engine_executors: list = []
 
 
 def _init_mlx_thread() -> None:
@@ -169,15 +169,18 @@ class EngineCore:
         # Each EngineCore gets its own thread + GPU stream so different
         # models can run scheduler.step() concurrently.
         self._mlx_stream = mx.new_thread_local_stream(mx.default_device())
-        # Pin the stream immortal: hold a process-lifetime strong reference so
-        # GC never destroys it at unload and its Metal command queue is never
-        # recycled. Restores the proven-good immortal-queue invariant that the
-        # #1248 split removed (DeepSeek-V4 unload SIGSEGV). See registry note.
-        _immortal_engine_streams.append(self._mlx_stream)
         self._mlx_executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=1,
             thread_name_prefix=f"mlx-engine-{self._engine_id[:8]}",
         )
+        # Pin both immortal so this worker thread — and its thread_local MLX
+        # CompilerCache — is NEVER destructed mid-process at unload. Exiting the
+        # thread runs ~CompilerCache() which frees @mx.compile graphs' Python
+        # objects unsafely at thread-exit -> DeepSeek-V4 unload SIGSEGV. See the
+        # registry note above (#1248). close() drops EngineCore's refs but these
+        # registries keep the thread + stream alive for the process lifetime.
+        _immortal_engine_streams.append(self._mlx_stream)
+        _immortal_engine_executors.append(self._mlx_executor)
 
         # Create scheduler with per-engine stream
         scheduler_config = self.config.scheduler_config or SchedulerConfig()
@@ -754,9 +757,15 @@ class EngineCore:
                 except RuntimeError:
                     pass
 
-        if self._mlx_executor is not None:
-            self._mlx_executor.shutdown(wait=True)
-            self._mlx_executor = None
+        # Do NOT shut down the per-engine executor: shutdown(wait=True) exits
+        # the worker thread, which runs MLX's thread_local CompilerCache
+        # destructor and frees @mx.compile graphs' Python objects from a dyld
+        # thread-exit handler -> use-after-free SIGSEGV for DeepSeek V4 (proven
+        # via native crash frame). The executor is already idle here (shutdown +
+        # deep_reset were dispatched and joined above). Just drop our reference;
+        # _immortal_engine_executors keeps the thread alive for the process
+        # lifetime, matching the good-baseline single-global-thread behavior.
+        self._mlx_executor = None
 
         # Clear output collectors
         for collector in self._output_collectors.values():

--- a/tests/test_per_engine_threads.py
+++ b/tests/test_per_engine_threads.py
@@ -144,7 +144,15 @@ class TestPerEngineExecutor:
 
             engine.close()
 
-    def test_close_shuts_down_executor(self):
+    def test_close_pins_executor_immortal_not_shut_down(self):
+        """close() must NOT shut down the per-engine executor: exiting its
+        worker thread runs MLX's thread_local CompilerCache destructor, which
+        frees @mx.compile graphs' Python objects unsafely at thread-exit ->
+        DeepSeek-V4 unload SIGSEGV (#1248). The executor is pinned immortal so
+        its worker thread stays alive for the process lifetime; close() only
+        drops EngineCore's own reference."""
+        import omlx.engine_core as ec
+
         mock_model = MagicMock()
         mock_model.model_type = "test"
         mock_tokenizer = MagicMock()
@@ -155,10 +163,14 @@ class TestPerEngineExecutor:
 
             engine = EngineCore(mock_model, mock_tokenizer)
             executor = engine._mlx_executor
+            assert executor in ec._immortal_engine_executors
             engine.close()
 
+            # EngineCore drops its reference, but the executor (and its worker
+            # thread) must stay alive — NOT shut down.
             assert engine._mlx_executor is None
-            assert executor._shutdown
+            assert executor in ec._immortal_engine_executors
+            assert not executor._shutdown
 
 
 class TestImmortalStreamRegistry:
@@ -173,6 +185,8 @@ class TestImmortalStreamRegistry:
 
         assert hasattr(ec, "_immortal_engine_streams")
         assert isinstance(ec._immortal_engine_streams, list)
+        assert hasattr(ec, "_immortal_engine_executors")
+        assert isinstance(ec._immortal_engine_executors, list)
 
     def test_stream_registered_on_init(self):
         import omlx.engine_core as ec
@@ -246,9 +260,10 @@ class TestImmortalStreamRegistry:
             assert len(ec._immortal_engine_streams) == before + 3
 
     def test_close_does_not_shut_down_global_executor(self):
-        """Guardrail: the per-engine executor is shut down at close(), but the
-        process-global executor (get_mlx_executor) must NEVER be shut down by
-        an engine close()."""
+        """Guardrail: an engine close() must NEVER shut down the process-global
+        executor (get_mlx_executor). (The per-engine executor is also no longer
+        shut down — it is pinned immortal — but this test specifically protects
+        the shared global executor.)"""
         import omlx.engine_core as ec
 
         mock_model = MagicMock()

--- a/tests/test_per_engine_threads.py
+++ b/tests/test_per_engine_threads.py
@@ -161,6 +161,118 @@ class TestPerEngineExecutor:
             assert executor._shutdown
 
 
+class TestImmortalStreamRegistry:
+    """Per-engine streams must be pinned immortal so the underlying Metal
+    command queue is never recycled at unload (#1248 regression / DeepSeek-V4
+    unload SIGSEGV). The fix restores the good-baseline immortal-queue
+    invariant by holding a process-lifetime strong reference to every
+    per-engine stream in a module-global registry."""
+
+    def test_registry_exists(self):
+        import omlx.engine_core as ec
+
+        assert hasattr(ec, "_immortal_engine_streams")
+        assert isinstance(ec._immortal_engine_streams, list)
+
+    def test_stream_registered_on_init(self):
+        import omlx.engine_core as ec
+
+        mock_model = MagicMock()
+        mock_model.model_type = "test"
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.eos_token_id = 0
+
+        before = len(ec._immortal_engine_streams)
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+
+            engine = EngineCore(mock_model, mock_tokenizer)
+            # The engine's stream must be held by the registry immediately.
+            assert engine._mlx_stream in ec._immortal_engine_streams
+            assert len(ec._immortal_engine_streams) == before + 1
+
+            engine.close()
+
+    def test_stream_retained_after_close(self):
+        """close() must NOT drop the registry's strong reference: the stream
+        (and its Metal queue) stays alive for the process lifetime even after
+        the engine is closed and dereferenced."""
+        import gc
+        import omlx.engine_core as ec
+
+        mock_model = MagicMock()
+        mock_model.model_type = "test"
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.eos_token_id = 0
+
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+
+            engine = EngineCore(mock_model, mock_tokenizer)
+            stream = engine._mlx_stream
+            engine.close()
+
+            # Drop the only other strong references and force collection.
+            del engine
+            gc.collect()
+
+            # Registry must still hold the stream -> Metal queue immortal.
+            assert stream in ec._immortal_engine_streams
+
+    def test_registry_growth_bounded_by_engine_count(self):
+        """Growth is O(engines created), one entry per engine, regardless of
+        whether close() was called."""
+        import omlx.engine_core as ec
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.eos_token_id = 0
+
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+
+            before = len(ec._immortal_engine_streams)
+            engines = []
+            for _ in range(3):
+                m = MagicMock()
+                m.model_type = "test"
+                engines.append(EngineCore(m, mock_tokenizer))
+
+            assert len(ec._immortal_engine_streams) == before + 3
+
+            for e in engines:
+                e.close()
+
+            # close() does not remove entries; count is unchanged.
+            assert len(ec._immortal_engine_streams) == before + 3
+
+    def test_close_does_not_shut_down_global_executor(self):
+        """Guardrail: the per-engine executor is shut down at close(), but the
+        process-global executor (get_mlx_executor) must NEVER be shut down by
+        an engine close()."""
+        import omlx.engine_core as ec
+
+        mock_model = MagicMock()
+        mock_model.model_type = "test"
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.eos_token_id = 0
+
+        # Materialize the global executor and confirm it is distinct from the
+        # per-engine one and survives close().
+        global_exec = ec.get_mlx_executor()
+
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+
+            engine = EngineCore(mock_model, mock_tokenizer)
+            assert engine._mlx_executor is not global_exec
+            engine.close()
+
+            assert not global_exec._shutdown
+            # Same singleton is still returned and usable.
+            assert ec.get_mlx_executor() is global_exec
+            assert not global_exec._shutdown
+
+
 class TestConcurrentStreamIsolation:
     """Verify that per-engine streams don't leak across engines during
     concurrent execution."""


### PR DESCRIPTION
Unloading DeepSeek V4 crashed omlx serve with a native SIGSEGV.
Root cause: MLX's @mx.compile cache (CompilerCache) is a C++ thread_local; the per-engine executor introduced in #1304 runs V4's module-scope @mx.compile graphs, then EngineCore.close() called executor.shutdown(wait=True), exiting the worker thread → ~CompilerCache() freed those graphs' Python objects from a thread-exit handler (no GIL) → use-after-free. V4-only (only model with module-scope compiled graphs) and sync-immune. 

Fix: keep per-engine MLX worker threads alive for the process lifetime (matching the pre-#1304 global-thread behavior), so the destructor never runs mid-process.

Summary
Unloading DeepSeek-V4-Flash crashed the whole omlx serve process with a native SIGSEGV. The per-engine executor thread added in #1304 runs V4's @mx.compile graphs, and exiting that thread at unload triggers a use-after-free in MLX's thread_local compile-cache destructor. Fix: don't tear down the per-engine MLX worker thread at unload (matching the pre-#1304 single-global-thread behavior).

Root cause
MLX's @mx.compile cache (CompilerCache) is a C++ thread_local holding compiled graphs that reference Python objects. DeepSeek V4 is the only model with module-scope @mx.compile graphs, so they populate the per-engine thread's cache. EngineCore.close() called executor.shutdown(wait=True) → the worker thread exits → dyld runs ~CompilerCache() → it frees those Python objects from a thread-exit handler (no GIL, after gc already freed them) → use-after-free. V4-only and sync-immune (a thread-exit destructor, not GPU work). Pre-#1304, the shared global MLX thread never exited mid-process, so this never surfaced.
.ips crash frame (EXC_BAD_ACCESS at 0x10):
_pthread_exit → dyld::ThreadLocalVariables::finalizeList
→ mlx::core::detail::CompilerCache::~CompilerCache()
→ __deallocate_node(…CompilerCache::CacheEntry…) → tupledealloc
  
Fix
EngineCore.close() no longer shuts down the per-engine executor; the executor (and its stream) is held in a process-lifetime registry so the thread — and its thread_local CompilerCache — is never destructed mid-process:
# close(): was self._mlx_executor.shutdown(wait=True)
self._mlx_executor = None   # thread kept alive via module-global registry
No synchronization (sync-immune); MLX exposes no compile-cache-clear API. Cost: one idle thread per model load, reclaimed at exit.
  
Test plan
- Unit: updated tests/test_per_engine_threads.py; 280 tests pass (engine_core/engine_pool/per_engine_threads/stream_usage/keepalive/scheduler/batched_engine).
- Manual (512 GB Mac Studio): repeated load→serve→unload of DeepSeek-V4-Flash-mxfp8 — was SIGSEGV every time, now reaches Unloaded model … (settled); MiniMax/VLM unaffected.