### PR TITLE
Add OMLX_SYNC_STORE_CACHE to make prefix-cache commit synchronous (fixes back-to-back cache-miss race)

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1226,10 +1226,28 @@ class Scheduler:
                 # Async store_cache executor: single worker so submissions are
                 # serialized (matches the original synchronous order) and we
                 # never have two stores racing on the same paged_ssd index.
-                self._store_cache_executor = concurrent.futures.ThreadPoolExecutor(
-                    max_workers=1,
-                    thread_name_prefix="omlx-store-cache",
-                )
+                #
+                # OMLX_SYNC_STORE_CACHE=1 disables this executor so store_cache
+                # (including the cached_block_hash_to_block index registration)
+                # runs synchronously on the inference thread via the existing
+                # fallback path below. The prefix cache then becomes immediately
+                # consistent: a request arriving right after a prior one
+                # (back-to-back, an agentic loop, or a concurrent stream) reuses
+                # the just-computed prefix instead of re-prefilling because the
+                # async commit had not landed yet. The SSD write stays async via
+                # the background writer thread; only the cheap in-RAM register +
+                # hot-cache populate moves onto the inference thread.
+                if os.environ.get("OMLX_SYNC_STORE_CACHE") == "1":
+                    self._store_cache_executor = None
+                    logger.info(
+                        "OMLX_SYNC_STORE_CACHE=1 -> synchronous store_cache "
+                        "(immediate prefix-cache consistency)"
+                    )
+                else:
+                    self._store_cache_executor = concurrent.futures.ThreadPoolExecutor(
+                        max_workers=1,
+                        thread_name_prefix="omlx-store-cache",
+                    )
                 # Gate caps the post-completion store-cache pipeline so a burst
                 # of finishes cannot pile up unbounded KV caches in memory while
                 # the single writer drains. Cap starts at max_concurrent_requests

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1227,7 +1227,8 @@ class Scheduler:
                 # serialized (matches the original synchronous order) and we
                 # never have two stores racing on the same paged_ssd index.
                 #
-                # OMLX_SYNC_STORE_CACHE=1 disables this executor so store_cache
+                # OMLX_SYNC_STORE_CACHE=1 (or true/yes/on) disables this executor
+                # so store_cache
                 # (including the cached_block_hash_to_block index registration)
                 # runs synchronously on the inference thread via the existing
                 # fallback path below. The prefix cache then becomes immediately
@@ -1237,10 +1238,11 @@ class Scheduler:
                 # async commit had not landed yet. The SSD write stays async via
                 # the background writer thread; only the cheap in-RAM register +
                 # hot-cache populate moves onto the inference thread.
-                if os.environ.get("OMLX_SYNC_STORE_CACHE") == "1":
+                _sync = os.environ.get("OMLX_SYNC_STORE_CACHE", "").strip().lower()
+                if _sync in {"1", "true", "yes", "on"}:
                     self._store_cache_executor = None
                     logger.info(
-                        "OMLX_SYNC_STORE_CACHE=1 -> synchronous store_cache "
+                        "OMLX_SYNC_STORE_CACHE enabled -> synchronous store_cache "
                         "(immediate prefix-cache consistency)"
                     )
                 else:

--- a/tests/test_sync_store_cache.py
+++ b/tests/test_sync_store_cache.py
@@ -20,15 +20,19 @@ def make_scheduler(mock_model, mock_tokenizer, tmp_path):
     (the default branch spins up a real ThreadPoolExecutor + SSD writer thread).
 
     Returned as a factory so the test can set OMLX_SYNC_STORE_CACHE *before*
