### PR TITLE
fix(macOS): show qwen3_5_mtp models in VLM MTP drafter picker

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -1544,6 +1544,12 @@ final class ModelSettingsScreenVM: ObservableObject {
     static let diffusionConfigModelTypes: Set<String> = [
         "diffusion_gemma",
     ]
+    /// `config_model_type` values accepted by the HTML admin's VLM MTP
+    /// assistant-drafter picker. Mirrored from `dashboard.js`
+    /// (`VLM_MTP_DRAFTER_CONFIG_MODEL_TYPES`).
+    static let vlmMtpDrafterConfigModelTypes: Set<String> = [
+        "gemma4_assistant", "gemma4_unified_assistant", "qwen3_5_mtp",
+    ]
     static let diffusionUnsupportedCtKwargKeys: Set<String> = [
         "enable_thinking", "reasoning_effort", "preserve_thinking",
     ]
@@ -2029,9 +2035,9 @@ final class ModelSettingsScreenVM: ObservableObject {
     }
 
     /// Draft-model options for VLM MTP. mlx-vlm's MTP loop takes an
-    /// "assistant" drafter, so the picker filters to model ids containing
-    /// "assistant" (case-insensitive), matching the HTML editor's filter,
-    /// and drops the current model so it can't draft for itself.
+    /// assistant drafter. Match the HTML editor by accepting known
+    /// config-derived drafter types first, then falling back to names that
+    /// contain "assistant" or a standalone "mtp" token.
     ///
     /// The stored value is the model **id**, not its path: the server
     /// resolves the drafter by registry id (`engine_pool` looks it up in
@@ -2044,11 +2050,30 @@ final class ModelSettingsScreenVM: ObservableObject {
                         comment: "Initial placeholder option in the VLM MTP draft-model picker")),
         ]
         for m in allModels
