### PR TITLE
Fix engine-pool acquire-vs-use eviction race (#1667) + active-request counter leak (#1595)

### DIFF
--- a/omlx/engine/base.py
+++ b/omlx/engine/base.py
@@ -271,6 +271,19 @@ class BaseNonStreamingEngine(ABC):
         with self._active_lock:
             return self._active_count > 0
 
+    def _reset_activity_tracking(self) -> None:
+        """Clear the in-flight activity counter + records on engine teardown.
+
+        #1595: the memory-enforcer's immediate-abort eviction stops the engine WITHOUT
+        running the normal per-request completion callbacks (_end_activity), so the
+        ``_active_count`` atomic counter can be left non-zero. That phantom 'busy' count
+        both corrupts the status API and (via has_active_requests()) can make a stale
+        engine look permanently non-evictable. Called from EnginePool._unload_engine().
+        """
+        with self._active_lock:
+            self._active_count = 0
+            self._activities.clear()
+
     _ACTIVITY_RESERVED_KEYS = {
         "request_id",
         "kind",

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -17,6 +17,7 @@ import asyncio
 import gc
 import logging
 import time
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
@@ -69,6 +70,7 @@ class EngineEntry:
     loading_started_at: float | None = None  # Timestamp when current load started
     is_pinned: bool = False  # Never evict if True
     abort_loading: bool = False  # Set by memory enforcer to abort in-progress load
+    in_use: int = 0  # in-flight acquire/use lease count; never evict while > 0
 
 
 class EnginePool:
@@ -329,6 +331,7 @@ class EnginePool:
         self,
         model_id: str,
         force_lm: bool = False,
+        _lease: bool = False,
     ) -> (
         BaseEngine
         | EmbeddingEngine
@@ -377,6 +380,8 @@ class EnginePool:
                     await self._unload_engine(model_id)
                 else:
                     entry.last_access = time.time()
+                    if _lease:
+                        entry.in_use += 1
                     return entry.engine
 
             # Pre-load admission against the memory ceiling from the
@@ -428,7 +433,31 @@ class EnginePool:
             # Now load the model
             await self._load_engine(model_id, force_lm=force_lm)
 
-            return self._entries[model_id].engine
+            loaded = self._entries[model_id]
+            if _lease:
+                loaded.in_use += 1
+            return loaded.engine
+
+    async def release_engine(self, model_id: str) -> None:
+        """Release one in-use lease previously taken via get_engine(_lease=True)."""
+        async with self._lock:
+            e = self._entries.get(model_id)
+            if e is not None and e.in_use > 0:
+                e.in_use -= 1
+
+    @asynccontextmanager
+    async def acquire(self, model_id: str, force_lm: bool = False):
+        """Acquire an engine with an atomic in-use lease.
+
+        The lease is taken under the pool lock at acquire time and always
+        released in finally, so the engine cannot be evicted mid-request even
+        on exception.
+        """
+        engine = await self.get_engine(model_id, force_lm=force_lm, _lease=True)
+        try:
+            yield engine
+        finally:
+            await self.release_engine(model_id)
 
     def _find_lru_victim(self) -> str | None:
         """
@@ -443,6 +472,8 @@ class EnginePool:
         candidates = []
         for mid, e in self._entries.items():
             if e.engine is None or e.is_pinned:
+                continue
+            if e.in_use > 0:
                 continue
             try:
                 if e.engine.has_active_requests():
@@ -468,7 +499,7 @@ class EnginePool:
 
     def _is_idle_for_prefill_eviction(self, entry: EngineEntry) -> bool:
         engine = entry.engine
-        if engine is None or entry.is_pinned or entry.is_loading:
+        if engine is None or entry.is_pinned or entry.is_loading or entry.in_use > 0:
             return False
         try:
             if engine.has_active_requests():
@@ -570,6 +601,17 @@ class EnginePool:
             await entry.engine.stop()
         except Exception as e:
             logger.warning(f"Error stopping engine for {model_id}: {e}")
+
+        # #1595: the immediate-abort stop() above tears the engine down without the normal
+        # per-request completion callbacks, so a non-streaming engine's active_requests
+        # counter can leak a phantom count (a stale engine then looks permanently busy).
+        # Reset it on teardown so has_active_requests() and the status API stay consistent.
+        reset = getattr(entry.engine, "_reset_activity_tracking", None)
+        if callable(reset):
+            try:
+                reset()
+            except Exception as e:
+                logger.warning(f"Error resetting activity counter for {model_id}: {e}")
 
         # Yield to the event loop before dropping the engine reference.
         #
@@ -1182,7 +1224,7 @@ class EnginePool:
                     continue
 
                 # Check if model has active requests
-                has_active = entry.engine.has_active_requests()
+                has_active = entry.engine.has_active_requests() or entry.in_use > 0
 
                 if has_active:
                     entry.last_access = now

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -661,6 +661,8 @@ app.add_middleware(DebugRequestLoggingMiddleware)
 async def get_engine(
     model_id: str | None = None,
     engine_type: EngineType = EngineType.LLM,
+    _lease: bool = False,
+    _leased_out: list | None = None,
 ) -> Union[BaseEngine, EmbeddingEngine, RerankerEngine]:
     """
     Get engine for the specified model and type.
@@ -670,6 +672,13 @@ async def get_engine(
     Args:
         model_id: Model ID to get engine for, or None for default (LLM only)
         engine_type: Type of engine to retrieve (LLM, EMBEDDING, or RERANKER)
+        _lease: When True, take an atomic in-use lease on the engine that the
+            pool actually loaded (eviction-proof until released). The caller
+            MUST release exactly one lease per successful leased call.
+        _leased_out: When _lease is True, the EXACT pool model_id that was
+            leased is appended to this list. Release using that id (not the
+            request model) so the lease/release ids always match even when the
+            pool falls back to the default model.
 
     Returns:
         The loaded engine of the appropriate type
@@ -697,8 +706,14 @@ async def get_engine(
     # Resolve alias to real model_id
     model_id = pool.resolve_model_id(model_id, _server_state.settings_manager)
 
+    # Only thread the _lease kwarg through when a lease is actually requested,
+    # so the common non-lease path keeps the original pool.get_engine(model_id)
+    # call contract (LLM/STT/TTS/STS handlers, and pool mocks, never lease).
+    _lease_kwargs = {"_lease": True} if _lease else {}
     try:
-        engine = await pool.get_engine(model_id)
+        engine = await pool.get_engine(model_id, **_lease_kwargs)
+        if _lease and _leased_out is not None:
+            _leased_out.append(model_id)
     except ModelNotFoundError as e:
         # Fallback to default model if enabled (LLM only)
         if (
@@ -712,7 +727,12 @@ async def get_engine(
                 f"default model '{_server_state.default_model}'"
             )
             try:
-                return await pool.get_engine(_server_state.default_model)
+                fb_engine = await pool.get_engine(
+                    _server_state.default_model, **_lease_kwargs
+                )
+                if _lease and _leased_out is not None:
+                    _leased_out.append(_server_state.default_model)
+                return fb_engine
             except Exception:
                 pass  # Fall through to original 404
 
@@ -739,35 +759,42 @@ async def get_engine(
     except EnginePoolError as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-    # Validate engine type
-    if engine_type == EngineType.EMBEDDING:
-        if not isinstance(engine, EmbeddingEngine):
-            raise HTTPException(
-                status_code=400,
-                detail=f"Model '{model_id}' is not an embedding model. "
-                f"Use /v1/chat/completions for LLM models."
-            )
-    elif engine_type == EngineType.RERANKER:
-        if not isinstance(engine, RerankerEngine):
-            raise HTTPException(
-                status_code=400,
-                detail=f"Model '{model_id}' is not a reranker model. "
-                f"Use a SequenceClassification model for reranking."
-            )
-    elif engine_type == EngineType.LLM:
-        # #507: non-LLM engines (STT/TTS/STS/Embedding/Reranker) previously
-        # fell through and crashed on `engine.model_type` with an unhandled
-        # 500. Reject with a clear 400 pointing the caller at the right
-        # endpoint.
-        if not isinstance(engine, BaseEngine):
-            _endpoint_hint = _suggest_endpoint_for_engine(engine)
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"Model '{model_id}' is not an LLM / chat model. "
-                    f"{_endpoint_hint}"
-                ),
-            )
+    # Validate engine type. If a lease was taken above but validation fails,
+    # release it before raising so a rejected request never leaks an in_use
+    # count (which would pin the engine non-evictable forever).
+    try:
+        if engine_type == EngineType.EMBEDDING:
+            if not isinstance(engine, EmbeddingEngine):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Model '{model_id}' is not an embedding model. "
+                    f"Use /v1/chat/completions for LLM models."
+                )
+        elif engine_type == EngineType.RERANKER:
+            if not isinstance(engine, RerankerEngine):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Model '{model_id}' is not a reranker model. "
+                    f"Use a SequenceClassification model for reranking."
+                )
+        elif engine_type == EngineType.LLM:
+            # #507: non-LLM engines (STT/TTS/STS/Embedding/Reranker) previously
+            # fell through and crashed on `engine.model_type` with an unhandled
+            # 500. Reject with a clear 400 pointing the caller at the right
+            # endpoint.
+            if not isinstance(engine, BaseEngine):
+                _endpoint_hint = _suggest_endpoint_for_engine(engine)
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Model '{model_id}' is not an LLM / chat model. "
+                        f"{_endpoint_hint}"
+                    ),
+                )
+    except BaseException:
+        if _lease and _leased_out:
+            await pool.release_engine(_leased_out.pop())
+        raise
 
     return engine
 
