### PR TITLE
fix: lazy-load heavy imports to fix NumPy 2.x compatibility on startup

### DIFF
--- a/omlx/__init__.py
+++ b/omlx/__init__.py
@@ -14,17 +14,38 @@ Features:
 
 from omlx._version import __version__
 
-# Continuous batching engine (core functionality, no torch required)
-from omlx.request import Request, RequestOutput, RequestStatus, SamplingParams
-from omlx.scheduler import Scheduler, SchedulerConfig, SchedulerOutput
-from omlx.engine_core import EngineCore, AsyncEngineCore, EngineConfig
-from omlx.cache.prefix_cache import BlockAwarePrefixCache
-from omlx.cache.paged_cache import PagedCacheManager, CacheBlock, BlockTable
-from omlx.cache.stats import PrefixCacheStats, PagedCacheStats
-from omlx.model_registry import get_registry, ModelOwnershipError
+_LAZY = {
+    "Request": "omlx.request",
+    "RequestOutput": "omlx.request",
+    "RequestStatus": "omlx.request",
+    "SamplingParams": "omlx.request",
+    "Scheduler": "omlx.scheduler",
+    "SchedulerConfig": "omlx.scheduler",
+    "SchedulerOutput": "omlx.scheduler",
+    "EngineCore": "omlx.engine_core",
+    "AsyncEngineCore": "omlx.engine_core",
+    "EngineConfig": "omlx.engine_core",
+    "BlockAwarePrefixCache": "omlx.cache.prefix_cache",
+    "PagedCacheManager": "omlx.cache.paged_cache",
+    "CacheBlock": "omlx.cache.paged_cache",
+    "BlockTable": "omlx.cache.paged_cache",
+    "PrefixCacheStats": "omlx.cache.stats",
+    "PagedCacheStats": "omlx.cache.stats",
+    "CacheStats": "omlx.cache.stats",
+    "get_registry": "omlx.model_registry",
+    "ModelOwnershipError": "omlx.model_registry",
+}
 
-# Backward compatibility alias
-CacheStats = PagedCacheStats
+
+def __getattr__(name: str):
+    import importlib
+    if name in _LAZY:
+        mod = importlib.import_module(_LAZY[name])
+        attr = "PagedCacheStats" if name == "CacheStats" else name
+        val = getattr(mod, attr)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [
     # Request management


### PR DESCRIPTION
## Problem

`omlx launch claude` (and any subcommand that doesn't use MLX) crashes on startup when `scipy`/`sklearn` are compiled against NumPy 1.x but NumPy 2.x is installed:

```
ImportError: A module that was compiled using NumPy 1.x cannot be run in NumPy 2.1.3
```

The import chain:
```
omlx/__init__.py → omlx.scheduler → mlx_lm.generate → transformers
→ sklearn → scipy._sparsetools (NumPy 1.x binary) → crash
```

`omlx launch claude` never uses the scheduler or engine — it only touches `omlx/integrations/` — but the eager top-level imports crash the process before any subcommand logic runs.

## Fix

Replace the eager imports in `omlx/__init__.py` with a PEP 562 module-level `__getattr__` that defers loading until a symbol is actually accessed at runtime.

- `omlx launch` / `omlx launch claude` → no MLX stack loaded, no crash
- `omlx serve <model>` → lazy import triggers on first `Scheduler`/`EngineCore` access, works as before
- `from omlx import Scheduler` → still works, just deferred
- `__all__` is unchanged — public API is identical

## Test

```bash
# Before: crashes with NumPy 2.x
# After: works
python -c "import omlx; print(omlx.__version__)"
omlx launch claude

# Lazy load still works
python -c "from omlx import Scheduler; print('OK')"
```