### PR TITLE
✨ feature: Add support for Thaw menu bar manager

### DIFF
--- a/apps/omlx-mac/Sources/Menubar/MenubarVisibilityWatcher.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarVisibilityWatcher.swift
@@ -537,7 +537,8 @@ final class MenubarVisibilityWatcher {
         let bundleIDs = [
             "com.surteesstudios.Bartender",
             "com.jordanbaird.Ice",
-            "com.jordanbaird.ice"
+            "com.jordanbaird.ice",
+            "com.stonerl.Thaw"
         ]
         return bundleIDs.contains { bundleID in
             !NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).isEmpty


### PR DESCRIPTION
This change adds Thaw to the list of known menu bar managers in order to skip the menu bar auto-fix notification from appearing each time you start the application.

Issue: https://github.com/jundot/omlx/issues/1741