### PR TITLE
Lift TurboQuant toggle restriction on ParoQuant models

### DIFF
--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -456,6 +456,7 @@
   "modal.model_settings.turboquant_kv": "TurboQuant KV Cache",
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Lower bits = more compression, higher bits = better quality. Supports 2 to 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",
+  "modal.model_settings.paroquant_warning": "Warning: Compatibility with ParoQuant models is not fully verified; use with caution.",
   "modal.model_settings.mtp": "Native MTP",
   "modal.model_settings.mtp_hint": "Use the model's built-in MTP head for ~1.5× faster single-request decoding. (Qwen 3.5/3.6 and Deepseek-v4 only)<br><strong>Single-stream only: requests run one at a time.</strong><br>* mlx-lm PR <a href=\"https://github.com/ml-explore/mlx-lm/pull/990\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#990</a> by AirRunner, PR <a href=\"https://github.com/Blaizzy/mlx-lm/pull/15\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#15</a> by 0xClandestine",
   "modal.model_settings.mtp_conflict": "Disable DFlash and TurboQuant KV first — they patch the same path MTP relies on.",

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -456,6 +456,7 @@
   "modal.model_settings.turboquant_kv": "Caché KV TurboQuant",
   "modal.model_settings.turboquant_kv_hint": "Comprimir caché KV usando cuantización vectorial. Bits más bajos = más compresión, bits más altos = mejor calidad. Soporta de 2 a 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits por canal",
+  "modal.model_settings.paroquant_warning": "Advertencia: la compatibilidad con los modelos ParoQuant no está completamente verificada; utilícelo con precaución.",
   "modal.model_settings.mtp": "Native MTP",
   "modal.model_settings.mtp_hint": "Usa el módulo MTP integrado del modelo para una decodificación de solicitud única ~1.5× más rápida. (Solo Qwen 3.5/3.6 y Deepseek-v4)<br><strong>Solo flujo único: las solicitudes se procesan una a la vez.</strong><br>* mlx-lm PR <a href=\"https://github.com/ml-explore/mlx-lm/pull/990\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#990</a> by AirRunner, PR <a href=\"https://github.com/Blaizzy/mlx-lm/pull/15\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#15</a> by 0xClandestine",
   "modal.model_settings.mtp_conflict": "Disable DFlash and TurboQuant KV first — they patch the same path MTP relies on.",

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -456,6 +456,7 @@
   "modal.model_settings.turboquant_kv": "Cache KV TurboQuant",
   "modal.model_settings.turboquant_kv_hint": "Compressez le cache KV en utilisant la quantification vectorielle. Bits inférieurs = plus de compression, bits supérieurs = meilleure qualité. Supporte 2 à 8 bits.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits par canal",
