### PR TITLE
feat(dflash): expose prefix-cache controls and streaming metrics

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -140,11 +140,13 @@ class ModelSettingsRequest(BaseModel):
     dflash_in_memory_cache: bool | None = None
     dflash_in_memory_cache_max_entries: int | None = None
     dflash_in_memory_cache_max_bytes: int | None = None
+    dflash_max_snapshot_tokens: int | None = None
     dflash_ssd_cache: bool | None = None
     dflash_ssd_cache_max_bytes: int | None = None
     dflash_draft_window_size: int | None = None
     dflash_draft_sink_size: int | None = None
     dflash_verify_mode: str | None = None
+    dflash_l2_frontier_stride: int | None = None
     # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch)
     mtp_enabled: bool | None = None
     # VLM MTP speculative decoding via external assistant drafter (mlx-vlm 191d7c8+)
@@ -2078,6 +2080,11 @@ async def update_model_settings(
         current_settings.dflash_in_memory_cache_max_bytes = int(
             request.dflash_in_memory_cache_max_bytes
         )
+    if "dflash_max_snapshot_tokens" in sent:
+        value = request.dflash_max_snapshot_tokens
+        current_settings.dflash_max_snapshot_tokens = (
+            int(value) if value is not None and value >= 0 else None
+        )
     if "dflash_ssd_cache" in sent:
         ssd_requested = bool(request.dflash_ssd_cache)
         if ssd_requested:
@@ -2127,6 +2134,11 @@ async def update_model_settings(
         # Anything else (including empty string) → revert to dflash default.
         current_settings.dflash_verify_mode = (
             value if value in ("dflash", "adaptive", "ddtree", "off") else None
+        )
+    if "dflash_l2_frontier_stride" in sent:
+        value = request.dflash_l2_frontier_stride
+        current_settings.dflash_l2_frontier_stride = (
+            int(value) if value is not None and value >= 0 else None
         )
 
     # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch)
@@ -2331,8 +2343,13 @@ async def update_model_settings(
         or "dflash_in_memory_cache" in sent
         or "dflash_in_memory_cache_max_entries" in sent
         or "dflash_in_memory_cache_max_bytes" in sent
+        or "dflash_max_snapshot_tokens" in sent
         or "dflash_ssd_cache" in sent
         or "dflash_ssd_cache_max_bytes" in sent
+        or "dflash_draft_window_size" in sent
+        or "dflash_draft_sink_size" in sent
+        or "dflash_verify_mode" in sent
+        or "dflash_l2_frontier_stride" in sent
         # trust_remote_code is plumbed at model load time; toggling it on
         # an already-loaded engine has no effect until reload.
         or "trust_remote_code" in sent

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1634,6 +1634,7 @@
                     dflash_in_memory_cache_max_gib: settings.dflash_in_memory_cache_max_bytes
                         ? Math.round(settings.dflash_in_memory_cache_max_bytes / (1024 ** 3))
                         : 8,
+                    dflash_max_snapshot_tokens: settings.dflash_max_snapshot_tokens ?? null,
                     dflash_ssd_cache: settings.dflash_ssd_cache || false,
                     dflash_ssd_cache_max_gib: settings.dflash_ssd_cache_max_bytes
                         ? Math.round(settings.dflash_ssd_cache_max_bytes / (1024 ** 3))
@@ -1641,6 +1642,7 @@
                     dflash_draft_window_size: settings.dflash_draft_window_size ?? null,
                     dflash_draft_sink_size: settings.dflash_draft_sink_size ?? null,
                     dflash_verify_mode: settings.dflash_verify_mode || 'adaptive',
+                    dflash_l2_frontier_stride: settings.dflash_l2_frontier_stride ?? null,
                     dflash_compatible: model.dflash_compatible !== false,
                     dflash_compatibility_reason: model.dflash_compatibility_reason || '',
                     dflash_ssd_cache_available: !!model.dflash_ssd_cache_available,
@@ -1756,6 +1758,12 @@
                                 dflash_in_memory_cache_max_bytes: this.modelSettings.dflash_enabled
                                     ? Math.max(1, parseInt(this.modelSettings.dflash_in_memory_cache_max_gib) || 8) * (1024 ** 3)
                                     : 8 * (1024 ** 3),
+                                dflash_max_snapshot_tokens: this.modelSettings.dflash_enabled
+                                    && this.modelSettings.dflash_max_snapshot_tokens !== null
+                                    && this.modelSettings.dflash_max_snapshot_tokens !== undefined
+                                    && this.modelSettings.dflash_max_snapshot_tokens !== ''
+                                    ? Math.max(0, parseInt(this.modelSettings.dflash_max_snapshot_tokens))
+                                    : null,
                                 dflash_ssd_cache: this.modelSettings.dflash_enabled
                                     && !!this.modelSettings.dflash_in_memory_cache
                                     && !!this.modelSettings.dflash_ssd_cache_available
@@ -1776,6 +1784,12 @@
                                     : null,
                                 dflash_verify_mode: this.modelSettings.dflash_enabled
                                     ? (this.modelSettings.dflash_verify_mode || 'adaptive')
+                                    : null,
+                                dflash_l2_frontier_stride: this.modelSettings.dflash_enabled
+                                    && this.modelSettings.dflash_l2_frontier_stride !== null
+                                    && this.modelSettings.dflash_l2_frontier_stride !== undefined
+                                    && this.modelSettings.dflash_l2_frontier_stride !== ''
+                                    ? Math.max(0, parseInt(this.modelSettings.dflash_l2_frontier_stride))
                                     : null,
                                 mtp_enabled: !!this.modelSettings.mtp_enabled,
                                 vlm_mtp_enabled: !!this.modelSettings.vlm_mtp_enabled,
@@ -1864,11 +1878,13 @@
                         this.modelSettings.dflash_in_memory_cache = true;
                         this.modelSettings.dflash_in_memory_cache_max_entries = 4;
                         this.modelSettings.dflash_in_memory_cache_max_gib = 8;
+                        this.modelSettings.dflash_max_snapshot_tokens = null;
                         this.modelSettings.dflash_ssd_cache = false;
                         this.modelSettings.dflash_ssd_cache_max_gib = 20;
                         this.modelSettings.dflash_draft_window_size = null;
                         this.modelSettings.dflash_draft_sink_size = null;
                         this.modelSettings.dflash_verify_mode = 'adaptive';
+                        this.modelSettings.dflash_l2_frontier_stride = null;
                         this.modelSettings.mtp_enabled = false;
                         this.modelSettings.trust_remote_code = false;
                     } else if (response.status === 404) {

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -849,6 +849,12 @@
                                                    class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
                                             <p class="text-xs text-neutral-400 mt-1">Byte budget for L1 snapshots; LRU evicts when exceeded.</p>
                                         </div>
+                                        <div x-show="modelSettings.dflash_in_memory_cache" x-transition>
+                                            <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">Maximum snapshot tokens</label>
+                                            <input type="number" x-model.number="modelSettings.dflash_max_snapshot_tokens" min="0" step="1024" placeholder="32000"
+                                                   class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
+                                            <p class="text-xs text-neutral-400 mt-1">Largest prompt snapshot admitted to the DFlash prefix cache. Use 0 for no token cap; leave empty for the dflash default.</p>
+                                        </div>
                                         <div class="flex items-start justify-between gap-3">
                                             <div class="min-w-0">
                                                 <span class="text-sm font-medium text-neutral-700">SSD cache</span>
@@ -873,6 +879,12 @@
                                             <input type="number" x-model.number="modelSettings.dflash_ssd_cache_max_gib" min="1" max="1024" step="1" placeholder="20"
                                                    class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
                                             <p class="text-xs text-neutral-400 mt-1">Disk budget for L2 spill; oldest entries are evicted when exceeded.</p>
+                                        </div>
+                                        <div x-show="modelSettings.dflash_ssd_cache" x-transition>
+                                            <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">L2 frontier stride (tokens)</label>
+                                            <input type="number" x-model.number="modelSettings.dflash_l2_frontier_stride" min="0" step="8192" placeholder="0"
+                                                   class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
+                                            <p class="text-xs text-neutral-400 mt-1">Minimum spacing between long-prefill L2 snapshots. Use 0 or leave empty for the dflash default.</p>
                                         </div>
                                     </div>
                                 </div>

--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -355,6 +355,10 @@ class Usage(BaseUsage):
     generation_duration: Optional[float] = None
     prompt_tokens_per_second: Optional[float] = None
     generation_tokens_per_second: Optional[float] = None
+    # DFlash metrics (oMLX extension)
+    cache_hit_kind: Optional[str] = None
+    dflash_acceptance_ratio: Optional[float] = None
+    dflash_cycles_completed: Optional[int] = None
 
 
 class ChatCompletionResponse(BaseModel):

--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -359,6 +359,9 @@ class Usage(BaseUsage):
     cache_hit_kind: Optional[str] = None
     dflash_acceptance_ratio: Optional[float] = None
     dflash_cycles_completed: Optional[int] = None
+    dflash_peak_memory_gb: Optional[float] = None
+    dflash_prefill_tokens_restored: Optional[int] = None
+    dflash_prefill_tokens_computed: Optional[int] = None
 
 
 class ChatCompletionResponse(BaseModel):

--- a/omlx/engine/base.py
+++ b/omlx/engine/base.py
@@ -35,6 +35,8 @@ class GenerationOutput:
     tool_calls: Optional[List[Dict[str, Any]]] = None
     # Prefix cache stats
     cached_tokens: int = 0
+    # Engine-specific metrics surfaced by API usage payloads.
+    metrics: Dict[str, Any] = field(default_factory=dict)
 
 
 class BaseEngine(ABC):

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -719,7 +719,7 @@ class DFlashEngine(BaseEngine):
             stable_prefix_len=prefix_flow.stable_prefix_len,
             prefix_cache_active=prefix_flow.cache_active,
             publish_generation_snapshot=prefix_flow.publish_generation_snapshot,
-            prefix_hit_kind=prefix_flow.hit_kind,
+            prefix_hit_kind=getattr(prefix_flow, "hit_kind", None),
             runtime_context=self._runtime_context,
         )
         return event_iter, prefix_flow, stop_ids

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -740,10 +740,17 @@ class DFlashEngine(BaseEngine):
         return promptly so the single MLX executor thread is freed for the
         next request.
         """
-        from dflash_mlx.engine.events import SummaryEvent, TokenEvent
+        from dflash_mlx.engine.events import (
+            PrefillCompleteEvent,
+            SummaryEvent,
+            TokenEvent,
+        )
 
         event_iter = None
+        prefill_restored = 0
+        prefill_computed = len(prompt_tokens)
         try:
+            mx.reset_peak_memory()
             event_iter, prefix_flow, stop_ids = self._stream_dflash_events(
                 prompt_tokens=prompt_tokens,
                 max_tokens=max_tokens,
@@ -772,7 +779,11 @@ class DFlashEngine(BaseEngine):
                     logger.info("DFlash generation aborted by client")
                     break
 
-                if isinstance(event, TokenEvent):
+                if isinstance(event, PrefillCompleteEvent):
+                    prefill_restored = int(event.prefill_tokens_restored)
+                    prefill_computed = int(event.prefill_tokens_computed)
+
+                elif isinstance(event, TokenEvent):
                     token_id = int(event.token_id)
                     # Skip EOS/stop tokens from output
                     if token_id in stop_ids:
@@ -827,6 +838,9 @@ class DFlashEngine(BaseEngine):
                         "acceptance_ratio": accept_ratio,
                         "cycles_completed": cycles,
                         "cache_hit_kind": str(event.hit_kind),
+                        "peak_memory_gb": event.peak_memory_gb,
+                        "prefill_tokens_restored": prefill_restored,
+                        "prefill_tokens_computed": prefill_computed,
                     }
                     asyncio.run_coroutine_threadsafe(
                         queue.put(("", [], True, metrics)), loop
@@ -921,6 +935,7 @@ class DFlashEngine(BaseEngine):
                 else None
             )
             try:
+                mx.reset_peak_memory()
                 event_iter, prefix_flow, stop_ids = self._stream_dflash_events(
                     prompt_tokens=prompt_tokens,
                     max_tokens=max_tokens,
@@ -1009,6 +1024,7 @@ class DFlashEngine(BaseEngine):
                 "cache_hit_kind": str(summary.hit_kind),
                 "acceptance_ratio": float(summary.acceptance_ratio),
                 "cycles_completed": int(summary.cycles_completed),
+                "peak_memory_gb": summary.peak_memory_gb,
             }
         return GenerationOutput(
             text=text,

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -181,14 +181,6 @@ class DFlashEngine(BaseEngine):
             if model_settings
             else None
         )
-        # None → disabled (0). Route short-output requests to target-only when
-        # max_new_tokens < threshold and no exact prefix cache hit exists.
-        self._min_output_tokens = (
-            getattr(model_settings, "dflash_min_output_tokens", None)
-            if model_settings
-            else None
-        )
-
     @property
     def model_name(self) -> str:
         return self._model_name
@@ -256,15 +248,6 @@ class DFlashEngine(BaseEngine):
                     "dflash_l2_frontier_stride=%d ignored: installed dflash-mlx does not "
                     "support prefix_cache_l2_frontier_stride; upgrade dflash-mlx to apply",
                     self._l2_frontier_stride,
-                )
-        if self._min_output_tokens is not None:
-            if "dflash_min_output_tokens" in _sig:
-                optional_knobs["dflash_min_output_tokens"] = self._min_output_tokens
-            else:
-                logger.warning(
-                    "dflash_min_output_tokens=%d ignored: installed dflash-mlx does not "
-                    "support dflash_min_output_tokens; upgrade dflash-mlx to apply",
-                    self._min_output_tokens,
                 )
         if self._max_snapshot_tokens is not None:
             if "max_snapshot_tokens" in _sig:
@@ -1298,7 +1281,6 @@ class DFlashEngine(BaseEngine):
             "max_snapshot_tokens": self._max_snapshot_tokens,
             "ssd_cache": self._resolve_dflash_l2_dir() is not None,
             "l2_frontier_stride": self._l2_frontier_stride,
-            "min_output_tokens": self._min_output_tokens,
         }
 
     def get_cache_stats(self) -> dict[str, Any] | None:

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -143,6 +143,11 @@ class DFlashEngine(BaseEngine):
             if model_settings
             else 8 * 1024**3
         )
+        self._max_snapshot_tokens = (
+            getattr(model_settings, "dflash_max_snapshot_tokens", None)
+            if model_settings
+            else None
+        )
         self._ssd_cache_requested = (
             bool(getattr(model_settings, "dflash_ssd_cache", False))
             if model_settings
@@ -260,6 +265,15 @@ class DFlashEngine(BaseEngine):
                     "dflash_min_output_tokens=%d ignored: installed dflash-mlx does not "
                     "support dflash_min_output_tokens; upgrade dflash-mlx to apply",
                     self._min_output_tokens,
+                )
+        if self._max_snapshot_tokens is not None:
+            if "max_snapshot_tokens" in _sig:
+                optional_knobs["max_snapshot_tokens"] = self._max_snapshot_tokens
+            else:
+                logger.warning(
+                    "dflash_max_snapshot_tokens=%d ignored: installed dflash-mlx does "
+                    "not support max_snapshot_tokens; upgrade dflash-mlx to apply",
+                    self._max_snapshot_tokens,
                 )
         cfg = runtime_config_from_defaults(
             prefix_cache=self._in_memory_cache_enabled,
@@ -1265,6 +1279,7 @@ class DFlashEngine(BaseEngine):
             "in_fallback_mode": self._in_fallback_mode,
             "loaded": self._loaded,
             "in_memory_cache": self._in_memory_cache_enabled,
+            "max_snapshot_tokens": self._max_snapshot_tokens,
             "ssd_cache": self._resolve_dflash_l2_dir() is not None,
             "l2_frontier_stride": self._l2_frontier_stride,
             "min_output_tokens": self._min_output_tokens,

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -988,12 +988,20 @@ class DFlashEngine(BaseEngine):
         completion_token_count = (
             int(summary.generation_tokens) if summary is not None else len(generated)
         )
+        metrics = {}
+        if summary is not None:
+            metrics = {
+                "cache_hit_kind": str(summary.hit_kind),
+                "acceptance_ratio": float(summary.acceptance_ratio),
+                "cycles_completed": int(summary.cycles_completed),
+            }
         return GenerationOutput(
             text=text,
             tokens=generated,
             prompt_tokens=prompt_token_count,
             completion_tokens=completion_token_count,
             finish_reason="stop",
+            metrics=metrics,
         )
 
     async def stream_generate(
@@ -1105,6 +1113,7 @@ class DFlashEngine(BaseEngine):
                     completion_tokens=total_completion,
                     finished=finished,
                     finish_reason=finish_reason,
+                    metrics=metrics or {},
                 )
 
                 if finished:

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -170,6 +170,19 @@ class DFlashEngine(BaseEngine):
             if model_settings
             else None
         )
+        # None → dflash-mlx uses its 8192-token floor; set to raise the floor further.
+        self._l2_frontier_stride = (
+            getattr(model_settings, "dflash_l2_frontier_stride", None)
+            if model_settings
+            else None
+        )
+        # None → disabled (0). Route short-output requests to target-only when
+        # max_new_tokens < threshold and no exact prefix cache hit exists.
+        self._min_output_tokens = (
+            getattr(model_settings, "dflash_min_output_tokens", None)
+            if model_settings
+            else None
+        )
 
     @property
     def model_name(self) -> str:
@@ -223,6 +236,13 @@ class DFlashEngine(BaseEngine):
 
         l2_dir = self._resolve_dflash_l2_dir()
         l2_enabled = l2_dir is not None
+        # Only forward knobs that are explicitly configured (None → omit entirely so
+        # dflash-mlx fills DEFAULT_RUNTIME_CONFIG and older versions stay compatible).
+        optional_knobs: dict[str, Any] = {}
+        if self._l2_frontier_stride is not None:
+            optional_knobs["prefix_cache_l2_frontier_stride"] = self._l2_frontier_stride
+        if self._min_output_tokens is not None:
+            optional_knobs["dflash_min_output_tokens"] = self._min_output_tokens
         cfg = runtime_config_from_defaults(
             prefix_cache=self._in_memory_cache_enabled,
             prefix_cache_max_entries=self._in_memory_cache_max_entries,
@@ -237,6 +257,7 @@ class DFlashEngine(BaseEngine):
             draft_window_size=self._draft_window_size,
             draft_sink_size=self._draft_sink_size,
             verify_mode=self._verify_mode,
+            **optional_knobs,
         )
         return build_runtime_context(cfg)
 
@@ -772,6 +793,7 @@ class DFlashEngine(BaseEngine):
                         "completion_tokens": gen_tokens,
                         "acceptance_ratio": accept_ratio,
                         "cycles_completed": cycles,
+                        "cache_hit_kind": str(event.hit_kind),
                     }
                     asyncio.run_coroutine_threadsafe(
                         queue.put(("", [], True, metrics)), loop
@@ -1216,6 +1238,8 @@ class DFlashEngine(BaseEngine):
             "loaded": self._loaded,
             "in_memory_cache": self._in_memory_cache_enabled,
             "ssd_cache": self._resolve_dflash_l2_dir() is not None,
+            "l2_frontier_stride": self._l2_frontier_stride,
+            "min_output_tokens": self._min_output_tokens,
         }
 
     def get_cache_stats(self) -> dict[str, Any] | None:

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -705,6 +705,7 @@ class DFlashEngine(BaseEngine):
             stable_prefix_len=prefix_flow.stable_prefix_len,
             prefix_cache_active=prefix_flow.cache_active,
             publish_generation_snapshot=prefix_flow.publish_generation_snapshot,
+            prefix_hit_kind=prefix_flow.hit_kind,
             runtime_context=self._runtime_context,
         )
         return event_iter, prefix_flow, stop_ids

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -231,18 +231,36 @@ class DFlashEngine(BaseEngine):
         return self._omlx_ssd_cache_dir / "dflash_l2"
 
     def _build_runtime_context(self) -> Any:
+        import inspect
+
         from dflash_mlx.runtime.config import runtime_config_from_defaults
         from dflash_mlx.runtime.context import build_runtime_context
 
         l2_dir = self._resolve_dflash_l2_dir()
         l2_enabled = l2_dir is not None
-        # Only forward knobs that are explicitly configured (None → omit entirely so
-        # dflash-mlx fills DEFAULT_RUNTIME_CONFIG and older versions stay compatible).
+        # Only forward knobs that are explicitly configured (non-None) AND supported by
+        # the installed dflash-mlx version.  Older installs don't accept these kwargs;
+        # passing them unconditionally would raise TypeError.
+        _sig = inspect.signature(runtime_config_from_defaults).parameters
         optional_knobs: dict[str, Any] = {}
         if self._l2_frontier_stride is not None:
-            optional_knobs["prefix_cache_l2_frontier_stride"] = self._l2_frontier_stride
+            if "prefix_cache_l2_frontier_stride" in _sig:
+                optional_knobs["prefix_cache_l2_frontier_stride"] = self._l2_frontier_stride
+            else:
+                logger.warning(
+                    "dflash_l2_frontier_stride=%d ignored: installed dflash-mlx does not "
+                    "support prefix_cache_l2_frontier_stride; upgrade dflash-mlx to apply",
+                    self._l2_frontier_stride,
+                )
         if self._min_output_tokens is not None:
-            optional_knobs["dflash_min_output_tokens"] = self._min_output_tokens
+            if "dflash_min_output_tokens" in _sig:
+                optional_knobs["dflash_min_output_tokens"] = self._min_output_tokens
+            else:
+                logger.warning(
+                    "dflash_min_output_tokens=%d ignored: installed dflash-mlx does not "
+                    "support dflash_min_output_tokens; upgrade dflash-mlx to apply",
+                    self._min_output_tokens,
+                )
         cfg = runtime_config_from_defaults(
             prefix_cache=self._in_memory_cache_enabled,
             prefix_cache_max_entries=self._in_memory_cache_max_entries,

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -54,6 +54,7 @@ MODEL_SPECIFIC_PROFILE_FIELDS = (
     "dflash_in_memory_cache",
     "dflash_in_memory_cache_max_entries",
     "dflash_in_memory_cache_max_bytes",
+    "dflash_max_snapshot_tokens",
     "dflash_ssd_cache",
     "dflash_ssd_cache_max_bytes",
     "dflash_draft_window_size",

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -59,6 +59,8 @@ MODEL_SPECIFIC_PROFILE_FIELDS = (
     "dflash_draft_window_size",
     "dflash_draft_sink_size",
     "dflash_verify_mode",
+    "dflash_l2_frontier_stride",
+    "dflash_min_output_tokens",
     "mtp_enabled",
     "vlm_mtp_enabled",
     "vlm_mtp_draft_model",

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -61,7 +61,6 @@ MODEL_SPECIFIC_PROFILE_FIELDS = (
     "dflash_draft_sink_size",
     "dflash_verify_mode",
     "dflash_l2_frontier_stride",
-    "dflash_min_output_tokens",
     "mtp_enabled",
     "vlm_mtp_enabled",
     "vlm_mtp_draft_model",

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -81,6 +81,13 @@ class ModelSettings:
         dflash_verify_mode: Verifier algorithm — "dflash", "adaptive", "ddtree", or "off"
             (None = dflash default "adaptive"). "adaptive" can shrink block size when
             acceptance drops.
+        dflash_l2_frontier_stride: Token stride at which L2 frontier snapshots are written
+            during cold prefill (None = dflash 8192-token floor, rounded to prefill-step
+            multiple). Values below 8192 are silently raised. Larger strides reduce
+            sync SSD writes on long-context prompts.
+        dflash_min_output_tokens: Route short-output requests to target-only generation when
+            max_new_tokens < threshold and no exact prefix cache hit exists (None / 0 = disabled).
+            Speculative decoding is unprofitable for very short outputs.
         mtp_enabled: Enable native multi-token prediction (mlx-lm PR 990 / PR 15 monkey-patch).
             When True, BatchGenerator uses MTP draft+verify for singleton decode and
             for multi-row decode batches whose cache positions are aligned. Unaligned
@@ -156,6 +163,8 @@ class ModelSettings:
     dflash_draft_window_size: Optional[int] = None
     dflash_draft_sink_size: Optional[int] = None
     dflash_verify_mode: Optional[str] = None  # "dflash" | "adaptive" | "ddtree" | "off"
+    dflash_l2_frontier_stride: Optional[int] = None  # Token stride for L2 frontier snapshots (None = 8192 floor)
+    dflash_min_output_tokens: Optional[int] = None  # Route to target-only when max_new_tokens < this and no exact hit
 
     # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch). When enabled, BatchGenerator
     # uses MTP draft+verify for singleton decode and aligned multi-row decode batches.

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -87,9 +87,6 @@ class ModelSettings:
             during cold prefill (None = dflash 8192-token floor, rounded to prefill-step
             multiple). Values below 8192 are silently raised. Larger strides reduce
             sync SSD writes on long-context prompts.
-        dflash_min_output_tokens: Route short-output requests to target-only generation when
-            max_new_tokens < threshold and no exact prefix cache hit exists (None / 0 = disabled).
-            Speculative decoding is unprofitable for very short outputs.
         mtp_enabled: Enable native multi-token prediction (mlx-lm PR 990 / PR 15 monkey-patch).
             When True, BatchGenerator uses MTP draft+verify for singleton decode and
             for multi-row decode batches whose cache positions are aligned. Unaligned
@@ -167,7 +164,6 @@ class ModelSettings:
     dflash_draft_sink_size: Optional[int] = None
     dflash_verify_mode: Optional[str] = None  # "dflash" | "adaptive" | "ddtree" | "off"
     dflash_l2_frontier_stride: Optional[int] = None  # Token stride for L2 frontier snapshots (None = 8192 floor)
-    dflash_min_output_tokens: Optional[int] = None  # Route to target-only when max_new_tokens < this and no exact hit
 
     # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch). When enabled, BatchGenerator
     # uses MTP draft+verify for singleton decode and aligned multi-row decode batches.

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -72,6 +72,8 @@ class ModelSettings:
         dflash_in_memory_cache: Enable DFlash L1 (RAM) prefix cache.
         dflash_in_memory_cache_max_entries: L1 cache max entries (default 4, matches dflash balanced profile).
         dflash_in_memory_cache_max_bytes: L1 cache byte budget.
+        dflash_max_snapshot_tokens: Maximum prompt tokens admitted to DFlash L1
+            (None = dflash default; 0 disables the token cap).
         dflash_ssd_cache: Enable DFlash L2 (SSD) prefix cache spill (uses omlx SSD cache dir).
         dflash_ssd_cache_max_bytes: L2 (SSD) disk budget; dflash evicts oldest entries when exceeded.
         dflash_draft_window_size: Draft model sliding-attention window (None = dflash default 1024).
@@ -155,6 +157,7 @@ class ModelSettings:
     dflash_in_memory_cache: bool = True
     dflash_in_memory_cache_max_entries: int = 4  # Matches dflash balanced profile default
     dflash_in_memory_cache_max_bytes: int = 8 * 1024 * 1024 * 1024  # 8 GiB (balanced profile default)
+    dflash_max_snapshot_tokens: Optional[int] = None  # None = dflash default (currently 32k)
     dflash_ssd_cache: bool = False  # Requires in-memory cache and an omlx paged SSD cache dir
     dflash_ssd_cache_max_bytes: int = 20 * 1024 * 1024 * 1024  # 20 GiB L2 disk budget
     # DFlash runtime tuning knobs. None = let dflash-mlx pick its own DEFAULT_RUNTIME_CONFIG

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3688,6 +3688,13 @@ async def stream_chat_completion(
                     cache_hit_kind=engine_metrics.get("cache_hit_kind"),
                     dflash_acceptance_ratio=engine_metrics.get("acceptance_ratio"),
                     dflash_cycles_completed=engine_metrics.get("cycles_completed"),
+                    dflash_peak_memory_gb=engine_metrics.get("peak_memory_gb"),
+                    dflash_prefill_tokens_restored=engine_metrics.get(
+                        "prefill_tokens_restored"
+                    ),
+                    dflash_prefill_tokens_computed=engine_metrics.get(
+                        "prefill_tokens_computed"
+                    ),
                 ),
             )
             yield f"data: {usage_chunk.model_dump_json(exclude_none=True)}\n\n"

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3666,6 +3666,7 @@ async def stream_chat_completion(
             total_time = end_time - start_time
             pt = last_output.prompt_tokens
             ct = last_output.completion_tokens
+            engine_metrics = last_output.metrics or {}
             usage_chunk = ChatCompletionChunk(
                 id=response_id,
                 model=request.model,
@@ -3684,6 +3685,9 @@ async def stream_chat_completion(
                     generation_duration=round(gen_duration, 2),
                     prompt_tokens_per_second=round(pt / ttft, 2) if ttft > 0 else None,
                     generation_tokens_per_second=round(ct / gen_duration, 2) if gen_duration > 0 else None,
+                    cache_hit_kind=engine_metrics.get("cache_hit_kind"),
+                    dflash_acceptance_ratio=engine_metrics.get("acceptance_ratio"),
+                    dflash_cycles_completed=engine_metrics.get("cycles_completed"),
                 ),
             )
             yield f"data: {usage_chunk.model_dump_json(exclude_none=True)}\n\n"

--- a/tests/integration/test_e2e_streaming.py
+++ b/tests/integration/test_e2e_streaming.py
@@ -26,6 +26,7 @@ class MockGenerationOutput:
     finished: bool = False
     tool_calls: Optional[List[Dict[str, Any]]] = None
     cached_tokens: int = 0
+    metrics: Dict[str, Any] = field(default_factory=dict)
 
 
 class MockTokenizer:
@@ -551,6 +552,51 @@ class TestStreamingHelperFunctions:
         json_str = first_event[6:-2]
         data = json.loads(json_str)
         assert data["choices"][0]["delta"].get("role") == "assistant"
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_completion_includes_dflash_metrics(self):
+        from omlx.api.openai_models import ChatCompletionRequest, Message
+        from omlx.server import stream_chat_completion
+
+        engine = MockBaseEngine()
+        engine.set_stream_outputs([
+            MockGenerationOutput(
+                text="Done",
+                new_text="Done",
+                prompt_tokens=8192,
+                completion_tokens=1,
+                finished=True,
+                finish_reason="stop",
+                metrics={
+                    "cache_hit_kind": "l1_exact",
+                    "acceptance_ratio": 0.75,
+                    "cycles_completed": 16,
+                },
+            ),
+        ])
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="Hello")],
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+
+        events = []
+        async for event in stream_chat_completion(
+            engine,
+            [{"role": "user", "content": "Hello"}],
+            request,
+            max_tokens=128,
+            temperature=0,
+            top_p=1,
+            top_k=0,
+        ):
+            events.extend(parse_sse_events(event))
+
+        usage = next(event["usage"] for event in events if event.get("usage"))
+        assert usage["cache_hit_kind"] == "l1_exact"
+        assert usage["dflash_acceptance_ratio"] == 0.75
+        assert usage["dflash_cycles_completed"] == 16
 
     @pytest.mark.asyncio
     async def test_stream_chat_completion_with_tools_streams_content_incrementally(self):

--- a/tests/test_admin_api_key.py
+++ b/tests/test_admin_api_key.py
@@ -82,6 +82,102 @@ class TestListModelsSettings:
         assert settings_dict["temperature"] == 0.7
 
 
+class TestDFlashAdminSettings:
+    """Tests for DFlash cache controls in the admin settings API."""
+
+    def test_request_accepts_supported_cache_controls(self):
+        request = admin_routes.ModelSettingsRequest(
+            dflash_max_snapshot_tokens=65536,
+            dflash_l2_frontier_stride=32768,
+        )
+
+        assert request.dflash_max_snapshot_tokens == 65536
+        assert request.dflash_l2_frontier_stride == 32768
+        assert request.model_fields_set == {
+            "dflash_max_snapshot_tokens",
+            "dflash_l2_frontier_stride",
+        }
+
+    def test_update_persists_supported_cache_controls(self):
+        entry = SimpleNamespace(
+            engine=None,
+            engine_type="dflash",
+            model_type="llm",
+            model_path="/tmp/test-model",
+            is_pinned=False,
+        )
+        engine_pool = MagicMock()
+        engine_pool.get_entry.return_value = entry
+        settings_manager = MagicMock()
+        settings_manager.get_settings.return_value = ModelSettings()
+
+        with (
+            patch.object(admin_routes, "_get_engine_pool", return_value=engine_pool),
+            patch.object(
+                admin_routes,
+                "_get_settings_manager",
+                return_value=settings_manager,
+            ),
+            patch.object(admin_routes, "_get_server_state", return_value=MagicMock()),
+        ):
+            result = asyncio.run(
+                admin_routes.update_model_settings(
+                    "test-model",
+                    admin_routes.ModelSettingsRequest(
+                        dflash_max_snapshot_tokens=65536,
+                        dflash_l2_frontier_stride=32768,
+                    ),
+                    is_admin=True,
+                )
+            )
+
+        saved = settings_manager.set_settings.call_args.args[1]
+        assert saved.dflash_max_snapshot_tokens == 65536
+        assert saved.dflash_l2_frontier_stride == 32768
+        assert result["settings"]["dflash_max_snapshot_tokens"] == 65536
+        assert result["settings"]["dflash_l2_frontier_stride"] == 32768
+
+    def test_null_clears_supported_cache_controls(self):
+        entry = SimpleNamespace(
+            engine=None,
+            engine_type="dflash",
+            model_type="llm",
+            model_path="/tmp/test-model",
+            is_pinned=False,
+        )
+        engine_pool = MagicMock()
+        engine_pool.get_entry.return_value = entry
+        settings_manager = MagicMock()
+        settings_manager.get_settings.return_value = ModelSettings(
+            dflash_max_snapshot_tokens=65536,
+            dflash_l2_frontier_stride=32768,
+        )
+
+        with (
+            patch.object(admin_routes, "_get_engine_pool", return_value=engine_pool),
+            patch.object(
+                admin_routes,
+                "_get_settings_manager",
+                return_value=settings_manager,
+            ),
+            patch.object(admin_routes, "_get_server_state", return_value=MagicMock()),
+        ):
+            asyncio.run(
+                admin_routes.update_model_settings(
+                    "test-model",
+                    admin_routes.ModelSettingsRequest(
+                        dflash_max_snapshot_tokens=None,
+                        dflash_l2_frontier_stride=None,
+                    ),
+                    is_admin=True,
+                )
+            )
+
+        saved = settings_manager.set_settings.call_args.args[1]
+        assert saved.dflash_max_snapshot_tokens is None
+        assert saved.dflash_l2_frontier_stride is None
+
+
 class TestValidateApiKey:
     """Tests for validate_api_key() format validation."""
 

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -572,6 +572,7 @@ class TestDFlashEngineInit:
         )
         ctx = engine._build_runtime_context()
         runtime = getattr(ctx, "runtime")
+        assert runtime.prefix_cache_l2_frontier_stride == 16384
         assert runtime.dflash_min_output_tokens == 32
 
     def test_get_stats_exposes_prefix_cache_knobs(self):

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -24,6 +24,7 @@ class TestDFlashModelSettings:
         assert settings.dflash_in_memory_cache is True
         assert settings.dflash_in_memory_cache_max_entries == 4
         assert settings.dflash_in_memory_cache_max_bytes == 8 * 1024 * 1024 * 1024
+        assert settings.dflash_max_snapshot_tokens is None
         assert settings.dflash_ssd_cache is False
         # New long-context tuning knobs (issue #1276). None → dflash-mlx default.
         assert settings.dflash_draft_window_size is None
@@ -74,6 +75,7 @@ class TestDFlashModelSettings:
             "dflash_in_memory_cache": False,
             "dflash_in_memory_cache_max_entries": 16,
             "dflash_in_memory_cache_max_bytes": 4 * 1024 * 1024 * 1024,
+            "dflash_max_snapshot_tokens": 65536,
             "dflash_ssd_cache": True,
         }
         settings = ModelSettings.from_dict(data)
@@ -87,6 +89,7 @@ class TestDFlashModelSettings:
         assert settings.dflash_in_memory_cache is False
         assert settings.dflash_in_memory_cache_max_entries == 16
         assert settings.dflash_in_memory_cache_max_bytes == 4 * 1024 * 1024 * 1024
+        assert settings.dflash_max_snapshot_tokens == 65536
         assert settings.dflash_ssd_cache is True
 
     def test_from_dict_missing_new_fields_uses_defaults(self):
@@ -100,6 +103,7 @@ class TestDFlashModelSettings:
         assert settings.dflash_in_memory_cache is True
         assert settings.dflash_in_memory_cache_max_entries == 4
         assert settings.dflash_in_memory_cache_max_bytes == 8 * 1024 * 1024 * 1024
+        assert settings.dflash_max_snapshot_tokens is None
         assert settings.dflash_ssd_cache is False
 
     def test_from_dict_ignores_removed_speculative_tokens(self):
@@ -135,6 +139,7 @@ class TestDFlashModelSettings:
             dflash_draft_quant_group_size=64,
             dflash_max_ctx=16384,
             dflash_in_memory_cache=False,
+            dflash_max_snapshot_tokens=65536,
             dflash_ssd_cache=False,
             dflash_ssd_cache_max_bytes=30 * 1024**3,
         )
@@ -148,6 +153,7 @@ class TestDFlashModelSettings:
         assert restored.dflash_draft_quant_group_size == original.dflash_draft_quant_group_size
         assert restored.dflash_max_ctx == original.dflash_max_ctx
         assert restored.dflash_in_memory_cache == original.dflash_in_memory_cache
+        assert restored.dflash_max_snapshot_tokens == original.dflash_max_snapshot_tokens
         assert restored.dflash_ssd_cache == original.dflash_ssd_cache
         assert restored.dflash_ssd_cache_max_bytes == original.dflash_ssd_cache_max_bytes
 
@@ -286,6 +292,7 @@ class TestDFlashEngineInit:
         assert stats["model_name"] == "test-model"
         assert stats["draft_model"] == "test-draft"
         assert stats["loaded"] is False
+        assert stats["max_snapshot_tokens"] is None
         assert "verify_mode" not in stats
 
     def test_cache_stats_returns_none(self):
@@ -638,6 +645,28 @@ class TestDFlashEngineInit:
         if "dflash_min_output_tokens" in sig:
             assert runtime.dflash_min_output_tokens == 32
 
+    def test_build_runtime_context_passes_max_snapshot_tokens(self):
+        """Long-context L1 admission must be configurable through oMLX."""
+        import inspect
+
+        try:
+            from omlx.engine.dflash import DFlashEngine
+            from dflash_mlx.runtime.config import runtime_config_from_defaults
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            model_settings=ModelSettings(dflash_max_snapshot_tokens=65536),
+        )
+        runtime = engine._build_runtime_context().runtime
+
+        if "max_snapshot_tokens" in inspect.signature(
+            runtime_config_from_defaults
+        ).parameters:
+            assert runtime.max_snapshot_tokens == 65536
+
     def test_get_stats_exposes_prefix_cache_knobs(self):
         """get_stats() should include l2_frontier_stride and min_output_tokens."""
         try:
@@ -656,6 +685,17 @@ class TestDFlashEngineInit:
         stats = engine.get_stats()
         assert stats["l2_frontier_stride"] == 16384
         assert stats["min_output_tokens"] == 64
+
+    def test_get_stats_exposes_max_snapshot_tokens(self):
+        from omlx.engine.dflash import DFlashEngine
+
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            model_settings=ModelSettings(dflash_max_snapshot_tokens=65536),
+        )
+
+        assert engine.get_stats()["max_snapshot_tokens"] == 65536
 
 
 class TestDFlashCompatibility:

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -31,7 +31,6 @@ class TestDFlashModelSettings:
         assert settings.dflash_draft_sink_size is None
         assert settings.dflash_verify_mode is None
         assert settings.dflash_l2_frontier_stride is None
-        assert settings.dflash_min_output_tokens is None
 
     def test_no_speculative_tokens_field(self):
         """dflash_speculative_tokens was removed in v2 and stays removed."""
@@ -61,7 +60,6 @@ class TestDFlashModelSettings:
         assert "dflash_draft_sink_size" not in d
         assert "dflash_verify_mode" not in d
         assert "dflash_l2_frontier_stride" not in d
-        assert "dflash_min_output_tokens" not in d
 
     def test_from_dict_with_dflash_fields(self):
         data = {
@@ -581,7 +579,7 @@ class TestDFlashEngineInit:
         assert runtime.prefix_cache_l2_max_bytes == 20 * 1024**3
 
 
-    def test_prefix_cache_knobs_default_to_none(self):
+    def test_prefix_cache_knob_defaults_to_none(self):
         """No settings → engine stores None → dflash-mlx fills its own defaults."""
         try:
             from omlx.engine.dflash import DFlashEngine
@@ -593,10 +591,9 @@ class TestDFlashEngineInit:
             draft_model_path="test-draft",
         )
         assert engine._l2_frontier_stride is None
-        assert engine._min_output_tokens is None
 
-    def test_prefix_cache_knobs_read_from_settings(self):
-        """DFlashEngine picks up l2_frontier_stride and min_output_tokens from ModelSettings."""
+    def test_prefix_cache_knob_read_from_settings(self):
+        """DFlashEngine picks up l2_frontier_stride from ModelSettings."""
         try:
             from omlx.engine.dflash import DFlashEngine
         except ImportError:
@@ -607,17 +604,15 @@ class TestDFlashEngineInit:
             draft_model_path="test-draft",
             model_settings=ModelSettings(
                 dflash_l2_frontier_stride=16384,
-                dflash_min_output_tokens=64,
             ),
         )
         assert engine._l2_frontier_stride == 16384
-        assert engine._min_output_tokens == 64
 
-    def test_build_runtime_context_passes_prefix_cache_knobs(self):
-        """l2_frontier_stride and min_output_tokens reach dflash-mlx RuntimeContext.
+    def test_build_runtime_context_passes_prefix_cache_knob(self):
+        """l2_frontier_stride reaches dflash-mlx RuntimeContext.
 
-        When the installed dflash-mlx predates PR3/PR4, the engine must silently
-        ignore the knobs (logging a warning) rather than raising TypeError.
+        When the installed dflash-mlx predates the setting, the engine must
+        ignore it (logging a warning) rather than raising TypeError.
         """
         import inspect
 
@@ -632,7 +627,6 @@ class TestDFlashEngineInit:
             draft_model_path="test-draft",
             model_settings=ModelSettings(
                 dflash_l2_frontier_stride=16384,
-                dflash_min_output_tokens=32,
             ),
         )
         # Must not raise TypeError regardless of installed dflash-mlx version.
@@ -642,8 +636,6 @@ class TestDFlashEngineInit:
         sig = inspect.signature(runtime_config_from_defaults).parameters
         if "prefix_cache_l2_frontier_stride" in sig:
             assert runtime.prefix_cache_l2_frontier_stride == 16384
-        if "dflash_min_output_tokens" in sig:
-            assert runtime.dflash_min_output_tokens == 32
 
     def test_build_runtime_context_passes_max_snapshot_tokens(self):
         """Long-context L1 admission must be configurable through oMLX."""
@@ -667,8 +659,8 @@ class TestDFlashEngineInit:
         ).parameters:
             assert runtime.max_snapshot_tokens == 65536
 
