### PR TITLE
fix: normalise logits_processors None to [] to avoid mlx-lm crash (#934)

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -385,6 +385,13 @@ def _patched_generation_batch_step(self):
         deltas = [model._uid_rope_deltas.get(uid, 0.0) for uid in self.uids]
         model.set_batch_rope_deltas(mx.array(deltas))
 
+    # Defensive: mlx-lm's GenerationBatch._step does `any(self.logits_processors)`
+    # and `for p in self.logits_processors[e]`, both of which crash when
+    # logits_processors is None.  Normalise to [] so the original code path
+    # works without modification.  See #934.
+    if self.logits_processors is None:
+        self.logits_processors = []
+
     result = _original_generation_batch_step(self)
 
     # self._next_tokens contains the just-sampled tokens (async eval pending).
@@ -571,7 +578,9 @@ def _patched_ppb_split(self, indices):
         new_batch.prefill_step_size = self.prefill_step_size
         new_batch.samplers = self.samplers
         new_batch.fallback_sampler = self.fallback_sampler
-        new_batch.logits_processors = self.logits_processors
+        # Defensive: normalise None → [] to avoid mlx-lm crash in _step
+        lps = self.logits_processors if self.logits_processors is not None else []
+        new_batch.logits_processors = lps
         new_batch.state_machines = self.state_machines
         new_batch.max_tokens = self.max_tokens
 
@@ -2030,7 +2039,7 @@ class Scheduler:
             max_tokens=sampling_params.max_tokens,
             stop_tokens=stop_tokens_seq,
             sampler=sampler,
-            logits_processors=logits_processors if logits_processors else None,
+            logits_processors=logits_processors if logits_processors else [],
             prefill_batch_size=1,
             completion_batch_size=self.config.completion_batch_size,
             prefill_step_size=self.config.prefill_step_size,


### PR DESCRIPTION
## Reproduction

- Install the [forgecode](https://forgecode.dev) harness
- Set up the `OpenAICompatible` provider to point at a local oMLX endpoint
- I don't know if this is model-dependent, but I was using https://huggingface.co/deepsweet/Qwen3.6-35B-A3B-MLX-VL-oQ8-FP16
- Send any prompt (I just started with "hi")
- Error output: 
```
 ERROR: POST http://127.0.0.1:8000/v1/chat/completions                                                                        
                                                                                                                                          
 Caused by:                                                                                                                               
     0: Failed to create completion message: {"error": {"message": "Cache corruption not recoverable after retries: 'NoneType' object is  
 not iterable", "type": "server_error"}}                                                                                                  
     1: {"message":"Cache corruption not recoverable after retries: 'NoneType' object is not iterable","type":"server_error"}             
```

- The "Cache corruption" error message seems to be spurious, I cleared the in-memory and ssd caches and it didn't resolve.

## Diagnosis

When `logits_processors` is `None` (no repetition/presence/frequency penalties configured), mlx-lm's `GenerationBatch._step` crashes with:

    TypeError: 'NoneType' object is not iterable

This is caught by omlx's cache corruption recovery, but since the root cause persists, requests fail after 3 retries with:

    Cache corruption not recoverable after retries: 'NoneType' object is not iterable

## Fix

Three layers of defense to normalise `None` → `[]`:

1. **`_create_batch_generator`** — pass `[]` instead of `None` to `BatchGenerator` constructor
2. **`_patched_generation_batch_step`** — normalise `None` → `[]` before calling mlx-lm's `_step` (which crashes at `any(None)`)
3. **`_patched_ppb_split`** — normalise `None` → `[]` when splitting batches

Consistent with the existing fix at line 6528 where `per_row_lps = list(logits_processors) if logits_processors else []` was already applied.
