### PR TITLE
fix: reclaim hot cache memory retained after model unload

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -4352,12 +4352,11 @@ async def clear_alltime_stats(is_admin: bool = Depends(require_admin)):
     return {"status": "ok"}
 
 
-def _iter_loaded_schedulers():
-    """Yield (model_id, scheduler) for each loaded model.
+def _iter_loaded_scheduler_records():
+    """Yield (model_id, scheduler, core) for each loaded model.
 
     Traverses the internal engine hierarchy: pool entry → async engine →
-    core engine → scheduler.  Both ``clear_ssd_cache`` and
-    ``clear_hot_cache`` share this traversal.
+    core engine → scheduler.
     """
     engine_pool = _get_engine_pool()
     if engine_pool is None:
@@ -4373,7 +4372,16 @@ def _iter_loaded_schedulers():
         core = getattr(async_core, "engine", None) if async_core is not None else None
         scheduler = getattr(core, "scheduler", None) if core is not None else None
         if scheduler is not None:
-            yield model_id, scheduler
+            yield model_id, scheduler, core
+
+
+def _iter_loaded_schedulers():
+    """Yield (model_id, scheduler) for each loaded model.
+
+    Both ``clear_ssd_cache`` and ``clear_hot_cache`` share this traversal.
+    """
+    for model_id, scheduler, _core in _iter_loaded_scheduler_records():
+        yield model_id, scheduler
 
 
 @router.post("/api/ssd-cache/clear")
@@ -4424,13 +4432,23 @@ async def clear_ssd_cache(is_admin: bool = Depends(require_admin)):
 
 @router.post("/api/hot-cache/clear")
 async def clear_hot_cache(is_admin: bool = Depends(require_admin)):
-    """Clear the in-memory (hot) cache for all loaded models.
+    """Clear the in-memory hot cache and release the buffers it held.
 
-    No filesystem fallback needed — hot cache is in-memory only and does
-    not survive process restart.
+    Dropping hot cache entries releases Python references, but MLX may keep
+    now-unused buffers in its allocator pool. Reclaim through the scheduler's
+    synchronized clear path so active engine streams and async store-cache
+    workers keep the same Metal safety barriers used by generation.
     """
+    import gc
+
+    from ..engine_core import get_mlx_executor
+    from ..scheduler import _sync_and_clear_cache
+    from ..utils.proc_memory import get_phys_footprint
+
+    footprint_before = get_phys_footprint()
     total_cleared = 0
-    for model_id, scheduler in _iter_loaded_schedulers():
+    reclaim_targets = []
+    for model_id, scheduler, core in _iter_loaded_scheduler_records():
         ssd_manager = getattr(scheduler, "paged_ssd_cache_manager", None)
         if ssd_manager is not None and hasattr(ssd_manager, "clear_hot_cache"):
             try:
@@ -4444,7 +4462,51 @@ async def clear_hot_cache(is_admin: bool = Depends(require_admin)):
         rate_tracker = getattr(scheduler, "_cache_rate_tracker", None)
         if rate_tracker is not None:
             rate_tracker.clear()
