### PR TITLE
fix(dflash): enforce prefill memory guard on DFlash primary path

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -27,7 +27,12 @@ from ..api.utils import clean_special_tokens, detect_and_strip_partial
 from ..utils.generation_config import load_generation_config_token_ids
 from ..utils.model_loading import maybe_apply_pre_load_patches
 from ..utils.tokenizer import create_streaming_detokenizer
-from .base import BaseEngine, GenerationOutput
+from ..memory_monitor import (
+    MemoryMonitor,
+    raise_if_prefill_exceeds,
+    set_model_info_from_model,
+)
+from .base import BaseEngine, GenerationOutput, _warn_scheduler_unreachable_once
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +70,44 @@ def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
             f"(model_type='{cfg.get('model_type', '')}')"
         )
     return True, ""
+
+
+class _DFlashPrefillGuard:
+    """Prefill-memory guard target for DFlash's primary (speculative) path,
+    which bypasses the Scheduler entirely.
+
+    Holds a ``MemoryMonitor`` (built from the target model's dims) plus the two
+    watermark attrs the ``ProcessMemoryEnforcer`` writes on schedulers each tick
+    (``_prefill_memory_guard``, ``_memory_hard_limit_bytes``). The enforcer
+    resolves this object via ``_resolve_scheduler`` so DFlash receives the same
+    ceiling as scheduler-driven engines, and ``preflight_or_raise`` delegates to
+    the shared ``raise_if_prefill_exceeds`` so the estimate + HTTP-400 mapping
+    match ``Scheduler.preflight_or_raise`` exactly.
+    """
+
+    def __init__(self, memory_monitor: MemoryMonitor, prefill_step_size: int):
+        self.memory_monitor = memory_monitor
+        self._prefill_step_size = prefill_step_size
+        # Written by ProcessMemoryEnforcer._propagate_memory_limit each tick.
+        self._prefill_memory_guard: bool = False
+        self._memory_hard_limit_bytes: int = 0
+
+    def preflight_or_raise(
+        self,
+        *,
+        num_prompt_tokens: int,
+        cached_tokens: int = 0,
+        request_id: str | None = None,
+    ) -> None:
+        raise_if_prefill_exceeds(
+            self.memory_monitor,
+            prefill_memory_guard=self._prefill_memory_guard,
+            hard_limit_bytes=self._memory_hard_limit_bytes,
+            prefill_step_size=self._prefill_step_size,
+            num_prompt_tokens=num_prompt_tokens,
+            cached_tokens=cached_tokens,
+            request_id=request_id,
+        )
 
 
 class DFlashEngine(BaseEngine):
@@ -117,6 +160,10 @@ class DFlashEngine(BaseEngine):
         self._fallback_engine: BaseEngine | None = None
         self._in_fallback_mode = False
         self._fallback_lock = asyncio.Lock()
+        # Primary-mode prefill memory guard. DFlash bypasses the scheduler, so
+        # it can't receive the enforcer's watermarks through one; this holder
+        # stands in (built in start(), resolved by the enforcer).
+        self._prefill_guard: "_DFlashPrefillGuard | None" = None
         self._runtime_context: Any | None = None
         self._dflash_prefix_cache: Any | None = None
         self._suppress_token_ids: set[int] = set()
@@ -332,6 +379,27 @@ class DFlashEngine(BaseEngine):
 
         self._runtime_context = self._build_runtime_context()
 
+        # Build the primary-mode prefill memory guard from the target model's
+        # dims (same estimation Scheduler uses). Best-effort: on failure the
+        # guard stays None and preflight degrades to a no-op — the request runs
+        # unguarded rather than being falsely rejected.
+        self._prefill_guard = None
+        if self._target_model is not None:
+            try:
+                monitor = MemoryMonitor(
+                    max_kv_cache_memory=None, eviction_enabled=False
+                )
+                set_model_info_from_model(monitor, self._target_model)
+                step = (
+                    getattr(self._scheduler_config, "prefill_step_size", 2048) or 2048
+                )
+                self._prefill_guard = _DFlashPrefillGuard(monitor, step)
+            except Exception as exc:
+                # Warn (not debug): a missing guard silently disables the
+                # prefill OOM protection this engine relies on.
+                logger.warning(f"DFlash prefill guard init failed: {exc}")
+                self._prefill_guard = None
+
         self._loaded = True
         self._in_fallback_mode = False
         max_ctx_display = "unlimited" if self._max_dflash_ctx is None else self._max_dflash_ctx
@@ -369,6 +437,14 @@ class DFlashEngine(BaseEngine):
         self._draft_backend = None
         self._executor_tokenizer = None
         self._output_parser_factory = None
