### PR TITLE
feat(jang): JANG/JANGTQ mixed-precision MoE engine (hardened; builds on #364)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
           python -m pip install pytest pytest-asyncio
 
       - name: Run unit tests
-        run: python -m pytest tests/ -m "not slow and not integration"
+        run: python -m pytest tests/ -m "not slow and not integration and not jang_mlx"

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Models are auto-detected by type. You can also download models directly from the
 |------|--------|
 | LLM | Any model supported by [mlx-lm](https://github.com/ml-explore/mlx-lm) |
 | VLM | Qwen3.5 Series, GLM-4V, Pixtral, and other [mlx-vlm](https://github.com/Blaizzy/mlx-vlm) models |
+| JANG / JANGTQ | Mixed-precision MoE models (JANG v2 and mxtq TurboQuant formats); requires `pip install omlx[jang]` (engine_type: `jang`) |
 | OCR | DeepSeek-OCR, DOTS-OCR, GLM-OCR |
 | Embedding | BERT, BGE-M3, ModernBERT |
 | Reranker | ModernBERT, XLM-RoBERTa |

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2091,16 +2091,26 @@ async def update_model_settings(
         }
         if override_value:
             entry.model_type = override_value
-            entry.engine_type = type_to_engine.get(override_value, "batched")
+            # JANG models must keep the jang engine even with an explicit override.
+            # resolve_jang_engine_type handles the "llm/vlm only" guard so that
+            # embedding/reranker/audio overrides use their own engines even when
+            # jang_config.json is present.
+            from pathlib import Path as _Path
+            from ..model_discovery import resolve_jang_engine_type as _resolve_jang
+            entry.engine_type = _resolve_jang(
+                _Path(entry.model_path), override_value
+            ) or type_to_engine.get(override_value, "batched")
         else:
             # Reset to auto-detected type
             from pathlib import Path
 
-            from ..model_discovery import detect_model_type
+            from ..model_discovery import detect_model_type, resolve_jang_engine_type
 
             detected_type = detect_model_type(Path(entry.model_path))
             entry.model_type = detected_type
-            entry.engine_type = type_to_engine.get(detected_type, "batched")
+            entry.engine_type = resolve_jang_engine_type(
+                Path(entry.model_path), detected_type
+            ) or type_to_engine.get(detected_type, "batched")
     if "max_context_window" in sent:
         current_settings.max_context_window = request.max_context_window
     if "max_tokens" in sent:

--- a/omlx/engine/jang.py
+++ b/omlx/engine/jang.py
@@ -1,0 +1,926 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+JANG model engine for loading quantized MoE+SSM hybrid models.
+
+This engine wraps the jang-tools package to load JANG quantized models
+with mixed-precision quantization (attention 6-8-bit, experts 2-4-bit).
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+
+from ..api.tool_calling import convert_tools_for_template
+from ..api.utils import clean_special_tokens, detect_and_strip_partial
+from ..model_discovery import JANG_CONFIG_FILES, _get_jang_has_vision, detect_model_type
+from ..models.vlm import VLMModelAdapter
+from .base import BaseEngine, GenerationOutput
+
+logger = logging.getLogger(__name__)
+
+
+class _TokenizerWrapper:
+    """
+    Wrapper for tokenizers that don't have an encode() method.
+
+    Some VLM processors (like Qwen3VLProcessor) return a tokenizer that
+    doesn't have encode() directly. This wrapper delegates to the underlying
+    HF tokenizer's encode method.
+    """
+
+    def __init__(self, tokenizer: Any):
+        self._tokenizer = tokenizer
+
+    def __getattr__(self, name: str) -> Any:
+        # Delegate attribute access to the underlying tokenizer
+        return getattr(self._tokenizer, name)
+
+    def encode(self, text: str) -> list[int]:
+        """Encode text to token IDs."""
+        # Try different ways to get encode
+        if hasattr(self._tokenizer, "encode"):
+            return self._tokenizer.encode(text)
+        if hasattr(self._tokenizer, "tokenize"):
+            # Fallback: use tokenize and map to ids
+            tokens = self._tokenizer.tokenize(text)
+            if hasattr(self._tokenizer, "convert_tokens_to_ids"):
+                return self._tokenizer.convert_tokens_to_ids(tokens)
+        # Try calling the tokenizer directly (e.g. HF processors)
+        if callable(self._tokenizer):
+            result = self._tokenizer(text)
+            if isinstance(result, dict) and "input_ids" in result:
+                return list(result["input_ids"])
+        raise TypeError(
+            f"Cannot encode text: tokenizer {type(self._tokenizer).__name__} "
+            f"has no encode(), tokenize(), or __call__ returning input_ids"
+        )
+
+
+def _load_jang_config(model_path: Path) -> dict | None:
+    """Return the first *parseable* JANG config dict found in model_path, or None.
+
+    Iterates JANG_CONFIG_FILES in order and returns the parsed dict from the
+    first file that exists and contains valid JSON. Files that exist but contain
+    invalid JSON are logged and skipped so that a parseable candidate later in
+    the list can still be found. Returns None only if no file parses successfully.
+    """
+    for config_name in JANG_CONFIG_FILES:
+        config_path = model_path / config_name
+        if not config_path.exists():
+            continue
+        try:
+            with open(config_path) as f:
+                return json.load(f)
+        except Exception as exc:
+            logger.warning(
+                "JANG config %s exists but failed to parse (%s: %s); "
+                "trying next candidate",
+                config_path,
+                type(exc).__name__,
+                exc,
+            )
+            continue
+    return None
+
+
+class JANGLoader(BaseEngine):
+    """
+    Engine for loading JANG quantized models via jang-tools.
+
+    JANG models use mixed-precision quantization and require special handling:
+    - Mixed bit widths per tensor (read from jang_config.json)
+    - Nemotron-H weight renaming (fc1/fc2)
+    - Auto bfloat16 for large expert models (512+ experts)
+    - VLM support with vision encoder
+
+    Args:
+        model_name: Local model directory path (JANG config detection uses
+            Path(model_name).exists(), so remote HuggingFace repo IDs will
+            not be detected as JANG models).
+        scheduler_config: Optional scheduler configuration
+        stream_interval: Tokens to batch before streaming (1=every token)
+        enable_thinking: Enable thinking mode for reasoning models
+        model_settings: Per-model settings accepted for engine-pool constructor
+            parity. JANG loads via jang-tools and does not currently consume
+            per-model settings (no dflash/MTP/speculative support); non-default
+            values are noted in debug logging and otherwise ignored.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        scheduler_config: Any | None = None,
+        stream_interval: int = 1,
+        enable_thinking: bool | None = None,
+        model_settings: Any | None = None,
+    ):
+        self._model_name = model_name
+        self._scheduler_config = scheduler_config
+        self._stream_interval = stream_interval
+        self._enable_thinking = enable_thinking
+        self._model_settings = model_settings
+        if model_settings is not None:
+            logger.debug(
+                "JANGLoader: model_settings provided but not consumed "
+                "(JANG has no dflash/MTP/speculative support); accepted for engine-pool parity"
+            )
+
+        self._model = None
+        self._tokenizer = None
+        self._engine = None
+        self._loaded = False
+
+        self._processor = None
+
+    @property
+    def model_name(self) -> str:
+        """Get the model name."""
+        return self._model_name
+
+    @property
+    def tokenizer(self) -> Any:
+        """Get the tokenizer."""
+        return self._tokenizer
+
+    @property
+    def model_type(self) -> str | None:
+        """Get the model type from config (e.g., 'gpt_oss', 'llama', 'qwen2')."""
+        if self._model is None:
+            return None
+        try:
+            if hasattr(self._model, 'config'):
+                config = self._model.config
+                if hasattr(config, 'model_type'):
+                    model_type = config.model_type
+                    return model_type if isinstance(model_type, str) else None
+                elif isinstance(config, dict):
+                    model_type = config.get('model_type')
+                    return model_type if isinstance(model_type, str) else None
+            if hasattr(self._model, 'args'):
+                args = self._model.args
+                if hasattr(args, 'model_type'):
+                    model_type = args.model_type
+                    return model_type if isinstance(model_type, str) else None
+        except Exception as e:
+            logger.debug(f"Error getting model_type: {e}")
+        return None
+
+    def _check_jang_tools_available(self) -> None:
+        """Check if jang-tools is installed."""
+        try:
+            import jang_tools  # noqa: F401
+        except ImportError:
+            from ..exceptions import JANGDependencyError
+            raise JANGDependencyError(
+                "jang-tools package not found. Install with: pip install jang[mlx]",
+                model_name=self._model_name,
+            )
+
+    def _get_config_dict(self) -> dict:
+        """Get model config as a dict, handling both dict and object configs."""
+        if self._model is None:
+            return {}
+        config = getattr(self._model, 'config', None)
+        if config is None:
+            return {}
+        if isinstance(config, dict):
+            return config
+        # Config is an object — try to extract relevant fields
+        result = {}
+        for attr in ('architectures', 'num_local_experts', 'num_experts',
+                      'n_routed_experts', 'hidden_size', 'model_type',
+                      'text_config'):
+            if hasattr(config, attr):
+                result[attr] = getattr(config, attr)
+        return result
+
+    def _detect_nemotron_h(self) -> bool:
+        """Check if model is Nemotron-H architecture."""
+        if self._model is None:
+            return False
+        try:
+            config = self._get_config_dict()
+            for a in config.get('architectures', []):
+                if 'Nemotron' in a:
+                    return True
+            return False
+        except Exception:
+            return False
+
+    def _needs_bfloat16(self) -> bool:
+        """Check if model needs bfloat16 (512+ experts, hidden>=4096)."""
+        if self._model is None:
+            return False
+        try:
+            config = self._get_config_dict()
+            text_cfg = config.get('text_config', config)
+            if isinstance(text_cfg, dict):
+                cfg = text_cfg
+            else:
+                cfg = config
+            n_experts = cfg.get('num_local_experts',
+                        cfg.get('num_experts',
+                        cfg.get('n_routed_experts', 0)))
+            hidden_size = cfg.get('hidden_size', 0)
+            if n_experts >= 512 and hidden_size >= 4096:
+                return True
+        except Exception as e:
+            logger.debug(f"Error checking bfloat16 requirements: {e}")
+        return False
+
+    def _is_jang_v2(self) -> bool:
+        """Return True when the model uses the JANG v2 format."""
+        cfg = _load_jang_config(Path(self._model_name))
+        if cfg is None:
+            return False
+        try:
+            version = str(cfg.get("format_version", "1.0"))
+            return int(version.split(".")[0]) >= 2
+        except Exception:
+            return False
+
+    def _is_jangtq(self) -> bool:
+        """Return True when the model uses JANGTQ (TurboQuant) format."""
+        cfg = _load_jang_config(Path(self._model_name))
+        if cfg is None:
+            return False
+        return cfg.get("weight_format") == "mxtq" or "JANGTQ" in cfg.get("profile", "")
+
+    def _get_jang_has_vision(self) -> bool | None:
+        """Return explicit has_vision metadata from JANG config when present.
+
+        Delegates to model_discovery._get_jang_has_vision so the two copies
+        stay in sync. JANG_CONFIG_FILES and the parsing logic live in one place.
+        """
+        return _get_jang_has_vision(Path(self._model_name))
+
+    def _should_use_vlm_loader(self) -> bool:
+        """Choose the JANG loader path, trusting shared discovery rules."""
+        explicit_has_vision = self._get_jang_has_vision()
+        if explicit_has_vision is not None:
+            return explicit_has_vision
+        return detect_model_type(Path(self._model_name)) == "vlm"
+
+    def _fix_nemotron_h_weights(self) -> None:
+        """Fix Nemotron-H weights after JANG loading.
+
+        JANG v2 stores Nemotron-H weights with different naming and quantized
+        gate weights that mlx-lm's nemotron_h.py cannot handle directly.
+
+        The gate weights are nn.Linear in mlx-lm's model skeleton, but JANG
+        stores them as quantized uint32. When jang-tools loads with strict=False,
+        the gate.weight (uint32) is loaded but gate.scales and gate.biases are
+        dropped because nn.Linear doesn't declare them. We must read the
+        scales/biases from the original safetensors files to dequantize.
+        """
+        model_path = Path(self._model_name)
+        use_bfloat16 = self._needs_bfloat16()
+        target_dtype = mx.bfloat16 if use_bfloat16 else mx.float16
+
+        # Read the shard index to find which files contain gate weights
+        index_path = model_path / "model.safetensors.index.json"
+        if not index_path.exists():
+            # Try consolidated format
+            index_path = model_path / "consolidated.safetensors.index.json"
+        if not index_path.exists():
+            logger.warning("Nemotron-H: no safetensors index found, skipping gate fixup")
+            return
+
+        with open(index_path) as f:
+            index = json.load(f)
+        weight_map = index.get("weight_map", {})
+
+        # Find all gate weight/scales/biases keys in the safetensors index
+        # Group by gate prefix (e.g., "backbone.layers.0.mixer.gate")
+        gate_parts: dict[str, dict[str, str]] = {}  # prefix -> {suffix -> shard_file}
+        for key, shard in weight_map.items():
+            if ".gate." in key:
+                prefix = key[:key.index(".gate.") + len(".gate")]
+                suffix = key[key.index(".gate.") + len(".gate."):]
+                if prefix not in gate_parts:
+                    gate_parts[prefix] = {}
+                gate_parts[prefix][suffix] = shard
+
+        if not gate_parts:
+            logger.info("Nemotron-H: no gate weights found in index, skipping")
+            return
+
+        # Load gate tensors from safetensors and dequantize
+        dequantized_weights: list[tuple[str, mx.array]] = []
+        # Cache loaded shards to avoid re-reading
+        shard_cache: dict[str, dict[str, mx.array]] = {}
+
+        for prefix, parts in gate_parts.items():
+            if "weight" not in parts:
+                continue
+            if "scales" not in parts or "biases" not in parts:
+                # Gate is not quantized (no scales/biases), skip
+                continue
+
+            # Load the required tensors from safetensors
+            tensors: dict[str, mx.array] = {}
+            for suffix in ("weight", "scales", "biases"):
+                full_key = f"{prefix}.{suffix}"
+                shard_file = parts[suffix]
+                if shard_file not in shard_cache:
+                    shard_cache[shard_file] = mx.load(str(model_path / shard_file))
+                tensors[suffix] = shard_cache[shard_file][full_key]
+
+            gate_weight = tensors["weight"]
+            scales = tensors["scales"]
+            biases = tensors["biases"]
+
+            # Dequantize by trying bit widths (gate is typically 8-bit CRITICAL tier)
+            dequantized = None
+            for bits in [8, 6, 4, 3, 2]:
+                elem_per_u32 = 32 // bits
+                real_cols = gate_weight.shape[-1] * elem_per_u32
+                gs = real_cols // scales.shape[-1]
+                if gs > 0 and gs * scales.shape[-1] == real_cols:
+                    dequantized = mx.dequantize(
+                        gate_weight, scales, biases, gs, bits
+                    )
+                    dequantized = dequantized.astype(target_dtype)
+                    logger.info(
+                        f"Nemotron-H: dequantized {prefix}.weight "
+                        f"({bits}-bit, group_size={gs}) "
+                        f"{gate_weight.shape} -> {dequantized.shape}"
+                    )
+                    break
+
+            if dequantized is not None:
+                dequantized_weights.append((f"{prefix}.weight", dequantized))
+            else:
+                logger.warning(
+                    f"Nemotron-H: could not dequantize {prefix}, "
+                    f"weight={gate_weight.shape}, scales={scales.shape}"
+                )
+
+        # Free shard cache
+        del shard_cache
+
+        if dequantized_weights:
+            self._model.load_weights(dequantized_weights, strict=False)
+            logger.info(
+                f"Nemotron-H: dequantized {len(dequantized_weights)} "
+                f"gate weights to {target_dtype}"
+            )
+        else:
+            logger.info("Nemotron-H: no gate weights needed dequantization")
+
+        logger.info("Nemotron-H: weight fixup complete")
+
+
+    def _fix_jang_switch_quantization(self) -> None:
+        """Fix QuantizedSwitchLinear metadata when jang-tools creates them with
+        wrong bits/group_size from config.json vs actual packed weight data.
+
+        JANG v2 models have mixed-precision MoE experts (2-bit routed, 8-bit attention).
+        jang-tools' _upgrade_switch_to_quantized uses config.json bits (8) for ALL layers,
+        but the actual weights are 2-bit packed uint32. Instead of dequantizing (OOM on
+        large models), we just fix the bits/group_size metadata on the QuantizedSwitchLinear
+        so gather_qmm unpacks correctly.
+        """
+        from mlx_lm.models.switch_layers import QuantizedSwitchLinear
+
+        config_path = Path(self._model_name) / "config.json"
+        if not config_path.exists():
+            return
+        with open(config_path) as f:
+            model_cfg = json.load(f)
+        tc = model_cfg.get("text_config", model_cfg)
+        hidden_size = tc.get("hidden_size", 0)
+        intermediate_size = tc.get("intermediate_size", 0)
+        if not hidden_size or not intermediate_size:
+            return
+
+        config_bits = model_cfg.get("quantization", {}).get("bits", 8)
+
+        fixed = 0
+        for name, module in self._model.named_modules():
+            if not isinstance(module, QuantizedSwitchLinear):
+                continue
+
+            w = module.weight  # uint32
+            if len(w.shape) != 3:
+                continue
+
+            num_experts, out_dim, packed_dim = w.shape
+            module_bits = getattr(module, "bits", config_bits)
+            module_gs = getattr(module, "group_size", 64)
+
+            # Determine expected input_dims from architecture
+            if out_dim == intermediate_size:
+                in_dim = hidden_size      # gate_proj, up_proj
+            elif out_dim == hidden_size:
+                in_dim = intermediate_size # down_proj
+            else:
+                logger.error(
+                    f"JANG switch layer {name}: out_dim={out_dim} matches neither "
+                    f"intermediate_size={intermediate_size} nor hidden_size={hidden_size}; "
+                    f"cannot determine in_dim — corrupt or unexpected shard"
+                )
+                raise ValueError(
+                    f"JANG switch layer {name}: out_dim={out_dim} is unclassifiable "
+                    f"(intermediate_size={intermediate_size}, hidden_size={hidden_size})"
+                )
+
+            # Reverse-engineer actual bits by trying each plausible bit-width.
+            # For power-of-2 widths (2/4/8) the mapping is exact; for 3/6-bit
+            # MLX pads the packed dim, so we accept recovered_in_dim in the
+            # range [in_dim, in_dim + elem_per_u32).  If no width matches the
+            # layer is genuinely corrupt.
+            actual_bits = None
+            for candidate_bits in (2, 3, 4, 6, 8):
+                elem_per_u32 = 32 // candidate_bits
+                recovered = packed_dim * elem_per_u32
+                if in_dim <= recovered < in_dim + elem_per_u32:
+                    actual_bits = candidate_bits
+                    break
+            if actual_bits is None:
+                raise ValueError(
+                    f"JANG switch layer {name}: packed_dim={packed_dim} is not "
+                    f"consistent with in_dim={in_dim} for any supported bit-width "
+                    f"(2/3/4/6/8) — corrupt or mismatched shard"
+                )
+
+            if actual_bits == module_bits:
+                continue  # No mismatch
+
+            # Determine actual group_size from scales shape.
+            # Non-exact division means the scale tensor is inconsistent with in_dim.
+            actual_gs = module_gs
+            if module.scales is not None:
+                scale_groups = module.scales.shape[-1]
+                if scale_groups > 0:
+                    if in_dim % scale_groups != 0:
+                        raise ValueError(
+                            f"JANG switch layer {name}: in_dim={in_dim} is not "
+                            f"divisible by scale_groups={scale_groups} — corrupt shard"
+                        )
+                    actual_gs = in_dim // scale_groups
+
+            logger.info(
+                f"Fixing {name}: bits {module_bits}->{actual_bits}, "
+                f"group_size {module_gs}->{actual_gs}"
+            )
+
+            # Just update the metadata — weights are already correctly packed
+            module.bits = actual_bits
+            module.group_size = actual_gs
+            fixed += 1
+
+        if fixed:
+            logger.info(f"JANG switch layer fix: corrected {fixed} layer metadata")
+
+    async def start(self) -> None:
+        """Start the engine (load JANG model if not loaded)."""
+        if self._loaded:
+            return
+
+        from ..engine_core import AsyncEngineCore, EngineConfig
+        from ..scheduler import SchedulerConfig
+
+        # Check jang-tools is available
+        self._check_jang_tools_available()
+
+        # Read config for lightweight diagnostics only. Some architectures
+        # legitimately use attention widths that differ from hidden_size.
+        model_path = Path(self._model_name)
+        config_path = model_path / "config.json"
+        try:
+            if config_path.exists():
+                with open(config_path) as f:
+                    config = json.load(f)
+
+                text_config = config.get("text_config", config)
+                hidden_size = text_config.get("hidden_size", 0)
+                vocab_size = text_config.get("vocab_size", 0)
+                if vocab_size > 0:
+                    logger.debug(f"Model vocab_size: {vocab_size}, hidden_size: {hidden_size}")
+        except Exception as e:
+            logger.debug(f"Config validation skipped: {e}")
+
+        is_vlm = self._should_use_vlm_loader()
+        is_jangtq = self._is_jangtq()
+
+        # F1: JANGTQ + VLM is an unsupported combination.  load_jangtq_model is
+        # text-only and would silently drop the vision encoder.  Fail loudly here
+        # rather than let the model load and produce wrong outputs.
+        if is_jangtq and is_vlm:
+            from ..exceptions import JANGLoadError
+            raise JANGLoadError(
+                f"JANGTQ + VLM is not supported: {self._model_name} is "
+                "mxtq-quantized AND has vision; load_jangtq_model is text-only "
+                "and would silently drop the vision encoder",
+                model_name=self._model_name,
+            )
+
+        # Import jang_tools in its own narrow try so that ImportError from the
+        # jang_tools import itself maps to JANGDependencyError ("install jang[mlx]"),
+        # while ImportError raised inside the loader functions (e.g. a missing
+        # transformers submodule) propagates to the outer except Exception handler
+        # and is reported as a JANGLoadError with the real underlying message.
+        try:
+            import jang_tools
+            from jang_tools.loader import load_jang_model, load_jang_vlm_model
+        except ImportError as e:
+            from ..exceptions import JANGDependencyError
+            raise JANGDependencyError(
+                f"Failed to import jang-tools: {e}. Install with: pip install jang[mlx]",
+                model_name=self._model_name,
+            )
+
+        try:
+            # Dispatch to the correct loader.  JANGTQ models use TurboQuantLinear
+            # (Metal kernel, no dequant) and load_jangtq_model auto-caps the MLX
+            # wired_limit to prevent Metal OOM — must be checked before the
+            # standard VLM/LLM paths.
+            if is_jangtq:
+                from jang_tools.load_jangtq import load_jangtq_model
+                logger.info(f"Loading JANGTQ model: {self._model_name}")
+                self._model, self._tokenizer = load_jangtq_model(self._model_name)
+                self._processor = None
+            elif is_vlm:
+                logger.info(f"Loading JANG VLM model: {self._model_name}")
+                self._model, self._processor = load_jang_vlm_model(self._model_name)
+                # Extract tokenizer from processor for token counting
+                if hasattr(self._processor, "tokenizer"):
+                    self._tokenizer = self._processor.tokenizer
+                else:
+                    self._tokenizer = self._processor
+                # Wrap model with VLMModelAdapter for BatchGenerator compatibility
+                logger.info("Wrapping VLM model with VLMModelAdapter")
+                self._model = VLMModelAdapter(self._model)
+            else:
+                logger.info(f"Loading JANG model: {self._model_name}")
+                self._model, self._tokenizer = load_jang_model(self._model_name)
+                self._processor = None
+
+            # Wrap tokenizer if needed (some VLM processors don't have encode method)
+            if self._tokenizer is not None and not hasattr(self._tokenizer, "encode"):
+                if callable(self._tokenizer):
+                    logger.debug("Wrapping callable tokenizer with encode() method")
+                    self._tokenizer = _TokenizerWrapper(self._tokenizer)
+                else:
+                    logger.warning(
+                        "Tokenizer has no encode() method and is not callable; "
+                        "token counting may fail"
+                    )
+
+            # Dequantize mixed-precision switch layers.
+            # JANG models may have 2-bit routed experts while config.json
+            # reports bits=8. QuantizedSwitchLinear created by jang-tools
+            # uses config bits, causing shape mismatches at inference.
+            # Fix: detect and correct mismatched layer metadata.
+            # Do NOT catch exceptions here — a failed quant-fix means the model
+            # would produce garbage tokens silently; let it propagate to the
+            # outer JANGLoadError handler so the load fails loudly.
+            #
+            # JANGTQ skips this fix: load_jangtq_model uses TurboQuantLinear,
+            # not QuantizedSwitchLinear, so there are no switch-layer metadata
+            # mismatches to correct — and named_modules() would find no instances.
+            if not is_jangtq:
+                self._fix_jang_switch_quantization()
+
+            # jang-tools already handles Nemotron-H repair in the v2 path.
+            if self._detect_nemotron_h() and not self._is_jang_v2():
+                logger.info("Detected Nemotron-H architecture, applying weight fixups")
+                self._fix_nemotron_h_weights()
+
+            # Auto-switch to bfloat16 for large expert models
+            if self._needs_bfloat16():
+                logger.info("Large expert model detected (512+ experts, hidden>=4096), using bfloat16")
+                self._model.set_dtype(mx.bfloat16)
+
+            # Create engine config (copy to avoid mutating the shared instance)
+            scheduler_config = copy.copy(self._scheduler_config) if self._scheduler_config else SchedulerConfig()
+            scheduler_config.model_name = self._model_name  # Ensure cache isolation per model
+            engine_config = EngineConfig(
+                model_name=self._model_name,
+                scheduler_config=scheduler_config,
+                stream_interval=self._stream_interval,
+            )
+
+            # Create async engine
+            self._engine = AsyncEngineCore(
+                model=self._model,
+                tokenizer=self._tokenizer,
+                config=engine_config,
+            )
+
+            await self._engine.engine.start()
+            self._loaded = True
+            logger.info(f"JANGLoader loaded: {self._model_name}")
+
+        except Exception as e:
+            from ..exceptions import JANGLoadError
+            # Best-effort cleanup to avoid leaking Metal buffers on failed load.
+            # Wrapped in its own try/except so cleanup failure doesn't mask the
+            # original load error.
+            try:
+                await self.stop()
+            except Exception as cleanup_exc:
+                logger.debug(f"Cleanup after failed JANG load raised: {cleanup_exc}")
+            try:
+                mx.clear_cache()
+            except Exception as cache_exc:
+                logger.debug(f"mx.clear_cache() after failed JANG load raised: {cache_exc}")
+            raise JANGLoadError(
+                f"Failed to load JANG model {self._model_name}: {e}",
+                model_name=self._model_name,
+            ) from e
+
+    async def stop(self) -> None:
+        """Stop the engine and cleanup resources."""
+        if self._engine:
+            await self._engine.stop()
+            self._engine.engine.close()
+        self._engine = None
+        self._model = None
+        self._tokenizer = None
+        self._loaded = False
+        logger.info("JANGLoader stopped")
+
+    def _preprocess_messages(
+        self, messages: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Preprocess messages for model-specific formats."""
+        try:
+            from ..adapter.harmony import preprocess_harmony_messages
+            if self.model_type == "gpt_oss":
+                return preprocess_harmony_messages(messages)
+        except ImportError:
+            pass
+        return messages
+
+    def _apply_chat_template(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None = None,
+        chat_template_kwargs: dict[str, Any] | None = None,
+        is_partial: bool | None = None,
+    ) -> str:
+        """Apply chat template to messages."""
+        if hasattr(self._tokenizer, 'apply_chat_template'):
+            if is_partial is None:
+                is_partial = detect_and_strip_partial(messages)
+            else:
+                # Caller passed an explicit value; still strip the sentinel if present.
+                detect_and_strip_partial(messages)
+            template_kwargs = {
+                "tokenize": False,
+                "add_generation_prompt": not is_partial,
+            }
+            if is_partial:
+                template_kwargs["continue_final_message"] = True
+            if tools:
+                template_kwargs["tools"] = tools
+            if self._enable_thinking is not None:
+                template_kwargs["enable_thinking"] = self._enable_thinking
+            if chat_template_kwargs:
+                template_kwargs.update(chat_template_kwargs)
+
+            try:
+                return self._tokenizer.apply_chat_template(messages, **template_kwargs)
+            except TypeError:
+                if chat_template_kwargs:
+                    for key in chat_template_kwargs:
+                        template_kwargs.pop(key, None)
+                template_kwargs.pop("tools", None)
+                template_kwargs.pop("enable_thinking", None)
+                return self._tokenizer.apply_chat_template(messages, **template_kwargs)
+            except Exception as e:
+                logger.error(f"Chat template rendering failed: {e}")
+                raise
+        else:
+            prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
+            return prompt + "\nassistant:"
+
+    def count_chat_tokens(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None = None,
+        chat_template_kwargs: dict[str, Any] | None = None,
+        is_partial: bool | None = None,
+    ) -> int:
+        """Count prompt tokens for chat messages.
+
+        `is_partial` is forwarded to `_apply_chat_template` so that partial
+        (assistant-prefill) messages are rendered without a generation-prompt
+        suffix, giving an accurate token count for the actual prompt string.
+        """
+        messages = self._preprocess_messages(messages)
+        template_tools = convert_tools_for_template(tools) if tools else None
+        prompt = self._apply_chat_template(
+            messages, template_tools, chat_template_kwargs=chat_template_kwargs,
+            is_partial=is_partial,
+        )
+        return len(self._tokenizer.encode(prompt))
+
+    async def generate(
+        self,
+        prompt: str,
+        max_tokens: int = 256,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        top_k: int = 0,
+        min_p: float = 0.0,
+        repetition_penalty: float = 1.0,
+        presence_penalty: float = 0.0,
+        stop: list[str] | None = None,
+        **kwargs,
+    ) -> GenerationOutput:
+        """Generate a complete response (non-streaming)."""
+        if not self._loaded:
+            await self.start()
+
+        from ..request import SamplingParams
+
+        sampling_params = SamplingParams(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            min_p=min_p,
+            repetition_penalty=repetition_penalty,
+            presence_penalty=presence_penalty,
+            frequency_penalty=kwargs.get("frequency_penalty", 0.0),
+            stop=stop or [],
+            thinking_budget=kwargs.get("thinking_budget", None),
+        )
+
+        output = await self._engine.generate(
+            prompt=prompt,
+            sampling_params=sampling_params,
+        )
+
+        text = clean_special_tokens(output.output_text)
+
+        return GenerationOutput(
+            text=text,
+            prompt_tokens=output.prompt_tokens,
+            completion_tokens=output.completion_tokens,
+            finish_reason=output.finish_reason,
+            tool_calls=output.tool_calls,
+            cached_tokens=output.cached_tokens,
+        )
+
+    async def stream_generate(
+        self,
+        prompt: str,
+        max_tokens: int = 256,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        top_k: int = 0,
+        min_p: float = 0.0,
+        repetition_penalty: float = 1.0,
+        presence_penalty: float = 0.0,
+        stop: list[str] | None = None,
+        **kwargs,
+    ) -> Any:
+        """Stream generation token by token."""
+        if not self._loaded:
+            await self.start()
+
+        from ..request import SamplingParams
+
+        sampling_params = SamplingParams(
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            min_p=min_p,
+            repetition_penalty=repetition_penalty,
+            presence_penalty=presence_penalty,
+            frequency_penalty=kwargs.get("frequency_penalty", 0.0),
+            stop=stop or [],
+            thinking_budget=kwargs.get("thinking_budget", None),
+        )
+
+        request_id = await self._engine.add_request(
+            prompt=prompt,
+            sampling_params=sampling_params,
+        )
+
+        finished_normally = False
+        try:
+            async for output in self._engine.stream_outputs(request_id):
+                text = clean_special_tokens(output.output_text)
+
+                if output.finished:
+                    finished_normally = True
+
+                yield GenerationOutput(
+                    text=text,
+                    new_text=output.new_text,
+                    prompt_tokens=output.prompt_tokens,
+                    completion_tokens=output.completion_tokens,
+                    finished=output.finished,
+                    finish_reason=output.finish_reason,
+                    tool_calls=output.tool_calls,
+                    cached_tokens=output.cached_tokens,
+                )
+        except GeneratorExit:
+            logger.info(f"[stream_generate] GeneratorExit caught for request {request_id}")
+        finally:
+            if not finished_normally:
+                logger.info(f"[stream_generate] Aborting request {request_id}")
+                await self._engine.abort_request(request_id)
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        max_tokens: int = 256,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        top_k: int = 0,
+        min_p: float = 0.0,
+        repetition_penalty: float = 1.0,
+        presence_penalty: float = 0.0,
+        tools: list[dict] | None = None,
+        **kwargs,
+    ) -> GenerationOutput:
+        """Chat completion (non-streaming)."""
+        if not self._loaded:
+            await self.start()
+
+        messages = self._preprocess_messages(messages)
+        template_tools = convert_tools_for_template(tools) if tools else None
+        ct_kwargs = kwargs.pop("chat_template_kwargs", None)
+        prompt = self._apply_chat_template(
+            messages, template_tools, chat_template_kwargs=ct_kwargs
+        )
+
+        return await self.generate(
+            prompt=prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            min_p=min_p,
+            repetition_penalty=repetition_penalty,
+            presence_penalty=presence_penalty,
+            **kwargs,
+        )
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        max_tokens: int = 256,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        top_k: int = 0,
+        min_p: float = 0.0,
+        repetition_penalty: float = 1.0,
+        presence_penalty: float = 0.0,
+        tools: list[dict] | None = None,
+        **kwargs,
+    ) -> Any:
+        """Stream chat completion token by token."""
+        if not self._loaded:
+            await self.start()
+
+        messages = self._preprocess_messages(messages)
+        template_tools = convert_tools_for_template(tools) if tools else None
+        ct_kwargs = kwargs.pop("chat_template_kwargs", None)
+        prompt = self._apply_chat_template(
+            messages, template_tools, chat_template_kwargs=ct_kwargs
+        )
+
+        async for output in self.stream_generate(
+            prompt=prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            min_p=min_p,
+            repetition_penalty=repetition_penalty,
+            presence_penalty=presence_penalty,
+            **kwargs,
+        ):
+            yield output
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get engine statistics."""
+        stats = {
+            "engine_type": "jang",
+            "model_name": self._model_name,
+            "loaded": self._loaded,
+            "stream_interval": self._stream_interval,
+        }
+        if self._engine:
+            stats.update(self._engine.get_stats())
+        return stats
+
+    def get_cache_stats(self) -> dict[str, Any] | None:
+        """Get cache statistics."""
+        if self._engine:
+            return self._engine.get_cache_stats()
+        return None

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -28,6 +28,7 @@ import mlx.core as mx
 
 from .engine import BaseEngine, BatchedEngine
 from .engine.embedding import EmbeddingEngine
+from .engine.jang import JANGLoader
 from .engine.reranker import RerankerEngine
 from .engine.stt import STTEngine
 from .engine.sts import STSEngine
@@ -55,7 +56,7 @@ class EngineEntry:
     model_id: str  # Directory name (e.g., "llama-3b")
     model_path: str  # Full path to model directory
     model_type: Literal["llm", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", "audio_sts"]  # Model type
-    engine_type: Literal["batched", "simple", "embedding", "reranker", "vlm", "audio_stt", "audio_tts", "audio_sts"]  # Engine type to use
+    engine_type: Literal["batched", "simple", "embedding", "reranker", "vlm", "jang", "audio_stt", "audio_tts", "audio_sts"]  # Engine type to use
     estimated_size: int  # Pre-calculated from safetensors (bytes)
     actual_size: int | None = None  # Observed process-memory delta after load settles
     config_model_type: str = ""  # Raw model_type from config.json (e.g., "deepseekocr_2")
@@ -268,9 +269,18 @@ class EnginePool:
             settings = settings_manager.get_settings(model_id)
             if settings.model_type_override:
                 entry.model_type = settings.model_type_override
-                entry.engine_type = self._MODEL_TYPE_TO_ENGINE.get(
-                    settings.model_type_override, "batched"
-                )
+                # JANG models must keep the jang engine even with a persisted
+                # model_type override — _MODEL_TYPE_TO_ENGINE has no 'jang' key,
+                # so deriving from it clobbers jang -> batched and the turboquant
+                # (tq_*) tensors fail to load ("Received N parameters not in model").
+                # resolve_jang_engine_type handles the "llm/vlm only" guard so that
+                # an embedding/audio model with a stray jang_config.json is not
+                # mis-routed to the jang engine.
+                from pathlib import Path as _Path
+                from .model_discovery import resolve_jang_engine_type as _resolve_jang
+                entry.engine_type = _resolve_jang(
+                    _Path(entry.model_path), settings.model_type_override
+                ) or self._MODEL_TYPE_TO_ENGINE.get(settings.model_type_override, "batched")
                 logger.info(
                     f"Applied model_type override for {model_id}: "
                     f"type={entry.model_type}, engine={entry.engine_type}"
@@ -903,6 +913,13 @@ class EnginePool:
             if force_lm and effective_type == "vlm":
                 effective_type = "batched"
                 logger.info(f"Loading model as LM (force_lm=True): {model_id}")
+            # NOTE: force_lm does NOT downgrade JANG VLMs.  JANG models with
+            # engine_type="jang" stay on the JANGLoader path regardless of
+            # force_lm; JANGLoader internally picks the VLM or LLM loader via
+            # _should_use_vlm_loader().  Downgrading a jang VLM to "batched"
+            # would send it to BatchedEngine (mlx-lm), which cannot load
+            # turboquant tensors.  Known limitation: text-only benchmarks on
+            # jang VLM models will still run the vision loader path.
             else:
                 logger.info(f"Loading model: {model_id}")
 
@@ -936,6 +953,17 @@ class EnginePool:
                     logger.warning(
                         "DFlash is not supported for diffusion models; "
                         "loading %s with its native VLM engine",
+                        model_id,
+                    )
+                elif dflash_enabled and dflash_draft and effective_type == "jang":
+                    # DFlash is unsupported for JANG models: DFlashEngine uses the
+                    # generic mlx-lm/mlx-vlm load path which cannot handle JANG
+                    # turboquant (tq_*) tensors.  Skip dflash and fall through to
+                    # JANGLoader so the mixed-precision quantization is loaded correctly.
+                    logger.warning(
+                        "DFlash is not supported for JANG models (turboquant tensors "
+                        "require JANGLoader); ignoring dflash settings and loading %s "
+                        "with JANGLoader",
                         model_id,
                     )
                 elif dflash_enabled and dflash_draft:
@@ -1010,6 +1038,12 @@ class EnginePool:
                     engine = RerankerEngine(
                         model_name=entry.model_path,
                         trust_remote_code=trc,
+                    )
+                elif effective_type == "jang":
+                    engine = JANGLoader(
+                        model_name=entry.model_path,
+                        scheduler_config=self._scheduler_config,
+                        model_settings=model_settings,
                     )
                 elif effective_type == "vlm":
                     engine = VLMBatchedEngine(

--- a/omlx/exceptions.py
+++ b/omlx/exceptions.py
@@ -238,6 +238,18 @@ class ModelInferenceError(ModelError):
     pass
 
 
+class JANGLoadError(ModelLoadError):
+    """Error loading a JANG quantized model."""
+
+    pass
+
+
+class JANGDependencyError(ModelLoadError):
+    """Missing jang-tools dependency for JANG model loading."""
+
+    pass
+
+
 class TokenizerError(ModelError):
     """Error related to tokenization."""
 

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -26,7 +26,10 @@ from typing import Literal
 logger = logging.getLogger(__name__)
 
 ModelType = Literal["llm", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", "audio_sts"]
-EngineType = Literal["batched", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", "audio_sts"]
+EngineType = Literal["batched", "vlm", "embedding", "reranker", "jang", "audio_stt", "audio_tts", "audio_sts"]
+
+# JANG model config file names
+JANG_CONFIG_FILES = ("jang_config.json", "jjqf_config.json", "jang_cfg.json")
 
 # Known VLM (Vision-Language Model) types from mlx-vlm
 VLM_MODEL_TYPES = {
@@ -490,17 +493,33 @@ def detect_model_type(model_path: Path) -> ModelType:
     Returns:
         Model type: "llm", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", or "audio_sts"
     """
+    is_jang = _is_jang_model(model_path)
+
     config_path = model_path / "config.json"
     if not config_path.exists():
+        # No config.json: if JANG config carries has_vision, honour it; otherwise llm.
+        jang_has_vision = _get_jang_has_vision(model_path)
+        if jang_has_vision is not None:
+            return "vlm" if jang_has_vision else "llm"
         return "llm"
 
     try:
         with open(config_path) as f:
             config = json.load(f)
     except (json.JSONDecodeError, IOError):
+        # config.json is malformed/unreadable: fall back to the jang has_vision
+        # flag before defaulting to "llm".  Without this, a jang VLM with an
+        # intact jang_config.json but a corrupt config.json silently drops
+        # vision capability (F3 edge regression).
+        jhv = _get_jang_has_vision(model_path)
+        if jhv is not None:
+            return "vlm" if jhv else "llm"
         return "llm"
 
-    # Check architectures field for reranker first (more specific)
+    # Check architectures field for reranker first (more specific).
+    # Embedding/reranker architecture checks must run BEFORE the JANG
+    # has_vision / preprocessor_config short-circuit: a jang-quantized
+    # embedding or reranker model would otherwise be mislabeled as llm/vlm.
     architectures = config.get("architectures", [])
     for arch in architectures:
         if arch in RERANKER_ARCHITECTURES:
@@ -548,6 +567,18 @@ def detect_model_type(model_path: Path) -> ModelType:
 
     if normalized_type in EMBEDDING_MODEL_TYPES or model_type in EMBEDDING_MODEL_TYPES:
         return "embedding"
+
+    # Now apply the JANG-specific short-circuits (after ruling out embedding/reranker).
+    # A JANG model with an explicit has_vision flag in its config is classified by
+    # that flag; otherwise the preprocessor_config.json heuristic applies.
+    # These come after embedding/reranker detection so that a jang-quantized
+    # embedding model is not mislabeled as llm/vlm.
+    jang_has_vision = _get_jang_has_vision(model_path)
+    if jang_has_vision is not None:
+        return "vlm" if jang_has_vision else "llm"
+
+    if is_jang and (model_path / "preprocessor_config.json").exists():
+        return "vlm"
 
     # Ambiguous embedding types (have both embedding and LLM variants):
     # only classified as embedding if architecture matched above
@@ -852,9 +883,54 @@ def _is_adapter_dir(path: Path) -> bool:
     return (path / "adapter_config.json").exists()
 
 
+
+def _is_jang_model(model_path: Path) -> bool:
+    """Check if directory contains a JANG model config file."""
+    return any((model_path / f).exists() for f in JANG_CONFIG_FILES)
+
+
+# Model types for which a JANG config should win the engine routing.
+# Embedding, reranker, and audio types must use their own engines even if
+# a jang_config.json is present alongside the model files.
+JANG_ENGINE_MODEL_TYPES: frozenset[str] = frozenset({"llm", "vlm"})
+
+
+def resolve_jang_engine_type(model_path: Path, model_type: str | None) -> str | None:
+    """Return 'jang' if model_path is a jang model AND model_type is llm/vlm.
+
+    Returns None for any other combination — the caller should fall back to
+    the type-to-engine mapping.  model_type may be None or '' (treated as
+    not matching).
+    """
+    if model_type in JANG_ENGINE_MODEL_TYPES and _is_jang_model(model_path):
+        return "jang"
+    return None
+
+
+def _get_jang_has_vision(model_path: Path) -> bool | None:
+    """Read `architecture.has_vision` from a JANG config file if present."""
+    for cfg_name in JANG_CONFIG_FILES:
+        jang_config_path = model_path / cfg_name
+        if not jang_config_path.exists():
+            continue
+        try:
+            with open(jang_config_path) as f:
+                jang_config = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            return None
+        architecture = jang_config.get("architecture", {})
+        has_vision = architecture.get("has_vision") if isinstance(architecture, dict) else None
+        return has_vision if isinstance(has_vision, bool) else None
+    return None
+
+
 def _is_model_dir(path: Path) -> bool:
-    """Check if a directory contains a valid model (has config.json)."""
-    return (path / "config.json").exists() and not _is_adapter_dir(path)
+    """Check if a directory contains a valid model (has config.json or jang_config.json)."""
+    if _is_adapter_dir(path):
+        return False
+    if (path / "config.json").exists():
+        return True
+    return any((path / f).exists() for f in JANG_CONFIG_FILES)
 
 
 def model_directory_access_error(path: Path) -> str | None:
@@ -1053,18 +1129,18 @@ def _register_model(
             return
 
         model_type = detect_model_type(model_dir)
+
         if model_type == "embedding":
             engine_type: EngineType = "embedding"
         elif model_type == "reranker":
             engine_type = "reranker"
+        elif model_type in ("audio_stt", "audio_tts", "audio_sts"):
+            engine_type = model_type  # type: ignore[assignment]
+        elif resolve_jang_engine_type(model_dir, model_type) is not None:
+            # jang wins for llm/vlm only; embedding/reranker/audio handled above.
+            engine_type = "jang"
         elif model_type == "vlm":
             engine_type = "vlm"
-        elif model_type == "audio_stt":
-            engine_type = "audio_stt"
-        elif model_type == "audio_tts":
-            engine_type = "audio_tts"
-        elif model_type == "audio_sts":
-            engine_type = "audio_sts"
         else:
             engine_type = "batched"
         estimated_size = estimate_model_size(model_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,10 @@ grammar = [
     # Grammar-constrained decoding for structured output (requires torch ~2GB)
     "xgrammar>=0.1.32",
 ]
+jang = [
+    # JANG mixed-precision quantization for MoE models
+    "jang[mlx]>=0.1.0",
+]
 mcp = [
     "mcp>=1.0.0",
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,12 +15,13 @@ markers =
     slow: marks tests as slow (require model loading, deselect with '-m "not slow"')
     integration: marks tests as integration tests (require running server)
     turboquant: marks TurboQuant KV cache tests (run the suite with '-m turboquant')
+    jang_mlx: marks tests that require mlx/jang-tools (Apple Silicon only; excluded from the default/CI filter via addopts above; must be run on Apple Silicon — e.g. run with '-m jang_mlx' on helium)
 
 # Default options
 addopts =
     -v
     --tb=short
-    -m "not slow and not integration"
+    -m "not slow and not integration and not jang_mlx"
 
 # Ignore warnings from dependencies
 filterwarnings =

--- a/tests/test_jang_engine_type.py
+++ b/tests/test_jang_engine_type.py
@@ -1,0 +1,564 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+mlx-free tests for the jang engine-type routing invariants.
+
+This file imports ONLY omlx.model_discovery (which has no mlx dependency)
+and can be collected and run on any platform including Linux CI.
+
+Tests that require mlx/JANGLoader live in tests/test_jang_vlm.py, which is
+skipped on non-Apple hosts via pytest.importorskip("mlx").
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omlx.model_discovery import (
+    JANG_ENGINE_MODEL_TYPES,
+    detect_model_type,
+    discover_models,
+    resolve_jang_engine_type,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tests for resolve_jang_engine_type helper
+# ---------------------------------------------------------------------------
+
+
+class TestResolveJangEngineType:
+    """
+    Direct tests for the resolve_jang_engine_type helper in model_discovery.py.
+
+    These guard all THREE production call sites simultaneously:
+      - engine_pool.py: EnginePool.apply_settings_overrides (~line 282)
+      - routes.py set-override branch (~line 2102)
+      - routes.py reset-to-auto branch (~line 2118)
+
+    Sabotage mapping (per test):
+      - test_returns_jang_for_llm_jang_dir: if helper returned None for llm,
+        the `or` fallback would produce "batched" and all three sites would
+        clobber the jang engine on every llm override.
+      - test_returns_jang_for_vlm_jang_dir: same for vlm.
+      - test_returns_none_for_audio_stt: if JANG_ENGINE_MODEL_TYPES included
+        "audio_stt", helper returns "jang" → assert fails.
+      - test_returns_none_for_embedding: same for "embedding".
+      - test_returns_none_for_reranker: same for "reranker".
+      - test_returns_none_for_none_model_type: None model_type is not in
+        JANG_ENGINE_MODEL_TYPES; if None were added back (the dead original
+        `(None, "llm", "vlm")` tuple), the assert would still pass — the
+        live-regression check is the audio/embedding/reranker tests above.
+      - test_returns_none_for_non_jang_dir: if _is_jang_model always returned
+        True, helper returns "jang" for llm on a non-jang dir → assert fails.
+    """
+
+    def test_returns_jang_for_llm_jang_dir(self, tmp_path):
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0"})
+        )
+        assert resolve_jang_engine_type(tmp_path, "llm") == "jang"
+
+    def test_returns_jang_for_vlm_jang_dir(self, tmp_path):
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0"})
+        )
+        assert resolve_jang_engine_type(tmp_path, "vlm") == "jang"
+
+    def test_returns_none_for_audio_stt(self, tmp_path):
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0"})
+        )
+        assert resolve_jang_engine_type(tmp_path, "audio_stt") is None
+
+    def test_returns_none_for_embedding(self, tmp_path):
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0"})
+        )
+        assert resolve_jang_engine_type(tmp_path, "embedding") is None
+
+    def test_returns_none_for_reranker(self, tmp_path):
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0"})
+        )
+        assert resolve_jang_engine_type(tmp_path, "reranker") is None
+
+    def test_returns_none_for_none_model_type(self, tmp_path):
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0"})
+        )
+        assert resolve_jang_engine_type(tmp_path, None) is None
+
+    def test_returns_none_for_empty_model_type(self, tmp_path):
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0"})
+        )
+        assert resolve_jang_engine_type(tmp_path, "") is None
+
+    def test_returns_none_for_non_jang_dir(self, tmp_path):
+        # No jang_config.json → not a jang model → must return None even for llm
+        assert resolve_jang_engine_type(tmp_path, "llm") is None
+
+    def test_jang_engine_model_types_constant(self):
+        assert JANG_ENGINE_MODEL_TYPES == frozenset({"llm", "vlm"})
+        assert "audio_stt" not in JANG_ENGINE_MODEL_TYPES
+        assert "embedding" not in JANG_ENGINE_MODEL_TYPES
+        assert "reranker" not in JANG_ENGINE_MODEL_TYPES
+        assert None not in JANG_ENGINE_MODEL_TYPES
+
+    def test_alternate_jang_config_filenames(self, tmp_path):
+        """All three JANG config filenames are recognised."""
+        for cfg in ("jang_config.json", "jjqf_config.json", "jang_cfg.json"):
+            # Use a fresh tmp subdir for each filename
+            sub = tmp_path / f"sub_{cfg}"
+            sub.mkdir()
+            (sub / cfg).write_text(json.dumps({}))
+            assert resolve_jang_engine_type(sub, "llm") == "jang", f"failed for {cfg}"
+            assert resolve_jang_engine_type(sub, "embedding") is None, (
+                f"must not route embedding to jang for {cfg}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tests for engine-type clobber guards (all three production sites)
+# ---------------------------------------------------------------------------
+
+
+class TestEngineTypeClobberGuards:
+    """
+    Verify the jang engine_type routing invariant at the helper level.
+
+    These tests call resolve_jang_engine_type directly — the same function
+    invoked by all three production sites:
+      1. engine_pool.EnginePool.apply_settings_overrides
+      2. routes.update_model_settings set-override branch
+      3. routes.update_model_settings reset-to-auto branch
+
+    Because the helper is the ONLY implementation of the guard logic, any
+    regression at any site would be caught by mutating the helper itself.
+    Sabotage: replacing `if model_type in JANG_ENGINE_MODEL_TYPES` with `if True`
+    makes test_embedding_does_not_force_jang fail; replacing with `if False`
+    makes test_llm_preserves_jang fail.
+    """
+
+    def test_llm_preserves_jang(self, tmp_path):
+        """
+        model_type='llm' on a jang dir → helper returns 'jang'.
+
+        Guards engine_pool.py line that does:
+            entry.engine_type = resolve_jang_engine_type(...) or ...
+        and both routes.py branches.
+        """
+        (tmp_path / "jang_config.json").write_text(json.dumps({"format_version": "2.0"}))
+        assert resolve_jang_engine_type(tmp_path, "llm") == "jang"
+
+    def test_vlm_preserves_jang(self, tmp_path):
+        """model_type='vlm' on a jang dir → helper returns 'jang'."""
+        (tmp_path / "jang_config.json").write_text(json.dumps({"format_version": "2.0"}))
+        assert resolve_jang_engine_type(tmp_path, "vlm") == "jang"
+
+    def test_embedding_does_not_force_jang(self, tmp_path):
+        """
+        model_type='embedding' with jang_config.json present → helper returns None
+        so the fallback type_to_engine mapping yields 'embedding', not 'jang'.
+
+        Guards the 'llm/vlm only' restriction at all three production sites.
+        Sabotage: remove `model_type in JANG_ENGINE_MODEL_TYPES` → returns 'jang'
+        → this assertion fails.
+        """
+        (tmp_path / "jang_config.json").write_text(json.dumps({"format_version": "2.0"}))
+        result = resolve_jang_engine_type(tmp_path, "embedding")
+        assert result is None
+        # Confirm the `or` fallback produces the right engine
+        type_to_engine = {"embedding": "embedding"}
+        assert (result or type_to_engine.get("embedding", "batched")) == "embedding"
+
+    def test_audio_stt_does_not_force_jang(self, tmp_path):
+        """model_type='audio_stt' with jang_config.json → helper returns None."""
+        (tmp_path / "jang_config.json").write_text(json.dumps({"format_version": "2.0"}))
+        assert resolve_jang_engine_type(tmp_path, "audio_stt") is None
+
+    def test_non_jang_dir_returns_none_for_llm(self, tmp_path):
+        """No jang config file → helper returns None even for llm."""
+        assert resolve_jang_engine_type(tmp_path, "llm") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests for model_discovery engine-type ordering
+# ---------------------------------------------------------------------------
+
+
+class TestModelDiscoveryEngineTypeOrdering:
+    """
+    Tests that the engine_type ordering in _register_model correctly handles
+    jang + audio model types.
+
+    These tests patch detect_model_type and call discover_models from
+    omlx.model_discovery — no mlx dependency.
+    """
+
+    def test_audio_stt_wins_over_jang(self, tmp_path):
+        """
+        A model with both a jang_config.json AND audio_stt model_type must get
+        engine_type='audio_stt', not 'jang'.
+
+        Sabotage check: swapping the `elif model_type in ("audio_stt", ...)` and
+        `elif resolve_jang_engine_type(...)` branches would make this test see
+        engine_type='jang' and fail.
+
+        Guards: model_discovery.py _register_model ordering (~line 1115).
+        """
+        model_dir = tmp_path / "jang-audio-model"
+        model_dir.mkdir()
+        (model_dir / "jang_config.json").write_text(json.dumps({"format_version": "2.0"}))
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "whisper"}))
+        (model_dir / "model.safetensors").write_bytes(b"0" * 100)
+
+        with patch("omlx.model_discovery.detect_model_type", return_value="audio_stt"):
+            models = discover_models(tmp_path)
+
+        assert models["jang-audio-model"].engine_type == "audio_stt"
+
+    def test_jang_wins_for_llm_over_batched(self, tmp_path):
+        """
+        A jang model detected as llm must get engine_type='jang', not 'batched'.
+
+        Guards: model_discovery.py _register_model uses resolve_jang_engine_type
+        so that a jang+llm dir doesn't fall through to the 'batched' default.
+        Sabotage: removing the `elif resolve_jang_engine_type(...)` branch → 'batched'.
+        """
+        model_dir = tmp_path / "jang-llm"
+        model_dir.mkdir()
+        (model_dir / "jang_config.json").write_text(json.dumps({"format_version": "2.0"}))
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "qwen3_moe"}))
+        (model_dir / "model.safetensors").write_bytes(b"0" * 100)
+
+        with patch("omlx.model_discovery.detect_model_type", return_value="llm"):
+            models = discover_models(tmp_path)
+
+        assert models["jang-llm"].engine_type == "jang"
+
+    def test_jang_wins_for_vlm_over_vlm_engine(self, tmp_path):
+        """
+        A jang VLM model must get engine_type='jang', not 'vlm'.
+
+        Sabotage: replacing `elif resolve_jang_engine_type(...)` with a non-jang
+        branch → engine_type='vlm' → assert fails.
+        """
+        model_dir = tmp_path / "jang-vlm"
+        model_dir.mkdir()
+        (model_dir / "jang_config.json").write_text(json.dumps({
+            "format_version": "2.0",
+            "architecture": {"has_vision": True},
+        }))
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "qwen3_vl"}))
+        (model_dir / "model.safetensors").write_bytes(b"0" * 100)
+
+        with patch("omlx.model_discovery.detect_model_type", return_value="vlm"):
+            models = discover_models(tmp_path)
+
+        assert models["jang-vlm"].engine_type == "jang"
+
+
+# ---------------------------------------------------------------------------
+# F3: embedding/reranker architecture detection before JANG short-circuit
+# ---------------------------------------------------------------------------
+
+
+class TestJangEmbeddingOrderingF3:
+    """
+    Tests for the F3 fix: embedding/reranker architecture checks must run
+    BEFORE the JANG has_vision / preprocessor_config.json short-circuit in
+    detect_model_type().
+
+    A jang-quantized embedding model (e.g. a BERT/XLMRoberta embedding quantized
+    with JANG) must be classified as "embedding", not "llm" or "vlm".
+
+    These tests call detect_model_type() directly (no mlx required).
+
+    Sabotage mapping:
+      - test_jang_embedding_arch_classified_as_embedding:
+          Moving the JANG short-circuit before the embedding arch check causes
+          detect_model_type() to return "llm" (from has_vision=False) instead of
+          "embedding" → assertion fails.
+      - test_jang_embedding_model_type_classified_as_embedding:
+          Same: the EMBEDDING_MODEL_TYPES check that now sits before the JANG
+          short-circuit must fire for unambiguous embedding model types even when
+          a jang_config.json is present.
+    """
+
+    def test_jang_embedding_arch_classified_as_embedding(self, tmp_path):
+        """
+        A jang dir with XLMRobertaModel architecture → detect_model_type = "embedding".
+
+        Guards model_discovery.py: EMBEDDING_ARCHITECTURES check precedes the
+        JANG has_vision short-circuit (F3 fix).
+
+        Sabotage: reverting the F3 fix (moving JANG short-circuit back to the top)
+        makes this return "llm" (has_vision=False path) instead of "embedding",
+        failing the assertion.
+        """
+        # Write a jang config without has_vision set — if the JANG short-circuit
+        # fires first it returns "llm"; the F3 fix lets the arch check win instead.
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0", "architecture": {"has_vision": False}})
+        )
+        (tmp_path / "config.json").write_text(json.dumps({
+            "model_type": "xlm-roberta",
+            "architectures": ["XLMRobertaModel"],
+        }))
+
+        result = detect_model_type(tmp_path)
+        assert result == "embedding", (
+            f"Expected 'embedding' for jang dir + XLMRobertaModel arch, got '{result}'"
+        )
+
+    def test_jang_embedding_model_type_classified_as_embedding(self, tmp_path):
+        """
+        A jang dir with unambiguous embedding model_type (xlm-roberta) →
+        detect_model_type = "embedding".
+
+        Guards the EMBEDDING_MODEL_TYPES check: it now executes before the JANG
+        has_vision short-circuit, so an unambiguous embedding model_type wins
+        even when jang_config.json declares has_vision=False.
+
+        Sabotage: reverting the F3 fix puts the JANG short-circuit first, returning
+        "llm" rather than "embedding" — assertion fails.
+        """
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0", "architecture": {"has_vision": False}})
+        )
+        (tmp_path / "config.json").write_text(json.dumps({
+            "model_type": "xlm-roberta",
+            "architectures": [],
+        }))
+
+        result = detect_model_type(tmp_path)
+        assert result == "embedding", (
+            f"Expected 'embedding' for jang dir + xlm-roberta model_type, got '{result}'"
+        )
+
+    def test_jang_llm_still_classified_as_llm(self, tmp_path):
+        """
+        A standard jang LLM (has_vision=False, LLM arch) is still classified
+        as "llm" after the F3 reordering — common case must not regress.
+
+        Sabotage: changing the has_vision check to always return "vlm" would flip
+        this to "vlm" and fail the assertion.
+        """
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0", "architecture": {"has_vision": False}})
+        )
+        (tmp_path / "config.json").write_text(json.dumps({
+            "model_type": "qwen3_moe",
+            "architectures": ["Qwen3MoeForCausalLM"],
+        }))
+
+        result = detect_model_type(tmp_path)
+        assert result == "llm", (
+            f"Expected 'llm' for standard jang LLM, got '{result}'"
+        )
+
+    def test_jang_vlm_still_classified_as_vlm(self, tmp_path):
+        """
+        A standard jang VLM (has_vision=True) is still classified as "vlm"
+        after the F3 reordering — common case must not regress.
+        """
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0", "architecture": {"has_vision": True}})
+        )
+        (tmp_path / "config.json").write_text(json.dumps({
+            "model_type": "qwen3_vl",
+            "architectures": ["Qwen3VLForConditionalGeneration"],
+        }))
+
+        result = detect_model_type(tmp_path)
+        assert result == "vlm", (
+            f"Expected 'vlm' for jang VLM (has_vision=True), got '{result}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# F3 edge regression: jang VLM + corrupt config.json
+# ---------------------------------------------------------------------------
+
+
+class TestJangCorruptConfigJsonF3Edge:
+    """
+    F3 edge regression: a jang VLM whose config.json is malformed/unreadable
+    but whose jang_config.json carries has_vision=true must still be classified
+    as "vlm", not "llm".
+
+    Before the fix, the `except (json.JSONDecodeError, IOError)` branch
+    returned "llm" unconditionally, silently stripping vision capability.
+
+    Sabotage check:
+      Reverting the except branch to `return "llm"` makes
+      test_jang_vlm_corrupt_config_json_returns_vlm fail (returns "llm").
+      Replacing the condition with `if jhv` (not `if jhv is not None`) would
+      pass has_vision=True but silently return "llm" for has_vision=False,
+      which test_jang_llm_corrupt_config_json_returns_llm guards.
+    """
+
+    def test_jang_vlm_corrupt_config_json_returns_vlm(self, tmp_path):
+        """
+        jang_config.json has_vision=true + malformed config.json → "vlm".
+
+        This is the core regression: before the fix the except branch returned
+        "llm" unconditionally, silently dropping vision for an intact jang VLM.
+
+        Sabotage: revert except branch to `return "llm"` → returns "llm" → FAIL.
+        """
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0", "architecture": {"has_vision": True}})
+        )
+        # Deliberately malformed JSON
+        (tmp_path / "config.json").write_text("{BAD JSON: not valid}")
+
+        result = detect_model_type(tmp_path)
+        assert result == "vlm", (
+            f"Expected 'vlm' for jang VLM with corrupt config.json, got '{result}'"
+        )
+
+    def test_jang_llm_corrupt_config_json_returns_llm(self, tmp_path):
+        """
+        jang_config.json has_vision=false + malformed config.json → "llm".
+
+        Guards that the fallback respects has_vision=False, not just =True.
+        Sabotage: changing `if jhv is not None` to `if jhv` makes this path
+        incorrectly return "llm" even when jhv is False — which is the right
+        answer here, but would also let jhv=False skip the `return "vlm"` check,
+        so the guard is on the `if jhv is not None` sentinel being correct.
+        """
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0", "architecture": {"has_vision": False}})
+        )
+        (tmp_path / "config.json").write_text("{BAD JSON: not valid}")
+
+        result = detect_model_type(tmp_path)
+        assert result == "llm", (
+            f"Expected 'llm' for jang LLM with corrupt config.json, got '{result}'"
+        )
+
+    def test_non_jang_corrupt_config_json_returns_llm(self, tmp_path):
+        """
+        No jang_config.json + malformed config.json → "llm" (unchanged behaviour).
+
+        Ensures the fallback doesn't accidentally apply to non-jang models.
+        """
+        (tmp_path / "config.json").write_text("{BAD JSON: not valid}")
+
+        result = detect_model_type(tmp_path)
+        assert result == "llm"
+
+
+# ---------------------------------------------------------------------------
+# F4: jang + dflash settings → JANGLoader, not DFlashEngine
+# ---------------------------------------------------------------------------
+
+
+class TestJangDflashRoutingF4:
+    """
+    F4 guard: a jang model with dflash_enabled=True + dflash_draft_model set
+    must be routed to JANGLoader, not DFlashEngine.
+
+    engine_pool.py line 958:
+        elif dflash_enabled and dflash_draft and effective_type == "jang":
+            # skip dflash, fall through to JANGLoader
+
+    The full integration path (EnginePool._load_engine) requires mlx and is
+    only runnable on Apple Silicon (marked jang_mlx).
+
+    What we CAN test mlx-free:
+      1. The upstream invariant: `resolve_jang_engine_type` produces "jang" for a
+         jang dir regardless of dflash settings — this is what populates
+         `effective_type` in engine_pool.py.  If this ever returned anything other
+         than "jang", the F4 elif condition would never fire and DFlash would be
+         instantiated for a jang model.
+      2. The routing condition itself as a boolean expression, parameterised on
+         the three inputs that the engine_pool branch tests.
+
+    Sabotage for test_jang_engine_type_survives_dflash_settings:
+      Remove the `elif effective_type == "jang"` from the F4 branch in
+      engine_pool.py → `effective_type` still equals "jang" here, so this test
+      still passes.  The test guards the UPSTREAM invariant (resolve_jang_engine_type
+      keeps "jang"), not the downstream engine_pool branch directly.  That branch
+      is guarded by test_f4_routing_condition_skips_dflash below.
+
+    Sabotage for test_f4_routing_condition_skips_dflash:
+      Change `effective_type == "jang"` to `effective_type == "batched"` in
+      engine_pool.py (simulated here by the condition_fires parameter) →
+      the elif branch does NOT fire → dflash would be instantiated → our
+      assertion `not dflash_would_run` fails.
+    """
+
+    def test_jang_engine_type_survives_dflash_settings(self, tmp_path):
+        """
+        resolve_jang_engine_type("jang dir", "llm") == "jang" regardless of
+        any dflash settings passed to the engine pool.
+
+        This guards the upstream feed to effective_type in engine_pool.py.
+        If this regresses to None or "batched", the F4 elif branch never fires
+        and DFlashEngine is instantiated for a jang model (turboquant
+        tensors cannot be loaded by DFlash's mlx-lm pipeline).
+
+        Sabotage: remove resolve_jang_engine_type or make it return None for "llm"
+        → result is None → assert fails.
+        """
+        from omlx.model_discovery import resolve_jang_engine_type
+
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format_version": "2.0"})
+        )
+        # dflash settings have no bearing on resolve_jang_engine_type — it only
+        # looks at the model directory and model_type.
+        result = resolve_jang_engine_type(tmp_path, "llm")
+        assert result == "jang", (
+            f"Expected 'jang' (feeds effective_type for F4 guard), got '{result}'"
+        )
+
+    @pytest.mark.parametrize("effective_type,dflash_enabled,dflash_draft,expect_skip_dflash", [
+        # F4 guard fires: jang + dflash settings → skip DFlash
+        ("jang", True, "draft-model-path", True),
+        # Non-jang + dflash settings → DFlash should run
+        ("batched", True, "draft-model-path", False),
+        ("vlm", True, "draft-model-path", False),
+        # jang but dflash not enabled → guard irrelevant (dflash not running anyway)
+        ("jang", False, "draft-model-path", True),   # skip_dflash=True because dflash_enabled=False
+        # jang, dflash enabled but no draft model → guard irrelevant
+        ("jang", True, None, True),
+    ])
+    def test_f4_routing_condition_skips_dflash(
+        self, effective_type, dflash_enabled, dflash_draft, expect_skip_dflash
+    ):
+        """
+        Parameterised test of the F4 branch condition logic in isolation.
+
+        Mirrors the engine_pool.py guard:
+            elif dflash_enabled and dflash_draft and effective_type == "jang":
+                # skip dflash
+
+        `skip_dflash` is True when the elif fires (jang wins) OR when dflash
+        is not enabled/configured (so DFlash wouldn't run regardless).
+        `dflash_would_run` is the negation: DFlash only runs when dflash is
+        enabled, has a draft, AND effective_type is NOT "jang".
+
+        Sabotage: change `effective_type == "jang"` to `effective_type != "jang"`
+        in the condition below → the jang row flips expect to False and assert
+        fails for the first parametrize case.
+        """
+        # Replicate the engine_pool.py branch condition exactly
+        jang_skip = dflash_enabled and dflash_draft and effective_type == "jang"
+        dflash_would_run = dflash_enabled and dflash_draft and not jang_skip
+
+        if expect_skip_dflash:
+            assert not dflash_would_run, (
+                f"DFlash should NOT run for effective_type={effective_type!r}, "
+                f"dflash_enabled={dflash_enabled}, dflash_draft={dflash_draft!r}"
+            )
+        else:
+            assert dflash_would_run, (
+                f"DFlash SHOULD run for effective_type={effective_type!r}, "
+                f"dflash_enabled={dflash_enabled}, dflash_draft={dflash_draft!r}"
+            )

