### PR TITLE
fix(server): log a fingerprint of rejected API keys instead of the raw key

### DIFF
--- a/omlx/admin/auth.py
+++ b/omlx/admin/auth.py
@@ -5,6 +5,7 @@ This module provides session-based authentication using signed tokens
 and API key verification for admin panel access.
 """
 
+import hashlib
 import os
 import secrets
 from typing import Optional
@@ -132,6 +133,25 @@ def compare_keys(provided_key: str, expected_key: str) -> bool:
         provided_key.encode("utf-8", "surrogatepass"),
         expected_key.encode("utf-8", "surrogatepass"),
     )
+
+
+def fingerprint_key(api_key: str) -> str:
+    """Return a short, non-reversible fingerprint of an API key for logging.
+
+    Logging a rejected key verbatim leaks the client's secret into the server
+    log. A truncated SHA-256 digest lets operators correlate repeated
+    rejections of the same key without exposing the key itself. surrogatepass
+    matches compare_keys() so any str the auth path accepts can be
+    fingerprinted, including lone surrogates from json escape sequences.
+
+    Args:
+        api_key: The (untrusted) key to fingerprint. Empty string is allowed.
+
+    Returns:
+        The first 8 hex characters of the SHA-256 digest of the UTF-8 bytes.
+    """
+    digest = hashlib.sha256(api_key.encode("utf-8", "surrogatepass")).hexdigest()
+    return digest[:8]
 
 
 def verify_api_key(api_key: str, server_api_key: str) -> bool:

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -284,7 +284,7 @@ async def verify_api_key(
     Checks the provided Bearer token against the main API key and all sub keys.
     Also accepts the x-api-key header as a fallback (Anthropic SDK compatibility).
     """
-    from .admin.auth import verify_any_api_key
+    from .admin.auth import fingerprint_key, verify_any_api_key
 
     # No auth required if no API key is configured
     if _server_state.api_key is None:
@@ -313,7 +313,7 @@ async def verify_api_key(
         else []
     )
     if not verify_any_api_key(api_key_value, _server_state.api_key, sub_keys):
-        logger.warning("Rejected API key: %r", api_key_value)
+        logger.warning("Rejected API key (fp=%s)", fingerprint_key(api_key_value))
         raise HTTPException(status_code=401, detail="Invalid API key")
 
     return True

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -453,3 +453,92 @@ class TestNonAsciiApiKeys:
             assert exc_info.value.status_code == 401
         finally:
             _server_state.api_key = original_key
