### PR TITLE
feat: add Gemma 4 unified audio input support

### DIFF
--- a/omlx/adapter/gemma4.py
+++ b/omlx/adapter/gemma4.py
@@ -243,14 +243,17 @@ def extract_gemma4_messages(
             continue
 
         # All other roles (user, system)
-        # Preserve image_url parts for VLM processing
+        # Preserve image_url and input_audio parts for VLM processing
         content = msg.get("content", "")
         if isinstance(content, list):
             from ..api.utils import _extract_multimodal_content_list
 
             multimodal_parts = _extract_multimodal_content_list(content)
-            has_images = any(p.get("type") == "image_url" for p in multimodal_parts)
-            if has_images:
+            multimodal_types = {"image_url", "input_audio"}
+            has_multimodal = any(
+                p.get("type") in multimodal_types for p in multimodal_parts
+            )
+            if has_multimodal:
                 content = multimodal_parts
             else:
                 content = _extract_text_from_content_list(content)

--- a/omlx/api/__init__.py
+++ b/omlx/api/__init__.py
@@ -70,6 +70,7 @@ from .anthropic_models import (
     ContentBlockImage,
     ContentBlockToolUse,
     ContentBlockToolResult,
+    ContentBlockInputAudio,
     # Messages
     SystemContent,
     AnthropicMessage,

--- a/omlx/api/anthropic_models.py
+++ b/omlx/api/anthropic_models.py
@@ -72,6 +72,18 @@ class ContentBlockDocument(BaseModel):
     cache_control: dict[str, str] | None = None
 
 
+class ContentBlockInputAudio(BaseModel):
+    """Audio input content block for multimodal audio models.
+
+    Uses the same shape as OpenAI's input_audio content part so that
+    the internal VLM engine receives a uniform representation regardless
+    of which API endpoint the client used.
+    """
+
+    type: Literal["input_audio"] = "input_audio"
+    input_audio: dict[str, Any]  # {"data": "<base64>", "format": "wav"}
+
+
 # Union type for all content blocks
 ContentBlock = (
     ContentBlockText
@@ -80,6 +92,7 @@ ContentBlock = (
     | ContentBlockToolResult
     | ContentBlockThinking
     | ContentBlockDocument
+    | ContentBlockInputAudio
 )
 
 

--- a/omlx/api/anthropic_utils.py
+++ b/omlx/api/anthropic_utils.py
@@ -115,6 +115,35 @@ def _append_anthropic_image_part(image_parts: list[dict], block_dict: dict[str, 
                 "url": source.get("url", ""),
             },
         })
+def _append_anthropic_image_part(image_parts: list[dict], block_dict: dict[str, Any]) -> None:
+    """Convert Anthropic image blocks to OpenAI-style image_url parts."""
+    source = block_dict.get("source", {})
+    if source.get("type") == "base64":
+        media_type = source.get("media_type", "image/jpeg")
+        data = source.get("data", "")
+        image_parts.append({
+            "type": "image_url",
+            "image_url": {
+                "url": f"data:{media_type};base64,{data}",
+            },
+        })
+    elif source.get("type") == "url":
+        image_parts.append({
+            "type": "image_url",
+            "image_url": {
+                "url": source.get("url", ""),
+            },
+        })
+
+
+def _append_anthropic_audio_part(audio_parts: list[dict], block_dict: dict[str, Any]) -> None:
+    """Pass through an input_audio block unchanged for the VLM engine."""
+    input_audio = block_dict.get("input_audio")
+    if input_audio and isinstance(input_audio, dict):
+        audio_parts.append({
+            "type": "input_audio",
+            "input_audio": input_audio,
+        })
 
 
 def _extract_images_from_tool_result_content(
@@ -133,10 +162,15 @@ def _build_message_from_parts(
     role: str,
     text_parts: list[str],
     image_parts: list[dict],
+    audio_parts: list[dict] | None = None,
 ) -> dict[str, Any] | None:
-    """Build a single internal message from accumulated text/image parts."""
-    if image_parts:
-        content_parts = list(image_parts)
+    """Build a single internal message from accumulated text/image/audio parts."""
+    media_parts = list(image_parts)
+    if audio_parts:
+        media_parts.extend(audio_parts)
+
+    if media_parts:
+        content_parts = list(media_parts)
         if text_parts:
             content_parts.append({
                 "type": "text",
@@ -211,6 +245,7 @@ def convert_anthropic_to_internal(
                 if role == "assistant":
                     text_parts: list[str] = []
                     image_parts: list[dict] = []
+                    audio_parts: list[dict] = []
                     tool_calls: list[dict] = []
                     thinking_parts: list[str] = []
                     for block in content:
@@ -222,6 +257,8 @@ def convert_anthropic_to_internal(
                             text_parts.append(block_dict.get("text", ""))
                         elif block_type == "image" and preserve_images:
                             _append_anthropic_image_part(image_parts, block_dict)
+                        elif block_type == "input_audio" and preserve_images:
+                            _append_anthropic_audio_part(audio_parts, block_dict)
                         elif block_type == "tool_use":
                             tool_input = block_dict.get("input", {})
                             if isinstance(tool_input, str):
@@ -249,7 +286,7 @@ def convert_anthropic_to_internal(
                                     text_parts.append(f"<think>\n{thinking_text}\n</think>")
                         elif block_type == "document":
                             text_parts.append(_decode_document_block(block_dict))
-                    msg_dict = _build_message_from_parts(role, text_parts, image_parts) or {
+                    msg_dict = _build_message_from_parts(role, text_parts, image_parts, audio_parts) or {
                         "role": role,
                         "content": "",
                     }
@@ -264,6 +301,7 @@ def convert_anthropic_to_internal(
                 if role == "user":
                     text_parts = []
                     image_parts = []
+                    audio_parts = []
                     saw_tool_result = False
                     for block in content:
                         block_dict = _content_block_to_dict(block)
@@ -274,12 +312,15 @@ def convert_anthropic_to_internal(
                             text_parts.append(block_dict.get("text", ""))
                         elif block_type == "image" and preserve_images:
                             _append_anthropic_image_part(image_parts, block_dict)
+                        elif block_type == "input_audio" and preserve_images:
+                            _append_anthropic_audio_part(audio_parts, block_dict)
                         elif block_type == "tool_result":
-                            msg_dict = _build_message_from_parts(role, text_parts, image_parts)
+                            msg_dict = _build_message_from_parts(role, text_parts, image_parts, audio_parts)
                             if msg_dict:
                                 processed_messages.append(msg_dict)
                             text_parts = []
                             image_parts = []
+                            audio_parts = []
                             saw_tool_result = True
                             processed_messages.append({
                                 "role": "tool",
@@ -304,7 +345,7 @@ def convert_anthropic_to_internal(
                                 text_parts.append(f"<think>\n{thinking_text}\n</think>")
                         elif block_type == "document":
                             text_parts.append(_decode_document_block(block_dict))
-                    msg_dict = _build_message_from_parts(role, text_parts, image_parts)
+                    msg_dict = _build_message_from_parts(role, text_parts, image_parts, audio_parts)
                     if msg_dict:
                         processed_messages.append(msg_dict)
                     elif not saw_tool_result:
@@ -314,6 +355,7 @@ def convert_anthropic_to_internal(
             # Content blocks list
             text_parts: list[str] = []
             image_parts: list[dict] = []
+            audio_parts: list[dict] = []
             thinking_parts: list[str] = []
             saw_tool_markup = False
             for block in content:
@@ -328,6 +370,9 @@ def convert_anthropic_to_internal(
 
                 elif block_type == "image" and preserve_images:
                     _append_anthropic_image_part(image_parts, block_dict)
+
+                elif block_type == "input_audio" and preserve_images:
+                    _append_anthropic_audio_part(audio_parts, block_dict)
 
                 elif block_type == "tool_use":
                     # Tool use in assistant message (model called a tool)
@@ -368,7 +413,7 @@ def convert_anthropic_to_internal(
                 elif block_type == "document":
                     text_parts.append(_decode_document_block(block_dict))
 
-            msg_dict = _build_message_from_parts(role, text_parts, image_parts) or {
+            msg_dict = _build_message_from_parts(role, text_parts, image_parts, audio_parts) or {
                 "role": role,
                 "content": "",
             }

--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -33,6 +33,13 @@ class ImageURL(BaseModel):
     detail: Optional[str] = "auto"  # "low", "high", "auto"
 
 
+class InputAudio(BaseModel):
+    """Audio input data for multimodal models (OpenAI format)."""
+
+    data: str  # Base64-encoded audio or data URI
+    format: str = "wav"  # Audio format: wav, mp3, etc.
+
+
 class ContentPart(BaseModel):
     """
     A part of a message content array.
@@ -40,10 +47,13 @@ class ContentPart(BaseModel):
     Supports:
     - text: Plain text content
     - image_url: Image input for vision models
+    - input_audio: Audio input for multimodal audio models
     """
-    type: str  # "text" or "image_url"
+
+    type: str  # "text", "image_url", or "input_audio"
     text: Optional[str] = None
     image_url: Optional[ImageURL] = None
+    input_audio: Optional[InputAudio] = None
 
 
 # =============================================================================

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -48,6 +48,7 @@ def detect_and_strip_partial(messages: list[dict]) -> bool:
 SPECIAL_TOKENS_PATTERN = re.compile(
     r"<\|im_end\|>|<\|im_start\|>|<\|endoftext\|>|"
     r"<\|end\|>|<\|eot_id\|>|<\|start_header_id\|>|<\|end_header_id\|>|"
+    r"<\|image\|>|<\|audio\|>|"  # Gemma 4 VLM special tokens
     r"</s>|<s>|<pad>|\[PAD\]|\[SEP\]|\[CLS\]"
 )
 
@@ -117,9 +118,9 @@ def _extract_text_from_content_list(content: list) -> str:
 
 
 def _extract_multimodal_content_list(content: list) -> list:
-    """Extract text and image parts from a content array, preserving images.
+    """Extract text, image, and audio parts from a content array.
 
-    Keeps both text and image_url items for VLM processing.
+    Keeps text, image_url, and input_audio items for VLM processing.
     Other content types (tool_use, thinking, refusal, etc.) are dropped.
     """
     parts = []
@@ -173,6 +174,16 @@ def _extract_multimodal_content_list(content: list) -> list:
                             "image_url": {
                                 "url": f"data:{media_type};base64,{data}",
                             },
+                        }
+                    )
+            elif item_type == "input_audio":
+                # OpenAI audio format: pass through for engine-side decoding
+                input_audio = item.get("input_audio")
+                if input_audio and isinstance(input_audio, dict):
+                    parts.append(
+                        {
+                            "type": "input_audio",
+                            "input_audio": input_audio,
                         }
                     )
     return parts
@@ -678,10 +689,13 @@ def extract_multimodal_content(
         if isinstance(content, str):
             processed_messages.append({"role": role, "content": content, **_extra})
         elif isinstance(content, list):
-            # Preserve image_url parts for VLM processing
+            # Preserve image_url and input_audio parts for VLM processing
             multimodal_parts = _extract_multimodal_content_list(content)
-            has_images = any(p.get("type") == "image_url" for p in multimodal_parts)
-            if has_images:
+            multimodal_types = {"image_url", "input_audio"}
+            has_multimodal = any(
+                p.get("type") in multimodal_types for p in multimodal_parts
+            )
+            if has_multimodal:
                 # Keep as content list for VLM engine
                 processed_messages.append(
                     {"role": role, "content": multimodal_parts, **_extra}

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -258,6 +258,32 @@ def _build_processor_via_pil_image_processor(cls, path, **kwargs):
             "torch+torchvision or upgrade mlx-vlm."
         )
 
+    # Read feature_extractor config if present (needed for audio models like gemma4_unified)
+    fe_config = {}
+    fe_type = None
+    for fname in ("processor_config.json", "preprocessor_config.json"):
+        cfg_path = p / fname
+        if not cfg_path.exists():
+            continue
+        with open(cfg_path) as f:
+            cfg = json.load(f)
+        fe_section = cfg.get("feature_extractor", {})
+        if isinstance(fe_section, dict):
+            fe_config = dict(fe_section)
+            fe_type = fe_config.pop("feature_extractor_type", None)
+            if fe_type:
+                break
+
+    feature_extractor = None
+    if fe_type:
+        # Dynamically import the feature extractor class
+        fe_cls = _resolve_feature_extractor_class(fe_type)
+        if fe_cls is not None:
+            try:
+                feature_extractor = fe_cls(**fe_config)
+                logger.debug("Created feature_extractor %s from %s", fe_type, path)
+            except Exception as e:
+                logger.warning("Failed to create feature_extractor %s: %s", fe_type, e)
     pil_cls = _resolve_pil_image_processor_class(ip_type, IMAGE_PROCESSOR_MAPPING_NAMES)
     if pil_cls is None:
         raise ImportError(
@@ -277,7 +303,11 @@ def _build_processor_via_pil_image_processor(cls, path, **kwargs):
     except (ImportError, AttributeError):
         pass
 
-    return cls(image_processor=image_processor, tokenizer=tokenizer)
+    processor_kwargs = {"image_processor": image_processor, "tokenizer": tokenizer}
+    if feature_extractor is not None:
+        processor_kwargs["feature_extractor"] = feature_extractor
+
+    return cls(**processor_kwargs)
 
 
 def _resolve_pil_image_processor_class(ip_type, mapping_names):
@@ -299,6 +329,37 @@ def _resolve_pil_image_processor_class(ip_type, mapping_names):
         candidate = getattr(mod, pil_name, None)
         if candidate is not None and not getattr(candidate, "is_dummy", False):
             return candidate
+    return None
+
+
+# Mapping from feature_extractor_type to (module, class) locations in mlx_vlm
+_FEATURE_EXTRACTOR_MAP = {
+    "Gemma4UnifiedAudioFeatureExtractor": (
+        "mlx_vlm.models.gemma4_unified.processing_gemma4_unified",
+        "Gemma4UnifiedAudioFeatureExtractor",
+    ),
+    "Gemma4AudioFeatureExtractor": (
+        "mlx_vlm.models.gemma4.audio_feature_extractor",
+        "Gemma4AudioFeatureExtractor",
+    ),
+}
+
+
+def _resolve_feature_extractor_class(fe_type: str):
+    """Resolve a feature extractor class by its ``feature_extractor_type`` string.
+
+    Returns the class object, or None if not found.
+    """
+    import importlib
+
+    if fe_type in _FEATURE_EXTRACTOR_MAP:
+        mod_name, cls_name = _FEATURE_EXTRACTOR_MAP[fe_type]
+        try:
+            mod = importlib.import_module(mod_name)
+            return getattr(mod, cls_name, None)
+        except ImportError:
+            return None
+
     return None
 
 
@@ -994,8 +1055,9 @@ class VLMBatchedEngine(BaseEngine):
         self,
         messages: list[dict[str, Any]],
         num_images: int,
+        num_audios: int = 0,
     ) -> tuple[list[dict[str, Any]], list[tuple[int, int]]]:
-        """Format VLM messages with image tokens on image-bearing user turns."""
+        """Format VLM messages with image/audio tokens on media-bearing user turns."""
         from mlx_vlm.prompt_utils import extract_text_from_content, get_message_json
 
         model_type = self.model_type or getattr(
@@ -1005,14 +1067,23 @@ class VLMBatchedEngine(BaseEngine):
             raise ValueError("Missing VLM model_type for chat template formatting")
 
         image_part_types = {"image", "image_url", "input_image"}
+        audio_part_types = {"input_audio"}
         has_explicit_images = any(
             isinstance(msg, dict)
             and self._count_content_parts(msg.get("content"), image_part_types) > 0
             for msg in messages
         )
 
+        has_explicit_audio = any(
+            isinstance(msg, dict)
+            and self._count_content_parts(msg.get("content"), audio_part_types) > 0
+            for msg in messages
+        )
+
         remaining_images = num_images
+        remaining_audios = num_audios
         assigned_fallback_images = False
+        assigned_fallback_audios = False
         formatted_messages: list[dict[str, Any]] = []
         image_message_ranges: list[tuple[int, int]] = []
 
@@ -1025,9 +1096,13 @@ class VLMBatchedEngine(BaseEngine):
             content = extract_text_from_content(raw_content)
 
             msg_num_images = 0
+            msg_num_audios = 0
             if role == "user":
                 explicit_images = self._count_content_parts(
                     raw_content, image_part_types
+                )
+                explicit_audios = self._count_content_parts(
+                    raw_content, audio_part_types
                 )
                 if explicit_images > 0 and remaining_images > 0:
                     msg_num_images = min(explicit_images, remaining_images)
@@ -1040,6 +1115,18 @@ class VLMBatchedEngine(BaseEngine):
                     msg_num_images = remaining_images
                     remaining_images = 0
                     assigned_fallback_images = True
+
+                if explicit_audios > 0 and remaining_audios > 0:
+                    msg_num_audios = min(explicit_audios, remaining_audios)
+                    remaining_audios -= msg_num_audios
+                elif (
+                    not has_explicit_audio
+                    and remaining_audios > 0
+                    and not assigned_fallback_audios
+                ):
+                    msg_num_audios = remaining_audios
+                    remaining_audios = 0
+                    assigned_fallback_audios = True
 
             if msg_num_images > 0:
                 image_message_ranges.append((idx, msg_num_images))
@@ -1065,9 +1152,9 @@ class VLMBatchedEngine(BaseEngine):
                     content,
                     role,
                     skip_image_token=role != "user" or msg_num_images == 0,
-                    skip_audio_token=True,
+                    skip_audio_token=role != "user" or msg_num_audios == 0,
                     num_images=msg_num_images,
-                    num_audios=0,
+                    num_audios=msg_num_audios,
                 )
                 # Collapse text-only list content to plain string so that
                 # simplified chat templates (without render_content macro)
@@ -1365,6 +1452,7 @@ class VLMBatchedEngine(BaseEngine):
         self,
         messages: list[dict[str, Any]],
         images: list[Any],
+        audio: list | None = None,
         chat_template_kwargs: dict[str, Any] | None = None,
         tools: list[dict] | None = None,
     ) -> Tuple[
@@ -1383,8 +1471,9 @@ class VLMBatchedEngine(BaseEngine):
         4. Compute image hash for prefix cache
 
         Args:
-            messages: Chat messages (text-only, images already extracted)
+            messages: Chat messages (text-only, media already extracted)
             images: List of PIL Image objects
+            audio: List of audio data (BytesIO, file paths, or numpy arrays)
 
         Returns:
             Tuple of (
@@ -1404,9 +1493,22 @@ class VLMBatchedEngine(BaseEngine):
               cumulative image hashes
         """
         from mlx_vlm.prompt_utils import apply_chat_template
-        from mlx_vlm.utils import prepare_inputs
+        from mlx_vlm.utils import load_audio as _load_audio, prepare_inputs
 
         num_images = len(images)
+        num_audios = len(audio) if audio else 0
+
+        # Normalize audio to numpy float32 arrays expected by processor.
+        # extract_images_from_messages produces BytesIO / file-path strings, but
+        # the processor's __call__ expects numpy arrays or (array, sample_rate)
+        # tuples. load_audio handles all three source types.
+        if audio:
+            audio = [
+                _load_audio(a, 16000)
+                if not isinstance(a, tuple)
+                else a
+                for a in audio
+            ]
         model_type = self.model_type or ""
 
         # Validate multi-image support
@@ -1421,7 +1523,9 @@ class VLMBatchedEngine(BaseEngine):
         # receive image tokens, regardless of conversation history shape.
         try:
             formatted_messages, image_message_ranges = (
-                self._format_messages_for_vlm_template(messages, num_images=num_images)
+                self._format_messages_for_vlm_template(
+                    messages, num_images=num_images, num_audios=num_audios
+                )
             )
         except Exception as e:
             logger.debug(
@@ -1434,6 +1538,7 @@ class VLMBatchedEngine(BaseEngine):
                 self._vlm_model.config,
                 messages,
                 num_images=num_images,
+                num_audios=num_audios,
                 return_messages=True,
             )
             image_message_ranges = []
@@ -1499,10 +1604,11 @@ class VLMBatchedEngine(BaseEngine):
             else:
                 raise
 
-        # Tokenize text and preprocess images
+        # Tokenize text and preprocess images and audio
         inputs = prepare_inputs(
             self._processor,
             images=images if images else None,
+            audio=audio if audio else None,
             prompts=[prompt] if isinstance(prompt, str) else prompt,
         )
 
@@ -1585,16 +1691,25 @@ class VLMBatchedEngine(BaseEngine):
             and v is not None
         }
 
-        if pixel_values is not None and num_images > 0:
-            # Compute whole-request image hash (used for KV prefix cache keying)
-            image_hash = compute_image_hash(images)
+        # Check for any multimodal inputs: images or audio
+        has_audio = "input_features" in extra_model_inputs
+        has_multimodal = (pixel_values is not None and num_images > 0) or has_audio
 
-            # Build call kwargs from extra_model_inputs
+
+
+        if has_multimodal:
+            # Build call kwargs from extra_model_inputs (includes input_features
+            # for audio, image_grid_thw, etc.)
             call_kwargs = dict(extra_model_inputs)
 
-            # Try per-image vision feature cache
-            if self._vision_cache is not None and self._vision_cache_enabled:
+            # Image-specific: compute hash and try vision feature cache
+            image_hash = None
+            image_token_count = None
+            if num_images > 0:
+                image_hash = compute_image_hash(images)
                 image_token_count = self._image_token_count(input_ids)
+
+            if num_images > 0 and self._vision_cache is not None and self._vision_cache_enabled:
                 per_hashes = compute_per_image_hashes(images)
                 cached_per_image = [
                     self._vision_cache.get(h, self._model_name) for h in per_hashes
@@ -2159,7 +2274,7 @@ class VLMBatchedEngine(BaseEngine):
             Tuple of (prompt_or_token_ids, vlm_embeds, vlm_kwargs, image_hash)
         """
         # Extract images from messages
-        text_messages, images = extract_images_from_messages(messages)
+        text_messages, images, audio = extract_images_from_messages(messages)
 
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
 
@@ -2178,16 +2293,13 @@ class VLMBatchedEngine(BaseEngine):
         ) = self._prepare_vision_inputs(
             vlm_messages,
             images,
+            audio=audio if audio else None,
             chat_template_kwargs=ct_kwargs,
             tools=template_tools,
         )
 
         if images:
             # Free Metal intermediates from vision encoding.
-            # Vision tower + projector produce large intermediate buffers
-            # that stay in the Metal cache pool until explicitly cleared.
-            # Without this, repeated VLM requests accumulate memory and
-            # eventually trigger ProcessMemoryEnforcer aborts (see #667).
             mx.synchronize()
             mx.clear_cache()
 
@@ -2215,7 +2327,7 @@ class VLMBatchedEngine(BaseEngine):
         # Extract text-only version for token counting
         from ..utils.image import extract_images_from_messages
 
-        text_messages, _ = extract_images_from_messages(messages)
+        text_messages, _, _ = extract_images_from_messages(messages)
 
         template_tools = convert_tools_for_template(tools) if tools else None
         prompt = self._apply_chat_template(

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -778,6 +778,11 @@ class Scheduler:
             self._load_generation_config_eos()
         )
 
+        # Load suppress_tokens from generation_config.json for Gemma 4 unified models.
+        # Prevents generation of multimodal placeholder tokens (<image|>, <audio|>)
+        # on text-only inputs.
+        self._model_suppress_tokens: set[int] = self._load_model_suppress_tokens()
+
         # For strict RotatingKVCache reuse, align paged cache block size to
         # the model's rotating window size when paged cache is enabled.
         self._align_block_size_with_rotating_window()
@@ -1533,6 +1538,51 @@ class Scheduler:
             logger.debug(f"Could not load generation_config.json: {e}")
             return None
 
+    def _load_model_suppress_tokens(self) -> set[int]:
+        """Load suppress_tokens from generation_config.json if available.
+
+        These tokens are set to -inf during generation to prevent multimodal
+        placeholder token emission (e.g. <image|>, <audio|>) on text-only inputs.
+        """
+        try:
+            model_path = getattr(self.tokenizer, "name_or_path", None)
+            if not model_path:
+                return set()
+            import json
+            import os
+
+            gc_path = os.path.join(model_path, "generation_config.json")
+            if not os.path.exists(gc_path):
+                try:
+                    from huggingface_hub import try_to_load_from_cache
+
+                    cached = try_to_load_from_cache(
+                        model_path, "generation_config.json"
+                    )
+                    if cached and isinstance(cached, str):
+                        gc_path = cached
+                    else:
+                        return set()
+                except (ImportError, Exception):
+                    return set()
+            with open(gc_path) as f:
+                gc = json.load(f)
+            suppress = gc.get("suppress_tokens")
+            if suppress is None:
+                return set()
+            if isinstance(suppress, list):
+                result = set(suppress)
+            else:
+                result = {suppress}
+            logger.info(
+                f"Loaded {len(result)} suppress token(s) from "
+                f"generation_config.json: {result}"
+            )
+            return result
+        except Exception as e:
+            logger.debug(f"Could not load suppress_tokens from generation_config: {e}")
+            return set()
+
     def _get_stop_tokens(self) -> set[int]:
         """Get stop token IDs from tokenizer and generation_config."""
         stop_tokens = set()
@@ -1553,6 +1603,26 @@ class Scheduler:
                 stop_tokens.add(eos_ids)
             else:
                 stop_tokens.update(eos_ids)
+
+        # Include end-of-turn token for models that use turn-based
+        # conversation delimiters (e.g. Gemma 4 with <turn|>).  Without
+        # this the model generates the full next turn after its response.
+        eot_token_id = getattr(self.tokenizer, "eot_token_id", None)
+        if eot_token_id is not None:
+            if isinstance(eot_token_id, list):
+                stop_tokens.update(eot_token_id)
+            else:
+                stop_tokens.add(eot_token_id)
+        elif hasattr(self.tokenizer, "eot_token") and self.tokenizer.eot_token:
+            # Encode the string value if eot_token_id isn't directly exposed
+            try:
+                encoded = self.tokenizer.encode(
+                    self.tokenizer.eot_token, add_special_tokens=False
+                )
+                if encoded:
+                    stop_tokens.update(encoded)
+            except Exception:
+                pass
 
         # Read additional EOS tokens from generation_config.json.
         # Some models (e.g. GLM-4.6V) define multiple EOS tokens there
@@ -1664,6 +1734,16 @@ class Scheduler:
                 else None
             ),
         )
+
+        # Suppress model-specific tokens (e.g. Gemma 4 <image|>/<audio|>)
+        if self._model_suppress_tokens:
+            _suppress_list = list(self._model_suppress_tokens)
+
+            def _suppress_logits(tokens, logits):
+                logits[..., _suppress_list] = mx.array(float("-inf"))
+                return logits
+
+            logits_processors.append(_suppress_logits)
 
         # Convert stop tokens from Set[int] to Sequence[Sequence[int]]
         # for the new BatchGenerator API (each stop token is a sequence).
@@ -3117,6 +3197,16 @@ class Scheduler:
                 else None
             ),
         )
+
+        # Suppress model-specific tokens (e.g. Gemma 4 <image|>/<audio|>)
+        if self._model_suppress_tokens:
+            _suppress_list = list(self._model_suppress_tokens)
+
+            def _suppress_logits(tokens, logits):
+                logits[..., _suppress_list] = mx.array(float("-inf"))
+                return logits
+
+            logits_processors.append(_suppress_logits)
 
         # Add thinking budget processor for reasoning models
         if (

--- a/omlx/utils/image.py
+++ b/omlx/utils/image.py
@@ -63,25 +63,30 @@ def load_image(url_or_base64: str) -> Image.Image:
 
 def extract_images_from_messages(
     messages: List[Dict[str, Any]],
-) -> Tuple[List[Dict[str, Any]], List[Image.Image]]:
+) -> Tuple[List[Dict[str, Any]], List[Image.Image], List]:
     """
-    Extract images from OpenAI-format messages.
+    Extract images and audio from OpenAI-format messages.
 
-    Processes messages containing content arrays with image_url parts,
-    loads the images, and returns cleaned text-only messages alongside
-    the loaded images.
+    Processes messages containing content arrays with image_url or input_audio
+    parts, loads the media, and returns cleaned text-only messages alongside
+    the loaded images and audio files.
 
     Args:
         messages: List of OpenAI-format chat messages. Each message may have
-            content as a string or a list of content parts (text/image_url).
+            content as a string or a list of content parts
+            (text/image_url/input_audio).
 
     Returns:
-        Tuple of (text_messages, images):
-        - text_messages: Messages with image parts removed, text parts joined
+        Tuple of (text_messages, images, audio):
+        - text_messages: Messages with media parts removed, text parts joined
         - images: List of loaded PIL Image objects in order of appearance
+        - audio: List of BytesIO/str audio references for load_audio()
     """
+    import binascii
+
     text_messages = []
     images = []
+    audio = []
 
     for msg in messages:
         role = msg.get("role", "user")
@@ -96,7 +101,7 @@ def extract_images_from_messages(
                     text_messages[-1][key] = msg[key]
             continue
 
-        # Content array with text and/or image_url parts
+        # Content array with text, image_url, and/or input_audio parts
         text_parts = []
         for part in content:
             if isinstance(part, dict):
@@ -135,6 +140,36 @@ def extract_images_from_messages(
                     except Exception as e:
                         logger.warning(f"Failed to load image: {e}")
 
+            elif part_type == "input_audio":
+                # OpenAI audio format: {"type":"input_audio","input_audio":{"data":"...","format":"wav"}}
+                input_audio = (
+                    part.get("input_audio") if isinstance(part, dict)
+                    else getattr(part, "input_audio", None)
+                )
+                if input_audio and isinstance(input_audio, dict):
+                    data = input_audio.get("data", "")
+                    if isinstance(data, str):
+                        stripped = data.strip()
+                        # Handle data URI (data:audio/wav;base64,...)
+                        if stripped.startswith("data:"):
+                            prefix, separator, encoded = stripped.partition(",")
+                            if separator == "," and ";base64" in prefix:
+                                try:
+                                    audio.append(io.BytesIO(base64.b64decode(encoded, validate=True)))
+                                except (binascii.Error, ValueError) as exc:
+                                    logger.warning(f"Failed to decode input_audio base64: {exc}")
+                                continue
+                        # Try raw base64 decode
+                        try:
+                            audio.append(io.BytesIO(base64.b64decode(stripped, validate=True)))
+                        except (binascii.Error, ValueError):
+                            # Not base64 — treat as file path/reference
+                            audio.append(stripped)
+                    elif isinstance(data, bytes):
+                        audio.append(io.BytesIO(data))
+                    else:
+                        audio.append(data)
+
         new_msg = {"role": role, "content": "\n".join(text_parts) if text_parts else ""}
         # Preserve extra fields
         for key in msg:
@@ -142,9 +177,7 @@ def extract_images_from_messages(
                 new_msg[key] = msg[key]
         text_messages.append(new_msg)
 
-    return text_messages, images
-
-
+    return text_messages, images, audio
 def compute_image_hash(images: List[Image.Image]) -> Optional[str]:
     """
     Compute a SHA256 hash from a list of images for prefix cache deduplication.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,11 @@ dependencies = [
     "jsonschema>=4.0.0",
     # Harmony format parser for gpt-oss models
     "openai-harmony",
-    # mlx-vlm from commit (041f889) - includes Qwen MTP batched
-    # target-verify drift fixes, Gemma4 rollback fixes, TurboQuant RHT L=1 value
-    # kernels, eager evaluation of cached MRoPE arrays on model load, and
-    # Gemma4 unified long text prefill fixes.
-    "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@041f8891176996c916f347e542b3aae179300546",
+    # mlx-vlm from commit (526c210, main) — includes Gemma4 unified audio prefill
+    # fixes (041f889), Qwen MTP batched target-verify drift fixes, Gemma4 rollback
+    # fixes, TurboQuant RHT L=1 value kernels, and eager evaluation of cached MRoPE
+    # arrays on model load.
+    "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@526c210b8ef841a2906beb2805e9c41b8b77f4e7",
     "Pillow>=9.0.0",
     # dflash-mlx v0.1.8 (39b2520) — bstnxbt repo. Apple G17 NAX verify path plus v0.1.7 Qwen/Gemma4 DFlash fixes
     "dflash-mlx @ git+https://github.com/bstnxbt/dflash-mlx@39b2520e805f1d1be3852c62944b389cff73fa35",

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -679,3 +679,126 @@ class TestAnthropicToolUseConversion:
         # Must use [Calling tool: ...] not [Tool call: ...]
         assert "[Calling tool: get_weather(" in content
         assert "[Tool call:" not in content
+
+
+class TestAnthropicAudioConversion:
+    """Tests for input_audio block handling in convert_anthropic_to_internal."""
+
+    def test_input_audio_block_preserved_with_preserve_images(self):
+        """input_audio blocks should be passed through when preserve_images=True."""
+        from omlx.api.anthropic_utils import convert_anthropic_to_internal
+        from omlx.api.anthropic_models import MessagesRequest, AnthropicMessage
+
+        import base64
+        fake_audio = base64.b64encode(b"\x00" * 100).decode()
+
+        request = MessagesRequest(
+            model="gemma4-unified",
+            max_tokens=1024,
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[
+                        {"type": "text", "text": "What sound is this?"},
+                        {
+                            "type": "input_audio",
+                            "input_audio": {
+                                "data": fake_audio,
+                                "format": "wav",
+                            },
+                        },
+                    ],
+                ),
+            ],
+        )
+
+        messages = convert_anthropic_to_internal(
+            request, preserve_images=True
+        )
+
+        assert len(messages) == 1
+        content = messages[0]["content"]
+        assert isinstance(content, list)
+
+        # Should have both text and audio parts
+        audio_parts = [p for p in content if p.get("type") == "input_audio"]
+        assert len(audio_parts) == 1
+        assert audio_parts[0]["input_audio"]["data"] == fake_audio
+        assert audio_parts[0]["input_audio"]["format"] == "wav"
+
+        text_parts = [p for p in content if p.get("type") == "text"]
+        assert len(text_parts) == 1
+
+    def test_input_audio_block_dropped_without_preserve_images(self):
+        """input_audio blocks should be dropped when preserve_images=False."""
+        from omlx.api.anthropic_utils import convert_anthropic_to_internal
+        from omlx.api.anthropic_models import MessagesRequest, AnthropicMessage
+
+        import base64
+        fake_audio = base64.b64encode(b"\x00" * 100).decode()
+
+        request = MessagesRequest(
+            model="gemma4-unified",
+            max_tokens=1024,
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[
+                        {"type": "text", "text": "What sound is this?"},
+                        {
+                            "type": "input_audio",
+                            "input_audio": {
+                                "data": fake_audio,
+                                "format": "wav",
+                            },
+                        },
+                    ],
+                ),
+            ],
+        )
+
+        messages = convert_anthropic_to_internal(
+            request, preserve_images=False
+        )
+
+        content = messages[0]["content"]
+        # Without preserve_images, content should be string, not list
+        assert isinstance(content, str)
+        assert "input_audio" not in str(content).lower()
+
+    def test_audio_only_message(self):
+        """A message with only audio blocks should still produce valid output."""
+        from omlx.api.anthropic_utils import convert_anthropic_to_internal
+        from omlx.api.anthropic_models import MessagesRequest, AnthropicMessage
+
+        import base64
+        fake_audio = base64.b64encode(b"\x00" * 100).decode()
+
+        request = MessagesRequest(
+            model="gemma4-unified",
+            max_tokens=1024,
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=[
+                        {
+                            "type": "input_audio",
+                            "input_audio": {
+                                "data": fake_audio,
+                                "format": "wav",
+                            },
+                        },
+                    ],
+                ),
+            ],
+        )
+
+        messages = convert_anthropic_to_internal(
+            request, preserve_images=True
+        )
+
+        assert len(messages) == 1
+        content = messages[0]["content"]
+        assert isinstance(content, list)
+        assert len(content) == 1
+        assert content[0]["type"] == "input_audio"

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -2368,6 +2368,49 @@ class TestExtractMultimodalContent:
             {"type": "image_url"},
         ])
         assert len(parts) == 0
+    def test_input_audio_pass_through(self):
+        """input_audio parts survive multimodal content extraction."""
+        parts = _extract_multimodal_content_list([
+            {"type": "input_audio", "input_audio": {"data": "abc", "format": "wav"}},
+        ])
+        assert len(parts) == 1
+        assert parts[0] == {
+            "type": "input_audio",
+            "input_audio": {"data": "abc", "format": "wav"},
+        }
+
+    def test_input_audio_non_dict_dropped(self):
+        """input_audio with non-dict data is dropped."""
+        parts = _extract_multimodal_content_list([
+            {"type": "input_audio", "input_audio": None},
+            {"type": "input_audio"},
+        ])
+        assert len(parts) == 0
+
+    def test_input_audio_preserved_with_image(self):
+        """input_audio and image_url coexist in extracted parts."""
+        parts = _extract_multimodal_content_list([
+            {"type": "text", "text": "Look and listen"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            {"type": "input_audio", "input_audio": {"data": "xyz", "format": "mp3"}},
+        ])
+        assert len(parts) == 3
+        types = [p["type"] for p in parts]
+        assert types == ["text", "image_url", "input_audio"]
+
+    def test_input_audio_with_model_dump(self):
+        """input_audio from Pydantic model_dump works."""
+        from unittest.mock import MagicMock
+
+        audio_part = MagicMock()
+        audio_part.model_dump.return_value = {
+            "type": "input_audio",
+            "input_audio": {"data": "audio_data", "format": "wav"},
+        }
+        parts = _extract_multimodal_content_list([audio_part])
+        assert len(parts) == 1
+        assert parts[0]["type"] == "input_audio"
+        assert parts[0]["input_audio"]["format"] == "wav"
 
 
 # =============================================================================

--- a/tests/test_gemma4_messages.py
+++ b/tests/test_gemma4_messages.py
@@ -163,6 +163,22 @@ class TestExtractGemma4Messages:
         types = [p["type"] for p in result[0]["content"]]
         assert "image_url" in types
         assert "text" in types
+    def test_input_audio_preserved_in_user_message(self):
+        """User messages with input_audio parts keep them for VLM processing."""
+        messages = [
+            Message(
+                role="user",
+                content=[
+                    {"type": "text", "text": "listen to this"},
+                    {"type": "input_audio", "input_audio": {"data": "abc", "format": "wav"}},
+                ],
+            ),
+        ]
+        result = extract_gemma4_messages(messages)
+        assert isinstance(result[0]["content"], list)
+        types = [p["type"] for p in result[0]["content"]]
+        assert "input_audio" in types
+        assert "text" in types
 
     def test_text_only_content_list_flattened(self):
         """User messages with text-only content list are flattened to string."""

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -115,9 +115,10 @@ class TestExtractImagesFromMessages:
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi there"},
         ]
-        text_msgs, images = extract_images_from_messages(messages)
+        text_msgs, images, audio = extract_images_from_messages(messages)
         assert len(text_msgs) == 2
         assert len(images) == 0
+        assert len(audio) == 0
         assert text_msgs[0]["content"] == "Hello"
 
     def test_message_with_image_url(self):
@@ -135,7 +136,7 @@ class TestExtractImagesFromMessages:
                 ],
             },
         ]
-        text_msgs, images = extract_images_from_messages(messages)
+        text_msgs, images, audio = extract_images_from_messages(messages)
         assert len(images) == 1
         assert isinstance(images[0], Image.Image)
         # Text-only message should contain only text part
@@ -156,7 +157,7 @@ class TestExtractImagesFromMessages:
                 ],
             },
         ]
-        text_msgs, images = extract_images_from_messages(messages)
+        text_msgs, images, audio = extract_images_from_messages(messages)
         assert len(images) == 1
         assert isinstance(images[0], Image.Image)
         assert text_msgs[0]["role"] == "user"
@@ -178,7 +179,7 @@ class TestExtractImagesFromMessages:
                 ],
             },
         ]
-        text_msgs, images = extract_images_from_messages(messages)
+        text_msgs, images, audio = extract_images_from_messages(messages)
         assert len(images) == 2
 
     def test_mixed_text_and_image_messages(self):
@@ -197,7 +198,7 @@ class TestExtractImagesFromMessages:
             },
             {"role": "assistant", "content": "I see an image."},
         ]
