### PR TITLE
feat(mac): Add VLM MTP toggle to model settings

### DIFF
--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -1,6 +1,162 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "profile.detail.acceleration.vlm_mtp" : {
+      "comment" : "Acceleration chip: VLM multi-token prediction",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VLM MTP"
+          }
+        }
+      }
+    },
+    "settings.experimental.vlm_mtp.block_size.label" : {
+      "comment" : "Row label for the VLM MTP draft block-size field",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Draft Block Size"
+          }
+        }
+      }
+    },
+    "settings.experimental.vlm_mtp.block_size.sub" : {
+      "comment" : "Sublabel for the VLM MTP draft block-size field",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tokens drafted per round. Empty uses the mlx-vlm default."
+          }
+        }
+      }
+    },
+    "settings.experimental.vlm_mtp.draft.label" : {
+      "comment" : "Row label for the VLM MTP draft-model picker",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VLM Draft Model"
+          }
+        }
+      }
+    },
+    "settings.experimental.vlm_mtp.draft.sub" : {
+      "comment" : "Sublabel for the VLM MTP draft-model picker",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Assistant drafter sharing the target's tokenizer."
+          }
+        }
+      }
+    },
+    "settings.experimental.vlm_mtp.label" : {
+      "comment" : "Row label for the VLM MTP toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VLM MTP"
+          }
+        }
+      }
+    },
+    "settings.experimental.vlm_mtp.sub" : {
+      "comment" : "Default sublabel for the VLM MTP toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Multi-token prediction for vision-language models via an assistant drafter."
+          }
+        }
+      }
+    },
+    "settings.mtp.conflict.vlm_mtp" : {
+      "comment" : "Tooltip / sublabel shown when native MTP can't be enabled because VLM MTP is on",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable VLM MTP before enabling Native MTP."
+          }
+        }
+      }
+    },
+    "settings.vlm_mtp.conflict.dflash" : {
+      "comment" : "Tooltip / sublabel shown when VLM MTP can't be enabled because DFlash is on",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable DFlash before enabling VLM MTP."
+          }
+        }
+      }
+    },
+    "settings.vlm_mtp.conflict.mtp" : {
+      "comment" : "Tooltip / sublabel shown when VLM MTP can't be enabled because native MTP is on",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable Native MTP before enabling VLM MTP."
+          }
+        }
+      }
+    },
+    "settings.vlm_mtp.conflict.specprefill" : {
+      "comment" : "Tooltip / sublabel shown when VLM MTP can't be enabled because SpecPrefill is on",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable SpecPrefill before enabling VLM MTP."
+          }
+        }
+      }
+    },
+    "settings.vlm_mtp.conflict.turboquant" : {
+      "comment" : "Tooltip / sublabel shown when VLM MTP can't be enabled because TurboQuant KV is on",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable TurboQuant KV before enabling VLM MTP."
+          }
+        }
+      }
+    },
+    "settings.vlm_mtp.draft.placeholder" : {
+      "comment" : "Initial placeholder option in the VLM MTP draft-model picker",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select assistant drafter…"
+          }
+        }
+      }
+    },
     "" : {
 
     },

--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -1121,16 +1121,52 @@ private struct ExperimentalSection: View {
                 }
             }
 
