### PR TITLE
feat: native video_url support for Qwen3-VL-family VLMs (torch-free)

### DIFF
--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -34,6 +34,13 @@ class ImageURL(BaseModel):
     detail: Optional[str] = "auto"  # "low", "high", "auto"
 
 
+class VideoURL(BaseModel):
+    """Video URL or base64 data URI for vision model input."""
+
+    url: str  # "https://..." or "data:video/mp4;base64,..."
+    detail: Optional[str] = "auto"  # "low", "high", "auto"
+
+
 class InputAudio(BaseModel):
     """Audio input data for multimodal models (OpenAI format)."""
 
@@ -62,13 +69,15 @@ class ContentPart(BaseModel):
     Supports:
     - text: Plain text content
     - image_url: Image input for vision models
+    - video_url: Video input for vision models
     - input_audio: Audio input for multimodal audio models
     - file: Document or text input for attachment preprocessing
     """
 
-    type: str  # "text", "image_url", "input_audio", or "file"
+    type: str  # "text", "image_url", "video_url", "input_audio", or "file"
     text: Optional[str] = None
     image_url: Optional[ImageURL] = None
+    video_url: Optional[VideoURL] = None
     input_audio: Optional[InputAudio] = None
     file: Optional[FileContent] = None
 

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -150,9 +150,9 @@ def _extract_text_from_content_list(content: list) -> str:
 
 
 def _extract_multimodal_content_list(content: list) -> list:
-    """Extract text, image, and audio parts from a content array.
+    """Extract text, image, video, and audio parts from a content array.
 
-    Keeps text, image_url, and input_audio items for VLM processing.
+    Keeps text, image_url, video_url, and input_audio items for VLM processing.
     Other content types (tool_use, thinking, refusal, etc.) are dropped.
     """
     parts = []
@@ -178,6 +178,20 @@ def _extract_multimodal_content_list(content: list) -> list:
                         {
                             "type": "image_url",
                             "image_url": {"url": url},
+                        }
+                    )
+            elif item_type == "video_url":
+                video_url_value = item.get("video_url")
+                url = None
+                if isinstance(video_url_value, str):
+                    url = video_url_value
+                elif isinstance(video_url_value, dict):
+                    url = video_url_value.get("url")
+                if url:
+                    parts.append(
+                        {
+                            "type": "video_url",
+                            "video_url": {"url": url},
                         }
                     )
             elif item_type == "input_image":
