### PR TITLE
fix: keep MTP decode eligibility per model instance

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -210,6 +210,24 @@ def _model_has_mtp_module(model: Any) -> bool:
     return hasattr(inner, "mtp") and getattr(inner, "mtp", None) is not None
 
 
+def _model_mtp_decode_enabled(model: Any) -> bool:
+    """Return the per-instance MTP decode flag captured at model load time.
+
+    ``mlx_lm_mtp._MTP_ACTIVE`` is a construction-time global: it is toggled
+    before each model load so patched model ``__init__`` methods know whether
+    to attach MTP heads. It must not be used as a decode-time eligibility
+    check because loading a later non-MTP model resets the global to False and
+    would disable MTP for already-loaded MTP models. Persist the decision on
+    the model instance instead and read it here.
+    """
+    candidates = [model]
+    for attr in ("language_model", "_language_model"):
+        inner = getattr(model, attr, None)
+        if inner is not None and inner is not model:
+            candidates.append(inner)
+    return any(bool(getattr(obj, "_omlx_mtp_decode_enabled", False)) for obj in candidates)
+
+
 def _batch_generator_allows_mtp_activation(batch_gen: Any) -> bool:
     """True when lazy MTP activation cannot race with a pending batch merge."""
     try:
@@ -229,12 +247,7 @@ def _mtp_common_eligible(gen_batch: Any) -> bool:
         return False
     if not _model_has_mtp_module(gen_batch.model):
         return False
-    try:
-        from . import is_mtp_active
-
-        if not is_mtp_active():
-            return False
-    except Exception:
+    if not _model_mtp_decode_enabled(gen_batch.model):
         return False
     uids = getattr(gen_batch, "uids", None)
     if uids is None or len(uids) == 0:
@@ -287,13 +300,15 @@ def _batch_rows_aligned_for_mtp(gen_batch: Any) -> bool:
 def _is_mtp_eligible(gen_batch: Any) -> bool:
     """``__init__`` and ``next`` only engage MTP for single-sequence batches
     when the model exposes ``mtp_forward``, has an attached MTP head, and
-    the process-wide ``mtp_active`` flag is on.
+    the model instance was loaded with MTP decode enabled.
 
     The MTP head may be attached unconditionally (e.g. by the mlx-vlm
     runtime patches, which need it for weight-load matching even when
     inference-time MTP is off) — so head presence alone is not enough
-    to decide whether to run the draft/verify cycle. ``is_mtp_active``
-    reflects the per-load ``model_settings.mtp_enabled`` choice.
+    to decide whether to run the draft/verify cycle. The per-instance
+    ``_omlx_mtp_decode_enabled`` marker reflects the per-load
+    ``model_settings.mtp_enabled`` choice without being affected by later
+    model loads in the same process.
     """
     if not _mtp_common_eligible(gen_batch):
         return False
@@ -336,13 +351,11 @@ def _ineligibility_reason(gen_batch: Any) -> str:
         )
     if not _model_has_mtp_module(gen_batch.model):
         return "model has no attached mtp head"
-    try:
-        from . import is_mtp_active
-
-        if not is_mtp_active():
-            return "mtp_active flag is off (model_settings.mtp_enabled was False at load time)"
-    except Exception:
-        return "is_mtp_active import failed"
+    if not _model_mtp_decode_enabled(gen_batch.model):
+        return (
+            "model instance MTP decode flag is off "
+            "(model_settings.mtp_enabled was False when this model was loaded)"
+        )
     uids = getattr(gen_batch, "uids", None)
     if uids is None:
         return "GenerationBatch has no uids"

--- a/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
+++ b/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
@@ -268,7 +268,9 @@ def _patch_model(dsv4: Any) -> None:
         # mtp_enabled=False produces a model indistinguishable from stock.
         from . import is_mtp_active
 
-        if n_mtp > 0 and is_mtp_active():
+        mtp_decode_enabled = bool(n_mtp > 0 and is_mtp_active())
+        self._omlx_mtp_decode_enabled = mtp_decode_enabled
+        if mtp_decode_enabled:
             n_main = config.num_hidden_layers
             self.mtp = [dsv4.MTPBlock(config, n_main + i) for i in range(n_mtp)]
 

--- a/omlx/patches/mlx_lm_mtp/qwen35_model.py
+++ b/omlx/patches/mlx_lm_mtp/qwen35_model.py
@@ -470,7 +470,9 @@ def _patch_text_model(q35: Any) -> None:
         # out because the inner ``language_model`` has no ``mtp``.
         from . import is_mtp_active
 
