### PR TITLE
engine/dflash: expose scheduler property for ProcessMemoryEnforcer

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -1202,6 +1202,18 @@ class DFlashEngine(BaseEngine):
         ):
             yield output
 
+    def scheduler(self):
+        """The scheduler of the fallback engine, or None when running in
+        speculative-decoding mode (no fallback engine instantiated yet).
+
+        DFlash bypasses the oMLX scheduler in normal speculative-decoding
+        mode; when it falls back to BatchedEngine/VLMBatchedEngine the fallback
+        engine's scheduler is the one that needs memory-limit propagation.
+        """
+        if self._fallback_engine is not None:
+            return getattr(self._fallback_engine, "scheduler", None)
+        return None
+
     def has_active_requests(self) -> bool:
         if self._fallback_engine is not None and self._fallback_engine.has_active_requests():
             return True


### PR DESCRIPTION
## Summary

`DFlashEngine` now exposes a `scheduler` property so that `ProcessMemoryEnforcer._resolve_scheduler()` and `EnginePool._resolve_scheduler_from_engine()` can find the fallback engine's scheduler without traversing a non-existent wrapper chain.

## Problem

`ProcessMemoryEnforcer` emits a loud once-per-lifetime warning on startup:



Both `_resolve_scheduler` and `_resolve_scheduler_from_engine` try `engine.scheduler` first, then fall back to `engine._engine.engine.scheduler`. `DFlashEngine` has neither — in normal speculative-decoding mode it bypasses the scheduler entirely, and its fallback engine's scheduler lives at `engine._fallback_engine.scheduler`.

## Fix



When DFlash is in normal mode, `scheduler` returns `None` — correct, since DFlash bypasses the scheduler and has no meaningful memory-limit to propagate. When fallback mode is entered, `scheduler` returns the BatchedEngine's scheduler, allowing memory-limit propagation to work correctly.

## Testing

Restart omlx with a DFlash-enabled model (e.g. `Qwen3.6-35B-A3B-DFlash`) and confirm no `ProcessMemoryEnforcer` warning appears.

## Notes

- The warning is still emitted once for any other engine type that genuinely breaks the wrapper chain — the once-per-type suppression is unchanged.
- Related: `#1627` ("Fixed engine close fallback paths so SSD cache managers are still released when shutdown/deep reset raises") in v0.4.2 addressed DFlash lifecycle stability issues.