-    def test_get_stats_exposes_prefix_cache_knobs(self):
-        """get_stats() should include l2_frontier_stride and min_output_tokens."""
+    def test_get_stats_exposes_prefix_cache_knob(self):
+        """get_stats() should include l2_frontier_stride."""
         try:
             from omlx.engine.dflash import DFlashEngine
         except ImportError:
@@ -679,12 +671,10 @@ class TestDFlashEngineInit:
             draft_model_path="test-draft",
             model_settings=ModelSettings(
                 dflash_l2_frontier_stride=16384,
-                dflash_min_output_tokens=64,
             ),
         )
         stats = engine.get_stats()
         assert stats["l2_frontier_stride"] == 16384
-        assert stats["min_output_tokens"] == 64
 
     def test_get_stats_exposes_max_snapshot_tokens(self):
         from omlx.engine.dflash import DFlashEngine

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -29,6 +29,8 @@ class TestDFlashModelSettings:
         assert settings.dflash_draft_window_size is None
         assert settings.dflash_draft_sink_size is None
         assert settings.dflash_verify_mode is None
+        assert settings.dflash_l2_frontier_stride is None
+        assert settings.dflash_min_output_tokens is None
 
     def test_no_speculative_tokens_field(self):
         """dflash_speculative_tokens was removed in v2 and stays removed."""
