### PR TITLE
fix(embedding): serve Qwen2ForCausalLM embedding models natively (#686)

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -147,6 +147,9 @@ CAUSAL_LM_RERANKER_ARCHITECTURES = {
 # (no lm_head weights). Detected by architecture + directory name heuristic.
 CAUSAL_LM_EMBEDDING_ARCHITECTURES = {
     "Qwen3ForCausalLM",  # Qwen3-Embedding uses CausalLM arch without lm_head
+    "Qwen2ForCausalLM",  # jina-code-embeddings & similar; only treated as an
+    # embedding when the dir-name heuristic (_is_causal_lm_embedding) also
+    # matches, so Qwen2/Qwen2.5 chat models are unaffected.
 }
 
 # Multimodal (VLM-based) reranker architectures.

--- a/omlx/models/base_model.py
+++ b/omlx/models/base_model.py
@@ -59,6 +59,41 @@ def mean_pooling(hidden_states: mx.array, attention_mask: mx.array) -> mx.array:
     return sum_embeddings / sum_mask
 
 
+def last_token_pool(
+    hidden_states: mx.array, attention_mask: Optional[mx.array] = None
+) -> mx.array:
+    """
+    Pool the last *non-pad* token of each sequence (mask-aware).
+
+    Decoder embedding models (Qwen2/Qwen3, gte-Qwen2, jina-code) represent a
+    sequence by its final token's hidden state. The pool must be
+    mask-aware because these tokenizers may pad on either side: a hardcoded
+    ``[:, -1]`` is only correct under left padding and silently corrupts vectors
+    under right padding.
+
+    Args:
+        hidden_states: Shape (batch_size, seq_len, hidden_size)
+        attention_mask: Shape (batch_size, seq_len). If None, uses the last
+            position.
+
+    Returns:
+        Pooled output of shape (batch_size, hidden_size)
+    """
+    if attention_mask is None:
+        return hidden_states[:, -1]
+
+    # Left padding: every sequence ends on a real token, so the last position
+    # is always valid and we can index it directly.
+    left_padding = attention_mask[:, -1].sum() == attention_mask.shape[0]
+    if left_padding:
+        return hidden_states[:, -1]
+
+    # Right (or mixed) padding: the last valid token is at sum(mask) - 1.
+    sequence_lengths = attention_mask.sum(axis=1) - 1
+    batch_size = hidden_states.shape[0]
+    return hidden_states[mx.arange(batch_size), sequence_lengths]
+
+
 def normalize_embeddings(embeddings: mx.array) -> mx.array:
     """
     L2 normalize embeddings.

--- a/omlx/models/embedding.py
+++ b/omlx/models/embedding.py
@@ -4,7 +4,7 @@ MLX Embedding Model wrapper.
 
 This module provides a wrapper around mlx-embeddings for generating
 text embeddings using Apple's MLX framework, with native fallback
-for XLMRoBERTa and BERT embedding models.
+for XLMRoBERTa, BERT, and Qwen2-decoder embedding models.
 """
 
 import inspect
@@ -58,6 +58,8 @@ class MLXEmbeddingModel:
     Supports:
     - Native XLMRoBERTa embedding (no mlx-embeddings dependency)
     - Native BERT embedding (no mlx-embeddings dependency)
+    - Native Qwen2-decoder embedding (last-token + L2; jina-code, gte-Qwen2)
+      — mlx-embeddings has no qwen2 module
     - mlx-embeddings fallback for other architectures
 
     Example:
@@ -111,8 +113,14 @@ class MLXEmbeddingModel:
         architectures = config_dict.get("architectures", [])
         arch = architectures[0] if architectures else ""
 
-        native_arches = {"XLMRobertaModel", "BertModel", "BertForMaskedLM"}
-        if arch not in native_arches:
+        native_arch_modules = {
+            "XLMRobertaModel": "xlm_roberta",
+            "BertModel": "xlm_roberta",
+            "BertForMaskedLM": "xlm_roberta",
+            "Qwen2ForCausalLM": "qwen2_embedding",
+        }
+        module_name = native_arch_modules.get(arch)
+        if module_name is None:
             logger.debug(
                 f"Architecture '{arch}' not natively supported for embedding, "
                 "trying mlx-embeddings"
@@ -120,7 +128,11 @@ class MLXEmbeddingModel:
             return False
 
         try:
-            from .xlm_roberta import Model, ModelArgs
+            from importlib import import_module
+
+            native_module = import_module(f"{__package__}.{module_name}")
+            Model = native_module.Model
+            ModelArgs = native_module.ModelArgs
 
             known_fields = {f.name for f in ModelArgs.__dataclass_fields__.values()}
             model_config = {

--- a/omlx/models/qwen2_embedding.py
+++ b/omlx/models/qwen2_embedding.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Native Qwen2 embedding adapter for omlx.
+
+Serves Qwen2-decoder embedding models (``architectures=["Qwen2ForCausalLM"]``,
+``model_type="qwen2"``) such as ``jinaai/jina-code-embeddings-1.5b`` (causal)
+and ``Alibaba-NLP/gte-Qwen2-1.5B-instruct`` (bidirectional), without depending
+on mlx-embeddings, which has no ``qwen2`` module and raises
+``ValueError("Model type qwen2 not supported.")`` for these checkpoints.
+
+These models pool the *last* (mask-aware) token of the final hidden state and
+L2-normalize, matching their SentenceTransformers configs
+(``pooling_mode_lasttoken: true`` + a Normalize module). Mean pooling would
+silently corrupt every vector, so last-token pooling is load-bearing here; the
+``_extract_embeddings_array`` consumer does not normalize, so the returned
+``text_embeds`` are already L2-normalized.
+
+Deltas from the Qwen3 embedder: Qwen2 has no QK-norm, applies attention bias on
+the q/k/v projections (``o_proj`` unbiased), and derives
+``head_dim = hidden_size // num_attention_heads`` (no explicit config field).
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .base_model import (
+    BaseModelArgs,
+    BaseModelOutput,
+    last_token_pool,
+    normalize_embeddings,
+)
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    """Qwen2 embedding model configuration."""
+
+    model_type: str = "qwen2"
+    hidden_size: int = 1536
+    num_hidden_layers: int = 28
+    intermediate_size: int = 8960
+    num_attention_heads: int = 12
+    num_key_value_heads: Optional[int] = None
+    head_dim: Optional[int] = None
+    max_position_embeddings: int = 32768
+    vocab_size: int = 151936
+
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 1000000.0
+
+    # Attention direction. A plain Qwen2 decoder-embedder (jina-code) is
+    # causal. Some Qwen2 embedders run the decoder *bidirectionally* and signal
+    # it with ``is_causal: false`` in config (Alibaba's gte-Qwen2 family, which
+    # ships a custom bidirectional modeling_qwen.py). Default causal; the config
+    # flips it off when needed.
+    is_causal: bool = True
+
+    tie_word_embeddings: bool = False
+
+    bos_token_id: Optional[int] = None
+    eos_token_id: Optional[int] = None
+    pad_token_id: Optional[int] = None
+
+    architectures: List[str] = field(
+        default_factory=lambda: ["Qwen2ForCausalLM"]
+    )
+
+    def __post_init__(self):
+        """Derive grouped-query and head dims that Qwen2 leaves implicit."""
+        if self.num_key_value_heads is None:
+            self.num_key_value_heads = self.num_attention_heads
+
+        if self.head_dim is None:
+            if self.hidden_size % self.num_attention_heads != 0:
+                raise ValueError(
+                    f"hidden_size ({self.hidden_size}) must be divisible by "
+                    f"num_attention_heads ({self.num_attention_heads})"
+                )
+            self.head_dim = self.hidden_size // self.num_attention_heads
+
+
+class Qwen2MLP(nn.Module):
+    """SwiGLU MLP: SiLU(gate_proj(x)) * up_proj(x) -> down_proj."""
+
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.gate_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.up_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.down_proj = nn.Linear(
+            config.intermediate_size, config.hidden_size, bias=False
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class Qwen2Attention(nn.Module):
+    """
+    Grouped-query attention for Qwen2.
+
+    Unlike Qwen3 there is no query/key RMSNorm, and the q/k/v projections carry
+    a bias (``o_proj`` does not). Grouped-query head expansion is handled by
+    ``mx.fast.scaled_dot_product_attention``.
+    """
+
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.num_key_value_heads = config.num_key_value_heads
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(
+            config.hidden_size, self.num_heads * self.head_dim, bias=True
+        )
+        self.k_proj = nn.Linear(
+            config.hidden_size, self.num_key_value_heads * self.head_dim, bias=True
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size, self.num_key_value_heads * self.head_dim, bias=True
+        )
+        self.o_proj = nn.Linear(
+            self.num_heads * self.head_dim, config.hidden_size, bias=False
+        )
+
+        self.rotary_emb = nn.RoPE(
+            self.head_dim,
+            traditional=False,
+            base=config.rope_theta,
+        )
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        bsz, q_len, _ = hidden_states.shape
+
+        queries = self.q_proj(hidden_states)
+        keys = self.k_proj(hidden_states)
+        values = self.v_proj(hidden_states)
+
+        queries = queries.reshape(
+            bsz, q_len, self.num_heads, self.head_dim
+        ).transpose(0, 2, 1, 3)
+        keys = keys.reshape(
+            bsz, q_len, self.num_key_value_heads, self.head_dim
+        ).transpose(0, 2, 1, 3)
+        values = values.reshape(
+            bsz, q_len, self.num_key_value_heads, self.head_dim
+        ).transpose(0, 2, 1, 3)
+
+        queries = self.rotary_emb(queries)
+        keys = self.rotary_emb(keys)
+
+        attn_output = mx.fast.scaled_dot_product_attention(
+            queries, keys, values, scale=self.scale, mask=attention_mask
+        )
+
+        attn_output = attn_output.transpose(0, 2, 1, 3).reshape(
+            bsz, q_len, self.num_heads * self.head_dim
+        )
+        return self.o_proj(attn_output)
+
+
+class Qwen2DecoderLayer(nn.Module):
+    """Pre-norm transformer decoder layer (RMSNorm, residual, SwiGLU)."""
+
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.self_attn = Qwen2Attention(config)
+        self.mlp = Qwen2MLP(config)
+        self.input_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, attention_mask=attention_mask)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+class Qwen2Model(nn.Module):
+    """Qwen2 transformer decoder stack."""
+
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            Qwen2DecoderLayer(config) for _ in range(config.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def _build_attention_mask(
+        self,
+        attention_mask: Optional[mx.array],
+        seq_length: int,
+        dtype: mx.Dtype,
+    ) -> mx.array:
+        """
+        Additive (batch, 1, seq, seq) mask combining key padding with the
+        causal triangle (skipped for bidirectional embedders).
+
+        Built as a single boolean keep-mask (query i may attend key j iff key j
+        is a real token, and — when causal — ``j <= i``) mapped to one finite
+        ``finfo.min`` fill. Using the dtype minimum rather than ``-inf`` keeps
+        fully-masked rows (the leading pad positions under *left* padding)
+        NaN-free: a uniform softmax over equal fills yields finite garbage at
+        pad positions that we never pool, instead of ``NaN`` that ``0 * NaN``
+        would propagate into real positions at the next layer. A single fill
+        also avoids the additive ``2 * finfo.min`` overflow back to ``-inf``.
+        """
+        if self.config.is_causal:
+            keep = mx.tril(mx.ones((seq_length, seq_length), dtype=mx.bool_))
+            keep = keep[None, None]  # (1, 1, seq, seq)
+        else:
+            keep = mx.ones((1, 1, seq_length, seq_length), dtype=mx.bool_)
+        if attention_mask is not None:
+            key_keep = (attention_mask != 0)[:, None, None, :]  # (batch, 1, 1, seq)
+            keep = keep & key_keep
+        return mx.where(keep, 0.0, mx.finfo(dtype).min).astype(dtype)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: Optional[mx.array] = None,
+    ) -> mx.array:
+        _, seq_length = input_ids.shape
+        hidden_states = self.embed_tokens(input_ids)
+
+        if attention_mask is not None and attention_mask.ndim != 2:
+            # Already an additive (batch, 1, seq, seq) mask; use as-is.
+            mask = attention_mask
+        else:
+            mask = self._build_attention_mask(
+                attention_mask, seq_length, hidden_states.dtype
+            )
+
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, attention_mask=mask)
+
+        return self.norm(hidden_states)
+
+
+class Model(nn.Module):
+    """Qwen2 decoder wrapped for embedding generation (last-token + L2)."""
+
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.model = Qwen2Model(config)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: Optional[mx.array] = None,
+    ) -> BaseModelOutput:
+        if input_ids.ndim != 2:
+            raise ValueError(f"input_ids must be 2D, got shape {input_ids.shape}")
+
+        batch_size, seq_len = input_ids.shape
+        if attention_mask is None:
+            attention_mask = mx.ones((batch_size, seq_len), dtype=mx.int32)
+        elif attention_mask.shape != (batch_size, seq_len):
+            raise ValueError(
+                f"attention_mask shape {attention_mask.shape} doesn't match "
+                f"input_ids shape {input_ids.shape}"
+            )
+
+        last_hidden_state = self.model(input_ids, attention_mask=attention_mask)
+
+        # Mask-aware last-token pool, then L2-normalize. The embedding consumer
+        # (_extract_embeddings_array) does not normalize, so text_embeds must be
+        # unit-norm already.
+        pooled_output = last_token_pool(last_hidden_state, attention_mask)
+        text_embeds = normalize_embeddings(pooled_output)
+
+        return BaseModelOutput(
+            text_embeds=text_embeds, last_hidden_state=last_hidden_state
+        )
+
+    def sanitize(self, weights: dict) -> dict:
+        """
+        Map a HuggingFace Qwen2ForCausalLM checkpoint onto this module tree.
+
+        Drops the unused LM head (and any precomputed rotary inverse-frequency
+        buffers) and normalizes the transformer prefix to ``model.``.
+        """
+        sanitized_weights = {}
+        for key, value in weights.items():
+            if "lm_head.weight" in key:
+                continue
+            if "rotary_emb.inv_freq" in key:
+                continue
+
+            if key.startswith("transformer."):
+                new_key = key.replace("transformer.", "model.", 1)
+            elif not key.startswith("model.") and "." in key:
+                new_key = f"model.{key}"
+            else:
+                new_key = key
+
+            sanitized_weights[new_key] = value
+
+        return sanitized_weights

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1559,3 +1559,155 @@ class TestGetEmbeddingMaxLength:
 
         with patch.object(server, "get_max_context_window", return_value=None):
             assert server.get_embedding_max_length("m", None) is None
+
+
+class TestNativeQwen2Embedding:
+    """Native Qwen2-decoder embedding adapter (jina-code / gte-Qwen2; #686)."""
+
+    # Tiny Qwen2 config exercising grouped-query attention (4 heads / 2 kv).
+    _CONFIG = {
+        "model_type": "qwen2",
+        "architectures": ["Qwen2ForCausalLM"],
+        "hidden_size": 64,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "intermediate_size": 128,
+        "vocab_size": 128,
+        "max_position_embeddings": 64,
+        "rms_norm_eps": 1e-6,
+        "rope_theta": 10000.0,
+        "tie_word_embeddings": True,
+    }
+
+    class MockQwen2Tokenizer:
+        """Right-padding tokenizer mirroring the native-path encode contract."""
+
+        def __init__(self, vocab_size: int):
+            self.vocab_size = vocab_size
+
+        def encode(self, text: str, add_special_tokens: bool = True):
+            return [abs(hash(token)) % self.vocab_size for token in text.split()] or [1]
+
+        def __call__(
+            self,
+            texts,
+            *,
+            padding=True,
+            truncation=True,
+            max_length=512,
+            return_tensors="np",
+        ):
+            del truncation, return_tensors
+            encoded = [self.encode(t)[:max_length] for t in texts]
+            target = max((len(ids) for ids in encoded), default=0) if padding else 0
+            input_ids, attention_mask = [], []
+            for ids in encoded:
+                pad = max(target - len(ids), 0)
+                input_ids.append(ids + [0] * pad)
+                attention_mask.append([1] * len(ids) + [0] * pad)
+            return {"input_ids": input_ids, "attention_mask": attention_mask}
+
+    def _write_full_qwen2_checkpoint(self, tmp_path, config):
+        """Write a complete native Qwen2 checkpoint from the adapter's own params."""
+        from mlx.utils import tree_flatten
+        from omlx.models.qwen2_embedding import Model, ModelArgs
+        from safetensors.numpy import save_file
+
+        model = Model(ModelArgs(**config))
+        weights = {
+            name: np.array(value) for name, value in tree_flatten(model.parameters())
+        }
+        save_file(weights, str(tmp_path / "model.safetensors"))
+
+    def _load(self, tmp_path):
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        (tmp_path / "config.json").write_text(json.dumps(self._CONFIG))
+        self._write_full_qwen2_checkpoint(tmp_path, self._CONFIG)
+
+        model = MLXEmbeddingModel(str(tmp_path))
+        tokenizer = self.MockQwen2Tokenizer(vocab_size=self._CONFIG["vocab_size"])
+        with patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=tokenizer,
+        ):
+            model.load()
+        return model
+
+    def test_load_native_qwen2_takes_native_path(self, tmp_path):
+        """Qwen2ForCausalLM routes through the native adapter, not mlx-embeddings."""
+        model = self._load(tmp_path)
+        assert model._using_native is True
+        assert model._hidden_size == self._CONFIG["hidden_size"]
+        # The adapter, not the qwen3/mlx-embeddings fallback.
+        from omlx.models.qwen2_embedding import Model as Qwen2EmbeddingModel
+
+        assert isinstance(model.model, Qwen2EmbeddingModel)
+
+    def test_qwen2_embed_shape_and_normalized(self, tmp_path):
+        """embed() returns one L2-normalized vector per input at the model dim."""
+        model = self._load(tmp_path)
+        output = model.embed(["def add(a, b): return a + b", "how to sort a list"])
+
+        assert len(output.embeddings) == 2
+        for emb in output.embeddings:
+            assert len(emb) == self._CONFIG["hidden_size"]
+            norm = math.sqrt(sum(x * x for x in emb))
+            assert abs(norm - 1.0) < 1e-3, f"not L2-normalized: norm={norm}"
+
+    def test_qwen2_last_token_pool_is_mask_aware(self, tmp_path):
+        """Left- vs right-padding the same sequence yields the same vector.
+
+        A causal decoder with RoPE encodes only relative positions, so the
+        final real-token state is padding-side invariant *iff* the pool indexes
+        the last non-pad token via the attention mask. A hardcoded ``[:, -1]``
+        would read a pad position under right padding and diverge.
+        """
+        import mlx.core as mx
+        from omlx.models.qwen2_embedding import Model, ModelArgs
+
+        mx.random.seed(0)
+        model = Model(ModelArgs(**self._CONFIG))
+        mx.eval(model.parameters())
+
+        right_ids = mx.array([[5, 9, 7, 0, 0]])
+        right_mask = mx.array([[1, 1, 1, 0, 0]])
+        left_ids = mx.array([[0, 0, 5, 9, 7]])
+        left_mask = mx.array([[0, 0, 1, 1, 1]])
+
+        right = np.array(model(right_ids, right_mask).text_embeds[0].tolist())
+        left = np.array(model(left_ids, left_mask).text_embeds[0].tolist())
+
+        # Mask-aware pooling agrees to float32 noise (~1e-4); a hardcoded
+        # ``[:, -1]`` pool would read the trailing pad token under right padding
+        # and diverge by O(0.1+). 1e-3 sits cleanly between the two regimes.
+        assert np.max(np.abs(right - left)) < 1e-3, (
+            "last-token pool is not mask-aware: left/right padding diverged"
+        )
+
+    def test_qwen2_is_causal_flag_controls_attention(self, tmp_path):
+        """is_causal=False makes attention bidirectional (gte-Qwen2 family).
+
+        Under causal attention an earlier token cannot attend to a later one, so
+        perturbing the last token leaves earlier hidden states unchanged; under
+        bidirectional attention it changes them. This pins the config gate that
+        distinguishes jina-code (causal) from gte-Qwen2 (``is_causal: false``).
+        """
+        import mlx.core as mx
+        from omlx.models.qwen2_embedding import Model, ModelArgs
+
+        base = mx.array([[5, 9, 7, 3]])
+        perturbed = mx.array([[5, 9, 7, 8]])  # differ only in the LAST token
+        mask = mx.array([[1, 1, 1, 1]])
+
+        def first_token_drift(is_causal):
+            mx.random.seed(0)
+            model = Model(ModelArgs(**{**self._CONFIG, "is_causal": is_causal}))
+            mx.eval(model.parameters())
+            a = np.array(model.model(base, mask).tolist())[0, 0]
+            b = np.array(model.model(perturbed, mask).tolist())[0, 0]
+            return float(np.max(np.abs(a - b)))
+
+        assert first_token_drift(is_causal=True) < 1e-6, "causal leaked future token"
+        assert first_token_drift(is_causal=False) > 1e-3, "bidirectional did not attend forward"

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -131,6 +131,38 @@ class TestDetectModelType:
         (llm_dir / "config.json").write_text(json.dumps(config))
         assert detect_model_type(llm_dir) == "llm"
 
+    def test_detect_qwen2_causal_lm_embedding(self, tmp_path):
+        """Qwen2ForCausalLM with an embedding-named dir is an embedding (#686).
+
+        jina-code-embeddings ships a Qwen2ForCausalLM architecture without
+        lm_head weights, so it must classify as an embedding model rather than
+        a chat LLM.
+        """
+        embed_dir = tmp_path / "jina-code-embeddings-1.5b"
+        embed_dir.mkdir()
+        config = {
+            "model_type": "qwen2",
+            "architectures": ["Qwen2ForCausalLM"],
+        }
+        (embed_dir / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(embed_dir) == "embedding"
+
+    def test_qwen2_causal_lm_without_embedding_name_is_llm(self, tmp_path):
+        """Qwen2ForCausalLM without an embedding-named dir stays an LLM (#686).
+
+        Regression guard: adding Qwen2ForCausalLM to the embedding-arch set must
+        not reclassify ordinary Qwen2/Qwen2.5 chat models, which is gated by the
+        _is_causal_lm_embedding directory-name heuristic.
+        """
+        llm_dir = tmp_path / "Qwen2.5-7B-Instruct"
+        llm_dir.mkdir()
+        config = {
+            "model_type": "qwen2",
+            "architectures": ["Qwen2ForCausalLM"],
+        }
+        (llm_dir / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(llm_dir) == "llm"
+
     def test_detect_lfm2_text_model_is_llm(self, tmp_path):
         """LFM2 text checkpoints share model_type with non-text variants."""
         llm_dir = tmp_path / "LFM2-1.2B"


### PR DESCRIPTION
Fixes #686.

## Summary

Serve Qwen2-based embedding models (`architectures: ["Qwen2ForCausalLM"]`,
`model_type: qwen2`) end to end — e.g. `jinaai/jina-code-embeddings-1.5b` (the
issue model), `Alibaba-NLP/gte-Qwen2-1.5B-instruct`. The first commit classified
them as embeddings; this adds a native adapter so they actually load and embed.

## Root cause

Classification alone routed these models to `MLXEmbeddingModel`, whose native
path only handled BERT/XLM-RoBERTa and whose `mlx-embeddings` fallback has no
`qwen2` module, so loading raised the exact error from the issue:

```
ValueError: Model type qwen2 not supported.
```

## Fix

- **`omlx/models/qwen2_embedding.py`** (new): a Qwen2 decoder wrapped for
  embeddings with **mask-aware last-token pooling + L2 normalization**, matching
  these models' SentenceTransformers configs (`pooling_mode_lasttoken: true` +
  a Normalize module). Mean pooling would silently corrupt every vector; the
  pool is mask-aware so left- and right-padded batches pool the same real token.
  Qwen2 deltas vs the Qwen3 embedder: no QK-norm, attention bias on q/k/v
  (`o_proj` unbiased), `head_dim = hidden_size // num_attention_heads`.
  An `is_causal` flag (default true) runs the decoder **causally** for plain
  decoder-embedders (jina-code) and **bidirectionally** when a model
  declares `is_causal: false` (Alibaba's gte-Qwen2 family ships a custom
  bidirectional `modeling_qwen.py`). The padding mask uses the dtype's finite
  min, not `-inf`, so fully-masked rows under left padding stay NaN-free.
- **`omlx/models/embedding.py`**: native dispatch is now an arch→module map
  (`Qwen2ForCausalLM` → the adapter; BERT/XLM unchanged). No change to the
  weight loader — `mx.load` already reads the bf16 checkpoints these models ship.
- **`omlx/models/base_model.py`**: a mask-aware `last_token_pool` helper.

## Sibling sweep

- Covered: single + batch input, left/right padding (mask-aware), causal
  (jina-code) and bidirectional (gte-Qwen2) Qwen2 embedders, float + base64
  output (unchanged downstream).
- Untouched: the `mlx-embeddings` fallback (Qwen3 embedders) and the native
  BERT/XLM path are not modified by this PR. The Qwen2 reranker is out of scope
  (separate `reranker.py` path, untouched).

## Tests

`tests/test_embedding.py` (`TestNativeQwen2Embedding`) drives the **real**
`_load_native` + `embed()` path for a `Qwen2ForCausalLM` fixture: native-path
routing, output shape + L2-norm, mask-aware last-token (left vs right padding
agree while a hardcoded `[-1]` pool diverges by ~0.2), and `is_causal` flipping
causal↔bidirectional. All red without the adapter (they fail with the issue's
`Model type qwen2 not supported`). `pytest tests/test_embedding.py
tests/test_model_discovery.py` → 219 passed.

## Real-model verification

vs a `transformers` reference (stock `Qwen2Model`, fp32, mask-aware last-token + L2):

| model | attention | oMLX↔ref mean cosine | ranking (relevant vs irrelevant) |
|---|---|---|---|
| jina-code-embeddings-1.5b | causal | 0.99990 | pass (Δ +0.75 / +0.62) |
| gte-Qwen2-1.5B-instruct | bidirectional (`is_causal:false`) | 0.99987 | pass (Δ +0.16 / +0.11) |

Zero-regression: Qwen3-Embedding-0.6B (the `mlx-embeddings` fallback) is
byte-identical before/after (0.0), and Qwen2.5-0.5B chat still classifies as
`llm`.

## Dependencies

No dependency change. `mlx-embeddings` has no `qwen2` module at its pin, at HEAD,
or in any release, so a bump won't help; an upstream PR adding `qwen2.py` to
`mlx-embeddings` is a sensible follow-up but not required here.
