### PR TITLE
feat(diffusion): enable tool calling on the serial diffusion lane

### DIFF
--- a/omlx/adapter/gemma4.py
+++ b/omlx/adapter/gemma4.py
@@ -301,6 +301,7 @@ class Gemma4OutputParserSession:
         self._tokenizer = tokenizer
         self._buffer = ""
         self._in_thought = False
+        self._text_mode = False
 
         self._detokenizer = create_streaming_detokenizer(tokenizer, model_path)
         if self._detokenizer is not None:
@@ -449,9 +450,24 @@ class Gemma4OutputParserSession:
             text = self._tokenizer.decode([token_id])
         return self._consume_text(text)
 
+    def process_text(self, text: str) -> OutputParserTokenResult:
+        """Process an already-detokenized text segment.
+
+        Engines that emit text segments instead of token ids (the serial
+        diffusion lane detokenizes inside ``stream_diffusion_generate``)
+        feed their output through this entry point so protocol markers
+        are handled identically to the token-id path.  Switches the
+        session to text mode so ``finalize`` does not flush the unused
+        token detokenizer.
+        """
+        self._text_mode = True
+        if not text:
+            return OutputParserTokenResult(stream_text="", visible_text="")
+        return self._consume_text(text)
+
     def finalize(self) -> OutputParserFinalizeResult:
         text = ""
-        if self._detokenizer is not None:
+        if self._detokenizer is not None and not self._text_mode:
             self._detokenizer.finalize()
             text = self._detokenizer.last_segment
 

--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -64,6 +64,12 @@ class OutputParserFactory:
     stop_token_ids: set[int] = field(default_factory=set)
     thinking_end_text: str | None = None
     thinking_end_trailing_text: str | None = None
+    # Marker strings that must survive special-token stripping so the
+    # parser session can see them in the text stream.  Engines that strip
+    # special tokens during detokenization (e.g. the serial diffusion
+    # lane) preserve the token ids of these markers and let the parser
+    # session remove them instead.
+    protocol_marker_texts: tuple[str, ...] = ()
 
 
 class HarmonyOutputParserSession:
@@ -295,7 +301,14 @@ def detect_output_parser(
         )
 
     if is_gemma4_model(model_name, model_config):
-        from .gemma4 import Gemma4OutputParserSession
+        from .gemma4 import (
+            _CLOSE_MARKER,
+            _OPEN_MARKER_BARE,
+            _TOOL_RESPONSE_CLOSE,
+            _TOOL_RESPONSE_OPEN,
+            _TURN_END_MARKER,
+            Gemma4OutputParserSession,
+        )
 
         return OutputParserFactory(
             kind="gemma4",
@@ -305,6 +318,13 @@ def detect_output_parser(
             ),
             stop_token_ids=set(),
             thinking_end_text="<channel|>",
+            protocol_marker_texts=(
+                _OPEN_MARKER_BARE,
+                _CLOSE_MARKER,
+                _TURN_END_MARKER,
+                _TOOL_RESPONSE_OPEN,
+                _TOOL_RESPONSE_CLOSE,
+            ),
         )
 
     if _is_cohere2_moe_model(model_name, model_config):

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -450,14 +450,18 @@ def _entry_is_diffusion_model(entry) -> bool:
 
 
 def _sanitize_diffusion_settings_dict(settings: dict) -> None:
-    """Clear unsupported diffusion-lane settings before ModelSettings parsing."""
+    """Clear unsupported diffusion-lane settings before ModelSettings parsing.
+
+    Tool-calling settings (``max_tool_result_tokens``) are intentionally NOT
+    cleared: tool calling is prompt-driven plus output parsing and works on
+    the diffusion lane when a tool parser matches the chat template.
+    """
     unsupported_none_fields = (
         "top_p",
         "top_k",
         "min_p",
         "repetition_penalty",
         "presence_penalty",
-        "max_tool_result_tokens",
         "enable_thinking",
         "preserve_thinking",
         "thinking_budget_tokens",
@@ -519,14 +523,17 @@ def _sanitize_diffusion_settings_dict(settings: dict) -> None:
 
 
 def _sanitize_diffusion_model_settings(settings) -> None:
-    """Clear settings that the serial diffusion lane does not implement."""
+    """Clear settings that the serial diffusion lane does not implement.
+
+    ``max_tool_result_tokens`` is intentionally preserved — tool calling
+    works on the diffusion lane (prompt-driven + output parsing).
+    """
     settings.top_p = None
     settings.top_k = None
     settings.min_p = None
     settings.repetition_penalty = None
     settings.presence_penalty = None
     settings.force_sampling = False
-    settings.max_tool_result_tokens = None
     settings.enable_thinking = None
     settings.preserve_thinking = None
     settings.thinking_budget_enabled = False

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -427,10 +427,46 @@ def _gemma4_args_to_json_robust(args_str: str) -> dict:
         except (json.JSONDecodeError, ValueError):
             return f": {json.dumps(value)}{suffix}"
 
+    # Keep the pre-step-5 text: if step 5 fails, its partial quoting has
+    # corrupted multi-line bare values and step 6 must start clean.
+    pre_quote_text = text
     text = regex.sub(
         r"(:\s*)([^\",\[\]{}\s][^,}]*?)(\s*[,}])", _quote_bare, text
     )
-    return json.loads(text)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # 6. Last resort: key-anchored value capture. Bare values that
+    # themselves contain commas, braces, or newlines (e.g. long markdown
+    # emitted into an ``answer:`` argument — observed live on the
+    # diffusion lane) defeat the per-pair regex in step 5. Anchor on the
+    # quoted keys produced by step 2 and treat everything between a
+    # key's colon and the next key (or the end) as that key's value.
+    # Operates on the pre-step-5 text so step 5's partial quoting cannot
+    # corrupt the captured values.
+    inner = pre_quote_text.strip()
+    if inner.startswith("{") and inner.endswith("}"):
+        inner = inner[1:-1]
+    key_pat = regex.compile(r'"([A-Za-z_]\w*)"\s*:')
+    key_matches = list(key_pat.finditer(inner))
+    if not key_matches:
+        return json.loads(text)  # re-raise original-style error
+    result: dict = {}
+    for i, km in enumerate(key_matches):
+        value_start = km.end()
+        value_end = (
+            key_matches[i + 1].start() if i + 1 < len(key_matches) else len(inner)
+        )
+        raw_value = inner[value_start:value_end].strip()
+        if i + 1 < len(key_matches):
+            raw_value = raw_value.rstrip().rstrip(",").rstrip()
+        try:
+            result[km.group(1)] = json.loads(raw_value)
+        except (json.JSONDecodeError, ValueError):
+            result[km.group(1)] = raw_value
+    return result
 
 
 def _parse_gemma4_tool_call_fallback(text: str) -> Union[dict, list]:
@@ -440,11 +476,18 @@ def _parse_gemma4_tool_call_fallback(text: str) -> Union[dict, list]:
     Extends mlx-lm's parser to handle:
     - Bare string values without ``<|"|>`` delimiters
     - Colons / dots / hyphens in function names
+    - Degenerate prefixes from the diffusion lane's parallel denoising,
+      which can drop a token from the opening (observed live:
+      ``calldone{...}`` — missing colon — and ``:done{...}`` — missing
+      ``call``). The text is already marker-delimited (between
+      ``<|tool_call>`` and ``<tool_call|>``), so a permissive prefix
+      cannot misfire on ordinary prose.
     """
     import regex
 
     pattern = regex.compile(
-        r"call:([\w:.-]+)(\{(?:[^{}]|(?2))*\})", regex.DOTALL
+        r"(?:call)?:?([\w.-]+(?::[\w.-]+)*)(\{(?:[^{}]|(?2))*\})",
+        regex.DOTALL,
     )
     matches = list(pattern.finditer(text))
     if not matches:

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -805,8 +805,27 @@ class VLMBatchedEngine(BaseEngine):
         return getattr(self, "_diffusion_family", None) == "block"
 
     @property
+    def supports_tool_calling(self) -> bool:
+        """True when a tool parser was injected into the tokenizer.
+
+        Tool calling is prompt-driven plus output parsing — it does not
+        require grammar-constrained decoding, so it works on any lane
+        (autoregressive or diffusion) whose chat template matched a
+        parser in ``_inject_tool_calling``.
+        """
+        return bool(getattr(self._tokenizer, "has_tool_calling", False))
+
+    @property
     def grammar_compiler(self):
         """Lazily create and return a GrammarCompiler for this VLM model."""
+        if self.is_diffusion_model:
+            # The diffusion lane denoises canvas positions in parallel —
+            # there is no sequential logit stream to mask, so compiled
+            # grammars cannot be enforced. Returning None routes
+            # response_format through the existing prompt-injection
+            # fallback (with the #1241 Warning header) instead of
+            # compiling a grammar that the lane would have to reject.
+            return None
         if self._grammar_compiler is not None:
             return self._grammar_compiler
         if self._grammar_compiler_init_attempted:
@@ -2802,9 +2821,10 @@ class VLMBatchedEngine(BaseEngine):
         if not self.is_diffusion_model:
             return
         kwargs = kwargs or {}
-        if tools:
+        if tools and not self.supports_tool_calling:
             raise InvalidRequestError(
-                "Tool calling is not supported with diffusion models.",
+                "Tool calling is not supported for this diffusion model "
+                "(no tool parser matched its chat template).",
                 field="tools",
             )
         if audio:
@@ -2999,6 +3019,63 @@ class VLMBatchedEngine(BaseEngine):
         block_text: list[str] = []
         emitted_tokens = 0
         last_stream_segment = ""
+
+        # Special tokens are stripped from the stream, EXCEPT protocol
+        # markers the model's output parser needs to see in the text:
+        # tool-call markers (e.g. Gemma's <|tool_call> / <tool_call|>)
+        # for the tool parser, and channel/turn markers for the output
+        # parser session (thought-channel → <think> conversion). They
+        # are removed downstream (parser session / parse_tool_calls /
+        # ToolCallStreamFilter) so they never leak to clients.
+        skip_special_ids = set(getattr(tokenizer, "all_special_ids", None) or [])
+        preserved_marker_texts: list[str] = []
+        if getattr(tokenizer, "has_tool_calling", False):
+            preserved_marker_texts.extend(
+                m
+                for m in (
+                    getattr(tokenizer, "tool_call_start", None),
+                    getattr(tokenizer, "tool_call_end", None),
+                )
+                if m
+            )
+
+        # Detect a protocol output parser (e.g. gemma4 channel markers).
+        # The diffusion lane emits detokenized text segments, so only
+        # sessions exposing ``process_text`` can be used here.
+        parser_session = None
+        try:
+            from ..adapter.output_parser import detect_output_parser
+
+            model_config = (
+                {"model_type": self.model_type} if self.model_type else None
+            )
+            factory = detect_output_parser(
+                self._model_name, tokenizer, model_config
+            )
+            if factory is not None:
+                session = factory.create_session(tokenizer)
+                if hasattr(session, "process_text"):
+                    parser_session = session
+                    preserved_marker_texts.extend(factory.protocol_marker_texts)
+        except Exception as e:
+            logger.debug("Diffusion output parser unavailable: %s", e)
+            parser_session = None
+
+        for marker in preserved_marker_texts:
+            try:
+                marker_id = tokenizer.convert_tokens_to_ids(marker)
+            except Exception:
+                marker_id = None
+            if marker_id is not None:
+                skip_special_ids.discard(marker_id)
+
+        def _parse_block(text: str, *, final: bool = False) -> str:
+            if parser_session is None:
+                return text
+            parsed = parser_session.process_text(text).visible_text
+            if final:
+                parsed += parser_session.finalize().visible_text
+            return parsed
         try:
             with limit_ctx:
                 results = stream_diffusion_generate(
@@ -3010,9 +3087,7 @@ class VLMBatchedEngine(BaseEngine):
                     diffusion_inputs.get("attention_mask"),
                     max_tokens=max_tokens,
                     temperature=temperature,
-                    skip_special_token_ids=set(
-                        getattr(tokenizer, "all_special_ids", None) or []
-                    ),
+                    skip_special_token_ids=skip_special_ids,
                     mm_token_type_ids=diffusion_inputs.get("mm_token_type_ids"),
                     prefill_step_size=DIFFUSION_PREFILL_STEP_SIZE,
                 )
@@ -3042,7 +3117,10 @@ class VLMBatchedEngine(BaseEngine):
                         continue
 
                     new_text = remove_special_tokens_preserve_whitespace(
-                        "".join(block_text)
+                        _parse_block(
+                            "".join(block_text),
+                            final=finish_reason is not None,
+                        )
                     )
                     full_text += new_text
                     completion_tokens = int(result_tokens or emitted_tokens)

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2929,10 +2929,13 @@ async def create_chat_completion(
     # Merge MCP tools with user-provided tools unless the request explicitly
     # disables tool use.
     tools_disabled = request.tool_choice == "none"
-    if getattr(engine, "is_diffusion_model", False):
+    if getattr(engine, "is_diffusion_model", False) and not getattr(
+        engine, "supports_tool_calling", False
+    ):
         if request.tools and not tools_disabled:
             raise InvalidRequestError(
-                "Tool calling is not supported with diffusion models.",
+                "Tool calling is not supported for this diffusion model "
+                "(no tool parser matched its chat template).",
                 field="tools",
             )
         tools_disabled = True
@@ -3287,16 +3290,18 @@ def _reject_diffusion_structured_outputs(
 ) -> None:
     if not getattr(engine, "is_diffusion_model", False):
         return
-    response_format_needs_grammar = _response_format_requests_grammar(response_format)
-    if (
-        structured_outputs is None
-        and not guided_grammar
-        and not response_format_needs_grammar
-    ):
+    # ``response_format`` (json_object / json_schema) is NOT rejected here:
+    # it degrades to prompt-injected JSON with a Warning header, the same
+    # fallback used when xgrammar is unavailable (#1241).  Only explicit
+    # grammar requests — ``structured_outputs`` and ``guided_grammar`` —
+    # are rejected, because logit-mask enforcement has no equivalent in
+    # the parallel denoising loop.
+    if structured_outputs is None and not guided_grammar:
         return
     raise InvalidRequestError(
-        "Structured response_format and guided grammar are not supported "
-        "with diffusion models.",
+        "structured_outputs and guided grammar are not supported "
+        "with diffusion models (response_format degrades to "
+        "prompt-injected JSON).",
         field="response_format",
     )
 
@@ -4684,10 +4689,13 @@ async def create_anthropic_message(
 
     # Merge MCP tools with user-provided Anthropic tools
     user_internal = convert_anthropic_tools_to_internal(request.tools)
-    if getattr(engine, "is_diffusion_model", False):
+    if getattr(engine, "is_diffusion_model", False) and not getattr(
+        engine, "supports_tool_calling", False
+    ):
         if user_internal:
             raise InvalidRequestError(
-                "Tool calling is not supported with diffusion models.",
+                "Tool calling is not supported for this diffusion model "
+                "(no tool parser matched its chat template).",
                 field="tools",
             )
         internal_tools = None
@@ -4999,9 +5007,14 @@ async def create_response(
 
     # Convert tools: flat → nested
     openai_tools = convert_responses_tools(request.tools)
-    if getattr(engine, "is_diffusion_model", False) and openai_tools:
+    if (
+        getattr(engine, "is_diffusion_model", False)
+        and not getattr(engine, "supports_tool_calling", False)
+        and openai_tools
+    ):
         raise InvalidRequestError(
-            "Tool calling is not supported with diffusion models.",
+            "Tool calling is not supported for this diffusion model "
+            "(no tool parser matched its chat template).",
             field="tools",
         )
 
@@ -5069,7 +5082,12 @@ async def create_response(
 
     # Merge MCP tools
     effective_tools = (
-        None if getattr(engine, "is_diffusion_model", False) else openai_tools
+        None
+        if (
+            getattr(engine, "is_diffusion_model", False)
+            and not getattr(engine, "supports_tool_calling", False)
+        )
+        else openai_tools
     )
     if _server_state.mcp_manager and effective_tools:
         effective_tools = _server_state.mcp_manager.get_merged_tools(openai_tools)

--- a/omlx/utils/tokenizer.py
+++ b/omlx/utils/tokenizer.py
@@ -120,7 +120,9 @@ def is_gemma4_model(model_name: str, config: dict[str, Any] | None = None) -> bo
     """
     if config is not None:
         model_type = config.get("model_type", "")
-        if model_type in {"gemma4", "gemma4_unified"}:
+        # diffusion_gemma shares Gemma 4's wire protocol (channel markers,
+        # call:name{...} tool calls), so it uses the same parser/extractor.
+        if model_type in {"gemma4", "gemma4_unified", "diffusion_gemma"}:
             logger.debug(f"Gemma 4 model detected via config.model_type: {model_name}")
             return True
 

--- a/tests/test_admin_profiles_api.py
+++ b/tests/test_admin_profiles_api.py
@@ -180,7 +180,9 @@ class TestProfileRoutes:
         assert "top_p" not in settings
         assert settings["guided_grammar_enabled"] is False
         assert "guided_grammar" not in settings
-        assert "max_tool_result_tokens" not in settings
+        # Tool calling works on the diffusion lane (prompt-driven +
+        # output parsing), so its settings are preserved.
+        assert settings["max_tool_result_tokens"] == 4096
         assert settings["turboquant_kv_enabled"] is False
         assert settings["specprefill_enabled"] is False
         assert settings["dflash_enabled"] is False
@@ -374,7 +376,8 @@ class TestModelsResponseActiveProfile:
         assert settings["force_sampling"] is False
         assert settings["guided_grammar_enabled"] is False
         assert "guided_grammar" not in settings
-        assert "max_tool_result_tokens" not in settings
+        # Tool calling works on the diffusion lane; setting preserved.
+        assert settings["max_tool_result_tokens"] == 4096
         assert settings["turboquant_kv_enabled"] is False
         assert settings["specprefill_enabled"] is False
         assert settings["dflash_enabled"] is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -73,11 +73,20 @@ class TestDiffusionStructuredOutputGuard:
             response_format={"type": "text"},
         )
 
