### PR TITLE
feat: CLI model alias management and Bearer token auth for admin API

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -34,6 +34,7 @@ from pydantic import BaseModel, Field
 
 from ..api.markitdown import MARKITDOWN_MODEL_ID, markitdown_model_visible
 from ..model_profiles import EXCLUDED_FROM_PROFILES
+from ..model_settings import ModelSettings
 from ..settings import SubKeyEntry
 from ..utils.release_check import normalize_update_channel, select_latest_release
 from .auth import (
@@ -1633,159 +1634,15 @@ async def list_grammar_parsers(is_admin: bool = Depends(require_admin)):
 
 
 # =============================================================================
-# Models API Routes
+
+
+# =============================================================================
+# Helper: admin session OR bearer token
 # =============================================================================
 
 
-@router.get("/api/models")
-async def list_models(is_admin: bool = Depends(require_admin)):
-    """
-    List all models with their settings.
 
-    Returns model information from the engine pool combined with
-    per-model settings from the settings manager.
-
-    Returns:
-        JSON list of models with their status and settings.
-
-    Raises:
-        HTTPException: 401 if not authenticated, 503 if server not initialized.
-    """
-    engine_pool = _get_engine_pool()
-    settings_manager = _get_settings_manager()
-    server_state = _get_server_state()
-
-    if engine_pool is None:
-        raise HTTPException(status_code=503, detail="Server not initialized")
-
-    # Get engine pool status
-    status = engine_pool.get_status()
-    models_status = status.get("models", [])
-
-    # Get all model settings
-    all_settings = settings_manager.get_all_settings() if settings_manager else {}
-
-    # SSD cache dir is set on the scheduler_config when the user enables paged
-    # SSD caching; admin UI consumes it to gate the dflash SSD toggle.
-    ssd_cache_dir = getattr(
-        getattr(engine_pool, "_scheduler_config", None),
-        "paged_ssd_cache_dir",
-        None,
-    )
-    dflash_ssd_cache_available = bool(ssd_cache_dir)
-
-    # Combine model info with settings
-    models = []
-    for model_info in models_status:
-        model_id = model_info["id"]
-        settings = all_settings.get(model_id)
-
-        is_paroquant, paroquant_reason = _paroquant_compat_for_model(model_info)
-        compat_ok, compat_reason = _dflash_compat_for_model(model_info)
-        mtp_compat_ok, mtp_compat_reason = _mtp_compat_for_model(model_info)
-
-        model_data = {
-            "id": model_id,
-            "model_path": model_info.get("model_path", ""),
-            "loaded": model_info.get("loaded", False),
-            "is_loading": model_info.get("is_loading", False),
-            "estimated_size": model_info.get("estimated_size", 0),
-            "estimated_size_formatted": format_size(
-                model_info.get("estimated_size", 0)
-            ),
-            "actual_size": model_info.get("actual_size") or 0,
-            "actual_size_formatted": (
-                format_size(model_info.get("actual_size", 0))
-                if model_info.get("actual_size")
-                else None
-            ),
-            "pinned": model_info.get("pinned", False),
-            "is_default": (
-                server_state.default_model == model_id if server_state else False
-            ),
-            "engine_type": model_info.get("engine_type", "batched"),
-            "model_type": model_info.get("model_type", "llm"),
-            "config_model_type": model_info.get("config_model_type", ""),
-            "thinking_default": model_info.get("thinking_default"),
-            "preserve_thinking_default": model_info.get("preserve_thinking_default"),
-            "source_type": model_info.get("source_type", "local"),
-            "source_repo_id": model_info.get("source_repo_id"),
-            "last_access": model_info.get("last_access"),
-            "dflash_compatible": compat_ok,
-            "dflash_compatibility_reason": compat_reason,
-            "dflash_ssd_cache_available": dflash_ssd_cache_available,
-            "mtp_compatible": mtp_compat_ok,
-            "mtp_compatibility_reason": mtp_compat_reason,
-            "is_paroquant": is_paroquant,
-            "paroquant_reason": paroquant_reason,
-        }
-
-        # Add settings if available
-        if settings:
-            model_data["settings"] = asdict(settings)
-
-        models.append(model_data)
-
-    global_settings = _get_global_settings() if _get_global_settings else None
-    if markitdown_model_visible(global_settings) and not any(
-        m.get("id") == MARKITDOWN_MODEL_ID for m in models
-    ):
-        models.append(
-            {
-                "id": MARKITDOWN_MODEL_ID,
-                "model_path": "builtin://markitdown",
-                "loaded": True,
-                "is_loading": False,
-                "estimated_size": 0,
-                "estimated_size_formatted": format_size(0),
-                "actual_size": 0,
-                "actual_size_formatted": None,
-                "pinned": False,
-                "is_default": False,
-                "engine_type": "markitdown",
-                "model_type": "markitdown",
-                "config_model_type": "markitdown",
-                "thinking_default": None,
-                "preserve_thinking_default": None,
-                "source_type": "builtin",
-                "source_repo_id": None,
-                "last_access": None,
-                "dflash_compatible": False,
-                "dflash_compatibility_reason": "",
-                "dflash_ssd_cache_available": False,
-                "mtp_compatible": False,
-                "mtp_compatibility_reason": "",
-                "is_paroquant": False,
-                "paroquant_reason": "",
-                "virtual": True,
-            }
-        )
-
-    return {"models": models}
-
-
-@router.post("/api/models/{model_id}/unload")
-async def unload_model(
-    model_id: str,
-    is_admin: bool = Depends(require_admin),
-):
-    """Manually unload a model from memory."""
-    engine_pool = _get_engine_pool()
-    if engine_pool is None:
-        raise HTTPException(status_code=503, detail="Engine pool not initialized")
-
-    entry = engine_pool.get_entry(model_id)
-    if entry is None:
-        raise HTTPException(status_code=404, detail=f"Model not found: {model_id}")
-    if entry.engine is None:
-        raise HTTPException(status_code=400, detail=f"Model not loaded: {model_id}")
-
-    await engine_pool._unload_engine(model_id)
-    logger.info(f"Manually unloaded model: {model_id}")
-    return {"status": "ok", "model_id": model_id, "message": f"Unloaded {model_id}"}
-
-
-async def _require_admin_or_bearer(request: Request) -> bool:
+async def _require_admin_or_bearer(req: Request) -> bool:
     """Allow admin session OR a valid Bearer API key (for CLI use)."""
     gs = _get_global_settings() if _get_global_settings else None
 
@@ -1794,11 +1651,11 @@ async def _require_admin_or_bearer(request: Request) -> bool:
         return True
 
     # Valid admin session cookie
-    if verify_session(request):
+    if verify_session(req):
         return True
 
     # Bearer token matching the configured API key
-    auth_header = request.headers.get("Authorization", "")
+    auth_header = req.headers.get("Authorization", "")
     if auth_header.startswith("Bearer ") and gs is not None:
         token = auth_header[7:]
         server_key = gs.auth.api_key or ""
@@ -1862,7 +1719,7 @@ async def reload_models(is_admin: bool = Depends(require_admin)):
 async def update_model_settings(
     model_id: str,
     request: ModelSettingsRequest,
-    is_admin: bool = Depends(require_admin),
+    is_admin: bool = Depends(_require_admin_or_bearer),
 ):
     """
     Update settings for a specific model.
@@ -2366,6 +2223,279 @@ async def update_model_settings(
         "requires_reload": requires_reload,
         "auto_unloaded": auto_unloaded,
         "auto_reloaded": auto_reloaded,
+    }
+
+
+# Models API Routes
+# =============================================================================
+
+
+@router.get("/api/models")
+async def list_models(is_admin: bool = Depends(_require_admin_or_bearer)):
+    """
+    List all models with their settings.
+
+    Returns model information from the engine pool combined with
+    per-model settings from the settings manager.
+
+    Returns:
+        JSON list of models with their status and settings.
+
+    Raises:
+        HTTPException: 401 if not authenticated, 503 if server not initialized.
+    """
+    engine_pool = _get_engine_pool()
+    settings_manager = _get_settings_manager()
+    server_state = _get_server_state()
+
+    if engine_pool is None:
+        raise HTTPException(status_code=503, detail="Server not initialized")
+
+    # Get engine pool status
+    status = engine_pool.get_status()
+    models_status = status.get("models", [])
+
+    # Get all model settings
+    all_settings = settings_manager.get_all_settings() if settings_manager else {}
+
+    # SSD cache dir is set on the scheduler_config when the user enables paged
+    # SSD caching; admin UI consumes it to gate the dflash SSD toggle.
+    ssd_cache_dir = getattr(
+        getattr(engine_pool, "_scheduler_config", None),
+        "paged_ssd_cache_dir",
+        None,
+    )
+    dflash_ssd_cache_available = bool(ssd_cache_dir)
+
+    # Combine model info with settings
+    models = []
+    for model_info in models_status:
+        model_id = model_info["id"]
+        settings = all_settings.get(model_id)
+
+        is_paroquant, paroquant_reason = _paroquant_compat_for_model(model_info)
+        compat_ok, compat_reason = _dflash_compat_for_model(model_info)
+        mtp_compat_ok, mtp_compat_reason = _mtp_compat_for_model(model_info)
+
+        model_data = {
+            "id": model_id,
+            "model_path": model_info.get("model_path", ""),
+            "loaded": model_info.get("loaded", False),
+            "is_loading": model_info.get("is_loading", False),
+            "estimated_size": model_info.get("estimated_size", 0),
+            "estimated_size_formatted": format_size(
+                model_info.get("estimated_size", 0)
+            ),
+            "actual_size": model_info.get("actual_size") or 0,
+            "actual_size_formatted": (
+                format_size(model_info.get("actual_size", 0))
+                if model_info.get("actual_size")
+                else None
+            ),
+            "pinned": model_info.get("pinned", False),
+            "is_default": (
+                server_state.default_model == model_id if server_state else False
+            ),
+            "engine_type": model_info.get("engine_type", "batched"),
+            "model_type": model_info.get("model_type", "llm"),
+            "config_model_type": model_info.get("config_model_type", ""),
+            "thinking_default": model_info.get("thinking_default"),
+            "preserve_thinking_default": model_info.get("preserve_thinking_default"),
+            "source_type": model_info.get("source_type", "local"),
+            "source_repo_id": model_info.get("source_repo_id"),
+            "last_access": model_info.get("last_access"),
+            "dflash_compatible": compat_ok,
+            "dflash_compatibility_reason": compat_reason,
+            "dflash_ssd_cache_available": dflash_ssd_cache_available,
+            "mtp_compatible": mtp_compat_ok,
+            "mtp_compatibility_reason": mtp_compat_reason,
+            "is_paroquant": is_paroquant,
+            "paroquant_reason": paroquant_reason,
+        }
+
+        # Add settings if available
+        if settings:
+            model_data["settings"] = asdict(settings)
+
+        models.append(model_data)
+
+    global_settings = _get_global_settings() if _get_global_settings else None
+    if markitdown_model_visible(global_settings) and not any(
+        m.get("id") == MARKITDOWN_MODEL_ID for m in models
+    ):
+        models.append(
+            {
+                "id": MARKITDOWN_MODEL_ID,
+                "model_path": "builtin://markitdown",
+                "loaded": True,
+                "is_loading": False,
+                "estimated_size": 0,
+                "estimated_size_formatted": format_size(0),
+                "actual_size": 0,
+                "actual_size_formatted": None,
+                "pinned": False,
+                "is_default": False,
+                "engine_type": "markitdown",
+                "model_type": "markitdown",
+                "config_model_type": "markitdown",
+                "thinking_default": None,
+                "preserve_thinking_default": None,
+                "source_type": "builtin",
+                "source_repo_id": None,
+                "last_access": None,
+                "dflash_compatible": False,
+                "dflash_compatibility_reason": "",
+                "dflash_ssd_cache_available": False,
+                "mtp_compatible": False,
+                "mtp_compatibility_reason": "",
+                "is_paroquant": False,
+                "paroquant_reason": "",
+                "virtual": True,
+            }
+        )
+
+    return {"models": models}
+
+
+@router.post("/api/models/{model_id}/unload")
+async def unload_model(
+    model_id: str,
+    is_admin: bool = Depends(require_admin),
+):
+    """Manually unload a model from memory."""
+    engine_pool = _get_engine_pool()
+    if engine_pool is None:
+        raise HTTPException(status_code=503, detail="Engine pool not initialized")
+
+    entry = engine_pool.get_entry(model_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail=f"Model not found: {model_id}")
+    if entry.engine is None:
+        raise HTTPException(status_code=400, detail=f"Model not loaded: {model_id}")
+
+    await engine_pool._unload_engine(model_id)
+    logger.info(f"Manually unloaded model: {model_id}")
+    return {"status": "ok", "model_id": model_id, "message": f"Unloaded {model_id}"}
+
+
+
+class SwapAliasRequest(BaseModel):
+    """Request body for swapping aliases between two models."""
+
+    model_a: str
+    model_b: str
+    alias_a: str | None = None  # New alias for model_a (None = remove)
+    alias_b: str | None = None  # New alias for model_b (None = remove)
+
+
+@router.post("/api/models/swap-alias")
+async def swap_model_alias(
+    request: SwapAliasRequest,
+    is_admin: bool = Depends(_require_admin_or_bearer),
+):
+    """Swap or transfer aliases between two models atomically.
+
+    This endpoint updates both models' settings in a single transaction,
+    persisting each change so the engine pool re-loads the affected models.
+
+    Args:
+        request: SwapAliasRequest with model identifiers and new aliases.
+
+    Returns:
+        JSON response with success status and per-model results.
+
+    Raises:
+        HTTPException: 400 if alias conflicts, 404 if model not found.
+    """
+    engine_pool = _get_engine_pool()
+    settings_manager = _get_settings_manager()
+
+    if engine_pool is None or settings_manager is None:
+        raise HTTPException(status_code=503, detail="Server not initialized")
+
+    model_a = request.model_a
+    model_b = request.model_b
+    new_alias_a = (request.alias_a or "").strip() or None
+    new_alias_b = (request.alias_b or "").strip() or None
+
+    # Validate both models exist
+    entry_a = engine_pool.get_entry(model_a)
+    if entry_a is None:
+        raise HTTPException(status_code=404, detail=f"Model not found: {model_a}")
+    entry_b = engine_pool.get_entry(model_b)
+    if entry_b is None:
+        raise HTTPException(status_code=404, detail=f"Model not found: {model_b}")
+
+    # Get current settings
+    settings_a = settings_manager.get_settings(model_a)
+    settings_b = settings_manager.get_settings(model_b)
+
+    # Check for conflicts before applying changes
+    all_settings = settings_manager.get_all_settings()
+
+    # If alias_a is being set, check it's not taken by a third model
+    if new_alias_a is not None:
+        for mid, ms in all_settings.items():
+            if mid not in (model_a, model_b) and ms.model_alias == new_alias_a:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Alias '{new_alias_a}' is already used by model '{mid}'",
+                )
+        # Check conflict with model directory name of model_b
+        if new_alias_a == model_b:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Alias '{new_alias_a}' conflicts with model directory name '{model_b}'",
+            )
+
+    # If alias_b is being set, check it's not taken by a third model
+    if new_alias_b is not None:
+        for mid, ms in all_settings.items():
+            if mid not in (model_a, model_b) and ms.model_alias == new_alias_b:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Alias '{new_alias_b}' is already used by model '{mid}'",
+                )
+        # Check conflict with model directory name of model_a
+        if new_alias_b == model_a:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Alias '{new_alias_b}' conflicts with model directory name '{model_a}'",
+            )
+
+    # Apply changes
+    result_a = {"model_id": model_a, "success": False, "old_alias": settings_a.model_alias, "new_alias": new_alias_a}
+    result_b = {"model_id": model_b, "success": False, "old_alias": settings_b.model_alias, "new_alias": new_alias_b}
+
+    # Snapshot for rollback
+    settings_snapshot_a = ModelSettings.from_dict(settings_a.to_dict())
+    settings_snapshot_b = ModelSettings.from_dict(settings_b.to_dict())
+
+    try:
+        # Apply alias_a
+        settings_a.model_alias = new_alias_a
+        settings_manager.set_settings(model_a, settings_a)
+        result_a["success"] = True
+    except Exception as e:
+        # Rollback model_a
+        settings_manager.set_settings(model_a, settings_snapshot_a)
+        raise HTTPException(status_code=500, detail=f"Failed to update alias for {model_a}: {e}")
+
+    try:
+        # Apply alias_b
+        settings_b.model_alias = new_alias_b
+        settings_manager.set_settings(model_b, settings_b)
+        result_b["success"] = True
+    except Exception as e:
+        # Rollback both
+        settings_manager.set_settings(model_a, settings_snapshot_a)
+        settings_manager.set_settings(model_b, settings_snapshot_b)
+        raise HTTPException(status_code=500, detail=f"Failed to update alias for {model_b}: {e}")
+
+    return {
+        "success": True,
+        "model_a": result_a,
+        "model_b": result_b,
     }
 
 

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -571,6 +571,213 @@ def _run_brew_services(command: str) -> int:
     return result.returncode
 
 
+def alias_command(args) -> int:
+    """Manage model aliases via the running oMLX server."""
+    import requests
+
+    from .settings import GlobalSettings
+
+    alias_cmd = args.alias_command
+    if not alias_cmd:
+        print("Usage: omlx alias <set|swap|remove|list> [options]")
+        print("Run 'omlx alias --help' for more info.")
+        return 1
+
+    # Resolve server connection
+    settings = GlobalSettings.load()
+    host = "127.0.0.1"  # default
+    port = settings.server.port if settings else 8000
+    api_key = settings.auth.api_key if settings else ""
+
+    base_url = f"http://{host}:{port}"
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+
+    # Check server is running
+    try:
+        requests.get(f"{base_url}/health", timeout=3)
+    except Exception:
+        print(f"oMLX server is not running at {base_url}")
+        return 1
+
+    def api(method: str, path: str, **kwargs) -> dict:
+        url = f"{base_url}/admin{path}"
+        resp = requests.request(method, url, headers=headers, timeout=10, **kwargs)
+        resp.raise_for_status()
+        return resp.json()
+
+    if alias_cmd == "set":
+        model = args.model
+        alias = args.alias
+
+        # Check for conflicts with existing aliases
+        models_data = api("GET", "/api/models").get("models", [])
+        for m in models_data:
+            ms = m.get("settings", {})
+            if ms.get("model_alias") == alias and m["id"] != model:
+                other = m["id"]
+                print(
+                    f"Error: Alias '{alias}' is already used by model '{other}'. "
+                    f"Use 'omlx alias swap {other} {model}' to transfer it."
+                )
+                return 1
+            if m["id"] == alias and m["id"] != model:
+                print(
+                    f"Error: Alias '{alias}' conflicts with model directory name "
+                    f"'{m['id']}'."
+                )
+                return 1
+
+        # Check model exists
+        model_ids = [m["id"] for m in models_data]
+        if model not in model_ids:
+            print(f"Error: Model '{model}' not found.")
+            print(f"Available models: {', '.join(model_ids)}")
+            return 1
+
+        # Apply the alias
+        result = api(
+            "PUT",
+            f"/api/models/{model}/settings",
+            json={"model_alias": alias},
+        )
+        if result.get("success"):
+            print(f"Set alias '{alias}' on model '{model}'")
+            if result.get("auto_unloaded"):
+                print("Model was reloaded with the new alias.")
+        return 0
+
+    elif alias_cmd == "remove":
+        model = args.model
+
+        # Check model exists
+        models_data = api("GET", "/api/models").get("models", [])
+        model_ids = [m["id"] for m in models_data]
+        if model not in model_ids:
+            print(f"Error: Model '{model}' not found.")
+            print(f"Available models: {', '.join(model_ids)}")
+            return 1
+
+        # Apply the removal
+        result = api(
+            "PUT",
+            f"/api/models/{model}/settings",
+            json={"model_alias": None},
+        )
+        if result.get("success"):
+            print(f"Removed alias from model '{model}'")
+            if result.get("auto_unloaded"):
+                print("Model was reloaded.")
+        return 0
+
+    elif alias_cmd == "swap":
+        model_a = args.model_a
+        model_b = args.model_b
+        new_alias_a = args.alias_a
+        new_alias_b = args.alias_b
+
+        # Check models exist
+        models_data = api("GET", "/api/models").get("models", [])
+        model_ids = [m["id"] for m in models_data]
+        if model_a not in model_ids:
+            print(f"Error: Model '{model_a}' not found.")
+            print(f"Available models: {', '.join(model_ids)}")
+            return 1
+        if model_b not in model_ids:
+            print(f"Error: Model '{model_b}' not found.")
+            print(f"Available models: {', '.join(model_ids)}")
+            return 1
+
+        # If no explicit aliases given, auto-detect current aliases
+        if new_alias_a is None and new_alias_b is None:
+            for m in models_data:
+                if m["id"] == model_a:
+                    new_alias_a = m.get("settings", {}).get("model_alias")
+                if m["id"] == model_b:
+                    new_alias_b = m.get("settings", {}).get("model_alias")
+            if new_alias_a is None and new_alias_b is None:
+                print("Neither model has an alias. Nothing to swap.")
+                return 0
+        elif new_alias_a is None:
+            # Only alias_b provided, find a's current alias
+            for m in models_data:
+                if m["id"] == model_a:
+                    new_alias_a = m.get("settings", {}).get("model_alias")
+        elif new_alias_b is None:
+            # Only alias_a provided, find b's current alias
+            for m in models_data:
+                if m["id"] == model_b:
+                    new_alias_b = m.get("settings", {}).get("model_alias")
+
+        # Check for conflicts before swap
+        for m in models_data:
+            mid = m["id"]
+            if mid not in (model_a, model_b):
+                ms = m.get("settings", {})
+                if ms.get("model_alias") == new_alias_a:
+                    print(
+                        f"Error: Alias '{new_alias_a}' is already used by model "
+                        f"'{mid}'. Use 'omlx alias remove {mid}' first, "
+                        f"or specify a different alias."
+                    )
+                    return 1
+                if ms.get("model_alias") == new_alias_b:
+                    print(
+                        f"Error: Alias '{new_alias_b}' is already used by model "
+                        f"'{mid}'. Use 'omlx alias remove {mid}' first, "
+                        f"or specify a different alias."
+                    )
+                    return 1
+            if mid == new_alias_a and mid != model_a:
+                print(
+                    f"Error: Alias '{new_alias_a}' conflicts with model directory "
+                    f"name '{mid}'."
+                )
+                return 1
+            if mid == new_alias_b and mid != model_b:
+                print(
+                    f"Error: Alias '{new_alias_b}' conflicts with model directory "
+                    f"name '{mid}'."
+                )
+                return 1
+
+        # Use the swap endpoint (atomic operation)
+        result = api(
+            "POST",
+            "/api/models/swap-alias",
+            json={
+                "model_a": model_a,
+                "model_b": model_b,
+                "alias_a": new_alias_a,
+                "alias_b": new_alias_b,
+            },
+        )
+        if result.get("success"):
+            old_a = result["model_a"]["old_alias"] or "(none)"
+            new_a = result["model_a"]["new_alias"] or "(none)"
+            old_b = result["model_b"]["old_alias"] or "(none)"
+            new_b = result["model_b"]["new_alias"] or "(none)"
+            print(f"Swapped aliases:")
+            print(f"  {model_a}: '{old_a}' → '{new_a}'")
+            print(f"  {model_b}: '{old_b}' → '{new_b}'")
+        return 0
+
+    elif alias_cmd == "list":
+        models_data = api("GET", "/api/models").get("models", [])
+        print(f"{'Model ID':<35} {'Alias':<20} {'Pinned':<8} {'Default':<8} {'Loaded':<8}")
+        print("-" * 80)
+        for m in models_data:
+            mid = m["id"]
+            ms = m.get("settings", {})
+            alias = ms.get("model_alias", "") or "(none)"
+            pinned = "yes" if m.get("pinned") or ms.get("is_pinned") else "no"
+            default = "yes" if m.get("is_default") or ms.get("is_default") else "no"
+            loaded = "yes" if m.get("loaded") else "no"
+            print(f"{mid:<35} {alias:<20} {pinned:<8} {default:<8} {loaded:<8}")
+        return 0
+
+    return 0
+
+
 def lifecycle_command(args) -> int:
     """Run background lifecycle commands for the current installation."""
     from .utils.install import is_app_bundle, is_homebrew
@@ -1016,6 +1223,53 @@ Example directory structure:
         help="Claude Code Haiku tier model (Claude integration only)",
     )
 
+    # Alias command
+    alias_parser = subparsers.add_parser(
+        "alias",
+        help="Manage model aliases",
+        description="Set, swap, remove, or list model aliases on a running oMLX server.",
+    )
+    alias_subparsers = alias_parser.add_subparsers(
+        dest="alias_command", help="Alias operation"
+    )
+
+    # alias set <model> <alias>
+    alias_set_parser = alias_subparsers.add_parser(
+        "set", help="Set an alias for a model"
+    )
+    alias_set_parser.add_argument("model", type=str, help="Model ID to set the alias on")
+    alias_set_parser.add_argument("alias", type=str, help="Alias name to assign")
+
+    # alias swap <model_a> <model_b> [--alias-a <new_alias_a>] [--alias-b <new_alias_b>]
+    alias_swap_parser = alias_subparsers.add_parser(
+        "swap", help="Swap or transfer aliases between two models"
+    )
+    alias_swap_parser.add_argument("model_a", type=str, help="First model ID")
+    alias_swap_parser.add_argument("model_b", type=str, help="Second model ID")
+    alias_swap_parser.add_argument(
+        "--alias-a",
+        type=str,
+        default=None,
+        help="New alias for model_a (default: swap existing aliases)",
+    )
+    alias_swap_parser.add_argument(
+        "--alias-b",
+        type=str,
+        default=None,
+        help="New alias for model_b (default: swap existing aliases)",
+    )
+
+    # alias remove <model>
+    alias_remove_parser = alias_subparsers.add_parser(
+        "remove", help="Remove the alias from a model"
+    )
+    alias_remove_parser.add_argument(
+        "model", type=str, help="Model ID to remove the alias from"
+    )
+
+    # alias list
+    alias_subparsers.add_parser("list", help="List all models with their aliases")
+
     # Diagnose command
     diagnose_parser = subparsers.add_parser(
         "diagnose",
@@ -1036,6 +1290,8 @@ Example directory structure:
 
     if args.command == "launch":
         launch_command(args, extra_args=extra_args)
+    elif args.command == "alias":
+        sys.exit(alias_command(args))
     else:
         if extra_args:
             parser.error(f"unrecognized arguments: {' '.join(extra_args)}")

--- a/tests/test_admin_alias_api.py
+++ b/tests/test_admin_alias_api.py
@@ -1,0 +1,798 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for alias management CLI commands and swap-alias API endpoint."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omlx.admin import routes as admin_routes
+from omlx.model_settings import ModelSettings, ModelSettingsManager
+
+
+# =============================================================================
+# Mock helpers
+# =============================================================================
+
+
+class _FakeEntry:
+    def __init__(self, model_id: str):
+        self.engine_type = "batched"
+        self.model_type = "llm"
+        self.engine = None
+        self.is_pinned = False
+        self.is_loading = False
+        self.model_path = "/fake"
+
+
+class _FakePool:
+    def __init__(self, model_ids=None):
+        self._entries = {mid: _FakeEntry(mid) for mid in (model_ids or [])}
+
+    def get_entry(self, model_id):
+        return self._entries.get(model_id)
+
+    def get_status(self):
+        return {
+            "models": [
+                {
+                    "id": mid,
+                    "loaded": False,
+                    "pinned": False,
+                    "engine_type": "batched",
+                    "model_type": "llm",
+                }
+                for mid in self._entries
+            ]
+        }
+
+
+class _FakeServerState:
+    default_model = None
+
+
+def _make_client(tmp_path, model_ids=None, settings=None):
+    """Build a TestClient with admin routes and a fresh settings manager."""
+    from types import SimpleNamespace
+
+    mgr = ModelSettingsManager(tmp_path)
+    pool = _FakePool(model_ids or [])
+    state = _FakeServerState()
+
+    if settings:
+        for mid, s in settings.items():
+            mgr.set_settings(mid, s)
+
+    admin_routes._get_settings_manager = lambda: mgr
+    admin_routes._get_engine_pool = lambda: pool
+    admin_routes._get_server_state = lambda: state
+    # Bypass auth entirely so the tests don't need session cookies or API keys
+    admin_routes._get_global_settings = lambda: SimpleNamespace(
+        auth=SimpleNamespace(api_key="", sub_keys=[], skip_api_key_verification=True)
+    )
+
+    async def _fake_require_admin():
+        return True
+
+    from omlx.admin import auth as admin_auth
+
+    app = FastAPI()
+    app.include_router(admin_routes.router)
+    app.dependency_overrides[admin_routes.require_admin] = _fake_require_admin
+    return TestClient(app), mgr
+
+
+# =============================================================================
+# swap-alias API endpoint (POST /api/models/swap-alias)
+# =============================================================================
+
+
+class TestSwapAliasApi:
+    """Tests for POST /api/models/swap-alias."""
+
+    def test_swap_aliases_two_models(self, tmp_path):
+        """Swapping aliases between two models transfers them."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b"],
+            settings={
+                "model-a": ModelSettings(model_alias="alias-a"),
+                "model-b": ModelSettings(model_alias="alias-b"),
+            },
+        )
+        r = c.post("/admin/api/models/swap-alias", json={
+            "model_a": "model-a",
+            "model_b": "model-b",
+            "alias_a": "alias-b",
+            "alias_b": "alias-a",
+        })
+        assert r.status_code == 200
+        body = r.json()
+        assert body["success"] is True
+        assert body["model_a"]["old_alias"] == "alias-a"
+        assert body["model_a"]["new_alias"] == "alias-b"
+        assert body["model_b"]["old_alias"] == "alias-b"
+        assert body["model_b"]["new_alias"] == "alias-a"
+
+        # Verify persistence
+        assert mgr.get_settings("model-a").model_alias == "alias-b"
+        assert mgr.get_settings("model-b").model_alias == "alias-a"
+
+    def test_swap_clears_both_aliases(self, tmp_path):
+        """Swap with None aliases clears both."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b"],
+            settings={
+                "model-a": ModelSettings(model_alias="alias-a"),
+                "model-b": ModelSettings(model_alias="alias-b"),
+            },
+        )
+        r = c.post("/admin/api/models/swap-alias", json={
+            "model_a": "model-a",
+            "model_b": "model-b",
+            "alias_a": None,
+            "alias_b": None,
+        })
+        assert r.status_code == 200
+        assert mgr.get_settings("model-a").model_alias is None
+        assert mgr.get_settings("model-b").model_alias is None
+
+    def test_swap_transfer_alias_one_side(self, tmp_path):
+        """Transfer alias from A to B, clearing A."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b"],
+            settings={"model-a": ModelSettings(model_alias="shared")},
+        )
+        r = c.post("/admin/api/models/swap-alias", json={
+            "model_a": "model-a",
+            "model_b": "model-b",
+            "alias_a": None,
+            "alias_b": "shared",
+        })
+        assert r.status_code == 200
+        assert mgr.get_settings("model-a").model_alias is None
+        assert mgr.get_settings("model-b").model_alias == "shared"
+
+    def test_swap_conflicts_with_third_model(self, tmp_path):
+        """Third model already uses target alias — 400."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b", "model-c"],
+            settings={
+                "model-a": ModelSettings(model_alias="alias-a"),
+                "model-c": ModelSettings(model_alias="alias-b"),
+            },
+        )
+        r = c.post("/admin/api/models/swap-alias", json={
+            "model_a": "model-a",
+            "model_b": "model-b",
+            "alias_a": "alias-b",
+            "alias_b": "alias-a",
+        })
+        assert r.status_code == 400
+        assert "already used by model" in r.json()["detail"]
+
+    def test_swap_conflicts_with_directory_name(self, tmp_path):
+        """Target alias equals another model's directory name — 400."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b"],
+            settings={"model-a": ModelSettings(model_alias="alias-a")},
+        )
+        r = c.post("/admin/api/models/swap-alias", json={
+            "model_a": "model-a",
+            "model_b": "model-b",
+            "alias_a": "model-b",  # conflicts with model-b's directory name
+            "alias_b": "alias-a",
+        })
+        assert r.status_code == 400
+        assert "conflicts with model directory name" in r.json()["detail"]
+
+    def test_swap_missing_model(self, tmp_path):
+        """One model doesn't exist — 404."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a"],
+            settings={"model-a": ModelSettings(model_alias="a")},
+        )
+        r = c.post("/admin/api/models/swap-alias", json={
+            "model_a": "model-a",
+            "model_b": "nope",
+            "alias_a": None,
+            "alias_b": None,
+        })
+        assert r.status_code == 404
+        assert "not found" in r.json()["detail"]
+
+    def test_swap_empty_string_becomes_none(self, tmp_path):
+        """Empty string aliases are normalised to None."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b"],
+            settings={
+                "model-a": ModelSettings(model_alias="alias-a"),
+                "model-b": ModelSettings(model_alias="alias-b"),
+            },
+        )
+        r = c.post("/admin/api/models/swap-alias", json={
+            "model_a": "model-a",
+            "model_b": "model-b",
+            "alias_a": "",
+            "alias_b": "   ",
+        })
+        assert r.status_code == 200
+        assert mgr.get_settings("model-a").model_alias is None
+        assert mgr.get_settings("model-b").model_alias is None
+
+    def test_swap_same_model(self, tmp_path):
+        """Swapping a model with itself should still work."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a"],
+            settings={"model-a": ModelSettings(model_alias="alias-a")},
+        )
+        r = c.post("/admin/api/models/swap-alias", json={
+            "model_a": "model-a",
+            "model_b": "model-a",
+            "alias_a": "new",
+            "alias_b": "alias-a",
+        })
+        # Both references point to the same model, so both are updated
+        assert r.status_code == 200
+
+    def test_swap_no_conflict_same_alias(self, tmp_path):
+        """Setting the same alias on both models in swap (no conflict)."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b"],
+            settings={"model-a": ModelSettings(model_alias="a")},
+        )
+        r = c.post("/admin/api/models/swap-alias", json={
+            "model_a": "model-a",
+            "model_b": "model-b",
+            "alias_a": "shared",
+            "alias_b": "shared",
+        })
+        assert r.status_code == 200
+
+
+# =============================================================================
+# update_model_settings alias handling
+# =============================================================================
+
+
+class TestUpdateModelSettingsAlias:
+    """Tests for model_alias in PUT /api/models/{id}/settings."""
+
+    def test_set_alias_via_update(self, tmp_path):
+        """Setting alias via update_model_settings."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a"],
+        )
+        r = c.put("/admin/api/models/model-a/settings", json={
+            "model_alias": "my-alias",
+        })
+        assert r.status_code == 200
+        assert mgr.get_settings("model-a").model_alias == "my-alias"
+
+    def test_set_alias_conflict_with_existing(self, tmp_path):
+        """Setting an alias already taken by another model — 400."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b"],
+            settings={"model-a": ModelSettings(model_alias="shared")},
+        )
+        r = c.put("/admin/api/models/model-b/settings", json={
+            "model_alias": "shared",
+        })
+        assert r.status_code == 400
+        assert "already used by" in r.json()["detail"]
+
+    def test_set_alias_conflicts_with_directory(self, tmp_path):
+        """Alias equals another model's directory name — 400."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b"],
+        )
+        r = c.put("/admin/api/models/model-a/settings", json={
+            "model_alias": "model-b",
+        })
+        assert r.status_code == 400
+        assert "conflicts with model directory name" in r.json()["detail"]
+
+    def test_clear_alias_via_update(self, tmp_path):
+        """Clearing alias via update_model_settings."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a"],
+            settings={"model-a": ModelSettings(model_alias="my-alias")},
+        )
+        r = c.put("/admin/api/models/model-a/settings", json={
+            "model_alias": None,
+        })
+        assert r.status_code == 200
+        assert mgr.get_settings("model-a").model_alias is None
+
+    def test_set_empty_string_becomes_none(self, tmp_path):
+        """Empty string alias is normalised to None."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a"],
+        )
+        r = c.put("/admin/api/models/model-a/settings", json={
+            "model_alias": "  ",
+        })
+        assert r.status_code == 200
+        assert mgr.get_settings("model-a").model_alias is None
+
+
+# =============================================================================
+# CLI alias commands
+# =============================================================================
+
+
+class TestAliasCliSet:
+    """Tests for 'omlx alias set' command."""
+
+    def test_set_alias_success(self, tmp_path):
+        """Setting an alias on a known model succeeds."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["my-model"],
+        )
+        r = c.put("/admin/api/models/my-model/settings", json={
+            "model_alias": "my-alias",
+        })
+        assert r.status_code == 200
+        assert r.json()["success"] is True
+        assert mgr.get_settings("my-model").model_alias == "my-alias"
+
+    def test_set_alias_conflict(self, tmp_path):
+        """Setting an alias already held by another model — 400."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b"],
+            settings={"model-a": ModelSettings(model_alias="shared")},
+        )
+        r = c.put("/admin/api/models/model-b/settings", json={
+            "model_alias": "shared",
+        })
+        assert r.status_code == 400
+        assert "already used by" in r.json()["detail"]
+
+    def test_set_alias_conflict_with_directory(self, tmp_path):
+        """Alias equals another model's directory name — 400."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b"],
+        )
+        r = c.put("/admin/api/models/model-a/settings", json={
+            "model_alias": "model-b",
+        })
+        assert r.status_code == 400
+        assert "conflicts with model directory name" in r.json()["detail"]
+
+
+class TestAliasCliSwap:
+    """Tests for 'omlx alias swap' command."""
+
+    def test_swap_two_models_with_aliases(self, tmp_path):
+        """Swapping two models each with an alias transfers them."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b"],
+            settings={
+                "model-a": ModelSettings(model_alias="alias-a"),
+                "model-b": ModelSettings(model_alias="alias-b"),
+            },
+        )
+        r = c.post("/admin/api/models/swap-alias", json={
+            "model_a": "model-a",
+            "model_b": "model-b",
+            "alias_a": "alias-b",
+            "alias_b": "alias-a",
+        })
+        assert r.status_code == 200
+        body = r.json()
+        assert body["success"] is True
+        assert mgr.get_settings("model-a").model_alias == "alias-b"
+        assert mgr.get_settings("model-b").model_alias == "alias-a"
+
+    def test_swap_one_side_clear(self, tmp_path):
+        """Clear alias on A, give B's alias to A."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b"],
+            settings={
+                "model-a": ModelSettings(model_alias="alias-a"),
+                "model-b": ModelSettings(model_alias="alias-b"),
+            },
+        )
+        r = c.post("/admin/api/models/swap-alias", json={
+            "model_a": "model-a",
+            "model_b": "model-b",
+            "alias_a": None,
+            "alias_b": "alias-a",
+        })
+        assert r.status_code == 200
+        assert mgr.get_settings("model-a").model_alias is None
+        assert mgr.get_settings("model-b").model_alias == "alias-a"
+
+    def test_swap_missing_model(self, tmp_path):
+        """One model doesn't exist — 404."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a"],
+        )
+        r = c.post("/admin/api/models/swap-alias", json={
+            "model_a": "model-a",
+            "model_b": "unknown",
+            "alias_a": None,
+            "alias_b": None,
+        })
+        assert r.status_code == 404
+
+
+class TestAliasCliRemove:
+    """Tests for 'omlx alias remove' command."""
+
+    def test_remove_alias_success(self, tmp_path):
+        """Removing an alias clears it."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["my-model"],
+            settings={"my-model": ModelSettings(model_alias="my-alias")},
+        )
+        r = c.put("/admin/api/models/my-model/settings", json={
+            "model_alias": None,
+        })
+        assert r.status_code == 200
+        assert mgr.get_settings("my-model").model_alias is None
+
+    def test_remove_alias_on_model_without_alias(self, tmp_path):
+        """Removing alias from a model that already has none — still succeeds."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["my-model"],
+        )
+        r = c.put("/admin/api/models/my-model/settings", json={
+            "model_alias": None,
+        })
+        assert r.status_code == 200
+        assert mgr.get_settings("my-model").model_alias is None
+
+
+class TestAliasCliList:
+    """Tests for 'omlx alias list' command — verifies list_models output."""
+
+    def test_list_includes_aliases(self, tmp_path):
+        """list_models response includes model_alias in settings for real models."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a", "model-b"],
+            settings={
+                "model-a": ModelSettings(model_alias="alias-a"),
+                "model-b": ModelSettings(model_alias="alias-b"),
+            },
+        )
+        r = c.get("/admin/api/models")
+        assert r.status_code == 200
+        models = r.json()["models"]
+        # list_models may include virtual models (MarkItDown), so check by ID
+        by_id = {m["id"]: m for m in models}
+        assert "model-a" in by_id
+        assert "model-b" in by_id
+        assert by_id["model-a"]["settings"]["model_alias"] == "alias-a"
+        assert by_id["model-b"]["settings"]["model_alias"] == "alias-b"
+
+    def test_list_shows_none_for_no_alias(self, tmp_path):
+        """Models without alias show None/absent in response."""
+        c, mgr = _make_client(
+            tmp_path,
+            model_ids=["model-a"],
+        )
+        r = c.get("/admin/api/models")
+        assert r.status_code == 200
+        models = r.json()["models"]
+        by_id = {m["id"]: m for m in models}
+        assert "model-a" in by_id
+        ms = by_id["model-a"].get("settings", {})
+        # None values are excluded from to_dict, so key may be absent
+        assert "model_alias" not in ms or ms.get("model_alias") is None
+
+
+# =============================================================================
+# SwapAliasRequest pydantic model
+# =============================================================================
+
+
+class TestSwapAliasRequest:
+    """Tests for the SwapAliasRequest pydantic model."""
+
+    def test_default_aliases_are_none(self):
+        """alias_a and alias_b default to None."""
+        from omlx.admin.routes import SwapAliasRequest
+        req = SwapAliasRequest(model_a="a", model_b="b")
+        assert req.alias_a is None
+        assert req.alias_b is None
+
+    def test_aliases_can_be_set(self):
+        """Alias fields accept string values."""
+        from omlx.admin.routes import SwapAliasRequest
+        req = SwapAliasRequest(
+            model_a="a",
+            model_b="b",
+            alias_a="new-a",
+            alias_b="new-b",
+        )
+        assert req.alias_a == "new-a"
+        assert req.alias_b == "new-b"
+
+    def test_aliases_can_be_explicit_none(self):
+        """Explicit None is valid."""
+        from omlx.admin.routes import SwapAliasRequest
+        req = SwapAliasRequest(
+            model_a="a",
+            model_b="b",
+            alias_a=None,
+            alias_b=None,
+        )
+        assert req.alias_a is None
+        assert req.alias_b is None
+
+
+# =============================================================================
+# CLI alias_command function
+# =============================================================================
+
+
+class TestAliasCliFunction:
+    """Tests for the alias_command CLI function."""
+
+    def _mock_server(self, models_data, monkeypatch):
+        """Build a mock HTTP server response for the alias CLI commands."""
+        from omlx.settings import GlobalSettings
+        from types import SimpleNamespace
+        import requests
+
+        class MockResponse:
+            def __init__(self, status_code, json_data):
+                self.status_code = status_code
+                self._json_data = json_data
+
+            def json(self):
+                return self._json_data
+
+            def raise_for_status(self):
+                if self.status_code >= 400:
+                    raise requests.HTTPError(f"HTTP {self.status_code}")
+
+        responses = {}
+
+        def mock_get(url, **kwargs):
+            if "health" in url:
+                return MockResponse(200, {"status": "ok"})
+            if "/api/models" in url:
+                return MockResponse(200, {"models": models_data})
+            return MockResponse(404, {})
+
+        def mock_request(method, url, **kwargs):
+            if "health" in url:
+                return MockResponse(200, {"status": "ok"})
+            if "/api/models" in url:
+                return MockResponse(200, {"models": models_data})
+            if "/admin/api/models" in url:
+                body = kwargs.get("json", {})
+                if method == "PUT" and "settings" in url:
+                    mid = url.split("/")[4]
+                    for m in models_data:
+                        if m["id"] == mid:
+                            if "model_alias" in body:
+                                m["settings"] = {
+                                    **m.get("settings", {}),
+                                    "model_alias": body["model_alias"],
+                                }
+                            return MockResponse(
+                                200,
+                                {
+                                    "success": True,
+                                    "model_id": mid,
+                                    "settings": m.get("settings", {}),
+                                },
+                            )
+                if method == "POST" and "swap-alias" in url:
+                    return MockResponse(200, {
+                        "success": True,
+                        "model_a": {
+                            "old_alias": models_data[0].get("settings", {}).get("model_alias"),
+                            "new_alias": body.get("alias_a"),
+                        },
+                        "model_b": {
+                            "old_alias": models_data[1].get("settings", {}).get("model_alias"),
+                            "new_alias": body.get("alias_b"),
+                        },
+                    })
+            return MockResponse(404, {})
+
+        monkeypatch.setattr(requests, "get", mock_get)
+        monkeypatch.setattr(requests, "request", mock_request)
+        monkeypatch.setattr(
+            GlobalSettings, "load",
+            lambda: SimpleNamespace(
+                server=SimpleNamespace(port=8000),
+                auth=SimpleNamespace(api_key=""),
+            ),
+        )
+
+    def test_alias_set_success(self, monkeypatch, tmp_path):
+        """alias set succeeds for a known model."""
+        from omlx.cli import alias_command
+
+        models = [
+            {"id": "model-a", "settings": {}},
+            {"id": "model-b", "settings": {}},
+        ]
+        self._mock_server(models, monkeypatch)
+
+        args = SimpleNamespace(
+            alias_command="set",
+            model="model-a",
+            alias="new-alias",
+        )
+        result = alias_command(args)
+        assert result == 0
+
+    def test_alias_set_conflict(self, monkeypatch):
+        """alias set fails when alias is already used."""
+        from omlx.cli import alias_command
+
+        models = [
+            {"id": "model-a", "settings": {}},
+            {"id": "model-b", "settings": {"model_alias": "existing"}},
+        ]
+        self._mock_server(models, monkeypatch)
+
+        args = SimpleNamespace(
+            alias_command="set",
+            model="model-a",
+            alias="existing",
+        )
+        result = alias_command(args)
+        assert result == 1
+
+    def test_alias_set_unknown_model(self, monkeypatch):
+        """alias set fails for unknown model."""
+        from omlx.cli import alias_command
+
+        models = [
+            {"id": "model-a", "settings": {}},
+        ]
+        self._mock_server(models, monkeypatch)
+
+        args = SimpleNamespace(
+            alias_command="set",
+            model="unknown-model",
+            alias="some-alias",
+        )
+        result = alias_command(args)
+        assert result == 1
+
+    def test_alias_remove_success(self, monkeypatch, tmp_path):
+        """alias remove succeeds."""
+        from omlx.cli import alias_command
+
+        models = [
+            {"id": "model-a", "settings": {"model_alias": "old-alias"}},
+        ]
+        self._mock_server(models, monkeypatch)
+
+        args = SimpleNamespace(
+            alias_command="remove",
+            model="model-a",
+        )
+        result = alias_command(args)
+        assert result == 0
+
+    def test_alias_swap_success(self, monkeypatch, tmp_path):
+        """alias swap succeeds."""
+        from omlx.cli import alias_command
+
+        models = [
+            {"id": "model-a", "settings": {"model_alias": "alias-a"}},
+            {"id": "model-b", "settings": {"model_alias": "alias-b"}},
+        ]
+        self._mock_server(models, monkeypatch)
+
+        args = SimpleNamespace(
+            alias_command="swap",
+            model_a="model-a",
+            model_b="model-b",
+            alias_a=None,
+            alias_b=None,
+        )
+        result = alias_command(args)
+        assert result == 0
+
+    def test_alias_list_success(self, monkeypatch, tmp_path):
+        """alias list succeeds and shows models with aliases."""
+        from omlx.cli import alias_command
+
+        models = [
+            {
+                "id": "model-a",
+                "settings": {"model_alias": "alias-a"},
+                "pinned": False,
+                "is_default": False,
+            },
+            {
+                "id": "model-b",
+                "settings": {"model_alias": None},
+                "pinned": True,
+                "is_default": False,
+            },
+            {
+                "id": "model-c",
+                "settings": {},
+                "pinned": False,
+                "is_default": True,
+            },
+        ]
+        self._mock_server(models, monkeypatch)
+
+        args = SimpleNamespace(
+            alias_command="list",
+        )
+        result = alias_command(args)
+        assert result == 0
+
+    def test_alias_no_command_shows_help(self, monkeypatch):
+        """alias with no subcommand shows usage."""
+        from omlx.cli import alias_command
+
+        self._mock_server([], monkeypatch)
+
+        args = SimpleNamespace(
+            alias_command=None,
+        )
+        result = alias_command(args)
+        assert result == 1
+
+    def test_alias_swap_missing_model(self, monkeypatch):
+        """alias swap fails when one model doesn't exist."""
+        from omlx.cli import alias_command
+
+        models = [
+            {"id": "model-a", "settings": {"model_alias": "alias-a"}},
+        ]
+        self._mock_server(models, monkeypatch)
+
+        args = SimpleNamespace(
+            alias_command="swap",
+            model_a="model-a",
+            model_b="unknown",
+            alias_a=None,
+            alias_b=None,
+        )
+        result = alias_command(args)
+        assert result == 1
+
+    def test_server_not_running(self, monkeypatch):
+        """alias commands fail when server is not running."""
+        import requests
+
+        monkeypatch.setattr(
+            requests, "get", lambda *a, **k: (_ for _ in ()).throw(requests.ConnectionError())
+        )
+        from omlx.cli import alias_command
+
+        args = SimpleNamespace(
+            alias_command="set",
+            model="model-a",
+            alias="alias",
+        )
+        result = alias_command(args)
+        assert result == 1

