### PR TITLE
fix(cli): catch KeyboardInterrupt on server shutdown

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -277,7 +277,10 @@ def serve_command(args):
         )
 
         print(f"Starting server at http://{settings.server.host}:{settings.server.port}")
-        uvicorn.Server(uvicorn_config).run(sockets=[serve_socket])
+        try:
+            uvicorn.Server(uvicorn_config).run(sockets=[serve_socket])
+        except KeyboardInterrupt:
+            pass
     finally:
         # Uvicorn closes sockets during normal shutdown; this covers failures
         # after bind succeeds but before the server takes ownership.


### PR DESCRIPTION
 Currently stopping the server in the terminal with `Strg-C` produces this error:

```
INFO:     Application startup complete.
^CINFO:     Shutting down
INFO:     Waiting for application shutdown.
2026-06-01 07:11:54,035 - omlx.process_memory_enforcer - INFO - Process memory enforcer stopped
2026-06-01 07:11:54,035 - omlx.server - INFO - Process memory enforcer stopped
2026-06-01 07:11:54,035 - omlx.admin.hf_downloader - INFO - HF Downloader shut down
2026-06-01 07:11:54,035 - omlx.server - INFO - HF Downloader stopped
2026-06-01 07:11:54,035 - omlx.engine_pool - INFO - Engine pool shutdown complete
2026-06-01 07:11:54,036 - omlx.server - INFO - Engine pool shutdown
INFO:     Application shutdown complete.
INFO:     Finished server process [5029]
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.14/3.14.5/Frameworks/Python.framework/Versions/3.14/lib/python3.14/asyncio/runners.py", line 127, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Cellar/python@3.14/3.14.5/Frameworks/Python.framework/Versions/3.14/lib/python3.14/asyncio/base_events.py", line 719, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/fry/code-local/Playground/temp/omlx/.venv/bin/omlx", line 6, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/fry/code-local/Playground/temp/omlx/omlx/cli.py", line 750, in main
    serve_command(args)
    ~~~~~~~~~~~~~^^^^^^
  File "/Users/fry/code-local/Playground/temp/omlx/omlx/cli.py", line 280, in serve_command
    uvicorn.Server(uvicorn_config).run(sockets=[serve_socket])
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fry/code-local/Playground/temp/omlx/.venv/lib/python3.14/site-packages/uvicorn/server.py", line 75, in run
    return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())
  File "/opt/homebrew/Cellar/python@3.14/3.14.5/Frameworks/Python.framework/Versions/3.14/lib/python3.14/asyncio/runners.py", line 204, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Cellar/python@3.14/3.14.5/Frameworks/Python.framework/Versions/3.14/lib/python3.14/asyncio/runners.py", line 132, in run
    raise KeyboardInterrupt()
KeyboardInterrupt
```

While harmless, it is very noisy and not helpful.

This simple fix catches the keyboard interrupt (and only that).