+  "modal.model_settings.paroquant_warning": "Avertissement : la compatibilité avec les modèles ParoQuant n'est pas entièrement vérifiée ; utiliser avec précaution.",
   "modal.model_settings.mtp": "Native MTP",
   "modal.model_settings.mtp_hint": "Use the model's built-in MTP head for ~1.5× faster single-request decoding. (Qwen 3.5/3.6 and Deepseek-v4 only)<br><strong>Single-stream only: requests run one at a time.</strong><br>* mlx-lm PR <a href=\"https://github.com/ml-explore/mlx-lm/pull/990\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#990</a> by AirRunner, PR <a href=\"https://github.com/Blaizzy/mlx-lm/pull/15\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#15</a> by 0xClandestine",
   "modal.model_settings.mtp_conflict": "Disable DFlash and TurboQuant KV first — they patch the same path MTP relies on.",

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -456,6 +456,7 @@
   "modal.model_settings.turboquant_kv": "TurboQuant KV Cache",
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Reduces memory ~60-75% with near-lossless quality for long context.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",
+  "modal.model_settings.paroquant_warning": "注意: ParoQuantモデルとの互換性は完全に検証されていません。注意して使用してください。",
   "modal.model_settings.mtp": "Native MTP",
   "modal.model_settings.mtp_hint": "モデル内蔵の MTP head で単一リクエストのデコードを約 1.5 倍高速化。(Qwen 3.5/3.6 と Deepseek-v4 のみ)<br><strong>シングルストリーム専用: リクエストは 1 件ずつ処理されます。</strong><br>* mlx-lm PR <a href=\"https://github.com/ml-explore/mlx-lm/pull/990\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#990</a> by AirRunner, PR <a href=\"https://github.com/Blaizzy/mlx-lm/pull/15\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#15</a> by 0xClandestine",
   "modal.model_settings.mtp_conflict": "Disable DFlash and TurboQuant KV first — they patch the same path MTP relies on.",

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -456,6 +456,7 @@
   "modal.model_settings.turboquant_kv": "TurboQuant KV Cache",
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Reduces memory ~60-75% with near-lossless quality for long context.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",
+  "modal.model_settings.paroquant_warning": "주의: ParoQuant 모델과의 호환성이 완전히 검증되지 않았습니다. 사용에 유의하세요.",
   "modal.model_settings.mtp": "Native MTP",
   "modal.model_settings.mtp_hint": "모델 내장 MTP head 로 단일 요청 디코딩을 약 1.5배 빠르게. (Qwen 3.5/3.6, Deepseek-v4 전용)<br><strong>단일 스트림 전용: 요청은 한 번에 하나씩 처리됩니다.</strong><br>* mlx-lm PR <a href=\"https://github.com/ml-explore/mlx-lm/pull/990\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#990</a> by AirRunner, PR <a href=\"https://github.com/Blaizzy/mlx-lm/pull/15\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#15</a> by 0xClandestine",
   "modal.model_settings.mtp_conflict": "DFlash 와 TurboQuant KV 를 먼저 끄세요. 같은 경로를 패치하기 때문에 MTP 와 함께 쓸 수 없습니다.",

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -456,6 +456,7 @@
   "modal.model_settings.turboquant_kv": "TurboQuant KV-кэш",
   "modal.model_settings.turboquant_kv_hint": "Сжимайте KV-кэш с помощью векторного квантования. Меньшее число бит = сильнее сжатие, большее = лучше качество. Поддерживает от 2 до 8 бит.",
   "modal.model_settings.turboquant_kv_bits_label": "Битов на канал",
+  "modal.model_settings.paroquant_warning": "Предупреждение: совместимость с моделями ParoQuant не проверена полностью; используйте с осторожностью.",
   "modal.model_settings.mtp": "Native MTP",
   "modal.model_settings.mtp_hint": "Используйте встроенную MTP head модели для ~1.5× более быстрого декодирования одиночных запросов. (Только Qwen 3.5/3.6 и Deepseek-v4)<br><strong>Только один поток: запросы обрабатываются по одному.</strong><br>* mlx-lm PR <a href=\"https://github.com/ml-explore/mlx-lm/pull/990\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#990</a> by AirRunner, PR <a href=\"https://github.com/Blaizzy/mlx-lm/pull/15\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#15</a> by 0xClandestine",
   "modal.model_settings.mtp_conflict": "Disable DFlash and TurboQuant KV first — they patch the same path MTP relies on.",

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -456,6 +456,7 @@
   "modal.model_settings.turboquant_kv": "TurboQuant KV Cache",
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Reduces memory ~60-75% with near-lossless quality for long context.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",
+  "modal.model_settings.paroquant_warning": "警告：與 ParoQuant 模型的相容性尚未完全驗證；請謹慎使用。",
   "modal.model_settings.mtp": "Native MTP",
   "modal.model_settings.mtp_hint": "使用模型內建的 MTP head 將單一請求解碼速度提升約 1.5 倍。(僅限 Qwen 3.5/3.6 和 Deepseek-v4)<br><strong>單一串流：請求逐個處理。</strong><br>* mlx-lm PR <a href=\"https://github.com/ml-explore/mlx-lm/pull/990\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#990</a> by AirRunner, PR <a href=\"https://github.com/Blaizzy/mlx-lm/pull/15\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#15</a> by 0xClandestine",
   "modal.model_settings.mtp_conflict": "Disable DFlash and TurboQuant KV first — they patch the same path MTP relies on.",

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -456,6 +456,7 @@
   "modal.model_settings.turboquant_kv": "TurboQuant KV Cache",
   "modal.model_settings.turboquant_kv_hint": "Compress KV cache using vector quantization. Reduces memory ~60-75% with near-lossless quality for long context.",
   "modal.model_settings.turboquant_kv_bits_label": "Bits per channel",
