### PR TITLE
fix(server): return 401 instead of 500 when an API key contains non-ASCII characters

### DIFF
--- a/omlx/admin/auth.py
+++ b/omlx/admin/auth.py
@@ -109,10 +109,35 @@ def verify_session_token(token: str, max_age: int = SESSION_MAX_AGE) -> bool:
         return False
 
 
+def compare_keys(provided_key: str, expected_key: str) -> bool:
+    """Compare two API keys in constant time, tolerating any str input.
+
+    secrets.compare_digest raises TypeError when given str arguments that
+    contain non-ASCII characters, which turns a bad client key into an
+    unhandled 500 instead of a 401. Comparing UTF-8 bytes accepts any
+    input while keeping the constant-time guarantee. surrogatepass covers
+    lone surrogates, which json.loads can produce from escape sequences
+    and which strict UTF-8 encoding rejects.
+
+    Both arguments must be str; None is the caller's responsibility.
+
+    Args:
+        provided_key: The key supplied by the client (untrusted).
+        expected_key: The configured key to compare against.
+
+    Returns:
+        True if the keys match, False otherwise.
+    """
+    return secrets.compare_digest(
+        provided_key.encode("utf-8", "surrogatepass"),
+        expected_key.encode("utf-8", "surrogatepass"),
+    )
+
+
 def verify_api_key(api_key: str, server_api_key: str) -> bool:
     """Verify an API key using constant-time comparison.
 
-    This function uses secrets.compare_digest to prevent timing attacks
+    This function uses constant-time comparison to prevent timing attacks
     when comparing the provided API key with the server's API key.
 
     Args:
@@ -130,7 +155,7 @@ def verify_api_key(api_key: str, server_api_key: str) -> bool:
     """
     if not api_key or not server_api_key:
         return False
-    return secrets.compare_digest(api_key, server_api_key)
+    return compare_keys(api_key, server_api_key)
 
 
 def verify_any_api_key(api_key: str, main_key: str, sub_keys: list) -> bool:
@@ -150,11 +175,11 @@ def verify_any_api_key(api_key: str, main_key: str, sub_keys: list) -> bool:
     if not api_key:
         return False
     # Check main key
-    if main_key and secrets.compare_digest(api_key, main_key):
+    if main_key and compare_keys(api_key, main_key):
         return True
     # Check sub keys
     for sk in sub_keys:
-        if sk.key and secrets.compare_digest(api_key, sk.key):
+        if sk.key and compare_keys(api_key, sk.key):
             return True
     return False
 

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -14,7 +14,6 @@ import json
 import logging
 import os
 import re
-import secrets
 import shutil
 import signal
 import subprocess
