### PR TITLE
feat: add Hermes tool call parser

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -874,6 +874,10 @@ class ToolCallStreamFilter:
             idx = text.find(marker)
             if idx >= 0:
                 starts.append((idx, len(marker), close))
+            if close:
+                close_idx = text.find(close)
+                if close_idx >= 0:
+                    starts.append((close_idx, len(close), None))
 
         ns_match = self._namespaced_open_re.search(text)
         if ns_match:
@@ -937,6 +941,8 @@ class ToolCallStreamFilter:
         keep = 0
         for marker, _close in self._marker_pairs:
             keep = max(keep, self._partial_prefix_len(text, marker))
+            if _close:
+                keep = max(keep, self._partial_prefix_len(text, _close))
 
         last_lt = text.rfind("<")
         if last_lt >= 0:
@@ -977,6 +983,8 @@ class ToolCallStreamFilter:
 
         for marker, _close in self._marker_pairs:
             if marker.startswith(tail):
+                return True
+            if _close and _close.startswith(tail):
                 return True
 
         # Drop unresolved bracket tool-call prefixes

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -224,6 +224,97 @@ def _parse_namespaced_tool_calls(
     return cleaned, tool_calls
 
 
+def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
+    """
+    Fallback parser for Hermes-style tool call formats.
+
+    Handles models that use <|tool_call_start|>...<|tool_call_end|> markers
+    with bracket-style content inside:
+        <|tool_call_start|>[function_name(arg1=value1, arg2=value2)]<|tool_call_end|>
+
+    Also handles JSON variant:
+        <|tool_call_start|>{"name": "func", "arguments": {...}}<|tool_call_end|>
+
+    Hermes models (NousResearch/Hermes) emit tool calls in this format.
+
+    Returns:
+        Tuple of (cleaned_text, tool_calls or None)
+    """
+    tool_calls = []
+    pattern = r"<\|tool_call_start\|>(.*?)<\|tool_call_end\|>"
+    matches = re.findall(pattern, text, re.DOTALL)
+
+    for match in matches:
+        content = match.strip()
+
+        # Try JSON format first: {"name": "func", "arguments": {...}}
+        try:
+            parsed = json.loads(content)
+            name = parsed.get("name", "")
+            arguments = parsed.get("arguments", {})
+            if name:
+                tool_calls.append(
+                    ToolCall(
+                        id=f"call_{uuid.uuid4().hex[:8]}",
+                        type="function",
+                        function=FunctionCall(
+                            name=name,
+                            arguments=_serialize_tool_call_arguments(arguments),
+                        ),
+                    )
+                )
+                continue
+        except (json.JSONDecodeError, AttributeError):
+            pass
+
+        # Hermes bracket format: [func_name(arg1=val1, arg2=val2)]
+        # Content may or may not have outer brackets
+        stripped = content.strip("[]")
+        bracket_match = re.match(
+            r"([A-Za-z_][\w.]*)\((.*?)\)\s*$", stripped, re.DOTALL
+        )
+        if bracket_match:
+            func_name = bracket_match.group(1)
+            args_str = bracket_match.group(2).strip()
+
+            arguments = {}
+            if args_str:
+                for arg_match in re.finditer(
+                    r'([A-Za-z_][\w]*)\s*=\s*("(?:[^"\\]|\\.)*"|\'(?:[^\'\\]|\\.)*\'|\{.*?\}|\[.*?\]|[^\s,]+)',
+                    args_str,
+                    re.DOTALL,
+                ):
+                    key = arg_match.group(1)
+                    val = arg_match.group(2).strip()
+
+                    if (val.startswith('"') and val.endswith('"')) or (
+                        val.startswith("'") and val.endswith("'")
+                    ):
+                        arguments[key] = val[1:-1]
+                    else:
+                        try:
+                            arguments[key] = json.loads(val)
+                        except (json.JSONDecodeError, ValueError):
+                            arguments[key] = val
+
+                tool_calls.append(
+                    ToolCall(
+                        id=f"call_{uuid.uuid4().hex[:8]}",
+                        type="function",
+                        function=FunctionCall(
+                            name=func_name,
+                            arguments=json.dumps(arguments, ensure_ascii=False),
+                        ),
+                    )
+                )
+
+    if not tool_calls:
+        return text, None
+
+    cleaned = re.sub(pattern, "", text, flags=re.DOTALL).strip()
+    return cleaned, tool_calls
+
+
 def _parse_bracket_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
     """
     Fallback parser for bracket-style tool call formats.
@@ -542,6 +633,12 @@ def parse_tool_calls(
         ns = ns_match.group(1)
         return _parse_namespaced_tool_calls(cleaned_text, ns)
 
+    # Fallback: Hermes-style tool calls (<|tool_call_start|>[func(args)]<|tool_call_end|>)
+    if "<|tool_call_start|>" in cleaned_text:
+        hermes_result = _parse_hermes_tool_calls(cleaned_text)
+        if hermes_result[1] is not None:
+            return hermes_result
+
     # Fallback: bracket tool call formats (from text-formatted history)
     if "[Calling tool:" in cleaned_text or "[Tool call:" in cleaned_text:
         return _parse_bracket_tool_calls(cleaned_text)
@@ -578,6 +675,15 @@ def parse_tool_calls(
                     cleaned_text[idx:],
                 )
                 cleaned_text = cleaned_text[:idx].strip()
+
+    # Strip Hermes markers if still present (models without has_tool_calling)
+    if "<|tool_call_start|>" in cleaned_text:
+        cleaned_text = re.sub(
+            r"<\|tool_call_start\|>.*?<\|tool_call_end\|>",
+            "",
+            cleaned_text,
+            flags=re.DOTALL,
+        ).strip()
 
     return cleaned_text, None
 

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -229,7 +229,7 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
     """
     Fallback parser for Hermes-style tool call formats.
 
-    Handles models that use <|tool_call_start|>...<|tool_call_end|> markers
+    Handles outputs that use <|tool_call_start|>...<|tool_call_end|> markers
     with bracket-style content inside:
         <|tool_call_start|>[function_name(arg1=value1, arg2=value2)]<|tool_call_end|>
 

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -236,7 +236,7 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
     Also handles JSON variant:
         <|tool_call_start|>{"name": "func", "arguments": {...}}<|tool_call_end|>
 
-    Hermes models (NousResearch/Hermes) emit tool calls in this format.
+    Some clients/agents emit tool calls using this Hermes-style wire format.
 
     Returns:
         Tuple of (cleaned_text, tool_calls or None)

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -16,6 +16,7 @@ Also includes structured output (JSON Schema) utilities:
 - validate_json_schema: Validate JSON against a schema
 """
 
+import ast
 import json
 import logging
 import re
@@ -267,46 +268,45 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
         except (json.JSONDecodeError, AttributeError):
             pass
 
-        # Hermes bracket format: [func_name(arg1=val1, arg2=val2)]
-        # Content may or may not have outer brackets
-        stripped = content.strip("[]")
-        bracket_match = re.match(
-            r"([A-Za-z_][\w.]*)\((.*?)\)\s*$", stripped, re.DOTALL
-        )
-        if bracket_match:
-            func_name = bracket_match.group(1)
-            args_str = bracket_match.group(2).strip()
+        # Hermes bracket format: [func_name(arg1=val1), other_tool(arg2=val2)]
+        # The payload is Python-expression-like; use ast so commas inside quoted
+        # strings or nested lists/dicts do not split calls incorrectly.
+        try:
+            parsed_expr = ast.parse(content, mode="eval").body
+        except SyntaxError:
+            parsed_expr = None
+
+        calls = parsed_expr.elts if isinstance(parsed_expr, ast.List) else [parsed_expr]
+        for call in calls:
+            if not isinstance(call, ast.Call):
+                continue
+
+            if isinstance(call.func, ast.Name):
+                func_name = call.func.id
+            elif isinstance(call.func, ast.Attribute):
+                func_name = ast.unparse(call.func)
+            else:
+                continue
 
             arguments = {}
-            if args_str:
-                for arg_match in re.finditer(
-                    r'([A-Za-z_][\w]*)\s*=\s*("(?:[^"\\]|\\.)*"|\'(?:[^\'\\]|\\.)*\'|\{.*?\}|\[.*?\]|[^\s,]+)',
-                    args_str,
-                    re.DOTALL,
-                ):
-                    key = arg_match.group(1)
-                    val = arg_match.group(2).strip()
+            for kw in call.keywords:
+                if kw.arg is None:
+                    continue
+                try:
+                    arguments[kw.arg] = ast.literal_eval(kw.value)
+                except (ValueError, SyntaxError):
+                    arguments[kw.arg] = ast.unparse(kw.value)
 
-                    if (val.startswith('"') and val.endswith('"')) or (
-                        val.startswith("'") and val.endswith("'")
-                    ):
-                        arguments[key] = val[1:-1]
-                    else:
-                        try:
-                            arguments[key] = json.loads(val)
-                        except (json.JSONDecodeError, ValueError):
-                            arguments[key] = val
-
-                tool_calls.append(
-                    ToolCall(
-                        id=f"call_{uuid.uuid4().hex[:8]}",
-                        type="function",
-                        function=FunctionCall(
-                            name=func_name,
-                            arguments=json.dumps(arguments, ensure_ascii=False),
-                        ),
-                    )
+            tool_calls.append(
+                ToolCall(
+                    id=f"call_{uuid.uuid4().hex[:8]}",
+                    type="function",
+                    function=FunctionCall(
+                        name=func_name,
+                        arguments=json.dumps(arguments, ensure_ascii=False),
+                    ),
                 )
+            )
 
     if not tool_calls:
         return text, None
@@ -831,7 +831,10 @@ class ToolCallStreamFilter:
             marker = ""
         if marker_end is None:
             marker_end = ""
-        self._marker_pairs: List[Tuple[str, str]] = [("<tool_call>", "</tool_call>")]
+        self._marker_pairs: List[Tuple[str, str]] = [
+            ("<|tool_call_start|>", "<|tool_call_end|>"),
+            ("<tool_call>", "</tool_call>"),
+        ]
         self._suppress_after_markers: List[str] = []
         if marker:
             if marker_end:

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -90,7 +90,6 @@ EMBEDDING_MODEL_TYPES = {
     "siglip",
     "colqwen2_5",
     "colqwen2-5",
-    "lfm2",
 }
 
 # Model types that have both embedding and LLM variants.
@@ -99,6 +98,7 @@ AMBIGUOUS_EMBEDDING_MODEL_TYPES = {
     "qwen3",
     "gemma3-text",
     "gemma3_text",
+    "lfm2",
 }
 
 # Known embedding architectures

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -131,6 +131,28 @@ class TestDetectModelType:
         (llm_dir / "config.json").write_text(json.dumps(config))
         assert detect_model_type(llm_dir) == "llm"
 
+    def test_detect_lfm2_text_model_is_llm(self, tmp_path):
+        """LFM2 text checkpoints share model_type with non-text variants."""
+        llm_dir = tmp_path / "LFM2-1.2B"
+        llm_dir.mkdir()
+        config = {
+            "model_type": "lfm2",
+            "architectures": ["Lfm2ForCausalLM"],
+        }
+        (llm_dir / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(llm_dir) == "llm"
+
+    def test_detect_lfm2_5_moe_text_model_is_llm(self, tmp_path):
+        """LiquidAI/LFM2.5-8B-A1B is a text-generation MoE LLM."""
+        llm_dir = tmp_path / "LFM2.5-8B-A1B"
+        llm_dir.mkdir()
+        config = {
+            "model_type": "lfm2_moe",
+            "architectures": ["Lfm2MoeForCausalLM"],
+        }
+        (llm_dir / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(llm_dir) == "llm"
+
     def test_detect_qwen3_vl_reranker(self, tmp_path):
         """Qwen3VLForConditionalGeneration + 'reranker' in dir name → reranker."""
         reranker_dir = tmp_path / "Qwen3-VL-Reranker-2B-4bit"

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -831,6 +831,21 @@ class TestToolCallStreamFilter:
         assert "execute_code" not in result
         assert result == "Before  After"
 
+    def test_orphan_hermes_end_marker_is_suppressed(self):
+        """A closing Hermes marker without a visible open marker must not leak."""
+        f = ToolCallStreamFilter(_make_tokenizer())
+        result = f.feed("Before <|tool_call_end|> After")
+        result += f.finish()
+        assert result == "Before  After"
+
+    def test_split_orphan_hermes_end_marker_is_suppressed(self):
+        """Split closing Hermes markers must be buffered until classified."""
+        f = ToolCallStreamFilter(_make_tokenizer())
+        chunks = ["Before ", "<|tool_call_en", "d|>", " After"]
+        result = "".join(f.feed(chunk) for chunk in chunks)
+        result += f.finish()
+        assert result == "Before  After"
+
     def test_finish_preserves_non_tool_angle_identifier_suffix_literal(self):
         """Non-tool literal tails like '<alpha' should not be dropped at stream end."""
         f = ToolCallStreamFilter(_make_tokenizer())
@@ -1320,6 +1335,36 @@ class TestParseBracketToolCalls:
         assert second_args["timeout"] == 400
         assert "diversify_hermes.py" in first_args["command"]
         assert "diversify_v2.py" in second_args["command"]
+
+    def test_hermes_fallback_runs_when_native_parser_rejects_bracket_payload(self):
+        """Tokenizer native parser failures should fall through to Hermes fallback."""
+
+        class NativeRejectingTokenizer:
+            has_tool_calling = True
+            tool_call_start = "<|tool_call_start|>"
+            tool_call_end = "<|tool_call_end|>"
+
+            @staticmethod
+            def tool_parser(text, tools):
+                raise ValueError("native parser rejected Hermes bracket payload")
+
+        text = (
+            "Before <|tool_call_start|>"
+            "[execute_code(command='python3 script.py', timeout=400)]"
+            "<|tool_call_end|>"
+        )
+        result = extract_tool_calls_with_thinking(
+            "",
+            text,
+            tokenizer=NativeRejectingTokenizer(),
+            tools=[{"type": "function", "function": {"name": "execute_code"}}],
+        )
+        assert result.cleaned_text == "Before"
+        assert result.tool_calls is not None
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "execute_code"
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args == {"command": "python3 script.py", "timeout": 400}
 
 
 class TestParseToolCallsWithThinkingFallback:

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -815,6 +815,22 @@ class TestToolCallStreamFilter:
         assert "[Tool call:" not in result
         assert result == "Before  unfinished and then  done"
 
+    def test_hermes_marker_pair_suppressed_without_tokenizer_metadata(self):
+        """Hermes markers should not leak in streams when tokenizer lacks marker attrs."""
+        f = ToolCallStreamFilter(_make_tokenizer())
+        chunks = [
+            "Before ",
+            "<|tool_call_start|>",
+            "[execute_code(command='x', timeout=1)]",
+            "<|tool_call_end|>",
+            " After",
+        ]
+        result = "".join(f.feed(chunk) for chunk in chunks)
+        result += f.finish()
+        assert "<|tool_call_start|>" not in result
+        assert "execute_code" not in result
+        assert result == "Before  After"
+
     def test_finish_preserves_non_tool_angle_identifier_suffix_literal(self):
         """Non-tool literal tails like '<alpha' should not be dropped at stream end."""
         f = ToolCallStreamFilter(_make_tokenizer())
@@ -1272,6 +1288,38 @@ class TestParseBracketToolCalls:
         cleaned, tool_calls = _parse_bracket_tool_calls(text)
         assert tool_calls is None
         assert cleaned == text
+
+    def test_hermes_multi_call_block_parses_python_keyword_arguments(self):
+        """Hermes blocks may contain multiple Python-style calls in one list."""
+        text = (
+            "┊ 🐍 preparing execute_code…\n"
+            "<|tool_call_start|>"
+            "[execute_code(command='python3 diversify_hermes.py --model "
+            "\"Qwen3.6-35B-A3B-ConfigI-MLX\" --timeout 180 && echo "
+            "\"Hermes mode completed\"', timeout=400), "
+            "execute_code(command='python3 diversify_v2.py --runs 50 --per-run 54 "
+            "--timeout 300 && echo \"v2 dynamic completed\"', timeout=400)]"
+            "<|tool_call_end|>"
+        )
+        result = extract_tool_calls_with_thinking(
+            "",
+            text,
+            tokenizer=_make_tokenizer(),
+            tools=[{"type": "function", "function": {"name": "execute_code"}}],
+        )
+        assert result.cleaned_text == "┊ 🐍 preparing execute_code…"
+        assert result.tool_calls is not None
+        assert len(result.tool_calls) == 2
+        assert [tc.function.name for tc in result.tool_calls] == [
+            "execute_code",
+            "execute_code",
+        ]
+        first_args = json.loads(result.tool_calls[0].function.arguments)
+        second_args = json.loads(result.tool_calls[1].function.arguments)
+        assert first_args["timeout"] == 400
+        assert second_args["timeout"] == 400
+        assert "diversify_hermes.py" in first_args["command"]
+        assert "diversify_v2.py" in second_args["command"]
 
 
 class TestParseToolCallsWithThinkingFallback:


### PR DESCRIPTION
## Summary

Adds fallback support for the Hermes-style/Liquid tool call wire format:

```text
<|tool_call_start|>[function_name(arg=value)]<|tool_call_end|>
```

Some clients/agents emit tool calls using these markers instead of oMLX's currently supported XML/prose bracket formats. Without this fallback, oMLX can surface raw marker text to users instead of returning structured tool calls.

This PR:
- parses Hermes-style JSON payloads inside `<|tool_call_start|>...<|tool_call_end|>`
- parses Python-expression-like bracket payloads such as `[read_file(path='/tmp/a.log')]`
- supports multiple calls in one Hermes block via AST parsing, e.g. `[tool_a(...), tool_b(...)]`
- suppresses Hermes start/end markers during streaming even when tokenizer metadata is absent
- suppresses orphan/split Hermes closing markers so `<|tool_call_end|>` cannot leak if it arrives without a visible open marker
- strips any remaining complete Hermes envelopes from final assistant text if parsing fails
- classifies LFM2 text checkpoints as LLMs instead of embeddings by treating `lfm2` as ambiguous and relying on architecture/name checks

## Verification

```text
/opt/homebrew/opt/python@3.12/libexec/bin/python3 -m pytest tests/test_tool_calling.py -q
161 passed in 0.16s

/opt/homebrew/opt/python@3.12/libexec/bin/python3 -m pytest tests/test_model_discovery.py -q
119 passed in 0.16s
```