### PR TITLE
fix(dflash): report prefix-cache hits as cached_tokens (#1441)

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -670,6 +670,18 @@ class DFlashEngine(BaseEngine):
         )
         return event_iter, prefix_flow, stop_ids
 
+    @staticmethod
+    def _cached_tokens_from_flow(prefix_flow) -> int:
+        """Prompt tokens served from the DFlash prefix snapshot (prefill skipped).
+
+        On a hit ``PrefixCacheFlow.hit_tokens`` is the number of matched prompt
+        tokens; surfacing it as ``cached_tokens`` makes DFlash report prefix-cache
+        hits like the batched engine does instead of always reporting 0 (#1441).
+        """
+        if prefix_flow is None:
+            return 0
+        return max(0, int(getattr(prefix_flow, "hit_tokens", 0) or 0))
+
     def _run_generate_streaming(
         self,
         prompt_tokens: list[int],
@@ -772,6 +784,9 @@ class DFlashEngine(BaseEngine):
                         "completion_tokens": gen_tokens,
                         "acceptance_ratio": accept_ratio,
                         "cycles_completed": cycles,
+                        # Prefix-snapshot hit count, surfaced on the final
+                        # (usage) chunk so the API reports cached_tokens (#1441).
+                        "cached_tokens": self._cached_tokens_from_flow(prefix_flow),
                     }
                     asyncio.run_coroutine_threadsafe(
                         queue.put(("", [], True, metrics)), loop
@@ -892,7 +907,7 @@ class DFlashEngine(BaseEngine):
                     final = parser_session.finalize()
                     if final.visible_text:
                         parsed_visible_parts.append(final.visible_text)
-                return summary, tokens, parser_session, parsed_visible_parts
+                return summary, tokens, parser_session, parsed_visible_parts, prefix_flow
             finally:
                 if event_iter is not None:
                     close = getattr(event_iter, "close", None)
@@ -906,7 +921,7 @@ class DFlashEngine(BaseEngine):
         self._active_request = True
         future = loop.run_in_executor(get_mlx_executor(), _run)
         try:
-            summary, generated, parser_session, parsed_visible_parts = (
+            summary, generated, parser_session, parsed_visible_parts, prefix_flow = (
                 await asyncio.shield(asyncio.wrap_future(future))
             )
         except asyncio.CancelledError:
@@ -953,6 +968,7 @@ class DFlashEngine(BaseEngine):
             tokens=generated,
             prompt_tokens=prompt_token_count,
             completion_tokens=completion_token_count,
+            cached_tokens=self._cached_tokens_from_flow(prefix_flow),
             finish_reason="stop",
         )
 
@@ -1063,6 +1079,9 @@ class DFlashEngine(BaseEngine):
                     tokens=new_tokens,
                     prompt_tokens=prompt_len,
                     completion_tokens=total_completion,
+                    # Carried only on the final (usage) chunk's metrics; 0 on
+                    # token deltas so the server's per-chunk sum isn't inflated.
+                    cached_tokens=(metrics or {}).get("cached_tokens", 0),
                     finished=finished,
                     finish_reason=finish_reason,
                 )

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -914,3 +914,90 @@ class TestDFlashOutputParserWiring:
             {"model_type": "qwen3"},
         )
         assert factory is None
