### PR TITLE
fix: strip superseded rotating tip payloads to stop hot-cache exhaustion

### DIFF
--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -35,6 +35,11 @@ from .type_registry import CacheTypeRegistry
 
 logger = logging.getLogger(__name__)
 
+# Cap on the supersede-on-extend lineage map (tip hash -> previous tip hash).
+# Each entry is two 32-byte hashes; the cap only guards against unbounded
+# growth from many distinct conversation chains over a long-lived process.
+_TIP_LINEAGE_MAX_ENTRIES = 4096
+
 
 @dataclass
 class BlockCacheEntry:
@@ -106,6 +111,13 @@ class BlockAwarePrefixCache(CacheManager):
 
         # Request to block table mapping
         self._request_tables: dict[str, BlockCacheEntry] = {}
+
+        # Supersede-on-extend lineage for rotating (sliding-window) models:
+        # newest tip block hash -> previous tip block hash. When a chain is
+        # extended again, the entry two generations back is stripped of its
+        # rotating payload (see _strip_rotating_payload); the immediate
+        # previous tip is kept intact as the walk-back fallback.
+        self._rotating_tip_lineage: dict[bytes, bytes] = {}
 
         # Callback for restoring cold blocks (deprecated in paged SSD-only mode)
         # Kept for API compatibility
@@ -460,6 +472,9 @@ class BlockAwarePrefixCache(CacheManager):
             )
 
         blocks_saved_to_ssd = 0
+        # Supersede-on-extend tracking (rotating models only, see below).
+        first_new_block_idx: int | None = None
+        tip_block_saved = False
 
         for i in range(num_new_blocks):
             start_idx = i * self.block_size
@@ -500,6 +515,8 @@ class BlockAwarePrefixCache(CacheManager):
                     continue
 
             # Allocate new block
+            if first_new_block_idx is None:
+                first_new_block_idx = len(block_table.block_ids)
             block = self.paged_cache.allocate_block()
             if not block:
                 # Handle memory pressure
@@ -639,6 +656,8 @@ class BlockAwarePrefixCache(CacheManager):
                     )
                     if saved:
                         blocks_saved_to_ssd += 1
