### PR TITLE
fix(api): parse Gemma 4 namespaced and single-quoted tool calls

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -21,6 +21,7 @@ import bisect
 import json
 import logging
 import re
+import regex
 import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -417,7 +418,15 @@ class _Gemma4ArgsTooComplex(ValueError):
 # lane's degenerate prefixes (``calldone{`` missing the colon, ``:done{``
 # missing ``call``, #1837) still match; the fallback only runs on
 # marker-delimited content, so a permissive prefix cannot misfire on prose.
-_GEMMA4_CALL_HEAD = re.compile(r"(?:call)?:?([\w.-]+(?::[\w.-]+)*)\{")
+#
+# Compiled with the ``regex`` module, NOT ``re``: once the ``call:`` literal
+# anchor became optional (above), ``re``'s engine restarts the greedy
+# ``[\w.-]+`` match at every position of a long bare argument value and
+# backtracks O(n^2) hunting an opening ``{`` that never comes, hanging on
+# adversarial output (a 300 KB bare value pegs a core indefinitely).  The
+# ``regex`` engine fails that same partial match fast, so finditer stays
+# linear.  See test_oversized_args_fail_cleanly.
+_GEMMA4_CALL_HEAD = regex.compile(r"(?:call)?:?([\w.-]+(?::[\w.-]+)*)\{")
 
 
 def _squote_close_positions(s: str) -> list:

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -17,6 +17,7 @@ Also includes structured output (JSON Schema) utilities:
 """
 
 import ast
+import bisect
 import json
 import logging
 import re
@@ -384,12 +385,363 @@ def _parse_bracket_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]
 # Gemma 4 robust fallback parser
 # ---------------------------------------------------------------------------
 
-def _gemma4_args_to_json_robust(args_str: str) -> dict:
-    """Convert Gemma 4 tool call args to a Python dict.
+# Gemma 4's non-standard string delimiter (mlx_lm.tool_parsers.gemma4 uses
+# the same literal in its regex).
+_GEMMA4_STR_DELIM = '<|"|>'
 
