### PR TITLE
feat: Add Codex App Desktop integration

### DIFF
--- a/omlx/integrations/__init__.py
+++ b/omlx/integrations/__init__.py
@@ -3,6 +3,7 @@
 from omlx.integrations.base import Integration, IntegrationContext
 from omlx.integrations.claude import ClaudeCodeIntegration
 from omlx.integrations.codex import CodexIntegration
+from omlx.integrations.codex_app import CodexAppIntegration
 from omlx.integrations.copilot import CopilotIntegration
 from omlx.integrations.hermes import HermesIntegration
 from omlx.integrations.openclaw import OpenClawIntegration
@@ -12,6 +13,7 @@ from omlx.integrations.pi import PiIntegration
 INTEGRATIONS: dict[str, Integration] = {
     "claude": ClaudeCodeIntegration(),
     "codex": CodexIntegration(),
+    "codex_app": CodexAppIntegration(),
     "opencode": OpenCodeIntegration(),
     "openclaw": OpenClawIntegration(),
     "hermes": HermesIntegration(),
@@ -34,6 +36,7 @@ __all__ = [
     "Integration",
     "IntegrationContext",
     "ClaudeCodeIntegration",
+    "CodexAppIntegration",
     "CopilotIntegration",
     "HermesIntegration",
     "INTEGRATIONS",

--- a/omlx/integrations/codex_app.py
+++ b/omlx/integrations/codex_app.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Codex App (OpenAI Codex App Desktop) integration.
+
+This integration launches the Codex App Desktop GUI/TUI via the
+``codex app`` subcommand, while sharing the same config file as
+the CLI variant (``~/.codex/config.toml``).
+
+Usage:
+    omlx launch codex_app --model qwen3.5
+
+Which launches:
+    codex app
+
+Both CLI and App use the same config file:
+    ~/.codex/config.toml
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import time
+from pathlib import Path
+
+from omlx.integrations.base import Integration, IntegrationContext
+from omlx.utils.install import get_cli_command_prefix
+
+
+class CodexAppIntegration(Integration):
+    """Codex App Desktop integration that configures ~/.codex/config.toml for oMLX."""
+
+    CONFIG_PATH = Path.home() / ".codex" / "config.toml"
+
+    def __init__(self):
+        super().__init__(
+            name="codex_app",
+            display_name="Codex App",
+            type="config_file",
+            install_check="codex",
+            install_hint="npm install -g @openai/codex",
+        )
+
+    def get_command(self, ctx: IntegrationContext) -> str:
+        return (
+            f"{get_cli_command_prefix()} "
+            f"launch codex_app --model {ctx.model or 'select-a-model'}"
+        )
+
+    def configure(self, ctx: IntegrationContext) -> None:
+        config_path = self.CONFIG_PATH
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        existing_content = ""
+        if config_path.exists():
+            # Create backup
+            timestamp = int(time.time())
+            backup = config_path.with_suffix(f".{timestamp}.bak")
+            try:
+                shutil.copy2(config_path, backup)
+                existing_content = config_path.read_text(encoding="utf-8")
+                print(f"Backup: {backup}")
+            except OSError as e:
+                print(f"Warning: could not create backup or read config: {e}")
+
+        # Parse existing config lines to preserve other settings
+        lines = existing_content.splitlines()
+        new_lines = []
+        in_any_section = False
+        in_omlx_section = False
+
+        # Keys to override at the top level
+        top_level_overrides = {
+            "model": f'"{ctx.model or "select-a-model"}"',
+            "model_provider": '"omlx"',
+        }
+
+        # If it is a reasoning model, add reasoning effort
+        is_reasoning = (
+            bool(ctx.reasoning)
+            if ctx.reasoning is not None
+            else bool(re.search(r"\b(thinking|o1|o3|r1)\b", ctx.model.lower()))
+        )
+        if is_reasoning:
+            top_level_overrides["model_reasoning_effort"] = '"high"'
+
+        # Keys managed by oMLX that should be removed when not applicable
+        managed_keys = {"model_reasoning_effort"} - set(top_level_overrides.keys())
+
+        seen_keys = set()
+
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("[") and stripped.endswith("]"):
+                in_any_section = True
+                in_omlx_section = stripped == "[model_providers.omlx]"
+
+            # Handle top-level keys
+            if not in_any_section and "=" in stripped:
+                key = stripped.split("=")[0].strip()
+                if key in top_level_overrides:
+                    new_lines.append(f"{key} = {top_level_overrides[key]}")
+                    seen_keys.add(key)
+                    continue
+                if key in managed_keys:
+                    continue
+
+            # Skip old oMLX section
+            if in_omlx_section:
+                continue
+
+            new_lines.append(line)
+
+        # Add missing top-level keys
+        for key, val in top_level_overrides.items():
+            if key not in seen_keys:
+                new_lines.insert(0, f"{key} = {val}")
+
+        # Append new oMLX provider section
+        new_lines.append("\n[model_providers.omlx]")
+        new_lines.append('name = "oMLX"')
+        new_lines.append(f'base_url = "{ctx.openai_base_url}"')
+        new_lines.append('env_key = "OMLX_API_KEY"')
+
+        config_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+        print(f"Config updated: {config_path}")
+
+    def launch(self, ctx: IntegrationContext) -> None:
+        self.configure(ctx)
+
+        env = self._scrubbed_env()
+        env["OMLX_API_KEY"] = ctx.auth_token
+
+        # Launch codex app (desktop GUI/TUI) instead of codex CLI
+        # Note: codex app doesn't accept -m flag, model is set in config
+        args = ["codex", "app"]
+        args.extend(ctx.extra_args)
+
+        os.execvpe("codex", args, env)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -10,6 +10,7 @@ from omlx.integrations import get_integration, list_integrations
 from omlx.integrations.base import IntegrationContext
 from omlx.integrations.claude import ClaudeCodeIntegration
 from omlx.integrations.codex import CodexIntegration
+from omlx.integrations.codex_app import CodexAppIntegration
 from omlx.integrations.copilot import CopilotIntegration
 from omlx.integrations.hermes import HermesIntegration
 from omlx.integrations.openclaw import OpenClawIntegration
@@ -31,12 +32,13 @@ def ctx(**overrides) -> IntegrationContext:
 class TestIntegrationRegistry:
     def test_list_integrations(self):
         integrations = list_integrations()
-        assert len(integrations) == 7
+        assert len(integrations) == 8
         names = {i.name for i in integrations}
         assert names == {
             "claude",
-            "copilot",
             "codex",
+            "codex_app",
+            "copilot",
             "opencode",
             "openclaw",
             "hermes",
@@ -45,8 +47,9 @@ class TestIntegrationRegistry:
 
     def test_get_integration(self):
         assert get_integration("claude") is not None
-        assert get_integration("copilot") is not None
         assert get_integration("codex") is not None
+        assert get_integration("codex_app") is not None
+        assert get_integration("copilot") is not None
         assert get_integration("opencode") is not None
         assert get_integration("openclaw") is not None
         assert get_integration("hermes") is not None
@@ -239,6 +242,73 @@ name = "old-omlx"
         assert "PYTHONHOME" not in captured["env"]
         assert "PYTHONPATH" not in captured["env"]
         assert "PYTHONDONTWRITEBYTECODE" not in captured["env"]
+
+
+class TestCodexAppIntegration:
+    def test_get_command(self):
+        from omlx.integrations.codex_app import CodexAppIntegration
+        codex_app = CodexAppIntegration()
+        cmd = codex_app.get_command(ctx(port=8000, api_key="key", model="qwen3.5"))
+        assert "omlx launch codex_app" in cmd
+        assert "--model qwen3.5" in cmd
+
+    def test_configure(self, tmp_path):
+        from omlx.integrations.codex_app import CodexAppIntegration
+        codex_app = CodexAppIntegration()
+        config_path = tmp_path / "codex" / "config.toml"
+        with patch.object(CodexAppIntegration, "CONFIG_PATH", config_path):
+            codex_app.configure(ctx(port=8000, api_key="test-key", model="qwen3.5"))
+
+        assert config_path.exists()
+        content = config_path.read_text()
+        assert 'model = "qwen3.5"' in content
+        assert 'model_provider = "omlx"' in content
+        assert 'base_url = "http://127.0.0.1:8000/v1"' in content
+        assert 'env_key = "OMLX_API_KEY"' in content
+
+    def test_launch_app(self, tmp_path):
+        from omlx.integrations.codex_app import CodexAppIntegration
+        codex_app = CodexAppIntegration()
+        config_path = tmp_path / "codex" / "config.toml"
+        captured = {}
+
+        def fake_execvpe(binary, argv, env):
+            captured["argv"] = argv
+            captured["env"] = env
+
+        base_env = {
+            "PATH": "/usr/bin",
+            "PYTHONHOME": "/bundle/python",
+            "PYTHONPATH": "/bundle/lib",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+        with (
+            patch.object(CodexAppIntegration, "CONFIG_PATH", config_path),
+            patch("omlx.integrations.codex_app.os.environ", base_env),
+            patch("omlx.integrations.codex_app.os.execvpe", side_effect=fake_execvpe),
+        ):
+            codex_app.launch(
+                ctx(
+                    port=8000,
+                    api_key="key",
+                    model="qwen3.5",
+                    extra_args=(),
+                )
+            )
+
+        # Codex App should launch with "app" subcommand, not "-m <model>"
+        assert captured["argv"] == ["codex", "app"]
+        assert captured["env"]["OMLX_API_KEY"] == "key"
+        assert "PYTHONHOME" not in captured["env"]
+        assert "PYTHONPATH" not in captured["env"]
+        assert "PYTHONDONTWRITEBYTECODE" not in captured["env"]
+
+    def test_type(self):
+        from omlx.integrations.codex_app import CodexAppIntegration
+        codex_app = CodexAppIntegration()
+        assert codex_app.type == "config_file"
+        assert codex_app.display_name == "Codex App"
+        assert codex_app.name == "codex_app"
 
 
 class TestOpenCodeIntegration:


### PR DESCRIPTION
## Summary

Adds support for launching the **OpenAI Codex App Desktop** (`codex app`) through omlx, alongside the existing Codex CLI integration.

## Changes

- **Add `omlx/integrations/codex_app.py`** — New `CodexAppIntegration` class that handles the desktop app variant
- **Update `omlx/integrations/__init__.py`** — Register `codex_app` in the `INTEGRATIONS` registry

## How It Works

Both CLI and Desktop App share the same `~/.codex/config.toml` config file. The only difference is the launch command:

- **CLI**: `codex -m <model>`
- **App Desktop**: `codex app` (model is set via config, not CLI args)

## Usage

```bash
# Launch Codex CLI (existing)
omlx launch codex --model qwen3.5

# Launch Codex App Desktop (new)
omlx launch codex_app --model qwen3.5
```

## Testing

Tested locally with oMLX server running and available models. The integration:
1. Writes `~/.codex/config.toml` with the selected model and oMLX provider settings
2. Launches `codex app` with the `OMLX_API_KEY` environment variable
3. Creates automatic backups of existing config files

## Notes

- The desktop app does not accept a `-m` flag for model selection, so the model is configured purely through the TOML config file
- The config format is identical to the CLI variant, ensuring compatibility
- No breaking changes to existing integrations