@@ -39,6 +38,7 @@ from ..utils.release_check import normalize_update_channel, select_latest_releas
 from .auth import (
     REMEMBER_ME_MAX_AGE,
     SESSION_MAX_AGE,
+    compare_keys,
     create_session_token,
     require_admin,
     validate_api_key,
@@ -1490,7 +1490,7 @@ async def create_sub_key(
         raise HTTPException(status_code=400, detail=error_msg)
 
     # Check for duplicate (against main key and existing sub keys)
-    if global_settings.auth.api_key and secrets.compare_digest(
+    if global_settings.auth.api_key and compare_keys(
         request.key, global_settings.auth.api_key
     ):
         raise HTTPException(
@@ -1498,7 +1498,7 @@ async def create_sub_key(
         )
 
     for sk in global_settings.auth.sub_keys:
-        if sk.key and secrets.compare_digest(request.key, sk.key):
+        if sk.key and compare_keys(request.key, sk.key):
             raise HTTPException(status_code=400, detail="This key already exists")
 
     entry = SubKeyEntry(
@@ -1540,7 +1540,7 @@ async def delete_sub_key(
 
     # Find and remove the key
     for i, sk in enumerate(global_settings.auth.sub_keys):
-        if sk.key and secrets.compare_digest(request.key, sk.key):
+        if sk.key and compare_keys(request.key, sk.key):
             removed = global_settings.auth.sub_keys.pop(i)
             try:
                 global_settings.save()

--- a/tests/test_admin_api_key.py
+++ b/tests/test_admin_api_key.py
@@ -359,6 +359,30 @@ class TestSubKeyCRUD:
         finally:
             _restore_getter(original)
 
+    def test_delete_sub_key_lone_surrogate_returns_404(self):
+        """Regression for #1717: a lone-surrogate key must 404, not 500.
+
+        delete_sub_key compares request.key without a validate_api_key
+        gate, so the comparison itself must tolerate any str json.loads
+        can produce, including lone surrogates from escape sequences.
+        """
+        import json
+
+        from fastapi import HTTPException
+        from omlx.settings import SubKeyEntry
+
+        mock_settings = _mock_global_settings(api_key="main-key")
+        mock_settings.auth.sub_keys = [SubKeyEntry(key="real-sub-key")]
+        original = _patch_getter(mock_settings)
+        try:
+            request = admin_routes.DeleteSubKeyRequest(key=json.loads('"\\ud800abcd"'))
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(admin_routes.delete_sub_key(request, is_admin=True))
+            assert exc_info.value.status_code == 404
+            assert len(mock_settings.auth.sub_keys) == 1
+        finally:
+            _restore_getter(original)
+
     def test_create_sub_key_rollback_on_save_failure(self):
         """Sub key should be rolled back if save() fails."""
         from fastapi import HTTPException

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -364,3 +364,92 @@ class TestAdminAuth:
 
         # Empty key
         assert verify_api_key("", server_key) is False
+
+
+class TestNonAsciiApiKeys:
+    """Regression tests for #1717: non-ASCII keys must yield 401, not 500.
+
+    secrets.compare_digest raises TypeError for str arguments containing
+    non-ASCII characters, which surfaced as an unhandled 500 on every
+    authenticated endpoint. compare_keys compares UTF-8 bytes instead.
+    """
+
+    def test_compare_keys_non_ascii_mismatch(self):
+        """Non-ASCII client key against ASCII server key returns False."""
+        from omlx.admin.auth import compare_keys
+
+        assert compare_keys("café-key", "secret123") is False
+
+    def test_compare_keys_non_ascii_match(self):
+        """Matching non-ASCII keys compare equal."""
+        from omlx.admin.auth import compare_keys
+
+        assert compare_keys("clé-secrète-héhé", "clé-secrète-héhé") is True
+
+    def test_verify_api_key_non_ascii_client_key(self):
+        """verify_api_key must not raise on a non-ASCII client key."""
+        from omlx.admin.auth import verify_api_key
+
+        assert verify_api_key("café", "secret123") is False
+
+    def test_verify_api_key_non_ascii_server_key(self):
+        """A configured non-ASCII key compares without raising.
+
+        Function-level only: over HTTP, Starlette decodes header values as
+        latin-1, so a client sending UTF-8 non-ASCII bytes will not match a
+        configured non-ASCII key anyway. The point here is no TypeError.
+        """
+        from omlx.admin.auth import verify_api_key
+
+        assert verify_api_key("pässwörd", "pässwörd") is True
+        assert verify_api_key("password", "pässwörd") is False
+
+    def test_compare_keys_lone_surrogate(self):
+        """Lone surrogates (json.loads can produce them) must not raise.
+
+        Strict UTF-8 encoding rejects lone surrogates, which would revive
+        the 500 on any JSON route that compares keys without validating
+        printability first (delete_sub_key).
+        """
+        import json
+
+        from omlx.admin.auth import compare_keys
+
+        surrogate_key = json.loads('"\\ud800abcd"')
+        assert compare_keys(surrogate_key, "secret123") is False
+        assert compare_keys("secret123", surrogate_key) is False
+        assert compare_keys(surrogate_key, surrogate_key) is True
+
+    def test_verify_any_api_key_non_ascii_sub_keys(self):
+        """verify_any_api_key must not raise when sub keys are checked."""
+        from omlx.admin.auth import verify_any_api_key
+        from unittest.mock import MagicMock
+
+        sub_key = MagicMock()
+        sub_key.key = "sub-key-1"
+
+        assert verify_any_api_key("café", "main-key", [sub_key]) is False
+        sub_key.key = "clé-única"
+        assert verify_any_api_key("clé-única", "main-key", [sub_key]) is True
+
+    def test_server_dependency_non_ascii_bearer_returns_401(self):
+        """The server auth dependency turns a non-ASCII bearer into 401, not 500."""
+        from omlx.server import verify_api_key, _server_state
+        from fastapi import HTTPException
+        from fastapi.security import HTTPAuthorizationCredentials
+        import asyncio
+
+        original_key = _server_state.api_key
+        _server_state.api_key = "correct-key"
+
+        try:
+            credentials = HTTPAuthorizationCredentials(
+                scheme="Bearer", credentials="smart-quote-’key’"
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    verify_api_key(request=_mock_request(), credentials=credentials)
+                )
+            assert exc_info.value.status_code == 401
+        finally:
+            _server_state.api_key = original_key


### PR DESCRIPTION
Fixes #1717.

## Problem

Any request whose Bearer token or `x-api-key` header contains a non-ASCII character makes every authenticated endpoint return HTTP 500 with "comparing strings with non-ASCII characters is not supported". The report shows this on both `/v1/models` and `/v1/chat/completions`.

## Root cause

This is not an inference or KV cache problem. `/v1/models` fails too, and that endpoint never touches the engine.

`verify_api_key` in `server.py` passes the client-supplied key into `secrets.compare_digest(str, str)` in `omlx/admin/auth.py`. CPython's `compare_digest` raises `TypeError` when either `str` argument contains non-ASCII characters, and FastAPI surfaces that as an unhandled 500.

A non-ASCII key is easy to produce by accident; pasting a key through anything that substitutes smart quotes is enough. `validate_api_key` also accepts non-ASCII printable characters, so a configured main key or sub key can trigger the same TypeError on every request.

## Fix

Added `compare_keys` to `omlx/admin/auth.py`. It encodes both sides as UTF-8 and compares bytes, which `compare_digest` accepts for any content, and keeps the constant-time property. All key comparisons (`verify_api_key`, `verify_any_api_key`, and the sub-key duplicate and delete checks in `admin/routes.py`) now go through it. Removed the now-unused `secrets` import in `routes.py`.

Encoding uses `surrogatepass` because `json.loads` can produce lone surrogates from escape sequences, and strict UTF-8 encoding rejects those. That matters for `delete_sub_key`, which compares `request.key` without a `validate_api_key` gate; with strict encoding that route would have kept its 500.

## Testing

- 8 new regression tests: 7 in `tests/test_api_auth.py` (helper behavior for non-ASCII and lone surrogates on either side, and the server auth dependency returning 401, not TypeError, for a non-ASCII bearer) and 1 in `tests/test_admin_api_key.py` (`delete_sub_key` with a lone-surrogate key returns 404, not 500).
- Full suite: 5175 passed, 0 failed, 40 skipped, 66 deselected.
- Live test: started a server with `--api-key`, sent non-ASCII `Bearer` and `x-api-key` values to `/v1/models` and `/v1/chat/completions`. All returned 401 with the standard error body, the correct key returned 200, and the server log contained no unhandled errors.

One thing I could not reproduce is the "first request works, then everything fails" sequence in the report. The 500 is per-request and depends only on the bytes the client sends. My read is that the failing requests carried a non-ASCII key the whole time and the successful first request used a different stored credential. Either way the fix removes the 500.

## Scope note

This does not make configured non-ASCII keys usable over HTTP. Starlette decodes header values as latin-1, so a client sending UTF-8 non-ASCII bytes will never match a configured non-ASCII key; it now gets a clean 401 instead of a 500. If you would rather also reject non-ASCII keys at creation time (400 going forward, migrate existing, the same shape as the hot-cache "auto" fix in #1612), I am happy to do that as a follow-up.
