### PR TITLE
fix(serve): make startup failures visible under launchd (#1814)

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -71,6 +71,82 @@ def _has_cli_overrides(args) -> bool:
     return False
 
 
+def _line_buffer_stdout_if_piped() -> None:
+    """Line-buffer stdout when it is not a tty (launchd / brew services).
+
+    Under launchd stdout is a pipe or file and therefore block-buffered:
+    startup prints (banner, bind address) only reach the service log when
+    the process exits, so a failed startup looks like a silent hang (#1814).
+    Line buffering makes them appear as they happen.
+    """
+    stdout = sys.stdout
+    if stdout is None or stdout.isatty():
+        return
+    try:
+        stdout.reconfigure(line_buffering=True)
+    except (AttributeError, ValueError, OSError):
+        pass
+
+
+def _describe_port_listener(port: int) -> str:
+    """Best-effort "title (pid N)" for the process listening on `port`.
+
+    Uses lsof + ps so the title reflects the setproctitle rename
+    ("omlx-server"), which is what users see in ps output. Returns "" when
+    the owner cannot be identified.
+    """
+    import subprocess
+
+    try:
+        res = subprocess.run(
+            ["lsof", "-ti", f"TCP:{port}", "-sTCP:LISTEN"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        pids = res.stdout.split()
+        if not pids:
+            return ""
+        pid = pids[0]
+        res = subprocess.run(
+            ["ps", "-p", pid, "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        title = res.stdout.strip() or "unknown process"
+        return f"{title} (pid {pid})"
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return ""
+
+
+def _bind_socket_or_explain(config, host: str, port: int):
+    """config.bind_socket() with a useful diagnosis when the bind fails.
+
+    uvicorn logs the bare OSError ("[Errno 48] Address already in use") and
+    raises SystemExit. Under launchd that single line is easy to miss, and
+    the common cause is a stale omlx-server still holding the port after an
+    unclean service stop (#1814). Name the owner and the fix before exiting.
+    """
+    import logging
+
+    try:
+        return config.bind_socket()
+    except SystemExit:
+        holder = _describe_port_listener(port)
+        msg = f"Could not bind http://{host}:{port}."
+        if holder:
+            msg += f" Port {port} is already in use by {holder}."
+            if "omlx-server" in holder:
+                pid = holder.rsplit("(pid ", 1)[-1].rstrip(")")
+                msg += (
+                    " A previous omlx-server is still running;"
+                    f" stop it with 'omlx stop' or 'kill {pid}' and retry."
+                )
+        logging.getLogger("omlx.cli").error(msg)
+        raise
+
+
 def serve_command(args):
     """Start the OpenAI-compatible multi-model server."""
     import logging
@@ -83,6 +159,7 @@ def serve_command(args):
     from .logging_config import configure_file_logging, AdminStatsAccessFilter
 
     process_title.set_process_title()
+    _line_buffer_stdout_if_piped()
 
     try:
         from ._build_info import build_number
@@ -220,7 +297,9 @@ def serve_command(args):
     )
     # Bind a socket per host so an occupied port fails fast before model preload.
     # uvicorn.Server.run(sockets=[...]) accepts a list and listens on all of them.
-    serve_sockets = [uvicorn_config.bind_socket()]
+    serve_sockets = [
+        _bind_socket_or_explain(uvicorn_config, bind_hosts[0], settings.server.port)
+    ]
     for h in bind_hosts[1:]:
         extra_cfg = uvicorn.Config(
             "omlx.server:app",
@@ -229,7 +308,9 @@ def serve_command(args):
             log_level=uvicorn_level,
             access_log=show_access_log,
         )
-        serve_sockets.append(extra_cfg.bind_socket())
+        serve_sockets.append(
+            _bind_socket_or_explain(extra_cfg, h, settings.server.port)
+        )
 
     try:
         # Import server and config after the port is known to be available.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1038,3 +1038,98 @@ class TestCLIDocstrings:
         assert (
             "multi-model" in result.stdout.lower() or "server" in result.stdout.lower()
         )
+
+
+class TestPortConflictVisibility:
+    """Tests for the #1814 launchd diagnosability helpers."""
+
+    # --- _line_buffer_stdout_if_piped ---
+
+    def test_line_buffers_piped_stdout(self, monkeypatch):
+        import io
+
+        from omlx.cli import _line_buffer_stdout_if_piped
+
+        stream = io.TextIOWrapper(io.BytesIO(), encoding="utf-8")
+        assert stream.line_buffering is False
+        monkeypatch.setattr(sys, "stdout", stream)
+        _line_buffer_stdout_if_piped()
+        assert stream.line_buffering is True
+
+    def test_leaves_tty_stdout_alone(self, monkeypatch):
+        from omlx.cli import _line_buffer_stdout_if_piped
+
+        stream = MagicMock()
+        stream.isatty.return_value = True
+        monkeypatch.setattr(sys, "stdout", stream)
+        _line_buffer_stdout_if_piped()
+        stream.reconfigure.assert_not_called()
+
+    def test_tolerates_reconfigure_failure(self, monkeypatch):
+        from omlx.cli import _line_buffer_stdout_if_piped
+
+        stream = MagicMock()
+        stream.isatty.return_value = False
+        stream.reconfigure.side_effect = ValueError("cannot reconfigure")
+        monkeypatch.setattr(sys, "stdout", stream)
+        _line_buffer_stdout_if_piped()  # must not raise
+
+    # --- _describe_port_listener ---
+
+    def test_describes_own_listener(self):
+        import os
+        import shutil
+
+        from omlx.cli import _describe_port_listener
+
+        if not shutil.which("lsof"):
+            pytest.skip("lsof not available")
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            sock.listen(1)
+            port = sock.getsockname()[1]
+            desc = _describe_port_listener(port)
+        assert f"(pid {os.getpid()})" in desc
+
+    def test_returns_empty_for_free_port(self):
+        from omlx.cli import _describe_port_listener
+
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+        # Socket is closed, so nothing is listening on the port now.
+        assert _describe_port_listener(port) == ""
+
+    # --- _bind_socket_or_explain ---
+
+    def test_explains_occupied_port(self, caplog):
+        import shutil
+
+        import uvicorn
+
+        from omlx.cli import _bind_socket_or_explain
+
+        with socket.socket() as blocker:
+            blocker.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            blocker.bind(("127.0.0.1", 0))
+            blocker.listen(1)
+            port = blocker.getsockname()[1]
+            cfg = uvicorn.Config("omlx.server:app", host="127.0.0.1", port=port)
+            with caplog.at_level("ERROR", logger="omlx.cli"):
+                with pytest.raises(SystemExit):
+                    _bind_socket_or_explain(cfg, "127.0.0.1", port)
+        assert f"Could not bind http://127.0.0.1:{port}" in caplog.text
+        if shutil.which("lsof"):
+            assert f"already in use by" in caplog.text
+
+    def test_passes_through_successful_bind(self):
+        import uvicorn
+
+        from omlx.cli import _bind_socket_or_explain
+
+        cfg = uvicorn.Config("omlx.server:app", host="127.0.0.1", port=0)
+        sock = _bind_socket_or_explain(cfg, "127.0.0.1", 0)
+        try:
+            assert sock is not None
+        finally:
+            sock.close()


### PR DESCRIPTION
## Problem

#1814 reports omlx serve hanging at the startup banner under launchd / brew services. I could not reproduce a hang in any permutation I tried (two Macs on macOS 26.5.1, venv and Homebrew tap builds, 0.4.3 and 0.4.4rc1, internal and external-USB model dirs, isolated LaunchAgent and real brew services, including model load, inference, and stop/restart cycles). What I did reproduce is a failure mode that looks exactly like that hang in the service log:

1. A stale omlx-server holds the port. pkill patterns miss it because setproctitle renames the process, so it survives cleanup attempts.
2. Each new launchd spawn dies on "[Errno 48] Address already in use", a single stderr line that is easy to miss. With the formula's keep_alive this repeats forever.
3. Under launchd, stdout is a pipe and block-buffered, so the banner and bind prints only reach the log when the process exits, after the error line. The log reads "banner, then nothing", which presents as a hang at the banner.
4. Sampling the surviving process shows it blocked in select at ~0% CPU. That is the healthy stale server sitting in its kqueue loop, not a hung startup.

## Change

Both changes are in the serve startup path in cli.py:

- Line-buffer stdout when it is not a tty, so service logs show startup progress as it happens.
- When the bind fails, name the owner: look up the listening pid with lsof and its process title with ps, then log a clear message. When the owner is another omlx-server, say so and give the fix:

```
Could not bind http://127.0.0.1:8000. Port 8000 is already in use by omlx-server (pid 1234). A previous omlx-server is still running; stop it with 'omlx stop' or 'kill 1234' and retry.
```

## Testing

- 7 new unit tests in tests/test_cli.py covering the line-buffering helper, the port-owner lookup, and the bind wrapper (occupied port raises SystemExit with the diagnosis logged; successful bind passes through).
- Full suite: 5580 passed, 40 skipped. One pre-existing failure in test_mlx_vlm_diffusion_patch.py also fails on clean main in my environment (stale mlx-vlm pin in my venv, unrelated to this change).
- Live test on macOS 26.5.1: spawned a LaunchAgent against an occupied port and confirmed the ordered log plus the new error; freed the port and confirmed a normal startup, model load, and clean SIGTERM shutdown.

This fixes the diagnosability half of #1814. If the reporter still sees a hang on a verified-clean port after this, the new log output should show exactly where it stops.