### PR TITLE
feat(tts): forward language parameter to TTS engine

### DIFF
--- a/omlx/api/audio_models.py
+++ b/omlx/api/audio_models.py
@@ -33,6 +33,7 @@ class AudioSpeechRequest(BaseModel):
     model: str
     input: str
     voice: Optional[str] = None
+    language: Optional[str] = None
     instructions: Optional[str] = None
     speed: Optional[float] = 1.0
     response_format: Optional[str] = "wav"

--- a/omlx/api/audio_routes.py
+++ b/omlx/api/audio_routes.py
@@ -263,14 +263,15 @@ async def _stream_speech_response(
             and hasattr(engine, "stream_synthesize_pcm")
         ):
             logger.info(
-                "TTS native streaming start: model=%s, text_len=%d, voice=%s",
-                request.model, len(request.input), request.voice,
+                "TTS native streaming start: model=%s, text_len=%d, voice=%s, language=%s",
+                request.model, len(request.input), request.voice, request.language or "auto",
             )
             stream_format: Optional[tuple[int, int, int]] = None
             try:
                 async for sample_rate, channels, sample_width, pcm_bytes in engine.stream_synthesize_pcm(
                     request.input,
                     voice=request.voice,
+                    language=request.language,
                     speed=request.speed,
                     instructions=request.instructions,
                     ref_audio=ref_audio_path,
@@ -310,8 +311,8 @@ async def _stream_speech_response(
 
         segments = _split_tts_text(request.input)
         logger.info(
-            "TTS streaming start: model=%s, text_len=%d, segments=%d, voice=%s",
-            request.model, len(request.input), len(segments), request.voice,
+            "TTS streaming start: model=%s, text_len=%d, segments=%d, voice=%s, language=%s",
+            request.model, len(request.input), len(segments), request.voice, request.language or "auto",
         )
 
         stream_format: Optional[tuple[int, int, int]] = None
@@ -319,6 +320,7 @@ async def _stream_speech_response(
             wav_bytes = await engine.synthesize(
                 segment,
                 voice=request.voice,
+                language=request.language,
                 speed=request.speed,
                 instructions=request.instructions,
                 ref_audio=ref_audio_path,
@@ -546,6 +548,7 @@ async def create_speech(request: AudioSpeechRequest):
         wav_bytes = await engine.synthesize(
             request.input,
             voice=request.voice,
+            language=request.language,
             speed=request.speed,
             instructions=request.instructions,
             ref_audio=ref_audio_path,

--- a/omlx/engine/tts.py
+++ b/omlx/engine/tts.py
@@ -135,6 +135,7 @@ class TTSEngine(BaseNonStreamingEngine):
         self,
         text: str,
         voice: Optional[str] = None,
+        language: Optional[str] = None,
         speed: float = 1.0,
         instructions: Optional[str] = None,
         ref_audio: Optional[str] = None,
@@ -172,8 +173,8 @@ class TTSEngine(BaseNonStreamingEngine):
         import time
 
         logger.info(
-            "TTS synthesize: model=%s, text_len=%d, voice=%s, speed=%.1f, ref_audio=%s",
-            self._model_name, len(text), voice, speed,
+            "TTS synthesize: model=%s, text_len=%d, voice=%s, language=%s, speed=%.1f, ref_audio=%s",
+            self._model_name, len(text), voice, language or "auto", speed,
             "yes" if ref_audio else "no",
         )
 
@@ -198,6 +199,8 @@ class TTSEngine(BaseNonStreamingEngine):
                     gen_kwargs["instruct"] = voice
             if instructions is not None and "instruct" in gen_params:
                 gen_kwargs["instruct"] = instructions
+            if language and "lang_code" in gen_params:
+                gen_kwargs["lang_code"] = language
             if speed != 1.0:
                 gen_kwargs["speed"] = speed
             if ref_audio is not None and "ref_audio" in gen_params:
@@ -264,6 +267,7 @@ class TTSEngine(BaseNonStreamingEngine):
         self,
         text: str,
         voice: Optional[str] = None,
+        language: Optional[str] = None,
         speed: float = 1.0,
         instructions: Optional[str] = None,
         ref_audio: Optional[str] = None,
@@ -286,8 +290,8 @@ class TTSEngine(BaseNonStreamingEngine):
         import time
 
         logger.info(
-            "TTS native stream start: model=%s, text_len=%d, voice=%s, interval=%.2fs",
-            self._model_name, len(text), voice, streaming_interval,
+            "TTS native stream start: model=%s, text_len=%d, voice=%s, language=%s, interval=%.2fs",
+            self._model_name, len(text), voice, language or "auto", streaming_interval,
         )
 
         model = self._model
@@ -309,6 +313,8 @@ class TTSEngine(BaseNonStreamingEngine):
                     gen_kwargs["instruct"] = voice
             if instructions is not None and "instruct" in gen_params:
                 gen_kwargs["instruct"] = instructions
+            if language and "lang_code" in gen_params:
+                gen_kwargs["lang_code"] = language
             if speed != 1.0:
                 gen_kwargs["speed"] = speed
             if ref_audio is not None and "ref_audio" in gen_params:


### PR DESCRIPTION
The OpenAI-compatible /v1/audio/speech endpoint accepts an optional 'language' field (e.g. 'german', 'english') but it was silently dropped — AudioSpeechRequest had no language field, TTSEngine never received it, and the upstream Qwen3-TTS model fell back to lang_code "auto".

- Add language field to AudioSpeechRequest
- Accept and forward language in TTSEngine.synthesize() and stream_synthesize_pcm(), mapped to lang_code for Qwen3-TTS models
- Pass request.language in audio_routes.py for all three call sites: native streaming, segmented fallback, and non-streaming synthesis
- Log language in all TTS log lines