### PR TITLE
feat(api): OpenAI-compatible logprobs for /v1/chat/completions (#1549)

### DIFF
--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -11,9 +11,15 @@ These models define the request and response schemas for:
 """
 
 import json
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
-from pydantic import AliasChoices, BaseModel, Field, field_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 from omlx.api.shared_models import (
     BaseUsage,
@@ -31,7 +37,7 @@ class ImageURL(BaseModel):
     """Image URL or base64 data URI for vision model input."""
 
     url: str  # "https://..." or "data:image/jpeg;base64,..."
-    detail: Optional[str] = "auto"  # "low", "high", "auto"
+    detail: str | None = "auto"  # "low", "high", "auto"
 
 
 class InputAudio(BaseModel):
@@ -48,11 +54,11 @@ class FileContent(BaseModel):
     ``data`` is accepted as an oMLX legacy alias for dashboard clients.
     """
 
-    filename: Optional[str] = None
-    mime_type: Optional[str] = None
-    file_data: Optional[str] = None
-    data: Optional[str] = None
-    file_id: Optional[str] = None
+    filename: str | None = None
+    mime_type: str | None = None
+    file_data: str | None = None
+    data: str | None = None
+    file_id: str | None = None
 
 
 class ContentPart(BaseModel):
@@ -67,10 +73,10 @@ class ContentPart(BaseModel):
     """
 
     type: str  # "text", "image_url", "input_audio", or "file"
-    text: Optional[str] = None
-    image_url: Optional[ImageURL] = None
-    input_audio: Optional[InputAudio] = None
-    file: Optional[FileContent] = None
+    text: str | None = None
+    image_url: ImageURL | None = None
+    input_audio: InputAudio | None = None
+    file: FileContent | None = None
 
 
 # =============================================================================
@@ -90,15 +96,15 @@ class Message(BaseModel):
     """
 
     role: str
-    content: Optional[Union[str, List[ContentPart], List[dict]]] = None
+    content: str | list[ContentPart] | list[dict] | None = None
     # Reasoning/thinking content from <think> blocks (OpenAI reasoning_content field)
-    reasoning_content: Optional[str] = None
+    reasoning_content: str | None = None
     # For assistant messages with tool calls
-    tool_calls: Optional[List[dict]] = None
+    tool_calls: list[dict] | None = None
     # For tool response messages (role="tool")
-    tool_call_id: Optional[str] = None
+    tool_call_id: str | None = None
     # Participant name, rendered into chat template (e.g. Kimi K2/K2.5 named assistants)
-    name: Optional[str] = None
+    name: str | None = None
     # Continue from this message instead of starting a new turn (prefill / partial mode)
     partial: bool = False
 
@@ -212,9 +218,9 @@ class ResponseFormatJsonSchema(BaseModel):
     """JSON Schema definition for structured output."""
 
     name: str
-    description: Optional[str] = None
+    description: str | None = None
     schema_: dict = Field(alias="schema")  # JSON Schema specification
-    strict: Optional[bool] = False
+    strict: bool | None = False
 
     class Config:
         populate_by_name = True
@@ -231,7 +237,7 @@ class ResponseFormat(BaseModel):
     """
 
     type: str = "text"  # "text", "json_object", "json_schema"
-    json_schema: Optional[ResponseFormatJsonSchema] = None
+    json_schema: ResponseFormatJsonSchema | None = None
 
 
 class StructuredOutputOptions(BaseModel):
@@ -249,10 +255,10 @@ class StructuredOutputOptions(BaseModel):
 
     model_config = {"populate_by_name": True}
 
-    json_schema: Optional[Union[str, dict]] = Field(None, alias="json")
-    regex: Optional[str] = None
-    choice: Optional[List[str]] = None
-    grammar: Optional[str] = None
+    json_schema: str | dict | None = Field(None, alias="json")
+    regex: str | None = None
+    choice: list[str] | None = None
+    grammar: str | None = None
 
 
 # =============================================================================
@@ -270,44 +276,47 @@ class ChatCompletionRequest(BaseModel):
     """Request for chat completion."""
 
     model: str
-    messages: List[Message]
+    messages: list[Message]
     temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None
     repetition_penalty: float | None = None
-    max_tokens: Optional[int] = Field(
+    max_tokens: int | None = Field(
         default=None,
         validation_alias=AliasChoices("max_tokens", "max_completion_tokens"),
     )
     stream: bool = False
-    stream_options: Optional[StreamOptions] = None
-    stop: Optional[List[str]] = None
+    stream_options: StreamOptions | None = None
+    stop: list[str] | None = None
     min_p: float | None = None
     xtc_probability: float | None = None
     xtc_threshold: float | None = None
     presence_penalty: float | None = None
     frequency_penalty: float | None = None
     # Tool calling
-    tools: Optional[List[ToolDefinition]] = None
-    tool_choice: Optional[Union[str, dict]] = None  # "auto", "none", or specific tool
+    tools: list[ToolDefinition] | None = None
+    tool_choice: str | dict | None = None  # "auto", "none", or specific tool
     # Structured output
-    response_format: Optional[Union[ResponseFormat, dict]] = None
+    response_format: ResponseFormat | dict | None = None
     # vLLM-compatible structured output (grammar, regex, choice, json)
-    structured_outputs: Optional[Union[StructuredOutputOptions, dict]] = None
+    structured_outputs: StructuredOutputOptions | dict | None = None
     # vLLM/OpenAI-compatible grammar alias, normalized to structured_outputs
-    guided_grammar: Optional[str] = None
+    guided_grammar: str | None = None
     # Chat template kwargs (e.g. enable_thinking, reasoning_effort)
-    chat_template_kwargs: Optional[Dict[str, Any]] = None
+    chat_template_kwargs: dict[str, Any] | None = None
     # Thinking budget (max thinking tokens, None = unlimited)
-    thinking_budget: Optional[int] = Field(default=None, ge=0)
+    thinking_budget: int | None = Field(default=None, ge=0)
     # SpecPrefill: per-request enable/disable (None = use model setting)
-    specprefill: Optional[bool] = None
+    specprefill: bool | None = None
     # SpecPrefill: per-request keep percentage (0.1-0.5, None = use model setting)
-    specprefill_keep_pct: Optional[float] = None
+    specprefill_keep_pct: float | None = None
     # SpecPrefill: per-request threshold override (min tokens to trigger, None = use model setting)
-    specprefill_threshold: Optional[int] = None
+    specprefill_threshold: int | None = None
     # Seed for reproducible generation (best-effort)
-    seed: Optional[int] = None
+    seed: int | None = None
+    # Per-token logprobs (OpenAI-compatible; #1549)
+    logprobs: bool | None = False
+    top_logprobs: int | None = None
 
     @field_validator("stop", mode="before")
     @classmethod
@@ -317,14 +326,44 @@ class ChatCompletionRequest(BaseModel):
             return [v]
         return v
 
+    @model_validator(mode="after")
+    def _validate_logprobs(self):
+        """Enforce OpenAI logprobs rules: top_logprobs needs logprobs, range 0-20."""
+        if self.top_logprobs is not None:
+            if not self.logprobs:
+                raise ValueError("`top_logprobs` requires `logprobs` to be true")
+            if not 0 <= self.top_logprobs <= 20:
+                raise ValueError("`top_logprobs` must be between 0 and 20")
+        return self
+
 
 class AssistantMessage(BaseModel):
     """Response message from the assistant."""
 
     role: str = "assistant"
-    content: Optional[str] = None
-    reasoning_content: Optional[str] = None
-    tool_calls: Optional[List[ToolCall]] = None
+    content: str | None = None
+    reasoning_content: str | None = None
+    tool_calls: list[ToolCall] | None = None
+
+
+class TopLogprob(BaseModel):
+    """A candidate token and its logprob at one position (OpenAI shape)."""
+    token: str
+    logprob: float
+    bytes: list[int] | None = None
+
+
+class ChatCompletionTokenLogprob(BaseModel):
+    """Logprob info for a single generated token (OpenAI shape)."""
+    token: str
+    logprob: float
+    bytes: list[int] | None = None
+    top_logprobs: list[TopLogprob] = Field(default_factory=list)
+
+
+class ChoiceLogprobs(BaseModel):
+    """Per-choice logprobs payload (OpenAI ``choices[].logprobs``)."""
+    content: list[ChatCompletionTokenLogprob] | None = None
 
 
 class ChatCompletionChoice(BaseModel):
@@ -332,14 +371,15 @@ class ChatCompletionChoice(BaseModel):
 
     index: int = 0
     message: AssistantMessage
-    finish_reason: Optional[str] = "stop"
+    finish_reason: str | None = "stop"
+    logprobs: ChoiceLogprobs | None = None
 
 
 class PromptTokensDetails(BaseModel):
     """Breakdown of prompt tokens used."""
 
-    cached_tokens: Optional[int] = None
-    audio_tokens: Optional[int] = None
+    cached_tokens: int | None = None
+    audio_tokens: int | None = None
 
 
 class Usage(BaseUsage):
@@ -349,15 +389,15 @@ class Usage(BaseUsage):
     When present, timing values are in seconds.
     """
 
-    prompt_tokens_details: Optional[PromptTokensDetails] = None
+    prompt_tokens_details: PromptTokensDetails | None = None
     # Timing metrics (oMLX extension, seconds)
-    model_load_duration: Optional[float] = None
-    time_to_first_token: Optional[float] = None
-    total_time: Optional[float] = None
-    prompt_eval_duration: Optional[float] = None
-    generation_duration: Optional[float] = None
-    prompt_tokens_per_second: Optional[float] = None
-    generation_tokens_per_second: Optional[float] = None
+    model_load_duration: float | None = None
+    time_to_first_token: float | None = None
+    total_time: float | None = None
+    prompt_eval_duration: float | None = None
+    generation_duration: float | None = None
+    prompt_tokens_per_second: float | None = None
+    generation_tokens_per_second: float | None = None
 
 
 class ChatCompletionResponse(BaseModel):
@@ -367,7 +407,7 @@ class ChatCompletionResponse(BaseModel):
     object: str = "chat.completion"
     created: int = Field(default_factory=get_unix_timestamp)
     model: str
-    choices: List[ChatCompletionChoice]
+    choices: list[ChatCompletionChoice]
     usage: Usage = Field(default_factory=Usage)
 
 
@@ -380,24 +420,24 @@ class CompletionRequest(BaseModel):
     """Request for text completion."""
 
     model: str
-    prompt: Union[str, List[str]]
+    prompt: str | list[str]
     temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None
     repetition_penalty: float | None = None
-    max_tokens: Optional[int] = None
+    max_tokens: int | None = None
     stream: bool = False
-    stream_options: Optional[StreamOptions] = None
-    stop: Optional[List[str]] = None
+    stream_options: StreamOptions | None = None
+    stop: list[str] | None = None
     min_p: float | None = None
     xtc_probability: float | None = None
     xtc_threshold: float | None = None
     presence_penalty: float | None = None
     frequency_penalty: float | None = None
     # Seed for reproducible generation (best-effort)
-    seed: Optional[int] = None
+    seed: int | None = None
     # Cap reasoning/thinking tokens (parity with /v1/chat/completions)
-    thinking_budget: Optional[int] = Field(default=None, ge=0)
+    thinking_budget: int | None = Field(default=None, ge=0)
 
     @field_validator("stop", mode="before")
     @classmethod
@@ -413,7 +453,7 @@ class CompletionChoice(BaseModel):
 
     index: int = 0
     text: str
-    finish_reason: Optional[str] = "stop"
+    finish_reason: str | None = "stop"
 
 
 class CompletionResponse(BaseModel):
@@ -423,7 +463,7 @@ class CompletionResponse(BaseModel):
     object: str = "text_completion"
     created: int = Field(default_factory=get_unix_timestamp)
     model: str
-    choices: List[CompletionChoice]
+    choices: list[CompletionChoice]
     usage: Usage = Field(default_factory=Usage)
 
 
@@ -449,7 +489,7 @@ class ModelsResponse(BaseModel):
     """Response for listing models."""
 
     object: str = "list"
-    data: List[ModelInfo]
+    data: list[ModelInfo]
 
 
 # =============================================================================
@@ -469,7 +509,7 @@ class MCPToolInfo(BaseModel):
 class MCPToolsResponse(BaseModel):
     """Response for listing MCP tools."""
 
-    tools: List[MCPToolInfo]
+    tools: list[MCPToolInfo]
     count: int
 
 
@@ -480,13 +520,13 @@ class MCPServerInfo(BaseModel):
     state: str
     transport: str
     tools_count: int
-    error: Optional[str] = None
+    error: str | None = None
 
 
 class MCPServersResponse(BaseModel):
     """Response for listing MCP servers."""
 
-    servers: List[MCPServerInfo]
+    servers: list[MCPServerInfo]
 
 
 class MCPExecuteRequest(BaseModel):
@@ -502,9 +542,9 @@ class MCPExecuteResponse(BaseModel):
     """Response from executing an MCP tool."""
 
     tool_name: str
-    content: Optional[Union[str, list, dict]] = None
+    content: str | list | dict | None = None
     is_error: bool = False
-    error_message: Optional[str] = None
+    error_message: str | None = None
 
 
 # =============================================================================
@@ -515,10 +555,10 @@ class MCPExecuteResponse(BaseModel):
 class ChatCompletionChunkDelta(BaseModel):
     """Delta content in a streaming chunk."""
 
-    role: Optional[str] = None
-    content: Optional[str] = None
-    reasoning_content: Optional[str] = None
-    tool_calls: Optional[List[dict]] = None
+    role: str | None = None
+    content: str | None = None
+    reasoning_content: str | None = None
+    tool_calls: list[dict] | None = None
 
 
 class ChatCompletionChunkChoice(BaseModel):
@@ -526,7 +566,8 @@ class ChatCompletionChunkChoice(BaseModel):
 
     index: int = 0
     delta: ChatCompletionChunkDelta
-    finish_reason: Optional[str] = None
+    finish_reason: str | None = None
+    logprobs: ChoiceLogprobs | None = None
 
 
 class ChatCompletionChunk(BaseModel):
@@ -536,5 +577,5 @@ class ChatCompletionChunk(BaseModel):
     object: str = "chat.completion.chunk"
     created: int = Field(default_factory=get_unix_timestamp)
     model: str
-    choices: List[ChatCompletionChunkChoice]
-    usage: Optional[Usage] = None  # Present on last chunk when include_usage=true
+    choices: list[ChatCompletionChunkChoice]
+    usage: Usage | None = None  # Present on last chunk when include_usage=true

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -232,6 +232,9 @@ class ThinkingParser:
     def __init__(self, start_in_thinking: bool = False):
         self._in_thinking: bool = start_in_thinking
         self._buffer: str = ""  # Buffer for potential partial tags
+        # Per-char logprob objects parallel to ``_buffer`` (only populated on
+        # the logprob-aware path; the text-only path never reads it).
+        self._buffer_lps: list = []
         # Recovery state for malformed thinking: when the prompt prepends
         # ``<think>`` and the model never emits ``</think>`` before EOS,
         # everything we streamed went out as thinking. The streamed events
@@ -251,15 +254,43 @@ class ThinkingParser:
         Returns:
             Tuple of (thinking_text, content_text) extracted from this chunk.
         """
-        if not text:
-            return ("", "")
+        thinking_delta, content_delta, _ = self._process(text, None)
+        return (thinking_delta, content_delta)
 
-        # Prepend any buffered partial tag content
+    def feed_with_logprob(self, text: str, token_logprob):
+        """Logprob-aware feed for a single token's text (#1549).
+
+        Identical text routing to :meth:`feed`, but also returns the logprob
+        objects for the content tokens emitted by this call — one entry per
+        content-contributing token, aligned to ``content_delta`` even across
+        tag-lookahead buffering. Tokens whose text is tag markup or thinking
+        produce no content entry.
+
+        Returns:
+            Tuple of (thinking_delta, content_delta, content_logprobs).
+        """
+        return self._process(text, token_logprob)
+
+    def _process(self, text: str, lp):
+        """Shared core for feed/feed_with_logprob.
+
+        When ``lp`` is None this is the text-only path (no logprob tracking,
+        behaviour identical to the original ``feed``). Otherwise every char of
+        ``text`` is attributed to ``lp`` and content logprobs are returned.
+        """
+        track = lp is not None
+        if not text:
+            return ("", "", [] if track else None)
+
+        # Prepend any buffered partial tag content (and its per-char logprobs).
+        char_lps = (self._buffer_lps + [lp] * len(text)) if track else None
         text = self._buffer + text
         self._buffer = ""
+        self._buffer_lps = []
 
         thinking_out = []
         content_out = []
+        content_lp_chars = []
 
         i = 0
         while i < len(text):
@@ -284,6 +315,8 @@ class ThinkingParser:
                 if self._could_be_tag(remaining):
                     # Buffer the rest and wait for more data
                     self._buffer = remaining
+                    if track:
+                        self._buffer_lps = char_lps[i:]
                     break
 
                 # Not a tag, emit the '<' as regular content
@@ -291,12 +324,16 @@ class ThinkingParser:
                     thinking_out.append('<')
                 else:
                     content_out.append('<')
+                    if track:
+                        content_lp_chars.append(char_lps[i])
                 i += 1
             else:
                 if self._in_thinking:
                     thinking_out.append(text[i])
                 else:
                     content_out.append(text[i])
+                    if track:
+                        content_lp_chars.append(char_lps[i])
                 i += 1
 
         thinking_delta = "".join(thinking_out)
@@ -305,7 +342,17 @@ class ThinkingParser:
             self._thinking_accumulated.append(thinking_delta)
         if content_delta:
             self._content_emitted = True
-        return (thinking_delta, content_delta)
+        content_lps = self._group_lps(content_lp_chars) if track else None
+        return (thinking_delta, content_delta, content_lps)
+
+    @staticmethod
+    def _group_lps(lp_chars: list) -> list:
+        """Collapse per-char logprob objects to one entry per token (by identity)."""
+        out: list = []
+        for clp in lp_chars:
+            if not out or out[-1] is not clp:
+                out.append(clp)
+        return out
 
     def finish(self) -> Tuple[str, str]:
         """Flush any remaining buffered content.
@@ -321,8 +368,23 @@ class ThinkingParser:
             Tuple of (thinking_text, content_text) from remaining buffer
             (plus recovered content if applicable).
         """
+        thinking_delta, content_delta, _ = self._finish_impl(False)
+        return (thinking_delta, content_delta)
+
+    def finish_with_logprob(self):
+        """Logprob-aware flush; returns (thinking_delta, content_delta, content_logprobs).
+
+        The malformed-thinking recovery path re-emits accumulated thinking text
+        as content; those tokens were never tracked as content, so the recovered
+        content carries no logprobs (empty list).
+        """
+        return self._finish_impl(True)
+
+    def _finish_impl(self, track: bool):
         partial = self._buffer
+        partial_lps = self._buffer_lps
         self._buffer = ""
+        self._buffer_lps = []
 
         # Recovery: prompt opened a thinking block (or model echoed
         # ``<think>`` itself), the close tag never arrived, and nothing
@@ -339,18 +401,19 @@ class ThinkingParser:
         ):
             recovered = "".join(self._thinking_accumulated) + partial
             self._content_emitted = True
-            return ("", recovered)
+            return ("", recovered, [] if track else None)
 
         if not partial:
-            return ("", "")
+            return ("", "", [] if track else None)
 
         # Partial tag never completed — emit it as-is in the current mode.
         if self._in_thinking:
             self._thinking_accumulated.append(partial)
-            return (partial, "")
+            return (partial, "", [] if track else None)
         else:
             self._content_emitted = True
-            return ("", partial)
+            content_lps = self._group_lps(partial_lps) if track else None
+            return ("", partial, content_lps)
 
     @staticmethod
     def _could_be_tag(text: str) -> bool:

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -6,9 +6,65 @@ Utility functions for text processing.
 
 import json
 import re
-from typing import Any, List
+from typing import Any, List, Optional
 
-from .openai_models import Message
+from ..request import TokenLogprob
+from .openai_models import (
+    ChatCompletionTokenLogprob,
+    ChoiceLogprobs,
+    Message,
+    TopLogprob,
+)
+
+
+# =============================================================================
+# Logprobs formatting (#1549)
+# =============================================================================
+
+
+def _decode_token_text_bytes(tokenizer, token_id: int):
+    """Decode a single token id to (text, utf-8 byte list). Best-effort."""
+    try:
+        text = tokenizer.decode([int(token_id)])
+    except Exception:
+        text = ""
+    try:
+        token_bytes = list(text.encode("utf-8"))
+    except Exception:
+        token_bytes = None
+    return text, token_bytes
+
+
+def token_logprob_to_openai(
+    token_logprob: TokenLogprob, tokenizer
+) -> ChatCompletionTokenLogprob:
+    """Convert an engine ``TokenLogprob`` to the OpenAI response shape."""
+    text, token_bytes = _decode_token_text_bytes(tokenizer, token_logprob.token_id)
+    top = []
+    for tid, lp in zip(token_logprob.top_ids, token_logprob.top_logprobs):
+        t_text, t_bytes = _decode_token_text_bytes(tokenizer, tid)
+        top.append(TopLogprob(token=t_text, logprob=float(lp), bytes=t_bytes))
+    return ChatCompletionTokenLogprob(
+        token=text,
+        logprob=float(token_logprob.logprob),
+        bytes=token_bytes,
+        top_logprobs=top,
+    )
+
+
+def build_choice_logprobs(
+    token_logprobs: Optional[List[TokenLogprob]], tokenizer
+) -> Optional[ChoiceLogprobs]:
+    """Build an OpenAI ``ChoiceLogprobs`` from engine ``TokenLogprob`` entries.
+
+    Returns ``None`` when there are no entries so the field is omitted from the
+    response (callers use ``exclude_none=True``).
+    """
+    if not token_logprobs:
+        return None
+    return ChoiceLogprobs(
+        content=[token_logprob_to_openai(tl, tokenizer) for tl in token_logprobs]
+    )
 
 # Model families whose chat templates consume message.reasoning_content directly.
 _NATIVE_REASONING_MODEL_TYPES = {"minimax_m3", "minimax_m3_vl"}

--- a/omlx/engine/base.py
+++ b/omlx/engine/base.py
@@ -15,6 +15,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 import mlx.core as mx
 
 from omlx.engine_core import get_mlx_executor
+from omlx.request import TokenLogprob
 
 _preflight_logger = logging.getLogger("omlx.engine.preflight")
 
@@ -79,6 +80,10 @@ class GenerationOutput:
     diffusion_work_tps: float = 0.0
     generated_at: Optional[float] = None
     generated_until: Optional[float] = None
+    # Per-token logprobs (None unless the request opted in). For streaming,
+    # carries the entries for this chunk's new tokens; for non-streaming, the
+    # full sequence accumulated across steps.
+    logprobs: Optional[List[TokenLogprob]] = None
 
 
 class BaseEngine(ABC):

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -556,6 +556,8 @@ class BatchedEngine(BaseEngine):
             thinking_budget=kwargs.get("thinking_budget", None),
             compiled_grammar=kwargs.get("compiled_grammar", None),
             seed=kwargs.get("seed", None),
+            logprobs=kwargs.get("logprobs", False),
+            top_logprobs=kwargs.get("top_logprobs", None),
         )
 
         output = await self._engine.generate(
@@ -572,6 +574,7 @@ class BatchedEngine(BaseEngine):
             finish_reason=output.finish_reason,
             tool_calls=output.tool_calls,
             cached_tokens=output.cached_tokens,
+            logprobs=getattr(output, "logprobs", None),
         )
 
     async def stream_generate(
@@ -625,6 +628,8 @@ class BatchedEngine(BaseEngine):
             thinking_budget=kwargs.get("thinking_budget", None),
             compiled_grammar=kwargs.get("compiled_grammar", None),
             seed=kwargs.get("seed", None),
+            logprobs=kwargs.get("logprobs", False),
+            top_logprobs=kwargs.get("top_logprobs", None),
         )
 
         # SpecPrefill: pass per-request overrides to engine
@@ -674,6 +679,7 @@ class BatchedEngine(BaseEngine):
                     cached_tokens=output.cached_tokens,
                     generated_at=getattr(output, "generated_at", None),
                     generated_until=getattr(output, "generated_until", None),
+                    logprobs=getattr(output, "logprobs", None),
                 )
         except GeneratorExit:
             # Client disconnected

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -2658,6 +2658,8 @@ class VLMBatchedEngine(BaseEngine):
             thinking_budget=kwargs.get("thinking_budget", None),
             compiled_grammar=kwargs.get("compiled_grammar", None),
             seed=kwargs.get("seed", None),
+            logprobs=kwargs.get("logprobs", False),
+            top_logprobs=kwargs.get("top_logprobs", None),
         )
 
         output = await self._engine.generate(
@@ -2679,6 +2681,7 @@ class VLMBatchedEngine(BaseEngine):
             finish_reason=output.finish_reason,
             tool_calls=output.tool_calls,
             cached_tokens=output.cached_tokens,
+            logprobs=getattr(output, "logprobs", None),
         )
 
     async def stream_generate(
@@ -2761,6 +2764,8 @@ class VLMBatchedEngine(BaseEngine):
             thinking_budget=kwargs.get("thinking_budget", None),
             compiled_grammar=kwargs.get("compiled_grammar", None),
             seed=kwargs.get("seed", None),
+            logprobs=kwargs.get("logprobs", False),
+            top_logprobs=kwargs.get("top_logprobs", None),
         )
 
         # SpecPrefill: pass per-request overrides
@@ -2809,6 +2814,7 @@ class VLMBatchedEngine(BaseEngine):
                     finish_reason=output.finish_reason,
                     tool_calls=output.tool_calls,
                     cached_tokens=output.cached_tokens,
+                    logprobs=getattr(output, "logprobs", None),
                 )
         except GeneratorExit:
             logger.info(f"[vlm_stream_generate] GeneratorExit for request {request_id}")

--- a/omlx/logprobs.py
+++ b/omlx/logprobs.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Engine-side per-token logprob extraction (#1549).
+
+Reduces a full-vocabulary logprob vector (computed for sampling) to a compact
+``TokenLogprob`` so the large array can be freed immediately. Called only when a
+request opts in via ``sampling_params.logprobs`` — the disabled path never
+reaches here, keeping inference unaffected.
+"""
+
+import mlx.core as mx
+
+from .request import TokenLogprob
+
+
+def extract_token_logprob(
+    logprobs_vec: mx.array, chosen_token_id: int, top_k: int
+) -> TokenLogprob:
+    """Reduce a full-vocab logprob vector to a compact ``TokenLogprob``.
+
+    Args:
+        logprobs_vec: 1-D log-probability vector over the vocabulary.
+        chosen_token_id: The token actually sampled at this position.
+        top_k: Number of top candidates to keep (already clamped to the
+            effective server cap). ``0`` keeps only the chosen token's logprob.
+
+    Returns:
+        A ``TokenLogprob`` with the chosen logprob and the top-K candidates
+        sorted by logprob descending.
+    """
+    chosen_lp = float(logprobs_vec[chosen_token_id].item())
+
+    top_ids: list[int] = []
+    top_lps: list[float] = []
+    if top_k and top_k > 0:
+        vocab = logprobs_vec.shape[-1]
+        k = min(int(top_k), vocab)
+        # Top-K (unordered) via argpartition, then sort that slice descending.
+        part = mx.argpartition(-logprobs_vec, kth=k - 1)[:k]
+        order = mx.argsort(-logprobs_vec[part])
+        ordered = part[order]
+        top_ids = ordered.tolist()
+        top_lps = logprobs_vec[ordered].tolist()
+
+    return TokenLogprob(
+        token_id=int(chosen_token_id),
+        logprob=chosen_lp,
+        top_ids=top_ids,
+        top_logprobs=top_lps,
+    )

--- a/omlx/output_collector.py
+++ b/omlx/output_collector.py
@@ -8,8 +8,7 @@ providing non-blocking output collection with intelligent aggregation.
 """
 
 import asyncio
-from dataclasses import dataclass, field
-from typing import List, Optional
+from dataclasses import dataclass
 
 from .request import RequestOutput
 
@@ -46,7 +45,7 @@ class RequestOutputCollector:
             aggregate: If True, merge outputs when producer gets ahead.
                        This prevents buffer explosion under load.
         """
-        self.output: Optional[RequestOutput] = None
+        self.output: RequestOutput | None = None
         self.ready = asyncio.Event()
         self.aggregate = aggregate
         self._is_waiting = False
@@ -71,7 +70,7 @@ class RequestOutputCollector:
             self.output = output
         self.ready.set()
 
-    def get_nowait(self) -> Optional[RequestOutput]:
+    def get_nowait(self) -> RequestOutput | None:
         """
         Get output without blocking.
 
@@ -136,6 +135,11 @@ class RequestOutputCollector:
         merged_new_token_ids = existing.new_token_ids + new.new_token_ids
         merged_new_text = existing.new_text + new.new_text
 
+        # Accumulate per-token logprobs in order (None unless requested)
+        merged_logprobs = None
+        if existing.logprobs is not None or new.logprobs is not None:
+            merged_logprobs = (existing.logprobs or []) + (new.logprobs or [])
+
         return RequestOutput(
             request_id=new.request_id,
             new_token_ids=merged_new_token_ids,
@@ -158,6 +162,7 @@ class RequestOutputCollector:
             ),
             tool_calls=new.tool_calls,  # Preserve tool_calls for Harmony models
             cached_tokens=new.cached_tokens,
+            logprobs=merged_logprobs,
             error=new.error or existing.error,
             error_code=new.error_code or existing.error_code,
             error_metadata=new.error_metadata or existing.error_metadata,

--- a/omlx/request.py
+++ b/omlx/request.py
@@ -257,6 +257,25 @@ class Request:
 
 
 @dataclass
+class TokenLogprob:
+    """Compact per-token logprob info carried from engine to API layer (#1549).
+
+    Holds the chosen token's logprob plus the top-K candidates (ids + logprobs,
+    sorted descending). Token-string / bytes decoding is deferred to the API
+    layer where the tokenizer lives.
+    """
+
+    token_id: int
+    logprob: float
+    top_ids: List[int] = field(default_factory=list)
+    top_logprobs: List[float] = field(default_factory=list)
+    # Decoded text of this token (set by the scheduler), used to keep
+    # streaming logprobs aligned to content tokens through the thinking/tool
+    # text routing. Empty when not needed.
+    text: str = ""
+
+
+@dataclass
 class RequestOutput:
     """
     Output for a single request after a generation step.
@@ -289,6 +308,9 @@ class RequestOutput:
     tool_calls: Optional[List[Dict[str, str]]] = None
     # Prefix cache stats
     cached_tokens: int = 0
+    # Per-token logprobs for tokens generated in this step (None unless the
+    # request opted in via sampling_params.logprobs). One entry per new token.
+    logprobs: Optional[List[TokenLogprob]] = None
     # Error message (set when engine encounters an unrecoverable error)
     error: Optional[str] = None
     # Structured internal error classification for API-layer mapping.

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -52,6 +52,7 @@ from .cache.prefix_cache import BlockAwarePrefixCache
 from .exceptions import PrefillMemoryExceededError, is_cache_corruption_error
 from .prefill_progress import get_prefill_tracker
 from .prefill_transient_tracker import PrefillTransientTracker
+from .logprobs import extract_token_logprob
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
 from .speculative.vlm_mtp import VLMMTPDrafter, run_vlm_mtp_decode
 from .utils.fatal import FATAL_TEARDOWN_TIMEOUT_S, fatal_exit
@@ -8245,13 +8246,29 @@ class Scheduler:
                             request.output_text = prefix_text + request.output_text
                     request.think_prefix_sent = True
 
-            # Immediately discard logprobs if not requested to free memory (~800KB per response)
-            # This prevents accumulation of large MLX arrays during streaming
-            if (
-                hasattr(response, "logprobs")
-                and response.logprobs is not None
-                and not request.sampling_params.logprobs
-            ):
+            # Logprobs: extract the compact per-token entry when requested, then
+            # drop the full-vocab array either way to free memory (~800KB per
+            # response). The disabled path stays a plain discard — no extra work.
+            token_logprobs = None
+            if hasattr(response, "logprobs") and response.logprobs is not None:
+                if request.sampling_params.logprobs and not is_stop:
+                    # Speculative/MTP paths report the proposing head's
+                    # distribution, not the target model's — suppress logprobs
+                    # there for now (#1549 v1; tracked for true support).
+                    mtp_logprobs_unsafe = (
+                        isinstance(response, _VLMMTPResponse)
+                        or getattr(self.model, "mtp", None) is not None
+                    )
+                    if not mtp_logprobs_unsafe:
+                        tl = extract_token_logprob(
+                            response.logprobs,
+                            response.token,
+                            request.sampling_params.top_logprobs or 0,
+                        )
+                        # Carry the token's decoded text so the API layer can
+                        # keep streaming logprobs aligned to content tokens.
+                        tl.text = new_text
+                        token_logprobs = [tl]
                 response.logprobs = None
 
             # Create output
@@ -8270,6 +8287,7 @@ class Scheduler:
                 generated_at=output_generated_at,
                 generated_until=output_generated_at,
                 cached_tokens=request.cached_tokens,
+                logprobs=token_logprobs,
             )
 
             if not is_finished:

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -165,6 +165,8 @@ from .api.tool_calling import (
     sanitize_tool_call_markup,
 )
 from .api.utils import (
+    build_choice_logprobs,
+    clean_output_text,
     clean_special_tokens,
     detect_and_strip_partial,
     extract_multimodal_content,
@@ -173,7 +175,7 @@ from .api.utils import (
     prepare_system_messages_for_template,
     uses_native_reasoning_content,
 )
-from .engine import BaseEngine, VLMBatchedEngine
+from .engine import BaseEngine, BatchedEngine, VLMBatchedEngine
 from .engine.embedding import EmbeddingEngine
 from .engine.reranker import RerankerEngine
 from .engine_pool import EnginePool
@@ -3386,6 +3388,18 @@ async def create_chat_completion(
         if request.stop:
             chat_kwargs["stop"] = request.stop
 
+        # Per-token logprobs (#1549): forward to the engine, clamping the requested
+        # top_logprobs to the server-side cap. Only set when requested so the
+        # disabled path is unchanged. Built before the preflight call below so the
+        # guard sees the complete chat_kwargs.
+        if getattr(request, "logprobs", False):
+            cap = 20
+            gs = _server_state.global_settings
+            if gs is not None and getattr(gs, "sampling", None) is not None:
+                cap = getattr(gs.sampling, "top_logprobs_k", 20)
+            chat_kwargs["logprobs"] = True
+            chat_kwargs["top_logprobs"] = min(request.top_logprobs or 0, cap)
+
         # Pre-flight prefill memory guard. Must run BEFORE either branch wraps
         # the response in a StreamingResponse — starlette emits
         # http.response.start (status 200) before iterating the body generator,
@@ -3514,6 +3528,14 @@ async def create_chat_completion(
 
             finish_reason = "tool_calls" if tool_calls else output.finish_reason
 
+            # Per-token logprobs (#1549). D1: raw generation order — under
+            # thinking/tool extraction these cover the generated tokens, not the
+            # post-processed content substring. Gate on the request so logprobs are
+            # never serialized unless the client asked, independent of engine output.
+            choice_logprobs = None
+            if getattr(request, "logprobs", False):
+                choice_logprobs = build_choice_logprobs(output.logprobs, engine.tokenizer)
+
             return ChatCompletionResponse(
                 model=request.model,
                 choices=[
@@ -3526,6 +3548,7 @@ async def create_chat_completion(
                             tool_calls=tool_calls,
                         ),
                         finish_reason=finish_reason,
+                        logprobs=choice_logprobs,
                     )
                 ],
                 usage=Usage(
@@ -4198,6 +4221,10 @@ async def stream_chat_completion(
             thinking_filter = _thinking_filter
         else:
             stream_content = False
+    # Per-token logprobs (#1549): only when requested AND no tool-call filter is
+    # active. The tool filter buffers/strips markup independently, so logprob
+    # alignment through it is not supported yet — omit rather than misalign.
+    want_logprobs = getattr(request, "logprobs", False) and tool_filter is None
     try:
         async for output in engine.stream_chat(messages=messages, **kwargs):
             if first_token_time is None and output.new_text:
@@ -4207,7 +4234,25 @@ async def stream_chat_completion(
                 accumulated_text += output.new_text
 
             if stream_content and output.new_text:
-                thinking_delta, content_delta = thinking_parser.feed(output.new_text)
+                if want_logprobs and output.logprobs:
+                    # Feed per token so content logprobs stay aligned to content
+                    # tokens through tag-lookahead buffering (#1549, Phase 3b).
+                    td_parts, cd_parts, content_lps = [], [], []
+                    for tl in output.logprobs:
+                        td_i, cd_i, clps_i = thinking_parser.feed_with_logprob(
+                            tl.text, tl
+                        )
+                        if td_i:
+                            td_parts.append(td_i)
+                        if cd_i:
+                            cd_parts.append(cd_i)
+                        if clps_i:
+                            content_lps.extend(clps_i)
+                    thinking_delta = "".join(td_parts)
+                    content_delta = "".join(cd_parts)
+                else:
+                    thinking_delta, content_delta = thinking_parser.feed(output.new_text)
+                    content_lps = None
 
                 # Emit reasoning_content delta
                 if thinking_delta:
@@ -4234,6 +4279,11 @@ async def stream_chat_completion(
                     if tool_filter:
                         content_delta = tool_filter.feed(content_delta)
                     if content_delta:
+                        # Logprobs (#1549): content_lps are aligned to this
+                        # chunk's content tokens (per-token feed above).
+                        chunk_logprobs = build_choice_logprobs(
+                            content_lps, engine.tokenizer
+                        )
                         chunk = ChatCompletionChunk(
                             id=response_id,
                             model=request.model,
@@ -4243,6 +4293,7 @@ async def stream_chat_completion(
                                         content=content_delta
                                     ),
                                     finish_reason=None,
+                                    logprobs=chunk_logprobs,
                                 )
                             ],
                         )
@@ -4256,7 +4307,13 @@ async def stream_chat_completion(
 
     # Flush remaining buffered content from thinking/tool-call parsers
     if stream_content:
-        thinking_delta, content_delta = thinking_parser.finish()
+        if want_logprobs:
+            thinking_delta, content_delta, content_lps = (
+                thinking_parser.finish_with_logprob()
+            )
+        else:
+            thinking_delta, content_delta = thinking_parser.finish()
+            content_lps = None
         if thinking_delta:
             if thinking_filter:
                 thinking_delta = thinking_filter.feed(thinking_delta)
@@ -4294,6 +4351,7 @@ async def stream_chat_completion(
             if tool_filter:
                 content_delta = tool_filter.feed(content_delta)
             if content_delta:
+                chunk_logprobs = build_choice_logprobs(content_lps, engine.tokenizer)
                 chunk = ChatCompletionChunk(
                     id=response_id,
                     model=request.model,
@@ -4301,6 +4359,7 @@ async def stream_chat_completion(
                         ChatCompletionChunkChoice(
                             delta=ChatCompletionChunkDelta(content=content_delta),
                             finish_reason=None,
+                            logprobs=chunk_logprobs,
                         )
                     ],
                 )

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -596,6 +596,13 @@ class SamplingSettings:
     top_p: float = 0.95
     top_k: int = 0
     repetition_penalty: float = 1.0
+    # Launch-side cap for OpenAI per-token top_logprobs, clamped to OpenAI's
+    # 0-20 range (#1549). 0 disables the top list; the per-request `logprobs`
+    # flag remains the cost gate.
+    top_logprobs_k: int = 20
+
+    def __post_init__(self):
+        self.top_logprobs_k = max(0, min(int(self.top_logprobs_k), 20))
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
@@ -607,6 +614,7 @@ class SamplingSettings:
             "top_p": self.top_p,
             "top_k": self.top_k,
             "repetition_penalty": self.repetition_penalty,
+            "top_logprobs_k": self.top_logprobs_k,
         }
 
     @classmethod
@@ -620,6 +628,7 @@ class SamplingSettings:
             top_p=data.get("top_p", 0.95),
             top_k=data.get("top_k", 0),
             repetition_penalty=data.get("repetition_penalty", 1.0),
+            top_logprobs_k=data.get("top_logprobs_k", 20),
         )
 
 

--- a/tests/integration/test_logprobs_api.py
+++ b/tests/integration/test_logprobs_api.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end API tests for OpenAI-style chat logprobs (#1549, Phase 4).
+
+Exercises the real /v1/chat/completions handler (non-streaming + streaming) via
+TestClient with a mock engine, asserting the OpenAI logprobs shape, streaming
+content-token alignment, validation, and the server-side cap clamp. No model is
+loaded.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from omlx.engine.base import BaseEngine, GenerationOutput
+from omlx.request import TokenLogprob
+
+from .test_e2e_streaming import MockBaseEngine, MockEnginePool, parse_sse_events
+
+
+class LogprobEngine(MockBaseEngine):
+    """Mock engine returning real GenerationOutput objects with logprobs."""
+
+    def __init__(self):
+        super().__init__()
+        self.chat_output = GenerationOutput(
+            text="Hi", prompt_tokens=5, completion_tokens=1, finish_reason="stop"
+        )
+        self.stream_output = []
+        self.last_kwargs = None
+
+    def count_chat_tokens(self, *args, **kwargs):
+        return 5
+
+    async def chat(self, messages, **kwargs):
+        self.last_kwargs = kwargs
+        return self.chat_output
+
+    async def stream_chat(self, messages, **kwargs):
+        self.last_kwargs = kwargs
+        for out in self.stream_output:
+            yield out
+
+    async def preflight_chat(self, messages, **kwargs):
+        # No-op preflight (mirrors BaseEngine.preflight_chat default); the chat
+        # handler now calls this before the logprobs path under the prefill guard.
+        return None
+
+
+# get_engine() gates on isinstance(engine, BaseEngine); register the mock so the
+# /v1/chat/completions LLM-type check accepts it without implementing the ABC.
+BaseEngine.register(LogprobEngine)
+
+
+class LogprobPool(MockEnginePool):
+    """Adds get_entry() (used by the chat handler for preserve_thinking) and
+    absorbs the leased-engine plumbing — upstream's LLM lease feature threads
+    ``_lease``/``runtime_settings`` through ``get_engine()`` and releases via
+    ``release_engine()`` once the response stream completes."""
+
+    def get_entry(self, model_id):
+        return None
+
+    async def get_engine(self, model_id: str, **kwargs):
+        return await super().get_engine(model_id)
+
+    async def release_engine(self, model_id: str):
+        return None
+
+
+@pytest.fixture
+def engine():
+    return LogprobEngine()
+
+
+@pytest.fixture
+def client(engine):
+    from omlx.server import _server_state, app
+
+    orig_pool = _server_state.engine_pool
+    orig_default = _server_state.default_model
+    _server_state.engine_pool = LogprobPool(engine)
+    _server_state.default_model = "test-model"
+    yield TestClient(app, raise_server_exceptions=False)
+    _server_state.engine_pool = orig_pool
+    _server_state.default_model = orig_default
+
+
+def _body(**extra):
+    body = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 8,
+    }
+    body.update(extra)
+    return body
+
+
+class TestNonStreamingLogprobs:
+    def test_logprobs_present_and_shaped(self, client, engine):
+        engine.chat_output = GenerationOutput(
+            text="Hi",
+            prompt_tokens=5,
+            completion_tokens=1,
+            finish_reason="stop",
+            logprobs=[
+                TokenLogprob(
+                    token_id=1, logprob=-0.12, top_ids=[1, 4],
+                    top_logprobs=[-0.12, -1.8],
+                )
+            ],
+        )
+        r = client.post("/v1/chat/completions", json=_body(logprobs=True, top_logprobs=2))
+        assert r.status_code == 200
+        lp = r.json()["choices"][0]["logprobs"]
+        assert lp is not None
+        assert lp["content"][0]["logprob"] == -0.12
+        assert lp["content"][0]["bytes"] is not None
+        assert len(lp["content"][0]["top_logprobs"]) == 2
+
+    def test_logprobs_absent_when_not_requested(self, client, engine):
+        engine.chat_output = GenerationOutput(
+            text="Hi", completion_tokens=1, finish_reason="stop",
+            logprobs=[TokenLogprob(token_id=1, logprob=-0.1)],
+        )
+        r = client.post("/v1/chat/completions", json=_body())
+        assert r.status_code == 200
+        assert r.json()["choices"][0].get("logprobs") is None
+
+    def test_disabled_path_forwards_no_logprob_kwargs(self, client, engine):
+        # Perf invariant: when logprobs aren't requested, nothing logprobs-related
+        # is forwarded to the engine, so the generation path is unchanged.
+        engine.chat_output = GenerationOutput(
+            text="Hi", completion_tokens=1, finish_reason="stop"
+        )
+        r = client.post("/v1/chat/completions", json=_body())
+        assert r.status_code == 200
+        assert "logprobs" not in engine.last_kwargs
+        assert "top_logprobs" not in engine.last_kwargs
+
+
+class TestStreamingLogprobs:
+    def test_streaming_logprobs_aligned_with_angle_bracket(self, client, engine):
+        # "a", "<", "b" — the '<' triggers tag-lookahead buffering; all three
+        # content tokens must still be represented exactly once.
+        engine.stream_output = [
+            GenerationOutput(
+                text="a", new_text="a", completion_tokens=1,
+                logprobs=[TokenLogprob(token_id=1, logprob=-0.1, text="a")],
+            ),
+            GenerationOutput(
+                text="a<", new_text="<", completion_tokens=2,
+                logprobs=[TokenLogprob(token_id=2, logprob=-0.2, text="<")],
+            ),
+            GenerationOutput(
+                text="a<b", new_text="b", completion_tokens=3, finished=True,
+                finish_reason="stop",
+                logprobs=[TokenLogprob(token_id=3, logprob=-0.3, text="b")],
+            ),
+        ]
+        r = client.post("/v1/chat/completions", json=_body(stream=True, logprobs=True))
+        assert r.status_code == 200
+        events = parse_sse_events(r.text)
+        entries = []
+        content = ""
+        for ev in events:
+            if not ev.get("choices"):
+                continue
+            ch = ev["choices"][0]
+            content += (ch.get("delta") or {}).get("content") or ""
+            lp = ch.get("logprobs")
+            if lp and lp.get("content"):
+                entries.extend(lp["content"])
+        assert content == "a<b"
+        assert len(entries) == 3  # one entry per content token — aligned
+
+    def test_streaming_no_logprobs_when_not_requested(self, client, engine):
+        engine.stream_output = [
+            GenerationOutput(
+                text="hi", new_text="hi", completion_tokens=1, finished=True,
+                finish_reason="stop",
+                logprobs=[TokenLogprob(token_id=1, logprob=-0.1, text="hi")],
+            ),
+        ]
+        r = client.post("/v1/chat/completions", json=_body(stream=True))
+        assert r.status_code == 200
+        for ev in parse_sse_events(r.text):
+            if ev.get("choices"):
+                assert ev["choices"][0].get("logprobs") is None
+
+
+class TestValidation:
+    def test_top_logprobs_above_20_rejected(self, client):
+        r = client.post("/v1/chat/completions", json=_body(logprobs=True, top_logprobs=21))
+        assert r.status_code == 422
+
+    def test_top_logprobs_without_logprobs_rejected(self, client):
+        r = client.post("/v1/chat/completions", json=_body(top_logprobs=3))
+        assert r.status_code == 422
+
+
+class TestServerCapClamp:
+    def test_requested_top_logprobs_clamped_to_server_cap(self, client, engine):
+        from omlx.server import _server_state
+
+        engine.chat_output = GenerationOutput(
+            text="Hi", completion_tokens=1, finish_reason="stop",
+            logprobs=[TokenLogprob(token_id=1, logprob=-0.1)],
+        )
+        orig = _server_state.global_settings
+        _server_state.global_settings = SimpleNamespace(
+            sampling=SimpleNamespace(top_logprobs_k=1),
+            server=SimpleNamespace(preserve_mid_system_cache=True),
+        )
+        try:
+            r = client.post(
+                "/v1/chat/completions", json=_body(logprobs=True, top_logprobs=5)
+            )
+            assert r.status_code == 200
+            # Handler clamped 5 -> server cap 1 before forwarding to the engine.
+            assert engine.last_kwargs["top_logprobs"] == 1
+            assert engine.last_kwargs["logprobs"] is True
+        finally:
+            _server_state.global_settings = orig

--- a/tests/test_logprobs_extraction.py
+++ b/tests/test_logprobs_extraction.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for engine-side per-token logprob extraction (#1549, Phase 2a)."""
+
+import mlx.core as mx
+
+from omlx.logprobs import extract_token_logprob
+from omlx.request import RequestOutput, TokenLogprob
+
+# vocab=5 logprob vector; descending order by value is idx 1, 4, 2, 0, 3
+LP = mx.array([-3.0, -0.1, -2.0, -5.0, -1.0])
+
+
+class TestExtractTokenLogprob:
+    def test_returns_token_logprob_type(self):
+        assert isinstance(extract_token_logprob(LP, 1, 2), TokenLogprob)
+
+    def test_chosen_logprob(self):
+        tl = extract_token_logprob(LP, chosen_token_id=1, top_k=0)
+        assert tl.token_id == 1
+        assert abs(tl.logprob - (-0.1)) < 1e-5
+
+    def test_chosen_can_differ_from_argmax(self):
+        # chosen token 0 (logprob -3.0) even though argmax is 1
+        tl = extract_token_logprob(LP, chosen_token_id=0, top_k=0)
+        assert tl.token_id == 0
+        assert abs(tl.logprob - (-3.0)) < 1e-5
+
+    def test_topk_ids_sorted_descending(self):
+        tl = extract_token_logprob(LP, chosen_token_id=1, top_k=3)
+        assert tl.top_ids == [1, 4, 2]
+        assert all(
+            a >= b for a, b in zip(tl.top_logprobs, tl.top_logprobs[1:])
+        )
+
+    def test_topk_logprobs_match_ids(self):
+        tl = extract_token_logprob(LP, chosen_token_id=1, top_k=2)
+        assert tl.top_ids == [1, 4]
+        assert abs(tl.top_logprobs[0] - (-0.1)) < 1e-5
+        assert abs(tl.top_logprobs[1] - (-1.0)) < 1e-5
+
+    def test_topk_zero_returns_empty_top_but_keeps_chosen(self):
+        tl = extract_token_logprob(LP, chosen_token_id=2, top_k=0)
+        assert tl.top_ids == []
+        assert tl.top_logprobs == []
+        assert abs(tl.logprob - (-2.0)) < 1e-5
+
+    def test_topk_clamped_to_vocab(self):
+        tl = extract_token_logprob(LP, chosen_token_id=1, top_k=100)
+        assert len(tl.top_ids) == 5
+        assert tl.top_ids[0] == 1  # still sorted desc
+
+
+class TestRequestOutputLogprobsField:
+    def test_default_none(self):
+        out = RequestOutput(request_id="r1")
+        assert out.logprobs is None
+
+    def test_accepts_list(self):
+        tl = TokenLogprob(token_id=1, logprob=-0.1, top_ids=[1], top_logprobs=[-0.1])
+        out = RequestOutput(request_id="r1", logprobs=[tl])
+        assert out.logprobs[0].token_id == 1
+
+
+class TestOutputCollectorLogprobsMerge:
+    """_merge_outputs must accumulate per-token logprobs across steps (#1549)."""
+
+    def test_merge_concatenates_logprobs(self):
+        from omlx.output_collector import RequestOutputCollector
+
+        c = RequestOutputCollector(aggregate=True)
+        t1 = TokenLogprob(token_id=1, logprob=-0.1)
+        t2 = TokenLogprob(token_id=2, logprob=-0.2)
+        c.put(RequestOutput(request_id="r", new_token_ids=[1], logprobs=[t1]))
+        c.put(RequestOutput(request_id="r", new_token_ids=[2], logprobs=[t2]))
+        out = c.get_nowait()
+        assert [tl.token_id for tl in out.logprobs] == [1, 2]
+
+    def test_merge_one_side_none(self):
+        from omlx.output_collector import RequestOutputCollector
+
+        c = RequestOutputCollector(aggregate=True)
+        t1 = TokenLogprob(token_id=1, logprob=-0.1)
+        c.put(RequestOutput(request_id="r", new_token_ids=[1], logprobs=[t1]))
+        c.put(RequestOutput(request_id="r", new_token_ids=[2], logprobs=None))
+        out = c.get_nowait()
+        assert [tl.token_id for tl in out.logprobs] == [1]
+
+    def test_merge_both_none_stays_none(self):
+        from omlx.output_collector import RequestOutputCollector
+
+        c = RequestOutputCollector(aggregate=True)
+        c.put(RequestOutput(request_id="r", new_token_ids=[1]))
+        c.put(RequestOutput(request_id="r", new_token_ids=[2]))
+        out = c.get_nowait()
+        assert out.logprobs is None
+
+
+class TestGenerationOutputLogprobs:
+    def test_default_none(self):
+        from omlx.engine.base import GenerationOutput
+
+        assert GenerationOutput(text="hi").logprobs is None
+
+    def test_accepts_logprobs(self):
+        from omlx.engine.base import GenerationOutput
+
+        tl = TokenLogprob(token_id=1, logprob=-0.1)
+        go = GenerationOutput(text="hi", logprobs=[tl])
+        assert go.logprobs[0].token_id == 1
+
+
+class _FakeTokenizer:
+    def __init__(self, mapping):
+        self._m = mapping
+
+    def decode(self, ids):
+        return "".join(self._m.get(int(i), "?") for i in ids)
+
+
+class TestBuildChoiceLogprobs:
+    """OpenAI-shape formatting from engine TokenLogprob (#1549, Phase 3)."""
+
+    def test_none_and_empty_return_none(self):
+        from omlx.api.utils import build_choice_logprobs
+
+        assert build_choice_logprobs(None, None) is None
+        assert build_choice_logprobs([], None) is None
+
+    def test_token_and_bytes_decoded(self):
+        from omlx.api.utils import build_choice_logprobs
+
+        tok = _FakeTokenizer({1: "Hi", 4: " Hello", 2: "x"})
+        tls = [
+            TokenLogprob(
+                token_id=1, logprob=-0.1, top_ids=[1, 4], top_logprobs=[-0.1, -1.0]
+            )
+        ]
+        cl = build_choice_logprobs(tls, tok)
+        entry = cl.content[0]
+        assert entry.token == "Hi"
+        assert entry.logprob == -0.1
+        assert entry.bytes == list("Hi".encode("utf-8"))
+        assert [t.token for t in entry.top_logprobs] == ["Hi", " Hello"]
+        assert entry.top_logprobs[1].bytes == list(" Hello".encode("utf-8"))
+
+    def test_top_logprobs_zero_yields_empty_top_list(self):
+        from omlx.api.utils import build_choice_logprobs
+
+        tok = _FakeTokenizer({2: "x"})
+        tls = [TokenLogprob(token_id=2, logprob=-0.5, top_ids=[], top_logprobs=[])]
+        cl = build_choice_logprobs(tls, tok)
+        assert cl.content[0].token == "x"
+        assert cl.content[0].top_logprobs == []
+
+    def test_one_entry_per_token(self):
+        from omlx.api.utils import build_choice_logprobs
+
+        tok = _FakeTokenizer({1: "a", 2: "b", 3: "c"})
+        tls = [
+            TokenLogprob(token_id=1, logprob=-0.1),
+            TokenLogprob(token_id=2, logprob=-0.2),
+            TokenLogprob(token_id=3, logprob=-0.3),
+        ]
+        cl = build_choice_logprobs(tls, tok)
+        assert [e.token for e in cl.content] == ["a", "b", "c"]
+
+
+def _lp(tid, text):
+    return TokenLogprob(token_id=tid, logprob=-0.1 * tid, text=text)
+
+
+class TestThinkingParserLogprobAlignment:
+    """Streaming logprob/content-token alignment under buffering (#1549, Phase 3b)."""
+
+    def test_text_only_feed_unchanged(self):
+        from omlx.api.thinking import ThinkingParser
+
+        p = ThinkingParser()
+        assert p.feed("<think>hi</think>yo") == ("hi", "yo")
+        assert p.finish() == ("", "")
+
+    def test_angle_bracket_in_content_keeps_all_logprobs(self):
+        # The drift case: "a", "<", "b" — the '<' triggers tag-lookahead buffering.
+        from omlx.api.thinking import ThinkingParser
+
+        p = ThinkingParser()
+        td, cd, clps = p.feed_with_logprob("a", _lp(1, "a"))
+        assert cd == "a" and [x.token_id for x in clps] == [1]
+        td, cd, clps = p.feed_with_logprob("<", _lp(2, "<"))
+        assert cd == "" and clps == []  # buffered, nothing emitted yet
+        td, cd, clps = p.feed_with_logprob("b", _lp(3, "b"))
+        assert cd == "<b" and [x.token_id for x in clps] == [2, 3]
+        # Total content entries (1 + 0 + 2) == 3 content tokens. Aligned.
+
+    def test_special_token_thinking_tokens_excluded(self):
+        from omlx.api.thinking import ThinkingParser
+
+        p = ThinkingParser()
+        td, cd, clps = p.feed_with_logprob("<think>", _lp(1, "<think>"))
+        assert cd == "" and clps == []
+        td, cd, clps = p.feed_with_logprob("reason", _lp(2, "reason"))
+        assert td == "reason" and cd == "" and clps == []
+        td, cd, clps = p.feed_with_logprob("</think>", _lp(3, "</think>"))
+        assert cd == "" and clps == []
+        td, cd, clps = p.feed_with_logprob("ans", _lp(4, "ans"))
+        assert cd == "ans" and [x.token_id for x in clps] == [4]
+
+    def test_finish_flushes_buffered_content_logprob(self):
+        from omlx.api.thinking import ThinkingParser
+
+        p = ThinkingParser()
+        td, cd, clps = p.feed_with_logprob("<", _lp(1, "<"))
+        assert cd == ""
+        td, cd, clps = p.finish_with_logprob()
+        assert cd == "<" and [x.token_id for x in clps] == [1]
+
+    def test_split_tag_across_tokens_drops_tag_keeps_content(self):
+        from omlx.api.thinking import ThinkingParser
+
+        p = ThinkingParser()
+        # "<", "think>" arriving as two tokens => a real open tag, no content
+        td, cd, clps = p.feed_with_logprob("<", _lp(1, "<"))
+        assert cd == "" and clps == []
+        td, cd, clps = p.feed_with_logprob("think>", _lp(2, "think>"))
+        assert cd == "" and clps == []  # completed <think>, consumed
+        td, cd, clps = p.feed_with_logprob("hi", _lp(3, "hi"))
+        assert td == "hi" and cd == "" and clps == []

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -31,6 +31,9 @@ from omlx.api.openai_models import (
     ResponseFormatJsonSchema,
     ToolCall,
     ToolDefinition,
+    TopLogprob,
+    ChatCompletionTokenLogprob,
+    ChoiceLogprobs,
     Usage,
 )
 
@@ -845,3 +848,87 @@ class TestStopCoercion:
             stop=["a"],
         )
         assert req.stop == ["a"]
+
+
+class TestChatCompletionLogprobs:
+    """OpenAI-style logprobs request params and response models (#1549)."""
+
+    def _msgs(self):
+        return [Message(role="user", content="hi")]
+
+    def test_request_accepts_logprobs_fields(self):
+        req = ChatCompletionRequest(
+            model="m", messages=self._msgs(), logprobs=True, top_logprobs=5
+        )
+        assert req.logprobs is True
+        assert req.top_logprobs == 5
+
+    def test_request_defaults_logprobs_off(self):
+        req = ChatCompletionRequest(model="m", messages=self._msgs())
+        assert req.logprobs is False
+        assert req.top_logprobs is None
+
+    def test_top_logprobs_requires_logprobs_true(self):
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(model="m", messages=self._msgs(), top_logprobs=5)
+
+    def test_top_logprobs_rejects_above_20(self):
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(
+                model="m", messages=self._msgs(), logprobs=True, top_logprobs=21
+            )
+
+    def test_top_logprobs_rejects_negative(self):
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(
+                model="m", messages=self._msgs(), logprobs=True, top_logprobs=-1
+            )
+
+    def test_top_logprobs_zero_allowed_with_logprobs(self):
+        req = ChatCompletionRequest(
+            model="m", messages=self._msgs(), logprobs=True, top_logprobs=0
+        )
+        assert req.top_logprobs == 0
+
+    def test_logprobs_true_without_top_logprobs_ok(self):
+        req = ChatCompletionRequest(model="m", messages=self._msgs(), logprobs=True)
+        assert req.logprobs is True
+        assert req.top_logprobs is None
+
+    def test_response_models_openai_shape(self):
+        lp = ChoiceLogprobs(
+            content=[
+                ChatCompletionTokenLogprob(
+                    token="Hi",
+                    logprob=-0.12,
+                    bytes=[72, 105],
+                    top_logprobs=[
+                        TopLogprob(token="Hi", logprob=-0.12, bytes=[72, 105]),
+                        TopLogprob(
+                            token="Hello",
+                            logprob=-1.8,
+                            bytes=[72, 101, 108, 108, 111],
+                        ),
+                    ],
+                )
+            ]
+        )
+        choice = ChatCompletionChoice(
+            message=AssistantMessage(content="Hi"), logprobs=lp
+        )
+        dumped = json.loads(choice.model_dump_json(exclude_none=True))
+        entry = dumped["logprobs"]["content"][0]
+        assert entry["token"] == "Hi"
+        assert entry["bytes"] == [72, 105]
+        assert entry["top_logprobs"][1]["token"] == "Hello"
+
+    def test_choice_logprobs_absent_by_default(self):
+        choice = ChatCompletionChoice(message=AssistantMessage(content="Hi"))
+        dumped = json.loads(choice.model_dump_json(exclude_none=True))
+        assert "logprobs" not in dumped
+
+    def test_chunk_choice_has_logprobs_field(self):
+        chunk_choice = ChatCompletionChunkChoice(
+            delta=ChatCompletionChunkDelta(content="Hi")
+        )
+        assert chunk_choice.logprobs is None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1861,6 +1861,30 @@ class TestSamplingSettings:
         assert with_policy.max_context_window_policy == 128_000
         assert with_policy.to_dict()["max_context_window_policy"] == 128_000
 
+    def test_top_logprobs_k_default_is_20(self):
+        """Launch-side logprobs cap defaults to 20 (#1549)."""
+        assert SamplingSettings().top_logprobs_k == 20
+
+    def test_top_logprobs_k_clamped_high(self):
+        """Values above the OpenAI ceiling clamp to 20."""
+        assert SamplingSettings(top_logprobs_k=50).top_logprobs_k == 20
+
+    def test_top_logprobs_k_clamped_negative(self):
+        """Negative values clamp to 0."""
+        assert SamplingSettings(top_logprobs_k=-5).top_logprobs_k == 0
+
+    def test_top_logprobs_k_roundtrip(self):
+        """top_logprobs_k round-trips through from_dict / to_dict."""
+        settings = SamplingSettings.from_dict({"top_logprobs_k": 5})
+        assert settings.top_logprobs_k == 5
+        assert settings.to_dict()["top_logprobs_k"] == 5
+
+    def test_top_logprobs_k_from_dict_default(self):
+        assert SamplingSettings.from_dict({}).top_logprobs_k == 20
+
+    def test_top_logprobs_k_from_dict_clamps(self):
+        assert SamplingSettings.from_dict({"top_logprobs_k": 99}).top_logprobs_k == 20
+
 
 class TestClaudeCodeSettings:
     """Tests for ClaudeCodeSettings dataclass."""


### PR DESCRIPTION
Adds per-token logprobs to `/v1/chat/completions` for supported streaming and non-streaming generation paths, addressing #1549. Requests can opt into `logprobs` and `top_logprobs`; the response includes the selected token probability and requested top candidates when they can be aligned reliably with returned content.

The scheduler reduces sampling distributions to compact payloads, forwards them through the text/VLM engines, and preserves token order across collector merges. The request range is 0–20, with a configurable server cap. Requests that do not enable logprobs keep the existing generation path.

Logprobs are omitted when alignment or target-model probabilities cannot be established: speculative/protocol-parser paths, active tool filtering, rewritten non-streaming content, and ambiguous streaming segments. Mixed supported/unsupported chunks preserve all response text. Token byte payloads are null for ambiguous replacement-character decoding rather than reporting fabricated UTF-8 bytes.

Validation: 1,539 local tests passed across API/schema/settings, extraction and serialization, server/scheduler/collector, thinking/tool parsing, streaming cancellation, and text/VLM engine suites. Regression cases include partial-tag buffering, tokens spanning markup and content, missing logprobs in aggregated output, and split Unicode byte fallback. `git diff --check` passes. Fresh GitHub CI runs on the rebased head; live-model performance was not remeasured for this revision.
