### PR TITLE
fix(api): harden /v1/completions thinking_budget (validation, stream parity, tokenizer detection) on top of #1844

### DIFF
--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -299,7 +299,7 @@ class ChatCompletionRequest(BaseModel):
     # Chat template kwargs (e.g. enable_thinking, reasoning_effort)
     chat_template_kwargs: Optional[Dict[str, Any]] = None
     # Thinking budget (max thinking tokens, None = unlimited)
-    thinking_budget: Optional[int] = None
+    thinking_budget: Optional[int] = Field(default=None, ge=0)
     # SpecPrefill: per-request enable/disable (None = use model setting)
     specprefill: Optional[bool] = None
     # SpecPrefill: per-request keep percentage (0.1-0.5, None = use model setting)
@@ -397,7 +397,7 @@ class CompletionRequest(BaseModel):
     # Seed for reproducible generation (best-effort)
     seed: Optional[int] = None
     # Cap reasoning/thinking tokens (parity with /v1/chat/completions)
-    thinking_budget: Optional[int] = None
+    thinking_budget: Optional[int] = Field(default=None, ge=0)
 
     @field_validator("stop", mode="before")
     @classmethod

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -27,6 +27,97 @@ _THINKING_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
 _THINKING_TAIL_PATTERN = re.compile(r'^(.*?)</think>', re.DOTALL)
 
 
+def _safe_tokenizer_attr(tokenizer, attr: str, default=None):
+    if tokenizer is None:
+        return default
+    try:
+        return getattr(tokenizer, attr, default)
+    except (AttributeError, TypeError, ValueError):
+        return default
+
+
+def _single_token_id(value) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _convert_token_to_id(tokenizer, token: str) -> int | None:
+    convert = _safe_tokenizer_attr(tokenizer, "convert_tokens_to_ids")
+    if not callable(convert):
+        return None
+    try:
+        token_id = convert(token)
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return None
+    if token_id == _safe_tokenizer_attr(tokenizer, "unk_token_id"):
+        return None
+    return _single_token_id(token_id)
+
+
+def _encode_prompt_ids(tokenizer, prompt: str) -> list[int] | None:
+    encode = _safe_tokenizer_attr(tokenizer, "encode")
+    if not callable(encode):
+        return None
+    try:
+        return list(encode(prompt, add_special_tokens=False))
+    except TypeError:
+        try:
+            return list(encode(prompt))
+        except Exception:
+            return None
+    except Exception:
+        return None
+
+
+def prompt_opens_thinking(tokenizer, prompt: str) -> tuple[bool, str]:
+    """Return whether a raw prompt would make the engine prepend ``<think>``.
+
+    Presentation-layer stripping must mirror the engine/scheduler decision, not
+    just the raw text suffix. Some prompts can contain a literal ``<think>``
+    without tokenizing to the model's think-start id, and templates can leave
+    the think-start token in the final token tail without the raw string ending
+    in the visible tag.
+    """
+    think_tag = (
+        _safe_tokenizer_attr(tokenizer, "think_start", _OPEN_TAG) or _OPEN_TAG
+    )
+    if tokenizer is None:
+        return prompt.rstrip().endswith(think_tag), think_tag
+
+    think_start_id = _single_token_id(
+        _safe_tokenizer_attr(tokenizer, "think_start_id")
+    )
+    if think_start_id is None:
+        think_start_id = _convert_token_to_id(tokenizer, think_tag)
+    if think_start_id is None:
+        return False, think_tag
+
+    prompt_ids = _encode_prompt_ids(tokenizer, prompt)
+    if not prompt_ids or not think_start_id:
+        return False, think_tag
+
+    last_tokens = list(prompt_ids[-3:])
+    if think_start_id not in last_tokens:
+        return False, think_tag
+
+    last_idx = len(last_tokens) - 1 - last_tokens[::-1].index(think_start_id)
+    after_start = last_tokens[last_idx + 1 :]
+
+    if after_start:
+        think_end_id = _single_token_id(_safe_tokenizer_attr(tokenizer, "think_end_id"))
+        if think_end_id is None:
+            think_end_tag = _safe_tokenizer_attr(tokenizer, "think_end", _CLOSE_TAG)
+            think_end_id = _convert_token_to_id(tokenizer, think_end_tag or _CLOSE_TAG)
+        if think_end_id is not None and think_end_id in after_start:
+            return False, think_tag
+
+    return True, think_tag
+
+
 def extract_thinking(text: str) -> Tuple[str, str]:
     """Extract thinking and content from complete text.
 

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -10,7 +10,7 @@ their chain-of-thought reasoning in <think>...</think> tags.
 """
 
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import List, Optional, Tuple
 
 
@@ -73,14 +73,19 @@ def _encode_prompt_ids(tokenizer, prompt: str) -> list[int] | None:
         return None
 
 
