### PR TITLE
fix(memory): treat MLX fused SDPA as O(n) for all head_dim

### DIFF
--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -34,6 +34,13 @@ except ImportError:
     HAS_MLX_METAL = False
     mx = None
 
+# MLX fused SDPA (mx.fast.scaled_dot_product_attention) uses an O(n) tiled
+# kernel for all head_dim values as of MLX 0.22.  omlx 0.4.x requires
+# MLX >= 0.31, so the unfused fallback path (full attention-score matrix
+# in float32) never executes.  Set the threshold to infinity so the
+# estimator always uses the compact O(n) formula.
+_SDPA_FALLBACK_HEAD_DIM: float = float("inf")
+
 
 @dataclass
 class MemoryInfo:
@@ -483,14 +490,13 @@ class MemoryMonitor:
         eff_chunk = min(chunk_size, new_tokens)
         full_kv_len = new_tokens + max(cached_tokens, 0)
 
-        if hd > 128:
-            # Fallback: full attention matrix materialized in float32
-            # scores [B, n_q, eff_chunk, full_kv_len] + output
-            # [B, n_q, eff_chunk, hd]
+        if hd > _SDPA_FALLBACK_HEAD_DIM:
+            # Unfused fallback: full attention matrix materialized in float32.
+            # Not reached on MLX >= 0.22 (omlx 0.4.x requirement).
             attn = n_q * eff_chunk * full_kv_len * 4
             attn += n_q * eff_chunk * hd * 4  # output buffer (small)
         else:
-            # Fused kernel: tiled, only output buffer
+            # Fused kernel: tiled O(n), only output buffer allocated.
             attn = n_q * eff_chunk * hd * 4
 
         # KV growth attributable to this request: only the new tokens.
@@ -509,11 +515,11 @@ class MemoryMonitor:
         in the caller's ``current`` baseline once eval'd); it is the quantity
         the adaptive throttle must keep under the remaining headroom.
 
