### PR TITLE
feat: support MiniMax M3 from in-progress mlx-vlm PR

### DIFF
--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -63,6 +63,8 @@ class OutputParserFactory:
     kind: str
     create_session: Callable[[Any], OutputParserSession]
     stop_token_ids: set[int] = field(default_factory=set)
+    thinking_start_text: str | None = None
+    thinking_start_output_text: str | None = None
     thinking_end_text: str | None = None
     thinking_end_trailing_text: str | None = None
     # Marker strings that must survive special-token stripping so the
@@ -157,6 +159,10 @@ def _is_cohere2_moe_model(
 
 
 _MINIMAX_M3_MODEL_TYPES = {"minimax_m3", "minimax_m3_vl"}
+_MINIMAX_THINK_START = "<mm:think>"
+_MINIMAX_THINK_END = "</mm:think>"
+_MINIMAX_EOS_TOKEN = "[e~["
+_MINIMAX_SPECIAL_TOKENS = (_MINIMAX_EOS_TOKEN, "]~b]", "]~!b[", "]!p~[", "]!d~[")
 _MINIMAX_TOOL_CALL_START = "]<]minimax[>[<tool_call>"
 _MINIMAX_TOOL_CALL_END = "]<]minimax[>[</tool_call>"
 
@@ -183,6 +189,83 @@ def _is_minimax_m3_model(
     return "minimax" in lowered and "m3" in lowered
 
 
+class _MiniMaxM3ProtocolNormalizer:
+    """Normalize MiniMax M3 protocol markers to oMLX-visible markers."""
+
+    _REPLACEMENTS = (
+        (_MINIMAX_THINK_START, "<think>"),
+        (_MINIMAX_THINK_END, "</think>"),
+        *tuple((token, "") for token in _MINIMAX_SPECIAL_TOKENS),
+    )
+    _MARKERS = tuple(marker for marker, _ in _REPLACEMENTS)
+
+    def __init__(self) -> None:
+        self._buffer = ""
+
+    @classmethod
+    def _replace_markers(cls, text: str) -> str:
+        for marker, replacement in cls._REPLACEMENTS:
+            text = text.replace(marker, replacement)
+        return text
+
+    @classmethod
+    def _partial_suffix_len(cls, text: str) -> int:
+        max_len = min(len(text), max(len(marker) for marker in cls._MARKERS) - 1)
+        for size in range(max_len, 0, -1):
+            suffix = text[-size:]
+            if any(marker.startswith(suffix) for marker in cls._MARKERS):
+                return size
+        return 0
+
+    def feed(self, text: str) -> str:
+        if not text:
+            return ""
+
+        self._buffer += text
+        keep = self._partial_suffix_len(self._buffer)
+        if keep:
+            ready = self._buffer[:-keep]
+            self._buffer = self._buffer[-keep:]
+        else:
+            ready = self._buffer
+            self._buffer = ""
+        return self._replace_markers(ready)
+
+    def finish(self) -> str:
+        text = self._replace_markers(self._buffer)
+        self._buffer = ""
+        return text
+
+
+def _token_id_for_text(tokenizer: Any, text: str) -> int | None:
+    try:
+        token_id = tokenizer.convert_tokens_to_ids(text)
+    except (AttributeError, KeyError, TypeError, ValueError):
+        token_id = None
+    if token_id is not None and token_id != getattr(tokenizer, "unk_token_id", None):
+        try:
+            return int(token_id)
+        except (TypeError, ValueError):
+            pass
+
+    try:
+        token_ids = tokenizer.encode(text, add_special_tokens=False)
+    except TypeError:
+        try:
+            token_ids = tokenizer.encode(text)
+        except Exception:
+            return None
+    except Exception:
+        return None
+
+    if len(token_ids) == 1:
+        try:
+            return int(token_ids[0])
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
 class MiniMaxM3OutputParserSession:
     """Parser session for MiniMax M3 XML-style tool calls."""
 
@@ -196,10 +279,14 @@ class MiniMaxM3OutputParserSession:
         try:
             from ..api.tool_calling import ToolCallStreamFilter
 
+            self._stream_filter = ToolCallStreamFilter(tokenizer)
             self._visible_filter = ToolCallStreamFilter(tokenizer)
         except Exception as e:  # noqa: BLE001
             logger.debug("MiniMax M3 stream filter unavailable: %s", e)
+            self._stream_filter = None
             self._visible_filter = None
+        self._stream_normalizer = _MiniMaxM3ProtocolNormalizer()
+        self._visible_normalizer = _MiniMaxM3ProtocolNormalizer()
 
     def _decode_token(self, token_id: int) -> str:
         if self._detokenizer is not None:
@@ -210,20 +297,46 @@ class MiniMaxM3OutputParserSession:
         except TypeError:
             return self._tokenizer.decode([token_id])
 
-    def _visible_text(self, text: str) -> str:
+    def _filtered_text(
+        self,
+        text: str,
+        tool_filter: Any,
+        normalizer: _MiniMaxM3ProtocolNormalizer,
+    ) -> str:
         if not text:
             return ""
-        if self._visible_filter is None:
-            return text
-        return self._visible_filter.feed(text)
+        if tool_filter is not None:
+            text = tool_filter.feed(text)
+        return normalizer.feed(text)
+
+    def _finish_filtered_text(
+        self,
+        tool_filter: Any,
+        normalizer: _MiniMaxM3ProtocolNormalizer,
+    ) -> str:
+        text = ""
+        if tool_filter is not None:
+            text += normalizer.feed(tool_filter.finish())
+        text += normalizer.finish()
+        return text
 
     def process_token(self, token_id: int) -> OutputParserTokenResult:
         decoded_text = self._decode_token(token_id)
         self._raw_text += decoded_text
+        is_stop = decoded_text == _MINIMAX_EOS_TOKEN
         return OutputParserTokenResult(
-            stream_text=decoded_text,
-            visible_text=self._visible_text(decoded_text),
-            record_token=True,
+            stream_text=self._filtered_text(
+                decoded_text,
+                self._stream_filter,
+                self._stream_normalizer,
+            ),
+            visible_text=self._filtered_text(
+                decoded_text,
+                self._visible_filter,
+                self._visible_normalizer,
+            ),
+            is_stop=is_stop,
+            record_token=not is_stop,
         )
 
     def finalize(self) -> OutputParserFinalizeResult:
@@ -234,11 +347,25 @@ class MiniMaxM3OutputParserSession:
             final_text = self._detokenizer.last_segment
             if final_text:
                 self._raw_text += final_text
-                stream_text += final_text
-                visible_text += self._visible_text(final_text)
+                stream_text += self._filtered_text(
+                    final_text,
+                    self._stream_filter,
+                    self._stream_normalizer,
+                )
+                visible_text += self._filtered_text(
+                    final_text,
+                    self._visible_filter,
+                    self._visible_normalizer,
+                )
 
-        if self._visible_filter is not None:
-            visible_text += self._visible_filter.finish()
+        stream_text += self._finish_filtered_text(
+            self._stream_filter,
+            self._stream_normalizer,
+        )
+        visible_text += self._finish_filtered_text(
+            self._visible_filter,
+            self._visible_normalizer,
+        )
 
         tool_calls: list[dict[str, str]] = []
         if _MINIMAX_TOOL_CALL_START in self._raw_text:
@@ -460,15 +587,24 @@ def detect_output_parser(
         )
 
     if _is_minimax_m3_model(model_name, model_config):
+        minimax_stop_ids = set()
+        eos_id = _token_id_for_text(tokenizer, _MINIMAX_EOS_TOKEN)
+        if eos_id is not None:
+            minimax_stop_ids.add(eos_id)
+
         return OutputParserFactory(
             kind="minimax_m3",
             create_session=lambda session_tokenizer: MiniMaxM3OutputParserSession(
                 session_tokenizer,
                 model_path=model_name,
             ),
-            stop_token_ids=set(),
-            thinking_end_text="</think>",
+            stop_token_ids=minimax_stop_ids,
+            thinking_start_text=_MINIMAX_THINK_START,
+            thinking_start_output_text="<think>\n",
+            thinking_end_text=_MINIMAX_THINK_END,
             protocol_marker_texts=(
+                _MINIMAX_THINK_START,
+                _MINIMAX_THINK_END,
                 _MINIMAX_TOOL_CALL_START,
                 _MINIMAX_TOOL_CALL_END,
             ),

--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -9,6 +9,7 @@ suppression) and exposes a uniform token-by-token interface.
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -153,6 +154,118 @@ def _is_cohere2_moe_model(
         model_config is not None
         and model_config.get("model_type") == "cohere2_moe"
     )
+
+
+_MINIMAX_M3_MODEL_TYPES = {"minimax_m3", "minimax_m3_vl"}
+_MINIMAX_TOOL_CALL_START = "]<]minimax[>[<tool_call>"
+_MINIMAX_TOOL_CALL_END = "]<]minimax[>[</tool_call>"
+
+
+def _serialize_minimax_tool_arguments(arguments: Any) -> str:
+    if isinstance(arguments, str):
+        return arguments or "{}"
+    if arguments is None:
+        return "{}"
+    try:
+        return json.dumps(arguments, ensure_ascii=False, separators=(",", ":"))
+    except TypeError:
+        return str(arguments)
+
+
+def _is_minimax_m3_model(
+    model_name: str,
+    model_config: dict[str, Any] | None = None,
+) -> bool:
+    model_type = model_config.get("model_type") if model_config else None
+    if model_type in _MINIMAX_M3_MODEL_TYPES:
+        return True
+    lowered = model_name.lower()
+    return "minimax" in lowered and "m3" in lowered
+
+
+class MiniMaxM3OutputParserSession:
+    """Parser session for MiniMax M3 XML-style tool calls."""
+
+    def __init__(self, tokenizer: Any, model_path: str | None = None):
+        self._tokenizer = tokenizer
+        self._raw_text = ""
+        self._detokenizer = create_streaming_detokenizer(tokenizer, model_path)
+        if self._detokenizer is not None:
+            self._detokenizer.reset()
+
+        try:
+            from ..api.tool_calling import ToolCallStreamFilter
+
+            self._visible_filter = ToolCallStreamFilter(tokenizer)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("MiniMax M3 stream filter unavailable: %s", e)
+            self._visible_filter = None
+
+    def _decode_token(self, token_id: int) -> str:
+        if self._detokenizer is not None:
+            self._detokenizer.add_token(token_id)
+            return self._detokenizer.last_segment
+        try:
+            return self._tokenizer.decode([token_id], skip_special_tokens=False)
+        except TypeError:
+            return self._tokenizer.decode([token_id])
+
+    def _visible_text(self, text: str) -> str:
+        if not text:
+            return ""
+        if self._visible_filter is None:
+            return text
+        return self._visible_filter.feed(text)
+
+    def process_token(self, token_id: int) -> OutputParserTokenResult:
+        decoded_text = self._decode_token(token_id)
+        self._raw_text += decoded_text
+        return OutputParserTokenResult(
+            stream_text=decoded_text,
+            visible_text=self._visible_text(decoded_text),
+            record_token=True,
+        )
+
+    def finalize(self) -> OutputParserFinalizeResult:
+        stream_text = ""
+        visible_text = ""
+        if self._detokenizer is not None:
+            self._detokenizer.finalize()
+            final_text = self._detokenizer.last_segment
+            if final_text:
+                self._raw_text += final_text
+                stream_text += final_text
+                visible_text += self._visible_text(final_text)
+
+        if self._visible_filter is not None:
+            visible_text += self._visible_filter.finish()
+
+        tool_calls: list[dict[str, str]] = []
+        if _MINIMAX_TOOL_CALL_START in self._raw_text:
+            try:
+                from mlx_vlm.tool_parsers.minimax_m3 import parse_tool_call
+
+                parsed = parse_tool_call(self._raw_text)
+                parsed_calls = parsed if isinstance(parsed, list) else [parsed]
+                tool_calls = [
+                    {
+                        "name": str(call.get("name", "")),
+                        "arguments": _serialize_minimax_tool_arguments(
+                            call.get("arguments")
+                        ),
+                    }
+                    for call in parsed_calls
+                    if isinstance(call, dict) and call.get("name")
+                ]
+            except Exception as e:  # noqa: BLE001
+                logger.debug("MiniMax M3 tool-call parse failed: %s", e)
+
+        return OutputParserFinalizeResult(
+            stream_text=stream_text,
+            visible_text=visible_text,
+            tool_calls=tool_calls,
+            finish_reason="tool_calls" if tool_calls else None,
+        )
 
 
 def _create_cohere2_moe_filter():
@@ -344,6 +457,21 @@ def detect_output_parser(
             ),
             stop_token_ids=set(),
             thinking_end_text="</think>",
+        )
+
+    if _is_minimax_m3_model(model_name, model_config):
+        return OutputParserFactory(
+            kind="minimax_m3",
+            create_session=lambda session_tokenizer: MiniMaxM3OutputParserSession(
+                session_tokenizer,
+                model_path=model_name,
+            ),
+            stop_token_ids=set(),
+            thinking_end_text="</think>",
+            protocol_marker_texts=(
+                _MINIMAX_TOOL_CALL_START,
+                _MINIMAX_TOOL_CALL_END,
+            ),
         )
 
     return None

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -13,12 +13,13 @@ import re
 from collections.abc import Callable, Sequence
 from typing import List, Optional, Tuple
 
-
 # Tags used for thinking blocks
 _OPEN_TAG = "<think>"
 _CLOSE_TAG = "</think>"
 _OPEN_LEN = len(_OPEN_TAG)   # 7
 _CLOSE_LEN = len(_CLOSE_TAG)  # 8
+_MINIMAX_OPEN_TAG = "<mm:think>"
+_MINIMAX_CLOSE_TAG = "</mm:think>"
 
 # Regex for non-streaming extraction (complete text)
 _THINKING_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
@@ -167,6 +168,10 @@ def extract_thinking(text: str) -> Tuple[str, str]:
     """
     if not text:
         return ("", "")
+
+    text = text.replace(_MINIMAX_OPEN_TAG, _OPEN_TAG).replace(
+        _MINIMAX_CLOSE_TAG, _CLOSE_TAG
+    )
 
     thinking_parts = []
     remaining = text

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -24,9 +24,9 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from jsonschema import validate, ValidationError
+from jsonschema import ValidationError, validate
 
-from .openai_models import FunctionCall, ResponseFormat, ToolCall, ToolDefinition
+from .openai_models import FunctionCall, ResponseFormat, ToolCall
 
 logger = logging.getLogger(__name__)
 
@@ -875,6 +875,7 @@ class ToolCallStreamFilter:
         if marker_end is None:
             marker_end = ""
         self._marker_pairs: List[Tuple[str, str]] = [
+            ("]<]minimax[>[<tool_call>", "]<]minimax[>[</tool_call>"),
             ("<|tool_call_start|>", "<|tool_call_end|>"),
             ("<tool_call>", "</tool_call>"),
         ]

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -1047,6 +1047,11 @@ class ToolCallStreamFilter:
 
         for marker, _close in self._marker_pairs:
             if marker.startswith(tail):
+                # MiniMax M3 markers start with ``]``. A single closing
+                # bracket at end-of-stream is much more likely to be literal
+                # prose than an incomplete MiniMax control marker.
+                if tail == "]":
+                    continue
                 return True
 
         for close_marker in self._orphan_close_markers:
@@ -1194,6 +1199,9 @@ class ToolCallStreamFilter:
 
         if keep:
             buf = self._buffer[:-keep]
+            tail = self._buffer[-keep:]
+            if not self._should_drop_tail_at_finish(tail):
+                buf += tail
         else:
             buf = self._buffer
         self._buffer = ""

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -48,6 +48,7 @@ SPECIAL_TOKENS_PATTERN = re.compile(
     r"<\|im_end\|>|<\|im_start\|>|<\|endoftext\|>|"
     r"<\|end\|>|<\|eot_id\|>|<\|start_header_id\|>|<\|end_header_id\|>|"
     r"<\|image\|>|<\|audio\|>|"  # Gemma 4 VLM special tokens
+    r"\[e~\[|\]~b\]|\]~!b\[|\]!p~\[|\]!d~\[|"  # MiniMax M3 special tokens
     r"</s>|<s>|<pad>|\[PAD\]|\[SEP\]|\[CLS\]|"
     r"<eos>|<bos>|<end_of_turn>|<start_of_turn>"  # Gemma special tokens (fixes #1087)
 )

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -10,6 +10,30 @@ from typing import Any, List
 
 from .openai_models import Message
 
+# Model families whose chat templates consume message.reasoning_content directly.
+_NATIVE_REASONING_MODEL_TYPES = {"minimax_m3", "minimax_m3_vl"}
+
+
+def uses_native_reasoning_content(
+    model_name: str | None = None,
+    *,
+    config_model_type: str | None = None,
+    engine_model_type: str | None = None,
+    preserve_thinking_default: bool | None = None,
+) -> bool:
+    """Return whether history should keep reasoning in message fields."""
+    if preserve_thinking_default is True:
+        return True
+
+    if config_model_type in _NATIVE_REASONING_MODEL_TYPES:
+        return True
+    if engine_model_type in _NATIVE_REASONING_MODEL_TYPES:
+        return True
+
+    lowered = (model_name or "").lower()
+    return "minimax" in lowered and "m3" in lowered
+
+
 # =============================================================================
 # Partial Mode Detection
 # =============================================================================
@@ -796,6 +820,16 @@ def _apply_reasoning_reconstruction(
     string to attach as a ``reasoning_content`` field, or ``None`` to skip.
     """
     if role != "assistant" or not reasoning:
+        if role != "assistant" or not native:
+            return content, None
+        text = content if isinstance(content, str) else ""
+        if isinstance(content, list):
+            text = _extract_text_from_content_list(content)
+        from .thinking import extract_thinking
+
+        inline_reasoning, inline_content = extract_thinking(text)
+        if inline_reasoning:
+            return inline_content, inline_reasoning
         return content, None
     text = content if isinstance(content, str) else ""
     if isinstance(content, list):

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -811,7 +811,12 @@ class BlockAwarePrefixCache(CacheManager):
         # Non-sliceable cache types use sliding window or have no sequence dimension
         # RotatingKVCache: sliding window, seq_len limited to max_size
         # ArraysCache: no traditional sequence dimension
-        non_sliceable_types = {"ArraysCache", "CacheList"}
+        non_sliceable_types = {
+            "ArraysCache",
+            "CacheList",
+            "MiniMaxM3KVCache",
+            "MiniMaxM3BatchKVCache",
+        }
 
         # Step 1: Search for a sliceable KVCache layer (full attention)
         for layer_idx, layer_state in enumerate(cache_data):
@@ -865,7 +870,12 @@ class BlockAwarePrefixCache(CacheManager):
         # Only skip cache types that do not expose a sequence dimension here.
         # RotatingKVCache must be included because pure RotatingKVCache models
         # have no sliceable KVCache layers for Step 1 to find.
-        step2_skip_types = {"ArraysCache", "CacheList"}
+        step2_skip_types = {
+            "ArraysCache",
+            "CacheList",
+            "MiniMaxM3KVCache",
+            "MiniMaxM3BatchKVCache",
+        }
         max_seq_len = 0
         for layer_idx, layer_state in enumerate(cache_data):
             try:
@@ -1282,7 +1292,9 @@ class BlockAwarePrefixCache(CacheManager):
                         else:
                             block_slices.append((mx.zeros((1,)), mx.zeros((1,))))
                 else:
-                    # Other non-sliceable cache (ArraysCache/MambaCache)
+                    # Other non-sliceable cache (ArraysCache/MambaCache or
+                    # model-specific caches such as MiniMax M3). N-tuple
+                    # caches keep every element via the SSD V3 marker format.
                     # GDN recurrent state summarizes the ENTIRE sequence in a
                     # fixed-size matrix. Each block boundary snapshot captures
                     # the state at that point in the sequence. Without a snapshot,
@@ -1302,7 +1314,17 @@ class BlockAwarePrefixCache(CacheManager):
                             state = snapshot_cache_data[layer_idx]["state"]
                         else:
                             state = layer_state["state"]
-                        if isinstance(state, (list, tuple)) and len(state) >= 2:
+                        if isinstance(state, (list, tuple)) and len(state) > 2:
+                            cloned = [
+                                (
+                                    self._clone_tensor(elem)
+                                    if hasattr(elem, "shape")
+                                    else elem
+                                )
+                                for elem in state
+                            ]
+                            block_slices.append(("__nstate__", cache_type_name, cloned))
+                        elif isinstance(state, (list, tuple)) and len(state) >= 2:
                             conv_state = (
                                 state[0] if state[0] is not None else mx.array([])
                             )
@@ -1881,13 +1903,6 @@ class BlockAwarePrefixCache(CacheManager):
                         f"{new_count} block(s) ({valid_token_count} tokens)"
                     )
 
