### PR TITLE
fix: normalize 0.0.0.0 bind address to 127.0.0.1 for connections

### DIFF
--- a/apps/omlx-mac/Sources/App/AppDelegate.swift
+++ b/apps/omlx-mac/Sources/App/AppDelegate.swift
@@ -167,7 +167,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let runtime = try PythonRuntime.resolve()
             let server = ServerProcess(
                 runtime: runtime,
-                host: config.host,
+                bindAddress: config.bindAddress,
                 port: config.port,
                 basePath: URL(fileURLWithPath: config.basePath, isDirectory: true)
             )

--- a/apps/omlx-mac/Sources/AppView/AppServices.swift
+++ b/apps/omlx-mac/Sources/AppView/AppServices.swift
@@ -359,24 +359,23 @@ final class AppServices: NSObject, ObservableObject {
     /// double-write here. When the server is offline (wizard dropouts,
     /// dev), we DO write so the next spawn reads the right values.
     func applyServerEndpoint(host: String? = nil, port: Int? = nil) async throws {
-        let resolvedHost = host ?? config.host
+        let resolvedBindAddress = host ?? config.bindAddress
         let resolvedPort = port ?? config.port
 
         var updated = config
-        updated.host = resolvedHost
+        updated.bindAddress = resolvedBindAddress
         updated.port = resolvedPort
         if server == nil {
             try updated.save()
         }
         self.config = updated
 
-        // The HTTP client also needs to know about the new endpoint so future
-        // admin calls land on the new bind address.
-        client.configure(host: resolvedHost, port: resolvedPort, apiKey: updated.apiKey)
+        // The HTTP client uses the connectable host (normalises 0.0.0.0 → 127.0.0.1).
+        client.configure(host: updated.host, port: resolvedPort, apiKey: updated.apiKey)
 
         if let server {
             await server.stop()
-            try server.reconfigure(host: resolvedHost, port: resolvedPort)
+            try server.reconfigure(bindAddress: resolvedBindAddress, port: resolvedPort)
             _ = try server.start()
         }
     }

--- a/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ServerScreen.swift
@@ -703,7 +703,8 @@ final class ServerScreenVM: ObservableObject {
             self.host = dto.server.host
             self.portText = String(dto.server.port)
             self.logLevel = canonicalize(level: dto.server.logLevel)
-            self.effectiveHost = dto.server.host
+            // effectiveHost is used for endpoint URLs — normalise 0.0.0.0 → 127.0.0.1
+            self.effectiveHost = dto.server.host == "0.0.0.0" ? "127.0.0.1" : dto.server.host
             self.effectivePort = dto.server.port
             self.sseKeepaliveMode = dto.server.sseKeepaliveMode ?? "chunk"
             self.serverAliasesText = dto.server.serverAliases.joined(separator: ", ")
@@ -947,7 +948,7 @@ final class ServerScreenVM: ObservableObject {
             await commit(GlobalSettingsPatch(host: next))
             do {
                 try await services.applyServerEndpoint(host: next)
-                self.effectiveHost = next
+                self.effectiveHost = next == "0.0.0.0" ? "127.0.0.1" : next
             } catch {
                 self.lastError = error.omlxDescription
             }
@@ -1030,7 +1031,7 @@ final class ServerScreenVM: ObservableObject {
                         port: portChanged ? parsedPort : nil
                     )
                     if let p = parsedPort, portChanged { self.effectivePort = p }
-                    if hostChanged { self.effectiveHost = host }
+                    if hostChanged { self.effectiveHost = host == "0.0.0.0" ? "127.0.0.1" : host }
                 } else {
                     try await services.restartServer()
                 }

--- a/apps/omlx-mac/Sources/Config/AppConfig.swift
+++ b/apps/omlx-mac/Sources/Config/AppConfig.swift
@@ -25,7 +25,13 @@
 import Foundation
 
 struct AppConfig: Sendable, Equatable, Codable {
-    var host: String
+    /// The raw bind address the user configured (e.g. `0.0.0.0`, `127.0.0.1`, `localhost`).
+    var bindAddress: String
+    /// The connectable host — normalises `0.0.0.0` → `127.0.0.1` because
+    /// `0.0.0.0` is a bind wildcard, not a connectable address.
+    var host: String {
+        bindAddress == "0.0.0.0" ? "127.0.0.1" : bindAddress
+    }
     var port: Int
     var apiKey: String?
     /// Always `OMLX_BASE_PATH` if set, else `~/.omlx`. Set at load() time
@@ -42,7 +48,7 @@ struct AppConfig: Sendable, Equatable, Codable {
     static var `default`: AppConfig {
         let base = currentBasePath()
         return AppConfig(
-            host: "127.0.0.1",
+            bindAddress: "127.0.0.1",
             port: 8000,
             apiKey: nil,
             basePath: base,
@@ -179,7 +185,7 @@ struct AppConfig: Sendable, Equatable, Codable {
         var c = Self.default
 
         if let slice = try? readSettings(basePath: c.basePath) {
-            if let h = slice.host { c.host = h }
+            if let h = slice.bindAddress { c.bindAddress = h }
             if let p = slice.port { c.port = p }
             if let k = slice.apiKey, !k.isEmpty { c.apiKey = k }
             // settings.json may not have model_dir on a brand-new install;
@@ -192,7 +198,7 @@ struct AppConfig: Sendable, Equatable, Codable {
         // Env overrides for non-path fields. basePath is already env-driven
         // via currentBasePath().
         let env = ProcessInfo.processInfo.environment
-        if let h = env["OMLX_HOST"], !h.isEmpty { c.host = h }
+        if let h = env["OMLX_HOST"], !h.isEmpty { c.bindAddress = h }
         if let pStr = env["OMLX_PORT"], let p = Int(pStr) { c.port = p }
         if let k = env["OMLX_API_KEY"], !k.isEmpty { c.apiKey = k }
         return c
@@ -218,7 +224,7 @@ struct AppConfig: Sendable, Equatable, Codable {
         }
 
         var server = (json["server"] as? [String: Any]) ?? [:]
-        server["host"] = host
+        server["bind_address"] = bindAddress
         server["port"] = port
         json["server"] = server
 
@@ -250,7 +256,7 @@ struct AppConfig: Sendable, Equatable, Codable {
 
     /// Subset of `<basePath>/settings.json` we project into AppConfig.
     struct ServerSettingsSlice {
-        var host: String?
+        var bindAddress: String?
         var port: Int?
         var apiKey: String?
         var modelDir: String?
@@ -268,8 +274,11 @@ struct AppConfig: Sendable, Equatable, Codable {
         let auth   = json["auth"]   as? [String: Any]
         let model  = json["model"]  as? [String: Any]
         let hf     = json["huggingface"] as? [String: Any]
+        // Migrate: read bind_address first, fall back to legacy "host" key.
+        let bindAddr = server?["bind_address"] as? String
+            ?? server?["host"] as? String
         return ServerSettingsSlice(
-            host: server?["host"] as? String,
+            bindAddress: bindAddr,
             port: server?["port"] as? Int,
             apiKey: auth?["api_key"] as? String,
             modelDir: model?["model_dir"] as? String,

--- a/apps/omlx-mac/Sources/Menubar/MenubarController.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarController.swift
@@ -416,7 +416,7 @@ final class MenubarController: NSObject {
     // MARK: - Pollers
 
     /// Bind endpoint the stats poller should hit. Sourced from the live
-    /// `ServerProcess` (which `reconfigure(host:port:)` keeps current) so a
+    /// `ServerProcess` (which `reconfigure(bindAddress:port:)` keeps current) so a
     /// runtime port/host change re-points the poller, falling back to the
     /// config snapshot only when there is no server. Mirrors the
     /// `displayPort`/`displayHost` resolution used for the visible items.

--- a/apps/omlx-mac/Sources/Server/ServerProcess.swift
+++ b/apps/omlx-mac/Sources/Server/ServerProcess.swift
@@ -70,7 +70,12 @@ final class ServerProcess: @unchecked Sendable {
 
     // Inputs
 
-    private(set) var host: String
+    private(set) var bindAddress: String
+    /// The connectable host — normalises `0.0.0.0` → `127.0.0.1` because
+    /// `0.0.0.0` is a bind wildcard, not a connectable address.
+    var host: String {
+        bindAddress == "0.0.0.0" ? "127.0.0.1" : bindAddress
+    }
     private(set) var port: Int
     private(set) var basePath: URL
     private let runtime: PythonRuntime
@@ -82,14 +87,14 @@ final class ServerProcess: @unchecked Sendable {
     /// process so a stale resolver / spawn args can never reach a running
     /// uvicorn.
     enum ReconfigureError: Error { case serverIsLive }
-    func reconfigure(host: String? = nil, port: Int? = nil, basePath: URL? = nil) throws {
+    func reconfigure(bindAddress: String? = nil, port: Int? = nil, basePath: URL? = nil) throws {
         switch state {
         case .running, .starting, .stopping, .unresponsive:
             throw ReconfigureError.serverIsLive
         case .stopped, .failed:
             break
         }
-        if let host { self.host = host }
+        if let bindAddress { self.bindAddress = bindAddress }
         if let port { self.port = port }
         if let basePath { self.basePath = basePath }
         self.resolver = PortConflictResolver(host: self.host, port: self.port)
@@ -117,16 +122,17 @@ final class ServerProcess: @unchecked Sendable {
 
     init(
         runtime: PythonRuntime,
-        host: String = "127.0.0.1",
+        bindAddress: String = "127.0.0.1",
         port: Int = 8000,
         basePath: URL = ServerProcess.defaultBasePath()
     ) {
         self.runtime  = runtime
-        self.host     = host
+        self.bindAddress = bindAddress
         self.port     = port
         self.basePath = basePath
         self.logURL   = ServerProcess.defaultLogURL()
-        self.resolver = PortConflictResolver(host: host, port: port)
+        let connectableHost = bindAddress == "0.0.0.0" ? "127.0.0.1" : bindAddress
+        self.resolver = PortConflictResolver(host: connectableHost, port: port)
     }
 
     // MARK: - Public surface

--- a/apps/omlx-mac/Sources/Welcome/WelcomeWindow.swift
+++ b/apps/omlx-mac/Sources/Welcome/WelcomeWindow.swift
@@ -271,7 +271,7 @@ final class WelcomeViewModel: ObservableObject {
                              as NSString).expandingTildeInPath as NSString)
             .standardizingPath
         var config = services.config
-        config.host = "127.0.0.1"
+        config.bindAddress = "127.0.0.1"
         config.basePath = resolvedBase
         config.port = port
         // modelDir is always a literal path. The wizard's "Reset" button
@@ -325,7 +325,7 @@ final class WelcomeViewModel: ObservableObject {
                 let runtime = try PythonRuntime.resolve()
                 proc = ServerProcess(
                     runtime: runtime,
-                    host: config.host,
+                    bindAddress: config.bindAddress,
                     port: config.port,
                     basePath: URL(fileURLWithPath: config.basePath, isDirectory: true)
                 )
@@ -383,9 +383,7 @@ final class WelcomeViewModel: ObservableObject {
     @discardableResult
     func openWebDashboard() -> Bool {
         guard let services else { return false }
-        let port = services.config.port
-        let host = services.config.host
-        guard let url = URL(string: "http://\(host):\(port)/admin/dashboard") else {
+        guard let url = URL(string: "http://\(services.config.host):\(services.config.port)/admin/dashboard") else {
             return false
         }
         NSWorkspace.shared.open(url)

--- a/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
@@ -80,20 +80,29 @@ final class MenubarControllerPortTests: XCTestCase {
     }
 
     func testDisplayHostPrefersLiveServer() {
-        let server = ServerProcess(runtime: makeRuntime(), host: "0.0.0.0", port: 8080)
+        let server = ServerProcess(runtime: makeRuntime(), bindAddress: "127.0.0.1", port: 8080)
         XCTAssertEqual(
             MenubarController.displayHost(server: server, fallback: "127.0.0.1"),
-            "0.0.0.0"
+            "127.0.0.1"
+        )
+    }
+
+    func testDisplayHostUsesServerConnectableHost() {
+        let server = ServerProcess(runtime: makeRuntime(), bindAddress: "0.0.0.0", port: 8080)
+        XCTAssertEqual(
+            MenubarController.displayHost(server: server, fallback: "127.0.0.1"),
+            "127.0.0.1",
+            "ServerProcess.host returns the connectable host (0.0.0.0 → 127.0.0.1)."
         )
     }
 
     func testDisplayHostFollowsReconfigure() throws {
-        let server = ServerProcess(runtime: makeRuntime(), host: "127.0.0.1", port: 8080)
-        try server.reconfigure(host: "0.0.0.0")
+        let server = ServerProcess(runtime: makeRuntime(), bindAddress: "127.0.0.1", port: 8080)
+        try server.reconfigure(bindAddress: "localhost")
         XCTAssertEqual(
             MenubarController.displayHost(server: server, fallback: "127.0.0.1"),
-            "0.0.0.0",
-            "Listen Address changes propagate to the server via saveHost → applyServerEndpoint → server.reconfigure(host:); the menubar must reflect that."
+            "localhost",
+            "Listen Address changes propagate to the server via saveHost → applyServerEndpoint → server.reconfigure(bindAddress:); the menubar must reflect that."
         )
     }
 


### PR DESCRIPTION
When the server binds to 0.0.0.0, client code that builds connection URLs was using 0.0.0.0 verbatim — a bind wildcard, not a connectable address. This caused macOS ATS errors and broken connections in the menubar poller and SwiftUI screens.

- AppConfig: rename host → bindAddress (stored), add host (computed, normalizes 0.0.0.0 → 127.0.0.1). JSON key migrated to bind_address with backward-compat migration from legacy host key.
- ServerProcess: same pattern — bindAddress stored, host computed. Init and reconfigure take bindAddress: parameter.
- AppServices: use bindAddress for server binding, host for HTTP client.
- ServerScreenVM: normalize dto.server.host for endpoint URL display.
- WelcomeWindow: use bindAddress for server construction, host for URLs.
- MenubarController: simplify displayHost (no longer normalizes).
- PortConflictResolver: unchanged (uses connectable host).
- IntegrationsScreen: simplify formatDisplayHost (no longer normalizes).
- Tests: update for new parameter names and behavior.