### PR TITLE
fix(api): trim tool call function names

### DIFF
--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -146,6 +146,11 @@ class FunctionCall(BaseModel):
     name: str
     arguments: str  # JSON string
 
+    @field_validator("name", mode="before")
+    @classmethod
+    def _normalize_name(cls, v: Any) -> str:
+        return str(v).strip() if v is not None else ""
+
     @field_validator("arguments", mode="before")
     @classmethod
     def _validate_arguments_json(cls, v: Any) -> str:

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -155,6 +155,13 @@ class TestFunctionCallAndToolCall:
         assert fc.name == "no_args"
         assert fc.arguments == "{}"
 
+    def test_function_call_strips_name_whitespace(self):
+        """Model-emitted function names must not include incidental whitespace."""
+        fc = FunctionCall(name="Bash\n\n", arguments={})
+
+        assert fc.name == "Bash"
+        assert fc.arguments == "{}"
+
     def test_tool_call(self):
         """Test creating tool call."""
         tc = ToolCall(


### PR DESCRIPTION
## Summary

Trim incidental whitespace from parsed tool-call function names.

## Problem

When using oMLX behind Claude Code's Anthropic `/v1/messages` API, GLM-4.5-Air can emit tool-use names with trailing newlines, for example `Bash\n`, `Read\n`, or `WebSearch\n\n`.

Claude Code treats tool names as exact identifiers, so the response is rejected as:

```text
Error: No such tool available: Bash\n
```

The underlying tool exists as `Bash`; the generated name just contains incidental whitespace.

## Change

Normalize `FunctionCall.name` with `strip()` at the Pydantic model boundary. This keeps downstream OpenAI and Anthropic response conversion from propagating invalid tool names.

## Validation

- Added a unit test covering `FunctionCall(name="Bash\n\n", arguments={})`.
- Ran `uv run --dev pytest tests/test_openai_models.py -v`: 67 passed.