@@ -1182,9 +1196,9 @@ def extract_multimodal_content(
         if isinstance(content, str):
             processed_messages.append({"role": role, "content": content, **_extra})
         elif isinstance(content, list):
-            # Preserve image_url and input_audio parts for VLM processing
+            # Preserve image_url, video_url, and input_audio parts for VLM processing
             multimodal_parts = _extract_multimodal_content_list(content)
-            multimodal_types = {"image_url", "input_audio"}
+            multimodal_types = {"image_url", "video_url", "input_audio"}
             has_multimodal = any(
                 p.get("type") in multimodal_types for p in multimodal_parts
             )

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -47,9 +47,11 @@ from ..cache.vision_feature_cache import VisionFeatureSSDCache
 from ..exceptions import InvalidRequestError
 from ..models.vlm import VLMModelAdapter
 from ..utils.image import (
+    cleanup_temp_video_paths,
     compute_image_hash,
     compute_per_image_hashes,
     extract_images_from_messages,
+    extract_media_from_messages,
 )
 from .base import (
     BaseEngine,
@@ -251,6 +253,34 @@ def _patch_video_processor_bug():
         pass
 
     _video_processor_patched = True
+
+
+def _attach_torch_free_video_processor(processor) -> None:
+    """Attach a numpy/PIL video processor shim for Qwen3-VL when missing."""
+    if processor is None:
+        return
+
+    cls_name = processor.__class__.__name__
+    existing_vp = getattr(processor, "video_processor", None)
+    if existing_vp is not None:
+        return
+
+    is_qwen3_vl = cls_name == "Qwen3VLProcessor"
+    has_video_token = getattr(processor, "video_token", None) is not None
+    if not is_qwen3_vl and not has_video_token:
+        return
+
+    image_processor = getattr(processor, "image_processor", None)
+    if image_processor is None:
+        return
+
+    try:
+        from ..utils.video import TorchFreeQwen3VLVideoProcessor
+
+        processor.video_processor = TorchFreeQwen3VLVideoProcessor(image_processor)
+        logger.debug("Attached torch-free Qwen3-VL video processor shim")
+    except Exception as exc:
+        logger.warning("Failed to attach torch-free video processor shim: %s", exc)
 
 
 _torch_free_ip_patched = False
@@ -939,6 +969,10 @@ _QWEN_VISION_MODELS = {
 # processor is loaded.
 _IMAGE_TOKEN_UPPER_BOUND_FALLBACK = 1280
 
+# Conservative per-video placeholder budget for preflight when exact counts
+# are unavailable. Videos expand to many more tokens than a single image.
+_VIDEO_TOKEN_UPPER_BOUND_FALLBACK = 8192
+
 
 def _derive_image_token_upper_bound(processor: Any) -> int:
     """Derive the per-image token upper bound from the processor config.
@@ -999,6 +1033,24 @@ def _count_image_tokens(
             if ptype in ("image_url", "image", "input_image"):
                 image_parts += 1
     return image_parts * per_image_upper_bound
+
+
+def _count_video_tokens(
+    messages: list[dict[str, Any]],
+    per_video_upper_bound: int = _VIDEO_TOKEN_UPPER_BOUND_FALLBACK,
+) -> int:
+    """Count video_url content parts and return a conservative token budget."""
+    video_parts = 0
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") == "video_url":
+                video_parts += 1
+    return video_parts * per_video_upper_bound
 
 
 def _smart_resize_tokens(
@@ -1403,6 +1455,7 @@ class VLMBatchedEngine(BaseEngine):
         )
 
         _fix_processor_none_pixels(self._processor)
+        _attach_torch_free_video_processor(self._processor)
         self._diffusion_family = self._detect_diffusion_family()
         if self.is_diffusion_model:
             logger.info(
@@ -1757,8 +1810,10 @@ class VLMBatchedEngine(BaseEngine):
         messages: list[dict[str, Any]],
         num_images: int,
         num_audios: int = 0,
+        num_videos: int = 0,
+        videos: list[Any] | None = None,
     ) -> tuple[list[dict[str, Any]], list[tuple[int, int]]]:
-        """Format VLM messages with image/audio tokens on media-bearing user turns."""
+        """Format VLM messages with image/audio/video tokens on user turns."""
         from mlx_vlm.prompt_utils import extract_text_from_content, get_message_json
 
         model_type = self.model_type or getattr(
@@ -1769,6 +1824,7 @@ class VLMBatchedEngine(BaseEngine):
 
         image_part_types = {"image", "image_url", "input_image"}
         audio_part_types = {"input_audio"}
+        video_part_types = {"video_url"}
         has_explicit_images = any(
             isinstance(msg, dict)
             and self._count_content_parts(msg.get("content"), image_part_types) > 0
@@ -1781,10 +1837,20 @@ class VLMBatchedEngine(BaseEngine):
             for msg in messages
         )
 
+        has_explicit_videos = any(
+            isinstance(msg, dict)
+            and self._count_content_parts(msg.get("content"), video_part_types) > 0
+            for msg in messages
+        )
+
         remaining_images = num_images
         remaining_audios = num_audios
+        remaining_videos = num_videos
         assigned_fallback_images = False
         assigned_fallback_audios = False
+        assigned_fallback_videos = False
+        videos_consumed = 0
+        video_refs = [str(v) for v in (videos or [])]
         formatted_messages: list[dict[str, Any]] = []
         image_message_ranges: list[tuple[int, int]] = []
 
@@ -1798,12 +1864,17 @@ class VLMBatchedEngine(BaseEngine):
 
             msg_num_images = 0
             msg_num_audios = 0
+            msg_num_videos = 0
+            msg_video_refs: list[str] = []
             if role == "user":
                 explicit_images = self._count_content_parts(
                     raw_content, image_part_types
                 )
                 explicit_audios = self._count_content_parts(
                     raw_content, audio_part_types
+                )
+                explicit_videos = self._count_content_parts(
+                    raw_content, video_part_types
                 )
                 if explicit_images > 0 and remaining_images > 0:
                     msg_num_images = min(explicit_images, remaining_images)
@@ -1829,6 +1900,24 @@ class VLMBatchedEngine(BaseEngine):
                     remaining_audios = 0
                     assigned_fallback_audios = True
 
+                if explicit_videos > 0 and remaining_videos > 0:
+                    msg_num_videos = min(explicit_videos, remaining_videos)
+                    remaining_videos -= msg_num_videos
+                elif (
+                    not has_explicit_videos
+                    and remaining_videos > 0
+                    and not assigned_fallback_videos
+                ):
+                    msg_num_videos = remaining_videos
+                    remaining_videos = 0
+                    assigned_fallback_videos = True
+
+                if msg_num_videos > 0:
+                    msg_video_refs = video_refs[
+                        videos_consumed : videos_consumed + msg_num_videos
+                    ]
+                    videos_consumed += msg_num_videos
+
             if msg_num_images > 0:
                 image_message_ranges.append((idx, msg_num_images))
 
@@ -1848,14 +1937,23 @@ class VLMBatchedEngine(BaseEngine):
             ):
                 formatted_messages.append(msg)
             else:
+                message_kwargs: dict[str, Any] = {
+                    "skip_image_token": role != "user" or msg_num_images == 0,
+                    "skip_audio_token": role != "user" or msg_num_audios == 0,
+                    "num_images": msg_num_images,
+                    "num_audios": msg_num_audios,
+                }
+                if msg_num_videos > 0 and msg_video_refs:
+                    message_kwargs["video"] = (
+                        msg_video_refs[0]
+                        if len(msg_video_refs) == 1
+                        else msg_video_refs
+                    )
                 formatted = get_message_json(
                     model_type,
                     content,
                     role,
-                    skip_image_token=role != "user" or msg_num_images == 0,
-                    skip_audio_token=role != "user" or msg_num_audios == 0,
-                    num_images=msg_num_images,
-                    num_audios=msg_num_audios,
+                    **message_kwargs,
                 )
                 # Collapse text-only list content to plain string so that
                 # simplified chat templates (without render_content macro)
@@ -2168,6 +2266,7 @@ class VLMBatchedEngine(BaseEngine):
         messages: list[dict[str, Any]],
         images: list[Any],
         audio: list | None = None,
+        videos: list[Any] | None = None,
         chat_template_kwargs: dict[str, Any] | None = None,
         tools: list[dict] | None = None,
     ) -> Tuple[
@@ -2207,18 +2306,50 @@ class VLMBatchedEngine(BaseEngine):
             - image_cache_key_ranges: Per-image-turn cache key boundaries with
               cumulative image hashes
         """
+        video_list = videos or []
+        try:
+            return self._prepare_vision_inputs_impl(
+                messages=messages,
+                images=images,
+                audio=audio,
+                videos=video_list,
+                chat_template_kwargs=chat_template_kwargs,
+                tools=tools,
+            )
+        finally:
+            cleanup_temp_video_paths(video_list)
+
+    def _prepare_vision_inputs_impl(
+        self,
+        messages: list[dict[str, Any]],
+        images: list[Any],
+        audio: list | None,
+        videos: list[Any],
+        chat_template_kwargs: dict[str, Any] | None,
+        tools: list[dict] | None,
+    ) -> Tuple[
+        List[int],
+        Optional[mx.array],
+        Optional[Dict[str, Any]],
+        Optional[str],
+        int,
+        List[Tuple[int, str]],
+    ]:
         from mlx_vlm.prompt_utils import apply_chat_template
         from mlx_vlm.utils import load_audio as _load_audio
         from mlx_vlm.utils import prepare_inputs
 
         num_images = len(images)
         num_audios = len(audio) if audio else 0
+        num_videos = len(videos)
 
         model_type = self.model_type or ""
-        if model_type == COHERE2_MOE_MODEL_TYPE and (num_images > 0 or num_audios > 0):
+        if model_type == COHERE2_MOE_MODEL_TYPE and (
+            num_images > 0 or num_audios > 0 or num_videos > 0
+        ):
             raise InvalidRequestError(
                 "Cohere2 MoE is a text-only model and does not support "
-                "image or audio input.",
+                "image, video, or audio input.",
                 field="messages",
             )
 
@@ -2249,7 +2380,11 @@ class VLMBatchedEngine(BaseEngine):
         try:
             formatted_messages, image_message_ranges = (
                 self._format_messages_for_vlm_template(
-                    messages, num_images=num_images, num_audios=num_audios
+                    messages,
+                    num_images=num_images,
+                    num_audios=num_audios,
+                    num_videos=num_videos,
+                    videos=videos,
                 )
             )
         except Exception as e:
@@ -2330,17 +2465,22 @@ class VLMBatchedEngine(BaseEngine):
             else:
                 raise
 
-        # Tokenize text and preprocess images and audio
+        # Tokenize text and preprocess images, videos, and audio
         inputs = prepare_inputs(
             self._processor,
             images=images if images else None,
+            videos=[str(v) for v in videos] if videos else None,
             audio=audio if audio else None,
             prompts=[prompt] if isinstance(prompt, str) else prompt,
         )
 
         input_ids = inputs["input_ids"]
         pixel_values = inputs.get("pixel_values")
+        pixel_values_videos = inputs.get("pixel_values_videos")
         attention_mask = inputs.get("attention_mask")
+        vision_pixel_values = pixel_values
+        if vision_pixel_values is None and pixel_values_videos is not None and num_videos > 0:
+            vision_pixel_values = pixel_values_videos
 
         image_cache_key_start = 0
         image_cache_key_ranges: list[Tuple[int, str]] = []
@@ -2418,9 +2558,13 @@ class VLMBatchedEngine(BaseEngine):
             and v is not None
         }
 
-        # Check for any multimodal inputs: images or audio
+        # Check for any multimodal inputs: images, videos, or audio
         has_audio = "input_features" in extra_model_inputs
-        has_multimodal = (pixel_values is not None and num_images > 0) or has_audio
+        has_multimodal = (
+            (pixel_values is not None and num_images > 0)
+            or (pixel_values_videos is not None and num_videos > 0)
+            or has_audio
+        )
 
         if has_multimodal:
             # Build call kwargs from extra_model_inputs (includes input_features
@@ -2436,6 +2580,7 @@ class VLMBatchedEngine(BaseEngine):
 
             if (
                 num_images > 0
+                and num_videos == 0
                 and self._vision_cache is not None
                 and self._vision_cache_enabled
             ):
@@ -2479,7 +2624,7 @@ class VLMBatchedEngine(BaseEngine):
                     # Some or all uncached — compute all, then cache per-image
                     try:
                         features = self._compute_vision_features(
-                            pixel_values, extra_model_inputs
+                            vision_pixel_values, extra_model_inputs
                         )
                         if (
                             features is not None
@@ -2520,7 +2665,10 @@ class VLMBatchedEngine(BaseEngine):
             # expect it as a positional/keyword arg named 'mask'.
             try:
                 embed_features = self._vlm_model.get_input_embeddings(
-                    input_ids, pixel_values, mask=attention_mask, **call_kwargs
+                    input_ids,
+                    vision_pixel_values,
+                    mask=attention_mask,
+                    **call_kwargs,
                 )
             except TypeError:
                 # cached_image_features kwarg not supported — disable and retry
@@ -2533,7 +2681,10 @@ class VLMBatchedEngine(BaseEngine):
                     self._vision_cache_enabled = False
                     call_kwargs.pop("cached_image_features")
                     embed_features = self._vlm_model.get_input_embeddings(
-                        input_ids, pixel_values, mask=attention_mask, **call_kwargs
+                        input_ids,
+                        vision_pixel_values,
+                        mask=attention_mask,
+                        **call_kwargs,
                     )
                 else:
                     raise
@@ -3037,6 +3188,7 @@ class VLMBatchedEngine(BaseEngine):
                 getattr(self, "_processor", None)
             ),
         )
+        num_tokens += _count_video_tokens(messages)
         scheduler = getattr(getattr(self._engine, "engine", None), "scheduler", None)
         if scheduler is None:
             _warn_scheduler_unreachable_once(self, "preflight_chat")
@@ -3254,8 +3406,8 @@ class VLMBatchedEngine(BaseEngine):
         Returns:
             Tuple of (prompt_or_token_ids, vlm_embeds, vlm_kwargs, image_hash)
         """
-        # Extract images from messages
-        text_messages, images, audio = extract_images_from_messages(messages)
+        # Extract media from messages
+        text_messages, images, audio, videos = extract_media_from_messages(messages)
 
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
 
@@ -3275,11 +3427,12 @@ class VLMBatchedEngine(BaseEngine):
             vlm_messages,
             images,
             audio=audio if audio else None,
+            videos=videos if videos else None,
             chat_template_kwargs=ct_kwargs,
             tools=template_tools,
         )
 
-        if images:
+        if images or videos:
             # Free Metal intermediates from vision encoding.
             mx.synchronize()
             mx.clear_cache()

--- a/omlx/utils/image.py
+++ b/omlx/utils/image.py
@@ -8,14 +8,35 @@ hashes for prefix cache deduplication.
 """
 
 import base64
+import binascii
 import hashlib
 import io
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from PIL import Image, ImageOps
 
 logger = logging.getLogger(__name__)
+
+# Decoded payload cap for data:video/... URIs (~100 MiB).
+VIDEO_DECODED_SIZE_CAP = 100 * 1024 * 1024
+
+_VIDEO_MIME_SUFFIX = {
+    "video/mp4": ".mp4",
+    "video/webm": ".webm",
+    "video/quicktime": ".mov",
+    "video/x-matroska": ".mkv",
+}
+
+
+class TempVideoPath(str):
+    """Path to a decoded data-URL video written to a temporary file."""
+
+
+VideoReference = Union[str, bytes, Path, TempVideoPath]
 
 
 def load_image(url_or_base64: str) -> Image.Image:
@@ -61,32 +82,92 @@ def load_image(url_or_base64: str) -> Image.Image:
     return img.convert("RGB")
 
 
-def extract_images_from_messages(
-    messages: List[Dict[str, Any]],
-) -> Tuple[List[Dict[str, Any]], List[Image.Image], List]:
-    """
-    Extract images and audio from OpenAI-format messages.
+def load_video_reference(url_or_data: str) -> VideoReference:
+    """Load a video reference acceptable by ``mlx_vlm.utils.prepare_inputs``.
 
-    Processes messages containing content arrays with image_url or input_audio
-    parts, loads the media, and returns cleaned text-only messages alongside
-    the loaded images and audio files.
+    HTTP(S) URLs and local file paths are returned unchanged. Data URIs are
+    decoded, size-checked, and written to a temporary file whose path is
+    returned as :class:`TempVideoPath` for later cleanup.
+
+    Raises:
+        ValueError: On invalid base64 or oversize decoded payloads.
+    """
+    if url_or_data.startswith("data:"):
+        try:
+            header, data_part = url_or_data.split(",", 1)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid video data URI format: {url_or_data[:50]}..."
+            ) from exc
+        if ";base64" not in header:
+            raise ValueError(
+                f"Unsupported video data URI (expected base64): {header}"
+            )
+        try:
+            video_bytes = base64.b64decode(data_part, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError(
+                f"Invalid base64 in video data URI: {exc}"
+            ) from exc
+        if len(video_bytes) > VIDEO_DECODED_SIZE_CAP:
+            cap_mib = VIDEO_DECODED_SIZE_CAP // (1024 * 1024)
+            raise ValueError(
+                f"Decoded video data too large: {len(video_bytes)} bytes "
+                f"exceeds {cap_mib} MiB cap"
+            )
+        mime = header[5:].split(";", 1)[0].strip().lower()
+        suffix = _VIDEO_MIME_SUFFIX.get(mime, ".mp4")
+        fd, path = tempfile.mkstemp(prefix="omlx_video_", suffix=suffix)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(video_bytes)
+        except Exception:
+            os.unlink(path)
+            raise
+        return TempVideoPath(path)
+
+    if url_or_data.startswith(("http://", "https://")):
+        return url_or_data
+
+    return url_or_data
+
+
+def cleanup_temp_video_paths(videos: List[VideoReference]) -> None:
+    """Delete temporary files created for decoded video data URIs."""
+    for video in videos:
+        if isinstance(video, TempVideoPath):
+            try:
+                os.unlink(video)
+            except OSError:
+                logger.debug("Failed to delete temp video file %s", video, exc_info=True)
+
+
+def extract_media_from_messages(
+    messages: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Image.Image], List, List[VideoReference]]:
+    """
+    Extract images, audio, and videos from OpenAI-format messages.
+
+    Processes messages containing content arrays with image_url, video_url,
+    or input_audio parts, loads the media, and returns cleaned text-only
+    messages alongside the loaded media references.
 
     Args:
         messages: List of OpenAI-format chat messages. Each message may have
             content as a string or a list of content parts
-            (text/image_url/input_audio).
+            (text/image_url/video_url/input_audio).
 
     Returns:
-        Tuple of (text_messages, images, audio):
+        Tuple of (text_messages, images, audio, videos):
         - text_messages: Messages with media parts removed, text parts joined
         - images: List of loaded PIL Image objects in order of appearance
         - audio: List of BytesIO/str audio references for load_audio()
+        - videos: List of file paths/URLs for ``prepare_inputs(videos=...)``
     """
-    import binascii
-
     text_messages = []
     images = []
     audio = []
+    videos: List[VideoReference] = []
 
     for msg in messages:
         role = msg.get("role", "user")
@@ -170,6 +251,22 @@ def extract_images_from_messages(
                     else:
                         audio.append(data)
 
+            elif part_type == "video_url":
+                video_url_obj = (
+                    part.get("video_url") if isinstance(part, dict)
+                    else getattr(part, "video_url", None)
+                )
+                url = None
+                if isinstance(video_url_obj, str):
+                    url = video_url_obj
+                elif isinstance(video_url_obj, dict):
+                    url = video_url_obj.get("url")
+                elif video_url_obj is not None:
+                    url = getattr(video_url_obj, "url", None)
+
+                if url:
+                    videos.append(load_video_reference(url))
+
         new_msg = {"role": role, "content": "\n".join(text_parts) if text_parts else ""}
         # Preserve extra fields
         for key in msg:
@@ -177,7 +274,35 @@ def extract_images_from_messages(
                 new_msg[key] = msg[key]
         text_messages.append(new_msg)
 
+    return text_messages, images, audio, videos
+
+
+def extract_images_from_messages(
+    messages: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Image.Image], List]:
+    """
+    Extract images and audio from OpenAI-format messages.
+
+    Processes messages containing content arrays with image_url or input_audio
+    parts, loads the media, and returns cleaned text-only messages alongside
+    the loaded images and audio files. Video parts are stripped from text
+    messages but not returned (see :func:`extract_media_from_messages`).
+
+    Args:
+        messages: List of OpenAI-format chat messages. Each message may have
+            content as a string or a list of content parts
+            (text/image_url/input_audio).
+
+    Returns:
+        Tuple of (text_messages, images, audio):
+        - text_messages: Messages with media parts removed, text parts joined
+        - images: List of loaded PIL Image objects in order of appearance
+        - audio: List of BytesIO/str audio references for load_audio()
+    """
+    text_messages, images, audio, _videos = extract_media_from_messages(messages)
     return text_messages, images, audio
+
+
 def compute_image_hash(images: List[Image.Image]) -> Optional[str]:
     """
     Compute a SHA256 hash from a list of images for prefix cache deduplication.

--- a/omlx/utils/video.py
+++ b/omlx/utils/video.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Torch-free Qwen3-VL video preprocessing for oMLX."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, List, Optional, Sequence, Tuple, Union
+
+import numpy as np
+from PIL import Image
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.video_utils import VideoMetadata
+
+# Video pixel budgets from transformers Qwen3VLVideoProcessor defaults.
+_DEFAULT_VIDEO_MIN_PIXELS = 128 * 32 * 32
+_DEFAULT_VIDEO_MAX_PIXELS = 32 * 32 * 768
+
+
+def smart_resize(
+    num_frames: int,
+    height: int,
+    width: int,
+    *,
+    temporal_factor: int = 2,
+    factor: int = 32,
+    min_pixels: int = _DEFAULT_VIDEO_MIN_PIXELS,
+    max_pixels: int = _DEFAULT_VIDEO_MAX_PIXELS,
+) -> Tuple[int, int]:
+    """Mirror HF ``smart_resize`` for Qwen3-VL videos."""
+    if height < factor or width < factor:
+        raise ValueError(
+            f"height:{height} or width:{width} must be larger than factor:{factor}"
+        )
+    if max(height, width) / min(height, width) > 200:
+        raise ValueError(
+            f"absolute aspect ratio must be smaller than 200, got "
+            f"{max(height, width) / min(height, width)}"
+        )
+    h_bar = round(height / factor) * factor
+    w_bar = round(width / factor) * factor
+    t_bar = math.ceil(num_frames / temporal_factor) * temporal_factor
+
+    if t_bar * h_bar * w_bar > max_pixels:
+        beta = math.sqrt((num_frames * height * width) / max_pixels)
+        h_bar = max(factor, math.floor(height / beta / factor) * factor)
+        w_bar = max(factor, math.floor(width / beta / factor) * factor)
+    elif t_bar * h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (num_frames * height * width))
+        h_bar = math.ceil(height * beta / factor) * factor
+        w_bar = math.ceil(width * beta / factor) * factor
+
+    return h_bar, w_bar
+
+
+def _resize_video_frames(video: np.ndarray, target_h: int, target_w: int) -> np.ndarray:
+    """Bicubic resize each frame of a ``(T, C, H, W)`` video."""
+    t, c, h, w = video.shape
+    if target_h == h and target_w == w:
+        return video
+    out = np.empty((t, c, target_h, target_w), dtype=video.dtype)
+    for i, frame in enumerate(video):
+        arr = np.transpose(frame, (1, 2, 0))
+        if arr.dtype in (np.float32, np.float64):
+            arr = (arr * 255).clip(0, 255).astype(np.uint8)
+        pil = Image.fromarray(arr)
+        pil = pil.resize((target_w, target_h), resample=Image.BICUBIC)
+        out[i] = np.transpose(np.array(pil), (2, 0, 1))
+    return out
+
+
+def _to_video_tchw(video: Union[np.ndarray, Sequence[Any]]) -> np.ndarray:
+    """Normalize video input to ``(T, C, H, W)`` uint8."""
+    if isinstance(video, np.ndarray):
+        arr = video
+    elif isinstance(video, list):
+        frames = []
+        for frame in video:
+            if isinstance(frame, np.ndarray):
+                frames.append(frame)
+            else:
+                frames.append(np.asarray(frame))
+        if not frames:
+            raise ValueError("Empty video frame list")
+        if frames[0].ndim == 3 and frames[0].shape[-1] in (1, 3, 4):
+            arr = np.stack(frames, axis=0)
+        elif frames[0].ndim == 3 and frames[0].shape[0] in (1, 3, 4):
+            arr = np.stack(frames, axis=0)
+        else:
+            raise ValueError(f"Unsupported frame shape: {frames[0].shape}")
+    else:
+        arr = np.asarray(video)
+
+    if arr.ndim != 4:
+        raise ValueError(f"Expected video with 4 dimensions, got shape {arr.shape}")
+
+    if arr.shape[1] in (1, 3, 4) and arr.shape[-1] not in (1, 3, 4):
+        tchw = arr
+    elif arr.shape[-1] in (1, 3, 4):
+        tchw = np.transpose(arr, (0, 3, 1, 2))
+    else:
+        raise ValueError(f"Cannot infer channel dimension for shape {arr.shape}")
+
+    if tchw.dtype != np.uint8:
+        if np.issubdtype(tchw.dtype, np.floating) and tchw.max() <= 1.0:
+            tchw = (tchw * 255).clip(0, 255).astype(np.uint8)
+        else:
+            tchw = tchw.clip(0, 255).astype(np.uint8)
+    return tchw
+
+
+class TorchFreeQwen3VLVideoProcessor:
+    """Numpy/PIL shim for ``Qwen3VLVideoProcessor`` in torch-free environments."""
+
+    model_input_names = ["pixel_values_videos", "video_grid_thw"]
+
+    def __init__(
+        self,
+        image_processor: Any,
+        *,
+        min_pixels: Optional[int] = None,
+        max_pixels: Optional[int] = None,
+        fps: float = 2.0,
+        min_frames: int = 4,
+        max_frames: int = 768,
+    ) -> None:
+        self.patch_size = int(getattr(image_processor, "patch_size", 16))
+        self.temporal_patch_size = int(
+            getattr(image_processor, "temporal_patch_size", 2)
+        )
+        self.merge_size = int(getattr(image_processor, "merge_size", 2))
+        self.do_rescale = bool(getattr(image_processor, "do_rescale", True))
+        self.rescale_factor = float(
+            getattr(image_processor, "rescale_factor", 1 / 255.0)
+        )
+        self.do_normalize = bool(getattr(image_processor, "do_normalize", True))
+        self.image_mean = list(
+            getattr(image_processor, "image_mean", [0.5, 0.5, 0.5])
+        )
+        self.image_std = list(getattr(image_processor, "image_std", [0.5, 0.5, 0.5]))
+        self.do_convert_rgb = bool(getattr(image_processor, "do_convert_rgb", True))
+        self.min_pixels = (
+            int(min_pixels)
+            if min_pixels is not None
+            else _DEFAULT_VIDEO_MIN_PIXELS
+        )
+        self.max_pixels = (
+            int(max_pixels)
+            if max_pixels is not None
+            else _DEFAULT_VIDEO_MAX_PIXELS
+        )
+        self.fps = float(fps)
+        self.min_frames = int(min_frames)
+        self.max_frames = int(max_frames)
+
+    def _process_one(self, video: np.ndarray) -> Tuple[np.ndarray, List[int], VideoMetadata]:
+        video = _to_video_tchw(video)
+        t, c, h, w = video.shape
+        if c == 1 and self.do_convert_rgb:
+            video = np.repeat(video, 3, axis=1)
+            c = 3
+        elif c == 4 and self.do_convert_rgb:
+            video = video[:, :3]
+            c = 3
+
+        resized_h, resized_w = smart_resize(
+            num_frames=t,
+            height=h,
+            width=w,
+            temporal_factor=self.temporal_patch_size,
+            factor=self.patch_size * self.merge_size,
+            min_pixels=self.min_pixels,
+            max_pixels=self.max_pixels,
+        )
+        video = _resize_video_frames(video, resized_h, resized_w)
+
+        video_f = video.astype(np.float32)
+        if self.do_rescale and video.dtype == np.uint8:
+            video_f = video_f * self.rescale_factor
+        if self.do_normalize:
+            mean = np.array(self.image_mean, dtype=np.float32)[None, :, None, None]
+            std = np.array(self.image_std, dtype=np.float32)[None, :, None, None]
+            video_f = (video_f - mean) / std
+
+        pad = (-video_f.shape[0]) % self.temporal_patch_size
+        if pad:
+            video_f = np.concatenate(
+                [video_f, np.repeat(video_f[-1:], pad, axis=0)], axis=0
+            )
+
+        t_padded = video_f.shape[0]
+        grid_t = t_padded // self.temporal_patch_size
+        grid_h = resized_h // self.patch_size
+        grid_w = resized_w // self.patch_size
+        ps = self.patch_size
+        tps = self.temporal_patch_size
+        ms = self.merge_size
+
+        patches = video_f[None, ...]
+        patches = patches.reshape(
+            1,
+            grid_t,
+            tps,
+            c,
+            grid_h // ms,
+            ms,
+            ps,
+            grid_w // ms,
+            ms,
+            ps,
+        )
+        patches = patches.transpose(0, 1, 4, 7, 5, 8, 3, 2, 6, 9)
+        flatten = patches.reshape(1, grid_t * grid_h * grid_w, c * tps * ps * ps)
+
+        metadata = VideoMetadata(
+            total_num_frames=t,
+            fps=None,
+            width=w,
+            height=h,
+            frames_indices=list(range(t)),
+        )
+        return flatten[0], [grid_t, grid_h, grid_w], metadata
+
+    def __call__(self, videos: Any, **kwargs: Any) -> BatchFeature:
+        return_metadata = kwargs.pop("return_metadata", False)
+        fps = kwargs.pop("fps", None)
+        if not isinstance(videos, list):
+            videos = [videos]
+
+        all_patches: List[np.ndarray] = []
+        all_thw: List[List[int]] = []
+        all_metadata: List[VideoMetadata] = []
+
+        for idx, video in enumerate(videos):
+            patches, thw, metadata = self._process_one(video)
+            if fps is not None:
+                video_fps = fps[idx] if isinstance(fps, (list, tuple)) else fps
+                metadata.fps = float(video_fps)
+            elif metadata.fps is None:
+                metadata.fps = self.fps
+            all_patches.append(patches)
+            all_thw.append(thw)
+            all_metadata.append(metadata)
+
+        data = {
+            "pixel_values_videos": np.concatenate(all_patches, axis=0).astype(
+                np.float32
+            ),
+            "video_grid_thw": np.array(all_thw, dtype=np.int64),
+        }
+        if return_metadata:
+            data["video_metadata"] = all_metadata
+        return BatchFeature(data=data)
+
+    def preprocess(self, videos: Any, **kwargs: Any) -> BatchFeature:
+        return self(videos, **kwargs)

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -2885,6 +2885,115 @@ class TestExtractMultimodalContent:
         assert parts[0]["type"] == "input_audio"
         assert parts[0]["input_audio"]["format"] == "wav"
 
