### PR TITLE
fix: macOS 27 beta HOST_VM_INFO64 compatibility

### DIFF
--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -31,6 +31,7 @@ import asyncio
 import ctypes
 import ctypes.util
 import logging
+import struct
 import subprocess
 import sys
 import time
@@ -163,19 +164,24 @@ def get_macos_vm_stats() -> dict[str, int] | None:
     if _libc is None or _MACH_HOST is None:
         return None
     try:
-        stats = _VMStats64()
-        count = ctypes.c_uint(ctypes.sizeof(_VMStats64) // 4)
+        # Use a generous buffer (512 ints = 2048 bytes) so the kernel
+        # can write whatever vm_statistics64_data_t layout it has.
+        # Only read the first 4 fields (free / active / inactive / wired)
+        # which are uint32 at fixed offsets in every macOS version.
+        count = ctypes.c_uint(512)
+        buf = (ctypes.c_uint8 * 2048)()
         rc = _libc.host_statistics64(
-            _MACH_HOST, _HOST_VM_INFO64, ctypes.byref(stats), ctypes.byref(count)
+            _MACH_HOST, _HOST_VM_INFO64, ctypes.byref(buf), ctypes.byref(count)
         )
         if rc != 0:
             return None
+        raw = bytes(buf)
         ps = _VM_PAGE_SIZE
         return {
-            "free": stats.free_count * ps,
-            "active": stats.active_count * ps,
-            "inactive": stats.inactive_count * ps,
-            "wired": stats.wire_count * ps,
+            "free": struct.unpack_from("<I", raw, 0)[0] * ps,
+            "active": struct.unpack_from("<I", raw, 4)[0] * ps,
+            "inactive": struct.unpack_from("<I", raw, 8)[0] * ps,
+            "wired": struct.unpack_from("<I", raw, 12)[0] * ps,
         }
     except Exception:  # noqa: BLE001
         return None

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -56,7 +56,7 @@ def get_system_memory() -> int:
         import psutil
 
         return psutil.virtual_memory().total
-    except ImportError:
+    except Exception:
         pass
 
     # Fallback for Unix systems

--- a/omlx/utils/hardware.py
+++ b/omlx/utils/hardware.py
@@ -149,7 +149,7 @@ def get_max_working_set_bytes() -> int:
 
         total_ram = psutil.virtual_memory().total
         return int(total_ram * 0.75)
-    except ImportError:
+    except Exception:
         pass
 
     # Last resort: default


### PR DESCRIPTION
## Summary

On macOS 27 beta, the `host_statistics64(HOST_VM_INFO64)` syscall begins returning `MIG_ARRAY_TOO_LARGE` (-307) after a few calls, breaking the health check, admin stats endpoints, and process memory enforcer.

The kernel reports a larger expected count for `vm_statistics64_data_t` than the current hardcoded `_VMStats64` ctypes struct provides.

## Changes

**`omlx/process_memory_enforcer.py`** — Replace the hardcoded struct with a generously-sized raw byte buffer. Since `get_macos_vm_stats()` only reads the first 4 fields (free, active, inactive, wired at fixed uint32 offsets), this works on any macOS version without version detection.

**`omlx/settings.py`** — Widen `except ImportError` to `except Exception` in `get_system_memory()` so psutil `RuntimeError`s from the same `host_statistics64` issue fall through to the `sysconf` fallback.

**`omlx/utils/hardware.py`** — Same change in `get_max_working_set_bytes()` for its psutil fallback path.

## Testing

- 101/101 `test_process_memory_enforcer.py` tests pass (previously 26 failures on macOS 27)
- Manual verification: `get_macos_vm_stats()` succeeds across 20+ iterations spanning the kernel mode switch
- `get_system_memory()` and `get_max_working_set_bytes()` both return correct values via sysconf fallback

Closes #1749