-    def test_rejects_json_response_format(self):
-        with pytest.raises(InvalidRequestError, match="Structured response_format"):
+    def test_allows_json_response_format_degrades_to_prompt(self):
+        # response_format degrades to prompt-injected JSON (with the
+        # #1241 Warning header) instead of being rejected — the same
+        # fallback used when xgrammar is not installed.
+        _reject_diffusion_structured_outputs(
+            self._DiffusionEngine(),
+            response_format={"type": "json_object"},
+        )
+
+    def test_rejects_structured_outputs(self):
+        with pytest.raises(InvalidRequestError, match="structured_outputs"):
             _reject_diffusion_structured_outputs(
                 self._DiffusionEngine(),
-                response_format={"type": "json_object"},
+                structured_outputs={"json_schema": {"type": "object"}},
             )
 
     def test_rejects_guided_grammar(self):

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -1806,6 +1806,48 @@ class TestParseGemma4ToolCallFallback:
         with pytest.raises(ValueError):
             _parse_gemma4_tool_call_fallback("not a tool call")
 
+    def test_degenerate_prefix_missing_colon(self):
+        """Diffusion lane can drop the colon: ``calldone{...}``."""
+        result = _parse_gemma4_tool_call_fallback('calldone{answer: ok}')
+        assert result["name"] == "done"
+        assert result["arguments"] == {"answer": "ok"}
+
+    def test_degenerate_prefix_missing_call(self):
+        """Diffusion lane can drop ``call``: ``:done{...}``."""
+        result = _parse_gemma4_tool_call_fallback(':done{answer: ok}')
+        assert result["name"] == "done"
+        assert result["arguments"] == {"answer": "ok"}
+
+    def test_long_bare_value_with_commas_and_newlines(self):
+        """Key-anchored capture recovers markdown-laden bare values
+        (observed live: hindsight reflect ``done`` calls whose ``answer``
+        contains tables, commas, and newlines)."""
+        text = (
+            "calldone{answer:# Title\n\n"
+            "| A | B |\n| :--- | :--- |\n| x, y | z |\n"
+            ",directive_compliance:1. ok. 2. fine."
+            ",memory_ids:[mm-abc123]"
+            ",mental_model_ids:[]"
+            ",observation_ids:[]}"
+        )
+        result = _parse_gemma4_tool_call_fallback(text)
+        assert result["name"] == "done"
+        args = result["arguments"]
+        assert set(args.keys()) == {
+            "answer",
+            "directive_compliance",
+            "memory_ids",
+            "mental_model_ids",
+            "observation_ids",
+        }
+        assert args["answer"].startswith("# Title")
+        assert "x, y" in args["answer"]
+        assert args["observation_ids"] == []
+
+    def test_prose_without_braces_still_raises(self):
+        with pytest.raises(ValueError):
+            _parse_gemma4_tool_call_fallback("just words, no payload")
+
 
 class TestParseToolCallsGemma4Integration:
     """Integration tests for parse_tool_calls() with Gemma 4 tokenizer."""

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -247,6 +247,7 @@ class TestVLMDiffusionLane:
         not HAS_MLX, reason="mlx is required to import VLMBatchedEngine"
     )
     async def test_diffusion_preflight_rejects_tools(self):