+    def test_video_url_nested_dict_normalized(self):
+        """video_url nested dict normalizes to url-only shape."""
+        parts = _extract_multimodal_content_list([
+            {
+                "type": "video_url",
+                "video_url": {
+                    "url": "data:video/mp4;base64,AAA",
+                    "detail": "auto",
+                },
+            },
+        ])
+        assert parts == [
+            {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,AAA"}},
+        ]
+
+    def test_video_url_string_form_normalized(self):
+        """video_url with string value (not nested dict) should be normalized."""
+        parts = _extract_multimodal_content_list([
+            {"type": "video_url", "video_url": "data:video/mp4;base64,AAA"},
+        ])
+        assert parts == [
+            {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,AAA"}},
+        ]
+
+    def test_video_url_missing_url_dropped(self):
+        """video_url item with no extractable URL should be dropped."""
+        assert _extract_multimodal_content_list([
+            {"type": "video_url", "video_url": None},
+        ]) == []
+        assert _extract_multimodal_content_list([
+            {"type": "video_url"},
+        ]) == []
+        assert _extract_multimodal_content_list([
+            {"type": "video_url", "video_url": {}},
+        ]) == []
+        assert _extract_multimodal_content_list([
+            {"type": "video_url", "video_url": {"url": ""}},
+        ]) == []
+
+    def test_video_url_from_content_part_model(self):
+        """video_url from ContentPart model_dump should be normalized."""
+        from omlx.api.openai_models import ContentPart, VideoURL
+
+        part = ContentPart(
+            type="video_url",
+            video_url=VideoURL(url="file:///tmp/a.mp4"),
+        )
+        parts = _extract_multimodal_content_list([part])
+        assert parts == [
+            {"type": "video_url", "video_url": {"url": "file:///tmp/a.mp4"}},
+        ]
+
+    def test_extract_multimodal_content_preserves_video_list(self):
+        """text + video_url content stays as a list for VLM processing."""
+        messages = [
+            Message(
+                role="user",
+                content=[
+                    {"type": "text", "text": "Describe this video"},
+                    {
+                        "type": "video_url",
+                        "video_url": {
+                            "url": "data:video/mp4;base64,AAA",
+                            "detail": "auto",
+                        },
+                    },
+                ],
+            )
+        ]
+        result = extract_multimodal_content(messages)
+        content = result[0]["content"]
+        assert isinstance(content, list)
+        assert [p["type"] for p in content] == ["text", "video_url"]
+        assert content[1] == {
+            "type": "video_url",
+            "video_url": {"url": "data:video/mp4;base64,AAA"},
+        }
+
+    def test_video_url_coexists_with_image_and_audio(self):
+        """text + image_url + video_url + input_audio preserve order and shape."""
+        parts = _extract_multimodal_content_list([
+            {"type": "text", "text": "Look, watch, and listen"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            {"type": "video_url", "video_url": "data:video/mp4;base64,AAA"},
+            {
+                "type": "input_audio",
+                "input_audio": {"data": "xyz", "format": "mp3"},
+            },
+        ])
+        assert len(parts) == 4
+        assert [p["type"] for p in parts] == [
+            "text",
+            "image_url",
+            "video_url",
+            "input_audio",
+        ]
+        assert parts[1] == {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,abc"},
+        }
+        assert parts[2] == {
+            "type": "video_url",
+            "video_url": {"url": "data:video/mp4;base64,AAA"},
+        }
+        assert parts[3] == {
+            "type": "input_audio",
+            "input_audio": {"data": "xyz", "format": "mp3"},
+        }
+
 
 # =============================================================================
 # Partial Mode & Name Preservation

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -3,16 +3,20 @@
 
 import base64
 import io
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 from PIL import Image
 
 from omlx.utils.image import (
+    TempVideoPath,
     compute_image_hash,
     compute_per_image_hashes,
     extract_images_from_messages,
+    extract_media_from_messages,
     load_image,
+    load_video_reference,
 )
 
 
@@ -375,6 +379,122 @@ class TestExtractImagesFromMessages:
         assert len(audio) == 1
         # Text content should be preserved
         assert "Describe this image and audio" in text_msgs[0]["content"]
+
+
+# =============================================================================
+# Tests: extract_media_from_messages (video)
+# =============================================================================
+
+
+class TestExtractMediaFromMessagesVideo:
+    """Tests for video_url extraction via extract_media_from_messages()."""
+
+    def test_video_url_data_uri_extracts_temp_file(self):
+        """Data URI video decodes to a temp file with matching bytes."""
+        payload = b"fake-mp4-bytes"
+        uri = (
+            "data:video/mp4;base64,"
+            + base64.b64encode(payload).decode("ascii")
+        )
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "video_url", "video_url": {"url": uri}},
+                    {"type": "text", "text": "Describe this clip"},
+                ],
+            },
+        ]
+
+        text_msgs, images, audio, videos = extract_media_from_messages(messages)
+
+        assert len(videos) == 1
+        assert len(images) == 0
+        assert len(audio) == 0
+        assert text_msgs[0]["content"] == "Describe this clip"
+        video_path = videos[0]
+        assert isinstance(video_path, TempVideoPath)
+        assert os.path.exists(video_path)
+        try:
+            with open(video_path, "rb") as handle:
+                assert handle.read() == payload
+        finally:
+            if os.path.exists(video_path):
+                os.unlink(video_path)
+
+    def test_video_url_string_form_extracts(self):
+        """String-form video_url returns one reference and strips media part."""
+        uri = "https://example.com/clip.mp4"
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "video_url", "video_url": uri},
+                    {"type": "text", "text": "What happens?"},
+                ],
+            },
+        ]
+
+        text_msgs, images, audio, videos = extract_media_from_messages(messages)
+
+        assert videos == [uri]
+        assert text_msgs[0]["content"] == "What happens?"
+
+    def test_video_url_file_path_passthrough(self):
+        """Local file path is returned unchanged."""
+        path = "/tmp/local_clip.mp4"
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "video_url", "video_url": {"url": path}},
+                ],
+            },
+        ]
+
+        _text_msgs, _images, _audio, videos = extract_media_from_messages(messages)
+
+        assert videos == [path]
+
+    def test_video_url_http_passthrough(self):
+        """HTTP URL is returned unchanged without fetching."""
+        url = "https://example.com/a.mp4"
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "video_url", "video_url": {"url": url}},
+                ],
+            },
+        ]
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            _text_msgs, _images, _audio, videos = extract_media_from_messages(messages)
+
+        mock_urlopen.assert_not_called()
+        assert videos == [url]
+
+    def test_video_url_invalid_base64_raises(self):
+        """Malformed base64 in a video data URI raises ValueError."""
+        with pytest.raises(ValueError, match=r"(?i)video.*base64|base64.*video"):
+            load_video_reference("data:video/mp4;base64,%%%")
+
+    def test_video_url_decoded_cap_raises(self, monkeypatch):
+        """Oversize decoded video payloads raise ValueError mentioning the cap."""
+        monkeypatch.setattr(
+            "omlx.utils.image.VIDEO_DECODED_SIZE_CAP",
+            4,
+        )
+        payload = b"12345"
+        uri = (
+            "data:video/mp4;base64,"
+            + base64.b64encode(payload).decode("ascii")
+        )
+        with pytest.raises(ValueError) as exc_info:
+            load_video_reference(uri)
+        message = str(exc_info.value).lower()
+        assert "video" in message
+        assert "100" in message or "cap" in message or "too large" in message
 
 
 # =============================================================================

