### PR TITLE
oq: expose language_model on the sanitize-plan proxy so oQ can quantize nested VLMs (e.g. MiniMax-M3)

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -1993,6 +1993,13 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
 
                 proxy = _Proxy()
                 proxy.config = model_config
+                # Nested-VLM sanitizes (e.g. MiniMax-M3 minimax_m3_vl) read
+                # self.language_model.args.{num_hidden_layers,num_local_experts}
+                # for MoE expert stacking; expose text_config so proxy-based
+                # discovery works without instantiating the full model.
+                _lm_proxy = type("_LMProxy", (), {})()
+                _lm_proxy.args = text_config
+                proxy.language_model = _lm_proxy
                 w = model_module.Model.sanitize(proxy, weights)
 
                 w = sanitize_weights(model_module.VisionModel, w, vision_config)


### PR DESCRIPTION
### What

oQ's streaming sanitize-plan discovery uses a lightweight `_Proxy` instead of instantiating the model, so it can quantize models that don't fit in RAM. Nested-VLM `Model.sanitize` implementations (e.g. `minimax_m3_vl`) read `self.language_model.args.{num_hidden_layers, num_local_experts}` for MoE expert stacking, which the proxy didn't provide — discovery failed with `'_Proxy' object has no attribute 'language_model'`.

This exposes a `language_model` proxy carrying `text_config` so VLM sanitize plans work without instantiating the model. +7 lines, no behavior change for non-VLM paths.

### Relationship to #1875

**Complementary, not competing.** #1875 (thanks @jundot) adds MiniMax-M3 *serving* (MSA attention, cache handlers, tool/reasoning parsing). This PR is the *quantization* side — without it there's no way to **produce** an M3 oQ checkpoint in the first place. (I originally opened this with serving edits too; I've dropped those since #1875 covers them properly — this is now scoped to just the oq.py fix.)

### Tested

Used to produce **[unigilby/MiniMax-M3-oQ4](https://huggingface.co/unigilby/MiniMax-M3-oQ4)** (4-bit, public) — a fused-layout checkpoint that loads on the M3 mlx-vlm code this stack pins (`086ab9d`; verified identical M3 model code through `8fd6fe7`). Happy to point it at #1875 as a test artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)