### PR TITLE
fix(tool-calling): parse Gemma 4 parenthesized call:name(...) tool calls (#1846)

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -486,15 +486,37 @@ class _Gemma4ArgsTooComplexError(ValueError):
 # linear.  See test_oversized_args_fail_cleanly.
 _GEMMA4_CALL_HEAD = regex.compile(r"(?:call)?:?([\w.-]+(?::[\w.-]+)*)\{")
 
+# The parenthesized variant of the head (#1846): under instruction-dense
+# agentic load (large system prompt + many tool schemas + a big tool result)
+# Gemma 4 26B reproducibly degrades from ``call:name{...}`` to a Python-kwargs
+# shell ``call:name(key=value, ...)`` — same name grammar and same ``<|"|>``
+# string quoting, only the OUTER ``{}`` becomes ``()`` and the top-level
+# ``:`` separator becomes ``=``.  The nested grammar (objects, arrays, strings)
+# is unchanged, so the hardened transcoder is reused for the inner content; only
+# the outer shell needs a separate head + span scan.  Compiled with ``regex``,
+# not ``re``, for the SAME reason as ``_GEMMA4_CALL_HEAD``: the optional/tolerant
+# prefix makes ``re`` backtrack O(n^2) on a long bare value hunting an opening
+# ``(`` that never comes (the #1854 ReDoS).  See test_oversized_paren_args.
+_GEMMA4_CALL_HEAD_PAREN = regex.compile(r"(?:call)?:?([\w.-]+(?::[\w.-]+)*)\(")
+
+# Matching close character for each balanced opener the parsers track.
+_GEMMA4_CLOSE_CHAR = {"{": "}", "[": "]", "(": ")"}
+
 
 def _squote_close_positions(s: str) -> list:
     """Indices of single quotes that can CLOSE a single-quoted value.
 
     A closing quote is one whose next non-whitespace character is ``,``,
-    ``}``, ``]`` or end of input.  Anchoring closes this way (rather than
-    taking the first quote) keeps apostrophes inside values from pairing
-    across values: in ``{a: 'it's ok', b: 1}`` the quote in ``it's`` is
-    followed by ``s`` so it cannot close the string.
+    ``}``, ``]``, ``)`` or end of input.  ``)`` is an anchor for the
+    parenthesized variant (#1846): a single-quoted value can be the last
+    argument right before the call's closing paren, as in
+    ``call:f(msg='hi')`` where the quote is followed immediately by ``)``.
+    The curly form never closes a value with ``)`` (its values end at
+    ``,``/``}``/``]``), so adding it does not change curly parsing.
+    Anchoring closes this way (rather than taking the first quote) keeps
+    apostrophes inside values from pairing across values: in
+    ``{a: 'it's ok', b: 1}`` the quote in ``it's`` is followed by ``s`` so
+    it cannot close the string.
 
     Computed in one reverse pass so each lookup is O(log n) via bisect; a
     forward scan that peeks past whitespace at every quote would be
@@ -504,7 +526,7 @@ def _squote_close_positions(s: str) -> list:
     next_sig = ""  # next non-whitespace char AFTER the current index
     for idx in range(len(s) - 1, -1, -1):
         ch = s[idx]
-        if ch == "'" and (next_sig == "" or next_sig in ",}]"):
+        if ch == "'" and (next_sig == "" or next_sig in ",}])"):
             closes.append(idx)
         if not ch.isspace():
             next_sig = ch
@@ -513,10 +535,17 @@ def _squote_close_positions(s: str) -> list:
 
 
 def _scan_gemma4_args_span(
-    text: str, open_idx: int, squote_closes: list
+    text: str, open_idx: int, squote_closes: list,
+    open_ch: str = "{", close_ch: str = "}",
 ) -> int:
-    """Return the end index (exclusive) of the balanced ``{...}`` starting at
-    ``open_idx``, or -1 if no balanced span exists within bounds.
+    """Return the end index (exclusive) of the balanced ``open_ch...close_ch``
+    span starting at ``open_idx``, or -1 if no balanced span exists within
+    bounds.  Defaults to braces (the canonical ``call:name{...}`` form); the
+    parenthesized variant (#1846) passes ``(``/``)`` to find the call's outer
+    span — nested ``{}``/``[]`` then pass through as ordinary characters for
+    depth purposes (only the tracked pair is counted), while the string-skip
+    logic below is character-agnostic so a ``)`` inside any string still
+    cannot close the span.
 
     Iterative single-pass walk that counts brace depth only OUTSIDE string
     literals (``<|"|>``-paired strings, standard JSON double-quoted strings,
@@ -569,16 +598,16 @@ def _scan_gemma4_args_span(
             i = j + 1
             last_sig = '"'
             continue
-        if ch == "'" and last_sig in ":,[":
+        if ch == "'" and last_sig in ":=,[":
             k = bisect.bisect_right(squote_closes, i)
             if k < len(squote_closes):
                 i = squote_closes[k] + 1
                 last_sig = "'"
                 continue
             # No valid close ahead: treat the quote as ordinary content.
-        if ch == "{":
+        if ch == open_ch:
             depth += 1
-        elif ch == "}":
+        elif ch == close_ch:
             depth -= 1
             if depth == 0:
                 return i + 1
@@ -688,17 +717,22 @@ def _gemma4_transcode_to_json(args_str: str) -> dict:
     while True:
         i = _skip_ws(i)
         if expect == "object":
-            if i >= n or args_str[i] != "{":
-                raise ValueError("Gemma 4 args must start with '{'")
+            # The outer container is ``{`` for the canonical form and ``(`` for
+            # the parenthesized variant (#1846).  Either way it is an object;
+            # we always emit ``{`` to JSON and remember the real opener on the
+            # stack so its matching closer (``}`` or ``)``) is accepted below.
+            if i >= n or args_str[i] not in "{(":
+                raise ValueError("Gemma 4 args must start with '{' or '('")
             out.append("{")
-            stack.append("{")
+            stack.append(args_str[i])
             i += 1
             expect = "key"
         elif expect == "key":
             if i >= n:
                 raise ValueError("unterminated object")
-            if args_str[i] == "}":
-                # Empty object, or tolerated trailing comma.
+            if args_str[i] == _GEMMA4_CLOSE_CHAR[stack[-1]]:
+                # Empty object, or tolerated trailing comma.  Closer is ``}``
+                # for a ``{`` opener and ``)`` for the paren variant's ``(``.
                 if out and out[-1] == ", ":
                     out.pop()
                 out.append("}")
@@ -714,17 +748,27 @@ def _gemma4_transcode_to_json(args_str: str) -> dict:
                 if marked is not None:
                     key, i = marked
                 else:
-                    # Bare key: everything up to the colon.
+                    # Bare key: everything up to the separator.  ``=`` is a
+                    # separator too for the parenthesized kwargs variant
+                    # (#1846), so it bounds the key just like ``:``.
                     j = i
-                    while j < n and args_str[j] not in ":,{}[]'\"":
+                    while j < n and args_str[j] not in ":=,{}[]'\"":
                         j += 1
                     key = args_str[i:j].strip()
                     if not key:
                         raise ValueError("malformed object key")
                     i = j
             i = _skip_ws(i)
-            if i >= n or args_str[i] != ":":
-                raise ValueError("expected ':' after object key")
+            # Accept ``=`` as well as ``:`` — the parenthesized variant (#1846)
+            # uses ``key=value``.  This is applied universally (not only at top
+            # level), so it does widen the curly grammar to also accept ``=``
+            # separators; that is a strict superset, so every valid ``:``-based
+            # curly parse is unchanged and a previously-rejected ``{a = 1}`` now
+            # succeeds rather than corrupting anything.  ``=`` inside a value is
+            # untouched: strings are read atomically and bare values stop only
+            # at ``,``/``}``/``]`` (plus ``)`` when a paren container is open).
+            if i >= n or args_str[i] not in ":=":
+                raise ValueError("expected ':' or '=' after object key")
             out.append(json.dumps(key))
             out.append(": ")
             i += 1
@@ -766,9 +810,17 @@ def _gemma4_transcode_to_json(args_str: str) -> dict:
                 out.append(json.dumps(content))
                 expect = "delim"
                 continue
-            # Bare value: runs to the next structural separator.
+            # Bare value: runs to the next structural separator.  When the
+            # call uses the parenthesized outer shell (#1846), ``)`` also
+            # terminates a bare value so the closing paren of the call is not
+            # swallowed (``call:f(units=metric)`` — the value is ``metric``,
+            # not ``metric)``).  For the curly form ``)`` stays ordinary
+            # content so a value may legitimately contain parentheses
+            # (``{expr: f(x)}``).  ``(`` is only ever the outermost container,
+            # so its presence on the stack is the reliable signal.
+            stops = ",)}]" if "(" in stack else ",}]"
             j = i
-            while j < n and args_str[j] not in ",}]":
+            while j < n and args_str[j] not in stops:
                 j += 1
             value = args_str[i:j].strip()
             i = j
@@ -795,8 +847,11 @@ def _gemma4_transcode_to_json(args_str: str) -> dict:
             if ch == ",":
                 out.append(", ")
                 i += 1
-                expect = "key" if stack[-1] == "{" else "value"
-            elif ch == "}" and stack[-1] == "{":
+                # After a comma, an object (``{`` or the paren outer ``(``)
+                # expects a key; an array expects a value.
+                expect = "key" if stack[-1] in "{(" else "value"
+            elif stack[-1] in "{(" and ch == _GEMMA4_CLOSE_CHAR[stack[-1]]:
+                # Object close: ``}`` for ``{``, ``)`` for the paren outer.
                 out.append("}")
                 stack.pop()
                 i += 1
@@ -914,6 +969,11 @@ def _parse_gemma4_tool_call_fallback(text: str) -> Union[dict, list]:
     - bare string values without ``<|"|>`` delimiters
     - single-quoted values, including commas, colons, braces and
       apostrophes inside them (#1830)
+    - the parenthesized kwargs variant ``call:name(key=value, ...)`` that
+      Gemma 4 26B degrades to under instruction-dense agentic load (#1846).
+      The nested grammar is identical to the curly form, so only the outer
+      ``()`` shell and the ``=`` separator are new; both head forms are
+      collected and processed in document order (see below).
     - degenerate ``call:`` prefixes from the diffusion lane's parallel
       denoising, which can drop a token from the opening (observed live:
       ``calldone{...}`` — missing colon — and ``:done{...}`` — missing
@@ -927,15 +987,30 @@ def _parse_gemma4_tool_call_fallback(text: str) -> Union[dict, list]:
     recovery, thinking-content promotion), not just this one.
     """
     squote_closes = _squote_close_positions(text)
+
+    # Collect heads from both the canonical curly form and the parenthesized
+    # variant (#1846), then process them in document order so the consumed-span
+    # dedup below holds across BOTH forms: a curly head that falls inside an
+    # already-consumed paren span (the inner ``{...}`` of ``call:f(a={...})``)
+    # is string/structure content, not a sibling call, and must be skipped.
+    heads = [(m.start(), m, "{", "}") for m in _GEMMA4_CALL_HEAD.finditer(text)]
+    heads += [
+        (m.start(), m, "(", ")")
+        for m in _GEMMA4_CALL_HEAD_PAREN.finditer(text)
+    ]
+    heads.sort(key=lambda h: h[0])
+
     results = []
     consumed_until = 0
-    for m in _GEMMA4_CALL_HEAD.finditer(text):
-        # A "call:" inside an already-consumed args span is string content
+    for start, m, open_ch, close_ch in heads:
+        # A head inside an already-consumed args span is string content
         # (e.g. quoted prose mentioning a tool call), not a sibling call.
-        if m.start() < consumed_until:
+        if start < consumed_until:
             continue
         open_idx = m.end() - 1
-        end = _scan_gemma4_args_span(text, open_idx, squote_closes)
+        end = _scan_gemma4_args_span(
+            text, open_idx, squote_closes, open_ch, close_ch
+        )
         if end == -1:
             continue
         args_str = text[open_idx:end]

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -1998,6 +1998,32 @@ class TestParseToolCallsGemma4Integration:
         assert "<|tool_call>" not in cleaned
         assert "<tool_call|>" not in cleaned
 
+    def test_fallback_parses_parenthesized_variant(self):
+        """End-to-end: the paren kwargs variant (#1846) reaches the Gemma 4
+        fallback (native parser raises) and is extracted instead of stripped.
+
+        Before the fix the block was deleted: native parser fails, the
+        curly-only fallback also fails, and the client gets empty content.
+        """
+        tok = self._make_gemma4_tokenizer()
+        text = (
+            '<|tool_call>\n'
+            'call:todo(todos=[{content:<|"|>Draft the plan<|"|>,'
+            'id:<|"|>todo-1<|"|>,status:<|"|>pending<|"|>}])\n'
+            '<tool_call|>'
+        )
+
+        cleaned, tool_calls = parse_tool_calls(text, tok, None)
+
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "todo"
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args["todos"][0]["content"] == "Draft the plan"
+        assert args["todos"][0]["status"] == "pending"
+        assert "<|tool_call>" not in cleaned
+        assert "<tool_call|>" not in cleaned
+
     def test_brace_in_json_string_survives_remap(self):
         """A ``}`` inside a JSON double-quoted value must not truncate the
         args span, even when the parse then remaps onto a registered tool
@@ -2234,6 +2260,157 @@ class TestGemma4SingleQuotedArgs:
             "call:bad{:::}\ncall:good{x: 1}"
         )
         assert result == {"name": "good", "arguments": {"x": 1}}
+
+
+class TestGemma4ParenthesizedArgs:
+    """Tests for the parenthesized ``call:name(key=value, ...)`` variant.
+
+    Gemma 4 26B reproducibly degrades to this Python-kwargs form under
+    instruction-dense agentic load (#1846).  The nested grammar is identical
+    to the canonical curly form, so these tests focus on the new outer shell
+    (``()`` instead of ``{}``, ``=`` instead of ``:``) and on confirming the
+    #1854 security invariants hold on the new path.
+    """
+
+    def test_issue_1846_exact_format(self):
+        """The reporter's verbatim emission (3/3 captured samples)."""
+        result = _parse_gemma4_tool_call_fallback(
+            'call:todo(todos=[{content:<|"|>Clarify goal and draft labor '
+            'graph for t_77d3100f<|"|>,id:<|"|>todo-1<|"|>,'
+            'status:<|"|>pending<|"|>}])'
+        )
+        assert result == {
+            "name": "todo",
+            "arguments": {
+                "todos": [
+                    {
+                        "content": (
+                            "Clarify goal and draft labor graph "
+                            "for t_77d3100f"
+                        ),
+                        "id": "todo-1",
+                        "status": "pending",
+                    }
+                ]
+            },
+        }
+
+    def test_simple_kwargs_with_trailing_bare_value(self):
+        # The trailing bare value must not swallow the closing ``)``.
+        result = _parse_gemma4_tool_call_fallback(
+            'call:get_weather(location=<|"|>Tokyo<|"|>, units=metric)'
+        )
+        assert result == {
+            "name": "get_weather",
+            "arguments": {"location": "Tokyo", "units": "metric"},
+        }
+
+    def test_empty_paren_call(self):
+        result = _parse_gemma4_tool_call_fallback("call:ping()")
+        assert result == {"name": "ping", "arguments": {}}
+
+    def test_scalar_value_mix(self):
+        result = _parse_gemma4_tool_call_fallback(
+            'call:f(a=1, b=<|"|>two<|"|>, c=true, d=null, e=3.5)'
+        )
+        assert result == {
+            "name": "f",
+            "arguments": {
+                "a": 1, "b": "two", "c": True, "d": None, "e": 3.5
+            },
+        }
+
+    def test_array_of_scalars(self):
+        result = _parse_gemma4_tool_call_fallback("call:f(items=[1, 2, 3])")
+        assert result == {"name": "f", "arguments": {"items": [1, 2, 3]}}
+
+    def test_namespaced_name_with_paren(self):
+        # Name grammar is shared with the curly head; remap is a later step.
+        result = _parse_gemma4_tool_call_fallback("call:google:mcp:todo(x=1)")
+        assert result == {"name": "google:mcp:todo", "arguments": {"x": 1}}
+
+    def test_mixed_curly_and_paren_siblings(self):
+        result = _parse_gemma4_tool_call_fallback("call:a{x: 1}\ncall:b(y=2)")
+        assert result == [
+            {"name": "a", "arguments": {"x": 1}},
+            {"name": "b", "arguments": {"y": 2}},
+        ]
+
+    def test_close_paren_inside_string_does_not_close_span(self):
+        result = _parse_gemma4_tool_call_fallback(
+            'call:note(text=<|"|>smile :) and (parens)<|"|>)'
+        )
+        assert result == {
+            "name": "note",
+            "arguments": {"text": "smile :) and (parens)"},
+        }
+
+    def test_equals_inside_string_value_preserved(self):
+        result = _parse_gemma4_tool_call_fallback(
+            'call:f(expr=<|"|>a=b=c<|"|>)'
+        )
+        assert result == {"name": "f", "arguments": {"expr": "a=b=c"}}
+
+    def test_curly_value_with_parens_unaffected(self):
+        # Regression guard: ``)`` is ordinary content in the curly form, so a
+        # value may contain parentheses.  This is why ``)`` is a bare-value
+        # terminator only when a paren container is open.
+        result = _gemma4_args_to_json_robust("{expr: f(x)}")
+        assert result == {"expr": "f(x)"}
+
+    def test_single_quoted_value_before_close_paren(self):
+        # The degeneration is a Python-kwargs shell, so single-quoted strings
+        # are its native string form (observed live on gemma-4-26b).  When such
+        # a value is the last argument its closing quote sits right before the
+        # call's ``)``, so ``)`` must anchor a single-quote close exactly as
+        # ``,``/``}``/``]`` do; otherwise the quotes leak into the value.
+        result = _parse_gemma4_tool_call_fallback(
+            "call:create_todo(content='clarify the goal')"
+        )
+        assert result == {
+            "name": "create_todo",
+            "arguments": {"content": "clarify the goal"},
+        }
+
+    def test_single_quoted_values_parity_curly_and_paren(self):
+        # Both shells normalize single-quoted values identically; the paren
+        # form must not retain the quotes the curly form strips.
+        curly = _gemma4_args_to_json_robust("{a: 'x', b: 'y'}")
+        paren = _parse_gemma4_tool_call_fallback("call:f(a='x', b='y')")
+        assert curly == {"a": "x", "b": "y"}
+        assert paren == {"name": "f", "arguments": {"a": "x", "b": "y"}}
+
+    def test_oversized_paren_args_fail_cleanly(self):
+        """Args beyond the length cap are a clean no-match, not a hang.
+
+        Guards the #1854 ReDoS: the paren head's optional/tolerant prefix on
+        the ``re`` module would backtrack O(n^2) hunting an opening ``(``.
+        """
+        huge = "call:f(a=" + "x" * 300_000 + ")"
+        with pytest.raises(ValueError):
+            _parse_gemma4_tool_call_fallback(huge)
+
+    def test_deep_paren_nesting_fails_cleanly(self):
+        """Depth bound surfaces as ValueError, never RecursionError."""
+        deep = "call:f(" + "a={" * 80 + "1" + "}" * 80 + ")"
+        with pytest.raises(ValueError):
+            _parse_gemma4_tool_call_fallback(deep)
+
+    def test_nul_bytes_cannot_forge_references_paren(self):
+        """The NUL-placeholder forge vector stays closed on the paren path."""
+        result = _gemma4_args_to_json_robust(
+            '(a=<|"|>captured<|"|>, b=\x000\x00)'
+        )
+        assert result["a"] == "captured"
+        assert result["b"] == "\x000\x00"  # literal, NOT a copy of a
+
+    def test_paren_call_inside_quoted_value_not_double_parsed(self):
+        result = _parse_gemma4_tool_call_fallback(
+            'call:a(x=1)\ncall:b(note=<|"|>use call:c(y=2) later<|"|>)'
+        )
+        assert isinstance(result, list)
+        assert [r["name"] for r in result] == ["a", "b"]
+        assert result[1]["arguments"]["note"] == "use call:c(y=2) later"
 
 
 class TestRemapToolCallNames:


### PR DESCRIPTION
Fixes the parser half of #1846 (the issue's suggested fix #1).

## Problem

Under instruction-dense agentic load (large system prompt + many tool schemas + a big tool result, the reporter measured ~28-41k prompt tokens), Gemma 4 26B reproducibly degrades from the canonical `call:name{...}` markup to a Python-kwargs shell `call:name(key=value, ...)`. The reporter's bisection shows the trigger is an interaction of an instruction-dense system prompt with a large tool-schema surface, not length or tool count alone.

The gemma4 fallback parser matched only the curly form, so the whole `<|tool_call>...<tool_call|>` block was stripped: the API returned empty `content` with `finish_reason=stop` and agent loops died silently with no recovery path for the client, operator, or model (the reporter saw 16 consecutive Hermes failures, all this signature).

## Approach

The parenthesized form is the curly grammar with only the outer shell changed: `()` instead of `{}` and a top-level `=` separator instead of `:`. The nested grammar (objects, arrays, `<|"|>`-quoted strings) is identical, so the #1854-hardened inner transcoder is reused as-is for the inner content; only the outer shell needed new handling.

- add `_GEMMA4_CALL_HEAD_PAREN`, compiled with the `regex` module (not `re`) for the same ReDoS reason as the curly head: the optional `(?:call)?` prefix backtracks quadratically on `re` when hunting an opening `(` that never comes
- generalize `_scan_gemma4_args_span` to any balanced pair (defaults keep the existing brace caller byte-identical)
- accept `(` as the outer object opener and `=` as a key/value separator in the transcoder, additively, so the curly path is unchanged
- terminate a bare value at `)` only when a paren container is open, so the closing paren is not swallowed while curly values may still legitimately contain parentheses
- anchor a single-quote value close on `)` as well as `,` `}` `]`, so a single-quoted last argument (the Python-kwargs shell's native string form) is normalized like the curly form instead of leaking its quotes; the curly form never closes a value with `)`, so its parsing is unchanged
- collect curly and paren heads and process them in document order so the consumed-span dedup holds across both forms

Scope: this is fix #1 from the issue only. The reporter's suggested fix #2 (pass-through instead of strip on parse failure) is a cross-cutting behavior change and is deliberately out of scope here.

## Tests

`TestGemma4ParenthesizedArgs` covers the reporter's exact fixture, kwargs/scalars/arrays, single-quoted values, namespaced names, mixed curly+paren siblings, a curly-values-with-parens regression, and the #1854 security matrix re-run for the paren shape (oversized args, deep nesting, NUL forge, `)` and `=` inside strings), plus one end-to-end integration test through `parse_tool_calls`. Full local suite green.

## Live test (gemma-4-26B-A4B-it 4bit, the reporter's model)

Verified on the real model rather than only the test harness:

- the real loaded tokenizer exposes `tool_call_start = '<|tool_call>'`, so the Gemma 4 fallback gate triggers in production exactly as in the test
- the native `tool_parser` raises `ValueError` on the paren form, so it routes to the fallback rather than being mis-parsed
- the reporter's exact paren fixture is extracted as a `todo` call with the nested args intact
- driven through the live HTTP server, the model emitted the paren form `call:create_todo(content='...')` end-to-end and both calls came back as real `tool_calls` (this is also what surfaced the single-quote normalization above)
- clean-format curly tool calling still works end-to-end through the server (no regression)

## Fails-safe residuals (disclosed)

Both result in a clean DROP of the call, never a corrupt-then-execute:

1. An unbalanced `)` in a BARE (unquoted) value inside a paren call closes the span early and the call is dropped. The common case uses `<|"|>` or single-quote quoting and is immune.
2. A `)` in a nested bare value within a paren call is malformed structure and the call is dropped.