-    return {"status": "ok", "total_cleared": total_cleared}
+        executor = getattr(core, "_mlx_executor", None)
+        if executor is not None:
+            reclaim_targets.append((model_id, executor, getattr(scheduler, "_stream", None)))
+
+    # Also clear managers orphaned by an abnormal teardown: they hold live
+    # hot cache but are no longer attached to a loaded scheduler, so the loop
+    # above cannot reach them. The shared budget still references them.
+    pool = _get_engine_pool()
+    budget = getattr(getattr(pool, "_scheduler_config", None), "hot_cache_budget", None)
+    if budget is not None and hasattr(budget, "clear_all_owners"):
+        try:
+            total_cleared += budget.clear_all_owners()
+        except Exception as exc:
+            logger.warning("Failed to clear orphaned hot caches: %s", exc)
+
+    # Return pooled buffers to the OS using scheduler._sync_and_clear_cache(),
+    # the same lock/synchronize/clear helper used by generation. Run on each
+    # loaded engine's executor so its thread-local stream is present. If every
+    # model has been unloaded, still run one reclaim on the fallback executor so
+    # orphaned/no-loaded hot cache cleanup can release MLX's allocator pool.
+    gc.collect()
+    loop = asyncio.get_running_loop()
+    if reclaim_targets:
+        for model_id, executor, stream in reclaim_targets:
+            try:
+                await loop.run_in_executor(executor, _sync_and_clear_cache, stream)
+            except RuntimeError as exc:
+                if "cannot schedule new futures after shutdown" not in str(exc):
+                    raise
+                logger.warning(
+                    "Engine executor unavailable while reclaiming MLX buffers "
+                    "for model '%s': %s",
+                    model_id,
+                    exc,
+                )
+                await loop.run_in_executor(get_mlx_executor(), _sync_and_clear_cache)
+    else:
+        await loop.run_in_executor(get_mlx_executor(), _sync_and_clear_cache)
+    bytes_reclaimed = max(0, footprint_before - get_phys_footprint())
+
+    return {
+        "status": "ok",
+        "total_cleared": total_cleared,
+        "bytes_reclaimed": bytes_reclaimed,
+    }
 
 
 @router.post("/api/cache/probe")

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -693,6 +693,38 @@ class SharedHotCacheBudget:
                 entry = self._entries.pop(key)
                 self._total_bytes = max(0, self._total_bytes - entry.size_bytes)
 
+    def clear_all_owners(self) -> int:
+        """Clear the hot cache of every manager the budget still references.
+
+        The budget keeps a strong reference to each owning manager, so a
+        manager orphaned by an abnormal teardown stays reachable here even
+        when it is no longer attached to a loaded scheduler. Snapshot the
+        owners under the lock, then clear outside it (clear_hot_cache calls
+        forget_owner, which re-takes the lock).
+        """
+        with self._lock:
+            owners = []
+            seen = set()
+            for entry in self._entries.values():
+                if id(entry.owner) not in seen:
+                    seen.add(id(entry.owner))
+                    owners.append(entry.owner)
+        cleared = 0
+        for owner in owners:
+            fn = getattr(owner, "clear_hot_cache", None)
+            if callable(fn):
+                try:
+                    cleared += fn()
+                except Exception:
+                    # Keep going for the other owners, but do not hide the
+                    # failure: a silently-swallowed error makes admin recovery
+                    # look successful while memory is still pinned.
+                    logger.warning(
+                        "clear_hot_cache failed for an orphaned owner",
+                        exc_info=True,
+                    )
+        return cleared
+
     def put(
         self, owner: Any, block_hash: bytes, size_bytes: int
     ) -> list[tuple[Any, bytes]]:

--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -821,6 +821,31 @@ class EngineCore:
                     fn()
                 except RuntimeError:
                     pass
+            except Exception:
+                # A failing shutdown/deep_reset must not abort close(), or the
+                # SSD cache manager below stays open and its writer thread keeps
+                # the manager (and its hot cache) alive until restart.
+                logger.warning(
+                    "Engine %s: %s raised during close()",
+                    self._engine_id,
+                    getattr(fn, "__name__", fn),
+                    exc_info=True,
+                )
+
+        # Guarantee the SSD cache manager is released even if shutdown() did not
+        # reach its own close() above. The manager's writer thread holds a strong
+        # reference to it, so an unclosed manager leaks until restart.
+        manager = getattr(self.scheduler, "paged_ssd_cache_manager", None)
+        if manager is not None:
+            try:
+                manager.close()
+            except Exception:
+                logger.warning(
+                    "Engine %s: SSD cache manager close() failed during teardown",
+                    self._engine_id,
+                    exc_info=True,
+                )
+            self.scheduler.paged_ssd_cache_manager = None
 
         if self._mlx_executor is not None:
             # MLX's @mx.compile cache is a C++ thread_local CompilerCache. If

