### PR TITLE
fix(embedding): Respect embedding context length

### DIFF
--- a/omlx/api/embedding_models.py
+++ b/omlx/api/embedding_models.py
@@ -58,6 +58,17 @@ class EmbeddingRequest(BaseModel):
     Only supported by some models. If not supported, returns full dimensions.
     """
 
+    max_length: Optional[int] = Field(default=None, gt=0)
+    """
+    Optional maximum token length for each input text. When omitted, the
+    server uses the model's effective context window.
+    """
+
+    truncation: bool = True
+    """
+    Whether to truncate inputs longer than max_length.
+    """
+
     @model_validator(mode="after")
     def validate_input_source(self) -> "EmbeddingRequest":
         """Require exactly one input source."""

--- a/omlx/engine/embedding.py
+++ b/omlx/engine/embedding.py
@@ -113,7 +113,7 @@ class EmbeddingEngine(BaseNonStreamingEngine):
     async def embed(
         self,
         texts: Union[List[str], List[Dict[str, str]]],
-        max_length: int = 512,
+        max_length: int | None = None,
         padding: bool = True,
         truncation: bool = True,
     ) -> EmbeddingOutput:
@@ -122,7 +122,8 @@ class EmbeddingEngine(BaseNonStreamingEngine):
 
         Args:
             texts: List of input texts
-            max_length: Maximum token length for each text
+            max_length: Maximum token length for each text. If omitted, the
+                model resolves its configured limit.
             padding: Whether to pad shorter sequences
             truncation: Whether to truncate longer sequences
 

--- a/omlx/models/embedding.py
+++ b/omlx/models/embedding.py
@@ -23,6 +23,16 @@ from .mlx_embeddings_compat import (
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_EMBEDDING_MAX_LENGTH = 512
+_TOKENIZER_MAX_LENGTH_SENTINEL = 10**18
+_CONTEXT_LENGTH_ATTRS = (
+    "max_position_embeddings",
+    "max_seq_len",
+    "max_seq_length",
+    "seq_length",
+    "n_positions",
+)
+
 
 @dataclass
 class EmbeddingOutput:
@@ -310,6 +320,76 @@ class MLXEmbeddingModel:
             return [{"text": text} for text in inputs]
         return [dict(item) for item in inputs]
 
+    @staticmethod
+    def _positive_context_length(value: Any) -> Optional[int]:
+        """Return a usable positive context length from config/tokenizer metadata."""
+        if isinstance(value, bool) or not isinstance(value, int):
+            return None
+        if 0 < value < _TOKENIZER_MAX_LENGTH_SENTINEL:
+            return value
+        return None
+
+    @classmethod
+    def _get_config_value(cls, config: Any, key: str) -> Optional[int]:
+        if config is None:
+            return None
+        if isinstance(config, dict):
+            return cls._positive_context_length(config.get(key))
+        return cls._positive_context_length(getattr(config, key, None))
+
+    @classmethod
+    def _context_length_from_config(cls, config: Any) -> Optional[int]:
+        """Read context length from model config objects or dictionaries."""
+        for key in _CONTEXT_LENGTH_ATTRS:
+            value = cls._get_config_value(config, key)
+            if value is not None:
+                return value
+
+        for nested_key in ("text_config", "language_config"):
+            nested = None
+            if isinstance(config, dict):
+                nested = config.get(nested_key)
+            elif config is not None:
+                nested = getattr(config, nested_key, None)
+            for key in _CONTEXT_LENGTH_ATTRS:
+                value = cls._get_config_value(nested, key)
+                if value is not None:
+                    return value
+
+        return None
+
+    def _resolve_max_length(self, max_length: int | None) -> int:
+        """Resolve embedding token length when callers omit an explicit limit."""
+        if max_length is not None:
+            value = self._positive_context_length(max_length)
+            if value is None:
+                raise ValueError("max_length must be a positive integer")
+            return value
+
+        for config in (
+            getattr(self.model, "config", None),
+            getattr(self.processor, "config", None),
+        ):
+            value = self._context_length_from_config(config)
+            if value is not None:
+                return value
+
+        processor = self.processor
+        tokenizers = [
+            processor,
+            getattr(processor, "tokenizer", None),
+            getattr(processor, "_tokenizer", None),
+        ]
+        for tokenizer in tokenizers:
+            for attr_name in ("model_max_length", "max_length"):
+                value = self._positive_context_length(
+                    getattr(tokenizer, attr_name, None)
+                )
+                if value is not None:
+                    return value
+
+        return _DEFAULT_EMBEDDING_MAX_LENGTH
+
     def _prepare_embedding_inputs(
         self,
         processor,
@@ -407,7 +487,7 @@ class MLXEmbeddingModel:
     def embed(
         self,
         inputs: Union[str, List[str], List[Dict[str, str]]],
-        max_length: int = 512,
+        max_length: int | None = None,
         padding: bool = True,
         truncation: bool = True,
     ) -> EmbeddingOutput:
@@ -416,7 +496,8 @@ class MLXEmbeddingModel:
 
         Args:
             texts: List of input texts
-            max_length: Maximum token length for each text
+            max_length: Maximum token length for each text. If omitted, use
+                model/tokenizer metadata when available.
             padding: Whether to pad shorter sequences
             truncation: Whether to truncate longer sequences
 
@@ -426,6 +507,7 @@ class MLXEmbeddingModel:
         if not self._loaded:
             self.load()
 
+        max_length = self._resolve_max_length(max_length)
         normalized_inputs = self._normalize_embedding_inputs(inputs)
         input_texts = [item["text"] for item in normalized_inputs if "text" in item]
         has_image_inputs = any("image" in item for item in normalized_inputs)
@@ -459,7 +541,9 @@ class MLXEmbeddingModel:
                 masks = []
                 for text in input_texts:
                     enc = processor.encode(text, add_special_tokens=True)
-                    ids = list(enc.ids)[:max_length]
+                    ids = list(enc.ids)
+                    if truncation:
+                        ids = ids[:max_length]
                     encoded_ids.append(ids)
                 max_len = max(len(ids) for ids in encoded_ids)
                 padded = []

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1181,6 +1181,21 @@ def get_max_context_window(model_id: str | None = None) -> int | None:
     return _server_state.sampling.max_context_window
 
 
+def get_embedding_max_length(
+    model_id: str | None = None,
+    request_max_length: int | None = None,
+) -> int:
+    """Get max token length for embedding requests."""
+    if request_max_length is not None:
+        return request_max_length
+
+    max_context_window = get_max_context_window(model_id)
+    if max_context_window is not None:
+        return max_context_window
+
+    return 512
+
+
 def scale_anthropic_tokens(token_count: int, model_id: str | None = None) -> int:
     """
     Scale token count for Anthropic API response if context scaling is enabled.