-        text_msgs, images = extract_images_from_messages(messages)
+        text_msgs, images, audio = extract_images_from_messages(messages)
         assert len(images) == 1
         assert len(text_msgs) == 3
         # System message preserved as-is
@@ -212,7 +213,7 @@ class TestExtractImagesFromMessages:
                 "tool_calls": [{"id": "tc1", "function": {"name": "test"}}],
             },
         ]
-        text_msgs, images = extract_images_from_messages(messages)
+        text_msgs, images, audio = extract_images_from_messages(messages)
         assert "tool_calls" in text_msgs[0]
 
     def test_invalid_image_url_skipped(self):
@@ -226,7 +227,7 @@ class TestExtractImagesFromMessages:
                 ],
             },
         ]
-        text_msgs, images = extract_images_from_messages(messages)
+        text_msgs, images, audio = extract_images_from_messages(messages)
         assert len(images) == 0
 
     def test_pydantic_model_content_parts(self):
@@ -249,8 +250,131 @@ class TestExtractImagesFromMessages:
         messages = [
             {"role": "user", "content": [image_part, text_part]},
         ]
-        text_msgs, images = extract_images_from_messages(messages)
+        text_msgs, images, audio = extract_images_from_messages(messages)
         assert len(images) == 1
+
+    def test_input_audio_base64_data_uri(self):
+        """Messages with input_audio base64 data URI extract audio."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_audio", "input_audio": {
+                        "data": "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAABCxAgAEABAAZGF0YQAAAAA=",
+                        "format": "wav",
+                    }},
+                    {"type": "text", "text": "What do you hear?"},
+                ],
+            },
+        ]
+        text_msgs, images, audio = extract_images_from_messages(messages)
+        assert len(audio) == 1
+        assert len(images) == 0
+        # Audio should be a BytesIO object
+        assert hasattr(audio[0], "read")
+
+    def test_input_audio_raw_base64(self):
+        """Messages with raw base64 input_audio extract audio."""
+        import base64
+        raw_bytes = b"\x00\x01\x02\x03" * 16
+        b64 = base64.b64encode(raw_bytes).decode()
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_audio", "input_audio": {
+                        "data": b64,
+                        "format": "wav",
+                    }},
+                ],
+            },
+        ]
+        text_msgs, images, audio = extract_images_from_messages(messages)
+        assert len(audio) == 1
+        assert hasattr(audio[0], "read")
+
+    def test_input_audio_bytes_data(self):
+        """Messages with bytes input_audio.data extract audio."""
+        raw_bytes = b"\x00\x01\x02\x03" * 16
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_audio", "input_audio": {
+                        "data": raw_bytes,
+                        "format": "wav",
+                    }},
+                ],
+            },
+        ]
+        text_msgs, images, audio = extract_images_from_messages(messages)
+        assert len(audio) == 1
+        assert hasattr(audio[0], "read")
+
+    def test_input_audio_string_path(self):
+        """Non-base64 string input_audio.data is treated as a file path/reference."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_audio", "input_audio": {
+                        "data": "/tmp/audio.wav",
+                        "format": "wav",
+                    }},
+                ],
+            },
+        ]
+        text_msgs, images, audio = extract_images_from_messages(messages)
+        assert len(audio) == 1
+        # Should be the string path, not a BytesIO (not valid base64)
+        assert isinstance(audio[0], str)
+        assert audio[0] == "/tmp/audio.wav"
+
+    def test_invalid_input_audio_skipped(self):
+        """Invalid base64 in input_audio is skipped with warning."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_audio", "input_audio": {
+                        "data": "data:audio/wav;base64,!!!not_valid_base64!!!",
+                        "format": "wav",
+                    }},
+                    {"type": "text", "text": "test"},
+                ],
+            },
+        ]
+        text_msgs, images, audio = extract_images_from_messages(messages)
+        assert len(audio) == 0
+
+    def test_audio_mixed_with_images(self):
+        """Audio and images in the same message both extracted."""
+        img = _make_test_image(4, 4)
+        b64 = _image_to_base64(img)
+        import base64 as b64_mod
+        raw_bytes = b"\x00\x01\x02\x03" * 16
+        audio_b64 = b64_mod.b64encode(raw_bytes).decode()
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}},
+                    {"type": "input_audio", "input_audio": {
+                        "data": audio_b64,
+                        "format": "wav",
+                    }},
+                    {"type": "text", "text": "Describe this image and audio"},
+                ],
+            },
+        ]
+        text_msgs, images, audio = extract_images_from_messages(messages)
+        assert len(images) == 1
+        assert len(audio) == 1
+        # Text content should be preserved
+        assert "Describe this image and audio" in text_msgs[0]["content"]
 
 
 # =============================================================================

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -933,6 +933,42 @@ class TestSchedulerStopTokens:
         # MockTokenizer has eos_token_id = 2
         assert mock_tokenizer.eos_token_id in stop_tokens
 
+    def test_includes_eot_token_id(self, mock_model, mock_tokenizer):
+        """Test _get_stop_tokens() includes end-of-turn token when available."""
+        # eot_token_id as a single int
+        mock_tokenizer.eot_token_id = 106
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        stop_tokens = scheduler._get_stop_tokens()
+        assert 106 in stop_tokens
+        assert mock_tokenizer.eos_token_id in stop_tokens  # EOS still there too
+
+    def test_includes_eot_token_id_list(self, mock_model, mock_tokenizer):
+        """Test _get_stop_tokens() handles eot_token_id as a list."""
+        mock_tokenizer.eot_token_id = [106, 107]
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        stop_tokens = scheduler._get_stop_tokens()
+        assert 106 in stop_tokens
+        assert 107 in stop_tokens
+
+    def test_falls_back_to_eot_token_encoding(self, mock_model, mock_tokenizer):
+        """When eot_token_id is absent but eot_token string is present, encode it."""
+        mock_tokenizer.eot_token = "<turn|>"
+        # Ensure eot_token_id is NOT present
+        assert not hasattr(mock_tokenizer, "eot_token_id") or mock_tokenizer.eot_token_id is None
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        stop_tokens = scheduler._get_stop_tokens()
+        # The MockTokenizer.encode() returns hash-based IDs, so we get something
+        assert len([t for t in stop_tokens if t != mock_tokenizer.eos_token_id]) > 0
+
+    def test_no_eot_token_when_absent(self, mock_model, mock_tokenizer):
+        """When neither eot_token_id nor eot_token string is present, no crash."""
+        # MockTokenizer has no eot_token_id or eot_token by default
+        assert not hasattr(mock_tokenizer, "eot_token_id")
+        assert not hasattr(mock_tokenizer, "eot_token")
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        stop_tokens = scheduler._get_stop_tokens()
+        assert mock_tokenizer.eos_token_id in stop_tokens
+
 
 class TestSchedulerXtcSpecialTokens:
     """Tests for _get_xtc_special_tokens()."""

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -488,7 +488,7 @@ class TestProcessChatMessages:
     def test_text_only_uses_vlm_prepare_path(self, mock_extract):
         """Text-only turns on a VLM model still use _prepare_vision_inputs()."""
         text_msgs = [{"role": "user", "content": "Hello"}]
-        mock_extract.return_value = (text_msgs, [])
+        mock_extract.return_value = (text_msgs, [], [])
 
         engine = _make_loaded_engine()
         engine._prepare_vision_inputs = MagicMock(
@@ -508,6 +508,7 @@ class TestProcessChatMessages:
         engine._prepare_vision_inputs.assert_called_once_with(
             text_msgs,
             [],
+            audio=None,
             chat_template_kwargs=None,
             tools=None,
         )
@@ -516,7 +517,7 @@ class TestProcessChatMessages:
     def test_text_only_passes_tools_to_prepare_vision(self, mock_extract):
         """Text-only + tools still convert and pass tools through VLM path."""
         text_msgs = [{"role": "user", "content": "Hello"}]
-        mock_extract.return_value = (text_msgs, [])
+        mock_extract.return_value = (text_msgs, [], [])
 
         engine = _make_loaded_engine()
         engine._prepare_vision_inputs = MagicMock(
@@ -541,7 +542,7 @@ class TestProcessChatMessages:
 
         mock_image = Image.new("RGB", (4, 4), "red")
         text_msgs = [{"role": "user", "content": "Describe"}]
-        mock_extract.return_value = (text_msgs, [mock_image])
+        mock_extract.return_value = (text_msgs, [mock_image], [])
 
         engine = _make_loaded_engine()
         engine._apply_ocr_prompt = MagicMock(return_value=text_msgs)
@@ -570,7 +571,7 @@ class TestProcessChatMessages:
 
         mock_image = Image.new("RGB", (4, 4), "red")
         text_msgs = [{"role": "user", "content": "Describe"}]
-        mock_extract.return_value = (text_msgs, [mock_image])
+        mock_extract.return_value = (text_msgs, [mock_image], [])
 
         engine = _make_loaded_engine()
         engine._apply_ocr_prompt = MagicMock(return_value=text_msgs)
@@ -597,7 +598,7 @@ class TestProcessChatMessages:
 
         mock_image = Image.new("RGB", (4, 4), "red")
         text_msgs = [{"role": "user", "content": "Describe"}]
-        mock_extract.return_value = (text_msgs, [mock_image])
+        mock_extract.return_value = (text_msgs, [mock_image], [])
 
         engine = _make_loaded_engine()
         engine._apply_ocr_prompt = MagicMock(return_value=text_msgs)
@@ -693,6 +694,77 @@ class TestPrepareVisionInputs:
 
         with pytest.raises(ValueError, match="does not support multi-image"):
             engine._prepare_vision_inputs(messages, images)
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    @patch("mlx_vlm.prompt_utils.apply_chat_template")
+    def test_audio_passed_to_prepare_inputs(self, mock_vlm_act, mock_prepare):
+        """When audio is provided, it's passed to prepare_inputs."""
+        engine = self._setup_engine_for_vision(model_type="gemma4")
+
+        mock_vlm_act.return_value = [{"role": "user", "content": "formatted"}]
+        mock_prepare.return_value = {
+            "input_ids": mx.array([[1, 2, 3]]),
+            "pixel_values": None,
+        }
+
+        from PIL import Image
+        messages = [{"role": "user", "content": "Describe this recording"}]
+        images = [Image.new("RGB", (4, 4), "red")]
+        audio = [("fake_audio_array", 16000)]
+
+        engine._prepare_vision_inputs(messages, images, audio=audio)
+
+        # prepare_inputs should have been called with audio
+        mock_prepare.assert_called_once()
+        call_args = mock_prepare.call_args[0]
+        # First positional arg is images, second is processor, third is audio or config
+        # For gemma4, audio=audio kwarg should be present
+        call_kwargs = mock_prepare.call_args[1]
+        assert call_kwargs.get("audio") == audio
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    @patch("mlx_vlm.prompt_utils.apply_chat_template")
+    def test_audio_none_not_passed(self, mock_vlm_act, mock_prepare):
+        """When audio is None, it is not passed to prepare_inputs."""
+        engine = self._setup_engine_for_vision(model_type="gemma4")
+
+        mock_vlm_act.return_value = [{"role": "user", "content": "formatted"}]
+        mock_prepare.return_value = {
+            "input_ids": mx.array([[1, 2, 3]]),
+            "pixel_values": None,
+        }
+
+        from PIL import Image
+        messages = [{"role": "user", "content": "Hello"}]
+        images = [Image.new("RGB", (4, 4), "red")]
+
+        engine._prepare_vision_inputs(messages, images, audio=None)
+
+        call_kwargs = mock_prepare.call_args[1]
+        assert call_kwargs.get("audio") is None
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    @patch("mlx_vlm.prompt_utils.apply_chat_template")
+    def test_audio_empty_list_not_passed(self, mock_vlm_act, mock_prepare):
+        """Empty audio list is equivalent to None."""
+        engine = self._setup_engine_for_vision(model_type="gemma4")
+
+        mock_vlm_act.return_value = [{"role": "user", "content": "formatted"}]
+        mock_prepare.return_value = {
+            "input_ids": mx.array([[1, 2, 3]]),
+            "pixel_values": None,
+        }
+
+        from PIL import Image
+        messages = [{"role": "user", "content": "Hello"}]
+        images = [Image.new("RGB", (4, 4), "red")]
+
+        engine._prepare_vision_inputs(messages, images, audio=[])
+
+        call_kwargs = mock_prepare.call_args[1]
+        assert call_kwargs.get("audio") is None
 
 
 class TestFormatMessagesForVLMTemplate:
@@ -898,6 +970,101 @@ class TestFormatMessagesForVLMTemplate:
         assert isinstance(formatted[1]["content"], str)
         assert "reasoning_content" not in formatted[1]
 
+    def test_format_messages_with_audio_parts(self):
+        """Messages with input_audio parts retain audio type after formatting."""
+        engine = _make_loaded_engine(model_type="gemma4")
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is in this recording?"},
+                    {"type": "input_audio", "input_audio": {"data": "abc", "format": "wav"}},
+                ],
+            },
+        ]
+
+        formatted, image_ranges = engine._format_messages_for_vlm_template(
+            messages, num_images=0, num_audios=1
+        )
+
+        # System message should be string content
+        assert isinstance(formatted[0]["content"], str)
+        # User message with audio should be list content
+        assert isinstance(formatted[1]["content"], list)
+        types = [p.get("type") for p in formatted[1]["content"] if isinstance(p, dict)]
+        # get_message_json() converts "input_audio" to "audio" type markers
+        assert "audio" in types
+        assert image_ranges == []
+
+    def test_audio_parts_capped_by_num_audios(self):
+        """Only load up to num_audios audio parts even if more are in message."""
+        engine = _make_loaded_engine(model_type="gemma4")
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_audio", "input_audio": {"data": "a", "format": "wav"}},
+                    {"type": "input_audio", "input_audio": {"data": "b", "format": "wav"}},
+                    {"type": "text", "text": "Compare these recordings"},
+                ],
+            },
+        ]
+
+        formatted, image_ranges = engine._format_messages_for_vlm_template(
+            messages, num_images=0, num_audios=1
+        )
+
+        # Should have exactly 1 audio marker (get_message_json converts to "audio" type)
+        audio_count = 0
+        for part in formatted[0]["content"]:
+            if isinstance(part, dict) and part.get("type") == "audio":
+                audio_count += 1
+        assert audio_count == 1
+
+    def test_audio_and_image_in_same_message(self):
+        """Both audio and image placeholders coexist in the same user turn."""
+        engine = _make_loaded_engine(model_type="gemma4")
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                    {"type": "input_audio", "input_audio": {"data": "xyz", "format": "wav"}},
+                    {"type": "text", "text": "Describe this image and audio"},
+                ],
+            },
+        ]
+
+        formatted, image_ranges = engine._format_messages_for_vlm_template(
+            messages, num_images=1, num_audios=1
+        )
+
+        content = formatted[0]["content"]
+        types = [p.get("type") for p in content if isinstance(p, dict)]
+        assert "image" in types or "image_url" in types
+        assert "audio" in types
+        # Image range should be recorded
+        assert len(image_ranges) == 1
+
+    def test_text_only_messages_with_zero_audio(self):
+        """Text-only messages with num_audios=0 should produce string content."""
+        engine = _make_loaded_engine(model_type="gemma4")
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ]
+
+        formatted, image_ranges = engine._format_messages_for_vlm_template(
+            messages, num_images=0, num_audios=0
+        )
+
+        assert image_ranges == []
+        for msg in formatted:
+            assert isinstance(msg["content"], str), (
+                f"Expected string content for {msg['role']} message, "
+                f"got {type(msg['content'])}"
+            )
     def test_user_reasoning_content_is_ignored(self):
         """reasoning_content on user messages is not preserved verbatim.
 


### PR DESCRIPTION
- Support audio input alongside images in VLM engine (BytesIO → numpy, has_multimodal gate now includes audio, image code guarded with num_images > 0)
- Add gemma4_unified model type throughout adapter, API, and server layers
- Add suppress_tokens mechanism in scheduler to prevent emission of multimodal placeholder tokens (<image|>, <audio|>)
- Add end-of-turn token detection for Gemma 4 (<turn|>, ID 106) to prevent hallucinating past conversational turns
- Add PIL feature extractor fallback for audio processor compatibility
- Extract audio data from input_audio content blocks in messages
- Bump mlx-vlm pin to 526c210 (includes Gemma4 unified prefill fixes)
- Add tests for audio input, suppress tokens, scheduler, and VLM engine

Add Gemma 4 unified audio input support to the Anthropic and OpenAI endpoints, enabling audio alongside images and text in multimodal requests. Extends the VLM engine to process audio data alongside images, adds suppress-token logic for multimodal placeholder tokens, and adds end-of-turn detection for Gemma 4.

## Dependency Chain

**Upstream mlx-vlm pin: `041f889` → `526c210`**
Picks up [mlx-vlm#1292](https://github.com/Blaizzy/mlx-vlm/pull/1292) — video input support for Gemma 4 12B, which includes the Gemma4 unified prefill fixes needed for audio. Also includes #1291 (APC fix for single requests) and unrelated commits for PaddleOCR/Nemotron/Ideogram.

## Changes

### Anthropic Endpoint (`/v1/messages`)
- **`ContentBlockInputAudio`** model: `data` (base64) + `format` (default `"wav"`)
- **`convert_anthropic_to_internal()`** extended to preserve `input_audio` blocks when `preserve_images=True`, extracting audio data for VLM processing
- **`_build_message_from_parts()`** handles `input_audio` alongside images

### OpenAI Endpoint (`/v1/chat/completions`)
- **`InputAudio`** model: `data` (base64 or data URI) + `format` (default `"wav"`)
- **`ContentPart.type`** extended to accept `"input_audio"` with `InputAudio` field
- Audio content parts parsed through the same internal pipeline as Anthropic

### VLM Engine
- `has_multimodal` gate now includes audio (not just images)
- Image processing guarded with `num_images > 0` to avoid empty-image errors with audio-only requests
- Audio data extracted from `input_audio` content blocks in messages → BytesIO → numpy
- PIL feature extractor fallback for audio processor compatibility

### Scheduler
- **Suppress-tokens mechanism** prevents emission of multimodal placeholder tokens (`<image|>`, `<audio|>`) that would otherwise leak through logits post-processing
- **End-of-turn detection** for Gemma 4 (`<turn|>`, ID 106) prevents hallucinating past conversational turns

### Model Adapter
- `gemma4_unified` model type added throughout adapter, API, and server layers

## Test Coverage

| Layer | File | Tests | Coverage |
|-------|------|-------|----------|
| Anthropic conversion | `test_anthropic_adapter.py` | 3 | `ContentBlockInputAudio` preserve/drop/audio-only |
| API utils (shared) | `test_api_utils.py` | 4 | Audio content block extraction from messages |
| Image/audio utils | `test_image_utils.py` | 6 | Base64, raw bytes, paths, data URIs, mixed |
| **OpenAI models** | `test_openai_models.py` | **9** | `InputAudio` creation/validation/serialization; `ContentPart` with `type="input_audio"`; `Message` with mixed audio+text |
| **OpenAI adapter** | `test_openai_adapter.py` | **2** | `parse_request` with audio content (mixed + audio-only), verifies no crash |
| VLM engine | `test_vlm_engine.py` | ~177 lines | Audio pipeline, multimodal gate, BytesIO→numpy |
| Scheduler | `test_scheduler.py` | ~36 lines | Suppress tokens, end-of-turn detection |
| Gemma4 messages | `test_gemma4_messages.py` | ~16 lines | `<turn|>` token handling |

## File Stats

```
18 files changed, +1054, -66
```

**Production code (8 files):** `anthropic_models.py` (+13), `anthropic_utils.py` (+59/-?), `openai_models.py` (+12), `api/utils.py` (+24/-?), `engine/vlm.py` (+152/-?), `scheduler.py` (+90), `utils/image.py` (+57/-?), `adapter/gemma4.py` (+9/-?)

**Tests (8 files):** `test_anthropic_adapter.py` (+123), `test_api_utils.py` (+43), `test_image_utils.py` (+140/-?), `test_vlm_engine.py` (+177/-?), `test_scheduler.py` (+36), `test_gemma4_messages.py` (+16), `test_openai_models.py` (+113), `test_openai_adapter.py` (+45)

**Config (1 file):** `pyproject.toml` (mlx-vlm pin bump)

Fixes https://github.com/jundot/omlx/issues/591