@@ -57,6 +59,8 @@ class TestDFlashModelSettings:
         assert "dflash_draft_window_size" not in d
         assert "dflash_draft_sink_size" not in d
         assert "dflash_verify_mode" not in d
+        assert "dflash_l2_frontier_stride" not in d
+        assert "dflash_min_output_tokens" not in d
 
     def test_from_dict_with_dflash_fields(self):
         data = {
@@ -511,6 +515,83 @@ class TestDFlashEngineInit:
         ctx = engine._build_runtime_context()
         runtime = getattr(ctx, "runtime")
         assert runtime.prefix_cache_l2_max_bytes == 20 * 1024**3
+
+
+    def test_prefix_cache_knobs_default_to_none(self):
+        """No settings → engine stores None → dflash-mlx fills its own defaults."""
+        try:
+            from omlx.engine.dflash import DFlashEngine
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+        )
+        assert engine._l2_frontier_stride is None
+        assert engine._min_output_tokens is None
+
+    def test_prefix_cache_knobs_read_from_settings(self):
+        """DFlashEngine picks up l2_frontier_stride and min_output_tokens from ModelSettings."""
+        try:
+            from omlx.engine.dflash import DFlashEngine
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            model_settings=ModelSettings(
+                dflash_l2_frontier_stride=16384,
+                dflash_min_output_tokens=64,
+            ),
+        )
+        assert engine._l2_frontier_stride == 16384
+        assert engine._min_output_tokens == 64
+
+    def test_build_runtime_context_passes_prefix_cache_knobs(self):
+        """l2_frontier_stride and min_output_tokens reach dflash-mlx RuntimeContext."""
+        try:
+            from omlx.engine.dflash import DFlashEngine
+            import inspect
+            from dflash_mlx.runtime.config import runtime_config_from_defaults
+            if "prefix_cache_l2_frontier_stride" not in inspect.signature(
+                runtime_config_from_defaults
+            ).parameters:
+                pytest.skip("dflash-mlx < PR3 (no prefix_cache_l2_frontier_stride)")
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            model_settings=ModelSettings(
+                dflash_l2_frontier_stride=16384,
+                dflash_min_output_tokens=32,
+            ),
+        )
+        ctx = engine._build_runtime_context()
+        runtime = getattr(ctx, "runtime")
+        assert runtime.dflash_min_output_tokens == 32
+
+    def test_get_stats_exposes_prefix_cache_knobs(self):
+        """get_stats() should include l2_frontier_stride and min_output_tokens."""
+        try:
+            from omlx.engine.dflash import DFlashEngine
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            model_settings=ModelSettings(
+                dflash_l2_frontier_stride=16384,
+                dflash_min_output_tokens=64,
+            ),
+        )
+        stats = engine.get_stats()
+        assert stats["l2_frontier_stride"] == 16384
+        assert stats["min_output_tokens"] == 64
 
 
 class TestDFlashCompatibility:

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -550,15 +550,16 @@ class TestDFlashEngineInit:
         assert engine._min_output_tokens == 64
 
     def test_build_runtime_context_passes_prefix_cache_knobs(self):
