### PR TITLE
fix: Gemma 4 MoE multi-turn tool call corruption

### DIFF
--- a/omlx/adapter/gemma4.py
+++ b/omlx/adapter/gemma4.py
@@ -25,6 +25,17 @@ _LEADING_THOUGHT_RE = re.compile(
     re.DOTALL,
 )
 
+# Matches the STRAY bare-token spellings (<|tool_call> and <tool_call|>),
+# not the template's well-formed closing form (</tool_call|> with slash).
+_PROTOCOL_MARKER_RE = re.compile(r"<\|tool_call>|<tool_call\|>")
+
+
+def _strip_protocol_markers(text: Any) -> Any:
+    """Remove stray <|tool_call> / <tool_call|> tokens from assistant content."""
+    if not isinstance(text, str) or not text:
+        return text
+    return _PROTOCOL_MARKER_RE.sub("", text)
+
 
 def _try_parse_json(s: str) -> Any:
     """Parse string as JSON if possible, otherwise return as-is."""
@@ -172,6 +183,7 @@ def extract_gemma4_messages(
             # Per Gemma 4's multi-turn rule, prior thought blocks must not
             # be fed back into the next turn. Strip them before rendering.
             content = _strip_thinking(content)
+            content = _strip_protocol_markers(content)
 
             out_msg: dict = {"role": "assistant", "content": content or ""}
 

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -845,6 +845,10 @@ class ToolCallStreamFilter:
         # Same for suppress-after markers (e.g. "[TOOL" for "[TOOL_CALLS]").
         for sa_marker in self._suppress_after_markers:
             keep = max(keep, self._partial_prefix_len(text, sa_marker))
+        # Hold partial prefix of a stray-close marker so it reassembles before
+        # the strip check — prevents the "hello<tool_call|" + ">" split leak.
+        for close_marker in self._stray_close_markers:
+            keep = max(keep, self._partial_prefix_len(text, close_marker))
 
         bracket_idx = -1
         for bp in self._bracket_prefixes:
@@ -1010,9 +1014,6 @@ class ToolCallStreamFilter:
             self._buffer = ""
             if self._should_drop_tail_at_finish(tail):
                 return ""
-            for close in self._stray_close_markers:
-                if close in tail:
-                    tail = tail.replace(close, "")
             return tail
 
         if keep:

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -734,6 +734,9 @@ class ToolCallStreamFilter:
                 # One-sided markers (e.g. Mistral "[TOOL_CALLS]" with no
                 # end marker): suppress everything after the start marker.
                 self._suppress_after_markers.append(marker)
+        # Scoped to the configured pair only (not the hardcoded fallback) to
+        # avoid clobbering literal </tool_call> in prose output.
+        self._stray_close_markers: List[str] = [marker_end] if marker and marker_end else []
         self._namespaced_open_re = re.compile(r"<([A-Za-z_][\w.-]*):tool_call>")
         self._bracket_prefixes = ["[Calling tool:", "[Tool call:"]
         self._bracket_call_re = re.compile(
@@ -984,7 +987,11 @@ class ToolCallStreamFilter:
                 self._buffer = self._buffer[-keep:]
             break
 
-        return "".join(out)
+        result = "".join(out)
+        for close in self._stray_close_markers:
+            if close in result:
+                result = result.replace(close, "")
+        return result
 
     def finish(self) -> str:
         """Flush remaining safe buffer content.
@@ -1003,6 +1010,9 @@ class ToolCallStreamFilter:
             self._buffer = ""
             if self._should_drop_tail_at_finish(tail):
                 return ""
+            for close in self._stray_close_markers:
+                if close in tail:
+                    tail = tail.replace(close, "")
             return tail
 
         if keep:
@@ -1010,6 +1020,9 @@ class ToolCallStreamFilter:
         else:
             buf = self._buffer
         self._buffer = ""
+        for close in self._stray_close_markers:
+            if close in buf:
+                buf = buf.replace(close, "")
         return buf
 
 

--- a/tests/test_gemma4_messages.py
+++ b/tests/test_gemma4_messages.py
@@ -245,6 +245,41 @@ class TestExtractGemma4Messages:
         assert "tool_calls" in result[0]
         assert result[0]["tool_calls"][0]["function"]["name"] == "search"
 
+    def test_stray_tool_call_close_marker_stripped_from_content(self):
+        """Stray ``<tool_call|>`` in content is stripped; tool_calls are preserved."""
+        msg = Message(
+            role="assistant",
+            content="<tool_call|>",
+            tool_calls=[_tool_call_dict("c1", "search")],
+        )
+        result = extract_gemma4_messages([msg])
+        assert result[0]["content"] == ""
+        assert "tool_calls" in result[0]
+
+    def test_stray_tool_call_open_marker_stripped_from_content(self):
+        """A bare ``<|tool_call>`` in assistant content is stripped; void message dropped."""
+        msg = Message(role="assistant", content="<|tool_call>")
+        result = extract_gemma4_messages([msg])
+        assert result == []
+
+    def test_stray_markers_stripped_leaving_surrounding_prose(self):
+        """Prose surrounding a stray marker is preserved; only the marker is removed."""
+        msg = Message(role="assistant", content="Here is the result.<tool_call|>")
+        result = extract_gemma4_messages([msg])
+        assert result[0]["content"] == "Here is the result."
+
+    def test_multiple_stray_markers_stripped_from_prose(self):
+        """Multiple stray markers in prose are all removed."""
+        msg = Message(role="assistant", content="Part 1.<tool_call|>Part 2.<tool_call|>")
+        result = extract_gemma4_messages([msg])
+        assert result[0]["content"] == "Part 1.Part 2."
+
+    def test_both_stray_markers_stripped_together(self):
+        """Both open and close markers removed; resulting void message is dropped."""
+        msg = Message(role="assistant", content="<|tool_call><tool_call|>")
+        result = extract_gemma4_messages([msg])
+        assert result == []
+
 
 class TestStripThinking:
     """``_strip_thinking`` removes leading thought blocks only."""

--- a/tests/test_gemma4_rendering.py
+++ b/tests/test_gemma4_rendering.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests: Gemma 4 chat-template rendering with real tokenizer.
+
+Skipped when the Gemma 4 26B model is not present at MODEL_PATH.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+
+import pytest
+
+from omlx.adapter.gemma4 import extract_gemma4_messages
+from omlx.api.openai_models import Message
+
+
+def _find_gemma4_26b_model() -> str | None:
+    pattern = os.path.join(
+        os.path.expanduser("~"), ".omlx", "models", "gemma-4-26B-A4B-it*"
+    )
+    matches = [p for p in glob.glob(pattern) if os.path.isdir(p)]
+    return matches[0] if matches else None
+
+
+MODEL_PATH = _find_gemma4_26b_model()
+
+pytestmark = pytest.mark.skipif(
+    MODEL_PATH is None, reason="No gemma-4-26B-A4B-it* model found in ~/.omlx/models/"
+)
+
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+_TC = {
+    "id": "c1",
+    "type": "function",
+    "function": {"name": "get_weather", "arguments": "{}"},
+}
+
+
+def _load_tokenizer():
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained(MODEL_PATH)
+
+
+def _render(messages, tools=None):
+    tok = _load_tokenizer()
+    return tok.apply_chat_template(
+        messages, tools=tools, tokenize=False, add_generation_prompt=True
+    )
+
+
+def _marker_counts(rendered: str) -> tuple[int, int]:
+    return rendered.count("<|tool_call>"), rendered.count("<tool_call|>")
+
+
+class TestGemma4TemplateRendering:
+    def test_clean_history_renders_balanced(self):
+        """Clean multi-turn tool call → balanced <|tool_call> / <tool_call|>."""
+        openai_msgs = [
+            Message(role="user", content="What's the weather?"),
+            Message(role="assistant", content="", tool_calls=[_TC]),
+            Message(role="tool", content="sunny", tool_call_id="c1"),
+        ]
+        processed = extract_gemma4_messages(openai_msgs)
+        rendered = _render(processed, tools=_TOOLS)
+        opens, closes = _marker_counts(rendered)
+        assert opens == closes, f"imbalanced: opens={opens} closes={closes}"
+        assert opens >= 1
+
+    def test_stray_close_marker_in_content_causes_imbalance(self):
+        """Stray <tool_call|> in assistant content renders an extra close token.
+
+        This test documents the bug: when the client stores the stray marker
+        verbatim and feeds it back without sanitisation, the template embeds
+        it as a real special token, producing opens != closes.
+        """
+        raw_msgs = [
+            {"role": "user", "content": "What's the weather?"},
+            {"role": "assistant", "content": "", "tool_calls": [_TC]},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_responses": [{"name": "get_weather", "response": "sunny"}],
+            },
+            {"role": "user", "content": "Thanks"},
+            # The model generated only <tool_call|> on its next turn; the client
+            # stored it verbatim.
+            {"role": "assistant", "content": "<tool_call|>"},
+        ]
+        rendered = _render(raw_msgs, tools=_TOOLS)
+        opens, closes = _marker_counts(rendered)
+        assert opens != closes, (
+            f"Expected imbalance but got opens={opens} closes={closes}. "
+            "Bug may no longer reproduce with this model/template version."
+        )
+
+    def test_extract_gemma4_messages_fixes_imbalance(self):
+        """extract_gemma4_messages strips the stray marker → balanced rendering."""
+        openai_msgs = [
+            Message(role="user", content="What's the weather?"),
+            Message(role="assistant", content="", tool_calls=[_TC]),
+            Message(role="tool", content="sunny", tool_call_id="c1"),
+            Message(role="user", content="Thanks"),
+            Message(role="assistant", content="<tool_call|>"),
+        ]
+        processed = extract_gemma4_messages(openai_msgs)
+        rendered = _render(processed, tools=_TOOLS)
+        opens, closes = _marker_counts(rendered)
+        assert opens == closes, (
+            f"Still imbalanced after fix: opens={opens} closes={closes}"
+        )

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -2018,3 +2018,82 @@ class TestSerializeToolCallArguments:
             result = _serialize_tool_call_arguments("[1, 2]")
         assert result == "{}"
         assert any("non-dict" in r.message for r in caplog.records)
+
+
+class TestToolCallStreamFilterGemma4StrayClose:
+    """Stray closing-marker suppression for Gemma 4 <|tool_call>/<tool_call|>."""
+
+    def _make_filter(self):
+        return ToolCallStreamFilter(
+            _make_tokenizer_with_end("<|tool_call>", "<tool_call|>")
+        )
+
+    def test_stray_close_marker_alone_dropped(self):
+        """Bare <tool_call|> with no preceding open is suppressed."""
+        f = self._make_filter()
+        result = f.feed("<tool_call|>")
+        result += f.finish()
+        assert result == ""
+
+    def test_stray_close_after_text_dropped(self):
+        """Text before a stray close passes through; the close itself is dropped."""
+        f = self._make_filter()
+        result = f.feed("hello<tool_call|>")
+        result += f.finish()
+        assert result == "hello"
+
+    def test_stray_close_split_across_feeds_dropped(self):
+        """Stray close split across two feed() calls is dropped."""
+        f = self._make_filter()
+        r1 = f.feed("<tool_call")
+        r2 = f.feed("|>")
+        result = r1 + r2 + f.finish()
+        assert result == ""
+
+    def test_normal_open_close_pair_still_suppressed(self):
+        """Regression: a valid open/close pair is still fully suppressed."""
+        f = self._make_filter()
+        result = f.feed('<|tool_call>call:search{"q":"test"}<tool_call|>')
+        result += f.finish()
+        assert result == ""
+
+    def test_multiple_stray_closes_in_one_delta_all_dropped(self):
+        """Multiple stray close tokens in a single delta are all removed."""
+        f = self._make_filter()
+        result = f.feed("a<tool_call|>b<tool_call|>c")
+        result += f.finish()
+        assert result == "abc"
+
+    def test_default_xml_close_in_prose_passes_through(self):
+        """Prose containing </tool_call> (hardcoded fallback pair) is not stripped.
+
+        The stray-close strip is scoped to the tokenizer-configured marker only.
+        A model discussing XML tag syntax must not have its output corrupted.
+        """
+        f = self._make_filter()
+        result = f.feed("The closing tag is </tool_call> here.")
+        result += f.finish()
+        assert result == "The closing tag is </tool_call> here."
+
+    def test_stray_close_split_after_pipe_dropped(self):
+        """Stray close split at the | boundary (<tool_call| + >) is reassembled and dropped."""
+        f = self._make_filter()
+        r1 = f.feed("<tool_call|")
+        r2 = f.feed(">")
+        result = r1 + r2 + f.finish()
+        assert result == ""
+
+    def test_stray_close_split_after_pipe_with_prose_dropped(self):
+        """Prose-wrapped stray close split at the | boundary: prose passes, marker dropped."""
+        f = self._make_filter()
+        r1 = f.feed("hello<tool_call|")
+        r2 = f.feed("> world")
+        result = r1 + r2 + f.finish()
+        assert result == "hello world"
+
+    def test_valid_pair_plus_stray_close_in_same_delta(self):
+        """Valid open/close pair suppressed; trailing stray close in same delta dropped."""
+        f = self._make_filter()
+        result = f.feed('<|tool_call>call()<tool_call|> extra<tool_call|>')
+        result += f.finish()
+        assert result == " extra"


### PR DESCRIPTION
👋 First time contribution for me! Please let me know if you'd like to see stuff changed on this changeset, I'm happy to work with you all. Been loving oMLX for weeks now, figured it was time to give back.

## Problem domain

Multi-turn tool-calling conversations with Gemma 4 26B A4B were breaking on the second and later turns. Stray protocol tokens (`<|tool_call>`, `<tool_call|>`) were leaking from the streaming layer into the assistant message content. When that message was getting fed back through `apply_chat_template`, the tokens got treated as real special tokens, producing unbalanced delimiters that corrupt the model's context for all subsequent turns.

This PR fixes that by identifying and stripping stray closing markers in `tool_calling.py`, and sanitizes the `content` in Gemma 4 runs before re-rendering conversation history.

## Root cause(s)

1. `ToolCallStreamFilter` didn't strip stray close markers.
    + A `<tool_call|>` emitted outside a matched open/close pair passed through unfiltered
    + If the tokenizer split it across two feed calls (`<tool_call|` then `>`), the buffer would also flush each half immediately rather than holding them for reassembly
1. `extract_gemma4_messages` didn't sanitize content before re-rendering history.
    + Any marker that survived the streaming pass was embedded verbatim into the next turn's prompt

## How to reproduce

1. Load any Gemma 4 26B A4B model with at least one tool defined.
1. Send a request that causes a tool call.
1. Append the tool result and send a follow-up turn.
1. Observe incoherent output or tool use failure on turn 2+. Verbose prompt logging will show `<tool_call|>` embedded literally in the rendered prompt.

## Edge cases considered

- Split-feed: `<tool_call|>` split as `<tool_call| + >` across two `feed()` calls
    + Fixed by adding stray-close markers to the partial-prefix hold logic
- Well-formed `</tool_call>` in prose: The strip is scoped to the bare stray tokens only (no leading slash), so legitimate closing tags in prose are untouched
- Prose around a marker: The regex removes only the token
    + "Here is the result.<tool_call|>" becomes "Here is the result."

## Issues to close

This ought to finally close #617, which I was getting bit by. It might also close #1465 and/or #1410, but I'm not sure about that; those users should try re-testing if/when this makes it into `main`.