### PR TITLE
feat: Add support for Gemma 4 QAT models in quant tool

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -1714,16 +1714,46 @@ def validate_quantizable(config: dict) -> bool:
 
     Models with 'quantization' key (mlx-lm quantized) are excluded.
     Models with 'quantization_config' are excluded UNLESS they are native FP8
-    (e.g. MiniMax, DeepSeek) which are full-precision models stored in FP8 format.
+    (e.g. MiniMax, DeepSeek) which are full-precision models stored in FP8 format,
+    or QAT-trained models (e.g. Google Gemma 4 QAT variants) whose
+    quantization_config records training-time settings but whose weights are
+    stored in full precision (bfloat16/float16).
     """
     if "quantization" in config:
         return False
     if "quantization_config" in config:
         qc = config["quantization_config"]
-        if isinstance(qc, dict) and qc.get("quant_method") == "fp8":
-            return True
+        if isinstance(qc, dict):
+            quant_method = qc.get("quant_method", "")
+            # FP8 models are full-precision weights stored in FP8 format
+            if quant_method == "fp8":
+                return True
+            # QAT models carry quantization_config with no recognised
+            # weight-quantization method — weights are full-precision.
+            if not quant_method:
+                return True
         return False
     return True
+
+
+def _sensitivity_lm_config_override(config: dict) -> dict | None:
+    """Return a model_config override for mlx_lm.load when the model has a
+    QAT quantization_config that mlx-lm cannot process (missing quant_method).
+
+    mlx-lm does ``quantization_config["quant_method"]`` without a fallback, so
+    QAT configs (e.g. Google Gemma 4 QAT) raise KeyError and abort the load.
+    Passing ``{"quantization_config": None}`` via model_config causes
+    config.update() to replace the offending key before that branch runs.
+    """
+    for qc in (
+        config.get("quantization_config"),
+        config.get("text_config", {}).get("quantization_config"),
+    ):
+        # `and qc`: mlx-lm uses a walrus/truthiness guard so a falsy (empty)
+        # quantization_config never reaches the quant_method access — no override needed.
+        if isinstance(qc, dict) and qc and "quant_method" not in qc:
+            return {"quantization_config": None}
+    return None
 
 
 def make_predicate(config: dict, oq_level: int = 4) -> Callable:
@@ -4070,13 +4100,28 @@ def _measure_sensitivity(
 
     try:
         if is_vlm:
+            import mlx.nn as _nn
             from mlx_vlm.utils import load_model as vlm_load_model
 
-            model = vlm_load_model(
-                Path(model_path),
-                lazy=True,
-                trust_remote_code=trust_remote_code,
-            )
+            # mlx_vlm.load_model calls model.load_weights(weights) without strict=False.
+            # Shared-KV models (e.g. Gemma 4 2B/4B) omit k/v weights for shared layers,
+            # so strict=True raises ValueError. Relax temporarily — sensitivity only needs
+            # approximate weights; shared layers receive pre-computed KV at inference time.
+            _orig_lw = _nn.Module.load_weights
+
+            def _lenient_load_weights(self, file_or_weights, *args, **kwargs):
+                kwargs.pop("strict", None)
+                return _orig_lw(self, file_or_weights, *args, strict=False, **kwargs)
+
+            _nn.Module.load_weights = _lenient_load_weights
+            try:
+                model = vlm_load_model(
+                    Path(model_path),
+                    lazy=True,
+                    trust_remote_code=trust_remote_code,
+                )
+            finally:
+                _nn.Module.load_weights = _orig_lw
             from mlx_lm.tokenizer_utils import load as load_tokenizer
 
             tokenizer = load_tokenizer(Path(model_path))
@@ -4087,6 +4132,7 @@ def _measure_sensitivity(
                 model_path,
                 lazy=True,
                 trust_remote_code=trust_remote_code,
+                model_config=_sensitivity_lm_config_override(config),
             )
     except Exception as e:
         logger.error(f"Sensitivity measurement: model load failed ({e})")

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -1709,6 +1709,20 @@ class _DiscoveredPlan:
         )
 
 
+def _is_qat_unquantized_config(qc) -> bool:
+    """Return True if qc is a QAT training config with full-precision weights.
+
+    Gemma 4 QAT configs carry quant_type (e.g. "q4_0") recording the training
+    regime but store weights in bfloat16 — no quant_method means no actual
+    weight quantization has been applied.
+    """
+    return (
+        isinstance(qc, dict)
+        and qc.get("quant_type") == "q4_0"
+        and "quant_method" not in qc
+    )
+
+
 def validate_quantizable(config: dict) -> bool:
     """Check if a model config indicates it can be quantized.
 
