### PR TITLE
feat(models): support Cohere2 MoE models

### DIFF
--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -136,6 +136,176 @@ class HarmonyOutputParserSession:
         )
 
 
+_COHERE_COMMAND_MODEL_TYPES = {"cohere2_moe", "cohere2_vision"}
+_COHERE_END_OF_TURN_TOKEN = "<|END_OF_TURN_TOKEN|>"
+
+
+def _is_cohere_command_model(
+    model_name: str,
+    model_config: dict[str, Any] | None = None,
+) -> bool:
+    if model_config is not None:
+        model_type = str(model_config.get("model_type") or "").lower()
+        if model_type in _COHERE_COMMAND_MODEL_TYPES:
+            return True
+
+    name = (model_name or "").lower()
+    return "north-mini-code" in name or "command-a-plus" in name
+
+
+def _make_cohere_command_filter():
+    try:
+        from cohere_melody import PyFilter, PyFilterOptions
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "Cohere Command/North response parsing requires "
+            "cohere_melody>=0.9.0. Install or sync oMLX dependencies."
+        ) from exc
+
+    return PyFilter(PyFilterOptions().cmd4().stream_tool_actions())
+
+
+def _cohere_stop_token_ids(tokenizer: Any) -> set[int]:
+    ids: set[int] = set()
+
+    convert = getattr(tokenizer, "convert_tokens_to_ids", None)
+    if callable(convert):
+        try:
+            token_id = convert(_COHERE_END_OF_TURN_TOKEN)
+            if isinstance(token_id, int) and token_id >= 0:
+                ids.add(token_id)
+        except Exception:
+            pass
+
+    encode = getattr(tokenizer, "encode", None)
+    if callable(encode):
+        try:
+            encoded = encode(_COHERE_END_OF_TURN_TOKEN, add_special_tokens=False)
+        except TypeError:
+            try:
+                encoded = encode(_COHERE_END_OF_TURN_TOKEN)
+            except Exception:
+                encoded = None
+        except Exception:
+            encoded = None
+        if encoded:
+            ids.update(int(token_id) for token_id in encoded)
+
+    return ids
+
+
+class CohereCommandOutputParserSession:
+    """Parser session backed by Cohere's Melody parser for Command 4 markup."""
+
+    def __init__(self, tokenizer: Any, model_path: str | None = None):
+        self._tokenizer = tokenizer
+        self._filter = _make_cohere_command_filter()
+        self._detokenizer = create_streaming_detokenizer(tokenizer, model_path)
+        if self._detokenizer is not None:
+            self._detokenizer.reset()
+
+        self._thinking_open = False
+        self._thinking_started = False
+        self._tool_calls: dict[int, dict[str, str]] = {}
+        self._stop_token_ids = _cohere_stop_token_ids(tokenizer)
+
+    @staticmethod
+    def _is_special_token(text: str) -> bool:
+        return text.startswith("<|") and text.endswith("|>")
+
+    def _decode_token(self, token_id: int) -> str:
+        decoded = ""
+        try:
+            decoded = self._tokenizer.decode([token_id], skip_special_tokens=False)
+        except TypeError:
+            decoded = self._tokenizer.decode([token_id])
+        except Exception:
+            decoded = ""
+
+        if decoded and self._is_special_token(decoded):
+            return decoded
+
+        if self._detokenizer is not None:
+            self._detokenizer.add_token(token_id)
+            return self._detokenizer.last_segment
+
+        return decoded
+
+    def _remember_tool_calls(self, result: Any) -> None:
+        for call in getattr(result, "tool_calls", []) or []:
+            try:
+                index = int(getattr(call, "index", len(self._tool_calls)))
+            except Exception:
+                index = len(self._tool_calls)
+            call_id = str(getattr(call, "id", "") or f"call_{index}")
+            name = str(getattr(call, "name", "") or "")
+            arguments = str(getattr(call, "arguments", "") or "")
+            self._tool_calls[index] = {
+                "id": call_id,
+                "name": name,
+                "arguments": arguments,
+            }
+
+    def _format_result(self, result: Any) -> tuple[str, str]:
+        self._remember_tool_calls(result)
+
+        text = []
+        reasoning = getattr(result, "reasoning", None)
+        content = getattr(result, "content", None)
+
+        if reasoning:
+            if not self._thinking_open:
+                text.append("<think>\n")
+                self._thinking_open = True
+                self._thinking_started = True
+            text.append(str(reasoning))
+
+        if content:
+            if self._thinking_open:
+                text.append("</think>\n")
+                self._thinking_open = False
+            text.append(str(content))
+
+        out = "".join(text)
+        return out, out
+
+    def process_token(self, token_id: int) -> OutputParserTokenResult:
+        decoded = self._decode_token(token_id)
+        if token_id in self._stop_token_ids or decoded == _COHERE_END_OF_TURN_TOKEN:
+            return OutputParserTokenResult(
+                is_stop=True,
+                record_token=False,
+            )
+
+        if not decoded:
+            return OutputParserTokenResult(record_token=True)
+
+        result = self._filter.write_decoded(decoded)
+        stream_text, visible_text = self._format_result(result)
+        return OutputParserTokenResult(
+            stream_text=stream_text,
+            visible_text=visible_text,
+            record_token=True,
+        )
+
+    def finalize(self) -> OutputParserFinalizeResult:
+        result = self._filter.flush_partials()
+        stream_text, visible_text = self._format_result(result)
+
+        if self._thinking_open and self._thinking_started:
+            stream_text += "</think>"
+            visible_text += "</think>"
+            self._thinking_open = False
+
+        tool_calls = [self._tool_calls[index] for index in sorted(self._tool_calls)]
+        return OutputParserFinalizeResult(
+            stream_text=stream_text,
+            visible_text=visible_text,
+            tool_calls=tool_calls,
+            finish_reason="tool_calls" if tool_calls else None,
+        )
+
+
 def detect_output_parser(
     model_name: str,
     tokenizer: Any,
@@ -154,6 +324,18 @@ def detect_output_parser(
             stop_token_ids=temp_parser.get_stop_token_ids(),
             thinking_end_text="<|end|>",
             thinking_end_trailing_text="<|start|>assistant<|channel|>final<|message|>",
+        )
+
+    if _is_cohere_command_model(model_name, model_config):
+        return OutputParserFactory(
+            kind="cohere_command4",
+            create_session=lambda session_tokenizer: CohereCommandOutputParserSession(
+                session_tokenizer,
+                model_path=model_name,
+            ),
+            stop_token_ids=_cohere_stop_token_ids(tokenizer),
+            thinking_end_text="<|END_THINKING|>",
+            thinking_end_trailing_text="<|START_TEXT|>",
         )
 
     if is_gemma4_model(model_name, model_config):

--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -237,14 +237,16 @@ class CohereCommandOutputParserSession:
                 index = int(getattr(call, "index", len(self._tool_calls)))
             except Exception:
                 index = len(self._tool_calls)
-            call_id = str(getattr(call, "id", "") or f"call_{index}")
-            name = str(getattr(call, "name", "") or "")
-            arguments = str(getattr(call, "arguments", "") or "")
-            self._tool_calls[index] = {
-                "id": call_id,
-                "name": name,
-                "arguments": arguments,
-            }
+            stored = self._tool_calls.setdefault(
+                index,
+                {"id": f"call_{index}", "name": "", "arguments": ""},
+            )
+            if call_id := str(getattr(call, "id", "") or ""):
+                stored["id"] = call_id
+            if name := str(getattr(call, "name", "") or ""):
+                stored["name"] = name
+            if arguments := str(getattr(call, "arguments", "") or ""):
+                stored["arguments"] += arguments
 
     def _format_result(self, result: Any) -> tuple[str, str]:
         self._remember_tool_calls(result)

--- a/omlx/patches/cohere2_moe.py
+++ b/omlx/patches/cohere2_moe.py
@@ -1,0 +1,444 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime compatibility patch for Cohere2 MoE text models in mlx-lm.
+
+The pinned mlx-lm version used by oMLX does not include ``cohere2_moe`` yet.
+Register a local model module under ``mlx_lm.models.cohere2_moe`` so standard
+mlx-lm loading can handle North Mini Code style checkpoints without changing
+the engine path.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from dataclasses import dataclass
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.activations import swiglu
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.cache import KVCache, RotatingKVCache
+from mlx_lm.models.switch_layers import SwitchGLU
+
+logger = logging.getLogger(__name__)
+
+_MLX_LM_MODULE_NAME = "mlx_lm.models.cohere2_moe"
+_APPLIED = False
+
+
+def _upstream_module_available() -> bool:
+    try:
+        importlib.import_module(_MLX_LM_MODULE_NAME)
+    except ImportError:
+        return False
+    return True
+
+
+def apply_cohere2_moe_patch() -> bool:
+    """Register ``cohere2_moe`` with the live mlx-lm import machinery."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    if not _upstream_module_available():
+        sys.modules[_MLX_LM_MODULE_NAME] = sys.modules[__name__]
+        try:
+            import mlx_lm.models as models_pkg
+
+            models_pkg.cohere2_moe = sys.modules[__name__]
+        except Exception as e:
+            logger.debug("Could not attach Cohere2 MoE module to mlx_lm.models: %s", e)
+
+    try:
+        import mlx_lm.utils as mlx_lm_utils
+
+        mlx_lm_utils.MODEL_REMAPPING.setdefault("cohere2_vision", "cohere2_moe")
+    except Exception as e:
+        logger.debug("Could not update mlx-lm Cohere2 remapping: %s", e)
+
+    _APPLIED = True
+    return True
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str = "cohere2_moe"
+    hidden_size: int = 4096
+    head_dim: int = 128
+    num_hidden_layers: int = 32
+    intermediate_size: int = 4096
+    num_attention_heads: int = 128
+    num_key_value_heads: int = 8
+    num_experts: int = 128
+    num_experts_per_tok: int = 8
+    num_shared_experts: int = 4
+    shared_expert_combination_strategy: str = "average"
+    expert_selection_fn: str = "sigmoid"
+    norm_topk_prob: bool = True
+    rope_theta: float = 50000.0
+    vocab_size: int = 262144
+    layer_norm_eps: float = 1e-5
+    logit_scale: float = 1.0
+    attention_bias: bool = False
+    sliding_window: int = 4096
+    sliding_window_pattern: int = 4
+    use_parallel_block: bool = True
+    use_qk_norm: bool = False
+    use_embedding_sharing: bool = True
+    first_k_dense_replace: int = 0
+    prefix_dense_intermediate_size: int = 16384
+    prefix_dense_sliding_window_pattern: int = 1
+    layer_types: list[str] | None = None
+
+    def __post_init__(self):
+        if self.layer_types is None:
+            pattern = ["sliding_attention"] * (self.sliding_window_pattern - 1) + [
+                "full_attention"
+            ]
+            self.layer_types = (pattern * (self.num_hidden_layers // len(pattern) + 1))[
+                : self.num_hidden_layers
+            ]
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.args = args
+        self.layer_idx = layer_idx
+
+        dim = args.hidden_size
+        self.n_heads = n_heads = args.num_attention_heads
+        self.n_kv_heads = n_kv_heads = args.num_key_value_heads
+        self.head_dim = head_dim = args.head_dim
+        if head_dim * n_heads != dim:
+            raise ValueError(
+                f"hidden_size must equal num_attention_heads * head_dim "
+                f"(got hidden_size={dim}, heads={n_heads}, head_dim={head_dim})."
+            )
+        self.scale = head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=args.attention_bias)
+        self.k_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.attention_bias)
+        self.v_proj = nn.Linear(dim, n_kv_heads * head_dim, bias=args.attention_bias)
+        self.o_proj = nn.Linear(n_heads * head_dim, dim, bias=args.attention_bias)
+
+        self.rope = nn.RoPE(head_dim, traditional=True, base=args.rope_theta)
+        self.use_sliding_window = args.layer_types[layer_idx] == "sliding_attention"
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: mx.array | None = None,
+        cache: tuple[mx.array, mx.array] | None = None,
+    ) -> mx.array:
+        batch, length, _ = x.shape
+        queries, keys, values = self.q_proj(x), self.k_proj(x), self.v_proj(x)
+
+        queries = queries.reshape(batch, length, self.n_heads, -1).transpose(0, 2, 1, 3)
+        keys = keys.reshape(batch, length, self.n_kv_heads, -1).transpose(0, 2, 1, 3)
+        values = values.reshape(batch, length, self.n_kv_heads, -1).transpose(
+            0, 2, 1, 3
+        )
+
+        if self.use_sliding_window:
+            if cache is None:
+                queries = self.rope(queries)
+                keys = self.rope(keys)
+            else:
+                queries = self.rope(queries, offset=cache.offset)
+                keys = self.rope(keys, offset=cache.offset)
+
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        sdpa_type = mx.float32 if queries.dtype == mx.float16 else queries.dtype
+        output = scaled_dot_product_attention(
+            queries.astype(sdpa_type),
+            keys,
+            values,
+            cache=cache,
+            scale=self.scale,
+            mask=mask,
+        ).astype(queries.dtype)
+        output = output.transpose(0, 2, 1, 3).reshape(batch, length, -1)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    """Dense MLP used for shared experts and prefix dense layers."""
+
+    def __init__(self, dim: int, hidden_dim: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=False)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=False)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class Cohere2MoeSparseMoeBlock(nn.Module):
+    """Sparse MoE block with sigmoid routing and optional shared experts."""
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        dim = args.hidden_size
+        intermediate_size = args.intermediate_size
+
+        self.num_experts = args.num_experts
+        self.top_k = args.num_experts_per_tok
+        self.norm_topk_prob = args.norm_topk_prob
+        self.expert_selection_fn = args.expert_selection_fn
+        self.gate = nn.Linear(dim, args.num_experts, bias=False)
+        self.switch_mlp = SwitchGLU(
+            dim,
+            intermediate_size,
+            args.num_experts,
+            bias=False,
+        )
+
+        self.num_shared_experts = args.num_shared_experts
+        self.shared_expert_combination_strategy = (
+            args.shared_expert_combination_strategy
+        )
+        if self.num_shared_experts > 0:
+            shared_intermediate = intermediate_size * self.num_shared_experts
+            self.shared_experts = MLP(dim, shared_intermediate)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        gates = self.gate(x)
+        if self.expert_selection_fn == "sigmoid":
+            gates = mx.sigmoid(gates)
+        else:
+            gates = mx.softmax(gates, axis=-1, precise=True)
+
+        k = self.top_k
+        inds = mx.argpartition(gates, kth=-k, axis=-1)[..., -k:]
+        scores = mx.take_along_axis(gates, inds, axis=-1)
+        if self.norm_topk_prob:
+            scores = scores / mx.sum(scores, axis=-1, keepdims=True)
+
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2)
+
+        if self.num_shared_experts > 0:
+            shared_out = self.shared_experts(x)
+            if self.shared_expert_combination_strategy == "average":
+                y = (y + shared_out) / 2
+            else:
+                y = y + shared_out
+
+        return y
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.hidden_size = args.hidden_size
+        self.layer_idx = layer_idx
+        self.self_attn = Attention(args, layer_idx)
+
+        if layer_idx >= args.first_k_dense_replace:
+            self.mlp = Cohere2MoeSparseMoeBlock(args)
+        else:
+            self.mlp = MLP(args.hidden_size, args.prefix_dense_intermediate_size)
+
+        self.input_layernorm = nn.LayerNorm(
+            args.hidden_size,
+            eps=args.layer_norm_eps,
+            bias=False,
+        )
+        self.use_parallel_block = args.use_parallel_block
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: mx.array | None = None,
+        cache: tuple[mx.array, mx.array] | None = None,
+    ) -> mx.array:
+        h = self.input_layernorm(x)
+        attn_h = self.self_attn(h, mask, cache)
+
+        if self.use_parallel_block:
+            ff_h = self.mlp(h)
+            return attn_h + ff_h + x
+
+        h = attn_h + x
+        ff_h = self.mlp(self.input_layernorm(h))
+        return ff_h + h
+
+
+class Cohere2MoeModel(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.vocab_size = args.vocab_size
+        self.num_hidden_layers = args.num_hidden_layers
+        assert self.vocab_size > 0
+        self.window_size = args.sliding_window
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            TransformerBlock(args=args, layer_idx=i)
+            for i in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.LayerNorm(
+            args.hidden_size,
+            eps=args.layer_norm_eps,
+            bias=False,
+        )
+
+    def __call__(self, inputs: mx.array, cache=None):
+        h = self.embed_tokens(inputs)
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        full_cache = None
+        swa_cache = None
+        for i, c in enumerate(cache):
+            layer_type = self.args.layer_types[i]
+            if layer_type == "full_attention" and full_cache is None:
+                full_cache = c
+            elif layer_type == "sliding_attention" and swa_cache is None:
+                swa_cache = c
+
+        full_mask = create_attention_mask(h, full_cache)
+        swa_mask = create_attention_mask(h, swa_cache, window_size=self.window_size)
+
+        for i, (layer, c) in enumerate(zip(self.layers, cache)):
+            is_full = self.args.layer_types[i] == "full_attention"
+            h = layer(h, full_mask if is_full else swa_mask, c)
+
+        return self.norm(h)
+
+
+def _clean_weight_key(key: str) -> str:
+    replacements = (
+        ("model.language_model.model.", "model."),
+        ("language_model.model.", "model."),
+        ("model.language_model.", ""),
+        ("language_model.", ""),
+    )
+    for prefix, replacement in replacements:
+        if key.startswith(prefix):
+            return replacement + key[len(prefix) :]
+    return key
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.model_type = args.model_type
+        self.model = Cohere2MoeModel(args)
+        self.args = args
+        if not args.use_embedding_sharing:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(self, inputs: mx.array, cache=None):
+        out = self.model(inputs, cache)
+        if self.args.use_embedding_sharing:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = self.lm_head(out)
+        return out * self.args.logit_scale
+
+    def sanitize(self, weights):
+        sanitized = {}
+        for key, value in weights.items():
+            if any(
+                marker in key
+                for marker in (
+                    "vision_tower",
+                    "multi_modal_projector",
+                    "image_newline",
+                    "rotary_emb.inv_freq",
+                )
+            ):
+                continue
+            sanitized[_clean_weight_key(key)] = value
+
+        weights = sanitized
+        if self.args.use_embedding_sharing:
+            weights.pop("lm_head.weight", None)
+
+        has_stacked_experts = any(
+            ".mlp.switch_mlp.up_proj.weight" in key
+            or ".mlp.switch_mlp.up_proj.weight_packed" in key
+            for key in weights
+        )
+        if not has_stacked_experts:
+            self._stack_raw_expert_weights(weights)
+
+        return weights
+
+    def _stack_raw_expert_weights(self, weights):
+        for layer_idx in range(
+            self.args.first_k_dense_replace,
+            self.args.num_hidden_layers,
+        ):
+            prefix = f"model.layers.{layer_idx}.mlp"
+            for suffix in ("weight", "weight_packed"):
+                expert_key = f"{prefix}.experts.0.gate_proj.{suffix}"
+                if expert_key not in weights:
+                    continue
+                for name in ("up_proj", "down_proj", "gate_proj"):
+                    to_join = [
+                        weights.pop(f"{prefix}.experts.{e}.{name}.{suffix}")
+                        for e in range(self.args.num_experts)
+                    ]
+                    weights[f"{prefix}.switch_mlp.{name}.{suffix}"] = mx.stack(to_join)
+                    for extra in (
+                        "weight_scale",
+                        "weight_global_scale",
+                        "input_global_scale",
+                        "bias",
+                    ):
+                        extra_key = f"{prefix}.experts.0.{name}.{extra}"
+                        if extra_key not in weights:
+                            continue
+                        to_join_extra = [
+                            weights.pop(f"{prefix}.experts.{e}.{name}.{extra}")
+                            for e in range(self.args.num_experts)
+                        ]
+                        weights[f"{prefix}.switch_mlp.{name}.{extra}"] = mx.stack(
+                            to_join_extra
+                        )
+
+    @property
+    def quant_predicate(self):
+        """Keep router gates and attention at higher precision when quantizing."""
+
+        def predicate(path, _):
+            if "mlp.gate" in path:
+                return {"group_size": 64, "bits": 8}
+            if "self_attn" in path:
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
+
+    def make_cache(self):
+        caches = []
+        for i in range(self.args.num_hidden_layers):
+            if self.args.layer_types[i] == "full_attention":
+                caches.append(KVCache())
+            else:
+                caches.append(
+                    RotatingKVCache(max_size=self.args.sliding_window, keep=0)
+                )
+        return caches
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+
+__all__ = ["Model", "ModelArgs", "apply_cohere2_moe_patch", "is_applied"]

--- a/omlx/patches/cohere2_moe.py
+++ b/omlx/patches/cohere2_moe.py
@@ -94,19 +94,52 @@ class ModelArgs(BaseModelArgs):
     use_parallel_block: bool = True
     use_qk_norm: bool = False
     use_embedding_sharing: bool = True
+    layer_norm_bias: bool = False
+    rms_norm_eps: float | None = None
     first_k_dense_replace: int = 0
     prefix_dense_intermediate_size: int = 16384
     prefix_dense_sliding_window_pattern: int = 1
     layer_types: list[str] | None = None
+    mlp_layer_types: list[str] | None = None
 
     def __post_init__(self):
         if self.layer_types is None:
-            pattern = ["sliding_attention"] * (self.sliding_window_pattern - 1) + [
+            prefix_layers = [
+                (
+                    "sliding_attention"
+                    if (i + 1) % self.prefix_dense_sliding_window_pattern != 0
+                    else "full_attention"
+                )
+                for i in range(self.first_k_dense_replace)
+            ]
+            sliding_window_pattern = self.sliding_window_pattern or 4
+            rest_pattern = ["sliding_attention"] * (sliding_window_pattern - 1) + [
                 "full_attention"
             ]
-            self.layer_types = (pattern * (self.num_hidden_layers // len(pattern) + 1))[
-                : self.num_hidden_layers
+            rest_count = self.num_hidden_layers - self.first_k_dense_replace
+            rest_layers = (rest_pattern * (rest_count // len(rest_pattern) + 1))[
+                :rest_count
             ]
+            self.layer_types = prefix_layers + rest_layers
+        if self.mlp_layer_types is None:
+            self.mlp_layer_types = [
+                "dense" if i < self.first_k_dense_replace else "sparse"
+                for i in range(self.num_hidden_layers)
+            ]
+
+
+def _is_prefix_dense_layer(args: ModelArgs, layer_idx: int) -> bool:
+    return args.mlp_layer_types[layer_idx] == "dense"
+
+
+def _norm_layer(args: ModelArgs):
+    if args.rms_norm_eps is not None:
+        return nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+    return nn.LayerNorm(
+        args.hidden_size,
+        eps=args.layer_norm_eps,
+        bias=args.layer_norm_bias,
+    )
 
 
 class Attention(nn.Module):
@@ -119,11 +152,6 @@ class Attention(nn.Module):
         self.n_heads = n_heads = args.num_attention_heads
         self.n_kv_heads = n_kv_heads = args.num_key_value_heads
         self.head_dim = head_dim = args.head_dim
-        if head_dim * n_heads != dim:
-            raise ValueError(
-                f"hidden_size must equal num_attention_heads * head_dim "
-                f"(got hidden_size={dim}, heads={n_heads}, head_dim={head_dim})."
-            )
         self.scale = head_dim**-0.5
 
         self.q_proj = nn.Linear(dim, n_heads * head_dim, bias=args.attention_bias)
@@ -133,6 +161,10 @@ class Attention(nn.Module):
 
         self.rope = nn.RoPE(head_dim, traditional=True, base=args.rope_theta)
         self.use_sliding_window = args.layer_types[layer_idx] == "sliding_attention"
+        self.force_rope = (
+            _is_prefix_dense_layer(args, layer_idx)
+            and args.prefix_dense_sliding_window_pattern == 1
+        )
 
     def __call__(
         self,
@@ -149,7 +181,7 @@ class Attention(nn.Module):
             0, 2, 1, 3
         )
 
-        if self.use_sliding_window:
+        if self.use_sliding_window or self.force_rope:
             if cache is None:
                 queries = self.rope(queries)
                 keys = self.rope(keys)
@@ -247,16 +279,12 @@ class TransformerBlock(nn.Module):
         self.layer_idx = layer_idx
         self.self_attn = Attention(args, layer_idx)
 
-        if layer_idx >= args.first_k_dense_replace:
-            self.mlp = Cohere2MoeSparseMoeBlock(args)
-        else:
+        if _is_prefix_dense_layer(args, layer_idx):
             self.mlp = MLP(args.hidden_size, args.prefix_dense_intermediate_size)
+        else:
+            self.mlp = Cohere2MoeSparseMoeBlock(args)
 
-        self.input_layernorm = nn.LayerNorm(
-            args.hidden_size,
-            eps=args.layer_norm_eps,
-            bias=False,
-        )
+        self.input_layernorm = _norm_layer(args)
         self.use_parallel_block = args.use_parallel_block
 
     def __call__(
@@ -290,11 +318,7 @@ class Cohere2MoeModel(nn.Module):
             TransformerBlock(args=args, layer_idx=i)
             for i in range(args.num_hidden_layers)
         ]
-        self.norm = nn.LayerNorm(
-            args.hidden_size,
-            eps=args.layer_norm_eps,
-            bias=False,
-        )
+        self.norm = _norm_layer(args)
 
     def __call__(self, inputs: mx.array, cache=None):
         h = self.embed_tokens(inputs)

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -187,6 +187,43 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def _normalize_parser_tool_calls(raw_tool_calls):
+    """Convert parser-emitted tool-call dicts into OpenAI ToolCall models."""
+    if not raw_tool_calls:
+        return None
+
+    from .api.openai_models import FunctionCall, ToolCall
+
+    tool_calls = []
+    for tc in raw_tool_calls:
+        if hasattr(tc, "function"):
+            tool_calls.append(tc)
+            continue
+
+        if isinstance(tc, dict):
+            name = tc.get("name", "")
+            arguments = tc.get("arguments", "{}")
+            call_id = (
+                tc.get("id") or tc.get("call_id") or f"call_{uuid.uuid4().hex[:8]}"
+            )
+        else:
+            name = getattr(tc, "name", "")
+            arguments = getattr(tc, "arguments", "{}")
+            call_id = getattr(tc, "id", "") or f"call_{uuid.uuid4().hex[:8]}"
+
+        tool_calls.append(
+            ToolCall(
+                id=call_id,
+                type="function",
+                function=FunctionCall(
+                    name=name,
+                    arguments=arguments,
+                ),
+            )
+        )
+
+    return tool_calls or None
+
 # Security bearer for API key authentication
 security = HTTPBearer(auto_error=False)
 
@@ -2940,21 +2977,10 @@ async def create_chat_completion(
         thinking_content, regular_content = extract_thinking(raw_text)
         cleaned_thinking = sanitize_tool_call_markup(thinking_content, engine.tokenizer)
 
-        # For Harmony (gpt-oss) models, tool_calls are already extracted by the parser
-        # For other models, parse from text output
-        if engine.model_type == "gpt_oss" and output.tool_calls:
-            from .api.openai_models import ToolCall, FunctionCall
-            tool_calls = [
-                ToolCall(
-                    id=f"call_{uuid.uuid4().hex[:8]}",
-                    type="function",
-                    function=FunctionCall(
-                        name=tc["name"],
-                        arguments=tc["arguments"],
-                    ),
-                )
-                for tc in output.tool_calls
-            ]
+        # Protocol parsers (Harmony, Cohere Command/North) extract tool calls
+        # before generic text parsing sees the provider-specific control markup.
+        if output.tool_calls:
+            tool_calls = _normalize_parser_tool_calls(output.tool_calls)
             cleaned_text = regular_content
         else:
             extraction = extract_tool_calls_with_thinking(
@@ -3656,19 +3682,7 @@ async def stream_chat_completion(
     tool_calls = None
     cleaned_text = accumulated_text
     if last_output and last_output.tool_calls:
-        # Harmony model — tool_calls already extracted by parser
-        from .api.openai_models import ToolCall, FunctionCall
-        tool_calls = [
-            ToolCall(
-                id=f"call_{uuid.uuid4().hex[:8]}",
-                type="function",
-                function=FunctionCall(
-                    name=tc["name"],
-                    arguments=tc["arguments"],
-                ),
-            )
-            for tc in last_output.tool_calls
-        ]
+        tool_calls = _normalize_parser_tool_calls(last_output.tool_calls)
         cleaned_text = ""
     elif has_tools and accumulated_text:
         # Separate thinking from content, then parse tool calls from content
@@ -4051,19 +4065,7 @@ async def stream_anthropic_messages(
     # For other models, parse from accumulated text
     tool_calls = None
     if last_output and last_output.tool_calls:
-        # Harmony model - tool_calls already extracted by parser
-        from .api.openai_models import ToolCall, FunctionCall
-        tool_calls = [
-            ToolCall(
-                id=f"call_{uuid.uuid4().hex[:8]}",
-                type="function",
-                function=FunctionCall(
-                    name=tc["name"],
-                    arguments=tc["arguments"],
-                ),
-            )
-            for tc in last_output.tool_calls
-        ]
+        tool_calls = _normalize_parser_tool_calls(last_output.tool_calls)
     elif kwargs.get("tools"):
         # Non-Harmony: separate thinking, then parse tool calls from content
         # (falls back to thinking content for small models)
@@ -4417,21 +4419,10 @@ async def create_anthropic_message(
         thinking_content, regular_content = extract_thinking(raw_text)
         cleaned_thinking = sanitize_tool_call_markup(thinking_content, engine.tokenizer)
 
-        # For Harmony (gpt-oss) models, tool_calls are already extracted by the parser
-        # For other models, parse from text output
-        if engine.model_type == "gpt_oss" and output.tool_calls:
-            from .api.openai_models import ToolCall, FunctionCall
-            tool_calls = [
-                ToolCall(
-                    id=f"call_{uuid.uuid4().hex[:8]}",
-                    type="function",
-                    function=FunctionCall(
-                        name=tc["name"],
-                        arguments=tc["arguments"],
-                    ),
-                )
-                for tc in output.tool_calls
-            ]
+        # Protocol parsers (Harmony, Cohere Command/North) extract tool calls
+        # before generic text parsing sees the provider-specific control markup.
+        if output.tool_calls:
+            tool_calls = _normalize_parser_tool_calls(output.tool_calls)
             cleaned_text = regular_content
         else:
             extraction = extract_tool_calls_with_thinking(
@@ -4842,8 +4833,8 @@ async def create_response(
         thinking_content, regular_content = extract_thinking(raw_text)
 
         # Parse tool calls
-        if engine.model_type == "gpt_oss" and output.tool_calls:
-            tool_calls = output.tool_calls
+        if output.tool_calls:
+            tool_calls = _normalize_parser_tool_calls(output.tool_calls)
             cleaned_text = regular_content
         else:
             extraction = extract_tool_calls_with_thinking(
@@ -5232,7 +5223,7 @@ async def stream_responses_api(
     tool_calls = None
     cleaned_text = accumulated_text
     if last_output and last_output.tool_calls:
-        tool_calls = last_output.tool_calls
+        tool_calls = _normalize_parser_tool_calls(last_output.tool_calls)
         cleaned_text = ""
     elif has_tools and accumulated_text:
         thinking_content, regular_content = extract_thinking(accumulated_text)

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -141,6 +141,12 @@ def maybe_apply_pre_load_patches(
         if apply_step3p7_patch():
             logger.info("Step 3.7 pre-load patch applied for %s", model_name)
 
+    if model_type == "cohere2_moe":
+        from ..patches.cohere2_moe import apply_cohere2_moe_patch
+
+        if apply_cohere2_moe_patch():
+            logger.info("Cohere2 MoE pre-load patch applied for %s", model_name)
+
     text_config = config.get("text_config")
     text_model_type = (
         text_config.get("model_type") if isinstance(text_config, dict) else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ dependencies = [
     "jsonschema>=4.0.0",
     # Harmony format parser for gpt-oss models
     "openai-harmony",
+    # Cohere Command/North response parser (reasoning + tool-action markers)
+    "cohere_melody>=0.9.0",
     # mlx-vlm from commit (c9a6743, main) — includes Gemma4 shared-KV/load fixes,
     # Qwen quantized KV cache prompt-state fixes, Qwen3-VL visual mask/deepstack
     # chunked-prefill fixes, Phi 3.5 VL EOS fixes, and speculative prefill fixes.

--- a/tests/test_cohere2_moe_patch.py
+++ b/tests/test_cohere2_moe_patch.py
@@ -6,6 +6,7 @@ import sys
 from unittest.mock import MagicMock
 
 import mlx.core as mx
+import mlx.nn as nn
 
 from omlx.utils import model_loading
 from omlx.utils.model_loading import maybe_apply_pre_load_patches
@@ -109,6 +110,56 @@ def test_tiny_model_forward_and_cache_types():
     assert isinstance(cache[0], KVCache)
     assert isinstance(cache[1], RotatingKVCache)
     assert model.layers is model.model.layers
+
+
+def test_tiny_model_forward_with_attention_width_larger_than_hidden_size():
+    from omlx.patches.cohere2_moe import apply_cohere2_moe_patch
+
+    apply_cohere2_moe_patch()
+    from mlx_lm.models import cohere2_moe
+
+    args = cohere2_moe.ModelArgs(
+        **_tiny_args_config(
+            hidden_size=8,
+            head_dim=4,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            intermediate_size=8,
+        )
+    )
+    model = cohere2_moe.Model(args)
+
+    logits = model(mx.array([[1, 2, 3]], dtype=mx.int32))
+    mx.eval(logits)
+
+    assert logits.shape == (1, 3, 32)
+    assert model.model.layers[0].self_attn.q_proj.weight.shape == (16, 8)
+    assert model.model.layers[0].self_attn.o_proj.weight.shape == (8, 16)
+
+
+def test_rms_norm_and_prefix_dense_force_rope_config():
+    from omlx.patches.cohere2_moe import apply_cohere2_moe_patch
+
+    apply_cohere2_moe_patch()
+    from mlx_lm.models import cohere2_moe
+
+    args = cohere2_moe.ModelArgs(
+        **_tiny_args_config(
+            rms_norm_eps=1e-6,
+            layer_norm_bias=False,
+            prefix_dense_sliding_window_pattern=1,
+            mlp_layer_types=["dense", "sparse"],
+            layer_types=["full_attention", "sliding_attention"],
+        )
+    )
+    model = cohere2_moe.Model(args)
+
+    assert isinstance(model.model.norm, nn.RMSNorm)
+    assert isinstance(model.model.layers[0].input_layernorm, nn.RMSNorm)
+    assert model.model.layers[0].self_attn.use_sliding_window is False
+    assert model.model.layers[0].self_attn.force_rope is True
+    assert model.model.layers[1].self_attn.use_sliding_window is True
+    assert model.model.layers[1].self_attn.force_rope is False
 
 
 def test_sanitize_accepts_north_prefixed_switch_mlp_weights():

--- a/tests/test_cohere2_moe_patch.py
+++ b/tests/test_cohere2_moe_patch.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Cohere2 MoE mlx-lm compatibility patch."""
+
+import importlib
+import sys
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+
+from omlx.utils import model_loading
+from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+
+def _tiny_args_config(**overrides):
+    cfg = {
+        "model_type": "cohere2_moe",
+        "hidden_size": 16,
+        "head_dim": 4,
+        "num_hidden_layers": 2,
+        "intermediate_size": 8,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "num_experts": 2,
+        "num_experts_per_tok": 1,
+        "num_shared_experts": 0,
+        "vocab_size": 32,
+        "sliding_window": 8,
+        "sliding_window_pattern": 2,
+        "first_k_dense_replace": 1,
+        "prefix_dense_intermediate_size": 12,
+        "layer_types": ["full_attention", "sliding_attention"],
+        "norm_topk_prob": False,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def test_pre_load_dispatch_applies_cohere2_moe_patch(tmp_path, monkeypatch):
+    monkeypatch.setattr(model_loading, "_patch_mlx_lm_load_config", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "omlx.patches.mlx_lm_mtp",
+        MagicMock(set_mtp_active=MagicMock()),
+    )
+    apply_mock = MagicMock(return_value=True)
+    monkeypatch.setitem(
+        sys.modules,
+        "omlx.patches.cohere2_moe",
+        MagicMock(apply_cohere2_moe_patch=apply_mock),
+    )
+    (tmp_path / "config.json").write_text('{"model_type": "cohere2_moe"}')
+
+    maybe_apply_pre_load_patches(str(tmp_path))
+
+    apply_mock.assert_called_once_with()
+
+
+def test_apply_registers_cohere2_moe_module():
+    from omlx.patches.cohere2_moe import apply_cohere2_moe_patch, is_applied
+
+    first = apply_cohere2_moe_patch()
+    second = apply_cohere2_moe_patch()
+
+    assert is_applied() is True
+    assert first in (True, False)
+    assert second is False
+    assert "mlx_lm.models.cohere2_moe" in sys.modules
+
+    import mlx_lm.models as models_pkg
+
+    module = importlib.import_module("mlx_lm.models.cohere2_moe")
+    assert models_pkg.cohere2_moe is module
+    assert module.Model.__name__ == "Model"
+    assert module.ModelArgs.__name__ == "ModelArgs"
+
+
+def test_get_classes_resolves_cohere2_moe_and_vision_remap():
+    from mlx_lm.utils import _get_classes
+
+    from omlx.patches.cohere2_moe import apply_cohere2_moe_patch
+
+    apply_cohere2_moe_patch()
+
+    model_cls, args_cls = _get_classes({"model_type": "cohere2_moe"})
+    assert model_cls.__name__ == "Model"
+    assert args_cls.__name__ == "ModelArgs"
+
+    model_cls, args_cls = _get_classes({"model_type": "cohere2_vision"})
+    assert model_cls.__name__ == "Model"
+    assert args_cls.__name__ == "ModelArgs"
+
+
+def test_tiny_model_forward_and_cache_types():
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    from omlx.patches.cohere2_moe import apply_cohere2_moe_patch
+
+    apply_cohere2_moe_patch()
+    from mlx_lm.models import cohere2_moe
+
+    args = cohere2_moe.ModelArgs(**_tiny_args_config())
+    model = cohere2_moe.Model(args)
+
+    logits = model(mx.array([[1, 2, 3]], dtype=mx.int32))
+    mx.eval(logits)
+
+    assert logits.shape == (1, 3, 32)
+    cache = model.make_cache()
+    assert isinstance(cache[0], KVCache)
+    assert isinstance(cache[1], RotatingKVCache)
+    assert model.layers is model.model.layers
+
+
+def test_sanitize_accepts_north_prefixed_switch_mlp_weights():
+    from omlx.patches.cohere2_moe import apply_cohere2_moe_patch
+
+    apply_cohere2_moe_patch()
+    from mlx_lm.models import cohere2_moe
+
+    args = cohere2_moe.ModelArgs(**_tiny_args_config())
+    model = cohere2_moe.Model(args)
+
+    weights = {
+        "vision_tower.patch_embed.weight": mx.zeros((1,)),
+        "language_model.model.embed_tokens.weight": mx.zeros((32, 16)),
+        "language_model.model.layers.1.mlp.switch_mlp.up_proj.weight": mx.zeros(
+            (2, 8, 16)
+        ),
+        "language_model.model.layers.1.mlp.switch_mlp.gate_proj.weight": mx.zeros(
+            (2, 8, 16)
+        ),
+        "language_model.model.layers.1.mlp.switch_mlp.down_proj.weight": mx.zeros(
+            (2, 16, 8)
+        ),
+        "lm_head.weight": mx.zeros((32, 16)),
+    }
+
+    out = model.sanitize(weights)
+
+    assert "vision_tower.patch_embed.weight" not in out
+    assert "lm_head.weight" not in out
+    assert "model.model.embed_tokens.weight" not in out
+    assert "model.embed_tokens.weight" in out
+    assert "model.layers.1.mlp.switch_mlp.up_proj.weight" in out
+
+
+def test_sanitize_stacks_raw_expert_weights_for_hf_layout():
+    from omlx.patches.cohere2_moe import apply_cohere2_moe_patch
+
+    apply_cohere2_moe_patch()
+    from mlx_lm.models import cohere2_moe
+
+    args = cohere2_moe.ModelArgs(**_tiny_args_config())
+    model = cohere2_moe.Model(args)
+    weights = {}
+    for expert in range(args.num_experts):
+        weights[f"model.layers.1.mlp.experts.{expert}.up_proj.weight"] = mx.full(
+            (8, 16), expert + 1
+        )
+        weights[f"model.layers.1.mlp.experts.{expert}.gate_proj.weight"] = mx.full(
+            (8, 16), expert + 2
+        )
+        weights[f"model.layers.1.mlp.experts.{expert}.down_proj.weight"] = mx.full(
+            (16, 8), expert + 3
+        )
+
+    out = model.sanitize(weights)
+
+    up = out["model.layers.1.mlp.switch_mlp.up_proj.weight"]
+    gate = out["model.layers.1.mlp.switch_mlp.gate_proj.weight"]
+    down = out["model.layers.1.mlp.switch_mlp.down_proj.weight"]
+    assert up.shape == (2, 8, 16)
+    assert gate.shape == (2, 8, 16)
+    assert down.shape == (2, 16, 8)
+    assert not any(".experts." in key for key in out)

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -2,7 +2,6 @@
 """Tests for model discovery functionality."""
 
 import json
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -150,6 +149,19 @@ class TestDetectModelType:
         config = {
             "model_type": "lfm2_moe",
             "architectures": ["Lfm2MoeForCausalLM"],
+        }
+        (llm_dir / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(llm_dir) == "llm"
+
+    def test_detect_north_mini_code_cohere2_moe_as_llm(self, tmp_path):
+        """North Mini Code is text-only despite the HF repo pipeline tag."""
+        llm_dir = tmp_path / "North-Mini-Code-1.0-bf16"
+        llm_dir.mkdir()
+        config = {
+            "model_type": "cohere2_moe",
+            "architectures": ["Cohere2MoeForCausalLM"],
+            "num_experts": 128,
+            "num_experts_per_tok": 8,
         }
         (llm_dir / "config.json").write_text(json.dumps(config))
         assert detect_model_type(llm_dir) == "llm"

--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import json
+from collections import deque
+from types import SimpleNamespace
 
+from omlx.adapter import output_parser as output_parser_mod
 from omlx.adapter.gemma4 import Gemma4OutputParserSession
 from omlx.adapter.harmony import load_harmony_gpt_oss_encoding
 from omlx.adapter.output_parser import detect_output_parser
@@ -51,6 +54,62 @@ class HarmonyTokenizer:
     @property
     def detokenizer(self):
         return FakeDetokenizer(lambda token_id: self._encoding.decode([token_id]))
+
+
+class CohereCommandTokenizer:
+    def __init__(self, token_map: dict[int, str]):
+        self._token_map = token_map
+
+    def convert_tokens_to_ids(self, token: str) -> int:
+        for token_id, text in self._token_map.items():
+            if text == token:
+                return token_id
+        return -1
+
+    def encode(self, text, add_special_tokens: bool = False):
+        return [
+            token_id
+            for token_id, token_text in self._token_map.items()
+            if token_text == text
+        ]
+
+    def decode(self, token_ids, skip_special_tokens: bool = False):
+        return "".join(self._token_map[token_id] for token_id in token_ids)
+
+
+class _QueuedMelodyFilter:
+    def __init__(self, results):
+        self.results = deque(results)
+        self.decoded = []
+        self.flushed = False
+
+    def write_decoded(self, decoded_text: str):
+        self.decoded.append(decoded_text)
+        if self.results:
+            return self.results.popleft()
+        return SimpleNamespace(content=None, reasoning=None, tool_calls=[])
+
+    def flush_partials(self):
+        self.flushed = True
+        return SimpleNamespace(content=None, reasoning=None, tool_calls=[])
+
+
+def _melody_result(content=None, reasoning=None, tool_calls=None):
+    return SimpleNamespace(
+        content=content,
+        reasoning=reasoning,
+        tool_calls=tool_calls or [],
+    )
+
+
+def _patch_cohere_filter(monkeypatch, results):
+    queued = _QueuedMelodyFilter(results)
+    monkeypatch.setattr(
+        output_parser_mod,
+        "_make_cohere_command_filter",
+        lambda: queued,
+    )
+    return queued
 
 
 def _write_json(path, data):
@@ -380,3 +439,79 @@ class TestOutputParserFactory:
         thinking, content = extract_thinking(output_text)
         assert thinking == "Let me think about this"
         assert content == "Four"
+
+    def test_detects_cohere2_moe_by_config(self):
+        tokenizer = CohereCommandTokenizer({4: "<|END_OF_TURN_TOKEN|>"})
+        factory = detect_output_parser(
+            "mlx-community/North-Mini-Code-1.0-bf16",
+            tokenizer,
+            {"model_type": "cohere2_moe"},
+        )
+
+        assert factory is not None
+        assert factory.kind == "cohere_command4"
+        assert factory.stop_token_ids == {4}
+        assert factory.thinking_end_text == "<|END_THINKING|>"
+
+
+class TestCohereCommandOutputParserSession:
+    def test_streams_reasoning_and_content_as_think_envelope(self, monkeypatch):
+        queued = _patch_cohere_filter(
+            monkeypatch,
+            [
+                _melody_result(reasoning="Plan"),
+                _melody_result(reasoning=" more"),
+                _melody_result(content="Answer"),
+            ],
+        )
+        tokenizer = CohereCommandTokenizer({1: "a", 2: "b", 3: "c"})
+        session = output_parser_mod.CohereCommandOutputParserSession(tokenizer)
+
+        stream = []
+        visible = []
+        for token_id in [1, 2, 3]:
+            result = session.process_token(token_id)
+            stream.append(result.stream_text)
+            visible.append(result.visible_text)
+        final = session.finalize()
+        stream.append(final.stream_text)
+        visible.append(final.visible_text)
+
+        assert queued.decoded == ["a", "b", "c"]
+        assert queued.flushed is True
+        assert "".join(stream) == "<think>\nPlan more</think>\nAnswer"
+        assert "".join(visible) == "<think>\nPlan more</think>\nAnswer"
+
+    def test_converts_melody_tool_calls_on_finalize(self, monkeypatch):
+        tool_call = SimpleNamespace(
+            index=0,
+            id="call_0",
+            name="run_command",
+            arguments='{"cmd":"pwd"}',
+        )
+        _patch_cohere_filter(
+            monkeypatch,
+            [_melody_result(tool_calls=[tool_call])],
+        )
+        tokenizer = CohereCommandTokenizer({1: "tool"})
+        session = output_parser_mod.CohereCommandOutputParserSession(tokenizer)
+
+        result = session.process_token(1)
+        final = session.finalize()
+
+        assert result.stream_text == ""
+        assert result.visible_text == ""
+        assert final.tool_calls == [
+            {"id": "call_0", "name": "run_command", "arguments": '{"cmd":"pwd"}'}
+        ]
+        assert final.finish_reason == "tool_calls"
+
+    def test_end_of_turn_token_stops_without_recording(self, monkeypatch):
+        _patch_cohere_filter(monkeypatch, [_melody_result()])
+        tokenizer = CohereCommandTokenizer({4: "<|END_OF_TURN_TOKEN|>"})
+        session = output_parser_mod.CohereCommandOutputParserSession(tokenizer)
+
+        result = session.process_token(4)
+
+        assert result.is_stop is True
+        assert result.record_token is False

--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -506,6 +506,64 @@ class TestCohereCommandOutputParserSession:
         ]
         assert final.finish_reason == "tool_calls"
 
+    def test_accumulates_streamed_melody_tool_call_deltas(self, monkeypatch):
+        _patch_cohere_filter(
+            monkeypatch,
+            [
+                _melody_result(
+                    tool_calls=[
+                        SimpleNamespace(
+                            index=0,
+                            id="0",
+                            name="",
+                            arguments="",
+                        )
+                    ]
+                ),
+                _melody_result(
+                    tool_calls=[
+                        SimpleNamespace(
+                            index=0,
+                            id="",
+                            name="run_command",
+                            arguments="",
+                        )
+                    ]
+                ),
+                _melody_result(
+                    tool_calls=[
+                        SimpleNamespace(
+                            index=0,
+                            id="",
+                            name="",
+                            arguments='{"cmd":"',
+                        )
+                    ]
+                ),
+                _melody_result(
+                    tool_calls=[
+                        SimpleNamespace(
+                            index=0,
+                            id="",
+                            name="",
+                            arguments='pwd"}',
+                        )
+                    ]
+                ),
+            ],
+        )
+        tokenizer = CohereCommandTokenizer({1: "a", 2: "b", 3: "c", 4: "d"})
+        session = output_parser_mod.CohereCommandOutputParserSession(tokenizer)
+
+        for token_id in [1, 2, 3, 4]:
+            session.process_token(token_id)
+        final = session.finalize()
+
+        assert final.tool_calls == [
+            {"id": "0", "name": "run_command", "arguments": '{"cmd":"pwd"}'}
+        ]
+        assert final.finish_reason == "tool_calls"
+
     def test_end_of_turn_token_stops_without_recording(self, monkeypatch):
         _patch_cohere_filter(monkeypatch, [_melody_result()])
         tokenizer = CohereCommandTokenizer({4: "<|END_OF_TURN_TOKEN|>"})


### PR DESCRIPTION
## Summary

Hi maintainers, this PR adds support for Cohere2 MoE / Cohere Command 4 style text models, with `mlx-community/North-Mini-Code-1.0-bf16` as the concrete test target.

It closes #1809.

## What changed

- Added a local `cohere2_moe` compatibility module for the pinned `mlx-lm` version.
- Wired pre-load patching so `model_type: cohere2_moe` checkpoints can load through the existing batched LM path.
- Added Cohere Command/North output parser detection.
- Used `cohere_melody` for Command 4 parsing, including reasoning output and end-of-turn stopping.
- Accumulated streamed Melody tool-call deltas per index so sparse id/name chunks and JSON argument fragments finalize correctly.
- Added focused regression coverage for:
  - model discovery / patch dispatch;
  - `cohere2_moe` class registration and tiny forward passes;
  - North-style attention where `num_attention_heads * head_dim` is wider than `hidden_size`;
  - RMSNorm / prefix dense RoPE behavior;
  - prefixed and stacked expert weight layouts;
  - Cohere Command parser reasoning/content/tool-call streaming.

## Benchmarks

Full raw result JSON plus compact summary are attached here:
https://gist.github.com/michaelasper/bf32033bf66335194550788652d7843b

Environment:

- Model: `mlx-community/North-Mini-Code-1.0-bf16`
- Hardware: Apple M3 Ultra, 256 GB unified memory
- Python: 3.13.13
- Platform: macOS 26.4.1 arm64
- Branch: `michaelasper/omlx:feat/cohere2-moe`
- Result timestamp: 2026-06-10 20:44:06 to 20:54:01 America/Chicago

Throughput config: prompt lengths `[4096, 16384]`, generation length `128`, batch sizes `[2, 4]`.

| Test | Prompt TPS | Gen TPS | TTFT | Peak memory |
| --- | ---: | ---: | ---: | ---: |
| pp4096/tg128 | 2385.8 | 80.3 | 1717.3 ms | 57.78 GB |
| pp16384/tg128 | 1944.5 | 75.0 | 8426.4 ms | 58.26 GB |
| batch 2x pp1024/tg128 | 2039.9 | 85.0 | avg 1003.9 ms | |
| batch 4x pp1024/tg128 | 2021.8 | 131.5 | avg 1892.7 ms | |

Accuracy config: 10-sample slices, batch size `4`. The evaluator auto-switched to thinking parsing for all five benchmarks because the model emitted `<think>` tags.

| Benchmark | Score | Time |
| --- | ---: | ---: |
| MMLU | 7/10, 70% | 350.2s |
| HellaSwag | 10/10, 100% | 57.0s |
| GSM8K | 9/10, 90% | 74.8s |
| TruthfulQA | 9/10, 90% | 45.0s |
| SafetyBench | 10/10, 100% | 35.5s |

## Verification

Ran locally after rebasing onto `origin/main`:

```bash
.venv/bin/python -m pytest tests/test_output_parser.py tests/test_cohere2_moe_patch.py
.venv/bin/python -m ruff check \
  omlx/adapter/output_parser.py tests/test_output_parser.py \
  omlx/patches/cohere2_moe.py tests/test_cohere2_moe_patch.py
```

Results:

- Parser/model tests: 25 passed.
- Ruff: all checks passed.
- Throughput benchmark: completed and unloaded the model cleanly.
- Accuracy benchmark: completed 5 selected benchmark slices and unloaded the model cleanly.

## Notes

This is intentionally scoped as a compatibility patch while the pinned `mlx-lm` does not provide native `cohere2_moe` support. If native support lands upstream in `mlx-lm`, this patch should be easy to revisit or remove.

I am happy to split this if you would prefer model loading and parser/tool-call support as separate PRs.