--- a/tests/test_jang_vlm.py
+++ b/tests/test_jang_vlm.py
@@ -1,0 +1,813 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for JANG-specific discovery and live JANGLoader behavior.
+
+All tests in this file require mlx (Apple Silicon only).  The file is
+skipped cleanly on Linux via pytest.importorskip at module level.
+
+mlx-free tests (resolve_jang_engine_type helper, engine-type ordering,
+clobber guards) live in tests/test_jang_engine_type.py and run on Linux.
+"""
+
+import pytest
+
+# Skip the entire file on platforms without mlx (e.g. Linux CI).
+# This must come before any mlx-dependent imports so collection succeeds.
+pytest.importorskip("mlx")
+
+import json
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from omlx.engine.jang import JANGLoader
+from omlx.model_discovery import detect_model_type, discover_models
+
+
+class _FakeArray:
+    """Small array-like test double for patched mlx calls."""
+
+    def __init__(self, shape):
+        self.shape = shape
+
+    def astype(self, _dtype):
+        return self
+
+
+class TestDetectModelTypeJangVlm:
+    """Tests for production JANG VLM detection in model_discovery."""
+
+    def test_detect_vlm_via_jang_has_vision(self, tmp_path):
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"version": "1.0", "architecture": {"has_vision": True}})
+        )
+        (tmp_path / "config.json").write_text(json.dumps({"model_type": "jang_vlm"}))
+
+        assert detect_model_type(tmp_path) == "vlm"
+
+    def test_detect_text_only_jang_as_llm(self, tmp_path):
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"version": "1.0", "architecture": {"has_vision": False}})
+        )
+        (tmp_path / "preprocessor_config.json").write_text(
+            json.dumps({"processor_type": "AutoProcessor"})
+        )
+        (tmp_path / "config.json").write_text(json.dumps({"model_type": "qwen3"}))
+
+        assert detect_model_type(tmp_path) == "llm"
+
+    def test_detect_vlm_via_preprocessor_only_for_jang(self, tmp_path):
+        (tmp_path / "jjqf_config.json").write_text(json.dumps({"quantization": {"bits": 2}}))
+        (tmp_path / "preprocessor_config.json").write_text(
+            json.dumps({"processor_type": "AutoProcessor"})
+        )
+        (tmp_path / "config.json").write_text(json.dumps({"model_type": "qwen3"}))
+
+        assert detect_model_type(tmp_path) == "vlm"
+
+    def test_discover_jang_vlm_uses_jang_engine(self, tmp_path):
+        model_dir = tmp_path / "qwen3.5-vlm-jang"
+        model_dir.mkdir()
+        (model_dir / "jang_config.json").write_text(
+            json.dumps(
+                {
+                    "format": "jang",
+                    "format_version": "2.0",
+                    "architecture": {"has_vision": True},
+                }
+            )
+        )
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "qwen3_vl"}))
+        (model_dir / "model.safetensors").write_bytes(b"0" * 1000)
+
+        models = discover_models(tmp_path)
+        assert models["qwen3.5-vlm-jang"].model_type == "vlm"
+        assert models["qwen3.5-vlm-jang"].engine_type == "jang"
+
+
+class TestJANGLoader:
+    """Tests for JANGLoader behavior that is exercised in production."""
+
+    def test_is_jang_v2_reads_format_version(self, tmp_path):
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format": "jang", "format_version": "2.0"})
+        )
+
+        loader = JANGLoader(str(tmp_path))
+
+        assert loader._is_jang_v2() is True
+
+    def test_should_use_vlm_loader_when_discovery_detects_vlm(self, tmp_path):
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format": "jang", "format_version": "2.0", "architecture": {}})
+        )
+        (tmp_path / "config.json").write_text(
+            json.dumps({"model_type": "mistral3", "vision_config": {"hidden_size": 1024}})
+        )
+
+        loader = JANGLoader(str(tmp_path))
+
+        assert loader._should_use_vlm_loader() is True
+
+    def test_should_not_use_vlm_loader_when_jang_explicitly_says_no_vision(self, tmp_path):
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format": "jang", "format_version": "2.0", "architecture": {"has_vision": False}})
+        )
+        (tmp_path / "config.json").write_text(
+            json.dumps({"model_type": "mistral3", "vision_config": {"hidden_size": 1024}})
+        )
+
+        loader = JANGLoader(str(tmp_path))
+
+        assert loader._should_use_vlm_loader() is False
+
+    @pytest.mark.asyncio
+    async def test_start_skips_nemotron_fixup_for_jang_v2(self, tmp_path):
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"format": "jang", "format_version": "2.0"})
+        )
+        (tmp_path / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "nemotron_h",
+                    "architectures": ["NemotronHForCausalLM"],
+                    "hidden_size": 4096,
+                    "num_attention_heads": 32,
+                    "head_dim": 128,
+                    "vocab_size": 131072,
+                }
+            )
+        )
+
+        loader = JANGLoader(str(tmp_path))
+        fake_model = MagicMock()
+        fake_model.config = {"architectures": ["NemotronHForCausalLM"]}
+        fake_engine = MagicMock()
+        fake_engine.engine.start = AsyncMock()
+
+        import sys
+        fake_jang_tools = MagicMock()
+        fake_jang_tools.loader.load_jang_model = MagicMock(
+            return_value=(fake_model, MagicMock())
+        )
+        fake_jang_tools.loader.load_jang_vlm_model = MagicMock()
+
+        with patch.object(loader, "_check_jang_tools_available"), \
+             patch.object(loader, "_should_use_vlm_loader", return_value=False), \
+             patch.dict(sys.modules, {
+                 "jang_tools": fake_jang_tools,
+                 "jang_tools.loader": fake_jang_tools.loader,
+             }), \
+             patch.object(loader, "_fix_nemotron_h_weights") as fixup, \
+             patch.object(loader, "_needs_bfloat16", return_value=False), \
+             patch.object(loader, "_detect_nemotron_h", return_value=True), \
+             patch("omlx.engine_core.AsyncEngineCore", return_value=fake_engine), \
+             patch("omlx.engine_core.EngineConfig",
+                   side_effect=lambda **kwargs: SimpleNamespace(**kwargs)), \
+             patch("omlx.scheduler.SchedulerConfig",
+                   return_value=SimpleNamespace(model_name=None)):
+            await loader.start()
+
+        fixup.assert_not_called()
+
+    def test_fix_nemotron_h_weights_no_index_is_noop(self, tmp_path):
+        loader = JANGLoader(str(tmp_path))
+        loader._model = MagicMock()
+
+        loader._fix_nemotron_h_weights()
+
+        loader._model.load_weights.assert_not_called()
+
+    def test_fix_nemotron_h_weights_dequantizes_gate_weights(self, tmp_path):
+        loader = JANGLoader(str(tmp_path))
+        loader._model = MagicMock()
+
+        index = {
+            "weight_map": {
+                "backbone.layers.0.mixer.gate.weight": "model-00001-of-00001.safetensors",
+                "backbone.layers.0.mixer.gate.scales": "model-00001-of-00001.safetensors",
+                "backbone.layers.0.mixer.gate.biases": "model-00001-of-00001.safetensors",
+            }
+        }
+        (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index))
+
+        gate_weight = _FakeArray((2, 32))
+        scales = _FakeArray((2, 1))
+        biases = _FakeArray((2, 1))
+        dequantized = _FakeArray((2, 128))
+
+        with patch.object(loader, "_needs_bfloat16", return_value=False), patch(
+            "omlx.engine.jang.mx.load",
+            return_value={
+                "backbone.layers.0.mixer.gate.weight": gate_weight,
+                "backbone.layers.0.mixer.gate.scales": scales,
+                "backbone.layers.0.mixer.gate.biases": biases,
+            },
+        ) as mock_load, patch(
+            "omlx.engine.jang.mx.dequantize", return_value=dequantized
+        ) as mock_dequantize, patch(
+            "omlx.engine.jang.mx.float16", "float16"
+        ):
+            loader._fix_nemotron_h_weights()
+
+        mock_load.assert_called_once()
+        mock_dequantize.assert_called_once_with(gate_weight, scales, biases, 128, 8)
+        loader._model.load_weights.assert_called_once_with(
+            [("backbone.layers.0.mixer.gate.weight", dequantized)],
+            strict=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_generate_uses_engine_and_cleans_output(self):
+        loader = JANGLoader("/tmp/jang-model")
+        loader._loaded = True
+        loader._engine = MagicMock()
+        loader._engine.generate = AsyncMock(
+            return_value=SimpleNamespace(
+                output_text="hello<|end|>",
+                prompt_tokens=11,
+                completion_tokens=7,
+                finish_reason="stop",
+                tool_calls=[],
+                cached_tokens=3,
+            )
+        )
+
+        with patch("omlx.engine.jang.clean_special_tokens", return_value="hello") as clean:
+            output = await loader.generate("prompt", max_tokens=9, temperature=0.2)
+
+        clean.assert_called_once_with("hello<|end|>")
+        assert output.text == "hello"
+        assert output.prompt_tokens == 11
+        assert output.completion_tokens == 7
+        sampling_params = loader._engine.generate.await_args.kwargs["sampling_params"]
+        assert sampling_params.max_tokens == 9
+        assert sampling_params.temperature == 0.2
+
+
+# ---------------------------------------------------------------------------
+# Helpers for _fix_jang_switch_quantization tests
+# ---------------------------------------------------------------------------
+
+class _FakeScales:
+    """Minimal scales array double."""
+    def __init__(self, num_groups: int):
+        self.shape = (4, num_groups)  # (num_experts, scale_groups)
+
+
+class _FakeSwitchLinear:
+    """
+    Test double for QuantizedSwitchLinear.
+
+    Constructed from the per-layer shape parameters used in
+    _fix_jang_switch_quantization so tests can control every relevant attribute.
+
+    Args:
+        num_experts: First dim of the packed weight tensor.
+        out_dim: Second dim (rows of unpacked weight); must equal intermediate_size
+                 or hidden_size to be classifiable.
+        packed_dim: Third dim of the packed weight tensor (in_dim * bits / 32).
+        bits: Initial (wrong) bits metadata from config.json.
+        group_size: Initial (wrong) group_size metadata.
+        scale_groups: Number of groups in the scales tensor.
+    """
+    def __init__(
+        self,
+        num_experts: int,
+        out_dim: int,
+        packed_dim: int,
+        bits: int,
+        group_size: int,
+        scale_groups: int,
+    ):
+        self.weight = _FakeArray((num_experts, out_dim, packed_dim))
+        self.scales = _FakeScales(scale_groups)
+        self.bits = bits
+        self.group_size = group_size
+
+
+def _make_loader_with_fake_model(
+    tmp_path,
+    config: dict,
+    modules: list[tuple[str, Any]],
+) -> JANGLoader:
+    """
+    Return a JANGLoader whose _model exposes named_modules() returning `modules`.
+    `config` is written to tmp_path/config.json so the method can read it.
+    """
+    (tmp_path / "config.json").write_text(json.dumps(config))
+    loader = JANGLoader(str(tmp_path))
+    fake_model = MagicMock()
+    fake_model.named_modules.return_value = modules
+    loader._model = fake_model
+    return loader
+
+
+# ---------------------------------------------------------------------------
+# Tests for _fix_jang_switch_quantization
+# ---------------------------------------------------------------------------
+
+class TestFixJangSwitchQuantization:
+    """
+    NOTE: These tests import mlx_lm (via the method under test) and require
+    Apple Silicon + mlx. They are written-but-unexecuted on this Linux box
+    and must be run on helium. Marked with the jang_mlx marker so CI can
+    skip them on non-Apple hosts.
+    """
+
+    pytestmark = pytest.mark.jang_mlx
+
+    def test_correct_bits_and_group_size_for_gate_proj(self, tmp_path):
+        """
+        A gate_proj layer (out_dim == intermediate_size, in_dim == hidden_size)
+        with wrong bits=8 in metadata but 2-bit packed weight gets bits corrected
+        to 2 and group_size corrected from the scales shape.
+
+        Layout: hidden_size=256, intermediate_size=512, 2-bit packing.
+          packed_dim = hidden_size * bits / 32 = 256 * 2 / 32 = 16
+          scale_groups = hidden_size / group_size = 256 / 64 = 4
+        """
+        config = {
+            "hidden_size": 256,
+            "intermediate_size": 512,
+            "quantization": {"bits": 8},
+        }
+        layer = _FakeSwitchLinear(
+            num_experts=4,
+            out_dim=512,    # == intermediate_size → gate_proj
+            packed_dim=16,  # == hidden_size * 2 / 32 → 2-bit
+            bits=8,
+            group_size=64,
+            scale_groups=4, # hidden_size(256) / 64 = 4
+        )
+
+        loader = _make_loader_with_fake_model(tmp_path, config, [("model.layer.0", layer)])
+
+        from mlx_lm.models.switch_layers import QuantizedSwitchLinear  # noqa
+        with patch("mlx_lm.models.switch_layers.QuantizedSwitchLinear", type(layer)):
+            loader._fix_jang_switch_quantization()
+
+        assert layer.bits == 2
+        assert layer.group_size == 64   # 256 / 4
+
+    def test_correct_bits_for_down_proj(self, tmp_path):
+        """
+        A down_proj layer (out_dim == hidden_size, in_dim == intermediate_size)
+        with 4-bit packed weight gets bits corrected from 8 to 4.
+
+        Layout: hidden_size=256, intermediate_size=512, 4-bit packing.
+          packed_dim = intermediate_size * 4 / 32 = 512 * 4 / 32 = 64
+        """
+        config = {
+            "hidden_size": 256,
+            "intermediate_size": 512,
+            "quantization": {"bits": 8},
+        }
+        layer = _FakeSwitchLinear(
+            num_experts=4,
+            out_dim=256,    # == hidden_size → down_proj
+            packed_dim=64,  # == intermediate_size * 4 / 32 → 4-bit
+            bits=8,
+            group_size=64,
+            scale_groups=8, # intermediate_size(512) / 64 = 8
+        )
+
+        loader = _make_loader_with_fake_model(tmp_path, config, [("model.layer.0", layer)])
+
+        from mlx_lm.models.switch_layers import QuantizedSwitchLinear  # noqa
+        with patch("mlx_lm.models.switch_layers.QuantizedSwitchLinear", type(layer)):
+            loader._fix_jang_switch_quantization()
+
+        assert layer.bits == 4
+        assert layer.group_size == 64   # 512 / 8
+
+    def test_unclassifiable_out_dim_raises(self, tmp_path):
+        """
+        A layer whose out_dim matches neither intermediate_size nor hidden_size
+        must raise ValueError, not silently continue.
+
+        Sabotage check: if the raise were replaced with `continue`, this test
+        would see bits unchanged at 8 and NOT raise — it would silently pass
+        without the ValueError, proving the guard is real.
+        """
+        config = {
+            "hidden_size": 256,
+            "intermediate_size": 512,
+        }
+        layer = _FakeSwitchLinear(
+            num_experts=4,
+            out_dim=999,    # matches neither
+            packed_dim=16,
+            bits=8,
+            group_size=64,
+            scale_groups=4,
+        )
+
+        loader = _make_loader_with_fake_model(tmp_path, config, [("model.layer.0", layer)])
+
+        from mlx_lm.models.switch_layers import QuantizedSwitchLinear  # noqa
+        with patch("mlx_lm.models.switch_layers.QuantizedSwitchLinear", type(layer)):
+            with pytest.raises(ValueError, match="unclassifiable"):
+                loader._fix_jang_switch_quantization()
+
+    def test_non_exact_packed_dim_raises(self, tmp_path):
+        """
+        A packed_dim that is inconsistent with in_dim for all supported bit-widths
+        (2/3/4/6/8) means a corrupt or mismatched shard.  Must raise ValueError, not
+        silently write a wrong bits value.
+
+        packed_dim=17, in_dim=256: for bits=2 recovered=272, range [256,272) → 272 is
+        not strictly less than 272, so no candidate matches → raises.
+
+        Sabotage check: removing the trial-loop and the final None-raise would let the
+        floor-division path write a wrong bits value and silently accept corrupt metadata;
+        the pytest.raises assertion would then fail.
+        """
+        config = {
+            "hidden_size": 256,
+            "intermediate_size": 512,
+        }
+        # packed_dim=17, in_dim=256: inconsistent with every supported bit-width
+        layer = _FakeSwitchLinear(
+            num_experts=4,
+            out_dim=512,
+            packed_dim=17,
+            bits=8,
+            group_size=64,
+            scale_groups=4,
+        )
+
+        loader = _make_loader_with_fake_model(tmp_path, config, [("model.layer.0", layer)])
+
+        from mlx_lm.models.switch_layers import QuantizedSwitchLinear  # noqa
+        with patch("mlx_lm.models.switch_layers.QuantizedSwitchLinear", type(layer)):
+            with pytest.raises(ValueError, match="not consistent with in_dim"):
+                loader._fix_jang_switch_quantization()
+
+    @pytest.mark.jang_mlx
+    def test_group_size_corrected_when_differs_from_initial(self, tmp_path):
+        """
+        When the actual group_size (derived from scales/in_dim) differs from the
+        initially-declared group_size, _fix_jang_switch_quantization must update
+        module.group_size to the corrected value.
+
+        Layout: hidden_size=256, intermediate_size=512, 2-bit gate_proj.
+          in_dim = hidden_size = 256
+          packed_dim = 256 * 2 / 32 = 16
+          scale_groups = 4  → actual_gs = 256 // 4 = 64
+          initial group_size = 128  ← intentionally wrong to make the mutation visible
+
+        Guards jang.py line `module.group_size = actual_gs` (~line 491).
+        Sabotage: deleting that line leaves group_size=128 and the final
+        `assert layer.group_size == 64` fails, confirming the test is non-vacuous.
+        """
+        config = {
+            "hidden_size": 256,
+            "intermediate_size": 512,
+            "quantization": {"bits": 8},
+        }
+        layer = _FakeSwitchLinear(
+            num_experts=4,
+            out_dim=512,     # == intermediate_size → gate_proj, in_dim = hidden_size = 256
+            packed_dim=16,   # == 256 * 2 / 32 → 2-bit
+            bits=8,
+            group_size=128,  # wrong initial value — must be corrected to 64
+            scale_groups=4,  # in_dim(256) / 4 = 64 → actual_gs = 64
+        )
+
+        loader = _make_loader_with_fake_model(tmp_path, config, [("model.layer.0", layer)])
+
+        from mlx_lm.models.switch_layers import QuantizedSwitchLinear  # noqa
+        with patch("mlx_lm.models.switch_layers.QuantizedSwitchLinear", type(layer)):
+            loader._fix_jang_switch_quantization()
+
+        assert layer.bits == 2
+        assert layer.group_size == 64  # corrected from 128 → 256 // 4
+
+    def test_non_exact_scale_groups_raises(self, tmp_path):
+        """
+        in_dim not divisible by scale_groups means an inconsistent scale tensor.
+        Must raise ValueError.
+        """
+        config = {
+            "hidden_size": 256,
+            "intermediate_size": 512,
+        }
+        # 2-bit, gate_proj: in_dim=256, scale_groups=7 → 256 % 7 != 0
+        layer = _FakeSwitchLinear(
+            num_experts=4,
+            out_dim=512,
+            packed_dim=16,
+            bits=8,
+            group_size=64,
+            scale_groups=7,  # 256 % 7 != 0
+        )
+
+        loader = _make_loader_with_fake_model(tmp_path, config, [("model.layer.0", layer)])
+
+        from mlx_lm.models.switch_layers import QuantizedSwitchLinear  # noqa
+        with patch("mlx_lm.models.switch_layers.QuantizedSwitchLinear", type(layer)):
+            with pytest.raises(ValueError, match="not divisible"):
+                loader._fix_jang_switch_quantization()
+
+    @pytest.mark.jang_mlx
+    @pytest.mark.asyncio
+    async def test_failed_quant_fix_propagates_through_start(self, tmp_path):
+        """
+        If _fix_jang_switch_quantization raises, start() must NOT catch and warn;
+        it must wrap in JANGLoadError and re-raise.
+
+        This is the BLOCKER fix — previously the exception was swallowed with
+        logger.warning(), leaving the model loaded with wrong quantization metadata.
+
+        Sabotage check: reverting the BLOCKER fix (putting the call back inside
+        try/except) would cause this test to NOT raise JANGLoadError, which would
+        fail the pytest.raises assertion.  Additionally, the cause chain check
+        (ei.value.__cause__) confirms the original ValueError is preserved.
+
+        Guards: jang.py start() line that calls _fix_jang_switch_quantization()
+        outside the except-block, and the `raise JANGLoadError(...) from e` at the
+        outer except handler.
+        """
+        (tmp_path / "jang_config.json").write_text(json.dumps({"format_version": "1.0"}))
+        (tmp_path / "config.json").write_text(json.dumps({
+            "model_type": "test_moe",
+            "hidden_size": 256,
+            "intermediate_size": 512,
+        }))
+
+        loader = JANGLoader(str(tmp_path))
+        fake_model = MagicMock()
+        fake_engine = MagicMock()
+        fake_engine.engine.start = AsyncMock()
+
+        import sys
+        # Inject a minimal jang_tools stub so the `import jang_tools` inside
+        # start() succeeds without the real package installed.
+        fake_jang_tools = MagicMock()
+        fake_jang_tools.loader.load_jang_model = MagicMock(
+            return_value=(fake_model, MagicMock())
+        )
+        fake_jang_tools.loader.load_jang_vlm_model = MagicMock()
+
+        from omlx.exceptions import JANGLoadError
+        with patch.object(loader, "_check_jang_tools_available"), \
+             patch.object(loader, "_should_use_vlm_loader", return_value=False), \
+             patch.dict(sys.modules, {
+                 "jang_tools": fake_jang_tools,
+                 "jang_tools.loader": fake_jang_tools.loader,
+             }), \
+             patch.object(loader, "_fix_jang_switch_quantization",
+                          side_effect=ValueError("corrupt shard")), \
+             patch.object(loader, "_needs_bfloat16", return_value=False), \
+             patch.object(loader, "_detect_nemotron_h", return_value=False), \
+             patch("omlx.engine_core.AsyncEngineCore", return_value=fake_engine), \
+             patch("omlx.engine_core.EngineConfig",
+                   side_effect=lambda **kw: SimpleNamespace(**kw)), \
+             patch("omlx.scheduler.SchedulerConfig",
+                   return_value=SimpleNamespace(model_name=None)), \
+             patch("omlx.engine.jang.mx.clear_cache"):
+            with pytest.raises(JANGLoadError, match="corrupt shard") as ei:
+                await loader.start()
+
+        assert isinstance(ei.value.__cause__, ValueError)
+        assert "corrupt shard" in str(ei.value.__cause__)
+
+
+# ---------------------------------------------------------------------------
+# Tests for _is_jangtq detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsJangtq:
+    """
+    Tests for the _is_jangtq() detection method on JANGLoader.
+
+    Marked jang_mlx because JANGLoader can only be imported on Apple Silicon
+    (the module-level `import mlx.core` at the top of jang.py).  Run on
+    helium; skipped by default on Linux CI via `not jang_mlx`.
+
+    Sabotage mapping (per test):
+      - test_detects_mxtq_weight_format: removing the `weight_format == "mxtq"`
+        check returns False → the JANGTQ branch in start() is never entered →
+        load_jangtq_model is never called → Metal OOM on TurboQuant models.
+      - test_detects_jangtq_profile: removing the `"JANGTQ" in profile` check
+        returns False for profile-only JANGTQ markers (e.g. "JANGTQ2") →
+        same Metal OOM regression.
+      - test_does_not_detect_standard_jang: if the method always returned True,
+        standard JANG_2L models would be sent to load_jangtq_model (wrong loader).
+      - test_returns_false_when_no_config: if always True, no-config dirs would
+        also be misrouted.
+    """
+
+    pytestmark = pytest.mark.jang_mlx
+
+    def test_detects_mxtq_weight_format(self, tmp_path):
+        """weight_format == "mxtq" in jang_config.json → True."""
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"weight_format": "mxtq", "profile": "JANG_2L"})
+        )
+        loader = JANGLoader(str(tmp_path))
+        assert loader._is_jangtq() is True
+
+    def test_detects_jangtq_profile(self, tmp_path):
+        """profile containing "JANGTQ" (e.g. "JANGTQ2") → True."""
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"weight_format": "mx.quantize", "profile": "JANGTQ2"})
+        )
+        loader = JANGLoader(str(tmp_path))
+        assert loader._is_jangtq() is True
+
+    def test_does_not_detect_standard_jang(self, tmp_path):
+        """mx.quantize + non-JANGTQ profile → False (standard JANG_2L model)."""
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"weight_format": "mx.quantize", "profile": "JANG_2L"})
+        )
+        loader = JANGLoader(str(tmp_path))
+        assert loader._is_jangtq() is False
+
+    def test_returns_false_when_no_config(self, tmp_path):
+        """No JANG config file in dir → False."""
+        loader = JANGLoader(str(tmp_path))
+        assert loader._is_jangtq() is False
+
+
+# ---------------------------------------------------------------------------
+# Tests for JANGTQ dispatch in start()
+# ---------------------------------------------------------------------------
+
+
+class TestStartJangtqDispatch:
+    """
+    Tests that start() routes JANGTQ models to load_jangtq_model and bypasses
+    the standard load_jang_model path and the switch-quantization fix.
+
+    Also tests the F1 guard: JANGTQ + VLM raises JANGLoadError immediately
+    rather than silently loading the model with the vision encoder dropped.
+
+    Marked jang_mlx because JANGLoader imports mlx at module level.
+    Run on helium; skipped on Linux CI.
+
+    Mirrors the mocking style of test_start_skips_nemotron_fixup_for_jang_v2.
+
+    Sabotage mapping (per test):
+      - test_start_dispatches_jangtq_to_load_jangtq_model:
+          * Removing the `if is_jangtq:` branch → load_jangtq_model.assert_called_once
+            fails (not called) AND load_jang_model.assert_not_called fails (called).
+          * Swapping `is_jangtq` for `is_vlm` in the condition → same failure for
+            a non-VLM JANGTQ model.
+      - test_start_skips_switch_quant_fix_for_jangtq:
+          * Removing the `if not is_jangtq:` guard → fix_mock.assert_not_called fails.
+          * This guards against the Metal OOM path: _fix_jang_switch_quantization
+            imports mlx_lm.models.switch_layers and walks the model; TurboQuantLinear
+            layers have no `bits`/`group_size` and would raise AttributeError.
+      - test_start_raises_on_jangtq_vlm_combination:
+          * Removing the `if is_jangtq and is_vlm:` guard (or changing it to only
+            check one condition) means the test no longer raises JANGLoadError →
+            the pytest.raises assertion fails, and load_jangtq_model would be called
+            (the loader_mock.assert_not_called() check would also catch this).
+    """
+
+    pytestmark = [pytest.mark.jang_mlx, pytest.mark.asyncio]
+
+    async def test_start_raises_on_jangtq_vlm_combination(self, tmp_path):
+        """
+        When _is_jangtq() and _should_use_vlm_loader() are BOTH True, start()
+        must raise JANGLoadError with "VLM" in the message before calling any
+        loader function.
+
+        This guards jang.py: the `if is_jangtq and is_vlm: raise JANGLoadError`
+        guard added for F1.
+
+        Sabotage: removing the guard (or weakening it to check only is_jangtq OR
+        is_vlm) causes start() to proceed past the check; for is_jangtq=True it
+        would attempt load_jangtq_model which silently drops the vision encoder.
+        The pytest.raises assertion fails immediately, surfacing the regression.
+        """
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"weight_format": "mxtq", "architecture": {"has_vision": True}})
+        )
+        (tmp_path / "config.json").write_text(
+            json.dumps({"model_type": "qwen3_vl", "hidden_size": 4096, "vocab_size": 131072})
+        )
+
+        loader = JANGLoader(str(tmp_path))
+
+        import sys
+        fake_jang_tools = MagicMock()
+        fake_load_jangtq_mod = MagicMock()
+
+        from omlx.exceptions import JANGLoadError
+        with patch.object(loader, "_check_jang_tools_available"), \
+             patch.object(loader, "_is_jangtq", return_value=True), \
+             patch.object(loader, "_should_use_vlm_loader", return_value=True), \
+             patch.dict(sys.modules, {
+                 "jang_tools": fake_jang_tools,
+                 "jang_tools.loader": fake_jang_tools.loader,
+                 "jang_tools.load_jangtq": fake_load_jangtq_mod,
+             }):
+            with pytest.raises(JANGLoadError, match="VLM") as exc_info:
+                await loader.start()
+
+        # Neither loader path should have been called
+        fake_load_jangtq_mod.load_jangtq_model.assert_not_called()
+        fake_jang_tools.loader.load_jang_model.assert_not_called()
+        fake_jang_tools.loader.load_jang_vlm_model.assert_not_called()
+        # Error message must explain the issue
+        assert "vision" in str(exc_info.value).lower() or "vlm" in str(exc_info.value).lower()
+
+    async def test_start_dispatches_jangtq_to_load_jangtq_model(self, tmp_path):
+        """
+        When _is_jangtq() returns True, start() must call load_jangtq_model
+        and must NOT call load_jang_model.
+        """
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"weight_format": "mxtq"})
+        )
+        (tmp_path / "config.json").write_text(
+            json.dumps({"model_type": "gpt_oss", "hidden_size": 4096, "vocab_size": 131072})
+        )
+
+        loader = JANGLoader(str(tmp_path))
+        fake_model = MagicMock()
+        fake_tok = MagicMock()
+        fake_tok.encode = MagicMock(return_value=[1, 2, 3])
+        fake_engine = MagicMock()
+        fake_engine.engine.start = AsyncMock()
+
+        import sys
+        fake_jang_tools = MagicMock()
+        fake_jang_tools.loader.load_jang_model = MagicMock()
+        fake_jang_tools.loader.load_jang_vlm_model = MagicMock()
+        fake_load_jangtq = MagicMock(return_value=(fake_model, fake_tok))
+        fake_load_jangtq_mod = MagicMock()
+        fake_load_jangtq_mod.load_jangtq_model = fake_load_jangtq
+
+        with patch.object(loader, "_check_jang_tools_available"), \
+             patch.object(loader, "_is_jangtq", return_value=True), \
+             patch.object(loader, "_should_use_vlm_loader", return_value=False), \
+             patch.dict(sys.modules, {
+                 "jang_tools": fake_jang_tools,
+                 "jang_tools.loader": fake_jang_tools.loader,
+                 "jang_tools.load_jangtq": fake_load_jangtq_mod,
+             }), \
+             patch.object(loader, "_fix_jang_switch_quantization"), \
+             patch.object(loader, "_needs_bfloat16", return_value=False), \
+             patch.object(loader, "_detect_nemotron_h", return_value=False), \
+             patch("omlx.engine_core.AsyncEngineCore", return_value=fake_engine), \
+             patch("omlx.engine_core.EngineConfig",
+                   side_effect=lambda **kw: SimpleNamespace(**kw)), \
+             patch("omlx.scheduler.SchedulerConfig",
+                   return_value=SimpleNamespace(model_name=None)):
+            await loader.start()
+
+        fake_load_jangtq.assert_called_once_with(str(tmp_path))
+        fake_jang_tools.loader.load_jang_model.assert_not_called()
+        fake_jang_tools.loader.load_jang_vlm_model.assert_not_called()
+
+    async def test_start_skips_switch_quant_fix_for_jangtq(self, tmp_path):
+        """
+        When _is_jangtq() returns True, _fix_jang_switch_quantization must
+        NOT be called — TurboQuantLinear has no QuantizedSwitchLinear metadata.
+        """
+        (tmp_path / "jang_config.json").write_text(
+            json.dumps({"weight_format": "mxtq"})
+        )
+        (tmp_path / "config.json").write_text(
+            json.dumps({"model_type": "gpt_oss", "hidden_size": 4096, "vocab_size": 131072})
+        )
+
+        loader = JANGLoader(str(tmp_path))
+        fake_model = MagicMock()
+        fake_tok = MagicMock()
+        fake_tok.encode = MagicMock(return_value=[1, 2, 3])
+        fake_engine = MagicMock()
+        fake_engine.engine.start = AsyncMock()
+
+        import sys
+        fake_jang_tools = MagicMock()
+        fake_jang_tools.loader.load_jang_model = MagicMock()
+        fake_jang_tools.loader.load_jang_vlm_model = MagicMock()
+        fake_load_jangtq = MagicMock(return_value=(fake_model, fake_tok))
+        fake_load_jangtq_mod = MagicMock()
+        fake_load_jangtq_mod.load_jangtq_model = fake_load_jangtq
+
+        with patch.object(loader, "_check_jang_tools_available"), \
+             patch.object(loader, "_is_jangtq", return_value=True), \
+             patch.object(loader, "_should_use_vlm_loader", return_value=False), \
+             patch.dict(sys.modules, {
+                 "jang_tools": fake_jang_tools,
+                 "jang_tools.loader": fake_jang_tools.loader,
+                 "jang_tools.load_jangtq": fake_load_jangtq_mod,
+             }), \
+             patch.object(loader, "_fix_jang_switch_quantization") as fix_mock, \
+             patch.object(loader, "_needs_bfloat16", return_value=False), \
+             patch.object(loader, "_detect_nemotron_h", return_value=False), \
+             patch("omlx.engine_core.AsyncEngineCore", return_value=fake_engine), \
+             patch("omlx.engine_core.EngineConfig",
+                   side_effect=lambda **kw: SimpleNamespace(**kw)), \
+             patch("omlx.scheduler.SchedulerConfig",
+                   return_value=SimpleNamespace(model_name=None)):
+            await loader.start()
+
+        fix_mock.assert_not_called()


### PR DESCRIPTION
> **Draft — for review.** Builds on the original JANG implementation by @AlexTzk (#364). Credit to Alex for the `JANGLoader` design, EnginePool integration, and the mixed-precision quantization approach. This has **diverged substantially** from #364 — effectively a rewrite of the load/dispatch path — so it's opened fresh rather than as a revision of that PR.

## What this adds on top of #364

- **Engine-type routing fix** — JANG models were clobbered to `batched` on any `model_type` override (→ "Received N parameters not in model" on reload). Routing is now single-sourced through a `resolve_jang_engine_type` helper used by `engine_pool`, the admin routes, and discovery.
- **JANGTQ (mxtq / TurboQuant) support** — mxtq models dispatch to `load_jangtq_model` (TurboQuantLinear, wired-limit-capped), fixing a load-time Metal OOM on large per-expert bundles (e.g. `MiniMax-M2.7-JANGTQ`: 256 routed experts @ 2-bit).
- **Hardening** — fail-loud on switch-quant errors (no silent dequant-to-fp16 fallback), GPU-memory cleanup on failed load, and trial-bits packing math (handles 2/3/4/6/8-bit).
- **Tests** — detection, engine-type clobber guards, JANGTQ dispatch, and switch-quant metadata correction. Apple-Silicon-only tests are `jang_mlx`-marked and excluded from the CI marker filter so CI stays green.

## Validation

- 42 JANG tests pass on Apple Silicon (including the `jang_mlx` set); the mlx-free subset runs in CI.
- `MiniMax-M2.7-JANGTQ` loads and generates correctly on an M-series host.
