### PR TITLE
fix(server): fail loud on response_format grammar-compile failure

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2689,6 +2689,18 @@ def _compile_grammar_for_request(
                     "Install with: pip install 'omlx[grammar]'"
                 )
             raise HTTPException(status_code=400, detail=detail)
+        # response_format path: if a non-empty schema was actually
+        # requested, fail loud rather than silently ignoring it.
+        # json_object (empty schema {}) and the no-schema case return None.
+        if fmt.get("json_schema"):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Structured output requires xgrammar, but it is not "
+                    "available; cannot honor the requested response_format "
+                    "json_schema. Install with: pip install 'omlx[grammar]'"
+                ),
+            )
         return None
 
     try:
@@ -2698,14 +2710,17 @@ def _compile_grammar_for_request(
             )
         return _compile_bare_grammar(compiler, fmt)
     except Exception as e:
-        if structured_outputs is not None:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Grammar compilation error: {e}",
-            )
-        logger.warning("Grammar compilation from response_format failed, "
-                       "falling back to prompt injection: %s", e)
-    return None
+        # Fail loud. Reaching here means _build_format_element returned a
+        # non-None fmt (json_schema / grammar / regex / json_object), so a
+        # compiled grammar is genuinely required. Silently returning None on
+        # the response_format path degraded to UNCONSTRAINED generation, which
+        # emits wrong-shaped output the caller cannot detect — forbidden by the
+        # fail-fast policy. Surface the original xgrammar error (chained via
+        # `from e`) for both the structured_outputs and response_format paths.
+        raise HTTPException(
+            status_code=400,
+            detail=f"Grammar compilation error: {e}",
+        ) from e
 
 
 # =============================================================================

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -367,10 +367,24 @@ class TestCompileGrammarForRequest:
         assert "xgrammar" in exc_info.value.detail
 
     def test_returns_none_when_no_compiler_and_response_format(self):
-        """response_format gracefully falls back to None when no compiler."""
+        """json_object (no concrete schema) still falls back to None when no
+        compiler — only a requested json_schema must fail loud."""
         engine = _make_engine(grammar_compiler=None)
         result = self._call(engine, response_format={"type": "json_object"})
         assert result is None
+
+    def test_raises_when_no_compiler_and_response_format_json_schema(self):
+        """A requested json_schema must not be silently ignored when xgrammar
+        is unavailable — fail loud instead of unconstrained generation."""
+        from fastapi import HTTPException
+        engine = _make_engine(grammar_compiler=None)
+        with pytest.raises(HTTPException) as exc_info:
+            self._call(engine, response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "t", "schema": {"type": "object"}},
+            })
+        assert exc_info.value.status_code == 400
+        assert "xgrammar" in exc_info.value.detail
 
     def test_bare_json_schema(self):
         """No reasoning_parser: compile_json_schema called directly."""
@@ -487,17 +501,21 @@ class TestCompileGrammarForRequest:
         assert exc_info.value.status_code == 400
         assert "bad schema" in exc_info.value.detail
 
-    def test_compilation_error_returns_none_for_response_format(self):
-        """response_format compilation errors → graceful fallback to None."""
+    def test_compilation_error_raises_for_response_format(self):
+        """response_format compile errors fail loud (HTTP 400), not a silent
+        fallback to unconstrained generation that emits wrong-shaped output."""
+        from fastapi import HTTPException
         compiler = MagicMock()
         compiler.compile_json_schema.side_effect = RuntimeError("bad")
         engine = _make_engine(grammar_compiler=compiler)
 
-        result = self._call(engine, response_format={
-            "type": "json_schema",
-            "json_schema": {"name": "t", "schema": {"type": "object"}},
-        })
-        assert result is None
+        with pytest.raises(HTTPException) as exc_info:
+            self._call(engine, response_format={
+                "type": "json_schema",
+                "json_schema": {"name": "t", "schema": {"type": "object"}},
+            })
+        assert exc_info.value.status_code == 400
+        assert "bad" in exc_info.value.detail
 
 
 # =========================================================================


### PR DESCRIPTION
## Symptom
A `response_format` `json_schema` that fails to compile — or is requested when xgrammar isn't installed — returns `200` with unconstrained, wrong-shaped output the caller cannot detect.

## Root cause
`_compile_grammar_for_request` returned `None` on the `response_format` path when grammar compilation raised, and when no compiler was available but a schema was requested. `None` means "generate unconstrained," so a structured-output request silently degraded to free-form text.

## Fix
- On compile error, raise `HTTPException(400)` chained from the original xgrammar error (`from e`), matching the existing `structured_outputs` path.
- When xgrammar is unavailable but a non-empty `json_schema` was requested, raise `400` instead of ignoring it.

## Trade-offs / operator-visible change
Behavior change: a request that previously got a degraded `200` now gets a `400` carrying the compiler error. `json_object` (empty schema) and the no-schema case still return `None` (unconstrained), unchanged — only an explicitly requested schema fails loud.

## Verification
`tests/test_grammar.py`: updated the two tests that encoded the old silent-fallback contract to assert the `400`, and added a test for the no-compiler + `json_schema` case. `pytest -m "not slow and not integration" tests/test_grammar.py`: **58 passed, 3 skipped**.
