### PR TITLE
Detect NeMo ASR models as STT

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -387,6 +387,47 @@ def _has_sentence_transformers_embedding_pipeline(model_path: Path) -> bool:
     )
 
 
+def _looks_like_nemo_asr_config(config: dict) -> bool:
+    """Return True for NeMo ASR exports that omit HF ``model_type``.
+
+    NVIDIA Parakeet TDT/CTC MLX conversions keep the original NeMo ASR
+    training config instead of a HuggingFace-style ``model_type`` or
+    ``architectures`` field.  mlx-audio can load these models by name, but
+    oMLX must still classify them as STT during discovery or they fall through
+    to the LLM engine and fail with a misleading ``'model_type'`` error.
+
+    Only top-level NeMo ASR module targets are considered so multimodal models
+    with nested ``audio_config`` sections are not misclassified.
+    """
+    if not isinstance(config, dict):
+        return False
+
+    module_targets: list[str] = []
+    for key in ("preprocessor", "encoder", "decoder", "joint"):
+        value = config.get(key)
+        if isinstance(value, dict):
+            target = value.get("_target_")
+            if isinstance(target, str):
+                module_targets.append(target.lower())
+
+    if not any("nemo.collections.asr" in target for target in module_targets):
+        return False
+
+    # NeMo ASR configs include an audio preprocessor plus tokenizer/decoder
+    # metadata.  Requiring these keeps the heuristic narrow while covering
+    # Parakeet TDT exports whose config has no model_type at all.
+    preprocessor = config.get("preprocessor")
+    has_audio_preprocessor = isinstance(preprocessor, dict) and (
+        "audio" in str(preprocessor.get("_target_", "")).lower()
+        or "melspectrogram" in str(preprocessor.get("_target_", "")).lower()
+    )
+    has_asr_head = isinstance(config.get("decoder"), dict) or isinstance(
+        config.get("joint"), dict
+    )
+    has_tokenizer = isinstance(config.get("tokenizer"), dict)
+    return has_audio_preprocessor and has_asr_head and has_tokenizer
+
+
 def _has_vision_subconfig(config: dict) -> bool:
     """
     Return True if ``config`` carries evidence of a vision sub-config.
@@ -555,6 +596,12 @@ def detect_model_type(model_path: Path) -> ModelType:
     for arch in architectures:
         if arch in AUDIO_STT_ARCHITECTURES:
             return "audio_stt"
+
+    # NeMo ASR exports such as mlx-community/parakeet-tdt-0.6b-v3 ship a
+    # NeMo training config without HF model_type/architectures.  They are
+    # still STT models and mlx-audio can load them by directory/repo name.
+    if _looks_like_nemo_asr_config(config):
+        return "audio_stt"
     for arch in architectures:
         if arch in AUDIO_TTS_ARCHITECTURES:
             return "audio_tts"

--- a/tests/test_audio_discovery.py
+++ b/tests/test_audio_discovery.py
@@ -11,18 +11,14 @@ All tests run without mlx-audio installed — only config.json parsing is tested
 import json
 from pathlib import Path
 
-import pytest
-
 from omlx.model_discovery import (
-    DiscoveredModel,
+    AUDIO_STS_ARCHITECTURES,
+    AUDIO_STS_MODEL_TYPES,
     _is_unsupported_model,
     detect_model_type,
     discover_models,
     estimate_model_size,
-    AUDIO_STS_MODEL_TYPES,
-    AUDIO_STS_ARCHITECTURES,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -66,6 +62,34 @@ class TestDetectAudioModelType:
             "architectures": ["Qwen3ASRForConditionalGeneration"],
         })
         assert detect_model_type(tmp_path) == "audio_stt"
+
+    def test_nemo_asr_config_without_model_type_returns_audio_stt(self, tmp_path):
+        """Parakeet/NeMo ASR MLX exports omit HF model_type but are STT."""
+        _write_config(tmp_path, {
+            "sample_rate": 16000,
+            "preprocessor": {
+                "_target_": "nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor",
+                "features": 128,
+            },
+            "encoder": {"_target_": "nemo.collections.asr.modules.ConformerEncoder"},
+            "decoder": {"_target_": "nemo.collections.asr.modules.RNNTDecoder"},
+            "joint": {"_target_": "nemo.collections.asr.modules.RNNTJoint"},
+            "tokenizer": {"model_path": "nemo:tokenizer.model"},
+        })
+        assert detect_model_type(tmp_path) == "audio_stt"
+
+    def test_nemo_asr_config_without_tokenizer_defaults_to_llm(self, tmp_path):
+        """Partial NeMo-like configs should not be classified as STT."""
+        _write_config(tmp_path, {
+            "sample_rate": 16000,
+            "preprocessor": {
+                "_target_": "nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor",
+                "features": 128,
+            },
+            "encoder": {"_target_": "nemo.collections.asr.modules.ConformerEncoder"},
+            "decoder": {"_target_": "nemo.collections.asr.modules.RNNTDecoder"},
+        })
+        assert detect_model_type(tmp_path) == "llm"
 
     def test_whisper_model_type_returns_audio_stt(self, tmp_path):
         """model_type="whisper" without known STT architecture -> audio_stt."""
@@ -259,6 +283,25 @@ class TestDiscoverModelsIncludesAudio:
         models = discover_models(tmp_path)
         assert "whisper-small" in models
         assert models["whisper-small"].engine_type in ("stt", "audio_stt")
+
+    def test_discover_nemo_asr_model_without_model_type(self, tmp_path):
+        """Parakeet-style NeMo ASR config is discovered as audio_stt."""
+        stt_dir = tmp_path / "parakeet-tdt-0.6b-v3"
+        _make_model(stt_dir, {
+            "sample_rate": 16000,
+            "preprocessor": {
+                "_target_": "nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor",
+                "features": 128,
+            },
+            "encoder": {"_target_": "nemo.collections.asr.modules.ConformerEncoder"},
+            "decoder": {"_target_": "nemo.collections.asr.modules.RNNTDecoder"},
+            "joint": {"_target_": "nemo.collections.asr.modules.RNNTJoint"},
+            "tokenizer": {"model_path": "nemo:tokenizer.model"},
+        })
+
+        models = discover_models(tmp_path)
+        assert models["parakeet-tdt-0.6b-v3"].model_type == "audio_stt"
+        assert models["parakeet-tdt-0.6b-v3"].engine_type == "audio_stt"
 
     def test_discover_tts_model(self, tmp_path):
         """TTS model included in discover_models results."""


### PR DESCRIPTION
## Summary
- detect NeMo ASR model configs as speech-to-text engines
- add coverage for mlx-community/parakeet-tdt-0.6b-v3-style configs

## Tests
- uv run --python 3.13 pytest tests/test_audio_discovery.py -v