--- a/tests/test_video_utils.py
+++ b/tests/test_video_utils.py
@@ -1,0 +1,180 @@
+"""Unit tests for torch-free Qwen3-VL video preprocessing."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from omlx.utils.video import TorchFreeQwen3VLVideoProcessor, smart_resize
+
+
+def _make_processor(**overrides):
+    image_processor = SimpleNamespace(
+        patch_size=16,
+        temporal_patch_size=2,
+        merge_size=2,
+        do_rescale=True,
+        rescale_factor=1 / 255.0,
+        do_normalize=True,
+        image_mean=[0.5, 0.5, 0.5],
+        image_std=[0.5, 0.5, 0.5],
+        do_convert_rgb=True,
+        **overrides,
+    )
+    return TorchFreeQwen3VLVideoProcessor(image_processor)
+
+
+def _make_video(num_frames: int, height: int, width: int, value: int = 0) -> np.ndarray:
+    return np.full((num_frames, height, width, 3), value, dtype=np.uint8)
+
+
+def test_shape_eight_frames_240x320():
+    processor = _make_processor()
+    video = _make_video(8, 240, 320)
+    out = processor([video])
+
+    resized_h, resized_w = smart_resize(
+        8,
+        240,
+        320,
+        temporal_factor=2,
+        factor=32,
+        min_pixels=processor.min_pixels,
+        max_pixels=processor.max_pixels,
+    )
+    grid_t = 4
+    grid_h = resized_h // 16
+    grid_w = resized_w // 16
+
+    assert resized_h == 256
+    assert resized_w == 320
+    assert out["pixel_values_videos"].shape == (
+        grid_t * grid_h * grid_w,
+        3 * 2 * 16 * 16,
+    )
+    assert out["video_grid_thw"].tolist() == [[grid_t, grid_h, grid_w]]
+
+
+def test_odd_frame_count_pads_last_frame():
+    processor = _make_processor()
+    video = _make_video(7, 240, 320)
+    out = processor([video])
+
+    resized_h, resized_w = smart_resize(
+        7,
+        240,
+        320,
+        temporal_factor=2,
+        factor=32,
+        min_pixels=processor.min_pixels,
+        max_pixels=processor.max_pixels,
+    )
+    grid_t = 4
+    grid_h = resized_h // 16
+    grid_w = resized_w // 16
+
+    assert out["video_grid_thw"].tolist() == [[grid_t, grid_h, grid_w]]
+    assert out["pixel_values_videos"].shape[0] == grid_t * grid_h * grid_w
+
+
+def test_normalization_constant_color():
+    processor = _make_processor()
+    video = _make_video(2, 32, 32, value=128)
+    out = processor([video])
+    expected = (128 / 255.0 - 0.5) / 0.5
+
+    values = out["pixel_values_videos"]
+    assert values.dtype == np.float32
+    np.testing.assert_allclose(values, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_patch_ordering_black_then_white():
+    processor = _make_processor()
+    frames = [
+        np.zeros((32, 32, 3), dtype=np.uint8),
+        np.full((32, 32, 3), 255, dtype=np.uint8),
+    ]
+    out = processor([frames])
+
+    black = (0 / 255.0 - 0.5) / 0.5
+    white = (1.0 - 0.5) / 0.5
+    patch = out["pixel_values_videos"][0]
+    spatial = 16 * 16
+    assert np.all(patch[0:spatial] == pytest.approx(black))
+    assert np.all(patch[spatial : 2 * spatial] == pytest.approx(white))
+
+
+def test_two_videos_concatenated_grids():
+    processor = _make_processor()
+    video_a = _make_video(4, 64, 64)
+    video_b = _make_video(4, 96, 128)
+    out = processor([video_a, video_b])
+
+    out_a = processor([video_a])
+    out_b = processor([video_b])
+    expected_rows = out_a["pixel_values_videos"].shape[0] + out_b["pixel_values_videos"].shape[0]
+
+    assert out["pixel_values_videos"].shape[0] == expected_rows
+    assert out["video_grid_thw"].shape == (2, 3)
+    assert out["video_grid_thw"].tolist() == [
+        out_a["video_grid_thw"][0].tolist(),
+        out_b["video_grid_thw"][0].tolist(),
+    ]
+
+
+def test_video_metadata_fields_and_fps():
+    processor = _make_processor()
+    video = _make_video(4, 64, 64)
+    out = processor([video], fps=3.5, return_metadata=True)
+
+    metadata = out["video_metadata"][0]
+    assert metadata.total_num_frames == 4
+    assert metadata.fps == 3.5
+    assert metadata.frames_indices == [0, 1, 2, 3]
+    assert metadata.width == 64
+    assert metadata.height == 64
+
+
+def test_output_dtype_float32():
+    processor = _make_processor()
+    video = _make_video(2, 32, 32)
+    out = processor([video])
+    assert out["pixel_values_videos"].dtype == np.float32
+
+
+def test_default_call_output_is_mlx_convertible():
+    import mlx.core as mx
+
+    processor = _make_processor()
+    video = _make_video(4, 64, 64)
+    out = processor([video])
+
+    assert set(out.keys()) == {"pixel_values_videos", "video_grid_thw"}
+    for value in out.values():
+        mx.array(value)
+
+
+def test_return_metadata_opt_in():
+    processor = _make_processor()
+    video = _make_video(4, 64, 64)
+    out = processor([video], fps=3.5, return_metadata=True)
+
+    assert "video_metadata" in out
+    assert out["video_metadata"][0].fps == 3.5
+
+
+def test_shim_attributes_from_image_processor():
+    image_processor = SimpleNamespace(
+        patch_size=16,
+        temporal_patch_size=2,
+        merge_size=2,
+        do_rescale=True,
+        rescale_factor=1 / 255.0,
+        do_normalize=True,
+        image_mean=[0.5, 0.5, 0.5],
+        image_std=[0.5, 0.5, 0.5],
+        do_convert_rgb=True,
+    )
+    processor = TorchFreeQwen3VLVideoProcessor(image_processor)
+    assert processor.merge_size == 2
+    assert processor.temporal_patch_size == 2

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -1018,6 +1018,7 @@ class TestProcessChatMessages:
             text_msgs,
             [],
             audio=None,
+            videos=None,
             chat_template_kwargs=None,
             tools=None,
         )
@@ -1137,6 +1138,66 @@ class TestProcessChatMessages:
 
         call_kwargs = engine._prepare_vision_inputs.call_args[1]
         assert call_kwargs["tools"] is None
+
+    @patch("omlx.engine.vlm.extract_media_from_messages")
+    def test_process_chat_messages_passes_videos_to_prepare(self, mock_extract):
+        """Video references are forwarded to _prepare_vision_inputs()."""
+        text_msgs = [{"role": "user", "content": "Describe"}]
+        mock_extract.return_value = (text_msgs, [], [], ["/tmp/a.mp4"])
+
+        engine = _make_loaded_engine()
+        engine._prepare_vision_inputs = MagicMock(
+            return_value=([1, 2, 3], None, None, None, 0, [])
+        )
+
+        messages = [{"role": "user", "content": "Describe"}]
+        engine._process_chat_messages(messages, tools=None, kwargs={})
+
+        engine._prepare_vision_inputs.assert_called_once_with(
+            text_msgs,
+            [],
+            audio=None,
+            videos=["/tmp/a.mp4"],
+            chat_template_kwargs=None,
+            tools=None,
+        )
+
+    def test_text_only_and_image_only_paths_unchanged(self):
+        """Text-only and image-only paths still pass videos=None to prepare."""
+        engine = _make_loaded_engine()
+        engine._prepare_vision_inputs = MagicMock(
+            return_value=([1, 2, 3], None, None, None, 0, [])
+        )
+
+        with patch(
+            "omlx.engine.vlm.extract_media_from_messages",
+            return_value=([{"role": "user", "content": "Hi"}], [], [], []),
+        ):
+            result = engine._process_chat_messages(
+                [{"role": "user", "content": "Hi"}],
+                tools=None,
+                kwargs={},
+            )
+
+        assert result == ([1, 2, 3], None, None, None, 0, [])
+        assert engine._prepare_vision_inputs.call_args[1]["videos"] is None
+
+        from PIL import Image
+
+        mock_image = Image.new("RGB", (4, 4), "red")
+        text_msgs = [{"role": "user", "content": "Describe"}]
+        engine._apply_ocr_prompt = MagicMock(return_value=text_msgs)
+        with patch(
+            "omlx.engine.vlm.extract_media_from_messages",
+            return_value=(text_msgs, [mock_image], [], []),
+        ):
+            engine._process_chat_messages(
+                [{"role": "user", "content": "Describe"}],
+                tools=None,
+                kwargs={},
+            )
+
+        assert engine._prepare_vision_inputs.call_args[1]["videos"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -1852,6 +1913,162 @@ class TestSplitVisionFeatures:
 
 
 # ---------------------------------------------------------------------------
+# TestVideoVLMPath
+# ---------------------------------------------------------------------------
+
+
+class TestVideoVLMPath:
+    """Tests for video_url decoding and mlx-vlm video input plumbing."""
+
+    def test_format_messages_for_vlm_template_adds_video_message(self, monkeypatch):
+        """Video-bearing user turns emit mlx-vlm video placeholders."""
+        captured = {}
+
+        def fake_get_message_json(model_type, content, role, **kwargs):
+            captured.update(kwargs)
+            return {
+                "role": role,
+                "content": [
+                    {
+                        "type": "video",
+                        "video": kwargs.get("video"),
+                        "fps": 1,
+                    },
+                    {"type": "text", "text": content},
+                ],
+            }
+
+        monkeypatch.setattr(
+            "mlx_vlm.prompt_utils.get_message_json",
+            fake_get_message_json,
+        )
+
+        engine = _make_loaded_engine(model_type="qwen3_5_moe")
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "/tmp/a.mp4"},
+                    },
+                    {"type": "text", "text": "Describe"},
+                ],
+            },
+        ]
+
+        formatted, image_ranges = engine._format_messages_for_vlm_template(
+            messages,
+            num_images=0,
+            num_audios=0,
+            num_videos=1,
+            videos=["/tmp/a.mp4"],
+        )
+
+        assert captured.get("video") == "/tmp/a.mp4"
+        assert captured.get("num_images") == 0
+        assert captured.get("num_audios") == 0
+        assert image_ranges == []
+        assert formatted[0]["content"][0]["type"] == "video"
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    def test_prepare_vision_inputs_passes_videos_to_prepare_inputs(self, mock_prepare):
+        """prepare_inputs receives videos= and video_grid_thw survives embedding kwargs."""
+        engine = _make_loaded_engine(model_type="qwen3_5_moe")
+        mock_processor = MagicMock()
+        mock_processor.apply_chat_template.return_value = "<prompt>"
+        mock_processor.tokenizer = engine._tokenizer
+        engine._processor = mock_processor
+
+        grid = mx.array([[2, 4, 4]])
+        mock_prepare.return_value = {
+            "input_ids": mx.array([[1, 2, 3]]),
+            "attention_mask": mx.array([[1, 1, 1]]),
+            "pixel_values_videos": mx.zeros((1, 3, 8, 8)),
+            "video_grid_thw": grid,
+        }
+
+        embed_features = MagicMock()
+        embed_features.inputs_embeds = mx.zeros((1, 3, 16))
+        embed_features.to_dict.return_value = {}
+        engine._vlm_model.get_input_embeddings = MagicMock(return_value=embed_features)
+
+        messages = [{"role": "user", "content": "Describe"}]
+        token_ids, embeds, vlm_kwargs, image_hash, cache_start, cache_ranges = (
+            engine._prepare_vision_inputs(
+                messages,
+                [],
+                videos=["/tmp/a.mp4"],
+            )
+        )
+
+        assert mock_prepare.call_args[1]["videos"] == ["/tmp/a.mp4"]
+        assert token_ids == [1, 2, 3]
+        assert embeds is not None
+        assert image_hash is None
+        assert cache_start == 0
+        assert cache_ranges == []
+        engine._vlm_model.get_input_embeddings.assert_called_once()
+        call_kwargs = engine._vlm_model.get_input_embeddings.call_args[1]
+        assert call_kwargs["video_grid_thw"] is grid
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_video_grid_thw_uses_qwen_vision_tower(self):
+        """video_grid_thw routes through the qwen vision tower when no image grid."""
+        engine = _make_loaded_engine(model_type="qwen3_5_moe")
+        mock_tower = MagicMock(return_value=mx.ones((4, 128)))
+        mock_weight = SimpleNamespace(dtype=mx.float32)
+        mock_tower.patch_embed.proj.weight = mock_weight
+        engine._vlm_model = SimpleNamespace(
+            config=engine._vlm_model.config,
+            vision_tower=mock_tower,
+        )
+
+        grid = mx.array([[1, 4, 4]])
+        pixel_values = mx.zeros((1, 3, 8, 8))
+
+        engine._compute_vision_features(
+            pixel_values,
+            {"video_grid_thw": grid},
+        )
+
+        mock_tower.assert_called_once()
+        assert mock_tower.call_args[0][1] is grid
+
+    @pytest.mark.asyncio
+    async def test_preflight_counts_video_parts(self):
+        """preflight_chat adds a conservative video token budget."""
+        from omlx.engine.vlm import _VIDEO_TOKEN_UPPER_BOUND_FALLBACK
+
+        engine = _make_loaded_engine(model_type="qwen3_5_moe")
+        engine._tokenizer = MockVLMTokenizer()
+        engine._tokenizer.encode = MagicMock(return_value=list(range(42)))
+
+        mock_scheduler = MagicMock()
+        engine._engine.engine = MagicMock()
+        engine._engine.engine.scheduler = mock_scheduler
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "https://example.com/a.mp4"},
+                    },
+                    {"type": "text", "text": "Describe"},
+                ],
+            },
+        ]
+
+        await engine.preflight_chat(messages)
+
+        seen = mock_scheduler.preflight_or_raise.call_args[1]
+        assert seen["num_prompt_tokens"] == 42 + _VIDEO_TOKEN_UPPER_BOUND_FALLBACK
+
+
+# ---------------------------------------------------------------------------
 # TestStopSafety
 # ---------------------------------------------------------------------------
 
@@ -1900,6 +2117,75 @@ class TestStopSafety:
 
         mock_inner_engine.close.assert_called_once()
 
+
+# ---------------------------------------------------------------------------
+# Torch-free video processor shim attach
+# ---------------------------------------------------------------------------
+
+
+class TestTorchFreeVideoProcessorAttach:
+    """Tests for _attach_torch_free_video_processor at processor load."""
+
+    def test_attaches_when_video_token_and_no_video_processor(self):
+        from omlx.engine.vlm import _attach_torch_free_video_processor
+
+        ip = SimpleNamespace(
+            patch_size=16,
+            temporal_patch_size=2,
+            merge_size=2,
+            do_rescale=True,
+            rescale_factor=1 / 255.0,
+            do_normalize=True,
+            image_mean=[0.5, 0.5, 0.5],
+            image_std=[0.5, 0.5, 0.5],
+            do_convert_rgb=True,
+        )
+
+        class FakeProcessor:
+            video_token = "<|video_pad|>"
+            image_processor = ip
+
+        processor = FakeProcessor()
+        _attach_torch_free_video_processor(processor)
+
+        from omlx.utils.video import TorchFreeQwen3VLVideoProcessor
+
+        assert isinstance(processor.video_processor, TorchFreeQwen3VLVideoProcessor)
+
+    def test_leaves_existing_video_processor_untouched(self):
+        from omlx.engine.vlm import _attach_torch_free_video_processor
+
+        existing = object()
+
+        class Qwen3VLProcessor:
+            video_token = "<|video_pad|>"
+            video_processor = existing
+            image_processor = SimpleNamespace(patch_size=16)
+
+        processor = Qwen3VLProcessor()
+        _attach_torch_free_video_processor(processor)
+
+        assert processor.video_processor is existing
+
+    def test_degrades_when_shim_construction_raises(self, caplog):
+        from omlx.engine.vlm import _attach_torch_free_video_processor
+
+        class Qwen3VLProcessor:
+            video_token = "<|video_pad|>"
+            image_processor = SimpleNamespace(patch_size=16)
+
+        processor = Qwen3VLProcessor()
+        assert not hasattr(processor, "video_processor")
+
+        with patch(
+            "omlx.utils.video.TorchFreeQwen3VLVideoProcessor",
+            side_effect=RuntimeError("shim failed"),
+        ):
+            with caplog.at_level("WARNING"):
+                _attach_torch_free_video_processor(processor)
+
+        assert "Failed to attach torch-free video processor shim" in caplog.text
+        assert not hasattr(processor, "video_processor")
     @pytest.mark.asyncio
     async def test_stop_drops_vlm_refs_and_cache_before_inner_close(self):
         """VLM wrapper refs and feature cache are released before final reclaim."""


### PR DESCRIPTION
## What

Adds native `video_url` content-part support to the OpenAI chat-completions
route for Qwen3-VL-family VLMs (tested end-to-end on Qwen3.6-35B-A3B 8-bit).
Previously, `{"type": "video_url", ...}` parts were silently dropped before
reaching the engine; users had to pre-extract frames client-side and send
them as multiple `image_url` parts, losing the model's real temporal video
path (`video_grid_thw` + video tokens).

```jsonc
{"role": "user", "content": [
  {"type": "text", "text": "Describe this video."},
  {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,..."}}
]}
```

Data URLs, local file paths, and http(s) URLs are accepted (data URLs are
decoded to a temp file with a 100 MiB cap and cleaned up after prefill).

## Why the shim (`omlx/utils/video.py`)

oMLX runs torch-free, and transformers' `Qwen3VLVideoProcessor` is
torchvision-gated — `AutoProcessor.from_pretrained` can't even construct it
without torch, which is why `_patch_video_processor_bug()` strips
`video_processor` today (kept intact by this PR). Unlike images, transformers
ships no PIL-backend video processor, so this PR adds
`TorchFreeQwen3VLVideoProcessor`: a numpy/PIL reimplementation of the
reference preprocessing (smart_resize → rescale/normalize → temporal pairing
→ patchify → `pixel_values_videos` + `video_grid_thw`), attached as
`processor.video_processor` after load for Qwen3-VL-family processors only.
Attachment is fail-soft: if construction raises, serving degrades to current
behavior (warning logged, images unaffected).

`video_metadata` is opt-in (`return_metadata=True`) because mlx-vlm's
processor wrapper merges the video processor's entire output into
`to_mlx(...)` — metadata objects would break MLX array conversion.

## Changes

- `omlx/api/openai_models.py` — `VideoURL` model, `video_url` on `ContentPart`
- `omlx/api/utils.py` — preserve/normalize `video_url` parts through
  multimodal extraction (nested-dict, string, and pydantic forms)
- `omlx/utils/image.py` — `extract_media_from_messages()` returning
  `(text, images, audio, videos)`; existing `extract_images_from_messages()`
  keeps its exact 3-tuple contract as a thin delegation
- `omlx/engine/vlm.py` — video part counting in preflight, `num_videos`
  template formatting via `get_message_json(video=...)`,
  `prepare_inputs(videos=...)`, `video_grid_thw` into the existing
  qwen vision-feature path, temp cleanup, shim attach point
- `omlx/utils/video.py` + `tests/test_video_utils.py` — the shim and its
  exact tensor-math tests (shape/grid, normalization values, patch-order
  trap with black/white temporal halves, odd-frame handling, MLX
  convertibility of default output)

## Testing

- ~30 new unit tests, no torch imports, no model weights needed;
  `pytest tests/ -m "not slow and not integration"` green (5574 → 5592+).
- Live E2E on Qwen3.6-35B-A3B-oQ8-mtp (M3 Ultra): data-URL mp4 of a moving
  blue square → model reports object/color/direction correctly; ~350 video
  prompt tokens for 8 sampled frames; images/tool-calling regression-clean;
  no temp-file leaks.

## Out of scope

Anthropic route, audio, video feature caching (image feature cache bypassed
when videos present), streaming video.