-def prompt_opens_thinking(tokenizer, prompt: str) -> tuple[bool, str]:
+def prompt_opens_thinking(
+    tokenizer,
+    prompt: str,
+    prompt_token_ids: Sequence[int] | None = None,
+) -> tuple[bool, str]:
     """Return whether a raw prompt would make the engine prepend ``<think>``.
 
     Presentation-layer stripping must mirror the engine/scheduler decision, not
     just the raw text suffix. Some prompts can contain a literal ``<think>``
     without tokenizing to the model's think-start id, and templates can leave
     the think-start token in the final token tail without the raw string ending
-    in the visible tag.
+    in the visible tag. When the caller already has prompt ids from the same
+    tokenizer path as the scheduler, those ids are authoritative.
     """
     think_tag = (
         _safe_tokenizer_attr(tokenizer, "think_start", _OPEN_TAG) or _OPEN_TAG
@@ -96,7 +101,10 @@ def prompt_opens_thinking(tokenizer, prompt: str) -> tuple[bool, str]:
     if think_start_id is None:
         return False, think_tag
 
-    prompt_ids = _encode_prompt_ids(tokenizer, prompt)
+    if prompt_token_ids is None:
+        prompt_ids = _encode_prompt_ids(tokenizer, prompt)
+    else:
+        prompt_ids = list(prompt_token_ids)
     if not prompt_ids or not think_start_id:
         return False, think_tag
 

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -73,6 +73,22 @@ def _encode_prompt_ids(tokenizer, prompt: str) -> list[int] | None:
         return None
 
 
+def _think_end_token_ids(tokenizer) -> list[int] | None:
+    think_end_id = _single_token_id(_safe_tokenizer_attr(tokenizer, "think_end_id"))
+    if think_end_id is not None:
+        return [think_end_id]
+
+    think_end_tag = _safe_tokenizer_attr(tokenizer, "think_end", _CLOSE_TAG)
+    encoded = _encode_prompt_ids(tokenizer, think_end_tag or _CLOSE_TAG)
+    if encoded:
+        return encoded
+
+    token_id = _convert_token_to_id(tokenizer, _CLOSE_TAG)
+    if token_id is not None:
+        return [token_id]
+    return None
+
+
 def prompt_opens_thinking(
     tokenizer,
     prompt: str,
@@ -116,11 +132,8 @@ def prompt_opens_thinking(
     after_start = last_tokens[last_idx + 1 :]
 
     if after_start:
-        think_end_id = _single_token_id(_safe_tokenizer_attr(tokenizer, "think_end_id"))
-        if think_end_id is None:
-            think_end_tag = _safe_tokenizer_attr(tokenizer, "think_end", _CLOSE_TAG)
-            think_end_id = _convert_token_to_id(tokenizer, think_end_tag or _CLOSE_TAG)
-        if think_end_id is not None and think_end_id in after_start:
+        think_end_ids = _think_end_token_ids(tokenizer)
+        if think_end_ids and think_end_ids[0] in after_start:
             return False, think_tag
 
     return True, think_tag

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -153,7 +153,7 @@ from .api.responses_utils import (
     format_sse_event,
     normalize_response_output_to_messages,
 )
-from .api.thinking import ThinkingParser, extract_thinking
+from .api.thinking import ThinkingParser, extract_thinking, prompt_opens_thinking
 from .api.tool_calling import (
     ToolCallStreamFilter,
     build_json_system_prompt,
@@ -3749,8 +3749,9 @@ async def stream_completion(
     # Parity with the non-streaming path: when the prompt opens a thinking
     # block, the first chunk carries the scheduler's synthetic think opener;
     # strip it once so the stream is a pure continuation of the prompt.
-    think_tag = getattr(getattr(engine, "tokenizer", None), "think_start", "<think>") or "<think>"
-    pending_think_prefix_strip = prompt.rstrip().endswith(think_tag)
+    pending_think_prefix_strip, think_tag = prompt_opens_thinking(
+        getattr(engine, "tokenizer", None), prompt
+    )
 
     (
         temperature,

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2705,9 +2705,11 @@ async def create_completion(
     prompts = request.prompt if isinstance(request.prompt, list) else [request.prompt]
 
     # Validate context window for each prompt
+    prompt_token_ids_by_prompt = []
     for prompt in prompts:
-        num_tokens = len(engine.tokenizer.encode(prompt))
-        validate_context_window(num_tokens, request.model)
+        prompt_token_ids = list(engine.tokenizer.encode(prompt))
+        prompt_token_ids_by_prompt.append(prompt_token_ids)
+        validate_context_window(len(prompt_token_ids), request.model)
 
     # Pre-flight prefill memory guard — see create_chat_completion for
     # the reason this must precede any StreamingResponse return.
@@ -2722,7 +2724,11 @@ async def create_completion(
         return StreamingResponse(
             _with_sse_keepalive(
                 stream_completion(
-                    engine, prompts[0], request, model_load_duration=model_load_duration
+                    engine,
+                    prompts[0],
+                    request,
+                    model_load_duration=model_load_duration,
+                    prompt_token_ids=prompt_token_ids_by_prompt[0],
                 ),
                 http_request=http_request,
                 keepalive_chunk=_resolve_keepalive("openai_completion"),
@@ -3741,6 +3747,7 @@ async def stream_completion(
     prompt: str,
     request: CompletionRequest,
     model_load_duration: float = 0.0,
+    prompt_token_ids: list[int] | None = None,
 ) -> AsyncIterator[str]:
     """Stream completion response."""
     start_time = time.perf_counter()
@@ -3750,7 +3757,7 @@ async def stream_completion(
     # block, the first chunk carries the scheduler's synthetic think opener;
     # strip it once so the stream is a pure continuation of the prompt.
     pending_think_prefix_strip, think_tag = prompt_opens_thinking(
-        getattr(engine, "tokenizer", None), prompt
+        getattr(engine, "tokenizer", None), prompt, prompt_token_ids=prompt_token_ids
     )
 
     (

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1270,6 +1270,20 @@ def get_sampling_params(
     )
 
 
+def _strip_synthetic_think_prefix(chunk_text: str, think_tag: str) -> str:
+    """Drop the scheduler's synthetic think opener from a raw completions chunk.
+
+    Raw completions are a pure continuation of the prompt. When the prompt
+    itself ends with an open think tag, the scheduler still prepends a
+    synthetic ``"<think>\\n"`` to the first streamed chunk (chat streams rely
+    on it to rebuild the reasoning block), but the opener belongs to the
+    prompt and the non-streaming completions path never returns it. Stripping
+    it keeps both completion paths returning the same continuation.
+    """
+    prefix = f"{think_tag}\n"
+    return chunk_text[len(prefix) :] if chunk_text.startswith(prefix) else chunk_text
+
+
 def _resolve_thinking_budget(request, model_id: str | None) -> int | None:
     """Resolve thinking budget: request param > model settings > None."""
     # Check request-level override (OpenAI format)
@@ -3732,6 +3746,11 @@ async def stream_completion(
     start_time = time.perf_counter()
     first_token_time = None
     last_output = None
+    # Parity with the non-streaming path: when the prompt opens a thinking
+    # block, the first chunk carries the scheduler's synthetic think opener;
+    # strip it once so the stream is a pure continuation of the prompt.
+    think_tag = getattr(getattr(engine, "tokenizer", None), "think_start", "<think>") or "<think>"
+    pending_think_prefix_strip = prompt.rstrip().endswith(think_tag)
 
     (
         temperature,
@@ -3782,6 +3801,11 @@ async def stream_completion(
                 first_token_time = time.perf_counter()
             last_output = output
 
+            chunk_text = output.new_text
+            if pending_think_prefix_strip and chunk_text:
+                chunk_text = _strip_synthetic_think_prefix(chunk_text, think_tag)
+                pending_think_prefix_strip = False
+
             data = {
                 "id": f"cmpl-{uuid.uuid4().hex[:8]}",
                 "object": "text_completion",
@@ -3790,7 +3814,7 @@ async def stream_completion(
                 "choices": [
                     {
                         "index": 0,
-                        "text": output.new_text,
+                        "text": chunk_text,
                         "finish_reason": (
                             output.finish_reason if output.finished else None
                         ),

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -602,6 +602,26 @@ class TestCompletionsStreamThinkPrefixParity:
 
         assert (opens, tag) == (True, "<think>")
 
+    def test_prompt_detection_reuses_precomputed_prompt_ids(self):
+        """The streaming presentation guard should use the same prompt ids as
+        context validation instead of re-encoding with different tokenizer
+        options."""
+        from omlx.api.thinking import prompt_opens_thinking
+
+        class Tokenizer:
+            think_start = "<think>"
+            think_start_id = 41
+            think_end_id = 42
+
+            def encode(self, prompt, add_special_tokens=False):
+                raise AssertionError("prompt ids should already be available")
+
+        opens, tag = prompt_opens_thinking(
+            Tokenizer(), "templated suffix", prompt_token_ids=[100, 41, 99]
+        )
+
+        assert (opens, tag) == (True, "<think>")
+
     def test_prompt_detection_rejects_disabled_thinking_pattern(self):
         from omlx.api.thinking import prompt_opens_thinking
 
@@ -665,6 +685,24 @@ class TestCompletionsStreamThinkPrefixParity:
                     "detector so it only strips when the engine would add the "
                     "synthetic opener."
                 )
+                prompt_detector_calls = [
+                    call
+                    for call in ast.walk(node)
+                    if (
+                        isinstance(call, ast.Call)
+                        and isinstance(call.func, ast.Name)
+                        and call.func.id == "prompt_opens_thinking"
+                    )
+                ]
+                assert any(
+                    keyword.arg == "prompt_token_ids"
+                    for call in prompt_detector_calls
+                    for keyword in call.keywords
+                ), (
+                    "stream_completion must pass the validation prompt ids "
+                    "into prompt_opens_thinking so both paths use the same "
+                    "tokenizer defaults."
+                )
                 assert "_strip_synthetic_think_prefix" in called, (
                     "stream_completion must strip the synthetic think opener "
                     "from the first chunk when the prompt opens the thinking "
@@ -672,3 +710,38 @@ class TestCompletionsStreamThinkPrefixParity:
                 )
                 return
         raise AssertionError("stream_completion not found in server.py")
+
+    def test_create_completion_threads_validation_prompt_ids_to_streaming(self):
+        """The completion endpoint should reuse the prompt ids it already
+        computed for context-window validation on the stream path."""
+        import ast
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[1] / "omlx" / "server.py"
+        ).read_text()
+        for node in ast.walk(ast.parse(source)):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == "create_completion"
+            ):
+                stream_calls = [
+                    call
+                    for call in ast.walk(node)
+                    if (
+                        isinstance(call, ast.Call)
+                        and isinstance(call.func, ast.Name)
+                        and call.func.id == "stream_completion"
+                    )
+                ]
+                assert any(
+                    keyword.arg == "prompt_token_ids"
+                    for call in stream_calls
+                    for keyword in call.keywords
+                ), (
+                    "create_completion must thread the validation prompt ids "
+                    "to stream_completion instead of making the strip guard "
+                    "re-encode the prompt."
+                )
+                return
+        raise AssertionError("create_completion not found in server.py")

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -430,3 +430,26 @@ class TestResolveThinkingBudget:
         req = MagicMock(spec=[])
         result = resolve(req, None)
         assert result is None
+
+
+class TestCompletionsThinkingBudget:
+    """The /v1/completions surface carries thinking_budget like chat."""
+
+    def test_completion_request_accepts_thinking_budget(self):
+        from omlx.api.openai_models import CompletionRequest
+
+        req = CompletionRequest(model="m", prompt="<think>\n", thinking_budget=300)
+        assert req.thinking_budget == 300
+
+    def test_completion_request_thinking_budget_defaults_to_none(self):
+        from omlx.api.openai_models import CompletionRequest
+
+        req = CompletionRequest(model="m", prompt="p")
+        assert req.thinking_budget is None
+
+    def test_resolve_thinking_budget_reads_completion_request(self):
+        from omlx.api.openai_models import CompletionRequest
+        from omlx.server import _resolve_thinking_budget
+
+        req = CompletionRequest(model="m", prompt="p", thinking_budget=128)
+        assert _resolve_thinking_budget(req, None) == 128

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -567,6 +567,80 @@ class TestCompletionsStreamThinkPrefixParity:
 
         assert _strip_synthetic_think_prefix("<think>data", "<think>") == "<think>data"
 
+    def test_prompt_detection_uses_tokenizer_over_text_suffix(self):
+        """A textual ``<think>`` suffix is not enough: completions should only
+        strip when the engine would actually add the synthetic opener."""
+        from omlx.api.thinking import prompt_opens_thinking
+
+        class Tokenizer:
+            think_start = "<think>"
+            think_start_id = 41
+            think_end_id = 42
+
+            def encode(self, prompt, add_special_tokens=False):
+                return [10, 11, 12]
+
+        opens, tag = prompt_opens_thinking(Tokenizer(), "literal <think>\n")
+
+        assert (opens, tag) == (False, "<think>")
+
+    def test_prompt_detection_handles_tokenized_template_suffix(self):
+        """Mirror Scheduler._detect_needs_think_prefix: a prompt can need the
+        synthetic opener when the think-start token is in the final token tail,
+        even if the raw text does not literally end with the tag string."""
+        from omlx.api.thinking import prompt_opens_thinking
+
+        class Tokenizer:
+            think_start = "<think>"
+            think_start_id = 41
+            think_end_id = 42
+
+            def encode(self, prompt, add_special_tokens=False):
+                return [100, 41, 99]
+
+        opens, tag = prompt_opens_thinking(Tokenizer(), "templated suffix")
+
+        assert (opens, tag) == (True, "<think>")
+
+    def test_prompt_detection_rejects_disabled_thinking_pattern(self):
+        from omlx.api.thinking import prompt_opens_thinking
+
+        class Tokenizer:
+            think_start = "<think>"
+            think_start_id = 41
+            think_end_id = 42
+
+            def encode(self, prompt, add_special_tokens=False):
+                return [41, 42]
+
+        opens, tag = prompt_opens_thinking(Tokenizer(), "<think></think>")
+
+        assert (opens, tag) == (False, "<think>")
+
+    def test_prompt_detection_rejects_text_suffix_when_think_id_is_unavailable(self):
+        """If a tokenizer is present but cannot resolve the think-start id,
+        mirror the scheduler and do not assume a synthetic opener exists."""
+        from omlx.api.thinking import prompt_opens_thinking
+
+        class Tokenizer:
+            think_start = "<think>"
+            unk_token_id = 0
+
+            def convert_tokens_to_ids(self, token):
+                return self.unk_token_id
+
+            def encode(self, prompt, add_special_tokens=False):
+                return [10, 11, 12]
+
+        opens, tag = prompt_opens_thinking(Tokenizer(), "literal <think>\n")
+
+        assert (opens, tag) == (False, "<think>")
+
+    def test_prompt_detection_keeps_text_fallback_without_tokenizer(self):
+        from omlx.api.thinking import prompt_opens_thinking
+
+        assert prompt_opens_thinking(None, "literal <think>\n") == (True, "<think>")
+
     def test_stream_completion_wires_the_strip(self):
         """Structural guard: the streaming handler must call the strip
         helper, or the prefix leaks back on the first chunk."""
@@ -586,6 +660,11 @@ class TestCompletionsStreamThinkPrefixParity:
                     for call in ast.walk(node)
                     if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
                 }
+                assert "prompt_opens_thinking" in called, (
+                    "stream_completion must use the tokenizer-backed prompt "
+                    "detector so it only strips when the engine would add the "
+                    "synthetic opener."
+                )
                 assert "_strip_synthetic_think_prefix" in called, (
                     "stream_completion must strip the synthetic think opener "
                     "from the first chunk when the prompt opens the thinking "

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -454,23 +454,142 @@ class TestCompletionsThinkingBudget:
         req = CompletionRequest(model="m", prompt="p", thinking_budget=128)
         assert _resolve_thinking_budget(req, None) == 128
 
-    def test_both_completion_paths_resolve_the_budget(self):
-        """Source-level guard, repo style: the field alone is useless if the
-        handlers stop threading it to the engine — which was the original
-        bug. Both the streaming and non-streaming completion paths must
-        resolve the budget."""
+    @staticmethod
+    def _engine_call_passes_budget(handler_name: str, engine_method: str) -> bool:
+        """True when ``handler_name`` calls ``<obj>.<engine_method>(...)`` with
+        a ``thinking_budget`` keyword built from ``_resolve_thinking_budget``.
+
+        Structural AST check: immune to reformatting, wrappers, and comments,
+        unlike substring counting."""
+        import ast
         from pathlib import Path
 
-        server_src = (
+        source = (
             Path(__file__).resolve().parents[1] / "omlx" / "server.py"
         ).read_text()
-        assert (
-            server_src.count(
-                "thinking_budget=_resolve_thinking_budget(request, request.model)"
-            )
-            >= 2
-        ), (
-            "/v1/completions must pass thinking_budget to engine.generate and "
-            "engine.stream_generate via _resolve_thinking_budget; dropping "
-            "either path silently disables the budget again. See #1825."
+        for node in ast.walk(ast.parse(source)):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == handler_name
+            ):
+                for call in ast.walk(node):
+                    if not isinstance(call, ast.Call):
+                        continue
+                    func = call.func
+                    if not (isinstance(func, ast.Attribute) and func.attr == engine_method):
+                        continue
+                    for keyword in call.keywords:
+                        if keyword.arg != "thinking_budget":
+                            continue
+                        value = keyword.value
+                        if (
+                            isinstance(value, ast.Call)
+                            and isinstance(value.func, ast.Name)
+                            and value.func.id == "_resolve_thinking_budget"
+                        ):
+                            return True
+                return False
+        raise AssertionError(f"{handler_name} not found in server.py")
+
+    def test_non_streaming_completion_path_resolves_the_budget(self):
+        """The field alone is useless if the handler stops threading it to
+        the engine — which was the original bug. See #1825."""
+        assert self._engine_call_passes_budget("create_completion", "generate"), (
+            "/v1/completions (non-streaming) must pass "
+            "thinking_budget=_resolve_thinking_budget(...) to engine.generate; "
+            "dropping it silently disables the budget again. See #1825."
         )
+
+    def test_streaming_completion_path_resolves_the_budget(self):
+        assert self._engine_call_passes_budget("stream_completion", "stream_generate"), (
+            "/v1/completions (streaming) must pass "
+            "thinking_budget=_resolve_thinking_budget(...) to "
+            "engine.stream_generate; dropping it silently disables the "
+            "budget again. See #1825."
+        )
+
+    def test_negative_thinking_budget_is_rejected_on_completions(self):
+        """A negative budget has no semantics anywhere in the enforcement
+        chain; reject it at the API boundary instead of accepting it
+        silently."""
+        import pytest
+        from pydantic import ValidationError
+
+        from omlx.api.openai_models import CompletionRequest
+
+        with pytest.raises(ValidationError):
+            CompletionRequest(model="m", prompt="p", thinking_budget=-1)
+
+    def test_negative_thinking_budget_is_rejected_on_chat(self):
+        import pytest
+        from pydantic import ValidationError
+
+        from omlx.api.openai_models import ChatCompletionRequest
+
+        with pytest.raises(ValidationError):
+            ChatCompletionRequest(
+                model="m",
+                messages=[{"role": "user", "content": "hi"}],
+                thinking_budget=-1,
+            )
+
+    def test_zero_thinking_budget_is_accepted(self):
+        """Zero is meaningful (thinking off), keep it valid."""
+        from omlx.api.openai_models import CompletionRequest
+
+        req = CompletionRequest(model="m", prompt="p", thinking_budget=0)
+        assert req.thinking_budget == 0
+
+
+class TestCompletionsStreamThinkPrefixParity:
+    """Raw completions are a continuation of the prompt: when the prompt
+    opens the thinking block itself, the synthetic ``<think>\\n`` opener the
+    scheduler prepends for chat streams must not leak into the completions
+    stream — the non-streaming path never returns it."""
+
+    def test_synthetic_prefix_is_stripped(self):
+        from omlx.server import _strip_synthetic_think_prefix
+
+        assert (
+            _strip_synthetic_think_prefix("<think>\n</think>\n\nHi", "<think>")
+            == "</think>\n\nHi"
+        )
+
+    def test_chunk_without_prefix_is_untouched(self):
+        from omlx.server import _strip_synthetic_think_prefix
+
+        assert _strip_synthetic_think_prefix("Hello", "<think>") == "Hello"
+
+    def test_bare_tag_without_newline_is_untouched(self):
+        """Only the exact synthetic shape (tag + newline) is synthetic;
+        anything else is model output and must pass through."""
+        from omlx.server import _strip_synthetic_think_prefix
+
+        assert _strip_synthetic_think_prefix("<think>data", "<think>") == "<think>data"
+
+    def test_stream_completion_wires_the_strip(self):
+        """Structural guard: the streaming handler must call the strip
+        helper, or the prefix leaks back on the first chunk."""
+        import ast
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[1] / "omlx" / "server.py"
+        ).read_text()
+        for node in ast.walk(ast.parse(source)):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == "stream_completion"
+            ):
+                called = {
+                    call.func.id
+                    for call in ast.walk(node)
+                    if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+                }
+                assert "_strip_synthetic_think_prefix" in called, (
+                    "stream_completion must strip the synthetic think opener "
+                    "from the first chunk when the prompt opens the thinking "
+                    "block; the non-streaming path never returns it. See #1825."
+                )
+                return
+        raise AssertionError("stream_completion not found in server.py")

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -453,3 +453,24 @@ class TestCompletionsThinkingBudget:
 
         req = CompletionRequest(model="m", prompt="p", thinking_budget=128)
         assert _resolve_thinking_budget(req, None) == 128
+
+    def test_both_completion_paths_resolve_the_budget(self):
+        """Source-level guard, repo style: the field alone is useless if the
+        handlers stop threading it to the engine — which was the original
+        bug. Both the streaming and non-streaming completion paths must
+        resolve the budget."""
+        from pathlib import Path
+
+        server_src = (
+            Path(__file__).resolve().parents[1] / "omlx" / "server.py"
+        ).read_text()
+        assert (
+            server_src.count(
+                "thinking_budget=_resolve_thinking_budget(request, request.model)"
+            )
+            >= 2
+        ), (
+            "/v1/completions must pass thinking_budget to engine.generate and "
+            "engine.stream_generate via _resolve_thinking_budget; dropping "
+            "either path silently disables the budget again. See #1825."
+        )

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -685,6 +685,30 @@ class TestCompletionsStreamThinkPrefixParity:
 
         assert (opens, tag) == (False, "<think>")
 
+    def test_prompt_detection_rejects_multi_token_disabled_thinking_pattern(self):
+        """Mirror the scheduler's encode(think_end) fallback: when the close
+        marker is multi-token, seeing its first token after <think> still means
+        the prompt disabled thinking."""
+        from omlx.api.thinking import prompt_opens_thinking
+
+        class Tokenizer:
+            think_start = "<think>"
+            think_start_id = 41
+            think_end = "</think>"
+            unk_token_id = 0
+
+            def convert_tokens_to_ids(self, token):
+                return self.unk_token_id
+
+            def encode(self, prompt, add_special_tokens=False):
+                if prompt == self.think_end:
+                    return [42, 43]
+                return [41, 42]
+
+        opens, tag = prompt_opens_thinking(Tokenizer(), "<think></think>")
+
+        assert (opens, tag) == (False, "<think>")
+
     def test_prompt_detection_rejects_text_suffix_when_think_id_is_unavailable(self):
         """If a tokenizer is present but cannot resolve the think-start id,
         mirror the scheduler and do not assume a synthetic opener exists."""

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -456,8 +456,13 @@ class TestCompletionsThinkingBudget:
 
     @staticmethod
     def _engine_call_passes_budget(handler_name: str, engine_method: str) -> bool:
-        """True when ``handler_name`` calls ``<obj>.<engine_method>(...)`` with
-        a ``thinking_budget`` keyword built from ``_resolve_thinking_budget``.
+        """True when ``handler_name`` threads a ``thinking_budget`` resolved from
+        ``_resolve_thinking_budget`` into ``<obj>.<engine_method>(...)``.
+
+        Accepts both wirings: the inline ``thinking_budget=_resolve_thinking_budget(...)``
+        keyword and the ``**gen_kwargs`` dict-unpack pattern the chat path uses
+        (#1844), where the handler sets ``gen_kwargs["thinking_budget"]`` from the
+        resolved value and unpacks the dict into the engine call.
 
         Structural AST check: immune to reformatting, wrappers, and comments,
         unlike substring counting."""
@@ -467,28 +472,71 @@ class TestCompletionsThinkingBudget:
         source = (
             Path(__file__).resolve().parents[1] / "omlx" / "server.py"
         ).read_text()
+
+        def _is_resolve_call(value) -> bool:
+            return (
+                isinstance(value, ast.Call)
+                and isinstance(value.func, ast.Name)
+                and value.func.id == "_resolve_thinking_budget"
+            )
+
         for node in ast.walk(ast.parse(source)):
-            if (
+            if not (
                 isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
                 and node.name == handler_name
             ):
-                for call in ast.walk(node):
-                    if not isinstance(call, ast.Call):
-                        continue
-                    func = call.func
-                    if not (isinstance(func, ast.Attribute) and func.attr == engine_method):
-                        continue
-                    for keyword in call.keywords:
-                        if keyword.arg != "thinking_budget":
-                            continue
-                        value = keyword.value
-                        if (
-                            isinstance(value, ast.Call)
-                            and isinstance(value.func, ast.Name)
-                            and value.func.id == "_resolve_thinking_budget"
-                        ):
-                            return True
+                continue
+
+            # Locals bound directly to _resolve_thinking_budget(...), e.g.
+            #     thinking_budget = _resolve_thinking_budget(request, request.model)
+            resolved_locals = {
+                t.id
+                for n in ast.walk(node)
+                if isinstance(n, ast.Assign) and _is_resolve_call(n.value)
+                for t in n.targets
+                if isinstance(t, ast.Name)
+            }
+            # Dicts that get a "thinking_budget" entry from the resolved value, e.g.
+            #     gen_kwargs["thinking_budget"] = thinking_budget
+            budget_dicts = set()
+            for n in ast.walk(node):
+                if not isinstance(n, ast.Assign):
+                    continue
+                for t in n.targets:
+                    if (
+                        isinstance(t, ast.Subscript)
+                        and isinstance(t.value, ast.Name)
+                        and isinstance(t.slice, ast.Constant)
+                        and t.slice.value == "thinking_budget"
+                        and (
+                            _is_resolve_call(n.value)
+                            or (
+                                isinstance(n.value, ast.Name)
+                                and n.value.id in resolved_locals
+                            )
+                        )
+                    ):
+                        budget_dicts.add(t.value.id)
+
+            for call in ast.walk(node):
+                if not isinstance(call, ast.Call):
+                    continue
+                func = call.func
+                if not (isinstance(func, ast.Attribute) and func.attr == engine_method):
+                    continue
+                for keyword in call.keywords:
+                    # inline: engine.generate(..., thinking_budget=_resolve_thinking_budget(...))
+                    if keyword.arg == "thinking_budget" and _is_resolve_call(keyword.value):
+                        return True
+                    # dict-unpack: engine.generate(..., **gen_kwargs)
+                    if (
+                        keyword.arg is None
+                        and isinstance(keyword.value, ast.Name)
+                        and keyword.value.id in budget_dicts
+                    ):
+                        return True
                 return False
+            return False
         raise AssertionError(f"{handler_name} not found in server.py")
 
     def test_non_streaming_completion_path_resolves_the_budget(self):


### PR DESCRIPTION
## Summary

Follow-up to #1844. That PR already forwards `thinking_budget` on `/v1/completions`; this one hardens the remaining edges around that path.

Raw completions can use a thinking budget when the prompt already opens a thinking block, for example by ending with `<think>\n`. The remaining issues were: negative budgets were accepted, streaming completions could leak the scheduler's synthetic `<think>\n` opener, and the stream strip guard needed to mirror the scheduler's token-level detection instead of relying on raw text.

## Changes

- Reject negative `thinking_budget` values on chat and completions.
- Strip the synthetic `<think>\n` opener from streamed raw completions so streaming and non-streaming responses match.
- Detect open thinking prompts from tokenizer ids, reusing the prompt ids already computed for context validation.
- Keep the detector aligned with scheduler behavior, including disabled-thinking prompts and multi-token `</think>` markers.

## Tests

Adds coverage for completions parsing/forwarding, negative-budget validation, stream prefix stripping, tokenizer-backed prompt detection, prompt-id reuse, disabled-thinking patterns, and the structural wiring guards for both completion paths.

Validation: targeted thinking-budget tests pass; broader `completion or thinking or budget` selection was re-run during review.