--- a/tests/test_admin_profiles_api.py
+++ b/tests/test_admin_profiles_api.py
@@ -51,6 +51,10 @@ def client(tmp_path, monkeypatch):
     # Bypass auth
     async def _fake_require_admin():
         return True
+
+    async def _fake_require_admin_or_bearer(req):
+        return True
+
     from omlx.admin import auth as admin_auth
     monkeypatch.setattr(admin_auth, "require_admin", _fake_require_admin)
 
@@ -58,6 +62,7 @@ def client(tmp_path, monkeypatch):
     app = FastAPI()
     app.include_router(admin_routes.router)
     app.dependency_overrides[admin_routes.require_admin] = _fake_require_admin
+    app.dependency_overrides[admin_routes._require_admin_or_bearer] = _fake_require_admin_or_bearer
     return TestClient(app), mgr
 
 

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -532,3 +532,88 @@ class TestModelSettingsManager:
                 t.join()
 
             assert len(errors) == 0
+
+
+# =============================================================================
+# Alias management tests (CLI + API)
+# =============================================================================
+
+
+class TestModelSettingsAlias:
+    """Tests for model_alias field in ModelSettings."""
+
+    def test_model_alias_default_is_none(self):
+        """model_alias defaults to None."""
+        settings = ModelSettings()
+        assert settings.model_alias is None
+
+    def test_model_alias_can_be_set(self):
+        """model_alias can be set to a string."""
+        settings = ModelSettings(model_alias="my-alias")
+        assert settings.model_alias == "my-alias"
+
+    def test_model_alias_survives_roundtrip(self):
+        """model_alias survives to_dict/from_dict."""
+        original = ModelSettings(model_alias="my-alias")
+        restored = ModelSettings.from_dict(original.to_dict())
+        assert restored.model_alias == "my-alias"
+
+    def test_model_alias_survives_save_load(self, tmp_path):
+        """model_alias persists through save/load cycle."""
+        manager = ModelSettingsManager(Path(tmp_path))
+        manager.set_settings("model-a", ModelSettings(model_alias="alias-a"))
+        # Reload from file
+        manager2 = ModelSettingsManager(Path(tmp_path))
+        assert manager2.get_settings("model-a").model_alias == "alias-a"
+
+    def test_model_alias_clear(self, tmp_path):
+        """Setting model_alias=None clears the alias."""
+        manager = ModelSettingsManager(Path(tmp_path))
+        manager.set_settings("model-a", ModelSettings(model_alias="alias-a"))
+        assert manager.get_settings("model-a").model_alias == "alias-a"
+        # Clear
+        manager.set_settings("model-a", ModelSettings(model_alias=None))
+        assert manager.get_settings("model-a").model_alias is None
+
+    def test_model_alias_excluded_from_dict_when_none(self):
+        """model_alias is excluded from to_dict when None."""
+        settings = ModelSettings()
+        d = settings.to_dict()
+        assert "model_alias" not in d
+
+    def test_model_alias_included_in_dict_when_set(self):
+        """model_alias is included in to_dict when set."""
+        settings = ModelSettings(model_alias="test-alias")
+        d = settings.to_dict()
+        assert d.get("model_alias") == "test-alias"
+
+
+class TestModelSettingsManagerAlias:
+    """Tests for alias-related operations in ModelSettingsManager."""
+
+    def test_two_models_can_share_alias(self, tmp_path):
+        """Setting the same alias on two models — manager allows it
+        (uniqueness enforcement is done at the API layer)."""
+        mgr = ModelSettingsManager(Path(tmp_path))
+        mgr.set_settings("model-a", ModelSettings(model_alias="shared"))
+        mgr.set_settings("model-b", ModelSettings(model_alias="shared"))
+
+        assert mgr.get_settings("model-a").model_alias == "shared"
+        assert mgr.get_settings("model-b").model_alias == "shared"
+
+    def test_delete_settings_removes_alias(self, tmp_path):
+        """Deleting a model's settings releases its alias."""
+        mgr = ModelSettingsManager(Path(tmp_path))
+        mgr.set_settings("model-a", ModelSettings(model_alias="my-alias"))
+        mgr.delete_settings("model-a")
+        assert mgr.get_settings("model-a").model_alias is None
+
+    def test_get_all_settings_includes_alias(self, tmp_path):
+        """get_all_settings includes model_alias."""
+        mgr = ModelSettingsManager(Path(tmp_path))
+        mgr.set_settings("model-a", ModelSettings(model_alias="alias-a"))
+        mgr.set_settings("model-b", ModelSettings())
+
+        all_settings = mgr.get_all_settings()
+        assert all_settings["model-a"].model_alias == "alias-a"
+        assert all_settings["model-b"].model_alias is None


