### PR TITLE
feat: persist benchmark telemetry with CLI history and GUI viewer

### DIFF
--- a/omlx/admin/accuracy_benchmark.py
+++ b/omlx/admin/accuracy_benchmark.py
@@ -134,14 +134,47 @@ def cleanup_old_runs() -> None:
 # --- Accumulated results ---
 
 
+def _get_save_path():
+    from omlx.settings import get_settings
+    path = get_settings().base_path / "bench_results_accuracy.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _load_accumulated():
+    global _accumulated_results
+    if not getattr(_load_accumulated, "loaded", False):
+        try:
+            import json
+            path = _get_save_path()
+            if path.exists():
+                with open(path, "r") as f:
+                    _accumulated_results[:] = json.load(f)
+        except Exception as e:
+            logger.error(f"Failed to load accuracy results: {e}")
+        _load_accumulated.loaded = True
+
+
+def _save_accumulated():
+    try:
+        import json
+        path = _get_save_path()
+        with open(path, "w") as f:
+            json.dump(_accumulated_results, f, indent=2)
+    except Exception as e:
+        logger.error(f"Failed to save accuracy results: {e}")
+
+
 def get_accumulated_results() -> list[dict]:
     """Get all accumulated benchmark results."""
+    _load_accumulated()
     return _accumulated_results
 
 
 def reset_accumulated_results() -> None:
     """Clear all accumulated results."""
     _accumulated_results.clear()
+    _save_accumulated()
 
 
 # --- Queue management ---
@@ -487,8 +520,12 @@ async def run_accuracy_benchmark(
                     k: round(v, 4) for k, v in result.category_scores.items()
                 }
 
-            # Accumulate persistently
+            # Accumulate persistently. Load any on-disk history first so this
+            # save merges with prior runs instead of clobbering them — the
+            # lazy load may not have been triggered by a poll yet this session.
+            _load_accumulated()
             _accumulated_results.append(result_data)
+            _save_accumulated()
 
             run.results.append(result_data)
             completed += 1

--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -879,6 +879,24 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
         # Done
         overall_duration = time.perf_counter() - overall_start
         run.status = "completed"
