### PR TITLE
fix(memory): charge unfused SDPA score matrix at compute dtype, not fp32

### DIFF
--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -36,12 +36,19 @@ except ImportError:
 
 # Mirrors MLX Metal ScaledDotProductAttention::use_fallback for the
 # generation/inference path. Full prefill and short vector kernels support
-# different head dimensions; unsupported cases fall back to an unfused fp32
-# score matrix allocation.
+# different head dimensions; unsupported cases fall back to an unfused
+# score-matrix allocation.
 _SDPA_VECTOR_QUERY_TOKEN_THRESHOLD = 8
 _SDPA_FULL_SUPPORTED_HEAD_DIMS = frozenset({64, 80, 128})
 _SDPA_VECTOR_SUPPORTED_HEAD_DIMS = frozenset({64, 96, 128, 256})
-_SDPA_FALLBACK_SCORE_DTYPE_SIZE = 4
+# Default bytes/elem for the materialized unfused score matrix when the model's
+# compute dtype is unknown. MLX softmax accumulates in fp32, but the dominant
+# scratch buffer is allocated at the model's compute dtype, not fp32 — measured
+# ~2.1-2.2 bytes/elem on MLX 0.31.2 for a head_dim=256 prefill (fp16/bf16),
+# ~4.4 for fp32. Callers that know the model dtype pass it via
+# ``set_model_info(compute_dtype_size=...)``; this default covers the rare
+# dim-less path and matches the fp16/bf16 majority of MLX inference models.
+_SDPA_FALLBACK_SCORE_DTYPE_SIZE = 2
 
 
 @dataclass
@@ -122,7 +129,11 @@ class MemoryMonitor:
         self._num_layers: Optional[int] = None
         self._num_kv_heads: Optional[int] = None
         self._head_dim: Optional[int] = None
-        self._dtype_size: float = 2  # Default float16/bfloat16
+        self._dtype_size: float = 2  # KV storage width (may be fractional w/ TurboQuant)
+        # SDPA score-matrix width = model compute/activation dtype, distinct from
+        # _dtype_size (which the scheduler may override to a fractional TurboQuant
+        # KV width). Set via set_model_info(compute_dtype_size=...).
+        self._score_dtype_size: float = _SDPA_FALLBACK_SCORE_DTYPE_SIZE
         self._num_attention_heads: Optional[int] = None
         self._num_kv_cache_layers: Optional[int] = None
 
@@ -301,6 +312,7 @@ class MemoryMonitor:
         dtype_size: float = 2,
         num_attention_heads: Optional[int] = None,
         num_kv_cache_layers: Optional[int] = None,
+        compute_dtype_size: Optional[float] = None,
     ) -> None:
         """
         Set model information for memory estimation.
@@ -309,18 +321,28 @@ class MemoryMonitor:
             num_layers: Number of transformer layers
             num_kv_heads: Number of KV attention heads
             head_dim: Dimension per attention head
-            dtype_size: Bytes per element. This may be fractional for
-                quantized KV cache layouts.
+            dtype_size: Bytes per element of the *stored KV cache*. This may
+                be fractional for quantized (e.g. TurboQuant) KV layouts.
             num_attention_heads: Number of query attention heads (for SDPA
                 peak estimation). Defaults to num_kv_heads if not set.
             num_kv_cache_layers: Number of layers that use KVCache
                 (full attention). For hybrid models this may be less than
                 num_layers. Defaults to num_layers.
+            compute_dtype_size: Bytes per element of the model's
+                compute/activation dtype (2 for fp16/bf16, 4 for fp32). Used
+                for the unfused SDPA score-matrix transient, which is allocated
+                at the activation dtype regardless of KV quantization. Defaults
+                to the fp16/bf16 fallback when unknown.
         """
         self._num_layers = num_layers
         self._num_kv_heads = num_kv_heads
         self._head_dim = head_dim
         self._dtype_size = dtype_size
+        self._score_dtype_size = (
+            compute_dtype_size
+            if compute_dtype_size and compute_dtype_size > 0
+            else _SDPA_FALLBACK_SCORE_DTYPE_SIZE
+        )
         self._num_attention_heads = num_attention_heads or num_kv_heads
         self._num_kv_cache_layers = num_kv_cache_layers or num_layers
 
@@ -445,7 +467,7 @@ class MemoryMonitor:
         if self._uses_fused_sdpa(query_tokens, kv_len):
             return output
 
