### PR TITLE
fix: route VLM MTP through adapter for mRoPE position encoding

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -5737,6 +5737,12 @@ class Scheduler:
             self._remove_uid_from_active_batch(uid)
             if hasattr(self.model, "unregister_rope_delta"):
                 self.model.unregister_rope_delta(uid)
+            if uid < 0:
+                mtp_state = self._vlm_mtp_active.pop(uid, None)
+                if mtp_state is not None:
+                    close = getattr(mtp_state.generator, "close", None)
+                    if callable(close):
+                        close()
             del self.uid_to_request_id[uid]
             del self.request_id_to_uid[request.request_id]
 

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -5128,6 +5128,7 @@ class Scheduler:
                 request.request_id,
             )
             return None
+        target_model = self.model
 
         if not last_tokens:
             logger.warning(
@@ -5140,7 +5141,10 @@ class Scheduler:
         last_arr = mx.array(last_tokens)[None]  # (1, len_last)
         try:
             with mx.stream(self._stream):
-                out = lm(
+                set_batch_rope = getattr(target_model, "set_batch_rope_deltas", None)
+                if callable(set_batch_rope):
+                    set_batch_rope(mx.array([request.rope_deltas]))
+                out = target_model(
                     last_arr,
                     cache=prefilled_cache,
                     return_hidden=True,
@@ -5185,11 +5189,15 @@ class Scheduler:
 
         try:
             generator = run_vlm_mtp_decode(
-                target_language_model=lm,
+                target_language_model=target_model,
                 drafter=drafter,
                 prompt_cache=prefilled_cache,
                 hidden=hidden,
-                shared_kv_states=getattr(out, "shared_kv_states", {}) if not isinstance(out, tuple) else {},
+                shared_kv_states=(
+                    getattr(out, "shared_kv_states", {})
+                    if not isinstance(out, tuple)
+                    else {}
+                ),
                 first_bonus=int(first_bonus_arr.item()),
                 max_tokens=request.sampling_params.max_tokens,
                 sampler=mtp_sampler,

--- a/omlx/speculative/vlm_mtp.py
+++ b/omlx/speculative/vlm_mtp.py
@@ -184,6 +184,52 @@ class VLMMTPDrafter:
         self.source_path = source_path
 
 
+class _VLMAdapterMTPProxy:
+    """Expose VLM adapter calls while letting Qwen drafters bind embeddings.
+
+    mlx-vlm's MTP loop calls ``model.language_model`` when that attribute is
+    present, which would bypass oMLX's VLM adapter and lose mRoPE position
+    handling. Qwen's external drafter, however, needs a ``language_model``
+    attribute during ``bind()`` to find ``embed_tokens``. This proxy only
+    exposes ``language_model`` while ``draft_model.reset(model)`` runs.
+    """
+
+    def __init__(self, adapter: nn.Module, language_model: Any) -> None:
+        self._adapter = adapter
+        self._language_model = language_model
+        self._expose_language_model = False
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "language_model":
+            if self._expose_language_model:
+                return self._language_model
+            raise AttributeError(name)
+        return getattr(self._adapter, name)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._adapter(*args, **kwargs)
+
+
+class _MTPResetBindingProxy:
+    """Temporarily expose ``language_model`` during drafter reset."""
+
+    def __init__(self, drafter: nn.Module, target_proxy: _VLMAdapterMTPProxy) -> None:
+        self._drafter = drafter
+        self._target_proxy = target_proxy
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._drafter, name)
+
+    def reset(self, target_model: Any, *args: Any, **kwargs: Any) -> Any:
+        if target_model is self._target_proxy:
+            self._target_proxy._expose_language_model = True
+            try:
+                return self._drafter.reset(target_model, *args, **kwargs)
+            finally:
+                self._target_proxy._expose_language_model = False
+        return self._drafter.reset(target_model, *args, **kwargs)
+
+
 def load_vlm_mtp_drafter(path: str) -> Optional[VLMMTPDrafter]:
     """Load an MTP drafter (gemma4_assistant or qwen3_5_mtp); return None
     and log if the artifact is the wrong kind. Soft-fails so a misconfigured
@@ -267,6 +313,13 @@ def run_vlm_mtp_decode(
     already emitted the bonus token before the round loop starts
     (``emitted = 1`` baked in at the top of both helpers).
     """
+    target_for_rounds = target_language_model
+    drafter_model = drafter.model
+    adapter_lm = getattr(target_language_model, "_language_model", None)
+    if adapter_lm is not None:
+        target_for_rounds = _VLMAdapterMTPProxy(target_language_model, adapter_lm)
+        drafter_model = _MTPResetBindingProxy(drafter.model, target_for_rounds)
+
     is_batch = isinstance(first_bonus, mx.array) and first_bonus.size > 1
 
     if is_batch:
@@ -274,8 +327,8 @@ def run_vlm_mtp_decode(
         yield [int(x) for x in first_bonus_list]
         eos_set = set(eos_token_ids) if eos_token_ids else None
         for tokens, _ in _mtp_rounds_batch(
-            target_language_model,
-            drafter.model,
+            target_for_rounds,
+            drafter_model,
             prompt_cache,
             hidden,
             shared_kv_states,
@@ -303,8 +356,8 @@ def run_vlm_mtp_decode(
     yield first_bonus_int
 
     for tok, _ in _mtp_rounds(
-        target_language_model,
-        drafter.model,
+        target_for_rounds,
+        drafter_model,
         prompt_cache,
         hidden,
         shared_kv_states,

--- a/omlx/speculative/vlm_mtp.py
+++ b/omlx/speculative/vlm_mtp.py
@@ -49,6 +49,12 @@ from mlx_vlm.speculative import load_drafter as _vlm_load_drafter
 # the symbols are still ``_``-prefixed but this is now their canonical home.
 from mlx_vlm.speculative.utils import _mtp_rounds, _mtp_rounds_batch  # noqa: SLF001
 
+try:
+    from mlx_vlm.speculative.mtp import _buffer_mtp_target_cache  # noqa: SLF001
+except Exception:  # pragma: no cover - compatibility with older mlx-vlm
+    def _buffer_mtp_target_cache(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
 from ..utils.model_loading import materialize_lazy_state
 
 logger = logging.getLogger(__name__)
@@ -198,13 +204,24 @@ class _VLMAdapterMTPProxy:
         self._adapter = adapter
         self._language_model = language_model
         self._expose_language_model = False
+        self._allow_language_model_fast_paths = not bool(
+            getattr(adapter, "_uses_mrope", False)
+        )
 
     def __getattr__(self, name: str) -> Any:
         if name == "language_model":
             if self._expose_language_model:
                 return self._language_model
             raise AttributeError(name)
-        return getattr(self._adapter, name)
+        try:
+            return getattr(self._adapter, name)
+        except AttributeError:
+            if (
+                not self._allow_language_model_fast_paths
+                and (name == "model" or name.startswith("speculative_"))
+            ):
+                raise
+            return getattr(self._language_model, name)
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self._adapter(*args, **kwargs)
@@ -296,6 +313,7 @@ def run_vlm_mtp_decode(
     first_bonus: Union[int, mx.array],
     max_tokens: int,
     sampler: Callable[[mx.array], mx.array],
+    prompt_tokens: Optional[mx.array] = None,
     draft_block_size: Optional[int] = None,
     token_dtype: mx.Dtype = mx.int32,
     eos_token_ids: Optional[Set[int]] = None,
@@ -355,12 +373,14 @@ def run_vlm_mtp_decode(
 
     yield first_bonus_int
 
+    _buffer_mtp_target_cache(prompt_cache, drafter_model, draft_block_size)
     for tok, _ in _mtp_rounds(
         target_for_rounds,
         drafter_model,
         prompt_cache,
         hidden,
         shared_kv_states,
+        prompt_tokens=prompt_tokens,
         first_bonus=first_bonus_int,
         max_tokens=max_tokens,
         sampler=sampler,

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -33,6 +33,7 @@ from omlx.scheduler import (
     SchedulingPolicy,
     _PrefillState,
     _StoreCacheGate,
+    _VLMMTPDecodeState,
 )
 
 
@@ -645,6 +646,53 @@ class TestSchedulerAbortRequest:
 
         scheduler.batch_generator.remove.assert_called_once_with([uid])
 
+    def test_abort_vlm_mtp_request_clears_active_generator(
+        self, mock_model, mock_tokenizer
+    ):
+        """Aborting negative vlm_mtp UIDs must release the serialized drafter."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+
+        request = Request(
+            request_id="req-vlm-mtp",
+            prompt="Hello",
+            sampling_params=SamplingParams(),
+        )
+        request.prompt_token_ids = [1]
+        request.num_prompt_tokens = 1
+        request.status = RequestStatus.RUNNING
+
+        class ClosableGenerator:
+            closed = False
+
+            def __next__(self):
+                return 1
+
+            def close(self):
+                self.closed = True
+
+        generator = ClosableGenerator()
+        uid = -1
+        scheduler.requests[request.request_id] = request
+        scheduler.running[request.request_id] = request
+        scheduler.request_id_to_uid[request.request_id] = uid
+        scheduler.uid_to_request_id[uid] = request.request_id
+        scheduler._vlm_mtp_active[uid] = _VLMMTPDecodeState(
+            generator=generator,
+            request=request,
+            prompt_cache=[],
+            sampler=MagicMock(),
+            state_machine=MagicMock(),
+            max_tokens=16,
+        )
+        scheduler.batch_generator = MagicMock()
+
+        scheduler.abort_request(request.request_id)
+        scheduler._process_pending_aborts()
+
+        assert uid not in scheduler._vlm_mtp_active
+        assert generator.closed is True
+        scheduler.batch_generator.remove.assert_not_called()
+
     def test_abort_cleans_all_scheduler_state(self, mock_model, mock_tokenizer):
         """Abort must clean running, uid mappings, and requests dict.
 
@@ -1187,6 +1235,7 @@ class TestSchedulerSuppressTokens:
         assert captured["target_language_model"] is mock_model
         assert float(mock_model.batch_rope_deltas.item()) == 123.0
         assert captured["first_bonus"] == 2
+        assert "prompt_tokens" not in captured
 
         round_logits = mx.array([[0.0, 0.0, 1.0, 99.0, 0.0]])
         round_token = captured["sampler"](round_logits)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1132,12 +1132,28 @@ class TestSchedulerSuppressTokens:
                     shared_kv_states={},
                 )
 
-        mock_model._language_model = FakeLanguageModel()
+        class FakeVLMAdapter:
+            def __init__(self):
+                self._language_model = FakeLanguageModel()
+                self.calls = []
+                self.batch_rope_deltas = None
+
+            def set_batch_rope_deltas(self, deltas):
+                self.batch_rope_deltas = deltas
+
+            def __call__(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+                return self._language_model(*args, **kwargs)
+
+        mock_model = FakeVLMAdapter()
+        scheduler.model = mock_model
         request = Request(
             request_id="req-mtp",
             prompt=[1],
             sampling_params=SamplingParams(max_tokens=4),
         )
+        request.prompt_token_ids = [1]
+        request.rope_deltas = 123.0
         cache = [SimpleNamespace(state=mx.array([0]))]
 
         def sampler(logits):
@@ -1167,6 +1183,9 @@ class TestSchedulerSuppressTokens:
             )
 
         assert uid is not None
+        assert mock_model.calls
+        assert captured["target_language_model"] is mock_model
+        assert float(mock_model.batch_rope_deltas.item()) == 123.0
         assert captured["first_bonus"] == 2
 
         round_logits = mx.array([[0.0, 0.0, 1.0, 99.0, 0.0]])

--- a/tests/test_vlm_mtp.py
+++ b/tests/test_vlm_mtp.py
@@ -94,7 +94,9 @@ def test_run_vlm_mtp_decode_single_request_dispatches_to_mtp_rounds():
     with (
         patch.object(vlm_mtp, "_mtp_rounds", return_value=iter(yielded)) as m_single,
         patch.object(vlm_mtp, "_mtp_rounds_batch") as m_batch,
+        patch.object(vlm_mtp, "_buffer_mtp_target_cache") as m_buffer,
     ):
+        prompt_tokens = mx.array([[5, 6, 7]], dtype=mx.int32)
         out = list(
             vlm_mtp.run_vlm_mtp_decode(
                 target_language_model=target,
@@ -105,6 +107,7 @@ def test_run_vlm_mtp_decode_single_request_dispatches_to_mtp_rounds():
                 first_bonus=7,
                 max_tokens=4,
                 sampler=sampler,
+                prompt_tokens=prompt_tokens,
             )
         )
 
@@ -112,10 +115,16 @@ def test_run_vlm_mtp_decode_single_request_dispatches_to_mtp_rounds():
     assert out == [7, 11, 22, 33]
     m_single.assert_called_once()
     m_batch.assert_not_called()
+    m_buffer.assert_called_once()
+    buffer_args = m_buffer.call_args.args
+    assert buffer_args[0] == []
+    assert getattr(buffer_args[1], "_drafter", buffer_args[1]) is fake_model
+    assert buffer_args[2] is None
     # first_bonus int forwarded as int
     kwargs = m_single.call_args.kwargs
     assert kwargs["first_bonus"] == 7
     assert kwargs["max_tokens"] == 4
+    assert kwargs["prompt_tokens"] is prompt_tokens
 
 
 def test_run_vlm_mtp_decode_batch_dispatches_to_mtp_rounds_batch():
@@ -131,6 +140,7 @@ def test_run_vlm_mtp_decode_batch_dispatches_to_mtp_rounds_batch():
     with (
         patch.object(vlm_mtp, "_mtp_rounds_batch", return_value=iter(yielded)) as m_batch,
         patch.object(vlm_mtp, "_mtp_rounds") as m_single,
+        patch.object(vlm_mtp, "_buffer_mtp_target_cache") as m_buffer,
     ):
         out = list(
             vlm_mtp.run_vlm_mtp_decode(
@@ -150,6 +160,7 @@ def test_run_vlm_mtp_decode_batch_dispatches_to_mtp_rounds_batch():
     assert out == [[1, 2, 3], [1, None, 3], [None, None, None]]
     m_batch.assert_called_once()
     m_single.assert_not_called()
+    m_buffer.assert_not_called()
     kwargs = m_batch.call_args.kwargs
     # EOS forwarded as a fresh set (function does its own copy)
     assert kwargs["eos_token_ids"] == {2, 5}

--- a/tests/test_vlm_mtp_proxy.py
+++ b/tests/test_vlm_mtp_proxy.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for VLM MTP proxy classes.
+
+Validates that _VLMAdapterMTPProxy and _MTPResetBindingProxy correctly
+control attribute visibility so that:
+- _mtp_rounds / _mtp_rounds_batch see a target that does NOT expose
+  ``language_model`` (forcing ``lm = model`` and routing verify through
+  the adapter);
+- drafter.reset() can temporarily expose ``language_model`` for bind().
+"""
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from omlx.speculative.vlm_mtp import (
+    _MTPResetBindingProxy,
+    _VLMAdapterMTPProxy,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeLanguageModel:
+    """Mimics the patched LanguageModel with rollback_speculative_cache."""
+
+    def __init__(self):
+        self.rollback_called = False
+
+    def __call__(self, *args, **kwargs):
+        from mlx_vlm.models.base import LanguageModelOutput
+
+        return LanguageModelOutput(
+            logits=mx.zeros((1, 1, 4)),
+            hidden_states=[mx.zeros((1, 1, 8))],
+            gdn_states=[],
+            shared_kv_states={},
+        )
+
+    def rollback_speculative_cache(self, caches, gdn_states, accepted, block_size):
+        self.rollback_called = True
+        return accepted
+
+
+class FakeVLMAdapter:
+    """Mimics VLMModelAdapter with _language_model and patched methods."""
+
+    def __init__(self):
+        self._language_model = FakeLanguageModel()
+        self.forward_called = False
+        # Mimic _patch_vlm_model_adapter() which delegates to _language_model.
+        self.rollback_speculative_cache = self._language_model.rollback_speculative_cache
+
+    def __call__(self, *args, **kwargs):
+        self.forward_called = True
+        return self._language_model(*args, **kwargs)
+
+    def set_batch_rope_deltas(self, deltas):
+        pass
+
+
+class FakeDrafter(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.reset_target = None
+        self.reset_called = False
+
+    def reset(self, target_model, *args, **kwargs):
+        self.reset_target = target_model
+        self.reset_called = True
+        # bind() accesses target_model.language_model.model.embed_tokens
+        _ = target_model.language_model
+        return []
+
+
+# ---------------------------------------------------------------------------
+# _VLMAdapterMTPProxy tests
+# ---------------------------------------------------------------------------
+
+
+class TestVLMAdapterMTPProxy:
+    def test_language_model_not_exposed_by_default(self):
+        adapter = FakeVLMAdapter()
+        proxy = _VLMAdapterMTPProxy(adapter, adapter._language_model)
+
+        assert not hasattr(proxy, "language_model")
+        with pytest.raises(AttributeError):
+            _ = proxy.language_model
+
+    def test_language_model_exposed_when_flag_set(self):
+        adapter = FakeVLMAdapter()
+        proxy = _VLMAdapterMTPProxy(adapter, adapter._language_model)
+        proxy._expose_language_model = True
+
+        assert hasattr(proxy, "language_model")
+        assert proxy.language_model is adapter._language_model
+
+    def test_call_delegates_to_adapter(self):
+        adapter = FakeVLMAdapter()
+        proxy = _VLMAdapterMTPProxy(adapter, adapter._language_model)
+
+        proxy(mx.array([1]), cache=[])
+        assert adapter.forward_called
+
+    def test_non_language_model_attrs_delegate_to_adapter(self):
+        adapter = FakeVLMAdapter()
+        proxy = _VLMAdapterMTPProxy(adapter, adapter._language_model)
+
+        assert proxy._language_model is adapter._language_model
+
+    def test_rollback_speculative_cache_delegates(self):
+        adapter = FakeVLMAdapter()
+        proxy = _VLMAdapterMTPProxy(adapter, adapter._language_model)
+
+        proxy.rollback_speculative_cache([], [], 0, 4)
+        assert adapter._language_model.rollback_called
+
+    def test_mtp_rounds_sees_no_language_model(self):
+        """Simulates the hasattr check in _mtp_rounds / _mtp_rounds_batch."""
+        adapter = FakeVLMAdapter()
+        proxy = _VLMAdapterMTPProxy(adapter, adapter._language_model)
+
+        # _mtp_rounds line 547: lm = model.language_model if hasattr(...) else model
+        lm = proxy.language_model if hasattr(proxy, "language_model") else proxy
+        assert lm is proxy
+
+
+# ---------------------------------------------------------------------------
+# _MTPResetBindingProxy tests
+# ---------------------------------------------------------------------------
+
+
+class TestMTPResetBindingProxy:
+    def test_reset_temporarily_exposes_language_model(self):
+        adapter = FakeVLMAdapter()
+        proxy = _VLMAdapterMTPProxy(adapter, adapter._language_model)
+        drafter = FakeDrafter()
+        reset_proxy = _MTPResetBindingProxy(drafter, proxy)
+
+        # Before reset: language_model not exposed
+        assert not hasattr(proxy, "language_model")
+
+        reset_proxy.reset(proxy)
+
+        # Drafter's bind() saw language_model during reset
+        assert drafter.reset_called
+        assert drafter.reset_target is proxy
+
+        # After reset: language_model hidden again
+        assert not hasattr(proxy, "language_model")
+
+    def test_reset_non_proxy_target_passes_through(self):
+        adapter = FakeVLMAdapter()
+        proxy = _VLMAdapterMTPProxy(adapter, adapter._language_model)
+        drafter = FakeDrafter()
+        reset_proxy = _MTPResetBindingProxy(drafter, proxy)
+
+        other_target = SimpleNamespace(language_model=object())
+        reset_proxy.reset(other_target)
+
+        assert drafter.reset_called
+        assert drafter.reset_target is other_target
+
+    def test_other_attrs_delegate_to_drafter(self):
+        adapter = FakeVLMAdapter()
+        proxy = _VLMAdapterMTPProxy(adapter, adapter._language_model)
+        drafter = FakeDrafter()
+        reset_proxy = _MTPResetBindingProxy(drafter, proxy)
+
+        assert reset_proxy.reset_called is False  # getattr on drafter
+
+    def test_reset_exception_restores_hidden_state(self):
+        """language_model must be hidden again even if reset() raises."""
+        adapter = FakeVLMAdapter()
+        proxy = _VLMAdapterMTPProxy(adapter, adapter._language_model)
+
+        class FailingDrafter:
+            def reset(self, target_model, *args, **kwargs):
+                _ = target_model.language_model  # needs it exposed
+                raise RuntimeError("bind failed")
+
+        reset_proxy = _MTPResetBindingProxy(FailingDrafter(), proxy)
+
+        with pytest.raises(RuntimeError, match="bind failed"):
+            reset_proxy.reset(proxy)
+
+        # Must be hidden even after exception
+        assert not hasattr(proxy, "language_model")

--- a/tests/test_vlm_mtp_proxy.py
+++ b/tests/test_vlm_mtp_proxy.py
@@ -31,6 +31,7 @@ class FakeLanguageModel:
 
     def __init__(self):
         self.rollback_called = False
+        self.model = object()
 
     def __call__(self, *args, **kwargs):
         from mlx_vlm.models.base import LanguageModelOutput
@@ -46,15 +47,22 @@ class FakeLanguageModel:
         self.rollback_called = True
         return accepted
 
+    def speculative_logits_from_hidden(self, hidden):
+        return hidden
+
 
 class FakeVLMAdapter:
     """Mimics VLMModelAdapter with _language_model and patched methods."""
 
-    def __init__(self):
+    def __init__(self, expose_rollback: bool = True, uses_mrope: bool = False):
         self._language_model = FakeLanguageModel()
+        self._uses_mrope = uses_mrope
         self.forward_called = False
-        # Mimic _patch_vlm_model_adapter() which delegates to _language_model.
-        self.rollback_speculative_cache = self._language_model.rollback_speculative_cache
+        if expose_rollback:
+            # Mimic _patch_vlm_model_adapter() which delegates to _language_model.
+            self.rollback_speculative_cache = (
+                self._language_model.rollback_speculative_cache
+            )
 
     def __call__(self, *args, **kwargs):
         self.forward_called = True
@@ -119,6 +127,21 @@ class TestVLMAdapterMTPProxy:
 
         proxy.rollback_speculative_cache([], [], 0, 4)
         assert adapter._language_model.rollback_called
+
+    def test_rollback_falls_back_to_language_model_when_adapter_lacks_passthrough(self):
+        adapter = FakeVLMAdapter(expose_rollback=False)
+        proxy = _VLMAdapterMTPProxy(adapter, adapter._language_model)
+
+        proxy.rollback_speculative_cache([], [], 0, 4)
+        assert adapter._language_model.rollback_called
+
+    def test_mrope_proxy_hides_fast_path_attrs_but_keeps_rollback(self):
+        adapter = FakeVLMAdapter(expose_rollback=False, uses_mrope=True)
+        proxy = _VLMAdapterMTPProxy(adapter, adapter._language_model)
+
+        assert hasattr(proxy, "rollback_speculative_cache")
+        assert not hasattr(proxy, "model")
+        assert not hasattr(proxy, "speculative_logits_from_hidden")
 
     def test_mtp_rounds_sees_no_language_model(self):
         """Simulates the hasattr check in _mtp_rounds / _mtp_rounds_batch."""


### PR DESCRIPTION
## Summary

- VLM MTP decode path bypassed `VLMModelAdapter`, using `_language_model` directly — correct for Gemma 4 (no mRoPE), but wrong for Qwen3.6 VLM which uses mRoPE
- Prefill-final-forward and verify-forward both ran without mRoPE position encoding, producing garbled output
- Added `_VLMAdapterMTPProxy` and `_MTPResetBindingProxy` to route verify through adapter while preserving drafter `bind()` access to `language_model`
- Scheduler now sets `batch_rope_deltas` and calls adapter instead of raw language model

Closes #1779

## Test plan

- [x] 10 new unit tests for proxy visibility and delegation (`test_vlm_mtp_proxy.py`)
- [x] Updated existing scheduler MTP test
- [x] Manual verification: Qwen3.6-35B-A3B VLM with `vlm_mtp_enabled=True` produces correct output
- [x] Manual verification: Gemma 4 VLM MTP still works (no regression)