### PR TITLE
feat(mac): refresh Swift app onboarding and UI polish

### DIFF
--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -96,7 +96,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Native macOS app for the oMLX server"
+            "value" : "Local AI, no more waiting on your Mac."
           }
         }
       }
@@ -2935,13 +2935,13 @@
       }
     },
     "menubar.header.running" : {
-      "comment" : "Menubar status header when the server is running; placeholders are PID and port",
+      "comment" : "Menubar status header when the server is running; placeholder is the port",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Server: running · pid %1$@ · :%2$@"
+            "value" : "Server: running · :%@"
           }
         }
       }
@@ -2983,13 +2983,13 @@
       }
     },
     "menubar.header.unresponsive" : {
-      "comment" : "Menubar status header when the server is unresponsive; placeholder is PID",
+      "comment" : "Menubar status header when the server is unresponsive",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Server: unresponsive · pid %@ (auto-recover or Force Restart)"
+            "value" : "Server: unresponsive (auto-recover or Force Restart)"
           }
         }
       }
@@ -9936,7 +9936,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Session Stats"
+            "value" : "Serving Stats"
           }
         },
         "ja" : {
@@ -9965,6 +9965,66 @@
         }
       }
     },
+    "status.speed.prompt_processing" : {
+      "comment" : "Label for average prompt-processing speed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prompt Processing"
+          }
+        }
+      }
+    },
+    "status.speed.prompt_processing_note" : {
+      "comment" : "Note after prompt-processing speed label",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(excl. cached)"
+          }
+        }
+      }
+    },
+    "status.speed.prompt_processing.tile" : {
+      "comment" : "Tile label for average prompt-processing speed excluding cached tokens",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prompt Processing (excl. cached)"
+          }
+        }
+      }
+    },
+    "status.speed.section_label" : {
+      "comment" : "Header label above average serving speed metrics",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Average Speed"
+          }
+        }
+      }
+    },
+    "status.speed.token_generation" : {
+      "comment" : "Label for average token-generation speed",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token Generation"
+          }
+        }
+      }
+    },
     "status.system.subtitle" : {
       "comment" : "Subtitle of the System section showing CPU architecture and macOS version; placeholders are the architecture string and macOS major.minor numbers",
       "extractionState" : "extracted_with_value",
@@ -9983,7 +10043,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cached"
+            "value" : "Cached Tokens"
+          }
+        }
+      }
+    },
+    "status.tile.cache_efficiency" : {
+      "comment" : "Stat tile label for cache efficiency percentage",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache Efficiency"
           }
         }
       }
@@ -10052,7 +10124,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Total Tokens"
+            "value" : "Total Prefill Tokens"
           }
         }
       }
@@ -10112,7 +10184,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Download in the background, install on next launch"
+            "value" : "Download in the background, then show Install & Restart"
           }
         }
       }
@@ -10361,7 +10433,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enter your API key"
+            "value" : "Create an API key"
           }
         }
       }
@@ -10385,7 +10457,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This key is also your Web Dashboard login password. Use something memorable, and keep it private."
+            "value" : "This key is also your Web Dashboard login password."
           }
         }
       }
@@ -10673,7 +10745,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Run an MLX server on your Mac. Keep agent context warm with smart caching, then plug Claude Code, OpenClaw, Cursor, and other tools into localhost."
+            "value" : "macOS-native MLX server with smart caching.\nClaude Code, OpenClaw, and Cursor respond in 5 seconds, not 90."
+          }
+        }
+      }
+    },
+    "welcome.header.subtitle" : {
+      "comment" : "Short tagline under the Welcome wizard's main heading",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local AI, no more waiting."
           }
         }
       }
@@ -10697,7 +10781,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Local AI,\nno more waiting."
+            "value" : "oMLX"
           }
         }
       }
@@ -10781,7 +10865,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Where downloaded and imported models are stored."
+            "value" : "Where downloaded models are stored."
           }
         }
       }

--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -2941,7 +2941,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Server: running · :%@"
+            "value" : "Server: running (port %@)"
           }
         }
       }

--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -1613,6 +1613,18 @@
         }
       }
     },
+    "common.back" : {
+      "comment" : "Back button label",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back"
+          }
+        }
+      }
+    },
     "common.open" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -7372,7 +7384,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Default 8080. Server restarts on save."
+            "value" : "Default 8000. Server restarts on save."
           }
         }
       }
@@ -10318,54 +10330,6 @@
         }
       }
     },
-    "welcome.api_key.confirm.label" : {
-      "comment" : "Row label for the API key confirmation field",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confirm"
-          }
-        }
-      }
-    },
-    "welcome.api_key.confirm.sub" : {
-      "comment" : "Sublabel for the Confirm API key field",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Re-enter the key to catch typos"
-          }
-        }
-      }
-    },
-    "welcome.api_key.generate" : {
-      "comment" : "Button label that mints a random API key",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generate"
-          }
-        }
-      }
-    },
-    "welcome.api_key.generate.help" : {
-      "comment" : "Tooltip on the Generate API key button",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generate a random 40-char API key"
-          }
-        }
-      }
-    },
     "welcome.api_key.hide" : {
       "comment" : "Tooltip on the eye-slash button that masks the API key field",
       "extractionState" : "manual",
@@ -10391,25 +10355,13 @@
       }
     },
     "welcome.api_key.placeholder" : {
-      "comment" : "Placeholder text inside the API key text fields",
+      "comment" : "Placeholder text inside the API key text field",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "sk-omlx-…"
-          }
-        }
-      }
-    },
-    "welcome.api_key.section" : {
-      "comment" : "Section heading above the API key rows in Welcome wizard",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API Key"
+            "value" : "Enter your API key"
           }
         }
       }
@@ -10427,13 +10379,13 @@
       }
     },
     "welcome.api_key.sub" : {
-      "comment" : "Sublabel describing API key format requirements",
+      "comment" : "Sublabel explaining API key usage",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "At least 4 printable characters, no whitespace"
+            "value" : "This key is also your Web Dashboard login password. Use something memorable, and keep it private."
           }
         }
       }
@@ -10486,32 +10438,32 @@
         }
       }
     },
-    "welcome.button.open_admin" : {
-      "comment" : "Secondary footer button: start server and open the browser dashboard",
+    "welcome.button.get_started" : {
+      "comment" : "Primary footer button that advances from the intro to setup",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Open Admin Panel & Close"
+            "value" : "Get Started"
           }
         }
       }
     },
-    "welcome.button.reset" : {
-      "comment" : "Clear the Model Directory override",
+    "welcome.button.open_dashboard" : {
+      "comment" : "Footer button that opens the local web dashboard",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reset"
+            "value" : "Open Web Dashboard"
           }
         }
       }
     },
     "welcome.button.start_server" : {
-      "comment" : "Primary footer button that spawns the server and closes the wizard",
+      "comment" : "Primary footer button that spawns the server",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -10529,7 +10481,43 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Starting…"
+            "value" : "Starting Server..."
+          }
+        }
+      }
+    },
+    "welcome.complete.description" : {
+      "comment" : "Description on the Welcome completion page",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "oMLX is running locally at http://127.0.0.1:%@. Open the web dashboard to download your first model, manage settings, and connect your coding tools."
+          }
+        }
+      }
+    },
+    "welcome.complete.status" : {
+      "comment" : "Short success status on the Welcome completion page",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server started. Dashboard is ready."
+          }
+        }
+      }
+    },
+    "welcome.complete.title" : {
+      "comment" : "Heading on the Welcome completion page",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All set!"
           }
         }
       }
@@ -10554,18 +10542,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Invalid port."
-          }
-        }
-      }
-    },
-    "welcome.error.key_mismatch" : {
-      "comment" : "Welcome wizard validation: confirm field differs",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "API keys do not match."
           }
         }
       }
@@ -10697,7 +10673,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LLM inference, optimized for your Mac"
+            "value" : "Run an MLX server on your Mac. Keep agent context warm with smart caching, then plug Claude Code, OpenClaw, Cursor, and other tools into localhost."
+          }
+        }
+      }
+    },
+    "welcome.header.meta" : {
+      "comment" : "Short metadata line on the Welcome intro page",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple Silicon · macOS-native · Apache 2.0"
           }
         }
       }
@@ -10709,31 +10697,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Welcome to oMLX"
-          }
-        }
-      }
-    },
-    "welcome.hint.models_library" : {
-      "comment" : "Hint line pointing the user to Downloads after first-run",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your model library starts empty — visit Downloads to fetch your first model."
-          }
-        }
-      }
-    },
-    "welcome.hint.reopen" : {
-      "comment" : "Hint line telling the user how to get back to the Welcome wizard",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You can re-open this wizard anytime from the menubar."
+            "value" : "Local AI,\nno more waiting."
           }
         }
       }
@@ -10745,7 +10709,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Stored in `~/.omlx/settings.json`. Sub-keys for individual apps can be added later in Security."
+            "value" : "Settings are stored in ~/.omlx/settings.json."
           }
         }
       }
@@ -10757,19 +10721,43 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Confirm where weights live and pick an API key. You can change either later in Settings."
+            "value" : "Choose where models live, pick a port, and create the API key you'll use from apps and the web dashboard."
           }
         }
       }
     },
-    "welcome.storage.base_dir.label" : {
-      "comment" : "Row label for the Base Directory picker in Welcome wizard",
+    "welcome.setup.title" : {
+      "comment" : "Heading on the Welcome setup page",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Base Directory"
+            "value" : "Set up your local server"
+          }
+        }
+      }
+    },
+    "welcome.setup.local.title" : {
+      "comment" : "Title for the local server setup card",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local server"
+          }
+        }
+      }
+    },
+    "welcome.setup.local.body" : {
+      "comment" : "Body for the local server setup card",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "oMLX binds to 127.0.0.1 on first run, so clients on this Mac can use it without exposing the server to your network."
           }
         }
       }
@@ -10786,26 +10774,14 @@
         }
       }
     },
-    "welcome.storage.model_dir.placeholder" : {
-      "comment" : "Placeholder string shown when Model Directory is unset; placeholder is the base path's leaf name",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "<%@>/models"
-          }
-        }
-      }
-    },
     "welcome.storage.model_dir.sub" : {
-      "comment" : "Sublabel hinting that Model Directory is optional",
+      "comment" : "Sublabel explaining the model directory",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Optional — defaults to <base>/models"
+            "value" : "Where downloaded and imported models are stored."
           }
         }
       }
@@ -10823,25 +10799,13 @@
       }
     },
     "welcome.storage.port.sub" : {
-      "comment" : "Sublabel for the port field with the recommended range",
+      "comment" : "Sublabel for the port field with the recommended default",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1024-65535 recommended; default 8080"
-          }
-        }
-      }
-    },
-    "welcome.storage.section" : {
-      "comment" : "Section heading above the Storage rows in Welcome wizard",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Storage"
+            "value" : "Default 8000. Change this only if the port is already in use."
           }
         }
       }

--- a/apps/omlx-mac/Scripts/build.sh
+++ b/apps/omlx-mac/Scripts/build.sh
@@ -9,7 +9,7 @@
 #      any new minor/patch within the pin range each build
 #   2. (auto) rebuild the venvstacks export if sources have drifted
 #   3. stage the Swift `.app` and copy the venvstacks-produced Python
-#      layers into Contents/Frameworks/ verbatim
+#      layers into Contents/Resources/Python/ verbatim
 #   4. embed the omlx package from the worktree and ad-hoc sign
 #
 # venvstacks is the single source of truth for the bundle's Python
@@ -111,6 +111,44 @@ ok()   { printf "${GREEN}[build.sh]${RESET} %s\n" "$*"; }
 warn() { printf "${YELLOW}[build.sh]${RESET} %s\n" "$*"; }
 die()  { printf "${RED}[build.sh ERROR]${RESET} %s\n" "$*" >&2; exit 1; }
 