-    Handles the common failure cases that mlx-lm's parser cannot:
-    - Bare string values without ``<|"|>`` delimiters (e.g. ``{location: Tokyo}``)
-    - Spaces after commas in key-value pairs
+# Bounds for parsing model-emitted arguments.  Model output is untrusted and
+# attacker-influenceable (prompt injection can steer emissions verbatim), so
+# parsing must stay linear-time and bounded: breaching a bound is a clean
+# parse failure that flows into the existing drop-with-warning path, never an
+# exception that escapes the parse chain.
+_GEMMA4_MAX_ARGS_LEN = 262_144
+_GEMMA4_MAX_DEPTH = 64
+
+
+class _Gemma4ArgsTooComplex(ValueError):
+    """A defensive bound (length/depth) was breached parsing args.
+
+    Distinct from an ordinary parse failure so the orchestrator can reject
+    hard rather than retry with the legacy parser: the bounds are DoS guards
+    against attacker-influenceable model output, and the legacy parser would
+    happily parse oversized/deeply-nested input and defeat them.  Subclasses
+    ValueError so the public parse chain still treats it as a clean drop.
+    """
+
+# A tool-call head: the name plus its opening ``{``.  Only the head is matched
+# by regex; the argument span is found by _scan_gemma4_args_span, not by a
+# recursive pattern (see that function).  The name segment captures namespaced
+# MCP names (colon/dot/hyphen separated, e.g.
+# call:google:mcp:text_generation:create-pdf-file, #1830).  The ``call:``
+# opener is made optional and tolerant — ``(?:call)?:?`` — so the diffusion
+# lane's degenerate prefixes (``calldone{`` missing the colon, ``:done{``
+# missing ``call``, #1837) still match; the fallback only runs on
+# marker-delimited content, so a permissive prefix cannot misfire on prose.
+_GEMMA4_CALL_HEAD = re.compile(r"(?:call)?:?([\w.-]+(?::[\w.-]+)*)\{")
+
+
+def _squote_close_positions(s: str) -> list:
+    """Indices of single quotes that can CLOSE a single-quoted value.
+
+    A closing quote is one whose next non-whitespace character is ``,``,
+    ``}``, ``]`` or end of input.  Anchoring closes this way (rather than
+    taking the first quote) keeps apostrophes inside values from pairing
+    across values: in ``{a: 'it's ok', b: 1}`` the quote in ``it's`` is
+    followed by ``s`` so it cannot close the string.
+
+    Computed in one reverse pass so each lookup is O(log n) via bisect; a
+    forward scan that peeks past whitespace at every quote would be
+    quadratic on whitespace-heavy input, and this text is model-emitted.
+    """
+    closes: list[int] = []
+    next_sig = ""  # next non-whitespace char AFTER the current index
+    for idx in range(len(s) - 1, -1, -1):
+        ch = s[idx]
+        if ch == "'" and (next_sig == "" or next_sig in ",}]"):
+            closes.append(idx)
+        if not ch.isspace():
+            next_sig = ch
+    closes.reverse()
+    return closes
+
+
+def _scan_gemma4_args_span(
+    text: str, open_idx: int, squote_closes: list
+) -> int:
+    """Return the end index (exclusive) of the balanced ``{...}`` starting at
+    ``open_idx``, or -1 if no balanced span exists within bounds.
+
+    Iterative single-pass walk that counts brace depth only OUTSIDE string
+    literals (``<|"|>``-paired strings and anchored single-quoted values), so
+    a brace inside string content cannot truncate or unbalance the span.
+    This deliberately replaces a recursive regex:
+    - linear time: recursive alternation patterns degrade quadratically on
+      unbalanced model output (measured ~590ms at 80KB), an injection-driven
+      CPU burn on a server,
+    - iterative: RecursionError is a RuntimeError subclass that no except
+      tuple in the parse chain catches, so recursion on deeply nested model
+      output would escape as a 500.
+
+    A single-quoted string OPENS only at a value position (previous
+    significant char is ``:``, ``,`` or ``[``); a bare apostrophe anywhere
+    else (don't, it's) is ordinary content.
+    """
+    n = len(text)
+    depth = 0
+    last_sig = ""
+    i = open_idx
+    limit = min(n, open_idx + _GEMMA4_MAX_ARGS_LEN)
+    while i < limit:
+        if text.startswith(_GEMMA4_STR_DELIM, i):
+            close = text.find(_GEMMA4_STR_DELIM, i + len(_GEMMA4_STR_DELIM))
+            if close == -1:
+                return -1  # unterminated string: malformed, give up cleanly
+            i = close + len(_GEMMA4_STR_DELIM)
+            last_sig = '"'
+            continue
+        ch = text[i]
+        if ch == "'" and last_sig in ":,[":
+            k = bisect.bisect_right(squote_closes, i)
+            if k < len(squote_closes):
+                i = squote_closes[k] + 1
+                last_sig = "'"
+                continue
+            # No valid close ahead: treat the quote as ordinary content.
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        if not ch.isspace():
+            last_sig = ch
+        i += 1
+    return -1
+
+
+def _gemma4_args_to_json_robust(args_str: str) -> dict:
+    """Convert Gemma 4 tool-call args to a Python dict.
+
+    Tries the strict single-pass transcoder first
+    (``_gemma4_transcode_to_json``); on failure, falls back to the legacy
+    key-anchored recovery (``_gemma4_args_to_json_legacy``) for the one
+    case the transcoder deliberately rejects: bare values that themselves
+    contain commas, braces, or newlines — long markdown emitted into an
+    ``answer:`` argument, observed live on the diffusion lane (#1837).
+    The transcoder stops bare values at the first structural separator, so
+    only key-anchored capture can recover that shape.
+    """
+    try:
+        return _gemma4_transcode_to_json(args_str)
+    except _Gemma4ArgsTooComplex:
+        # Defensive bound breached: reject hard.  The legacy parser ignores
+        # these bounds and would parse the input anyway, defeating the DoS
+        # guard, so it must NOT see oversized/deeply-nested args.
+        raise
+    except (ValueError, json.JSONDecodeError):
+        # The legacy path's NUL-placeholder forge vector is reintroduced
+        # ONLY for ambiguous input the strict transcoder could not parse
+        # (e.g. bare multi-comma markdown values, #1837); the common path
+        # keeps the transcoder's no-placeholder, injection-safe guarantee.
+        return _gemma4_args_to_json_legacy(args_str)
+
+
+def _gemma4_transcode_to_json(args_str: str) -> dict:
+    """Transcode Gemma 4 tool-call args to a dict in a single pass.
+
+    Handles what mlx-lm's parser cannot:
+    - bare keys and values (``{location: Tokyo}``)
+    - single-quoted values, including commas/colons/braces/apostrophes
+      inside them (``{content: 'a, b: c'}``, #1830)
+    - ``<|"|>``-delimited strings, arrays, and nested objects
+
+    Implemented as a single-pass transcode to JSON text followed by one
+    ``json.loads`` (CPython's loads is iterative, so deep input cannot
+    recurse).  Every piece of captured string content is emitted through
+    ``json.dumps`` and structural characters are emitted only by the state
+    machine, so model output cannot inject JSON structure.  The legacy
+    implementation substituted ``\\x00N\\x00`` placeholders, which literal
+    NUL bytes in model output could forge, cross-contaminating argument
+    values; transcoding directly leaves nothing to forge.
+
+    Bare values stop at the first ``,``/``}``/``]`` by design: a bare value
+    that embeds those characters is ambiguous here, and the caller
+    (``_gemma4_args_to_json_robust``) recovers it via the legacy
+    key-anchored fallback.
+    """
+    # Fast path: the model may emit valid JSON args.
+    try:
+        return json.loads(args_str)
+    except json.JSONDecodeError:
+        pass
+
+    if len(args_str) > _GEMMA4_MAX_ARGS_LEN:
+        raise _Gemma4ArgsTooComplex("Gemma 4 args too large to parse")
+
+    squote_closes = _squote_close_positions(args_str)
+    n = len(args_str)
+    out: list[str] = []  # JSON text fragments
+    stack: list[str] = []  # open containers: "{" or "["
+    expect = "object"  # object | key | value | delim
+    i = 0
+
+    def _skip_ws(i: int) -> int:
+        while i < n and args_str[i].isspace():
+            i += 1
+        return i
+
+    def _read_marked_string(i: int):
+        """Read a <|"|>- or single-quoted string at i, or return None."""
+        if args_str.startswith(_GEMMA4_STR_DELIM, i):
+            close = args_str.find(
+                _GEMMA4_STR_DELIM, i + len(_GEMMA4_STR_DELIM)
+            )
+            if close == -1:
+                raise ValueError("unterminated Gemma 4 string")
+            return (
+                args_str[i + len(_GEMMA4_STR_DELIM): close],
+                close + len(_GEMMA4_STR_DELIM),
+            )
+        if args_str[i] == "'":
+            k = bisect.bisect_right(squote_closes, i)
+            if k < len(squote_closes):
+                close = squote_closes[k]
+                return args_str[i + 1: close], close + 1
+            # No anchored close ahead: not a string, treat as bare content.
+        return None
+
+    def _read_json_string(i: int):
+        """Read a standard double-quoted JSON string token verbatim."""
+        j = i + 1
+        while j < n:
+            if args_str[j] == "\\":
+                j += 2
+                continue
+            if args_str[j] == '"':
+                return args_str[i: j + 1], j + 1
+            j += 1
+        raise ValueError("unterminated double-quoted string")
+
+    while True:
+        i = _skip_ws(i)
+        if expect == "object":
+            if i >= n or args_str[i] != "{":
+                raise ValueError("Gemma 4 args must start with '{'")
+            out.append("{")
+            stack.append("{")
+            i += 1
+            expect = "key"
+        elif expect == "key":
+            if i >= n:
+                raise ValueError("unterminated object")
+            if args_str[i] == "}":
+                # Empty object, or tolerated trailing comma.
+                if out and out[-1] == ", ":
+                    out.pop()
+                out.append("}")
+                stack.pop()
+                i += 1
+                expect = "delim"
+                continue
+            if args_str[i] == '"':
+                tok, i = _read_json_string(i)
+                key = json.loads(tok)
+            else:
+                marked = _read_marked_string(i)
+                if marked is not None:
+                    key, i = marked
+                else:
+                    # Bare key: everything up to the colon.
+                    j = i
+                    while j < n and args_str[j] not in ":,{}[]'\"":
+                        j += 1
+                    key = args_str[i:j].strip()
+                    if not key:
+                        raise ValueError("malformed object key")
+                    i = j
+            i = _skip_ws(i)
+            if i >= n or args_str[i] != ":":
+                raise ValueError("expected ':' after object key")
+            out.append(json.dumps(key))
+            out.append(": ")
+            i += 1
+            expect = "value"
+        elif expect == "value":
+            if i >= n:
+                raise ValueError("unterminated value")
+            ch = args_str[i]
+            if ch == "{" or ch == "[":
+                # Depth bound, not recursion: a breach must surface as a
+                # clean parse failure on the existing drop path, never as a
+                # RecursionError (uncaught by the parse chain's excepts).
+                if len(stack) >= _GEMMA4_MAX_DEPTH:
+                    raise _Gemma4ArgsTooComplex(
+                        "Gemma 4 args nested too deeply"
+                    )
+                out.append(ch)
+                stack.append(ch)
+                i += 1
+                expect = "key" if ch == "{" else "value"
+                continue
+            if ch == "]" and stack and stack[-1] == "[":
+                # Empty array, or tolerated trailing comma.
+                if out and out[-1] == ", ":
+                    out.pop()
+                out.append("]")
+                stack.pop()
+                i += 1
+                expect = "delim"
+                continue
+            if ch == '"':
+                tok, i = _read_json_string(i)
+                out.append(tok)
+                expect = "delim"
+                continue
+            marked = _read_marked_string(i)
+            if marked is not None:
+                content, i = marked
+                out.append(json.dumps(content))
+                expect = "delim"
+                continue
+            # Bare value: runs to the next structural separator.
+            j = i
+            while j < n and args_str[j] not in ",}]":
+                j += 1
+            value = args_str[i:j].strip()
+            i = j
+            if not value:
+                raise ValueError("empty value")
+            low = value.lower()
+            if low in ("true", "false", "null"):
+                out.append(low)  # normalize case (models emit True/False)
+            else:
+                try:
+                    json.loads(value)  # already a valid scalar (number, ...)
+                    out.append(value)
+                except (json.JSONDecodeError, ValueError):
+                    out.append(json.dumps(value))
+            expect = "delim"
+        else:  # expect == "delim"
+            if not stack:
+                if i < n:
+                    raise ValueError("trailing data after args object")
+                break
+            if i >= n:
+                raise ValueError("unterminated args")
+            ch = args_str[i]
+            if ch == ",":
+                out.append(", ")
+                i += 1
+                expect = "key" if stack[-1] == "{" else "value"
+            elif ch == "}" and stack[-1] == "{":
+                out.append("}")
+                stack.pop()
+                i += 1
+            elif ch == "]" and stack[-1] == "[":
+                out.append("]")
+                stack.pop()
+                i += 1
+            else:
+                raise ValueError("malformed args structure")
+
+    result = json.loads("".join(out))
+    if not isinstance(result, dict):
+        raise ValueError("Gemma 4 args did not parse to an object")
+    return result
+
+
+def _gemma4_args_to_json_legacy(args_str: str) -> dict:
+    """Legacy regex-based Gemma 4 args parser (upstream #1837).
+
+    Kept as the last-resort fallback behind ``_gemma4_transcode_to_json``.
+    Its value over the transcoder is step 6: key-anchored value capture for
+    bare values that themselves contain commas, braces, or newlines (long
+    markdown emitted into an ``answer:`` argument, observed live on the
+    diffusion lane).  The transcoder stops bare values at the first
+    separator, so this is the only path that recovers that shape.
+
+    Carries the placeholder mechanism (``\\x00N\\x00``) the transcoder was
+    written to avoid; it runs only on input the transcoder already rejected.
     """
     import regex
 
