### PR TITLE
fix(api): strip Gemma special tokens from model output (fixes #1087)

### DIFF
--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -49,7 +49,8 @@ SPECIAL_TOKENS_PATTERN = re.compile(
     r"<\|im_end\|>|<\|im_start\|>|<\|endoftext\|>|"
     r"<\|end\|>|<\|eot_id\|>|<\|start_header_id\|>|<\|end_header_id\|>|"
     r"<\|image\|>|<\|audio\|>|"  # Gemma 4 VLM special tokens
-    r"</s>|<s>|<pad>|\[PAD\]|\[SEP\]|\[CLS\]"
+    r"</s>|<s>|<pad>|\[PAD\]|\[SEP\]|\[CLS\]|"
+    r"<eos>|<bos>|<end_of_turn>|<start_of_turn>"  # Gemma special tokens (fixes #1087)
 )
 
 

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -117,6 +117,13 @@ class TestCleanOutputText:
         result = clean_output_text("[CLS]Hello[SEP]World[PAD]")
         assert result == "HelloWorld"
 
+    def test_clean_gemma_special_tokens(self):
+        """Gemma special tokens must be stripped from output too (#1087)."""
+        assert clean_output_text("answer<eos>") == "answer"
+        assert clean_output_text("answer<end_of_turn>") == "answer"
+        assert clean_output_text("<start_of_turn>hi") == "hi"
+        assert clean_output_text("<bos>hello<eos>") == "hello"
+
     def test_clean_multiple_tokens(self):
         """Test removing multiple special tokens."""
         result = clean_output_text("<|im_start|>Hello<|im_end|><|endoftext|>")


### PR DESCRIPTION
Fixes #1087.

`SPECIAL_TOKENS_PATTERN` in `omlx/api/utils.py` stripped special tokens for the Llama / Qwen / Mistral / GPT-2 families but omitted Gemma's — `<eos>`, `<bos>`, `<end_of_turn>`, `<start_of_turn>` — so they leaked into assistant `message.content`, most visibly in structured outputs.

This adds those four to the strip pattern, so both `clean_special_tokens()` and `clean_output_text()` remove them on every engine output path.

### Test
Adds `test_clean_gemma_special_tokens` (covers `<eos>`, `<end_of_turn>`, `<start_of_turn>`, and `<bos>…<eos>`). The existing `</s>` / `<s>` / `<pad>` / `[PAD]` / `[SEP]` / `[CLS]` cases still pass, guarding the pattern.

`pytest tests/test_api_utils.py` → 201 passed.