### PR TITLE
fix: honor per-model SpecPrefill settings on every generation path

### DIFF
--- a/omlx/engine/base.py
+++ b/omlx/engine/base.py
@@ -158,6 +158,41 @@ async def _run_scheduler_preflight_with_cleanup_retry(
         return
 
 
+def resolve_specprefill_kwargs(
+    kwargs: Dict[str, Any], model_settings: Any
+) -> Dict[str, Any]:
+    """Pop per-request SpecPrefill overrides from ``kwargs``, falling back
+    to per-model settings for keep_pct/threshold (issue #1263).
+
+    Per-request API values win. When a request carries no override, the
+    model's configured ``specprefill_keep_pct`` / ``specprefill_threshold``
+    apply here — at the engine chokepoint — so every entry point (chat
+    streaming and non-streaming, /v1/completions, /v1/messages, admin
+    benchmark) honors the settings without each route re-injecting them.
+
+    The ``specprefill`` enable flag stays request-only: engine_core already
+    enables SpecPrefill whenever the draft model is loaded, and the draft
+    model only loads when ``specprefill_enabled`` was set.
+    """
+    resolved: Dict[str, Any] = {}
+    if kwargs.get("specprefill") is not None:
+        resolved["specprefill"] = kwargs.pop("specprefill")
+    keep_pct = kwargs.pop("specprefill_keep_pct", None)
+    if keep_pct is None:
+        keep_pct = getattr(model_settings, "specprefill_keep_pct", None)
+    if keep_pct is not None:
+        resolved["specprefill_keep_pct"] = keep_pct
+    threshold = kwargs.pop("specprefill_threshold", None)
+    if threshold is None:
+        threshold = getattr(model_settings, "specprefill_threshold", None)
+    if threshold is not None:
+        resolved["specprefill_threshold"] = threshold
+    system_end = kwargs.pop("specprefill_system_end", None)
+    if system_end is not None:
+        resolved["specprefill_system_end"] = system_end
+    return resolved
+
+
 @dataclass
 class GenerationOutput:
     """

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -21,6 +21,7 @@ from .base import (
     _clear_teardown_references,
     _run_scheduler_preflight_with_cleanup_retry,
     _warn_scheduler_unreachable_once,
+    resolve_specprefill_kwargs,
 )
 
 logger = logging.getLogger(__name__)
@@ -906,9 +907,8 @@ class BatchedEngine(BaseEngine):
             seed=kwargs.get("seed", None),
         )
 
-        # SpecPrefill: forward per-request overrides to the engine, mirroring
-        # stream_generate so the non-streaming path is not silently ignored.
-        specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
+        # SpecPrefill: per-request overrides, falling back to model settings
+        specprefill_kwargs = resolve_specprefill_kwargs(kwargs, self._model_settings)
         tools = kwargs.pop("tools", None)
 
         output = await self._engine.generate(
@@ -984,8 +984,8 @@ class BatchedEngine(BaseEngine):
             seed=kwargs.get("seed", None),
         )
 
-        # SpecPrefill: pass per-request overrides to engine
-        specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
+        # SpecPrefill: per-request overrides, falling back to model settings
+        specprefill_kwargs = resolve_specprefill_kwargs(kwargs, self._model_settings)
         tools = kwargs.pop("tools", None)
 
         engine = self._engine

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -59,6 +59,7 @@ from .base import (
     _clear_teardown_references,
     _run_scheduler_preflight_with_cleanup_retry,
     _warn_scheduler_unreachable_once,
+    resolve_specprefill_kwargs,
 )
 
 logger = logging.getLogger(__name__)
@@ -3566,9 +3567,8 @@ class VLMBatchedEngine(BaseEngine):
             seed=kwargs.get("seed", None),
         )
 
-        # SpecPrefill: forward per-request overrides to the engine, mirroring
-        # stream_generate so the non-streaming path is not silently ignored.
-        specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
+        # SpecPrefill: per-request overrides, falling back to model settings
+        specprefill_kwargs = resolve_specprefill_kwargs(kwargs, self._model_settings)
         tools = kwargs.pop("tools", None)
 
         output = await self._engine.generate(
@@ -3679,8 +3679,8 @@ class VLMBatchedEngine(BaseEngine):
             seed=kwargs.get("seed", None),
         )
 
-        # SpecPrefill: pass per-request overrides
-        specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
+        # SpecPrefill: per-request overrides, falling back to model settings
+        specprefill_kwargs = resolve_specprefill_kwargs(kwargs, self._model_settings)
         tools = kwargs.pop("tools", None)
 
         engine = self._engine

--- a/tests/test_specprefill.py
+++ b/tests/test_specprefill.py
@@ -906,3 +906,210 @@ class TestTargetPrefillLeftoverCleanup:
         # Entry cleanup must restore the genuine rope before prefill runs
         assert seen["rope"] is genuine
         assert layer.self_attn.rope is genuine
+
+
+class TestResolveSpecprefillKwargs:
+    """Issue #1263 — per-model SpecPrefill settings reach the request.
+
+    The server only injects settings on the OpenAI chat route; every other
+    entry point (admin benchmark, non-streaming chat, /v1/completions,
+    /v1/messages) used to drop them. The engine-level helper applies the
+    model-settings fallback at the add_request chokepoint instead.
+    """
+
+    def _resolve(self, kwargs, settings):
+        from omlx.engine.base import resolve_specprefill_kwargs
+
+        return resolve_specprefill_kwargs(kwargs, settings)
+
+    def test_settings_fill_missing_values(self):
+        from omlx.model_settings import ModelSettings
+
+        settings = ModelSettings(
+            specprefill_keep_pct=0.1, specprefill_threshold=32768
+        )
+        resolved = self._resolve({}, settings)
+        assert resolved == {
+            "specprefill_keep_pct": 0.1,
+            "specprefill_threshold": 32768,
+        }
+
+    def test_request_value_wins_over_settings(self):
+        from omlx.model_settings import ModelSettings
+
+        settings = ModelSettings(
+            specprefill_keep_pct=0.1, specprefill_threshold=32768
+        )
+        kwargs = {"specprefill_keep_pct": 0.4, "specprefill_threshold": 2048}
+        resolved = self._resolve(kwargs, settings)
+        assert resolved["specprefill_keep_pct"] == 0.4
+        assert resolved["specprefill_threshold"] == 2048
+
+    def test_no_request_no_settings_yields_empty(self):
+        from omlx.model_settings import ModelSettings
+
+        assert self._resolve({}, ModelSettings()) == {}
+
+    def test_none_model_settings(self):
+        assert self._resolve({"specprefill_threshold": 4096}, None) == {
+            "specprefill_threshold": 4096
+        }
+
+    def test_kwargs_are_consumed(self):
+        kwargs = {
+            "specprefill": True,
+            "specprefill_keep_pct": 0.3,
+            "specprefill_threshold": 1024,
+            "specprefill_system_end": 17,
+            "unrelated": "stays",
+        }
+        resolved = self._resolve(kwargs, None)
+        assert kwargs == {"unrelated": "stays"}
+        assert resolved == {
+            "specprefill": True,
+            "specprefill_keep_pct": 0.3,
+            "specprefill_threshold": 1024,
+            "specprefill_system_end": 17,
+        }
+
+    def test_enable_flag_not_defaulted_from_settings(self):
+        """The enable flag stays request-only: engine_core already enables
+        SpecPrefill whenever the draft model is loaded, so the helper must
+        not inject specprefill=True/False from settings."""
+        from omlx.model_settings import ModelSettings
+
+        settings = ModelSettings(specprefill_enabled=True)
+        assert "specprefill" not in self._resolve({}, settings)
+
+
+class _FakeCoreEngine:
+    """Minimal AsyncEngineCore stand-in recording add_request/generate kwargs."""
+
+    def __init__(self):
+        self.add_request_kwargs = None
+        self.generate_kwargs = None
+
+    async def add_request(self, **kwargs):
+        self.add_request_kwargs = kwargs
+        return "req-1"
+
+    async def generate(self, **kwargs):
+        from types import SimpleNamespace
+
+        self.generate_kwargs = kwargs
+        return SimpleNamespace(
+            output_text="ok",
+            prompt_tokens=3,
+            completion_tokens=1,
+            finish_reason="stop",
+            tool_calls=None,
+            cached_tokens=0,
+            first_token_at=None,
+        )
+
+    async def stream_outputs(self, request_id):
+        from types import SimpleNamespace
+
+        yield SimpleNamespace(
+            output_text="ok",
+            new_text="ok",
+            prompt_tokens=3,
+            completion_tokens=1,
+            finished=True,
+            finish_reason="stop",
+            tool_calls=None,
+            cached_tokens=0,
+        )
+
+    async def abort_request(self, request_id):
+        return True
+
+
+class TestEngineSettingsFallback:
+    """Issue #1263 — BatchedEngine/VLM engines honor per-model SpecPrefill
+    settings on every generation path, not just the OpenAI chat route."""
+
+    def _batched_engine(self, settings):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine("test-model", model_settings=settings)
+        engine._loaded = True
+        engine._engine = _FakeCoreEngine()
+        return engine
+
+    def _vlm_engine(self, settings):
+        from omlx.engine.vlm import VLMBatchedEngine
+
+        engine = VLMBatchedEngine("test-model", model_settings=settings)
+        engine._loaded = True
+        engine._engine = _FakeCoreEngine()
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_batched_stream_generate_falls_back_to_settings(self):
+        """Benchmark path: stream_generate with no explicit kwargs."""
+        from omlx.model_settings import ModelSettings
+
+        engine = self._batched_engine(
+            ModelSettings(specprefill_keep_pct=0.1, specprefill_threshold=65536)
+        )
+        async for _ in engine.stream_generate(prompt="hi", max_tokens=4):
+            pass
+        sent = engine._engine.add_request_kwargs
+        assert sent["specprefill_keep_pct"] == 0.1
+        assert sent["specprefill_threshold"] == 65536
+
+    @pytest.mark.asyncio
+    async def test_batched_stream_generate_request_override_wins(self):
+        from omlx.model_settings import ModelSettings
+
+        engine = self._batched_engine(ModelSettings(specprefill_threshold=65536))
+        async for _ in engine.stream_generate(
+            prompt="hi", max_tokens=4, specprefill_threshold=2048
+        ):
+            pass
+        assert engine._engine.add_request_kwargs["specprefill_threshold"] == 2048
+
+    @pytest.mark.asyncio
+    async def test_batched_generate_forwards_specprefill(self):
+        """Non-streaming path (engine.chat) used to drop the kwargs entirely."""
+        from omlx.model_settings import ModelSettings
+
+        engine = self._batched_engine(ModelSettings(specprefill_threshold=32768))
+        await engine.generate(
+            prompt="hi", max_tokens=4, specprefill_keep_pct=0.25
+        )
+        sent = engine._engine.generate_kwargs
+        assert sent["specprefill_keep_pct"] == 0.25
+        assert sent["specprefill_threshold"] == 32768
+
+    @pytest.mark.asyncio
+    async def test_batched_no_settings_sends_nothing(self):
+        """No settings, no kwargs → engine_core/scheduler defaults apply."""
+        engine = self._batched_engine(None)
+        async for _ in engine.stream_generate(prompt="hi", max_tokens=4):
+            pass
+        sent = engine._engine.add_request_kwargs
+        assert "specprefill_threshold" not in sent
+        assert "specprefill_keep_pct" not in sent
+
+    @pytest.mark.asyncio
+    async def test_vlm_stream_generate_falls_back_to_settings(self):
+        from omlx.model_settings import ModelSettings
+
+        engine = self._vlm_engine(
+            ModelSettings(specprefill_keep_pct=0.1, specprefill_threshold=65536)
+        )
+        async for _ in engine.stream_generate(prompt=[1, 2, 3], max_tokens=4):
+            pass
+        sent = engine._engine.add_request_kwargs
+        assert sent["specprefill_keep_pct"] == 0.1
+        assert sent["specprefill_threshold"] == 65536
+
+    @pytest.mark.asyncio
+    async def test_vlm_generate_forwards_specprefill(self):
+        from omlx.model_settings import ModelSettings
+
+        engine = self._vlm_engine(ModelSettings(specprefill_threshold=32768))
+        await engine.generate(prompt=[1, 2, 3], max_tokens=4)
+        assert engine._engine.generate_kwargs["specprefill_threshold"] == 32768


### PR DESCRIPTION
## Summary

Fixes #1263 — the per-model `specprefill_threshold` / `specprefill_keep_pct` settings were silently ignored on most paths, so SpecPrefill always activated at the hardcoded boundary (threshold 8192, keep 20%) regardless of configuration.

## Root cause

The settings→request chain only existed on the **OpenAI chat-completions route**, which injects the values into `chat_kwargs` server-side (`server.py`, added in ba9f8b7 for #443). Every other entry point dropped them:

| Path | Break |
|---|---|
| **Admin benchmark** | `_run_single_test` calls `engine.stream_generate(prompt, max_tokens, temperature, top_p)` — no specprefill kwargs at all. This is the path both reports in #1263 used (logs show `omlx.admin.benchmark`), which is why threshold=32768 still activated at pp16384 and keep_pct=0.1 still logged `keep=20%`. |
| **Non-streaming chat** (`engine.chat`) | `BatchedEngine.generate` / `VLMBatchedEngine.generate` built `SamplingParams` and called `engine_core.generate(prompt, sampling_params)` — the specprefill kwargs died unused in `**kwargs`. |
| **`/v1/completions` and `/v1/messages`** | Those routes never build specprefill `chat_kwargs` server-side, so nothing was forwarded even on streaming. |

Meanwhile activation still *happened* because `engine_core.add_request` enables SpecPrefill whenever the draft model is loaded — so users saw it firing, just never at their configured threshold. Exactly the reported symptom.

## Fix

Apply the model-settings fallback at the **engine chokepoint** instead of per-route injection: new `resolve_specprefill_kwargs(kwargs, model_settings)` in `omlx/engine/base.py` pops the per-request overrides (which still win) and fills `specprefill_threshold` / `specprefill_keep_pct` from the engine's own `model_settings`. Both `BatchedEngine` and `VLMBatchedEngine` use it in `stream_generate` **and** `generate`, so the benchmark, non-streaming chat, `/v1/completions`, and `/v1/messages` all resolve identically with no server-side changes.

Precedence: per-request API value → server-injected live setting (chat route, unchanged) → engine model-settings snapshot → dflash/scheduler defaults.

The `specprefill` **enable** flag intentionally stays request-only: `engine_core` already enables SpecPrefill iff the draft model is loaded, and the draft model only loads when `specprefill_enabled` was set — defaulting it from settings here would be redundant.

## Tests

- `TestResolveSpecprefillKwargs` — settings fill missing values; per-request wins; empty when neither set; kwargs consumed; enable flag never injected from settings
- `TestEngineSettingsFallback` — through real `BatchedEngine`/`VLMBatchedEngine` `stream_generate`/`generate` with a recording engine-core fake: settings reach `add_request`/`generate` (the benchmark + non-streaming repros, RED before this fix), request override wins, nothing sent when nothing configured

## Test plan

- [x] `pytest tests/ -m "not slow and not integration"` — 5444 passed, 22 skipped
- [x] New engine-path tests fail on main, pass with the fix
- [ ] Manual: configure `specprefill_threshold: 32768`, run admin benchmark at pp16384 → no `SpecPrefill: scored` log line; pp65536 → activates