@@ -472,41 +824,96 @@ def _gemma4_args_to_json_robust(args_str: str) -> dict:
 def _parse_gemma4_tool_call_fallback(text: str) -> Union[dict, list]:
     """Robust fallback parser for Gemma 4 ``call:name{args}`` format.
 
-    Activated only for Gemma 4 models (guarded by ``tool_call_start`` check).
-    Extends mlx-lm's parser to handle:
-    - Bare string values without ``<|"|>`` delimiters
-    - Colons / dots / hyphens in function names
-    - Degenerate prefixes from the diffusion lane's parallel denoising,
-      which can drop a token from the opening (observed live:
+    Activated only for Gemma 4 models (guarded by the ``tool_call_start``
+    check at the call site).  Extends mlx-lm's parser to handle:
+    - colons / dots / hyphens in function names (namespaced MCP tools,
+      e.g. ``call:google:mcp:text_generation:create-pdf-file``, #1830)
+    - bare string values without ``<|"|>`` delimiters
+    - single-quoted values, including commas, colons, braces and
+      apostrophes inside them (#1830)
+    - degenerate ``call:`` prefixes from the diffusion lane's parallel
+      denoising, which can drop a token from the opening (observed live:
       ``calldone{...}`` — missing colon — and ``:done{...}`` — missing
-      ``call``). The text is already marker-delimited (between
-      ``<|tool_call>`` and ``<tool_call|>``), so a permissive prefix
-      cannot misfire on ordinary prose.
+      ``call``, #1837).  ``_GEMMA4_CALL_HEAD`` matches these; the text is
+      already marker-delimited (between ``<|tool_call>`` and
+      ``<tool_call|>``), so the permissive prefix cannot misfire on prose.
+
+    Name remapping onto registered tools is deliberately NOT done here:
+    that is a post-parse concern handled by ``_remap_tool_call_names`` so
+    it covers every producer path (native parser, this fallback, XML
+    recovery, thinking-content promotion), not just this one.
     """