-            // Native MTP — last row of the experimental group.
+            // Native MTP
             Row(label: String(localized: "settings.experimental.mtp.label",
                               defaultValue: "Native MTP",
                               comment: "Row label for the Native MTP toggle"),
-                sublabel: mtpSublabel,
-                isLast: true) {
+                sublabel: mtpSublabel) {
                 Toggle("", isOn: vm.bindProfile($vm.mtpEnabled))
                     .labelsHidden().toggleStyle(.switch)
                     .disabled(mtpToggleDisabled)
                     .help(vm.mtpConflictReason ?? vm.model?.mtpCompatibilityReason ?? "")
+            }
+
+            // VLM MTP — last row of the experimental group. Reveals the
+            // draft-model picker and block-size field when enabled.
+            Row(label: String(localized: "settings.experimental.vlm_mtp.label",
+                              defaultValue: "VLM MTP",
+                              comment: "Row label for the VLM MTP toggle"),
+                sublabel: vlmMtpSublabel,
+                isLast: !vm.vlmMtpEnabled) {
+                Toggle("", isOn: vm.bindProfile($vm.vlmMtpEnabled))
+                    .labelsHidden().toggleStyle(.switch)
+                    .disabled(vlmMtpToggleDisabled)
+                    .help(vm.vlmMtpConflictReason ?? "")
+            }
+            if vm.vlmMtpEnabled {
+                Row(label: String(localized: "settings.experimental.vlm_mtp.draft.label",
+                                  defaultValue: "VLM Draft Model",
+                                  comment: "Row label for the VLM MTP draft-model picker"),
+                    sublabel: String(localized: "settings.experimental.vlm_mtp.draft.sub",
+                                     defaultValue: "Assistant drafter sharing the target's tokenizer.",
+                                     comment: "Sublabel for the VLM MTP draft-model picker")) {
+                    Popup(
+                        selection: vm.bindProfile($vm.vlmMtpDraftModel),
+                        width: 260,
+                        options: vm.vlmMtpDraftModelOptions()
+                    )
+                }
+                Row(label: String(localized: "settings.experimental.vlm_mtp.block_size.label",
+                                  defaultValue: "Draft Block Size",
+                                  comment: "Row label for the VLM MTP draft block-size field"),
+                    sublabel: String(localized: "settings.experimental.vlm_mtp.block_size.sub",
+                                     defaultValue: "Tokens drafted per round. Empty uses the mlx-vlm default.",
+                                     comment: "Sublabel for the VLM MTP draft block-size field"),
+                    isLast: true) {
+                    TextInput(text: vm.bindProfile($vm.vlmMtpDraftBlockSize),
+                              placeholder: "4", mono: true, width: 80)
+                }
             }
         }
     }
@@ -1178,6 +1214,17 @@ private struct ExperimentalSection: View {
                       defaultValue: "Multi-token prediction. Speeds generation when the model supports it.",
                       comment: "Default sublabel for the Native MTP toggle")
     }
+
+    private var vlmMtpToggleDisabled: Bool {
+        vm.vlmMtpConflictReason != nil
+    }
+
+    private var vlmMtpSublabel: String {
+        if let reason = vm.vlmMtpConflictReason { return reason }
+        return String(localized: "settings.experimental.vlm_mtp.sub",
+                      defaultValue: "Multi-token prediction for vision-language models via an assistant drafter.",
+                      comment: "Default sublabel for the VLM MTP toggle")
+    }
 }
 
 // MARK: - View model