-    construction.
+    construction. Each created scheduler gets its own cache subdirectory so
+    multiple instances cannot share on-disk state.
     """
     created = []
 
     def _make():
         if not scheduler_module.HAS_TIERED_CACHE:
             pytest.skip("tiered cache modules are unavailable")
-        config = SchedulerConfig(paged_ssd_cache_dir=str(tmp_path / "cache"))
-        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+        cache_dir = tmp_path / f"cache-{len(created)}"
+        config = SchedulerConfig(paged_ssd_cache_dir=str(cache_dir))
+        scheduler = Scheduler(
+            model=mock_model, tokenizer=mock_tokenizer, config=config
+        )
         if scheduler.block_aware_cache is None:
             scheduler.shutdown()
             pytest.skip("paged SSD cache did not initialize in this environment")
@@ -56,8 +60,16 @@ class TestSyncStoreCacheFlag:
         assert scheduler._store_cache_executor is None
         assert scheduler.block_aware_cache is not None
 
-    def test_non_one_value_keeps_async(self, make_scheduler, monkeypatch):
-        """Only the exact value "1" enables sync mode; other values are async."""
-        monkeypatch.setenv("OMLX_SYNC_STORE_CACHE", "0")
+    @pytest.mark.parametrize("value", ["true", "True", "yes", "on", " 1 "])
+    def test_truthy_values_enable_sync(self, make_scheduler, monkeypatch, value):
+        """Truthy values (case/whitespace-insensitive) also enable sync mode."""
+        monkeypatch.setenv("OMLX_SYNC_STORE_CACHE", value)
+        scheduler = make_scheduler()
+        assert scheduler._store_cache_executor is None
+
+    @pytest.mark.parametrize("value", ["0", "false", "off", ""])
+    def test_falsy_values_keep_async(self, make_scheduler, monkeypatch, value):
+        """Falsy / unrecognized values keep the async executor."""
+        monkeypatch.setenv("OMLX_SYNC_STORE_CACHE", value)
         scheduler = make_scheduler()
         assert scheduler._store_cache_executor is not None

--- a/tests/test_sync_store_cache.py
+++ b/tests/test_sync_store_cache.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for OMLX_SYNC_STORE_CACHE.
+
+The env flag disables the async store-cache executor so store_cache (including
+the cached_block_hash_to_block index registration) runs synchronously on the
+inference thread via the existing fallback path, making the prefix cache
+immediately consistent for back-to-back / rapid requests.
+"""
+
+import pytest
+
+import omlx.scheduler as scheduler_module
+from omlx.scheduler import Scheduler, SchedulerConfig
+
+
+@pytest.fixture
+def make_scheduler(mock_model, mock_tokenizer, tmp_path):
+    """Factory that builds a Scheduler with the paged SSD cache enabled (so the
+    store-cache executor branch is exercised) and shuts each one down on teardown
+    (the default branch spins up a real ThreadPoolExecutor + SSD writer thread).
+
+    Returned as a factory so the test can set OMLX_SYNC_STORE_CACHE *before*
+    construction.
+    """
+    created = []
+
+    def _make():
+        if not scheduler_module.HAS_TIERED_CACHE:
+            pytest.skip("tiered cache modules are unavailable")
+        config = SchedulerConfig(paged_ssd_cache_dir=str(tmp_path / "cache"))
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+        if scheduler.block_aware_cache is None:
+            scheduler.shutdown()
+            pytest.skip("paged SSD cache did not initialize in this environment")
+        created.append(scheduler)
+        return scheduler
+
+    yield _make
+
+    for scheduler in created:
+        scheduler.shutdown()
+
+
+class TestSyncStoreCacheFlag:
+    def test_default_uses_async_executor(self, make_scheduler, monkeypatch):
+        """Unset (default): the async store-cache executor is created."""
+        monkeypatch.delenv("OMLX_SYNC_STORE_CACHE", raising=False)
+        scheduler = make_scheduler()
+        assert scheduler._store_cache_executor is not None
+
+    def test_flag_disables_executor(self, make_scheduler, monkeypatch):
+        """OMLX_SYNC_STORE_CACHE=1: executor is disabled -> store_cache runs
+        synchronously via the fallback path, while the cache stays enabled."""
+        monkeypatch.setenv("OMLX_SYNC_STORE_CACHE", "1")
+        scheduler = make_scheduler()
+        assert scheduler._store_cache_executor is None
+        assert scheduler.block_aware_cache is not None
+
+    def test_non_one_value_keeps_async(self, make_scheduler, monkeypatch):
+        """Only the exact value "1" enables sync mode; other values are async."""
+        monkeypatch.setenv("OMLX_SYNC_STORE_CACHE", "0")
+        scheduler = make_scheduler()
+        assert scheduler._store_cache_executor is not None


