### PR TITLE
Fix TurboQuant Cache Reconstruction Crash and Performance Bottleneck

### DIFF
--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -1884,59 +1884,79 @@ class BlockAwarePrefixCache(CacheManager):
                         _state_length,
                     )
 
-                    key_states, value_states = [], []
+                    current_tq_ks, current_tq_vs = [], []
+                    valid_fp16_ks, valid_fp16_vs = [], []
+                    
+                    tq_bits, tq_seed = 4.0, 0
+                    if first_block_meta_states and layer_idx < len(first_block_meta_states):
+                        ms = first_block_meta_states[layer_idx]
+                        if isinstance(ms, (list, tuple)) and len(ms) >= 3:
+                            tq_bits = float(ms[1])
+                            tq_seed = int(ms[2])
+
                     for block_data in all_block_data:
                         if layer_idx >= len(block_data):
                             continue
                         bd = block_data[layer_idx]
                         if isinstance(bd, tuple) and len(bd) == 2:
                             if isinstance(bd[0], str) and bd[0] == "__turboquant_v2__":
-                                ks, vs = bd[1]
+                                current_tq_ks.append(bd[1][0])
+                                current_tq_vs.append(bd[1][1])
                             else:
                                 ks, vs = bd
-                            key_states.append(ks)
-                            value_states.append(vs)
-                    if not key_states:
-                        logger.debug(f"TQ layer {layer_idx}: no block data")
-                        return None
-                    # Concatenate along token dimension
-                    cat_ks = key_states[0]
-                    for s in key_states[1:]:
-                        cat_ks = _concat_state(cat_ks, s)
-                    cat_vs = value_states[0]
-                    for s in value_states[1:]:
-                        cat_vs = _concat_state(cat_vs, s)
-                    try:
-                        from mlx_lm.models.cache import KVCache
-                        from mlx_vlm.turboquant import TurboQuantKVCache
+                                if hasattr(ks, "shape") and ks.shape == (1,):
+                                    continue  # Skip placeholder
+                                valid_fp16_ks.append(ks)
+                                valid_fp16_vs.append(vs)
 
-                        tq_bits = 4.0
-                        tq_seed = 0
-                        ms = None
-                        if first_block_meta_states and layer_idx < len(
-                            first_block_meta_states
-                        ):
-                            ms = first_block_meta_states[layer_idx]
-                        if isinstance(ms, (list, tuple)) and len(ms) >= 3:
-                            tq_bits = float(ms[1])
-                            tq_seed = int(ms[2])
-                        # Dequantize back to fp16 KVCache for merge compatibility.
-                        # TQ will be re-applied at decode start (lazy quantization).
-                        tq = TurboQuantKVCache(bits=tq_bits, seed=tq_seed)
-                        tq.keys = cat_ks
-                        tq.values = cat_vs
-                        tq.offset = _state_length(cat_ks)
-                        _rebuild_codecs(tq, cat_ks, cat_vs)
-                        keys, values = tq.dequantize()
-                        cache = KVCache()
-                        cache.keys = keys
-                        cache.values = values
-                        cache.offset = keys.shape[2]
-                        reconstructed_caches.append(cache)
+                    try:
+                        from mlx_vlm.turboquant import TurboQuantKVCache, _concat_state, _state_length
+                        from mlx_lm.models.cache import KVCache
+                        from omlx.turboquant_kv import _rebuild_codecs
+
+                        # If we have TQ states, concatenate them
+                        tq = None
+                        if current_tq_ks:
+                            cat_ks = current_tq_ks[0]
+                            for s in current_tq_ks[1:]:
+                                cat_ks = _concat_state(cat_ks, s)
+                            cat_vs = current_tq_vs[0]
+                            for s in current_tq_vs[1:]:
+                                cat_vs = _concat_state(cat_vs, s)
+                            
+                            tq = TurboQuantKVCache(bits=tq_bits, seed=tq_seed)
+                            tq.keys = cat_ks
+                            tq.values = cat_vs
+                            tq.offset = _state_length(cat_ks)
+                            _rebuild_codecs(tq, cat_ks, cat_vs)
+
+                        if valid_fp16_ks:
+                            # Mixed state fallback: dequantize TQ and concatenate with fp16
+                            fp16_ks_list, fp16_vs_list = [], []
+                            if tq is not None:
+                                k, v = tq.dequantize()
+                                fp16_ks_list.append(k)
+                                fp16_vs_list.append(v)
+                            fp16_ks_list.extend(valid_fp16_ks)
+                            fp16_vs_list.extend(valid_fp16_vs)
+                            
+                            cat_ks = mx.concatenate(fp16_ks_list, axis=2) if len(fp16_ks_list) > 1 else fp16_ks_list[0]
+                            cat_vs = mx.concatenate(fp16_vs_list, axis=2) if len(fp16_vs_list) > 1 else fp16_vs_list[0]
+                            cache = KVCache()
+                            cache.keys = cat_ks
+                            cache.values = cat_vs
+                            cache.offset = cat_ks.shape[2]
+                            reconstructed_caches.append(cache)
+                        elif tq is not None:
+                            # Pure TQ state: return TurboQuantKVCache directly!
+                            # This completely avoids dequantize -> requantize overhead.
+                            reconstructed_caches.append(tq)
+                        else:
+                            # No valid data for this layer
+                            return None
+
                     except Exception as e:
-                        logger.error(
-                            f"TQ layer {layer_idx}: reconstruction failed: {e}"
-                        )
+                        logger.error(f"TQ layer {layer_idx}: reconstruction failed: {e}")
                         return None
                     continue
 
@@ -2093,10 +2113,11 @@ class BlockAwarePrefixCache(CacheManager):
             return reconstructed_caches
 
         except Exception as e:
-            logger.warning(f"Failed to reconstruct cache: {e}")
             import traceback
 
-            logger.debug(traceback.format_exc())
+            logger.warning(
+                f"Failed to reconstruct cache: {e}\n{traceback.format_exc()}"
+            )
             return None
 
     def _fallback_reconstruct_layer(

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -806,6 +806,17 @@ def _collect_cache_storage_arrays(cache_obj: Any) -> list[mx.array]:
     """Collect concrete backing arrays from cache objects, not state slices."""
     arrays: list[mx.array] = []
 
+    def _extract(val: Any):
+        if isinstance(val, mx.array):
+            arrays.append(val)
+        elif hasattr(val, "__dataclass_fields__"):
+            import dataclasses
+            for f in dataclasses.fields(val):
+                _extract(getattr(val, f.name))
+        elif isinstance(val, (list, tuple)):
+            for v in val:
+                _extract(v)
+
     if isinstance(cache_obj, mx.array):
         return [cache_obj]
 
@@ -821,8 +832,7 @@ def _collect_cache_storage_arrays(cache_obj: Any) -> list[mx.array]:
 
     for attr in ("keys", "values", "left_padding", "lengths"):
         value = getattr(cache_obj, attr, None)
-        if isinstance(value, mx.array):
-            arrays.append(value)
+        _extract(value)
 
     return arrays
 
@@ -2292,7 +2302,11 @@ class Scheduler:
         from mlx_lm.models.cache import CacheList, KVCache
         from mlx_vlm.turboquant import TurboQuantKVCache
 
-        kv_indices = [i for i, c in enumerate(prompt_cache) if isinstance(c, KVCache)]
+        kv_indices = [
+            i
+            for i, c in enumerate(prompt_cache)
+            if isinstance(c, (KVCache, TurboQuantKVCache))
+        ]
         skip_last = self._turboquant_skip_last and len(kv_indices) > 1
         last_kv_idx = kv_indices[-1] if skip_last else -1
 


### PR DESCRIPTION
This patch resolves two critical issues related to TurboQuant prefix caching: a crash when reloading boundary snapshots, and a massive performance regression in token generation/prefill speeds after a cache hit.

1. Fix AttributeError crash on boundary snapshots with TurboQuant
File: omlx/cache/prefix_cache.py

`omlx.cache.prefix_cache - WARNING - Failed to reconstruct cache: 'mlx.core.array' object has no attribute 'norms'`

Issue: When boundary snapshots are created, sliceable cache layers are intentionally skipped to save space, leaving mx.zeros((1,)) placeholder tensors. During cache reconstruction, the __turboquant_v2__ loading logic did not filter out these placeholders. It appended them to the state list and passed them to _concat_state(), which crashed with AttributeError because it expected the norms and indices attributes of a TurboQuantMSEState.

Solution:

Added a check to skip (1,) placeholder tensors inside the block data loop.
Implemented a robust fallback mechanism that seamlessly handles mixed-state blocks (e.g., a mix of true fp16 cache blocks from a draft model and TQ blocks) by selectively dequantizing TQ blocks only when necessary.
2. Eliminate massive TQ cache hit performance regression
Files: omlx/cache/prefix_cache.py, omlx/scheduler.py

Issue: After successfully reloading a TurboQuant cache, prefill and token generation speeds were drastically reduced (often by >50%). This occurred due to two cascading issues:

reconstruct_cache unconditionally dequantized the TQ blocks into fp16 arrays, relying on _apply_turboquant_kv_convert in the scheduler to re-quantize them. This dequantize -> quantize path created a massive, unevaluated lazy computational graph.
The _collect_cache_storage_arrays function in the scheduler (responsible for pre-evaluating cache arrays to prevent lazy evaluation stalls) only checked for strict mx.array instances. Since TurboQuant stores its tensors inside dataclasses (like TurboQuantMSEState), the arrays were completely ignored by mx.eval. As a result, the massive graph was evaluated lazily token-by-token during generation.
Solution:

Zero-Overhead Reconstruction (prefix_cache.py): Optimized the reconstruction logic to directly return the assembled TurboQuantKVCache object when all valid blocks are TQ. This completely bypasses the dequantize -> requantize cycle, keeping operations entirely in the quantized space.
Recursive Array Materialization (scheduler.py): Refactored _collect_cache_storage_arrays to use a recursive _extract helper. It now robustly traverses dataclasses, tuples, and lists, ensuring that all nested mx.arrays (like norms and indices) are correctly collected and materialized via mx.eval before generation begins.
Fix skip_last Logic (scheduler.py): Updated _apply_turboquant_kv_convert to account for TurboQuantKVCache layers when determining the last_kv_idx. This ensures the turboquant_skip_last optimization remains intact even when the cache is loaded directly as TQ layers.