+
+
+class TestDFlashCachedTokens:
+    """#1441: DFlash must surface prefix-cache hits as cached_tokens.
+
+    When a DFlash prefix snapshot hits, prefill is skipped for the matched
+    tokens (PrefixCacheFlow.hit_tokens). The engine previously never set
+    cached_tokens on its GenerationOutput, so the API always reported 0 with
+    DFlash enabled (restored when disabled). These cover the pure mapping; the
+    end-to-end wiring is exercised by the CI-gated integration test below.
+    """
+
+    def test_hit_reports_matched_tokens(self):
+        from omlx.engine.dflash import DFlashEngine
+
+        flow = SimpleNamespace(hit_tokens=4273)
+        assert DFlashEngine._cached_tokens_from_flow(flow) == 4273
+
+    def test_miss_is_zero(self):
+        from omlx.engine.dflash import DFlashEngine
+
+        assert DFlashEngine._cached_tokens_from_flow(SimpleNamespace(hit_tokens=0)) == 0
+
+    def test_none_flow_is_zero(self):
+        from omlx.engine.dflash import DFlashEngine
+
+        assert DFlashEngine._cached_tokens_from_flow(None) == 0
+
+    def test_missing_attr_is_zero(self):
+        from omlx.engine.dflash import DFlashEngine
+
+        assert DFlashEngine._cached_tokens_from_flow(SimpleNamespace()) == 0
+
+    def test_negative_is_clamped(self):
+        from omlx.engine.dflash import DFlashEngine
+
+        assert DFlashEngine._cached_tokens_from_flow(SimpleNamespace(hit_tokens=-5)) == 0
+
+
+class TestDFlashCachedTokensWiring:
+    """End-to-end: a prefix hit reaches GenerationOutput.cached_tokens.
+
+    Requires dflash-mlx (for SummaryEvent / the inner event loop); skipped where
+    it is unavailable, runs in CI.
+    """
+
+    @pytest.mark.asyncio
+    async def test_generate_sets_cached_tokens_from_hit(self, monkeypatch):
+        try:
+            from dflash_mlx.engine.events import SummaryEvent
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+        from omlx.engine.dflash import DFlashEngine
+
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            model_settings=ModelSettings(),
+        )
+        engine._loaded = True
+        engine._tokenizer_obj = SimpleNamespace(
+            encode=lambda s: [1, 2, 3],
+            decode=lambda toks, **kw: "hi",
+        )
+        engine._output_parser_factory = None
+        engine._should_fallback = lambda toks: False
+        engine._detect_needs_think_prefix = lambda toks: False
+
+        summary = SummaryEvent(
+            elapsed_us=1000,
+            prompt_token_count=4273,
+            generated_token_ids=(5,),
+            generation_tokens=1,
+            accepted_from_draft=0,
+            acceptance_ratio=0.0,
+            cycles_completed=1,
+            phase_timings_us={},
+        )
+        fake_flow = SimpleNamespace(hit_tokens=4273)
+
+        def fake_stream_events(*, prompt_tokens, max_tokens):
+            return iter([summary]), fake_flow, [2]
+
+        monkeypatch.setattr(engine, "_stream_dflash_events", fake_stream_events)
+
+        out = await engine.generate("hello", max_tokens=4)
+        assert out.cached_tokens == 4273


### PR DESCRIPTION
## Summary

Fixes #1441 (DFlash breaks KV prefix cache — `cached_tokens: 0` when DFlash is enabled, restored when disabled).

After verifying the issue, it has **split in two** since it was filed (v0.3.12):

1. **Perf half — already fixed.** DFlashEngine now plumbs the prefix snapshot into `stream_dflash_generate` (`PrefixCacheFlow` + a persistent L1/L2 `runtime_context`), so prefill **is** skipped on a hit. I asserted this on the dflash-mlx side: a cold lookup misses, and a repeat of the same 4273-token prompt returns `l1_exact` with `matched_tokens == 4273` (prefill skipped) — the existing `test_prefix_cache_hit_kind.py` suite covers it (87 passed).
2. **Reporting half — this PR.** The hit count (`PrefixCacheFlow.hit_tokens`) was computed but never mapped onto the output's `cached_tokens`, so the API always reported 0 with DFlash on. `BatchedEngine`/VLM already set `cached_tokens=output.cached_tokens`; DFlashEngine had **zero** `cached_tokens` references.

## Fix

Surface `PrefixCacheFlow.hit_tokens` (matched prompt tokens) as `cached_tokens`, mirroring BatchedEngine:

- `_cached_tokens_from_flow(prefix_flow)` — pure mapping (hit → count, miss/None/missing/negative → 0).
- **Non-streaming** `generate()` — thread `prefix_flow` out of the executor `_run` and set `cached_tokens` on the output.
- **Streaming** `stream_generate()` — carry the count on the **final (usage) chunk's** `metrics` only, so the server's per-chunk `total_cached_tokens += output.cached_tokens` sum isn't inflated; token deltas report 0.

## Test plan

- [x] `pytest tests/test_dflash_engine.py -k "TestDFlashCachedTokens and not Wiring"` — 5 pure-mapping unit tests (run locally)
- [x] CI-gated `test_generate_sets_cached_tokens_from_hit` — asserts `generate()` sets `cached_tokens` from a prefix hit (skips where dflash-mlx is unavailable, runs in CI)
- [x] `tests/test_dflash_engine.py` — 55 passed (4 pre-existing `_build_runtime_context` env failures are unrelated, pass in CI); `test_output_collector.py`/`test_server_metrics.py` — 63 passed
- [x] No new ruff findings

Rebased onto current `main`.