### PR DESCRIPTION
<!-- PR title: Add OMLX_SYNC_STORE_CACHE to make prefix-cache commit synchronous (fixes the back-to-back cache-miss race)
     Open against jundot/omlx:main from your fork branch. Apply omlx-sync-store-cache.patch (only the logical change). -->

Fixes #1731.

### What

Adds an opt-in env flag `OMLX_SYNC_STORE_CACHE=1` that disables the single-worker
`_store_cache_executor` so `store_cache` (including the `cached_block_hash_to_block` index
registration) runs synchronously on the inference thread via the **existing** synchronous
fallback path (`scheduler.py`, the `else: self._async_store_cache_worker(...)` branch). With
it set, the prefix cache is immediately consistent, so a request arriving right after a prior
one reuses the just-computed prefix instead of re-prefilling.

### Why

Currently the post-request commit (which registers the prefix-cache index) is deferred to a
background worker. A request that arrives before the commit lands misses and re-prefills. The
window is <3 s when idle but is hit by rapid or overlapping requests that re-send a shared
prefix within that window, which then re-prefill instead of reusing it. See #1731 for a
self-contained repro.

### Proof (same model/config, only the flag differs; flag confirmed in server log)

```
baseline (async):                gap=0  warm=58.8s  MISS
OMLX_SYNC_STORE_CACHE=1 (sync):  gap=0  warm= 3.8s  HIT
                                 gap=5  warm= 4.5s  HIT
```

### Overhead

Negligible, and **not** a throughput regression:
- The SSD/disk write stays async — `save_block` enqueues to the background writer thread (and
  under `hot_cache_only=true` no disk write happens at all). No disk I/O moves to the inference thread.
- Phase timers show `store_cache_worker_sync = 0.0–0.2 ms`; the only sizeable store line
  (`store_cache_main_dispatch ≈ 250 ms`) is the `mx.eval` of the KV, which already runs on the
  inference thread in the async path (the pre-eval), so it is not added here.
- A/B cold-request times are within noise (57–72 s baseline vs 59–65 s sync).

### Tests

Adds `tests/test_sync_store_cache.py` (3 cases, fast — no model load, uses the existing
`mock_model`/`mock_tokenizer` conftest fixtures and the same `Scheduler(...)` construction as
`tests/test_scheduler.py`):
- default (unset) → `_store_cache_executor` is created (async);
- `OMLX_SYNC_STORE_CACHE=1` → `_store_cache_executor is None` and the cache is still enabled;
- any non-`"1"` value → stays async.

`pytest tests/test_sync_store_cache.py` → 3 passed in ~1.2s. (The flag-on case asserts the
executor is `None`, so it fails on unpatched `main` — it genuinely guards the fix.)

### Notes for review

- **Default unchanged:** flag unset → identical single-worker `ThreadPoolExecutor` as before.
- **Metal-safe:** running `_async_store_cache_worker` inline is safer than the threaded path —
  it runs on the thread that owns `self._stream`, so the worker's "KV must be concrete before a
  *different* thread slices/views it" invariant can't be violated. The pre-`mx.eval` still runs;
  `_mx_buffer_access_lock` is an `RLock`.
- **Intentional:** in sync mode the shutdown block (guarded by `_store_cache_executor is not
  None`) is skipped, so `_store_cache_gate` stays non-None. Harmless — `_inflight_store_futures`
  and `_pending_async_removes` are never populated in sync mode (the gate's note_submitted /
  note_done and the inflight futures live only inside the executor branch and `_drain_*`), so
  there's nothing to drain or reset.
- I considered a lighter "register the index sync, extract data async" variant — it's
  **incorrect**: in `store_cache`, `register_block_hash` and the tensor extraction/store are
  coupled, and reconstruct drops a matched block whose data fails to load (false hit →
  re-prefill → un-register → thrash). Hence the full-but-cheap synchronous path.

Happy to switch the gate from an env var to a settings field if that fits the project better.

