### PR TITLE
fix(scheduler): count chunked prefill against concurrency cap

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -4115,12 +4115,14 @@ def _build_active_models_data() -> dict:
         active_requests = 0
         waiting_requests = 0
         running_by_id = {}
+        has_scheduler_snapshot = False
         waiting_ids = set()
         waiting = []
         activities = []
 
         # Get per-model active/waiting request counts.
         # Follow the same pattern as server.py /api/status endpoint.
+        collector_request_ids: set = set()
         active_request_ids: set = set()
         entry = engine_pool._entries.get(model_id)
         if entry and entry.engine is not None:
@@ -4130,18 +4132,17 @@ def _build_active_models_data() -> dict:
                 if core is not None:
                     collectors = getattr(core, "_output_collectors", {})
                     try:
-                        active_request_ids = set(collectors.keys())
-                        active_requests = len(collectors)
+                        collector_request_ids = set(collectors.keys())
                     except RuntimeError:
                         # Scheduler state is mutated from the engine executor;
                         # keep the dashboard endpoint best-effort rather than
                         # failing on a concurrent dict resize.
-                        active_request_ids = set()
-                        active_requests = len(collectors)
+                        collector_request_ids = set()
 
                     sched = getattr(core, "scheduler", None)
                     if sched is not None and hasattr(sched, "snapshot_for_admin"):
                         snap = sched.snapshot_for_admin()
+                        has_scheduler_snapshot = True
                         running_by_id = snap["running_by_id"]
                         waiting_queue = snap["waiting"]
                         waiting_requests = len(waiting_queue)
@@ -4162,6 +4163,12 @@ def _build_active_models_data() -> dict:
 
         prefilling = tracker.get_model_progress(model_id)
         prefilling_ids = {p["request_id"] for p in prefilling}
+        if has_scheduler_snapshot:
+            active_request_ids = set(running_by_id) | prefilling_ids
+        elif collector_request_ids:
+            active_request_ids = collector_request_ids - waiting_ids
+        if has_scheduler_snapshot or collector_request_ids:
+            active_requests = len(active_request_ids)
 
         # Generating = active requests that finished prefill.
         generating = []

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -5589,6 +5589,10 @@ class Scheduler:
         """Get number of running requests."""
         return len(self.running)
 