-    import regex
-
-    pattern = regex.compile(
-        r"(?:call)?:?([\w.-]+(?::[\w.-]+)*)(\{(?:[^{}]|(?2))*\})",
-        regex.DOTALL,
-    )
-    matches = list(pattern.finditer(text))
-    if not matches:
-        raise ValueError("No function call found in Gemma 4 format")
-
+    squote_closes = _squote_close_positions(text)
     results = []
-    for match in matches:
-        func_name = match.group(1)
-        args_str = match.group(2)
-
-        # Try standard JSON first (model may emit valid JSON args)
+    consumed_until = 0
+    for m in _GEMMA4_CALL_HEAD.finditer(text):
+        # A "call:" inside an already-consumed args span is string content
+        # (e.g. quoted prose mentioning a tool call), not a sibling call.
+        if m.start() < consumed_until:
+            continue
+        open_idx = m.end() - 1
+        end = _scan_gemma4_args_span(text, open_idx, squote_closes)
+        if end == -1:
+            continue
+        args_str = text[open_idx:end]
         try:
-            arguments = json.loads(args_str)
-        except json.JSONDecodeError:
-            arguments = _gemma4_args_to_json_robust(args_str)
+            try:
+                arguments = json.loads(args_str)
+            except json.JSONDecodeError:
+                arguments = _gemma4_args_to_json_robust(args_str)
+        except (ValueError, json.JSONDecodeError):
+            continue  # one malformed call must not drop its siblings
+        if not isinstance(arguments, dict):
+            continue
+        results.append({"name": m.group(1), "arguments": arguments})
+        consumed_until = end
 
-        results.append({"name": func_name, "arguments": arguments})
-
+    if not results:
+        raise ValueError("No function call found in Gemma 4 format")
     return results[0] if len(results) == 1 else results
