### PR TITLE
perf(turboquant): bump mlx-vlm to 0.6.0 for batched-TQ decode speedup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,12 +72,9 @@ dependencies = [
     "jsonschema>=4.0.0",
     # Harmony format parser for gpt-oss models
     "openai-harmony",
-    # mlx-vlm from commit (6f60ee4, main) - includes both TurboQuant decode fixes:
-    # "Bug 1" (fused single-token-quantize, fixed earlier on main) and "Bug 2" (the
-    # RHT masked-decode kernel, Blaizzy/mlx-vlm#1244, now merged) — so oMLX no longer
-    # needs its interim monkey-patch. (Also provides: Gemma4 MTP server batching PR
-    # #1166, speculative utils refactor PR #1169, Qwen native MTP drafter, MiniCPM-V 4.6.)
-    "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@6f60ee4458d85b636e2e6c09c33d32fc360d5e62",
+    # mlx-vlm 0.6.0: TurboQuant decode fixes + RHT value-kernel speedup (#1252) —
+    # ~50% faster batched-TQ masked decode at long context (validated vs #1547).
+    "mlx-vlm==0.6.0",
     "Pillow>=9.0.0",
     # dflash-mlx v0.1.8 (39b2520) — bstnxbt repo. Apple G17 NAX verify path plus v0.1.7 Qwen/Gemma4 DFlash fixes
     "dflash-mlx @ git+https://github.com/bstnxbt/dflash-mlx@39b2520e805f1d1be3852c62944b389cff73fa35",


### PR DESCRIPTION
## Summary

Bumps the `mlx-vlm` dependency from the `6f60ee4` commit pin to the **0.6.0 PyPI release**. This is the upstream-released version of the TurboQuant decode fixes oMLX has been carrying, and it additionally lands the **RHT value-kernel speedup** (Blaizzy/mlx-vlm#1252) that directly accelerates the batched TurboQuant decode path wired up in #1547.

## Why it's faster

In 0.5.0 the L=1 value-sum fast kernel was gated off whenever RHT was active (`if not self.use_rht and ...`) and fell back to an einsum on every decode step. RHT is on for any power-of-two head dim (e.g. Llama head_dim 64), so batched-TQ decode always took the slow path. 0.6.0 removes that gate and applies the RHT inverse on the kernel result (`_value_rotate_inverse`), so the Metal kernel runs under RHT. The value-sum cost scales with KV length, so the win shows at long context — exactly the regime where you'd reach for TurboQuant KV compression in the first place.

## Validation

Re-ran the #1547 harness plus a long-context **decode** A/B on `mlx-community/Llama-3.2-1B-Instruct-4bit` (ctx=3584, two-point measurement so prefill cancels and only decode steps are timed):

| scenario | 0.5.0 | 0.6.0 | Δ |
|---|---:|---:|---:|
| **batch TQ** (B=4, masked decode) | 165.1 tok/s | **249.8 tok/s** | **+51%** |
| single TQ (B=1, causal/fused path) | 124.2 | 126.1 | flat |
| batch fp16 (reference) | 506.5 | 493.8 | within noise |

The gain is isolated to the masked batch-decode path; single-seq (fused causal kernel) and fp16 are unchanged — confirming the improvement is the value kernel, not measurement drift.

KV occupancy and accuracy are **identical** to 0.5.0 (TQ 0.312× fp16; 69% projected saving at 8K context; batch-vs-single token match unchanged).

## Blast radius

- **No oMLX code changes.** `TurboQuantKVCache.{decode,prefill}_attention` and `from_cache` signatures are unchanged; the existing `omlx/patches/turboquant_attention.py` routing works as-is.
- `transformers` (already 5.8.1) satisfies 0.6.0's `>=5.5.0`; `mlx-audio` was already a transitive core dep, so no new core packages.

## Test plan

- [x] TurboQuant suite (`-m turboquant`): 32/32 pass on 0.6.0
- [x] Full CI-equivalent suite (`pytest -m "not slow and not integration"`): 4877 passed, 37 skipped (only the pre-existing, CI-absent local `dflash_mlx` env failures remain — unrelated to this bump)
- [x] #1547 memory/accuracy harness: occupancy + accuracy identical to 0.5.0
- [x] Long-context decode A/B: +51% batch-TQ decode (table above)