-        """l2_frontier_stride and min_output_tokens reach dflash-mlx RuntimeContext."""
+        """l2_frontier_stride and min_output_tokens reach dflash-mlx RuntimeContext.
+
+        When the installed dflash-mlx predates PR3/PR4, the engine must silently
+        ignore the knobs (logging a warning) rather than raising TypeError.
+        """
+        import inspect
+
         try:
             from omlx.engine.dflash import DFlashEngine
-            import inspect
             from dflash_mlx.runtime.config import runtime_config_from_defaults
-            if "prefix_cache_l2_frontier_stride" not in inspect.signature(
-                runtime_config_from_defaults
-            ).parameters:
-                pytest.skip("dflash-mlx < PR3 (no prefix_cache_l2_frontier_stride)")
         except ImportError:
             pytest.skip("dflash-mlx not installed")
 
@@ -570,10 +571,15 @@ class TestDFlashEngineInit:
                 dflash_min_output_tokens=32,
             ),
         )
+        # Must not raise TypeError regardless of installed dflash-mlx version.
         ctx = engine._build_runtime_context()
         runtime = getattr(ctx, "runtime")
-        assert runtime.prefix_cache_l2_frontier_stride == 16384
-        assert runtime.dflash_min_output_tokens == 32
+
+        sig = inspect.signature(runtime_config_from_defaults).parameters
+        if "prefix_cache_l2_frontier_stride" in sig:
+            assert runtime.prefix_cache_l2_frontier_stride == 16384
+        if "dflash_min_output_tokens" in sig:
+            assert runtime.dflash_min_output_tokens == 32
 
     def test_get_stats_exposes_prefix_cache_knobs(self):
         """get_stats() should include l2_frontier_stride and min_output_tokens."""

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -212,6 +212,63 @@ class TestDFlashEngineInit:
         assert engine._draft_quant_activation_bits == 32
         assert engine._draft_quant_group_size == 128
 
