### PR TITLE
feat: expose DFlash copyspec_mode (prompt-lookup drafting) as a per-model setting

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -145,6 +145,7 @@ class ModelSettingsRequest(BaseModel):
     dflash_draft_window_size: int | None = None
     dflash_draft_sink_size: int | None = None
     dflash_verify_mode: str | None = None
+    dflash_copyspec_mode: str | None = None
     # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch)
     mtp_enabled: bool | None = None
     # VLM MTP speculative decoding via external assistant drafter (mlx-vlm 191d7c8+)
@@ -2282,6 +2283,13 @@ async def update_model_settings(
         # Anything else (including empty string) → revert to dflash default.
         current_settings.dflash_verify_mode = (
             value if value in ("dflash", "adaptive", "ddtree", "off") else None
+        )
+    if "dflash_copyspec_mode" in sent:
+        value = request.dflash_copyspec_mode
+        # dflash-mlx accepts: conservative | auto | off.
+        # Anything else (including empty string) → revert to dflash default.
+        current_settings.dflash_copyspec_mode = (
+            value if value in ("conservative", "auto", "off") else None
         )
 
     # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch)

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1454,6 +1454,7 @@
                     dflash_draft_window_size: s.dflash_draft_window_size ?? null,
                     dflash_draft_sink_size: s.dflash_draft_sink_size ?? null,
                     dflash_verify_mode: s.dflash_verify_mode || 'adaptive',
+                    dflash_copyspec_mode: s.dflash_copyspec_mode || 'conservative',
                     dflash_compatible: model?.dflash_compatible !== false,
                     dflash_compatibility_reason: model?.dflash_compatibility_reason || '',
                     dflash_ssd_cache_available: !!model?.dflash_ssd_cache_available,
@@ -1950,6 +1951,9 @@
                                 dflash_verify_mode: this.modelSettings.dflash_enabled
                                     ? (this.modelSettings.dflash_verify_mode || 'adaptive')
                                     : null,
+                                dflash_copyspec_mode: this.modelSettings.dflash_enabled
+                                    ? (this.modelSettings.dflash_copyspec_mode || 'conservative')
+                                    : null,
                                 mtp_enabled: !!this.modelSettings.mtp_enabled,
                                 vlm_mtp_enabled: !!this.modelSettings.vlm_mtp_enabled,
                                 vlm_mtp_draft_model: this.modelSettings.vlm_mtp_enabled
@@ -2086,6 +2090,7 @@
                         this.modelSettings.dflash_draft_window_size = null;
                         this.modelSettings.dflash_draft_sink_size = null;
                         this.modelSettings.dflash_verify_mode = 'adaptive';
+                        this.modelSettings.dflash_copyspec_mode = 'conservative';
                         this.modelSettings.mtp_enabled = false;
                         this.modelSettings.trust_remote_code = false;
                     } else if (response.status === 404) {

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -833,6 +833,16 @@
                                                 </select>
                                                 <p class="text-xs text-neutral-400 mt-1">Verifier algorithm. "adaptive" shrinks block size when acceptance drops; "off" disables speculative verify.</p>
                                             </div>
+                                            <div>
+                                                <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">Copyspec mode</label>
+                                                <select x-model="modelSettings.dflash_copyspec_mode"
+                                                        class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all bg-white">
+                                                    <option value="conservative">conservative (default)</option>
+                                                    <option value="auto">auto</option>
+                                                    <option value="off">off</option>
+                                                </select>
+                                                <p class="text-xs text-neutral-400 mt-1">Prompt-lookup drafting. "conservative" disables copyspec after one missed copy block; "auto" A/B-probes throughput and latches it on/off — helps copy-heavy output like code edits and quoting.</p>
+                                            </div>
                                         </div>
                                         <div class="flex items-start justify-between gap-3 pt-2 border-t border-neutral-200">
                                             <div class="min-w-0">

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -227,6 +227,11 @@ class DFlashEngine(BaseEngine):
             if model_settings
             else None
         )
+        self._copyspec_mode = (
+            getattr(model_settings, "dflash_copyspec_mode", None)
+            if model_settings
+            else None
+        )
 
     @property
     def model_name(self) -> str:
@@ -294,6 +299,7 @@ class DFlashEngine(BaseEngine):
             draft_window_size=self._draft_window_size,
             draft_sink_size=self._draft_sink_size,
             verify_mode=self._verify_mode,
+            copyspec_mode=self._copyspec_mode,
         )
         return build_runtime_context(cfg)
 

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -59,6 +59,7 @@ MODEL_SPECIFIC_PROFILE_FIELDS = (
     "dflash_draft_window_size",
     "dflash_draft_sink_size",
     "dflash_verify_mode",
+    "dflash_copyspec_mode",
     "mtp_enabled",
     "vlm_mtp_enabled",
     "vlm_mtp_draft_model",

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -81,6 +81,10 @@ class ModelSettings:
         dflash_verify_mode: Verifier algorithm — "dflash", "adaptive", "ddtree", or "off"
             (None = dflash default "adaptive"). "adaptive" can shrink block size when
             acceptance drops.
+        dflash_copyspec_mode: Prompt-lookup (copyspec) drafting policy — "conservative",
+            "auto", or "off" (None = dflash default "conservative"). "auto" A/B-probes
+            copyspec throughput and latches it on/off per workload; helps copy-heavy
+            output (code edits, quoting) that the conservative one-strike disable kills.
         mtp_enabled: Enable native multi-token prediction (mlx-lm PR 990 / PR 15 monkey-patch).
             When True, BatchGenerator uses MTP draft+verify for singleton decode and
             for multi-row decode batches whose cache positions are aligned. Unaligned
@@ -156,6 +160,7 @@ class ModelSettings:
     dflash_draft_window_size: Optional[int] = None
     dflash_draft_sink_size: Optional[int] = None
     dflash_verify_mode: Optional[str] = None  # "dflash" | "adaptive" | "ddtree" | "off"
+    dflash_copyspec_mode: Optional[str] = None  # "conservative" | "auto" | "off"
 
     # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch). When enabled, BatchGenerator
     # uses MTP draft+verify for singleton decode and aligned multi-row decode batches.

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -29,6 +29,7 @@ class TestDFlashModelSettings:
         assert settings.dflash_draft_window_size is None
         assert settings.dflash_draft_sink_size is None
         assert settings.dflash_verify_mode is None
+        assert settings.dflash_copyspec_mode is None
 
     def test_no_speculative_tokens_field(self):
         """dflash_speculative_tokens was removed in v2 and stays removed."""
@@ -57,6 +58,7 @@ class TestDFlashModelSettings:
         assert "dflash_draft_window_size" not in d
         assert "dflash_draft_sink_size" not in d
         assert "dflash_verify_mode" not in d
+        assert "dflash_copyspec_mode" not in d
 
     def test_from_dict_with_dflash_fields(self):
         data = {
@@ -115,11 +117,13 @@ class TestDFlashModelSettings:
             "dflash_draft_window_size": 2048,
             "dflash_draft_sink_size": 32,
             "dflash_verify_mode": "adaptive",
+            "dflash_copyspec_mode": "auto",
         }
         settings = ModelSettings.from_dict(data)
         assert settings.dflash_draft_window_size == 2048
         assert settings.dflash_draft_sink_size == 32
         assert settings.dflash_verify_mode == "adaptive"
+        assert settings.dflash_copyspec_mode == "auto"
 
     def test_roundtrip_serialization(self):
         original = ModelSettings(
@@ -431,6 +435,7 @@ class TestDFlashEngineInit:
         assert engine._draft_window_size is None
         assert engine._draft_sink_size is None
         assert engine._verify_mode is None
+        assert engine._copyspec_mode is None
 
     def test_long_context_knobs_read_from_settings(self):
         """Issue #1276 — DFlashEngine picks up window/sink/verify_mode from ModelSettings."""
@@ -446,11 +451,13 @@ class TestDFlashEngineInit:
                 dflash_draft_window_size=2048,
                 dflash_draft_sink_size=32,
                 dflash_verify_mode="adaptive",
+                dflash_copyspec_mode="auto",
             ),
         )
         assert engine._draft_window_size == 2048
         assert engine._draft_sink_size == 32
         assert engine._verify_mode == "adaptive"
+        assert engine._copyspec_mode == "auto"
 
     def test_build_runtime_context_passes_knobs(self):
         """The new kwargs reach dflash-mlx and end up in RuntimeContext.runtime."""