@@ -2157,11 +2172,17 @@ async def create_embeddings(
     if not embedding_inputs:
         raise HTTPException(status_code=400, detail="Input cannot be empty")
 
+    max_length = get_embedding_max_length(request.model, request.max_length)
+
     async def _build_embeddings():
         start_time = time.perf_counter()
         try:
             async with acquire_embedding_engine(request.model) as engine:
-                output = await engine.embed(embedding_inputs)
+                output = await engine.embed(
+                    embedding_inputs,
+                    max_length=max_length,
+                    truncation=request.truncation,
+                )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except TypeError as e:
@@ -2170,7 +2191,8 @@ async def create_embeddings(
         elapsed = time.perf_counter() - start_time
         logger.info(
             f"Embedding: {len(embedding_inputs)} inputs, {output.dimensions} dims, "
-            f"{output.total_tokens} tokens in {elapsed:.3f}s"
+            f"{output.total_tokens} tokens, max_length={max_length}, "
+            f"truncation={request.truncation} in {elapsed:.3f}s"
         )
         get_server_metrics().record_request_complete(
             prompt_tokens=output.total_tokens,

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -7,6 +7,7 @@ to verify request/response formats without loading actual models.
 """
 
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock
 
@@ -63,6 +64,7 @@ class MockEmbeddingEngineImpl(EmbeddingEngine):
         # Don't call super().__init__ to avoid loading real model
         self._model_name = model_name
         self._model = None  # Set as None but present
+        self.calls: List[Dict[str, Any]] = []
 
     @property
     def model_name(self) -> str:
@@ -75,6 +77,7 @@ class MockEmbeddingEngineImpl(EmbeddingEngine):
         pass
 
     async def embed(self, texts, **kwargs) -> MockEmbeddingOutput:
+        self.calls.append({"texts": list(texts), "kwargs": dict(kwargs)})
         return MockEmbeddingOutput(
             embeddings=[[0.1, 0.2, 0.3] for _ in texts],
             total_tokens=len(texts) * 5,
@@ -249,6 +252,7 @@ class MockEnginePool:
         self._models = [
             {"id": "test-model", "loaded": True, "pinned": False, "size": 1000000}
         ]
+        self._entries: Dict[str, Any] = {}
 
     @property
     def model_count(self) -> int:
@@ -267,7 +271,7 @@ class MockEnginePool:
         return 1000000
 
     def get_entry(self, model_id: str):
-        return None
+        return self._entries.get(model_id)
 
     def resolve_model_id(self, model_id_or_alias, settings_manager=None):
         return model_id_or_alias
@@ -1048,6 +1052,54 @@ class TestEmbeddingsEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert len(data["data"]) == 2
+
+    def test_embeddings_use_discovered_context_length(self, client, mock_engine_pool):
+        """Embedding requests should not fall back to mlx-embeddings' 512 default."""
+        mock_engine_pool._models.append(
+            {"id": "test-embed-model", "loaded": True, "pinned": False, "size": 500000}
+        )
+        mock_engine_pool._entries["test-embed-model"] = SimpleNamespace(
+            model_context_length=40960
+        )
+
+        response = client.post(
+            "/v1/embeddings",
+            json={
+                "model": "test-embed-model",
+                "input": "hello",
+            },
+        )
+
+        assert response.status_code == 200
+        kwargs = mock_engine_pool._embedding_engine.calls[-1]["kwargs"]
+        assert kwargs["max_length"] == 40960
+        assert kwargs["truncation"] is True
+
+    def test_embeddings_request_max_length_overrides_default(
+        self, client, mock_engine_pool
+    ):
+        """Explicit max_length should be forwarded to the embedding engine."""
+        mock_engine_pool._models.append(
+            {"id": "test-embed-model", "loaded": True, "pinned": False, "size": 500000}
+        )
+        mock_engine_pool._entries["test-embed-model"] = SimpleNamespace(
+            model_context_length=40960
+        )
+
+        response = client.post(
+            "/v1/embeddings",
+            json={
+                "model": "test-embed-model",
+                "input": "hello",
+                "max_length": 1024,
+                "truncation": False,
+            },
+        )
+
+        assert response.status_code == 200
+        kwargs = mock_engine_pool._embedding_engine.calls[-1]["kwargs"]
+        assert kwargs["max_length"] == 1024
+        assert kwargs["truncation"] is False
 
     def test_embeddings_response_format(self, client, mock_engine_pool):
         """Test embeddings response format."""

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -11,6 +11,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -59,6 +60,23 @@ class TestEmbeddingModels:
         assert request.input == ["Hello", "World"]
         assert request.encoding_format == "base64"
         assert request.dimensions == 256
+
+    def test_embedding_request_max_length_and_truncation(self):
+        """Test optional embedding token length controls."""
+        request = EmbeddingRequest(
+            input="Hello",
+            model="all-MiniLM-L6-v2",
+            max_length=4096,
+            truncation=False,
+        )
+
+        assert request.max_length == 4096
+        assert request.truncation is False
+
+    def test_embedding_request_rejects_invalid_max_length(self):
+        """Test max_length must be a positive integer."""
+        with pytest.raises(ValueError, match="greater than 0"):
+            EmbeddingRequest(input="Hello", model="all-MiniLM-L6-v2", max_length=0)
 
     def test_embedding_request_items_input(self):
         """Test EmbeddingRequest with structured items."""
@@ -503,6 +521,98 @@ class TestEmbeddingCompileFallback:
             result = model.embed(["test"])
 
         assert len(result.embeddings) == 1
+
+    def test_default_max_length_uses_model_config(self):
+        """Omitted max_length should use model context metadata, not 512."""
+        import mlx.core as mx
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel("test-model")
+        model._loaded = True
+        model._is_compiled = False
+        model._compiled_embed = None
+        model.model = SimpleNamespace(
+            config=SimpleNamespace(max_position_embeddings=40960)
+        )
+        model.processor = SimpleNamespace()
+
+        mock_outputs = MagicMock(spec=[])
+        mock_outputs.text_embeds = mx.array([[0.5, 0.6]])
+        mock_outputs.pooler_output = None
+        mock_outputs.last_hidden_state = None
+
+        with patch("mlx_embeddings.generate", return_value=mock_outputs) as generate:
+            model.embed(["test"])
+
+        assert generate.call_args.kwargs["max_length"] == 40960
+
+    def test_default_max_length_uses_tokenizer_config_fallback(self):
+        """Tokenizer model_max_length is used when model config lacks a limit."""
+        import mlx.core as mx
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel("test-model")
+        model._loaded = True
+        model._is_compiled = False
+        model._compiled_embed = None
+        model.model = SimpleNamespace(config=SimpleNamespace())
+        model.processor = SimpleNamespace(model_max_length=8192)
+
+        mock_outputs = MagicMock(spec=[])
+        mock_outputs.text_embeds = mx.array([[0.5, 0.6]])
+        mock_outputs.pooler_output = None
+        mock_outputs.last_hidden_state = None
+
+        with patch("mlx_embeddings.generate", return_value=mock_outputs) as generate:
+            model.embed(["test"])
+
+        assert generate.call_args.kwargs["max_length"] == 8192
+
+    def test_unknown_default_max_length_falls_back_to_512(self):
+        """Keep a conservative final fallback when no metadata exists."""
+        import mlx.core as mx
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel("test-model")
+        model._loaded = True
+        model._is_compiled = False
+        model._compiled_embed = None
+        model.model = SimpleNamespace(config=SimpleNamespace())
+        model.processor = SimpleNamespace()
+
+        mock_outputs = MagicMock(spec=[])
+        mock_outputs.text_embeds = mx.array([[0.5, 0.6]])
+        mock_outputs.pooler_output = None
+        mock_outputs.last_hidden_state = None
+
+        with patch("mlx_embeddings.generate", return_value=mock_outputs) as generate:
+            model.embed(["test"])
+
+        assert generate.call_args.kwargs["max_length"] == 512
+
+    def test_explicit_max_length_is_respected(self):
+        """Explicit max_length should override metadata."""
+        import mlx.core as mx
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel("test-model")
+        model._loaded = True
+        model._is_compiled = False
+        model._compiled_embed = None
+        model.model = SimpleNamespace(
+            config=SimpleNamespace(max_position_embeddings=40960)
+        )
+        model.processor = SimpleNamespace()
+
+        mock_outputs = MagicMock(spec=[])
+        mock_outputs.text_embeds = mx.array([[0.5, 0.6]])
+        mock_outputs.pooler_output = None
+        mock_outputs.last_hidden_state = None
+
+        with patch("mlx_embeddings.generate", return_value=mock_outputs) as generate:
+            model.embed(["test"], max_length=1024)
+
+        assert generate.call_args.kwargs["max_length"] == 1024
 
     def test_custom_processor_compiled_path_uses_prepare_embedding_inputs(self):
         """Custom embedding processors should use their own prepare API."""
@@ -1004,6 +1114,8 @@ class TestEmbeddingModelsPydantic:
 
         assert request.encoding_format == "float"
         assert request.dimensions is None
+        assert request.max_length is None
+        assert request.truncation is True
 
     def test_embedding_data_defaults(self):
         """Test EmbeddingData default values."""


### PR DESCRIPTION
Fixes #1687.

The embeddings endpoint now uses the model’s effective context window by default instead of falling through to the `mlx-embeddings` 512-token default. It also adds optional `max_length` and `truncation` request controls for callers who want to override that behavior explicitly.

### Details

- Adds `max_length` and `truncation` to `EmbeddingRequest`.
- Threads the effective embedding max length from the server into `EmbeddingEngine.embed()`.
- Resolves embedding max length from model/tokenizer metadata for direct model usage.
- Keeps `512` only as a final fallback when no model/tokenizer limit is known.
- Preserves explicit caller overrides, including intentionally passing `max_length: 512`.

### Testing

I ran the focused test coverage:

```bash
pytest tests/test_embedding.py tests/integration/test_server_endpoints.py::TestEmbeddingsEndpoint -q
```

Result:

```text
87 passed, 1 deselected
```

I also tested locally with `mlx-community/Qwen3-Embedding-8B-mxfp8`. The server logs now show:

```text
max_length=40960, truncation=True
```

and embeddings for long inputs with identical prefixes but different suffixes no longer collapse to the same vector/hash, confirming content beyond the old 512-token cutoff is being used.

### Backwards Compatibility

Existing embedding requests continue to work unchanged. The main behavioral change is that long inputs may now use more compute/memory because they are no longer silently capped at 512 tokens. Callers that want the previous cap can pass `max_length: 512` explicitly.