@@ -1728,9 +1742,8 @@ def validate_quantizable(config: dict) -> bool:
             # FP8 models are full-precision weights stored in FP8 format
             if quant_method == "fp8":
                 return True
-            # QAT models carry quantization_config with no recognised
-            # weight-quantization method — weights are full-precision.
-            if not quant_method:
+            # QAT models record training-time quant_type but weights are fp16/bf16
+            if _is_qat_unquantized_config(qc):
                 return True
         return False
     return True
@@ -1749,9 +1762,7 @@ def _sensitivity_lm_config_override(config: dict) -> dict | None:
         config.get("quantization_config"),
         config.get("text_config", {}).get("quantization_config"),
     ):
-        # `and qc`: mlx-lm uses a walrus/truthiness guard so a falsy (empty)
-        # quantization_config never reaches the quant_method access — no override needed.
-        if isinstance(qc, dict) and qc and "quant_method" not in qc:
+        if _is_qat_unquantized_config(qc):
             return {"quantization_config": None}
     return None
 

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -1489,9 +1489,7 @@ class _DiscoveredPlan:
         if not sources:
             return None
         if recipe and not (
-            transform == "reshape"
-            and len(recipe) == 1
-            and recipe[0][0] == "reshape"
+            transform == "reshape" and len(recipe) == 1 and recipe[0][0] == "reshape"
         ):
             return None
         if transform not in ("passthrough", "stack") and not (
@@ -2393,6 +2391,7 @@ def _gs_for_mode(bits: int, default_gs: int) -> int:
 
 # --- chunked-quantize helpers (added for Qwen3.5-397B) ---------------------
 import struct as _struct
+
 import numpy as _np
 
 
@@ -3090,9 +3089,9 @@ def quantize_oq_streaming(
             )
         elif _model_exceeds_ram and auto_proxy_sensitivity:
             logger.warning(
-                f"oQ{oq_level:g}: model size ({_model_bytes/1e9:.1f} GB) exceeds "
-                f"{int(_MAX_MODEL_RAM_FRACTION*100)}% of system RAM "
-                f"({_system_ram/1e9:.1f} GB). Auto-building a uniform "
+                f"oQ{oq_level:g}: model size ({_model_bytes / 1e9:.1f} GB) exceeds "
+                f"{int(_MAX_MODEL_RAM_FRACTION * 100)}% of system RAM "
+                f"({_system_ram / 1e9:.1f} GB). Auto-building a uniform "
                 f"{_PROXY_QUANT_BITS}-bit proxy on disk so sensitivity "
                 "measurement stays data-driven."
             )
@@ -3100,6 +3099,7 @@ def quantize_oq_streaming(
             try:
                 _proxy_dir = _build_proxy_for_sensitivity(
                     model_path,
+                    config=config,
                     dtype=dtype,
                     working_dir=str(output.parent),
                     trust_remote_code=trust_remote_code,
@@ -3128,7 +3128,7 @@ def quantize_oq_streaming(
                     logger.info(f"oQ{oq_level:g}: cleaned up proxy at {_proxy_dir}")
         elif _model_exceeds_ram:
             raise RuntimeError(
-                f"oQ{oq_level:g}: model exceeds {int(_MAX_MODEL_RAM_FRACTION*100)}% "
+                f"oQ{oq_level:g}: model exceeds {int(_MAX_MODEL_RAM_FRACTION * 100)}% "
                 "of system RAM and auto_proxy_sensitivity is disabled. "
                 "Enable auto_proxy_sensitivity, pass sensitivity_model_path "
                 "with a pre-quantized version of this model, or run on a "
@@ -3536,8 +3536,7 @@ def quantize_oq_streaming(
 
     cb("saving", 100.0)
     logger.info(
-        f"oQ{oq_level:g} streaming: completed -> {output_path} "
-        f"({total_shards} shards)"
+        f"oQ{oq_level:g} streaming: completed -> {output_path} ({total_shards} shards)"
     )
 
 
@@ -3583,7 +3582,7 @@ def _load_calibration_data(
             )
         except Exception as e:
             logger.warning(
-                f"Built-in calibration failed: {e}, " "falling back to mlx-lm default"
+                f"Built-in calibration failed: {e}, falling back to mlx-lm default"
             )
 
     if dataset == "default":
@@ -3642,9 +3641,7 @@ def _load_builtin_calibration(
         raise ValueError("No calibration text available")
 
     total_kb = sum(len(t) for t in texts) // 1024
-    logger.info(
-        f"Built-in calibration: {len(texts)} texts, " f"{total_kb} KB ({dataset})"
-    )
+    logger.info(f"Built-in calibration: {len(texts)} texts, {total_kb} KB ({dataset})")
 
     all_ids = []
     for text in texts:
@@ -3763,8 +3760,7 @@ def _load_hf_calibration(tokenizer, dataset: str, num_samples: int, seq_length: 
         tokens = tokens[indices]
 
     logger.info(
-        f"Calibration: {tokens.shape[0]} samples × {seq_length} tokens "
-        f"from {dataset}"
+        f"Calibration: {tokens.shape[0]} samples × {seq_length} tokens from {dataset}"
     )
     return tokens
 
@@ -4021,10 +4017,7 @@ def _measure_sensitivity_from_model(
         saved = _temporary_quantize_block(
             block, config, oq_level, _OQ_DEFAULT_GROUP_SIZE
         )
-        if (
-            isinstance(position_ids, dict)
-            and position_ids.get("kind") == "glm_moe_dsa"
-        ):
+        if isinstance(position_ids, dict) and position_ids.get("kind") == "glm_moe_dsa":
             position_ids["prev_topk_indices"] = prev_aux
         out_quant, _ = _forward_layer_result(block, inputs, layer_mask, position_ids)
         if out_quant is not None:
@@ -4036,10 +4029,7 @@ def _measure_sensitivity_from_model(
 
         _restore_saved_weights(block, saved)
 
-        if (
-            isinstance(position_ids, dict)
-            and position_ids.get("kind") == "glm_moe_dsa"
-        ):
+        if isinstance(position_ids, dict) and position_ids.get("kind") == "glm_moe_dsa":
             position_ids["prev_topk_indices"] = baseline_aux
         inputs = out_float
         mx.synchronize()
@@ -4181,6 +4171,7 @@ def _perturb_bits_for(bits: int):
 def _build_proxy_for_sensitivity(
     model_path: str,
     *,
+    config: dict | None = None,
     dtype: str,
     working_dir: str | None = None,
     trust_remote_code: bool = False,
@@ -4297,10 +4288,7 @@ def _build_streaming_proxy_for_sensitivity(
 
     for tensor_name in tensor_names:
         handled_packed = False
-        if (
-            hasattr(all_weights, "pop_packed")
-            and not _is_mtp_tensor(tensor_name)
-        ):
+        if hasattr(all_weights, "pop_packed") and not _is_mtp_tensor(tensor_name):
             src_info = all_weights.source_quant_info(tensor_name)
             if src_info is not None and _should_quantize_tensor(
                 tensor_name, all_weights.plan_shape(tensor_name)
@@ -4335,11 +4323,7 @@ def _build_streaming_proxy_for_sensitivity(
                 pred = universal_quant_predicate(
                     tensor_name, None, config, _PROXY_QUANT_BITS
                 )
-                if (
-                    pred is not False
-                    and len(shape) >= 2
-                    and shape[-1] % base_gs == 0
-                ):
+                if pred is not False and len(shape) >= 2 and shape[-1] % base_gs == 0:
                     if (
                         mx.issubdtype(w_mx.dtype, mx.floating)
                         and w_mx.dtype != target_dtype
@@ -4360,9 +4344,7 @@ def _build_streaming_proxy_for_sensitivity(
                     del qw, scales, biases
                 else:
                     if cast_predicate is None or cast_predicate(tensor_name):
-                        w_mx = _cast_passthrough_tensor(
-                            tensor_name, w_mx, target_dtype
-                        )
+                        w_mx = _cast_passthrough_tensor(tensor_name, w_mx, target_dtype)
                     out_shard_data[tensor_name] = w_mx
             else:
                 if cast_predicate is None or cast_predicate(tensor_name):
@@ -4579,12 +4561,11 @@ def _measure_sensitivity_from_quantized_model(
             else:
                 mx.eval(m.weight, m.scales)
 
-        if (
-            isinstance(position_ids, dict)
-            and position_ids.get("kind") == "glm_moe_dsa"
-        ):
+        if isinstance(position_ids, dict) and position_ids.get("kind") == "glm_moe_dsa":
             position_ids["prev_topk_indices"] = prev_aux
-        out_perturbed, _ = _forward_layer_result(block, inputs, layer_mask, position_ids)
+        out_perturbed, _ = _forward_layer_result(
+            block, inputs, layer_mask, position_ids
+        )
 
         modules_by_path = dict(
             tree_flatten(block.leaf_modules(), is_leaf=nn.Module.is_module)
@@ -4612,10 +4593,7 @@ def _measure_sensitivity_from_quantized_model(
             mx.eval(mse_val)
             sensitivity[layer_idx] = mse_val.item()
 
-        if (
-            isinstance(position_ids, dict)
-            and position_ids.get("kind") == "glm_moe_dsa"
-        ):
+        if isinstance(position_ids, dict) and position_ids.get("kind") == "glm_moe_dsa":
             position_ids["prev_topk_indices"] = baseline_aux
         inputs = out_baseline
         mx.eval(inputs)

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -4116,6 +4116,9 @@ def _measure_sensitivity(
 
             _nn.Module.load_weights = _lenient_load_weights
             try:
+                # No QAT config override needed here: mlx_vlm.utils.load_model
+                # uses quantization_config.get("quant_method") rather than direct
+                # key access, so a missing quant_method falls through silently.
                 model = vlm_load_model(
                     Path(model_path),
                     lazy=True,

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -17,19 +17,18 @@ except ImportError:
     HAS_MLX = False
 
 from omlx.oq import (
-    OQ_LEVELS,
     _LEVEL_BITS,
     _MAX_MODEL_RAM_FRACTION,
     _OQ_BPW_TARGETS,
     _PROXY_QUANT_BITS,
     _PROXY_QUANT_GROUP_SIZE,
-    _DiscoveredPlan,
-    _TrackedTensor,
+    OQ_LEVELS,
     _bpw_targets_for_level,
     _build_proxy_for_sensitivity,
     _build_streaming_proxy_for_sensitivity,
     _build_quant_plan,
     _discover_sanitize_plan,
+    _DiscoveredPlan,
     _extract_layer_index,
     _format_size,
     _forward_layer,
@@ -44,7 +43,9 @@ from omlx.oq import (
     _perturb_bits_for,
     _progress_total_bytes,
     _quantize_chunked,
+    _sensitivity_lm_config_override,
     _should_quantize_tensor,
+    _TrackedTensor,
     _validate_oq_dtype_for_model,
     estimate_bpw_and_size,
     estimate_memory,
@@ -731,8 +732,14 @@ class TestValidateQuantizable:
     def test_already_quantized(self):
         assert validate_quantizable({"quantization": {"bits": 4}}) is False
 
-    def test_quantization_config(self):
-        assert validate_quantizable({"quantization_config": {"bits": 4}}) is False
+    def test_quantization_config_with_known_method(self):
+        # Real HF quantization configs always carry quant_method
+        assert (
+            validate_quantizable(
+                {"quantization_config": {"quant_method": "gptq", "bits": 4}}
+            )
+            is False
+        )
 
     def test_fp8_native_is_quantizable(self):
         # Native FP8 models (MiniMax, DeepSeek) should be quantizable
@@ -747,6 +754,67 @@ class TestValidateQuantizable:
             validate_quantizable({"quantization_config": {"quant_method": "gptq"}})
             is False
         )
+
+    def test_qat_no_quant_method_is_quantizable(self):
+        # QAT models have quantization_config with no quant_method — full-precision weights
+        assert (
+            validate_quantizable({"quantization_config": {"quant_type": "q4_0"}})
+            is True
+        )
+
+    def test_qat_empty_quant_method_is_quantizable(self):
+        assert validate_quantizable({"quantization_config": {}}) is True
+
+    def test_awq_not_quantizable(self):
+        assert (
+            validate_quantizable({"quantization_config": {"quant_method": "awq"}})
+            is False
+        )
+
+
+# =============================================================================
+# Test _sensitivity_lm_config_override
+# =============================================================================
+
+
+class TestSensitivityLmConfigOverride:
+    def test_no_quantization_config(self):
+        assert _sensitivity_lm_config_override({"model_type": "llama"}) is None
+
+    def test_qat_config_top_level(self):
+        # QAT config with no quant_method → should override
+        result = _sensitivity_lm_config_override(
+            {"quantization_config": {"quant_type": "q4_0"}}
+        )
+        assert result == {"quantization_config": None}
+
+    def test_qat_config_in_text_config(self):
+        # QAT config nested in text_config (VLM layout) → should override
+        result = _sensitivity_lm_config_override(
+            {"text_config": {"quantization_config": {"quant_type": "q4_0"}}}
+        )
+        assert result == {"quantization_config": None}
+
+    def test_fp8_config_no_override(self):
+        # FP8 has quant_method set — not a QAT config, no override needed
+        assert (
+            _sensitivity_lm_config_override(
+                {"quantization_config": {"quant_method": "fp8"}}
+            )
+            is None
+        )
+
+    def test_known_method_no_override(self):
+        assert (
+            _sensitivity_lm_config_override(
+                {"quantization_config": {"quant_method": "gptq"}}
+            )
+            is None
+        )
+
+    def test_empty_quantization_config(self):
+        # Empty dict: no quant_method but also nothing to process — no override
+        assert _sensitivity_lm_config_override({"quantization_config": {}}) is None
 
 
 # =============================================================================
@@ -1173,9 +1241,9 @@ class TestLevelBudgetPlan:
         plan = _build_quant_plan(
             named_shapes, config, 2, target_bpw=2.8, hard_cap_bpw=3.0
         )
-        assert (
-            plan.effective_bpw >= 2.7
-        ), f"Expected bpw >= 2.7, got {plan.effective_bpw:.2f}"
+        assert plan.effective_bpw >= 2.7, (
+            f"Expected bpw >= 2.7, got {plan.effective_bpw:.2f}"
+        )
         assert plan.effective_bpw <= 3.0
         # Attention should be boosted via protection floor
         attn_boosts = [k for k in plan.boost_map if "q_proj" in k or "v_proj" in k]
@@ -2727,9 +2795,9 @@ class TestQuantizeOqStreamingFp8:
 
     def test_exceeds_ram_no_scratch_files(self, tmp_path):
         """On-the-fly dequant produces zero scratch/temp shard files."""
-        from unittest.mock import patch
-        import tempfile
         import os
+        import tempfile
+        from unittest.mock import patch
 
         src = tmp_path / "src"
         src.mkdir()
@@ -2931,9 +2999,9 @@ class TestQuantizeOqStreamingFp8:
 
         idx = _LazyTensorIndex([str(src / "model.safetensors")])
         assert len(idx._fp8_pairs) == 0, "BF16 weight should not pair with .scale"
-        assert (
-            "model.layers.0.self_attn.q_proj.scale" in idx
-        ), "scale key must remain visible"
+        assert "model.layers.0.self_attn.q_proj.scale" in idx, (
+            "scale key must remain visible"
+        )
 
 
 # =============================================================================

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -762,8 +762,13 @@ class TestValidateQuantizable:
             is True
         )
 
-    def test_qat_empty_quant_method_is_quantizable(self):
-        assert validate_quantizable({"quantization_config": {}}) is True
+    def test_empty_quantization_config_not_quantizable(self):
+        # Empty config has no quant_type — not a QAT config, not quantizable
+        assert validate_quantizable({"quantization_config": {}}) is False
+
+    def test_legacy_bits_config_not_quantizable(self):
+        # Legacy configs with only {"bits": N} lack quant_type and are not QAT
+        assert validate_quantizable({"quantization_config": {"bits": 4}}) is False
 
     def test_awq_not_quantizable(self):
         assert (
@@ -809,6 +814,13 @@ class TestSensitivityLmConfigOverride:
             _sensitivity_lm_config_override(
                 {"quantization_config": {"quant_method": "gptq"}}
             )
+            is None
+        )
+
+    def test_non_qat_config_without_quant_method_no_override(self):
+        # Legacy bits-only config has no quant_type — not a QAT config, no override
+        assert (
+            _sensitivity_lm_config_override({"quantization_config": {"bits": 4}})
             is None
         )
 

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -25,8 +25,8 @@ from omlx.oq import (
     OQ_LEVELS,
     _bpw_targets_for_level,
     _build_proxy_for_sensitivity,
-    _build_streaming_proxy_for_sensitivity,
     _build_quant_plan,
+    _build_streaming_proxy_for_sensitivity,
     _discover_sanitize_plan,
     _DiscoveredPlan,
     _extract_layer_index,
@@ -1852,9 +1852,7 @@ class TestBuildProxyForSensitivity:
             trust_remote_code=True,
         )
 
-        assert calls == [
-            (str(tmp_path / "src_model"), proxy_dir, "bfloat16", True)
-        ]
+        assert calls == [(str(tmp_path / "src_model"), proxy_dir, "bfloat16", True)]
         assert proxy_dir.exists()
 
     def test_returns_path_under_system_temp(self, tmp_path):
@@ -1967,12 +1965,11 @@ class TestBuildProxyForSensitivity:
             str(src / "model.safetensors"),
         )
 
-        with patch("omlx.oq._build_model_sanitizer", return_value=None), patch(
-            "omlx.oq._build_non_quantizable_set", return_value=set()
+        with (
+            patch("omlx.oq._build_model_sanitizer", return_value=None),
+            patch("omlx.oq._build_non_quantizable_set", return_value=set()),
         ):
-            _build_streaming_proxy_for_sensitivity(
-                str(src), out, dtype="bfloat16"
-            )
+            _build_streaming_proxy_for_sensitivity(str(src), out, dtype="bfloat16")
 
         config = json.loads((out / "config.json").read_text(encoding="utf-8"))
         assert config["quantization"]["bits"] == _PROXY_QUANT_BITS


### PR DESCRIPTION
Earlier today, the DeepMind team [released quantization-aware training versions](https://blog.google/innovation-and-ai/technology/developers-tools/quantization-aware-training-gemma-4/) of their Gemma 4 family of models, which are versions that behave much better when run through quantization, but their configs look a little different than others:

* They're missing `quant_method` like MiniMax and DeepSeek and others
* They still have `quantization_config` keys though

This changeset checks for the structure of these keys in the quantization config and if it's present, it allows Gemma 4 QAT models through to be quantized. Sure, the training doesn't directly affect oQ4 quantization, but it's my hope? theory? that oQ4 on these models is a bit smarter than oQ4 on the non-QAT models.

