### PR TITLE
fix: use 'hermes chat' subcommand in Hermes launch integration

### DIFF
--- a/omlx/integrations/hermes.py
+++ b/omlx/integrations/hermes.py
@@ -142,8 +142,11 @@ class HermesIntegration(Integration):
         # Hermes Agent v0.12.0's classic prompt_toolkit REPL registers an
         # invalid Ctrl+Shift+C keybinding ("c-S-c") on startup. The modern TUI
         # path avoids that startup crash and is the supported interactive UX.
-        args = ["hermes", "--provider", "omlx", "--tui"]
+        # --provider is a subcommand flag on `hermes chat`, not a top-level
+        # flag, and "omlx" is not a valid CLI provider value — the provider is
+        # read from ~/.hermes/config.yaml which configure() already wrote above.
+        args = ["hermes", "chat", "--tui"]
         if ctx.model:
-            args.extend(["--model", ctx.model])
+            args.extend(["-m", ctx.model])
 
         os.execvpe("hermes", args, env)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -821,10 +821,9 @@ class TestHermesIntegration:
         assert captured["binary"] == "hermes"
         assert captured["argv"] == [
             "hermes",
-            "--provider",
-            "omlx",
+            "chat",
             "--tui",
-            "--model",
+            "-m",
             "qwen3.5",
         ]
         assert "PYTHONHOME" not in captured["env"]
@@ -851,7 +850,7 @@ class TestHermesIntegration:
         ):
             hermes.launch(ctx(port=8000, api_key="", model=""))
 
-        assert captured["argv"] == ["hermes", "--provider", "omlx", "--tui"]
+        assert captured["argv"] == ["hermes", "chat", "--tui"]
 
     def test_type(self):
         hermes = HermesIntegration()


### PR DESCRIPTION
## Problem

`omlx launch hermes` fails immediately after writing `~/.hermes/config.yaml`:

```
hermes: error: argument command: invalid choice: 'omlx'
```

The integration was calling:
```
hermes --provider omlx --tui [--model <model>]
```

Two issues with this invocation:
1. `--provider` is a flag on the `hermes chat` subcommand, not a global flag. Passing it before the subcommand causes argparse to interpret `omlx` as the subcommand name, which is invalid.
2. `omlx` is not a valid `--provider` value in the Hermes CLI anyway — custom providers are configured via `~/.hermes/config.yaml`, which `configure()` already writes correctly.

## Fix

Use `hermes chat --tui` as the subcommand and pass the model via `-m` (the short flag accepted by `hermes chat`):

```python
# before
args = ["hermes", "--provider", "omlx", "--tui"]
if ctx.model:
    args.extend(["--model", ctx.model])

# after
args = ["hermes", "chat", "--tui"]
if ctx.model:
    args.extend(["-m", ctx.model])
```

The provider selection is already handled by the `config.yaml` written in `configure()` — no CLI flag needed.

## Test plan

- [ ] `omlx launch hermes` no longer errors on launch
- [ ] Hermes TUI opens with omlx as the active provider (visible in the model selector)
- [ ] `--model` override is passed correctly via `-m`