### PR TITLE
Fix login page to honor system dark mode setting

### DIFF
--- a/omlx/admin/templates/base.html
+++ b/omlx/admin/templates/base.html
@@ -32,7 +32,11 @@
     <script>
         // Apply theme immediately to prevent flash of wrong theme
         (function() {
-            var theme = localStorage.getItem('omlx-chat-theme') || 'light';
+            var stored = localStorage.getItem('omlx-chat-theme');
+            var theme = stored || 'auto';
+            if (theme === 'auto') {
+                theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            }
             document.documentElement.setAttribute('data-theme', theme);
         })();
     </script>


### PR DESCRIPTION
## Problem

The login page on the admin endpoint didn't honor the system dark mode setting, unlike the chat and dashboard pages.

## Root Cause

The theme initialization script in `base.html` was defaulting to `'light'` and never checking `prefers-color-scheme` when the stored theme value was `'auto'`.

## Fix

Updated the inline theme script in `base.html` to:
- Default to `'auto'` instead of `'light'` when no theme is stored in localStorage
- Check `window.matchMedia('(prefers-color-scheme: dark)')` when the theme is `'auto'` to detect the system dark mode preference

This matches the behavior already used by `chat.html`.