### PR TITLE
fix(mac): prevent crash when deleting chat template kwargs

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -785,14 +785,13 @@ private struct ChatTemplateKwargsEditor: View {
                     addMenu
                 }
             }
-            ForEach(Array(vm.chatTemplateEntries.enumerated()), id: \.element.id) { idx, entry in
-                let isLast = idx == vm.chatTemplateEntries.count - 1
+            ForEach(vm.chatTemplateEntries) { entry in
+                let isLast = entry.id == vm.chatTemplateEntries.last?.id
                 FreeRow(isLast: isLast) {
                     EntryEditor(
                         vm: vm,
                         client: client,
-                        index: idx,
-                        entry: entry
+                        entryID: entry.id
                     )
                 }
             }
@@ -835,15 +834,22 @@ private struct ChatTemplateKwargsEditor: View {
 private struct EntryEditor: View {
     @ObservedObject var vm: ModelSettingsScreenVM
     let client: OMLXClient
-    let index: Int
-    let entry: ChatTemplateKwargEntry
+    let entryID: UUID
 
     @Environment(\.omlxTheme) private var theme
 
+    private var entry: ChatTemplateKwargEntry {
+        vm.chatTemplateEntries.first { $0.id == entryID } ?? ChatTemplateKwargEntry(kind: .custom, value: "")
+    }
+
     private var binding: Binding<ChatTemplateKwargEntry> {
         Binding(
-            get: { vm.chatTemplateEntries[index] },
-            set: { vm.chatTemplateEntries[index] = $0 }
+            get: { vm.chatTemplateEntries.first { $0.id == entryID } ?? ChatTemplateKwargEntry(kind: .custom, value: "") },
+            set: { newValue in
+                if let idx = vm.chatTemplateEntries.firstIndex(where: { $0.id == entryID }) {
+                    vm.chatTemplateEntries[idx] = newValue
+                }
+            }
         )
     }
 
@@ -855,7 +861,7 @@ private struct EntryEditor: View {
                     .foregroundStyle(theme.textSecondary)
                 Spacer()
                 Button {
-                    vm.removeKwarg(id: entry.id)
+                    vm.removeKwarg(id: entryID)
                 } label: {
                     Image(systemName: "xmark")
                         .font(.system(size: 11, weight: .medium))


### PR DESCRIPTION
Fixes #1614

## Problem

Adding 2+ custom chat kwargs in model advanced settings and then deleting any one causes the app to crash and request a restart.

## Root cause

`EntryEditor` received a plain `Int` index from the `ForEach` and used it to subscript `vm.chatTemplateEntries` in its `binding` getter/setter. When a kwarg was removed, the array shrunk but SwiftUI still held views with stale indices — triggering an out-of-bounds access.

## Fix

- `EntryEditor` now takes a stable `UUID` (`entryID`) instead of an `Int` index.
- `binding` getter/setter looks up entries via `firstIndex(where:)` on the UUID, which is safe across deletions and reorders.
- `ForEach` simplified to iterate entries directly — no more `enumerated()`.

## Changes

- `apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift`
- `EntryEditor`: `index: Int` → `entryID: UUID`
- `binding`: UUID-based lookup with safe fallback
- `ForEach`: `ForEach(Array(...enumerated()))` → `ForEach(vm.chatTemplateEntries)`