### PR TITLE
fix(omlx): faithful bge serving on MLX — reranker bf16 load + embedding eval-mode & CLS pooling

### DIFF
--- a/omlx/models/embedding.py
+++ b/omlx/models/embedding.py
@@ -147,6 +147,11 @@ class MLXEmbeddingModel:
             self._validate_native_weights(model_instance, weights)
             model_instance.load_weights(list(weights.items()), strict=False)
             mx.eval(model_instance.parameters())
+            # Embedding inference must be deterministic: put the model in eval
+            # mode so dropout (p>0 in XLM-RoBERTa/BERT) is disabled. Without this
+            # every /v1/embeddings call applies random dropout, producing
+            # non-deterministic, corrupted vectors.
+            model_instance.train(False)
 
             try:
                 tokenizer = AutoTokenizer.from_pretrained(

--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -138,7 +138,6 @@ class MLXRerankerModel:
         """Load XLMRoberta model using omlx native implementation."""
         import mlx.core as mx
         from mlx.utils import tree_unflatten
-        from safetensors import safe_open
         from transformers import AutoTokenizer
 
         from .xlm_roberta import Model, ModelArgs
@@ -157,13 +156,15 @@ class MLXRerankerModel:
         # Create model
         model = Model(config)
 
-        # Load weights
+        # Load weights. Use mx.load (not safetensors.safe_open + get_tensor),
+        # which reads safetensors directly into MLX arrays and supports the
+        # bfloat16 dtype. safe_open(framework="mlx").get_tensor() routes bf16
+        # through numpy, which has no bfloat16 dtype and raises
+        # "TypeError: data type 'bfloat16' not understood".
         weights = {}
         weight_files = list(model_path.glob("*.safetensors"))
         for wf in weight_files:
-            with safe_open(wf, framework="mlx") as f:
-                for key in f.keys():
-                    weights[key] = f.get_tensor(key)
+            weights.update(mx.load(str(wf)))
 
         # Sanitize weights (remove "roberta." prefix, etc.)
         weights = model.sanitize(weights)
@@ -457,12 +458,10 @@ class MLXRerankerModel:
                 "Expected projector.safetensors for JinaForRanking models."
             )
 
-        from safetensors import safe_open
-
-        weights = {}
-        with safe_open(projector_path, framework="mlx") as f:
-            for key in f.keys():
-                weights[key] = f.get_tensor(key)
+        # mx.load reads safetensors into MLX arrays with bfloat16 support;
+        # safe_open(framework="mlx").get_tensor() routes bf16 through numpy and
+        # raises "TypeError: data type 'bfloat16' not understood".
+        weights = mx.load(str(projector_path))
 
         required_keys = ("linear1.weight", "linear2.weight")
         missing_keys = [key for key in required_keys if key not in weights]

--- a/omlx/models/xlm_roberta.py
+++ b/omlx/models/xlm_roberta.py
@@ -465,8 +465,16 @@ class Model(nn.Module):
             logits = self.classifier(sequence_output)
             pooled_output = self._process_outputs(logits)
 
-        # Normalized features for embeddings
-        text_embeds = mean_pooling(sequence_output, attention_mask)
+        # Normalized features for embeddings. Honor pooling_config.pooling_mode
+        # so models that require CLS pooling (e.g. BAAI bge-m3 dense, which is
+        # trained on the [CLS] token — mean pooling significantly degrades it)
+        # are served faithfully. Default "mean" preserves prior behavior for all
+        # other XLM-RoBERTa / BERT embedding models.
+        pooling_mode = (self.config.pooling_config or {}).get("pooling_mode", "mean")
+        if pooling_mode == "cls":
+            text_embeds = sequence_output[:, 0]
+        else:
+            text_embeds = mean_pooling(sequence_output, attention_mask)
         text_embeds = normalize_embeddings(text_embeds)
 
         return BaseModelOutput(


### PR DESCRIPTION
## Problem

Loading an `XLMRobertaForSequenceClassification` reranker whose weights are stored in **bfloat16** crashes at load time:

```
File "omlx/models/reranker.py", line 166, in _load_xlm_roberta
    weights[key] = f.get_tensor(key)
TypeError: data type 'bfloat16' not understood
POST /v1/rerank → 500 (unhandled): data type 'bfloat16' not understood
```

`safetensors.safe_open(wf, framework="mlx").get_tensor(key)` still routes the tensor through numpy, and numpy has no `bfloat16` dtype — so any bf16 reranker (e.g. a bf16 `BAAI/bge-reranker-v2-m3` export) returns 500 on every `/v1/rerank` call.

## Fix

Use `mx.load(str(path))`, which reads a safetensors file directly into MLX arrays and supports `bfloat16` natively. `mx` is already imported in both functions, so the change is minimal. fp16/fp32 weights are unaffected (`mx.load` handles all three), and the now-unused local `from safetensors import safe_open` imports are removed.

Two call sites share the identical pattern and are both fixed:
- `_load_xlm_roberta` (the reported reranker path)
- the `JinaForRanking` projector loader

## Testing

- **`_load_xlm_roberta`**: verified on Apple Silicon (M2) with a bf16 `bge-reranker-v2-m3` export — `/v1/rerank` previously 500'd on every call, and after this change returns 200 with correct relevance scores (relevant doc 0.84 vs irrelevant ~0.00007). Back-to-back 24-document reranks are stable at Metal speed.
- **JinaForRanking projector**: not hardware-tested (no bf16 JinaForRanking model on hand), but it is the identical `safe_open + get_tensor` → `mx.load` substitution and is dtype-agnostic.