### PR TITLE
debug: prefix-cache divergence probe for always-miss diagnosis (#1003)

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1198,6 +1198,12 @@ class Scheduler:
         # Track active specprefill request for RoPE cleanup
         self._specprefill_active_request_id: str | None = None
 
+        # DEBUG-only prefix-cache divergence probe (issue #1003): recent
+        # stored cache sequences, so a miss can be traced to the exact
+        # token where the new prompt diverges from what was cached.
+        # Populated only when debug logging is enabled — zero cost otherwise.
+        self._cache_probe_seqs: deque[tuple[str, list[int]]] = deque(maxlen=4)
+
         # VLM MTP: gemma4_assistant drafter attached by VLMBatchedEngine.
         # When set, eligible requests bypass mlx-lm BatchGenerator for decode
         # and run through mlx-vlm's _mtp_rounds round loop instead.
@@ -4711,6 +4717,55 @@ class Scheduler:
 
         return extracted, model_cache_config
 
+    @staticmethod
+    def _common_prefix_len(a: list[int], b: list[int]) -> int:
+        n = min(len(a), len(b))
+        for i in range(n):
+            if a[i] != b[i]:
+                return i
+        return n
+
+    def _log_prefix_divergence(self, request: Request) -> None:
+        """DEBUG-only prefix-cache miss diagnostic (issue #1003).
+
+        Compares the new prompt against recently stored cache sequences and
+        logs the first divergent token offset with decoded context on both
+        sides, so an always-miss report can be traced to the exact prompt
+        position (template re-render drift, client echo changes, eviction)
+        instead of guessing from hit counters.
+        """
+        prompt = request.prompt_token_ids or []
+        if not prompt or not self._cache_probe_seqs:
+            return
+        best_id, best_seq, best_p = None, None, -1
+        for ref_id, seq in list(self._cache_probe_seqs):
+            p = self._common_prefix_len(prompt, seq)
+            if p > best_p:
+                best_id, best_seq, best_p = ref_id, seq, p
+        if best_seq is None:
+            return
+        cached = request.cached_tokens or 0
+        reusable = min(len(prompt), len(best_seq))
+        block = self.config.paged_cache_block_size
+        logger.debug(
+            f"Request {request.request_id}: prefix probe vs stored {best_id}: "
+            f"common_prefix={best_p}/{reusable} tokens "
+            f"(~{best_p // max(1, block)} blocks of {block}), "
+            f"served cached_tokens={cached}, prompt={len(prompt)}"
+        )
+        if best_p < reusable:
+            lo = max(0, best_p - 12)
+            hi = best_p + 12
+            try:
+                stored_ctx = self.tokenizer.decode(best_seq[lo:hi])
+                prompt_ctx = self.tokenizer.decode(prompt[lo:hi])
+            except Exception:
+                stored_ctx = prompt_ctx = "<decode failed>"
+            logger.debug(
+                f"Request {request.request_id}: first divergence at token "
+                f"{best_p}: stored=...{stored_ctx!r} vs prompt=...{prompt_ctx!r}"
+            )
+
     def add_request(self, request: Request) -> None:
         """
         Add a new request to the scheduler.
@@ -4850,6 +4905,11 @@ class Scheduler:
         else:
             # No paged SSD cache configured - process all tokens
             request.remaining_tokens = request.prompt_token_ids
+
+        # DEBUG-only: trace where this prompt diverges from recently stored
+        # cache sequences (issue #1003 always-miss diagnosis).
+        if logger.isEnabledFor(logging.DEBUG):
+            self._log_prefix_divergence(request)
 
         # SpecPrefill: score remaining tokens with draft model if applicable.
         # Must run AFTER prefix cache check (scoring applies only to uncached suffix).
@@ -6945,6 +7005,14 @@ class Scheduler:
                             else:
                                 cacheable_sequence = full_token_sequence
                             token_sequence_to_store = cacheable_sequence
+                            # DEBUG-only divergence probe (issue #1003)
+                            if logger.isEnabledFor(logging.DEBUG):
+                                self._cache_probe_seqs.append(
+                                    (
+                                        request.request_id,
+                                        list(token_sequence_to_store),
+                                    )
+                                )
                             cache_to_store = request._extracted_cache
                             model_cache_config = getattr(
                                 request, "_model_cache_config", None

--- a/tests/test_prefix_divergence_probe.py
+++ b/tests/test_prefix_divergence_probe.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the DEBUG-only prefix-cache divergence probe (issue #1003)."""
+
+import logging
+from collections import deque
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from omlx.scheduler import Scheduler
+
+
+class _FakeTokenizer:
+    def decode(self, ids):
+        return "".join(chr(ord("a") + (i % 26)) for i in ids)
+
+
+def _make_scheduler(block_size=2048):
+    sched = object.__new__(Scheduler)
+    sched._cache_probe_seqs = deque(maxlen=4)
+    sched.tokenizer = _FakeTokenizer()
+    sched.config = MagicMock(spec=[])
+    sched.config.paged_cache_block_size = block_size
+    return sched
+
+
+def _request(prompt_ids, cached_tokens=0, request_id="req-new"):
+    return SimpleNamespace(
+        request_id=request_id,
+        prompt_token_ids=prompt_ids,
+        cached_tokens=cached_tokens,
+    )
+
+
+class TestCommonPrefixLen:
+    def test_identical(self):
+        assert Scheduler._common_prefix_len([1, 2, 3], [1, 2, 3]) == 3
+
+    def test_divergent(self):
+        assert Scheduler._common_prefix_len([1, 2, 3, 4], [1, 2, 9, 4]) == 2
+
+    def test_length_mismatch(self):
+        assert Scheduler._common_prefix_len([1, 2], [1, 2, 3, 4]) == 2
+
+    def test_empty(self):
+        assert Scheduler._common_prefix_len([], [1]) == 0
+
+
+class TestDivergenceProbe:
+    def test_logs_divergence_offset_and_context(self, caplog):
+        sched = _make_scheduler()
+        stored = list(range(100))
+        sched._cache_probe_seqs.append(("req-old", stored))
+        prompt = list(range(50)) + [999] + list(range(51, 80))
+
+        with caplog.at_level(logging.DEBUG, logger="omlx.scheduler"):
+            sched._log_prefix_divergence(_request(prompt))
+
+        text = caplog.text
+        assert "prefix probe vs stored req-old" in text
+        assert "common_prefix=50/80" in text
+        assert "first divergence at token 50" in text
+
+    def test_full_match_logs_no_divergence_line(self, caplog):
+        sched = _make_scheduler()
+        stored = list(range(100))
+        sched._cache_probe_seqs.append(("req-old", stored))
+        # Prompt extends the stored sequence — common prefix covers all
+        # reusable tokens, so only the summary line should be emitted.
+        prompt = stored + [200, 201]
+
+        with caplog.at_level(logging.DEBUG, logger="omlx.scheduler"):
+            sched._log_prefix_divergence(_request(prompt, cached_tokens=100))
+
+        assert "prefix probe" in caplog.text
+        assert "first divergence" not in caplog.text
+
+    def test_picks_best_matching_stored_sequence(self, caplog):
+        sched = _make_scheduler()
+        sched._cache_probe_seqs.append(("req-a", [9, 9, 9]))
+        sched._cache_probe_seqs.append(("req-b", [1, 2, 3, 4, 5]))
+        prompt = [1, 2, 3, 7, 7]
+
+        with caplog.at_level(logging.DEBUG, logger="omlx.scheduler"):
+            sched._log_prefix_divergence(_request(prompt))
+
+        assert "vs stored req-b" in caplog.text
+        assert "common_prefix=3/5" in caplog.text
+
+    def test_noop_without_stored_sequences(self, caplog):
+        sched = _make_scheduler()
+        with caplog.at_level(logging.DEBUG, logger="omlx.scheduler"):
+            sched._log_prefix_divergence(_request([1, 2, 3]))
+        assert caplog.text == ""
+
+    def test_noop_with_empty_prompt(self, caplog):
+        sched = _make_scheduler()
+        sched._cache_probe_seqs.append(("req-old", [1, 2]))
+        with caplog.at_level(logging.DEBUG, logger="omlx.scheduler"):
+            sched._log_prefix_divergence(_request([]))
+        assert caplog.text == ""
+
+    def test_decode_failure_is_tolerated(self, caplog):
+        sched = _make_scheduler()
+        sched.tokenizer = MagicMock()
+        sched.tokenizer.decode.side_effect = RuntimeError("boom")
+        sched._cache_probe_seqs.append(("req-old", [1, 2, 3, 4]))
+
+        with caplog.at_level(logging.DEBUG, logger="omlx.scheduler"):
+            sched._log_prefix_divergence(_request([1, 9, 9, 9]))
+
+        assert "first divergence at token 1" in caplog.text
+        assert "<decode failed>" in caplog.text


### PR DESCRIPTION
## Summary

Diagnostic instrumentation for #1003 (KV prefix cache always misses for long agent sessions on thinking models since 0.3.8). Hit counters alone can't show **where** a new prompt stops matching what was cached — which is exactly the question that separates the candidate causes (template re-render drift vs client-side history edits vs eviction). This is the log you asked the reporter to capture, made decisive.

## What it does

When debug logging is enabled, the scheduler keeps the token sequences of the last 4 stored cache entries (`_cache_probe_seqs`, deque maxlen=4). On each `add_request`, after the prefix-cache lookup, it logs:

```
Request <id>: prefix probe vs stored <ref>: common_prefix=P/R tokens (~B blocks of 2048), served cached_tokens=C, prompt=N
Request <id>: first divergence at token P: stored=...'<decoded ±12 tokens>' vs prompt=...'<decoded ±12 tokens>'
```

Zero cost at default log levels — both the recording and the probe are gated on `logger.isEnabledFor(logging.DEBUG)`.

## Offline findings that motivated this (round-trip harness vs the real Qwen3.6 template + tokenizer)

Simulating multi-turn agent traffic through omlx's actual parse/echo/re-render code paths:

- `preserve_thinking=True` + client echoes `reasoning_content` on all turns + canonical emission whitespace → **100% token-exact prefix reuse**, including through structured tool-call round-trips. The 0.3.8 feature is not inherently cache-breaking.
- Non-canonical emission whitespace (e.g. `\n\n</think>`) and Anthropic-style echo-last-only clients each cause divergence — but always **tail-bounded** (last 1–2 turns), never a head wipe-out.
- So none of the omlx-side mechanisms reproduce the reported *total* always-miss; the live divergence offset (which this probe logs) is the missing evidence.

Related observation for a follow-up: `needs_think_prefix` store carve-out (scheduler, c8ee5ea) caches only prompt tokens for reasoning models — correct pre-0.3.7, but with `preserve_thinking=True` it now discards generated tokens that the next prompt *does* contain, capping best-case reuse at the previous prompt boundary.

## Test plan

- [x] 10 new unit tests (`tests/test_prefix_divergence_probe.py`): divergence offset + context logging, full-match summary-only, best-of-4 selection, empty-state no-ops, decode-failure tolerance
- [x] `pytest tests/ -m "not slow and not integration"` — 5442 passed, 22 skipped