### PR TITLE
feat(chat): thinking budget settings

### DIFF
--- a/omlx/admin/static/css/dashboard.css
+++ b/omlx/admin/static/css/dashboard.css
@@ -119,6 +119,7 @@
         background-color: var(--bg-secondary) !important;
         color: var(--text-primary) !important;
         border-color: var(--border-faint) !important;
+        color-scheme: dark;
     }
     [data-theme="dark"] input:not([type="range"]):focus,
     [data-theme="dark"] select:focus,

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -103,6 +103,8 @@
             },
             savingModelSettings: false,
             loadingGenDefaults: false,
+            modelSettingsThinkingBudgetBeforeInput: null,
+            modelSettingsThinkingBudgetStepping: false,
             reasoningParsers: [],
 
             // Profile / template / preset state
@@ -995,6 +997,55 @@
             },
 
             // ===== Profiles / Templates =====
+            normalizeThinkingBudgetTokens(value, fallback = 4096) {
+                if (value === '' || value == null) return fallback;
+                const n = Number(value);
+                if (!Number.isFinite(n)) return fallback;
+                if (n <= 0) return 1;
+                return Math.floor(n);
+            },
+
+            stepModelSettingsThinkingBudget(direction) {
+                if (!this.modelSettings.enableThinkingBudget) return;
+                let v = Number(this.modelSettings.thinking_budget_tokens);
+                if (!Number.isFinite(v) || v <= 0) v = 4096;
+                this.modelSettings.thinking_budget_tokens = direction > 0
+                    ? Math.max(1, Math.floor(v * 2))
+                    : Math.max(1, Math.floor(v / 2));
+                this.modelSettingsThinkingBudgetBeforeInput = this.modelSettings.thinking_budget_tokens;
+            },
+
+            onModelSettingsThinkingBudgetInput(event) {
+                if (this.modelSettingsThinkingBudgetStepping) return;
+                const el = event.target;
+                const rawValue = el.value;
+                const raw = Number(rawValue);
+                const prev = Number(this.modelSettingsThinkingBudgetBeforeInput);
+                const fromTextEdit = typeof event.inputType === 'string' && event.inputType.length > 0;
+                if (!fromTextEdit && Number.isFinite(prev) && Number.isFinite(raw) && raw !== prev) {
+                    const delta = raw - prev;
+                    if (delta !== 0) {
+                        this.modelSettingsThinkingBudgetStepping = true;
+                        this.modelSettings.thinking_budget_tokens = prev;
+                        this.stepModelSettingsThinkingBudget(delta > 0 ? 1 : -1);
+                        el.value = this.modelSettings.thinking_budget_tokens;
+                        this.modelSettingsThinkingBudgetBeforeInput = this.modelSettings.thinking_budget_tokens;
+                        this.modelSettingsThinkingBudgetStepping = false;
+                        return;
+                    }
+                }
+                this.modelSettingsThinkingBudgetBeforeInput = rawValue;
+                this.modelSettings.thinking_budget_tokens = rawValue;
+            },
+
+            clampModelSettingsThinkingBudget() {
+                if (!this.modelSettings.enableThinkingBudget) return;
+                this.modelSettings.thinking_budget_tokens = this.normalizeThinkingBudgetTokens(
+                    this.modelSettings.thinking_budget_tokens
+                );
+                this.modelSettingsThinkingBudgetBeforeInput = this.modelSettings.thinking_budget_tokens;
+            },
+
             formValuesForProfile() {
                 const ms = this.modelSettings;
                 const out = {};
@@ -1002,7 +1053,9 @@
                 for (const k of this.profileFields.universal.concat(this.profileFields.model_specific)) {
                     if (k === 'chat_template_kwargs' || k === 'forced_ct_kwargs') continue;  // handle below
                     if (k === 'thinking_budget_enabled') {
-                        if (ms.enableThinkingBudget) out.thinking_budget_tokens = ms.thinking_budget_tokens ?? null;
+                        if (ms.enableThinkingBudget) {
+                            out.thinking_budget_tokens = this.normalizeThinkingBudgetTokens(ms.thinking_budget_tokens);
+                        }
                         continue;
                     }
                     if (k === 'index_cache_freq') {
@@ -1665,7 +1718,7 @@
                                 enable_thinking: this.modelSettings.enable_thinking,
                                 thinking_budget_enabled: this.modelSettings.enableThinkingBudget,
                                 thinking_budget_tokens: this.modelSettings.enableThinkingBudget
-                                    ? (this.modelSettings.thinking_budget_tokens || null)
+                                    ? this.normalizeThinkingBudgetTokens(this.modelSettings.thinking_budget_tokens)
                                     : 0,
                                 max_tool_result_tokens: this.modelSettings.enableToolResultLimit
                                     ? (this.modelSettings.max_tool_result_tokens || null)

--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -62,6 +62,12 @@
         --timeline-accent: #60a5fa;
     }
 
+    [data-theme="dark"] input:not([type="range"]),
+    [data-theme="dark"] select,
+    [data-theme="dark"] textarea {
+        color-scheme: dark;
+    }
+
     body {
         background-color: var(--bg-primary) !important;
         color: var(--text-primary) !important;
@@ -1905,13 +1911,13 @@
                     <div x-show="thinkingModeValue() === 'on_limit'" x-collapse class="space-y-1">
                         <label class="text-[10px] font-bold uppercase tracking-wider block"
                             style="color: var(--text-secondary);">Thinking tokens</label>
-                        <input type="number" x-model.number="modelSettings.thinking_budget_tokens"
-                            @focus="_thinkingBudgetBeforeInput = modelSettings.thinking_budget_tokens"
+                        <input type="number" x-model="modelSettings.thinking_budget_tokens"
+                            @focus="_thinkingBudgetEditing = true; _thinkingBudgetBeforeInput = modelSettings.thinking_budget_tokens"
                             @keydown.arrow-up.prevent="stepThinkingBudgetTokens(1)"
                             @keydown.arrow-down.prevent="stepThinkingBudgetTokens(-1)"
                             @input="onThinkingBudgetTokensInput($event)"
-                            @change="clampThinkingBudgetTokens()"
-                            placeholder="4001" min="1" step="1000"
+                            @blur="_thinkingBudgetEditing = false; clampThinkingBudgetTokens()"
+                            placeholder="4096" min="1" step="1"
                             class="w-full px-3 py-2 text-xs border border-line rounded-xl bg-surface thinking-budget-input"
                             style="color: var(--text-primary);">
                     </div>
@@ -2039,6 +2045,7 @@
             _adminModelsList: null,
             _adminModelsListPromise: null,
             _thinkingBudgetBeforeInput: null,
+            _thinkingBudgetEditing: false,
             _thinkingBudgetStepping: false,
             chatSessions: {},
             messages: [],
@@ -2176,19 +2183,11 @@
 
             stepThinkingBudgetTokens(direction) {
                 if (this.thinkingModeValue() !== 'on_limit') return;
-                const step = 1024;
                 let v = Number(this.modelSettings.thinking_budget_tokens);
-                if (!Number.isFinite(v) || v <= 0) v = 0;
-
-                if (direction > 0) {
-                    this.modelSettings.thinking_budget_tokens = v <= 0 ? 1 : v + step;
-                } else if (v <= 1) {
-                    this.modelSettings.thinking_budget_tokens = 1;
-                } else if (v <= step) {
-                    this.modelSettings.thinking_budget_tokens = 1;
-                } else {
-                    this.modelSettings.thinking_budget_tokens = v - step;
-                }
+                if (!Number.isFinite(v) || v <= 0) v = 4096;
+                this.modelSettings.thinking_budget_tokens = direction > 0
+                    ? Math.max(1, Math.floor(v * 2))
+                    : Math.max(1, Math.floor(v / 2));
                 this._thinkingBudgetBeforeInput = this.modelSettings.thinking_budget_tokens;
                 this.onModelSettingsChange();
             },
@@ -2196,12 +2195,14 @@
             onThinkingBudgetTokensInput(event) {
                 if (this._thinkingBudgetStepping) return;
                 const el = event.target;
-                const raw = Number(el.value);
+                const rawValue = el.value;
+                const raw = Number(rawValue);
                 const prev = Number(this._thinkingBudgetBeforeInput);
-                if (Number.isFinite(prev) && Number.isFinite(raw) && raw !== prev) {
+                const fromTextEdit = typeof event.inputType === 'string' && event.inputType.length > 0;
+                if (!fromTextEdit && Number.isFinite(prev) && Number.isFinite(raw) && raw !== prev) {
                     const delta = raw - prev;
-                    // Native spinners use (min + n*step); 4096 is off-grid when min=1, step=100/1024
-                    if (delta !== 0 && Math.abs(delta) < 1024) {
+                    // Native number spinners emit input events without text input metadata.
+                    if (delta !== 0) {
                         this._thinkingBudgetStepping = true;
                         this.modelSettings.thinking_budget_tokens = prev;
                         this.stepThinkingBudgetTokens(delta > 0 ? 1 : -1);
@@ -2211,8 +2212,8 @@
                         return;
                     }
                 }
-                this._thinkingBudgetBeforeInput = raw;
-                this.modelSettings.thinking_budget_tokens = raw;
+                this._thinkingBudgetBeforeInput = rawValue;
+                this.modelSettings.thinking_budget_tokens = rawValue;
                 this.onModelSettingsChange();
             },
 
@@ -2248,13 +2249,14 @@
             },
 
             captureSessionModelSettings() {
-                if (this.modelSettings.thinking_budget_enabled) {
-                    this.modelSettings.thinking_budget_tokens = this.normalizeThinkingBudgetTokens(
-                        this.modelSettings.thinking_budget_tokens
+                const modelSettings = this.cloneData(this.modelSettings);
+                if (modelSettings.thinking_budget_enabled && !this._thinkingBudgetEditing) {
+                    modelSettings.thinking_budget_tokens = this.normalizeThinkingBudgetTokens(
+                        modelSettings.thinking_budget_tokens
                     );
                 }
                 return {
-                    modelSettings: this.cloneData(this.modelSettings),
+                    modelSettings,
                     speculativeEngine: this.speculativeEngine,
                     speculativeDraftModel: this.speculativeDraftModel,
                 };
@@ -2957,7 +2959,9 @@
                     ? (context._apiVariantChainId ?? null)
                     : null;
                 const model = this.resolveApiModel(messages, context.model, variantUserIndex);
-                const generation = this.resolveApiGenerationOverrides(messages, variantUserIndex);
+                const generation = context._generation
+                    ? { ...context._generation }
+                    : this.resolveApiGenerationOverrides(messages, variantUserIndex);
                 return {
                     model,
                     messages: this.buildMessagesForApi(messages, context.systemPrompt, {
@@ -4451,6 +4455,7 @@
             model: sourceModel,
             systemPrompt: sourceSystemPrompt,
             _profile: this.resolveStreamProfile(null, chatSession),
+            _generation: this.snapshotGenerationSettings(),
         }, 0);
     },
 
@@ -4463,6 +4468,7 @@
             _variantUserIndex: streamContext?._variantUserIndex ?? null,
             _excludeVariantsAtUserIndex: streamContext?._excludeVariantsAtUserIndex ?? null,
             _apiVariantChainId: streamContext?._apiVariantChainId ?? null,
+            _generation: streamContext?._generation ?? this.snapshotGenerationSettings(),
         };
         const chatSession = this.getChatSession(context.chatId, true);
         const stream = this.getStreamSession(context.chatId, true);

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -420,7 +420,13 @@
                                     </button>
                                 </div>
                                 <div x-show="modelSettings.enableThinkingBudget" x-transition class="pt-1">
-                                    <input type="number" x-model.number="modelSettings.thinking_budget_tokens" placeholder="{{ t('modal.model_settings.thinking_budget_placeholder') }}" min="1" step="100"
+                                    <input type="number" x-model="modelSettings.thinking_budget_tokens"
+                                           @focus="modelSettingsThinkingBudgetBeforeInput = modelSettings.thinking_budget_tokens"
+                                           @keydown.arrow-up.prevent="stepModelSettingsThinkingBudget(1)"
+                                           @keydown.arrow-down.prevent="stepModelSettingsThinkingBudget(-1)"
+                                           @input="onModelSettingsThinkingBudgetInput($event)"
+                                           @blur="clampModelSettingsThinkingBudget()"
+                                           placeholder="{{ t('modal.model_settings.thinking_budget_placeholder') }}" min="1" step="1"
                                            class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
                                 </div>
                             </div>


### PR DESCRIPTION
Some UI improvement based on experience from #1529.
## Summary
- Allow thinking budget fields to be typed freely before normalization (previously the UI keeps updating the box to default before user can type). 
- Change thinking budget up/down controls to double or halve the current value instead of fixed increments (I think this is better when tuning large or small budgets; we can discuss on the choice). 
- Apply dark-mode native input chrome for up/down controls in chat and dashboard.

## Testing
- `uv run pytest tests/test_thinking_budget.py tests/test_thinking_toggle.py`
- `uv run pytest -m "not slow"`