@@ -854,6 +881,43 @@ async def get_reranker_engine(model: str) -> RerankerEngine:
         HTTPException: If model not found, is not a reranker model, or memory error
     """
     return await get_engine(model, EngineType.RERANKER)
+
+
+@asynccontextmanager
+async def acquire_embedding_engine(model: str):
+    """Acquire an embedding engine with an atomic, eviction-proof in-use lease.
+
+    Resolves + loads + validates exactly like get_embedding_engine, but holds
+    the engine non-evictable for the duration of the request and releases the
+    lease on the EXACT pool model_id the pool loaded (handles default-model
+    fallback) in finally.
+    """
+    leased: list = []
+    engine = await get_engine(
+        model, EngineType.EMBEDDING, _lease=True, _leased_out=leased
+    )
+    try:
+        yield engine
+    finally:
+        if leased:
+            await get_engine_pool().release_engine(leased[0])
+
+
+@asynccontextmanager
+async def acquire_reranker_engine(model: str):
+    """Acquire a reranker engine with an atomic, eviction-proof in-use lease.
+
+    See acquire_embedding_engine for the lease/release contract.
+    """
+    leased: list = []
+    engine = await get_engine(
+        model, EngineType.RERANKER, _lease=True, _leased_out=leased
+    )
+    try:
+        yield engine
+    finally:
+        if leased:
+            await get_engine_pool().release_engine(leased[0])
 
 
 def get_sampling_params(
@@ -1840,7 +1904,11 @@ async def create_embeddings(
             detail="Server is busy with oQ quantization. Please try again after quantization completes.",
         )
 
-    engine = await get_embedding_engine(request.model)
+    # Validate the model up front (resolves + loads + type-checks) so a bad
+    # model still 400/404s before we start the streaming response. The actual
+    # eviction-proof lease is taken inside _build_embeddings, which is where
+    # the engine is used (the StreamingResponse runs that coroutine later).
+    await get_embedding_engine(request.model)
 
     if request.items is not None:
         embedding_inputs = normalize_embedding_items(request.items)
@@ -1855,7 +1923,8 @@ async def create_embeddings(
     async def _build_embeddings():
         start_time = time.perf_counter()
         try:
-            output = await engine.embed(embedding_inputs)
+            async with acquire_embedding_engine(request.model) as engine:
+                output = await engine.embed(embedding_inputs)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except TypeError as e:
@@ -1959,7 +2028,9 @@ async def create_rerank(
             detail="Server is busy with oQ quantization. Please try again after quantization completes.",
         )
 
-    engine = await get_reranker_engine(request.model)
+    # Validate the model up front (resolves + loads + type-checks). The
+    # eviction-proof lease is held only around the actual rerank() call below.
+    await get_reranker_engine(request.model)
 
     # Preserve original structure for the engine (multimodal rerankers need
     # dicts with 'image'), but keep a normalized text view for logging and
@@ -1976,11 +2047,12 @@ async def create_rerank(
     # Perform reranking
     start_time = time.perf_counter()
 
-    output = await engine.rerank(
-        query=request.query,
-        documents=documents_raw,
-        top_n=request.top_n,
-    )
+    async with acquire_reranker_engine(request.model) as engine:
+        output = await engine.rerank(
+            query=request.query,
+            documents=documents_raw,
+            top_n=request.top_n,
+        )
 
     elapsed = time.perf_counter() - start_time
     logger.info(

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -282,7 +282,9 @@ class MockEnginePool:
             "max_model_memory": self.max_model_memory,
         }
 
-    async def get_engine(self, model_id: str):
+    async def get_engine(self, model_id: str, _lease: bool = False):
+        # _lease mirrors the real EnginePool's acquire-vs-use lease (#1667);
+        # the mock has no eviction so it just accepts the flag.
         # Return appropriate engine based on model name pattern
         if "embed" in model_id.lower():
             if self._embedding_engine:
@@ -293,6 +295,10 @@ class MockEnginePool:
                 return self._reranker_engine
             raise ValueError(f"No reranker engine for {model_id}")
         return self._llm_engine
+
+    async def release_engine(self, model_id: str) -> None:
+        # No-op release counterpart of the in-use lease (#1667).
+        return None
 
 
 @pytest.fixture

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -1709,3 +1709,210 @@ class TestMemorySettleBarrier:
 
         assert pool._entries["model-a"].engine is None
         assert pool._current_model_memory == 0
+
+
+class TestEnginePoolInUseLease:
+    """Tests for the acquire-vs-use in-use lease (#1667).
+
+    The memory enforcer must never evict an engine that a request has
+    acquired but not yet registered activity on. The lease is taken under the
+    pool lock at acquire time and skipped by every eviction path, in addition
+    to the existing has_active_requests() gate.
+    """
+
+    @staticmethod
+    def _loaded_entry(model_id: str, last_access: float = 0.0) -> EngineEntry:
+        engine = MagicMock()
+        engine.has_active_requests.return_value = False  # looks idle
+        engine.stop = AsyncMock()
+        # Mirror TestEnginePoolPrefillEviction: no scheduler → prefill-idle.
+        engine.scheduler = None
+        engine._engine = None
+        return EngineEntry(
+            model_id=model_id,
+            model_path=f"/models/{model_id}",
+            model_type="embedding",
+            engine_type="embedding",
+            estimated_size=1024,
+            engine=engine,
+            last_access=last_access,
+        )
+
+    def test_engine_entry_in_use_default_zero(self):
+        """EngineEntry exposes an in_use lease counter defaulting to 0."""
+        entry = EngineEntry(
+            model_id="x",
+            model_path="/p",
+            model_type="embedding",
+            engine_type="embedding",
+            estimated_size=1,
+        )
+        assert entry.in_use == 0
+
+    def test_find_lru_victim_skips_in_use_engine(self):
+        """An idle-looking engine with in_use > 0 must not be an LRU victim."""
+        pool = _make_pool(ceiling=0)
+        pool._entries = {
+            "leased": self._loaded_entry("leased", last_access=1.0),  # oldest
+            "free": self._loaded_entry("free", last_access=2.0),
+        }
+        pool._entries["leased"].in_use = 1
+
+        victim = pool._find_lru_victim()
+        # Without the lease the older "leased" would be picked; lease forces "free".
+        assert victim == "free"
+
+    def test_find_lru_victim_none_when_only_in_use(self):
+        """If the only loaded engine is leased, there is no LRU victim."""
+        pool = _make_pool(ceiling=0)
+        pool._entries = {"leased": self._loaded_entry("leased", last_access=1.0)}
+        pool._entries["leased"].in_use = 2
+
+        assert pool._find_lru_victim() is None
+
+    def test_is_idle_for_prefill_eviction_skips_in_use(self):
+        """Prefill-pressure eviction must skip a leased (in_use > 0) engine."""
+        pool = _make_pool(ceiling=0)
+        entry = self._loaded_entry("leased")
+        # Idle-looking → would be evictable, but the lease blocks it.
+        assert pool._is_idle_for_prefill_eviction(entry) is True
+        entry.in_use = 1
+        assert pool._is_idle_for_prefill_eviction(entry) is False
+
+    @pytest.mark.asyncio
+    async def test_check_ttl_expirations_skips_in_use(self):
+        """TTL eviction must not unload a leased engine even when idle past TTL."""
+        pool = _make_pool(ceiling=0)
+        entry = self._loaded_entry("leased", last_access=100.0)
+        entry.in_use = 1
+        pool._entries = {"leased": entry}
+
+        settings_manager = MagicMock()
+        settings = MagicMock()
+        settings.ttl_seconds = 60
+        settings_manager.get_settings.return_value = settings
+
+        with patch("time.time", return_value=200.0):  # 100s idle > 60s TTL
+            expired = await pool.check_ttl_expirations(settings_manager)
+
+        assert expired == []
+        assert pool._entries["leased"].engine is not None
+        # in_use counts as activity → last_access refreshed
+        assert pool._entries["leased"].last_access == 200.0
+
+    @pytest.mark.asyncio
+    async def test_release_engine_floors_at_zero(self):
+        """release_engine decrements under lock and never goes below 0."""
+        pool = _make_pool(ceiling=0)
+        entry = self._loaded_entry("leased")
+        entry.in_use = 1
+        pool._entries = {"leased": entry}
+
+        await pool.release_engine("leased")
+        assert entry.in_use == 0
+        # Extra release is a no-op (floor at 0), not a negative count.
+        await pool.release_engine("leased")
+        assert entry.in_use == 0
+        # Unknown model id is a harmless no-op.
+        await pool.release_engine("nope")
+
+    @pytest.mark.asyncio
+    async def test_acquire_leases_then_releases_on_success(self):
+        """acquire() leases on enter and releases in finally on normal exit."""
+        pool = _make_pool(ceiling=0)
+        entry = self._loaded_entry("model-a")
+        pool._entries = {"model-a": entry}
+
+        async with pool.acquire("model-a") as engine:
+            assert engine is entry.engine
+            assert entry.in_use == 1  # leased while in use
+        assert entry.in_use == 0  # released on exit
+
+    @pytest.mark.asyncio
+    async def test_acquire_releases_lease_on_exception(self):
+        """acquire() releases the lease even if the body raises."""
+        pool = _make_pool(ceiling=0)
+        entry = self._loaded_entry("model-a")
+        pool._entries = {"model-a": entry}
+
+        with pytest.raises(RuntimeError, match="boom"):
+            async with pool.acquire("model-a"):
+                assert entry.in_use == 1
+                raise RuntimeError("boom")
+        assert entry.in_use == 0  # no leaked lease
+
+
+class TestResetActivityTracking:
+    """Tests for BaseNonStreamingEngine._reset_activity_tracking (#1595)."""
+
+    @staticmethod
+    def _engine():
+        from omlx.engine.base import BaseNonStreamingEngine
+
+        class DummyEngine(BaseNonStreamingEngine):
+            @property
+            def model_name(self):
+                return "dummy"
+
+            async def start(self):
+                pass
+
+            async def stop(self):
+                pass
+
+            def get_stats(self):
+                return {}
+
+        return DummyEngine()
+
+    def test_reset_clears_leaked_counter_and_activities(self):
+        """Reset zeros a leaked _active_count and clears _activities.
+
+        Mirrors the immediate-abort eviction case where stop() runs without
+        the per-request completion callbacks, leaving a phantom busy count.
+        """
+        engine = self._engine()
+        with engine._active_lock:
+            engine._active_count = 2
+            engine._activities = {"a": {}, "b": {}}
+        assert engine.has_active_requests() is True  # phantom busy
+
+        engine._reset_activity_tracking()
+
+        assert engine._active_count == 0
+        assert engine._activities == {}
+        assert engine.has_active_requests() is False
+
+    @pytest.mark.asyncio
+    async def test_unload_engine_calls_reset_on_teardown(self):
+        """EnginePool._unload_engine resets activity tracking after stop()."""
+        pool = _make_pool(ceiling=0)
+        engine = self._engine()
+        with engine._active_lock:
+            engine._active_count = 1  # leaked phantom busy
+        entry = EngineEntry(
+            model_id="model-a",
+            model_path="/models/model-a",
+            model_type="embedding",
+            engine_type="embedding",
+            estimated_size=1024,
+            engine=engine,
+            last_access=0.0,
+        )
+        pool._entries = {"model-a": entry}
+        pool._current_model_memory = entry.estimated_size
+
+        with (
+            patch("omlx.engine_pool.mx") as mock_mx,
+            patch("omlx.engine_pool.get_mlx_executor", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_mx.get_active_memory = MagicMock(return_value=0)
+            mock_mx.synchronize = MagicMock()
+            mock_mx.clear_cache = MagicMock()
+
+            await pool._unload_engine("model-a")
+
+        # Teardown reset the leaked counter (getattr-guarded reset called).
+        assert engine._active_count == 0
+        assert engine.has_active_requests() is False


### PR DESCRIPTION
## Summary

Fixes two related memory-enforcer bugs that intermittently 500 `/v1/embeddings` and `/v1/rerank` with:

```
RuntimeError: Engine not started. Call start() first.
```

Both stem from the same gap: eviction is gated only by `has_active_requests()`, which is blind during the window between acquiring an engine and registering activity on it.

Fixes #1667. Closely related to #1595 (this PR also defuses it).

### Bug A — acquire-vs-use eviction race (#1667)

`EnginePool.get_engine()` returns the engine handle, then releases the pool lock. The request handler then runs **outside** the lock (`engine = await get_embedding_engine(...)` ... later `await engine.embed(...)`). For the non-streaming engines (embedding/reranker), the in-use signal (`_active_count` via `_begin_activity`) is registered only **after** the `if self._model is None: raise RuntimeError("Engine not started...")` guard inside `embed()`/`rerank()`. So `has_active_requests()` returns `False` for the entire span from acquire until `_begin_activity`.

Meanwhile the `ProcessMemoryEnforcer`'s ~1s poll takes the same pool lock and `_find_lru_victim()` / `_is_idle_for_prefill_eviction()` / `check_ttl_expirations()` see the engine as idle, so they evict it. The suspended request resumes against a torn-down engine and raises. The embedding engine (smallest, usually oldest `last_access`) is the usual victim — the recurring cause of "embedder degraded" episodes for downstream consumers.

### Bug B — active-request counter leak (#1595)

The immediate-abort eviction stops a non-streaming engine **without** the normal per-request completion callbacks (`_end_activity`), so `_active_count` can be left non-zero — a phantom "busy" count that corrupts the status API and (via `has_active_requests()`) can make a stale engine look permanently non-evictable.

## Fix — atomic in-use lease + teardown reset

Take the in-use signal **at acquire time, under the pool lock**, so eviction can never tear down an engine a request holds or is acquiring:

- `EngineEntry.in_use: int = 0` refcount.
- `get_engine(..., _lease: bool = False)` increments `entry.in_use` under `self._lock` at **both** return points (already-loaded + post-load).
- `release_engine(model_id)` decrements under the lock (floored at 0); `acquire(model_id)` `@asynccontextmanager` leases on enter and **always** releases in `finally` (so a request error can't leak the lease).
- All **three** eviction paths skip `in_use > 0`: `_find_lru_victim`, `_is_idle_for_prefill_eviction`, `check_ttl_expirations` (in addition to `has_active_requests()`).
- `server.py` threads `_lease` / `_leased_out` so the **exact** pool-resolved model_id (incl. the default-model fallback) is captured, and releases the lease on validation failure. `/v1/embeddings` and `/v1/rerank` wrap the real `embed()`/`rerank()` call in `async with pool.acquire(model_id)` (the embeddings lease is taken inside the deferred `StreamingResponse` coroutine, which is where the engine is actually used). LLM/STT/TTS/STS handlers are unchanged. The non-lease path keeps the original `pool.get_engine(model_id)` call contract.
- #1595: `BaseNonStreamingEngine._reset_activity_tracking()` zeros `_active_count` and clears `_activities` under `_active_lock`, called (getattr-guarded) from `EnginePool._unload_engine()` after `stop()`.

This closes both sub-windows (acquire→activity, and the guard→increment gap inside `embed()`) and **preserves eviction of genuinely idle engines** — only engines that are leased/in-use are protected.

## Testing

Tests run with the repo's `pytest` suites (Python 3.11, mlx available):

- `tests/test_engine_pool.py` + `tests/test_embedding.py`: **154 passed** (incl. 10 new regression tests).
- New regression tests (`TestEnginePoolInUseLease`, `TestResetActivityTracking`): the three eviction paths skip `in_use > 0`; `acquire()` leases then releases on success **and** on exception; `release_engine` floors at 0; `_reset_activity_tracking` clears a leaked counter; `_unload_engine` invokes the reset on teardown. Verified these **fail** against the pre-fix code and **pass** with the fix (non-vacuous).
- Server/rerank/embeddings suites (`tests/test_server.py`, `tests/test_rerank_models.py`, integration endpoint tests): **green**. The integration `MockEnginePool` was updated to mirror the new lease API (`_lease` kwarg + no-op `release_engine`).
- Full default suite (`-m "not slow and not integration"` plus the explicit integration endpoint tests): **green** except two pre-existing `test_install_detection.py` failures that are environment artifacts of running under a Homebrew-installed interpreter (`is_homebrew()` detects the Cellar path); they fail identically on unmodified `main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