+        # Deliberately keep self._prefill_guard alive across the transition.
+        # Its MemoryMonitor holds only dims (no model ref), so it stays valid
+        # and cheap. Nulling it here would open a window — guard gone, fallback
+        # scheduler not yet started — where _resolve_scheduler returns None
+        # (spurious "scheduler unreachable" warning + an unguarded admission
+        # gap). The enforcer prefers the fallback scheduler once it is up, and
+        # fallback-mode preflight delegates to the fallback engine, so the
+        # stale guard is simply never consulted. Cleared in stop().
         # The fallback engine (BatchedEngine / VLMBatchedEngine) starts next.
         # Revert dflash's class patches now so the fallback's model loads
         # onto clean linear_attn / self_attn classes (issue #1388).
@@ -444,6 +520,7 @@ class DFlashEngine(BaseEngine):
         self._tokenizer_obj = None
         self._executor_tokenizer = None
         self._output_parser_factory = None
+        self._prefill_guard = None
         self._in_fallback_mode = False
         self._loaded = False
         # Revert class-level __call__ patches dflash installed during start().
@@ -536,6 +613,87 @@ class DFlashEngine(BaseEngine):
             is_partial=is_partial,
         )
         return len(self._tokenizer_obj.encode(prompt))
+
+    async def preflight_chat(
+        self,
+        messages: list,
+        tools: list | None = None,
+        request_id: str | None = None,
+        **kwargs,
+    ) -> None:
+        """Prefill-memory preflight for chat requests.
+
+        DFlash bypasses the scheduler, so it implements the front-door guard
+        itself (BaseEngine's no-op would leave primary-mode prefills
+        unprotected). In fallback mode it delegates to the fallback engine,
+        whose scheduler runs the full guard. Raises ``PrefillMemoryExceededError``
+        (→ HTTP 400) when the prompt's prefill peak would exceed the ceiling.
+        Mirrors ``BatchedEngine.preflight_chat``.
+        """
+        if not self._loaded:
+            await self.start()
+        if self._in_fallback_mode and self._fallback_engine is not None:
+            await self._fallback_engine.preflight_chat(
+                messages, tools=tools, request_id=request_id, **kwargs
+            )
+            return
+        if self._prefill_guard is None:
+            _warn_scheduler_unreachable_once(
+                self, "preflight_chat", "primary-mode prefill guard unavailable"
+            )
+            return
+        try:
+            num_tokens = self.count_chat_tokens(
+                messages,
+                tools,
+                chat_template_kwargs=kwargs.get("chat_template_kwargs"),
+                is_partial=kwargs.get("is_partial"),
+            )
+        except Exception as e:
+            logger.warning(
+                "DFlashEngine.preflight_chat: token count raised %s; skipping "
+                "prefill memory check, real chat path will surface the error",
+                type(e).__name__,
+            )
+            return
+        self._prefill_guard.preflight_or_raise(
+            num_prompt_tokens=num_tokens, request_id=request_id
+        )
+
+    async def preflight_completion(
+        self,
+        prompt: str,
+        request_id: str | None = None,
+        **kwargs,
+    ) -> None:
+        """Prefill-memory preflight for plain completions. See ``preflight_chat``."""
+        if not self._loaded:
+            await self.start()
+        if self._in_fallback_mode and self._fallback_engine is not None:
+            await self._fallback_engine.preflight_completion(
+                prompt, request_id=request_id, **kwargs
+            )
+            return
+        if self._prefill_guard is None:
+            _warn_scheduler_unreachable_once(
+                self,
+                "preflight_completion",
+                "primary-mode prefill guard unavailable",
+            )
+            return
+        try:
+            num_tokens = len(self._tokenizer_obj.encode(prompt))
+        except Exception as e:
+            logger.warning(
+                "DFlashEngine.preflight_completion: tokenizer.encode raised %s; "
+                "skipping prefill memory check, real completion path will "
+                "surface the error",
+                type(e).__name__,
+            )
+            return
+        self._prefill_guard.preflight_or_raise(
+            num_prompt_tokens=num_tokens, request_id=request_id
+        )
 
     @property
     def supports_multimodal_fallback(self) -> bool:

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -96,16 +96,17 @@ class _DFlashPrefillGuard:
         self,
         *,
         num_prompt_tokens: int,
-        cached_tokens: int = 0,
         request_id: str | None = None,
     ) -> None:
+        # Deliberately no cached_tokens parameter: a DFlash prefix-cache hit
+        # reconstructs the matched KV into active memory, so the full prompt
+        # must always be charged (see DFlashEngine.preflight_chat).
         raise_if_prefill_exceeds(
             self.memory_monitor,
             prefill_memory_guard=self._prefill_memory_guard,
             hard_limit_bytes=self._memory_hard_limit_bytes,
             prefill_step_size=self._prefill_step_size,
             num_prompt_tokens=num_prompt_tokens,
-            cached_tokens=cached_tokens,
             request_id=request_id,
         )
 

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -656,6 +656,12 @@ class DFlashEngine(BaseEngine):
                 type(e).__name__,
             )
             return