+    def _num_admitted_requests(self) -> int:
+        """Return requests already occupying scheduler capacity."""
+        return len(self.running) + len(self.prefilling)
+
     def _preflight_memory_check(self, request: "Request") -> str | None:
         """
         Estimate whether prefill would exceed memory limits.
@@ -5674,15 +5678,19 @@ class Scheduler:
         # Track SpecPrefill: these requests must be alone (RoPE patching affects whole model)
         batch_specprefill_status: bool | None = None
 
-        while self.waiting and len(self.running) < self.config.max_num_seqs:
+        while (
+            self.waiting
+            and self._num_admitted_requests() < self.config.max_num_seqs
+        ):
             # Admission pause: set by ProcessMemoryEnforcer when phys
             # crosses soft_threshold. New prefills wait; in-flight requests
-            # continue. First request always passes (self.running is empty)
+            # continue. First request always passes (no admitted work yet)
             # so admission can recover by completing the current generation.
-            if self._admission_paused and self.running:
+            admitted = self._num_admitted_requests()
+            if self._admission_paused and admitted:
                 logger.debug(
-                    "Admission paused by memory pressure, %d running",
-                    len(self.running),
+                    "Admission paused by memory pressure, %d admitted",
+                    admitted,
                 )
                 break
 
@@ -5709,23 +5717,23 @@ class Scheduler:
                 )
                 break
 
-            # Generation memory guard: when requests are already running,
+            # Generation memory guard: when requests are already admitted,
             # defer scheduling if memory pressure is high to prevent
             # Metal allocation failures during batch_generator.next().
-            # First request always passes (self.running is empty).
+            # First request always passes (no admitted work yet).
             if (
                 self._prefill_memory_guard
                 and self._memory_limit_bytes > 0
-                and self.running
+                and admitted
             ):
                 current = max(mx.get_active_memory(), get_phys_footprint())
                 if current > self._memory_limit_bytes:
                     logger.debug(
                         "Generation memory guard: deferring scheduling "
-                        "(%s > %s), %d running",
+                        "(%s > %s), %d admitted",
                         current,
                         self._memory_limit_bytes,
-                        len(self.running),
+                        admitted,
                     )
                     break
 

--- a/tests/test_active_models_visibility.py
+++ b/tests/test_active_models_visibility.py
@@ -69,7 +69,8 @@ def test_active_models_generation_includes_activity_and_waiting_rows():
         data = admin_routes._build_active_models_data()
 
     model = data["models"][0]
-    assert data["total_active_requests"] == 3
+    assert data["total_active_requests"] == 2
+    assert model["active_requests"] == 2
     assert model["waiting_requests"] == 1
     assert model["prefilling"] == [
         {"request_id": "prefill-1", "processed": 10, "total": 20}
@@ -93,6 +94,37 @@ def test_active_models_generation_includes_activity_and_waiting_rows():
             "max_tokens": 64,
         }
     ]
+
+
+def test_active_models_does_not_count_waiting_collectors_as_active():
+    waiting_request = SimpleNamespace(
+        request_id="wait-1",
+        arrival_time=105.0,
+        num_prompt_tokens=30,
+    )
+    scheduler = SimpleNamespace(
+        snapshot_for_admin=lambda: {
+            "running_by_id": {},
+            "waiting": [waiting_request],
+        },
+    )
+
+    with (
+        patch.object(admin_routes, "_get_engine_pool", return_value=FakePool(scheduler)),
+        patch("omlx.admin.routes._get_server_state", return_value=None),
+        patch.object(admin_routes, "_get_settings_manager", return_value=None),
+        patch.object(admin_routes, "_get_global_settings", return_value=None),
+        patch("omlx.prefill_progress.get_prefill_tracker", return_value=EmptyPrefillTracker()),
+        patch("time.monotonic", return_value=110.0),
+    ):
+        data = admin_routes._build_active_models_data()
+
+    model = data["models"][0]
+    assert data["total_active_requests"] == 0
+    assert data["total_waiting_requests"] == 1
+    assert model["active_requests"] == 0
+    assert model["waiting_requests"] == 1
+    assert model["generating"] == []
 
 
 def test_active_models_loading_includes_elapsed_and_percent_estimate():

--- a/tests/test_scheduler_chunked_prefill.py
+++ b/tests/test_scheduler_chunked_prefill.py
@@ -473,6 +473,31 @@ class TestScheduleWaitingChunkedFork:
         assert req in sched.prefilling
         assert req.request_id not in sched.running
 
+    def test_prefilling_request_counts_against_concurrency_cap(self):
+        """A chunked prefill already in flight consumes a scheduler slot."""
+        sched = _make_scheduler(chunked_prefill=True, step_size=4)
+        sched.config.max_num_seqs = 1
+
+        inflight = _make_request("inflight", n_tokens=10)
+        sched.requests[inflight.request_id] = inflight
+        sched.prefilling.append(inflight)
+        sched._prefill_states[inflight.request_id] = _make_prefill_state(
+            sched,
+            inflight,
+        )
+
+        queued = _make_request("queued", n_tokens=10)
+        sched.add_request(queued)
+
+        with patch.object(sched, "_begin_prefill") as mock_begin:
+            scheduled, rejected = sched._schedule_waiting()
+
+        mock_begin.assert_not_called()
+        assert scheduled == []
+        assert rejected == []
+        assert queued in sched.waiting
+        assert inflight in sched.prefilling
+
     def test_long_prompt_completes_in_first_chunk_goes_to_running(self):
         """If the first chunk happens to finish the prefill, request goes to running."""
         sched, req = self._setup(n_tokens=10, step_size=4)


### PR DESCRIPTION
Fixes #1704.

## Summary
With `max_concurrent_requests=1`, a second long request could start while the first request was still in chunked prefill. The scheduler only counted decode-stage `running` requests, so `prefilling` work stopped consuming an admission slot until it reached decode.

This PR counts both `running` and `prefilling` requests as admitted scheduler work. It also makes the Active Models dashboard use the scheduler snapshot for active vs waiting counts, so queued collectors are shown as waiting instead of active.

## Root cause
Chunked prefill keeps long prompts in `Scheduler.prefilling` between prefill chunks. `_schedule_waiting()` compared only `len(self.running)` against `max_num_seqs`, which let another waiting request begin prefill even when the configured concurrency cap was already occupied by an in-flight prefill.

The dashboard had the same state-model mismatch in the other direction: it treated every output collector as active even after a scheduler snapshot identified the request as waiting.

## The fix
- Add a small admitted-work helper that counts `running` plus `prefilling`.
- Use that count for waiting-queue admission and the memory-pressure guard.
- Derive dashboard active request IDs from scheduler `running_by_id` plus `prefilling_ids` when a scheduler snapshot exists.
- Add regression coverage for chunked-prefill admission and queued dashboard collectors.

## Scope / safety
The change stays inside the existing scheduler admission gate and admin snapshot rendering. It does not change request execution, cache layout, API schemas, or non-chunked prefill behavior; it only makes the configured concurrency cap include work that is already admitted but still prefilling.

## Test plan
```bash
.venv/bin/python -m pytest tests/test_scheduler_chunked_prefill.py tests/test_active_models_visibility.py -q
# 52 passed

.venv/bin/python -m pytest tests/test_scheduler.py tests/test_scheduler_admission.py tests/test_status_endpoint.py -q
# 144 passed

.venv/bin/python -m pytest tests/test_server_metrics.py -q
# 29 passed

.venv/bin/python -m pytest tests/ -m "not slow and not integration" -q
# 5169 passed, 40 skipped, 66 deselected
```