@@ -466,6 +473,7 @@ class TestDFlashEngineInit:
                 dflash_draft_window_size=512,
                 dflash_draft_sink_size=16,
                 dflash_verify_mode="dflash",
+                dflash_copyspec_mode="auto",
             ),
         )
         ctx = engine._build_runtime_context()
@@ -473,9 +481,10 @@ class TestDFlashEngineInit:
         assert runtime.draft_window_size == 512
         assert runtime.draft_sink_size == 16
         assert runtime.verify_mode == "dflash"
+        assert runtime.copyspec_mode == "auto"
 
     def test_build_runtime_context_defaults_to_dflash_mlx_values(self):
-        """None settings → dflash-mlx fills DEFAULT_RUNTIME_CONFIG (1024 / 64 / 'adaptive')."""
+        """None settings → dflash-mlx fills DEFAULT_RUNTIME_CONFIG (1024 / 64 / 'adaptive' / 'conservative')."""
         try:
             from omlx.engine.dflash import DFlashEngine
         except ImportError:
@@ -490,6 +499,7 @@ class TestDFlashEngineInit:
         assert runtime.draft_window_size == 1024
         assert runtime.draft_sink_size == 64
         assert runtime.verify_mode == "adaptive"
+        assert runtime.copyspec_mode == "conservative"
 
     def test_l2_max_bytes_from_settings(self, tmp_path):
         """Issue #1326 — dflash L2 disk budget comes from the per-model setting,


### PR DESCRIPTION
## Summary

dflash-mlx ships prompt-lookup (copyspec) drafting with three policies — `conservative` / `auto` / `off` — but omlx never passes the `copyspec_mode` kwarg to `runtime_config_from_defaults`, so every model is hard-pinned to `conservative`. (The `DFLASH_COPYSPEC_MODE` env var doesn't help either: dflash-mlx only resolves it on its CLI path, not the programmatic one omlx uses.)

`conservative` permanently disables copyspec for the rest of a request after **one** missed copy block. In chat/agentic serving the first copy attempt often whiffs early in a response, killing copyspec even when the output later becomes extremely copy-heavy — e.g. a coding agent re-emitting a 2,000-token file with a 3-line change. `auto` (a windowed A/B latch in dflash-mlx) recovers exactly that case: it probes copyspec-on vs -off throughput, latches to the winner, and self-disables with exponential backoff on workloads where copy never pays.

This PR wires `dflash_copyspec_mode` through the same path as `dflash_verify_mode` (#1276 lineage), defaulting to `None` → dflash-mlx's own default (`conservative`), so behavior is unchanged unless a user opts in.

**No dflash-mlx bump needed** — the pinned `0.1.9 @ 5d70fae` already contains `copyspec_mode` (incl. the `auto` gate); verified against the installed package.

## Changes

- `omlx/model_settings.py` — new `dflash_copyspec_mode: Optional[str]` field + docstring
- `omlx/model_profiles.py` — added to the model-specific profile field list
- `omlx/admin/routes.py` — request field + update handler (validates `conservative|auto|off`, anything else → `None` = dflash default)
- `omlx/engine/dflash.py` — read from settings, pass `copyspec_mode=` into `runtime_config_from_defaults`
- `omlx/admin/static/js/dashboard.js` / `_modal_model_settings.html` — Copyspec mode select in the DFlash long-context tuning section (load, save, defaults-reset)
- `tests/test_dflash_engine.py` — extended the existing knob tests: dataclass default, `to_dict` omission when `None`, `from_dict` round-trip, engine reads setting, kwarg reaches `RuntimeContext.runtime`, dflash-mlx default fill-in

## Test plan

- [x] `pytest tests/ -m "not slow and not integration"` — 5432 passed, 22 skipped
- [x] `tests/test_admin_profiles_api.py` field-accounting test confirms the new field is classified (profile-eligible)
- [x] `runtime.copyspec_mode == "auto"` asserted end-to-end through `_build_runtime_context()` against the pinned dflash-mlx
- [ ] Manual: flip a DFlash model to `auto` in the dashboard and confirm copyspec counters move in `/v1/internal/metrics` on a copy-heavy prompt