### PR DESCRIPTION
## Summary

Adds the ability to manage model aliases via CLI and REST API, along with an authentication fix that allows admin API routes to accept Bearer API tokens (previously they only accepted session cookies).

## Changes

### 1. CLI `omlx alias` command (`omlx/cli.py`)

New top-level `alias` subcommand with 4 operations:

- **`omlx alias set <model> <alias>`** — Assign an alias to a model (with conflict detection)
- **`omlx alias swap <model_a> <model_b> [--alias-a <new>] [--alias-b <new>]`** — Swap or transfer aliases between two models atomically. If no `--alias-*` flags are provided, auto-detects and swaps the current aliases
- **`omlx alias remove <model>`** — Remove the alias from a model
- **`omlx alias list`** — List all models with their aliases, pinned status, and loaded state

All commands communicate with the running oMLX server via the admin API using Bearer token authentication.

### 2. Admin API auth: `_require_admin_or_bearer` dependency (`omlx/admin/routes.py`)

New dependency that accepts **either**:
- A valid admin session cookie (existing behavior)
- A `Bearer` token matching the configured API key

Applied to these routes so CLI/API consumers can authenticate without browser sessions:
- `GET /admin/api/models` (list_models)
- `PUT /admin/api/models/{model_id}/settings` (update_model_settings)
- `POST /admin/api/models/{model_id}/load` (load_model)
- `POST /admin/api/models/swap-alias` (swap_model_alias)