-            # Build model cache config if we have type info
-            model_cache_config = None
-            if layer_cache_types and len(layer_cache_types) == num_layers:
-                model_cache_config = ModelCacheConfig.from_type_list(
-                    layer_cache_types, model_name=""
-                )
-
             # Reconstruct caches for each layer
             reconstructed_caches = []
 
@@ -1975,7 +1990,7 @@ class BlockAwarePrefixCache(CacheManager):
                             last_block_meta_states[layer_idx][0]
                         )
 
-                    NON_SLICEABLE_SUB_CLASSES = {
+                    non_sliceable_sub_classes = {
                         "PoolingCache",
                         "ArraysCache",
                         "BatchPoolingCache",
@@ -1983,7 +1998,7 @@ class BlockAwarePrefixCache(CacheManager):
 
                     def _is_non_sliceable_sub_class(class_name: str) -> bool:
                         return (
-                            class_name in NON_SLICEABLE_SUB_CLASSES
+                            class_name in non_sliceable_sub_classes
                             or CacheTypeRegistry.is_rotating_family(class_name)
                         )
 
@@ -2165,6 +2180,34 @@ class BlockAwarePrefixCache(CacheManager):
                             f"TQ layer {layer_idx}: reconstruction failed: {e}"
                         )
                         return None
+                    continue
+
+                # === Generic N-tuple non-sliceable cache: use latest boundary ===
+                last_block_layer_data = all_block_data[-1][layer_idx]
+                if (
+                    isinstance(last_block_layer_data, tuple)
+                    and len(last_block_layer_data) >= 3
+                    and last_block_layer_data[0] == "__nstate__"
+                ):
+                    marker_class = last_block_layer_data[1] or cache_type_name
+                    elements = last_block_layer_data[2]
+                    marker_handler = CacheTypeRegistry.get_handler_by_class_name(
+                        marker_class
+                    )
+                    meta_state = None
+                    if last_block_meta_states and layer_idx < len(
+                        last_block_meta_states
+                    ):
+                        meta_state = last_block_meta_states[layer_idx]
+                    cache = marker_handler.deserialize_state(
+                        tuple(elements), meta_state
+                    )
+                    if cache is None:
+                        logger.error(
+                            f"Layer {layer_idx}: failed to reconstruct {marker_class}"
+                        )
+                        return None
+                    reconstructed_caches.append(cache)
                     continue
 
                 # Collect layer data from all blocks
@@ -2531,6 +2574,8 @@ class BlockAwarePrefixCache(CacheManager):
             "RotatingKVCache",
             "BatchRotatingKVCache",
             "CacheList",
+            "MiniMaxM3KVCache",
+            "MiniMaxM3BatchKVCache",
         }
 
         expected_seq_len = None

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -814,7 +814,6 @@ class BlockAwarePrefixCache(CacheManager):
         non_sliceable_types = {
             "ArraysCache",
             "CacheList",
-            "MiniMaxM3KVCache",
             "MiniMaxM3BatchKVCache",
         }
 
@@ -873,7 +872,6 @@ class BlockAwarePrefixCache(CacheManager):
         step2_skip_types = {
             "ArraysCache",
             "CacheList",
-            "MiniMaxM3KVCache",
             "MiniMaxM3BatchKVCache",
         }
         max_seq_len = 0
@@ -1099,6 +1097,43 @@ class BlockAwarePrefixCache(CacheManager):
                     if not isinstance(state, (list, tuple)) or len(state) < 2:
                         # Placeholder from boundary snapshot (skipped sliceable layer).
                         continue
+
+                    axis_info = handler.get_state_axis_info()
+                    if len(state) != 2 or len(axis_info) != 2:
+                        seq_len = handler.get_state_seq_len_from_tuple(tuple(state))
+                        actual_end = min(end_idx, seq_len)
+                        if seq_len <= 0 or start_idx >= actual_end:
+                            continue
+
+                        sliced_elements = []
+                        for info, elem in zip(axis_info, state):
+                            if elem is None:
+                                sliced_elements.append(None)
+                                continue
+                            if (
+                                info.sliceable
+                                and info.sequence_axis is not None
+                                and hasattr(elem, "shape")
+                                and info.sequence_axis < len(elem.shape)
+                            ):
+                                slices = [slice(None)] * len(elem.shape)
+                                slices[info.sequence_axis] = slice(
+                                    start_idx, actual_end
+                                )
+                                sliced_elements.append(
+                                    self._clone_tensor(elem[tuple(slices)])
+                                )
+                            else:
+                                sliced_elements.append(
+                                    self._clone_tensor(elem)
+                                    if hasattr(elem, "shape")
+                                    else elem
+                                )
+                        block_slices.append(
+                            ("__nstate__", cache_type_name, sliced_elements)
+                        )
+                        continue
+
                     keys, values = state
 
                     # KV cache shape: (batch, n_kv_heads, seq_len, head_dim)
@@ -2182,8 +2217,58 @@ class BlockAwarePrefixCache(CacheManager):
                         return None
                     continue
 
-                # === Generic N-tuple non-sliceable cache: use latest boundary ===
+                # === Generic N-tuple sliceable cache: concatenate block slices ===
                 last_block_layer_data = all_block_data[-1][layer_idx]
+                if (
+                    handler.supports_block_slicing
+                    and isinstance(last_block_layer_data, tuple)
+                    and len(last_block_layer_data) >= 3
+                    and last_block_layer_data[0] == "__nstate__"
+                ):
+                    marker_class = last_block_layer_data[1] or cache_type_name
+                    marker_handler = CacheTypeRegistry.get_handler_by_class_name(
+                        marker_class
+                    )
+                    axis_info = marker_handler.get_state_axis_info()
+                    layer_states = []
+                    for block_data in all_block_data:
+                        if layer_idx >= len(block_data):
+                            logger.debug(
+                                f"Layer {layer_idx}: missing block data for "
+                                f"{marker_class}"
+                            )
+                            return None
+                        block_layer_data = block_data[layer_idx]
+                        if (
+                            not isinstance(block_layer_data, tuple)
+                            or len(block_layer_data) < 3
+                            or block_layer_data[0] != "__nstate__"
+                        ):
+                            logger.debug(
+                                f"Layer {layer_idx}: expected N-tuple block data "
+                                f"for {marker_class}"
+                            )
+                            return None
+                        elements = tuple(block_layer_data[2])
+                        state_dict = {
+                            "states": elements,
+                            "cache_type": marker_class,
+                        }
+                        for info, elem in zip(axis_info, elements):
+                            state_dict[info.name] = elem
+                        layer_states.append(state_dict)
+
+                    concat_state = marker_handler.concatenate_states(layer_states)
+                    cache = marker_handler.reconstruct_cache(concat_state, None)
+                    if cache is None:
+                        logger.error(
+                            f"Layer {layer_idx}: failed to reconstruct {marker_class}"
+                        )
+                        return None
+                    reconstructed_caches.append(cache)
+                    continue
+
+                # === Generic N-tuple non-sliceable cache: use latest boundary ===
                 if (
                     isinstance(last_block_layer_data, tuple)
                     and len(last_block_layer_data) >= 3
@@ -2568,13 +2653,13 @@ class BlockAwarePrefixCache(CacheManager):
             "BatchKVCache",
             "TurboQuantKVCache",
             "BatchTurboQuantKVCache",
+            "MiniMaxM3KVCache",
         }
         non_sliceable_types = {
             "ArraysCache",
             "RotatingKVCache",
             "BatchRotatingKVCache",
             "CacheList",
-            "MiniMaxM3KVCache",
             "MiniMaxM3BatchKVCache",
         }
 
@@ -2601,14 +2686,21 @@ class BlockAwarePrefixCache(CacheManager):
                     )
                     return False
 
-                keys, values = layer_data[0], layer_data[1]
-
-                # Check for None
-                if keys is None or values is None:
-                    logger.debug(
-                        f"Block validation failed: layer {layer_idx} has None keys/values"
-                    )
-                    return False
+                if (
+                    isinstance(layer_data, tuple)
+                    and len(layer_data) >= 3
+                    and layer_data[0] == "__nstate__"
+                ):
+                    elements = layer_data[2]
+                    if not isinstance(elements, (list, tuple)) or len(elements) < 2:
+                        logger.debug(
+                            f"Block validation failed: layer {layer_idx} has "
+                            "invalid N-tuple state"
+                        )
+                        return False
+                    keys, values = elements[0], elements[1]
+                else:
+                    keys, values = layer_data[0], layer_data[1]
 
                 # Skip seq_len check for non-sliceable types (e.g., ArraysCache, RotatingKVCache)
                 # This includes placeholder entries (1D tensors from non-last blocks)
@@ -2617,6 +2709,15 @@ class BlockAwarePrefixCache(CacheManager):
                     continue
                 if layer_cache_types and cache_type not in sliceable_types:
                     continue
+
+                # Check for None after non-sliceable N-tuple caches have been
+                # accepted. Pooling-style states can legitimately store None
+                # in their first elements.
+                if keys is None or values is None:
+                    logger.debug(
+                        f"Block validation failed: layer {layer_idx} has None keys/values"
+                    )
+                    return False
 
                 # Check shape consistency for sliceable types (KVCache, RotatingKVCache)
                 if hasattr(keys, "shape") and len(keys.shape) >= 3:

--- a/omlx/cache/type_handlers.py
+++ b/omlx/cache/type_handlers.py
@@ -38,6 +38,8 @@ class CacheType(Enum):
     CACHE_LIST = "CacheList"
     POOLING_CACHE = "PoolingCache"
     BATCH_POOLING_CACHE = "BatchPoolingCache"
+    MINIMAX_M3_KVCACHE = "MiniMaxM3KVCache"
+    MINIMAX_M3_BATCH_KVCACHE = "MiniMaxM3BatchKVCache"
 
 
 @dataclass
@@ -224,6 +226,23 @@ class CacheTypeHandler(ABC):
         if isinstance(state, (list, tuple)):
             return tuple(state)
         return ()