-        if n_mtp > 0 and is_mtp_active():
+        mtp_decode_enabled = bool(n_mtp > 0 and is_mtp_active())
+        self._omlx_mtp_decode_enabled = mtp_decode_enabled
+        if mtp_decode_enabled:
             self.mtp = q35.MTPModule(args)
 
     def __call__(

--- a/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py
@@ -203,19 +203,22 @@ def _patch_vlm_language_model(q35moe_lang: Any) -> None:
 
     def __init__(self, args, config=None):
         from . import is_mtp_attach_enabled
+        from ..mlx_lm_mtp import is_mtp_active
 
         original_init(self, args, config)
         # Attach MTPModule when the config declares MTP heads, so mlx-vlm's
         # load_weights (which skips Model.sanitize for is_mlx_format
         # checkpoints) can place the persisted mtp.* tensors. MTP speculative
         # decode invocation is gated downstream by
-        # ``mlx_lm_mtp.batch_generator._is_mtp_eligible`` via ``is_mtp_active``.
+        # ``mlx_lm_mtp.batch_generator._is_mtp_eligible`` via the per-instance
+        # ``_omlx_mtp_decode_enabled`` marker.
         #
         # Gated by ``is_mtp_attach_enabled()`` so checkpoints that declare
         # mtp_num_hidden_layers > 0 but ship no mtp.* weights (unsloth
         # Qwen3.6 UD MLX builds, issue #1426) don't trip strict load_weights
         # with "Missing N parameters" and silently fall back to LLM.
         n_mtp = int(getattr(args, "mtp_num_hidden_layers", 0) or 0)
+        self._omlx_mtp_decode_enabled = bool(n_mtp > 0 and is_mtp_active())
         if n_mtp > 0 and is_mtp_attach_enabled():
             self.mtp = q35moe_lang.MTPModule(args)
 

--- a/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
@@ -190,6 +190,7 @@ def _patch_vlm_language_model(q35_lang: Any) -> None:
 
     def __init__(self, args, config=None):
         from . import is_mtp_attach_enabled
+        from ..mlx_lm_mtp import is_mtp_active
 
         original_init(self, args, config)
         # Attach MTPModule when the config declares MTP heads so mlx-vlm's
@@ -197,13 +198,14 @@ def _patch_vlm_language_model(q35_lang: Any) -> None:
         # checkpoints) can place the persisted mtp.* tensors. Whether MTP
         # speculative decode is actually invoked at inference time is gated
         # downstream by ``mlx_lm_mtp.batch_generator._is_mtp_eligible``,
-        # which checks the process-wide ``is_mtp_active`` flag.
+        # which checks the per-instance ``_omlx_mtp_decode_enabled`` marker.
         #
         # Gated by ``is_mtp_attach_enabled()`` so checkpoints that declare
         # mtp_num_hidden_layers > 0 but ship no mtp.* weights (unsloth
         # Qwen3.6 UD MLX builds, issue #1426) don't fail strict load_weights
         # with "Missing N parameters" and silently downgrade to LLM.
         n_mtp = int(getattr(args, "mtp_num_hidden_layers", 0) or 0)
+        self._omlx_mtp_decode_enabled = bool(n_mtp > 0 and is_mtp_active())
         if n_mtp > 0 and is_mtp_attach_enabled():
             self.mtp = q35_lang.MTPModule(args)
 

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -42,6 +42,36 @@ class TestApplyOrchestrator:
         import omlx.patches.mlx_lm_mtp as mtp  # noqa: F401
 
 
+class TestBatchGeneratorMtpEligibility:
+    def test_decode_eligibility_uses_model_instance_flag(self):
+        """Later non-MTP model loads must not disable already-loaded MTP models.
+
+        ``set_mtp_active(False)`` is still used as a construction-time global
+        before each model load.  Decode eligibility must read the per-instance
+        marker captured during the MTP model's own load instead of the current
+        process-wide flag.
+        """
+        from omlx.patches.mlx_lm_mtp import set_mtp_active
+        from omlx.patches.mlx_lm_mtp.batch_generator import _mtp_common_eligible
+
+        model = SimpleNamespace(
+            mtp=object(),
+            mtp_forward=lambda *args, **kwargs: None,
+            _omlx_mtp_decode_enabled=True,
+        )
+        gen_batch = SimpleNamespace(
+            model=model,
+            uids=[0],
+            logits_processors=None,
+        )
+
+        set_mtp_active(False)
+        assert _mtp_common_eligible(gen_batch) is True
+
+        model._omlx_mtp_decode_enabled = False
+        assert _mtp_common_eligible(gen_batch) is False
+
+
 class TestCacheRollback:
     def test_arrays_cache_gains_rollback_slot(self):
         from omlx.patches.mlx_lm_mtp import cache_rollback


### PR DESCRIPTION
## Summary

- Capture MTP decode eligibility on the loaded model instance instead of reading the process-wide `_MTP_ACTIVE` flag at decode time.
- Keep `_MTP_ACTIVE` as the construction-time switch used by patched model initializers.
- Update Qwen, Qwen VLM/MoE VLM, and DeepSeek V4 MTP initializers to persist `_omlx_mtp_decode_enabled`.
- Add a regression test showing `set_mtp_active(False)` from a later non-MTP load does not disable an already-loaded MTP model.

Fixes #1758.

## Why

`maybe_apply_pre_load_patches()` resets `_MTP_ACTIVE` before every model load. In 0.4.2, `batch_generator._mtp_common_eligible()` checked that same process-wide flag during decode. Loading a later non-MTP model therefore disabled MTP for an already-loaded `Qwen3.6-*-mtp` model, even though the model still had its MTP head attached.

## Validation

Local targeted validation:

```text
compile_ok
eligibility_regression_check_ok
```

Command used:

```bash
PYTHONPATH=/path/to/omlx:/Applications/oMLX.app/Contents/Resources/Python/framework-mlx-base/lib/python3.11/site-packages \
/Applications/oMLX.app/Contents/Resources/Python/cpython-3.11/bin/python3.11 - <<'PY'
import py_compile
from types import SimpleNamespace
...
PY
```

I also applied the same hot patch to a local oMLX 0.4.2 app bundle and verified that loading/unloading `models--PaddlePaddle--PaddleOCR-VL-1.6` no longer disables MTP for an already-loaded `Qwen3.6-27B-oQ8-mtp`:

```text
MTP path activated for uid=1 (model has mtp_forward, batch=1)
MTP[1] finish=stop tokens=15 cycles=8 accept=6/8 (75.0%)
Chat completion: 14 tokens in 1.43s (27.3 tok/s), prompt: 21
```