+        # Deliberately no cached_tokens: a DFlash prefix-cache hit
+        # *reconstructs* the matched KV into active memory (dflash_mlx
+        # ``hydrate_target_cache`` clones every array), so the full prompt's
+        # KV is allocated this request — unlike the scheduler's resident
+        # paged cache. Subtracting hit tokens here would under-count and
+        # defeat the OOM guard.
         self._prefill_guard.preflight_or_raise(
             num_prompt_tokens=num_tokens, request_id=request_id
         )
@@ -691,6 +697,9 @@ class DFlashEngine(BaseEngine):
                 type(e).__name__,
             )
             return
+        # Deliberately no cached_tokens — see preflight_chat: a prefix-cache
+        # hit reconstructs KV into active memory, so the full prompt is
+        # charged.
         self._prefill_guard.preflight_or_raise(
             num_prompt_tokens=num_tokens, request_id=request_id
         )

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -756,6 +756,11 @@ def raise_if_prefill_exceeds(
     same math ``Scheduler.preflight_or_raise`` uses. No-op when the guard is
     disabled, no limit is set, the monitor is missing, or the request fits.
     Maps to HTTP 400 via the server's ``prefill_memory_exceeded_handler``.
+
+    ``cached_tokens`` means prompt KV *already resident in current memory*
+    (e.g. the scheduler's paged prefix cache) — not merely "tokens that hit
+    a cache". A cache whose hits re-allocate KV (DFlash prefix snapshots)
+    must pass 0.
     """
     if not prefill_memory_guard:
         return

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -16,7 +16,7 @@ import logging
 import threading
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from omlx.cache.paged_cache import PagedCacheManager
@@ -602,3 +602,210 @@ class MemoryMonitor:
             f"MemoryMonitor(max_kv_cache={format_bytes(self._max_kv_cache_memory)}, "
             f"used={format_bytes(info.used_bytes)})"
         )
+
+
+def set_model_info_from_model(monitor: "MemoryMonitor", model: Any) -> None:
+    """Populate ``monitor`` with KV/SDPA dims read from an mlx-lm ``model``.
+
+    The engine-agnostic baseline used by engines that bypass the
+    ``Scheduler`` (currently ``DFlashEngine``'s primary speculative path) so
+    they can run the same prefill-peak estimate the scheduler-driven engines
+    get. Best-effort: on any extraction failure the monitor is left dim-less
+    and ``estimate_prefill_peak_bytes`` returns 0, making the guard a no-op
+    rather than raising spuriously.
+
+    Note this populates the *uncompressed* (base-dtype) KV size — it does not
+    apply the TurboQuant fractional-byte adjustment that
+    ``Scheduler._set_model_info_for_monitor`` layers on, because that depends
+    on scheduler-side TurboQuant configuration. For a memory *guard* the
+    uncompressed estimate is the conservative (never-under-count) choice.
+    """
+    try:
+        # Try to get model config
+        config = None
+        if hasattr(model, "config"):
+            config = model.config
+        elif hasattr(model, "args"):
+            config = model.args
+
+        if config is None:
+            logger.debug("Could not extract model config for memory estimation")
+            return
+
+        # VLM / multimodal configs (e.g. Qwen3.6-VL, Gemma-4) nest the
+        # language-model dimensions under a sub-config. Prefer
+        # ``text_config`` / ``language_config`` / ``llm_config`` when ANY of
+        # them exposes the LM layer count, even if the top-level config also
+        # has one — on some VLM packs the top-level field refers to the
+        # *vision encoder*, not the LM, and accepting it silently miscalibrates
+        # the SDPA-peak estimate. Probe ``num_hidden_layers`` and the legacy
+        # ``n_layer`` alias. Falls back to the top-level config only when no
+        # sub-config has either field.
+        for sub_attr in ("text_config", "language_config", "llm_config"):
+            sub = getattr(config, sub_attr, None)
+            if sub is not None and (
+                getattr(sub, "num_hidden_layers", None)
+                or getattr(sub, "n_layer", None)
+            ):
+                config = sub
+                break
+
+        # Extract KV cache dimensions
+        num_layers = getattr(config, "num_hidden_layers", None) or getattr(
+            config, "n_layer", None
+        )
+        num_kv_heads = (
+            getattr(config, "num_key_value_heads", None)
+            or getattr(config, "num_attention_heads", None)
+            or getattr(config, "n_head", None)
+        )
+        head_dim = getattr(config, "head_dim", None)
+        hidden_size = getattr(config, "hidden_size", None) or getattr(
+            config, "n_embd", None
+        )
+
+        # Calculate head_dim if not directly available
+        if head_dim is None and hidden_size and num_kv_heads:
+            num_heads = getattr(config, "num_attention_heads", None) or num_kv_heads
+            head_dim = hidden_size // num_heads
+
+        # Determine dtype size
+        dtype_size = 2  # Default float16
+        if hasattr(model, "dtype"):
+            if model.dtype == mx.float32:
+                dtype_size = 4
+            elif model.dtype == mx.bfloat16:
+                dtype_size = 2
+
+        # Extract num_attention_heads (query heads) for SDPA peak estimation
+        num_attention_heads = (
+            getattr(config, "num_attention_heads", None)
+            or getattr(config, "n_head", None)
+            or num_kv_heads
+        )
+
+        # Count KVCache layers for hybrid models. Mirrors
+        # Scheduler._set_model_info_for_monitor: recurse into CacheList so
+        # wrapped full-attention layers are counted, not just bare KVCache.
+        num_kv_cache_layers = num_layers
+        if hasattr(model, "make_cache"):
+            try:
+                cache_list = model.make_cache()
+                from mlx_lm.models.cache import CacheList, KVCache
+
+                def _count_kv(c: Any) -> int:
+                    if type(c) is KVCache:
+                        return 1
+                    if isinstance(c, CacheList):
+                        return sum(_count_kv(inner) for inner in c.caches)
+                    return 0
+
+                num_kv_cache_layers = sum(_count_kv(c) for c in cache_list)
+                if num_kv_cache_layers == 0:
+                    num_kv_cache_layers = num_layers  # fallback
+            except Exception:
+                pass
+
+        # Truthiness alone isn't enough — MagicMock proxies leaking through the
+        # descent (test scaffolds that don't fully spec ``model.config``) are
+        # truthy but fail any later numeric comparison (``> 128`` etc.) deep
+        # inside MemoryMonitor. Insist on real positive integers before calling.
+        def _pos_int(v: Any) -> bool:
+            return isinstance(v, int) and not isinstance(v, bool) and v > 0
+
+        if _pos_int(num_layers) and _pos_int(num_kv_heads) and _pos_int(head_dim):
+            monitor.set_model_info(
+                num_layers=num_layers,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                dtype_size=dtype_size,
+                num_attention_heads=num_attention_heads,
+                num_kv_cache_layers=num_kv_cache_layers,
+            )
+            logger.debug(
+                f"Model info for memory estimation: "
+                f"layers={num_layers} ({num_kv_cache_layers} KVCache), "
+                f"kv_heads={num_kv_heads}, q_heads={num_attention_heads}, "
+                f"head_dim={head_dim}, dtype_size={dtype_size}"
+            )
+        else:
+            logger.debug(
+                f"Incomplete model info: layers={num_layers}, "
+                f"kv_heads={num_kv_heads}, head_dim={head_dim}"
+            )
+
+    except Exception as e:
+        logger.debug(f"Failed to extract model info: {e}")
+
+
+def raise_if_prefill_exceeds(
+    monitor: "MemoryMonitor | None",
+    *,
+    prefill_memory_guard: bool,
+    hard_limit_bytes: int,
+    prefill_step_size: int,
+    num_prompt_tokens: int,
+    cached_tokens: int = 0,
+    request_id: str | None = None,
+) -> None:
+    """Raise ``PrefillMemoryExceededError`` if a prompt's prefill peak would
+    push memory past ``hard_limit_bytes``.
+
+    The shared front-door guard, taking token counts + watermarks directly so
+    an engine without a ``Scheduler`` (``DFlashEngine``) enforces with the
+    same math ``Scheduler.preflight_or_raise`` uses. No-op when the guard is
+    disabled, no limit is set, the monitor is missing, or the request fits.
+    Maps to HTTP 400 via the server's ``prefill_memory_exceeded_handler``.
+    """
+    if not prefill_memory_guard:
+        return
+    if hard_limit_bytes <= 0:
+        return
+    if monitor is None:
+        return
+    if mx is None:  # no MLX runtime → nothing to measure against; no-op
+        return
+
+    new_tokens = max(int(num_prompt_tokens) - max(int(cached_tokens), 0), 0)
+    if new_tokens == 0:
+        return
+
+    peak = monitor.estimate_prefill_peak_bytes(
+        new_tokens, prefill_step_size, cached_tokens=cached_tokens
+    )
+    if peak == 0:
+        return
+
+    from omlx.utils.proc_memory import get_phys_footprint
+
+    current = max(mx.get_active_memory(), get_phys_footprint())
+    if current + peak <= hard_limit_bytes:
+        return
+
+    from omlx.exceptions import PrefillMemoryExceededError
+
+    usage_gb = current / (1024**3)
+    ceiling_gb = hard_limit_bytes / (1024**3)
+    message = (
+        f"Prefill would require ~{format_bytes(current + peak)} peak "
+        f"(current {format_bytes(current)} + KV+SDPA {format_bytes(peak)}) "
+        f"but ceiling is {format_bytes(hard_limit_bytes)} "
+        f"(usage {usage_gb:.1f} GB, ceiling {ceiling_gb:.1f} GB). "
+        f"Reduce context length, free system memory, or loosen "
+        f"memory_guard_tier (safe → balanced → aggressive)."
+    )
+
+    if not request_id:
+        import uuid as _uuid
+
+        request_id = f"preflight-{_uuid.uuid4().hex[:8]}"
+    logger.warning(
+        "Preflight rejected (%d tokens, cached=%d, request_id=%s): %s",
+        num_prompt_tokens, cached_tokens, request_id, message,
+    )
+    raise PrefillMemoryExceededError(
+        message=message,
+        request_id=request_id,
+        estimated_bytes=int(current + peak),
+        limit_bytes=int(hard_limit_bytes),
+    )

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -693,13 +693,18 @@ class ProcessMemoryEnforcer:
 
     @staticmethod
     def _resolve_scheduler(entry: Any) -> Any | None:
-        """Resolve the Scheduler instance from an EnginePool entry.
+        """Resolve the watermark target (Scheduler or DFlash guard) from an
+        EnginePool entry.
 
         Most engines (BatchedEngine, VLMBatchedEngine) wrap the scheduler
         as ``entry.engine._engine.engine.scheduler`` (AsyncEngineCore →
         EngineCore → Scheduler). Some non-streaming engines may expose
-        ``entry.engine.scheduler`` directly. Returns None if neither
-        path resolves.
+        ``entry.engine.scheduler`` directly — including ``DFlashEngine`` in
+        fallback mode, whose ``scheduler`` property resolves the fallback
+        engine's real scheduler. DFlash's *primary* speculative path has no
+        scheduler at all, so it exposes a lightweight ``_prefill_guard`` that
+        carries the same watermark attrs; tried last so standard engines
+        resolve unchanged. Returns None if nothing resolves.
         """
         eng = entry.engine
         if eng is None:
@@ -708,12 +713,16 @@ class ProcessMemoryEnforcer:
         if sched is not None:
             return sched
         inner = getattr(eng, "_engine", None)
-        if inner is None:
-            return None
-        inner_engine = getattr(inner, "engine", None)
-        if inner_engine is None:
-            return None
-        return getattr(inner_engine, "scheduler", None)
+        if inner is not None:
+            inner_engine = getattr(inner, "engine", None)
+            if inner_engine is not None:
+                sched = getattr(inner_engine, "scheduler", None)
+                if sched is not None:
+                    return sched
+        # DFlash primary mode bypasses the scheduler entirely; the enforcer
+        # still needs to push the ceiling somewhere, so it lands on the
+        # engine's ``_prefill_guard`` (None for every non-DFlash engine).
+        return getattr(eng, "_prefill_guard", None)
 
     def _propagate_memory_limit(self) -> None:
         """Propagate ceiling-derived watermarks to all schedulers.

--- a/tests/test_dflash_prefill_memory_guard.py
+++ b/tests/test_dflash_prefill_memory_guard.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests that DFlashEngine enforces the prefill memory guard.
+
+DFlash bypasses the scheduler (its primary speculative path runs outside the
+Scheduler), so it inherited ``BaseEngine``'s no-op ``preflight_chat`` and ran
+long prefills completely unguarded — a latent OOM (observed end-to-end against
+Qwen3-Coder-Next + DFlash with 56k-token prompts). The fix gives DFlash its own
+``_DFlashPrefillGuard`` (a MemoryMonitor + the enforcer's watermarks) and
+``preflight_*`` overrides that reuse the shared ``raise_if_prefill_exceeds``.
+
+These tests pin the guard math (mirroring ``test_scheduler_prefill_memory_guard``)
+and the engine-level delegation so a refactor can't silently revert it.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import mlx.core as mx
+import pytest
+
+from omlx.engine.dflash import DFlashEngine, _DFlashPrefillGuard
+from omlx.exceptions import PrefillMemoryExceededError
+from omlx.memory_monitor import MemoryMonitor, set_model_info_from_model
+
+
+class _ModelConfig:
+    """Minimal config exposing the fields the estimator reads."""
+
+    def __init__(
+        self,
+        num_hidden_layers: int = 32,
+        num_key_value_heads: int = 8,
+        num_attention_heads: int = 32,
+        head_dim: int = 192,  # > 128 → SDPA fallback path
+    ) -> None:
+        self.num_hidden_layers = num_hidden_layers
+        self.num_key_value_heads = num_key_value_heads
+        self.num_attention_heads = num_attention_heads
+        self.head_dim = head_dim
+
+
+def _make_target_model() -> MagicMock:
+    model = MagicMock()
+    model.config = _ModelConfig()
+    # Strip make_cache so the KVCache-counting branch doesn't iterate a Mock.
+    del model.make_cache
+    model.dtype = mx.float16
+    return model
+
+
+def _make_guard(step: int = 2048) -> _DFlashPrefillGuard:
+    monitor = MemoryMonitor(max_kv_cache_memory=None, eviction_enabled=False)
+    set_model_info_from_model(monitor, _make_target_model())
+    return _DFlashPrefillGuard(monitor, step)
+
+
+def _zero_mem():
+    """Patch the live-memory probes to 0 so the estimate alone drives the check."""
+    return patch(
+        "omlx.memory_monitor.mx.get_active_memory", return_value=0
+    ), patch("omlx.utils.proc_memory.get_phys_footprint", return_value=0)
+
+
+# --- guard math (mirrors the scheduler guard tests) -----------------------
+
+
+def test_guard_populates_estimator_dims():
+    guard = _make_guard()
+    m = guard.memory_monitor
+    assert m._num_attention_heads == 32
+    assert m._head_dim == 192
+    assert m._num_layers == 32
+    assert m._num_kv_heads == 8
+
+
+def test_estimator_produces_nonzero_peak():
+    guard = _make_guard()
+    assert guard.memory_monitor.estimate_prefill_peak_bytes(65536, 2048) > 0
+
+
+def test_preflight_passes_within_limit():
+    """Positive control: a normal prompt under a generous limit must NOT raise."""
+    guard = _make_guard()
+    guard._prefill_memory_guard = True
+    guard._memory_hard_limit_bytes = 10**18
+    p1, p2 = _zero_mem()
+    with p1, p2:
+        guard.preflight_or_raise(num_prompt_tokens=32768)  # no exception
+
+
+def test_preflight_raises_when_oversized():
+    guard = _make_guard()
+    guard._prefill_memory_guard = True
+    guard._memory_hard_limit_bytes = 1  # any allocation exceeds
+    p1, p2 = _zero_mem()
+    with p1, p2:
+        with pytest.raises(PrefillMemoryExceededError) as exc:
+            guard.preflight_or_raise(num_prompt_tokens=65536, request_id="r1")
+    err = exc.value
+    assert err.estimated_bytes > 0
+    assert err.limit_bytes == 1
+    assert err.request_id == "r1"
+    assert "Prefill would require" in err.message
+    assert "KV+SDPA" in err.message
+
+
+def test_preflight_noop_when_guard_disabled():
+    guard = _make_guard()
+    guard._prefill_memory_guard = False
+    guard._memory_hard_limit_bytes = 1
+    guard.preflight_or_raise(num_prompt_tokens=65536)  # no exception
+
+
+def test_preflight_noop_when_hard_limit_zero():
+    guard = _make_guard()
+    guard._prefill_memory_guard = True
+    guard._memory_hard_limit_bytes = 0
+    guard.preflight_or_raise(num_prompt_tokens=65536)  # no exception
+
+
+def test_preflight_noop_when_fully_cached():
+    guard = _make_guard()
+    guard._prefill_memory_guard = True
+    guard._memory_hard_limit_bytes = 1
+    # new_tokens == 0 → nothing to prefill.
+    guard.preflight_or_raise(num_prompt_tokens=1000, cached_tokens=1000)
+
+
+def test_preflight_noop_when_no_dims():
+    """No model dims → estimator returns 0 → guard must not raise spuriously."""
+    monitor = MemoryMonitor(max_kv_cache_memory=None, eviction_enabled=False)
+    guard = _DFlashPrefillGuard(monitor, 2048)
+    guard._prefill_memory_guard = True
+    guard._memory_hard_limit_bytes = 1
+    p1, p2 = _zero_mem()
+    with p1, p2:
+        guard.preflight_or_raise(num_prompt_tokens=65536)  # no exception
+
+
+# --- engine-level delegation ----------------------------------------------
+
+
+def _bare_engine() -> DFlashEngine:
+    """A DFlashEngine with only the attrs preflight_* touches (no full init)."""
+    eng = DFlashEngine.__new__(DFlashEngine)
+    eng._loaded = True
+    eng._in_fallback_mode = False
+    eng._fallback_engine = None
+    eng._prefill_guard = None
+    return eng
+
+
+async def test_engine_preflight_chat_delegates_to_guard():
+    eng = _bare_engine()
+    eng._prefill_guard = MagicMock()
+    eng.count_chat_tokens = MagicMock(return_value=12345)
+
+    await eng.preflight_chat([{"role": "user", "content": "hi"}], request_id="r1")
+
+    eng._prefill_guard.preflight_or_raise.assert_called_once_with(
+        num_prompt_tokens=12345, request_id="r1"
+    )
+
+
+async def test_engine_preflight_chat_delegates_to_fallback_in_fallback_mode():
+    eng = _bare_engine()
+    eng._in_fallback_mode = True
+    eng._fallback_engine = AsyncMock()
+    eng._prefill_guard = MagicMock()  # must NOT be consulted in fallback mode
+
+    await eng.preflight_chat([{"role": "user", "content": "hi"}], request_id="r1")
+
+    eng._fallback_engine.preflight_chat.assert_awaited_once()
+    eng._prefill_guard.preflight_or_raise.assert_not_called()
+
+
+async def test_engine_preflight_chat_noop_without_guard():
+    eng = _bare_engine()  # _prefill_guard is None, not in fallback
+    with patch("omlx.engine.dflash._warn_scheduler_unreachable_once") as warn:
+        await eng.preflight_chat([{"role": "user", "content": "hi"}])
+    warn.assert_called_once()
+
+
+async def test_engine_preflight_completion_delegates_to_guard():
+    eng = _bare_engine()
+    eng._prefill_guard = MagicMock()
+    eng._tokenizer_obj = MagicMock()
+    eng._tokenizer_obj.encode.return_value = list(range(777))
+
+    await eng.preflight_completion("hello", request_id="rc")
+
+    eng._prefill_guard.preflight_or_raise.assert_called_once_with(
+        num_prompt_tokens=777, request_id="rc"
+    )

--- a/tests/test_dflash_prefill_memory_guard.py
+++ b/tests/test_dflash_prefill_memory_guard.py
@@ -19,7 +19,11 @@ import pytest
 
 from omlx.engine.dflash import DFlashEngine, _DFlashPrefillGuard
 from omlx.exceptions import PrefillMemoryExceededError
-from omlx.memory_monitor import MemoryMonitor, set_model_info_from_model
+from omlx.memory_monitor import (
+    MemoryMonitor,
+    raise_if_prefill_exceeds,
+    set_model_info_from_model,
+)
 
 
 class _ModelConfig:
@@ -117,12 +121,32 @@ def test_preflight_noop_when_hard_limit_zero():
     guard.preflight_or_raise(num_prompt_tokens=65536)  # no exception
 
 
-def test_preflight_noop_when_fully_cached():
+def test_shared_helper_noop_when_fully_cached():
+    """The fully-cached no-op belongs to ``raise_if_prefill_exceeds`` (for
+    engines whose caches keep KV resident); the DFlash guard itself has no
+    ``cached_tokens`` parameter."""
+    monitor = MemoryMonitor(max_kv_cache_memory=None, eviction_enabled=False)
+    set_model_info_from_model(monitor, _make_target_model())
+    # new_tokens == 0 → nothing to prefill → no exception.
+    raise_if_prefill_exceeds(
+        monitor,
+        prefill_memory_guard=True,
+        hard_limit_bytes=1,
+        prefill_step_size=2048,
+        num_prompt_tokens=1000,
+        cached_tokens=1000,
+    )
+
+
+def test_guard_rejects_cached_tokens():
+    """The narrowed signature is deliberate: a DFlash prefix-cache hit
+    reconstructs KV into active memory, so accepting a hit count here would
+    under-count the prefill peak and defeat the OOM guard."""
     guard = _make_guard()
     guard._prefill_memory_guard = True
     guard._memory_hard_limit_bytes = 1
-    # new_tokens == 0 → nothing to prefill.
-    guard.preflight_or_raise(num_prompt_tokens=1000, cached_tokens=1000)
+    with pytest.raises(TypeError):
+        guard.preflight_or_raise(num_prompt_tokens=1000, cached_tokens=1000)
 
 
 def test_preflight_noop_when_no_dims():

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -1856,3 +1856,49 @@ class TestTwoWatermarkPressureLevels:
         assert status["current_bytes"] == 88 * 1024**3
         # Utilization computed against the max value
         assert abs(status["utilization"] - 0.88) < 0.01
+
+
+class TestDFlashGuardPropagation:
+    """The enforcer must reach DFlash's primary-mode guard target.
+
+    DFlash bypasses the scheduler: in primary mode it exposes a lightweight
+    ``_prefill_guard``; in fallback mode its ``scheduler`` property resolves
+    the fallback engine's real scheduler (covered by test_dflash_engine.py).
+    Without the ``_prefill_guard`` arm in ``_resolve_scheduler`` the watermarks
+    never reach a primary-mode DFlash and the prefill guard stays dead.
+    """
+
+    def test_resolves_primary_guard(self, enforcer):
+        guard = MagicMock(spec=[])
+        engine = MagicMock(spec=["_prefill_guard"])
+        engine._prefill_guard = guard
+        entry = _make_entry("dflash", engine=engine)
+        enforcer._engine_pool._entries = {"dflash": entry}
+
+        assert enforcer._resolve_scheduler(entry) is guard
+
+        enforcer._propagate_memory_limit()
+        assert guard._memory_hard_limit_bytes == 10 * 1024**3
+        assert guard._prefill_memory_guard == enforcer._prefill_memory_guard
+
+    def test_dflash_primary_does_not_warn(self, enforcer, caplog):
+        engine = MagicMock(spec=["_prefill_guard"])
+        engine._prefill_guard = MagicMock(spec=[])
+        entry = _make_entry("dflash", engine=engine)
+        enforcer._engine_pool._entries = {"dflash": entry}
+
+        with caplog.at_level("WARNING", logger="omlx.process_memory_enforcer"):
+            enforcer._propagate_memory_limit()
+
+        assert not [
+            r for r in caplog.records if "could not resolve scheduler" in r.message
+        ]
+
+    def test_non_dflash_resolution_unchanged(self, enforcer):
+        """A standard engine with a direct ``.scheduler`` still resolves via the
+        existing chain — the DFlash arm must not interfere."""
+        scheduler = MagicMock(spec=[])
+        engine = MagicMock(spec=["scheduler"])
+        engine.scheduler = scheduler
+        entry = _make_entry("model-a", engine=engine)
+        assert enforcer._resolve_scheduler(entry) is scheduler


### PR DESCRIPTION
Builds on #1755 (which exposed `DFlashEngine.scheduler` for **fallback** mode) and the recent move of the prefill guard to HTTP 400. Those land the guard for DFlash's fallback path; this PR adds the missing **primary-mode** guard so DFlash is protected in both modes, reusing the same machinery rather than reshaping it.

## Summary
- DFlash's primary (speculative) path bypasses the `Scheduler`, so it inherited `BaseEngine`'s no-op `preflight_chat`/`preflight_completion` and ran prefills with **no** memory guard — a long prompt could OOM the process instead of returning a clean HTTP 400.
- Give DFlash a `_DFlashPrefillGuard` (built in `start()`) plus `preflight_*` overrides that estimate the prefill peak and raise `PrefillMemoryExceededError`; in fallback mode they delegate to the fallback engine, whose scheduler already runs the full guard.
- The `ProcessMemoryEnforcer` reaches the new guard through a small `_prefill_guard` arm in `_resolve_scheduler`.

## Why
After #1755, `DFlashEngine.scheduler` resolves the fallback engine's scheduler, so the enforcer can propagate watermarks **once DFlash enters fallback mode**. But in normal speculative mode DFlash has no scheduler at all — the enforcer had nowhere to push the ceiling, and the front-door preflight was still `BaseEngine`'s no-op. An oversized prompt served on the primary path therefore skipped the guard entirely and could drive the process past the memory ceiling (observed end-to-end serving Qwen3-Coder-Next + DFlash with 56k-token prompts). This closes that primary-mode gap with the same pieces #1755 and the 400 handler already established.

## Changes
- `omlx/memory_monitor.py`: two additive, engine-agnostic helpers — `set_model_info_from_model()` (populate a `MemoryMonitor`'s KV/SDPA dims from an mlx-lm model; `CacheList`-aware layer counting, matching `Scheduler._set_model_info_for_monitor`) and `raise_if_prefill_exceeds()` (the shared peak-estimate-and-raise). **`Scheduler` is intentionally left untouched** — it keeps its own (now TurboQuant-coupled) copy, so this PR doesn't reshape the scheduler hot path or its preflight math.
- `omlx/engine/dflash.py`: `_DFlashPrefillGuard` holds a `MemoryMonitor` + the enforcer's watermark attrs; `preflight_chat`/`preflight_completion` estimate the peak and raise, or delegate to the fallback engine in fallback mode. Coexists with the `scheduler` property added in #1755.
- `omlx/process_memory_enforcer.py`: `_resolve_scheduler` resolves a primary-mode DFlash to its `_prefill_guard` (`None` for every other engine, so standard resolution is unchanged). Fallback-mode resolution and the "could not resolve scheduler" warning suppression are already handled by #1755 and untouched here.
- The guard uses the uncompressed (base-dtype) KV estimate — the conservative, never-undercount choice for an OOM guard.

## Tests
New `tests/test_dflash_prefill_memory_guard.py` (12 cases: guard math mirroring `test_scheduler_prefill_memory_guard`, plus engine-level delegation including fallback-mode pass-through) and `TestDFlashGuardPropagation` in `tests/test_process_memory_enforcer.py` (enforcer reaches the primary guard; standard engines unchanged; no spurious warning).

```
.venv/bin/python -m pytest tests/test_dflash_prefill_memory_guard.py \
  tests/test_process_memory_enforcer.py tests/test_dflash_engine.py \
  tests/test_engine_preflight.py -q
# 198 passed
```

Also verified the new tests fail when the fix is reverted: neutralizing `raise_if_prefill_exceeds` makes `test_preflight_raises_when_oversized` fail with "DID NOT RAISE".