-        where m.id != modelID
-            && m.id.range(of: "assistant", options: .caseInsensitive) != nil {
+        where Self.isVlmMtpDraftModelCandidate(m, currentModelID: modelID) {
             out.append((m.id, m.id))
         }
         return out
+    }
+
+    static func isVlmMtpDraftModelCandidate(_ model: ModelDTO, currentModelID: String) -> Bool {
+        guard model.id != currentModelID else { return false }
+
+        if let type = model.configModelType?.lowercased(),
+           vlmMtpDrafterConfigModelTypes.contains(type) {
+            return true
+        }
+
+        let searchText = [model.id, model.modelPath]
+            .compactMap { $0 }
+            .joined(separator: " ")
+        if searchText.range(of: "assistant", options: .caseInsensitive) != nil {
+            return true
+        }
+        return searchText.range(
+            of: #"(^|[-_/\s])mtp($|[-_/\s])"#,
+            options: [.regularExpression, .caseInsensitive]
+        ) != nil
     }
 
     var isDSAConfigModel: Bool {

--- a/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import oMLX
+
+@MainActor
+final class ModelSettingsScreenVMTests: XCTestCase {
+
+    func testVlmMtpDraftModelOptionsIncludeQwenMtpConfigType() {
+        let vm = ModelSettingsScreenVM()
+        vm.modelID = "Qwopus3.6-35B-A3B-v1-4bit-MLXVLM-Target"
+        vm.allModels = [
+            makeModel(
+                id: "Qwopus3.6-35B-A3B-v1-4bit-MLXVLM-Target",
+                configModelType: "qwen3_5_moe"
+            ),
+            makeModel(
+                id: "Qwopus3.6-35B-A3B-v1-4bit-MLXVLM-MTP-Drafter",
+                configModelType: "qwen3_5_mtp"
+            ),
+            makeModel(id: "Qwen3.6-Regular-Model", configModelType: "qwen3_5_moe"),
+        ]
+
+        let values = vm.vlmMtpDraftModelOptions().map(\.0)
+
+        XCTAssertTrue(values.contains("Qwopus3.6-35B-A3B-v1-4bit-MLXVLM-MTP-Drafter"))
+        XCTAssertFalse(values.contains("Qwopus3.6-35B-A3B-v1-4bit-MLXVLM-Target"))
+        XCTAssertFalse(values.contains("Qwen3.6-Regular-Model"))
+    }
+
+    func testVlmMtpDraftModelOptionsKeepAssistantAndStandaloneMtpFallbacks() {
+        let vm = ModelSettingsScreenVM()
+        vm.modelID = "target"
+        vm.allModels = [
+            makeModel(id: "gemma-assistant-draft", configModelType: nil),
+            makeModel(id: "model-MTP-draft", configModelType: nil),
+            makeModel(id: "model-MTPLX-runtime", configModelType: nil),
+        ]
+
+        let values = vm.vlmMtpDraftModelOptions().map(\.0)
+
+        XCTAssertTrue(values.contains("gemma-assistant-draft"))
+        XCTAssertTrue(values.contains("model-MTP-draft"))
+        XCTAssertFalse(values.contains("model-MTPLX-runtime"))
+    }
+
+    private func makeModel(id: String, configModelType: String?) -> ModelDTO {
+        ModelDTO(
+            id: id,
+            modelPath: nil,
+            loaded: false,
+            isLoading: false,
+            estimatedSize: 0,
+            estimatedSizeFormatted: nil,
+            pinned: nil,
+            isDefault: nil,
+            engineType: nil,
+            modelType: nil,
+            configModelType: configModelType,
+            thinkingDefault: nil,
+            dflashCompatible: nil,
+            dflashCompatibilityReason: nil,
+            dflashSsdCacheAvailable: nil,
+            mtpCompatible: nil,
+            mtpCompatibilityReason: nil,
+            settings: nil
+        )
+    }
+}

--- a/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
+++ b/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		DBB000000000000000000105 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000105 /* ThemeTests.swift */; };
 		DBB000000000000000000106 /* ReleasesCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000106 /* ReleasesCheckerTests.swift */; };
 		DBB000000000000000000107 /* ModelsScreenSortingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000107 /* ModelsScreenSortingTests.swift */; };
+		DBB000000000000000000108 /* ModelSettingsScreenVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000108 /* ModelSettingsScreenVMTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -210,6 +211,7 @@
 		DCC000000000000000000105 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000106 /* ReleasesCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleasesCheckerTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000107 /* ModelsScreenSortingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsScreenSortingTests.swift; sourceTree = "<group>"; };
+		DCC000000000000000000108 /* ModelSettingsScreenVMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelSettingsScreenVMTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000010 /* oMLXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = oMLXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -274,6 +276,7 @@
 				DCC000000000000000000105 /* ThemeTests.swift */,
 				DCC000000000000000000106 /* ReleasesCheckerTests.swift */,
 				DCC000000000000000000107 /* ModelsScreenSortingTests.swift */,
+				DCC000000000000000000108 /* ModelSettingsScreenVMTests.swift */,
 			);
 			path = oMLXTests;
 			sourceTree = "<group>";
@@ -667,6 +670,7 @@
 				DBB000000000000000000105 /* ThemeTests.swift in Sources */,
 				DBB000000000000000000106 /* ReleasesCheckerTests.swift in Sources */,
 				DBB000000000000000000107 /* ModelsScreenSortingTests.swift in Sources */,
+				DBB000000000000000000108 /* ModelSettingsScreenVMTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary

- Mirror the web admin VLM MTP drafter detection in the native macOS model settings UI.
- Allow known drafter `config_model_type` values, including `qwen3_5_mtp`, `gemma4_assistant`, and `gemma4_unified_assistant`.
- Keep the existing fallback for model names containing `assistant` or standalone `mtp`, while avoiding false matches like `MTPLX`.
- Add regression coverage for Qwen VLM MTP drafter selection.

https://github.com/jundot/omlx/issues/1859