### PR TITLE
fix(embeddings): fall back to model context length when no window is set

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1217,16 +1217,19 @@ def get_max_context_window(model_id: str | None = None) -> int | None:
 def get_embedding_max_length(
     model_id: str | None = None,
     request_max_length: int | None = None,
-) -> int:
-    """Get max token length for embedding requests."""
+) -> int | None:
+    """Get max token length for embedding requests.
+
+    Returns ``None`` when neither the request nor the server's
+    ``max_context_window`` pins a limit, so the embedding model resolves its
+    own configured context length (``max_position_embeddings`` / tokenizer
+    ``model_max_length`` in ``MLXEmbeddingModel._resolve_max_length``) instead
+    of re-truncating long-context models at the legacy 512-token cap (#1687).
+    """
     if request_max_length is not None:
         return request_max_length
 
-    max_context_window = get_max_context_window(model_id)
-    if max_context_window is not None:
-        return max_context_window
-
-    return 512
+    return get_max_context_window(model_id)
 
 
 def scale_anthropic_tokens(token_count: int, model_id: str | None = None) -> int:

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1487,3 +1487,27 @@ class TestNativeEmbeddingLoading:
         emb = output.embeddings[0]
         norm = math.sqrt(sum(x * x for x in emb))
         assert abs(norm - 1.0) < 0.01, f"Embedding not normalized: norm={norm}"
+
+
+class TestGetEmbeddingMaxLength:
+    """The server helper that resolves the per-request embedding token cap."""
+
+    def test_request_override_wins(self):
+        from omlx import server
+
+        with patch.object(server, "get_max_context_window", return_value=32768):
+            assert server.get_embedding_max_length("m", 4096) == 4096
+
+    def test_uses_configured_context_window(self):
+        from omlx import server
+
+        with patch.object(server, "get_max_context_window", return_value=32768):
+            assert server.get_embedding_max_length("m", None) == 32768
+
+    def test_returns_none_without_window_so_model_resolves(self):
+        # No request override and no configured window: defer to the model's
+        # own context-length resolution instead of a hard 512 cap (#1687).
+        from omlx import server
+
+        with patch.object(server, "get_max_context_window", return_value=None):
+            assert server.get_embedding_max_length("m", None) is None


### PR DESCRIPTION
Follow-up to #1694, which resolved the 512-token embedding truncation from #1687.

#1694's `get_embedding_max_length()` falls back to a hard `512` when neither the request nor the server's `max_context_window` pins a limit. In that no-window case it re-introduces the original #1687 symptom: a long-context embedding model is capped at 512 even though `MLXEmbeddingModel._resolve_max_length()` can read its real limit from `max_position_embeddings` / tokenizer `model_max_length`.

That model-side resolver only runs when it receives `max_length=None`, but the server always hands it a concrete `512` first — so for `/v1/embeddings` it never fires, and the config-aware resolution added in #1694 is effectively bypassed.

**Change:** return `None` from `get_embedding_max_length()` when nothing pins a limit, letting the existing model resolver do its job. `512` is preserved as that resolver's final fallback when the model exposes no usable metadata, so the conservative default is unchanged.

- `get_embedding_max_length()` now returns `int | None`; its single caller passes the value straight to `embed(max_length=...)`, which already accepts `None`.
- Added `TestGetEmbeddingMaxLength` covering the request-override, configured-window, and no-window (returns `None`) paths.

Verification: `pytest tests/test_embedding.py` → 83 passed.
