### PR TITLE
fix: count tracked model memory in pre-load admission (#1623)

### DIFF
--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -416,7 +416,18 @@ class EnginePool:
             ceiling = self._current_ceiling()
             if ceiling > 0:
                 while True:
-                    current = max(mx.get_active_memory(), get_phys_footprint())
+                    # Consult the tracked accumulator alongside live memory:
+                    # after a model settles or idles, mx.get_active_memory() and
+                    # the process footprint can read well below the model's true
+                    # resident size, while _current_model_memory still reflects
+                    # the committed total. Using only live memory lets a second
+                    # large model load without evicting the first, over-
+                    # committing past the ceiling (#1623).
+                    current = max(
+                        mx.get_active_memory(),
+                        get_phys_footprint(),
+                        self._current_model_memory,
+                    )
                     projected = current + entry.estimated_size
                     if projected <= ceiling:
                         break

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -982,6 +982,63 @@ class TestEnginePoolEviction:
         assert pool._entries["model-a"].engine is None
         assert pool._entries["model-b"].engine is not None
 
+    @pytest.fixture
+    def undercounting_memory_pool(self, small_mock_model_dir, monkeypatch):
+        """Pool where live Metal memory under-reports the committed footprint.
+
+        The #1623 condition: after a model settles/idles, both
+        `mx.get_active_memory()` and `get_phys_footprint()` can read well below
+        the model's true resident size, while the tracked accumulator
+        (`_current_model_memory`) still reflects it. Unlike `tight_memory_pool`,
+        this fixture does NOT proxy phys_footprint to the accumulator — it leaves
+        live memory at 0 so admission has to consult the accumulator itself.
+        """
+        pool = _make_pool(ceiling=2500)  # each model fits alone, not both
+        pool.discover_models(str(small_mock_model_dir))
+        monkeypatch.setattr("omlx.engine_pool.get_phys_footprint", lambda: 0)
+        monkeypatch.setattr("omlx.engine_pool.mx.get_active_memory", lambda: 0)
+        return pool
+
+    @pytest.mark.asyncio
+    async def test_eviction_when_live_memory_undercounts(
+        self, undercounting_memory_pool
+    ):
+        """#1623: a second model must still evict the first when live memory
+        under-reports but the tracked accumulator shows the pair over-commits.
+
+        Without consulting `_current_model_memory`, admission sees
+        `current = max(0, 0) = 0`, projects `0 + model-b` under the ceiling, and
+        loads model-b alongside model-a — over-committing past the ceiling.
+        """
+        pool = undercounting_memory_pool
+
+        mock_engine_a = MagicMock()
+        mock_engine_a.start = AsyncMock()
+        mock_engine_a.stop = AsyncMock()
+        mock_engine_a.has_active_requests.return_value = False
+
+        mock_engine_b = MagicMock()
+        mock_engine_b.start = AsyncMock()
+        mock_engine_b.has_active_requests.return_value = False
+
+        def create_engine(*args, **kwargs):
+            if "model-a" in str(kwargs.get("model_name", args[0] if args else "")):
+                return mock_engine_a
+            return mock_engine_b
+
+        with patch("omlx.engine_pool.BatchedEngine", side_effect=create_engine):
+            await pool.get_engine("model-a")
+            assert pool.loaded_model_count == 1
+
+            # Load model-b: the pair exceeds the ceiling, so model-a must be
+            # evicted first even though live memory reads 0.
+            await pool.get_engine("model-b")
+
+        mock_engine_a.stop.assert_called_once()
+        assert pool._entries["model-a"].engine is None
+        assert pool._entries["model-b"].engine is not None
+        assert pool.loaded_model_count == 1
+
     @pytest.mark.asyncio
     async def test_insufficient_memory_all_pinned(self, tight_memory_pool):
         """Test InsufficientMemoryError when all models are pinned."""


### PR DESCRIPTION
## Summary

Fixes #1623 (v0.4.0 regression: a second large model loads side-by-side instead of switching, over-committing memory and failing the next prefill).

The pre-load admission check in `EnginePool.get_engine()` gated on live memory only:

```python
current = max(mx.get_active_memory(), get_phys_footprint())
projected = current + entry.estimated_size
if projected <= ceiling: break   # admit, no eviction
```

It never consulted the tracked accumulator `_current_model_memory`. After a model settles or idles, both `mx.get_active_memory()` and the process footprint can read **well below** the model's true resident size (Metal releases pooled memory; the SSD hot cache isn't counted), while `_current_model_memory` still reflects the committed total. So loading a second large model projected under the ceiling and was admitted **without evicting the first** — pushing memory to 57+ GB and failing the next request with a prefill memory-guard error.

This is a v0.4.0 regression: 0.3.7's `_ensure_memory_available()` (removed along with `max_model_memory` in the `memory_guard_tier` refactor) evicted using the accumulator.

## Fix

Add `self._current_model_memory` to the `max()`:

```python
current = max(
    mx.get_active_memory(),
    get_phys_footprint(),
    self._current_model_memory,
)
```

The accumulator is a floor on committed model memory that live reads can dip below. This also makes pre-load admission **consistent with the request-time prefill-eviction path** (`_evict_idle_lru_for_prefill`), which already takes `max(active, phys, _current_model_memory)` — the pre-load gate was the lone path missing it.

## Test plan

- [x] New regression test `test_eviction_when_live_memory_undercounts`: with `active = phys = 0` but the accumulator showing the pair over-commits, the second model must still evict the first. **Fails on `main` (model-a not evicted), passes with the fix.**
- [x] `pytest tests/test_engine_pool.py` — 83 passed (incl. the existing `test_eviction_before_load`, unaffected: its fixture already proxies phys to the accumulator, so `max(0, acc, acc) == acc`).
- [x] `pytest tests/test_process_memory_enforcer.py tests/test_scheduler_admission.py tests/test_scheduler_prefill_memory_guard.py tests/test_memory_monitor.py tests/test_server_prefill_memory_handler.py` — 177 passed.
- [x] No new ruff findings.