-        head_dim > 128: MLX SDPA fallback materializes the full attention
-        matrix [B, n_q, n_tokens, kv_len] in float32, plus a small output
-        buffer — so the transient scales with ``n_tokens * kv_len``.
-        head_dim <= 128: fused kernel is tiled / O(n), so only the output
-        buffer is allocated and throttling is effectively a no-op (correct).
+        MLX fused SDPA is tiled O(n) for all head_dim values on MLX >= 0.22,
+        so only the output buffer is allocated.  The unfused fallback
+        (full scores matrix in float32, scaling with n_tokens * kv_len) is
+        guarded by ``_SDPA_FALLBACK_HEAD_DIM`` and is not reachable with the
+        current omlx MLX dependency.
 
         Returns 0 when model info is unavailable.
         """
@@ -521,7 +527,7 @@ class MemoryMonitor:
         n_q = self._num_attention_heads or 0
         if n_q == 0 or hd == 0 or n_tokens <= 0:
             return 0
-        if hd > 128:
+        if hd > _SDPA_FALLBACK_HEAD_DIM:
             return n_q * n_tokens * max(kv_len, 0) * 4 + n_q * n_tokens * hd * 4
         return n_q * n_tokens * hd * 4
 

--- a/tests/test_memory_monitor_vlm_config.py
+++ b/tests/test_memory_monitor_vlm_config.py
@@ -316,3 +316,79 @@ class TestSetModelInfoTurboQuantDtype:
 
         assert full_dtype_peak > headroom
         assert turboquant_peak < headroom
+
+
+class TestSdpaThreshold:
+    """MLX fused SDPA supports all head_dim values on MLX >= 0.22.
+
+    ``_SDPA_FALLBACK_HEAD_DIM`` must be infinity so ``estimate_prefill_peak_bytes``
+    and ``estimate_chunk_transient_bytes`` always use the compact O(n) formula
+    and never over-estimate SDPA memory for large head_dim models like
+    Qwen3.6-VL (head_dim=256).
+    """
+
+    def test_sdpa_fallback_threshold_is_infinite(self):
+        from omlx.memory_monitor import _SDPA_FALLBACK_HEAD_DIM
+        import math
+
+        assert math.isinf(_SDPA_FALLBACK_HEAD_DIM) and _SDPA_FALLBACK_HEAD_DIM > 0, (
+            "_SDPA_FALLBACK_HEAD_DIM must be +inf so large head_dim models "
+            "(e.g. head_dim=256) always use the fused O(n) formula"
+        )
+
+    def test_estimate_prefill_uses_fused_formula_for_large_head_dim(self):
+        """head_dim=256 must NOT trigger the full attention-score matrix path."""
+        monitor = MemoryMonitor(max_kv_cache_memory=None, eviction_enabled=False)
+        monitor.set_model_info(
+            num_layers=28,
+            num_kv_heads=4,
+            num_attention_heads=28,
+            head_dim=256,
+            dtype_size=2,
+        )
+        n_q = 28
+        hd = 256
+        chunk = 512
+        new_tokens = 327872
+        full_kv_len = new_tokens
+
+        # Fused O(n) formula: only output buffer (eff_chunk = min(chunk, new_tokens))
+        eff_chunk = min(chunk, new_tokens)
+        expected_attn = n_q * eff_chunk * hd * 4
+        kv = monitor.estimate_prompt_kv_bytes(new_tokens)
+        expected_peak = expected_attn + kv
+
+        actual = monitor.estimate_prefill_peak_bytes(new_tokens, chunk, cached_tokens=0)
+        assert actual == expected_peak, (
+            f"head_dim=256 should use fused formula ({expected_peak:,} bytes), "
+            f"got {actual:,} bytes"
+        )
+        # Sanity-check: the SDPA term alone should be orders of magnitude
+        # smaller than the unfused score-matrix would have been.
+        unfused_sdpa_approx = n_q * eff_chunk * full_kv_len * 4
+        assert expected_attn < unfused_sdpa_approx // 100, (
+            "fused SDPA term should be orders of magnitude smaller than the "
+            "unfused score-matrix estimate"
+        )
+
+    def test_estimate_chunk_transient_uses_fused_formula_for_large_head_dim(self):
+        """head_dim=256 chunk transient must use the O(n) output-buffer formula."""
+        monitor = MemoryMonitor(max_kv_cache_memory=None, eviction_enabled=False)
+        monitor.set_model_info(
+            num_layers=28,
+            num_kv_heads=4,
+            num_attention_heads=28,
+            head_dim=256,
+            dtype_size=2,
+        )
+        n_q = 28
+        hd = 256
+        n_tokens = 512
+        kv_len = 327872
+
+        expected = n_q * n_tokens * hd * 4
+        actual = monitor.estimate_chunk_transient_bytes(n_tokens, kv_len)
+        assert actual == expected, (
+            f"head_dim=256 chunk transient should be {expected:,} bytes "
+            f"(output buffer only), got {actual:,} bytes"
+        )


### PR DESCRIPTION
## Problem

After #1448 fixed VLM nested-config walking, the stale `hd > 128` threshold in `estimate_prefill_peak_bytes` and `estimate_chunk_transient_bytes` became the dominant source of false-positive 413 rejections for models with `head_dim > 128`.

For **Qwen3.6-VL** (`head_dim = 256`) at 327 K tokens the SDPA estimate was:

| Path | Formula | Result |
|------|---------|--------|
| Old (`hd > 128`) unfused fallback | `n_q × chunk × full_kv_len × 4` | **~40 GB** |
| Correct fused kernel | `n_q × chunk × hd × 4` | **~32 MB** |

The ~1200x over-estimate pushed the preflight peak well past the memory ceiling → HTTP 413 on every request.

## Root cause

The `hd > 128` check assumed MLX only provided a fused (O(n) tiled) SDPA kernel for `head_dim ≤ 128`, materialising the full float32 attention-score matrix for larger values. That was true for MLX < 0.22 but has been false since then: `mx.fast.scaled_dot_product_attention` uses the same O(n) Metal tiling for all head_dim values. omlx 0.4.x already requires MLX ≥ 0.31, so the fallback path is never reached.

## Fix

Replace the hard-coded sentinel `128` with a module-level constant:

```python
# MLX fused SDPA supports arbitrary head_dim as of MLX 0.22.
# omlx 0.4.x requires MLX >= 0.31 — unfused fallback never executes.
_SDPA_FALLBACK_HEAD_DIM: float = float("inf")
```

Both `estimate_prefill_peak_bytes` and `estimate_chunk_transient_bytes` now use the fused O(n) formula unconditionally. The dead fallback branch is kept in place so it can be revived if a future MLX version re-introduces the restriction.

## Note

The turboquant KV dtype fix originally bundled in this PR was merged in #1763. This PR now contains only the SDPA threshold fix, rebased on top of that merge.

## Tests

Added `TestSdpaThreshold` (3 tests):
- Constant is `+inf`
- `head_dim=256` at 327 K tokens uses the fused formula in `estimate_prefill_peak_bytes`
- `head_dim=256` uses the fused formula in `estimate_chunk_transient_bytes`

All 17 tests in `test_memory_monitor_vlm_config.py` pass.