### PR TITLE
feat(thinking): add guided soft thinking budgets

### DIFF
--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -402,11 +402,11 @@ class ThinkingBudgetProcessor:
     # Multiplier on the soft-zone ramp; 2.0 can reach the cap halfway through
     # the zone when the close-think token is already very near the top.
     _SOFT_BIAS_FACTOR = 2.0
-    # Only nudge the close-think token if it is already in the candidate set.
-    # This keeps the bias model-driven while avoiding a full vocabulary sort.
+    # Use the top-k values to estimate the local candidate span without a full
+    # vocabulary sort.
     _SOFT_BIAS_TOP_K = 32
-    # Once eligible, allow a small push above the top logit, but cap it so
-    # the soft zone remains a nudge instead of a deterministic force.
+    # Allow a small push above the top logit, but cap it so the soft zone
+    # remains a nudge instead of a deterministic force.
     _SOFT_BIAS_MAX_OVERSHOOT = 1.0
 
     def __init__(
@@ -490,14 +490,14 @@ class ThinkingBudgetProcessor:
     def _apply_soft_bias(self, logits, mx):
         """Progressively boost the close-think logit through the soft zone.
 
-        At each step, look at the model's top-k candidates. If the next valid
-        close-think token is in that set, raise it toward the top as the
-        budget runs out. The closer it is to the top within the top-k span,
-        the stronger the ramp.
+        At each step, look at the model's top-k candidates to estimate the
+        local logit span, then raise the next valid close-think token toward
+        the top as the budget runs out. The closer it is to the top relative
+        to that span, the stronger the ramp.
 
-        Tokens outside the top-k set are left unchanged. Eligible tokens can
-        overtake the top by a small fixed margin only, so the soft zone remains
-        a nudge instead of a deterministic force.
+        Far-away close tokens get a weaker boost. The target can overtake
+        the top by a small fixed margin only, so the soft zone remains a nudge
+        instead of a deterministic force.
 
         The whole path stays in lazy MLX array ops — no ``.item()``/eval,
         so the decode loop never syncs on this bias (``progress`` comes
@@ -515,16 +515,15 @@ class ThinkingBudgetProcessor:
         top_logit = top_values[..., -1:]
         end_logit = logits[..., next_id : next_id + 1]
 
-        eligible = end_logit >= kth_logit
         gap_to_top = mx.maximum(top_logit - end_logit, 0.0)
         topk_span = mx.maximum(top_logit - kth_logit, 1e-6)
         normalized_gap = gap_to_top / topk_span
-        proximity = 1.0 / mx.square(1.0 + normalized_gap)
+        proximity = 1.0 / (1.0 + normalized_gap)
         ramp = mx.minimum(self._SOFT_BIAS_FACTOR * progress * proximity, 1.0)
         target = end_logit + ramp * (
             (top_logit + self._SOFT_BIAS_MAX_OVERSHOOT) - end_logit
         )
-        logits[..., next_id : next_id + 1] = mx.where(eligible, target, end_logit)
+        logits[..., next_id : next_id + 1] = target
         return logits
 
     def _next_close_token_id(self) -> int:

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -381,10 +381,9 @@ class ThinkingBudgetProcessor:
     a no-op for the rest of generation.
 
     Includes a soft budget zone over the last 30% of the token budget:
-    instead of a single hard cut, the close-think logit is progressively
-    boosted relative to the model's own logit distribution, encouraging a
-    natural stopping point before the hard force at 100%. Mirrors vLLM's
-    soft thinking budget (vllm-project/vllm#38277).
+    instead of a single hard cut, a plausible close-think token is
+    progressively boosted, encouraging a natural stopping point before the
+    hard force at 100%.
 
     Handles both single-token and multi-token close-think sequences, and
     supports alternative think markers (e.g. ``<longcat_think>``).
@@ -403,6 +402,13 @@ class ThinkingBudgetProcessor:
     # Multiplier on the measured gap; 2.0 makes the close-think logit
     # dominate at 50% of the zone, 1.0 only reaches the top at 100%.
     _SOFT_BIAS_FACTOR = 2.0
+    # Only nudge the close-think token if it is already close to the model's
+    # preferred next token. Otherwise a very large gap would create a very
+    # large boost and behave like an early hard force.
+    _SOFT_BIAS_MAX_GAP = 5.0
+    # Once eligible, allow a small push above the top logit, but cap it so
+    # the soft zone remains a nudge instead of a deterministic force.
+    _SOFT_BIAS_MAX_OVERSHOOT = 1.0
 
     def __init__(
         self,
@@ -486,15 +492,14 @@ class ThinkingBudgetProcessor:
         """Progressively boost the close-think logit through the soft zone.
 
         At each step, measure the gap between the top logit and the
-        close-think token, then raise the close-think logit toward (and
-        past) the top as the budget runs out::
+        close-think token. If the close-think token is already plausible,
+        raise it toward the top as the budget runs out::
 
             target = end_logit + 2 * gap * progress
 
-        progress=0 leaves logits unchanged, 0.5 makes close-think equal to
-        the top logit, and 1.0 makes it dominate — so the model can close
-        the thinking block at a natural boundary instead of being cut
-        mid-sentence by the hard force.
+        Tokens that are too far below the top are left unchanged. Eligible
+        tokens can overtake the top by a small fixed margin only, so a large
+        gap does not become a large artificial boost.
 
         The whole path stays in lazy MLX array ops — no ``.item()``/eval,
         so the decode loop never syncs on this bias (``progress`` comes
@@ -507,9 +512,12 @@ class ThinkingBudgetProcessor:
         next_id = self._next_close_token_id()
         top_logit = mx.max(logits, axis=-1, keepdims=True)
         end_logit = logits[..., next_id : next_id + 1]
-        gap = mx.maximum(top_logit - end_logit, 1.0)
-        target = end_logit + self._SOFT_BIAS_FACTOR * progress * gap
-        logits[..., next_id : next_id + 1] = mx.maximum(end_logit, target)
+        gap_to_top = top_logit - end_logit
+        eligible = gap_to_top <= self._SOFT_BIAS_MAX_GAP
+        boost_gap = mx.maximum(gap_to_top, 1.0)
+        boosted = end_logit + self._SOFT_BIAS_FACTOR * progress * boost_gap
+        capped = mx.minimum(boosted, top_logit + self._SOFT_BIAS_MAX_OVERSHOOT)
+        logits[..., next_id : next_id + 1] = mx.where(eligible, capped, end_logit)
         return logits
 
     def _next_close_token_id(self) -> int:

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -399,13 +399,12 @@ class ThinkingBudgetProcessor:
     # Tuned on local validation: 0.7 stays closer to the requested budget while
     # still avoiding abrupt hard-wall cuts; see the PR for the sweep.
     _SOFT_ZONE_START_FRAC = 0.7
-    # Multiplier on the measured gap; 2.0 makes the close-think logit
-    # dominate at 50% of the zone, 1.0 only reaches the top at 100%.
+    # Multiplier on the soft-zone ramp; 2.0 can reach the cap halfway through
+    # the zone when the close-think token is already very near the top.
     _SOFT_BIAS_FACTOR = 2.0
-    # Only nudge the close-think token if it is within the observed useful
-    # gap range. Otherwise a very large gap would create a very large boost
-    # and behave like an early hard force.
-    _SOFT_BIAS_MAX_GAP = 30.0
+    # Only nudge the close-think token if it is already in the candidate set.
+    # This keeps the bias model-driven while avoiding a full vocabulary sort.
+    _SOFT_BIAS_TOP_K = 32
     # Once eligible, allow a small push above the top logit, but cap it so
     # the soft zone remains a nudge instead of a deterministic force.
     _SOFT_BIAS_MAX_OVERSHOOT = 1.0
@@ -491,15 +490,14 @@ class ThinkingBudgetProcessor:
     def _apply_soft_bias(self, logits, mx):
         """Progressively boost the close-think logit through the soft zone.
 
-        At each step, measure the gap between the top logit and the
-        close-think token. If the close-think token is already plausible,
-        raise it toward the top as the budget runs out::
+        At each step, look at the model's top-k candidates. If the next valid
+        close-think token is in that set, raise it toward the top as the
+        budget runs out. The closer it is to the top within the top-k span,
+        the stronger the ramp.
 
-            target = end_logit + 2 * gap * progress
-
-        Tokens that are too far below the top are left unchanged. Eligible
-        tokens can overtake the top by a small fixed margin only, so a large
-        gap does not become a large artificial boost.
+        Tokens outside the top-k set are left unchanged. Eligible tokens can
+        overtake the top by a small fixed margin only, so the soft zone remains
+        a nudge instead of a deterministic force.
 
         The whole path stays in lazy MLX array ops — no ``.item()``/eval,
         so the decode loop never syncs on this bias (``progress`` comes
@@ -510,14 +508,23 @@ class ThinkingBudgetProcessor:
         """
         progress = (self._thinking_tokens - self._soft_start) / self._soft_span
         next_id = self._next_close_token_id()
-        top_logit = mx.max(logits, axis=-1, keepdims=True)
+        top_k = min(self._SOFT_BIAS_TOP_K, logits.shape[-1])
+        top_values = mx.topk(logits, k=top_k, axis=-1)
+        # MLX returns the selected values sorted ascending: kth ... top.
+        kth_logit = top_values[..., :1]
+        top_logit = top_values[..., -1:]
         end_logit = logits[..., next_id : next_id + 1]
-        gap_to_top = top_logit - end_logit
-        eligible = gap_to_top <= self._SOFT_BIAS_MAX_GAP
-        boost_gap = mx.maximum(gap_to_top, 1.0)
-        boosted = end_logit + self._SOFT_BIAS_FACTOR * progress * boost_gap
-        capped = mx.minimum(boosted, top_logit + self._SOFT_BIAS_MAX_OVERSHOOT)
-        logits[..., next_id : next_id + 1] = mx.where(eligible, capped, end_logit)
+
+        eligible = end_logit >= kth_logit
+        gap_to_top = mx.maximum(top_logit - end_logit, 0.0)
+        topk_span = mx.maximum(top_logit - kth_logit, 1e-6)
+        normalized_gap = gap_to_top / topk_span
+        proximity = 1.0 / mx.square(1.0 + normalized_gap)
+        ramp = mx.minimum(self._SOFT_BIAS_FACTOR * progress * proximity, 1.0)
+        target = end_logit + ramp * (
+            (top_logit + self._SOFT_BIAS_MAX_OVERSHOOT) - end_logit
+        )
+        logits[..., next_id : next_id + 1] = mx.where(eligible, target, end_logit)
         return logits
 
     def _next_close_token_id(self) -> int:

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -380,6 +380,12 @@ class ThinkingBudgetProcessor:
     exceeded, forces the close-think token(s) one at a time, then becomes
     a no-op for the rest of generation.
 
+    Includes a soft budget zone over the last 30% of the token budget:
+    instead of a single hard cut, the close-think logit is progressively
+    boosted relative to the model's own logit distribution, encouraging a
+    natural stopping point before the hard force at 100%. Mirrors vLLM's
+    soft thinking budget (vllm-project/vllm#38277).
+
     Handles both single-token and multi-token close-think sequences, and
     supports alternative think markers (e.g. ``<longcat_think>``).
 
@@ -387,7 +393,11 @@ class ThinkingBudgetProcessor:
         think_end_token_ids: Token ID(s) for the close-think tag.
         budget: Maximum number of thinking tokens before forcing close.
         think_start_token_id: Token ID for the open-think tag (re-entry detection).
+        soft_budget: Enable the progressive soft zone (default True).
     """
+
+    # Fraction of the budget where the soft zone begins (0.7 = last 30%).
+    _SOFT_ZONE_START_FRAC = 0.7
 
     def __init__(
         self,
@@ -397,6 +407,7 @@ class ThinkingBudgetProcessor:
         leading_token_ids: Optional[List[int]] = None,
         trailing_token_ids: Optional[List[int]] = None,
         token_to_piece: Optional[Callable[[int], str | bytes | None]] = None,
+        soft_budget: bool = True,
     ):
         self._think_end_ids = think_end_token_ids
         # Full force sequence: \n + </think> + \n\n (matches training pattern)
@@ -408,6 +419,8 @@ class ThinkingBudgetProcessor:
         self._budget = budget
         self._think_start_id = think_start_token_id
         self._token_to_piece = token_to_piece
+        self._soft_budget = soft_budget
+        self._soft_start = int(budget * self._SOFT_ZONE_START_FRAC) if budget > 0 else 0
 
         # State
         self._thinking_tokens: int = 0
@@ -456,7 +469,37 @@ class ThinkingBudgetProcessor:
                     return self._force_next_token(logits, mx)
                 self._waiting_utf8 = True
                 self._recent_tokens = []
+            elif self._soft_budget and self._thinking_tokens > self._soft_start:
+                return self._apply_soft_bias(logits, mx)
 
+        return logits
+
+    def _apply_soft_bias(self, logits, mx):
+        """Progressively boost the close-think logit through the soft zone.
+
+        At each step, measure the gap between the top logit and the
+        close-think token, then raise the close-think logit toward (and
+        past) the top as the budget runs out::
+
+            target = end_logit + 2 * gap * progress
+
+        progress=0 leaves logits unchanged, 0.5 makes close-think equal to
+        the top logit, and 1.0 makes it dominate — so the model can close
+        the thinking block at a natural boundary instead of being cut
+        mid-sentence by the hard force.
+        """
+        span = max(1, self._budget - self._soft_start)
+        progress = (self._thinking_tokens - self._soft_start) / span
+        end_id = self._think_end_ids[0]
+        top_logit = mx.max(logits).item()
+        end_logit = logits[..., end_id].item()
+        gap = max(top_logit - end_logit, 1.0)
+        target = end_logit + 2.0 * gap * progress
+        if target <= end_logit:
+            return logits
+        for token_id in self._think_end_ids:
+            if logits[..., token_id].item() < target:
+                logits[..., token_id] = target
         return logits
 
     def _update_state(self, token_id: int) -> None:

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -426,6 +426,9 @@ class ThinkingBudgetProcessor:
         self._token_to_piece = token_to_piece
         self._soft_budget = soft_budget
         self._soft_start = int(budget * self._SOFT_ZONE_START_FRAC) if budget > 0 else 0
+        # Invariant after construction; floored at 1 so tiny budgets cannot
+        # divide by zero in the progress computation.
+        self._soft_span = max(1, budget - self._soft_start)
 
         # State
         self._thinking_tokens: int = 0
@@ -500,8 +503,7 @@ class ThinkingBudgetProcessor:
         ids could make the model sample them out of order and leak a
         marker fragment into the thinking text.
         """
-        span = max(1, self._budget - self._soft_start)
-        progress = (self._thinking_tokens - self._soft_start) / span
+        progress = (self._thinking_tokens - self._soft_start) / self._soft_span
         next_id = self._next_close_token_id()
         top_logit = mx.max(logits, axis=-1, keepdims=True)
         end_logit = logits[..., next_id : next_id + 1]

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -402,10 +402,10 @@ class ThinkingBudgetProcessor:
     # Multiplier on the measured gap; 2.0 makes the close-think logit
     # dominate at 50% of the zone, 1.0 only reaches the top at 100%.
     _SOFT_BIAS_FACTOR = 2.0
-    # Only nudge the close-think token if it is already close to the model's
-    # preferred next token. Otherwise a very large gap would create a very
-    # large boost and behave like an early hard force.
-    _SOFT_BIAS_MAX_GAP = 5.0
+    # Only nudge the close-think token if it is within the observed useful
+    # gap range. Otherwise a very large gap would create a very large boost
+    # and behave like an early hard force.
+    _SOFT_BIAS_MAX_GAP = 30.0
     # Once eligible, allow a small push above the top logit, but cap it so
     # the soft zone remains a nudge instead of a deterministic force.
     _SOFT_BIAS_MAX_OVERSHOOT = 1.0

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -492,20 +492,41 @@ class ThinkingBudgetProcessor:
         the top logit, and 1.0 makes it dominate — so the model can close
         the thinking block at a natural boundary instead of being cut
         mid-sentence by the hard force.
+
+        The whole path stays in lazy MLX array ops — no ``.item()``/eval,
+        so the decode loop never syncs on this bias (``progress`` comes
+        from Python-side counters). Only the *next valid* token of the
+        close marker is boosted; for multi-token markers, boosting later
+        ids could make the model sample them out of order and leak a
+        marker fragment into the thinking text.
         """
         span = max(1, self._budget - self._soft_start)
         progress = (self._thinking_tokens - self._soft_start) / span
-        end_id = self._think_end_ids[0]
-        top_logit = mx.max(logits).item()
-        end_logit = logits[..., end_id].item()
-        gap = max(top_logit - end_logit, 1.0)
-        target = end_logit + self._SOFT_BIAS_FACTOR * gap * progress
-        if target <= end_logit:
-            return logits
-        for token_id in self._think_end_ids:
-            if logits[..., token_id].item() < target:
-                logits[..., token_id] = target
+        next_id = self._next_close_token_id()
+        top_logit = mx.max(logits, axis=-1, keepdims=True)
+        end_logit = logits[..., next_id : next_id + 1]
+        gap = mx.maximum(top_logit - end_logit, 1.0)
+        target = end_logit + self._SOFT_BIAS_FACTOR * progress * gap
+        logits[..., next_id : next_id + 1] = mx.maximum(end_logit, target)
         return logits
+
+    def _next_close_token_id(self) -> int:
+        """The only close-marker token that is valid to sample next.
+
+        For a multi-token close marker, the model must emit the ids in
+        order; if the tail of recently generated tokens already matches a
+        proper prefix of the marker, the next id of the sequence is the
+        one to encourage. Otherwise (and always for single-token markers)
+        it is the first id.
+        """
+        ids = self._think_end_ids
+        if len(ids) == 1:
+            return ids[0]
+        recent = self._recent_tokens
+        for k in range(min(len(recent), len(ids) - 1), 0, -1):
+            if recent[-k:] == ids[:k]:
+                return ids[k]
+        return ids[0]
 
     def _update_state(self, token_id: int) -> None:
         """Update thinking state based on the last generated token."""

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -9,6 +9,7 @@ Used by reasoning models like DeepSeek R1, Qwen3/3.5, MiniMax that wrap
 their chain-of-thought reasoning in <think>...</think> tags.
 """
 
+import math
 import re
 from collections.abc import Callable, Sequence
 from typing import List, Optional, Tuple
@@ -399,14 +400,11 @@ class ThinkingBudgetProcessor:
     # Tuned on local validation: 0.7 stays closer to the requested budget while
     # still avoiding abrupt hard-wall cuts; see the PR for the sweep.
     _SOFT_ZONE_START_FRAC = 0.7
-    # Multiplier on the soft-zone ramp; 2.0 can reach the cap halfway through
-    # the zone when the close-think token is already very near the top.
-    _SOFT_BIAS_FACTOR = 2.0
-    # Use the top-k values to estimate the local candidate span without a full
-    # vocabulary sort.
-    _SOFT_BIAS_TOP_K = 32
-    # Allow a small push above the top logit, but cap it so the soft zone
-    # remains a nudge instead of a deterministic force.
+    # Sigmoid ramp shape for the soft zone. The close-token logit is pulled
+    # toward the current top logit near the hard wall, so the absolute boost
+    # naturally scales with how implausible the close token currently is.
+    _SOFT_SIGMOID_CENTER = 0.8
+    _SOFT_SIGMOID_SHARPNESS = 10.0
     _SOFT_BIAS_MAX_OVERSHOOT = 1.0
 
     def __init__(
@@ -433,7 +431,7 @@ class ThinkingBudgetProcessor:
         self._soft_start = int(budget * self._SOFT_ZONE_START_FRAC) if budget > 0 else 0
         # Invariant after construction; floored at 1 so tiny budgets cannot
         # divide by zero in the progress computation.
-        self._soft_span = max(1, budget - self._soft_start)
+        self._soft_span = max(1, budget - self._soft_start - 1)
 
         # State
         self._thinking_tokens: int = 0
@@ -490,14 +488,9 @@ class ThinkingBudgetProcessor:
     def _apply_soft_bias(self, logits, mx):
         """Progressively boost the close-think logit through the soft zone.
 
-        At each step, look at the model's top-k candidates to estimate the
-        local logit span, then raise the next valid close-think token toward
-        the top as the budget runs out. The closer it is to the top relative
-        to that span, the stronger the ramp.
-
-        Far-away close tokens get a weaker boost. The target can overtake
-        the top by a small fixed margin only, so the soft zone remains a nudge
-        instead of a deterministic force.
+        At each step, pull the next valid close-think token toward the current
+        top logit with a normalized sigmoid ramp. The absolute boost scales
+        with the gap, but only becomes strong late in the soft zone.
 
         The whole path stays in lazy MLX array ops — no ``.item()``/eval,
         so the decode loop never syncs on this bias (``progress`` comes
@@ -507,24 +500,28 @@ class ThinkingBudgetProcessor:
         marker fragment into the thinking text.
         """
         progress = (self._thinking_tokens - self._soft_start) / self._soft_span
+        ramp = self._normalized_soft_ramp(progress)
         next_id = self._next_close_token_id()
-        top_k = min(self._SOFT_BIAS_TOP_K, logits.shape[-1])
-        top_values = mx.topk(logits, k=top_k, axis=-1)
-        # MLX returns the selected values sorted ascending: kth ... top.
-        kth_logit = top_values[..., :1]
-        top_logit = top_values[..., -1:]
+        top_logit = mx.max(logits, axis=-1, keepdims=True)
         end_logit = logits[..., next_id : next_id + 1]
-
-        gap_to_top = mx.maximum(top_logit - end_logit, 0.0)
-        topk_span = mx.maximum(top_logit - kth_logit, 1e-6)
-        normalized_gap = gap_to_top / topk_span
-        proximity = 1.0 / (1.0 + normalized_gap)
-        ramp = mx.minimum(self._SOFT_BIAS_FACTOR * progress * proximity, 1.0)
-        target = end_logit + ramp * (
-            (top_logit + self._SOFT_BIAS_MAX_OVERSHOOT) - end_logit
+        logits[..., next_id : next_id + 1] = (
+            end_logit
+            + ramp * ((top_logit + self._SOFT_BIAS_MAX_OVERSHOOT) - end_logit)
         )
-        logits[..., next_id : next_id + 1] = target
         return logits
+
+    @classmethod
+    def _normalized_soft_ramp(cls, progress: float) -> float:
+        """Map soft-zone progress [0, 1] to a late-rising sigmoid [0, 1]."""
+        progress = min(max(progress, 0.0), 1.0)
+
+        def sigmoid(x: float) -> float:
+            return 1.0 / (1.0 + math.exp(-cls._SOFT_SIGMOID_SHARPNESS * x))
+
+        start = sigmoid(0.0 - cls._SOFT_SIGMOID_CENTER)
+        finish = sigmoid(1.0 - cls._SOFT_SIGMOID_CENTER)
+        value = sigmoid(progress - cls._SOFT_SIGMOID_CENTER)
+        return min(max((value - start) / (finish - start), 0.0), 1.0)
 
     def _next_close_token_id(self) -> int:
         """The only close-marker token that is valid to sample next.

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -432,6 +432,11 @@ class ThinkingBudgetProcessor:
         # Invariant after construction; floored at 1 so tiny budgets cannot
         # divide by zero in the progress computation.
         self._soft_span = max(1, budget - self._soft_start - 1)
+        self._soft_ramp_start = self._soft_sigmoid(0.0)
+        self._soft_ramp_span = max(
+            self._soft_sigmoid(1.0) - self._soft_ramp_start,
+            1e-6,
+        )
 
         # State
         self._thinking_tokens: int = 0
@@ -511,17 +516,23 @@ class ThinkingBudgetProcessor:
         return logits
 
     @classmethod
-    def _normalized_soft_ramp(cls, progress: float) -> float:
+    def _soft_sigmoid(cls, progress: float) -> float:
+        return 1.0 / (
+            1.0
+            + math.exp(
+                -cls._SOFT_SIGMOID_SHARPNESS
+                * (progress - cls._SOFT_SIGMOID_CENTER)
+            )
+        )
+
+    def _normalized_soft_ramp(self, progress: float) -> float:
         """Map soft-zone progress [0, 1] to a late-rising sigmoid [0, 1]."""
         progress = min(max(progress, 0.0), 1.0)
-
-        def sigmoid(x: float) -> float:
-            return 1.0 / (1.0 + math.exp(-cls._SOFT_SIGMOID_SHARPNESS * x))
-
-        start = sigmoid(0.0 - cls._SOFT_SIGMOID_CENTER)
-        finish = sigmoid(1.0 - cls._SOFT_SIGMOID_CENTER)
-        value = sigmoid(progress - cls._SOFT_SIGMOID_CENTER)
-        return min(max((value - start) / (finish - start), 0.0), 1.0)
+        value = self._soft_sigmoid(progress)
+        return min(
+            max((value - self._soft_ramp_start) / self._soft_ramp_span, 0.0),
+            1.0,
+        )
 
     def _next_close_token_id(self) -> int:
         """The only close-marker token that is valid to sample next.

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -380,7 +380,7 @@ class ThinkingBudgetProcessor:
     exceeded, forces the close-think token(s) one at a time, then becomes
     a no-op for the rest of generation.
 
-    Includes a soft budget zone over the last 50% of the token budget:
+    Includes a soft budget zone over the last 30% of the token budget:
     instead of a single hard cut, the close-think logit is progressively
     boosted relative to the model's own logit distribution, encouraging a
     natural stopping point before the hard force at 100%. Mirrors vLLM's
@@ -396,10 +396,10 @@ class ThinkingBudgetProcessor:
         soft_budget: Enable the progressive soft zone (default True).
     """
 
-    # Fraction of the budget where the soft zone begins (0.5 = last 50%).
-    # Tuned on local validation: an earlier zone closes thinking sooner at
-    # equal answer/recall quality, saving budget; see the PR for the sweep.
-    _SOFT_ZONE_START_FRAC = 0.5
+    # Fraction of the budget where the soft zone begins (0.7 = last 30%).
+    # Tuned on local validation: 0.7 stays closer to the requested budget while
+    # still avoiding abrupt hard-wall cuts; see the PR for the sweep.
+    _SOFT_ZONE_START_FRAC = 0.7
     # Multiplier on the measured gap; 2.0 makes the close-think logit
     # dominate at 50% of the zone, 1.0 only reaches the top at 100%.
     _SOFT_BIAS_FACTOR = 2.0

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -401,11 +401,11 @@ class ThinkingBudgetProcessor:
     # still avoiding abrupt hard-wall cuts; see the PR for the sweep.
     _SOFT_ZONE_START_FRAC = 0.7
     # Sigmoid ramp shape for the soft zone. The close-token logit is pulled
-    # toward the current top logit near the hard wall, so the absolute boost
-    # naturally scales with how implausible the close token currently is.
+    # toward just below the current top logit near the hard wall, so the
+    # soft path nudges without becoming a deterministic force before 100%.
     _SOFT_SIGMOID_CENTER = 0.8
     _SOFT_SIGMOID_SHARPNESS = 10.0
-    _SOFT_BIAS_MAX_OVERSHOOT = 1.0
+    _SOFT_TARGET_MARGIN = 0.25
 
     def __init__(
         self,
@@ -488,9 +488,10 @@ class ThinkingBudgetProcessor:
     def _apply_soft_bias(self, logits, mx):
         """Progressively boost the close-think logit through the soft zone.
 
-        At each step, pull the next valid close-think token toward the current
-        top logit with a normalized sigmoid ramp. The absolute boost scales
-        with the gap, but only becomes strong late in the soft zone.
+        At each step, pull the next valid close-think token toward just below
+        the current top logit with a normalized sigmoid ramp. The absolute
+        boost scales with the gap, but only becomes strong late in the soft
+        zone and never overtakes the model's preferred token.
 
         The whole path stays in lazy MLX array ops — no ``.item()``/eval,
         so the decode loop never syncs on this bias (``progress`` comes
@@ -504,10 +505,9 @@ class ThinkingBudgetProcessor:
         next_id = self._next_close_token_id()
         top_logit = mx.max(logits, axis=-1, keepdims=True)
         end_logit = logits[..., next_id : next_id + 1]
-        logits[..., next_id : next_id + 1] = (
-            end_logit
-            + ramp * ((top_logit + self._SOFT_BIAS_MAX_OVERSHOOT) - end_logit)
-        )
+        target_logit = top_logit - self._SOFT_TARGET_MARGIN
+        boosted_logit = end_logit + ramp * (target_logit - end_logit)
+        logits[..., next_id : next_id + 1] = mx.maximum(end_logit, boosted_logit)
         return logits
 
     @classmethod

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -380,7 +380,7 @@ class ThinkingBudgetProcessor:
     exceeded, forces the close-think token(s) one at a time, then becomes
     a no-op for the rest of generation.
 
-    Includes a soft budget zone over the last 30% of the token budget:
+    Includes a soft budget zone over the last 50% of the token budget:
     instead of a single hard cut, the close-think logit is progressively
     boosted relative to the model's own logit distribution, encouraging a
     natural stopping point before the hard force at 100%. Mirrors vLLM's
@@ -396,8 +396,13 @@ class ThinkingBudgetProcessor:
         soft_budget: Enable the progressive soft zone (default True).
     """
 
-    # Fraction of the budget where the soft zone begins (0.7 = last 30%).
-    _SOFT_ZONE_START_FRAC = 0.7
+    # Fraction of the budget where the soft zone begins (0.5 = last 50%).
+    # Tuned on local validation: an earlier zone closes thinking sooner at
+    # equal answer/recall quality, saving budget; see the PR for the sweep.
+    _SOFT_ZONE_START_FRAC = 0.5
+    # Multiplier on the measured gap; 2.0 makes the close-think logit
+    # dominate at 50% of the zone, 1.0 only reaches the top at 100%.
+    _SOFT_BIAS_FACTOR = 2.0
 
     def __init__(
         self,
@@ -494,7 +499,7 @@ class ThinkingBudgetProcessor:
         top_logit = mx.max(logits).item()
         end_logit = logits[..., end_id].item()
         gap = max(top_logit - end_logit, 1.0)
-        target = end_logit + 2.0 * gap * progress
+        target = end_logit + self._SOFT_BIAS_FACTOR * gap * progress
         if target <= end_logit:
             return logits
         for token_id in self._think_end_ids:

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -5529,7 +5529,11 @@ async def create_response(
                         messages = _inject_json_instruction(messages, json_instruction)
             else:
                 compiled_grammar = None
-        messages = _inject_thinking_budget_instruction(messages, thinking_budget)
+        messages = _inject_thinking_budget_instruction(
+            messages,
+            thinking_budget,
+            final_json=response_format is not None,
+        )
 
         # Merge MCP tools
         effective_tools = (

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3112,6 +3112,10 @@ async def create_chat_completion(
                 if k not in forced_keys:
                     merged_ct_kwargs[k] = v
 
+        thinking_budget = _resolve_thinking_budget(request, request.model)
+        if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
+            merged_ct_kwargs["enable_thinking"] = True
+
         # Extract messages - different engines need different content handling.
         # Templates that expose message.reasoning_content natively (Qwen 3.6+)
         # get reasoning as a separate field; others fall back to <think> inlined
@@ -3218,6 +3222,15 @@ async def create_chat_completion(
             json_instruction = build_json_system_prompt(response_format)
             if json_instruction:
                 messages = _inject_json_instruction(messages, json_instruction)
+        messages = _inject_thinking_budget_instruction(
+            messages,
+            thinking_budget,
+            final_json=(
+                _response_format_requests_grammar(response_format)
+                or structured_outputs is not None
+                or guided_grammar is not None
+            ),
+        )
 
         # Merge MCP tools with user-provided tools unless the request explicitly
         # disables tool use.
@@ -3323,16 +3336,8 @@ async def create_chat_completion(
             chat_kwargs["seed"] = request.seed
 
         # Add thinking budget if applicable
-        thinking_budget = _resolve_thinking_budget(request, request.model)
         if thinking_budget is not None:
             chat_kwargs["thinking_budget"] = thinking_budget
-
-        # Auto-set enable_thinking in chat template kwargs when a thinking
-        # budget is active (from request or model settings).  Some chat
-        # templates (e.g. Gemma 4) explicitly suppress thinking unless this
-        # kwarg is True.
-        if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
-            merged_ct_kwargs["enable_thinking"] = True
 
         # Auto-set preserve_thinking only when the template advertises support
         # for it (Qwen 3.6+). Other templates silently ignore unknown kwargs
@@ -3596,6 +3601,23 @@ def _inject_json_instruction(messages: list, instruction: str) -> list:
         messages.insert(0, {"role": "system", "content": instruction})
 
     return messages
+
+
+def _inject_thinking_budget_instruction(
+    messages: list,
+    budget: int | None,
+    *,
+    final_json: bool = False,
+) -> list:
+    """Guide reasoning length in the prompt when a thinking budget is active."""
+    if budget is None or budget <= 0:
+        return list(messages)
+    final_kind = "final JSON answer" if final_json else "final answer"
+    instruction = (
+        f"Think step by step and use fewer than {budget} reasoning tokens "
+        f"before the {final_kind}."
+    )
+    return _inject_json_instruction(messages, instruction)
 
 
 def _normalize_structured_outputs(
@@ -4943,6 +4965,10 @@ async def create_anthropic_message(
                 elif thinking_type == "disabled":
                     merged_ct_kwargs["enable_thinking"] = False
 
+        thinking_budget = _resolve_thinking_budget(request, request.model)
+        if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
+            merged_ct_kwargs["enable_thinking"] = True
+
         logger.debug(
             f"Tool result truncation config: max_tokens={max_tool_result_tokens}, "
             f"has_tokenizer={engine.tokenizer is not None}"
@@ -5008,6 +5034,11 @@ async def create_anthropic_message(
             )
             merge_system_fallback_roles = True
 
+        messages = _inject_thinking_budget_instruction(
+            messages,
+            thinking_budget,
+        )
+
         # Detect and strip partial mode at the API boundary — exactly once.
         is_partial = detect_and_strip_partial(messages)
 
@@ -5046,15 +5077,8 @@ async def create_anthropic_message(
         }
 
         # Add thinking budget if applicable
-        thinking_budget = _resolve_thinking_budget(request, request.model)
         if thinking_budget is not None:
             chat_kwargs["thinking_budget"] = thinking_budget
-
-        # Auto-set enable_thinking in chat template kwargs when a thinking
-        # budget is active but enable_thinking was not already set (e.g. via
-        # the Anthropic thinking.type field above or model settings).
-        if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
-            merged_ct_kwargs["enable_thinking"] = True
 
         # Auto-set preserve_thinking only when the template advertises support
         # for it (Qwen 3.6+). Gated on detection so other templates don't
@@ -5459,6 +5483,10 @@ async def create_response(
             if ms.preserve_thinking is not None:
                 merged_ct_kwargs["preserve_thinking"] = ms.preserve_thinking
 
+        thinking_budget = _resolve_thinking_budget(request, request.model)
+        if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
+            merged_ct_kwargs["enable_thinking"] = True
+
         # Note: extract_text_content/extract_harmony_messages/extract_multimodal_content
         # are NOT called here because convert_responses_input_to_messages() already
         # returns plain dicts in {"role": str, "content": str} format.
@@ -5501,6 +5529,7 @@ async def create_response(
                         messages = _inject_json_instruction(messages, json_instruction)
             else:
                 compiled_grammar = None
+        messages = _inject_thinking_budget_instruction(messages, thinking_budget)
 
         # Merge MCP tools
         effective_tools = (
@@ -5589,13 +5618,8 @@ async def create_response(
             chat_kwargs["seed"] = request.seed
 
         # Add thinking budget if applicable
-        thinking_budget = _resolve_thinking_budget(request, request.model)
         if thinking_budget is not None:
             chat_kwargs["thinking_budget"] = thinking_budget
-
-        # Auto-set enable_thinking when thinking budget is active.
-        if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
-            merged_ct_kwargs["enable_thinking"] = True
 
         # Auto-set preserve_thinking only when the template advertises support
         # for it (Qwen 3.6+). Gated on detection so other templates don't

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3609,7 +3609,7 @@ def _inject_thinking_budget_instruction(
     *,
     final_json: bool = False,
 ) -> list:
-    """Guide reasoning length in the prompt when a thinking budget is active."""
+    """Guide reasoning length with a cache-friendly tail system note."""
     if budget is None or budget <= 0:
         return list(messages)
     final_kind = "final JSON answer" if final_json else "final answer"
@@ -3617,7 +3617,7 @@ def _inject_thinking_budget_instruction(
         f"Think step by step and use fewer than {budget} reasoning tokens "
         f"before the {final_kind}."
     )
-    return _inject_json_instruction(messages, instruction)
+    return [*messages, {"role": "system", "content": instruction}]
 
 
 def _normalize_structured_outputs(

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -6,7 +6,7 @@ These tests cover the _inject_json_instruction function from server.py
 which is used for injecting JSON schema instructions into messages.
 """
 
-from omlx.server import _inject_json_instruction
+from omlx.server import _inject_json_instruction, _inject_thinking_budget_instruction
 
 
 class TestInjectJsonInstruction:
@@ -192,3 +192,45 @@ class TestInjectJsonInstructionEdgeCases:
         result = _inject_json_instruction(messages, instruction)
 
         assert "\u4e2d\u6587" in result[0]["content"]
+
+
+class TestInjectThinkingBudgetInstruction:
+    """Tests for thinking-budget prompt guidance."""
+
+    def test_appends_budget_to_leading_system_message(self):
+        messages = [
+            {"role": "system", "content": "You solve carefully."},
+            {"role": "user", "content": "2+2?"},
+        ]
+
+        result = _inject_thinking_budget_instruction(messages, 100)
+
+        assert len(result) == 2
+        assert result[0]["role"] == "system"
+        assert "You solve carefully." in result[0]["content"]
+        assert "fewer than 100 reasoning tokens" in result[0]["content"]
+
+    def test_prepends_system_message_when_missing(self):
+        messages = [{"role": "user", "content": "2+2?"}]
+
+        result = _inject_thinking_budget_instruction(messages, 50)
+
+        assert len(result) == 2
+        assert result[0]["role"] == "system"
+        assert "fewer than 50 reasoning tokens" in result[0]["content"]
+        assert result[1]["role"] == "user"
+
+    def test_can_reference_final_json_answer(self):
+        messages = [{"role": "user", "content": "2+2?"}]
+
+        result = _inject_thinking_budget_instruction(messages, 50, final_json=True)
+
+        assert "fewer than 50 reasoning tokens" in result[0]["content"]
+        assert "final JSON answer" in result[0]["content"]
+
+    def test_does_not_inject_for_zero_budget(self):
+        messages = [{"role": "user", "content": "2+2?"}]
+
+        result = _inject_thinking_budget_instruction(messages, 0)
+
+        assert result == messages

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -197,7 +197,7 @@ class TestInjectJsonInstructionEdgeCases:
 class TestInjectThinkingBudgetInstruction:
     """Tests for thinking-budget prompt guidance."""
 
-    def test_appends_budget_to_leading_system_message(self):
+    def test_appends_budget_as_tail_system_message(self):
         messages = [
             {"role": "system", "content": "You solve carefully."},
             {"role": "user", "content": "2+2?"},
@@ -205,28 +205,30 @@ class TestInjectThinkingBudgetInstruction:
 
         result = _inject_thinking_budget_instruction(messages, 100)
 
-        assert len(result) == 2
+        assert len(result) == 3
         assert result[0]["role"] == "system"
-        assert "You solve carefully." in result[0]["content"]
-        assert "fewer than 100 reasoning tokens" in result[0]["content"]
+        assert result[0]["content"] == "You solve carefully."
+        assert result[1]["role"] == "user"
+        assert result[2]["role"] == "system"
+        assert "fewer than 100 reasoning tokens" in result[2]["content"]
 
-    def test_prepends_system_message_when_missing(self):
+    def test_appends_system_message_when_missing(self):
         messages = [{"role": "user", "content": "2+2?"}]
 
         result = _inject_thinking_budget_instruction(messages, 50)
 
         assert len(result) == 2
-        assert result[0]["role"] == "system"
-        assert "fewer than 50 reasoning tokens" in result[0]["content"]
-        assert result[1]["role"] == "user"
+        assert result[0]["role"] == "user"
+        assert result[1]["role"] == "system"
+        assert "fewer than 50 reasoning tokens" in result[1]["content"]
 
     def test_can_reference_final_json_answer(self):
         messages = [{"role": "user", "content": "2+2?"}]
 
         result = _inject_thinking_budget_instruction(messages, 50, final_json=True)
 
-        assert "fewer than 50 reasoning tokens" in result[0]["content"]
-        assert "final JSON answer" in result[0]["content"]
+        assert "fewer than 50 reasoning tokens" in result[1]["content"]
+        assert "final JSON answer" in result[1]["content"]
 
     def test_does_not_inject_for_zero_budget(self):
         messages = [{"role": "user", "content": "2+2?"}]

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -817,3 +817,114 @@ class TestCompletionsStreamThinkPrefixParity:
                 )
                 return
         raise AssertionError("create_completion not found in server.py")
+
+@pytest.mark.skipif(not HAS_MLX, reason="mlx not available")
+class TestSoftThinkingBudget:
+    """Unit tests for the progressive soft budget zone (vllm#38277 port)."""
+
+    THINK_END_ID = 42
+    THINK_START_ID = 41
+
+    def _make_processor(self, budget: int = 10, soft_budget: bool = True, end_ids=None):
+        return ThinkingBudgetProcessor(
+            think_end_token_ids=end_ids or [self.THINK_END_ID],
+            budget=budget,
+            think_start_token_id=self.THINK_START_ID,
+            soft_budget=soft_budget,
+        )
+
+    def _ramp_logits(self, vocab_size: int = 100, top_id: int = 7, top: float = 5.0):
+        """Logits with a known top value and zeros elsewhere."""
+        logits = mx.zeros((1, vocab_size))
+        logits[0, top_id] = top
+        return logits
+
+    def _step(self, proc, n_tokens: int, logits=None):
+        """Run proc for a history of n_tokens generated tokens."""
+        tokens = _make_tokens(*range(10, 10 + n_tokens))
+        return proc(tokens, logits if logits is not None else _make_logits())
+
+    def test_no_bias_before_soft_zone(self):
+        """Below 70% of the budget, logits pass through unchanged."""
+        proc = self._make_processor(budget=10)
+        # budget=10 -> soft_start=7; steps 1..7 stay free.
+        for step in range(1, 8):
+            logits = self._step(proc, step, self._ramp_logits())
+            assert logits[0, self.THINK_END_ID].item() == 0.0
+        assert not proc._forcing
+
+    def test_soft_zone_boosts_end_logit_progressively(self):
+        """Inside the soft zone the close-think logit ramps toward the top."""
+        proc = self._make_processor(budget=10)
+        boosts = []
+        for step in range(1, 10):
+            logits = self._step(proc, step, self._ramp_logits(top=5.0))
+            boosts.append(logits[0, self.THINK_END_ID].item())
+        # Steps 8 and 9 are in the soft zone (soft_start=7, budget=10).
+        assert boosts[6] == 0.0  # step 7: boundary, progress=0 -> unchanged
+        assert boosts[7] > 0.0  # step 8: progress=1/3
+        assert boosts[8] > boosts[7]  # step 9: progress=2/3, ramps up
+        # Adaptive formula: target = end + 2*gap*progress with gap=5.0.
+        assert boosts[7] == pytest.approx(2.0 * 5.0 * (1.0 / 3.0))
+        assert boosts[8] == pytest.approx(2.0 * 5.0 * (2.0 / 3.0))
+
+    def test_soft_zone_end_dominates_at_high_progress(self):
+        """Past 50% of the soft zone the close-think logit exceeds the top."""
+        proc = self._make_processor(budget=10)
+        logits = None
+        for step in range(1, 10):
+            logits = self._step(proc, step, self._ramp_logits(top=5.0))
+        # progress=2/3 -> target = 2*5*(2/3) = 6.67 > top (5.0)
+        assert logits[0, self.THINK_END_ID].item() > 5.0
+
+    def test_hard_force_still_applies_at_budget(self):
+        """The 100% hard force stays as the safety net."""
+        proc = self._make_processor(budget=10)
+        logits = None
+        for step in range(1, 11):
+            logits = self._step(proc, step, self._ramp_logits())
+        assert proc._forcing
+        assert logits[0, self.THINK_END_ID].item() == 0.0
+        assert logits[0, 0].item() == float("-inf")
+
+    def test_natural_close_in_soft_zone_stops_biasing(self):
+        """Sampling </think> naturally inside the soft zone ends the ramp."""
+        proc = self._make_processor(budget=10)
+        for step in range(1, 9):
+            self._step(proc, step, self._ramp_logits())
+        # Model emits </think> as token 9 (inside the soft zone).
+        tokens = _make_tokens(*range(10, 18), self.THINK_END_ID)
+        logits = proc(tokens, self._ramp_logits())
+        assert proc._done
+        assert logits[0, self.THINK_END_ID].item() == 0.0  # no further bias
+
+    def test_soft_budget_disabled_keeps_hard_only(self):
+        """soft_budget=False restores the previous hard-cut-only behavior."""
+        proc = self._make_processor(budget=10, soft_budget=False)
+        logits = None
+        for step in range(1, 10):
+            logits = self._step(proc, step, self._ramp_logits())
+            assert logits[0, self.THINK_END_ID].item() == 0.0
+        assert not proc._forcing
+        logits = self._step(proc, 10, self._ramp_logits())
+        assert proc._forcing
+
+    def test_multi_token_end_boosts_all_ids_with_first_gap(self):
+        """Multi-token close sequences clamp every end id to the target."""
+        end_ids = [42, 43]
+        proc = self._make_processor(budget=10, end_ids=end_ids)
+        logits = None
+        for step in range(1, 10):
+            logits = self._step(proc, step, self._ramp_logits(top=5.0))
+        target = 2.0 * 5.0 * (2.0 / 3.0)
+        assert logits[0, 42].item() == pytest.approx(target)
+        assert logits[0, 43].item() == pytest.approx(target)
+
+    def test_min_gap_floor_when_end_already_near_top(self):
+        """gap is floored at 1.0 so the ramp still progresses on flat logits."""
+        proc = self._make_processor(budget=10)
+        logits = None
+        for step in range(1, 10):
+            logits = self._step(proc, step, _make_logits())  # all zeros, gap->1.0
+        # progress=2/3, gap floor 1.0 -> target = 2*1*(2/3)
+        assert logits[0, self.THINK_END_ID].item() == pytest.approx(4.0 / 3.0)

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -967,3 +967,74 @@ class TestSoftThinkingBudget:
         assert not proc._done
         assert logits[0, 42].item() > 0.0  # first id targeted
         assert logits[0, 43].item() == 0.0  # out-of-order id not boosted
+
+    @pytest.mark.parametrize(
+        ("end_ids", "recent", "expected"),
+        [
+            # Repeated leading id [A, A, B]: one trailing A is a 1-prefix, a
+            # double A a 2-prefix; an [A, B] tail is NOT a prefix of
+            # [A, A, B], so the bias falls back to ids[0].
+            ([1, 1, 2], [1], 1),
+            ([1, 1, 2], [1, 1], 2),
+            ([1, 1, 2], [1, 1, 1], 2),
+            ([1, 1, 2], [1, 2], 1),
+            ([1, 1, 2], [2, 1], 1),
+            # Overlapping marker [A, B, A]: a completed [A, B] tail targets
+            # the closing ids[2]; a bare trailing A re-matches the 1-prefix
+            # and targets ids[1].
+            ([1, 2, 1], [1], 2),
+            ([1, 2, 1], [1, 2], 1),
+            ([1, 2, 1], [2, 1], 2),
+            ([1, 2, 1], [1, 2, 1], 2),
+        ],
+    )
+    def test_next_close_token_id_on_repeated_and_overlapping_markers(
+        self, end_ids, recent, expected
+    ):
+        """Pin the longest-proper-prefix resolution on markers with repeated
+        or overlapping ids: the biased token must always keep the generated
+        tail a valid marker prefix, never leak a fragment."""
+        proc = self._make_processor(end_ids=end_ids)
+        proc._recent_tokens = list(recent)
+        assert proc._next_close_token_id() == expected
+
+    def test_soft_zone_policy_constants(self):
+        """The zone boundaries are product choices, not incidental values:
+        the soft zone covers the last 50% of the budget, and FACTOR=2 makes
+        the close-think logit overtake the top halfway through the zone.
+        Changing either changes when models stop thinking; update the PR
+        narrative (and the vllm#38277 port) together with this test."""
+        assert ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC == 0.5
+        assert ThinkingBudgetProcessor._SOFT_BIAS_FACTOR == 2.0
+
+    def test_degenerate_budgets_keep_the_hard_cut_contract(self):
+        """Tiny budgets must degrade to the hard cut without a crash or a
+        dead zone: 0 and 1 force at the very first step, 2 has no usable
+        soft step before the wall."""
+        for budget in (0, 1):
+            proc = self._make_processor(budget=budget)
+            logits = self._step(proc, 1, self._ramp_logits())
+            assert proc._forcing
+            assert logits[0, self.THINK_END_ID].item() == 0.0
+            assert logits[0, 0].item() == float("-inf")
+
+        proc = self._make_processor(budget=2)
+        logits = self._step(proc, 1, self._ramp_logits())
+        assert not proc._forcing
+        assert logits[0, self.THINK_END_ID].item() == 0.0  # no bias yet
+        self._step(proc, 2, self._ramp_logits())
+        assert proc._forcing
+
+    def test_budget_three_gets_one_soft_step(self):
+        """budget=3 is the smallest budget with a live soft step: step 2
+        runs the ramp at progress 1/2 (boost = FACTOR * gap * 1/2), step 3
+        is the hard wall."""
+        proc = self._make_processor(budget=3)
+        logits = self._step(proc, 1, _make_logits())
+        assert logits[0, self.THINK_END_ID].item() == 0.0
+        # Flat logits: the gap floors at 1.0, so the boost is the pure ramp.
+        logits = self._step(proc, 2, _make_logits())
+        assert not proc._forcing
+        assert logits[0, self.THINK_END_ID].item() == pytest.approx(self.FACTOR * 1.0 * 0.5)
+        self._step(proc, 3, _make_logits())
+        assert proc._forcing

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -824,11 +824,16 @@ class TestSoftThinkingBudget:
 
     THINK_END_ID = 42
     THINK_START_ID = 41
+    BUDGET = 10
+    FRAC = ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC
+    FACTOR = ThinkingBudgetProcessor._SOFT_BIAS_FACTOR
+    SOFT_START = int(BUDGET * FRAC)
+    SPAN = BUDGET - SOFT_START
 
-    def _make_processor(self, budget: int = 10, soft_budget: bool = True, end_ids=None):
+    def _make_processor(self, budget: int = None, soft_budget: bool = True, end_ids=None):
         return ThinkingBudgetProcessor(
             think_end_token_ids=end_ids or [self.THINK_END_ID],
-            budget=budget,
+            budget=self.BUDGET if budget is None else budget,
             think_start_token_id=self.THINK_START_ID,
             soft_budget=soft_budget,
         )
@@ -844,44 +849,46 @@ class TestSoftThinkingBudget:
         tokens = _make_tokens(*range(10, 10 + n_tokens))
         return proc(tokens, logits if logits is not None else _make_logits())
 
+    def _expected_boost(self, step: int, top: float = 5.0) -> float:
+        """target - end_logit for a zeroed end logit at a given think step."""
+        if step <= self.SOFT_START:
+            return 0.0
+        progress = (step - self.SOFT_START) / max(1, self.SPAN)
+        return self.FACTOR * max(top, 1.0) * progress
+
     def test_no_bias_before_soft_zone(self):
-        """Below 70% of the budget, logits pass through unchanged."""
-        proc = self._make_processor(budget=10)
-        # budget=10 -> soft_start=7; steps 1..7 stay free.
-        for step in range(1, 8):
+        """Up to the zone boundary, logits pass through unchanged."""
+        proc = self._make_processor()
+        for step in range(1, self.SOFT_START + 1):
             logits = self._step(proc, step, self._ramp_logits())
             assert logits[0, self.THINK_END_ID].item() == 0.0
         assert not proc._forcing
 
     def test_soft_zone_boosts_end_logit_progressively(self):
         """Inside the soft zone the close-think logit ramps toward the top."""
-        proc = self._make_processor(budget=10)
+        proc = self._make_processor()
         boosts = []
-        for step in range(1, 10):
+        for step in range(1, self.BUDGET):
             logits = self._step(proc, step, self._ramp_logits(top=5.0))
             boosts.append(logits[0, self.THINK_END_ID].item())
-        # Steps 8 and 9 are in the soft zone (soft_start=7, budget=10).
-        assert boosts[6] == 0.0  # step 7: boundary, progress=0 -> unchanged
-        assert boosts[7] > 0.0  # step 8: progress=1/3
-        assert boosts[8] > boosts[7]  # step 9: progress=2/3, ramps up
-        # Adaptive formula: target = end + 2*gap*progress with gap=5.0.
-        assert boosts[7] == pytest.approx(2.0 * 5.0 * (1.0 / 3.0))
-        assert boosts[8] == pytest.approx(2.0 * 5.0 * (2.0 / 3.0))
+        assert boosts[self.SOFT_START - 1] == 0.0  # boundary step: progress=0
+        for step in range(self.SOFT_START + 1, self.BUDGET):
+            assert boosts[step - 1] == pytest.approx(self._expected_boost(step))
+        assert boosts[self.BUDGET - 2] > boosts[self.SOFT_START]
 
     def test_soft_zone_end_dominates_at_high_progress(self):
-        """Past 50% of the soft zone the close-think logit exceeds the top."""
-        proc = self._make_processor(budget=10)
+        """Past 1/FACTOR of the soft zone the close-think logit exceeds the top."""
+        proc = self._make_processor()
         logits = None
-        for step in range(1, 10):
+        for step in range(1, self.BUDGET):
             logits = self._step(proc, step, self._ramp_logits(top=5.0))
-        # progress=2/3 -> target = 2*5*(2/3) = 6.67 > top (5.0)
         assert logits[0, self.THINK_END_ID].item() > 5.0
 
     def test_hard_force_still_applies_at_budget(self):
         """The 100% hard force stays as the safety net."""
-        proc = self._make_processor(budget=10)
+        proc = self._make_processor()
         logits = None
-        for step in range(1, 11):
+        for step in range(1, self.BUDGET + 1):
             logits = self._step(proc, step, self._ramp_logits())
         assert proc._forcing
         assert logits[0, self.THINK_END_ID].item() == 0.0
@@ -889,42 +896,41 @@ class TestSoftThinkingBudget:
 
     def test_natural_close_in_soft_zone_stops_biasing(self):
         """Sampling </think> naturally inside the soft zone ends the ramp."""
-        proc = self._make_processor(budget=10)
-        for step in range(1, 9):
+        proc = self._make_processor()
+        in_zone = self.SOFT_START + 1
+        for step in range(1, in_zone):
             self._step(proc, step, self._ramp_logits())
-        # Model emits </think> as token 9 (inside the soft zone).
-        tokens = _make_tokens(*range(10, 18), self.THINK_END_ID)
+        tokens = _make_tokens(*range(10, 10 + in_zone - 1), self.THINK_END_ID)
         logits = proc(tokens, self._ramp_logits())
         assert proc._done
         assert logits[0, self.THINK_END_ID].item() == 0.0  # no further bias
 
     def test_soft_budget_disabled_keeps_hard_only(self):
         """soft_budget=False restores the previous hard-cut-only behavior."""
-        proc = self._make_processor(budget=10, soft_budget=False)
-        logits = None
-        for step in range(1, 10):
+        proc = self._make_processor(soft_budget=False)
+        for step in range(1, self.BUDGET):
             logits = self._step(proc, step, self._ramp_logits())
             assert logits[0, self.THINK_END_ID].item() == 0.0
         assert not proc._forcing
-        logits = self._step(proc, 10, self._ramp_logits())
+        self._step(proc, self.BUDGET, self._ramp_logits())
         assert proc._forcing
 
     def test_multi_token_end_boosts_all_ids_with_first_gap(self):
         """Multi-token close sequences clamp every end id to the target."""
         end_ids = [42, 43]
-        proc = self._make_processor(budget=10, end_ids=end_ids)
+        proc = self._make_processor(end_ids=end_ids)
         logits = None
-        for step in range(1, 10):
+        for step in range(1, self.BUDGET):
             logits = self._step(proc, step, self._ramp_logits(top=5.0))
-        target = 2.0 * 5.0 * (2.0 / 3.0)
+        target = self._expected_boost(self.BUDGET - 1)
         assert logits[0, 42].item() == pytest.approx(target)
         assert logits[0, 43].item() == pytest.approx(target)
 
     def test_min_gap_floor_when_end_already_near_top(self):
         """gap is floored at 1.0 so the ramp still progresses on flat logits."""
-        proc = self._make_processor(budget=10)
+        proc = self._make_processor()
         logits = None
-        for step in range(1, 10):
+        for step in range(1, self.BUDGET):
             logits = self._step(proc, step, _make_logits())  # all zeros, gap->1.0
-        # progress=2/3, gap floor 1.0 -> target = 2*1*(2/3)
-        assert logits[0, self.THINK_END_ID].item() == pytest.approx(4.0 / 3.0)
+        progress = (self.BUDGET - 1 - self.SOFT_START) / max(1, self.SPAN)
+        assert logits[0, self.THINK_END_ID].item() == pytest.approx(self.FACTOR * 1.0 * progress)

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -1000,16 +1000,16 @@ class TestSoftThinkingBudget:
 
     def test_soft_zone_policy_constants(self):
         """The zone boundaries are product choices, not incidental values:
-        the soft zone covers the last 50% of the budget, and FACTOR=2 makes
+        the soft zone covers the last 30% of the budget, and FACTOR=2 makes
         the close-think logit overtake the top halfway through the zone.
         Changing either changes when models stop thinking; update the PR
         narrative (and the vllm#38277 port) together with this test."""
-        assert ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC == 0.5
+        assert ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC == 0.7
         assert ThinkingBudgetProcessor._SOFT_BIAS_FACTOR == 2.0
 
     def test_degenerate_budgets_keep_the_hard_cut_contract(self):
         """Tiny budgets must degrade to the hard cut without a crash or a
-        dead zone: 0 and 1 force at the very first step, 2 has no usable
+        dead zone: 0 and 1 force at the very first step, 2 and 3 have no usable
         soft step before the wall."""
         for budget in (0, 1):
             proc = self._make_processor(budget=budget)
@@ -1018,23 +1018,27 @@ class TestSoftThinkingBudget:
             assert logits[0, self.THINK_END_ID].item() == 0.0
             assert logits[0, 0].item() == float("-inf")
 
-        proc = self._make_processor(budget=2)
-        logits = self._step(proc, 1, self._ramp_logits())
-        assert not proc._forcing
-        assert logits[0, self.THINK_END_ID].item() == 0.0  # no bias yet
-        self._step(proc, 2, self._ramp_logits())
-        assert proc._forcing
+        for budget in (2, 3):
+            proc = self._make_processor(budget=budget)
+            for step in range(1, budget):
+                logits = self._step(proc, step, self._ramp_logits())
+                assert not proc._forcing
+                assert logits[0, self.THINK_END_ID].item() == 0.0  # no bias yet
+            self._step(proc, budget, self._ramp_logits())
+            assert proc._forcing
 
-    def test_budget_three_gets_one_soft_step(self):
-        """budget=3 is the smallest budget with a live soft step: step 2
-        runs the ramp at progress 1/2 (boost = FACTOR * gap * 1/2), step 3
+    def test_budget_four_gets_one_soft_step(self):
+        """budget=4 is the smallest budget with a live soft step: step 3
+        runs the ramp at progress 1/2 (boost = FACTOR * gap * 1/2), step 4
         is the hard wall."""
-        proc = self._make_processor(budget=3)
+        proc = self._make_processor(budget=4)
         logits = self._step(proc, 1, _make_logits())
         assert logits[0, self.THINK_END_ID].item() == 0.0
-        # Flat logits: the gap floors at 1.0, so the boost is the pure ramp.
         logits = self._step(proc, 2, _make_logits())
+        assert logits[0, self.THINK_END_ID].item() == 0.0
+        # Flat logits: the gap floors at 1.0, so the boost is the pure ramp.
+        logits = self._step(proc, 3, _make_logits())
         assert not proc._forcing
         assert logits[0, self.THINK_END_ID].item() == pytest.approx(self.FACTOR * 1.0 * 0.5)
-        self._step(proc, 3, _make_logits())
+        self._step(proc, 4, _make_logits())
         assert proc._forcing

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -952,3 +952,18 @@ class TestSoftThinkingBudget:
             logits = self._step(proc, step, _make_logits())  # all zeros, gap->1.0
         progress = (self.BUDGET - 1 - self.SOFT_START) / max(1, self.SPAN)
         assert logits[0, self.THINK_END_ID].item() == pytest.approx(self.FACTOR * 1.0 * progress)
+
+    def test_multi_token_wrong_prefix_falls_back_to_first_id(self):
+        """A generated tail that matches a LATER marker id (not a proper
+        prefix) must not be treated as a partial close: bias ids[0]."""
+        end_ids = [42, 43]
+        proc = self._make_processor(end_ids=end_ids)
+        in_zone = self.SOFT_START + 2
+        for step in range(1, in_zone):
+            self._step(proc, step, self._ramp_logits(top=5.0))
+        # Model emits the SECOND marker id out of order: not a close prefix.
+        tokens = _make_tokens(*range(10, 10 + in_zone - 1), end_ids[1])
+        logits = proc(tokens, self._ramp_logits(top=5.0))
+        assert not proc._done
+        assert logits[0, 42].item() > 0.0  # first id targeted
+        assert logits[0, 43].item() == 0.0  # out-of-order id not boosted

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -915,8 +915,12 @@ class TestSoftThinkingBudget:
         self._step(proc, self.BUDGET, self._ramp_logits())
         assert proc._forcing
 
-    def test_multi_token_end_boosts_all_ids_with_first_gap(self):
-        """Multi-token close sequences clamp every end id to the target."""
+    def test_multi_token_end_boosts_only_first_id(self):
+        """Without a partial close prefix, only the first marker id is boosted.
+
+        Boosting later ids too could make the model sample them out of
+        order and leak a close-marker fragment into the thinking text.
+        """
         end_ids = [42, 43]
         proc = self._make_processor(end_ids=end_ids)
         logits = None
@@ -924,7 +928,21 @@ class TestSoftThinkingBudget:
             logits = self._step(proc, step, self._ramp_logits(top=5.0))
         target = self._expected_boost(self.BUDGET - 1)
         assert logits[0, 42].item() == pytest.approx(target)
-        assert logits[0, 43].item() == pytest.approx(target)
+        assert logits[0, 43].item() == 0.0
+
+    def test_multi_token_partial_prefix_biases_next_id(self):
+        """After the model emits the first marker id, the second is boosted."""
+        end_ids = [42, 43]
+        proc = self._make_processor(end_ids=end_ids)
+        in_zone = self.SOFT_START + 2
+        for step in range(1, in_zone):
+            self._step(proc, step, self._ramp_logits(top=5.0))
+        # Model naturally samples the first id of the close marker.
+        tokens = _make_tokens(*range(10, 10 + in_zone - 1), end_ids[0])
+        logits = proc(tokens, self._ramp_logits(top=5.0))
+        assert not proc._done  # marker not complete yet
+        assert logits[0, 43].item() > 0.0  # continuation id boosted
+        assert logits[0, 42].item() == 0.0  # first id no longer targeted
 
     def test_min_gap_floor_when_end_already_near_top(self):
         """gap is floored at 1.0 so the ramp still progresses on flat logits."""

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -827,7 +827,7 @@ class TestSoftThinkingBudget:
     BUDGET = 10
     FRAC = ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC
     FACTOR = ThinkingBudgetProcessor._SOFT_BIAS_FACTOR
-    MAX_GAP = 30.0
+    TOP_K = 32
     MAX_OVERSHOOT = 1.0
     SOFT_START = int(BUDGET * FRAC)
     SPAN = BUDGET - SOFT_START
@@ -853,22 +853,60 @@ class TestSoftThinkingBudget:
         logits[0, self.THINK_END_ID] = end
         return logits
 
+    def _ranked_logits(
+        self,
+        *,
+        end: float,
+        top: float = 40.0,
+        above_end_count: int = 31,
+        vocab_size: int = 100,
+    ):
+        """Logits where the close token has a controlled top-k rank."""
+        logits = mx.zeros((1, vocab_size))
+        for rank in range(above_end_count):
+            logits[0, rank] = top - (top - end) * rank / max(above_end_count, 1)
+        logits[0, self.THINK_END_ID] = end
+        return logits
+
+    def _outside_topk_logits(
+        self,
+        *,
+        end: float = 20.0,
+        top: float = 40.0,
+        step: float = 0.5,
+        vocab_size: int = 100,
+    ):
+        """Close token is within a fixed gap, but outside the top-k set."""
+        logits = mx.zeros((1, vocab_size))
+        for rank in range(self.TOP_K):
+            logits[0, rank] = top - step * rank
+        logits[0, self.THINK_END_ID] = end
+        return logits
+
     def _step(self, proc, n_tokens: int, logits=None):
         """Run proc for a history of n_tokens generated tokens."""
         tokens = _make_tokens(*range(10, 10 + n_tokens))
         return proc(tokens, logits if logits is not None else _make_logits())
 
-    def _expected_end_logit(self, step: int, top: float = 5.0, end: float = 0.0) -> float:
+    def _expected_end_logit(
+        self,
+        step: int,
+        top: float = 5.0,
+        end: float = 0.0,
+        kth: float = 0.0,
+    ) -> float:
         """Expected close-think logit at a given think step."""
         if step <= self.SOFT_START:
             return end
-        gap_to_top = top - end
-        if gap_to_top > self.MAX_GAP:
+        if end < kth:
             return end
         progress = (step - self.SOFT_START) / max(1, self.SPAN)
-        boost_gap = max(gap_to_top, 1.0)
-        boosted = end + self.FACTOR * boost_gap * progress
-        return min(boosted, top + self.MAX_OVERSHOOT)
+        gap_to_top = max(top - end, 0.0)
+        topk_span = max(top - kth, 1e-6)
+        normalized_gap = gap_to_top / topk_span
+        proximity = 1.0 / (1.0 + normalized_gap) ** 2
+        ramp = min(self.FACTOR * progress * proximity, 1.0)
+        return end + ramp * ((top + self.MAX_OVERSHOOT) - end)
 
     def test_no_bias_before_soft_zone(self):
         """Up to the zone boundary, logits pass through unchanged."""
@@ -895,17 +933,39 @@ class TestSoftThinkingBudget:
         proc = self._make_processor()
         logits = None
         for step in range(1, self.BUDGET):
-            logits = self._step(proc, step, self._ramp_logits(top=5.0))
+            logits = self._step(proc, step, self._ramp_logits(top=5.0, end=4.5))
         assert logits[0, self.THINK_END_ID].item() > 5.0
         assert logits[0, self.THINK_END_ID].item() == pytest.approx(6.0)
 
     def test_soft_zone_does_not_boost_implausible_close_token(self):
-        """A close-think token far below the top logit is not promoted."""
+        """A close-think token outside the top-k set is not promoted."""
         proc = self._make_processor()
         logits = None
         for step in range(1, self.BUDGET):
-            logits = self._step(proc, step, self._ramp_logits(top=60.0, end=0.0))
-        assert logits[0, self.THINK_END_ID].item() == 0.0
+            logits = self._step(proc, step, self._outside_topk_logits())
+        assert logits[0, self.THINK_END_ID].item() == 20.0
+
+    def test_soft_zone_prefers_near_top_close_token_over_topk_edge(self):
+        """A close token near the top gets a stronger final rank than one at
+        the edge of the top-k set."""
+        near_proc = self._make_processor()
+        edge_proc = self._make_processor()
+        near_logits = edge_logits = None
+        for step in range(1, self.BUDGET):
+            near_logits = self._step(
+                near_proc,
+                step,
+                self._ranked_logits(end=39.0, top=40.0, above_end_count=10),
+            )
+            edge_logits = self._step(
+                edge_proc,
+                step,
+                self._ranked_logits(end=10.0, top=40.0, above_end_count=31),
+            )
+        assert near_logits[0, self.THINK_END_ID].item() > edge_logits[
+            0, self.THINK_END_ID
+        ].item()
+        assert edge_logits[0, self.THINK_END_ID].item() > 10.0
 
     def test_hard_force_still_applies_at_budget(self):
         """The 100% hard force stays as the safety net."""
@@ -968,11 +1028,11 @@ class TestSoftThinkingBudget:
         assert logits[0, 42].item() == 0.0  # first id no longer targeted
 
     def test_min_gap_floor_when_end_already_near_top_is_capped(self):
-        """gap is floored at 1.0 so the ramp still progresses on flat logits."""
+        """Flat logits are maximally close and can use the overshoot cap."""
         proc = self._make_processor()
         logits = None
         for step in range(1, self.BUDGET):
-            logits = self._step(proc, step, _make_logits())  # all zeros, gap->1.0
+            logits = self._step(proc, step, _make_logits())
         assert logits[0, self.THINK_END_ID].item() == pytest.approx(self.MAX_OVERSHOOT)
 
     def test_multi_token_wrong_prefix_falls_back_to_first_id(self):
@@ -1022,13 +1082,13 @@ class TestSoftThinkingBudget:
 
     def test_soft_zone_policy_constants(self):
         """The zone boundaries are product choices, not incidental values:
-        the soft zone covers the last 30% of the budget, only near-top close
+        the soft zone covers the last 30% of the budget, only top-k close
         tokens are eligible, and eligible tokens can only overtake the top by
         a small margin. Changing these values changes when models stop
         thinking; update the PR narrative together with this test."""
         assert ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC == 0.7
         assert ThinkingBudgetProcessor._SOFT_BIAS_FACTOR == 2.0
-        assert ThinkingBudgetProcessor._SOFT_BIAS_MAX_GAP == 30.0
+        assert ThinkingBudgetProcessor._SOFT_BIAS_TOP_K == 32
         assert ThinkingBudgetProcessor._SOFT_BIAS_MAX_OVERSHOOT == 1.0
 
     def test_degenerate_budgets_keep_the_hard_cut_contract(self):
@@ -1053,16 +1113,16 @@ class TestSoftThinkingBudget:
 
     def test_budget_four_gets_one_soft_step(self):
         """budget=4 is the smallest budget with a live soft step: step 3
-        runs the ramp at progress 1/2 (boost = FACTOR * gap * 1/2), step 4
+        runs the ramp at progress 1/2, step 4
         is the hard wall."""
         proc = self._make_processor(budget=4)
         logits = self._step(proc, 1, _make_logits())
         assert logits[0, self.THINK_END_ID].item() == 0.0
         logits = self._step(proc, 2, _make_logits())
         assert logits[0, self.THINK_END_ID].item() == 0.0
-        # Flat logits: the gap floors at 1.0, so the boost is the pure ramp.
+        # Flat logits: proximity is maximal, so the boost reaches the cap.
         logits = self._step(proc, 3, _make_logits())
         assert not proc._forcing
-        assert logits[0, self.THINK_END_ID].item() == pytest.approx(self.FACTOR * 1.0 * 0.5)
+        assert logits[0, self.THINK_END_ID].item() == pytest.approx(self.MAX_OVERSHOOT)
         self._step(proc, 4, _make_logits())
         assert proc._forcing

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -827,6 +827,8 @@ class TestSoftThinkingBudget:
     BUDGET = 10
     FRAC = ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC
     FACTOR = ThinkingBudgetProcessor._SOFT_BIAS_FACTOR
+    MAX_GAP = 5.0
+    MAX_OVERSHOOT = 1.0
     SOFT_START = int(BUDGET * FRAC)
     SPAN = BUDGET - SOFT_START
 
@@ -838,10 +840,17 @@ class TestSoftThinkingBudget:
             soft_budget=soft_budget,
         )
 
-    def _ramp_logits(self, vocab_size: int = 100, top_id: int = 7, top: float = 5.0):
-        """Logits with a known top value and zeros elsewhere."""
+    def _ramp_logits(
+        self,
+        vocab_size: int = 100,
+        top_id: int = 7,
+        top: float = 5.0,
+        end: float = 0.0,
+    ):
+        """Logits with known top and close-think values."""
         logits = mx.zeros((1, vocab_size))
         logits[0, top_id] = top
+        logits[0, self.THINK_END_ID] = end
         return logits
 
     def _step(self, proc, n_tokens: int, logits=None):
@@ -849,12 +858,17 @@ class TestSoftThinkingBudget:
         tokens = _make_tokens(*range(10, 10 + n_tokens))
         return proc(tokens, logits if logits is not None else _make_logits())
 
-    def _expected_boost(self, step: int, top: float = 5.0) -> float:
-        """target - end_logit for a zeroed end logit at a given think step."""
+    def _expected_end_logit(self, step: int, top: float = 5.0, end: float = 0.0) -> float:
+        """Expected close-think logit at a given think step."""
         if step <= self.SOFT_START:
-            return 0.0
+            return end
+        gap_to_top = top - end
+        if gap_to_top > self.MAX_GAP:
+            return end
         progress = (step - self.SOFT_START) / max(1, self.SPAN)
-        return self.FACTOR * max(top, 1.0) * progress
+        boost_gap = max(gap_to_top, 1.0)
+        boosted = end + self.FACTOR * boost_gap * progress
+        return min(boosted, top + self.MAX_OVERSHOOT)
 
     def test_no_bias_before_soft_zone(self):
         """Up to the zone boundary, logits pass through unchanged."""
@@ -865,7 +879,7 @@ class TestSoftThinkingBudget:
         assert not proc._forcing
 
     def test_soft_zone_boosts_end_logit_progressively(self):
-        """Inside the soft zone the close-think logit ramps toward the top."""
+        """Inside the soft zone a plausible close-think logit ramps up."""
         proc = self._make_processor()
         boosts = []
         for step in range(1, self.BUDGET):
@@ -873,16 +887,25 @@ class TestSoftThinkingBudget:
             boosts.append(logits[0, self.THINK_END_ID].item())
         assert boosts[self.SOFT_START - 1] == 0.0  # boundary step: progress=0
         for step in range(self.SOFT_START + 1, self.BUDGET):
-            assert boosts[step - 1] == pytest.approx(self._expected_boost(step))
+            assert boosts[step - 1] == pytest.approx(self._expected_end_logit(step))
         assert boosts[self.BUDGET - 2] > boosts[self.SOFT_START]
 
-    def test_soft_zone_end_dominates_at_high_progress(self):
-        """Past 1/FACTOR of the soft zone the close-think logit exceeds the top."""
+    def test_soft_zone_caps_overshoot_at_high_progress(self):
+        """The close-think logit can overtake the top, but only by a small cap."""
         proc = self._make_processor()
         logits = None
         for step in range(1, self.BUDGET):
             logits = self._step(proc, step, self._ramp_logits(top=5.0))
         assert logits[0, self.THINK_END_ID].item() > 5.0
+        assert logits[0, self.THINK_END_ID].item() == pytest.approx(6.0)
+
+    def test_soft_zone_does_not_boost_implausible_close_token(self):
+        """A close-think token far below the top logit is not promoted."""
+        proc = self._make_processor()
+        logits = None
+        for step in range(1, self.BUDGET):
+            logits = self._step(proc, step, self._ramp_logits(top=20.0, end=0.0))
+        assert logits[0, self.THINK_END_ID].item() == 0.0
 
     def test_hard_force_still_applies_at_budget(self):
         """The 100% hard force stays as the safety net."""
@@ -926,7 +949,7 @@ class TestSoftThinkingBudget:
         logits = None
         for step in range(1, self.BUDGET):
             logits = self._step(proc, step, self._ramp_logits(top=5.0))
-        target = self._expected_boost(self.BUDGET - 1)
+        target = self._expected_end_logit(self.BUDGET - 1)
         assert logits[0, 42].item() == pytest.approx(target)
         assert logits[0, 43].item() == 0.0
 
@@ -944,14 +967,13 @@ class TestSoftThinkingBudget:
         assert logits[0, 43].item() > 0.0  # continuation id boosted
         assert logits[0, 42].item() == 0.0  # first id no longer targeted
 
-    def test_min_gap_floor_when_end_already_near_top(self):
+    def test_min_gap_floor_when_end_already_near_top_is_capped(self):
         """gap is floored at 1.0 so the ramp still progresses on flat logits."""
         proc = self._make_processor()
         logits = None
         for step in range(1, self.BUDGET):
             logits = self._step(proc, step, _make_logits())  # all zeros, gap->1.0
-        progress = (self.BUDGET - 1 - self.SOFT_START) / max(1, self.SPAN)
-        assert logits[0, self.THINK_END_ID].item() == pytest.approx(self.FACTOR * 1.0 * progress)
+        assert logits[0, self.THINK_END_ID].item() == pytest.approx(self.MAX_OVERSHOOT)
 
     def test_multi_token_wrong_prefix_falls_back_to_first_id(self):
         """A generated tail that matches a LATER marker id (not a proper
@@ -1000,12 +1022,14 @@ class TestSoftThinkingBudget:
 
     def test_soft_zone_policy_constants(self):
         """The zone boundaries are product choices, not incidental values:
-        the soft zone covers the last 30% of the budget, and FACTOR=2 makes
-        the close-think logit overtake the top halfway through the zone.
-        Changing either changes when models stop thinking; update the PR
-        narrative (and the vllm#38277 port) together with this test."""
+        the soft zone covers the last 30% of the budget, only near-top close
+        tokens are eligible, and eligible tokens can only overtake the top by
+        a small margin. Changing these values changes when models stop
+        thinking; update the PR narrative together with this test."""
         assert ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC == 0.7
         assert ThinkingBudgetProcessor._SOFT_BIAS_FACTOR == 2.0
+        assert ThinkingBudgetProcessor._SOFT_BIAS_MAX_GAP == 5.0
+        assert ThinkingBudgetProcessor._SOFT_BIAS_MAX_OVERSHOOT == 1.0
 
     def test_degenerate_budgets_keep_the_hard_cut_contract(self):
         """Tiny budgets must degrade to the hard cut without a crash or a

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -827,7 +827,7 @@ class TestSoftThinkingBudget:
     BUDGET = 10
     FRAC = ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC
     FACTOR = ThinkingBudgetProcessor._SOFT_BIAS_FACTOR
-    MAX_GAP = 5.0
+    MAX_GAP = 30.0
     MAX_OVERSHOOT = 1.0
     SOFT_START = int(BUDGET * FRAC)
     SPAN = BUDGET - SOFT_START
@@ -904,7 +904,7 @@ class TestSoftThinkingBudget:
         proc = self._make_processor()
         logits = None
         for step in range(1, self.BUDGET):
-            logits = self._step(proc, step, self._ramp_logits(top=20.0, end=0.0))
+            logits = self._step(proc, step, self._ramp_logits(top=60.0, end=0.0))
         assert logits[0, self.THINK_END_ID].item() == 0.0
 
     def test_hard_force_still_applies_at_budget(self):
@@ -1028,7 +1028,7 @@ class TestSoftThinkingBudget:
         thinking; update the PR narrative together with this test."""
         assert ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC == 0.7
         assert ThinkingBudgetProcessor._SOFT_BIAS_FACTOR == 2.0
-        assert ThinkingBudgetProcessor._SOFT_BIAS_MAX_GAP == 5.0
+        assert ThinkingBudgetProcessor._SOFT_BIAS_MAX_GAP == 30.0
         assert ThinkingBudgetProcessor._SOFT_BIAS_MAX_OVERSHOOT == 1.0
 
     def test_degenerate_budgets_keep_the_hard_cut_contract(self):

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for ThinkingBudgetProcessor logits processor."""
 
+import math
 from unittest.mock import MagicMock
 
 import pytest
@@ -820,17 +821,16 @@ class TestCompletionsStreamThinkPrefixParity:
 
 @pytest.mark.skipif(not HAS_MLX, reason="mlx not available")
 class TestSoftThinkingBudget:
-    """Unit tests for the progressive soft budget zone (vllm#38277 port)."""
+    """Unit tests for the progressive soft budget zone."""
 
     THINK_END_ID = 42
     THINK_START_ID = 41
     BUDGET = 10
     FRAC = ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC
-    FACTOR = ThinkingBudgetProcessor._SOFT_BIAS_FACTOR
-    TOP_K = 32
+    CENTER = 0.8
+    SHARPNESS = 10.0
     MAX_OVERSHOOT = 1.0
     SOFT_START = int(BUDGET * FRAC)
-    SPAN = BUDGET - SOFT_START
 
     def _make_processor(self, budget: int = None, soft_budget: bool = True, end_ids=None):
         return ThinkingBudgetProcessor(
@@ -861,14 +861,14 @@ class TestSoftThinkingBudget:
         above_end_count: int = 31,
         vocab_size: int = 100,
     ):
-        """Logits where the close token has a controlled top-k rank."""
+        """Logits where the close token has a controlled rank."""
         logits = mx.zeros((1, vocab_size))
         for rank in range(above_end_count):
             logits[0, rank] = top - (top - end) * rank / max(above_end_count, 1)
         logits[0, self.THINK_END_ID] = end
         return logits
 
-    def _outside_topk_logits(
+    def _many_candidates_above_close_logits(
         self,
         *,
         end: float = 20.0,
@@ -876,9 +876,9 @@ class TestSoftThinkingBudget:
         step: float = 0.5,
         vocab_size: int = 100,
     ):
-        """Close token is within a fixed gap, but outside the top-k set."""
+        """Logits with many plausible tokens above the close token."""
         logits = mx.zeros((1, vocab_size))
-        for rank in range(self.TOP_K):
+        for rank in range(32):
             logits[0, rank] = top - step * rank
         logits[0, self.THINK_END_ID] = end
         return logits
@@ -891,19 +891,21 @@ class TestSoftThinkingBudget:
     def _expected_end_logit(
         self,
         step: int,
-        top: float = 5.0,
         end: float = 0.0,
-        kth: float = 0.0,
+        top: float = 5.0,
+        budget: int = None,
     ) -> float:
         """Expected close-think logit at a given think step."""
-        if step <= self.SOFT_START:
+        budget = self.BUDGET if budget is None else budget
+        soft_start = int(budget * self.FRAC)
+        if step <= soft_start:
             return end
-        topk_span = max(top - kth, 1e-6)
-        progress = (step - self.SOFT_START) / max(1, self.SPAN)
-        gap_to_top = max(top - end, 0.0)
-        normalized_gap = gap_to_top / topk_span
-        proximity = 1.0 / (1.0 + normalized_gap)
-        ramp = min(self.FACTOR * progress * proximity, 1.0)
+        soft_steps = max(1, budget - soft_start - 1)
+        progress = min(max((step - soft_start) / soft_steps, 0.0), 1.0)
+        start = 1.0 / (1.0 + math.exp(-self.SHARPNESS * (0.0 - self.CENTER)))
+        finish = 1.0 / (1.0 + math.exp(-self.SHARPNESS * (1.0 - self.CENTER)))
+        value = 1.0 / (1.0 + math.exp(-self.SHARPNESS * (progress - self.CENTER)))
+        ramp = (value - start) / max(finish - start, 1e-6)
         return end + ramp * ((top + self.MAX_OVERSHOOT) - end)
 
     def test_no_bias_before_soft_zone(self):
@@ -926,55 +928,58 @@ class TestSoftThinkingBudget:
             assert boosts[step - 1] == pytest.approx(self._expected_end_logit(step))
         assert boosts[self.BUDGET - 2] > boosts[self.SOFT_START]
 
-    def test_soft_zone_caps_overshoot_at_high_progress(self):
-        """The close-think logit can overtake the top, but only by a small cap."""
+    def test_soft_zone_uses_sigmoid_gap_aware_target(self):
+        """The soft nudge pulls toward the top logit near the hard wall."""
         proc = self._make_processor()
         logits = None
         for step in range(1, self.BUDGET):
-            logits = self._step(proc, step, self._ramp_logits(top=5.0, end=4.5))
-        assert logits[0, self.THINK_END_ID].item() > 5.0
-        assert logits[0, self.THINK_END_ID].item() == pytest.approx(6.0)
+            logits = self._step(proc, step, self._ramp_logits(top=5.0, end=0.0))
+        target = self._expected_end_logit(self.BUDGET - 1, top=5.0, end=0.0)
+        assert target == pytest.approx(6.0)
+        assert logits[0, self.THINK_END_ID].item() == pytest.approx(target)
 
-    def test_soft_zone_boosts_close_token_just_below_topk(self):
-        """A close-think token just under the top-k set gets a small nudge."""
+    def test_soft_zone_boost_scales_with_gap_to_top(self):
+        """Far-away close tokens get a larger absolute boost."""
         proc = self._make_processor()
         logits = None
         for step in range(1, self.BUDGET):
-            logits = self._step(proc, step, self._outside_topk_logits())
+            logits = self._step(proc, step, self._many_candidates_above_close_logits())
         target = self._expected_end_logit(
             self.BUDGET - 1,
-            top=40.0,
-            kth=24.5,
             end=20.0,
+            top=40.0,
         )
         assert logits[0, self.THINK_END_ID].item() == pytest.approx(target)
 
-    def test_soft_zone_far_below_topk_gets_weaker_boost(self):
-        """A far close token is still nudged, but less than a near-tail one."""
+    def test_soft_zone_farther_close_token_gets_stronger_absolute_boost(self):
+        """The target is top-relative, not a fixed offset."""
         near_proc = self._make_processor()
         far_proc = self._make_processor()
         near_logits = far_logits = None
         for step in range(1, self.BUDGET):
-            near_logits = self._step(near_proc, step, self._outside_topk_logits())
+            near_logits = self._step(
+                near_proc,
+                step,
+                self._many_candidates_above_close_logits(),
+            )
             far_logits = self._step(
                 far_proc,
                 step,
-                self._outside_topk_logits(end=5.0),
+                self._many_candidates_above_close_logits(end=5.0),
             )
 
+        near_boost = near_logits[0, self.THINK_END_ID].item() - 20.0
         far_boost = far_logits[0, self.THINK_END_ID].item() - 5.0
-        assert far_boost > 0.0
-        assert near_logits[0, self.THINK_END_ID].item() > far_logits[
-            0, self.THINK_END_ID
-        ].item()
+        assert far_boost > near_boost
+        assert near_logits[0, self.THINK_END_ID].item() == pytest.approx(41.0)
+        assert far_logits[0, self.THINK_END_ID].item() == pytest.approx(41.0)
 
-    def test_soft_zone_prefers_near_top_close_token_over_topk_edge(self):
-        """A close token near the top gets a stronger final rank than one at
-        the edge of the top-k set."""
+    def test_soft_zone_prefers_near_top_close_token_before_saturation(self):
+        """Before the ramp saturates, near-top close tokens stay more natural."""
         near_proc = self._make_processor()
         edge_proc = self._make_processor()
-        near_logits = edge_logits = None
-        for step in range(1, self.BUDGET):
+        target_step = self.SOFT_START + 1
+        for step in range(1, target_step + 1):
             near_logits = self._step(
                 near_proc,
                 step,
@@ -1050,13 +1055,15 @@ class TestSoftThinkingBudget:
         assert logits[0, 43].item() > 0.0  # continuation id boosted
         assert logits[0, 42].item() == 0.0  # first id no longer targeted
 
-    def test_min_gap_floor_when_end_already_near_top_is_capped(self):
-        """Flat logits are maximally close and can use the overshoot cap."""
+    def test_flat_logits_receive_the_overshoot_cap_near_hard_wall(self):
+        """Flat logits can overtake the top by the configured cap."""
         proc = self._make_processor()
         logits = None
         for step in range(1, self.BUDGET):
             logits = self._step(proc, step, _make_logits())
-        assert logits[0, self.THINK_END_ID].item() == pytest.approx(self.MAX_OVERSHOOT)
+        assert logits[0, self.THINK_END_ID].item() == pytest.approx(
+            self._expected_end_logit(self.BUDGET - 1, top=0.0)
+        )
 
     def test_multi_token_wrong_prefix_falls_back_to_first_id(self):
         """A generated tail that matches a LATER marker id (not a proper
@@ -1105,13 +1112,12 @@ class TestSoftThinkingBudget:
 
     def test_soft_zone_policy_constants(self):
         """The zone boundaries are product choices, not incidental values:
-        the soft zone covers the last 30% of the budget, top-k logits define
-        the local plausibility span, and the close token can only overtake the
-        top by a small margin. Changing these values changes when models stop
-        thinking; update the PR narrative together with this test."""
+        the soft zone covers the last 30% of the budget and uses a late
+        sigmoid pull toward the top logit. Changing these values changes when
+        models stop thinking; update the PR narrative together with this test."""
         assert ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC == 0.7
-        assert ThinkingBudgetProcessor._SOFT_BIAS_FACTOR == 2.0
-        assert ThinkingBudgetProcessor._SOFT_BIAS_TOP_K == 32
+        assert ThinkingBudgetProcessor._SOFT_SIGMOID_CENTER == 0.8
+        assert ThinkingBudgetProcessor._SOFT_SIGMOID_SHARPNESS == 10.0
         assert ThinkingBudgetProcessor._SOFT_BIAS_MAX_OVERSHOOT == 1.0
 
     def test_degenerate_budgets_keep_the_hard_cut_contract(self):
@@ -1143,9 +1149,9 @@ class TestSoftThinkingBudget:
         assert logits[0, self.THINK_END_ID].item() == 0.0
         logits = self._step(proc, 2, _make_logits())
         assert logits[0, self.THINK_END_ID].item() == 0.0
-        # Flat logits: proximity is maximal, so the boost reaches the cap.
+        # Flat logits reach the midpoint of the normalized ramp.
         logits = self._step(proc, 3, _make_logits())
         assert not proc._forcing
-        assert logits[0, self.THINK_END_ID].item() == pytest.approx(self.MAX_OVERSHOOT)
+        assert logits[0, self.THINK_END_ID].item() == pytest.approx(1.0)
         self._step(proc, 4, _make_logits())
         assert proc._forcing

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -829,7 +829,7 @@ class TestSoftThinkingBudget:
     FRAC = ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC
     CENTER = 0.8
     SHARPNESS = 10.0
-    MAX_OVERSHOOT = 1.0
+    TARGET_MARGIN = 0.25
     SOFT_START = int(BUDGET * FRAC)
 
     def _make_processor(self, budget: int = None, soft_budget: bool = True, end_ids=None):
@@ -906,7 +906,8 @@ class TestSoftThinkingBudget:
         finish = 1.0 / (1.0 + math.exp(-self.SHARPNESS * (1.0 - self.CENTER)))
         value = 1.0 / (1.0 + math.exp(-self.SHARPNESS * (progress - self.CENTER)))
         ramp = (value - start) / max(finish - start, 1e-6)
-        return end + ramp * ((top + self.MAX_OVERSHOOT) - end)
+        target = end + ramp * ((top - self.TARGET_MARGIN) - end)
+        return max(end, target)
 
     def test_no_bias_before_soft_zone(self):
         """Up to the zone boundary, logits pass through unchanged."""
@@ -928,15 +929,16 @@ class TestSoftThinkingBudget:
             assert boosts[step - 1] == pytest.approx(self._expected_end_logit(step))
         assert boosts[self.BUDGET - 2] > boosts[self.SOFT_START]
 
-    def test_soft_zone_uses_sigmoid_gap_aware_target(self):
-        """The soft nudge pulls toward the top logit near the hard wall."""
+    def test_soft_zone_uses_sigmoid_top_margin_target(self):
+        """The soft nudge pulls near, but not above, the top logit."""
         proc = self._make_processor()
         logits = None
         for step in range(1, self.BUDGET):
             logits = self._step(proc, step, self._ramp_logits(top=5.0, end=0.0))
         target = self._expected_end_logit(self.BUDGET - 1, top=5.0, end=0.0)
-        assert target == pytest.approx(6.0)
+        assert target == pytest.approx(4.75)
         assert logits[0, self.THINK_END_ID].item() == pytest.approx(target)
+        assert logits[0, self.THINK_END_ID].item() < logits[0, 7].item()
 
     def test_soft_zone_boost_scales_with_gap_to_top(self):
         """Far-away close tokens get a larger absolute boost."""
@@ -971,8 +973,17 @@ class TestSoftThinkingBudget:
         near_boost = near_logits[0, self.THINK_END_ID].item() - 20.0
         far_boost = far_logits[0, self.THINK_END_ID].item() - 5.0
         assert far_boost > near_boost
-        assert near_logits[0, self.THINK_END_ID].item() == pytest.approx(41.0)
-        assert far_logits[0, self.THINK_END_ID].item() == pytest.approx(41.0)
+        assert near_logits[0, self.THINK_END_ID].item() == pytest.approx(39.75)
+        assert far_logits[0, self.THINK_END_ID].item() == pytest.approx(39.75)
+
+    def test_soft_zone_never_overtakes_top_before_hard_cut(self):
+        """The soft path must not become a temperature-0 hard force."""
+        proc = self._make_processor()
+        logits = None
+        for step in range(1, self.BUDGET):
+            logits = self._step(proc, step, self._ramp_logits(top=10.0, end=-20.0))
+        assert logits[0, self.THINK_END_ID].item() == pytest.approx(9.75)
+        assert logits[0, self.THINK_END_ID].item() < logits[0, 7].item()
 
     def test_soft_zone_prefers_near_top_close_token_before_saturation(self):
         """Before the ramp saturates, near-top close tokens stay more natural."""
@@ -1055,15 +1066,13 @@ class TestSoftThinkingBudget:
         assert logits[0, 43].item() > 0.0  # continuation id boosted
         assert logits[0, 42].item() == 0.0  # first id no longer targeted
 
-    def test_flat_logits_receive_the_overshoot_cap_near_hard_wall(self):
-        """Flat logits can overtake the top by the configured cap."""
+    def test_flat_logits_are_not_penalized_or_forced_by_soft_zone(self):
+        """Flat logits already leave the close token tied with the top."""
         proc = self._make_processor()
         logits = None
         for step in range(1, self.BUDGET):
             logits = self._step(proc, step, _make_logits())
-        assert logits[0, self.THINK_END_ID].item() == pytest.approx(
-            self._expected_end_logit(self.BUDGET - 1, top=0.0)
-        )
+        assert logits[0, self.THINK_END_ID].item() == pytest.approx(0.0)
 
     def test_multi_token_wrong_prefix_falls_back_to_first_id(self):
         """A generated tail that matches a LATER marker id (not a proper
@@ -1118,7 +1127,7 @@ class TestSoftThinkingBudget:
         assert ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC == 0.7
         assert ThinkingBudgetProcessor._SOFT_SIGMOID_CENTER == 0.8
         assert ThinkingBudgetProcessor._SOFT_SIGMOID_SHARPNESS == 10.0
-        assert ThinkingBudgetProcessor._SOFT_BIAS_MAX_OVERSHOOT == 1.0
+        assert ThinkingBudgetProcessor._SOFT_TARGET_MARGIN == 0.25
 
     def test_degenerate_budgets_keep_the_hard_cut_contract(self):
         """Tiny budgets must degrade to the hard cut without a crash or a
@@ -1149,9 +1158,10 @@ class TestSoftThinkingBudget:
         assert logits[0, self.THINK_END_ID].item() == 0.0
         logits = self._step(proc, 2, _make_logits())
         assert logits[0, self.THINK_END_ID].item() == 0.0
-        # Flat logits reach the midpoint of the normalized ramp.
+        # Flat logits already tie the close token with the top, so the soft
+        # path leaves them unchanged rather than manufacturing a forced close.
         logits = self._step(proc, 3, _make_logits())
         assert not proc._forcing
-        assert logits[0, self.THINK_END_ID].item() == pytest.approx(1.0)
+        assert logits[0, self.THINK_END_ID].item() == pytest.approx(0.0)
         self._step(proc, 4, _make_logits())
         assert proc._forcing

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -898,13 +898,11 @@ class TestSoftThinkingBudget:
         """Expected close-think logit at a given think step."""
         if step <= self.SOFT_START:
             return end
-        if end < kth:
-            return end
+        topk_span = max(top - kth, 1e-6)
         progress = (step - self.SOFT_START) / max(1, self.SPAN)
         gap_to_top = max(top - end, 0.0)
-        topk_span = max(top - kth, 1e-6)
         normalized_gap = gap_to_top / topk_span
-        proximity = 1.0 / (1.0 + normalized_gap) ** 2
+        proximity = 1.0 / (1.0 + normalized_gap)
         ramp = min(self.FACTOR * progress * proximity, 1.0)
         return end + ramp * ((top + self.MAX_OVERSHOOT) - end)
 
@@ -937,13 +935,38 @@ class TestSoftThinkingBudget:
         assert logits[0, self.THINK_END_ID].item() > 5.0
         assert logits[0, self.THINK_END_ID].item() == pytest.approx(6.0)
 
-    def test_soft_zone_does_not_boost_implausible_close_token(self):
-        """A close-think token outside the top-k set is not promoted."""
+    def test_soft_zone_boosts_close_token_just_below_topk(self):
+        """A close-think token just under the top-k set gets a small nudge."""
         proc = self._make_processor()
         logits = None
         for step in range(1, self.BUDGET):
             logits = self._step(proc, step, self._outside_topk_logits())
-        assert logits[0, self.THINK_END_ID].item() == 20.0
+        target = self._expected_end_logit(
+            self.BUDGET - 1,
+            top=40.0,
+            kth=24.5,
+            end=20.0,
+        )
+        assert logits[0, self.THINK_END_ID].item() == pytest.approx(target)
+
+    def test_soft_zone_far_below_topk_gets_weaker_boost(self):
+        """A far close token is still nudged, but less than a near-tail one."""
+        near_proc = self._make_processor()
+        far_proc = self._make_processor()
+        near_logits = far_logits = None
+        for step in range(1, self.BUDGET):
+            near_logits = self._step(near_proc, step, self._outside_topk_logits())
+            far_logits = self._step(
+                far_proc,
+                step,
+                self._outside_topk_logits(end=5.0),
+            )
+
+        far_boost = far_logits[0, self.THINK_END_ID].item() - 5.0
+        assert far_boost > 0.0
+        assert near_logits[0, self.THINK_END_ID].item() > far_logits[
+            0, self.THINK_END_ID
+        ].item()
 
     def test_soft_zone_prefers_near_top_close_token_over_topk_edge(self):
         """A close token near the top gets a stronger final rank than one at
@@ -1082,9 +1105,9 @@ class TestSoftThinkingBudget:
 
     def test_soft_zone_policy_constants(self):
         """The zone boundaries are product choices, not incidental values:
-        the soft zone covers the last 30% of the budget, only top-k close
-        tokens are eligible, and eligible tokens can only overtake the top by
-        a small margin. Changing these values changes when models stop
+        the soft zone covers the last 30% of the budget, top-k logits define
+        the local plausibility span, and the close token can only overtake the
+        top by a small margin. Changing these values changes when models stop
         thinking; update the PR narrative together with this test."""
         assert ThinkingBudgetProcessor._SOFT_ZONE_START_FRAC == 0.7
         assert ThinkingBudgetProcessor._SOFT_BIAS_FACTOR == 2.0


### PR DESCRIPTION
## Summary

This PR keeps `thinking_budget` as a hard safety wall, but gives the model a softer path to finish before it hits that wall.

- A request budget adds a short tail-system hint, so the model knows to keep reasoning under the requested budget. This is the main control signal, and placing it at the prompt tail keeps volatile budget text away from the stable prefix.
- In the last 30% of the budget, the logits processor nudges only the next valid close-thinking token with a late sigmoid ramp.
- The soft target is capped below the current winner: it pulls toward `top_logit - 0.25`, and never lowers the close token if it was already better. This avoids turning the soft zone into a temperature-0 forced close.
- The nudge stays in lazy MLX ops, with no `.item()` sync in the decode loop.
- Multi-token close markers are handled one token at a time, so marker fragments are not boosted out of order.
- If the model still does not close naturally, the existing hard force closes thinking at 100% of the budget.

<img width="1672" height="941" alt="ig_0751637ddbc5cb82016a3067e101248191b2b3e2c62103832e" src="https://github.com/user-attachments/assets/b0ae17e0-07f8-4a3f-8ede-ddfc7b89cf1d" />


## Validation

- `uv run --active --no-sync python -m pytest tests/test_structured_output.py tests/test_thinking_budget.py tests/test_api_utils.py::TestPrepareSystemMessagesForTemplate -q` -> 99 passed
- `uv run --active --no-sync python -m compileall -q omlx/api/thinking.py tests/test_thinking_budget.py`
- `git diff --check`

Real oMLX, strict `json_schema`, reasoning parser enabled, two structured prompts, temperatures `0` and `0.3`, budgets `50/100/300`.

The table below uses true internal processor events from `BENCH_THINK_DONE`. `hard cut` means the hard wall forced the close token at the exact internal budget; `natural close` means the model emitted the close token before the wall.

| model | JSON | recall | budget 50 internal events | budget 100 internal events | budget 300 internal events |
|---|---:|---:|---|---|---|
| Qwen3.6-35B-A3B-nvfp4 | 12/12 | 42/42 | natural close `1/4 @ 49`; hard cut `3/4 @ 50` | natural close `2/4 @ 73`; natural close `1/4 @ 99`; hard cut `1/4 @ 100` | natural close `2/4 @ 298`; hard cut `2/4 @ 300` |
| gemma-4-31b-it-nvfp4 | 12/12 | 41/42 | natural close `2/4 @ 4`; natural close `1/4 @ 49`; hard cut `1/4 @ 50` | natural close `1/4 @ 96`; natural close `1/4 @ 97`; hard cut `2/4 @ 100` | natural close `1/4 @ 100`; natural close `1/4 @ 101`; hard cut `2/4 @ 300` |


## References

- [Token-Budget-Aware LLM Reasoning](https://arxiv.org/abs/2412.18547) motivates the prompt hint: the paper shows that CoT reasoning can be compressed by including a reasonable token budget in the prompt.
- [Steering LLM Thinking with Budget Guidance](https://arxiv.org/abs/2506.13752) motivates keeping decode-time control soft: it steers reasoning with token-level guidance instead of relying only on abrupt budget forcing.
- https://github.com/vllm-project/vllm/pull/45727