-        scores = n_q * query_tokens * kv_len * _SDPA_FALLBACK_SCORE_DTYPE_SIZE
+        scores = n_q * query_tokens * kv_len * self._score_dtype_size
         return scores + output
 
     def estimate_prefill_peak_bytes(
@@ -724,6 +746,9 @@ def set_model_info_from_model(monitor: "MemoryMonitor", model: Any) -> None:
                 dtype_size=dtype_size,
                 num_attention_heads=num_attention_heads,
                 num_kv_cache_layers=num_kv_cache_layers,
+                # This path uses the uncompressed base dtype for KV, so
+                # dtype_size already equals the compute/activation dtype.
+                compute_dtype_size=dtype_size,
             )
             logger.debug(
                 f"Model info for memory estimation: "

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -8496,6 +8496,9 @@ class Scheduler:
                     dtype_size=dtype_size,
                     num_attention_heads=num_attention_heads,
                     num_kv_cache_layers=num_kv_cache_layers,
+                    # SDPA scores are materialized at the compute/activation
+                    # dtype, not the (possibly fractional TurboQuant) KV width.
+                    compute_dtype_size=base_dtype_size,
                 )
                 logger.debug(
                     f"Model info for memory estimation: "

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -335,7 +335,42 @@ class TestEstimatePrefillPeakBytes:
         expected_sdpa = self._expected_fallback_sdpa(8, 2048, 32768, 256)
         expected_kv = m.estimate_prompt_kv_bytes(32768)
         assert peak == expected_sdpa + expected_kv
-        assert expected_sdpa > 8 * 2048 * 256 * 4
+        assert expected_sdpa > 8 * 2048 * 256 * 2
+
+    def test_sdpa_fallback_scores_track_compute_dtype(self):
+        # The unfused score matrix is materialized at the model's compute
+        # dtype, not fp32 and not the (possibly fractional TurboQuant) KV width.
+        # fp32 model -> 4 bytes/elem; bf16/fp16 -> 2.
+        def _scores(monitor, n_q, chunk, kv, hd):
+            out = n_q * chunk * hd * 4
+            return monitor._estimate_sdpa_activation_bytes(chunk, kv) - out
+
+        n_q, chunk, kv, hd = 8, 2048, 32768, 256
+        m_bf16 = MemoryMonitor(max_kv_cache_memory=10 * 1024**3)
+        m_bf16.set_model_info(
+            num_layers=48, num_kv_heads=4, head_dim=hd,
+            num_attention_heads=n_q, compute_dtype_size=2,
+        )
+        m_fp32 = MemoryMonitor(max_kv_cache_memory=10 * 1024**3)
+        m_fp32.set_model_info(
+            num_layers=48, num_kv_heads=4, head_dim=hd,
+            num_attention_heads=n_q, compute_dtype_size=4,
+        )
+        assert _scores(m_bf16, n_q, chunk, kv, hd) == n_q * chunk * kv * 2
+        assert _scores(m_fp32, n_q, chunk, kv, hd) == n_q * chunk * kv * 4
+
+    def test_sdpa_score_dtype_ignores_fractional_kv_width(self):
+        # TurboQuant sets a fractional KV dtype_size; the score matrix must
+        # still be charged at the compute dtype, not ~0.5 bytes/elem.
+        n_q, chunk, kv, hd = 8, 2048, 32768, 256
+        m = MemoryMonitor(max_kv_cache_memory=10 * 1024**3)
+        m.set_model_info(
+            num_layers=48, num_kv_heads=4, head_dim=hd, dtype_size=0.5,
+            num_attention_heads=n_q, compute_dtype_size=2,
+        )
+        out = n_q * chunk * hd * 4
+        scores = m._estimate_sdpa_activation_bytes(chunk, kv) - out
+        assert scores == n_q * chunk * kv * 2
 
     def test_sdpa_fallback_accounts_for_cached_kv_span(self):
         """Regression for M3: SDPA fallback spans the FULL prompt (cached + new),


### PR DESCRIPTION
  ## Summary

  The `head_dim > 128` prefill estimator over-charges the unfused MLX SDPA
  fallback by ~2×, producing **false `prefill_memory_exceeded` (413) rejections**
  for long-context prefills that actually fit under the ceiling.

  `estimate_prefill_peak_bytes` / `estimate_chunk_transient_bytes` charge the
  materialized fallback score matrix at a hardcoded **4 bytes/elem (fp32)**. MLX's
  softmax *accumulates* in fp32, but the dominant materialized scratch buffer that
  drives peak memory is allocated at the model's **compute/activation dtype**. For
  the fp16/bf16 models that make up every current head_dim=256 pack (Gemma 4,
  Qwen3.5/3.6), that's ~2 bytes/elem — so the estimate is double the real
  transient.

  This refines the head_dim dispatch from #1797 (which correctly restored the
  O(kv_len) estimate for head_dim=256 prefill — the dispatch is right; only the
  per-element byte width was wrong).

  ## Why thread the dtype instead of hardcoding `2`

  Hardcoding `2` would under-count a genuine fp32 model by 2× and risk the Metal
  OOM / SIGABRT the guard exists to prevent (omlx serves arbitrary HF models, not
  just bf16 ones). So instead of swapping one wrong constant for another, the score
  matrix is charged at the model's actual compute dtype, plumbed through as a new
  `compute_dtype_size`.

  This is deliberately **distinct from `dtype_size`**: the scheduler may override
  `dtype_size` to a fractional TurboQuant *KV-storage* width (~0.5), but the SDPA
  score matrix is always materialized at the activation dtype regardless of KV
  quantization. Reusing `dtype_size` would massively under-count under TurboQuant.

  ## Measurements (MLX 0.31.2)

  Synthetic SDPA at prefill shape (`n_q=16, n_kv=2, query=2048`, GQA, causal),
  peak via `mx.get_peak_memory`:

  | head_dim | kv=8k | kv=16k | kv=64k | scaling |
  |---------:|------:|-------:|-------:|---------|
  | 128      | ~25 MB | ~34 MB | flat   | **fused, O(1)** |
  | 256      | 621 MB | 1191 MB | 4614 MB | **unfused, O(kv)** |

  - head_dim=128 is flat → fused; head_dim=256 grows linearly → unfused
    (confirms #1797's dispatch).
  - Element width tracks input dtype: **fp16/bf16 ≈ 2.1–2.2 B/elem**, fp32 ≈ 4.4.

  ### Real-model confirmation

  `mlx-community/Qwen3.5-4B-OptiQ-4bit` (head_dim=256 hybrid, bf16 — same family as
  Qwen3.6-35B-A3B), dims read from the loaded model, MLX 0.31.2, prefill chunk
  q=2048, **transient = peak − pre-op baseline**:

  | kv_len | transient | bytes/elem | est new (×2) | est old (×4) |
  |-------:|----------:|-----------:|-------------:|-------------:|
  | 8,192  | 587 MB    | 2.19       | 570 MB       | 1,107 MB     |
  | 16,384 | 1,141 MB  | 2.13       | 1,107 MB     | 2,181 MB     |
  | 32,768 | 2,248 MB  | 2.09       | 2,181 MB     | 4,329 MB     |
  | 65,536 | 4,463 MB  | 2.08       | 4,329 MB     | 8,623 MB     |

  Baseline-free marginal slope = **2.06 bytes/score-elem**. The compute-dtype-aware
  estimate tracks measured (small ~3% softmax-temp gap, absorbed by the enforcer's
  `hard_threshold` margin); the pre-fix fp32 width over-predicts ~2×.

  ## Impact

  Real 413 on Qwen3.6-35B-A3B-oQ6 (64 GB Mac mini, ~96k context, `aggressive` tier):

  | | current | KV+SDPA | peak | vs 58 GB ceiling |
  |---|---|---|---|---|
  | Before (×4) | 45.11 | 13.53 | **58.64** | rejected (413) |
  | After (×2)  | 45.11 | 5.97  | **51.08** | admitted |

  The guard stays protective: the term is still O(kv_len), so genuinely oversized
  prefills are still rejected before OOM/SIGABRT.

  ## Live validation (0.4.4rc1, M4 Pro 64 GB)

  Patched build deployed and stress-tested against `Qwen3.6-35B-A3B-oQ6`
  (head_dim=256, bf16) with cold, unique-content prompts (no prefix-cache):

  | Prompt | Tokens | Before fix | After fix |
  |--------|-------:|-----------|-----------|
  | cold-50k  |  50,048 | —          | ✅ 200, completed |
  | cold-100k | 100,049 | false 413  | ✅ 200, completed |
  | cold-130k | 130,049 | false 413  | ✅ 200, completed |

  - **Zero** false `prefill_memory_exceeded` preflight rejections across the run.
  - Guard still protective: a 240k-token prompt was admitted, then correctly
    aborted by the mid-prefill enforcer at 223,232 tokens when it genuinely reached
    60 GB — no OOM/SIGABRT.

  ## Changes

  - `memory_monitor.py`: add `_score_dtype_size`, set via
    `set_model_info(compute_dtype_size=...)`; the SDPA fallback term uses it.
    `_SDPA_FALLBACK_SCORE_DTYPE_SIZE` becomes the documented default for the
    dim-less path.
  - `set_model_info_from_model` / `Scheduler._set_model_info_for_monitor`: pass the
    base compute dtype (2 for fp16/bf16, 4 for fp32).
  - `tests/test_memory_monitor.py`: lock in compute-dtype tracking and that a
    fractional TurboQuant KV width does not leak into the score-matrix term.

  ## Test plan

  - `pytest tests/test_memory_monitor.py` — 45/45 pass.
  - Live-validated on a 0.4.4rc1 build (MLX 0.31.2) — see table above.

  ## Reproducing the measurements

  Self-contained script (run against any head_dim=256 model):

  <details>
  <summary><code>verify_sdpa_score_dtype.py</code></summary>

  ```python
  """Verify the unfused SDPA score-matrix dtype: loads a real head_dim=256 model,
  reads its attention dims + compute dtype, and measures the prefill transient
  (peak - baseline) of mx.fast.scaled_dot_product_attention across a kv_len sweep.

  Usage: python verify_sdpa_score_dtype.py mlx-community/Qwen3.5-4B-OptiQ-4bit
  """

  import sys
  import mlx.core as mx
  from mlx_lm import load
  from omlx.memory_monitor import MemoryMonitor


  def _find_attn_dims(model):
      head_dim = n_q = n_kv = dtype = None
      for _, mod in (model.named_modules() if hasattr(model, "named_modules") else []):
          if hasattr(mod, "n_heads") and hasattr(mod, "n_kv_heads"):
              n_q, n_kv = int(mod.n_heads), int(mod.n_kv_heads)
              hd = getattr(mod, "head_dim", None)
              if hd is not None:
                  head_dim = int(hd)
              for _, p in (mod.parameters().items() if hasattr(mod, "parameters") else []):
                  if isinstance(p, mx.array):
                      dtype = p.dtype

  def measure(n_q, n_kv, head_dim, q_len, kv_len, dtype):
      mx.clear_cache()
      q = mx.random.normal((1, n_q, q_len, head_dim)).astype(dtype)
      k = mx.random.normal((1, n_kv, kv_len, head_dim)).astype(dtype)
      v = mx.random.normal((1, n_kv, kv_len, head_dim)).astype(dtype)
      mx.eval(q, k, v); mx.synchronize()
      baseline = mx.get_active_memory()
      mx.reset_peak_memory()
      out = mx.fast.scaled_dot_product_attention(q, k, v, scale=head_dim**-0.5, mask="causal")
      mx.eval(out)
      return mx.get_peak_memory() - baseline


  def main():
      path = sys.argv[1] if len(sys.argv) > 1 else "mlx-community/Qwen3.5-4B-OptiQ-4bit"
      print(f"mlx {mx.__version__}  |  loading {path} ...")
      model, _ = load(path)
      n_q, n_kv, head_dim, dtype = _find_attn_dims(model)
      n_q, n_kv, head_dim = n_q or 16, n_kv or 2, head_dim or 256
      dtype = dtype or mx.bfloat16
      print(f"real attn dims: n_q={n_q} n_kv={n_kv} head_dim={head_dim} dtype={dtype}")

      mon = MemoryMonitor(max_kv_cache_memory=8 * 1024**3, eviction_enabled=False)
      mon.set_model_info(num_layers=1, num_kv_heads=n_kv, head_dim=head_dim,
                         num_attention_heads=n_q,
                         compute_dtype_size=4 if dtype == mx.float32 else 2)

      q_len = 2048
      print(f"\nchunk={q_len}, transient = peak - baseline:\n")
      print(f"{'kv_len':>8} {'transient':>12} {'B/elem':>8} {'est_new':>12} {'est_old':>12}")
      out_buf = n_q * q_len * head_dim * 4
      rows = []
      for kv in (8192, 16384, 32768, 65536):
          tr = measure(n_q, n_kv, head_dim, q_len, kv, dtype)
          elems = n_q * q_len * kv
          est_new = mon.estimate_chunk_transient_bytes(q_len, kv)
          est_old = elems * 4 + out_buf
          rows.append((tr, elems))
          print(f"{kv:>8} {tr/1e6:>10.1f}MB {tr/elems:>8.2f} {est_new/1e6:>10.1f}MB {est_old/1e6:>10.1f}MB")
      (t0, e0), (t1, e1) = rows[0], rows[-1]
      print(f"\nmarginal slope: {(t1 - t0) / (e1 - e0):.2f} bytes/score-elem (~2 => compute-dtype, not fp32)")


  if __name__ == "__main__":
      main()
  ```
  </details>

  Refines #1797.