### PR TITLE
Disable paged cache when SSD cache init fails

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -906,11 +906,13 @@ class Scheduler:
                 paged_cache_manager=self.paged_cache_manager,
             )
 
-            # Initialize paged SSD cache
-            self._init_tiered_cache()
+            # Initialize paged SSD cache. If the backing directory is not
+            # usable (for example, an external cache drive is disconnected),
+            # continue with cache disabled instead of leaving partial state.
+            cache_initialized = self._init_tiered_cache()
 
             # Set cold restore callback for prefix cache
-            if self.paged_ssd_cache_manager is not None:
+            if cache_initialized and self.paged_ssd_cache_manager is not None:
                 self.block_aware_cache.set_cold_restore_callback(
                     self._restore_block_from_cold
                 )
@@ -927,18 +929,23 @@ class Scheduler:
                         f"max_blocks={max_blocks}"
                     )
 
-            # Async store_cache executor: single worker so submissions are
-            # serialized (matches the original synchronous order) and we
-            # never have two stores racing on the same paged_ssd index.
-            self._store_cache_executor = concurrent.futures.ThreadPoolExecutor(
-                max_workers=1,
-                thread_name_prefix="omlx-store-cache",
-            )
-            # Gate caps the post-completion store-cache pipeline so a burst
-            # of finishes cannot pile up unbounded KV caches in memory while
-            # the single writer drains. Cap starts at max_concurrent_requests
-            # and is shrunk by ProcessMemoryEnforcer under pressure (#1383).
-            self._store_cache_gate = _StoreCacheGate(cap=self.config.max_num_seqs)
+                # Async store_cache executor: single worker so submissions are
+                # serialized (matches the original synchronous order) and we
+                # never have two stores racing on the same paged_ssd index.
+                self._store_cache_executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=1,
+                    thread_name_prefix="omlx-store-cache",
+                )
+                # Gate caps the post-completion store-cache pipeline so a burst
+                # of finishes cannot pile up unbounded KV caches in memory while
+                # the single writer drains. Cap starts at max_concurrent_requests
+                # and is shrunk by ProcessMemoryEnforcer under pressure (#1383).
+                self._store_cache_gate = _StoreCacheGate(cap=self.config.max_num_seqs)
+            else:
+                self._disable_paged_cache_components()
+                logger.info(
+                    "oMLX cache disabled after paged SSD cache initialization failed"
+                )
         else:
             logger.info(
                 "oMLX cache disabled (mlx-lm BatchGenerator manages KV internally)"
@@ -6974,7 +6981,7 @@ class Scheduler:
         except Exception as e:
             logger.debug(f"Failed to extract model info: {e}")
 
-    def _init_tiered_cache(self) -> None:
+    def _init_tiered_cache(self) -> bool:
         """Initialize paged SSD cache components if configured.
 
         In paged SSD-only mode:
@@ -6988,14 +6995,14 @@ class Scheduler:
                     "paged SSD cache requested but ssd_cache/memory_monitor modules "
                     "not available. Install required dependencies."
                 )
-            return
+            return False
 
         # In paged SSD-only mode, paged_ssd_cache_dir is required
         if not self.config.paged_ssd_cache_dir:
             logger.debug(
                 "paged SSD cache not configured (no --ssd-cache-dir specified)"
             )
-            return
+            return False
 
         try:
             cache_dir = (
@@ -7062,10 +7069,24 @@ class Scheduler:
                     f"max_size={self._format_bytes(self.config.paged_ssd_cache_max_size)}, "
                     f"block_size={self.config.paged_cache_block_size} tokens"
                 )
+            return True
 
         except Exception as e:
             logger.error(f"Failed to initialize paged SSD cache: {e}")
             self.paged_ssd_cache_manager = None
+            return False
+
+    def _disable_paged_cache_components(self) -> None:
+        """Clear paged-cache runtime state after SSD cache setup fails."""
+        if self.paged_ssd_cache_manager is not None:
+            try:
+                self.paged_ssd_cache_manager.close()
+            except Exception as e:
+                logger.debug("Failed to close paged SSD cache manager: %s", e)
+        self.paged_ssd_cache_manager = None
+        self.paged_cache_manager = None
+        self.block_aware_cache = None
+        self._boundary_snapshot_store = None
 
     def _check_memory_pressure(self) -> None:
         """Check memory and evict blocks if needed.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -16,11 +16,12 @@ Note: BatchGenerator is mocked; step() is too complex for unit tests.
 """
 
 from collections import deque
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
 import pytest
 
+import omlx.scheduler as scheduler_module
 from omlx.request import Request, RequestOutput, RequestStatus, SamplingParams
 from omlx.scheduler import Scheduler, SchedulerConfig, SchedulerOutput, SchedulingPolicy
 
@@ -191,6 +192,35 @@ class TestSchedulerInitialization:
         )
 
         assert scheduler.config.max_num_seqs == 64
+
+    def test_init_falls_back_when_paged_ssd_cache_unavailable(
+        self, mock_model, mock_tokenizer, tmp_path, monkeypatch, caplog
+    ):
+        """Unusable SSD cache directories should not leave partial cache state."""
+        if not scheduler_module.HAS_TIERED_CACHE:
+            pytest.skip("tiered cache modules are unavailable")
+
+        class BrokenPagedSSDCacheManager:
+            def __init__(self, *args, **kwargs):
+                raise OSError("cache directory is not writable")
+
+        monkeypatch.setattr(
+            scheduler_module,
+            "PagedSSDCacheManager",
+            BrokenPagedSSDCacheManager,
+        )
+
+        config = SchedulerConfig(paged_ssd_cache_dir=str(tmp_path / "missing-drive"))
+
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+
+        assert scheduler.paged_ssd_cache_manager is None
+        assert scheduler.paged_cache_manager is None
+        assert scheduler.block_aware_cache is None
+        assert scheduler._boundary_snapshot_store is None
+        assert scheduler._store_cache_executor is None
+        assert scheduler._store_cache_gate is None
+        assert "Failed to initialize paged SSD cache" in caplog.text
 
     def test_init_statistics_zero(self, mock_model, mock_tokenizer):
         """Test Scheduler initializes with zero statistics."""
@@ -2158,6 +2188,7 @@ class TestDetectNeedsThinkPrefix:
         in their mlx-lm tokenizer, causing think_start_id to raise TypeError.
         """
         from unittest.mock import PropertyMock
+
         from conftest import MockTokenizer
 
         tokenizer = MockTokenizer()


### PR DESCRIPTION
## Problem

When paged SSD cache is configured but the backing directory is unavailable or not writable, scheduler startup can leave partial cache state behind. `PagedSSDCacheManager` fails, but `PagedCacheManager`, `BlockAwarePrefixCache`, and the store-cache executor can still remain active.

This is easy to hit when the cache directory points to an external drive that is not currently mounted.

## Root cause

`_init_tiered_cache()` did not report whether paged SSD cache initialization succeeded. The scheduler therefore continued setting up the cache pipeline even after initialization failed.

## Fix

- Make `_init_tiered_cache()` return whether setup succeeded.
- Only attach the cold-restore callback and start the store-cache executor when setup succeeds.
- Clear paged cache runtime state when setup fails, so the scheduler falls back to normal no-cache operation for that run.

## Tests

- `.venv/bin/pytest tests/test_scheduler.py::TestSchedulerInitialization::test_init_falls_back_when_paged_ssd_cache_unavailable -q`
- `.venv/bin/pytest tests/test_scheduler.py -q`
- `.venv/bin/pytest tests/test_scheduler.py::TestSchedulerConfig tests/test_cache_factory.py tests/test_paged_ssd_cache.py::TestPagedSSDCacheManager::test_initialization -q`
- `.venv/bin/pytest tests/test_cache_factory.py tests/test_paged_ssd_cache.py::TestPagedSSDCacheManager::test_initialization -q`
- `.venv/bin/ruff check --select I001,F401,F811 tests/test_scheduler.py`
- `git diff --check`

Fixes #1455