### PR TITLE
fix(cache): suppress spurious "failed to save block" warning

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -2606,14 +2606,4 @@ class PagedSSDCacheManager(CacheManager):
         """
         return self._max_size
 
-    @property
-    def is_read_only(self) -> bool:
-        """
-        True when the cache is configured with no write capacity
-        (hot-cache-only mode with no hot cache capacity).
 
-        In this state, ``save_block()`` intentionally skips persistence
-        and returns ``False``. Callers should treat the "failure" as
-        expected rather than a real error.
-        """
-        return self._hot_cache_only and not self._hot_cache_enabled

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -1419,6 +1419,10 @@ class PagedSSDCacheManager(CacheManager):
 
             if self._hot_cache_only:
                 # Hot cache disabled but hot_cache_only set: block is not retained.
+                logger.info(
+                    f"Hot cache only with no capacity, "
+                    f"skipping block {block_hash.hex()[:16]}"
+                )
                 return False
 
             # SSD path: add to index for SSD file tracking

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -2605,3 +2605,15 @@ class PagedSSDCacheManager(CacheManager):
             Configured maximum cache size in bytes.
         """
         return self._max_size
+
+    @property
+    def is_read_only(self) -> bool:
+        """
+        True when the cache is configured with no write capacity
+        (hot-cache-only mode with no hot cache capacity).
+
+        In this state, ``save_block()`` intentionally skips persistence
+        and returns ``False``. Callers should treat the "failure" as
+        expected rather than a real error.
+        """
+        return self._hot_cache_only and not self._hot_cache_enabled

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -2605,5 +2605,3 @@ class PagedSSDCacheManager(CacheManager):
             Configured maximum cache size in bytes.
         """
         return self._max_size
-
-

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -645,14 +645,10 @@ class BlockAwarePrefixCache(CacheManager):
                             f"tokens [{global_start}:{global_end}], {len(block_kv_data)} layers"
                         )
                     else:
-                        if not (
-                            self.paged_ssd_cache._hot_cache_only
-                            and not self.paged_ssd_cache._hot_cache_enabled
-                        ):
-                            logger.warning(
-                                f"Block {block.block_id} was not persisted "
-                                f"to tiered cache"
-                            )
+                        logger.info(
+                            f"Block {block.block_id} was not persisted "
+                            f"to tiered cache"
+                        )
                         # Persistence failed: roll back metadata so we don't
                         # retain a block that cannot be reconstructed later.
                         self.paged_cache.free_block(block.block_id)

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -645,9 +645,16 @@ class BlockAwarePrefixCache(CacheManager):
                             f"tokens [{global_start}:{global_end}], {len(block_kv_data)} layers"
                         )
                     else:
-                        logger.info(
-                            f"Failed to save block {block.block_id} to tiered cache"
-                        )
+                        if self.paged_ssd_cache.is_read_only:
+                            logger.debug(
+                                f"Block {block.block_id} not saved: "
+                                f"cache is read-only"
+                            )
+                        else:
+                            logger.warning(
+                                f"Block {block.block_id} was not persisted "
+                                f"to tiered cache"
+                            )
                         # Persistence failed: roll back metadata so we don't
                         # retain a block that cannot be reconstructed later.
                         self.paged_cache.free_block(block.block_id)

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -645,7 +645,10 @@ class BlockAwarePrefixCache(CacheManager):
                             f"tokens [{global_start}:{global_end}], {len(block_kv_data)} layers"
                         )
                     else:
-                        if not self.paged_ssd_cache.is_read_only:
+                        if not (
+                            self.paged_ssd_cache._hot_cache_only
+                            and not self.paged_ssd_cache._hot_cache_enabled
+                        ):
                             logger.warning(
                                 f"Block {block.block_id} was not persisted "
                                 f"to tiered cache"

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -645,12 +645,7 @@ class BlockAwarePrefixCache(CacheManager):
                             f"tokens [{global_start}:{global_end}], {len(block_kv_data)} layers"
                         )
                     else:
-                        if self.paged_ssd_cache.is_read_only:
-                            logger.debug(
-                                f"Block {block.block_id} not saved: "
-                                f"cache is read-only"
-                            )
-                        else:
+                        if not self.paged_ssd_cache.is_read_only:
                             logger.warning(
                                 f"Block {block.block_id} was not persisted "
                                 f"to tiered cache"

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -645,7 +645,7 @@ class BlockAwarePrefixCache(CacheManager):
                             f"tokens [{global_start}:{global_end}], {len(block_kv_data)} layers"
                         )
                     else:
-                        logger.warning(
+                        logger.info(
                             f"Failed to save block {block.block_id} to tiered cache"
                         )
                         # Persistence failed: roll back metadata so we don't

--- a/tests/test_hot_cache.py
+++ b/tests/test_hot_cache.py
@@ -1242,3 +1242,98 @@ class TestSSDWriteDrops:
                 assert block_hash not in mgr._pending_write_hashes
         finally:
             mgr.close()
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestReadOnlyCache:
+    """Verify is_read_only property and save_block behavior when
+    hot_cache_only=True but hot_cache_max_bytes=0 (no write capacity)."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "read_only",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=0,
+            hot_cache_only=True,
+        )
+        yield mgr
+        mgr.close()
+
+    def _make_cache_data(self, num_layers=2):
+        return [
+            (
+                mx.zeros((1, 8, 32, 64)),
+                mx.zeros((1, 8, 32, 64)),
+            )
+            for _ in range(num_layers)
+        ]
+
+    def test_is_read_only_true_when_no_capacity(self, manager):
+        """hot_cache_only=True with hot_cache_max_bytes=0 means no write tier."""
+        assert manager.is_read_only is True
+
+    def test_is_read_only_false_when_hot_cache_has_capacity(self, tmp_path):
+        """hot_cache_only=True with positive capacity means write-back is active."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "has_capacity",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=10 * 1024**2,
+            hot_cache_only=True,
+        )
+        try:
+            assert mgr.is_read_only is False
+        finally:
+            mgr.close()
+
+    def test_is_read_only_false_when_ssd_active(self, tmp_path):
+        """hot_cache_only=False (normal SSD mode) is never read-only."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_active",
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=0,
+            hot_cache_only=False,
+        )
+        try:
+            assert mgr.is_read_only is False
+        finally:
+            mgr.close()
+
+    def test_save_block_returns_false_and_logs_info(self, manager, caplog):
+        """save_block returns False and logs at INFO, not WARNING."""
+        import logging
+
+        block_hash = b"read_only_save_test"
+        cache_data = self._make_cache_data()
+
+        with caplog.at_level(logging.INFO, logger="omlx.cache.paged_ssd_cache"):
+            result = manager.save_block(
+                block_hash=block_hash,
+                cache_data=cache_data,
+                token_count=32,
+                model_name="test-model",
+                layer_cache_types=["KVCache"] * 2,
+            )
+
+        assert result is False
+        assert not manager.has_block(block_hash)
+
+        # Must have an INFO log about the skip
+        info_lines = [
+            r.message
+            for r in caplog.records
+            if "skipping block" in r.message
+        ]
+        assert info_lines, "expected INFO log about skipping block"
+
+        # No WARNING about block persistence failure should be emitted
+        persist_warnings = [
+            r.message
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "tiered cache" in r.message
+        ]
+        assert not persist_warnings, (
+            f"expected no WARNING about tiered cache persistence, "
+            f"got: {persist_warnings}"
+        )

