### PR TITLE
feat(server): add max_context_window_policy for server-wide context cap

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -207,7 +207,19 @@ class EngineType(Enum):
 class SamplingDefaults:
     """Default sampling parameters."""
 
+    # Fallback context length used by ``get_max_context_window`` only
+    # when neither a per-model override nor a model-config-discovered
+    # native context length is available. Setting this does NOT cap
+    # models that declare their own context — use
+    # ``max_context_window_policy`` for the operator-policy cap.
     max_context_window: int = 32768
+    # Optional operator policy cap. When set, models whose native
+    # context length is discovered get ``min(native, policy)``. Per-model
+    # overrides and the fallback default above are not affected — those
+    # represent explicit choices that the policy cannot override
+    # without surprising migration semantics for existing
+    # ``settings.json`` files.
+    max_context_window_policy: int | None = None
     max_tokens: int = 32768
     temperature: float = 1.0
     top_p: float = 0.95
@@ -1148,14 +1160,25 @@ def get_max_context_window(model_id: str | None = None) -> int | None:
     """
     Get effective max context window limit.
 
-    Priority (#1308):
-        1. Explicit per-model setting (admin UI / settings.json override).
-        2. Context length discovered from the model's ``config.json`` at
-           server startup (``max_position_embeddings`` etc.); without
-           this tier the server would advertise the 32 K global default
-           even for models that declare 256 K+ natively.
-        3. Global default from ``SamplingConfig`` — last-resort fallback
-           for models whose config files don't expose a context length.
+    Resolution:
+        1. **Per-model override** (admin UI / settings.json) — always
+           wins. An operator who has set a per-model number knows what
+           they want; ``max_context_window_policy`` does not clamp it.
+        2. **Model-config-discovered native context length** (#1308),
+           optionally clamped by the operator policy: if
+           ``sampling.max_context_window_policy`` is set, return
+           ``min(native, policy)``; otherwise return ``native`` as-is.
+        3. **Fallback default** from ``SamplingSettings.max_context_window``
+           — only used when neither tier 1 nor tier 2 yields a value.
+           Treated as a default, NOT capped by the policy; existing
+           ``settings.json`` files carrying the historical ``32768``
+           default keep working unchanged after upgrade.
+
+    The policy field is intentionally nullable and unset by default so
+    no existing install behavior shifts. Setting it engages
+    ``min(native, policy)`` across every model whose native context is
+    discoverable; per-model overrides remain the operator's escape
+    hatch for individual models that should exceed the policy.
 
     Returns:
         Max context window token count, or ``None`` if no tier resolves
@@ -1169,15 +1192,25 @@ def get_max_context_window(model_id: str | None = None) -> int | None:
     if model_id and _server_state.settings_manager:
         model_settings = _server_state.settings_manager.get_settings(model_id)
 
+    # Priority 1: explicit per-model override (not capped by policy)
     if model_settings and model_settings.max_context_window is not None:
         return model_settings.max_context_window
 
+    # Priority 2: model-native context, optionally clamped by policy
     pool = _server_state.engine_pool
     if model_id and pool is not None:
         entry = pool.get_entry(model_id)
         if entry is not None and entry.model_context_length is not None:
-            return entry.model_context_length
+            native = entry.model_context_length
+            policy = getattr(
+                _server_state.sampling, "max_context_window_policy", None
+            )
+            if policy is not None and policy > 0:
+                return min(native, policy)
+            return native
 
+    # Priority 3: fallback default (not capped — preserves legacy
+    # settings.json behavior).
     return _server_state.sampling.max_context_window
 
 
@@ -1312,6 +1345,9 @@ def init_server(
     if global_settings and global_settings.sampling:
         _server_state.sampling = SamplingDefaults(
             max_context_window=global_settings.sampling.max_context_window,
+            max_context_window_policy=getattr(
+                global_settings.sampling, "max_context_window_policy", None
+            ),
             max_tokens=global_settings.sampling.max_tokens,
             temperature=global_settings.sampling.temperature,
             top_p=global_settings.sampling.top_p,

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -511,7 +511,18 @@ class NetworkSettings:
 class SamplingSettings:
     """Default sampling parameters for generation."""
 
+    # Fallback context length used by ``server.get_max_context_window``
+    # only when neither a per-model override nor a model-config
+    # discovered native context length is available. Default kept at
+    # 32768 so existing ``settings.json`` files carrying the historical
+    # default keep working unchanged after upgrade.
     max_context_window: int = 32768
+    # Optional operator policy cap. When set, the server returns
+    # ``min(native_context, max_context_window_policy)`` for models
+    # whose native context length is discovered. Unset (None) by
+    # default so no install behavior changes implicitly. Per-model
+    # overrides and the fallback default above are not affected.
+    max_context_window_policy: int | None = None
     max_tokens: int = 32768
     temperature: float = 1.0
     top_p: float = 0.95
@@ -522,6 +533,7 @@ class SamplingSettings:
         """Convert to dictionary."""
         return {
             "max_context_window": self.max_context_window,
+            "max_context_window_policy": self.max_context_window_policy,
             "max_tokens": self.max_tokens,
             "temperature": self.temperature,
             "top_p": self.top_p,
@@ -534,6 +546,9 @@ class SamplingSettings:
         """Create from dictionary."""
         return cls(
             max_context_window=data.get("max_context_window", 32768),
+            max_context_window_policy=data.get(
+                "max_context_window_policy", None
+            ),
             max_tokens=data.get("max_tokens", 32768),
             temperature=data.get("temperature", 1.0),
             top_p=data.get("top_p", 0.95),

--- a/tests/test_context_window.py
+++ b/tests/test_context_window.py
@@ -12,12 +12,19 @@ from omlx.model_settings import ModelSettings
 class TestGetMaxContextWindow:
     """Tests for get_max_context_window() priority logic."""
 
-    def _make_server_state(self, global_max_ctx=32768):
-        """Create a mock server state with given global max_context_window."""
+    def _make_server_state(
+        self, global_max_ctx=32768, policy_cap=None
+    ):
+        """Create a mock server state with given global
+        ``max_context_window`` fallback and optional
+        ``max_context_window_policy`` cap."""
         from omlx.server import SamplingDefaults
 
         state = MagicMock()
-        state.sampling = SamplingDefaults(max_context_window=global_max_ctx)
+        state.sampling = SamplingDefaults(
+            max_context_window=global_max_ctx,
+            max_context_window_policy=policy_cap,
+        )
         state.settings_manager = None
         # Discovery-tier (#1308) lookups are exercised in TestGetMaxContextWindow
         # in test_server.py; nulling the pool here keeps these focused on the
@@ -72,6 +79,101 @@ class TestGetMaxContextWindow:
         with patch("omlx.server._server_state", state):
             result = get_max_context_window(None)
             assert result == 16384
+
+    def _mount_native_and_policy(
+        self, native_ctx: int | None, policy_cap: int | None
+    ):
+        """Mount a server state with a model that has the given native
+        context length, the policy field set to ``policy_cap``, and no
+        per-model override."""
+        state = self._make_server_state(
+            global_max_ctx=32768, policy_cap=policy_cap
+        )
+        mock_manager = MagicMock()
+        mock_manager.get_settings.return_value = ModelSettings(
+            max_context_window=None
+        )
+        state.settings_manager = mock_manager
+
+        mock_pool = MagicMock()
+        mock_entry = MagicMock()
+        mock_entry.model_context_length = native_ctx
+        mock_pool.get_entry.return_value = mock_entry
+        state.engine_pool = mock_pool
+        return state
+
+    def test_policy_unset_native_wins_unchanged(self):
+        """With ``max_context_window_policy`` unset, the model's
+        native context length is returned verbatim — existing
+        installs see no behavior change after this PR."""
+        from omlx.server import get_max_context_window
+
+        state = self._mount_native_and_policy(
+            native_ctx=262_144, policy_cap=None
+        )
+        with patch("omlx.server._server_state", state):
+            assert get_max_context_window("big-model") == 262_144
+
+    def test_policy_set_clamps_native(self):
+        """With ``max_context_window_policy=128_000`` and a model that
+        natively declares 256 K, the effective cap is the policy."""
+        from omlx.server import get_max_context_window
+
+        state = self._mount_native_and_policy(
+            native_ctx=262_144, policy_cap=128_000
+        )
+        with patch("omlx.server._server_state", state):
+            assert get_max_context_window("big-model") == 128_000, (
+                "Policy of 128k must clamp a model that natively declares 256k"
+            )
+
+    def test_policy_set_native_below_policy_wins(self):
+        """When the model's native length is already below the policy,
+        the native value wins — policy is a ceiling, not a floor."""
+        from omlx.server import get_max_context_window
+
+        state = self._mount_native_and_policy(
+            native_ctx=32_768, policy_cap=128_000
+        )
+        with patch("omlx.server._server_state", state):
+            assert get_max_context_window("small-model") == 32_768
+
+    def test_per_model_override_escapes_policy(self):
+        """A per-model override is the operator's explicit per-model
+        choice; the global policy cap does NOT clamp it. This is the
+        operator's escape hatch for individual models that should
+        exceed the policy."""
+        from omlx.server import get_max_context_window
+
+        state = self._mount_native_and_policy(
+            native_ctx=100_000, policy_cap=64_000
+        )
+        # Add a per-model override above both native and policy
+        state.settings_manager = MagicMock()
+        state.settings_manager.get_settings.return_value = ModelSettings(
+            max_context_window=200_000
+        )
+        with patch("omlx.server._server_state", state):
+            assert get_max_context_window("override-model") == 200_000, (
+                "Per-model override must escape the policy clamp"
+            )
+
+    def test_policy_does_not_apply_to_fallback_path(self):
+        """When the model has no discoverable native context AND no
+        per-model override, the fallback default applies — the policy
+        is documented as clamping the *native* path only. Existing
+        ``settings.json`` files with the historical 32768 fallback
+        therefore keep working unchanged even when a policy is later
+        added to the install."""
+        from omlx.server import get_max_context_window
+
+        # native_ctx=None: model config doesn't expose a context length
+        state = self._mount_native_and_policy(
+            native_ctx=None, policy_cap=16_000
+        )
+        with patch("omlx.server._server_state", state):
+            # Fallback (32768) returned, not the policy (16_000).
+            assert get_max_context_window("no-native-model") == 32_768
 
 
 class TestValidateContextWindow:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -513,7 +513,13 @@ class TestGetMaxContextWindow:
         self._state.settings_manager = manager
 
     def test_global_default_when_nothing_discovered(self):
-        """No model context, no per-model override → global default."""
+        """No model context, no per-model override → global default.
+
+        Fallback default kept at 32768 so existing ``settings.json``
+        files carrying the historical default keep working unchanged.
+        Operators who want a real server-wide cap set
+        ``max_context_window_policy`` instead — see TestPolicyCap below.
+        """
         self._mount_pool({"llama-3": self._entry("llama-3", None)})
         assert get_max_context_window("llama-3") == 32768
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1654,7 +1654,12 @@ class TestSamplingSettings:
     def test_defaults(self):
         """Test default values."""
         settings = SamplingSettings()
+        # Fallback default kept at 32768 so existing settings.json
+        # files carrying the historical default keep working unchanged
+        # after upgrade. ``max_context_window_policy`` is the explicit
+        # operator policy cap (None by default).
         assert settings.max_context_window == 32768
+        assert settings.max_context_window_policy is None
         assert settings.max_tokens == 32768
         assert settings.temperature == 1.0
         assert settings.top_p == 0.95
@@ -1685,7 +1690,23 @@ class TestSamplingSettings:
         """Test from_dict uses defaults for missing fields."""
         settings = SamplingSettings.from_dict({})
         assert settings.max_context_window == 32768
+        assert settings.max_context_window_policy is None
         assert settings.repetition_penalty == 1.0
+
+    def test_policy_field_round_trip(self):
+        """``max_context_window_policy`` must serialize and
+        deserialize without losing its ``None`` semantics."""
+        unset = SamplingSettings.from_dict({})
+        assert unset.max_context_window_policy is None
+        # to_dict preserves None
+        d = unset.to_dict()
+        assert d["max_context_window_policy"] is None
+        # Setting an explicit value round-trips
+        with_policy = SamplingSettings.from_dict(
+            {"max_context_window_policy": 128_000}
+        )
+        assert with_policy.max_context_window_policy == 128_000
+        assert with_policy.to_dict()["max_context_window_policy"] == 128_000
 
 
 class TestClaudeCodeSettings:


### PR DESCRIPTION
## Summary

Reworked per the maintainer review. The original PR changed `max_context_window` semantics from "fallback" to "policy cap"; this rev instead adds a **separate nullable field** alongside the existing fallback, preserving all current behavior unless explicitly opted in.

## Design

`SamplingSettings.max_context_window_policy: int | None = None` (unset by default). When set, `get_max_context_window` returns `min(native, policy)` for models whose native context length was discovered. Per-model overrides and the fallback default are not capped — those are explicit operator choices that the policy must not silently override.

## Resolution

| Per-model override | Native (config.json) | Policy field | Effective cap | Notes |
|---|---|---|---|---|
| — | 262 144 | unset (None) | 262 144 | **No behavior change for existing installs** |
| — | 262 144 | 128 000 | **128 000** | Policy clamps the native value |
| — | 32 768 | 128 000 | 32 768 | Native already below policy — native wins |
| 200 000 | 262 144 | 128 000 | 200 000 | Per-model override escapes the clamp |
| — | (none discovered) | 16 000 | 32 768 | Fallback path; policy does not apply here |

## Why a separate field

- **Preserves existing `settings.json` behavior** — files carrying the historical `max_context_window=32768` default keep working as fallback only; no model gets silently clamped after upgrade.
- **Avoids `1_000_000` as a pseudo "no policy" value**, which would have failed for models whose native context is above that.
- **Discoverability** — `..._policy` reads as what it does, and the existing field's role is unchanged so the dashboard label can be clarified without breaking semantics.

## Test plan

- [x] `pytest tests/test_context_window.py tests/test_context_scaling.py tests/test_settings.py tests/test_server.py` — 243 passed
- [x] New `TestGetMaxContextWindow` cases: policy unset, policy clamps, native below policy, per-model override escapes, fallback-only path unaffected
- [x] `TestSamplingSettings::test_policy_field_round_trip` covers None-semantics serialization

Dashboard label/help-text clarification for the existing field is intentionally out of scope for this PR.