+  "modal.model_settings.paroquant_warning": "警告：与 ParoQuant 模型的兼容性尚未完全验证；请谨慎使用。",
   "modal.model_settings.mtp": "Native MTP",
   "modal.model_settings.mtp_hint": "使用模型内置的 MTP head 将单一请求解码速度提升约 1.5 倍。(仅限 Qwen 3.5/3.6 和 Deepseek-v4)<br><strong>单一流：请求逐个处理。</strong><br>* mlx-lm PR <a href=\"https://github.com/ml-explore/mlx-lm/pull/990\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#990</a> by AirRunner, PR <a href=\"https://github.com/Blaizzy/mlx-lm/pull/15\" target=\"_blank\" rel=\"noopener\" class=\"text-blue-500 hover:text-blue-700 underline\">#15</a> by 0xClandestine",
   "modal.model_settings.mtp_conflict": "Disable DFlash and TurboQuant KV first — they patch the same path MTP relies on.",

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -581,14 +581,16 @@
                                         <div class="min-w-0">
                                             <span class="text-sm font-medium text-neutral-700">{{ t('modal.model_settings.turboquant_kv') }}</span>
                                             <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.turboquant_kv_hint') }}</p>
+                                            <p x-show="modelSettings.is_paroquant"
+                                               class="text-xs text-amber-600 mt-1">{{ t('modal.model_settings.paroquant_warning') }}</p>
                                         </div>
                                         <button type="button"
-                                                @click="if (!modelSettings.is_paroquant && !modelSettings.mtp_enabled && !modelSettings.vlm_mtp_enabled) modelSettings.turboquant_kv_enabled = !modelSettings.turboquant_kv_enabled"
-                                                :disabled="modelSettings.is_paroquant || modelSettings.mtp_enabled || modelSettings.vlm_mtp_enabled"
-                                                :title="modelSettings.is_paroquant ? modelSettings.paroquant_reason : (modelSettings.mtp_enabled || modelSettings.vlm_mtp_enabled ? '{{ t('modal.model_settings.mtp_conflict_turboquant') }}' : '')"
+                                                @click="if (!modelSettings.mtp_enabled && !modelSettings.vlm_mtp_enabled) modelSettings.turboquant_kv_enabled = !modelSettings.turboquant_kv_enabled"
+                                                :disabled="modelSettings.mtp_enabled || modelSettings.vlm_mtp_enabled"
+                                                :title="modelSettings.mtp_enabled || modelSettings.vlm_mtp_enabled ? '{{ t('modal.model_settings.mtp_conflict_turboquant') }}' : ''"
                                                 :class="[
                                                     modelSettings.turboquant_kv_enabled ? 'bg-black' : 'bg-neutral-200',
-                                                    (modelSettings.is_paroquant || modelSettings.mtp_enabled || modelSettings.vlm_mtp_enabled) ? 'opacity-40 cursor-not-allowed' : ''
+                                                    (modelSettings.mtp_enabled || modelSettings.vlm_mtp_enabled) ? 'opacity-40 cursor-not-allowed' : ''
                                                 ]"
                                                 class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                                             <span :class="modelSettings.turboquant_kv_enabled ? 'translate-x-5' : 'translate-x-0'"


### PR DESCRIPTION
I use ParoQuant model in openclaw and it works well without any collision.
However, since we cannot rule out potential hidden bugs, I replaced the hard restriction with a warning banner advising caution, while still allowing users to enable the option itself.

Key Changes:
Logic Update: Removed the modelSettings.is_paroquant condition from @click, :disabled, and :class attributes to allow the toggle to be operable even for ParoQuant models. (Mutual exclusivity is now maintained only with MTP, which remains incompatible).
UI Update: Designed a warning banner using x-show="modelSettings.is_paroquant" to display an amber warning icon and a cautionary notice when a ParoQuant model is detected.

Added Localization Strings
The multilingual translation strings for the warning banner have been added to the localization configuration files (such as ko.json and en.json) as follows:
"paroquant_turboquant_warning": "Warning: Using TurboQuant with ParoQuant models may cause accuracy degradation."