### PR TITLE
fix(server): reject non-ASCII configured API keys at validation time

### DIFF
--- a/omlx/admin/auth.py
+++ b/omlx/admin/auth.py
@@ -211,6 +211,14 @@ def validate_api_key(api_key: str) -> tuple[bool, str]:
     - Minimum 4 characters
     - No whitespace characters (space, tab, newline, etc.)
     - Printable characters only (no control characters)
+    - ASCII characters only
+
+    The ASCII-only rule is not cosmetic: HTTP request headers are decoded as
+    latin-1 by the ASGI layer, so a client cannot transmit a non-ASCII key
+    intact. A configured key such as "café" therefore starts the server
+    fine but can never be matched over the wire, yielding silent 401s on every
+    authenticated request. Rejecting it at configuration time surfaces the
+    misconfiguration immediately instead.
 
     Args:
         api_key: The API key string to validate.
@@ -224,6 +232,8 @@ def validate_api_key(api_key: str) -> tuple[bool, str]:
         return False, "API key must not contain whitespace"
     if not api_key.isprintable():
         return False, "API key must contain only printable characters"
+    if not api_key.isascii():
+        return False, "API key must contain only ASCII characters"
     return True, ""
 
 

--- a/tests/test_admin_api_key.py
+++ b/tests/test_admin_api_key.py
@@ -152,6 +152,31 @@ class TestValidateApiKey:
         assert is_valid is False
         assert "printable" in msg
 
+    def test_non_ascii_accented(self):
+        # Printable but non-ASCII: passes isprintable(), caught by isascii().
+        # Such a key can never be matched over HTTP (headers are latin-1
+        # decoded), so it must be rejected at configuration time.
+        is_valid, msg = validate_api_key("café-key")
+        assert is_valid is False
+        assert "ASCII" in msg
+
+    def test_non_ascii_emoji(self):
+        is_valid, msg = validate_api_key("key-\U0001f511")
+        assert is_valid is False
+        assert "ASCII" in msg
+
+    def test_non_ascii_cyrillic(self):
+        is_valid, msg = validate_api_key("ключ-секрет")
+        assert is_valid is False
+        assert "ASCII" in msg
+
+    def test_ascii_key_still_valid(self):
+        # Regression guard: ordinary ASCII keys remain valid after the
+        # ASCII-only rule was added.
+        is_valid, msg = validate_api_key("sk-abc123XYZ")
+        assert is_valid is True
+        assert msg == ""
+
 
 class TestVerifyApiKeyAdmin:
     """Tests for verify_api_key() constant-time comparison."""


### PR DESCRIPTION
## Problem

A configured non-ASCII API key (for example `café`) lets the server start
normally but can never be matched over HTTP, producing silent 401s on every
authenticated request with no indication of the cause.

Root cause: HTTP request headers are decoded as latin-1 by the ASGI layer, so a
client's UTF-8 key bytes arrive mangled. A configured `café` is compared against
the latin-1 string `cafÃ©` that reaches the auth code, and never matches.

`validate_api_key()` already rejected whitespace and non-printable keys, but
accepted non-ASCII ones because `str.isprintable()` returns `True` for accented
letters and emoji. So nothing flagged the misconfiguration.

This is the configuration-side sibling of #1719 (which fixed a non-ASCII *client*
key raising 500 instead of 401).

## Fix

Add an `isascii()` rule to `validate_api_key()`. The three admin routes that set
the main key and sub keys already call this function and surface its error
message, so a non-ASCII key is now rejected at creation/update time with a clear
reason instead of failing silently at request time.

## Repro confirming the mechanism

With a server configured key of `café`, a client sending the real UTF-8 key in
either `Authorization: Bearer` or `x-api-key` is received server-side as the
latin-1 string `cafÃ©` and rejected (401). There is no value a normal UTF-8
client can send that arrives as `café`.

## Scope

This covers the admin-API key-management paths. The `OMLX_API_KEY` environment
path does not run `validate_api_key()`, so a non-ASCII env key is still accepted
silently. I kept that out of this PR to keep it minimal and can send a startup
warning for the env/config path as a follow-up if you would like it.

## Testing

- New unit tests in `tests/test_admin_api_key.py` (accented, emoji, and Cyrillic
  keys rejected with an ASCII message; an ASCII key remains valid as a regression
  guard).
- Full suite: 5441 passed, 0 failed.