### PR TITLE
fix: show chat composer on tablet portrait (768px)

### DIFF
--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -778,7 +778,7 @@
     }
 
     /* Mobile responsive */
-    @media (max-width: 768px) {
+    @media (max-width: 767px) {
         .sidebar-width {
             position: fixed;
             z-index: 50;


### PR DESCRIPTION
## What

At 768px viewport width (standard iPad portrait), the bottom chat composer / message text box did not appear in the admin chat UI.

## Why

The mobile responsive CSS block used `@media (max-width: 768px)`, which turns the left sidebar into a **fixed, full-height overlay** at exactly 768px. But the JS initializes the sidebar **open** at that same width:

```js
sidebarOpen: window.innerWidth >= 768,
```

So at exactly 768px the overlay sidebar is open by default and covers the bottom message composer, making it look like the input box is missing. This is an off-by-one against Tailwind's `<768 = mobile` convention that the JS already follows.

## Fix

Change the mobile breakpoint from `max-width: 768px` to `max-width: 767px` in `omlx/admin/templates/chat.html`, so at 768px the sidebar stays in static flow beside the chat and the composer is fully visible.

## Testing

Ran the server against this template and loaded `/admin/chat` at 768×1024:

- Sidebar renders in static flow (`position: static`), beside the chat — not as an overlay.
- Message composer is fully visible (`x=325, w=378`), no overlap with the sidebar.
- Served HTML confirmed to contain `max-width: 767px`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)