+
+        # Save to local history
+        try:
+            from omlx.settings import get_settings
+            import datetime
+
+            save_path = get_settings().base_path / "bench_results_throughput.jsonl"
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+            run_data = {
+                "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+                "model_id": request.model_id,
+                "total_time": round(overall_duration, 1),
+                "results": run.results
+            }
+            with open(save_path, "a") as f:
+                f.write(json.dumps(run_data) + "\n")
+        except Exception as e:
+            logger.error(f"Failed to save throughput benchmark history: {e}")
         await _send_event(run, {
             "type": "done",
             "summary": {

--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -152,6 +152,63 @@ def cleanup_old_runs(max_runs: int = 10) -> None:
             del _benchmark_runs[bid]
 
 
+# --- Throughput history persistence ---
+#
+# Completed runs are appended to an on-disk JSONL log so history survives
+# server restarts. Surfaced via the throughput history pane (web + app) and
+# the `omlx bench-history` CLI. Append-only — no in-memory accumulation, so
+# there is nothing to clobber.
+
+
+def _throughput_history_path() -> Path:
+    from omlx.settings import get_settings
+
+    path = get_settings().base_path / "bench_results_throughput.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _append_throughput_run(run_data: dict) -> None:
+    """Append one completed throughput run to the on-disk history log."""
+    try:
+        with open(_throughput_history_path(), "a") as f:
+            f.write(json.dumps(run_data) + "\n")
+    except Exception as e:
+        logger.error(f"Failed to save throughput benchmark history: {e}")
+
+
+def get_throughput_history() -> list[dict]:
+    """Read accumulated throughput runs from disk, newest first."""
+    runs: list[dict] = []
+    try:
+        path = _throughput_history_path()
+        if path.exists():
+            with open(path, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        runs.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        # Skip a partially-written/corrupt line rather than
+                        # failing the whole history read.
+                        continue
+    except Exception as e:
+        logger.error(f"Failed to read throughput benchmark history: {e}")
+    runs.reverse()  # newest first
+    return runs
+
+
+def reset_throughput_history() -> None:
+    """Clear all accumulated throughput history."""
+    try:
+        path = _throughput_history_path()
+        if path.exists():
+            path.unlink()
+    except Exception as e:
+        logger.error(f"Failed to reset throughput benchmark history: {e}")
+
 
 def _generate_prompt(tokenizer: Any, target_tokens: int) -> str:
     """Generate a prompt with exactly target_tokens tokens.
@@ -880,23 +937,16 @@ async def run_benchmark(run: BenchmarkRun, engine_pool: Any) -> None:
         overall_duration = time.perf_counter() - overall_start
         run.status = "completed"
 
-        # Save to local history
-        try:
-            from omlx.settings import get_settings
-            import datetime
+        # Persist to local history (survives restart; surfaced via the
+        # throughput history pane and `omlx bench-history`).
+        import datetime
 
-            save_path = get_settings().base_path / "bench_results_throughput.jsonl"
-            save_path.parent.mkdir(parents=True, exist_ok=True)
-            run_data = {
-                "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
-                "model_id": request.model_id,
-                "total_time": round(overall_duration, 1),
-                "results": run.results
-            }
-            with open(save_path, "a") as f:
-                f.write(json.dumps(run_data) + "\n")
-        except Exception as e:
-            logger.error(f"Failed to save throughput benchmark history: {e}")
+        _append_throughput_run({
+            "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+            "model_id": request.model_id,
+            "total_time": round(overall_duration, 1),
+            "results": run.results,
+        })
         await _send_event(run, {
             "type": "done",
             "summary": {

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -5444,6 +5444,38 @@ async def get_active_benchmark(is_admin: bool = Depends(require_admin)):
     }
 
 
+@router.get("/api/bench/throughput/results")
+async def get_throughput_benchmark_history(
+    is_admin: bool = Depends(require_admin),
+):
+    """Get accumulated throughput benchmark runs (newest first).
+
+    Declared before the `/api/bench/{bench_id}/...` routes so the literal
+    `throughput` segment is not captured as a bench_id. Shape mirrors
+    `/api/bench/accuracy/results` so both GUIs poll them the same way.
+    """
+    from .benchmark import get_active_run, get_throughput_history
+
+    active = get_active_run()
+    return {
+        "runs": get_throughput_history(),
+        "running": active is not None,
+        "current_model": active.request.model_id if active is not None else None,
+        "current_bench_id": active.bench_id if active is not None else None,
+    }
+
+
+@router.post("/api/bench/throughput/results/reset")
+async def reset_throughput_benchmark_history(
+    is_admin: bool = Depends(require_admin),
+):
+    """Clear all accumulated throughput benchmark history."""
+    from .benchmark import reset_throughput_history
+
+    reset_throughput_history()
+    return {"status": "reset"}
+
+
 @router.post("/api/bench/start")
 async def start_benchmark(
     request: Request,

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -398,6 +398,10 @@
             // race a 409 on the server.
             benchOtherActive: null,
 
+            // Persisted throughput run history (newest first), loaded from
+            // /api/bench/throughput/results so it survives server restarts.
+            benchHistory: [],
+
             // Bench sub-tab & dropdown
             benchTab: 'throughput',
             benchDropdown: false,
@@ -575,6 +579,7 @@
                 if (value === 'bench') {
                     if (!this.benchDeviceInfo) await this.loadBenchDeviceInfo();
                     await this.loadBenchState();
+                    await this.loadBenchHistory();
                     await this.loadAccState();
                 }
             },
@@ -2627,6 +2632,7 @@
                             this.benchProgress = null;
                             es.close();
                             this.benchEventSource = null;
+                            this.loadBenchHistory();
                         } else if (data.type === 'upload_skipped') {
                             this.benchUploadSkipped = { features: data.features || [] };
                             this.benchUploading = false;
@@ -2635,6 +2641,7 @@
                             es.close();
                             this.benchEventSource = null;
                             this.loadModels();
+                            this.loadBenchHistory();
                         } else if (data.type === 'error') {
                             this.benchError = data.message;
                             this.benchRunning = false;
@@ -2844,6 +2851,45 @@
                 }
             },
 
+            async loadBenchHistory() {
+                // Load accumulated throughput runs (newest first) from disk so
+                // history survives server restarts. Mirrors loadAccState.
+                try {
+                    const resp = await fetch('/admin/api/bench/throughput/results');
+                    if (resp.ok) {
+                        const data = await resp.json();
+                        this.benchHistory = (data.runs || []).map(r => ({ ...r, _expanded: false }));
+                    }
+                } catch (err) {
+                    console.error('Failed to load benchmark history:', err);
+                }
+            },
+
+            async resetBenchHistory() {
+                try {
+                    await fetch('/admin/api/bench/throughput/results/reset', { method: 'POST' });
+                    this.benchHistory = [];
+                } catch (err) {
+                    console.error('Failed to reset benchmark history:', err);
+                }
+            },
+
+            benchHistorySingle(run) {
+                return (run.results || []).filter(r => r.test_type === 'single');
+            },
+
+            benchHistoryBatch(run) {
+                return (run.results || []).filter(r => r.test_type === 'batch');
+            },
+
+            benchFormatTimestamp(ts) {
+                // Stored as ISO-8601 UTC (…Z). Render in the viewer's locale.
+                if (!ts) return '';
+                const d = new Date(ts);
+                if (isNaN(d)) return ts;
+                return d.toLocaleString();
+            },
+
             // User clicked "View live" on the banner — clear the stale
             // result display, attach to the active run. The replay-on-
             // subscribe stream re-delivers every event so the new bench
@@ -2881,6 +2927,7 @@
                 if (tab === 'throughput') {
                     this.loadBenchDeviceInfo();
                     this.loadBenchState();
+                    this.loadBenchHistory();
                 }
             },
 

--- a/omlx/admin/templates/dashboard/_bench.html
+++ b/omlx/admin/templates/dashboard/_bench.html
@@ -385,6 +385,99 @@
                         </div>
                     </div>
 
+                    <!-- Benchmark History -->
+                    <div x-show="benchHistory.length > 0" x-cloak class="bg-white rounded-2xl border border-neutral-200 overflow-hidden mb-6">
+                        <div class="flex items-center justify-between px-6 py-4 bg-neutral-100 border-b border-neutral-200">
+                            <div class="flex items-center gap-3">
+                                <i data-lucide="history" class="w-4 h-4 text-neutral-500"></i>
+                                <span class="text-xs font-bold uppercase tracking-wider text-neutral-600">Benchmark History</span>
+                                <span class="text-xs text-neutral-400" x-text="benchHistory.length + (benchHistory.length === 1 ? ' run' : ' runs')"></span>
+                            </div>
+                            <button @click="if (confirm('Clear all saved benchmark history? This cannot be undone.')) resetBenchHistory()"
+                                    class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-neutral-600 hover:text-red-600 transition-colors">
+                                <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
+                                Clear
+                            </button>
+                        </div>
+                        <div class="divide-y divide-neutral-100">
+                            <template x-for="(run, idx) in benchHistory" :key="run.timestamp + '-' + idx">
+                                <div>
+                                    <!-- Run header (click to expand) -->
+                                    <button @click="run._expanded = !run._expanded"
+                                            class="w-full flex items-center justify-between px-6 py-4 hover:bg-neutral-50 transition-colors text-left">
+                                        <div class="min-w-0">
+                                            <div class="text-sm font-medium text-neutral-900 truncate" x-text="run.model_id"></div>
+                                            <div class="text-xs text-neutral-400 mt-0.5" x-text="benchFormatTimestamp(run.timestamp)"></div>
+                                        </div>
+                                        <div class="flex items-center gap-4 flex-shrink-0">
+                                            <span class="text-xs text-neutral-500 tabular-nums" x-text="(run.total_time != null ? run.total_time + 's' : '')"></span>
+                                            <i data-lucide="chevron-down" class="w-4 h-4 text-neutral-400 transition-transform" :class="run._expanded && 'rotate-180'"></i>
+                                        </div>
+                                    </button>
+                                    <!-- Run detail -->
+                                    <div x-show="run._expanded" x-collapse x-cloak class="px-6 pb-5 space-y-4">
+                                        <!-- Single request results -->
+                                        <div x-show="benchHistorySingle(run).length > 0" class="overflow-x-auto">
+                                            <table class="w-full text-sm">
+                                                <thead>
+                                                    <tr class="border-b border-neutral-200 bg-neutral-50">
+                                                        {{ bench_th('bench.results.single.test', 'bench.metrics.test.tooltip', align='left') }}
+                                                        {{ bench_th('bench.results.single.ttft', 'bench.metrics.ttft.tooltip') }}
+                                                        {{ bench_th('bench.results.single.tpot', 'bench.metrics.tpot.tooltip') }}
+                                                        {{ bench_th('bench.results.single.pp_tps', 'bench.metrics.pp_tps.tooltip') }}
+                                                        {{ bench_th('bench.results.single.tg_tps', 'bench.metrics.tg_tps.tooltip') }}
+                                                        {{ bench_th('bench.results.single.e2e_latency', 'bench.metrics.e2e.tooltip') }}
+                                                        {{ bench_th('bench.results.single.throughput', 'bench.metrics.throughput.tooltip') }}
+                                                        {{ bench_th('bench.results.single.peak_mem', 'bench.metrics.peak_mem.tooltip') }}
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <template x-for="r in benchHistorySingle(run)" :key="r.pp">
+                                                        <tr class="border-b border-neutral-100 hover:bg-neutral-50">
+                                                            <td class="px-4 py-3 font-medium text-neutral-900" x-text="'pp' + r.pp + '/tg' + r.tg"></td>
+                                                            <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.ttft_ms.toFixed(1)"></td>
+                                                            <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.tpot_ms.toFixed(2)"></td>
+                                                            <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.processing_tps.toFixed(1) + ' tok/s'"></td>
+                                                            <td class="px-4 py-3 text-right tabular-nums font-medium text-neutral-900" x-text="r.gen_tps.toFixed(1) + ' tok/s'"></td>
+                                                            <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.e2e_latency_s.toFixed(3) + 's'"></td>
+                                                            <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.total_throughput.toFixed(1) + ' tok/s'"></td>
+                                                            <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="benchFormatMemory(r.peak_memory_bytes)"></td>
+                                                        </tr>
+                                                    </template>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                        <!-- Batch results -->
+                                        <div x-show="benchHistoryBatch(run).length > 0" class="overflow-x-auto">
+                                            <table class="w-full text-sm">
+                                                <thead>
+                                                    <tr class="border-b border-neutral-200 bg-neutral-50">
+                                                        {{ bench_th('bench.results.batch.batch_size', 'bench.metrics.batch_size.tooltip', align='left') }}
+                                                        {{ bench_th('bench.results.batch.tg_tps', 'bench.metrics.tg_tps.tooltip') }}
+                                                        {{ bench_th('bench.results.batch.pp_tps', 'bench.metrics.pp_tps.tooltip') }}
+                                                        {{ bench_th('bench.results.batch.avg_ttft', 'bench.metrics.avg_ttft.tooltip') }}
+                                                        {{ bench_th('bench.results.batch.e2e_latency', 'bench.metrics.e2e.tooltip') }}
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <template x-for="r in benchHistoryBatch(run)" :key="r.batch_size">
+                                                        <tr class="border-b border-neutral-100 hover:bg-neutral-50">
+                                                            <td class="px-4 py-3 font-medium text-neutral-900" x-text="r.batch_size + 'x'"></td>
+                                                            <td class="px-4 py-3 text-right tabular-nums font-medium text-neutral-900" x-text="r.tg_tps.toFixed(1) + ' tok/s'"></td>
+                                                            <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.pp_tps.toFixed(1) + ' tok/s'"></td>
+                                                            <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.avg_ttft_ms.toFixed(1)"></td>
+                                                            <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.e2e_latency_s.toFixed(3) + 's'"></td>
+                                                        </tr>
+                                                    </template>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+                                </div>
+                            </template>
+                        </div>
+                    </div>
+
                     <!-- Metrics Reference -->
                     <div class="bg-white rounded-2xl border border-neutral-200 overflow-hidden">
                         <button @click="benchShowMetrics = !benchShowMetrics"

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -725,6 +725,56 @@ def diagnose_command(args) -> int:
     return 1
 
 
+def bench_history_command(args):
+    """Display history of locally saved benchmarks."""
+    import json
+    from .settings import init_settings
+    settings = init_settings(base_path=None, cli_args=None)
+    
+    acc_path = settings.base_path / "bench_results_accuracy.json"
+    tp_path = settings.base_path / "bench_results_throughput.jsonl"
+    
+    print("=" * 80)
+    print(" OMLX BENCHMARK HISTORY")
+    print("=" * 80)
+    
+    print("\n[Accuracy Benchmarks]")
+    if acc_path.exists():
+        try:
+            with open(acc_path, "r") as f:
+                results = json.load(f)
+            if not results:
+                print("  No accuracy results found.")
+            else:
+                for r in results:
+                    print(f"  {r.get('model_id')} — {r.get('benchmark')}: {r.get('accuracy', 0)*100:.1f}%")
+        except Exception as e:
+            print(f"  Error reading accuracy results: {e}")
+    else:
+        print("  No accuracy results found.")
+        
+    print("\n[Throughput Benchmarks]")
+    if tp_path.exists():
+        try:
+            with open(tp_path, "r") as f:
+                lines = f.readlines()
+            if not lines:
+                print("  No throughput results found.")
+            else:
+                for line in lines:
+                    if not line.strip(): continue
+                    r = json.loads(line)
+                    print(f"  {r.get('timestamp', '')[:10]} - {r.get('model_id')}:")
+                    for single in r.get('results', []):
+                        if single.get('test_type') == 'single':
+                            print(f"    PP={single.get('pp')} | TG={single.get('tg')} -> {single.get('gen_tps', 0):.1f} tok/s")
+        except Exception as e:
+            print(f"  Error reading throughput results: {e}")
+    else:
+        print("  No throughput results found.")
+    return 0
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="omlx: Production-ready LLM server for Apple Silicon",
@@ -1029,6 +1079,12 @@ Example directory structure:
         help="What to diagnose. 'menubar' checks Tahoe ControlCenter visibility.",
     )
 
+    bench_history_parser = subparsers.add_parser(
+        "bench-history",
+        help="View local benchmark history",
+        description="View locally saved accuracy and throughput benchmarks.",
+    )
+
     # Use parse_known_args so `omlx launch <tool> -- ...` can forward unknown
     # tokens (e.g. `-r`, `--resume <id>`) to the underlying tool binary.
     # Non-launch commands keep the previous strictness by rejecting unknowns.
@@ -1045,6 +1101,8 @@ Example directory structure:
             sys.exit(lifecycle_command(args))
         elif args.command == "diagnose":
             sys.exit(diagnose_command(args))
+        elif args.command == "bench-history":
+            sys.exit(bench_history_command(args))
         else:
             parser.print_help()
             sys.exit(1)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -641,3 +641,69 @@ class TestSanitizeUploadError:
         from omlx.admin.benchmark import _sanitize_upload_error
         resp = self._resp(status=503, text="")
         assert _sanitize_upload_error(resp) == "HTTP 503"
+
+
+# =============================================================================
+# Throughput history persistence tests
+# =============================================================================
+
+
+class TestThroughputHistory:
+    """Persisted throughput history must survive restarts and tolerate a
+    partially-written log, since the file is appended to live during runs."""
+
+    def _settings(self, tmp_path):
+        s = MagicMock()
+        s.base_path = tmp_path
+        return s
+
+    def test_empty_when_no_file(self, tmp_path):
+        from omlx.admin.benchmark import get_throughput_history
+
+        with patch("omlx.settings.get_settings", return_value=self._settings(tmp_path)):
+            assert get_throughput_history() == []
+
+    def test_append_then_read_newest_first(self, tmp_path):
+        from omlx.admin.benchmark import (
+            _append_throughput_run,
+            get_throughput_history,
+        )
+
+        with patch("omlx.settings.get_settings", return_value=self._settings(tmp_path)):
+            _append_throughput_run({"timestamp": "2026-06-15T10:00:00Z", "model_id": "m1"})
+            _append_throughput_run({"timestamp": "2026-06-15T11:00:00Z", "model_id": "m2"})
+            hist = get_throughput_history()
+
+        assert [r["model_id"] for r in hist] == ["m2", "m1"]
+
+    def test_corrupt_line_is_skipped(self, tmp_path):
+        from omlx.admin.benchmark import (
+            _append_throughput_run,
+            _throughput_history_path,
+            get_throughput_history,
+        )
+
+        with patch("omlx.settings.get_settings", return_value=self._settings(tmp_path)):
+            _append_throughput_run({"timestamp": "2026-06-15T10:00:00Z", "model_id": "m1"})
+            with open(_throughput_history_path(), "a") as f:
+                f.write("{ not valid json\n")
+            _append_throughput_run({"timestamp": "2026-06-15T12:00:00Z", "model_id": "m3"})
+            hist = get_throughput_history()
+
+        # The corrupt middle line must not break the read of the valid runs.
+        assert {r["model_id"] for r in hist} == {"m1", "m3"}
+
+    def test_reset_clears_and_is_idempotent(self, tmp_path):
+        from omlx.admin.benchmark import (
+            _append_throughput_run,
+            get_throughput_history,
+            reset_throughput_history,
+        )
+
+        with patch("omlx.settings.get_settings", return_value=self._settings(tmp_path)):
+            _append_throughput_run({"timestamp": "2026-06-15T10:00:00Z", "model_id": "m1"})
+            reset_throughput_history()
+            assert get_throughput_history() == []
+            # Resetting again with no file must not raise.
+            reset_throughput_history()
+            assert get_throughput_history() == []


### PR DESCRIPTION
## Motivation

Benchmark results were ephemeral:

- **Accuracy** results lived in an in-memory `_accumulated_results` list.
- **Throughput** results were attached to `BenchmarkRun` objects in a dict truncated to the last 10 runs to bound memory.

Restarting the server permanently lost all benchmark history.

## Changes

### 1. Persist results to disk (under the configured oMLX base path, `~/.omlx` by default)

- **Accuracy** → `bench_results_accuracy.json`. Saved on each completed benchmark and on reset. `get_accumulated_results()` loads from disk, so the existing admin results endpoint — and the existing GUI pane — retains history across restarts with no frontend changes. On-disk history is loaded before each append so a save **merges** with prior runs rather than clobbering them (important when a run completes after a restart before the GUI has polled).
- **Throughput** → `bench_results_throughput.jsonl`. One JSON line appended per completed run. Append-only, so there is no in-memory accumulation to clobber.

### 2. `omlx bench-history` CLI command

Prints accumulated accuracy and throughput results from the terminal.

### 3. Throughput history viewer in the admin GUI

The throughput results had no GUI surface (unlike accuracy). Added one:

- New `GET /api/bench/throughput/results` (+ `/reset`) endpoint, mirroring the accuracy results API. Declared before the `/api/bench/{bench_id}/...` routes so the literal `throughput` segment is not captured as a `bench_id`.
- A **Benchmark History** pane in the throughput bench tab: collapsible per-run cards (model, timestamp, total time) that expand into full single + batch metric tables, with a clear-history control. Loads on tab open and refreshes after each run completes.

All file I/O is wrapped in try/except and logs on failure, so persistence can never break a benchmark run. The history read tolerates a partially-written/corrupt JSONL line (skips it rather than failing the whole read), since the log is appended to live during runs.

## Files

- `omlx/admin/accuracy_benchmark.py` — load/save helpers; save on completion + reset; load-before-append merge.
- `omlx/admin/benchmark.py` — reusable throughput persistence helpers (`_append_throughput_run` / `get_throughput_history` / `reset_throughput_history`); append each completed run.
- `omlx/admin/routes.py` — throughput history results + reset endpoints.
- `omlx/admin/static/js/dashboard.js` — `loadBenchHistory` / `resetBenchHistory` + per-run single/batch splitters.
- `omlx/admin/templates/dashboard/_bench.html` — collapsible throughput history pane.
- `omlx/cli.py` — `bench-history` subcommand + handler.
- `tests/test_benchmark.py` — coverage for append/newest-first ordering, corrupt-line tolerance, and idempotent reset.

## Testing

- **Unit:** `tests/test_benchmark.py` — full suite (49 tests) passes, including new `TestThroughputHistory` coverage.
- **API:** Both throughput endpoints verified end-to-end through the FastAPI app (correct response shape, reset, and route ordering vs. the `{bench_id}` catch-all).
- **GUI:** Verified live in a browser against a running `omlx serve` — the throughput history pane renders persisted runs, expands into the correct single/batch metric tables, and clears on reset.
- **Persistence (from the original commit):** Verified against a live server with `mlx-community/Qwen2.5-0.5B-Instruct-4bit` — ran throughput + accuracy benchmarks, **restarted the server**, ran a second accuracy benchmark before polling, and confirmed the pre-restart result survived and the new one was appended (no clobber); confirmed `reset` clears history.