--- a/tests/test_hot_cache.py
+++ b/tests/test_hot_cache.py
@@ -1246,8 +1246,8 @@ class TestSSDWriteDrops:
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
 class TestReadOnlyCache:
-    """Verify is_read_only property and save_block behavior when
-    hot_cache_only=True but hot_cache_max_bytes=0 (no write capacity)."""
+    """Verify save_block behavior when hot_cache_only=True but
+    hot_cache_max_bytes=0 (no write capacity) — no WARNING is emitted."""
 
     @pytest.fixture
     def manager(self, tmp_path):
@@ -1268,36 +1268,6 @@ class TestReadOnlyCache:
             )
             for _ in range(num_layers)
         ]
-
-    def test_is_read_only_true_when_no_capacity(self, manager):
-        """hot_cache_only=True with hot_cache_max_bytes=0 means no write tier."""
-        assert manager.is_read_only is True
-
-    def test_is_read_only_false_when_hot_cache_has_capacity(self, tmp_path):
-        """hot_cache_only=True with positive capacity means write-back is active."""
-        mgr = PagedSSDCacheManager(
-            cache_dir=tmp_path / "has_capacity",
-            max_size_bytes=100 * 1024**2,
-            hot_cache_max_bytes=10 * 1024**2,
-            hot_cache_only=True,
-        )
-        try:
-            assert mgr.is_read_only is False
-        finally:
-            mgr.close()
-
-    def test_is_read_only_false_when_ssd_active(self, tmp_path):
-        """hot_cache_only=False (normal SSD mode) is never read-only."""
-        mgr = PagedSSDCacheManager(
-            cache_dir=tmp_path / "ssd_active",
-            max_size_bytes=100 * 1024**2,
-            hot_cache_max_bytes=0,
-            hot_cache_only=False,
-        )
-        try:
-            assert mgr.is_read_only is False
-        finally:
-            mgr.close()
 
     def test_save_block_returns_false_and_logs_info(self, manager, caplog):
         """save_block returns False and logs at INFO, not WARNING."""


### PR DESCRIPTION
This fixes the somewhat confusing warning:

```
omlx.cache.prefix_cache - WARNING - Failed to save block 1 to tiered cache
```

When `Hot Cache Only` is enabled. The commit message below with more detail was generated by my coding agent:

---

When running with `Hot Cache Only` and `Cache Enabled` (hot-cache-only mode with 0B hot cache capacity), every block save attempt is intentionally skipped — there is no storage tier to write to. Previously this emitted a `WARNING`-level `"Failed to save block N to tiered cache"` that appeared to be a real failure.

**Changes:**

1. **`paged_ssd_cache.py`** — the hot-cache-only skip path in `save_block` now logs at `INFO` with `"Hot cache only with no capacity, skipping block ..."`, making the reason visible and clear.

2. **`prefix_cache.py`** — the caller's message is downgraded from `WARNING` to `INFO` and reworded to `"Block N was not persisted to tiered cache"`. This is safe because every `False` return from `save_block` already logs its own specific reason at the appropriate level (error for exceptions, warning for queue full, info for read-only skip).

3. **`tests/test_hot_cache.py`** — added `TestReadOnlyCache` verifying that `save_block` returns `False` and no `WARNING` about tiered cache persistence is emitted in the read-only configuration.