--- a/tests/test_admin_hot_cache_clear.py
+++ b/tests/test_admin_hot_cache_clear.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for POST /admin/api/hot-cache/clear.
+
+Covers the regression where clearing freed no RAM after every model was
+unloaded: the clear must still run a buffer reclaim (and report the bytes
+freed) even when no scheduler is loaded.
+"""
+
+import asyncio
+import concurrent.futures
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import omlx.server  # noqa: F401 — triggers set_admin_getters
+import omlx.admin.routes as admin_routes
+
+
+MODEL_ID = "test-model"
+
+
+def _run_clear():
+    return asyncio.run(admin_routes.clear_hot_cache(is_admin=True))
+
+
+def _pool(models, entries=None):
+    """Mock engine pool exposing get_status()['models'] and _entries."""
+    pool = MagicMock(spec=[])
+    pool.get_status = MagicMock(return_value={"models": models})
+    pool._entries = entries or {}
+    return pool
+
+
+def _loaded_entry(clear_hot_cache_mock, executor, stream="engine-stream"):
+    """Build the entry.engine._engine.engine.scheduler chain a loaded model has."""
+    scheduler = SimpleNamespace(
+        paged_ssd_cache_manager=SimpleNamespace(
+            clear_hot_cache=clear_hot_cache_mock,
+        ),
+        _cache_rate_tracker=None,
+        _stream=stream,
+    )
+    core = SimpleNamespace(scheduler=scheduler, _mlx_executor=executor)
+    return SimpleNamespace(
+        engine=SimpleNamespace(
+            _engine=SimpleNamespace(engine=core),
+        )
+    )
+
+
+class _reclaim_env:
+    """Patch the MLX reclaim dependencies the route imports lazily."""
+
+    def __init__(self, footprint_before=1000, footprint_after=400):
+        self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        self.clear_cache = MagicMock()
+        self.synchronize = MagicMock()
+        self.footprint = MagicMock(side_effect=[footprint_before, footprint_after])
+        self.get_mlx_executor = MagicMock(return_value=self._executor)
+
+    def __enter__(self):
+        self._patches = [
+            patch("mlx.core.clear_cache", self.clear_cache),
+            patch("mlx.core.synchronize", self.synchronize),
+            patch("omlx.engine_core.get_mlx_executor", self.get_mlx_executor),
+            patch("omlx.utils.proc_memory.get_phys_footprint", self.footprint),
+        ]
+        for p in self._patches:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in self._patches:
+            p.stop()
+        self._executor.shutdown(wait=True)
+        return False
+
+
+class TestHotCacheClear:
+    def test_reclaims_buffers_when_no_model_loaded(self):
+        """The bug case: no model loaded, yet the pool still holds the buffers.
+
+        The clear loop has nothing to iterate, but the reclaim must still run
+        so the retained Metal pool is returned to the OS.
+        """
+        pool = _pool(models=[])
+        with _reclaim_env() as env, patch.object(
+            admin_routes, "_get_engine_pool", return_value=pool
+        ):
+            result = _run_clear()
+
+        assert result["total_cleared"] == 0
+        assert env.get_mlx_executor.called
+        assert env.clear_cache.called, "mx.clear_cache must run even with no model loaded"
+        assert env.synchronize.called, "synchronize() barrier must precede clear_cache()"
+        assert result["bytes_reclaimed"] == 600
+
+    def test_clears_loaded_model_then_reclaims(self):
+        """Loaded model: its hot cache dict is cleared and buffers reclaimed."""
+        clear_mock = MagicMock(return_value=7)
+        with _reclaim_env() as env:
+            entry = _loaded_entry(clear_mock, env._executor, stream="loaded-stream")
+            pool = _pool(
+                models=[{"id": MODEL_ID, "loaded": True}],
+                entries={MODEL_ID: entry},
+            )
+            with patch.object(admin_routes, "_get_engine_pool", return_value=pool):
+                result = _run_clear()
+
+        assert clear_mock.called
+        assert result["total_cleared"] == 7
+        assert env.clear_cache.called
+        env.synchronize.assert_any_call("loaded-stream")
+        env.get_mlx_executor.assert_not_called()
+
+    def test_response_shape(self):
+        pool = _pool(models=[])
+        with _reclaim_env(), patch.object(
+            admin_routes, "_get_engine_pool", return_value=pool
+        ):
+            result = _run_clear()
+
+        assert set(result.keys()) == {"status", "total_cleared", "bytes_reclaimed"}
+        assert result["status"] == "ok"
+
+
+class TestClearReachesOrphans:
+    """Orphaned hot caches are reached through the shared budget."""
+
+    def test_clears_orphan_via_budget_with_no_model_loaded(self):
+        orphan_clear = MagicMock(return_value=5)
+        pool = _pool(models=[])
+        pool._scheduler_config = SimpleNamespace(
+            hot_cache_budget=SimpleNamespace(clear_all_owners=orphan_clear)
+        )
+        with _reclaim_env(), patch.object(
+            admin_routes, "_get_engine_pool", return_value=pool
+        ):
+            result = _run_clear()
+
+        assert orphan_clear.called
+        assert result["total_cleared"] == 5
+
+    def test_no_budget_is_tolerated(self):
+        pool = _pool(models=[])
+        pool._scheduler_config = SimpleNamespace(hot_cache_budget=None)
+        with _reclaim_env(), patch.object(
+            admin_routes, "_get_engine_pool", return_value=pool
+        ):
+            result = _run_clear()
+
+        assert result["total_cleared"] == 0
+
+
+class TestClearReclaimBranches:
+    """Cover the per-engine reclaim branches and their fallbacks."""
+
+    def test_engine_executor_shutdown_falls_back_to_global(self):
+        """A loaded engine whose executor is already shut down still reclaims.
+
+        run_in_executor raises 'cannot schedule new futures after shutdown';
+        the route must fall back to the global executor instead of failing.
+        """
+        dead = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        dead.shutdown(wait=True)
+        with _reclaim_env() as env:
+            entry = _loaded_entry(MagicMock(return_value=0), dead, stream="dead-stream")
+            pool = _pool(
+                models=[{"id": MODEL_ID, "loaded": True}],
+                entries={MODEL_ID: entry},
+            )
+            with patch.object(admin_routes, "_get_engine_pool", return_value=pool):
+                result = _run_clear()
+
+        assert result["status"] == "ok"
+        assert env.get_mlx_executor.called, "must fall back to the global executor"
+        assert env.clear_cache.called
+
+    def test_non_matching_runtime_error_propagates(self):
+        """Any RuntimeError other than executor-shutdown must not be swallowed."""
+        bad = MagicMock()
+        bad.submit = MagicMock(side_effect=RuntimeError("boom"))
+        entry = _loaded_entry(MagicMock(return_value=0), bad, stream="s")
+        pool = _pool(
+            models=[{"id": MODEL_ID, "loaded": True}],
+            entries={MODEL_ID: entry},
+        )
+        with _reclaim_env() as env, patch.object(
+            admin_routes, "_get_engine_pool", return_value=pool
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                _run_clear()
+        assert not env.get_mlx_executor.called, "must not fall back on a non-shutdown error"
+
+    def test_mixed_loaded_and_orphan_no_double_count(self):
+        """Loaded model and a separate orphan owner are both counted, once each."""
+        with _reclaim_env() as env:
+            entry = _loaded_entry(MagicMock(return_value=7), env._executor, stream="mixed-stream")
+            pool = _pool(
+                models=[{"id": MODEL_ID, "loaded": True}],
+                entries={MODEL_ID: entry},
+            )
+            pool._scheduler_config = SimpleNamespace(
+                hot_cache_budget=SimpleNamespace(clear_all_owners=MagicMock(return_value=5))
+            )
+            with patch.object(admin_routes, "_get_engine_pool", return_value=pool):
+                result = _run_clear()
+
+        assert result["total_cleared"] == 12  # 7 loaded + 5 orphan, no double count
+        env.synchronize.assert_any_call("mixed-stream")
+        env.get_mlx_executor.assert_not_called()
+
+    def test_two_loaded_engines_sync_each_stream(self):
+        """Each loaded engine is synchronized on its own stream; no global fallback."""
+        with _reclaim_env() as env:
+            e1 = _loaded_entry(MagicMock(return_value=1), env._executor, stream="stream-a")
+            e2 = _loaded_entry(MagicMock(return_value=1), env._executor, stream="stream-b")
+            pool = _pool(
+                models=[{"id": "m1", "loaded": True}, {"id": "m2", "loaded": True}],
+                entries={"m1": e1, "m2": e2},
+            )
+            with patch.object(admin_routes, "_get_engine_pool", return_value=pool):
+                result = _run_clear()
+
+        assert result["total_cleared"] == 2
+        env.synchronize.assert_any_call("stream-a")
+        env.synchronize.assert_any_call("stream-b")
+        env.get_mlx_executor.assert_not_called()

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -1194,3 +1194,40 @@ class TestGlobalMLXExecutor:
             f"Expected concurrent execution (max_concurrent >= 2), got {max_concurrent}. "
             f"Per-engine executors should allow parallel step() calls."
         )
+
+
+class TestEngineCoreCloseReleasesSSDManager:
+    """close() must release the SSD cache manager even if shutdown() fails.
+
+    The manager's writer thread holds a strong reference to it, so an unclosed
+    manager (and its hot cache) leaks until restart.
+    """
+
+    def test_manager_closed_when_shutdown_raises(self, mock_model, mock_tokenizer):
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+
+            scheduler = engine.scheduler
+            manager = MagicMock()
+            scheduler.paged_ssd_cache_manager = manager
+            scheduler.shutdown = MagicMock(side_effect=ValueError("boom"))
+
+            engine.close()  # must not raise
+
+            manager.close.assert_called_once()
+            assert scheduler.paged_ssd_cache_manager is None
+
+    def test_manager_closed_on_normal_close(self, mock_model, mock_tokenizer):
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+
+            scheduler = engine.scheduler
+            manager = MagicMock()
+            scheduler.paged_ssd_cache_manager = manager
+
+            engine.close()
+
+            manager.close.assert_called_once()
+            assert scheduler.paged_ssd_cache_manager is None

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -2632,3 +2632,35 @@ class TestInlineLRUUnlinks:
             assert mgr._stats["evict_unlink_failures"] >= 1
         finally:
             mgr.close()
+
+
+class TestSharedHotCacheBudgetClearAllOwners:
+    """clear_all_owners reaches managers the budget still pins (orphaned)."""
+
+    class _FakeOwner:
+        def __init__(self, budget, n):
+            self._budget = budget
+            self._n = n
+            self.cleared = False
+
+        def clear_hot_cache(self):
+            self._budget.forget_owner(self)
+            self.cleared = True
+            return self._n
+
+    def test_clears_every_tracked_owner(self):
+        budget = SharedHotCacheBudget(1 << 20)
+        o1 = self._FakeOwner(budget, 3)
+        o2 = self._FakeOwner(budget, 4)
+        budget.put(o1, b"h1", 100)
+        budget.put(o1, b"h2", 100)
+        budget.put(o2, b"h3", 200)
+
+        cleared = budget.clear_all_owners()
+
+        assert cleared == 7
+        assert o1.cleared and o2.cleared
+        assert len(budget._entries) == 0
+
+    def test_empty_budget_is_noop(self):
+        assert SharedHotCacheBudget(1 << 20).clear_all_owners() == 0


### PR DESCRIPTION
After a model is unloaded the server can keep tens of GB of resident memory
belonging to a hot cache no longer attached to any model. The memory guard
counts that footprint against the load ceiling, so the next load is rejected
with `507`, and `POST /api/hot-cache/clear` returns ok but frees nothing. The
only recovery is a process restart.

## Reproduction

1. Serve a model and send a large request so the hot cache fills (a prompt
   around 100k tokens).
2. Let an abort and an unload interleave, as a multi step workflow produces, or
   otherwise unload through a path where engine teardown does not complete.
3. `/api/status` shows `loaded_count: 0` and `current_model_memory: 0`, yet the
   process still holds a large resident set (about 57 GB in my case).
4. `POST /api/hot-cache/clear` returns ok but resident memory does not move.
5. Loading a larger model is rejected with `507`:

```
507: Cannot load gemma-4-31B-it: projected memory 129.88GB would exceed the
memory ceiling 107.52GB (current: 68.72GB, model: 61.16GB).
```

`current` in the guard is `max(mx.get_active_memory(), get_phys_footprint())`,
so the retained footprint counts even with nothing loaded. A clean unload
reclaims fully, so this only appears when teardown does not complete.

## Changes (three commits)

1. `fix(engine): always release SSD cache manager on engine close`.
   `EngineCore.close()` only caught `RuntimeError` from `scheduler.shutdown` and
   `deep_reset`, so any other exception aborted `close()` before it reached
   `PagedSSDCacheManager.close()`. The manager's writer thread then kept it and
   its hot cache alive until restart. Swallow non-`RuntimeError` from
   `shutdown`/`deep_reset`, then close the SSD manager explicitly if it is still
   set. This removes the cause of the orphan on the teardown path.

2. `feat(cache): reclaim hot cache orphaned by an abnormal teardown`.
   `SharedHotCacheBudget` keeps a strong reference to each manager through
   `_HotCacheBudgetEntry.owner`, so a manager orphaned by a skipped `close()` is
   unreachable through the loaded-only iterator. Add `clear_all_owners()`, which
   clears the hot cache of every manager the budget still references and logs
   per-owner failures instead of swallowing them. The strong owner reference was
   added in `6dcf197`.

3. `fix(admin): reclaim hot cache memory on clear via the synchronized path`.
   `clear_hot_cache` now reclaims MLX's buffer pool after clearing the hot cache
   dicts, and calls `clear_all_owners()` so orphans are reached through the
   budget. The reclaim runs `scheduler._sync_and_clear_cache(stream)` on each
   loaded engine's own executor, targeting that engine's `_stream`, which is the
   same `_mx_buffer_access_lock` and `synchronize` barrier generation uses
   (issues #300, #1106). With no model loaded it falls back to the global
   executor. It returns `bytes_reclaimed`, measured before the dicts are cleared
   so raw host-byte entries are counted.

## Safety

The reclaim no longer calls bare `mx.clear_cache()` on the global executor.
`_sync_and_clear_cache` holds `_mx_buffer_access_lock` and synchronizes the
engine stream and the default stream before `clear_cache()`, so it does not
release buffers still referenced by an active engine stream or read by the async
store-cache worker (issues #300, #1106, #435). Running it on each engine's own
executor mirrors how `scheduler` reclaims internally.

## Test plan

1. `pytest tests/test_admin_hot_cache_clear.py tests/test_paged_ssd_cache.py tests/test_engine_core.py`
2. Full suite.
3. Real MLX smoke: an orphaned manager left in the budget with no model loaded
   is reclaimed through the synchronized path, and `mx.get_cache_memory()` drops
   to zero.

## Related

Same symptom, different trigger: #1322 (RAM not released after a cancelled
download, loads blocked until restart) and #1060 (memory stuck after a VLM
unload, subsequent loads fail with `507`). PR #1593 (merged) fixed the adjacent
teardown case where streaming generators held the engine ref after stop; the
`close()` gap fixed here is in the same teardown path. The strong owner
reference that pins an orphaned manager was introduced in `6dcf197`.
