### PR TITLE
fix(server): surface DFlash in-flight requests on dashboard Active Models card

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -4476,6 +4476,12 @@ def _build_active_models_data() -> dict:
                 snapshot = entry.engine.get_activity_snapshot()
                 active_requests = snapshot.get("active_requests", 0)
                 activities = snapshot.get("activities", [])
+            elif hasattr(entry.engine, "has_active_requests"):
+                # DFlash bypasses the scheduler and exposes neither an
+                # AsyncEngineCore (_engine) nor get_activity_snapshot, so the
+                # dashboard previously read it as permanently idle (#1477).
+                # Fall back to its boolean in-flight signal.
+                active_requests = 1 if entry.engine.has_active_requests() else 0
 
         prefilling = tracker.get_model_progress(model_id)
         prefilling_ids = {p["request_id"] for p in prefilling}

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2192,15 +2192,22 @@ async def server_status(_: bool = Depends(verify_api_key)):
             if engine is None:
                 continue
             async_core = getattr(engine, "_engine", None)
-            if async_core is None:
-                continue
-            core = getattr(async_core, "engine", None)
-            if core is None:
-                continue
-            active_requests += len(getattr(core, "_output_collectors", {}))
-            sched = getattr(core, "scheduler", None)
-            if sched is not None:
-                waiting_requests += len(getattr(sched, "waiting", []))
+            if async_core is not None:
+                core = getattr(async_core, "engine", None)
+                if core is None:
+                    continue
+                active_requests += len(getattr(core, "_output_collectors", {}))
+                sched = getattr(core, "scheduler", None)
+                if sched is not None:
+                    waiting_requests += len(getattr(sched, "waiting", []))
+            elif hasattr(engine, "get_activity_snapshot"):
+                active_requests += engine.get_activity_snapshot().get(
+                    "active_requests", 0
+                )
+            elif hasattr(engine, "has_active_requests"):
+                # DFlash exposes neither _engine nor get_activity_snapshot;
+                # use its boolean in-flight signal so it is not missed (#1477).
+                active_requests += 1 if engine.has_active_requests() else 0
 
     return {
         "status": "ok",

--- a/tests/test_active_models_visibility.py
+++ b/tests/test_active_models_visibility.py
@@ -220,6 +220,72 @@ def test_active_models_includes_non_streaming_activity_rows():
     ]
 
 
+# ── DFlash boolean activity fallback (#1477) ──────────────────────────────
+
+
+class FakeDFlashEngine:
+    """DFlash exposes a boolean in-flight signal but neither an
+    AsyncEngineCore (_engine) nor get_activity_snapshot."""
+
+    def __init__(self, active):
+        self._active = active
+
+    def has_active_requests(self):
+        return self._active
+
+
+class FakeDFlashPool:
+    def __init__(self, active):
+        self._entries = {
+            "dflash-model": SimpleNamespace(engine=FakeDFlashEngine(active))
+        }
+
+    def get_status(self):
+        return {
+            "current_model_memory": 1024,
+            "final_ceiling": 2048,
+            "models": [
+                {
+                    "id": "dflash-model",
+                    "loaded": True,
+                    "is_loading": False,
+                    "estimated_size": 1024,
+                    "pinned": False,
+                }
+            ],
+        }
+
+
+def _build_dflash_data(active):
+    class EmptyPrefillTracker:
+        def get_model_progress(self, model_id):
+            return []
+
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=FakeDFlashPool(active)),
+        patch("omlx.admin.routes._get_server_state", return_value=None),
+        patch.object(admin_routes, "_get_settings_manager", return_value=None),
+        patch.object(admin_routes, "_get_global_settings", return_value=None),
+        patch("omlx.prefill_progress.get_prefill_tracker", return_value=EmptyPrefillTracker()),
+        patch("time.monotonic", return_value=110.0),
+    ):
+        return admin_routes._build_active_models_data()
+
+
+def test_dflash_reports_active_via_boolean_signal():
+    data = _build_dflash_data(active=True)
+    model = data["models"][0]
+    assert model["active_requests"] == 1
+    assert data["total_active_requests"] == 1
+
+
+def test_dflash_reports_idle_when_no_active_request():
+    data = _build_dflash_data(active=False)
+    model = data["models"][0]
+    assert model["active_requests"] == 0
+    assert data["total_active_requests"] == 0
+
+
 # ── idle / TTL countdown (#1307) ──────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #1477.

