### PR TITLE
fix(scheduler): log hot-cache-only mode instead of SSD cache when SSD is skipped

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -910,11 +910,18 @@ class Scheduler:
                 self.block_aware_cache.set_cold_restore_callback(
                     self._restore_block_from_cold
                 )
-                logger.info(
-                    f"paged SSD cache enabled: {self.config.paged_ssd_cache_dir}, "
-                    f"block_size={self.config.paged_cache_block_size}, "
-                    f"max_blocks={max_blocks}"
-                )
+                if self.config.hot_cache_only:
+                    logger.info(
+                        f"hot-cache-only mode enabled: "
+                        f"block_size={self.config.paged_cache_block_size}, "
+                        f"max_blocks={max_blocks}"
+                    )
+                else:
+                    logger.info(
+                        f"paged SSD cache enabled: {self.config.paged_ssd_cache_dir}, "
+                        f"block_size={self.config.paged_cache_block_size}, "
+                        f"max_blocks={max_blocks}"
+                    )
 
             # Async store_cache executor: single worker so submissions are
             # serialized (matches the original synchronous order) and we
@@ -6818,12 +6825,19 @@ class Scheduler:
                         "Failed to initialize boundary snapshot SSD store: %s", e
                     )
 
-            logger.info(
-                f"paged SSD cache enabled: "
-                f"cache_dir={self.config.paged_ssd_cache_dir}, "
-                f"max_size={self._format_bytes(self.config.paged_ssd_cache_max_size)}, "
-                f"block_size={self.config.paged_cache_block_size} tokens"
-            )
+            if self.config.hot_cache_only:
+                logger.info(
+                    f"hot-cache-only mode enabled: "
+                    f"hot_cache_max={self._format_bytes(self.config.hot_cache_max_size)}, "
+                    f"block_size={self.config.paged_cache_block_size} tokens"
+                )
+            else:
+                logger.info(
+                    f"paged SSD cache enabled: "
+                    f"cache_dir={self.config.paged_ssd_cache_dir}, "
+                    f"max_size={self._format_bytes(self.config.paged_ssd_cache_max_size)}, "
+                    f"block_size={self.config.paged_cache_block_size} tokens"
+                )
 
         except Exception as e:
             logger.error(f"Failed to initialize paged SSD cache: {e}")


### PR DESCRIPTION
## Summary

When `cache.hot_cache_only` is true, the scheduler still logged `paged SSD cache enabled: ...` during cache init, even though the SSD tier is skipped in that mode. The line did not match what actually happens (empty SSD cache dir, no spill, no `queue full`), so reading the startup log gives no sign that hot-only mode is on.

Both `logger.info` sites in the paged-cache init path now check `self.config.hot_cache_only` and log a `hot-cache-only mode enabled: ...` line when it is set. The full-SSD text is unchanged. This is a log-text change only, no caching behavior changes.

### Before (hot_cache_only: true)

```
paged SSD cache enabled: /Users/.../.omlx/cache, block_size=256, max_blocks=...
paged SSD cache enabled: cache_dir=/Users/.../.omlx/cache, max_size=..., block_size=256 tokens
```

### After (hot_cache_only: true)

```
hot-cache-only mode enabled: block_size=256, max_blocks=...
hot-cache-only mode enabled: hot_cache_max=..., block_size=256 tokens
```

With `hot_cache_only: false`, both lines are byte-for-byte unchanged.

## Why no automated test

Both lines only fire during a full Scheduler model-load init. The existing tests check the cache classes (`PagedSSDCacheManager` and the rest) directly, and nothing in the suite runs a full scheduler init, so there is no place to hang a caplog assertion. Adding one would mean standing up a mock scheduler init just to check a log string, which is more setup than a log-text change is worth. I tested it at runtime instead (below).

## Test plan

Tested on Apple Silicon with a plain text model (non-VLM, non-dflash) so it goes through the standard scheduler paged-cache init path, confirmed by `PagedSSDCacheManager initialized` in the startup log:

- [x] **hot_cache_only: true** - two `hot-cache-only mode enabled` lines, zero `paged SSD cache enabled`, SSD cache dir stays at 0B
- [x] **hot_cache_only: false** (regression guard) - two `paged SSD cache enabled` lines, zero hot-only lines, original text unchanged
- [x] **runtime spot-check** (hot-only) - SSD dir stays empty, zero `queue full`, prefix cache still hits (warm pass ~17.6s vs cold ~26.7s on the same 2K prefix)

Fixes #1316