+
+    def serialize_meta_state(self, cache_obj: Any) -> tuple[Any, ...]:
+        """Return JSON-safe metadata for ``cache_obj``.
+
+        Most mlx-lm caches already expose a tuple-shaped ``meta_state``.
+        Some model-specific caches expose scalar strings; normalize them so
+        SSD/boundary snapshot metadata never iterates a string character by
+        character.
+        """
+        meta_state = getattr(cache_obj, "meta_state", ())
+        if meta_state in (None, ""):
+            return ()
+        if isinstance(meta_state, tuple):
+            return meta_state
+        if isinstance(meta_state, list):
+            return tuple(meta_state)
+        return (meta_state,)
 
     def deserialize_state(
         self,
@@ -980,11 +999,11 @@ class CacheListHandler(CacheTypeHandler):
         # Sanitize sub_meta_states for sub-cache types that don't support
         # meta_state (inherit _BaseCache's strict setter which rejects
         # truthy values).  Use "" to match _BaseCache.meta_state getter.
-        _NO_META_STATE_TYPES = frozenset(
+        no_meta_state_types = frozenset(
             {"KVCache", "ConcatenateKVCache", "ArraysCache"}
         )
         sanitized_sub_meta_states = [
-            "" if cls_name in _NO_META_STATE_TYPES else sub_meta
+            "" if cls_name in no_meta_state_types else sub_meta
             for cls_name, sub_meta in zip(class_names, sub_meta_states)
         ]
 
@@ -1062,6 +1081,222 @@ class CacheListHandler(CacheTypeHandler):
 
     def _get_meta_state_keys(self) -> tuple[str, ...]:
         return ("class_names", "sub_meta_states")
+
+
+def _minimax_index_offset(index_keys: Any, meta_state: Any | None = None) -> int:
+    if isinstance(meta_state, str):
+        try:
+            return int(meta_state)
+        except ValueError:
+            pass
+    if isinstance(meta_state, (list, tuple)) and meta_state:
+        try:
+            return int(meta_state[0])
+        except (TypeError, ValueError):
+            pass
+    if (
+        index_keys is not None
+        and hasattr(index_keys, "shape")
+        and len(index_keys.shape) >= 3
+    ):
+        return int(index_keys.shape[2])
+    return 0
+
+
+class _MiniMaxM3CacheHandlerBase(CacheTypeHandler):
+    """Shared MiniMax M3 sparse-cache serialization helpers."""
+
+    @property
+    def supports_block_slicing(self) -> bool:
+        return False
+
+    def get_state_axis_info(self) -> tuple[CacheStateAxisInfo, ...]:
+        return (
+            CacheStateAxisInfo("keys", 2, False),
+            CacheStateAxisInfo("values", 2, False),
+            CacheStateAxisInfo("index_keys", 2, False),
+        )
+
+    def serialize_meta_state(self, cache_obj: Any) -> tuple[Any, ...]:
+        return (int(getattr(cache_obj, "index_offset", 0) or 0),)
+
+    def get_seq_len(self, state: dict[str, Any]) -> int:
+        keys = state.get("keys")
+        if keys is not None and hasattr(keys, "shape") and len(keys.shape) >= 3:
+            return int(keys.shape[2])
+        index_keys = state.get("index_keys")
+        if (
+            index_keys is not None
+            and hasattr(index_keys, "shape")
+            and len(index_keys.shape) >= 3
+        ):
+            return int(index_keys.shape[2])
+        return 0
+
+    def slice_state(
+        self,
+        state: dict[str, Any],
+        start_idx: int,
+        end_idx: int,
+    ) -> dict[str, Any] | None:
+        return {
+            **state,
+            "is_full_state": True,
+            "cache_type": self.cache_type.value,
+        }
+
+    def concatenate_states(self, states: list[dict[str, Any]]) -> dict[str, Any]:
+        return states[-1] if states else {}
+
+    def _get_state_keys(self) -> tuple[str, ...]:
+        return ("keys", "values", "index_keys")
+
+    def _get_meta_state_keys(self) -> tuple[str, ...]:
+        return ("index_offset",)
+
+
+class MiniMaxM3KVCacheHandler(_MiniMaxM3CacheHandlerBase):
+    """Handler for MiniMax M3 sparse attention side-index caches."""
+
+    @property
+    def cache_type(self) -> CacheType:
+        return CacheType.MINIMAX_M3_KVCACHE
+
+    def serialize_state(self, cache_obj: Any) -> tuple[Any, ...]:
+        kv_state, index_state = cache_obj.state
+        if kv_state is None:
+            return (None, None, index_state)
+        if isinstance(kv_state, (list, tuple)) and len(kv_state) >= 2:
+            return (kv_state[0], kv_state[1], index_state)
+        return (None, None, index_state)
+
+    def extract_state(self, cache_obj: Any) -> dict[str, Any]:
+        keys, values, index_keys = self.serialize_state(cache_obj)
+        return {
+            "keys": keys,
+            "values": values,
+            "index_keys": index_keys,
+            "states": (keys, values, index_keys),
+            "is_full_state": True,
+            "cache_type": self.cache_type.value,
+        }
+
+    def deserialize_state(
+        self,
+        elements: tuple[Any, ...],
+        meta_state: Any | None = None,
+    ) -> Any:
+        try:
+            from mlx_vlm.models.minimax_m3_vl.language import MiniMaxM3KVCache
+        except Exception as e:  # noqa: BLE001
+            logger.error("mlx-vlm MiniMaxM3KVCache unavailable: %s", e)
+            return None
+
+        keys = elements[0] if len(elements) > 0 else None
+        values = elements[1] if len(elements) > 1 else None
+        index_keys = elements[2] if len(elements) > 2 else None
+
+        cache = MiniMaxM3KVCache()
+        if keys is not None and values is not None:
+            cache.kv_cache.state = (keys, values)
+        cache.index_keys = index_keys
+        cache.index_offset = _minimax_index_offset(index_keys, meta_state)
+        return cache
+
+    def reconstruct_cache(
+        self,
+        state: dict[str, Any],
+        meta_state: tuple | None = None,
+    ) -> Any:
+        elements = state.get("states")
+        if elements is None:
+            elements = (
+                state.get("keys"),
+                state.get("values"),
+                state.get("index_keys"),
+            )
+        return self.deserialize_state(tuple(elements), meta_state)
+
+
+class MiniMaxM3BatchKVCacheHandler(_MiniMaxM3CacheHandlerBase):
+    """Handler for batched MiniMax M3 sparse attention caches."""
+
+    @property
+    def cache_type(self) -> CacheType:
+        return CacheType.MINIMAX_M3_BATCH_KVCACHE
+
+    def get_state_axis_info(self) -> tuple[CacheStateAxisInfo, ...]:
+        return (
+            CacheStateAxisInfo("keys", 2, False),
+            CacheStateAxisInfo("values", 2, False),
+            CacheStateAxisInfo("offset", None, False),
+            CacheStateAxisInfo("left_padding", None, False),
+            CacheStateAxisInfo("index_keys", 2, False),
+        )
+
+    def serialize_state(self, cache_obj: Any) -> tuple[Any, ...]:
+        kv_state, index_state = cache_obj.state
+        if isinstance(kv_state, (list, tuple)) and len(kv_state) >= 4:
+            return (
+                kv_state[0],
+                kv_state[1],
+                kv_state[2],
+                kv_state[3],
+                index_state,
+            )
+        return (None, None, None, None, index_state)
+
+    def extract_state(self, cache_obj: Any) -> dict[str, Any]:
+        keys, values, offset, left_padding, index_keys = self.serialize_state(cache_obj)
+        return {
+            "keys": keys,
+            "values": values,
+            "offset": offset,
+            "left_padding": left_padding,
+            "index_keys": index_keys,
+            "states": (keys, values, offset, left_padding, index_keys),
+            "is_full_state": True,
+            "cache_type": self.cache_type.value,
+        }
+
+    def deserialize_state(
+        self,
+        elements: tuple[Any, ...],
+        meta_state: Any | None = None,
+    ) -> Any:
+        try:
+            from mlx_vlm.models.minimax_m3_vl.language import MiniMaxM3BatchKVCache
+        except Exception as e:  # noqa: BLE001
+            logger.error("mlx-vlm MiniMaxM3BatchKVCache unavailable: %s", e)
+            return None
+
+        keys = elements[0] if len(elements) > 0 else None
+        values = elements[1] if len(elements) > 1 else None
+        offset = elements[2] if len(elements) > 2 else None
+        left_padding = elements[3] if len(elements) > 3 else None
+        index_keys = elements[4] if len(elements) > 4 else None
+
+        left_padding_arg = left_padding if left_padding is not None else [0]
+        cache = MiniMaxM3BatchKVCache(left_padding_arg)
+        cache.state = ((keys, values, offset, left_padding_arg), index_keys)
+        cache.index_offset = _minimax_index_offset(index_keys, meta_state)
+        return cache
+
+    def reconstruct_cache(
+        self,
+        state: dict[str, Any],
+        meta_state: tuple | None = None,
+    ) -> Any:
+        elements = state.get("states")
+        if elements is None:
+            elements = (
+                state.get("keys"),
+                state.get("values"),
+                state.get("offset"),
+                state.get("left_padding"),
+                state.get("index_keys"),
+            )
+        return self.deserialize_state(tuple(elements), meta_state)
 
 
 # Default handler for unknown types - falls back to KVCache behavior

--- a/omlx/cache/type_handlers.py
+++ b/omlx/cache/type_handlers.py
@@ -1084,6 +1084,12 @@ class CacheListHandler(CacheTypeHandler):
 
 
 def _minimax_index_offset(index_keys: Any, meta_state: Any | None = None) -> int:
+    if (
+        index_keys is not None
+        and hasattr(index_keys, "shape")
+        and len(index_keys.shape) >= 3
+    ):
+        return int(index_keys.shape[2])
     if isinstance(meta_state, str):
         try:
             return int(meta_state)
@@ -1094,12 +1100,6 @@ def _minimax_index_offset(index_keys: Any, meta_state: Any | None = None) -> int
             return int(meta_state[0])
         except (TypeError, ValueError):
             pass
-    if (
-        index_keys is not None
-        and hasattr(index_keys, "shape")
-        and len(index_keys.shape) >= 3
-    ):
-        return int(index_keys.shape[2])
     return 0
 
 
@@ -1162,6 +1162,17 @@ class MiniMaxM3KVCacheHandler(_MiniMaxM3CacheHandlerBase):
     def cache_type(self) -> CacheType:
         return CacheType.MINIMAX_M3_KVCACHE
 
+    @property
+    def supports_block_slicing(self) -> bool:
+        return True
+
+    def get_state_axis_info(self) -> tuple[CacheStateAxisInfo, ...]:
+        return (
+            CacheStateAxisInfo("keys", 2, True),
+            CacheStateAxisInfo("values", 2, True),
+            CacheStateAxisInfo("index_keys", 2, True),
+        )
+
     def serialize_state(self, cache_obj: Any) -> tuple[Any, ...]:
         kv_state, index_state = cache_obj.state
         if kv_state is None:
@@ -1177,7 +1188,73 @@ class MiniMaxM3KVCacheHandler(_MiniMaxM3CacheHandlerBase):
             "values": values,
             "index_keys": index_keys,
             "states": (keys, values, index_keys),
-            "is_full_state": True,
+            "cache_type": self.cache_type.value,
+        }
+
+    def slice_state(
+        self,
+        state: dict[str, Any],
+        start_idx: int,
+        end_idx: int,
+    ) -> dict[str, Any] | None:
+        if not HAS_MLX:
+            return None
+
+        keys = state.get("keys")
+        values = state.get("values")
+        index_keys = state.get("index_keys")
+        if keys is None or values is None:
+            return None
+
+        try:
+            seq_len = int(keys.shape[2])
+            actual_end = min(end_idx, seq_len)
+            if start_idx >= actual_end:
+                return None
+
+            keys_slice = keys[:, :, start_idx:actual_end, :]
+            values_slice = values[:, :, start_idx:actual_end, :]
+            if index_keys is not None:
+                index_end = min(actual_end, int(index_keys.shape[2]))
+                index_slice = index_keys[:, :, start_idx:index_end, :]
+            else:
+                index_slice = None
+
+            return {
+                "keys": keys_slice,
+                "values": values_slice,
+                "index_keys": index_slice,
+                "states": (keys_slice, values_slice, index_slice),
+                "cache_type": self.cache_type.value,
+            }
+        except Exception as e:
+            logger.warning("Failed to slice MiniMax M3 cache state: %s", e)
+            return None
+
+    def concatenate_states(self, states: list[dict[str, Any]]) -> dict[str, Any]:
+        if not HAS_MLX or not states:
+            return {}
+
+        keys_list = [s.get("keys") for s in states if s.get("keys") is not None]
+        values_list = [
+            s.get("values") for s in states if s.get("values") is not None
+        ]
+        index_list = [
+            s.get("index_keys")
+            for s in states
+            if s.get("index_keys") is not None
+        ]
+        if not keys_list or not values_list:
+            return {}
+
+        keys = mx.concatenate(keys_list, axis=2)
+        values = mx.concatenate(values_list, axis=2)
+        index_keys = mx.concatenate(index_list, axis=2) if index_list else None
+        return {
+            "keys": keys,
+            "values": values,
+            "index_keys": index_keys,
+            "states": (keys, values, index_keys),
             "cache_type": self.cache_type.value,
         }
 

--- a/omlx/cache/type_registry.py
+++ b/omlx/cache/type_registry.py
@@ -6,17 +6,19 @@ This module provides a registry for looking up cache type handlers
 by cache type enum or class name string.
 """
 
-from typing import Any, Dict, Optional, Type
 import logging
+from typing import Any, Dict
 
 from .type_handlers import (
-    CacheType,
-    CacheTypeHandler,
-    KVCacheHandler,
-    RotatingKVCacheHandler,
     ArraysCacheHandler,
     CacheListHandler,
+    CacheType,
+    CacheTypeHandler,
     DefaultCacheHandler,
+    KVCacheHandler,
+    MiniMaxM3BatchKVCacheHandler,
+    MiniMaxM3KVCacheHandler,
+    RotatingKVCacheHandler,
     SizedArraysCache,
 )
 
@@ -64,6 +66,8 @@ class CacheTypeRegistry:
         # patches/deepseek_v4/cache_handlers.py and register on patch apply.
         "PoolingCache": CacheType.POOLING_CACHE,
         "BatchPoolingCache": CacheType.BATCH_POOLING_CACHE,
+        "MiniMaxM3KVCache": CacheType.MINIMAX_M3_KVCACHE,
+        "MiniMaxM3BatchKVCache": CacheType.MINIMAX_M3_BATCH_KVCACHE,
     }
 
     # Default handler instance
@@ -245,6 +249,8 @@ def _initialize_default_handlers() -> None:
     CacheTypeRegistry.register(RotatingKVCacheHandler())
     CacheTypeRegistry.register(ArraysCacheHandler())
     CacheTypeRegistry.register(CacheListHandler())
+    CacheTypeRegistry.register(MiniMaxM3KVCacheHandler())
+    CacheTypeRegistry.register(MiniMaxM3BatchKVCacheHandler())
 
 
 # Initialize handlers when module is imported

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -83,6 +83,7 @@ VLM_LANGUAGE_PROMPT_KWARGS = ("mm_token_type_ids", "token_type_ids")
 
 COHERE2_MOE_MODEL_TYPE = "cohere2_moe"
 MINIMAX_M3_VL_MODEL_TYPE = "minimax_m3_vl"
+MINIMAX_M3_MODEL_TYPES = {"minimax_m3", MINIMAX_M3_VL_MODEL_TYPE}
 
 DIFFUSION_PREFILL_STEP_SIZE = 2048
 
@@ -119,6 +120,23 @@ def _read_config_model_type(model_path: str | Path) -> str | None:
         return None
     model_type = data.get("model_type")
     return model_type if isinstance(model_type, str) else None
+
+
+def _apply_minimax_m3_thinking_mode(
+    model_type: str | None,
+    template_kwargs: dict[str, Any],
+) -> None:
+    """Map oMLX enable_thinking to MiniMax M3's thinking_mode template kwarg."""
+    if model_type not in MINIMAX_M3_MODEL_TYPES:
+        return
+    if "thinking_mode" in template_kwargs or "enable_thinking" not in template_kwargs:
+        return
+
+    enable_thinking = template_kwargs["enable_thinking"]
+    if enable_thinking is True:
+        template_kwargs["thinking_mode"] = "enabled"
+    elif enable_thinking is False:
+        template_kwargs["thinking_mode"] = "disabled"
 
 
 def _attach_vlm_tokenizer_runtime(tokenizer: Any, model_path: Path, eos_token_id: Any):
@@ -1971,6 +1989,7 @@ class VLMBatchedEngine(BaseEngine):
             template_kwargs["tools"] = tools
         if chat_template_kwargs:
             template_kwargs.update(chat_template_kwargs)
+        _apply_minimax_m3_thinking_mode(model_type, template_kwargs)
 
         # Use processor or its tokenizer for chat template application
         template_target = self._processor
@@ -2036,6 +2055,7 @@ class VLMBatchedEngine(BaseEngine):
                     prefix_template_kwargs["tools"] = tools
                 if chat_template_kwargs:
                     prefix_template_kwargs.update(chat_template_kwargs)
+                _apply_minimax_m3_thinking_mode(model_type, prefix_template_kwargs)
 
                 images_consumed = 0
                 for msg_idx, msg_num_images in image_message_ranges:
@@ -2293,6 +2313,7 @@ class VLMBatchedEngine(BaseEngine):
                 template_kwargs["enable_thinking"] = self._enable_thinking
             if chat_template_kwargs:
                 template_kwargs.update(chat_template_kwargs)
+            _apply_minimax_m3_thinking_mode(self.model_type, template_kwargs)
 
             try:
                 return self._tokenizer.apply_chat_template(messages, **template_kwargs)
@@ -3053,6 +3074,7 @@ class VLMBatchedEngine(BaseEngine):
             template_kwargs["tools"] = tools
         if chat_template_kwargs:
             template_kwargs.update(chat_template_kwargs)
+        _apply_minimax_m3_thinking_mode(model_type, template_kwargs)
 
         template_target = self._processor
         if not hasattr(template_target, "apply_chat_template"):

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -82,6 +82,7 @@ OCR_EXTRA_STOP_SEQUENCES: List[str] = [
 VLM_LANGUAGE_PROMPT_KWARGS = ("mm_token_type_ids", "token_type_ids")
 
 COHERE2_MOE_MODEL_TYPE = "cohere2_moe"
+MINIMAX_M3_VL_MODEL_TYPE = "minimax_m3_vl"
 
 DIFFUSION_PREFILL_STEP_SIZE = 2048
 
@@ -557,6 +558,131 @@ _VISION_TOWER_PREFIX = "vision_tower."
 
 
 @contextlib.contextmanager
+def _force_minimax_m3_moe_sanitize_on_load(model_dir: Path):
+    """Force mlx-vlm's MiniMax M3 MoE sanitize path for MLX-format checkpoints.
+
+    mlx-vlm's MiniMax M3 loader can pack ``shared_experts`` into the routed
+    ``switch_mlp`` when ``Model.sanitize`` runs.  MLX-format checkpoints skip
+    sanitize upstream, but current MiniMax-M3-4bit weights are still stored in
+    the unpacked MoE layout, so strict loading sees those tensors as unknown.
+    Hide only the safetensors ``format=mlx`` metadata during this load so the
+    upstream sanitize path runs before quantization and load_weights.
+    """
+    if _read_config_model_type(model_dir) != MINIMAX_M3_VL_MODEL_TYPE:
+        yield
+        return
+
+    import safetensors
+    from mlx_vlm.models.minimax_m3_vl import minimax_m3_vl as _minimax_m3_vl
+
+    original_safe_open = safetensors.safe_open
+    original_sanitize_moe_weights = _minimax_m3_vl._sanitize_moe_weights
+    target_dir = model_dir.resolve()
+
+    class _SafeOpenMetadataWrapper:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __enter__(self):
+            self._inner.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._inner.__exit__(*args)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        def metadata(self):
+            metadata = self._inner.metadata()
+            if isinstance(metadata, dict) and metadata.get("format") == "mlx":
+                metadata = dict(metadata)
+                metadata.pop("format", None)
+            return metadata
+
+    def _patched_safe_open(filename, *args, **kwargs):
+        handle = original_safe_open(filename, *args, **kwargs)
+        try:
+            path = Path(filename).resolve()
+        except TypeError:
+            return handle
+        if path.parent == target_dir and path.suffix == ".safetensors":
+            return _SafeOpenMetadataWrapper(handle)
+        return handle
+
+    def _pack_mlx_unpacked_moe_weights(weights: dict, args: Any) -> int:
+        pack_shared = (
+            args.n_shared_experts == 1
+            and args.shared_intermediate_size == args.intermediate_size
+        )
+        if not pack_shared:
+            return 0
+
+        packed = 0
+        for layer_idx in range(args.num_hidden_layers):
+            prefix = f"language_model.model.layers.{layer_idx}.block_sparse_moe"
+            for suffix in ("weight", "scales", "biases", "bias"):
+                gate_key = f"{prefix}.switch_mlp.gate_proj.{suffix}"
+                up_key = f"{prefix}.switch_mlp.up_proj.{suffix}"
+                shared_gate_key = f"{prefix}.shared_experts.gate_proj.{suffix}"
+                shared_up_key = f"{prefix}.shared_experts.up_proj.{suffix}"
+                gate_up_key = f"{prefix}.switch_mlp.gate_up_proj.{suffix}"
+
+                if (
+                    gate_up_key not in weights
+                    and gate_key in weights
+                    and up_key in weights
+                    and shared_gate_key in weights
+                    and shared_up_key in weights
+                ):
+                    gate = weights.pop(gate_key)
+                    up = weights.pop(up_key)
+                    shared_gate = weights.pop(shared_gate_key)
+                    shared_up = weights.pop(shared_up_key)
+                    routed_gate_up = mx.concatenate([gate, up], axis=1)
+                    shared_gate_up = mx.expand_dims(
+                        mx.concatenate([shared_gate, shared_up], axis=0), axis=0
+                    )
+                    weights[gate_up_key] = mx.concatenate(
+                        [routed_gate_up, shared_gate_up], axis=0
+                    )
+                    packed += 1
+
+                down_key = f"{prefix}.switch_mlp.down_proj.{suffix}"
+                shared_down_key = f"{prefix}.shared_experts.down_proj.{suffix}"
+                packed_down_key = f"{prefix}.switch_mlp.down_proj.{suffix}"
+                if down_key in weights and shared_down_key in weights:
+                    down = weights.pop(down_key)
+                    shared_down = mx.expand_dims(weights.pop(shared_down_key), axis=0)
+                    weights[packed_down_key] = mx.concatenate(
+                        [down, shared_down], axis=0
+                    )
+                    packed += 1
+        return packed
+
+    def _patched_sanitize_moe_weights(weights: dict, args: Any) -> None:
+        original_sanitize_moe_weights(weights, args)
+        packed = _pack_mlx_unpacked_moe_weights(weights, args)
+        if packed:
+            logger.info(
+                "MiniMax M3 MLX-format MoE sanitize packed %d tensor groups",
+                packed,
+            )
+
+    safetensors.safe_open = _patched_safe_open
+    _minimax_m3_vl._sanitize_moe_weights = _patched_sanitize_moe_weights
+    try:
+        logger.info(
+            "MiniMax M3 MLX-format MoE sanitize patch active for %s",
+            model_dir.name,
+        )
+        yield
+    finally:
+        safetensors.safe_open = original_safe_open
+        _minimax_m3_vl._sanitize_moe_weights = original_sanitize_moe_weights
+
+
+@contextlib.contextmanager
 def _remap_nested_visual_on_load(model_dir: Path):
     """Remap ``language_model.model.visual.*`` → ``vision_tower.*`` during
     ``load_model`` for MLX-format models where sanitize is skipped.
@@ -977,6 +1103,7 @@ class VLMBatchedEngine(BaseEngine):
             _patch_torch_free_image_processor()
             with (
                 _strip_audio_config_if_orphaned(Path(self._model_name)),
+                _force_minimax_m3_moe_sanitize_on_load(Path(self._model_name)),
                 _remap_nested_visual_on_load(Path(self._model_name)),
             ):
                 custom_loaded = maybe_load_custom_quantization(

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -945,8 +945,9 @@ class VLMBatchedEngine(BaseEngine):
 
     @property
     def model_type(self) -> str | None:
-        if self._vlm_model is not None and hasattr(self._vlm_model, "config"):
-            config = self._vlm_model.config
+        vlm_model = getattr(self, "_vlm_model", None)
+        if vlm_model is not None and hasattr(vlm_model, "config"):
+            config = vlm_model.config
             if hasattr(config, "model_type"):
                 return config.model_type
         return None
@@ -1605,8 +1606,9 @@ class VLMBatchedEngine(BaseEngine):
 
         # Strategy 1: upstream encode_image (gemma4 and future models)
         if hasattr(model, "encode_image"):
+            image_grid_thw = extra_model_inputs.get("image_grid_thw")
             image_position_ids = extra_model_inputs.get("image_position_ids")
-            if image_position_ids is not None:
+            if image_grid_thw is not None or image_position_ids is not None:
                 try:
                     signature = inspect.signature(model.encode_image)
                 except (TypeError, ValueError):
@@ -1614,12 +1616,16 @@ class VLMBatchedEngine(BaseEngine):
 
                 if signature is None:
                     try:
+                        if image_grid_thw is not None:
+                            return model.encode_image(
+                                pixel_values, image_grid_thw=image_grid_thw
+                            )
                         return model.encode_image(
                             pixel_values, image_position_ids=image_position_ids
                         )
                     except TypeError:
                         logger.debug(
-                            "encode_image rejected image_position_ids; "
+                            "encode_image rejected image metadata; "
                             "retrying without it",
                             exc_info=True,
                         )
@@ -1629,7 +1635,16 @@ class VLMBatchedEngine(BaseEngine):
                         p.kind == inspect.Parameter.VAR_KEYWORD
                         for p in parameters.values()
                     )
-                    if "image_position_ids" in parameters or accepts_kwargs:
+                    if image_grid_thw is not None and (
+                        "image_grid_thw" in parameters or accepts_kwargs
+                    ):
+                        return model.encode_image(
+                            pixel_values, image_grid_thw=image_grid_thw
+                        )
+
+                    if image_position_ids is not None and (
+                        "image_position_ids" in parameters or accepts_kwargs
+                    ):
                         return model.encode_image(
                             pixel_values, image_position_ids=image_position_ids
                         )
@@ -1643,7 +1658,7 @@ class VLMBatchedEngine(BaseEngine):
                             inspect.Parameter.POSITIONAL_OR_KEYWORD,
                         )
                     ]
-                    if len(positional_parameters) >= 2:
+                    if image_position_ids is not None and len(positional_parameters) >= 2:
                         return model.encode_image(pixel_values, image_position_ids)
 
             return model.encode_image(pixel_values)

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -129,10 +129,10 @@ def _apply_minimax_m3_thinking_mode(
     """Map oMLX enable_thinking to MiniMax M3's thinking_mode template kwarg."""
     if model_type not in MINIMAX_M3_MODEL_TYPES:
         return
-    if "thinking_mode" in template_kwargs or "enable_thinking" not in template_kwargs:
+    enable_thinking = template_kwargs.pop("enable_thinking", None)
+    if "thinking_mode" in template_kwargs:
         return
 
-    enable_thinking = template_kwargs["enable_thinking"]
     if enable_thinking is True:
         template_kwargs["thinking_mode"] = "enabled"
     elif enable_thinking is False:

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -59,6 +59,7 @@ VLM_MODEL_TYPES = {
     "deepseekocr_2",
     "dots_ocr",
     "glm_ocr",
+    "minimax_m3_vl",
     "minicpmv",
     "phi4_siglip",
     "phi4mm",
@@ -70,6 +71,7 @@ VLM_MODEL_TYPES = {
 # models and adapts their language model to oMLX's scheduler.
 VLM_NATIVE_TEXT_MODEL_TYPES = {
     "cohere2_moe",
+    "minimax_m3",
 }
 
 # Known VLM architectures

--- a/omlx/models/vlm.py
+++ b/omlx/models/vlm.py
@@ -53,6 +53,7 @@ class VLMModelAdapter(nn.Module):
         super().__init__()
         self._vlm_model = vlm_model
         self._language_model = vlm_model.language_model
+        self._uses_minimax_m3_positions = self._detect_minimax_m3(vlm_model)
         self._uses_mrope = self._detect_mrope(vlm_model)
 
         # Pending vision embeddings state (set before prefill, cleared after)
@@ -149,8 +150,22 @@ class VLMModelAdapter(nn.Module):
         self._embed_offset = 0
 
     @staticmethod
+    def _detect_minimax_m3(vlm_model) -> bool:
+        """Check if VLM model uses MiniMax M3 position-id semantics."""
+        config = getattr(vlm_model, "config", None)
+        if config is None:
+            return False
+        minimax_types = {"minimax_m3", "minimax_m3_vl"}
+        if getattr(config, "model_type", None) in minimax_types:
+            return True
+        text_config = getattr(config, "text_config", None)
+        return getattr(text_config, "model_type", None) in minimax_types
+
+    @staticmethod
     def _detect_mrope(vlm_model) -> bool:
         """Check if VLM model uses multi-dimensional RoPE (mRoPE)."""
+        if VLMModelAdapter._detect_minimax_m3(vlm_model):
+            return True
         config = getattr(vlm_model, "config", None)
         if config is None:
             return False
@@ -196,6 +211,45 @@ class VLMModelAdapter(nn.Module):
         an array of rope_deltas aligned to the batch slot order.
         """
         self._batch_rope_deltas = deltas
+
+    def _batch_rope_deltas_for_size(self, batch_size: int) -> Optional[mx.array]:
+        """Return rope deltas aligned to the current model input batch size."""
+        if self._batch_rope_deltas is None:
+            return None
+        deltas = self._batch_rope_deltas.reshape(-1)
+        if deltas.size == batch_size:
+            return deltas
+        if not self._uses_minimax_m3_positions:
+            logger.debug(
+                "Skipping mRoPE batch deltas with %d rows for %d-row input",
+                deltas.size,
+                batch_size,
+            )
+            return None
+        if deltas.size > batch_size:
+            logger.debug(
+                "Truncating mRoPE batch deltas from %d to %d rows",
+                deltas.size,
+                batch_size,
+            )
+            return deltas[:batch_size]
+        logger.debug(
+            "Padding mRoPE batch deltas from %d to %d rows",
+            deltas.size,
+            batch_size,
+        )
+        pad = mx.zeros((batch_size - deltas.size,), dtype=deltas.dtype)
+        return mx.concatenate([deltas, pad], axis=0)
+
+    def _position_ids_from_starts(
+        self, starts: mx.array, batch_size: int, seq_len: int
+    ) -> mx.array:
+        """Build model-specific decode position_ids from per-row start offsets."""
+        starts = starts.reshape(-1)[:batch_size]
+        if self._uses_minimax_m3_positions:
+            steps = mx.arange(seq_len, dtype=starts.dtype)
+            return starts[:, None] + steps[None, :]
+        return mx.broadcast_to(starts[None, :, None], (3, batch_size, seq_len))
 
     def get_last_rope_deltas(self) -> float:
         """Extract rope_deltas from language model after VLM prefill.
@@ -261,21 +315,21 @@ class VLMModelAdapter(nn.Module):
                     if hasattr(c, "offset"):
                         offsets = c.offset
                         break
-                B, L = input_ids.shape
-                deltas = self._batch_rope_deltas
+                batch_size, seq_len = input_ids.shape
+                deltas = self._batch_rope_deltas_for_size(batch_size)
                 base_offsets = None
                 if isinstance(offsets, mx.array):
                     if offsets.ndim == 0:
-                        base_offsets = mx.broadcast_to(offsets, (B,))
-                    elif offsets.size >= B:
-                        base_offsets = offsets[:B]
+                        base_offsets = mx.broadcast_to(offsets, (batch_size,))
+                    elif offsets.size >= batch_size:
+                        base_offsets = offsets[:batch_size]
                 elif isinstance(offsets, (int, float)):
-                    base_offsets = mx.broadcast_to(mx.array(offsets), (B,))
+                    base_offsets = mx.broadcast_to(mx.array(offsets), (batch_size,))
 
-                if base_offsets is not None and deltas.size == B:
-                    positions = base_offsets + deltas
-                    position_ids = mx.broadcast_to(
-                        positions[None, :, None], (3, B, L)
+                if base_offsets is not None and deltas is not None:
+                    positions = base_offsets + deltas.astype(base_offsets.dtype)
+                    position_ids = self._position_ids_from_starts(
+                        positions, batch_size, seq_len
                     )
                     result = self._language_model(
                         input_ids, cache=cache, position_ids=position_ids, **kwargs
@@ -291,9 +345,9 @@ class VLMModelAdapter(nn.Module):
                         offsets = c.offset
                         break
                 if offsets is not None:
-                    B, L = input_ids.shape
-                    position_ids = mx.broadcast_to(
-                        offsets[None, :, None], (3, B, L)
+                    batch_size, seq_len = input_ids.shape
+                    position_ids = self._position_ids_from_starts(
+                        offsets, batch_size, seq_len
                     )
                     result = self._language_model(
                         input_ids, cache=cache, position_ids=position_ids, **kwargs

--- a/omlx/patches/minimax_m3_sparse_attention.py
+++ b/omlx/patches/minimax_m3_sparse_attention.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Patch MiniMax M3 sparse attention for batched left-padded caches."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_PATCH_MARKER = "_omlx_minimax_m3_sparse_left_padding_patch"
+_LEFT_PADDING_ATTR = "_omlx_minimax_m3_sparse_left_padding"
+
+
+def _storage_q_positions(
+    q_positions: Any,
+    left_padding: Any,
+    batch_size: int,
+    seq_len: int,
+):
+    """Map semantic query positions to batched-cache storage positions."""
+    if q_positions is None or left_padding is None:
+        return q_positions
+    if not isinstance(left_padding, mx.array):
+        return q_positions
+
+    padding = left_padding.reshape(-1)[:batch_size]
+    if padding.size == 0:
+        return q_positions
+
+    if not isinstance(q_positions, mx.array):
+        return q_positions
+
+    padding = padding.astype(q_positions.dtype)
+    if q_positions.ndim == 0:
+        return q_positions + padding[0]
+    if q_positions.ndim == 1:
+        if q_positions.shape[0] == batch_size and seq_len == 1:
+            return q_positions + padding
+        return q_positions + padding[0]
+    if q_positions.ndim == 2:
+        return q_positions + padding[:, None]
+    if q_positions.ndim == 3:
+        return q_positions + padding[None, :, None]
+    return q_positions
+
+
+def _adjust_sparse_positions(self, q_positions, batch_size: int, seq_len: int):
+    return _storage_q_positions(
+        q_positions,
+        getattr(self, _LEFT_PADDING_ATTR, None),
+        batch_size,
+        seq_len,
+    )
+
+
+def _make_patched_call(original_call):
+    def patched_call(self, x, mask=None, cache=None, position_ids=None):
+        previous = getattr(self, _LEFT_PADDING_ATTR, None)
+        installed = False
+        if position_ids is not None and cache is not None:
+            left_padding = getattr(cache, "left_padding", None)
+            if isinstance(left_padding, mx.array):
+                setattr(self, _LEFT_PADDING_ATTR, left_padding)
+                installed = True
+        try:
+            return original_call(
+                self, x, mask=mask, cache=cache, position_ids=position_ids
+            )
+        finally:
+            if installed:
+                if previous is None:
+                    try:
+                        delattr(self, _LEFT_PADDING_ATTR)
+                    except AttributeError:
+                        pass
+                else:
+                    setattr(self, _LEFT_PADDING_ATTR, previous)
+
+    setattr(patched_call, _PATCH_MARKER, True)
+    return patched_call
+
+
+def _make_patched_build_sparse_mask(original):
+    def patched_build_sparse_mask(
+        self,
+        idx_queries,
+        idx_keys,
+        q_start,
+        mask=None,
+        return_block_indices=False,
+        build_token_mask=True,
+        q_positions=None,
+    ):
+        q_positions = _adjust_sparse_positions(
+            self, q_positions, idx_queries.shape[0], idx_queries.shape[2]
+        )
+        return original(
+            self,
+            idx_queries,
+            idx_keys,
+            q_start,
+            mask,
+            return_block_indices,
+            build_token_mask,
+            q_positions,
+        )
+
+    setattr(patched_build_sparse_mask, _PATCH_MARKER, True)
+    return patched_build_sparse_mask
+
+
+def _make_patched_build_sparse_decode_indices(original):
+    def patched_build_sparse_decode_indices(
+        self,
+        idx_queries,
+        idx_keys,
+        q_start,
+        q_positions=None,
+    ):
+        q_positions = _adjust_sparse_positions(
+            self, q_positions, idx_queries.shape[0], idx_queries.shape[2]
+        )
+        return original(self, idx_queries, idx_keys, q_start, q_positions)
+
+    setattr(patched_build_sparse_decode_indices, _PATCH_MARKER, True)
+    return patched_build_sparse_decode_indices
+
+
+def _make_patched_sparse_decode_attention(original):
+    def patched_sparse_decode_attention(
+        self,
+        queries,
+        keys,
+        values,
+        topk_idx,
+        topk_valid,
+        q_start,
+        *,
+        topk_all_valid=False,
+        q_positions=None,
+    ):
+        q_positions = _adjust_sparse_positions(
+            self, q_positions, queries.shape[0], queries.shape[2]
+        )
+        return original(
+            self,
+            queries,
+            keys,
+            values,
+            topk_idx,
+            topk_valid,
+            q_start,
+            topk_all_valid=topk_all_valid,
+            q_positions=q_positions,
+        )
+
+    setattr(patched_sparse_decode_attention, _PATCH_MARKER, True)
+    return patched_sparse_decode_attention
+
+
+def apply_minimax_m3_sparse_attention_patch() -> bool:
+    """Patch mlx-vlm MiniMax M3 sparse attention once.
+
+    MiniMax M3 keeps sparse-index keys in the same left-padded storage layout as
+    batched KV cache, but sparse query positions are semantic token positions.
+    With unequal prompt lengths, sparse block selection compares semantic query
+    positions against storage key positions and can mask valid current-row keys.
+    """
+    try:
+        from mlx_vlm.models.minimax_m3_vl import language as minimax_language
+    except ImportError:
+        logger.debug("minimax_m3_sparse_attention: mlx-vlm MiniMax M3 not available")
+        return False
+
+    attention_cls = getattr(minimax_language, "MiniMaxAttention", None)
+    if attention_cls is None:
+        logger.debug("minimax_m3_sparse_attention: MiniMaxAttention class not found")
+        return False
+
+    current_call = attention_cls.__dict__.get("__call__")
+    if getattr(current_call, _PATCH_MARKER, False):
+        return False
+
+    attention_cls.__call__ = _make_patched_call(current_call)
+    attention_cls._build_sparse_mask = _make_patched_build_sparse_mask(
+        attention_cls.__dict__["_build_sparse_mask"]
+    )
+    attention_cls._build_sparse_decode_indices = (
+        _make_patched_build_sparse_decode_indices(
+            attention_cls.__dict__["_build_sparse_decode_indices"]
+        )
+    )
+    attention_cls._sparse_decode_attention = _make_patched_sparse_decode_attention(
+        attention_cls.__dict__["_sparse_decode_attention"]
+    )
+    logger.info("MiniMax M3 sparse attention left-padding patch applied")
+    return True
+
+
+__all__ = ["apply_minimax_m3_sparse_attention_patch", "_storage_q_positions"]

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -2325,7 +2325,7 @@ class Scheduler:
         NOTE: Detokenizers are NOT pooled - each request gets a fresh instance
         to prevent state contamination that causes text corruption.
         """
-        detok = self._request_detokenizers.pop(request_id, None)
+        self._request_detokenizers.pop(request_id, None)
         # Let GC collect - no pooling to prevent state contamination
 
     def _get_output_parser_session(
@@ -2773,9 +2773,6 @@ class Scheduler:
             block_size > 0
             and self.block_aware_cache is not None
             and _prompt_cache_needs_snapshots(prompt_cache)
-        )
-        all_boundaries = (
-            boundary_enabled  # always stop at every boundary for hybrid models
         )
         base_size = _cache_base_sizes(prompt_cache) if boundary_enabled else 0
         # Sanity check: base_size from cache offsets should match the number
@@ -4235,6 +4232,20 @@ class Scheduler:
             return None
         return getattr(factory, "thinking_end_text", None)
 
+    def _get_output_parser_thinking_start_text(self) -> str | None:
+        """Return parser-provided thinking open text, if the parser has one."""
+        factory = getattr(self, "_output_parser_factory", None)
+        if factory is None:
+            return None
+        return getattr(factory, "thinking_start_text", None)
+
+    def _get_output_parser_thinking_start_output_text(self) -> str | None:
+        """Return normalized text to prepend when parser thinking starts in prompt."""
+        factory = getattr(self, "_output_parser_factory", None)
+        if factory is None:
+            return None
+        return getattr(factory, "thinking_start_output_text", None)
+
     def _encode_thinking_marker(self, text: str) -> list[int] | None:
         """Encode a parser/tokenizer thinking marker into token IDs."""
         try:
@@ -4435,29 +4446,48 @@ class Scheduler:
         Returns False for disabled-thinking patterns like <think></think>
         where </think> immediately follows <think> in the prompt tail.
         """
+        think_start_ids = None
         think_start_id = self._get_think_token_id("think_start_id")
-        if think_start_id is None:
+        if think_start_id is not None:
+            think_start_ids = [think_start_id]
+        else:
+            think_start_text = self._get_output_parser_thinking_start_text() or "<think>"
             try:
-                think_start_id = self.tokenizer.convert_tokens_to_ids("<think>")
-                if think_start_id == getattr(self.tokenizer, "unk_token_id", None):
-                    return False
+                token_id = self.tokenizer.convert_tokens_to_ids(think_start_text)
+                if (
+                    isinstance(token_id, int)
+                    and token_id != getattr(self.tokenizer, "unk_token_id", None)
+                ):
+                    think_start_ids = [token_id]
             except (AttributeError, KeyError, TypeError):
-                return False
+                think_start_ids = None
 
-        if not think_start_id or not request.prompt_token_ids:
+            if think_start_ids is None:
+                think_start_ids = self._encode_thinking_marker(think_start_text)
+
+        if not think_start_ids or not request.prompt_token_ids:
             return False
 
-        last_tokens = list(request.prompt_token_ids[-3:])
-        if think_start_id not in last_tokens:
+        lookback = max(3, len(think_start_ids) + 2)
+        last_tokens = list(request.prompt_token_ids[-lookback:])
+        last_idx = None
+        for idx in range(len(last_tokens) - len(think_start_ids), -1, -1):
+            if last_tokens[idx : idx + len(think_start_ids)] == think_start_ids:
+                last_idx = idx
+                break
+        if last_idx is None:
             return False
 
         # <think> found. Check if </think> follows it (disabled thinking pattern).
-        last_idx = len(last_tokens) - 1 - last_tokens[::-1].index(think_start_id)
-        after_start = last_tokens[last_idx + 1 :]
+        after_start = last_tokens[last_idx + len(think_start_ids) :]
 
         if after_start:
             think_end_ids = self._resolve_think_end_token_ids()
-            if think_end_ids and think_end_ids[0] in after_start:
+            if think_end_ids and len(after_start) >= len(think_end_ids):
+                for idx in range(len(after_start) - len(think_end_ids) + 1):
+                    if after_start[idx : idx + len(think_end_ids)] == think_end_ids:
+                        return False
+            elif think_end_ids and think_end_ids[0] in after_start:
                 return False
 
         return True
@@ -7148,9 +7178,9 @@ class Scheduler:
                     # Phase 2: conversation sparse prefill
                     conv_tokens = all_tokens[sys_count:]
                     selected = request.specprefill_indices
-                    M = len(conv_tokens)
+                    conv_len = len(conv_tokens)
                     pos_offset = request.specprefill_position_offset
-                    last_idx = M - 1
+                    last_idx = conv_len - 1
 
                     # Remove last token from selected set — BatchGenerator
                     # will process it separately for generation kickoff.
@@ -7169,11 +7199,11 @@ class Scheduler:
                             phase="specprefill_sparse",
                             detail="sparse target prefill",
                             extra={
-                                "scored_tokens": M,
+                                "scored_tokens": conv_len,
                                 "selected_tokens": int(selected.shape[0]),
                                 "keep_percent": (
-                                    round(int(selected.shape[0]) / M * 100)
-                                    if M > 0
+                                    round(int(selected.shape[0]) / conv_len * 100)
+                                    if conv_len > 0
                                     else 0
                                 ),
                                 "prompt_tokens": request.num_prompt_tokens,
@@ -7194,7 +7224,7 @@ class Scheduler:
                         progress_callback=_sparse_progress,
                     )
                     # sparse_prefill installs _OffsetAdjustedRoPE with
-                    # adjustment = M - N'. Subtract 1 to account for the
+                    # adjustment = conv_len - selected_len'. Subtract 1 to account for the
                     # extra token BatchGenerator will process.
                     for _, layer in _find_attention_layers(self.model):
                         attn = _get_attn_module(layer)
@@ -7205,14 +7235,14 @@ class Scheduler:
                         ):
                             attn.rope._adjustment -= 1
 
-                    N = int(selected.shape[0])
+                    selected_len = int(selected.shape[0])
                     t_prefill = time.monotonic() - t0
                     total_prompt = request.num_prompt_tokens
                     cached = request.cached_tokens
                     logger.info(
-                        f"SpecPrefill: sparse prefill {N}/{M} conv tokens in {t_prefill:.1f}s "
+                        f"SpecPrefill: sparse prefill {selected_len}/{conv_len} conv tokens in {t_prefill:.1f}s "
                         f"(total {total_prompt}, cached {cached}, "
-                        f"system {sys_count} full, conv {M} sparse)"
+                        f"system {sys_count} full, conv {conv_len} sparse)"
                     )
 
                     # Set up request as if we had a prefix cache hit
@@ -7631,12 +7661,23 @@ class Scheduler:
                             new_text = ""
                         break
 
-            # Prepend <think> tag for first chunk if this is a reasoning model
-            # (skip when a protocol parser already manages reasoning formatting)
-            if parser_session is None and getattr(request, "needs_think_prefix", False):
+            # Prepend <think> tag for first chunk if this is a reasoning model.
+            # Protocol parsers may expose a normalized prefix when their prompt
+            # uses a model-specific open-think marker (e.g. MiniMax <mm:think>).
+            if getattr(request, "needs_think_prefix", False):
                 if not getattr(request, "think_prefix_sent", False):
-                    think_tag = getattr(self.tokenizer, "think_start", "<think>")
-                    new_text = think_tag + "\n" + new_text
+                    if parser_session is None:
+                        think_tag = getattr(self.tokenizer, "think_start", "<think>")
+                        prefix_text = think_tag + "\n"
+                    else:
+                        prefix_text = (
+                            self._get_output_parser_thinking_start_output_text()
+                            or ""
+                        )
+                    if prefix_text:
+                        new_text = prefix_text + new_text
+                        if parser_session is not None:
+                            request.output_text = prefix_text + request.output_text
                     request.think_prefix_sent = True
 
             # Immediately discard logprobs if not requested to free memory (~800KB per response)

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1025,6 +1025,7 @@ _KNOWN_SLICEABLE_CACHE_TYPES = frozenset(
         "TurboQuantKVCache",
         "BatchTurboQuantKVCache",
         "ChunkedKVCache",
+        "MiniMaxM3KVCache",
     }
 )
 

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -2613,6 +2613,8 @@ class Scheduler:
                 "BatchTurboQuantKVCache",
             ):
                 return True
+            if class_name in ("MiniMaxM3KVCache", "MiniMaxM3BatchKVCache"):
+                return False
             if isinstance(c, CacheList):
                 return all(_ok(inner) for inner in c.caches)
             return False
@@ -5128,10 +5130,12 @@ class Scheduler:
 
                 # Determine cache type using registry if available
                 cache_type_name = class_name
+                handler = None
                 if HAS_CACHE_TYPE_HANDLERS and CacheTypeRegistry is not None:
                     try:
                         cache_type = CacheTypeRegistry.detect_cache_type(layer_cache)
                         cache_type_name = cache_type.value
+                        handler = CacheTypeRegistry.get_handler(cache_type)
                     except Exception:
                         pass
 
@@ -5186,8 +5190,15 @@ class Scheduler:
                     continue
 
                 if hasattr(layer_cache, "state"):
-                    state = layer_cache.state
-                    meta = getattr(layer_cache, "meta_state", ())
+                    if handler is not None and class_name in (
+                        "MiniMaxM3KVCache",
+                        "MiniMaxM3BatchKVCache",
+                    ):
+                        state = handler.serialize_state(layer_cache)
+                        meta = handler.serialize_meta_state(layer_cache)
+                    else:
+                        state = layer_cache.state
+                        meta = getattr(layer_cache, "meta_state", ())
 
                     if class_name in ("RotatingKVCache", "BatchRotatingKVCache"):
                         state, meta = self._normalize_rotating_snapshot_state(

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -171,6 +171,7 @@ from .api.utils import (
     extract_text_content,
     has_nonleading_system_message,
     prepare_system_messages_for_template,
+    uses_native_reasoning_content,
 )
 from .engine import BaseEngine, VLMBatchedEngine
 from .engine.embedding import EmbeddingEngine
@@ -981,23 +982,23 @@ def _suggest_endpoint_for_engine(engine: object) -> str:
     # Import audio engine classes lazily so that oMLX without the [audio]
     # extra still imports this module.
     try:
-        from omlx.engine.stt import STTEngine
+        from omlx.engine.stt import STTEngine as stt_engine_cls
     except Exception:  # pragma: no cover - defensive
-        STTEngine = None  # type: ignore[assignment]
+        stt_engine_cls = None
     try:
-        from omlx.engine.tts import TTSEngine
+        from omlx.engine.tts import TTSEngine as tts_engine_cls
     except Exception:  # pragma: no cover - defensive
-        TTSEngine = None  # type: ignore[assignment]
+        tts_engine_cls = None
     try:
-        from omlx.engine.sts import STSEngine
+        from omlx.engine.sts import STSEngine as sts_engine_cls
     except Exception:  # pragma: no cover - defensive
-        STSEngine = None  # type: ignore[assignment]
+        sts_engine_cls = None
 
-    if STTEngine is not None and isinstance(engine, STTEngine):
+    if stt_engine_cls is not None and isinstance(engine, stt_engine_cls):
         return "Use /v1/audio/transcriptions for speech-to-text models."
-    if TTSEngine is not None and isinstance(engine, TTSEngine):
+    if tts_engine_cls is not None and isinstance(engine, tts_engine_cls):
         return "Use /v1/audio/speech for text-to-speech models."
-    if STSEngine is not None and isinstance(engine, STSEngine):
+    if sts_engine_cls is not None and isinstance(engine, sts_engine_cls):
         return "Use /v1/audio/process for speech-to-speech / audio processing models."
     if isinstance(engine, EmbeddingEngine):
         return "Use /v1/embeddings for embedding models."
@@ -2925,7 +2926,18 @@ async def create_chat_completion(
     # get reasoning as a separate field; others fall back to <think> inlined
     # in content.
     _entry = get_engine_pool().get_entry(resolved_model)
-    native_reasoning = bool(_entry and _entry.preserve_thinking_default is True)
+    native_reasoning = uses_native_reasoning_content(
+        resolved_model,
+        config_model_type=(
+            getattr(_entry, "config_model_type", None) if _entry is not None else None
+        ),
+        engine_model_type=getattr(engine, "model_type", None),
+        preserve_thinking_default=(
+            getattr(_entry, "preserve_thinking_default", None)
+            if _entry is not None
+            else None
+        ),
+    )
     is_vlm = isinstance(engine, VLMBatchedEngine)
     is_dflash_vlm = not is_vlm and getattr(
         engine, "supports_multimodal_fallback", False
@@ -4723,7 +4735,18 @@ async def create_anthropic_message(
         engine, "supports_multimodal_fallback", False
     )
     _entry = get_engine_pool().get_entry(resolved_model)
-    native_reasoning = bool(_entry and _entry.preserve_thinking_default is True)
+    native_reasoning = uses_native_reasoning_content(
+        resolved_model,
+        config_model_type=(
+            getattr(_entry, "config_model_type", None) if _entry is not None else None
+        ),
+        engine_model_type=getattr(engine, "model_type", None),
+        preserve_thinking_default=(
+            getattr(_entry, "preserve_thinking_default", None)
+            if _entry is not None
+            else None
+        ),
+    )
     if engine.model_type == "gpt_oss":
         messages = convert_anthropic_to_internal_harmony(
             request,

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -159,6 +159,20 @@ def maybe_apply_pre_load_patches(
         if apply_mlx_vlm_diffusion_patch():
             logger.info("mlx-vlm diffusion patch applied for %s", model_name)
 
+    minimax_m3_types = {"minimax_m3", "minimax_m3_vl"}
+    if for_vlm and (
+        model_type in minimax_m3_types or text_model_type in minimax_m3_types
+    ):
+        from ..patches.minimax_m3_sparse_attention import (
+            apply_minimax_m3_sparse_attention_patch,
+        )
+
+        if apply_minimax_m3_sparse_attention_patch():
+            logger.info(
+                "MiniMax M3 sparse attention patch applied for %s",
+                model_name,
+            )
+
     # Apply the MTP patch whenever the model has MTP heads on a compatible
     # model_type — even when mtp_enabled is False. The patch is required
     # for *sanitize correctness*: stock mlx-lm Model.sanitize triggers a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,9 @@ dependencies = [
     "openai-harmony",
     # Cohere Command/Cohere2 output parser for reasoning and tool calls
     "cohere_melody>=0.9.0",
-    # mlx-vlm from commit (5a4222a, main) - includes DiffusionGemma support
-    # plus prior Gemma4/Qwen/Qwen3-VL/Phi VLM fixes.
-    "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@5a4222a15c70cb3725179d591442b1fbe1044b60",
+    # mlx-vlm from PR #1374 commit (086ab9d, minimax-m3-support)
+    # includes MiniMax M3 plus prior DiffusionGemma/Gemma4/Qwen VLM fixes.
+    "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@086ab9d5d575fec64d8d8ad907ce000007c25c1a",
     "Pillow>=9.0.0",
     # dflash-mlx v0.1.9 (5d70fae) - bstnxbt repo. Apple G17 NAX verify,
     # PR #37 prefix snapshot metrics, CopySpec mode, and Qwen text wrapper fix.

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -53,6 +53,7 @@ from omlx.api.utils import (
     extract_multimodal_content,
     extract_text_content,
     prepare_system_messages_for_template,
+    uses_native_reasoning_content,
 )
 
 
@@ -585,6 +586,47 @@ class TestExtractTextContentNativeReasoningContent:
         assert len(result) == 1
         assert result[0]["content"] == "A"
         assert "reasoning_content" not in result[0]
+
+    def test_native_mode_recovers_inline_thinking_from_history(self):
+        """Inline <think> history is converted back to a native reasoning field."""
+        messages = [
+            Message(role="assistant", content="<think>\nR\n</think>\n\nA"),
+        ]
+        result = extract_text_content(messages, native_reasoning_content=True)
+        assert len(result) == 1
+        assert result[0]["content"] == "A"
+        assert result[0]["reasoning_content"] == "R"
+        assert "<think>" not in result[0]["content"]
+
+    def test_native_mode_recovers_minimax_inline_thinking_from_history(self):
+        """MiniMax native tags are also normalized into reasoning_content."""
+        messages = [
+            Message(role="assistant", content="<mm:think>R</mm:think>A"),
+        ]
+        result = extract_text_content(messages, native_reasoning_content=True)
+        assert len(result) == 1
+        assert result[0]["content"] == "A"
+        assert result[0]["reasoning_content"] == "R"
+
+
+class TestUsesNativeReasoningContent:
+    def test_detects_minimax_m3_by_config_type(self):
+        assert uses_native_reasoning_content(
+            "any-name",
+            config_model_type="minimax_m3_vl",
+        )
+
+    def test_detects_minimax_m3_by_model_name(self):
+        assert uses_native_reasoning_content("MiniMax-M3-4bit")
+
+    def test_preserve_thinking_models_are_native(self):
+        assert uses_native_reasoning_content(
+            "qwen",
+            preserve_thinking_default=True,
+        )
+
+    def test_plain_model_is_not_native(self):
+        assert not uses_native_reasoning_content("llama-3")
 
 
 class TestConvertAnthropicToInternal:

--- a/tests/test_cache_type_handlers.py
+++ b/tests/test_cache_type_handlers.py
@@ -297,13 +297,44 @@ class TestMiniMaxM3CacheHandlers:
 
         handler = MiniMaxM3KVCacheHandler()
 
-        assert handler.supports_block_slicing is False
+        assert handler.supports_block_slicing is True
         assert handler.serialize_state(cache) == (keys, values, index_keys)
         assert handler.serialize_meta_state(cache) == (12,)
 
         extracted = handler.extract_state(cache)
         assert extracted["states"] == (keys, values, index_keys)
-        assert extracted["is_full_state"] is True
+        assert "is_full_state" not in extracted
+
+    def test_single_cache_axis_info_is_sliceable(self):
+        handler = MiniMaxM3KVCacheHandler()
+
+        info = handler.get_state_axis_info()
+
+        assert [i.name for i in info] == ["keys", "values", "index_keys"]
+        assert [i.sequence_axis for i in info] == [2, 2, 2]
+        assert all(i.sliceable is True for i in info)
+
+    def test_single_cache_slices_and_concatenates_index_keys(self):
+        mx = pytest.importorskip("mlx.core")
+        keys = mx.arange(1 * 2 * 8 * 3, dtype=mx.float32).reshape(1, 2, 8, 3)
+        values = keys + 100
+        index_keys = mx.arange(1 * 1 * 8 * 3, dtype=mx.float32).reshape(1, 1, 8, 3)
+        handler = MiniMaxM3KVCacheHandler()
+
+        first = handler.slice_state(
+            {"keys": keys, "values": values, "index_keys": index_keys}, 0, 4
+        )
+        second = handler.slice_state(
+            {"keys": keys, "values": values, "index_keys": index_keys}, 4, 8
+        )
+        concatenated = handler.concatenate_states([first, second])
+
+        assert concatenated["states"][0].shape == keys.shape
+        assert concatenated["states"][1].shape == values.shape
+        assert concatenated["states"][2].shape == index_keys.shape
+        assert mx.max(mx.abs(concatenated["states"][0] - keys)).item() == 0.0
+        assert mx.max(mx.abs(concatenated["states"][1] - values)).item() == 0.0
+        assert mx.max(mx.abs(concatenated["states"][2] - index_keys)).item() == 0.0
 
     def test_batch_cache_serializes_kv_metadata_and_index_keys(self):
         keys = MagicMock()
@@ -351,7 +382,7 @@ class TestMiniMaxM3CacheHandlers:
 
         assert restored.kv_cache.state == (keys, values)
         assert restored.index_keys is index_keys
-        assert restored.index_offset == 7
+        assert restored.index_offset == 12
 
     def test_batch_cache_deserialize_rebuilds_nested_state(self, monkeypatch):
         self._install_fake_minimax_module(monkeypatch)
@@ -370,6 +401,35 @@ class TestMiniMaxM3CacheHandlers:
         assert restored.left_padding_arg is left_padding
         assert restored.state == ((keys, values, offset, left_padding), index_keys)
         assert restored.index_offset == 9
+
+    def test_restored_single_caches_merge_and_extract_for_batch_requests(self):
+        mx = pytest.importorskip("mlx.core")
+        language = pytest.importorskip("mlx_vlm.models.minimax_m3_vl.language")
+        handler = MiniMaxM3KVCacheHandler()
+
+        restored = []
+        for row, length in enumerate((4, 6)):
+            keys = mx.full((1, 2, length, 3), row + 1, dtype=mx.float32)
+            values = mx.full((1, 2, length, 3), (row + 1) * 10, dtype=mx.float32)
+            index_keys = mx.full((1, 1, length, 3), (row + 1) * 100, dtype=mx.float32)
+            restored.append(
+                handler.deserialize_state((keys, values, index_keys), (999,))
+            )
+
+        batch = language.MiniMaxM3BatchKVCache.merge(restored)
+
+        assert batch.left_padding.tolist() == [2, 0]
+        assert batch.offset.tolist() == [4, 6]
+        assert batch.index_offset == 6
+        for row, length in enumerate((4, 6)):
+            extracted = batch.extract(row)
+            row_keys, row_values = extracted.kv_cache.state
+            assert row_keys.shape[2] == length
+            assert row_values.shape[2] == length
+            assert extracted.index_keys.shape[2] == length
+            assert float(row_keys[0, 0, 0, 0].item()) == row + 1
+            assert float(row_values[0, 0, 0, 0].item()) == (row + 1) * 10
+            assert float(extracted.index_keys[0, 0, 0, 0].item()) == (row + 1) * 100
 
 
 class TestRotatingKVCacheHandler:

--- a/tests/test_cache_type_handlers.py
+++ b/tests/test_cache_type_handlers.py
@@ -6,8 +6,9 @@ This module tests the abstract and concrete handlers for various cache types
 from mlx-lm, enabling type-aware cache operations like slicing and reconstruction.
 """
 
-from typing import Any, Dict, List, Optional, Tuple
-from unittest.mock import MagicMock, patch, PropertyMock
+import sys
+import types
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -16,9 +17,10 @@ from omlx.cache.type_handlers import (
     CacheListHandler,
     CacheStateInfo,
     CacheType,
-    CacheTypeHandler,
     DefaultCacheHandler,
     KVCacheHandler,
+    MiniMaxM3BatchKVCacheHandler,
+    MiniMaxM3KVCacheHandler,
     RotatingKVCacheHandler,
     SizedArraysCache,
 )
@@ -233,6 +235,141 @@ class TestKVCacheHandlerWithMLX:
         # not meta_state (meta_state offset can exceed tensor length
         # after partial prefix match or walk-back truncation)
         assert cache.offset == 32  # keys.shape[2]
+
+
+class TestMiniMaxM3CacheHandlers:
+    """Tests for MiniMax M3 sparse cache handler contracts."""
+
+    @staticmethod
+    def _install_fake_minimax_module(monkeypatch):
+        module = types.ModuleType("mlx_vlm.models.minimax_m3_vl.language")
+
+        class FakeInnerKVCache:
+            def __init__(self):
+                self.state = None
+
+        class MiniMaxM3KVCache:
+            def __init__(self):
+                self.kv_cache = FakeInnerKVCache()
+                self.index_keys = None
+                self.index_offset = 0
+
+        class MiniMaxM3BatchKVCache:
+            def __init__(self, left_padding):
+                self.left_padding_arg = left_padding
+                self.state = None
+                self.index_keys = None
+                self.index_offset = 0
+
+        module.MiniMaxM3KVCache = MiniMaxM3KVCache
+        module.MiniMaxM3BatchKVCache = MiniMaxM3BatchKVCache
+        monkeypatch.setitem(
+            sys.modules,
+            "mlx_vlm.models.minimax_m3_vl.language",
+            module,
+        )
+
+    def test_registry_detects_minimax_cache_class_names(self):
+        minimax_cache_cls = type("MiniMaxM3KVCache", (), {})
+        minimax_batch_cache_cls = type("MiniMaxM3BatchKVCache", (), {})
+
+        assert (
+            CacheTypeRegistry.detect_cache_type(minimax_cache_cls())
+            == CacheType.MINIMAX_M3_KVCACHE
+        )
+        assert (
+            CacheTypeRegistry.detect_cache_type(minimax_batch_cache_cls())
+            == CacheType.MINIMAX_M3_BATCH_KVCACHE
+        )
+        assert (
+            CacheTypeRegistry.get_handler_by_class_name("MiniMaxM3KVCache").cache_type
+            == CacheType.MINIMAX_M3_KVCACHE
+        )
+
+    def test_single_cache_serializes_nested_state_as_flat_tuple(self):
+        keys = MagicMock()
+        values = MagicMock()
+        index_keys = MagicMock()
+        index_keys.shape = (1, 4, 12, 64)
+        cache = MagicMock()
+        cache.state = ((keys, values), index_keys)
+        cache.index_offset = 12
+
+        handler = MiniMaxM3KVCacheHandler()
+
+        assert handler.supports_block_slicing is False
+        assert handler.serialize_state(cache) == (keys, values, index_keys)
+        assert handler.serialize_meta_state(cache) == (12,)
+
+        extracted = handler.extract_state(cache)
+        assert extracted["states"] == (keys, values, index_keys)
+        assert extracted["is_full_state"] is True
+
+    def test_batch_cache_serializes_kv_metadata_and_index_keys(self):
+        keys = MagicMock()
+        values = MagicMock()
+        offset = MagicMock()
+        left_padding = MagicMock()
+        index_keys = MagicMock()
+        index_keys.shape = (2, 4, 9, 64)
+        cache = MagicMock()
+        cache.state = ((keys, values, offset, left_padding), index_keys)
+        cache.index_offset = 9
+
+        handler = MiniMaxM3BatchKVCacheHandler()
+
+        assert handler.supports_block_slicing is False
+        assert handler.serialize_state(cache) == (
+            keys,
+            values,
+            offset,
+            left_padding,
+            index_keys,
+        )
+        assert handler.serialize_meta_state(cache) == (9,)
+
+    def test_minimax_meta_state_string_is_not_iterated_characterwise(self):
+        class FakeMiniMaxCache:
+            index_offset = 123
+            meta_state = "123"
+
+        assert MiniMaxM3KVCacheHandler().serialize_meta_state(FakeMiniMaxCache()) == (
+            123,
+        )
+
+    def test_single_cache_deserialize_rebuilds_nested_state(self, monkeypatch):
+        self._install_fake_minimax_module(monkeypatch)
+        keys = MagicMock()
+        values = MagicMock()
+        index_keys = MagicMock()
+        index_keys.shape = (1, 4, 12, 64)
+
+        restored = MiniMaxM3KVCacheHandler().deserialize_state(
+            (keys, values, index_keys),
+            meta_state="7",
+        )
+
+        assert restored.kv_cache.state == (keys, values)
+        assert restored.index_keys is index_keys
+        assert restored.index_offset == 7
+
+    def test_batch_cache_deserialize_rebuilds_nested_state(self, monkeypatch):
+        self._install_fake_minimax_module(monkeypatch)
+        keys = MagicMock()
+        values = MagicMock()
+        offset = MagicMock()
+        left_padding = MagicMock()
+        index_keys = MagicMock()
+        index_keys.shape = (2, 4, 9, 64)
+
+        restored = MiniMaxM3BatchKVCacheHandler().deserialize_state(
+            (keys, values, offset, left_padding, index_keys),
+            meta_state=(9,),
+        )
+
+        assert restored.left_padding_arg is left_padding
+        assert restored.state == ((keys, values, offset, left_padding), index_keys)
+        assert restored.index_offset == 9
 
 
 class TestRotatingKVCacheHandler:

--- a/tests/test_engine_preflight.py
+++ b/tests/test_engine_preflight.py
@@ -348,7 +348,6 @@ async def test_vlm_preflight_chat_converts_pydantic_tools(monkeypatch):
     scheduler.preflight_or_raise = lambda **k: None  # type: ignore[assignment]
 
     called_with = {}
-    original_apply = engine._apply_chat_template
 
     def _spy(messages, tools, **kwargs):
         called_with["tools"] = tools

--- a/tests/test_minimax_m3_sparse_attention_patch.py
+++ b/tests/test_minimax_m3_sparse_attention_patch.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the MiniMax M3 batched sparse attention patch."""
+
+import mlx.core as mx
+
+
+def test_storage_q_positions_adds_left_padding_for_minimax_2d_positions():
+    from omlx.patches.minimax_m3_sparse_attention import _storage_q_positions
+
+    positions = mx.array([[2048], [1960], [1984]], dtype=mx.int32)
+    left_padding = mx.array([0, 88, 64], dtype=mx.int32)
+
+    adjusted = _storage_q_positions(positions, left_padding, 3, 1)
+    assert adjusted.tolist() == [[2048], [2048], [2048]]
+
+
+def test_storage_q_positions_handles_decode_vector_positions():
+    from omlx.patches.minimax_m3_sparse_attention import _storage_q_positions
+
+    positions = mx.array([2048, 1960, 1984], dtype=mx.int32)
+    left_padding = mx.array([0, 88, 64], dtype=mx.int32)
+
+    adjusted = _storage_q_positions(positions, left_padding, 3, 1)
+    assert adjusted.tolist() == [2048, 2048, 2048]
+
+
+def test_storage_q_positions_leaves_absent_padding_unchanged():
+    from omlx.patches.minimax_m3_sparse_attention import _storage_q_positions
+
+    positions = mx.array([[11, 12]], dtype=mx.int32)
+
+    assert _storage_q_positions(positions, None, 1, 2) is positions
+
+
+def test_preload_dispatches_minimax_m3_sparse_patch(tmp_path, monkeypatch):
+    import omlx.patches.minimax_m3_sparse_attention as patch
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    calls = []
+
+    def fake_apply():
+        calls.append(True)
+        return True
+
+    monkeypatch.setattr(patch, "apply_minimax_m3_sparse_attention_patch", fake_apply)
+    (tmp_path / "config.json").write_text('{"model_type": "minimax_m3_vl"}')
+
+    maybe_apply_pre_load_patches(str(tmp_path), for_vlm=True)
+
+    assert calls == [True]
+
+
+def test_preload_skips_minimax_m3_sparse_patch_for_llm_path(tmp_path, monkeypatch):
+    import omlx.patches.minimax_m3_sparse_attention as patch
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    calls = []
+
+    def fake_apply():
+        calls.append(True)
+        return True
+
+    monkeypatch.setattr(patch, "apply_minimax_m3_sparse_attention_patch", fake_apply)
+    (tmp_path / "config.json").write_text('{"model_type": "minimax_m3_vl"}')
+
+    maybe_apply_pre_load_patches(str(tmp_path), for_vlm=False)
+
+    assert calls == []
+
+
+def test_minimax_m3_sparse_patch_is_idempotent_when_available():
+    from omlx.patches.minimax_m3_sparse_attention import (
+        apply_minimax_m3_sparse_attention_patch,
+    )
+
+    first = apply_minimax_m3_sparse_attention_patch()
+    second = apply_minimax_m3_sparse_attention_patch()
+
+    assert first in (True, False)
+    assert second is False

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -2,7 +2,6 @@
 """Tests for model discovery functionality."""
 
 import json
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -228,6 +227,26 @@ class TestDetectModelType:
         config = {
             "model_type": "cohere2_moe",
             "architectures": ["Cohere2MoeForCausalLM"],
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "vlm"
+
+    def test_detect_minimax_m3_vl_as_vlm(self, tmp_path):
+        """MiniMax M3 VL is served by mlx-vlm."""
+        config = {
+            "model_type": "minimax_m3_vl",
+            "architectures": ["MiniMaxM3VLForConditionalGeneration"],
+            "vision_config": {"hidden_size": 1280},
+            "text_config": {"hidden_size": 6144},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "vlm"
+
+    def test_detect_minimax_m3_text_as_vlm_native_text(self, tmp_path):
+        """MiniMax M3 text-only checkpoints are implemented by mlx-vlm."""
+        config = {
+            "model_type": "minimax_m3",
+            "architectures": ["MiniMaxM3ForCausalLM"],
         }
         (tmp_path / "config.json").write_text(json.dumps(config))
         assert detect_model_type(tmp_path) == "vlm"

--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -424,6 +424,59 @@ class TestGemma4OutputParserSession:
 
 
 class TestOutputParserFactory:
+    def test_detects_minimax_m3_by_config(self):
+        tokenizer = CohereTokenizer({1: "x"})
+        factory = detect_output_parser(
+            "MiniMax-M3-4bit",
+            tokenizer,
+            {"model_type": "minimax_m3_vl"},
+        )
+
+        assert factory is not None
+        assert factory.kind == "minimax_m3"
+
+    def test_minimax_m3_parser_extracts_tool_calls(self, monkeypatch):
+        module = types.ModuleType("mlx_vlm.tool_parsers.minimax_m3")
+
+        def parse_tool_call(text):
+            assert "lookup" in text
+            return {"name": "lookup", "arguments": {"query": "mlx"}}
+
+        module.parse_tool_call = parse_tool_call
+        monkeypatch.setitem(sys.modules, "mlx_vlm.tool_parsers.minimax_m3", module)
+
+        start = "]<]minimax[>[<tool_call>"
+        end = "]<]minimax[>[</tool_call>"
+        tokenizer = CohereTokenizer(
+            {
+                1: "before ",
+                2: start,
+                3: ']<]minimax[>[<invoke name="lookup">',
+                4: "]<]minimax[>[</invoke>",
+                5: end,
+                6: " after",
+            }
+        )
+        factory = detect_output_parser(
+            "MiniMax-M3-4bit",
+            tokenizer,
+            {"model_type": "minimax_m3_vl"},
+        )
+        session = factory.create_session(tokenizer)
+
+        visible = []
+        stream = []
+        for token_id in [1, 2, 3, 4, 5, 6]:
+            result = session.process_token(token_id)
+            stream.append(result.stream_text)
+            visible.append(result.visible_text)
+        final = session.finalize()
+
+        assert start in "".join(stream)
+        assert "".join(visible) + final.visible_text == "before  after"
+        assert final.tool_calls == [{"name": "lookup", "arguments": '{"query":"mlx"}'}]
+        assert final.finish_reason == "tool_calls"
+
     def test_detects_gemma4(self):
         tokenizer = GemmaTokenizer({1: "x"})
         factory = detect_output_parser(

--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -472,10 +472,68 @@ class TestOutputParserFactory:
             visible.append(result.visible_text)
         final = session.finalize()
 
-        assert start in "".join(stream)
+        assert "".join(stream) == "before  after"
+        assert start not in "".join(stream)
         assert "".join(visible) + final.visible_text == "before  after"
         assert final.tool_calls == [{"name": "lookup", "arguments": '{"query":"mlx"}'}]
         assert final.finish_reason == "tool_calls"
+
+    def test_minimax_m3_parser_normalizes_thinking_and_strips_eos(self):
+        tokenizer = CohereTokenizer(
+            {
+                1: "<mm:think>",
+                2: "reasoning",
+                3: "</mm:think>",
+                4: "Answer",
+                5: "[e~[",
+                6: "]!d~[",
+            }
+        )
+        factory = detect_output_parser(
+            "MiniMax-M3-4bit",
+            tokenizer,
+            {"model_type": "minimax_m3_vl"},
+        )
+        session = factory.create_session(tokenizer)
+
+        stream = []
+        visible = []
+        stop_seen = False
+        record_flags = []
+        for token_id in [1, 2, 3, 4, 6, 5]:
+            result = session.process_token(token_id)
+            stream.append(result.stream_text)
+            visible.append(result.visible_text)
+            stop_seen = stop_seen or result.is_stop
+            record_flags.append(result.record_token)
+        final = session.finalize()
+        stream.append(final.stream_text)
+        visible.append(final.visible_text)
+
+        assert "".join(stream) == "<think>reasoning</think>Answer"
+        assert "".join(visible) == "<think>reasoning</think>Answer"
+        assert stop_seen is True
+        assert record_flags[-1] is False
+
+    def test_minimax_m3_factory_exposes_native_thinking_markers(self):
+        tokenizer = CohereTokenizer({})
+        tokenizer.convert_tokens_to_ids = lambda text: {
+            "[e~[": 200020,
+            "<mm:think>": 200059,
+            "</mm:think>": 200060,
+        }.get(text, -1)
+        tokenizer.unk_token_id = -1
+
+        factory = detect_output_parser(
+            "MiniMax-M3-4bit",
+            tokenizer,
+            {"model_type": "minimax_m3_vl"},
+        )
+
+        assert factory.thinking_start_text == "<mm:think>"
+        assert factory.thinking_start_output_text == "<think>\n"
+        assert factory.thinking_end_text == "</mm:think>"
+        assert factory.stop_token_ids == {200020}
 
     def test_detects_gemma4(self):
         tokenizer = GemmaTokenizer({1: "x"})

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -6,17 +6,15 @@ This module tests the block-aware prefix caching system that uses
 PagedCacheManager for block-based storage with SSD persistence.
 """
 
+import sys
 import time
-from pathlib import Path
-from typing import Any, Dict, List, Optional
-from unittest.mock import MagicMock, patch, PropertyMock
+import types
+from unittest.mock import MagicMock
 
 import pytest
 
 from omlx.cache.paged_cache import (
-    BlockHash,
     BlockTable,
-    CacheBlock,
     PagedCacheManager,
     compute_block_hash,
 )
@@ -500,6 +498,101 @@ class TestBlockAwarePrefixCacheWithSSD:
             block.block_hash
         )
         prefix_cache_with_ssd.paged_ssd_cache.delete_block.assert_not_called()
+
+    def test_minimax_m3_sliceable_nstate_blocks_round_trip(self, monkeypatch):
+        """MiniMax M3 single-cache blocks store K/V/index slices, not snapshots."""
+        mx = pytest.importorskip("mlx.core")
+
+        module = types.ModuleType("mlx_vlm.models.minimax_m3_vl.language")
+
+        class FakeInnerKVCache:
+            def __init__(self):
+                self.state = None
+
+        class MiniMaxM3KVCache:
+            def __init__(self):
+                self.kv_cache = FakeInnerKVCache()
+                self.index_keys = None
+                self.index_offset = 0
+
+        module.MiniMaxM3KVCache = MiniMaxM3KVCache
+        monkeypatch.setitem(
+            sys.modules,
+            "mlx_vlm.models.minimax_m3_vl.language",
+            module,
+        )
+
+        paged_cache = PagedCacheManager(
+            block_size=4,
+            max_blocks=100,
+            model_name="test-model",
+            initial_blocks=100,
+        )
+        mock_ssd = MagicMock()
+        saved_by_hash = {}
+
+        def save_block(**kwargs):
+            saved_by_hash[kwargs["block_hash"]] = (
+                kwargs["cache_data"],
+                {
+                    "model_name": "test-model",
+                    "num_layers": 1,
+                    "block_size": 4,
+                    "layer_cache_types": kwargs["layer_cache_types"],
+                    "layer_meta_states": kwargs["layer_meta_states"],
+                },
+            )
+            return True
+
+        mock_ssd.save_block.side_effect = save_block
+        cache = BlockAwarePrefixCache(
+            model=MockModel(num_layers=1),
+            paged_cache_manager=paged_cache,
+            paged_ssd_cache_manager=mock_ssd,
+        )
+
+        keys = mx.arange(1 * 2 * 8 * 3, dtype=mx.float32).reshape(1, 2, 8, 3)
+        values = keys + 100
+        index_keys = mx.arange(1 * 1 * 8 * 3, dtype=mx.float32).reshape(1, 1, 8, 3)
+        mx.eval(keys, values, index_keys)
+        cache_data = [
+            {
+                "state": (keys, values, index_keys),
+                "cache_type": "MiniMaxM3KVCache",
+                "class_name": "MiniMaxM3KVCache",
+                "meta_state": (999,),
+            }
+        ]
+
+        block_table = cache.store_cache("req-minimax", list(range(8)), cache_data)
+
+        assert block_table is not None
+        assert len(block_table.block_ids) == 2
+        assert mock_ssd.save_block.call_count == 2
+        for idx, call in enumerate(mock_ssd.save_block.call_args_list):
+            marker = call.kwargs["cache_data"][0]
+            assert marker[0] == "__nstate__"
+            assert marker[1] == "MiniMaxM3KVCache"
+            saved_keys, saved_values, saved_index = marker[2]
+            start = idx * 4
+            end = start + 4
+            assert saved_keys.tolist() == keys[:, :, start:end, :].tolist()
+            assert saved_values.tolist() == values[:, :, start:end, :].tolist()
+            assert saved_index.tolist() == index_keys[:, :, start:end, :].tolist()
+
+        def load_block_with_metadata(block_hash, **kwargs):
+            return saved_by_hash.get(block_hash, (None, None))
+
+        mock_ssd.load_block_with_metadata.side_effect = load_block_with_metadata
+        restored = cache.reconstruct_cache(block_table)
+
+        assert restored is not None
+        restored_cache = restored[0]
+        restored_keys, restored_values = restored_cache.kv_cache.state
+        assert restored_keys.tolist() == keys.tolist()
+        assert restored_values.tolist() == values.tolist()
+        assert restored_cache.index_keys.tolist() == index_keys.tolist()
+        assert restored_cache.index_offset == 8
 
 
 class TestPrefixIndexOperations:

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for thinking/reasoning content parser."""
 
-import pytest
-
 from omlx.api.thinking import ThinkingParser, extract_thinking
 
 
@@ -12,6 +10,12 @@ class TestExtractThinking:
     def test_basic_separation(self):
         """Standard <think>reasoning</think>answer case."""
         thinking, content = extract_thinking("<think>reasoning</think>Answer")
+        assert thinking == "reasoning"
+        assert content == "Answer"
+
+    def test_minimax_m3_tag_separation(self):
+        """MiniMax M3 <mm:think> tags are treated as thinking tags."""
+        thinking, content = extract_thinking("<mm:think>reasoning</mm:think>Answer")
         assert thinking == "reasoning"
         assert content == "Answer"
 
@@ -391,6 +395,11 @@ class TestCleanSpecialTokens:
     def test_removes_special_tokens(self):
         from omlx.api.utils import clean_special_tokens
         result = clean_special_tokens("<|im_end|>Hello<|endoftext|>")
+        assert result == "Hello"
+
+    def test_removes_minimax_m3_special_tokens(self):
+        from omlx.api.utils import clean_special_tokens
+        result = clean_special_tokens("]~!b[]~b]Hello[e~[]!p~[]!d~[")
         assert result == "Hello"
 
     def test_removes_special_preserves_think(self):

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -7,10 +7,17 @@ Tests JSON schema validation, JSON extraction, and tool conversion functions.
 
 import json
 import logging
-import pytest
-
 from unittest.mock import MagicMock
 
+import pytest
+
+from omlx.api.openai_models import (
+    FunctionCall,
+    ResponseFormat,
+    ResponseFormatJsonSchema,
+    ToolCall,
+    ToolDefinition,
+)
 from omlx.api.tool_calling import (
     ToolCallStreamFilter,
     _gemma4_args_to_json_robust,
@@ -27,13 +34,6 @@ from omlx.api.tool_calling import (
     parse_tool_calls_with_thinking_fallback,
     restore_gemma4_param_names,
     validate_json_schema,
-)
-from omlx.api.openai_models import (
-    FunctionCall,
-    ResponseFormat,
-    ResponseFormatJsonSchema,
-    ToolCall,
-    ToolDefinition,
 )
 
 
@@ -734,6 +734,14 @@ class TestToolCallStreamFilter:
         result = f.feed(
             'Before <tool_call>{"name":"get_weather","arguments":{"city":"SF"}}</tool_call> After'
         )
+        result += f.finish()
+        assert result == "Before  After"
+
+    def test_minimax_tool_call_suppresses_envelope_but_preserves_trailing_text(self):
+        """MiniMax M3 namespaced envelope suppression should not eat prose."""
+        f = ToolCallStreamFilter(_make_tokenizer())
+        result = f.feed('Before ]<]minimax[>[<tool_call><invoke name="x">')
+        result += f.feed("]<]minimax[>[</invoke>]<]minimax[>[</tool_call> After")
         result += f.finish()
         assert result == "Before  After"
 

--- a/tests/test_vision_feature_cache.py
+++ b/tests/test_vision_feature_cache.py
@@ -1,19 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for VisionFeatureSSDCache (memory LRU + SSD persistence)."""
 
-import shutil
-import tempfile
 import time
-from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import mlx.core as mx
 import pytest
 
 from omlx.cache.vision_feature_cache import (
     VisionFeatureSSDCache,
-    VisionFeatureSSDEntry,
     _composite_hash,
     _composite_key,
 )
@@ -290,6 +286,36 @@ class TestVLMEngineIntegration:
         engine._vlm_model.encode_image.assert_called_once_with(
             pixel_values, image_position_ids=image_position_ids
         )
+
+    def test_compute_vision_features_encode_image_with_grid_thw(self):
+        """MiniMax-style encode_image should receive image_grid_thw."""
+        from omlx.engine.vlm import VLMBatchedEngine
+
+        expected = mx.ones((10, 16))
+
+        class GridModel:
+            config = SimpleNamespace(model_type="minimax_m3_vl")
+
+            def __init__(self):
+                self.calls = []
+
+            def encode_image(self, pixel_values, image_grid_thw=None):
+                self.calls.append((pixel_values, image_grid_thw))
+                if image_grid_thw is None:
+                    raise ValueError("image_grid_thw required")
+                return expected
+
+        engine = VLMBatchedEngine.__new__(VLMBatchedEngine)
+        engine._vlm_model = GridModel()
+
+        pixel_values = mx.zeros((1, 3, 224, 224))
+        image_grid_thw = mx.array([[1, 4, 4]])
+        result = engine._compute_vision_features(
+            pixel_values, {"image_grid_thw": image_grid_thw}
+        )
+
+        assert result is expected
+        assert engine._vlm_model.calls == [(pixel_values, image_grid_thw)]
 
     def test_compute_vision_features_encode_image_without_position_support(self):
         """Models with a pixel-only encode_image signature should still work."""

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -711,7 +711,7 @@ class TestApplyChatTemplate:
         engine._apply_chat_template(messages)
 
         call_kwargs = tokenizer.apply_chat_template.call_args[1]
-        assert call_kwargs["enable_thinking"] is False
+        assert "enable_thinking" not in call_kwargs
         assert call_kwargs["thinking_mode"] == "disabled"
 
     def test_minimax_m3_preserves_explicit_thinking_mode(self):
@@ -730,8 +730,26 @@ class TestApplyChatTemplate:
         )
 
         call_kwargs = tokenizer.apply_chat_template.call_args[1]
-        assert call_kwargs["enable_thinking"] is False
+        assert "enable_thinking" not in call_kwargs
         assert call_kwargs["thinking_mode"] == "adaptive"
+
+    def test_minimax_m3_maps_request_enable_thinking_kwarg(self):
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "<prompt>"
+        engine = _make_loaded_engine(
+            model_type="minimax_m3_vl",
+            tokenizer=tokenizer,
+        )
+
+        messages = [{"role": "user", "content": "Hello"}]
+        engine._apply_chat_template(
+            messages,
+            chat_template_kwargs={"enable_thinking": True},
+        )
+
+        call_kwargs = tokenizer.apply_chat_template.call_args[1]
+        assert "enable_thinking" not in call_kwargs
+        assert call_kwargs["thinking_mode"] == "enabled"
 
     def test_fallback_when_no_template(self):
         """Tokenizer without apply_chat_template → manual concatenation."""

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -697,6 +697,42 @@ class TestApplyChatTemplate:
         call_kwargs = tokenizer.apply_chat_template.call_args[1]
         assert call_kwargs["enable_thinking"] is True
 
+    def test_minimax_m3_maps_enable_thinking_to_thinking_mode(self):
+        """MiniMax M3 templates use thinking_mode instead of enable_thinking."""
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "<prompt>"
+        engine = _make_loaded_engine(
+            model_type="minimax_m3_vl",
+            tokenizer=tokenizer,
+            enable_thinking=False,
+        )
+
+        messages = [{"role": "user", "content": "Hello"}]
+        engine._apply_chat_template(messages)
+
+        call_kwargs = tokenizer.apply_chat_template.call_args[1]
+        assert call_kwargs["enable_thinking"] is False
+        assert call_kwargs["thinking_mode"] == "disabled"
+
+    def test_minimax_m3_preserves_explicit_thinking_mode(self):
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "<prompt>"
+        engine = _make_loaded_engine(
+            model_type="minimax_m3_vl",
+            tokenizer=tokenizer,
+            enable_thinking=False,
+        )
+
+        messages = [{"role": "user", "content": "Hello"}]
+        engine._apply_chat_template(
+            messages,
+            chat_template_kwargs={"thinking_mode": "adaptive"},
+        )
+
+        call_kwargs = tokenizer.apply_chat_template.call_args[1]
+        assert call_kwargs["enable_thinking"] is False
+        assert call_kwargs["thinking_mode"] == "adaptive"
+
     def test_fallback_when_no_template(self):
         """Tokenizer without apply_chat_template → manual concatenation."""
         tokenizer = MagicMock(spec=[])  # spec=[] prevents auto-creating attributes

--- a/tests/test_vlm_model_adapter.py
+++ b/tests/test_vlm_model_adapter.py
@@ -1,12 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for models/vlm.py — VLMModelAdapter for BatchGenerator compatibility."""
 
-from unittest.mock import MagicMock, PropertyMock, patch
-
-import pytest
-
-# Mock mlx before importing the module
-import sys
+from unittest.mock import MagicMock
 
 
 # Create mock mlx modules
@@ -155,7 +150,7 @@ class TestVLMModelAdapter:
         expected = MagicMock()
         vlm.language_model.__call__ = MagicMock(return_value=expected)
 
-        result = adapter(input_ids, cache=cache)
+        adapter(input_ids, cache=cache)
         vlm.language_model.assert_called_once()
         call_args = vlm.language_model.call_args
         assert call_args[0][0] is input_ids
@@ -337,6 +332,16 @@ class TestMRoPEDetection:
         vlm = MagicMock(spec=[])
         assert VLMModelAdapter._detect_mrope(vlm) is False
 
+    def test_detect_mrope_true_for_minimax_m3_vl(self):
+        """MiniMax M3 uses per-row decode positions even without mrope_section."""
+        from omlx.models.vlm import VLMModelAdapter
+
+        vlm = MagicMock(spec=[])
+        vlm.config = MagicMock(spec=[])
+        vlm.config.model_type = "minimax_m3_vl"
+        assert VLMModelAdapter._detect_mrope(vlm) is True
+        assert VLMModelAdapter._detect_minimax_m3(vlm) is True
+
 
 class TestPerRequestMRoPEDecode:
     """Tests for per-request mRoPE position_ids computation during decode."""
@@ -358,9 +363,19 @@ class TestPerRequestMRoPEDecode:
         vlm.config.model_type = "qwen3_vl_moe"
         return vlm
 
+    def _make_minimax_m3_vlm_model(self):
+        """Create a mock MiniMax M3 VLM model."""
+        vlm = self._make_mrope_vlm_model()
+        vlm.config.model_type = "minimax_m3_vl"
+        vlm.config.text_config.model_type = "minimax_m3_vl"
+        vlm.config.text_config.rope_scaling = None
+        vlm.config.text_config.rope_parameters = None
+        return vlm
+
     def test_mrope_decode_uses_language_model_with_position_ids(self):
         """mRoPE decode with batch_rope_deltas should use language_model with position_ids."""
         import mlx.core as mx
+
         from omlx.models.vlm import VLMModelAdapter
 
         vlm = self._make_mrope_vlm_model()
@@ -384,6 +399,7 @@ class TestPerRequestMRoPEDecode:
     def test_mrope_always_uses_language_model(self):
         """mRoPE model always uses vlm language_model with position_ids."""
         import mlx.core as mx
+
         from omlx.models.vlm import VLMModelAdapter
 
         vlm = self._make_mrope_vlm_model()
@@ -400,6 +416,7 @@ class TestPerRequestMRoPEDecode:
     def test_position_ids_shape_and_values(self):
         """Verify position_ids = (3, batch, seq) with correct offset+delta values."""
         import mlx.core as mx
+
         from omlx.models.vlm import VLMModelAdapter
 
         vlm = self._make_mrope_vlm_model()
@@ -429,6 +446,7 @@ class TestPerRequestMRoPEDecode:
     def test_mrope_decode_scalar_cache_offset_uses_position_ids(self):
         """Singleton KVCache offset should not rely on stale language-model state."""
         import mlx.core as mx
+
         from omlx.models.vlm import VLMModelAdapter
 
         vlm = self._make_mrope_vlm_model()
@@ -447,9 +465,60 @@ class TestPerRequestMRoPEDecode:
         assert pos_ids.shape == (3, 1, 1)
         assert pos_ids[0, 0, 0].item() == 16384.0
 
+    def test_non_minimax_mrope_mismatched_delta_size_keeps_existing_path(self):
+        """Non-MiniMax mRoPE models keep prior no-position_ids mismatch behavior."""
+        import mlx.core as mx
+
+        from omlx.models.vlm import VLMModelAdapter
+
+        vlm = self._make_mrope_vlm_model()
+        adapter = VLMModelAdapter(vlm)
+        assert adapter._uses_minimax_m3_positions is False
+
+        adapter.set_batch_rope_deltas(mx.array([10.0, 0.0]))
+
+        input_ids = mx.zeros((3, 1), dtype=mx.int32)
+        cache_layer = MagicMock()
+        cache_layer.offset = mx.array([50, 30, 20])
+        cache = [cache_layer]
+
+        adapter(input_ids, cache=cache)
+
+        call_kwargs = vlm.language_model.call_args[1]
+        assert "position_ids" not in call_kwargs
+
+    def test_minimax_m3_decode_uses_2d_position_ids(self):
+        """MiniMax M3 expects position_ids = (batch, seq), not Qwen-style rank 3."""
+        import mlx.core as mx
+
+        from omlx.models.vlm import VLMModelAdapter
+
+        vlm = self._make_minimax_m3_vlm_model()
+        adapter = VLMModelAdapter(vlm)
+        assert adapter._uses_mrope is True
+        assert adapter._uses_minimax_m3_positions is True
+
+        adapter.set_batch_rope_deltas(mx.array([-50.0, 0.0]))
+
+        input_ids = mx.zeros((2, 2), dtype=mx.int32)
+        cache_layer = MagicMock()
+        cache_layer.offset = mx.array([100, 80])
+        cache = [cache_layer]
+
+        adapter(input_ids, cache=cache)
+
+        call_kwargs = vlm.language_model.call_args[1]
+        pos_ids = call_kwargs["position_ids"]
+        assert pos_ids.shape == (2, 2)
+        assert pos_ids[0, 0].item() == 50.0
+        assert pos_ids[0, 1].item() == 51.0
+        assert pos_ids[1, 0].item() == 80.0
+        assert pos_ids[1, 1].item() == 81.0
+
     def test_get_last_rope_deltas(self):
         """get_last_rope_deltas extracts value from language model."""
         import mlx.core as mx
+
         from omlx.models.vlm import VLMModelAdapter
 
         vlm = self._make_mrope_vlm_model()
@@ -526,4 +595,3 @@ class TestVLMModelAdapterModelProperty:
 
         # BatchGenerator accesses model.layers
         assert adapter.layers is vlm.language_model.model.layers
-


### PR DESCRIPTION
## Summary

- Add oMLX support for MiniMax M3 based on the in-progress `mlx-vlm` MiniMax M3 PR.
- Pin `mlx-vlm` to `Blaizzy/mlx-vlm@086ab9d5d575fec64d8d8ad907ce000007c25c1a`.
- Add MiniMax M3 / MiniMax M3 VL model discovery and mlx-vlm routing.
- Add MiniMax M3 cache type handlers for sparse index cache serialization, SSD snapshot storage, and restore.
- Keep MiniMax M3 cache out of TurboQuant eligibility until a dedicated implementation is proven.
- Add MiniMax M3 streaming tool-call suppression and parser integration.
