### PR TITLE
fix: force gemma4_unified detection as VLM

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -532,8 +532,15 @@ def detect_model_type(model_path: Path) -> ModelType:
 
     # Check for VLM: model_type field (only if vision capabilities are present)
     # Some model families (e.g., qwen3_5_moe) have both VLM and text-only variants.
-    # Text-only quants won't carry a vision sub-config.
+    # Text-only quants won't carry a vision sub-config. gemma4_unified is an
+    # exception: it is always VLM (unified audio+vision architecture) regardless
+    # of vision_config presence in config.json.
     if normalized_type in VLM_MODEL_TYPES:
+        if normalized_type == "gemma4_unified":
+            logger.info(
+                "gemma4_unified detected as VLM (unified models always include vision)"
+            )
+            return "vlm"
         if _has_vision_subconfig(config):
             return "vlm"
         logger.info(

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -282,14 +282,14 @@ class TestDetectModelType:
         (tmp_path / "config.json").write_text(json.dumps(config))
         assert detect_model_type(tmp_path) == "llm"
 
-    def test_detect_text_only_gemma4_unified_as_llm(self, tmp_path):
-        """Gemma4 unified without vision_config should not be forced to VLM."""
+    def test_detect_gemma4_unified_without_vision_config_as_vlm(self, tmp_path):
+        """Gemma4 unified is always VLM even without vision_config."""
         config = {
             "model_type": "gemma4_unified",
             "architectures": ["Gemma4UnifiedForConditionalGeneration"],
         }
         (tmp_path / "config.json").write_text(json.dumps(config))
-        assert detect_model_type(tmp_path) == "llm"
+        assert detect_model_type(tmp_path) == "vlm"
 
     def test_detect_vlm_qwen3_5_moe(self, tmp_path):
         """Test detection of Qwen3.5 MoE as VLM."""


### PR DESCRIPTION
## Summary

Forces `gemma4_unified` detection as VLM in model discovery.

### Problem
`gemma4_unified` models were detected as LLM when their `config.json` lacked `vision_config` (e.g., some quantized variants). Since unified models always include vision+audio capabilities by definition, they should never fall back to LLM.

### Changes

**`omlx/model_discovery.py`** — Force `gemma4_unified` → VLM detection regardless of `vision_config` presence.

**`tests/test_model_discovery.py`** — Updated `test_detect_text_only_gemma4_unified_as_llm` → `test_detect_gemma4_unified_without_vision_config_as_vlm` since `gemma4_unified` is always VLM.

### Notes
- The feature extractor mapping in `vlm.py` is **not changed** — `Gemma4UnifiedAudioFeatureExtractor` correctly resolves to `mlx_vlm.models.gemma4_unified.processing_gemma4_unified.Gemma4UnifiedAudioFeatureExtractor` in the pinned mlx-vlm (commit `54c9a11`). That class differs from `Gemma4AudioFeatureExtractor` (which produces mel spectrograms) — the unified extractor outputs raw waveform chunks with `audio_samples_per_token=640`.
- `gemma4_unified` is an architecture type (not a size label). Currently only the 12B uses it; future models with the same unified audio+vision architecture would also use this type.
- All 125 model discovery tests pass.