+                        if is_last_block:
+                            tip_block_saved = True
                         logger.debug(
                             f"Saved block {block.block_id} to tiered cache: "
                             f"tokens [{global_start}:{global_end}], {len(block_kv_data)} layers"
@@ -663,6 +682,44 @@ class BlockAwarePrefixCache(CacheManager):
                     block_table.block_ids.pop()
                     block_table.num_tokens -= len(block_tokens)
                     break
+
+        # Supersede-on-extend: on rotating (sliding-window) models every store
+        # of a growing conversation writes one tip block carrying the full
+        # sliding-window state of all rotating layers (hundreds of MB fp16 on
+        # a gemma3-class model). Restore only ever consumes the newest such
+        # block, and the immediate previous tip is kept intact as the
+        # walk-back fallback — so the tip two generations back is dead
+        # weight. Without stripping it, those blocks fill the hot cache after
+        # ~10-20 turns and LRU eviction breaks the prefix chain (multi-turn
+        # cache hit collapses to 0%). Steady state after stripping: two heavy
+        # blocks per chain.
+        if (
+            tip_block_saved
+            and first_new_block_idx is not None
+            and 0 < first_new_block_idx < len(block_table.block_ids)
+            and layer_cache_types
+            and any(
+                CacheTypeRegistry.is_rotating_family(t) for t in layer_cache_types
+            )
+        ):
+            prev_tip_id = block_table.block_ids[first_new_block_idx - 1]
+            new_tip_id = block_table.block_ids[-1]
+            prev_tip = self.paged_cache.allocated_blocks.get(prev_tip_id)
+            new_tip = self.paged_cache.allocated_blocks.get(new_tip_id)
+            if (
+                prev_tip is not None
+                and prev_tip.block_hash is not None
+                and new_tip is not None
+                and new_tip.block_hash is not None
+            ):
+                superseded = self._rotating_tip_lineage.pop(
+                    prev_tip.block_hash, None
+                )
+                if superseded is not None:
+                    self._strip_rotating_payload(superseded)
+                self._rotating_tip_lineage[new_tip.block_hash] = prev_tip.block_hash
+                if len(self._rotating_tip_lineage) > _TIP_LINEAGE_MAX_ENTRIES:
+                    self._rotating_tip_lineage.clear()
 
         # Update prefix index
         self._update_prefix_index(tokens, block_table.block_ids, extra_keys=extra_keys)
@@ -808,6 +865,78 @@ class BlockAwarePrefixCache(CacheManager):
                             return seq_len
 
         return 0
+
+    def _strip_rotating_payload(self, block_hash: bytes) -> bool:
+        """Replace a superseded tip block's rotating payload with placeholders.
+
+        Sliceable layers (KVCache/TurboQuant slices) in the block are kept —
+        only RotatingKVCache-family layer states are replaced with the same
+        ``(mx.zeros((1,)), mx.zeros((1,)))`` placeholder that non-tip blocks
+        receive at store time, so restore treats the stripped block exactly
+        like any other placeholder block (walk-back or reject).
+
+        The rewrite goes through ``forget_block()`` + ``save_block()``: the
+        hot-cache entry is removed via ``_hot_cache_remove`` (which also
+        forgets the shared-budget accounting) and the slim payload re-enters
+        via ``_hot_cache_put`` (which re-registers it), so the hot-cache and
+        shared-budget byte counters stay consistent. In SSD mode the slim
+        payload is re-enqueued and overwrites the same hash-derived file
+        path.
+
+        Returns:
+            True if the block was rewritten with at least one layer stripped.
+        """
+        if self.paged_ssd_cache is None or not HAS_MLX:
+            return False
+        try:
+            data, meta = self.paged_ssd_cache.load_block_with_metadata(block_hash)
+            if not data or not meta:
+                return False
+            types = meta.get("layer_cache_types") or []
+            new_data: list[Any] = []
+            stripped = 0
+            for i, layer in enumerate(data):
+                type_name = types[i] if i < len(types) else "KVCache"
+                if (
+                    CacheTypeRegistry.is_rotating_family(type_name)
+                    and isinstance(layer, (list, tuple))
+                    and len(layer) >= 2
+                    and hasattr(layer[0], "shape")
+                    and tuple(layer[0].shape) != (1,)
+                ):
+                    new_data.append((mx.zeros((1,)), mx.zeros((1,))))
+                    stripped += 1
+                else:
+                    new_data.append(layer)
+            if stripped == 0:
+                return False
+            # save_block dedups on an existing hash, so drop the old entry
+            # (hot cache, pending writes, SSD index) first. The brief gap is
+            # benign: a concurrent restore either already loaded the old
+            # payload or sees the placeholder version, which the
+            # walk-back/reject path handles like any partial match.
+            self.paged_ssd_cache.forget_block(block_hash)
+            saved = self.paged_ssd_cache.save_block(
+                block_hash=block_hash,
+                cache_data=new_data,
+                token_count=int(meta.get("token_count") or self.block_size),
+                model_name=meta.get("model_name", self.paged_cache.model_name),
+                layer_cache_types=types or None,
+                layer_meta_states=meta.get("layer_meta_states"),
+            )
+            if saved:
+                logger.debug(
+                    "Stripped rotating payload from superseded tip block %s "
+                    "(%d of %d layers)",
+                    block_hash.hex()[:16],
+                    stripped,
+                    len(data),
+                )
+            return bool(saved)
+        except Exception as e:
+            logger.debug("Rotating payload strip failed for %s: %s",
+                         block_hash.hex()[:16], e)
+            return False
 
     def _extract_block_tensor_slice(
         self,

--- a/omlx/cache/type_registry.py
+++ b/omlx/cache/type_registry.py
@@ -116,6 +116,27 @@ class CacheTypeRegistry:
         return cls.get_handler(cache_type)
 
     @classmethod
+    def is_rotating_family(cls, class_name: str) -> bool:
+        """Check whether a class name belongs to the RotatingKVCache family.
+
+        Stored blocks serialize ``type(cache).__name__``, so subclasses such
+        as PrefillReadyRotatingKVCache (used for warm-restored caches) appear
+        under their live class name. Callers that need "is this a rotating
+        layer?" must match the family through this registry rather than
+        comparing exact class names.
+
+        Args:
+            class_name: The class name string (e.g., "RotatingKVCache")
+
+        Returns:
+            True if the name maps to a rotating cache type
+        """
+        return cls._class_name_map.get(class_name) in (
+            CacheType.ROTATING_KVCACHE,
+            CacheType.BATCH_ROTATING_KVCACHE,
+        )
+
+    @classmethod
     def detect_cache_type(cls, cache_obj: Any) -> CacheType:
         """Detect cache type from object.
 

--- a/tests/test_prefix_cache_rotating_tip_strip.py
+++ b/tests/test_prefix_cache_rotating_tip_strip.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression guards for supersede-on-extend rotating tip stripping (#1795).
+
+On sliding-window models every store of a growing conversation writes one
+tip block carrying the full rotating state of all sliding layers (~205-410MB
+fp16 on a gemma3-class 25-sliding-layer model). Restore only ever consumes
+the newest such block, and the immediate previous tip serves as the
+walk-back fallback — so the tip two generations back is dead weight. Before
+the fix those blocks accumulated one per turn, filled the hot cache after
+~10-20 turns, and LRU eviction broke the prefix chain (multi-turn cache hit
+collapsed permanently to 0%).
+
+The fix tracks tip lineage in store_cache and strips the grandparent tip's
+rotating payload down to the standard placeholder, keeping sliceable
+(KVCache) layer slices intact and keeping the hot-cache / shared-budget byte
+counters consistent (rewrite goes through forget_block + save_block).
+
+Tests:
+- test_grandparent_tip_stripped_prev_tip_kept — 4-turn chain: tip two
+  generations back is stripped, immediate previous tip stays intact.
+- test_stripped_block_keeps_sliceable_layers — KVCache slice survives the
+  strip; only the rotating layer becomes a placeholder.
+- test_hot_cache_byte_counter_consistent — _hot_cache_total_bytes matches
+  the recomputed entry sizes and decreases after the strip.
+- test_shared_budget_counter_consistent — SharedHotCacheBudget accounting
+  matches the owner's hot cache bytes after the strip.
+- test_kvcache_only_model_unaffected — no rotating layers: no lineage
+  tracking, no rewrites.
+- test_prefill_ready_rotating_name_stripped — family detection covers the
+  PrefillReadyRotatingKVCache subclass name used by warm-restored caches.
+- test_registry_rotating_family — registry-level family matching.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from omlx.cache.paged_cache import PagedCacheManager
+from omlx.cache.paged_ssd_cache import PagedSSDCacheManager, SharedHotCacheBudget
+from omlx.cache.prefix_cache import BlockAwarePrefixCache
+from omlx.cache.type_registry import CacheTypeRegistry
+
+try:
+    import mlx.core as mx
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+
+BLOCK_SIZE = 4
+WINDOW = 4
+
+
+class MockModel:
+    def __init__(self, num_layers: int = 2):
+        self._num_layers = num_layers
+        self.layers = [MagicMock() for _ in range(num_layers)]
+
+    @property
+    def args(self):
+        a = MagicMock()
+        a.num_hidden_layers = self._num_layers
+        return a
+
+
+def _make_cache(tmp_path, budget=None):
+    """A prefix cache wired to a real hot-cache-only SSD manager."""
+    paged_cache = PagedCacheManager(
+        block_size=BLOCK_SIZE,
+        max_blocks=100,
+        model_name="test-model",
+        initial_blocks=100,
+    )
+    ssd = PagedSSDCacheManager(
+        cache_dir=tmp_path / "ssd_cache",
+        max_size_bytes=100 * 1024**2,
+        hot_cache_max_bytes=10 * 1024**2,
+        hot_cache_only=True,
+        hot_cache_budget=budget,
+    )
+    cache = BlockAwarePrefixCache(
+        model=MockModel(num_layers=2),
+        paged_cache_manager=paged_cache,
+        paged_ssd_cache_manager=ssd,
+    )
+    return cache, ssd
+
+
+def _hybrid_cache_data(seq_len, rotating_type="RotatingKVCache"):
+    """Gemma3-style hybrid: one sliceable KVCache + one rotating layer."""
+    return [
+        {
+            "state": (
+                mx.ones((1, 2, seq_len, 8)),
+                mx.ones((1, 2, seq_len, 8)),
+            ),
+            "cache_type": "KVCache",
+            "class_name": "KVCache",
+            "meta_state": (str(seq_len),),
+        },
+        {
+            "state": (
+                mx.ones((1, 2, WINDOW, 8)),
+                mx.ones((1, 2, WINDOW, 8)),
+            ),
+            "cache_type": rotating_type,
+            "class_name": rotating_type,
+            "meta_state": ("0", str(WINDOW), str(seq_len), str(WINDOW)),
+        },
+    ]
+
+
+def _kvcache_only_data(seq_len):
+    return [
+        {
+            "state": (
+                mx.ones((1, 2, seq_len, 8)),
+                mx.ones((1, 2, seq_len, 8)),
+            ),
+            "cache_type": "KVCache",
+            "class_name": "KVCache",
+            "meta_state": (str(seq_len),),
+        }
+        for _ in range(2)
+    ]
+
+
+def _store_turn(cache, turn, num_blocks, data_fn=_hybrid_cache_data):
+    """Simulate one conversation turn: store a chain of num_blocks blocks.
+
+    Each turn uses a fresh request id (as real multi-turn requests do);
+    earlier blocks dedup against the existing chain and only the new tail
+    is allocated and saved.
+    """
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    table = cache.store_cache(
+        f"turn-{turn}", tokens, data_fn(seq_len=len(tokens))
+    )
+    assert table is not None
+    assert len(table.block_ids) == num_blocks
+    return table
+
+
+def _block_hash(cache, table, idx):
+    block = cache.paged_cache.allocated_blocks[table.block_ids[idx]]
+    assert block.block_hash is not None
+    return block.block_hash
+
+
+def _rotating_layer_shape(ssd, block_hash):
+    data, meta = ssd.load_block_with_metadata(block_hash)
+    assert data is not None and meta is not None
+    types = meta["layer_cache_types"]
+    for i, type_name in enumerate(types):
+        if CacheTypeRegistry.is_rotating_family(type_name):
+            return tuple(data[i][0].shape)
+    raise AssertionError("no rotating layer in block")
+
+
+def _kvcache_layer_shape(ssd, block_hash):
+    data, meta = ssd.load_block_with_metadata(block_hash)
+    assert data is not None and meta is not None
+    types = meta["layer_cache_types"]
+    for i, type_name in enumerate(types):
+        if type_name == "KVCache":
+            return tuple(data[i][0].shape)
+    raise AssertionError("no KVCache layer in block")
+
+
+PLACEHOLDER_SHAPE = (1,)
+REAL_ROTATING_SHAPE = (1, 2, WINDOW, 8)
+
+
+def test_grandparent_tip_stripped_prev_tip_kept(tmp_path):
+    """Tip two generations back is stripped; previous tip stays intact."""
+    cache, ssd = _make_cache(tmp_path)
+
+    t1 = _store_turn(cache, 1, num_blocks=2)
+    tip1 = _block_hash(cache, t1, -1)
+    assert _rotating_layer_shape(ssd, tip1) == REAL_ROTATING_SHAPE
+
+    t2 = _store_turn(cache, 2, num_blocks=3)
+    tip2 = _block_hash(cache, t2, -1)
+    # tip1 is now the immediate previous tip: kept as walk-back fallback.
+    assert _rotating_layer_shape(ssd, tip1) == REAL_ROTATING_SHAPE
+    assert _rotating_layer_shape(ssd, tip2) == REAL_ROTATING_SHAPE
+
+    t3 = _store_turn(cache, 3, num_blocks=4)
+    tip3 = _block_hash(cache, t3, -1)
+    # tip1 is two generations back: rotating payload stripped.
+    assert _rotating_layer_shape(ssd, tip1) == PLACEHOLDER_SHAPE
+    assert _rotating_layer_shape(ssd, tip2) == REAL_ROTATING_SHAPE
+    assert _rotating_layer_shape(ssd, tip3) == REAL_ROTATING_SHAPE
+
+    t4 = _store_turn(cache, 4, num_blocks=5)
+    tip4 = _block_hash(cache, t4, -1)
+    # Steady state: exactly the two newest tips stay heavy.
+    assert _rotating_layer_shape(ssd, tip2) == PLACEHOLDER_SHAPE
+    assert _rotating_layer_shape(ssd, tip3) == REAL_ROTATING_SHAPE
+    assert _rotating_layer_shape(ssd, tip4) == REAL_ROTATING_SHAPE
+
+
+def test_stripped_block_keeps_sliceable_layers(tmp_path):
+    """Only the rotating layer is stripped; the KVCache slice survives,
+    and the stripped layer reads back as a standard placeholder."""
+    cache, ssd = _make_cache(tmp_path)
+
+    t1 = _store_turn(cache, 1, num_blocks=2)
+    tip1 = _block_hash(cache, t1, -1)
+    kv_shape_before = _kvcache_layer_shape(ssd, tip1)
+
+    _store_turn(cache, 2, num_blocks=3)
+    _store_turn(cache, 3, num_blocks=4)
+
+    assert _rotating_layer_shape(ssd, tip1) == PLACEHOLDER_SHAPE
+    assert _kvcache_layer_shape(ssd, tip1) == kv_shape_before
+
+    # The stripped layer must look like the standard last-block-only
+    # placeholder so restore's walk-back/reject path handles it natively.
+    data, meta = ssd.load_block_with_metadata(tip1)
+    rotating_idx = next(
+        i
+        for i, t in enumerate(meta["layer_cache_types"])
+        if CacheTypeRegistry.is_rotating_family(t)
+    )
+    assert cache._is_placeholder_state(data[rotating_idx])
+
+
+def test_hot_cache_byte_counter_consistent(tmp_path):
+    """The stripped entry shrinks and the byte counter stays exact."""
+    cache, ssd = _make_cache(tmp_path)
+
+    t1 = _store_turn(cache, 1, num_blocks=2)
+    tip1 = _block_hash(cache, t1, -1)
+    _store_turn(cache, 2, num_blocks=3)
+    tip1_size_before = ssd._hot_cache_entry_size(ssd._hot_cache[tip1])
+
+    _store_turn(cache, 3, num_blocks=4)
+
+    # The superseded tip's hot-cache entry must have shrunk in place.
+    tip1_size_after = ssd._hot_cache_entry_size(ssd._hot_cache[tip1])
+    assert tip1_size_after < tip1_size_before
+    # And the counter must equal the recomputed sum of live entry sizes.
+    expected = sum(
+        ssd._hot_cache_entry_size(entry) for entry in ssd._hot_cache.values()
+    )
+    assert ssd._hot_cache_total_bytes == expected
+
+
+def test_shared_budget_counter_consistent(tmp_path):
+    """Shared budget accounting matches the owner's hot-cache bytes."""
+    budget = SharedHotCacheBudget(max_bytes=10 * 1024**2)
+    cache, ssd = _make_cache(tmp_path, budget=budget)
+
+    _store_turn(cache, 1, num_blocks=2)
+    _store_turn(cache, 2, num_blocks=3)
+    _store_turn(cache, 3, num_blocks=4)
+
+    assert budget.total_bytes == ssd._hot_cache_total_bytes
+    expected = sum(
+        ssd._hot_cache_entry_size(entry) for entry in ssd._hot_cache.values()
+    )
+    assert budget.total_bytes == expected
+
+
+def test_kvcache_only_model_unaffected(tmp_path):
+    """Models without rotating layers never track lineage or rewrite."""
+    cache, ssd = _make_cache(tmp_path)
+
+    t1 = _store_turn(cache, 1, num_blocks=2, data_fn=_kvcache_only_data)
+    tip1 = _block_hash(cache, t1, -1)
+    kv_before = _kvcache_layer_shape(ssd, tip1)
+
+    _store_turn(cache, 2, num_blocks=3, data_fn=_kvcache_only_data)
+    _store_turn(cache, 3, num_blocks=4, data_fn=_kvcache_only_data)
+
+    assert cache._rotating_tip_lineage == {}
+    assert _kvcache_layer_shape(ssd, tip1) == kv_before
+
+
+def test_prefill_ready_rotating_name_stripped(tmp_path):
+    """Warm-restored caches serialize as PrefillReadyRotatingKVCache; the
+    family match must strip those tips too (exact-name comparison broke
+    here historically)."""
+    cache, ssd = _make_cache(tmp_path)
+
+    def data_fn(seq_len):
+        return _hybrid_cache_data(
+            seq_len, rotating_type="PrefillReadyRotatingKVCache"
+        )
+
+    t1 = _store_turn(cache, 1, num_blocks=2, data_fn=data_fn)
+    tip1 = _block_hash(cache, t1, -1)
+    assert _rotating_layer_shape(ssd, tip1) == REAL_ROTATING_SHAPE
+
+    _store_turn(cache, 2, num_blocks=3, data_fn=data_fn)
+    _store_turn(cache, 3, num_blocks=4, data_fn=data_fn)
+
+    assert _rotating_layer_shape(ssd, tip1) == PLACEHOLDER_SHAPE
+
+
+def test_registry_rotating_family():
+    assert CacheTypeRegistry.is_rotating_family("RotatingKVCache")
+    assert CacheTypeRegistry.is_rotating_family("PrefillReadyRotatingKVCache")
+    assert CacheTypeRegistry.is_rotating_family("BatchRotatingKVCache")
+    assert not CacheTypeRegistry.is_rotating_family("KVCache")
+    assert not CacheTypeRegistry.is_rotating_family("TurboQuantKVCache")
+    assert not CacheTypeRegistry.is_rotating_family("ArraysCache")
+    assert not CacheTypeRegistry.is_rotating_family("SomethingElse")


### PR DESCRIPTION
Fixes #1795.

Follows the shape requested in https://github.com/jundot/omlx/issues/1795#issuecomment — a focused version of the supersede-on-extend stripping approach:

## What it does

`store_cache` now tracks tip lineage per growing chain (newest tip hash → previous tip hash). After a new tip block is saved successfully, the tip **two generations back** has its rotating payload stripped down to the standard last-block-only placeholder. The **immediate previous tip is kept intact** as the walk-back fallback, so a turn whose own tip lands placeholder-only (periodic block-boundary quirk) degrades to a partial hit instead of a full cold re-prefill. Steady state: two heavy real-state blocks per chain instead of one per turn.

## Details, per the review notes on the issue

- **RotatingKVCache family detection**: added `CacheTypeRegistry.is_rotating_family()` and matched through the registry's class-name map rather than exact class-name equality, so warm-restored caches serialized as `PrefillReadyRotatingKVCache` (and batch variants) are covered.
- **Byte-counter consistency**: the strip rewrites the block through `forget_block()` + `save_block()`, so the hot-cache and shared-budget counters are updated through the normal `_hot_cache_remove` (budget `forget`) / `_hot_cache_put` (budget `put`) paths. A regression test asserts `_hot_cache_total_bytes` equals the recomputed sum of live entry sizes, and another asserts `SharedHotCacheBudget.total_bytes` matches the owner's counter after a strip.
- **Sliceable layers untouched**: only rotating-family layer states are replaced; KVCache/TurboQuant slices in the stripped block survive, and the stripped layer satisfies `_is_placeholder_state`, so restore handles it natively via the existing walk-back/reject path.
- **Scope gating**: lineage tracking only engages when the chain's `layer_cache_types` contains a rotating-family type, so pure-KVCache models never pay the load/rewrite cost (regression-tested).
- The lineage map is bounded (4096 entries, two 32-byte hashes each) purely as a guard for long-lived processes serving many distinct chains.

## Tests

`tests/test_prefix_cache_rotating_tip_strip.py` (7 new tests): grandparent stripped / previous tip kept across 4 turns, sliceable-layer survival + placeholder compatibility, hot-cache byte-counter exactness, shared-budget consistency, KVCache-only no-op, `PrefillReadyRotatingKVCache` name coverage, registry family matching.

Existing related suites pass unchanged (341 tests): `test_prefix_cache.py`, `test_prefix_cache_v4_block_storage.py`, `test_hot_cache.py`, `test_paged_ssd_cache.py`, `test_paged_cache.py`, `test_rotating_cache_contract.py`, `test_store_cache_gate.py`, `test_prefix_divergence_probe.py`.

## Field results

Running this (as a local patch on 0.4.3) on a gemma-3-27b-class sliding-window model, M-series 36GB, TurboQuant KV 4-bit, 4GB hot cache: multi-turn conversations that previously collapsed to a permanent 0% hit around ~21K tokens now sustain 97-99% hit up to the prefill safety cap (67K-133K depending on weights/ceiling), with no collapse over 150 turns.

I left the store-time trim (the other option discussed on the issue) out of this PR as requested; happy to follow up separately if useful.