### PR TITLE
fix(scheduler): exclude MLA models from TurboQuant KV cache (#1613)

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -793,6 +793,8 @@ class Scheduler:
         # TurboQuant KV cache (set by engine if model_settings has it enabled)
         self._turboquant_kv_bits: float | None = None
         self._turboquant_skip_last: bool = True
+        # Memoized MLA-architecture detection (see _model_uses_mla / #1613).
+        self._mla_model: bool | None = None
 
         # Request management - following vLLM's design
         self.waiting: deque[Request] = deque()  # Waiting queue (FCFS)
@@ -1715,6 +1717,88 @@ class Scheduler:
     # External prefill (composition pattern — replaces _process_prompts)
     # ------------------------------------------------------------------
 
+    def _model_uses_mla(self) -> bool:
+        """Detect Multi-head Latent Attention models (DeepSeek-V2/V3/V4,
+        GLM-4-MoE / GLM-4.7-Flash, Kimi-K2, ...).
+
+        MLA compresses K/V into a low-rank latent plus a separate rope key and
+        reads the *fetched* cache tensors directly — e.g.
+        ``kv_latent, k_pe = cache.update_and_fetch(...)`` then
+        ``k_pe.swapaxes(-1, -2)`` (mlx_lm/models/glm4_moe_lite.py). TurboQuant
+        replaces the cache state with quantized NamedTuples that have no array
+        methods, so that ``.swapaxes`` raises ``AttributeError`` (#1613). MLA
+        also stores keys/values with mismatched head dims, which the codec does
+        not support. Such models stay fp16 — no crash, no TurboQuant.
+
+        Result is memoized: the model never changes for a scheduler instance.
+        """
+        cached = getattr(self, "_mla_model", None)
+        if cached is not None:
+            return cached
+
+        detected = False
+        model = getattr(self, "model", None)
+
+        # kv_lora_rank is the defining MLA hyperparameter and is an int on real
+        # models. It may sit on the top-level config or be nested under a
+        # text/LM sub-config (VLM MLA, e.g. kimi_vl -> text_config). The
+        # isinstance(int) check guards against mocks where it is a sentinel.
+        def _cfg_has_kv_lora(cfg: Any, depth: int = 0) -> bool:
+            if cfg is None or depth > 3:
+                return False
+            if isinstance(getattr(cfg, "kv_lora_rank", None), int):
+                return True
+            return any(
+                _cfg_has_kv_lora(getattr(cfg, sub, None), depth + 1)
+                for sub in (
+                    "text_config",
+                    "llm_config",
+                    "language_config",
+                    "thinker_config",
+                )
+            )
+
+        # Config signal. For VLMs the scheduler sees VLMModelAdapter, whose
+        # .args delegates to the language model; also probe (_)language_model.
+        for holder in (
+            model,
+            getattr(model, "_language_model", None),
+            getattr(model, "language_model", None),
+        ):
+            if holder is None:
+                continue
+            if _cfg_has_kv_lora(getattr(holder, "args", None)) or _cfg_has_kv_lora(
+                getattr(holder, "config", None)
+            ):
+                detected = True
+                break
+
+        # Architecture signal: an attention submodule carrying the MLA
+        # down-projection, latent layernorm, or latent rank. Covers models
+        # whose config does not surface kv_lora_rank where the scheduler can
+        # see it (e.g. a directly-loaded VLM with a nested text config).
+        if not detected and model is not None and hasattr(model, "modules"):
+            try:
+                for m in model.modules():
+                    if (
+                        hasattr(m, "kv_a_proj_with_mqa")
+                        or hasattr(m, "kv_a_layernorm")
+                        or isinstance(getattr(m, "kv_lora_rank", None), int)
+                    ):
+                        detected = True
+                        break
+            except Exception:
+                pass
+
+        if detected:
+            logger.info(
+                "TurboQuant disabled: model uses Multi-head Latent Attention "
+                "(MLA), which is incompatible with quantized KV cache states; "
+                "keeping fp16 KV cache (#1613)."
+            )
+        self._mla_model = detected
+        return detected
+
     def _turboquant_eligible(self, prompt_cache: list[Any]) -> bool:
         """True if every cache layer can be safely TurboQuant-converted for
         continuous batching.
@@ -1725,8 +1809,15 @@ class Scheduler:
         rotating-attention caches (Llama-4, sliding-window) need
         maybe_trim_front / rotating semantics that BatchTurboQuantKVCache does
         not provide, so those models stay fp16 — no crash, no TurboQuant.
+
+        MLA models (DeepSeek / GLM-4.7-Flash) are also excluded: they keep
+        plain KVCache objects but read fetched cache tensors directly, which
+        TurboQuant's quantized states do not support (#1613).
         """
         from mlx_lm.models.cache import CacheList, KVCache
+
+        if self._model_uses_mla():
+            return False
 
         def _ok(c: Any) -> bool:
             if isinstance(c, KVCache):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -16,6 +16,7 @@ Note: BatchGenerator is mocked; step() coverage is limited to targeted paths.
 """
 
 from collections import deque
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
@@ -2526,3 +2527,105 @@ class TestBuildStateMachineStopStrings:
                 assert tok in node
                 node = node[tok]
             assert "__match__" in node
+
+
+class TestTurboQuantMLAGuard:
+    """Regression tests for #1613: MLA models must not be TurboQuant-converted.
+
+    GLM-4.7-Flash / DeepSeek use Multi-head Latent Attention and read fetched
+    cache tensors directly (k_pe.swapaxes(...)), which crashes on TurboQuant's
+    quantized NamedTuple states ('TurboQuantMSEState' object has no attribute
+    'swapaxes'). _turboquant_eligible() must return False for them so they stay
+    fp16.
+    """
+
+    def test_mla_model_ineligible_by_config(self, mock_model, mock_tokenizer):
+        from mlx_lm.models.cache import KVCache
+
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler._turboquant_kv_bits = 4.0
+        # MLA config exposes kv_lora_rank (GLM-4.7-Flash, DeepSeek-V*).
+        scheduler.model = SimpleNamespace(args=SimpleNamespace(kv_lora_rank=512))
+        scheduler._mla_model = None
+
+        assert scheduler._model_uses_mla() is True
+        assert scheduler._turboquant_eligible([KVCache()]) is False
+
+    def test_mla_model_ineligible_by_architecture(self, mock_model, mock_tokenizer):
+        from mlx_lm.models.cache import KVCache
+
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler._turboquant_kv_bits = 4.0
+        # No kv_lora_rank in config, but an attention submodule with the MLA
+        # down-projection / latent layernorm.
+        attn = SimpleNamespace(
+            kv_a_proj_with_mqa=object(),
+            kv_a_layernorm=object(),
+            kv_lora_rank=512,
+        )
+        scheduler.model = SimpleNamespace(
+            args=SimpleNamespace(), modules=lambda: [attn]
+        )
+        scheduler._mla_model = None
+
+        assert scheduler._model_uses_mla() is True
+        assert scheduler._turboquant_eligible([KVCache()]) is False
+
+    def test_standard_model_still_eligible(self, mock_model, mock_tokenizer):
+        from mlx_lm.models.cache import KVCache
+
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler._turboquant_kv_bits = 4.0
+        # Standard MHA/GQA model: no kv_lora_rank, no MLA submodules.
+        scheduler.model = SimpleNamespace(
+            args=SimpleNamespace(num_hidden_layers=4), modules=lambda: []
+        )
+        scheduler._mla_model = None
+
+        assert scheduler._model_uses_mla() is False
+        assert scheduler._turboquant_eligible([KVCache()]) is True
+
+    def test_mla_model_ineligible_nested_text_config(self, mock_model, mock_tokenizer):
+        # VLM MLA (e.g. kimi_vl): kv_lora_rank is nested under text_config, not
+        # on the top-level args.
+        from mlx_lm.models.cache import KVCache
+
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler._turboquant_kv_bits = 4.0
+        scheduler.model = SimpleNamespace(
+            args=SimpleNamespace(text_config=SimpleNamespace(kv_lora_rank=512))
+        )
+        scheduler._mla_model = None
+
+        assert scheduler._model_uses_mla() is True
+        assert scheduler._turboquant_eligible([KVCache()]) is False
+
+    def test_mla_vlm_adapter_delegates_to_language_model(
+        self, mock_model, mock_tokenizer
+    ):
+        # VLMModelAdapter exposes _language_model; its args surface kv_lora_rank.
+        from mlx_lm.models.cache import KVCache
+
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler._turboquant_kv_bits = 4.0
+        lm = SimpleNamespace(args=SimpleNamespace(kv_lora_rank=512))
+        scheduler.model = SimpleNamespace(args=SimpleNamespace(), _language_model=lm)
+        scheduler._mla_model = None
+
+        assert scheduler._model_uses_mla() is True
+        assert scheduler._turboquant_eligible([KVCache()]) is False
+
+    def test_mla_detection_is_memoized(self, mock_model, mock_tokenizer):
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        calls = {"n": 0}
+
+        def _modules():
+            calls["n"] += 1
+            return []
+
+        scheduler.model = SimpleNamespace(args=SimpleNamespace(), modules=_modules)
+        scheduler._mla_model = None
+
+        assert scheduler._model_uses_mla() is False
+        assert scheduler._model_uses_mla() is False
+        assert calls["n"] == 1  # walked once, then cached

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -425,10 +425,12 @@ def test_turboquant_eligible_gate():
 
     from omlx.scheduler import Scheduler
 
-    # _turboquant_eligible is pure (ignores self); call the unbound method
-    # with a throwaway self so we don't construct a full Scheduler.
+    # _turboquant_eligible consults the model for MLA architecture (#1613)
+    # before checking cache types; inject a non-MLA stub so this test isolates
+    # the cache-type gating it is exercising.
     def elig(cache):
-        return Scheduler._turboquant_eligible(SimpleNamespace(), cache)
+        stub = SimpleNamespace(_model_uses_mla=lambda: False)
+        return Scheduler._turboquant_eligible(stub, cache)
 
     assert elig([KVCache(), KVCache()]) is True
     assert elig([]) is False


### PR DESCRIPTION
## Summary

Multi-head Latent Attention (MLA) models crash the engine loop when TurboQuant is enabled:

```
omlx.scheduler   - INFO  - TurboQuant: converted 46/47 cache layers to 4.0-bit, skipped last KVCache layer
omlx.engine_core - ERROR - Engine loop error: 'TurboQuantMSEState' object has no attribute 'swapaxes'
```

This PR makes `Scheduler._turboquant_eligible()` recognise MLA architectures and keep them on an fp16 KV cache — **no crash, no TurboQuant** — with a one-time info log. Fixes #1613.

## Root cause

MLA attention (DeepSeek-V2/V3, GLM-4-MoE / GLM-4.7-Flash, MiniCPM3, …) does **not** delegate everything to `scaled_dot_product_attention(cache=...)`. It reads the *fetched* cache tensors directly:

```python
kv_latent, k_pe = cache.update_and_fetch(kv_latent, k_pe)
pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)   # <-- crash
```
(`mlx_lm/models/glm4_moe_lite.py`, `deepseek_v3.py`, …)

TurboQuant replaces each KV layer's state with a per-head quantized `TurboQuantMSEState` NamedTuple (`norms`, `indices`) that has no array methods, so `.swapaxes` (and the absorbed-MLA `embed_q`/`unembed_out` matmuls) raise `AttributeError`. MLA also stores the latent (`kv_lora_rank`, e.g. 512) and rope key (`qk_rope_head_dim`, e.g. 64) with **mismatched head dims** and a single head, which the per-head codec was never designed for.

This is consistent with the rest of the ecosystem — TurboQuant / KV-cache vector quant is **standard-attention (MHA/GQA) only** in `mlx-vlm`, vLLM, and SGLang; MLA always uses a *separate* KV path (FP8 grouped latent + bf16 rope) or none at all (MLX). So excluding MLA matches how every implementation treats it.

## The fix

A memoized `_model_uses_mla()` detector with three signals, called at the top of `_turboquant_eligible()`:

1. **Config** — `kv_lora_rank` (int), including nested `text_config`/`llm_config` and VLM-adapter `_language_model`/`language_model` delegation.
2. **Architecture** — module walk for `kv_a_proj_with_mqa` / `kv_a_layernorm` / int `kv_lora_rank`.

`_turboquant_eligible()` returns `False` for MLA, gating **both** conversion call sites (empty + post-prefill convert).

## Scope / safety — does not affect other functionality

- The change is a single early-return in the existing eligibility gate. For **non-MLA models the detector returns `False` immediately and the original cache-type logic runs byte-for-byte identically** — TurboQuant behaviour for dense/GQA models is unchanged.
- Detection is **memoized** (model never changes per scheduler), so there is no per-request cost; the module walk only runs once and only if the config signal misses.
- No public API, settings, or cache-format changes. MLA models simply keep the fp16 KV cache they already used before TurboQuant was toggled on.

## Coverage

Verified against all MLA families in the installed `mlx-lm`: `deepseek_v2`, `deepseek_v3`, `deepseek_v32`, `glm4_moe_lite`, `glm_moe_dsa`, `kimi_linear`, `kimi_vl`, `longcat_flash`, `longcat_flash_ngram`, `minicpm3`, `youtu_llm` — each caught by the config signal (top-level or nested) and/or the architecture walk. No false positives: only MLA models define `kv_lora_rank`.

## Test plan

New `tests/test_scheduler.py::TestTurboQuantMLAGuard` (6 cases):
- MLA detected by config, by architecture, by nested `text_config`, and via VLM-adapter `_language_model`
- standard MHA/GQA model **stays eligible**
- detection is memoized (single module walk)

```
pytest tests/test_scheduler.py::TestTurboQuantMLAGuard tests/test_turboquant.py tests/test_scheduler.py
# 134 passed
pytest            # full default suite: 4892 passed, 37 skipped
```

(The only failures in the full run are 4 pre-existing `test_dflash_engine.py` cases failing on a `dflash_mlx.runtime.config` import in this environment — unrelated to this change.)