+    def test_stream_events_forward_prefix_cache_hit_kind(self, monkeypatch):
+        """The adapter must preserve DFlash's live cache classification."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        import dflash_mlx.runtime as dflash_runtime
+        from dflash_mlx.server.prefix_cache_flow import PrefixCacheFlow
+        from omlx.engine.dflash import DFlashEngine
+
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+        )
+        engine._executor_tokenizer = MagicMock()
+        engine._draft_model = object()
+        engine._target_model = object()
+        engine._target_ops = object()
+        engine._draft_backend = object()
+        engine._runtime_context = object()
+
+        flow = SimpleNamespace(
+            snapshot=object(),
+            snapshot_service=object(),
+            stable_prefix_len=128,
+            cache_active=True,
+            publish_generation_snapshot=True,
+            hit_kind="l1_exact",
+        )
+        monkeypatch.setattr(
+            PrefixCacheFlow,
+            "for_request",
+            staticmethod(lambda **_kwargs: flow),
+        )
+        monkeypatch.setattr(dflash_runtime, "get_stop_token_ids", lambda _tokenizer: [2])
+
+        captured = {}
+
+        def fake_stream_dflash_generate(**kwargs):
+            captured.update(kwargs)
+            return iter(())
+
+        monkeypatch.setattr(
+            dflash_runtime,
+            "stream_dflash_generate",
+            fake_stream_dflash_generate,
+        )
+
+        event_iter, returned_flow, stop_ids = engine._stream_dflash_events(
+            prompt_tokens=[1, 2, 3],
+            max_tokens=16,
+        )
+
+        assert list(event_iter) == []
+        assert returned_flow is flow
+        assert stop_ids == [2]
+        assert captured["prefix_hit_kind"] == "l1_exact"
+
 
     def test_get_stats_no_verify_mode(self):
         """Stats should not include verify_mode (removed in v2)."""

--- a/tests/test_stream_usage.py
+++ b/tests/test_stream_usage.py
@@ -109,6 +109,19 @@ class TestUsageExtendedFields:
         assert dumped["model_load_duration"] == 55.93
         assert "prompt_tokens_details" not in dumped
 
+    def test_usage_with_dflash_metrics(self):
+        usage = Usage(
+            prompt_tokens=8192,
+            completion_tokens=128,
+            cache_hit_kind="l1_exact",
+            dflash_acceptance_ratio=0.75,
+            dflash_cycles_completed=16,
+        )
+        dumped = usage.model_dump(exclude_none=True)
+        assert dumped["cache_hit_kind"] == "l1_exact"
+        assert dumped["dflash_acceptance_ratio"] == 0.75
+        assert dumped["dflash_cycles_completed"] == 16
+
 
 class TestUsageChunkFormat:
     """Tests for usage chunk structure (OpenAI spec: choices=[], usage present)."""

--- a/tests/test_stream_usage.py
+++ b/tests/test_stream_usage.py
@@ -116,11 +116,17 @@ class TestUsageExtendedFields:
             cache_hit_kind="l1_exact",
             dflash_acceptance_ratio=0.75,
             dflash_cycles_completed=16,
+            dflash_peak_memory_gb=31.25,
+            dflash_prefill_tokens_restored=8188,
+            dflash_prefill_tokens_computed=4,
         )
         dumped = usage.model_dump(exclude_none=True)
         assert dumped["cache_hit_kind"] == "l1_exact"
         assert dumped["dflash_acceptance_ratio"] == 0.75
         assert dumped["dflash_cycles_completed"] == 16
+        assert dumped["dflash_peak_memory_gb"] == 31.25
+        assert dumped["dflash_prefill_tokens_restored"] == 8188
+        assert dumped["dflash_prefill_tokens_computed"] == 4
 
 
 class TestUsageChunkFormat:


### PR DESCRIPTION
## Summary

- Expose DFlash maximum snapshot tokens and L2 frontier stride through model
  settings, profiles, the admin API, and the dashboard.
- Pass optional runtime controls only when the installed `dflash-mlx`
  signature supports them, preserving compatibility with older releases.
- Forward prefix-cache hit classification and expose restored/computed tokens,
  DFlash cycles, draft acceptance, prefill throughput, and peak memory in
  streaming usage metrics.
- Keep metric forwarding compatible with older prefix-flow objects that do not
  expose `hit_kind`.

Depends on merged bstnxbt/dflash-mlx#37 for the new snapshot behavior and event
fields.

This is complementary to #1462: that PR handles request/policy identity and
cached-token accounting; this PR adds configurable snapshot controls and
detailed streaming performance metrics.

## Validation

Post-rebase affected suite:

```text
319 passed, 12 deselected in 2.05s
```

Full suite before the conflict-free rebase:

```text
5073 passed, 40 skipped, 66 deselected in 241.29s
```

Sibling dflash-mlx full suite:

```text
1102 passed, 8 skipped, 2 warnings in 44.92s
```

## Apple Silicon Benchmarks

Platform: MacBook Pro M1 Max, 64 GB unified memory, macOS 26.5.

All bundles used oQ6 quantized target matrices, FP16 target floating tensors,
and BF16 DFlash drafters. Thinking was disabled. Generation rates below use a
1K-token prompt and 256 generated tokens. Cache repeats use a 65,536-token
prompt.

| Family | Generation | 1K TTFT | 64K L1 exact | 64K L2 exact |
|---|---:|---:|---:|---:|
| Qwen 3.6 27B | 53.1 tok/s | 7.59 s | 0.92 s | 5.91 s |
| Qwen 3.6 35B-A3B | 190.1 tok/s | 1.42 s | 0.58 s | 6.10 s |
| Gemma 4 31B | 42.9 tok/s | 9.26 s | 0.95 s | 8.44 s |
| Gemma 4 26B-A4B | 141.0 tok/s | 1.48 s | 0.64 s | 5.02 s |

All 8K, 32K, and 64K L1/L2 probes restored the expected prefix and produced
the same deterministic response SHA-256 as their cold controls.

For the original Gemma 31B validation, DFlash decode reached 29.2 tok/s at
93.8% acceptance versus 9.4 tok/s target-only. At 64K, the measured peak
DFlash memory was 46.54 GB.

## Disclosure

This PR was vibe-coded with AI assistance and supervised, reviewed, and
validated by me.