+        """Tools rejected when no tool parser matched the chat template."""
         from omlx.exceptions import InvalidRequestError
 
         engine = _make_loaded_engine(model_type="diffusion_gemma")
@@ -257,6 +258,41 @@ class TestVLMDiffusionLane:
                 [{"role": "user", "content": "hi"}],
                 tools=[{"type": "function", "function": {"name": "lookup"}}],
             )
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not HAS_MLX, reason="mlx is required to import VLMBatchedEngine"
+    )
+    async def test_diffusion_preflight_allows_tools_with_parser(self):
+        """Tools accepted when the tokenizer has an injected tool parser."""
+        tokenizer = MockVLMTokenizer()
+        tokenizer.has_tool_calling = True
+        tokenizer.tool_call_start = "<|tool_call>"
+        tokenizer.tool_call_end = "<tool_call|>"
+        tokenizer.tool_parser = lambda text, tools=None: {
+            "name": "lookup",
+            "arguments": "{}",
+        }
+
+        engine = _make_loaded_engine(
+            model_type="diffusion_gemma", tokenizer=tokenizer
+        )
+        engine._diffusion_family = "block"
+
+        assert engine.supports_tool_calling is True
+        # Must not raise
+        await engine.preflight_chat(
+            [{"role": "user", "content": "hi"}],
+            tools=[{"type": "function", "function": {"name": "lookup"}}],
+        )
+
+    @pytest.mark.skipif(
+        not HAS_MLX, reason="mlx is required to import VLMBatchedEngine"
+    )
+    def test_diffusion_supports_tool_calling_false_without_parser(self):
+        engine = _make_loaded_engine(model_type="diffusion_gemma")
+        engine._diffusion_family = "block"
+        assert engine.supports_tool_calling is False
 
     @pytest.mark.skipif(
         not HAS_MLX, reason="mlx is required to import VLMBatchedEngine"


### PR DESCRIPTION
## Summary

Tool calling currently returns HTTP 400 on diffusion-lane models (`Tool calling is not supported with diffusion models.`). But tool calling is **prompt-driven plus output parsing** — it doesn't need grammar-constrained decoding. DiffusionGemma's chat template renders tool declarations and emits the same `<|tool_call>call:name{...}<tool_call|>` wire protocol as Gemma 4, which `mlx_vlm.tool_parsers.gemma4` already parses. The only blockers were the explicit request-time rejections and the stream's special-token stripping eating the protocol markers.

This PR makes the rejection **capability-based** instead of lane-based, so:
- DiffusionGemma (and any future diffusion model whose chat template matches a tool parser) gets working OpenAI-format `tool_calls` on `/v1/chat/completions`, `/v1/messages`, and `/v1/responses`, streaming included.
- Diffusion models *without* a matching tool parser still get a clean 400 (now with a more descriptive message).

## Changes

- **`VLMBatchedEngine.supports_tool_calling`** — new property, true when `_inject_tool_calling` matched a parser for the tokenizer's chat template.
- **Request validation** — `_validate_diffusion_request` and the three server-side guards gate on `supports_tool_calling` instead of `is_diffusion_model`.
- **Stream marker preservation** — the diffusion stream's special-token skipping now preserves tool-call markers and protocol markers (`OutputParserFactory.protocol_marker_texts`); they're consumed downstream by the gemma4 output parser session / `parse_tool_calls` / `ToolCallStreamFilter`, so they never leak to clients.
- **`Gemma4OutputParserSession.process_text`** — text-segment entry point for engines that detokenize internally (the diffusion lane emits text segments, not token ids). `is_gemma4_model` now also matches `model_type: diffusion_gemma` so thought-channel → `<think>` conversion works on the lane.
- **`response_format` degrade instead of 400** — `json_object`/`json_schema` on diffusion models now falls back to prompt-injected JSON with the existing #1241 `Warning` header (same path as when xgrammar isn't installed). `structured_outputs` and `guided_grammar` are **still rejected** — logit-mask enforcement has no equivalent in the parallel denoising loop. `grammar_compiler` returns `None` for diffusion models so the fallback engages even on `--with-grammar` installs.
- **Admin sanitizers** — keep `max_tool_result_tokens` for diffusion models (tool calling works now).

## Verification (diffusiongemma-26B-A4B-it-4bit, Apple Silicon, 0.4.4rc1 base)

| Probe | Result |
|---|---|
| Tool call emission | `finish_reason=tool_calls`, `{"name": "get_weather", "arguments": "{\"city\": \"Tokyo\"}"}` |
| Multi-turn tool-result follow-up | clean prose answer, no protocol marker leak |
| Streaming | tool-call delta with parsed arguments, `finish_reason=tool_calls` |
| `response_format: json_object` | 200 + `Warning` header + valid JSON body |
| `structured_outputs` | still 400 |
| Plain inference (no tools) | unaffected |

`pytest tests/` (excluding integration): **5498 passed, 40 skipped**. Existing tests updated where behavior intentionally changed (3 assertions), new tests added for the capability gate.

Fixes the tool-calling portion of #1805; related to the parser-coverage issue in #1830.