@@ -1221,6 +1268,7 @@ final class ModelSettingsScreenVM: ObservableObject {
         case dflashEnabled, dflashDraftModel, dflashDraftQuantBits, dflashMaxCtx
         case dflashInMemoryCache, dflashInMemoryCacheGib, dflashSsdCache
         case mtpEnabled
+        case vlmMtpEnabled, vlmMtpDraftModel, vlmMtpDraftBlockSize
     }
 
     static var modelTypeOptions: [(String, String)] {
@@ -1395,6 +1443,12 @@ final class ModelSettingsScreenVM: ObservableObject {
     // Experimental: native MTP
     @Published var mtpEnabled: Bool = false
 
+    // Experimental: VLM MTP (assistant-drafter speculative decoding for VLMs).
+    // Block size is held as a string for the editor; empty = mlx-vlm default.
+    @Published var vlmMtpEnabled: Bool = false
+    @Published var vlmMtpDraftModel: String = ""
+    @Published var vlmMtpDraftBlockSize: String = ""
+
     // Profiles
     @Published var profiles: [ProfileDTO] = []
     @Published var templates: [ProfileDTO] = []
@@ -1511,6 +1565,9 @@ final class ModelSettingsScreenVM: ObservableObject {
                         .map(String.init) ?? "8"
                     self.dflashSsdCache = s.dflashSsdCache ?? false
                     self.mtpEnabled = s.mtpEnabled ?? false
+                    self.vlmMtpEnabled = s.vlmMtpEnabled ?? false
+                    self.vlmMtpDraftModel = s.vlmMtpDraftModel ?? ""
+                    self.vlmMtpDraftBlockSize = s.vlmMtpDraftBlockSize.map(String.init) ?? ""
                     self.activeProfileName = s.activeProfileName
                 }
             }
@@ -1636,6 +1693,9 @@ final class ModelSettingsScreenVM: ObservableObject {
             patch.dflashInMemoryCacheMaxBytes = DflashByteSize.gibToBytes(Int(dflashInMemoryCacheGib))
         case .dflashSsdCache:          patch.dflashSsdCache = dflashSsdCache
         case .mtpEnabled:              patch.mtpEnabled = mtpEnabled
+        case .vlmMtpEnabled:           patch.vlmMtpEnabled = vlmMtpEnabled
+        case .vlmMtpDraftModel:        patch.vlmMtpDraftModel = vlmMtpDraftModel.isEmpty ? nil : vlmMtpDraftModel
+        case .vlmMtpDraftBlockSize:    patch.vlmMtpDraftBlockSize = Int(vlmMtpDraftBlockSize)
         }
         do {
             _ = try await client.updateModelSettings(id: modelID, patch: patch)
@@ -1679,6 +1739,29 @@ final class ModelSettingsScreenVM: ObservableObject {
         return out
     }
 
+    /// Draft-model options for VLM MTP. mlx-vlm's MTP loop takes an
+    /// "assistant" drafter, so the picker filters to model ids containing
+    /// "assistant" (case-insensitive), matching the HTML editor's filter,
+    /// and drops the current model so it can't draft for itself.
+    ///
+    /// The stored value is the model **id**, not its path: the server
+    /// resolves the drafter by registry id (`engine_pool` looks it up in
+    /// `_entries` keyed by model_id, then uses that entry's `model_path`).
+    /// This matches the web modal, which binds `m.id`.
+    func vlmMtpDraftModelOptions() -> [(String, String)] {
+        var out: [(String, String)] = [
+            ("", String(localized: "settings.vlm_mtp.draft.placeholder",
+                        defaultValue: "Select assistant drafter…",
+                        comment: "Initial placeholder option in the VLM MTP draft-model picker")),
+        ]
+        for m in allModels
+        where m.id != modelID
+            && m.id.range(of: "assistant", options: .caseInsensitive) != nil {
+            out.append((m.id, m.id))
+        }
+        return out
+    }
+
     var isDSAConfigModel: Bool {
         guard let type = model?.configModelType else { return false }
         return Self.dsaConfigModelTypes.contains(type)
@@ -1696,6 +1779,38 @@ final class ModelSettingsScreenVM: ObservableObject {
             return String(localized: "settings.mtp.conflict.turboquant",
                           defaultValue: "Disable TurboQuant KV before enabling MTP.",
                           comment: "Tooltip / sublabel shown when MTP can't be enabled because TurboQuant KV is on")
+        }
+        if vlmMtpEnabled {
+            return String(localized: "settings.mtp.conflict.vlm_mtp",
+                          defaultValue: "Disable VLM MTP before enabling Native MTP.",
+                          comment: "Tooltip / sublabel shown when native MTP can't be enabled because VLM MTP is on")
+        }
+        return nil
+    }
+
+    /// VLM MTP wraps mlx-vlm's MTP loop and is mutually exclusive with the
+    /// other speculative-decoding / KV-quant features. Mirrors the HTML
+    /// editor's gating so the toggle disables itself and surfaces why.
+    var vlmMtpConflictReason: String? {
+        if dflashEnabled {
+            return String(localized: "settings.vlm_mtp.conflict.dflash",
+                          defaultValue: "Disable DFlash before enabling VLM MTP.",
+                          comment: "Tooltip / sublabel shown when VLM MTP can't be enabled because DFlash is on")
+        }
+        if specprefillEnabled {
+            return String(localized: "settings.vlm_mtp.conflict.specprefill",
+                          defaultValue: "Disable SpecPrefill before enabling VLM MTP.",
+                          comment: "Tooltip / sublabel shown when VLM MTP can't be enabled because SpecPrefill is on")
+        }
+        if mtpEnabled {
+            return String(localized: "settings.vlm_mtp.conflict.mtp",
+                          defaultValue: "Disable Native MTP before enabling VLM MTP.",
+                          comment: "Tooltip / sublabel shown when VLM MTP can't be enabled because native MTP is on")
+        }
+        if turboquantKvEnabled {
+            return String(localized: "settings.vlm_mtp.conflict.turboquant",
+                          defaultValue: "Disable TurboQuant KV before enabling VLM MTP.",
+                          comment: "Tooltip / sublabel shown when VLM MTP can't be enabled because TurboQuant KV is on")
         }
         return nil
     }
@@ -1788,6 +1903,11 @@ final class ModelSettingsScreenVM: ObservableObject {
             putBool(ProfileSettingsKey.dflashSsdCache, dflashSsdCache)
         }
         putBool(ProfileSettingsKey.mtpEnabled, mtpEnabled)
+        putBool(ProfileSettingsKey.vlmMtpEnabled, vlmMtpEnabled)
+        if vlmMtpEnabled {
+            putString(ProfileSettingsKey.vlmMtpDraftModel, vlmMtpDraftModel)
+            putInt(ProfileSettingsKey.vlmMtpDraftBlockSize, vlmMtpDraftBlockSize)
+        }
 
         return out
     }

--- a/apps/omlx-mac/Sources/AppView/Screens/ProfileViews.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ProfileViews.swift
@@ -696,7 +696,7 @@ struct ProfileDetailCard: View {
         // global templates; they only appear on per-model profiles.
         let accelKeys = [
             "turboquant_kv_enabled", "dflash_enabled", "mtp_enabled",
-            "specprefill_enabled", "index_cache_freq",
+            "specprefill_enabled", "index_cache_freq", "vlm_mtp_enabled",
         ]
         let hasAcceleration = accelKeys.contains { s[$0] != nil }
         let templateKeys = ["reasoning_parser", "chat_template_kwargs", "forced_ct_kwargs"]
@@ -889,6 +889,12 @@ struct ProfileDetailCard: View {
                 flagChip(label: String(localized: "profile.detail.acceleration.mtp",
                                        defaultValue: "Native MTP",
                                        comment: "Acceleration chip: native multi-token prediction"),
+                         on: on)
+            }
+            if let on = s["vlm_mtp_enabled"].flatMap({ boolOf($0) }) {
+                flagChip(label: String(localized: "profile.detail.acceleration.vlm_mtp",
+                                       defaultValue: "VLM MTP",
+                                       comment: "Acceleration chip: VLM multi-token prediction"),
                          on: on)
             }
             if let on = s["specprefill_enabled"].flatMap({ boolOf($0) }) {

--- a/apps/omlx-mac/Sources/AppView/Screens/ProfileWorkingState.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ProfileWorkingState.swift
@@ -134,6 +134,9 @@ enum ProfileSettingsKey {
     static let dflashInMemoryCacheMaxBytes = "dflash_in_memory_cache_max_bytes"
     static let dflashSsdCache = "dflash_ssd_cache"
     static let mtpEnabled = "mtp_enabled"
+    static let vlmMtpEnabled = "vlm_mtp_enabled"
+    static let vlmMtpDraftModel = "vlm_mtp_draft_model"
+    static let vlmMtpDraftBlockSize = "vlm_mtp_draft_block_size"
 }
 
 /// Resolves the *display* scope for the model's currently active profile.

--- a/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
@@ -99,6 +99,10 @@ struct ModelSettingsDTO: Codable, Equatable, Sendable {
     let dflashSsdCache: Bool?
     // Experimental: native MTP (mlx-lm PR 990 / PR 15 monkey-patch)
     let mtpEnabled: Bool?
+    // Experimental: VLM MTP (mlx-vlm assistant-drafter speculative decoding)
+    let vlmMtpEnabled: Bool?
+    let vlmMtpDraftModel: String?
+    let vlmMtpDraftBlockSize: Int?
 }
 
 /// Patch body for PUT /admin/api/models/{id}/settings. Flat snake-cased
@@ -148,6 +152,10 @@ struct ModelSettingsPatch: Encodable, Equatable, Sendable {
     var dflashSsdCache: Bool? = nil
     // Experimental: native MTP
     var mtpEnabled: Bool? = nil
+    // Experimental: VLM MTP
+    var vlmMtpEnabled: Bool? = nil
+    var vlmMtpDraftModel: String? = nil
+    var vlmMtpDraftBlockSize: Int? = nil
 }
 
 /// Generic acknowledgment shape returned by non-streaming admin endpoints


### PR DESCRIPTION
The 0.4.1 server and web dashboard already support VLM MTP (vlm_mtp_enabled / vlm_mtp_draft_model / vlm_mtp_draft_block_size), but the native app's Advanced page doesn't expose a toggle for it, so the feature can only be enabled from the web dashboard or by editing model_settings.json. This commit surfaces it in the native app, mirroring the existing Native MTP and DFlash plumbing: the settings DTO and patch body, the profile-eligible keys, the server load, profile-dict persistence, and a toggle row that reveals an assistant-drafter picker and a draft-block-size field when enabled.

Fixes #1648.