### PR TITLE
feat: add Oh My Pi (omp) launcher integration

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -276,6 +276,7 @@ class GlobalSettingsRequest(BaseModel):
     integrations_openclaw_model: str | None = None
     integrations_hermes_model: str | None = None
     integrations_pi_model: str | None = None
+    integrations_omp_model: str | None = None
     integrations_openclaw_tools_profile: (
         Literal["minimal", "coding", "messaging", "full"] | None
     ) = None
@@ -2885,6 +2886,7 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
             "openclaw_model": global_settings.integrations.openclaw_model,
             "hermes_model": global_settings.integrations.hermes_model,
             "pi_model": global_settings.integrations.pi_model,
+            "omp_model": global_settings.integrations.omp_model,
             "copilot_model": global_settings.integrations.copilot_model,
             "openclaw_tools_profile": global_settings.integrations.openclaw_tools_profile,
         },
@@ -3335,6 +3337,9 @@ async def update_global_settings(
     if "integrations_pi_model" in request.model_fields_set:
         global_settings.integrations.pi_model = request.integrations_pi_model
         integrations_changed = True
+    if "integrations_omp_model" in request.model_fields_set:
+        global_settings.integrations.omp_model = request.integrations_omp_model
+        integrations_changed = True
     if "integrations_openclaw_tools_profile" in request.model_fields_set:
         global_settings.integrations.openclaw_tools_profile = (
             request.integrations_openclaw_tools_profile
@@ -3350,7 +3355,8 @@ async def update_global_settings(
             f"opencode={global_settings.integrations.opencode_model}, "
             f"openclaw={global_settings.integrations.openclaw_model}, "
             f"hermes={global_settings.integrations.hermes_model}, "
-            f"pi={global_settings.integrations.pi_model}"
+            f"pi={global_settings.integrations.pi_model}, "
+            f"omp={global_settings.integrations.omp_model}"
         )
 
     # Apply UI settings

--- a/omlx/admin/static/img/integrations/omp.svg
+++ b/omlx/admin/static/img/integrations/omp.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <style>
+    .bg { fill: #1a1a1a; }
+    .fg { fill: #ffffff; }
+    @media (prefers-color-scheme: light) {
+      .bg { fill: #f0ede8; }
+      .fg { fill: #1a1a1a; }
+    }
+  </style>
+  <rect class="bg" width="800" height="800"/>
+  <!-- Stylized pi glyph for Oh My Pi (omp) -->
+  <g class="fg">
+    <rect x="170" y="225" width="460" height="78"/>
+    <rect x="252" y="303" width="78" height="272"/>
+    <rect x="470" y="303" width="78" height="272"/>
+  </g>
+</svg>

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -41,7 +41,7 @@
                 network: { http_proxy: '', https_proxy: '', no_proxy: '', ca_bundle: '' },
                 auth: { api_key_set: false, api_key: '', skip_api_key_verification: false, sub_keys: [] },
                 claude_code: { context_scaling_enabled: false, target_context_size: 200000, mode: 'cloud', opus_model: null, sonnet_model: null, haiku_model: null },
-                integrations: { copilot_model: null, codex_model: null, opencode_model: null, openclaw_model: null, hermes_model: null, pi_model: null, openclaw_tools_profile: 'full' },
+                integrations: { copilot_model: null, codex_model: null, opencode_model: null, openclaw_model: null, hermes_model: null, pi_model: null, omp_model: null, openclaw_tools_profile: 'full' },
                 ui: { language: 'en' },
                 idle_timeout: { idle_timeout_seconds: null },
                 system: { total_memory_bytes: 0, total_memory: '', auto_model_memory: '', ssd_total_bytes: 0, ssd_total: '' },
@@ -2131,6 +2131,10 @@
                 return this._launchCmd('pi');
             },
 
+            get ompCommand() {
+                return this._launchCmd('omp');
+            },
+
             async saveIntegrationSettings() {
                 try {
                     const response = await fetch('/admin/api/global-settings', {
@@ -2143,6 +2147,7 @@
                             integrations_openclaw_model: this.globalSettings.integrations.openclaw_model,
                             integrations_hermes_model: this.globalSettings.integrations.hermes_model,
                             integrations_pi_model: this.globalSettings.integrations.pi_model,
+                            integrations_omp_model: this.globalSettings.integrations.omp_model,
                             integrations_openclaw_tools_profile: this.globalSettings.integrations.openclaw_tools_profile,
                         }),
                     });

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -901,6 +901,25 @@
                                 </button>
                             </div>
 
+                            <!-- Oh My Pi -->
+                            <div class="flex items-center gap-4 px-6 py-4 group">
+                                <div class="w-9 h-9 rounded-lg overflow-hidden flex-shrink-0">
+                                    <img src="/admin/static/img/integrations/omp.svg" alt="Oh My Pi" class="w-full h-full object-cover">
+                                </div>
+                                <div class="flex-1 min-w-0">
+                                    <div class="text-sm font-semibold text-neutral-800">Oh My Pi</div>
+                                    <code class="text-xs text-neutral-500 font-mono" x-text="ompCommand"></code>
+                                </div>
+                                <button x-data="{ copied: false }"
+                                        @click="copyToClipboard(ompCommand); copied = true; setTimeout(() => copied = false, 2000)"
+                                        class="p-2 rounded-lg transition-all opacity-0 group-hover:opacity-100 flex-shrink-0"
+                                        :class="copied ? 'text-green-500 opacity-100' : 'text-neutral-400 hover:text-neutral-700 hover:bg-neutral-100'"
+                                        :title="window.t('status.integrations.copy_command_tooltip')">
+                                    <svg x-show="!copied" class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+                                    <svg x-show="copied" x-cloak class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+                                </button>
+                            </div>
+
                             <!-- Copilot CLI -->
                             <div class="flex items-center gap-4 px-6 py-4 group">
                                 <div class="w-9 h-9 rounded-lg overflow-hidden flex-shrink-0">

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -948,13 +948,13 @@ Example directory structure:
     launch_parser = subparsers.add_parser(
         "launch",
         help="Launch an external tool with oMLX integration",
-        description="Configure and launch external coding tools (Claude Code, Copilot, Codex, OpenCode, OpenClaw, Hermes Agent, Pi) "
+        description="Configure and launch external coding tools (Claude Code, Copilot, Codex, OpenCode, OpenClaw, Hermes Agent, Pi, Oh My Pi) "
         "to use the running oMLX server.",
     )
     launch_parser.add_argument(
         "tool",
         type=str,
-        help="Tool to launch: claude, copilot, codex, opencode, openclaw, hermes, pi, or 'list' to show available",
+        help="Tool to launch: claude, copilot, codex, opencode, openclaw, hermes, pi, omp, or 'list' to show available",
     )
     launch_parser.add_argument(
         "--model",

--- a/omlx/integrations/__init__.py
+++ b/omlx/integrations/__init__.py
@@ -5,6 +5,7 @@ from omlx.integrations.claude import ClaudeCodeIntegration
 from omlx.integrations.codex import CodexIntegration
 from omlx.integrations.copilot import CopilotIntegration
 from omlx.integrations.hermes import HermesIntegration
+from omlx.integrations.omp import OhMyPiIntegration
 from omlx.integrations.openclaw import OpenClawIntegration
 from omlx.integrations.opencode import OpenCodeIntegration
 from omlx.integrations.pi import PiIntegration
@@ -16,6 +17,7 @@ INTEGRATIONS: dict[str, Integration] = {
     "openclaw": OpenClawIntegration(),
     "hermes": HermesIntegration(),
     "pi": PiIntegration(),
+    "omp": OhMyPiIntegration(),
     "copilot": CopilotIntegration(),
 }
 
@@ -36,6 +38,7 @@ __all__ = [
     "ClaudeCodeIntegration",
     "CopilotIntegration",
     "HermesIntegration",
+    "OhMyPiIntegration",
     "INTEGRATIONS",
     "get_integration",
     "list_integrations",

--- a/omlx/integrations/omp.py
+++ b/omlx/integrations/omp.py
@@ -1,0 +1,154 @@
+"""Oh My Pi (omp) integration."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import time
+from pathlib import Path
+
+import yaml
+
+from omlx.integrations.base import Integration, IntegrationContext
+from omlx.utils.install import get_cli_prefix
+
+
+def _get_agent_dir() -> Path:
+    """Get the omp agent config directory, respecting PI_CODING_AGENT_DIR.
+
+    oh-my-pi honors the same PI_CODING_AGENT_DIR override as upstream pi, but
+    defaults to ~/.omp/agent (not ~/.pi/agent).
+    """
+    env_dir = os.environ.get("PI_CODING_AGENT_DIR")
+    if env_dir:
+        return Path(env_dir).expanduser()
+    return Path.home() / ".omp" / "agent"
+
+
+class OhMyPiIntegration(Integration):
+    """Oh My Pi (omp) integration that configures the omp agent config directory.
+
+    omp is a fork of pi-coding-agent. It reads custom OpenAI-compatible
+    providers from ~/.omp/agent/models.yml using the same providers.<name>
+    schema as pi, but in YAML rather than JSON. omp only auto-migrates an
+    existing models.json to models.yml when models.yml is absent, so we
+    write/merge models.yml directly to stay robust across relaunches.
+    """
+
+    AGENT_DIR = _get_agent_dir()
+    MODELS_PATH = AGENT_DIR / "models.yml"
+
+    def __init__(self):
+        super().__init__(
+            name="omp",
+            display_name="Oh My Pi",
+            type="config_file",
+            install_check="omp",
+            install_hint=(
+                "bun install -g @oh-my-pi/pi-coding-agent "
+                "(or: curl -fsSL https://omp.sh/install | sh)"
+            ),
+        )
+
+    def get_command(self, ctx: IntegrationContext) -> str:
+        return (
+            f"{get_cli_prefix()} "
+            f"launch omp --model {ctx.model or 'select-a-model'}"
+        )
+
+    @staticmethod
+    def _is_reasoning_model(model: str | None) -> bool:
+        return bool(re.search(r"\b(thinking|o1|o3|r1)\b", (model or "").lower()))
+
+    def _read_config(self, config_path: Path) -> dict:
+        existing: dict = {}
+        if not config_path.exists():
+            return existing
+
+        try:
+            loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as e:
+            print(f"Warning: could not parse {config_path}: {e}")
+            print("Creating new config file.")
+            return existing
+
+        if loaded is None:
+            return existing
+        if not isinstance(loaded, dict):
+            print(f"Warning: {config_path} does not contain a YAML object.")
+            print("Creating new config file.")
+            return existing
+        return loaded
+
+    @staticmethod
+    def _create_backup(config_path: Path) -> None:
+        if not config_path.exists():
+            return
+
+        timestamp = int(time.time())
+        backup = config_path.with_suffix(f".{timestamp}.bak")
+        try:
+            shutil.copy2(config_path, backup)
+            print(f"Backup: {backup}")
+        except OSError as e:
+            print(f"Warning: could not create backup: {e}")
+
+    def configure(self, ctx: IntegrationContext) -> None:
+        config_path = self.MODELS_PATH
+        config = self._read_config(config_path)
+        self._create_backup(config_path)
+
+        providers = config.setdefault("providers", {})
+        if not isinstance(providers, dict):
+            providers = {}
+            config["providers"] = providers
+
+        provider_config: dict = {
+            "baseUrl": ctx.openai_base_url,
+            "api": "openai-completions",
+            "apiKey": ctx.auth_token,
+            "authHeader": True,
+        }
+        if ctx.model:
+            reasoning = (
+                bool(ctx.reasoning)
+                if ctx.reasoning is not None
+                else self._is_reasoning_model(ctx.model)
+            )
+            model_entry: dict = {
+                "id": ctx.model,
+                "name": ctx.model,
+                "reasoning": reasoning,
+                "input": ["text", "image"] if ctx.supports_images else ["text"],
+                "cost": {
+                    "input": 0,
+                    "output": 0,
+                    "cacheRead": 0,
+                    "cacheWrite": 0,
+                },
+            }
+            if ctx.context_window:
+                model_entry["contextWindow"] = ctx.context_window
+            if ctx.max_tokens:
+                model_entry["maxTokens"] = ctx.max_tokens
+            provider_config["models"] = [model_entry]
+        providers["omlx"] = provider_config
+
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        yaml_content = yaml.safe_dump(config, sort_keys=False, allow_unicode=True)
+        config_path.write_text(
+            yaml_content.rstrip() + "\n",
+            encoding="utf-8",
+        )
+        print(f"Config written: {config_path}")
+
+    def launch(self, ctx: IntegrationContext) -> None:
+        self.configure(ctx)
+
+        env = self._scrubbed_env()
+        args = ["omp"]
+        if ctx.model:
+            args.extend(["--model", f"omlx/{ctx.model}"])
+
+        os.execvpe("omp", args, env)

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -641,6 +641,7 @@ class IntegrationSettings:
     openclaw_model: str | None = None
     hermes_model: str | None = None
     pi_model: str | None = None
+    omp_model: str | None = None
     copilot_model: str | None = None
     openclaw_tools_profile: str = "coding"
 
@@ -652,6 +653,7 @@ class IntegrationSettings:
             "openclaw_model": self.openclaw_model,
             "hermes_model": self.hermes_model,
             "pi_model": self.pi_model,
+            "omp_model": self.omp_model,
             "copilot_model": self.copilot_model,
             "openclaw_tools_profile": self.openclaw_tools_profile,
         }
@@ -665,6 +667,7 @@ class IntegrationSettings:
             openclaw_model=data.get("openclaw_model"),
             hermes_model=data.get("hermes_model"),
             pi_model=data.get("pi_model"),
+            omp_model=data.get("omp_model"),
             copilot_model=data.get("copilot_model"),
             openclaw_tools_profile=data.get("openclaw_tools_profile", "coding"),
         )

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -12,6 +12,8 @@ from omlx.integrations.claude import ClaudeCodeIntegration
 from omlx.integrations.codex import CodexIntegration
 from omlx.integrations.copilot import CopilotIntegration
 from omlx.integrations.hermes import HermesIntegration
+from omlx.integrations.omp import OhMyPiIntegration
+from omlx.integrations.omp import _get_agent_dir as _get_omp_agent_dir
 from omlx.integrations.openclaw import OpenClawIntegration
 from omlx.integrations.opencode import OpenCodeIntegration
 from omlx.integrations.pi import PiIntegration, _get_agent_dir
@@ -31,7 +33,7 @@ def ctx(**overrides) -> IntegrationContext:
 class TestIntegrationRegistry:
     def test_list_integrations(self):
         integrations = list_integrations()
-        assert len(integrations) == 7
+        assert len(integrations) == 8
         names = {i.name for i in integrations}
         assert names == {
             "claude",
@@ -41,6 +43,7 @@ class TestIntegrationRegistry:
             "openclaw",
             "hermes",
             "pi",
+            "omp",
         }
 
     def test_get_integration(self):
@@ -51,6 +54,7 @@ class TestIntegrationRegistry:
         assert get_integration("openclaw") is not None
         assert get_integration("hermes") is not None
         assert get_integration("pi") is not None
+        assert get_integration("omp") is not None
         assert get_integration("nonexistent") is None
 
 
@@ -1083,6 +1087,164 @@ class TestPiIntegration:
         pi = PiIntegration()
         assert pi.type == "config_file"
         assert pi.display_name == "Pi"
+
+
+class TestOhMyPiIntegration:
+    def test_get_agent_dir_default(self, monkeypatch):
+        """Default agent dir is ~/.omp/agent when env var is not set."""
+        monkeypatch.delenv("PI_CODING_AGENT_DIR", raising=False)
+        assert _get_omp_agent_dir() == Path.home() / ".omp" / "agent"
+
+    def test_get_agent_dir_custom_env(self, tmp_path, monkeypatch):
+        """PI_CODING_AGENT_DIR env var overrides the default path."""
+        monkeypatch.setenv("PI_CODING_AGENT_DIR", str(tmp_path / "custom_omp"))
+        assert _get_omp_agent_dir() == tmp_path / "custom_omp"
+
+    def test_get_command(self):
+        omp = OhMyPiIntegration()
+        cmd = omp.get_command(ctx(port=8000, api_key="key", model="qwen3.5"))
+        assert "omlx launch omp" in cmd
+        assert "--model qwen3.5" in cmd
+
+    def test_get_command_no_model(self):
+        omp = OhMyPiIntegration()
+        cmd = omp.get_command(ctx(port=8000, api_key="", model=""))
+        assert "select-a-model" in cmd
+
+    def test_configure_new_file(self, tmp_path):
+        models_path = tmp_path / "omp" / "agent" / "models.yml"
+
+        omp = OhMyPiIntegration()
+        with patch.object(OhMyPiIntegration, "MODELS_PATH", models_path):
+            omp.configure(ctx(port=8000, api_key="test-key", model="qwen3.5"))
+
+        provider = yaml.safe_load(models_path.read_text())["providers"]["omlx"]
+        assert provider["baseUrl"] == "http://127.0.0.1:8000/v1"
+        assert provider["api"] == "openai-completions"
+        assert provider["apiKey"] == "test-key"
+        assert provider["authHeader"] is True
+        assert provider["models"][0]["id"] == "qwen3.5"
+        assert provider["models"][0]["input"] == ["text"]
+
+    def test_configure_custom_host(self, tmp_path):
+        models_path = tmp_path / "models.yml"
+
+        omp = OhMyPiIntegration()
+        with patch.object(OhMyPiIntegration, "MODELS_PATH", models_path):
+            omp.configure(
+                ctx(port=9000, api_key="key", model="test", host="192.168.1.100")
+            )
+
+        provider = yaml.safe_load(models_path.read_text())["providers"]["omlx"]
+        assert provider["baseUrl"] == "http://192.168.1.100:9000/v1"
+
+    def test_configure_creates_backup(self, tmp_path):
+        models_path = tmp_path / "models.yml"
+        models_path.write_text("providers:\n  old: {}\n")
+
+        omp = OhMyPiIntegration()
+        with patch.object(OhMyPiIntegration, "MODELS_PATH", models_path):
+            omp.configure(ctx(port=8000, api_key="", model="test"))
+
+        backups = list(tmp_path.glob("models.*.bak"))
+        assert len(backups) == 1
+        assert yaml.safe_load(backups[0].read_text()) == {"providers": {"old": {}}}
+
+    def test_configure_vlm_model(self, tmp_path):
+        models_path = tmp_path / "models.yml"
+
+        omp = OhMyPiIntegration()
+        with patch.object(OhMyPiIntegration, "MODELS_PATH", models_path):
+            omp.configure(
+                ctx(
+                    port=8000,
+                    api_key="key",
+                    model="qwen2.5-vl",
+                    model_type="vlm",
+                    context_window=32768,
+                    max_tokens=8192,
+                )
+            )
+
+        model_config = yaml.safe_load(models_path.read_text())["providers"]["omlx"][
+            "models"
+        ][0]
+        assert model_config["input"] == ["text", "image"]
+        assert model_config["contextWindow"] == 32768
+        assert model_config["maxTokens"] == 8192
+
+    def test_configure_reasoning_true_overrides_slug(self, tmp_path):
+        models_path = tmp_path / "models.yml"
+
+        omp = OhMyPiIntegration()
+        with patch.object(OhMyPiIntegration, "MODELS_PATH", models_path):
+            omp.configure(ctx(port=8000, model="qwen3.6", reasoning=True))
+
+        model_config = yaml.safe_load(models_path.read_text())["providers"]["omlx"][
+            "models"
+        ][0]
+        assert model_config["reasoning"] is True
+
+    def test_configure_reasoning_falls_back_to_slug(self, tmp_path):
+        models_path = tmp_path / "models.yml"
+
+        omp = OhMyPiIntegration()
+        with patch.object(OhMyPiIntegration, "MODELS_PATH", models_path):
+            omp.configure(ctx(port=8000, model="qwen3-thinking"))
+
+        model_config = yaml.safe_load(models_path.read_text())["providers"]["omlx"][
+            "models"
+        ][0]
+        assert model_config["reasoning"] is True
+
+    def test_configure_preserves_existing(self, tmp_path):
+        models_path = tmp_path / "models.yml"
+        models_path.write_text(
+            yaml.safe_dump(
+                {"providers": {"anthropic": {"baseUrl": "https://api.anthropic.com"}}}
+            )
+        )
+
+        omp = OhMyPiIntegration()
+        with patch.object(OhMyPiIntegration, "MODELS_PATH", models_path):
+            omp.configure(ctx(port=9000, api_key="", model="llama"))
+
+        models_config = yaml.safe_load(models_path.read_text())
+        assert "anthropic" in models_config["providers"]
+        assert models_config["providers"]["omlx"]["apiKey"] == "omlx"
+
+    def test_launch_scrubs_python_env(self, tmp_path):
+        omp = OhMyPiIntegration()
+        models_path = tmp_path / "models.yml"
+        captured = {}
+
+        def fake_execvpe(binary, argv, env):
+            captured["argv"] = argv
+            captured["env"] = env
+
+        base_env = {
+            "PATH": "/usr/bin",
+            "PYTHONHOME": "/bundle/python",
+            "PYTHONPATH": "/bundle/lib",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+        with (
+            patch.object(OhMyPiIntegration, "MODELS_PATH", models_path),
+            patch("omlx.integrations.omp.os.environ", base_env),
+            patch("omlx.integrations.omp.os.execvpe", side_effect=fake_execvpe),
+        ):
+            omp.launch(ctx(port=8000, api_key="key", model="qwen3.5"))
+
+        assert captured["argv"] == ["omp", "--model", "omlx/qwen3.5"]
+        assert "PYTHONHOME" not in captured["env"]
+        assert "PYTHONPATH" not in captured["env"]
+        assert "PYTHONDONTWRITEBYTECODE" not in captured["env"]
+
+    def test_type(self):
+        omp = OhMyPiIntegration()
+        assert omp.type == "config_file"
+        assert omp.display_name == "Oh My Pi"
+        assert omp.install_check == "omp"
 
 
 class TestClaudeCodeIntegration:


### PR DESCRIPTION
## What

Adds an **Oh My Pi** tile to the dashboard's Applications list that launches the [oh-my-pi](https://github.com/can1357/oh-my-pi) (`omp`) coding agent against the running oMLX server — a sibling of the existing **Pi** tile. Non-destructive: the Pi tile is unchanged.

## Why

`omp` is a popular fork of pi-coding-agent with a coding-first workflow. Users who run `omp` instead of vanilla `pi` had no one-click way to point it at their local oMLX server.

## How it works

`omp` is a separate binary from `pi` with its own config dir (`~/.omp/agent`), but it:
- honors the same `PI_CODING_AGENT_DIR` override, and
- reads custom OpenAI-compatible providers from `~/.omp/agent/models.yml` using the **same `providers.<name>` schema** as pi — just YAML instead of JSON.

`OhMyPiIntegration` therefore reuses `PiIntegration`'s provider schema but writes/merges `models.yml` (YAML) with the same read→backup→merge→write pattern as the Hermes integration, preserving any other providers the user already has, then execs `omp --model omlx/<model>`. (omp only auto-migrates `models.json`→`models.yml` when the latter is absent, so writing YAML directly is the robust path across relaunches.)

## Changes

- **New** `omlx/integrations/omp.py` — `OhMyPiIntegration`; registered in `omlx/integrations/__init__.py`
- `omlx/settings.py` + `omlx/admin/routes.py` — `omp_model` setting (parity with the other tools)
- `omlx/admin/templates/dashboard/_status.html` — new tile; `omlx/admin/static/js/dashboard.js` — `ompCommand` getter + save/default wiring
- `omlx/admin/static/img/integrations/omp.svg` — icon (theme-aware π glyph matching the existing set)
- `omlx/cli.py` — `launch` help text
- `tests/test_integrations.py` — `TestOhMyPiIntegration` + registry assertions

## Testing

- `pytest tests/test_integrations.py` → **101 passed** (13 new omp cases mirroring the Pi suite + registry updates).
- Verified end-to-end against the real `omp` v15.8.0: the generated `~/.omp/agent/models.yml` is accepted and `omp --list-models omlx` lists the configured model.
- Ran the server from source and confirmed the **Oh My Pi** tile renders in `/admin/dashboard`, and `omlx launch list` reports `omp`.