## Problem

DFlash models always show "idle" on the dashboard Active Models card, even
while they are generating. The same gap zeroes out `active_requests` in the
`/api/status` aggregate.

## Root cause

There are currently two ways that detection paths recognize in-flight work:

1. `engine._engine.engine._output_collectors` for AsyncEngineCore engines
   (BatchedEngine, VLMBatchedEngine), and
2. `engine.get_activity_snapshot()` for BaseNonStreamingEngine engines
   (embedding, reranker, TTS, etc.).

Of the 8 current loadable engine types, DFlashEngine is the only one that
neither sets `_engine` nor defines `get_activity_snapshot`, so it falls
through both checks and never contributes to `active_requests`. It always
reads as 0 active (idle):

| Engine | sets `_engine`? | has `get_activity_snapshot`? | caught by |
|---|---|---|---|
| BatchedEngine | yes | no | path 1 |
| VLMBatchedEngine | yes | no | path 1 |
| EmbeddingEngine | no | yes | path 2 |
| RerankerEngine | no | yes | path 2 |
| STTEngine | no | yes | path 2 |
| TTSEngine | no | yes | path 2 |
| STSEngine | no | yes | path 2 |
| DFlashEngine | no | no | falls through |

`self._engine` is assigned in exactly two engines (`batched.py`, `vlm.py`).
`get_activity_snapshot` is defined once, on `BaseNonStreamingEngine`
(`base.py`), and inherited by the five non-streaming engines. `base.py`
defines two independent base classes, `BaseEngine` and
`BaseNonStreamingEngine`; DFlashEngine subclasses `BaseEngine` (the branch
without `get_activity_snapshot`) and does not set `_engine`. The combination
is what makes it unique: BatchedEngine also subclasses `BaseEngine` and also
lacks `get_activity_snapshot`, but it sets `_engine`, so path 1 still catches
it.

## Fix

Add a third fallback in `_build_active_models_data` (`omlx/admin/routes.py`)
and the `/api/status` aggregate (`omlx/server.py`) that reads
`DFlashEngine.has_active_requests()` (`omlx/engine/dflash.py:1184`). That
method returns the engine's `_active_request` flag, set True at generation
entry (`dflash.py:887`, `:1007`) and cleared on completion (`dflash.py:786`,
`:885`); it also returns True when the engine has spilled to its batched
fallback and that fallback is busy. So it reads True whenever the engine is
mid-request, in either mode. DFlash serves one request at a time, so the
value contributed to the count is 0 or 1, which is accurate.

The fallback is ordered last, after the `_engine` and `get_activity_snapshot`
checks, so it only affects engines that miss the first two.

## Testing

Static checks:
- Checked each of the eight engine classes for both `_engine` and
  `get_activity_snapshot`; the table above is the result.
- `entry.engine` is the `DFlashEngine` instance directly
  (`engine_pool.py:824`), so the aggregate calls `has_active_requests()` on
  the engine itself rather than a wrapper.

Unit (`tests/test_active_models_visibility.py`, 2 new tests) cover the
`_build_active_models_data` path with a DFlash engine:
- `test_dflash_reports_active_via_boolean_signal` asserts `active_requests`
  is 1 when the engine reports active.
- `test_dflash_reports_idle_when_no_active_request` asserts it is 0 when idle.

64 tests pass across `test_active_models_visibility.py` and
`test_dflash_engine.py`.

Live runtime test covers the `/api/status` path on an M4 Pro Mini (64GB):
- Target `mlx-community/Qwen3.6-35B-A3B-4bit`, draft
  `z-lab/Qwen3.6-35B-A3B-DFlash`.
- Server log confirms a real DFlashEngine is built (`dflash_enabled` takes
  priority over the engine-type classification).
- `/api/status` `active_requests` reported 0 before generation, 1 during a
  600-token generation, and 0 after it finished.
- The fix keys off engine type, not the specific model, so any
  DFlash-enabled model exercises the same path.

Between the unit and live tests, both patched paths are exercised:
`_build_active_models_data` (the dashboard card) and `/api/status`.
