### PR TITLE
fix(scheduler): preserve prefill error outputs during decode

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6572,8 +6572,8 @@ class Scheduler:
 
                 if responses:
                     outputs, finished_ids = self._process_batch_responses(responses)
-                    output.outputs = outputs
-                    output.finished_request_ids = finished_ids
+                    output.outputs.extend(outputs)
+                    output.finished_request_ids.update(finished_ids)
                     self._cleanup_finished(finished_ids)
 
                     # Periodic Metal allocator cleanup during long decodes.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -12,7 +12,7 @@ Tests cover:
 - get_request(): request lookup
 - get_stats(): statistics
 
-Note: BatchGenerator is mocked; step() is too complex for unit tests.
+Note: BatchGenerator is mocked; step() coverage is limited to targeted paths.
 """
 
 from collections import deque
@@ -157,6 +157,44 @@ class TestSchedulerOutput:
         assert len(output.outputs) == 1
         assert output.outputs[0].request_id == "req-1"
         assert output.has_work is True
+
+
+class TestSchedulerStepOutputs:
+    """Tests for Scheduler.step output assembly."""
+
+    def test_decode_outputs_preserve_prefill_rejections(
+        self, mock_model, mock_tokenizer
+    ):
+        """Decode responses must not overwrite earlier rejection outputs."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+
+        prefill_error = RequestOutput(
+            request_id="prefill-failed",
+            finished=True,
+            finish_reason="error",
+            error="Memory limit exceeded during prefill",
+        )
+        decode_output = RequestOutput(
+            request_id="running",
+            new_token_ids=[123],
+            new_text="x",
+        )
+
+        scheduler._schedule_waiting = MagicMock(return_value=([], [prefill_error]))
+        scheduler._process_batch_responses = MagicMock(
+            return_value=([decode_output], {"running"})
+        )
+        scheduler._cleanup_finished = MagicMock()
+
+        scheduler.running = {"running": MagicMock()}
+        scheduler.batch_generator = MagicMock()
+        scheduler.batch_generator.next_generated.return_value = iter([MagicMock()])
+
+        output = scheduler.step()
+
+        assert output.outputs == [prefill_error, decode_output]
+        assert output.finished_request_ids == {"running"}
+        scheduler._cleanup_finished.assert_called_once_with({"running"})
 
 
 class TestSchedulerInitialization:


### PR DESCRIPTION
Closes #1621

## Summary

- Preserve scheduler rejection outputs when decode responses are produced in the same `step()`.
- Add a regression test covering a prefill failure output followed by decode output in the same scheduler step.

## Why

When prefill failed, `_schedule_waiting()` could return a terminal error `RequestOutput` for the failed request. If another request produced decode output in the same `Scheduler.step()`, the decode path replaced `output.outputs` instead of appending to it, dropping the prefill error output.

That left the failed request removed from scheduler state but without a finished output delivered to `engine_core`, so the client could wait indefinitely with no tokens and no error.

## Changes

- Changed `Scheduler.step()` to append decode outputs with `output.outputs.extend(outputs)`.
- Changed finished request ID handling to merge with `output.finished_request_ids.update(finished_ids)`.
- Added `TestSchedulerStepOutputs.test_decode_outputs_preserve_prefill_rejections`.

## Tests

```bash
.venv/bin/python -m pytest tests/test_scheduler.py -q
```

Result:

```text
105 passed
```

Also verified the new regression test fails when the scheduler fix is reverted.