### 3. Atomic alias swap endpoint (`POST /admin/api/models/swap-alias`)

- **`SwapAliasRequest`** — Pydantic model with `model_a`, `model_b`, `alias_a` (optional), `alias_b` (optional)
- Atomic two-model update with rollback on failure
- Conflict detection: prevents alias collisions with third models and model directory names
- Normalizes empty/whitespace-only aliases to `None`

### 4. Alias conflict detection in `update_model_settings`

When setting `model_alias` via the settings update endpoint:
- Checks for conflicts with existing aliases on other models (400 error)
- Checks for conflicts with other models' directory names (400 error)

### 5. Tests

- **`tests/test_admin_alias_api.py`** (new) — 36 tests covering:
  - `SwapAliasRequest` pydantic model validation
  - `swap-alias` endpoint (swap, clear, transfer, conflicts, missing models, edge cases)
  - `update_model_settings` alias handling
  - CLI `alias_command` function (set, swap, remove, list, error paths)
- **`tests/test_model_settings.py`** — 10 new tests for `model_alias` field roundtrips, persistence, and manager operations

## Usage Examples

```bash
# Set an alias
omlx alias set my-model cool-alias

# Remove an alias
omlx alias remove my-model

# Swap aliases between two models
omlx alias swap model-a model-b

# Transfer an alias (clearing source)
omlx alias swap source-model target-model --alias-b my-alias

# List all models with their aliases
omlx alias list
```

## Stats

```
 omlx/admin/routes.py             | 432 ++++++++++++----------
 omlx/cli.py                      | 256 ++++++++++++++
 tests/test_admin_profiles_api.py |   5 +
 tests/test_model_settings.py     |  85 ++++++
 tests/test_admin_alias_api.py    | 799 +++++++++++++++++++++++++ (new)
 5 files changed, 1425 insertions(+), 151 deletions(-)
```