### PR TITLE
Respect tool_choice none when MCP is configured

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2272,9 +2272,11 @@ async def create_chat_completion(
         if json_instruction:
             messages = _inject_json_instruction(messages, json_instruction)
 
-    # Merge MCP tools with user-provided tools
-    effective_tools = request.tools
-    if _server_state.mcp_manager:
+    # Merge MCP tools with user-provided tools unless the request explicitly
+    # disables tool use.
+    tools_disabled = request.tool_choice == "none"
+    effective_tools = None if tools_disabled else request.tools
+    if _server_state.mcp_manager and not tools_disabled:
         # Convert Pydantic ToolDefinition models to dicts for merge_tools
         user_tools_dicts = [t.model_dump() for t in request.tools] if request.tools else None
         effective_tools = _server_state.mcp_manager.get_merged_tools(user_tools_dicts)

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -794,6 +794,114 @@ class TestChatCompletionEndpoint:
         assert message["tool_calls"][0]["function"]["arguments"] == '{"city": "SF"}'
         assert data["choices"][0]["finish_reason"] == "tool_calls"
 
+    @pytest.mark.parametrize(
+        ("tool_choice", "request_tools", "expect_tools"),
+        [
+            (None, None, True),
+            ("auto", None, True),
+            ("none", None, False),
+            (
+                "none",
+                [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "user_search",
+                            "description": "Search from request tools",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "query": {"type": "string"},
+                                },
+                            },
+                        },
+                    }
+                ],
+                False,
+            ),
+        ],
+    )
+    def test_chat_completion_tool_choice_controls_mcp_tools(
+        self,
+        client,
+        mock_llm_engine,
+        tool_choice,
+        request_tools,
+        expect_tools,
+    ):
+        """tool_choice='none' should suppress request and globally configured tools."""
+        from omlx.server import _server_state
+
+        class RecordingMCPManager:
+            def __init__(self):
+                self.calls = []
+
+            def get_merged_tools(self, user_tools=None):
+                self.calls.append(user_tools)
+                return [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "mcp_search",
+                            "description": "Search via MCP",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "query": {"type": "string"},
+                                },
+                            },
+                        },
+                    }
+                ]
+
+        recorded_count_tools = []
+        recorded_chat_kwargs = []
+
+        def count_chat_tokens(messages, tools=None, **kwargs):
+            recorded_count_tools.append(tools)
+            return 1
+
+        async def chat(messages, **kwargs):
+            recorded_chat_kwargs.append(kwargs)
+            return MockGenerationOutput(
+                text="Plain response.",
+                prompt_tokens=1,
+                completion_tokens=1,
+                finish_reason="stop",
+            )
+
+        original_mcp_manager = _server_state.mcp_manager
+        manager = RecordingMCPManager()
+        mock_llm_engine.count_chat_tokens = count_chat_tokens
+        mock_llm_engine.chat = chat
+
+        payload = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        if tool_choice is not None:
+            payload["tool_choice"] = tool_choice
+        if request_tools is not None:
+            payload["tools"] = request_tools
+
+        try:
+            _server_state.mcp_manager = manager
+            response = client.post("/v1/chat/completions", json=payload)
+        finally:
+            _server_state.mcp_manager = original_mcp_manager
+
+        assert response.status_code == 200
+        assert recorded_chat_kwargs
+
+        if expect_tools:
+            assert manager.calls == [request_tools]
+            assert recorded_count_tools[0] is not None
+            assert "tools" in recorded_chat_kwargs[0]
+        else:
+            assert manager.calls == []
+            assert recorded_count_tools == [None]
+            assert "tools" not in recorded_chat_kwargs[0]
+
 
 class TestAnthropicMessagesEndpoint:
     """Tests for the /v1/messages endpoint (Anthropic format)."""


### PR DESCRIPTION
## Problem
When a global MCP manager is configured, chat completions always merge MCP tools into the effective tool list. Requests with `tool_choice: "none"` still receive tools in the chat template, so OpenAI-compatible clients cannot opt out of tool use per request.

## Fix
- Treat `tool_choice: "none"` as a request-level tool disable switch.
- Skip MCP tool merging and pass no tools to the chat template for that request.
- Keep MCP tool injection for requests that omit `tool_choice` or set it to `"auto"`.
- Cover the `tool_choice: "none"` case with and without request-provided tools.

## Tests
- `.venv/bin/pytest tests/integration/test_server_endpoints.py::TestChatCompletionEndpoint::test_chat_completion_tool_choice_controls_mcp_tools -q`
- `.venv/bin/pytest tests/integration/test_server_endpoints.py::TestChatCompletionEndpoint -q`
- `.venv/bin/pytest tests/integration/test_server_endpoints.py -q`
- `git diff --check`

Fixes #1583