### PR TITLE
fix(server): signal unenforced response_format via warning log and Warning header

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2231,8 +2231,11 @@ async def create_chat_completion(
     )
     # Fall back to prompt injection when grammar is not compiled. The degrade
     # is also surfaced to the caller as a Warning response header (#1241).
+    # Only response formats that actually request grammar-constrained JSON
+    # (json_object / json_schema) can be "unenforced"; a plain text format
+    # never asked for enforcement, so it must not warn (#1241 review).
     response_format_warning = None
-    if compiled_grammar is None and response_format:
+    if compiled_grammar is None and _response_format_requests_grammar(response_format):
         response_format_warning = _response_format_warning_header(response_format)
         json_instruction = build_json_system_prompt(response_format)
         if json_instruction:
@@ -2673,6 +2676,22 @@ def _response_format_requests_strict(response_format) -> bool:
         return False
     strict = js.get("strict") if isinstance(js, dict) else getattr(js, "strict", None)
     return bool(strict)
+
+
+def _response_format_requests_grammar(response_format) -> bool:
+    """True when an OpenAI ``response_format`` asks for grammar-constrained JSON.
+
+    Only ``json_object`` and ``json_schema`` map to grammar-constrained
+    decoding, so only those can be silently *unenforced* when no grammar
+    compiler is available.  A plain ``{"type": "text"}`` (or absent) format
+    never requested enforcement and must not trigger the downgrade Warning
+    header or prompt-injection fallback (#1241 review).
+    """
+    if response_format is None:
+        return False
+    rf = response_format
+    rf_type = rf.get("type") if isinstance(rf, dict) else getattr(rf, "type", None)
+    return rf_type in ("json_object", "json_schema")
 
 
 def _compile_grammar_for_request(

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2643,6 +2643,28 @@ def _compile_bare_grammar(compiler, fmt: dict):
     return None
 
 
+def _response_format_requests_strict(response_format) -> bool:
+    """True when an OpenAI ``response_format`` demands strict json_schema output.
+
+    A ``json_schema`` response_format with ``strict: true`` signals that the
+    caller expects schema-conformant output, not best-effort.  When
+    grammar-constrained decoding is unavailable the request still falls back to
+    prompt injection, but the downgrade is logged at a level that names the
+    unhonored ``strict`` intent so it is not silent (issue #1241).
+    """
+    if response_format is None:
+        return False
+    rf = response_format
+    rf_type = rf.get("type") if isinstance(rf, dict) else getattr(rf, "type", None)
+    if rf_type != "json_schema":
+        return False
+    js = rf.get("json_schema") if isinstance(rf, dict) else getattr(rf, "json_schema", None)
+    if js is None:
+        return False
+    strict = js.get("strict") if isinstance(js, dict) else getattr(js, "strict", None)
+    return bool(strict)
+
+
 def _compile_grammar_for_request(
     engine: BaseEngine,
     structured_outputs=None,
@@ -2657,9 +2679,12 @@ def _compile_grammar_for_request(
     so that protocol tokens (thinking tags, channel markers) are handled
     automatically.  When not set, the grammar is compiled bare.
 
-    Returns a compiled grammar object or ``None``.  Raises
-    :class:`HTTPException` on compilation errors or when xgrammar is
-    required but not installed.
+    Returns a compiled grammar object or ``None``.  ``structured_outputs``
+    raises :class:`HTTPException` when grammar is unavailable or fails to
+    compile.  A ``response_format`` degrades to ``None`` so the caller can fall
+    back to prompt injection; the downgrade is logged (and named as an
+    unhonored strict request when ``strict: true`` was set) rather than being
+    silent (#1241).
     """
     compiler = getattr(engine, 'grammar_compiler', None)
 
@@ -2689,6 +2714,8 @@ def _compile_grammar_for_request(
                     "Install with: pip install 'omlx[grammar]'"
                 )
             raise HTTPException(status_code=400, detail=detail)
+        if response_format is not None:
+            _warn_response_format_not_enforced(response_format)
         return None
 
     try:
@@ -2703,9 +2730,33 @@ def _compile_grammar_for_request(
                 status_code=400,
                 detail=f"Grammar compilation error: {e}",
             )
-        logger.warning("Grammar compilation from response_format failed, "
-                       "falling back to prompt injection: %s", e)
+        _warn_response_format_not_enforced(response_format, error=e)
     return None
+
+
+def _warn_response_format_not_enforced(response_format, error=None):
+    """Log that a ``response_format`` request fell back to prompt injection.
+
+    Previously a ``response_format`` that could not be grammar-constrained
+    (no compiler available, or a compilation error) degraded to best-effort
+    prompt injection silently, giving the client no signal that the schema was
+    not enforced (#1241).  A ``strict: true`` request gets a message that names
+    the unhonored strict intent.
+    """
+    reason = f" ({error})" if error is not None else ""
+    if _response_format_requests_strict(response_format):
+        logger.warning(
+            "response_format requested strict json_schema output but "
+            "grammar-constrained decoding is unavailable; strict enforcement "
+            "cannot be honored, falling back to best-effort prompt injection "
+            "(output is NOT schema-enforced)%s.", reason,
+        )
+    else:
+        logger.warning(
+            "response_format requested but grammar-constrained decoding is "
+            "unavailable; output will not be schema-enforced (falling back to "
+            "prompt injection)%s.", reason,
+        )
 
 
 # =============================================================================

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2679,19 +2679,21 @@ def _response_format_requests_strict(response_format) -> bool:
 
 
 def _response_format_requests_grammar(response_format) -> bool:
-    """True when an OpenAI ``response_format`` asks for grammar-constrained JSON.
+    """True when an OpenAI ``response_format`` maps to grammar-constrained JSON.
 
-    Only ``json_object`` and ``json_schema`` map to grammar-constrained
-    decoding, so only those can be silently *unenforced* when no grammar
-    compiler is available.  A plain ``{"type": "text"}`` (or absent) format
-    never requested enforcement and must not trigger the downgrade Warning
-    header or prompt-injection fallback (#1241 review).
+    Delegates to :func:`_build_format_element` so the unenforced-degrade signal
+    stays in sync with what actually gets compiled: a format earns the
+    Warning header / prompt-injection fallback only when a grammar element would
+    have been built for it.  That is non-``None`` exactly for ``json_object``
+    and a ``json_schema`` carrying a schema; a plain ``{"type": "text"}`` (or a
+    json_schema with no schema) maps to nothing and must not warn.  Sharing the
+    one source of truth keeps the header consistent with the server-side warn
+    log and avoids claiming "grammar-constrained decoding unavailable" for a
+    request that never described an enforceable grammar (#1241 review).
     """
     if response_format is None:
         return False
-    rf = response_format
-    rf_type = rf.get("type") if isinstance(rf, dict) else getattr(rf, "type", None)
-    return rf_type in ("json_object", "json_schema")
+    return _build_format_element(response_format=response_format) is not None
 
 
 def _compile_grammar_for_request(

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2229,8 +2229,11 @@ async def create_chat_completion(
         chat_template_kwargs=merged_ct_kwargs or None,
         reasoning_parser=reasoning_parser,
     )
-    # Fall back to prompt injection when grammar is not compiled
+    # Fall back to prompt injection when grammar is not compiled. The degrade
+    # is also surfaced to the caller as a Warning response header (#1241).
+    response_format_warning = None
     if compiled_grammar is None and response_format:
+        response_format_warning = _response_format_warning_header(response_format)
         json_instruction = build_json_system_prompt(response_format)
         if json_instruction:
             messages = _inject_json_instruction(messages, json_instruction)
@@ -2369,6 +2372,9 @@ async def create_chat_completion(
         keepalive = _resolve_keepalive("openai_chat")
         if keepalive == _KEEPALIVE_CHAT_CHUNK:
             keepalive = _chat_keepalive_chunk(response_id)
+        sse_headers = {"X-Accel-Buffering": "no", "Cache-Control": "no-cache"}
+        if response_format_warning:
+            sse_headers["Warning"] = response_format_warning
         return StreamingResponse(
             _with_sse_keepalive(
                 stream_chat_completion(engine, messages, request, model_load_duration=model_load_duration, resolved_model=resolved_model, response_id=response_id, **chat_kwargs),
@@ -2376,7 +2382,7 @@ async def create_chat_completion(
                 keepalive_chunk=keepalive,
             ),
             media_type="text/event-stream",
-            headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"},
+            headers=sse_headers,
         )
 
     # Non-streaming response with keepalive during prefill
@@ -2475,9 +2481,13 @@ async def create_chat_completion(
             ),
         ).model_dump_json(exclude_none=True)
 
+    json_headers = (
+        {"Warning": response_format_warning} if response_format_warning else None
+    )
     return StreamingResponse(
         _with_json_keepalive(http_request, _build_chat_completion()),
         media_type="application/json",
+        headers=json_headers,
     )
 
 
@@ -2757,6 +2767,30 @@ def _warn_response_format_not_enforced(response_format, error=None):
             "unavailable; output will not be schema-enforced (falling back to "
             "prompt injection)%s.", reason,
         )
+
+
+def _response_format_warning_header(response_format) -> str:
+    """Build an RFC 7234 ``Warning`` header for an unenforced response_format.
+
+    The server already logs the downgrade (see
+    :func:`_warn_response_format_not_enforced`), but that signal is only
+    visible to the operator.  This header surfaces the same fact to the API
+    caller so a client can tell that ``response_format`` fell back to
+    best-effort prompt injection rather than schema-enforced output (#1241).
+    Header values must be single-line ASCII, so the text is terse.
+    """
+    if _response_format_requests_strict(response_format):
+        text = (
+            "response_format strict json_schema not enforced; "
+            "grammar-constrained decoding unavailable, output is "
+            "best-effort and NOT schema-enforced"
+        )
+    else:
+        text = (
+            "response_format not enforced; grammar-constrained decoding "
+            "unavailable, output is best-effort"
+        )
+    return f'199 omlx "{text}"'
 
 
 # =============================================================================

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -499,6 +499,97 @@ class TestCompileGrammarForRequest:
         })
         assert result is None
 
+    # ---- #1241: strict json_schema response_format is a hard constraint ----
+
+    @staticmethod
+    def _strict_rf(strict):
+        return {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "t",
+                "strict": strict,
+                "schema": {"type": "object", "properties": {"a": {"type": "string"}}},
+            },
+        }
+
+    def test_strict_response_format_no_compiler_degrades_not_raises(self):
+        """strict:true response_format degrades to None (warn) rather than 400.
+
+        Reporter on #1241 listed explicit rejection as acceptable, but to avoid
+        a breaking behavior change we warn-and-fall-back instead of rejecting.
+        """
+        engine = _make_engine(grammar_compiler=None)
+        assert self._call(engine, response_format=self._strict_rf(True)) is None
+
+    def test_returns_none_when_no_compiler_and_nonstrict_response_format(self):
+        """strict:false response_format also degrades gracefully to None."""
+        engine = _make_engine(grammar_compiler=None)
+        assert self._call(engine, response_format=self._strict_rf(False)) is None
+
+    def test_returns_none_when_no_compiler_and_response_format_strict_absent(self):
+        """response_format without a strict flag defaults to best-effort (None)."""
+        engine = _make_engine(grammar_compiler=None)
+        result = self._call(engine, response_format={
+            "type": "json_schema",
+            "json_schema": {"name": "t", "schema": {"type": "object"}},
+        })
+        assert result is None
+
+    def test_compilation_error_strict_response_format_degrades_not_raises(self):
+        """A compile failure under strict:true degrades to None, not 400.
+
+        Mirrors the no-compiler path: response_format never hard-fails, even
+        when strict was requested (structured_outputs is the one that 400s).
+        """
+        compiler = MagicMock()
+        compiler.compile_json_schema.side_effect = RuntimeError("bad schema")
+        engine = _make_engine(grammar_compiler=compiler)
+        assert self._call(engine, response_format=self._strict_rf(True)) is None
+
+
+class TestResponseFormatRequestsStrict:
+    """Tests for _response_format_requests_strict."""
+
+    @staticmethod
+    def _call(response_format):
+        from omlx.server import _response_format_requests_strict
+        return _response_format_requests_strict(response_format)
+
+    def test_none(self):
+        assert self._call(None) is False
+
+    def test_json_object_not_strict(self):
+        assert self._call({"type": "json_object"}) is False
+
+    def test_text_not_strict(self):
+        assert self._call({"type": "text"}) is False
+
+    def test_json_schema_strict_true(self):
+        assert self._call({
+            "type": "json_schema",
+            "json_schema": {"name": "t", "strict": True, "schema": {}},
+        }) is True
+
+    def test_json_schema_strict_false(self):
+        assert self._call({
+            "type": "json_schema",
+            "json_schema": {"name": "t", "strict": False, "schema": {}},
+        }) is False
+
+    def test_json_schema_strict_absent(self):
+        assert self._call({
+            "type": "json_schema",
+            "json_schema": {"name": "t", "schema": {}},
+        }) is False
+
+    def test_pydantic_model_strict_true(self):
+        from omlx.api.openai_models import ResponseFormat, ResponseFormatJsonSchema
+        rf = ResponseFormat(
+            type="json_schema",
+            json_schema=ResponseFormatJsonSchema(name="t", strict=True, schema={}),
+        )
+        assert self._call(rf) is True
+
 
 # =========================================================================
 # GrammarConstraintProcessor

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -591,6 +591,47 @@ class TestResponseFormatRequestsStrict:
         assert self._call(rf) is True
 
 
+class TestResponseFormatRequestsGrammar:
+    """Tests for _response_format_requests_grammar — the gate that decides
+    whether an unenforced response_format earns a Warning header / fallback.
+    Only json_object and json_schema request grammar-constrained output; a
+    plain text format never asked for enforcement, so it must not warn
+    (#1241 review)."""
+
+    @staticmethod
+    def _call(response_format):
+        from omlx.server import _response_format_requests_grammar
+        return _response_format_requests_grammar(response_format)
+
+    def test_none(self):
+        assert self._call(None) is False
+
+    def test_text_does_not_request_grammar(self):
+        # The reviewer's case: type "text" must NOT emit a Warning header.
+        assert self._call({"type": "text"}) is False
+
+    def test_json_object(self):
+        assert self._call({"type": "json_object"}) is True
+
+    def test_json_schema(self):
+        assert self._call({
+            "type": "json_schema",
+            "json_schema": {"name": "t", "schema": {}},
+        }) is True
+
+    def test_pydantic_text_model(self):
+        from omlx.api.openai_models import ResponseFormat
+        assert self._call(ResponseFormat(type="text")) is False
+
+    def test_pydantic_json_schema_model(self):
+        from omlx.api.openai_models import ResponseFormat, ResponseFormatJsonSchema
+        rf = ResponseFormat(
+            type="json_schema",
+            json_schema=ResponseFormatJsonSchema(name="t", schema={}),
+        )
+        assert self._call(rf) is True
+
+
 class TestResponseFormatWarningHeader:
     """The unenforced-response_format degrade is surfaced to the caller as an
     RFC 7234 Warning response header, not just a server-side log (#1241)."""

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -591,6 +591,48 @@ class TestResponseFormatRequestsStrict:
         assert self._call(rf) is True
 
 
+class TestResponseFormatWarningHeader:
+    """The unenforced-response_format degrade is surfaced to the caller as an
+    RFC 7234 Warning response header, not just a server-side log (#1241)."""
+
+    @staticmethod
+    def _call(response_format):
+        from omlx.server import _response_format_warning_header
+        return _response_format_warning_header(response_format)
+
+    @staticmethod
+    def _strict_rf(strict):
+        return {
+            "type": "json_schema",
+            "json_schema": {"name": "t", "strict": strict, "schema": {}},
+        }
+
+    def test_strict_header_names_strict_intent(self):
+        header = self._call(self._strict_rf(True))
+        assert header.startswith('199 omlx "')
+        assert header.endswith('"')
+        assert "strict" in header
+        assert "NOT schema-enforced" in header
+
+    def test_non_strict_header_is_generic(self):
+        header = self._call(self._strict_rf(False))
+        assert header.startswith('199 omlx "')
+        assert "not enforced" in header
+        assert "strict" not in header
+
+    def test_json_object_header_is_generic(self):
+        header = self._call({"type": "json_object"})
+        assert header.startswith('199 omlx "')
+        assert "strict" not in header
+
+    def test_header_value_is_single_line_ascii(self):
+        # HTTP header values cannot contain CR/LF or non-ASCII bytes.
+        for rf in (self._strict_rf(True), {"type": "json_object"}):
+            header = self._call(rf)
+            header.encode("ascii")  # raises if non-ASCII
+            assert "\n" not in header and "\r" not in header
+
+
 # =========================================================================
 # GrammarConstraintProcessor
 # =========================================================================

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -619,6 +619,16 @@ class TestResponseFormatRequestsGrammar:
             "json_schema": {"name": "t", "schema": {}},
         }) is True
 
+    def test_json_schema_without_schema_maps_to_nothing(self):
+        # A json_schema that carries no schema compiles to no grammar, so it
+        # must not earn a Warning header claiming decoding was unavailable.
+        # Keeps the header in sync with what _build_format_element builds.
+        assert self._call({"type": "json_schema", "json_schema": {"name": "t"}}) is False
+        assert self._call({"type": "json_schema"}) is False
+
+    def test_unknown_type_does_not_request_grammar(self):
+        assert self._call({"type": "json"}) is False
+
     def test_pydantic_text_model(self):
         from omlx.api.openai_models import ResponseFormat
         assert self._call(ResponseFormat(type="text")) is False


### PR DESCRIPTION
`/v1/chat/completions` accepts `response_format` with `type: "json_schema"` and `strict: true`, returns 200, but the assistant content does not follow the schema. The request looks honored when it isn't, so a client has no way to tell that the output is unconstrained.

## Root cause

`response_format` is only schema-enforced when a grammar compiler is available. `_compile_grammar_for_request` (`server.py`) reads `engine.grammar_compiler`; when that is `None` (no xgrammar installed, or an engine that never installs one such as DFlash), or when grammar compilation raises, the request silently falls back to prompt injection (`server.py:2233`). The model is asked to produce JSON in the prompt, but nothing constrains decoding, so undeclared fields appear, required fields are dropped, and on larger inputs the content stops being valid JSON. `structured_outputs` already returns a 400 in this case; `response_format` was the silent path.

## Fix

The reporter asked for one of two things: enforce the schema, or signal that it wasn't. Enforcing on every engine is a larger change (it needs grammar wiring on engines that don't have a compiler at all). This PR does the signal, on both surfaces:

- **Operator-visible log.** The fallback now logs a warning instead of degrading silently. A `strict: true` request gets a message that names the unhonored strict intent.
- **Client-visible header.** The response carries an RFC 7234 `Warning` header (code 199) on both the streaming and non-streaming paths so the caller can detect the degrade without parsing the body. strict requests get a header that says the output is NOT schema-enforced; non-strict `response_format` requests get a generic one.

The request still returns 200 with best-effort content. I chose not to turn an accepted request into a 400. That is a breaking behavior change, and neither I nor the reporter owns this repo. If maintainers prefer a hard reject, the strict-detection helper (`_response_format_requests_strict`) is the single place to branch on.

## Scope

This addresses `/v1/chat/completions`, which is what the issue reports. `/v1/completions` and `/v1/messages` share `_compile_grammar_for_request`, so they get the warning log, but not the header. Extending the header to those endpoints is a separate change. Actually enforcing the schema on compiler-less engines (the other half of the reporter's ask) is also separate.

## Evidence

Live-tested against a DFlash model (`Qwen3.6-27B-4bit`), which has no grammar compiler, so every `response_format` request hits the fallback.

Strict `json_schema`, non-streaming. The body reproduces the bug from the issue (`src` instead of `dst`), and the header now flags it:

```
HTTP/1.1 200 OK
warning: 199 omlx "response_format strict json_schema not enforced; grammar-constrained decoding unavailable, output is best-effort and NOT schema-enforced"
content-type: application/json

{"choices":[{"message":{"role":"assistant","content":"{\"items\": [{\"id\": \"1\", \"src\": \"Hello.\"}]}"},"finish_reason":"stop"}], ...}
```

Strict `json_schema`, streaming (`stream: true`). Same header on the SSE response:

```
HTTP/1.1 200 OK
content-type: text/event-stream
warning: 199 omlx "response_format strict json_schema not enforced; grammar-constrained decoding unavailable, output is best-effort and NOT schema-enforced"
```

Non-strict `json_object`. Generic header, no strict wording:

```
HTTP/1.1 200 OK
warning: 199 omlx "response_format not enforced; grammar-constrained decoding unavailable, output is best-effort"
```

No `response_format` (control). No `Warning` header:

```
HTTP/1.1 200 OK
content-type: application/json
```

Unit tests: `tests/test_grammar.py` covers the strict-detection helper, the degrade-not-raise behavior, and the header text (strict vs generic, single-line ASCII). Full grammar suite is green (72 passed, 3 skipped, the skips are pre-existing).

Fixes #1241