+
+
+class TestRejectedKeyFingerprint:
+    """Regression tests for #1440 (item 4): a rejected API key must never be
+    logged verbatim. The auth path logs a short, non-reversible SHA-256
+    fingerprint instead, so operators can correlate repeated bad keys without
+    the secret landing in server.log.
+    """
+
+    def test_fingerprint_key_short_hex(self):
+        """fingerprint_key returns 8 lowercase hex characters."""
+        from omlx.admin.auth import fingerprint_key
+
+        fp = fingerprint_key("super-secret-key")
+        assert len(fp) == 8
+        assert all(c in "0123456789abcdef" for c in fp)
+
+    def test_fingerprint_key_deterministic(self):
+        """The same key always fingerprints to the same value."""
+        from omlx.admin.auth import fingerprint_key
+
+        assert fingerprint_key("abc123") == fingerprint_key("abc123")
+
+    def test_fingerprint_key_does_not_contain_secret(self):
+        """The fingerprint never leaks the raw key material."""
+        from omlx.admin.auth import fingerprint_key
+
+        secret = "sk-live-0123456789abcdef"
+        fp = fingerprint_key(secret)
+        assert secret not in fp
+        assert fp not in secret
+
+    def test_fingerprint_key_distinguishes_keys(self):
+        """Different keys produce different fingerprints."""
+        from omlx.admin.auth import fingerprint_key
+
+        assert fingerprint_key("key-a") != fingerprint_key("key-b")
+
+    def test_fingerprint_key_non_ascii_and_surrogate(self):
+        """fingerprint_key tolerates any str the auth path accepts (no raise).
+
+        Mirrors compare_keys: non-ASCII and lone surrogates (which json.loads
+        can produce) must fingerprint without a UnicodeEncodeError.
+        """
+        import json
+
+        from omlx.admin.auth import fingerprint_key
+
+        assert len(fingerprint_key("clé-secrète-héhé")) == 8
+        assert len(fingerprint_key("")) == 8
+        surrogate_key = json.loads('"\\ud800abcd"')
+        assert len(fingerprint_key(surrogate_key)) == 8
+
+    def test_rejected_key_logged_as_fingerprint_not_verbatim(self, caplog):
+        """The auth dependency logs the fingerprint, not the raw rejected key."""
+        import asyncio
+        import logging
+
+        from fastapi import HTTPException
+        from fastapi.security import HTTPAuthorizationCredentials
+
+        from omlx.admin.auth import fingerprint_key
+        from omlx.server import verify_api_key, _server_state
+
+        original_key = _server_state.api_key
+        _server_state.api_key = "correct-key"
+        bad_key = "sk-leaky-supersecret-0xCAFE"
+
+        try:
+            credentials = HTTPAuthorizationCredentials(
+                scheme="Bearer", credentials=bad_key
+            )
+            with caplog.at_level(logging.WARNING, logger="omlx.server"):
+                with pytest.raises(HTTPException) as exc_info:
+                    asyncio.run(
+                        verify_api_key(request=_mock_request(), credentials=credentials)
+                    )
+            assert exc_info.value.status_code == 401
+
+            rejection_logs = "\n".join(
+                r.getMessage()
+                for r in caplog.records
+                if "Rejected API key" in r.getMessage()
+            )
+            assert rejection_logs, "expected a rejection log line"
+            assert bad_key not in rejection_logs
+            assert fingerprint_key(bad_key) in rejection_logs
+        finally:
+            _server_state.api_key = original_key


### PR DESCRIPTION
Addresses item 4 of #1440 (the rejected-key logging item).

## Problem

When a request fails API key auth, `server.py` logs the rejected key verbatim at WARNING:

```python
logger.warning("Rejected API key: %r", api_key_value)
```

That writes the client's secret into `server.log` on every failed auth, at an always-on level. A user who mistypes a key, or whose key carries the non-ASCII problem fixed in #1719, leaks their credential straight into the logs.

## Fix

Log a short, non-reversible fingerprint instead of the raw value: the first 8 hex characters of the SHA-256 of the key. Operators can still correlate repeated rejections of the same key (a misconfigured client hammering the endpoint shows one stable `fp=`) without the secret ever landing in the log.

Added `fingerprint_key` to `omlx/admin/auth.py`, next to `compare_keys`, using the same `encode("utf-8", "surrogatepass")`. That keeps it tolerant of any `str` the auth path accepts, including the non-ASCII and lone-surrogate keys that #1719 already handles.

## Testing

- 6 new tests in `tests/test_api_auth.py`: fingerprint format (8 hex chars), determinism, that the fingerprint does not contain the raw secret, that distinct keys differ, that non-ASCII / empty / lone-surrogate inputs do not raise, and an end-to-end check that the auth dependency logs the fingerprint and not the raw rejected key (via `caplog`).
- Full suite: 5347 passed, 22 skipped, 66 deselected, 0 failed.
- Live test: started a server with `OMLX_API_KEY` set, sent a wrong `Bearer` key to `/v1/models`, and confirmed the server log shows `Rejected API key (fp=...)`, does not contain the raw key, and that the logged fingerprint matches `fingerprint_key` of the key I sent. A correct key returned 200.

## Scope note

This is a logging-only change; auth behavior is unchanged (a bad key still gets a 401). The other items in #1440 are design questions (open setup when no key is configured, the key being readable in the frontend, the session cookie's `Secure` flag), so I left those alone. Happy to take any of them as separate follow-ups if you confirm the intended behavior.