### PR TITLE
fix: add timeout protection to prevent engine stop deadlock

### DIFF
--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -745,8 +745,14 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
             })
             for model_id in loaded_ids:
                 try:
-                    await engine_pool._unload_engine(model_id)
+                    # Add timeout to prevent hang on corrupted engine state
+                    await asyncio.wait_for(
+                        engine_pool._unload_engine(model_id),
+                        timeout=60.0
+                    )
                     logger.info(f"Benchmark: unloaded {model_id}")
+                except asyncio.TimeoutError:
+                    logger.error(f"Benchmark: unload {model_id} timed out after 60s, skipping")
                 except Exception as e:
                     logger.warning(f"Benchmark: failed to unload {model_id}: {e}")
 
@@ -871,8 +877,14 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
             "total": total_tests,
         })
         try:
-            await engine_pool._unload_engine(request.model_id)
+            # Add timeout to prevent hang on corrupted engine state
+            await asyncio.wait_for(
+                engine_pool._unload_engine(request.model_id),
+                timeout=60.0
+            )
             logger.info(f"Benchmark: unloaded {request.model_id} after benchmark")
+        except asyncio.TimeoutError:
+            logger.error(f"Benchmark: unload {request.model_id} timed out after 60s")
         except Exception as e:
             logger.warning(f"Benchmark: failed to unload {request.model_id}: {e}")
 
@@ -912,8 +924,11 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
         })
         # Try to unload the model on cancellation
         try:
-            await engine_pool._unload_engine(request.model_id)
-        except Exception:
+            await asyncio.wait_for(
+                engine_pool._unload_engine(request.model_id),
+                timeout=60.0
+            )
+        except (asyncio.TimeoutError, Exception):
             pass
 
     except Exception as e:
@@ -926,6 +941,9 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
         })
         # Try to unload the model on error
         try:
-            await engine_pool._unload_engine(request.model_id)
-        except Exception:
+            await asyncio.wait_for(
+                engine_pool._unload_engine(request.model_id),
+                timeout=60.0
+            )
+        except (asyncio.TimeoutError, Exception):
             pass

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -364,9 +364,24 @@ class BatchedEngine(BaseEngine):
         logger.info(f"BatchedEngine loaded: {self._model_name}")
 
     async def stop(self) -> None:
-        """Stop the engine and cleanup resources."""
+        """Stop the engine and cleanup resources.
+        
+        Includes timeout protection to prevent indefinite hangs when the engine
+        is in a corrupted state (e.g., after MLX segfault or lock corruption).
+        See: https://github.com/jundot/omlx/issues/XXXX
+        """
         if self._engine:
-            await self._engine.stop()
+            try:
+                # Add timeout to prevent hang on corrupted engine state
+                await asyncio.wait_for(self._engine.stop(), timeout=30.0)
+            except asyncio.TimeoutError:
+                logger.error(
+                    "Engine stop timed out after 30s, forcing cleanup. "
+                    "This may indicate a corrupted engine state."
+                )
+            except Exception as e:
+                logger.warning(f"Error stopping engine: {e}")
+            
             if hasattr(self._engine, "engine") and self._engine.engine is not None:
                 try:
                     self._engine.engine.close()

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -640,7 +640,14 @@ class EnginePool:
         pre_unload_active = mx.get_active_memory()
 
         try:
-            await entry.engine.stop()
+            # Add timeout to prevent hang on corrupted engine state
+            # See: https://github.com/jundot/omlx/issues/XXXX
+            await asyncio.wait_for(entry.engine.stop(), timeout=30.0)
+        except asyncio.TimeoutError:
+            logger.error(
+                f"Engine stop timed out after 30s for {model_id}, forcing cleanup. "
+                "This may indicate a corrupted engine state."
+            )
         except Exception as e:
             logger.warning(f"Error stopping engine for {model_id}: {e}")
 


### PR DESCRIPTION
# Pull Request: Add timeout protection to prevent engine stop deadlock

## Summary

This PR adds timeout protection to `engine.stop()` and `_unload_engine()` calls to prevent indefinite hangs when the MLX inference engine encounters a segfault or lock corruption.

## Problem

When running benchmarks against certain models (e.g., `Intern-S2-Preview-FP8-MLX-4bit`), the omlx server can become completely unresponsive:

1. MLX inference engine encounters a segfault in `scheduler._patched_generation_batch_step()`
2. The crash triggers multiple recovery attempts, corrupting internal lock state
3. The main process and forked cache worker deadlock on `SimpleQueue` operations
4. `engine.stop()` is called but has **no timeout**, causing it to hang forever
5. The entire server becomes unresponsive, requiring manual `kill -9`

## Solution

Wrap all `engine.stop()` and `_unload_engine()` calls with `asyncio.wait_for()`:

| File | Change | Timeout |
|------|--------|---------|
| `omlx/engine/batched.py` | `stop()` method | 30s |
| `omlx/engine_pool.py` | `_unload_engine()` method | 30s |
| `omlx/admin/benchmark.py` | All `_unload_engine()` calls | 60s |

When a timeout occurs:
- Log an error message indicating corrupted engine state
- Proceed with cleanup (set `_engine = None`, etc.)
- Allow the server to recover gracefully

## Changes

### `omlx/engine/batched.py`
```python
async def stop(self) -> None:
    if self._engine:
        try:
            await asyncio.wait_for(self._engine.stop(), timeout=30.0)
        except asyncio.TimeoutError:
            logger.error("Engine stop timed out after 30s, forcing cleanup.")
        except Exception as e:
            logger.warning(f"Error stopping engine: {e}")
        # ... rest of cleanup
```

### `omlx/engine_pool.py`
```python
async def _unload_engine(self, model_id: str) -> None:
    # ...
    try:
        await asyncio.wait_for(entry.engine.stop(), timeout=30.0)
    except asyncio.TimeoutError:
        logger.error(f"Engine stop timed out after 30s for {model_id}")
    except Exception as e:
        logger.warning(f"Error stopping engine for {model_id}: {e}")
```

### `omlx/admin/benchmark.py`
All 4 `_unload_engine()` calls wrapped with 60s timeout:
```python
await asyncio.wait_for(
    engine_pool._unload_engine(model_id),
    timeout=60.0
)
```

## Testing

- [x] Code compiles without errors
- [x] Timeout logic tested with simulated hang scenarios
- [ ] Unit tests (if applicable)
- [ ] Integration test with problematic model

## Related Issues

Fixes: [Issue: Benchmark hangs indefinitely when engine encounters MLX segfault]

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] No new warnings introduced
- [ ] Documentation updated (if needed)