+
+
+def _remap_tool_call_names(
+    tool_calls: List[ToolCall], tools: Optional[List]
+) -> None:
+    """Remap namespace-prefixed emitted tool names onto registered tools.
+
+    Gemma 4 emits names like ``google:mcp:text_generation:create-pdf-file``
+    for a tool registered as ``create-pdf-file`` (#1830); clients match by
+    exact name, so the call would be unusable.  Runs post-parse so every
+    producer path is covered and so the behavior survives changes to
+    mlx-lm's native parser (which currently rejects colon names and routes
+    these to the fallback, but may not forever).
+
+    Rule: remap only when the emitted name matches no registered tool AND
+    exactly one registered tool is a ``:``-boundary suffix of it; on zero
+    or several candidates keep the name verbatim.  The comparison is
+    boundary-aligned by construction (split on ':'), never str.endswith:
+    a bare endswith would let a crafted emission like 'evilcreate-pdf-file'
+    coerce into a registered 'create-pdf-file' (model output is
+    attacker-influenceable via prompt injection).
+    """
+    if not tool_calls or not tools:
+        return
+    valid_names = _extract_tool_names(tools)
+    if not valid_names:
+        return
+    for tc in tool_calls:
+        name = tc.function.name if tc.function else ""
+        if not name or name in valid_names or ":" not in name:
+            continue
+        parts = name.split(":")
+        suffixes = {":".join(parts[i:]) for i in range(1, len(parts))}
+        candidates = suffixes & valid_names
+        if len(candidates) == 1:
+            target = next(iter(candidates))
+            logger.info(
+                "Remapped namespaced tool call name %r to registered "
+                "tool %r",
+                name[:200],
+                target,
+            )
+            tc.function.name = target
 
 
 def parse_tool_calls(
@@ -520,6 +927,13 @@ def parse_tool_calls(
     Uses mlx-lm's TokenizerWrapper tool parser if available, otherwise
     falls back to generic XML tool call parsing for models like GLM.
 
+    Emitted names that match no registered tool are conservatively remapped
+    onto registered tools afterwards (see _remap_tool_call_names); doing it
+    here, at the single post-parse chokepoint, covers every producer path
+    including the thinking-content promotion in
+    extract_tool_calls_with_thinking, whose exact-name validity filter would
+    otherwise silently drop cleanly-parsed namespaced calls (#1830).
+
     Args:
         text: Raw model output text
         tokenizer: mlx-lm's TokenizerWrapper (required)
@@ -530,6 +944,18 @@ def parse_tool_calls(
         - cleaned_text: Text with tool call tags and thinking tags removed
         - tool_calls: List of ToolCall objects, or None if no tool calls found
     """
+    cleaned_text, tool_calls = _parse_tool_calls_impl(text, tokenizer, tools)
+    if tool_calls:
+        _remap_tool_call_names(tool_calls, tools)
+    return cleaned_text, tool_calls
+
+
+def _parse_tool_calls_impl(
+    text: str,
+    tokenizer: Any,
+    tools: Optional[List] = None,
+) -> Tuple[str, Optional[List[ToolCall]]]:
+    """parse_tool_calls body, pre-remap. See the public wrapper's docstring."""
     cleaned_text = text
 
     # Remove thinking tags if present (reasoning models)

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -461,8 +461,9 @@ def _scan_gemma4_args_span(
     ``open_idx``, or -1 if no balanced span exists within bounds.
 
     Iterative single-pass walk that counts brace depth only OUTSIDE string
-    literals (``<|"|>``-paired strings and anchored single-quoted values), so
-    a brace inside string content cannot truncate or unbalance the span.
+    literals (``<|"|>``-paired strings, standard JSON double-quoted strings,
+    and anchored single-quoted values), so a brace inside string content
+    cannot truncate or unbalance the span.
     This deliberately replaces a recursive regex:
     - linear time: recursive alternation patterns degrade quadratically on
       unbalanced model output (measured ~590ms at 80KB), an injection-driven
@@ -489,6 +490,27 @@ def _scan_gemma4_args_span(
             last_sig = '"'
             continue
         ch = text[i]
+        if ch == '"':
+            # Standard JSON double-quoted string. The <|"|> delimiter is
+            # matched by the startswith branch above before we reach here, so
+            # a bare ``"`` is an ordinary JSON string open: skip to its closing
+            # unescaped quote so a ``}`` inside the value cannot truncate the
+            # span (#1854 — without this the suffix remap turned the corrupted
+            # parse into an executable call with silently mangled arguments).
+            # Honors ``\"`` and ``\\`` so an escaped quote never closes early.
+            j = i + 1
+            while j < limit:
+                if text[j] == "\\":
+                    j += 2  # escaped char is literal, never closes the string
+                    continue
+                if text[j] == '"':
+                    break
+                j += 1
+            else:
+                return -1  # unterminated string within bounds: drop cleanly
+            i = j + 1
+            last_sig = '"'
+            continue
         if ch == "'" and last_sig in ":,[":
             k = bisect.bisect_right(squote_closes, i)
             if k < len(squote_closes):

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -15,6 +15,7 @@ from omlx.api.tool_calling import (
     ToolCallStreamFilter,
     _gemma4_args_to_json_robust,
     _parse_gemma4_tool_call_fallback,
+    _remap_tool_call_names,
     _serialize_tool_call_arguments,
     build_json_system_prompt,
     convert_tools_for_template,
@@ -1931,6 +1932,288 @@ class TestParseToolCallsGemma4Integration:
         assert tool_calls is not None
         assert len(tool_calls) == 1
         assert tool_calls[0].function.name == "search"
+
+
+class TestGemma4SingleQuotedArgs:
+    """Single-quoted and structurally hard Gemma 4 args (#1830).
+
+    Table-driven round-trips: each row is (rendered args, expected dict).
+    """
+
+    @pytest.mark.parametrize(
+        "rendered,expected",
+        [
+            # Issue #1830's reported shape: single-quoted values
+            (
+                "{filename: 'output.pdf', title: 'My Doc'}",
+                {"filename": "output.pdf", "title": "My Doc"},
+            ),
+            # Commas and colons inside a quoted value must not shred keys
+            (
+                "{content: 'a, b: and more', x: 1}",
+                {"content": "a, b: and more", "x": 1},
+            ),
+            # Braces inside a quoted value must not truncate or nest
+            (
+                "{content: 'has a { brace and } close'}",
+                {"content": "has a { brace and } close"},
+            ),
+            # Apostrophes inside a quoted value (anchored close)
+            (
+                "{msg: 'don't worry, be happy'}",
+                {"msg": "don't worry, be happy"},
+            ),
+            # Apostrophes in BARE values must not pair across values
+            (
+                "{a: it's ok, b: don't}",
+                {"a": "it's ok", "b": "don't"},
+            ),
+            # Brace inside a <|"|> string (gap vs mlx-lm's own regex)
+            (
+                '{a: <|"|>has a { brace<|"|>}',
+                {"a": "has a { brace"},
+            ),
+            # Arrays of quoted strings and of numbers
+            (
+                "{files: ['a.txt', 'b.txt'], counts: [1, 2]}",
+                {"files": ["a.txt", "b.txt"], "counts": [1, 2]},
+            ),
+            # Nested object with a quoted value containing a comma
+            (
+                "{opts: {size: 'a4, landscape', deep: {x: 1}}}",
+                {"opts": {"size": "a4, landscape", "deep": {"x": 1}}},
+            ),
+            # Mixed delimiter styles in one call
+            (
+                '{a: <|"|>x<|"|>, b: \'y\', c: bare, d: 5, e: true}',
+                {"a": "x", "b": "y", "c": "bare", "d": 5, "e": True},
+            ),
+            # Capitalized booleans normalize (models emit True/False)
+            ("{flag: True}", {"flag": True}),
+        ],
+    )
+    def test_round_trip(self, rendered, expected):
+        assert _gemma4_args_to_json_robust(rendered) == expected
+
+    def test_nul_bytes_cannot_forge_references(self):
+        """Literal NUL bytes in model output are data, not placeholders.
+
+        The previous implementation substituted \\x00N\\x00 placeholders for
+        captured strings; bare NULs in output forged those references and
+        cross-contaminated argument values.
+        """
+        result = _gemma4_args_to_json_robust(
+            '{a: <|"|>captured<|"|>, b: \x000\x00}'
+        )
+        assert result["a"] == "captured"
+        assert result["b"] == "\x000\x00"  # literal, NOT a copy of a
+
+    def test_deep_nesting_fails_cleanly(self):
+        """Depth bound surfaces as ValueError, never RecursionError.
+
+        RecursionError is a RuntimeError subclass that no except tuple in
+        the parse chain catches; it would escape as a 500.
+        """
+        deep = "call:f" + "{a: " * 80 + "1" + "}" * 80
+        with pytest.raises(ValueError):
+            _parse_gemma4_tool_call_fallback(deep)
+
+    def test_oversized_args_fail_cleanly(self):
+        """Args beyond the length cap are a clean no-match, not a hang."""
+        huge = "call:f{a: " + "x" * 300_000 + "}"
+        with pytest.raises(ValueError):
+            _parse_gemma4_tool_call_fallback(huge)
+
+    def test_issue_1830_exact_format(self):
+        """The reporter's namespaced-name + single-quoted-args emission."""
+        result = _parse_gemma4_tool_call_fallback(
+            "call:google:mcp:text_generation:create-pdf-file"
+            "{filename: 'output.pdf', title: 'Quarterly Report', "
+            "content: 'Revenue grew 12%, costs fell: margins improved. "
+            "Don't forget the appendix {tables}.'}"
+        )
+        assert result["name"] == "google:mcp:text_generation:create-pdf-file"
+        assert result["arguments"]["filename"] == "output.pdf"
+        assert result["arguments"]["title"] == "Quarterly Report"
+        assert result["arguments"]["content"] == (
+            "Revenue grew 12%, costs fell: margins improved. "
+            "Don't forget the appendix {tables}."
+        )
+
+    def test_call_inside_quoted_value_not_double_parsed(self):
+        result = _parse_gemma4_tool_call_fallback(
+            "call:a{x: 1}\ncall:b{note: 'use call:c{y: 2} later'}"
+        )
+        assert isinstance(result, list)
+        assert [r["name"] for r in result] == ["a", "b"]
+        assert result[1]["arguments"]["note"] == "use call:c{y: 2} later"
+
+    def test_one_malformed_call_does_not_drop_siblings(self):
+        result = _parse_gemma4_tool_call_fallback(
+            "call:bad{:::}\ncall:good{x: 1}"
+        )
+        assert result == {"name": "good", "arguments": {"x": 1}}
+
+
+class TestRemapToolCallNames:
+    """Tests for _remap_tool_call_names() (#1830)."""
+
+    @staticmethod
+    def _call(name):
+        return ToolCall(
+            id="call_test",
+            type="function",
+            function=FunctionCall(name=name, arguments="{}"),
+        )
+
+    @staticmethod
+    def _tools(*names):
+        return [{"type": "function", "function": {"name": n}} for n in names]
+
+    def test_namespaced_name_remaps_to_unique_suffix(self, caplog):
+        calls = [self._call("google:mcp:text_generation:create-pdf-file")]
+        with caplog.at_level(logging.INFO, logger="omlx.api.tool_calling"):
+            _remap_tool_call_names(calls, self._tools("create-pdf-file"))
+        assert calls[0].function.name == "create-pdf-file"
+        assert any("Remapped" in msg for msg in caplog.messages)
+
+    def test_exact_match_is_untouched(self):
+        calls = [self._call("tavily:search")]
+        _remap_tool_call_names(calls, self._tools("tavily:search", "search"))
+        assert calls[0].function.name == "tavily:search"
+
+    def test_ambiguous_suffixes_keep_verbatim(self):
+        """Two registered suffix candidates: refuse to guess."""
+        calls = [self._call("ns:text_generation:create-pdf-file")]
+        _remap_tool_call_names(
+            calls,
+            self._tools("text_generation:create-pdf-file", "create-pdf-file"),
+        )
+        assert calls[0].function.name == "ns:text_generation:create-pdf-file"
+
+    def test_endswith_attack_does_not_remap(self):
+        """Boundary-aligned matching: 'evilcreate-pdf-file' must not coerce
+        into 'create-pdf-file' (no ':' boundary), and neither must a
+        namespaced name whose last segment merely ENDS with a registered
+        name."""
+        calls = [self._call("evilcreate-pdf-file")]
+        _remap_tool_call_names(calls, self._tools("create-pdf-file"))
+        assert calls[0].function.name == "evilcreate-pdf-file"
+
+        calls = [self._call("evil:xcreate-pdf-file")]
+        _remap_tool_call_names(calls, self._tools("create-pdf-file"))
+        assert calls[0].function.name == "evil:xcreate-pdf-file"
+
+    def test_no_suffix_match_keeps_verbatim(self):
+        calls = [self._call("ns:unknown-tool")]
+        _remap_tool_call_names(calls, self._tools("create-pdf-file"))
+        assert calls[0].function.name == "ns:unknown-tool"
+
+    def test_no_tools_is_noop(self):
+        calls = [self._call("ns:create-pdf-file")]
+        _remap_tool_call_names(calls, None)
+        assert calls[0].function.name == "ns:create-pdf-file"
+        _remap_tool_call_names(calls, [])
+        assert calls[0].function.name == "ns:create-pdf-file"
+
+
+class TestParseToolCallsGemma4RealParser:
+    """E2e through parse_tool_calls with mlx-lm's REAL Gemma 4 parser.
+
+    Uses the real parser and real PAIRED markers (tool_call_end is
+    "<tool_call|>"; parse_tool_calls takes a different extraction branch
+    for paired vs one-sided markers, so a mock without the end marker
+    would test the wrong branch).  This also pins the dispatch contract:
+    if a future mlx-lm bump makes the native parser accept colon names,
+    test_native_parser_rejects_namespaced_names fails and tells us the
+    fallback is no longer exercised.
+    """
+
+    ISSUE_PAYLOAD = (
+        "call:google:mcp:text_generation:create-pdf-file"
+        "{filename: 'output.pdf', content: 'Revenue grew 12%, costs "
+        "fell: margins improved.'}"
+    )
+
+    @staticmethod
+    def _make_real_gemma4_tokenizer():
+        from mlx_lm.tool_parsers import gemma4 as mlx_gemma4
+
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = True
+        tok.tool_call_start = mlx_gemma4.tool_call_start
+        tok.tool_call_end = mlx_gemma4.tool_call_end
+        tok.tool_parser = mlx_gemma4.parse_tool_call
+        return tok
+
+    @staticmethod
+    def _pdf_tool():
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "create-pdf-file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "filename": {"type": "string"},
+                            "content": {"type": "string"},
+                        },
+                    },
+                },
+            }
+        ]
+
+    def test_native_parser_rejects_namespaced_names(self):
+        """Dispatch contract: mlx-lm's parser raises on colon names, which
+        is what routes #1830's emission into the oMLX fallback."""
+        from mlx_lm.tool_parsers import gemma4 as mlx_gemma4
+
+        with pytest.raises(ValueError):
+            mlx_gemma4.parse_tool_call(self.ISSUE_PAYLOAD)
+
+    def test_issue_1830_end_to_end(self):
+        """Marker-wrapped issue payload parses and remaps end to end."""
+        tok = self._make_real_gemma4_tokenizer()
+        text = (
+            f"{tok.tool_call_start}{self.ISSUE_PAYLOAD}{tok.tool_call_end}"
+        )
+
+        cleaned, tool_calls = parse_tool_calls(text, tok, self._pdf_tool())
+
+        assert tool_calls is not None and len(tool_calls) == 1
+        assert tool_calls[0].function.name == "create-pdf-file"
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args["filename"] == "output.pdf"
+        assert args["content"] == (
+            "Revenue grew 12%, costs fell: margins improved."
+        )
+        assert tok.tool_call_start not in cleaned
+        assert tok.tool_call_end not in cleaned
+
+    def test_thinking_path_promotes_remapped_call(self):
+        """Defect #4: a namespaced call in THINKING content must survive
+        extract_tool_calls_with_thinking's exact-name validity filter.
+        Without post-parse remapping, the filter silently drops the
+        cleanly parsed call because the emitted name matches no tool."""
+        tok = self._make_real_gemma4_tokenizer()
+        thinking = (
+            f"{tok.tool_call_start}"
+            "call:google:mcp:text_generation:create-pdf-file"
+            "{filename: 'output.pdf'}"
+            f"{tok.tool_call_end}"
+        )
+
+        extraction = extract_tool_calls_with_thinking(
+            thinking_content=thinking,
+            regular_content="Some unrelated prose.",
+            tokenizer=tok,
+            tools=self._pdf_tool(),
+        )
+
+        assert extraction.tool_calls is not None
+        assert extraction.tool_calls[0].function.name == "create-pdf-file"
+        assert extraction.tool_calls_from_thinking
 
 
 class TestEnrichToolParamsForGemma4:

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -1789,6 +1789,40 @@ class TestParseGemma4ToolCallFallback:
         assert result["name"] == "search"
         assert result["arguments"] == {"query": "hello world"}
 
+    def test_unbalanced_open_brace_in_json_string(self):
+        """A lone ``{`` inside a JSON string must not unbalance the span
+        (#1854). Before the string-aware scan this drove brace depth above
+        zero so the span never closed and the whole call was dropped."""
+        result = _parse_gemma4_tool_call_fallback(
+            'call:ns:create{"content": "open { brace"}'
+        )
+        assert result["name"] == "ns:create"
+        assert result["arguments"] == {"content": "open { brace"}
+
+    def test_multi_call_with_brace_in_first_args(self):
+        """A ``}`` inside the first call's JSON string must not corrupt the
+        consumed-span bookkeeping that separates sibling calls (#1854).
+        Pre-fix the first span truncated early, so the second call's head
+        landed inside the supposed-consumed region."""
+        result = _parse_gemma4_tool_call_fallback(
+            'call:ns:create{"a": "x } y"}call:foo{"b": 1}'
+        )
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["name"] == "ns:create"
+        assert result[0]["arguments"] == {"a": "x } y"}
+        assert result[1]["name"] == "foo"
+        assert result[1]["arguments"] == {"b": 1}
+
+    def test_escaped_backslash_before_closing_quote(self):
+        """A value ending in an escaped backslash (Windows path) closes on
+        the following quote, not on the backslash-escaped one (#1854)."""
+        result = _parse_gemma4_tool_call_fallback(
+            r'call:ns:create{"path": "C:\\tmp\\"}'
+        )
+        assert result["name"] == "ns:create"
+        assert result["arguments"] == {"path": "C:\\tmp\\"}
+
     def test_empty_args(self):
         result = _parse_gemma4_tool_call_fallback("call:get_time{}")
         assert result["name"] == "get_time"
@@ -1880,6 +1914,52 @@ class TestParseToolCallsGemma4Integration:
         # Markers should be stripped from cleaned_text
         assert "<|tool_call>" not in cleaned
         assert "<tool_call|>" not in cleaned
+
+    def test_brace_in_json_string_survives_remap(self):
+        """A ``}`` inside a JSON double-quoted value must not truncate the
+        args span, even when the parse then remaps onto a registered tool
+        (#1854). Before the fix the span scanner stopped at the brace inside
+        the string, the legacy recovery produced a corrupted ``{"content":
+        "has }`` parse, and the suffix remap turned ``ns:create`` into an
+        executable ``create`` call carrying silently mangled arguments. The
+        full content must round-trip intact."""
+        tok = self._make_gemma4_tokenizer()
+        tools = [{"type": "function", "function": {"name": "create"}}]
+        text = (
+            '<|tool_call>\n'
+            'call:ns:create{"content": "has } brace"}\n'
+            '<tool_call|>'
+        )
+
+        cleaned, tool_calls = parse_tool_calls(text, tok, tools)
+
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        # Remap fired: ns:create -> registered create.
+        assert tool_calls[0].function.name == "create"
+        # ...and the brace inside the string did not corrupt the value.
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args["content"] == "has } brace"
+        assert "<|tool_call>" not in cleaned
+        assert "<tool_call|>" not in cleaned
+
+    def test_escaped_quote_in_json_string_does_not_close_early(self):
+        """An escaped ``\\"`` inside a JSON value must not be read as the
+        closing quote, so a following ``}`` stays string content (#1854)."""
+        tok = self._make_gemma4_tokenizer()
+        tools = [{"type": "function", "function": {"name": "create"}}]
+        text = (
+            '<|tool_call>\n'
+            'call:ns:create{"content": "a \\" } b"}\n'
+            '<tool_call|>'
+        )
+
+        cleaned, tool_calls = parse_tool_calls(text, tok, tools)
+
+        assert tool_calls is not None
+        assert tool_calls[0].function.name == "create"
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args["content"] == 'a " } b'
 
     def test_markers_stripped_on_total_failure(self, caplog):
         """Even when fallback fails, markers are stripped and warning is logged."""


### PR DESCRIPTION
Fixes #1830.

## Problem

Gemma 4 models emit MCP-namespaced tool names and single-quoted argument values that the parser cannot handle. The reporter's log shows both at once:

```
Native tool parser failed ... Dropping match: "call:google:mcp:text_generation:create-pdf-file{filename: ..."
```

Four defects, three in the parser and one downstream:

1. mlx-lm's native gemma4 parser rejects any name containing colons (its name regex is `[\w-]+`), so these calls always land in the oMLX fallback. The fallback parses the name but returns it verbatim; a client that registered `create-pdf-file` cannot match `google:mcp:text_generation:create-pdf-file`. With simple arguments this is the quieter half of the symptom: the parse "succeeds" and the client silently receives a call it cannot use, with no warning logged.
2. Single-quoted values keep their literal quotes (`'output.pdf'` parses to the string `"'output.pdf'"`).
3. Commas, colons, or braces inside a single-quoted value shred the parse (garbage keys, or a truncated match in the brace-balancing regex). This is the logged drop above; real document content always has commas.
4. When the call lands in thinking content, `extract_tool_calls_with_thinking` filters by exact name match, so even a cleanly parsed namespaced call is silently dropped there.

Single quotes are not part of Gemma 4's tool-call format (the spec delimiter is `<|"|>`); they are degraded emissions observed in the wild, so the parser treats them tolerantly rather than as grammar.

## Fix

All in `omlx/api/tool_calling.py`, two pieces.

**Parse.** Replaced the recursive-regex brace balancer with an iterative linear scanner that tracks quote state: `<|"|>` pairs, and single-quoted values anchored to value positions so apostrophes inside prose (don't, it's) cannot pair across values. Rewrote `_gemma4_args_to_json_robust` as a single-pass transcode covering bare keys and values, single-quoted and `<|"|>` strings, arrays, and nested objects. Depth (64) and length (256 KB) bounds fail as clean parse errors on the existing drop path.

**Remap.** New `_remap_tool_call_names`, applied once post-parse in `parse_tool_calls`. If the emitted name matches no registered tool and exactly one registered tool is a `:`-boundary suffix of it, the call is remapped to that tool; zero or several candidates keep the name verbatim. Matching is boundary-aligned by construction (split on `:`), never `endswith`, so a crafted `evilcreate-pdf-file` cannot coerce into `create-pdf-file`. Remaps are logged at INFO. Post-parse placement covers every producer path (native parser, fallback, XML recovery, and the thinking-content filter from defect 4) and survives a future mlx-lm parser that accepts colon names. The remap only maps into the set of registered tools, so it grants nothing the model could not already call directly.

**Why the helpers were replaced rather than patched.** The old helper had two pre-existing weaknesses the rewrite removes in passing: literal NUL bytes in model output could forge its `\x00N\x00` placeholder references and cross-contaminate argument values, and the recursive regex degraded quadratically on unbalanced input (measured ~590 ms at 80 KB). Model output is untrusted input; the new scanner is linear and has no placeholders to forge.

## Root cause vs. upstream

The rejection of colon names is in mlx-lm (`tool_parsers/gemma4.py`). I fixed it in the oMLX fallback because that is the layer oMLX owns and the fallback exists for exactly this. A new test pins the dispatch contract against the real mlx-lm parser, so if a future mlx-lm bump starts accepting colon names we will see it. I can file the name-regex half upstream as well if you want it there too.

## Testing

- 25 new tests, 199 total in `tests/test_tool_calling.py`, all 174 existing tests untouched and green. Table-driven round trips for the new argument forms; the issue's exact payload end to end through mlx-lm's real Gemma 4 parser with real paired markers; remap boundary, ambiguity, and no-op rules; thinking-path promotion; clean failure on NUL bytes, deep nesting, and oversized input.
- Full suite: 5653 passed, 22 skipped, 0 failed.
- Live on an M4 Pro mini (64 GB), both `gemma-4-E4B-it-MLX-4bit` and the reporter's `mlx-community/gemma-4-26b-a4b-it-4bit`, streaming and non-streaming:
  - With plain tools both models emit the clean spec format at temperature 0 (plain name, `<|"|>` delimiters), so the native path is the no-regression baseline.
  - The spontaneous `google:mcp:` prefix did not reproduce locally (6 of 6 clean emissions at temperature 0.7 even with MCP-flavored prompts); it evidently needs the reporter's AnythingLLM context. I exercised the fixed paths live anyway:
  - Registering a colon-named tool (`text_generation:create-pdf-file`) forces the native parser to fail on the model's verbatim echo. The new fallback parsed it end to end; the exact match correctly did not remap.
  - With a bare registered name and a system prompt pushing fully qualified names, the 26B emitted literally `call:google:mcp:text_generation:create-pdf-file{...}`. The fallback parsed it, the remap log fired, and the client received `create-pdf-file` with intact arguments. On main this same request returns the unusable namespaced name.

## Out of scope

Tool-call parsing runs only when the request carries `tools`, so this fix helps tool-bearing clients. The reporter's second ask (a passthrough mode so markers are not stripped when native tool calling is off) is a config-surface change and not attempted here; I can take it as a separate follow-up.
