### PR TITLE
fix(server): forward thinking_budget on /v1/completions (#1825)

### DIFF
--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -396,6 +396,8 @@ class CompletionRequest(BaseModel):
     frequency_penalty: float | None = None
     # Seed for reproducible generation (best-effort)
     seed: Optional[int] = None
+    # Cap reasoning/thinking tokens (parity with /v1/chat/completions)
+    thinking_budget: Optional[int] = None
 
     @field_validator("stop", mode="before")
     @classmethod

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2750,6 +2750,11 @@ async def create_completion(
             req_xtc_threshold=getattr(request, "xtc_threshold", None),
         )
 
+        gen_kwargs = {}
+        thinking_budget = _resolve_thinking_budget(request, request.model)
+        if thinking_budget is not None:
+            gen_kwargs["thinking_budget"] = thinking_budget
+
         for i, prompt in enumerate(prompts):
             output = await engine.generate(
                 prompt=prompt,
@@ -2765,6 +2770,7 @@ async def create_completion(
                 xtc_threshold=xtc_threshold,
                 stop=request.stop,
                 seed=request.seed,
+                **gen_kwargs,
             )
 
             choices.append(
@@ -3746,6 +3752,10 @@ async def stream_completion(
         req_xtc_probability=getattr(request, "xtc_probability", None),
         req_xtc_threshold=getattr(request, "xtc_threshold", None),
     )
+    gen_kwargs = {}
+    thinking_budget = _resolve_thinking_budget(request, request.model)
+    if thinking_budget is not None:
+        gen_kwargs["thinking_budget"] = thinking_budget
     try:
         async for output in engine.stream_generate(
             prompt=prompt,
@@ -3761,6 +3771,7 @@ async def stream_completion(
             xtc_threshold=xtc_threshold,
             stop=request.stop,
             seed=request.seed,
+            **gen_kwargs,
         ):
             if first_token_time is None and output.new_text:
                 first_token_time = time.perf_counter()

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -681,6 +681,95 @@ class TestCompletionEndpoint:
         data = response.json()
         assert data["usage"]["prompt_tokens_details"]["cached_tokens"] == 2048
 
+    def test_completion_forwards_thinking_budget(self, client, mock_llm_engine):
+        """Non-streaming /v1/completions must forward thinking_budget to the
+        engine. Regression for #1825: the field was absent from
+        CompletionRequest, so Pydantic dropped it and it never reached
+        generate()."""
+        mock_llm_engine.generate = AsyncMock(
+            return_value=MockGenerationOutput(text="Generated response.")
+        )
+
+        response = client.post(
+            "/v1/completions",
+            json={
+                "model": "test-model",
+                "prompt": "Explain why the sky is blue.",
+                "thinking_budget": 300,
+            },
+        )
+
+        assert response.status_code == 200
+        assert mock_llm_engine.generate.call_args.kwargs["thinking_budget"] == 300
+
+    def test_completion_streaming_forwards_thinking_budget(
+        self, client, mock_llm_engine
+    ):
+        """Streaming /v1/completions must forward thinking_budget to the
+        engine (companion to the non-streaming path; see #1825)."""
+        captured = {}
+
+        async def recording_stream_generate(prompt, **kwargs):
+            captured.update(kwargs)
+            yield MockGenerationOutput(text="Hi", new_text="Hi", finished=False)
+            yield MockGenerationOutput(
+                text="Hi there",
+                new_text=" there",
+                finished=True,
+                finish_reason="stop",
+            )
+
+        mock_llm_engine.stream_generate = recording_stream_generate
+
+        response = client.post(
+            "/v1/completions",
+            json={
+                "model": "test-model",
+                "prompt": "Explain why the sky is blue.",
+                "stream": True,
+                "thinking_budget": 300,
+            },
+        )
+
+        assert response.status_code == 200
+        assert captured.get("thinking_budget") == 300
+
+    def test_completion_thinking_budget_from_model_settings(
+        self, client, mock_llm_engine
+    ):
+        """A model-level thinking budget (admin settings) applies to
+        /v1/completions even when the request omits the parameter, matching
+        /v1/chat/completions."""
+        from omlx.model_settings import ModelSettings
+        from omlx.server import _server_state
+
+        class StubSettingsManager:
+            def get_settings(self, model_id):
+                return ModelSettings(
+                    thinking_budget_enabled=True,
+                    thinking_budget_tokens=256,
+                )
+
+        mock_llm_engine.generate = AsyncMock(
+            return_value=MockGenerationOutput(text="Generated response.")
+        )
+
+        original_settings_manager = _server_state.settings_manager
+        _server_state.settings_manager = StubSettingsManager()
+        try:
+            response = client.post(
+                "/v1/completions",
+                json={
+                    "model": "test-model",
+                    "prompt": "Explain why the sky is blue.",
+                },
+            )
+        finally:
+            _server_state.settings_manager = original_settings_manager
+
+        assert response.status_code == 200
+        assert mock_llm_engine.generate.call_args.kwargs["thinking_budget"] == 256
+
 
 class TestChatCompletionEndpoint:
     """Tests for the /v1/chat/completions endpoint."""


### PR DESCRIPTION
## Problem

#1825: thinking_budget works on /v1/chat/completions (and budget_tokens on /v1/messages) but is silently ignored on /v1/completions. The cause is what the reporter diagnosed: CompletionRequest has no thinking_budget field, so Pydantic drops the parameter before the handler sees it. The completion handlers also never call _resolve_thinking_budget, so a model-level budget never reached the engine on this endpoint either.

## Change

Mirrors the chat path:

- Add thinking_budget to CompletionRequest.
- Resolve it with _resolve_thinking_budget in create_completion (non-streaming) and stream_completion, and pass it to engine.generate / engine.stream_generate only when set, same as chat_kwargs on the chat path.

Behavior note: model-level thinking budgets configured in the dashboard now apply to /v1/completions too, where they were previously ignored. That matches the chat endpoint, but it is a change for raw-completion users of models with a budget configured.

Two scope notes:

- On this endpoint there is no chat template, so the budget caps thinking only when the prompt opens the think block (as the issue's repro does with a trailing `<think>\n`) or the model emits one.
- The spill-out behavior in the issue's second comment (thinking continuing past the close at low budgets) is in ThinkingBudgetProcessor and is not addressed here.

## Testing

- 3 new tests in tests/integration/test_server_endpoints.py: non-streaming and streaming forwarding of the request parameter, plus the model-settings fallback.
- Full suite: 5613 passed, 40 skipped.
- Draft until I finish the live test on a thinking model: run the issue's curl with thinking_budget 300 and confirm thinking caps near 300 tokens instead of ~1450.