+_is_mach_o_file() {
+    local path="$1"
+    local type
+    type="$(file -b "$path" 2>/dev/null || true)"
+    [[ "$type" == *"Mach-O"* ]]
+}
+
+_sign_embedded_mach_o_files() {
+    local root="$1"
+    local count=0
+
+    while IFS= read -r -d '' path; do
+        case "$path" in
+            *.dSYM/*) continue ;;
+        esac
+        _is_mach_o_file "$path" || continue
+        codesign --force --sign - "$path" >/dev/null 2>&1
+        count=$((count + 1))
+    done < <(find "$root" -type f -print0)
+
+    ok "  + signed $count embedded Mach-O files"
+}
+
+_app_python_layers_path() {
+    local app="$1"
+    for candidate in \
+        "$app/Contents/Resources/Python" \
+        "$app/Contents/Python" \
+        "$app/Contents/Frameworks"
+    do
+        if [ -d "$candidate/cpython-3.11" ] && [ -d "$candidate/framework-mlx-base" ]; then
+            printf "%s\n" "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
 if [ "$SWIFT_REBUILD" -eq 1 ] && [ "$BARE" -eq 0 ] && [ ! -d "$LOCAL_EXPORT" ]; then
     die "Swift rebuild requires existing venvstacks export at $LOCAL_EXPORT. Run build.sh release first."
 fi
@@ -157,8 +195,8 @@ resolve_donor_layers() {
     # Explicit OMLX_DONOR_APP override → use it, skip rebuild logic entirely.
     if [ -n "$OMLX_DONOR_APP_SET" ]; then
         [ -d "$OMLX_DONOR_APP" ] || die "OMLX_DONOR_APP set but not found: $OMLX_DONOR_APP"
-        DONOR_LAYERS="$OMLX_DONOR_APP/Contents/Python"
-        [ -d "$DONOR_LAYERS" ] || DONOR_LAYERS="$OMLX_DONOR_APP/Contents/Frameworks"
+        DONOR_LAYERS="$(_app_python_layers_path "$OMLX_DONOR_APP")" \
+            || die "OMLX_DONOR_APP missing bundled Python layers: $OMLX_DONOR_APP"
         DONOR_SOURCE="OMLX_DONOR_APP=$OMLX_DONOR_APP"
         return
     fi
@@ -176,8 +214,8 @@ resolve_donor_layers() {
                 _local_export_fresh \
                     || warn "Local export fingerprint mismatch; using stale layers (--no-rebuild-donor)."
             elif [ -d "$OMLX_DONOR_APP" ]; then
-                DONOR_LAYERS="$OMLX_DONOR_APP/Contents/Python"
-                [ -d "$DONOR_LAYERS" ] || DONOR_LAYERS="$OMLX_DONOR_APP/Contents/Frameworks"
+                DONOR_LAYERS="$(_app_python_layers_path "$OMLX_DONOR_APP")" \
+                    || die "Fallback donor missing bundled Python layers: $OMLX_DONOR_APP"
                 DONOR_SOURCE="$OMLX_DONOR_APP (fallback, --no-rebuild-donor)"
             else
                 die "No donor available: $LOCAL_EXPORT and $OMLX_DONOR_APP both missing, --no-rebuild-donor prevents rebuild."
@@ -269,9 +307,9 @@ if [ "$BARE" -eq 1 ]; then
     exit 0
 fi
 
-FRAMEWORKS_DIR="$STAGED_APP/Contents/Frameworks"
 RESOURCES_DIR="$STAGED_APP/Contents/Resources"
-mkdir -p "$FRAMEWORKS_DIR" "$RESOURCES_DIR"
+PYTHON_DIR="$RESOURCES_DIR/Python"
+mkdir -p "$PYTHON_DIR" "$RESOURCES_DIR"
 
 # --- Embed Python layers --------------------------------------------------
 
@@ -281,15 +319,15 @@ log "Using donor: $DONOR_SOURCE"
 [ -d "$DONOR_LAYERS/framework-mlx-base" ] || die "Donor missing framework-mlx-base at $DONOR_LAYERS"
 
 log "Copying cpython-3.11 from donor…"
-ditto "$DONOR_LAYERS/cpython-3.11" "$FRAMEWORKS_DIR/cpython-3.11"
+ditto "$DONOR_LAYERS/cpython-3.11" "$PYTHON_DIR/cpython-3.11"
 ok "  + cpython-3.11"
 
 log "Copying framework-mlx-base from donor (~1 GB)…"
-ditto "$DONOR_LAYERS/framework-mlx-base" "$FRAMEWORKS_DIR/framework-mlx-base"
+ditto "$DONOR_LAYERS/framework-mlx-base" "$PYTHON_DIR/framework-mlx-base"
 ok "  + framework-mlx-base"
 
 if [ -d "$DONOR_LAYERS/__venvstacks__" ]; then
-    ditto "$DONOR_LAYERS/__venvstacks__" "$FRAMEWORKS_DIR/__venvstacks__"
+    ditto "$DONOR_LAYERS/__venvstacks__" "$PYTHON_DIR/__venvstacks__"
     ok "  + __venvstacks__ metadata"
 fi
 
@@ -363,13 +401,16 @@ fi
 
 # --- Re-sign ad-hoc -------------------------------------------------------
 #
-# Even with CODE_SIGNING_ALLOWED=NO during xcodebuild, we re-sign the staged
-# bundle ad-hoc so Gatekeeper doesn't refuse to launch it from a non-derived
-# location on first quarantine attribute.
+# Even with CODE_SIGNING_ALLOWED=NO during xcodebuild, the staged bundle must
+# have a coherent app-bundle signature. Sign embedded native Python/MLX
+# libraries first, then seal the outer app bundle so TCC can match Full Disk
+# Access grants against the app identity instead of a bare linker signature.
 
-log "Ad-hoc resigning outer bundle…"
-codesign --force --sign - "$STAGED_APP" >/dev/null 2>&1 || \
-    warn "outer codesign emitted a warning; the app may still launch."
+log "Ad-hoc signing embedded native code…"
+_sign_embedded_mach_o_files "$PYTHON_DIR"
+
+log "Ad-hoc resigning app bundle…"
+codesign --force --sign - "$STAGED_APP"
 
 # Drop quarantine attributes so the bundle launches from anywhere.
 xattr -dr com.apple.quarantine "$STAGED_APP" 2>/dev/null || true

--- a/apps/omlx-mac/Scripts/build.sh
+++ b/apps/omlx-mac/Scripts/build.sh
@@ -33,6 +33,7 @@
 #   apps/omlx-mac/Scripts/build.sh debug              # Debug build instead
 #   apps/omlx-mac/Scripts/build.sh swift              # rebuild Swift app only; reuse existing _export/
 #   apps/omlx-mac/Scripts/build.sh swift debug        # Debug Swift app rebuild; reuse existing _export/
+#   apps/omlx-mac/Scripts/build.sh swift-fast         # like swift, but skip embedded native signing
 #   apps/omlx-mac/Scripts/build.sh release --bare     # skip Python embed
 #                                                       (no server, just the
 #                                                       AppView shell)
@@ -51,10 +52,18 @@
 set -euo pipefail
 
 SWIFT_REBUILD=0
-if [ "$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')" = "swift" ]; then
-    SWIFT_REBUILD=1
-    shift
-fi
+SKIP_EMBEDDED_SIGN=0
+case "$(echo "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+    swift)
+        SWIFT_REBUILD=1
+        shift
+        ;;
+    swift-fast)
+        SWIFT_REBUILD=1
+        SKIP_EMBEDDED_SIGN=1
+        shift
+        ;;
+esac
 
 CONFIG=Release
 if [ $# -gt 0 ]; then
@@ -63,7 +72,7 @@ if [ $# -gt 0 ]; then
         release) CONFIG=Release; shift ;;
         --*) ;;
         *)
-            echo "error: unknown configuration '$1' (expected swift|debug|release)" >&2
+            echo "error: unknown configuration '$1' (expected swift|swift-fast|debug|release)" >&2
             exit 2
             ;;
     esac
@@ -123,13 +132,21 @@ _sign_embedded_mach_o_files() {
     local count=0
 
     while IFS= read -r -d '' path; do
-        case "$path" in
-            *.dSYM/*) continue ;;
-        esac
         _is_mach_o_file "$path" || continue
         codesign --force --sign - "$path" >/dev/null 2>&1
         count=$((count + 1))
-    done < <(find "$root" -type f -print0)
+    done < <(
+        find "$root" \
+            \( -path "*/.dSYM/*" -o -path "*/__pycache__/*" \) -prune -o \
+            -type f \( \
+                -name "*.so" -o \
+                -name "*.dylib" -o \
+                -name "*.bundle" -o \
+                -perm -100 -o \
+                -perm -010 -o \
+                -perm -001 \
+            \) -print0
+    )
 
     ok "  + signed $count embedded Mach-O files"
 }
@@ -406,8 +423,12 @@ fi
 # libraries first, then seal the outer app bundle so TCC can match Full Disk
 # Access grants against the app identity instead of a bare linker signature.
 
-log "Ad-hoc signing embedded native code…"
-_sign_embedded_mach_o_files "$PYTHON_DIR"
+if [ "$SKIP_EMBEDDED_SIGN" -eq 1 ]; then
+    warn "swift-fast set: skipping embedded native code signing."
+else
+    log "Ad-hoc signing embedded native code…"
+    _sign_embedded_mach_o_files "$PYTHON_DIR"
+fi
 
 log "Ad-hoc resigning app bundle…"
 codesign --force --sign - "$STAGED_APP"

--- a/apps/omlx-mac/Sources/App/AppDelegate.swift
+++ b/apps/omlx-mac/Sources/App/AppDelegate.swift
@@ -9,10 +9,10 @@
 //   applicationDidFinishLaunching   → load AppConfig
 //                                     → install NSWindow observers (drive
 //                                       the dock-icon toggle)
-//                                     → if first run (no config.json):
-//                                         • create MenubarController (no server)
+//                                     → if first run (no settings.json):
 //                                         • show Welcome window (wizard
-//                                           persists config + spawns server)
+//                                           persists config + spawns server
+//                                           only after Start Server)
 //                                     else (returning user):
 //                                         • resolve PythonRuntime
 //                                         • spawn ServerProcess
@@ -138,12 +138,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             bootstrapServer(config: config)
             scheduleAccessoryPolicyFlip()
         } else {
-            // First run: stand up the menubar without a server, then run the
-            // wizard. The wizard's "Start Server" creates a ServerProcess via
-            // `services.bind(server:)`; AppDelegate adopts it back on close.
-            self.menubar = makeMenubar(server: nil, config: config)
-            // Stay in .regular until the wizard closes so the user sees the
-            // window in the Dock.
+            // First run: show the wizard only. Do not create the menubar or
+            // persist settings until the user clicks Start Server.
             NSApp.activate(ignoringOtherApps: true)
             presentWelcome()
         }
@@ -306,19 +302,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     server: finishedServer,
                     config: self.services.config
                 )
-            },
-            didSkip: { [weak self] snapshot in
-                // Spec §State machine: write the current Storage values on
-                // close so the next launch lands on AppView with the
-                // API-key-not-configured banner instead of re-firing the
-                // wizard.
-                guard let self else { return }
-                do {
-                    try snapshot.save()
-                    self.services.updateConfig(snapshot)
-                } catch {
-                    NSLog("oMLX: welcome skip — failed to persist partial config: \(error)")
-                }
             }
         )
         self.welcomeController = controller
@@ -343,9 +326,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         welcomeController = nil
 
-        // The wizard either spawned the server itself (success path) or the
-        // user closed it without starting (skipped). Rebuild the menubar
-        // with whatever state we ended up with.
+        // Close before Start Server is cancellation: no menubar, no settings,
+        // no base directory. Quit completely so relaunch shows Welcome again.
+        guard server != nil else {
+            explicitQuitRequested = true
+            NSApp.terminate(nil)
+            return
+        }
+
+        // The wizard spawned the server itself. Rebuild the menubar with the
+        // running server state and switch to menubar-only mode.
         if let server, menubar != nil {
             self.menubar = MenubarController(
                 server: server,
@@ -354,9 +344,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 requestQuit:  { [weak self] in self?.requestQuit() }
             )
         }
-        // First-run flow always ends in menubar-only mode. The observer's
-        // flag-based policy drop only fires for explicit Cmd-Q / Dock Quit
-        // closes, so we set .accessory here directly.
         scheduleAccessoryPolicyFlip()
     }
 

--- a/apps/omlx-mac/Sources/App/AppDelegate.swift
+++ b/apps/omlx-mac/Sources/App/AppDelegate.swift
@@ -295,12 +295,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             didFinish: { [weak self] _, finishedServer in
                 // The wizard returns the spawned ServerProcess. Adopt it so
                 // applicationWillTerminate can clean up correctly.
-                self?.server = finishedServer
+                guard let self else { return }
+                self.server = finishedServer
                 if let proc = finishedServer {
                     SignalHandlers.shared.install { [weak proc] in
                         proc?.reapSync()
                     }
                 }
+                self.menubar = self.makeMenubar(
+                    server: finishedServer,
+                    config: self.services.config
+                )
             },
             didSkip: { [weak self] snapshot in
                 // Spec §State machine: write the current Storage values on

--- a/apps/omlx-mac/Sources/AppView/AppSection.swift
+++ b/apps/omlx-mac/Sources/AppView/AppSection.swift
@@ -1,12 +1,10 @@
-// Top-level sections rendered by AppView's TabView. Each case becomes one
-// `Tab` value in `TabView(selection:)`, with `title` driving the visible
-// label (localized with a `defaultValue` fallback so the catalog isn't
-// load-bearing) and `symbol` driving the SF Symbol on the tab.
+// Top-level sections rendered by AppView's settings sidebar. Each case becomes
+// one selectable row, with `title` driving the visible label (localized with a
+// `defaultValue` fallback so the catalog isn't load-bearing) and `symbol`
+// driving the SF Symbol on the row.
 //
-// Section groupings (Server / Models / Benchmark / General) live inline
-// in AppView via `TabSection` blocks — there's no separate `SidebarGroup`
-// enum anymore; the visual grouping is purely a layout decision in the
-// TabView body.
+// Section groupings (Server / Models / Benchmark / General) live inline in
+// AppView; the visual grouping is purely a layout decision in the shell.
 
 import SwiftUI
 

--- a/apps/omlx-mac/Sources/AppView/AppView.swift
+++ b/apps/omlx-mac/Sources/AppView/AppView.swift
@@ -1,7 +1,7 @@
-// AppView shell. TabView(.sidebarAdaptable) backed by the `AppSection` enum,
-// one tab per screen, grouped into Server / Models / Benchmark / General
-// sections. Sized to the design canvas (1140×760) with a sane minimum so
-// the window survives a resize.
+// AppView shell. NavigationSplitView backed by the `AppSection` enum, one
+// sidebar row per screen, grouped into Server / Models / Benchmark / General
+// sections. Sized close to the minimum comfortable settings window so the
+// first open does not feel oversized, while still surviving a resize.
 //
 // The shell is the entry point for the menubar's `Admin Panel` item and is
 // hosted in the SwiftUI `Window` scene declared in `oMLXApp.swift`.
@@ -9,98 +9,26 @@
 import SwiftUI
 
 struct AppView: View {
-    @State private var selection: AppSection = .server
+    @State private var selection: AppSection? = .status
 
     @Environment(\.colorScheme) private var scheme
     @EnvironmentObject private var services: AppServices
 
     var body: some View {
         let theme = scheme == .dark ? OMLXTheme.dark : OMLXTheme.light
+        let section = selectedSection
 
-        // Experiment: TabView(.sidebarAdaptable). Tabs are top-level parallel
-        // destinations (fits our app better than NavSplit master-detail), and
-        // macOS 26 renders this style with the sidebar extending under the
-        // traffic-light buttons — what Settings.app uses.
-        TabView(selection: bindingForSelection()) {
-            TabSection {
-                Tab(AppSection.server.title, systemImage: AppSection.server.symbol, value: AppSection.server) {
-                    ContentScaffold(section: .server, detailTitle: detailTitle) { ServerScreen() }
-                }
-                Tab(AppSection.status.title, systemImage: AppSection.status.symbol, value: AppSection.status) {
-                    ContentScaffold(section: .status, detailTitle: detailTitle) { StatusScreen() }
-                }
-                Tab(AppSection.network.title, systemImage: AppSection.network.symbol, value: AppSection.network) {
-                    ContentScaffold(section: .network, detailTitle: detailTitle) { NetworkScreen() }
-                }
-                Tab(AppSection.performance.title, systemImage: AppSection.performance.symbol, value: AppSection.performance) {
-                    ContentScaffold(section: .performance, detailTitle: detailTitle) { PerformanceScreen() }
-                }
-                Tab(AppSection.logs.title, systemImage: AppSection.logs.symbol, value: AppSection.logs) {
-                    ContentScaffold(section: .logs, detailTitle: detailTitle) { LogsScreen() }
-                }
-            } header: {
-                Text(String(localized: "sidebar.group.server",
-                            defaultValue: "Server",
-                            comment: "Sidebar group heading for server-related screens"))
-            }
-            TabSection {
-                Tab(AppSection.models.title, systemImage: AppSection.models.symbol, value: AppSection.models) {
-                    ContentScaffold(section: .models, detailTitle: detailTitle) {
-                        if let id = services.modelDetailID {
-                            ModelSettingsScreen(modelID: id)
-                        } else {
-                            ModelsScreen()
-                        }
-                    }
-                }
-                Tab(AppSection.downloads.title, systemImage: AppSection.downloads.symbol, value: AppSection.downloads) {
-                    ContentScaffold(section: .downloads, detailTitle: detailTitle) { DownloadsScreen() }
-                }
-                Tab(AppSection.integrations.title, systemImage: AppSection.integrations.symbol, value: AppSection.integrations) {
-                    ContentScaffold(section: .integrations, detailTitle: detailTitle) { IntegrationsScreen() }
-                }
-                Tab(AppSection.quantization.title, systemImage: AppSection.quantization.symbol, value: AppSection.quantization) {
-                    ContentScaffold(section: .quantization, detailTitle: detailTitle) { QuantizationScreen() }
-                }
-            } header: {
-                Text(String(localized: "sidebar.group.models",
-                            defaultValue: "Models",
-                            comment: "Sidebar group heading for models/downloads/quant screens"))
-            }
-            TabSection {
-                Tab(AppSection.throughputBench.title, systemImage: AppSection.throughputBench.symbol, value: AppSection.throughputBench) {
-                    ContentScaffold(section: .throughputBench, detailTitle: detailTitle) {
-                        ThroughputBenchScreen(vm: services.throughputBench)
-                    }
-                }
-                Tab(AppSection.accuracyBench.title, systemImage: AppSection.accuracyBench.symbol, value: AppSection.accuracyBench) {
-                    ContentScaffold(section: .accuracyBench, detailTitle: detailTitle) {
-                        AccuracyBenchScreen(vm: services.accuracyBench)
-                    }
-                }
-            } header: {
-                Text(String(localized: "sidebar.group.benchmark",
-                            defaultValue: "Benchmark",
-                            comment: "Sidebar group heading for accuracy + throughput bench screens"))
-            }
-            TabSection {
-                Tab(AppSection.security.title, systemImage: AppSection.security.symbol, value: AppSection.security) {
-                    ContentScaffold(section: .security, detailTitle: detailTitle) { SecurityScreen() }
-                }
-                Tab(AppSection.about.title, systemImage: AppSection.about.symbol, value: AppSection.about) {
-                    ContentScaffold(section: .about, detailTitle: detailTitle) { AboutScreen() }
-                }
-            } header: {
-                Text(String(localized: "sidebar.group.general",
-                            defaultValue: "General",
-                            comment: "Sidebar group heading for the about/integrations/logs screens"))
+        NavigationSplitView {
+            SettingsSidebar(selection: bindingForSelection())
+        } detail: {
+            ContentScaffold(section: section, detailTitle: detailTitle) {
+                screen(for: section)
             }
         }
-        .tabViewStyle(.sidebarAdaptable)
-        .frame(minWidth: 880, idealWidth: 1140, minHeight: 600, idealHeight: 760)
-        // DesktopWash backdrop, kept on the outer container so it provides
-        // the radial-gradient background everywhere outside the sidebar.
-        .background(DesktopWash())
+        .navigationSplitViewStyle(.balanced)
+        .frame(minWidth: 880, idealWidth: 880, minHeight: 600, idealHeight: 600)
+        // The theme resolves this through the dynamic macOS window color so
+        // the shell tracks System Settings instead of a fixed canvas color.
         .background(theme.windowBg)
         .environment(\.omlxTheme, theme)
         .onChange(of: services.requestedSection) { _, requested in
@@ -119,18 +47,23 @@ struct AppView: View {
     /// Drilling out of ModelSettingsScreen via the sidebar (changing section)
     /// must clear the per-model detail id so we don't accidentally re-enter
     /// the detail when the user returns to Models.
-    private func bindingForSelection() -> Binding<AppSection> {
+    private func bindingForSelection() -> Binding<AppSection?> {
         Binding(
             get: { selection },
             set: { newValue in
+                guard let newValue else { return }
                 if newValue != .models { services.modelDetailID = nil }
                 selection = newValue
             }
         )
     }
 
+    private var selectedSection: AppSection {
+        selection ?? .status
+    }
+
     private var detailTitle: String? {
-        if selection == .models, let id = services.modelDetailID, !id.isEmpty {
+        if selectedSection == .models, let id = services.modelDetailID, !id.isEmpty {
             return id
         }
         return nil
@@ -157,6 +90,66 @@ struct AppView: View {
         case .accuracyBench:   AccuracyBenchScreen(vm: services.accuracyBench)
         case .security:     SecurityScreen()
         case .about:        AboutScreen()
+        }
+    }
+}
+
+// MARK: - Sidebar
+
+private struct SettingsSidebar: View {
+    @Binding var selection: AppSection?
+
+    var body: some View {
+        List(selection: $selection) {
+            Section {
+                SidebarRow(section: .status)
+                SidebarRow(section: .server)
+                SidebarRow(section: .network)
+                SidebarRow(section: .performance)
+                SidebarRow(section: .logs)
+            } header: {
+                Text(String(localized: "sidebar.group.server",
+                            defaultValue: "Server",
+                            comment: "Sidebar group heading for server-related screens"))
+            }
+            Section {
+                SidebarRow(section: .models)
+                SidebarRow(section: .downloads)
+                SidebarRow(section: .integrations)
+                SidebarRow(section: .quantization)
+            } header: {
+                Text(String(localized: "sidebar.group.models",
+                            defaultValue: "Models",
+                            comment: "Sidebar group heading for models/downloads/quant screens"))
+            }
+            Section {
+                SidebarRow(section: .throughputBench)
+                SidebarRow(section: .accuracyBench)
+            } header: {
+                Text(String(localized: "sidebar.group.benchmark",
+                            defaultValue: "Benchmark",
+                            comment: "Sidebar group heading for accuracy + throughput bench screens"))
+            }
+            Section {
+                SidebarRow(section: .security)
+                SidebarRow(section: .about)
+            } header: {
+                Text(String(localized: "sidebar.group.general",
+                            defaultValue: "General",
+                            comment: "Sidebar group heading for the about/integrations/logs screens"))
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationSplitViewColumnWidth(min: 180, ideal: 195, max: 215)
+    }
+}
+
+private struct SidebarRow: View {
+    let section: AppSection
+
+    var body: some View {
+        NavigationLink(value: section) {
+            Label(section.title, systemImage: section.symbol)
         }
     }
 }
@@ -205,6 +198,7 @@ private struct ContentScaffold<Content: View>: View {
                 .frame(maxWidth: 720, alignment: .topLeading)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 .padding(.bottom, 18)
+                .background(theme.windowBg)
             } else {
                 ScrollViewReader { proxy in
                     ScrollView {
@@ -240,9 +234,12 @@ private struct ContentScaffold<Content: View>: View {
                         }
                         services.requestedServerAnchor = nil
                     }
+                    .scrollContentBackground(.hidden)
+                    .background(theme.windowBg)
                 }
             }
         }
+        .background(theme.windowBg)
         // Title is rendered as content via sectionTitleHeader() — no
         // .navigationTitle here because the window toolbar is hidden in
         // AppView (matches the Settings.app pattern of inline titles on

--- a/apps/omlx-mac/Sources/AppView/Screens/AboutScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/AboutScreen.swift
@@ -54,7 +54,7 @@ private struct HeroCard: View {
                     .font(.omlxText(22, weight: .semibold))
                     .foregroundStyle(theme.text)
                 Text(String(localized: "about.hero.tagline",
-                            defaultValue: "Native macOS app for the oMLX server",
+                            defaultValue: "Local AI, no more waiting on your Mac.",
                             comment: "Tagline shown under the oMLX product name on the About screen hero card"))
                     .font(.omlxText(12))
                     .foregroundStyle(theme.textSecondary)

--- a/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
@@ -3,13 +3,13 @@
 // One tab for every "how the engine runs" knob. Three sections:
 //   • Scheduler — max_concurrent_requests (moved from ServerScreen for
 //     scheduler coherence), embedding_batch_size, and chunked_prefill.
-//   • Memory & Lifecycle — process / model memory limits, prefill memory
-//     guard, server-wide idle timeout, model fallback routing.
+//   • Memory & Lifecycle — prefill memory guard tier, server-wide idle
+//     timeout, model fallback routing.
 //   • Cache — master enable toggle gates a hot-cache toggle + size, a
 //     cold-cache directory + size, and an advanced initial-blocks tuning
 //     knob (requires restart).
 //
-// All thirteen fields are server-side already (`omlx/admin/routes.py:191-272`)
+// All fields are server-side already (`omlx/admin/routes.py:198-235`)
 // — Phase 3 is pure UI. Single Apply button at the bottom, Storage /
 // Network pattern: disabled until at least one trimmed draft diverges
 // from its loaded value, and only changed fields are sent in the PATCH
@@ -115,55 +115,71 @@ private struct MemoryLifecycleSection: View {
                    defaultValue: "Memory & Lifecycle",
                    comment: "Section header for memory and lifecycle settings"),
             subtitle: String(localized: "performance.section.memory.sub",
-                             defaultValue: "Ceilings + auto-unload behavior. Memory limits accept \"auto\", \"disabled\", \"24GB\", or \"50%\".",
-                             comment: "Subtitle explaining accepted memory limit values")
+                             defaultValue: "Memory admission control and auto-unload behavior.",
+                             comment: "Subtitle explaining memory and lifecycle settings")
         )
 
         ListGroup {
-            Row(
-                label: String(localized: "performance.memory.max_process",
-                              defaultValue: "Max Process Memory",
-                              comment: "Row label for the max process memory field"),
-                sublabel: String(localized: "performance.memory.max_process.sub",
-                                 defaultValue: "Total resident memory ceiling for the server process.",
-                                 comment: "Sublabel for max process memory")
-            ) {
-                TextInput(
-                    text: $vm.maxProcessMemory,
-                    placeholder: String(localized: "performance.memory.placeholder_auto",
-                                        defaultValue: "auto",
-                                        comment: "Memory field placeholder meaning automatic"),
-                    mono: true,
-                    width: 140
-                )
-            }
-            Row(
-                label: String(localized: "performance.memory.max_model",
-                              defaultValue: "Max Model Memory",
-                              comment: "Row label for the max model memory field"),
-                sublabel: String(localized: "performance.memory.max_model.sub",
-                                 defaultValue: "Engine pool ceiling. Models above this won't be auto-loaded.",
-                                 comment: "Sublabel for max model memory")
-            ) {
-                TextInput(
-                    text: $vm.maxModelMemory,
-                    placeholder: String(localized: "performance.memory.placeholder_auto",
-                                        defaultValue: "auto",
-                                        comment: "Memory field placeholder meaning automatic"),
-                    mono: true,
-                    width: 140
-                )
-            }
             Row(
                 label: String(localized: "performance.memory.prefill_guard",
                               defaultValue: "Prefill Memory Guard",
                               comment: "Row label for prefill memory guard toggle"),
                 sublabel: String(localized: "performance.memory.prefill_guard.sub",
-                                 defaultValue: "Preflight prefill memory before kicking the engine. Drops requests that would OOM.",
+                                 defaultValue: "Preflight prefill memory before kicking the engine and defer generation scheduling near the ceiling.",
                                  comment: "Sublabel for prefill memory guard")
             ) {
                 Toggle("", isOn: $vm.prefillMemoryGuard)
                     .labelsHidden().toggleStyle(.switch)
+            }
+            Row(
+                label: String(localized: "performance.memory.guard_tier",
+                              defaultValue: "Memory Guard Tier",
+                              comment: "Row label for memory guard tier popup"),
+                sublabel: vm.memoryGuardTierDescription
+            ) {
+                Popup(
+                    selection: $vm.memoryGuardTier,
+                    width: 150,
+                    options: [
+                        ("safe",
+                         String(localized: "performance.memory.guard_tier.safe",
+                                defaultValue: "Safe",
+                                comment: "Memory guard tier option: safe")),
+                        ("balanced",
+                         String(localized: "performance.memory.guard_tier.balanced",
+                                defaultValue: "Balanced",
+                                comment: "Memory guard tier option: balanced")),
+                        ("aggressive",
+                         String(localized: "performance.memory.guard_tier.aggressive",
+                                defaultValue: "Aggressive",
+                                comment: "Memory guard tier option: aggressive")),
+                        ("custom",
+                         String(localized: "performance.memory.guard_tier.custom",
+                                defaultValue: "Custom",
+                                comment: "Memory guard tier option: custom")),
+                    ]
+                )
+                .disabled(!vm.prefillMemoryGuard)
+            }
+            if vm.prefillMemoryGuard && vm.memoryGuardTier == "custom" {
+                Row(
+                    label: String(localized: "performance.memory.custom_ceiling",
+                                  defaultValue: "Custom Ceiling",
+                                  comment: "Row label for memory guard custom ceiling"),
+                    sublabel: String(localized: "performance.memory.custom_ceiling.sub",
+                                     defaultValue: "Fixed process memory ceiling in GB. Used only with the Custom tier.",
+                                     comment: "Sublabel for memory guard custom ceiling")
+                ) {
+                    TextInput(
+                        text: $vm.memoryGuardCustomCeilingText,
+                        placeholder: String(localized: "performance.memory.custom_ceiling.placeholder",
+                                            defaultValue: "GB",
+                                            comment: "Placeholder for custom memory guard ceiling"),
+                        mono: true,
+                        suffix: "GB",
+                        width: 110
+                    )
+                }
             }
             Row(
                 label: String(localized: "performance.memory.idle_timeout",
@@ -323,9 +339,9 @@ final class PerformanceScreenVM: ObservableObject {
     @Published var chunkedPrefill: Bool = false
 
     // Memory & Lifecycle
-    @Published var maxProcessMemory: String = ""
-    @Published var maxModelMemory: String = ""
     @Published var prefillMemoryGuard: Bool = false
+    @Published var memoryGuardTier: String = "balanced"
+    @Published var memoryGuardCustomCeilingText: String = ""
     @Published var idleTimeoutText: String = ""
     @Published var modelFallback: Bool = false
 
@@ -341,9 +357,9 @@ final class PerformanceScreenVM: ObservableObject {
     @Published private(set) var loadedMaxConcurrent: Int = 8
     @Published private(set) var loadedEmbeddingBatchSize: Int = 32
     @Published private(set) var loadedChunkedPrefill: Bool = false
-    @Published private(set) var loadedMaxProcessMemory: String = ""
-    @Published private(set) var loadedMaxModelMemory: String = ""
     @Published private(set) var loadedPrefillMemoryGuard: Bool = false
+    @Published private(set) var loadedMemoryGuardTier: String = "balanced"
+    @Published private(set) var loadedMemoryGuardCustomCeilingGb: Double = 0
     @Published private(set) var loadedIdleTimeoutSeconds: Int? = nil
     @Published private(set) var loadedModelFallback: Bool = false
     @Published private(set) var loadedCacheEnabled: Bool = true
@@ -360,9 +376,9 @@ final class PerformanceScreenVM: ObservableObject {
         parsedMaxConcurrent != loadedMaxConcurrent
             || parsedEmbeddingBatchSize != loadedEmbeddingBatchSize
             || chunkedPrefill != loadedChunkedPrefill
-            || trim(maxProcessMemory) != loadedMaxProcessMemory
-            || trim(maxModelMemory) != loadedMaxModelMemory
             || prefillMemoryGuard != loadedPrefillMemoryGuard
+            || canonicalMemoryGuardTier(memoryGuardTier) != loadedMemoryGuardTier
+            || parsedMemoryGuardCustomCeiling != loadedMemoryGuardCustomCeilingGb
             || parsedIdleTimeout != loadedIdleTimeoutSeconds
             || modelFallback != loadedModelFallback
             || cacheEnabled != loadedCacheEnabled
@@ -386,14 +402,16 @@ final class PerformanceScreenVM: ObservableObject {
                 self.loadedChunkedPrefill = sched.chunkedPrefill ?? false
             }
             if let mem = s.memory {
-                self.maxProcessMemory = mem.maxProcessMemory ?? ""
-                self.loadedMaxProcessMemory = mem.maxProcessMemory ?? ""
                 self.prefillMemoryGuard = mem.prefillMemoryGuard ?? false
                 self.loadedPrefillMemoryGuard = mem.prefillMemoryGuard ?? false
+                let tier = canonicalMemoryGuardTier(mem.memoryGuardTier ?? "balanced")
+                self.memoryGuardTier = tier
+                self.loadedMemoryGuardTier = tier
+                let customGb = mem.memoryGuardCustomCeilingGb ?? 0
+                self.memoryGuardCustomCeilingText = customGb > 0 ? trimDouble(customGb) : ""
+                self.loadedMemoryGuardCustomCeilingGb = customGb
             }
             if let model = s.model {
-                self.maxModelMemory = model.maxModelMemory ?? ""
-                self.loadedMaxModelMemory = model.maxModelMemory ?? ""
                 self.modelFallback = model.modelFallback ?? false
                 self.loadedModelFallback = model.modelFallback ?? false
             }
@@ -461,6 +479,14 @@ final class PerformanceScreenVM: ObservableObject {
             }
             initBlocks = n
         }
+        let tier = canonicalMemoryGuardTier(memoryGuardTier)
+        let customCeiling = parsedMemoryGuardCustomCeiling
+        if prefillMemoryGuard && tier == "custom" && customCeiling <= 0 {
+            self.lastError = String(localized: "performance.error.custom_ceiling_invalid",
+                                    defaultValue: "Custom Ceiling must be greater than 0 GB.",
+                                    comment: "Performance screen error when custom memory guard ceiling is invalid")
+            return
+        }
 
         var patch = GlobalSettingsPatch()
         // Scheduler
@@ -470,12 +496,14 @@ final class PerformanceScreenVM: ObservableObject {
         }
         if chunkedPrefill != loadedChunkedPrefill { patch.chunkedPrefill = chunkedPrefill }
         // Memory & lifecycle
-        let mpm = trim(maxProcessMemory)
-        if mpm != loadedMaxProcessMemory { patch.maxProcessMemory = mpm }
-        let mmm = trim(maxModelMemory)
-        if mmm != loadedMaxModelMemory { patch.maxModelMemory = mmm }
         if prefillMemoryGuard != loadedPrefillMemoryGuard {
             patch.memoryPrefillMemoryGuard = prefillMemoryGuard
+        }
+        if tier != loadedMemoryGuardTier {
+            patch.memoryGuardTier = tier
+        }
+        if customCeiling != loadedMemoryGuardCustomCeilingGb {
+            patch.memoryGuardCustomCeilingGb = customCeiling
         }
         if idleSeconds != loadedIdleTimeoutSeconds, let s = idleSeconds {
             patch.idleTimeoutSeconds = s
@@ -502,9 +530,9 @@ final class PerformanceScreenVM: ObservableObject {
             self.loadedMaxConcurrent = mc
             self.loadedEmbeddingBatchSize = embeddingBatchSize
             self.loadedChunkedPrefill = chunkedPrefill
-            self.loadedMaxProcessMemory = mpm
-            self.loadedMaxModelMemory = mmm
             self.loadedPrefillMemoryGuard = prefillMemoryGuard
+            self.loadedMemoryGuardTier = tier
+            self.loadedMemoryGuardCustomCeilingGb = customCeiling
             if let s = idleSeconds { self.loadedIdleTimeoutSeconds = s }
             self.loadedModelFallback = modelFallback
             self.loadedCacheEnabled = cacheEnabled
@@ -539,8 +567,50 @@ final class PerformanceScreenVM: ObservableObject {
         return t.isEmpty ? nil : Int(t)
     }
 
+    private var parsedMemoryGuardCustomCeiling: Double {
+        let t = memoryGuardCustomCeilingText.trimmingCharacters(in: .whitespaces)
+        return t.isEmpty ? 0 : (Double(t) ?? -1)
+    }
+
     private func trim(_ s: String) -> String {
         s.trimmingCharacters(in: .whitespaces)
+    }
+
+    private func trimDouble(_ v: Double) -> String {
+        let rounded = (v * 100).rounded() / 100
+        if rounded == Double(Int(rounded)) { return String(Int(rounded)) }
+        return String(rounded)
+    }
+
+    private func canonicalMemoryGuardTier(_ value: String) -> String {
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch normalized {
+        case "safe", "balanced", "aggressive", "custom":
+            return normalized
+        default:
+            return "balanced"
+        }
+    }
+
+    var memoryGuardTierDescription: String {
+        switch canonicalMemoryGuardTier(memoryGuardTier) {
+        case "safe":
+            return String(localized: "performance.memory.guard_tier.safe.sub",
+                          defaultValue: "Most conservative. Leaves more headroom before scheduling memory-heavy prefill.",
+                          comment: "Description for safe memory guard tier")
+        case "aggressive":
+            return String(localized: "performance.memory.guard_tier.aggressive.sub",
+                          defaultValue: "Uses more memory before throttling. Best when the Mac has ample headroom.",
+                          comment: "Description for aggressive memory guard tier")
+        case "custom":
+            return String(localized: "performance.memory.guard_tier.custom.sub",
+                          defaultValue: "Use a fixed GB ceiling instead of the adaptive tier calculation.",
+                          comment: "Description for custom memory guard tier")
+        default:
+            return String(localized: "performance.memory.guard_tier.balanced.sub",
+                          defaultValue: "Default tier. Balances throughput with process memory safety.",
+                          comment: "Description for balanced memory guard tier")
+        }
     }
 
 }

--- a/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
@@ -212,17 +212,10 @@ struct ServerHeroCard: View {
             buttons
         }
         .padding(18)
-        // Hero card surface: subtle accent gradient over a glass/material
-        // fill that's clipped to the rounded-rect outline. The gradient stays
-        // on top so the green/blue accent reads on both macOS 15 (over
-        // .thickMaterial) and macOS 26 (over real liquid glass).
+        // Hero card surface follows the grouped Settings style. Status is
+        // carried by the pill/actions, not by a colored background wash.
         .background(heroBackground)
-        .appGlass(.strong, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .strokeBorder(theme.groupBorder, lineWidth: 0.5)
-        )
         .padding(.horizontal, 14)
         .padding(.bottom, 14)
     }
@@ -328,23 +321,7 @@ struct ServerHeroCard: View {
 
     @ViewBuilder
     private var heroBackground: some View {
-        if theme.isDark {
-            LinearGradient(
-                colors: [
-                    Color(rgb24: 0x30D158, opacity: 0.08),
-                    Color(rgb24: 0x0A84FF, opacity: 0.06),
-                ],
-                startPoint: .topLeading, endPoint: .bottomTrailing
-            )
-        } else {
-            LinearGradient(
-                colors: [
-                    Color(rgb24: 0xF4FAF6),
-                    Color(rgb24: 0xF4F7FC),
-                ],
-                startPoint: .topLeading, endPoint: .bottomTrailing
-            )
-        }
+        theme.groupBg
     }
 }
 

--- a/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
@@ -46,7 +46,7 @@ struct ServerScreen: View {
                                   defaultValue: "Port",
                                   comment: "Row label for the server port field"),
                     sublabel: String(localized: "server.row.port.sub",
-                                     defaultValue: "Default 8080. Server restarts on save.",
+                                     defaultValue: "Default 8000. Server restarts on save.",
                                      comment: "Sublabel under the Port field"),
                     isLast: true
                 ) {
@@ -668,7 +668,7 @@ private struct HintFooter: View {
 @MainActor
 final class ServerScreenVM: ObservableObject {
     @Published var host: String = "127.0.0.1"
-    @Published var portText: String = "8080"
+    @Published var portText: String = "8000"
     @Published var logLevel: String = "info"
 
     // Phase 4 — Advanced disclosure.
@@ -694,7 +694,7 @@ final class ServerScreenVM: ObservableObject {
     /// Last applied (effective) values used to build endpoint URLs. Distinct
     /// from `host`/`portText` so the URLs don't flicker mid-edit.
     @Published var effectiveHost: String = "127.0.0.1"
-    @Published var effectivePort: Int = 8080
+    @Published var effectivePort: Int = 8000
 
     /// Apply-button baselines: snapshots of each Apply-managed draft taken
     /// after a successful `load()` or `applyServerSettings()`. The button's
@@ -703,7 +703,7 @@ final class ServerScreenVM: ObservableObject {
     ///
     /// Listen Address / Log Level / SSE Keep-Alive Mode auto-apply via the
     /// `bind()` wrapper and don't need baselines here.
-    private var baselinePortText: String = "8080"
+    private var baselinePortText: String = "8000"
     private var baselineSamplingContextText: String = "32768"
     private var baselineSamplingMaxTokensText: String = "32768"
     private var baselineSamplingTemperatureText: String = "1.0"

--- a/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
@@ -1,9 +1,9 @@
 // PR 7 — Status screen. Lays out:
 //   • ServerHeroCard (the same card the Server screen mounts; defined in
 //     ServerScreen.swift)
-//   • Session Stats — 4 StatTiles from /admin/api/stats (scope segmented)
+//   • Serving Stats — prefill/cache tiles + average speed from /admin/api/stats
 //   • System — slice of /admin/api/global-settings + uptime from /api/stats
-//   • Updates — three-state row + Channel/AutoCheck/AutoDownload (UpdateController stub)
+//   • Updates — release check status + auto-check/auto-download prefs
 //   • Active Now — active_models slice from /api/stats
 //
 // Polling is on-screen-only: a 5s timer ticks while the view is visible.
@@ -57,6 +57,16 @@ struct StatusScreen: View {
                 }
             }
             StatTilesRow(stats: vm.stats)
+
+            SectionHeader(String(localized: "status.speed.section_label",
+                                  defaultValue: "Average Speed",
+                                  comment: "Header label above average serving speed metrics"))
+            AverageSpeedTilesRow(stats: vm.stats)
+
+            SectionHeader(String(localized: "status.section.active_now",
+                                  defaultValue: "Active Now",
+                                  comment: "Section header for the currently active models list"))
+            ActiveNowList(models: vm.stats?.activeModels.models ?? [])
 
             SectionHeader(String(localized: "status.section.system",
                                   defaultValue: "System",
@@ -115,11 +125,6 @@ struct StatusScreen: View {
                                   defaultValue: "Updates",
                                   comment: "Section header for the updates section"))
             UpdatesSection(updates: services.updates)
-
-            SectionHeader(String(localized: "status.section.active_now",
-                                  defaultValue: "Active Now",
-                                  comment: "Section header for the currently active models list"))
-            ActiveNowList(models: vm.stats?.activeModels.models ?? [])
 
             if let error = vm.lastError {
                 Text(error)
@@ -339,53 +344,26 @@ private struct StatTilesRow: View {
     let stats: StatsDTO?
 
     var body: some View {
-        // `.top` alignment + each tile claiming `maxHeight: .infinity` keeps
-        // the four cards visually flush even when one of them wraps a
-        // subtitle to two lines at narrower widths.
         HStack(alignment: .top, spacing: 10) {
             StatTile(
                 label: String(localized: "status.tile.total",
-                              defaultValue: "Total Tokens",
-                              comment: "Stat tile label for total tokens served"),
-                value: stats.map { fmtNum($0.totalTokensServed) } ?? "—",
-                sub: String(localized: "status.tile.total.sub",
-                            defaultValue: "prompt + completion",
-                            comment: "Sub-label for the total tokens stat tile")
+                              defaultValue: "Total Prefill Tokens",
+                              comment: "Stat tile label for total prefill tokens processed"),
+                value: stats.map { fmtNum($0.totalPromptTokens) } ?? "—"
             )
             StatTile(
                 label: String(localized: "status.tile.cached",
-                              defaultValue: "Cached",
+                              defaultValue: "Cached Tokens",
                               comment: "Stat tile label for cached tokens"),
-                value: stats.map { fmtNum($0.totalCachedTokens) } ?? "—",
-                sub: stats.map {
-                    String(localized: "status.tile.cached.sub",
-                           defaultValue: "\(String(format: "%.1f", $0.cacheEfficiency))% efficiency",
-                           comment: "Sub-label showing cache efficiency percentage on the cached tile; placeholder is a formatted percentage")
-                },
-                accentRole: .success
+                value: stats.map { fmtNum($0.totalCachedTokens) } ?? "—"
             )
             StatTile(
-                label: String(localized: "status.tile.generation",
-                              defaultValue: "Generation",
-                              comment: "Stat tile label for average generation rate"),
-                value: stats.map { String(format: "%.1f tok/s", $0.avgGenerationTps) } ?? "—",
-                sub: String(localized: "status.tile.generation.sub",
-                            defaultValue: "across active models",
-                            comment: "Sub-label for the generation rate tile")
-            )
-            StatTile(
-                label: String(localized: "status.tile.requests",
-                              defaultValue: "Requests",
-                              comment: "Stat tile label for the total requests count"),
-                value: stats.map { fmtNum($0.totalRequests) } ?? "—",
-                sub: stats.map {
-                    String(localized: "status.tile.requests.sub",
-                           defaultValue: "\(($0.activeModels.totalActiveRequests ?? 0)) in flight",
-                           comment: "Sub-label showing in-flight request count; placeholder is the number of active requests")
-                }
+                label: String(localized: "status.tile.cache_efficiency",
+                              defaultValue: "Cache Efficiency",
+                              comment: "Stat tile label for cache efficiency percentage"),
+                value: stats.map { String(format: "%.1f%%", $0.cacheEfficiency) } ?? "—"
             )
         }
-        .fixedSize(horizontal: false, vertical: true)
         .padding(.horizontal, 14)
         .padding(.bottom, 4)
     }
@@ -408,26 +386,25 @@ private struct StatTile: View {
                 .foregroundStyle(theme.textSecondary)
                 .textCase(.uppercase)
                 .kerning(0.6)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
             Text(value)
                 .font(.omlxText(22, weight: .semibold))
                 .kerning(-0.5)
                 .foregroundStyle(accentColor)
+                .frame(maxWidth: .infinity)
             if let sub {
                 Text(sub)
                     .font(.omlxText(11))
                     .foregroundStyle(theme.textTertiary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
             }
         }
         .padding(16)
-        // maxHeight: .infinity lets every tile match the tallest sibling so
-        // the card backgrounds line up even when one subtitle wraps.
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, minHeight: 96, alignment: .center)
         .background(theme.groupBg)
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .strokeBorder(theme.groupBorder, lineWidth: 0.5)
-        )
     }
 
     private var accentColor: Color {
@@ -437,6 +414,29 @@ private struct StatTile: View {
         case .warning: return theme.amberDot
         case .danger:  return theme.redDot
         }
+    }
+}
+
+private struct AverageSpeedTilesRow: View {
+    let stats: StatsDTO?
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            StatTile(
+                label: String(localized: "status.speed.prompt_processing.tile",
+                              defaultValue: "Prompt Processing (excl. cached)",
+                              comment: "Tile label for average prompt-processing speed excluding cached tokens"),
+                value: stats.map { String(format: "%.1f tok/s", $0.avgPrefillTps) } ?? "—"
+            )
+            StatTile(
+                label: String(localized: "status.speed.token_generation",
+                              defaultValue: "Token Generation",
+                              comment: "Label for average token-generation speed"),
+                value: stats.map { String(format: "%.1f tok/s", $0.avgGenerationTps) } ?? "—"
+            )
+        }
+        .padding(.horizontal, 14)
+        .padding(.bottom, 4)
     }
 }
 
@@ -636,23 +636,6 @@ private struct UpdatesSection: View {
                 }
             }
             Row(
-                label: String(localized: "status.updates.channel",
-                              defaultValue: "Update Channel",
-                              comment: "Row label for the update channel picker"),
-                sublabel: String(localized: "status.updates.channel.sub",
-                                 defaultValue: "Stable receives tested releases. Beta gets new features sooner.",
-                                 comment: "Sublabel for the update channel picker")
-            ) {
-                Popup(
-                    selection: Binding(
-                        get: { updates.channel },
-                        set: { updates.channel = $0 }
-                    ),
-                    width: 130,
-                    options: UpdateChannel.allCases.map { ($0, $0.displayName) }
-                )
-            }
-            Row(
                 label: String(localized: "status.updates.auto_check",
                               defaultValue: "Automatically Check",
                               comment: "Row label for the auto-check updates toggle"),
@@ -672,7 +655,7 @@ private struct UpdatesSection: View {
                               defaultValue: "Auto-download Updates",
                               comment: "Row label for the auto-download updates toggle"),
                 sublabel: String(localized: "status.updates.auto_download.sub",
-                                 defaultValue: "Download in the background, install on next launch",
+                                 defaultValue: "Download in the background, then show Install & Restart",
                                  comment: "Sublabel for the auto-download toggle"),
                 isLast: true
             ) {

--- a/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
@@ -851,7 +851,7 @@ final class StatusScreenVM: ObservableObject {
     var endpointText: String {
         guard let s = stats else { return "—" }
         let host = s.host ?? "127.0.0.1"
-        let port = s.port ?? 8080
+        let port = s.port ?? 8000
         return "\(host):\(port)"
     }
 

--- a/apps/omlx-mac/Sources/AppView/Screens/ThroughputBenchScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ThroughputBenchScreen.swift
@@ -635,11 +635,14 @@ private struct TextExportSection: View {
             if isOpen {
                 ListGroup {
                     FreeRow(isLast: true) {
-                        Text(text)
-                            .font(.omlxMono(11))
-                            .foregroundStyle(theme.text)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .textSelection(.enabled)
+                        ScrollView(.horizontal, showsIndicators: true) {
+                            Text(text)
+                                .font(.omlxMono(11))
+                                .foregroundStyle(theme.text)
+                                .fixedSize(horizontal: true, vertical: true)
+                                .textSelection(.enabled)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
                 .padding(.bottom, 18)

--- a/apps/omlx-mac/Sources/Config/AppConfig.swift
+++ b/apps/omlx-mac/Sources/Config/AppConfig.swift
@@ -43,7 +43,7 @@ struct AppConfig: Sendable, Equatable, Codable {
         let base = currentBasePath()
         return AppConfig(
             host: "127.0.0.1",
-            port: 8080,
+            port: 8000,
             apiKey: nil,
             basePath: base,
             modelDir: defaultModelDir(forBasePath: base),

--- a/apps/omlx-mac/Sources/Menubar/MenubarController.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarController.swift
@@ -7,11 +7,11 @@
 //   • Stop Server     (RUNNING / STARTING / STOPPING / UNRESPONSIVE)
 //   • Start Server    (STOPPED / IDLE / FAILED)
 //   • Serving Stats     (Session + All-Time submenu)
-//   • Settings…         (Cmd-, — opens the SwiftUI AppView window via the
-//                        openAppView callback)
 //   • Open Web Dashboard (enabled when running — opens the web admin
 //                        dashboard in the browser via /admin/auto-login)
 //   • Chat with oMLX    (enabled when running — opens /admin/chat in browser)
+//   • Settings…         (Cmd-, — opens the SwiftUI AppView window via the
+//                        openAppView callback)
 //   • About oMLX
 //   • Quit oMLX       (Cmd-Q)
 //
@@ -104,6 +104,10 @@ final class MenubarController: NSObject {
         }
         statusItem.behavior = []
         statusItem.menu = menu
+        // This menu is state-driven by refreshMenuState(). If AppKit's
+        // automatic target/action enabling stays on, stopped-server items
+        // such as Web Dashboard and Chat can be re-enabled while opening.
+        menu.autoenablesItems = false
         menu.delegate = self
 
         buildMenu()
@@ -174,14 +178,6 @@ final class MenubarController: NSObject {
 
         menu.addItem(.separator())
 
-        adminPanelItem = item(String(localized: "menubar.item.settings",
-                                     defaultValue: "Settings…",
-                                     comment: "Menubar item that opens the native settings/preferences window"),
-                              action: #selector(openAdminPanel),
-                              symbol: "gearshape",
-                              keyEquivalent: ",")
-        menu.addItem(adminPanelItem)
-
         webAdminItem = item(String(localized: "menubar.item.web_dashboard",
                                    defaultValue: "Open Web Dashboard",
                                    comment: "Menubar item that opens the browser-based web admin dashboard with auto-login"),
@@ -197,6 +193,14 @@ final class MenubarController: NSObject {
         menu.addItem(chatItem)
 
         menu.addItem(.separator())
+
+        adminPanelItem = item(String(localized: "menubar.item.settings",
+                                     defaultValue: "Settings…",
+                                     comment: "Menubar item that opens the native settings/preferences window"),
+                              action: #selector(openAdminPanel),
+                              symbol: "gearshape",
+                              keyEquivalent: ",")
+        menu.addItem(adminPanelItem)
 
         let about = item(String(localized: "menubar.item.about",
                                 defaultValue: "About oMLX",
@@ -237,8 +241,7 @@ final class MenubarController: NSObject {
 
     private func refreshMenuState() {
         let state = server?.state ?? .stopped
-        let isRunning: Bool
-        if case .running = state { isRunning = true } else { isRunning = false }
+        let isRunning = serverIsRunning
         let isStarting: Bool
         if case .starting = state { isStarting = true } else { isStarting = false }
         let isStopping: Bool
@@ -306,12 +309,12 @@ final class MenubarController: NSObject {
                        comment: "Menubar status header while the server is starting"),
                 .systemBlue
             )
-        case .running(let pid):
+        case .running:
             let port = MenubarController.displayPort(server: server, fallback: config.port)
             return (
                 String(localized: "menubar.header.running",
-                       defaultValue: "Server: running · pid \(String(pid)) · :\(String(port))",
-                       comment: "Menubar status header when the server is running; placeholders are PID and port (rendered as plain integers, no grouping)"),
+                       defaultValue: "Server: running · :\(String(port))",
+                       comment: "Menubar status header when the server is running; placeholder is the port (rendered as a plain integer, no grouping)"),
                 .systemGreen
             )
         case .stopping:
@@ -321,11 +324,11 @@ final class MenubarController: NSObject {
                        comment: "Menubar status header while the server is stopping"),
                 .systemOrange
             )
-        case .unresponsive(let pid):
+        case .unresponsive:
             return (
                 String(localized: "menubar.header.unresponsive",
-                       defaultValue: "Server: unresponsive · pid \(String(pid)) (auto-recover or Force Restart)",
-                       comment: "Menubar status header when the server is unresponsive; placeholder is PID (plain integer, no grouping)"),
+                       defaultValue: "Server: unresponsive (auto-recover or Force Restart)",
+                       comment: "Menubar status header when the server is unresponsive"),
                 .systemOrange
             )
         case .failed(let msg):
@@ -562,6 +565,7 @@ final class MenubarController: NSObject {
     }
 
     @objc private func openWebAdmin() {
+        guard serverIsRunning else { return }
         let host = MenubarController.displayHost(server: server, fallback: config.host)
         let port = MenubarController.displayPort(server: server, fallback: config.port)
         guard let url = MenubarController.webAdminURL(host: host, port: port, apiKey: config.apiKey) else { return }
@@ -569,6 +573,7 @@ final class MenubarController: NSObject {
     }
 
     @objc private func openChat() {
+        guard serverIsRunning else { return }
         let host = MenubarController.displayHost(server: server, fallback: config.host)
         let port = MenubarController.displayPort(server: server, fallback: config.port)
         guard let url = URL(string: "http://\(host):\(port)/admin/chat") else { return }
@@ -594,6 +599,11 @@ final class MenubarController: NSObject {
         let it = NSMenuItem(title: title, action: nil, keyEquivalent: "")
         it.isEnabled = false
         return it
+    }
+
+    private var serverIsRunning: Bool {
+        if case .running = server?.state { return true }
+        return false
     }
 
     private func appendStat(_ label: String, _ value: String) {

--- a/apps/omlx-mac/Sources/Menubar/MenubarController.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarController.swift
@@ -313,7 +313,7 @@ final class MenubarController: NSObject {
             let port = MenubarController.displayPort(server: server, fallback: config.port)
             return (
                 String(localized: "menubar.header.running",
-                       defaultValue: "Server: running · :\(String(port))",
+                       defaultValue: "Server: running (port \(String(port)))",
                        comment: "Menubar status header when the server is running; placeholder is the port (rendered as a plain integer, no grouping)"),
                 .systemGreen
             )

--- a/apps/omlx-mac/Sources/Menubar/MenubarVisibilityWatcher.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarVisibilityWatcher.swift
@@ -1,11 +1,8 @@
-// PR 4 — Bartender / Tahoe ControlCenter hidden-icon detection.
+// PR 4 - Bartender / Tahoe ControlCenter hidden-icon detection.
 //
 // Ports the three-signal visibility check from app.py:355-410 plus the
-// one-shot recreate + escalation alert. Tahoe-aware copy includes a
-// deep-link to System Settings → Menu Bar (which 26.x exposed for per-app
-// status item visibility). The plist-edit "Auto-Fix" path (Full Disk
-// Access + Group Container plist) is deferred to a follow-up; the alert
-// gives the user manual recovery steps.
+// one-shot recreate + escalation alert. Tahoe-aware recovery includes
+// System Settings plus the StatusKit Auto-Fix flow from the pre-Swift app.
 
 import AppKit
 
@@ -16,6 +13,24 @@ final class MenubarVisibilityWatcher {
     private var didCheckOnce = false
     private var didRecreate = false
     private var didAlertOnce = false
+    private let statusKitPlistURL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(
+            "Library/Group Containers/group.com.apple.controlcenter/Library/Preferences/group.com.apple.controlcenter.plist"
+        )
+    private let logURL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("Library/Application Support/oMLX/logs/menubar.log")
+
+    private struct AutoFixOutcome {
+        let success: Bool
+        let message: String
+        let needsFullDiskAccess: Bool
+
+        init(success: Bool, message: String, needsFullDiskAccess: Bool = false) {
+            self.success = success
+            self.message = message
+            self.needsFullDiskAccess = needsFullDiskAccess
+        }
+    }
 
     init(initial: NSStatusItem, recreate: @escaping () -> NSStatusItem) {
         self.statusItem = initial
@@ -68,7 +83,6 @@ final class MenubarVisibilityWatcher {
 
     private func showHiddenAlert() {
         guard !didAlertOnce else { return }
-        didAlertOnce = true
 
         // Bring our process forward so the alert isn't behind another window.
         NSApp.activate(ignoringOtherApps: true)
@@ -76,31 +90,40 @@ final class MenubarVisibilityWatcher {
         let mac = ProcessInfo.processInfo.operatingSystemVersion.majorVersion
         let isTahoeOrNewer = mac >= 26
 
+        if isTahoeOrNewer, isKnownMenuBarManagerRunning() {
+            return
+        }
+
+        didAlertOnce = true
+
         let alert = NSAlert()
-        alert.messageText = "The oMLX menubar icon isn't showing up."
+        alert.messageText = "oMLX Menubar Icon Hidden"
 
         if isTahoeOrNewer {
             alert.informativeText = """
-            macOS Tahoe added per-app menu-bar visibility controls. Open \
-            System Settings → Menu Bar and confirm oMLX is enabled.
+            The oMLX menubar icon isn't showing up.
 
-            If a menu-bar manager (Bartender, Ice) is filtering items, \
-            oMLX may be excluded by its rules. Bartender in particular \
-            tends to hide PyObjC-style status items and now Swift apps \
-            built the same way.
+            On macOS Tahoe this is usually caused by the StatusKit approval \
+            flag being false in system preferences. Auto-Fix will approve \
+            oMLX and restart ControlCenter. It needs Full Disk Access.
+
+            You can also enable oMLX manually in System Settings > Menu Bar.
             """
+            alert.addButton(withTitle: "Auto-Fix")
             alert.addButton(withTitle: "Open Menu Bar Settings…")
-            alert.addButton(withTitle: "Quit oMLX")
-            alert.addButton(withTitle: "OK")
+            alert.addButton(withTitle: "View Log")
+            alert.addButton(withTitle: "Dismiss")
         } else {
             alert.informativeText = """
-            Try quitting and relaunching oMLX. If the icon still \
-            doesn't appear, check your menu-bar manager (Bartender, Ice, \
-            etc.) — third-party apps sometimes filter status items by \
-            category and may exclude oMLX.
+            The oMLX menubar icon isn't showing up.
+
+            macOS before Tahoe doesn't offer a System Settings toggle for \
+            third-party menubar apps. Try quitting and relaunching oMLX, \
+            and check menubar manager tools like Bartender or Ice if you \
+            use them.
             """
-            alert.addButton(withTitle: "Quit oMLX")
-            alert.addButton(withTitle: "OK")
+            alert.addButton(withTitle: "View Log")
+            alert.addButton(withTitle: "Dismiss")
         }
 
         alert.window.level = .floating
@@ -109,16 +132,465 @@ final class MenubarVisibilityWatcher {
         if isTahoeOrNewer {
             switch response {
             case .alertFirstButtonReturn:
-                if let url = URL(string: "x-apple.systempreferences:com.apple.MenuBar-Settings.extension") {
-                    NSWorkspace.shared.open(url)
-                }
+                runAutofixFlow()
             case .alertSecondButtonReturn:
-                NSApp.terminate(nil)
+                openMenuBarSettings()
+            case .alertThirdButtonReturn:
+                NSWorkspace.shared.open(logURL)
             default:
                 break
             }
         } else if response == .alertFirstButtonReturn {
-            NSApp.terminate(nil)
+            NSWorkspace.shared.open(logURL)
         }
+    }
+
+    // MARK: - StatusKit Auto-Fix
+
+    private func runAutofixFlow() {
+        let result = fixStatusKitPermission()
+        if result.needsFullDiskAccess {
+            showStatusKitAccessDeniedAlert()
+            return
+        }
+        showAutofixResultAlert(success: result.success, message: result.message)
+    }
+
+    private func fixStatusKitPermission() -> AutoFixOutcome {
+        let fileManager = FileManager.default
+
+        guard fileManager.fileExists(atPath: statusKitPlistURL.path) else {
+            return AutoFixOutcome(
+                success: false,
+                message: """
+                The StatusKit preferences file does not exist on this Mac. \
+                Your macOS version may not use this approval flow yet, so \
+                the issue is likely not auto-fixable.
+                """
+            )
+        }
+
+        let backup = backupStatusKitPlist()
+
+        var format = PropertyListSerialization.PropertyListFormat.binary
+        var outer: [String: Any]
+        do {
+            let data = try Data(contentsOf: statusKitPlistURL)
+            guard let plist = try PropertyListSerialization.propertyList(
+                from: data,
+                options: [.mutableContainersAndLeaves],
+                format: &format
+            ) as? [String: Any] else {
+                return AutoFixOutcome(
+                    success: false,
+                    message: "StatusKit preferences did not decode to a dictionary."
+                )
+            }
+            outer = plist
+        } catch {
+            if isPermissionError(error) {
+                return AutoFixOutcome(
+                    success: false,
+                    message: "Auto-Fix needs Full Disk Access to read the StatusKit preferences.",
+                    needsFullDiskAccess: true
+                )
+            }
+            return AutoFixOutcome(
+                success: false,
+                message: "Failed to read the StatusKit preferences: \(error.localizedDescription)"
+            )
+        }
+
+        let raw = outer["trackedApplications"]
+        let nestedAsData = raw is Data
+        var entries: [[String: Any]]
+
+        if raw == nil {
+            entries = []
+        } else if let rawData = raw as? Data {
+            var innerFormat = PropertyListSerialization.PropertyListFormat.binary
+            do {
+                guard let decoded = try PropertyListSerialization.propertyList(
+                    from: rawData,
+                    options: [.mutableContainersAndLeaves],
+                    format: &innerFormat
+                ) as? [[String: Any]] else {
+                    return AutoFixOutcome(
+                        success: false,
+                        message: "trackedApplications decoded to a non-list value. Aborting to avoid corrupting the file."
+                    )
+                }
+                entries = decoded
+            } catch {
+                return AutoFixOutcome(
+                    success: false,
+                    message: "Failed to decode trackedApplications: \(error.localizedDescription)"
+                )
+            }
+        } else if let rawEntries = raw as? [[String: Any]] {
+            entries = rawEntries
+        } else {
+            let typeName = String(describing: type(of: raw as Any))
+            return AutoFixOutcome(
+                success: false,
+                message: "Unexpected trackedApplications type: \(typeName)."
+            )
+        }
+
+        let primaryBundleID = Bundle.main.bundleIdentifier ?? "app.omlx"
+        let targetBundleIDs = Set([primaryBundleID, "app.omlx", "com.omlx.app"])
+        var normalizedEntries: [[String: Any]] = []
+        var changed = false
+        var foundAllowedApproval = false
+        var hasPrimaryMarker = false
+        var hasPrimaryApproval = false
+        var matchedBundleIDs: [String] = []
+
+        for var entry in entries {
+            if let bareBundleID = bareBundleIdentifier(in: entry),
+               targetBundleIDs.contains(bareBundleID) {
+                if bareBundleID == primaryBundleID {
+                    hasPrimaryMarker = true
+                }
+                normalizedEntries.append(entry)
+                continue
+            }
+
+            let locationBundleID = locationBundleIdentifier(in: entry)
+            let menuBundleIDs = menuItemBundleIdentifiers(in: entry)
+            let locationMatches = locationBundleID.map(targetBundleIDs.contains) ?? false
+            let menuMatches = menuBundleIDs.contains { targetBundleIDs.contains($0) }
+            let referencesOmlx = locationMatches || menuMatches
+
+            guard referencesOmlx else {
+                normalizedEntries.append(entry)
+                continue
+            }
+
+            guard let bundleID = locationBundleID, targetBundleIDs.contains(bundleID) else {
+                // Drop stale cross-app rows such as location=iTerm2 with
+                // menuItemLocations=oMLX. ControlCenter may keep those around
+                // after bundle-id changes, but they do not back the oMLX toggle.
+                changed = true
+                continue
+            }
+
+            matchedBundleIDs.append(bundleID)
+            if bundleID == primaryBundleID {
+                hasPrimaryApproval = true
+            }
+
+            let expectedMenuLocations = [["bundle": ["_0": bundleID]]]
+            if !menuBundleIDs.elementsEqual([bundleID]) {
+                entry["menuItemLocations"] = expectedMenuLocations
+                changed = true
+            }
+
+            if entry["isAllowed"] as? Bool == true {
+                foundAllowedApproval = true
+            } else {
+                entry["isAllowed"] = true
+                foundAllowedApproval = true
+                changed = true
+            }
+
+            normalizedEntries.append(entry)
+        }
+        entries = normalizedEntries
+
+        var appendedNew = false
+        if !hasPrimaryMarker {
+            entries.append(statusKitBundleMarker(bundleID: primaryBundleID))
+            changed = true
+            appendedNew = true
+        }
+        if !hasPrimaryApproval {
+            entries.append(statusKitApprovalEntry(bundleID: primaryBundleID))
+            changed = true
+            appendedNew = true
+            foundAllowedApproval = true
+        }
+
+        if !changed {
+            let knownIDs = matchedBundleIDs.isEmpty ? primaryBundleID : matchedBundleIDs.joined(separator: ", ")
+            return AutoFixOutcome(
+                success: true,
+                message: """
+                oMLX is already approved in StatusKit (\(knownIDs)). If the \
+                icon still doesn't appear, the root cause is something else. \
+                Share the latest menubar.log with the maintainer.
+                """
+            )
+        }
+
+        do {
+            prepareStatusKitPreferenceWrite()
+
+            if nestedAsData || raw == nil {
+                outer["trackedApplications"] = try PropertyListSerialization.data(
+                    fromPropertyList: entries,
+                    format: .binary,
+                    options: 0
+                )
+            } else {
+                outer["trackedApplications"] = entries
+            }
+
+            let serialized = try PropertyListSerialization.data(
+                fromPropertyList: outer,
+                format: .binary,
+                options: 0
+            )
+            try writeStatusKitPlist(serialized, backup: backup)
+            try validateStatusKitPlist()
+        } catch {
+            restoreStatusKitPlist(from: backup)
+            if isPermissionError(error) {
+                return AutoFixOutcome(
+                    success: false,
+                    message: "Auto-Fix needs Full Disk Access to write the StatusKit preferences.",
+                    needsFullDiskAccess: true
+                )
+            }
+            return AutoFixOutcome(
+                success: false,
+                message: "Failed to write the StatusKit preferences: \(error.localizedDescription)"
+            )
+        }
+
+        if !restartControlCenter() {
+            return AutoFixOutcome(
+                success: true,
+                message: """
+                StatusKit was updated but oMLX couldn't restart ControlCenter. \
+                Run `killall ControlCenter` manually.
+                """
+            )
+        }
+
+        let detail = appendedNew || !foundAllowedApproval
+            ? "appended a new \(primaryBundleID) entry"
+            : "approved the existing oMLX entry"
+        return AutoFixOutcome(
+            success: true,
+            message: """
+            Auto-Fix \(detail) in StatusKit and restarted ControlCenter. \
+            The menubar icon should appear within a few seconds. If it \
+            still doesn't, quit and relaunch oMLX.
+            """
+        )
+    }
+
+    private func backupStatusKitPlist() -> URL? {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: statusKitPlistURL.path) else {
+            return nil
+        }
+
+        let backupDirectory = fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/oMLX/backups")
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        let backupURL = backupDirectory
+            .appendingPathComponent("statuskit-\(formatter.string(from: Date())).plist")
+
+        do {
+            try fileManager.createDirectory(
+                at: backupDirectory,
+                withIntermediateDirectories: true
+            )
+            try fileManager.copyItem(at: statusKitPlistURL, to: backupURL)
+            return backupURL
+        } catch {
+            return nil
+        }
+    }
+
+    private func writeStatusKitPlist(_ data: Data, backup: URL?) throws {
+        let fileManager = FileManager.default
+        let temporaryURL = statusKitPlistURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(statusKitPlistURL.lastPathComponent + ".omlx-tmp")
+
+        do {
+            try data.write(to: temporaryURL, options: [.atomic])
+            _ = try fileManager.replaceItemAt(
+                statusKitPlistURL,
+                withItemAt: temporaryURL,
+                backupItemName: nil,
+                options: []
+            )
+        } catch {
+            try? fileManager.removeItem(at: temporaryURL)
+            restoreStatusKitPlist(from: backup)
+            throw error
+        }
+    }
+
+    private func validateStatusKitPlist() throws {
+        var format = PropertyListSerialization.PropertyListFormat.binary
+        let data = try Data(contentsOf: statusKitPlistURL)
+        _ = try PropertyListSerialization.propertyList(
+            from: data,
+            options: [],
+            format: &format
+        )
+    }
+
+    private func restoreStatusKitPlist(from backup: URL?) {
+        guard let backup else { return }
+        let fileManager = FileManager.default
+        do {
+            if fileManager.fileExists(atPath: statusKitPlistURL.path) {
+                try fileManager.removeItem(at: statusKitPlistURL)
+            }
+            try fileManager.copyItem(at: backup, to: statusKitPlistURL)
+        } catch {
+            // Best effort rollback; the result alert tells the user the write failed.
+        }
+    }
+
+    private func restartControlCenter() -> Bool {
+        _ = runKillall("cfprefsd")
+        return runKillall("ControlCenter")
+    }
+
+    private func prepareStatusKitPreferenceWrite() {
+        _ = runKillall("ControlCenter")
+        _ = runKillall("cfprefsd")
+    }
+
+    private func runKillall(_ processName: String) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
+        process.arguments = [processName]
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+
+    private func bareBundleIdentifier(in entry: [String: Any]) -> String? {
+        guard entry["location"] == nil,
+              entry["menuItemLocations"] == nil,
+              let bundle = entry["bundle"] as? [String: Any] else {
+            return nil
+        }
+        return bundle["_0"] as? String
+    }
+
+    private func locationBundleIdentifier(in entry: [String: Any]) -> String? {
+        guard let location = entry["location"] as? [String: Any],
+              let bundle = location["bundle"] as? [String: Any] else {
+            return nil
+        }
+        return bundle["_0"] as? String
+    }
+
+    private func menuItemBundleIdentifiers(in entry: [String: Any]) -> [String] {
+        guard let locations = entry["menuItemLocations"] as? [[String: Any]] else {
+            return []
+        }
+
+        return locations.compactMap { location in
+            guard let bundle = location["bundle"] as? [String: Any] else {
+                return nil
+            }
+            return bundle["_0"] as? String
+        }
+    }
+
+    private func statusKitBundleMarker(bundleID: String) -> [String: Any] {
+        ["bundle": ["_0": bundleID]]
+    }
+
+    private func statusKitApprovalEntry(bundleID: String) -> [String: Any] {
+        [
+            "location": ["bundle": ["_0": bundleID]],
+            "menuItemLocations": [["bundle": ["_0": bundleID]]],
+            "isAllowed": true
+        ]
+    }
+
+    private func isPermissionError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        if nsError.domain == NSCocoaErrorDomain,
+           nsError.code == NSFileReadNoPermissionError
+            || nsError.code == NSFileWriteNoPermissionError {
+            return true
+        }
+        if nsError.domain == NSPOSIXErrorDomain,
+           nsError.code == 1 || nsError.code == 13 {
+            return true
+        }
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+            return isPermissionError(underlying)
+        }
+        return false
+    }
+
+    private func isKnownMenuBarManagerRunning() -> Bool {
+        let bundleIDs = [
+            "com.surteesstudios.Bartender",
+            "com.jordanbaird.Ice",
+            "com.jordanbaird.ice"
+        ]
+        return bundleIDs.contains { bundleID in
+            !NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).isEmpty
+        }
+    }
+
+    // MARK: - Recovery Alerts
+
+    private func openMenuBarSettings() {
+        if let url = URL(
+            string: "x-apple.systempreferences:com.apple.ControlCenter-Settings.extension?MenuBar"
+        ) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private func openFullDiskAccessSettings() {
+        if let url = URL(
+            string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_AllFiles"
+        ) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    private func showStatusKitAccessDeniedAlert() {
+        NSApp.activate(ignoringOtherApps: true)
+
+        let alert = NSAlert()
+        alert.messageText = "Full Disk Access Required"
+        alert.informativeText = """
+        Auto-Fix needs macOS permission to edit the StatusKit approval file \
+        in your Group Containers folder.
+
+        Enable oMLX in System Settings > Privacy & Security > Full Disk \
+        Access, then run Auto-Fix again.
+        """
+        alert.addButton(withTitle: "Open Full Disk Access")
+        alert.addButton(withTitle: "Dismiss")
+        alert.window.level = .floating
+
+        if alert.runModal() == .alertFirstButtonReturn {
+            openFullDiskAccessSettings()
+        }
+    }
+
+    private func showAutofixResultAlert(success: Bool, message: String) {
+        NSApp.activate(ignoringOtherApps: true)
+
+        let alert = NSAlert()
+        alert.messageText = success ? "Auto-Fix Succeeded" : "Auto-Fix Failed"
+        alert.informativeText = message
+        alert.addButton(withTitle: "OK")
+        alert.window.level = .floating
+        alert.runModal()
     }
 }

--- a/apps/omlx-mac/Sources/Net/DTO/GlobalSettingsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/GlobalSettingsDTO.swift
@@ -42,7 +42,6 @@ struct GlobalSettingsDTO: Codable, Equatable, Sendable {
 
     struct ModelSettings: Codable, Equatable, Sendable {
         let modelDirs: [String]?
-        let maxModelMemory: String?
         let modelFallback: Bool?
     }
 
@@ -62,12 +61,12 @@ struct GlobalSettingsDTO: Codable, Equatable, Sendable {
     }
 
     /// Mirrors the `memory.*` block of GET /admin/api/global-settings.
-    /// `max_process_memory` accepts "auto", "disabled", or "NN%". The
-    /// prefill guard is a runtime-applied bool — when on, the server
-    /// preflights prefill memory before kicking the engine.
+    /// The prefill guard and tier are runtime-applied. When enabled, the
+    /// server preflights prefill memory before kicking the engine.
     struct MemorySettings: Codable, Equatable, Sendable {
-        let maxProcessMemory: String?
         let prefillMemoryGuard: Bool?
+        let memoryGuardTier: String?
+        let memoryGuardCustomCeilingGb: Double?
     }
 
     /// Mirrors the `idle_timeout.*` block. `idle_timeout_seconds == nil`
@@ -234,16 +233,15 @@ struct GlobalSettingsPatch: Encodable, Equatable, Sendable {
     //
     // All flat (snake-cased on the wire by `convertToSnakeCase`). Server
     // applies live wherever possible — see `omlx/admin/routes.py` for the
-    // per-field apply paths. `initial_cache_blocks` and `max_process_memory`
-    // are persisted but only take effect on restart; everything else is
-    // hot-applied.
+    // per-field apply paths. `initial_cache_blocks` requires restart;
+    // memory guard settings are hot-applied.
 
-    /// Free-form memory limit. Accepts `"auto"`, `"disabled"`, or `"NN%"`.
-    var maxProcessMemory: String? = nil
     var memoryPrefillMemoryGuard: Bool? = nil
+    /// Memory guard tier: `"safe"`, `"balanced"`, `"aggressive"`, or
+    /// `"custom"`. For custom, pair with `memoryGuardCustomCeilingGb`.
+    var memoryGuardTier: String? = nil
+    var memoryGuardCustomCeilingGb: Double? = nil
 
-    /// Max bytes the engine pool will hold (`"24GB"`, `"50%"`, etc.).
-    var maxModelMemory: String? = nil
     /// When the requested model isn't loaded, fall back to any loaded
     /// model rather than 404.
     var modelFallback: Bool? = nil

--- a/apps/omlx-mac/Sources/Net/OMLXClient.swift
+++ b/apps/omlx-mac/Sources/Net/OMLXClient.swift
@@ -45,7 +45,7 @@ final class OMLXClient: ObservableObject {
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
-    init(host: String = "127.0.0.1", port: Int = 8080, apiKey: String? = nil) {
+    init(host: String = "127.0.0.1", port: Int = 8000, apiKey: String? = nil) {
         self.host = host
         self.port = port
         self.apiKey = apiKey

--- a/apps/omlx-mac/Sources/Server/PythonRuntime.swift
+++ b/apps/omlx-mac/Sources/Server/PythonRuntime.swift
@@ -3,12 +3,12 @@
 //
 // Resolution order (first match wins):
 //   1. OMLX_PYTHON_OVERRIDE env var — dev escape hatch.
-//   2. Bundle.main/Contents/Frameworks/cpython-3.11/bin/python3 — production.
+//   2. Bundle.main/Contents/Resources/Python/cpython-3.11/bin/python3 — production.
 //      Layout matches the venvstacks export tree, which
 //      apps/omlx-mac/Scripts/build.sh copies verbatim into the Swift .app.
 //
 // In the bundled case the spawn environment also sets:
-//   PYTHONHOME = Contents/Frameworks/cpython-3.11
+//   PYTHONHOME = Contents/Resources/Python/cpython-3.11
 //     so the relocated interpreter finds its stdlib without grepping the
 //     host system's /usr/lib.
 //   PYTHONPATH = Contents/Resources : framework-mlx-base/site-packages
@@ -64,13 +64,13 @@ struct PythonRuntime {
         }
 
         let bundleRoot = Bundle.main.bundleURL
-        let frameworks = bundleRoot.appendingPathComponent("Contents/Frameworks")
-        let cpython = frameworks.appendingPathComponent("cpython-3.11")
+        let resources = bundleRoot.appendingPathComponent("Contents/Resources")
+        let pythonRoot = resources.appendingPathComponent("Python")
+        let cpython = pythonRoot.appendingPathComponent("cpython-3.11")
         let bundled = cpython.appendingPathComponent("bin/python3")
         tried.append(bundled.path)
         if FileManager.default.isExecutableFile(atPath: bundled.path) {
-            let resources = bundleRoot.appendingPathComponent("Contents/Resources")
-            let mlxFramework = frameworks
+            let mlxFramework = pythonRoot
                 .appendingPathComponent("framework-mlx-base/lib/python3.11/site-packages")
             return PythonRuntime(
                 executable: bundled,

--- a/apps/omlx-mac/Sources/Server/ServerProcess.swift
+++ b/apps/omlx-mac/Sources/Server/ServerProcess.swift
@@ -118,7 +118,7 @@ final class ServerProcess: @unchecked Sendable {
     init(
         runtime: PythonRuntime,
         host: String = "127.0.0.1",
-        port: Int = 8080,
+        port: Int = 8000,
         basePath: URL = ServerProcess.defaultBasePath()
     ) {
         self.runtime  = runtime

--- a/apps/omlx-mac/Sources/Theme/Components/CodeChip.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/CodeChip.swift
@@ -47,9 +47,9 @@ struct CodeChip: View {
 
 #Preview("CodeChip") {
     VStack(alignment: .leading, spacing: 10) {
-        CodeChip(value: "http://127.0.0.1:8080/v1")
-        CodeChip(value: "http://127.0.0.1:8080/health")
-        CodeChip(value: "OPENAI_BASE_URL=http://127.0.0.1:8080/v1", maxWidth: 280)
+        CodeChip(value: "http://127.0.0.1:8000/v1")
+        CodeChip(value: "http://127.0.0.1:8000/health")
+        CodeChip(value: "OPENAI_BASE_URL=http://127.0.0.1:8000/v1", maxWidth: 280)
     }
     .padding(24)
     .omlxThemed()

--- a/apps/omlx-mac/Sources/Theme/Components/ListGroup.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/ListGroup.swift
@@ -17,10 +17,6 @@ struct ListGroup<Content: View>: View {
         }
         .background(theme.groupBg)
         .clipShape(RoundedRectangle(cornerRadius: theme.cornerRadius, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: theme.cornerRadius, style: .continuous)
-                .strokeBorder(theme.groupBorder, lineWidth: 0.5)
-        )
         .padding(.horizontal, 14)
         .padding(.bottom, 6)
     }

--- a/apps/omlx-mac/Sources/Theme/Components/Row.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/Row.swift
@@ -53,7 +53,7 @@ struct Row<Trailing: View>: View {
                 Rectangle()
                     .fill(theme.rowSep)
                     .frame(height: 0.5)
-                    .padding(.leading, 14)
+                    .padding(.horizontal, 14)
             }
         }
     }
@@ -92,7 +92,7 @@ struct FreeRow<Content: View>: View {
                     Rectangle()
                         .fill(theme.rowSep)
                         .frame(height: 0.5)
-                        .padding(.leading, 14)
+                        .padding(.horizontal, 14)
                 }
             }
     }

--- a/apps/omlx-mac/Sources/Theme/Components/Row.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/Row.swift
@@ -105,9 +105,9 @@ struct FreeRow<Content: View>: View {
     return ListGroup {
         Row(
             label: "Listen Address",
-            sublabel: "Default 8080. Restart server to apply."
+            sublabel: "Default 8000. Restart server to apply."
         ) {
-            CodeChip(value: "127.0.0.1:8080")
+            CodeChip(value: "127.0.0.1:8000")
         }
         Row(label: "Auto-start on launch") {
             Toggle("", isOn: $autoStart).labelsHidden().toggleStyle(.switch)

--- a/apps/omlx-mac/Sources/Theme/Components/TextInput.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/TextInput.swift
@@ -60,7 +60,7 @@ struct TextInput: View {
 }
 
 #Preview("TextInput") {
-    @Previewable @State var port = "8080"
+    @Previewable @State var port = "8000"
     @Previewable @State var pwd = "sk-omlx-2k4j8"
     @Previewable @State var alias = ""
     return VStack(alignment: .leading, spacing: 14) {

--- a/apps/omlx-mac/Sources/Theme/Theme.swift
+++ b/apps/omlx-mac/Sources/Theme/Theme.swift
@@ -1,9 +1,9 @@
-// PR 3 — design tokens for the Tahoe (macOS 26) liquid-glass system.
+// Design tokens for the macOS settings UI.
 //
-// Lifted verbatim from omlx-components.jsx:10-94 in the design bundle.
-// Both light and dark variants must stay in sync with the canvas; mismatches
-// are caught by manual visual diffs and the snapshot tests in the test
-// target.
+// Surface, text, selection, and control colors intentionally resolve through
+// dynamic AppKit system colors so the app tracks System Settings across light
+// mode, dark mode, accent colors, accessibility contrast, and future macOS
+// appearance updates.
 
 import SwiftUI
 
@@ -73,89 +73,161 @@ struct OMLXTheme: Sendable {
 extension OMLXTheme {
     static let light = OMLXTheme(
         isDark: false,
-        windowBg: .white,
-        sidebarBg: .white(0.55),
-        sidebarBorder: .black(0.06),
-        contentBg: .white(0.75),
-        toolbarBg: .white(0.55),
-        toolbarBorder: .black(0.06),
-        groupBg: .white(0.72),
-        groupBorder: .black(0.06),
-        rowSep: .black(0.06),
-        separator: .black(0.08),
-        text: .black(0.88),
-        textSecondary: Color(rgb24: 0x3C3C43, opacity: 0.62),
-        textTertiary: Color(rgb24: 0x3C3C43, opacity: 0.32),
-        accent: Color(rgb24: 0x007AFF),
-        accentSoft: Color(rgb24: 0x007AFF, opacity: 0.16),
-        accentText: .white,
-        selBg: .black(0.06),
-        hoverBg: .black(0.04),
-        controlBg: .white(0.65),
-        controlBgHover: .white(0.85),
-        glassBg: .white(0.55),
-        glassBgStrong: .white(0.78),
-        inputBg: .white(0.85),
-        inputBorder: .black(0.10),
-        inputBorderFocus: Color(rgb24: 0x007AFF),
-        greenDot: Color(rgb24: 0x30D158),
-        amberDot: Color(rgb24: 0xFF9500),
-        redDot: Color(rgb24: 0xFF3B30),
-        blueDot: Color(rgb24: 0x007AFF),
-        codeBg: .black(0.05),
-        warningBg: Color(rgb24: 0xFFF4E0),
-        warningText: Color(rgb24: 0xB35900),
-        successBg: Color(rgb24: 0xE3F7EA),
-        successText: Color(rgb24: 0x1E7C3A),
-        desktopWashTopLeft: Color(rgb24: 0xA88CFF, opacity: 0.30),
-        desktopWashBottomRight: Color(rgb24: 0x78C8EB, opacity: 0.30),
-        desktopWashBase: Color(rgb24: 0xF3F1EE),
-        groupHighlightTopOpacity: 0.90,
+        windowBg: systemWindowBg,
+        sidebarBg: systemWindowBg,
+        sidebarBorder: systemSeparator,
+        contentBg: systemWindowBg,
+        toolbarBg: systemWindowBg,
+        toolbarBorder: systemSeparator,
+        groupBg: systemGroupBgLight,
+        groupBorder: systemSeparator,
+        rowSep: systemSeparator,
+        separator: systemSeparator,
+        text: systemText,
+        textSecondary: systemTextSecondary,
+        textTertiary: systemTextTertiary,
+        accent: systemAccent,
+        accentSoft: systemAccent.opacity(0.16),
+        accentText: systemAccentText,
+        selBg: systemSelection,
+        hoverBg: systemHover,
+        controlBg: systemControlBg,
+        controlBgHover: systemControlBg.opacity(0.92),
+        glassBg: systemWindowBg.opacity(0.70),
+        glassBgStrong: systemGroupBgLight,
+        inputBg: systemInputBg,
+        inputBorder: systemSeparator,
+        inputBorderFocus: systemAccent,
+        greenDot: systemGreen,
+        amberDot: systemOrange,
+        redDot: systemRed,
+        blueDot: systemAccent,
+        codeBg: systemCodeBgLight,
+        warningBg: systemOrange.opacity(0.16),
+        warningText: systemOrange,
+        successBg: systemGreen.opacity(0.16),
+        successText: systemGreen,
+        desktopWashTopLeft: .clear,
+        desktopWashBottomRight: .clear,
+        desktopWashBase: systemWindowBg,
+        groupHighlightTopOpacity: 0.35,
         groupShadowOpacity: 0.06
     )
 
     static let dark = OMLXTheme(
         isDark: true,
-        windowBg: Color(rgb24: 0x16161A),
-        sidebarBg: Color(rgb24: 0x1C1C20, opacity: 0.55),
-        sidebarBorder: .white(0.07),
-        contentBg: Color(rgb24: 0x16161A, opacity: 0.72),
-        toolbarBg: Color(rgb24: 0x1C1C20, opacity: 0.55),
-        toolbarBorder: .white(0.07),
-        groupBg: Color(rgb24: 0x303036, opacity: 0.55),
-        groupBorder: .white(0.08),
-        rowSep: .white(0.06),
-        separator: .white(0.10),
-        text: .white(0.94),
-        textSecondary: Color(rgb24: 0xEBEBF5, opacity: 0.65),
-        textTertiary: Color(rgb24: 0xEBEBF5, opacity: 0.35),
-        accent: Color(rgb24: 0x0A84FF),
-        accentSoft: Color(rgb24: 0x0A84FF, opacity: 0.22),
-        accentText: .white,
-        selBg: .white(0.10),
-        hoverBg: .white(0.05),
-        controlBg: .white(0.10),
-        controlBgHover: .white(0.16),
-        glassBg: .white(0.10),
-        glassBgStrong: .white(0.14),
-        inputBg: .black(0.30),
-        inputBorder: .white(0.10),
-        inputBorderFocus: Color(rgb24: 0x0A84FF),
-        greenDot: Color(rgb24: 0x30D158),
-        amberDot: Color(rgb24: 0xFF9F0A),
-        redDot: Color(rgb24: 0xFF453A),
-        blueDot: Color(rgb24: 0x0A84FF),
-        codeBg: .white(0.07),
-        warningBg: Color(rgb24: 0xFF9F0A, opacity: 0.18),
-        warningText: Color(rgb24: 0xFFB340),
-        successBg: Color(rgb24: 0x30D158, opacity: 0.18),
-        successText: Color(rgb24: 0x34C759),
-        desktopWashTopLeft: Color(rgb24: 0x6048DC, opacity: 0.22),
-        desktopWashBottomRight: Color(rgb24: 0x28A0D2, opacity: 0.18),
-        desktopWashBase: Color(rgb24: 0x0E0E12),
+        windowBg: systemWindowBg,
+        sidebarBg: systemWindowBg,
+        sidebarBorder: systemSeparator,
+        contentBg: systemWindowBg,
+        toolbarBg: systemWindowBg,
+        toolbarBorder: systemSeparator,
+        groupBg: systemGroupBgDark,
+        groupBorder: systemSeparator,
+        rowSep: systemSeparator,
+        separator: systemSeparator,
+        text: systemText,
+        textSecondary: systemTextSecondary,
+        textTertiary: systemTextTertiary,
+        accent: systemAccent,
+        accentSoft: systemAccent.opacity(0.22),
+        accentText: systemAccentText,
+        selBg: systemSelection,
+        hoverBg: systemHover,
+        controlBg: systemControlBg,
+        controlBgHover: systemControlBg.opacity(0.85),
+        glassBg: systemWindowBg.opacity(0.70),
+        glassBgStrong: systemGroupBgDark,
+        inputBg: systemInputBg,
+        inputBorder: systemSeparator,
+        inputBorderFocus: systemAccent,
+        greenDot: systemGreen,
+        amberDot: systemOrange,
+        redDot: systemRed,
+        blueDot: systemAccent,
+        codeBg: systemCodeBgDark,
+        warningBg: systemOrange.opacity(0.18),
+        warningText: systemOrange,
+        successBg: systemGreen.opacity(0.18),
+        successText: systemGreen,
+        desktopWashTopLeft: .clear,
+        desktopWashBottomRight: .clear,
+        desktopWashBase: systemWindowBg,
         groupHighlightTopOpacity: 0.08,
-        groupShadowOpacity: 0.30
+        groupShadowOpacity: 0.08
     )
+
+    private static var systemWindowBg: Color {
+        Color(nsColor: .underPageBackgroundColor)
+    }
+
+    private static var systemGroupBgLight: Color {
+        Color(nsColor: .windowBackgroundColor)
+    }
+
+    private static var systemGroupBgDark: Color {
+        Color(nsColor: .labelColor).opacity(0.03)
+    }
+
+    private static var systemControlBg: Color {
+        Color(nsColor: .controlColor)
+    }
+
+    private static var systemCodeBgLight: Color {
+        systemText.opacity(0.05)
+    }
+
+    private static var systemCodeBgDark: Color {
+        systemText.opacity(0.07)
+    }
+
+    private static var systemInputBg: Color {
+        Color(nsColor: .textBackgroundColor)
+    }
+
+    private static var systemSeparator: Color {
+        Color(nsColor: .separatorColor)
+    }
+
+    private static var systemText: Color {
+        Color(nsColor: .labelColor)
+    }
+
+    private static var systemTextSecondary: Color {
+        Color(nsColor: .secondaryLabelColor)
+    }
+
+    private static var systemTextTertiary: Color {
+        Color(nsColor: .tertiaryLabelColor)
+    }
+
+    private static var systemAccent: Color {
+        Color(nsColor: .controlAccentColor)
+    }
+
+    private static var systemAccentText: Color {
+        Color(nsColor: .alternateSelectedControlTextColor)
+    }
+
+    private static var systemSelection: Color {
+        Color(nsColor: .unemphasizedSelectedContentBackgroundColor)
+    }
+
+    private static var systemHover: Color {
+        Color(nsColor: .quaternaryLabelColor)
+    }
+
+    private static var systemGreen: Color {
+        Color(nsColor: .systemGreen)
+    }
+
+    private static var systemOrange: Color {
+        Color(nsColor: .systemOrange)
+    }
+
+    private static var systemRed: Color {
+        Color(nsColor: .systemRed)
+    }
 }
 
 // MARK: - Environment

--- a/apps/omlx-mac/Sources/Updater/UpdateController.swift
+++ b/apps/omlx-mac/Sources/Updater/UpdateController.swift
@@ -60,7 +60,17 @@ final class UpdateController: ObservableObject {
         didSet { if !suspendPersist { persist() } }
     }
     @Published var autoCheck: Bool {
-        didSet { if !suspendPersist { persist() } }
+        didSet {
+            guard !suspendPersist else { return }
+            persist()
+            if autoCheck {
+                backgroundCheck()
+                scheduleBackgroundChecker()
+            } else {
+                backgroundTimer?.invalidate()
+                backgroundTimer = nil
+            }
+        }
     }
     @Published var autoDownload: Bool {
         didSet { if !suspendPersist { persist() } }

--- a/apps/omlx-mac/Sources/Welcome/WelcomeWindow.swift
+++ b/apps/omlx-mac/Sources/Welcome/WelcomeWindow.swift
@@ -8,8 +8,8 @@
 //   • `WelcomeViewModel` is a @MainActor ObservableObject holding the wizard
 //     state across pages, the validation, and the "Start Server" action.
 //
-// First-run trigger lives in `AppDelegate` (PR 10 addition). When config.json
-// already exists (re-entry), the Welcome page is skipped via VM init state.
+// First-run trigger lives in `AppDelegate` (PR 10 addition). When settings.json
+// already exists (re-entry), the Welcome page is skipped via app boot flow.
 
 import AppKit
 import SwiftUI
@@ -25,18 +25,15 @@ final class WelcomeWindowController: NSObject, NSWindowDelegate {
     private weak var services: AppServices?
     private weak var server: ServerProcess?
     private let didFinish: (AppConfig, ServerProcess?) -> Void
-    private let didSkip: ((AppConfig) -> Void)?
 
     init(
         services: AppServices,
         server: ServerProcess?,
-        didFinish: @escaping (AppConfig, ServerProcess?) -> Void,
-        didSkip: ((AppConfig) -> Void)? = nil
+        didFinish: @escaping (AppConfig, ServerProcess?) -> Void
     ) {
         self.services = services
         self.server = server
         self.didFinish = didFinish
-        self.didSkip = didSkip
         super.init()
     }
 
@@ -69,13 +66,18 @@ final class WelcomeWindowController: NSObject, NSWindowDelegate {
 
         let win = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 680, height: 620),
-            styleMask: [.titled, .closable],
+            styleMask: [.titled, .closable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
         win.title = String(localized: "welcome.window.title",
                            defaultValue: "Welcome to oMLX",
                            comment: "Window title bar text for the Welcome wizard")
+        win.titleVisibility = .hidden
+        win.titlebarAppearsTransparent = true
+        win.titlebarSeparatorStyle = .none
+        win.backgroundColor = .windowBackgroundColor
+        win.isMovableByWindowBackground = true
         win.contentViewController = hosting
         win.center()
         win.delegate = self
@@ -100,17 +102,10 @@ final class WelcomeWindowController: NSObject, NSWindowDelegate {
         }
     }
 
-    /// Skip path: the user dismissed the wizard without running Start Server.
-    /// Spec §State machine says the current Storage values should be written
-    /// (with an empty API key when not validated) so the next launch lands
-    /// on AppView's API-key-not-configured banner instead of re-firing the
-    /// wizard. Triggered only when `vm.startCompleted` is false — otherwise
-    /// `onFinish` already wrote a complete config.
+    /// Closing before Start Server is cancellation, not partial setup. Do not
+    /// write settings.json or create the base path; AppDelegate will terminate
+    /// so the next launch starts from the Welcome intro again.
     private func handleWillClose() {
-        if let vm, !vm.startCompleted, let didSkip {
-            let snapshot = vm.skipSnapshot()
-            didSkip(snapshot)
-        }
         NotificationCenter.default.post(
             name: WelcomeWindowController.willCloseNotification,
             object: nil
@@ -398,36 +393,6 @@ final class WelcomeViewModel: ObservableObject {
         return true
     }
 
-    /// Spec §State machine — early close: write the current Storage values
-    /// (keep `apiKey` blank if not validated) so the user lands on AppView
-    /// with the API-key-not-configured banner instead of looping back into
-    /// the wizard. Called by `WelcomeWindowController` on `windowWillClose`
-    /// when `startCompleted` is false.
-    func skipSnapshot() -> AppConfig {
-        guard let services else { return AppConfig.default }
-        var cfg = services.config
-        let trimmedBase = ((basePath.trimmingCharacters(in: .whitespaces)
-                            as NSString).expandingTildeInPath as NSString)
-            .standardizingPath
-        if !trimmedBase.isEmpty { cfg.basePath = trimmedBase }
-        if let port = Int(portText.trimmingCharacters(in: .whitespaces)),
-           (1...65535).contains(port) {
-            cfg.port = port
-        }
-        let trimmedDir = modelDir.trimmingCharacters(in: .whitespaces)
-        cfg.modelDir = trimmedDir.isEmpty
-            ? AppConfig.defaultModelDir(forBasePath: cfg.basePath)
-            : trimmedDir
-        // Per spec: an unvalidated API key is dropped, so the user lands on
-        // the API-key-not-configured banner rather than persisting garbage.
-        if validateApiKey() {
-            cfg.apiKey = apiKey.trimmingCharacters(in: .whitespaces)
-        } else {
-            cfg.apiKey = ""
-        }
-        return cfg
-    }
-
     private func setupServerApiKey(client: OMLXClient, key: String) async -> Bool {
         // Try setup-api-key (fresh install). When the server already has a
         // key set, the endpoint returns 400 — we swallow that and let
@@ -461,6 +426,7 @@ struct WelcomeView: View {
         let theme = scheme == .dark ? OMLXTheme.dark : OMLXTheme.light
         ZStack {
             WelcomeBackdrop()
+                .ignoresSafeArea()
 
             VStack(spacing: 0) {
                 Group {
@@ -474,7 +440,6 @@ struct WelcomeView: View {
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-
                 WelcomeFooter(vm: vm)
             }
         }
@@ -508,22 +473,29 @@ private struct WelcomeIntroBody: View {
             Spacer(minLength: 18)
             WelcomeIcon(size: 88)
 
-            VStack(spacing: 10) {
+            VStack(spacing: 14) {
                 Text(String(localized: "welcome.header.title",
-                            defaultValue: "Local AI,\nno more waiting.",
+                            defaultValue: "oMLX",
                             comment: "Main heading shown on the Welcome wizard"))
-                    .font(.omlxDisplay(34, weight: .semibold))
+                    .font(.omlxDisplay(48, weight: .semibold))
                     .foregroundStyle(WelcomeStyle.text)
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
+                Text(String(localized: "welcome.header.subtitle",
+                            defaultValue: "Local AI, no more waiting.",
+                            comment: "Short tagline under the Welcome wizard's main heading"))
+                    .font(.omlxDisplay(25, weight: .semibold))
+                    .foregroundStyle(WelcomeStyle.text)
+                    .multilineTextAlignment(.center)
                 Text(String(localized: "welcome.header.tagline",
-                            defaultValue: "Run an MLX server on your Mac. Keep agent context warm with smart caching, then plug Claude Code, OpenClaw, Cursor, and other tools into localhost.",
+                            defaultValue: "macOS-native MLX server with smart caching.\nClaude Code, OpenClaw, and Cursor respond in 5 seconds, not 90.",
                             comment: "Sub-tagline under the Welcome wizard's main heading"))
-                    .font(.omlxText(14))
+                    .font(.omlxText(15))
                     .foregroundStyle(WelcomeStyle.muted)
                     .multilineTextAlignment(.center)
-                    .lineSpacing(3)
-                    .frame(maxWidth: 500)
+                    .lineSpacing(5)
+                    .frame(maxWidth: 540)
+                    .padding(.top, 6)
             }
 
             HStack(spacing: 10) {
@@ -602,7 +574,7 @@ private struct WelcomeSetupBody: View {
                                       defaultValue: "Model Directory",
                                       comment: "Row label for the Model Directory picker in Welcome wizard"),
                         subtitle: String(localized: "welcome.storage.model_dir.sub",
-                                         defaultValue: "Where downloaded and imported models are stored.",
+                                         defaultValue: "Where downloaded models are stored.",
                                          comment: "Sublabel explaining the model directory")
                     ) {
                         HStack(spacing: 8) {
@@ -613,14 +585,18 @@ private struct WelcomeSetupBody: View {
                                 .foregroundStyle(WelcomeStyle.muted)
                                 .lineLimit(1)
                                 .truncationMode(.middle)
-                                .frame(width: 176, alignment: .trailing)
-                            Button(String(localized: "welcome.button.browse",
-                                          defaultValue: "Browse...",
-                                          comment: "Folder picker trigger button in Welcome wizard")) {
+                                .frame(width: 232, alignment: .trailing)
+                            Button {
                                 vm.browseModelDirectory()
+                            } label: {
+                                Image(systemName: "folder")
+                                    .font(.system(size: 13, weight: .semibold))
                             }
                             .buttonStyle(.omlx(.normal, size: .small))
                             .disabled(vm.isStarting)
+                            .help(String(localized: "welcome.button.browse",
+                                         defaultValue: "Browse...",
+                                         comment: "Folder picker trigger button in Welcome wizard"))
                         }
                     }
 
@@ -632,7 +608,7 @@ private struct WelcomeSetupBody: View {
                                   defaultValue: "API Key",
                                   comment: "Row label for the primary API key field in Welcome wizard"),
                         subtitle: String(localized: "welcome.api_key.sub",
-                                         defaultValue: "This key is also your Web Dashboard login password. Use something memorable, and keep it private.",
+                                         defaultValue: "This key is also your Web Dashboard login password.",
                                          comment: "Sublabel explaining API key usage")
                     ) {
                         HStack(spacing: 8) {
@@ -680,7 +656,7 @@ private struct WelcomeSetupBody: View {
     @ViewBuilder
     private func keyField(_ binding: Binding<String>) -> some View {
         let placeholder = String(localized: "welcome.api_key.placeholder",
-                                 defaultValue: "Enter your API key",
+                                 defaultValue: "Create an API key",
                                  comment: "Placeholder text inside the API key text field")
         if keyVisible {
             TextInput(text: binding, placeholder: placeholder, mono: true, width: 210)

--- a/apps/omlx-mac/Sources/Welcome/WelcomeWindow.swift
+++ b/apps/omlx-mac/Sources/Welcome/WelcomeWindow.swift
@@ -1,14 +1,12 @@
-// First-run welcome wizard. Single-page Storage + API-key setup; spawns
-// the server on confirm.
+// First-run welcome wizard. Three-step flow: product intro, setup, and
+// success. The setup step persists config and spawns the server.
 //
 // Architecture
 //   • `WelcomeWindowController` is the AppKit owner of the NSWindow + the
-//     SwiftUI `WelcomeView` that drives the four pages. AppDelegate creates
-//     one on first run only — returning users never see this window.
+//     SwiftUI `WelcomeView`. AppDelegate creates one on first run only —
+//     returning users never see this window.
 //   • `WelcomeViewModel` is a @MainActor ObservableObject holding the wizard
 //     state across pages, the validation, and the "Start Server" action.
-//   • Single window, four pages (Welcome → Storage → API Key → Ready);
-//     Next/Back at the bottom; step indicator dots at the top.
 //
 // First-run trigger lives in `AppDelegate` (PR 10 addition). When config.json
 // already exists (re-entry), the Welcome page is skipped via VM init state.
@@ -54,7 +52,12 @@ final class WelcomeWindowController: NSObject, NSWindowDelegate {
         vm.onFinish = { [weak self] config, server in
             guard let self else { return }
             self.didFinish(config, server)
-            self.close()
+        }
+        vm.onOpenDashboard = { [weak self] in
+            self?.close()
+        }
+        vm.onClose = { [weak self] in
+            self?.close()
         }
         self.vm = vm
 
@@ -62,10 +65,10 @@ final class WelcomeWindowController: NSObject, NSWindowDelegate {
             .environmentObject(services)
 
         let hosting = NSHostingController(rootView: root)
-        hosting.view.frame = NSRect(x: 0, y: 0, width: 540, height: 600)
+        hosting.view.frame = NSRect(x: 0, y: 0, width: 680, height: 620)
 
         let win = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 540, height: 600),
+            contentRect: NSRect(x: 0, y: 0, width: 680, height: 620),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -117,18 +120,26 @@ final class WelcomeWindowController: NSObject, NSWindowDelegate {
 
 // MARK: - View model
 
+enum WelcomeStep: Equatable, Sendable {
+    case intro
+    case setup
+    case complete
+}
+
 @MainActor
 final class WelcomeViewModel: ObservableObject {
+    @Published var step: WelcomeStep = .intro
     @Published var basePath: String
     @Published var modelDir: String
     @Published var portText: String
     @Published var apiKey: String = ""
-    @Published var apiKeyConfirm: String = ""
     @Published var lastError: String?
     @Published var isStarting: Bool = false
     @Published var startCompleted: Bool = false
 
     var onFinish: ((AppConfig, ServerProcess?) -> Void)?
+    var onOpenDashboard: (() -> Void)?
+    var onClose: (() -> Void)?
 
     private weak var services: AppServices?
     private weak var server: ServerProcess?
@@ -141,7 +152,6 @@ final class WelcomeViewModel: ObservableObject {
         self.modelDir = cfg.modelDir
         self.portText = String(cfg.port)
         self.apiKey = cfg.apiKey ?? ""
-        self.apiKeyConfirm = cfg.apiKey ?? ""
     }
 
     /// Single-page validation gate — runs Storage + API-key checks in
@@ -150,17 +160,19 @@ final class WelcomeViewModel: ObservableObject {
         validateStorage() && validateApiKey()
     }
 
-    // MARK: API key generation
-
-    /// Mint a fresh API key via the shared `APIKeyGenerator` and mirror it
-    /// into both fields so the Confirm row stays in sync. Shared with the
-    /// Security screen so both surfaces produce the same `sk-omlx-<...>`
-    /// shape.
-    func generateApiKey() {
-        let key = APIKeyGenerator.random()
-        apiKey = key
-        apiKeyConfirm = key
+    func beginSetup() {
+        step = .setup
         lastError = nil
+    }
+
+    func backToIntro() {
+        guard !isStarting else { return }
+        step = .intro
+        lastError = nil
+    }
+
+    func requestClose() {
+        onClose?()
     }
 
     // MARK: Validation
@@ -203,12 +215,6 @@ final class WelcomeViewModel: ObservableObject {
             lastError = String(localized: "welcome.error.key_non_ascii",
                                defaultValue: "API key must contain only printable ASCII.",
                                comment: "Welcome wizard validation: api key has non-printable or non-ASCII chars")
-            return false
-        }
-        guard apiKey == apiKeyConfirm else {
-            lastError = String(localized: "welcome.error.key_mismatch",
-                               defaultValue: "API keys do not match.",
-                               comment: "Welcome wizard validation: confirm field differs")
             return false
         }
         lastError = nil
@@ -270,6 +276,7 @@ final class WelcomeViewModel: ObservableObject {
                              as NSString).expandingTildeInPath as NSString)
             .standardizingPath
         var config = services.config
+        config.host = "127.0.0.1"
         config.basePath = resolvedBase
         config.port = port
         // modelDir is always a literal path. The wizard's "Reset" button
@@ -372,26 +379,23 @@ final class WelcomeViewModel: ObservableObject {
         _ = await setupServerApiKey(client: services.client, key: trimmedKey)
 
         startCompleted = true
+        step = .complete
         onFinish?(config, proc)
         return true
     }
 
-    /// Drives Start Server **and** opens the admin dashboard in the user's
-    /// default browser. Spec §Flow page 4 splits the Ready action into two:
-    /// "Start Server" (Welcome closes; AppView opens) and "Open Admin Panel
-    /// & Close" (browser opens to the local dashboard). Implementation just
-    /// runs `startServer()` then hands the URL to NSWorkspace.
+    /// Opens the admin dashboard after the setup step has started the server.
     @discardableResult
-    func startServerAndOpenAdmin() async -> Bool {
-        let ok = await startServer()
-        guard ok, let services else { return ok }
+    func openWebDashboard() -> Bool {
+        guard let services else { return false }
         let port = services.config.port
         let host = services.config.host
         guard let url = URL(string: "http://\(host):\(port)/admin/dashboard") else {
-            return ok
+            return false
         }
         NSWorkspace.shared.open(url)
-        return ok
+        onOpenDashboard?()
+        return true
     }
 
     /// Spec §State machine — early close: write the current Storage values
@@ -455,327 +459,514 @@ struct WelcomeView: View {
 
     var body: some View {
         let theme = scheme == .dark ? OMLXTheme.dark : OMLXTheme.light
-        VStack(spacing: 0) {
-            ScrollView {
-                VStack(spacing: 24) {
-                    WelcomeHeader()
-                    SetupBody(vm: vm)
-                }
-                .padding(.horizontal, 32)
-                .padding(.top, 28)
-                .padding(.bottom, 24)
-            }
+        ZStack {
+            WelcomeBackdrop()
 
-            Footer(vm: vm)
+            VStack(spacing: 0) {
+                Group {
+                    switch vm.step {
+                    case .intro:
+                        WelcomeIntroBody()
+                    case .setup:
+                        WelcomeSetupBody(vm: vm)
+                    case .complete:
+                        WelcomeCompleteBody(vm: vm)
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                WelcomeFooter(vm: vm)
+            }
         }
-        .background(theme.windowBg)
         .environment(\.omlxTheme, theme)
-        .frame(width: 540, height: 640)
+        .frame(width: 680, height: 620)
     }
 }
 
-/// Top splash band — logo squircle, headline, tagline, and the three
-/// "what this app does" bullets. Static; appears on every wizard open
-/// (first-run and re-entry alike) since there's now only one page.
-private struct WelcomeHeader: View {
-    @Environment(\.omlxTheme) private var theme
+// MARK: - Welcome redesign
 
+private enum WelcomeStyle {
+    static let bg = Color(nsColor: .windowBackgroundColor)
+    static let panel = Color(nsColor: .controlBackgroundColor)
+    static let panelBorder = Color(nsColor: .separatorColor)
+    static let text = Color(nsColor: .labelColor)
+    static let muted = Color(nsColor: .secondaryLabelColor)
+    static let faint = Color(nsColor: .tertiaryLabelColor)
+    static let fill = Color(nsColor: .quaternaryLabelColor).opacity(0.16)
+    static let accent = Color.accentColor
+}
+
+private struct WelcomeBackdrop: View {
     var body: some View {
-        VStack(spacing: 12) {
-            // AppLogo's SVG has a 10pt margin inside a 160pt viewBox; the
-            // 73×73 frame (≈64 × 160/140) reads at the same visible ~64pt
-            // size the previous Squircle did. Matches AboutScreen/ServerScreen.
-            Image("AppLogo")
-                .resizable()
-                .interpolation(.high)
-                .frame(width: 73, height: 73)
-            VStack(spacing: 4) {
+        WelcomeStyle.bg
+    }
+}
+
+private struct WelcomeIntroBody: View {
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer(minLength: 18)
+            WelcomeIcon(size: 88)
+
+            VStack(spacing: 10) {
                 Text(String(localized: "welcome.header.title",
-                            defaultValue: "Welcome to oMLX",
+                            defaultValue: "Local AI,\nno more waiting.",
                             comment: "Main heading shown on the Welcome wizard"))
-                    .font(.omlxText(22, weight: .semibold))
-                    .foregroundStyle(theme.text)
+                    .font(.omlxDisplay(34, weight: .semibold))
+                    .foregroundStyle(WelcomeStyle.text)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
                 Text(String(localized: "welcome.header.tagline",
-                            defaultValue: "LLM inference, optimized for your Mac",
+                            defaultValue: "Run an MLX server on your Mac. Keep agent context warm with smart caching, then plug Claude Code, OpenClaw, Cursor, and other tools into localhost.",
                             comment: "Sub-tagline under the Welcome wizard's main heading"))
-                    .font(.omlxText(12))
-                    .foregroundStyle(theme.textSecondary)
+                    .font(.omlxText(14))
+                    .foregroundStyle(WelcomeStyle.muted)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(3)
+                    .frame(maxWidth: 500)
             }
+
+            HStack(spacing: 10) {
+                FeaturePill(icon: "lock.fill", title: "Localhost")
+                FeaturePill(icon: "memorychip", title: "MLX")
+                FeaturePill(icon: "bolt.fill", title: "Smart caching")
+            }
+            .padding(.top, 8)
+
+            Text(String(localized: "welcome.header.meta",
+                        defaultValue: "Apple Silicon · macOS-native · Apache 2.0",
+                        comment: "Short metadata line on the Welcome intro page"))
+                .font(.omlxText(12))
+                .foregroundStyle(WelcomeStyle.faint)
+
+            Spacer(minLength: 28)
         }
         .frame(maxWidth: .infinity)
+        .padding(.horizontal, 54)
     }
 }
 
-/// Single-page setup: Storage rows, API Key rows, hints. The footer's
-/// "Start Server" / "Open Admin Panel & Close" actions live on the
-/// outer `Footer` so this view is purely the editable body.
-private struct SetupBody: View {
+private struct WelcomeSetupBody: View {
     @ObservedObject var vm: WelcomeViewModel
-    @Environment(\.omlxTheme) private var theme
     @State private var keyVisible: Bool = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            Text(String(localized: "welcome.intro",
-                        defaultValue: "Confirm where weights live and pick an API key. You can change either later in Settings.",
-                        comment: "Intro paragraph at the top of the Welcome wizard's setup body"))
-                .font(.omlxText(12))
-                .foregroundStyle(theme.textSecondary)
-                .frame(maxWidth: .infinity, alignment: .leading)
+        VStack(spacing: 22) {
+            WelcomeIcon(size: 70)
 
-            // Storage
-            VStack(alignment: .leading, spacing: 6) {
-                sectionLabel(String(localized: "welcome.storage.section",
-                                    defaultValue: "Storage",
-                                    comment: "Section heading above the Storage rows in Welcome wizard"))
-                ListGroup {
-                    FreeRow {
-                        VStack(alignment: .leading, spacing: 6) {
-                            labelRow(String(localized: "welcome.storage.base_dir.label",
-                                            defaultValue: "Base Directory",
-                                            comment: "Row label for the Base Directory picker in Welcome wizard"))
-                            HStack(spacing: 8) {
-                                Text(vm.basePath)
-                                    .font(.omlxMono(11))
-                                    .foregroundStyle(theme.textSecondary)
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                Button(String(localized: "welcome.button.browse",
-                                              defaultValue: "Browse…",
-                                              comment: "Folder picker trigger button in Welcome wizard")) {
-                                    vm.browseBaseDirectory()
-                                }
-                                    .buttonStyle(.omlx(.normal, size: .small))
-                            }
-                        }
-                    }
-                    FreeRow {
-                        VStack(alignment: .leading, spacing: 6) {
-                            labelRow(String(localized: "welcome.storage.model_dir.label",
-                                            defaultValue: "Model Directory",
-                                            comment: "Row label for the Model Directory picker in Welcome wizard"),
-                                     sub: String(localized: "welcome.storage.model_dir.sub",
-                                                 defaultValue: "Optional — defaults to <base>/models",
-                                                 comment: "Sublabel hinting that Model Directory is optional"))
-                            HStack(spacing: 8) {
-                                Text(vm.modelDir.isEmpty
-                                     ? String(localized: "welcome.storage.model_dir.placeholder",
-                                              defaultValue: "<\((vm.basePath as NSString).lastPathComponent)>/models",
-                                              comment: "Placeholder string shown when Model Directory is unset; placeholder is the base path's leaf name")
-                                     : vm.modelDir)
-                                    .font(.omlxMono(11))
-                                    .foregroundStyle(theme.textSecondary)
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                if !vm.modelDir.isEmpty {
-                                    Button(String(localized: "welcome.button.reset",
-                                                  defaultValue: "Reset",
-                                                  comment: "Clear the Model Directory override")) {
-                                        vm.modelDir = ""
-                                    }
-                                        .buttonStyle(.omlx(.plain, size: .small))
-                                }
-                                Button(String(localized: "welcome.button.browse",
-                                              defaultValue: "Browse…",
-                                              comment: "Folder picker trigger button in Welcome wizard")) {
-                                    vm.browseModelDirectory()
-                                }
-                                    .buttonStyle(.omlx(.normal, size: .small))
-                            }
-                        }
-                    }
-                    Row(label: String(localized: "welcome.storage.port.label",
+            VStack(spacing: 6) {
+                Text(String(localized: "welcome.setup.title",
+                            defaultValue: "Set up your local server",
+                            comment: "Heading on the Welcome setup page"))
+                    .font(.omlxDisplay(24, weight: .semibold))
+                    .foregroundStyle(WelcomeStyle.text)
+                Text(String(localized: "welcome.intro",
+                            defaultValue: "Choose where models live, pick a port, and create the API key you'll use from apps and the web dashboard.",
+                            comment: "Intro paragraph at the top of the Welcome wizard's setup body"))
+                    .font(.omlxText(13))
+                    .foregroundStyle(WelcomeStyle.muted)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(2)
+                    .frame(maxWidth: 480)
+            }
+
+            VStack(alignment: .leading, spacing: 18) {
+                WelcomeNotice(
+                    icon: "memorychip.fill",
+                    title: String(localized: "welcome.setup.local.title",
+                                  defaultValue: "Local server",
+                                  comment: "Title for the local server setup card"),
+                    text: String(localized: "welcome.setup.local.body",
+                                 defaultValue: "oMLX binds to 127.0.0.1 on first run, so clients on this Mac can use it without exposing the server to your network.",
+                                 comment: "Body for the local server setup card")
+                )
+
+                VStack(spacing: 0) {
+                    SettingRow(
+                        icon: "number",
+                        title: String(localized: "welcome.storage.port.label",
                                       defaultValue: "Port",
                                       comment: "Row label for the server port field in Welcome wizard"),
-                        sublabel: String(localized: "welcome.storage.port.sub",
-                                         defaultValue: "1024-65535 recommended; default 8080",
-                                         comment: "Sublabel for the port field with the recommended range"),
-                        isLast: true) {
-                        TextInput(text: $vm.portText, mono: true, width: 100)
+                        subtitle: String(localized: "welcome.storage.port.sub",
+                                         defaultValue: "Default 8000. Change this only if the port is already in use.",
+                                         comment: "Sublabel for the port field with the recommended default")
+                    ) {
+                        TextInput(text: $vm.portText, mono: true, width: 96)
                     }
-                }
-            }
 
-            // API Key
-            VStack(alignment: .leading, spacing: 6) {
-                sectionLabel(String(localized: "welcome.api_key.section",
-                                    defaultValue: "API Key",
-                                    comment: "Section heading above the API key rows in Welcome wizard"))
-                ListGroup {
-                    FreeRow {
-                        VStack(alignment: .leading, spacing: 6) {
-                            labelRow(String(localized: "welcome.api_key.label",
-                                            defaultValue: "API Key",
-                                            comment: "Row label for the primary API key field in Welcome wizard"),
-                                     sub: String(localized: "welcome.api_key.sub",
-                                                 defaultValue: "At least 4 printable characters, no whitespace",
-                                                 comment: "Sublabel describing API key format requirements"))
-                            HStack(spacing: 6) {
-                                keyField($vm.apiKey)
-                                Button {
-                                    keyVisible.toggle()
-                                } label: {
-                                    Image(systemName: keyVisible ? "eye.slash" : "eye")
-                                        .font(.system(size: 12))
-                                }
-                                .buttonStyle(.omlx(.plain, size: .small))
-                                .help(keyVisible
-                                      ? String(localized: "welcome.api_key.hide",
-                                               defaultValue: "Hide key",
-                                               comment: "Tooltip on the eye-slash button that masks the API key field")
-                                      : String(localized: "welcome.api_key.show",
-                                               defaultValue: "Show key",
-                                               comment: "Tooltip on the eye button that unmasks the API key field"))
-                                Button {
-                                    vm.generateApiKey()
-                                    keyVisible = true
-                                } label: {
-                                    HStack(spacing: 4) {
-                                        Image(systemName: "sparkles")
-                                            .font(.system(size: 11))
-                                        Text(String(localized: "welcome.api_key.generate",
-                                                    defaultValue: "Generate",
-                                                    comment: "Button label that mints a random API key"))
-                                    }
-                                }
-                                .buttonStyle(.omlx(.normal, size: .small))
-                                .help(String(localized: "welcome.api_key.generate.help",
-                                             defaultValue: "Generate a random 40-char API key",
-                                             comment: "Tooltip on the Generate API key button"))
+                    WelcomeDivider()
+
+                    SettingRow(
+                        icon: "folder",
+                        title: String(localized: "welcome.storage.model_dir.label",
+                                      defaultValue: "Model Directory",
+                                      comment: "Row label for the Model Directory picker in Welcome wizard"),
+                        subtitle: String(localized: "welcome.storage.model_dir.sub",
+                                         defaultValue: "Where downloaded and imported models are stored.",
+                                         comment: "Sublabel explaining the model directory")
+                    ) {
+                        HStack(spacing: 8) {
+                            Text(vm.modelDir.isEmpty
+                                 ? AppConfig.defaultModelDir(forBasePath: vm.basePath)
+                                 : vm.modelDir)
+                                .font(.omlxMono(11))
+                                .foregroundStyle(WelcomeStyle.muted)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .frame(width: 176, alignment: .trailing)
+                            Button(String(localized: "welcome.button.browse",
+                                          defaultValue: "Browse...",
+                                          comment: "Folder picker trigger button in Welcome wizard")) {
+                                vm.browseModelDirectory()
                             }
+                            .buttonStyle(.omlx(.normal, size: .small))
+                            .disabled(vm.isStarting)
                         }
                     }
-                    FreeRow(isLast: true) {
-                        VStack(alignment: .leading, spacing: 6) {
-                            labelRow(String(localized: "welcome.api_key.confirm.label",
-                                            defaultValue: "Confirm",
-                                            comment: "Row label for the API key confirmation field"),
-                                     sub: String(localized: "welcome.api_key.confirm.sub",
-                                                 defaultValue: "Re-enter the key to catch typos",
-                                                 comment: "Sublabel for the Confirm API key field"))
-                            keyField($vm.apiKeyConfirm)
+
+                    WelcomeDivider()
+
+                    SettingRow(
+                        icon: "key",
+                        title: String(localized: "welcome.api_key.label",
+                                  defaultValue: "API Key",
+                                  comment: "Row label for the primary API key field in Welcome wizard"),
+                        subtitle: String(localized: "welcome.api_key.sub",
+                                         defaultValue: "This key is also your Web Dashboard login password. Use something memorable, and keep it private.",
+                                         comment: "Sublabel explaining API key usage")
+                    ) {
+                        HStack(spacing: 8) {
+                            keyField($vm.apiKey)
+                            Button {
+                                keyVisible.toggle()
+                            } label: {
+                                Image(systemName: keyVisible ? "eye.slash" : "eye")
+                                    .font(.system(size: 13, weight: .semibold))
+                            }
+                            .buttonStyle(.omlx(.plain, size: .small))
+                            .disabled(vm.isStarting)
+                            .help(keyVisible
+                                  ? String(localized: "welcome.api_key.hide",
+                                           defaultValue: "Hide key",
+                                           comment: "Tooltip on the eye-slash button that masks the API key field")
+                                  : String(localized: "welcome.api_key.show",
+                                           defaultValue: "Show key",
+                                           comment: "Tooltip on the eye button that unmasks the API key field"))
                         }
                     }
                 }
-            }
+                .background(WelcomeStyle.panel)
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(WelcomeStyle.panelBorder.opacity(0.45), lineWidth: 0.5)
+                )
 
-            VStack(alignment: .leading, spacing: 10) {
-                HintLine(text: String(localized: "welcome.hint.settings_path",
-                                      defaultValue: "Stored in `~/.omlx/settings.json`. Sub-keys for individual apps can be added later in Security.",
-                                      comment: "Hint line under the API key section pointing to settings.json"))
-                HintLine(text: String(localized: "welcome.hint.models_library",
-                                      defaultValue: "Your model library starts empty — visit Downloads to fetch your first model.",
-                                      comment: "Hint line pointing the user to Downloads after first-run"))
-                HintLine(text: String(localized: "welcome.hint.reopen",
-                                      defaultValue: "You can re-open this wizard anytime from the menubar.",
-                                      comment: "Hint line telling the user how to get back to the Welcome wizard"))
+                Text(String(localized: "welcome.hint.settings_path",
+                            defaultValue: "Settings are stored in ~/.omlx/settings.json.",
+                            comment: "Hint line under the API key section pointing to settings.json"))
+                    .font(.omlxText(11))
+                    .foregroundStyle(WelcomeStyle.faint)
+                    .frame(maxWidth: .infinity, alignment: .center)
             }
+            .frame(width: 560)
         }
+        .padding(.horizontal, 48)
+        .padding(.top, 18)
+        .padding(.bottom, 6)
+        .disabled(vm.isStarting)
     }
 
     @ViewBuilder
     private func keyField(_ binding: Binding<String>) -> some View {
         let placeholder = String(localized: "welcome.api_key.placeholder",
-                                 defaultValue: "sk-omlx-…",
-                                 comment: "Placeholder text inside the API key text fields")
+                                 defaultValue: "Enter your API key",
+                                 comment: "Placeholder text inside the API key text field")
         if keyVisible {
-            TextInput(text: binding, placeholder: placeholder, mono: true, width: 260)
+            TextInput(text: binding, placeholder: placeholder, mono: true, width: 210)
         } else {
             TextInput(text: binding, placeholder: placeholder,
-                      isSecure: true, mono: true, width: 260)
+                      isSecure: true, mono: true, width: 210)
         }
     }
-
-    @ViewBuilder
-    private func sectionLabel(_ text: String) -> some View {
-        Text(text)
-            .font(.omlxText(10, weight: .semibold))
-            .foregroundStyle(theme.textTertiary)
-            .textCase(.uppercase)
-            .kerning(0.6)
-            .padding(.horizontal, 14)
-    }
-
-    @ViewBuilder
-    private func labelRow(_ label: String, sub: String? = nil) -> some View {
-        VStack(alignment: .leading, spacing: 1) {
-            Text(label)
-                .font(.omlxText(12, weight: .medium))
-                .foregroundStyle(theme.text)
-            if let sub {
-                Text(sub)
-                    .font(.omlxText(11))
-                    .foregroundStyle(theme.textTertiary)
-            }
-        }
-    }
-
 }
 
-private struct Footer: View {
+private struct WelcomeCompleteBody: View {
     @ObservedObject var vm: WelcomeViewModel
-    @Environment(\.omlxTheme) private var theme
 
     var body: some View {
-        HStack(spacing: 8) {
-            if let error = vm.lastError {
-                Text(error)
-                    .font(.omlxText(11))
-                    .foregroundStyle(theme.redDot)
-                    .lineLimit(2)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+        VStack(spacing: 24) {
+            Spacer(minLength: 34)
+            WelcomeIcon(size: 84)
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 42, weight: .semibold))
+                .foregroundStyle(WelcomeStyle.accent)
+                .accessibilityHidden(true)
+
+            VStack(spacing: 10) {
+                Text(String(localized: "welcome.complete.title",
+                            defaultValue: "All set!",
+                            comment: "Heading on the Welcome completion page"))
+                    .font(.omlxDisplay(30, weight: .semibold))
+                    .foregroundStyle(WelcomeStyle.text)
+                Text(String(localized: "welcome.complete.description",
+                            defaultValue: "oMLX is running locally at http://127.0.0.1:\(vm.portText). Open the web dashboard to download your first model, manage settings, and connect your coding tools.",
+                            comment: "Description on the Welcome completion page"))
+                    .font(.omlxText(14))
+                    .foregroundStyle(WelcomeStyle.muted)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(3)
+                    .frame(maxWidth: 500)
+                Text(String(localized: "welcome.complete.status",
+                            defaultValue: "Server started. Dashboard is ready.",
+                            comment: "Short success status on the Welcome completion page"))
+                    .font(.omlxText(12, weight: .medium))
+                    .foregroundStyle(WelcomeStyle.faint)
+                    .padding(.top, 4)
+            }
+            Spacer(minLength: 40)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 54)
+    }
+}
+
+private struct WelcomeFooter: View {
+    @ObservedObject var vm: WelcomeViewModel
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 18) {
+            if vm.step == .setup {
+                Button {
+                    vm.backToIntro()
+                } label: {
+                    Label(String(localized: "common.back",
+                                 defaultValue: "Back",
+                                 comment: "Back button label"),
+                          systemImage: "chevron.left")
+                }
+                .buttonStyle(.omlx(.plain))
+                .disabled(vm.isStarting)
             } else {
                 Spacer()
+                    .frame(width: 90)
             }
 
-            // Two actions side-by-side. "Open Admin Panel & Close" performs
-            // the same start, then redirects the user to the local
-            // /admin/dashboard. Sits to the left of the primary Start Server
-            // button (macOS HIG: alternative on the left of primary).
-            Button(String(localized: "welcome.button.open_admin",
-                          defaultValue: "Open Admin Panel & Close",
-                          comment: "Secondary footer button: start server and open the browser dashboard")) {
-                Task {
-                    guard vm.validateSetup() else { return }
-                    _ = await vm.startServerAndOpenAdmin()
-                }
-            }
-            .buttonStyle(.omlx(.normal))
-            .disabled(vm.isStarting)
+            Spacer()
 
-            Button {
+            if let error = vm.lastError {
+                Text(error)
+                    .font(.omlxText(11.5))
+                    .foregroundStyle(Color(nsColor: .systemRed))
+                    .lineLimit(2)
+                    .multilineTextAlignment(.trailing)
+                    .frame(maxWidth: 320, alignment: .trailing)
+            }
+
+            primaryButton
+        }
+        .padding(.horizontal, 28)
+        .frame(height: 72)
+        .background(WelcomeStyle.panel.opacity(0.68))
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(WelcomeStyle.panelBorder.opacity(0.5))
+                .frame(height: 0.5)
+        }
+    }
+
+    @ViewBuilder
+    private var primaryButton: some View {
+        switch vm.step {
+        case .intro:
+            WelcomeCTA(
+                title: String(localized: "welcome.button.get_started",
+                              defaultValue: "Get Started",
+                              comment: "Primary footer button that advances from the intro to setup"),
+                systemImage: "arrow.right",
+                width: 142
+            ) {
+                vm.beginSetup()
+            }
+
+        case .setup:
+            WelcomeCTA(
+                title: vm.isStarting
+                    ? String(localized: "welcome.button.starting",
+                             defaultValue: "Starting Server...",
+                             comment: "Footer button label shown while the server is being spawned")
+                    : String(localized: "welcome.button.start_server",
+                             defaultValue: "Start Server",
+                             comment: "Primary footer button that spawns the server"),
+                systemImage: vm.isStarting ? nil : "arrow.right",
+                isBusy: vm.isStarting,
+                width: 160
+            ) {
                 Task {
                     guard vm.validateSetup() else { return }
                     _ = await vm.startServer()
                 }
-            } label: {
-                if vm.isStarting {
-                    HStack(spacing: 6) {
-                        ProgressView().controlSize(.small)
-                        Text(String(localized: "welcome.button.starting",
-                                    defaultValue: "Starting…",
-                                    comment: "Footer button label shown while the server is being spawned"))
-                    }
-                } else {
-                    Text(String(localized: "welcome.button.start_server",
-                                defaultValue: "Start Server",
-                                comment: "Primary footer button that spawns the server and closes the wizard"))
+            }
+            .disabled(vm.isStarting)
+
+        case .complete:
+            WelcomeCTA(
+                title: String(localized: "welcome.button.open_dashboard",
+                              defaultValue: "Open Web Dashboard",
+                              comment: "Footer button that opens the local web dashboard"),
+                systemImage: "arrow.up.right",
+                width: 210
+            ) {
+                _ = vm.openWebDashboard()
+            }
+        }
+    }
+}
+
+private struct WelcomeCTA: View {
+    let title: String
+    var systemImage: String?
+    var isBusy: Bool = false
+    var width: CGFloat
+    let action: () -> Void
+
+    @Environment(\.isEnabled) private var isEnabled
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                if isBusy {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+                Text(title)
+                    .font(.omlxText(13, weight: .medium))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.86)
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .font(.system(size: 12, weight: .semibold))
                 }
             }
-            .buttonStyle(.omlx(.primary))
-            .disabled(vm.isStarting)
+            .foregroundStyle(Color.white)
+            .frame(width: width, height: 32)
+            .background(WelcomeStyle.accent)
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .opacity(isEnabled ? 1.0 : 0.55)
         }
-        .padding(.horizontal, 24)
-        .padding(.vertical, 16)
-        .frame(maxWidth: .infinity)
-        .background(theme.toolbarBg)
-        .overlay(
-            Rectangle()
-                .fill(theme.toolbarBorder)
-                .frame(height: 0.5),
-            alignment: .top
-        )
+        .buttonStyle(.plain)
+    }
+}
+
+private struct WelcomeIcon: View {
+    let size: CGFloat
+
+    var body: some View {
+        Image("AppLogo")
+            .resizable()
+            .interpolation(.high)
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: size * 0.22, style: .continuous))
+            .shadow(color: Color.black.opacity(0.10), radius: 12, y: 6)
+            .accessibilityLabel("oMLX")
+    }
+}
+
+private struct FeaturePill: View {
+    let icon: String
+    let title: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 11, weight: .semibold))
+            Text(title)
+                .font(.omlxText(12, weight: .medium))
+        }
+        .foregroundStyle(WelcomeStyle.muted)
+        .padding(.horizontal, 11)
+        .padding(.vertical, 7)
+        .background(WelcomeStyle.fill)
+        .clipShape(Capsule())
+    }
+}
+
+private struct WelcomeNotice: View {
+    let icon: String
+    let title: String
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(WelcomeStyle.accent)
+                .frame(width: 24, height: 24)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.omlxText(13, weight: .semibold))
+                    .foregroundStyle(WelcomeStyle.text)
+                Text(text)
+                    .font(.omlxText(12))
+                    .foregroundStyle(WelcomeStyle.muted)
+                    .lineSpacing(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(14)
+        .background(WelcomeStyle.fill)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+}
+
+private struct SettingRow<Content: View>: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+    let content: () -> Content
+
+    init(
+        icon: String,
+        title: String,
+        subtitle: String,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.icon = icon
+        self.title = title
+        self.subtitle = subtitle
+        self.content = content
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 14) {
+            Image(systemName: icon)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(WelcomeStyle.muted)
+                .frame(width: 22)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.omlxText(13, weight: .medium))
+                    .foregroundStyle(WelcomeStyle.text)
+                Text(subtitle)
+                    .font(.omlxText(11.5))
+                    .foregroundStyle(WelcomeStyle.faint)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 16)
+            content()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 13)
+    }
+}
+
+private struct WelcomeDivider: View {
+    var body: some View {
+        Rectangle()
+            .fill(WelcomeStyle.panelBorder.opacity(0.42))
+            .frame(height: 0.5)
+            .padding(.leading, 52)
     }
 }

--- a/apps/omlx-mac/Tests/oMLXTests/WelcomeViewModelTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/WelcomeViewModelTests.swift
@@ -1,7 +1,6 @@
 // WelcomeViewModel drives the first-run wizard. The interesting behaviors
 // are validation gates (storage + api-key) feeding `lastError`, the
-// intro → setup → complete state, and `skipSnapshot()` which persists
-// Storage values without an unvalidated API key on early close.
+// intro → setup → complete state, and the Start Server validation path.
 
 import XCTest
 @testable import oMLX
@@ -10,8 +9,7 @@ import XCTest
 final class WelcomeViewModelTests: XCTestCase {
 
     // AppServices uses a weak reference to its services on WelcomeViewModel,
-    // so the test must keep a strong reference for the lifetime of each case
-    // — otherwise skipSnapshot() short-circuits to AppConfig.default.
+    // so the test must keep a strong reference for the lifetime of each case.
     private var services: AppServices!
 
     private func makeVM(basePath: String = "/Users/Fido/.omlx",
@@ -105,53 +103,5 @@ final class WelcomeViewModelTests: XCTestCase {
         vm.apiKey = "abcd\u{007F}"   // DEL char, outside printable ASCII
         XCTAssertFalse(vm.validateSetup())
         XCTAssertEqual(vm.lastError, "API key must contain only printable ASCII.")
-    }
-
-    // MARK: - skipSnapshot
-
-    func testSkipSnapshotPreservesStorageOnValidInputs() {
-        let vm = makeVM()
-        vm.basePath = "/tmp/custom-base"
-        vm.modelDir = "/tmp/custom-models"
-        vm.portText = "9090"
-
-        let snapshot = vm.skipSnapshot()
-        XCTAssertEqual(snapshot.basePath, "/tmp/custom-base")
-        XCTAssertEqual(snapshot.modelDir, "/tmp/custom-models")
-        XCTAssertEqual(snapshot.port,     9090)
-    }
-
-    func testSkipSnapshotDropsUnvalidatedApiKey() {
-        let vm = makeVM(apiKey: "previously-saved")
-        vm.apiKey = "ab"               // too short
-        let snapshot = vm.skipSnapshot()
-        XCTAssertEqual(snapshot.apiKey, "",
-                       "An invalid in-progress key should be dropped on skip, " +
-                       "not persisted over the saved value.")
-    }
-
-    func testSkipSnapshotKeepsValidatedApiKey() {
-        let vm = makeVM()
-        vm.apiKey = "secret-key"
-        let snapshot = vm.skipSnapshot()
-        XCTAssertEqual(snapshot.apiKey, "secret-key",
-                       "A fully-validated key should make it into the snapshot.")
-    }
-
-    func testSkipSnapshotDefaultsModelDirToBaseWhenBlank() {
-        let vm = makeVM(basePath: "/tmp/custom-base",
-                        modelDir: "/tmp/custom-models")
-        vm.modelDir = ""    // user hit Reset
-        let snapshot = vm.skipSnapshot()
-        XCTAssertEqual(snapshot.modelDir,
-                       AppConfig.defaultModelDir(forBasePath: snapshot.basePath))
-    }
-
-    func testSkipSnapshotIgnoresInvalidPort() {
-        let vm = makeVM(port: 8000)
-        vm.portText = "999999"   // out of range
-        let snapshot = vm.skipSnapshot()
-        XCTAssertEqual(snapshot.port, 8000,
-                       "Out-of-range port text should leave the existing port intact.")
     }
 }

--- a/apps/omlx-mac/Tests/oMLXTests/WelcomeViewModelTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/WelcomeViewModelTests.swift
@@ -1,8 +1,7 @@
 // WelcomeViewModel drives the first-run wizard. The interesting behaviors
 // are validation gates (storage + api-key) feeding `lastError`, the
-// "Generate" button keeping `apiKey` and `apiKeyConfirm` in lockstep via
-// the shared APIKeyGenerator, and `skipSnapshot()` which persists Storage
-// values without an unvalidated API key on early close.
+// intro → setup → complete state, and `skipSnapshot()` which persists
+// Storage values without an unvalidated API key on early close.
 
 import XCTest
 @testable import oMLX
@@ -17,7 +16,7 @@ final class WelcomeViewModelTests: XCTestCase {
 
     private func makeVM(basePath: String = "/Users/Fido/.omlx",
                         modelDir: String  = "/Users/Fido/.omlx/models",
-                        port: Int = 8080,
+                        port: Int = 8000,
                         apiKey: String? = nil) -> WelcomeViewModel {
         let cfg = AppConfig(
             host: "127.0.0.1",
@@ -31,43 +30,33 @@ final class WelcomeViewModelTests: XCTestCase {
         return WelcomeViewModel(services: services, server: nil)
     }
 
-    // MARK: - generateApiKey
+    // MARK: - flow
 
-    func testGenerateApiKeyPopulatesBothFields() {
+    func testStartsOnIntroStep() {
         let vm = makeVM()
-        XCTAssertEqual(vm.apiKey, "")
-        XCTAssertEqual(vm.apiKeyConfirm, "")
-        vm.generateApiKey()
-        XCTAssertFalse(vm.apiKey.isEmpty)
-        XCTAssertEqual(vm.apiKey, vm.apiKeyConfirm,
-                       "Confirm field must mirror the generated key.")
+        XCTAssertEqual(vm.step, .intro)
     }
 
-    func testGenerateApiKeyMatchesSharedGeneratorShape() {
-        // Welcome must produce keys indistinguishable from the Security
-        // screen's regenerate flow — both go through APIKeyGenerator.
-        let vm = makeVM()
-        vm.generateApiKey()
-        XCTAssertTrue(vm.apiKey.hasPrefix(APIKeyGenerator.prefix))
-        XCTAssertEqual(vm.apiKey.count,
-                       APIKeyGenerator.prefix.count + APIKeyGenerator.bodyLength)
-    }
-
-    func testGenerateApiKeyClearsPriorError() {
+    func testBeginSetupAdvancesToSetupAndClearsError() {
         let vm = makeVM()
         vm.apiKey = "abc"
         XCTAssertFalse(vm.validateApiKey())
         XCTAssertNotNil(vm.lastError)
-        vm.generateApiKey()
-        XCTAssertNil(vm.lastError,
-                     "Generate should clear any prior validation error.")
+        vm.beginSetup()
+        XCTAssertEqual(vm.step, .setup)
+        XCTAssertNil(vm.lastError)
+    }
+
+    func testDefaultPortIs8000() {
+        let vm = makeVM()
+        XCTAssertEqual(vm.portText, "8000")
     }
 
     // MARK: - validateSetup
 
     func testValidateSetupHappyPath() {
         let vm = makeVM()
-        vm.generateApiKey()
+        vm.apiKey = "secret-key"
         XCTAssertTrue(vm.validateSetup())
         XCTAssertNil(vm.lastError)
     }
@@ -75,14 +64,14 @@ final class WelcomeViewModelTests: XCTestCase {
     func testValidateSetupFailsOnEmptyBase() {
         let vm = makeVM()
         vm.basePath = "   "
-        vm.generateApiKey()
+        vm.apiKey = "secret-key"
         XCTAssertFalse(vm.validateSetup())
         XCTAssertEqual(vm.lastError, "Base directory is required.")
     }
 
     func testValidateSetupFailsOnInvalidPort() {
         let vm = makeVM()
-        vm.generateApiKey()
+        vm.apiKey = "secret-key"
         vm.portText = "0"
         XCTAssertFalse(vm.validateSetup())
         XCTAssertEqual(vm.lastError, "Port must be a number between 1 and 65535.")
@@ -90,7 +79,7 @@ final class WelcomeViewModelTests: XCTestCase {
 
     func testValidateSetupFailsOnPortNonNumeric() {
         let vm = makeVM()
-        vm.generateApiKey()
+        vm.apiKey = "secret-key"
         vm.portText = "abc"
         XCTAssertFalse(vm.validateSetup())
         XCTAssertEqual(vm.lastError, "Port must be a number between 1 and 65535.")
@@ -99,7 +88,6 @@ final class WelcomeViewModelTests: XCTestCase {
     func testValidateSetupFailsOnShortApiKey() {
         let vm = makeVM()
         vm.apiKey = "abc"
-        vm.apiKeyConfirm = "abc"
         XCTAssertFalse(vm.validateSetup())
         XCTAssertEqual(vm.lastError, "API key must be at least 4 characters.")
     }
@@ -108,7 +96,6 @@ final class WelcomeViewModelTests: XCTestCase {
         let vm = makeVM()
         // 4+ chars but a space inside — server-side validator rejects.
         vm.apiKey = "ab cd"
-        vm.apiKeyConfirm = "ab cd"
         XCTAssertFalse(vm.validateSetup())
         XCTAssertEqual(vm.lastError, "API key must not contain whitespace.")
     }
@@ -116,17 +103,8 @@ final class WelcomeViewModelTests: XCTestCase {
     func testValidateSetupFailsOnApiKeyNonPrintable() {
         let vm = makeVM()
         vm.apiKey = "abcd\u{007F}"   // DEL char, outside printable ASCII
-        vm.apiKeyConfirm = "abcd\u{007F}"
         XCTAssertFalse(vm.validateSetup())
         XCTAssertEqual(vm.lastError, "API key must contain only printable ASCII.")
-    }
-
-    func testValidateSetupFailsOnConfirmMismatch() {
-        let vm = makeVM()
-        vm.apiKey = "sk-omlx-AAAA"
-        vm.apiKeyConfirm = "sk-omlx-BBBB"
-        XCTAssertFalse(vm.validateSetup())
-        XCTAssertEqual(vm.lastError, "API keys do not match.")
     }
 
     // MARK: - skipSnapshot
@@ -146,7 +124,6 @@ final class WelcomeViewModelTests: XCTestCase {
     func testSkipSnapshotDropsUnvalidatedApiKey() {
         let vm = makeVM(apiKey: "previously-saved")
         vm.apiKey = "ab"               // too short
-        vm.apiKeyConfirm = "ab"
         let snapshot = vm.skipSnapshot()
         XCTAssertEqual(snapshot.apiKey, "",
                        "An invalid in-progress key should be dropped on skip, " +
@@ -155,10 +132,9 @@ final class WelcomeViewModelTests: XCTestCase {
 
     func testSkipSnapshotKeepsValidatedApiKey() {
         let vm = makeVM()
-        vm.generateApiKey()
-        let generated = vm.apiKey
+        vm.apiKey = "secret-key"
         let snapshot = vm.skipSnapshot()
-        XCTAssertEqual(snapshot.apiKey, generated,
+        XCTAssertEqual(snapshot.apiKey, "secret-key",
                        "A fully-validated key should make it into the snapshot.")
     }
 
@@ -172,10 +148,10 @@ final class WelcomeViewModelTests: XCTestCase {
     }
 
     func testSkipSnapshotIgnoresInvalidPort() {
-        let vm = makeVM(port: 8080)
+        let vm = makeVM(port: 8000)
         vm.portText = "999999"   // out of range
         let snapshot = vm.skipSnapshot()
-        XCTAssertEqual(snapshot.port, 8080,
+        XCTAssertEqual(snapshot.port, 8000,
                        "Out-of-range port text should leave the existing port intact.")
     }
 }


### PR DESCRIPTION
## Summary

This refreshes the native macOS app onboarding flow and applies a small round of Swift UI polish.

The first-run experience is now simpler, more focused, and aligned with the app's native macOS presentation.

## Scope

- Redesign first-run welcome/onboarding
- Polish shared Swift UI components touched by the new layout