### PR TITLE
refactor(omlx-mac): replace custom controls with native SwiftUI equivalents

### DIFF
--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -1,174 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "profile.detail.acceleration.vlm_mtp" : {
-      "comment" : "Acceleration chip: VLM multi-token prediction",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VLM MTP"
-          }
-        }
-      }
-    },
-    "settings.experimental.vlm_mtp.block_size.label" : {
-      "comment" : "Row label for the VLM MTP draft block-size field",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Draft Block Size"
-          }
-        }
-      }
-    },
-    "settings.experimental.vlm_mtp.block_size.sub" : {
-      "comment" : "Sublabel for the VLM MTP draft block-size field",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tokens drafted per round. Empty uses the mlx-vlm default."
-          }
-        }
-      }
-    },
-    "settings.experimental.vlm_mtp.draft.label" : {
-      "comment" : "Row label for the VLM MTP draft-model picker",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VLM Draft Model"
-          }
-        }
-      }
-    },
-    "settings.experimental.vlm_mtp.draft.sub" : {
-      "comment" : "Sublabel for the VLM MTP draft-model picker",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Assistant drafter sharing the target's tokenizer."
-          }
-        }
-      }
-    },
-    "settings.experimental.vlm_mtp.label" : {
-      "comment" : "Row label for the VLM MTP toggle",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "VLM MTP"
-          }
-        }
-      }
-    },
-    "settings.experimental.vlm_mtp.sub" : {
-      "comment" : "Default sublabel for the VLM MTP toggle",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Multi-token prediction for vision-language models via an assistant drafter."
-          }
-        }
-      }
-    },
-    "settings.speculative.conflict.vlm_mtp" : {
-      "comment" : "Tooltip / sublabel shown when another speculative feature can't be enabled because VLM MTP is on",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable VLM MTP before enabling this feature."
-          }
-        }
-      }
-    },
-    "settings.mtp.conflict.vlm_mtp" : {
-      "comment" : "Tooltip / sublabel shown when native MTP can't be enabled because VLM MTP is on",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable VLM MTP before enabling Native MTP."
-          }
-        }
-      }
-    },
-    "settings.vlm_mtp.conflict.dflash" : {
-      "comment" : "Tooltip / sublabel shown when VLM MTP can't be enabled because DFlash is on",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable DFlash before enabling VLM MTP."
-          }
-        }
-      }
-    },
-    "settings.vlm_mtp.conflict.mtp" : {
-      "comment" : "Tooltip / sublabel shown when VLM MTP can't be enabled because native MTP is on",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable Native MTP before enabling VLM MTP."
-          }
-        }
-      }
-    },
-    "settings.vlm_mtp.conflict.specprefill" : {
-      "comment" : "Tooltip / sublabel shown when VLM MTP can't be enabled because SpecPrefill is on",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable SpecPrefill before enabling VLM MTP."
-          }
-        }
-      }
-    },
-    "settings.vlm_mtp.conflict.turboquant" : {
-      "comment" : "Tooltip / sublabel shown when VLM MTP can't be enabled because TurboQuant KV is on",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disable TurboQuant KV before enabling VLM MTP."
-          }
-        }
-      }
-    },
-    "settings.vlm_mtp.draft.placeholder" : {
-      "comment" : "Initial placeholder option in the VLM MTP draft-model picker",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select assistant drafter…"
-          }
-        }
-      }
-    },
     "" : {
 
     },
@@ -1724,6 +1556,21 @@
     "Click to copy" : {
 
     },
+    "Close Window" : {
+
+    },
+    "common.back" : {
+      "comment" : "Back button label",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back"
+          }
+        }
+      }
+    },
     "common.cancel" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1789,18 +1636,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Create"
-          }
-        }
-      }
-    },
-    "common.back" : {
-      "comment" : "Back button label",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back"
           }
         }
       }
@@ -1947,18 +1782,6 @@
         }
       }
     },
-    "downloads.card.files.empty" : {
-      "comment" : "Empty state in the Files tab when the upstream API doesn't list any files",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No files reported."
-          }
-        }
-      }
-    },
     "downloads.card.error" : {
       "comment" : "Title shown in the model card sheet when the fetch failed",
       "extractionState" : "manual",
@@ -1967,6 +1790,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Couldn't load model card"
+          }
+        }
+      }
+    },
+    "downloads.card.files.empty" : {
+      "comment" : "Empty state in the Files tab when the upstream API doesn't list any files",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No files reported."
           }
         }
       }
@@ -2550,6 +2385,30 @@
         }
       }
     },
+    "integrations.codex.app" : {
+      "comment" : "Label for the Codex desktop app launcher command",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Desktop App"
+          }
+        }
+      }
+    },
+    "integrations.codex.cli" : {
+      "comment" : "Label for the Codex CLI launcher command",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "CLI"
+          }
+        }
+      }
+    },
     "integrations.command.terminal_caption" : {
       "comment" : "Caption above each shell command block",
       "extractionState" : "manual",
@@ -2814,6 +2673,18 @@
         }
       }
     },
+    "integrations.target_context.apply" : {
+      "comment" : "Apply button for the Claude Code target context size field",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Apply"
+          }
+        }
+      }
+    },
     "integrations.tool.codex" : {
       "comment" : "Display name for the Codex integration",
       "extractionState" : "manual",
@@ -3006,6 +2877,18 @@
         }
       }
     },
+    "menubar.alert.dismiss" : {
+      "comment" : "Button that dismisses an alert",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dismiss"
+          }
+        }
+      }
+    },
     "menubar.alert.ok" : {
       "comment" : "Default dismiss button on the port-conflict alert",
       "extractionState" : "manual",
@@ -3018,8 +2901,32 @@
         }
       }
     },
+    "menubar.alert.open_log" : {
+      "comment" : "Button that opens the server log file",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open Log"
+          }
+        }
+      }
+    },
+    "menubar.alert.open_settings" : {
+      "comment" : "Button that opens the oMLX settings window",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Open Settings"
+          }
+        }
+      }
+    },
     "menubar.alert.pid_known" : {
-      "comment" : "Substring describing a known PID; placeholder is the PID number",
+      "comment" : "Substring describing a known PID; placeholder is the PID number (plain integer, no grouping)",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
@@ -3067,13 +2974,61 @@
       }
     },
     "menubar.alert.port_in_use.title" : {
-      "comment" : "Title of the port-conflict alert; placeholder is the port number",
+      "comment" : "Title of the port-conflict alert; placeholder is the port number (plain integer, no grouping)",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Port %@ is in use."
+          }
+        }
+      }
+    },
+    "menubar.alert.server_failed.access_hint" : {
+      "comment" : "Hint shown when the server failure log suggests a model directory permission problem",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check that the configured model directory is mounted and readable. If it is on an external or protected location, grant oMLX access in macOS Privacy & Security settings."
+          }
+        }
+      }
+    },
+    "menubar.alert.server_failed.body" : {
+      "comment" : "Introductory body text for the server startup failure alert",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The server process exited before it became healthy."
+          }
+        }
+      }
+    },
+    "menubar.alert.server_failed.log_path" : {
+      "comment" : "Server startup failure alert line that shows the server log path",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Log: %@"
+          }
+        }
+      }
+    },
+    "menubar.alert.server_failed.title" : {
+      "comment" : "Title for the server startup failure alert",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "oMLX Server Failed to Start"
           }
         }
       }
@@ -3115,7 +3070,7 @@
       }
     },
     "menubar.header.running" : {
-      "comment" : "Menubar status header when the server is running; placeholder is the port",
+      "comment" : "Menubar status header when the server is running; placeholder is the port (rendered as a plain integer, no grouping)",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
@@ -3198,6 +3153,18 @@
         }
       }
     },
+    "menubar.item.downloading_update" : {
+      "comment" : "Menubar update item while an app update is downloading; placeholder is the percent",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Downloading update… %lld%%"
+          }
+        }
+      }
+    },
     "menubar.item.force_restart" : {
       "comment" : "Menubar item that force-restarts a stuck or failed server",
       "extractionState" : "manual",
@@ -3206,6 +3173,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Force Restart"
+          }
+        }
+      }
+    },
+    "menubar.item.install_update_version" : {
+      "comment" : "Menubar update item when an app update is available; placeholder is the version",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Install oMLX %@…"
           }
         }
       }
@@ -3266,6 +3245,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stop Server"
+          }
+        }
+      }
+    },
+    "menubar.item.update_available" : {
+      "comment" : "Menubar item shown when an app update is available",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Install Update…"
           }
         }
       }
@@ -3798,6 +3789,9 @@
         }
       }
     },
+    "oMLX" : {
+
+    },
     "performance.button.apply" : {
       "comment" : "Apply button at the bottom of the Performance screen",
       "extractionState" : "manual",
@@ -3954,6 +3948,18 @@
         }
       }
     },
+    "performance.error.custom_ceiling_invalid" : {
+      "comment" : "Performance screen error when custom memory guard ceiling is invalid",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Ceiling must be greater than 0 GB."
+          }
+        }
+      }
+    },
     "performance.error.embedding_batch_size_invalid" : {
       "comment" : "Performance screen error when embedding batch size input is invalid",
       "extractionState" : "manual",
@@ -3998,6 +4004,150 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Max Concurrent Requests must be a positive integer."
+          }
+        }
+      }
+    },
+    "performance.memory.custom_ceiling" : {
+      "comment" : "Row label for memory guard custom ceiling",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom Ceiling"
+          }
+        }
+      }
+    },
+    "performance.memory.custom_ceiling.placeholder" : {
+      "comment" : "Placeholder for custom memory guard ceiling",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "GB"
+          }
+        }
+      }
+    },
+    "performance.memory.custom_ceiling.sub" : {
+      "comment" : "Sublabel for memory guard custom ceiling",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fixed process memory ceiling in GB. Used only with the Custom tier."
+          }
+        }
+      }
+    },
+    "performance.memory.guard_tier" : {
+      "comment" : "Row label for memory guard tier popup",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Memory Guard Tier"
+          }
+        }
+      }
+    },
+    "performance.memory.guard_tier.aggressive" : {
+      "comment" : "Memory guard tier option: aggressive",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Aggressive"
+          }
+        }
+      }
+    },
+    "performance.memory.guard_tier.aggressive.sub" : {
+      "comment" : "Description for aggressive memory guard tier",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Uses more memory before throttling. Best when the Mac has ample headroom."
+          }
+        }
+      }
+    },
+    "performance.memory.guard_tier.balanced" : {
+      "comment" : "Memory guard tier option: balanced",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Balanced"
+          }
+        }
+      }
+    },
+    "performance.memory.guard_tier.balanced.sub" : {
+      "comment" : "Description for balanced memory guard tier",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Default tier. Balances throughput with process memory safety."
+          }
+        }
+      }
+    },
+    "performance.memory.guard_tier.custom" : {
+      "comment" : "Memory guard tier option: custom",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Custom"
+          }
+        }
+      }
+    },
+    "performance.memory.guard_tier.custom.sub" : {
+      "comment" : "Description for custom memory guard tier",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use a fixed GB ceiling instead of the adaptive tier calculation."
+          }
+        }
+      }
+    },
+    "performance.memory.guard_tier.safe" : {
+      "comment" : "Memory guard tier option: safe",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Safe"
+          }
+        }
+      }
+    },
+    "performance.memory.guard_tier.safe.sub" : {
+      "comment" : "Description for safe memory guard tier",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Most conservative. Leaves more headroom before scheduling memory-heavy prefill."
           }
         }
       }
@@ -4562,6 +4712,18 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "TurboQuant KV · %@"
+          }
+        }
+      }
+    },
+    "profile.detail.acceleration.vlm_mtp" : {
+      "comment" : "Acceleration chip: VLM multi-token prediction",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VLM MTP"
           }
         }
       }
@@ -6937,7 +7099,7 @@
       }
     },
     "server.hero.subtitle.listening" : {
-      "comment" : "Hero subtitle while server is running; placeholders are host and port",
+      "comment" : "Hero subtitle while server is running; placeholders are host and port (port is plain integer, no grouping)",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
@@ -6961,7 +7123,7 @@
       }
     },
     "server.hero.subtitle.starting" : {
-      "comment" : "Hero subtitle while server is starting up; placeholders are host and port",
+      "comment" : "Hero subtitle while server is starting up; placeholders are host and port (port is plain integer, no grouping)",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
@@ -7100,6 +7262,78 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Warning"
+          }
+        }
+      }
+    },
+    "server.model_dirs.add.help" : {
+      "comment" : "Tooltip for the add model directory button",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add model directory"
+          }
+        }
+      }
+    },
+    "server.model_dirs.browse.help" : {
+      "comment" : "Tooltip for choosing a model directory",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose folder"
+          }
+        }
+      }
+    },
+    "server.model_dirs.browse.message" : {
+      "comment" : "NSOpenPanel message for choosing a model directory",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose a directory containing MLX model folders."
+          }
+        }
+      }
+    },
+    "server.model_dirs.browse.prompt" : {
+      "comment" : "NSOpenPanel button label for choosing a model directory",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select"
+          }
+        }
+      }
+    },
+    "server.model_dirs.primary" : {
+      "comment" : "Badge for the first model directory",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Primary"
+          }
+        }
+      }
+    },
+    "server.model_dirs.remove.help" : {
+      "comment" : "Tooltip for removing a model directory",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remove model directory"
           }
         }
       }
@@ -7476,30 +7710,6 @@
         }
       }
     },
-    "server.row.base_path" : {
-      "comment" : "Row label for the Base Path text input",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Base Path"
-          }
-        }
-      }
-    },
-    "server.row.base_path.sub" : {
-      "comment" : "Sublabel under the Base Path field",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OMLX_BASE_PATH. Files move and the server restarts when this changes."
-          }
-        }
-      }
-    },
     "server.row.auto_start_on_launch" : {
       "comment" : "Row label for the server auto-start on app launch toggle",
       "extractionState" : "manual",
@@ -7524,6 +7734,54 @@
         }
       }
     },
+    "server.row.base_path" : {
+      "comment" : "Row label for the Base Path text input",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Base Path"
+          }
+        }
+      }
+    },
+    "server.row.base_path.sub" : {
+      "comment" : "Sublabel under the Base Path field",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OMLX_BASE_PATH. Files move and the server restarts when this changes."
+          }
+        }
+      }
+    },
+    "server.row.hf_cache" : {
+      "comment" : "Row label for enabling standard Hugging Face Hub cache model discovery",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use Hugging Face local cache"
+          }
+        }
+      }
+    },
+    "server.row.hf_cache.sub" : {
+      "comment" : "Sublabel for enabling Hugging Face local cache discovery",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Discover MLX-compatible models from the standard Hugging Face Hub cache."
+          }
+        }
+      }
+    },
     "server.row.listen_address" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -7542,6 +7800,30 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Log Level"
+          }
+        }
+      }
+    },
+    "server.row.models_directories" : {
+      "comment" : "Row label for the model directories editor",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Model Directories"
+          }
+        }
+      }
+    },
+    "server.row.models_directories.sub" : {
+      "comment" : "Sublabel under the model directories editor",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The first path is the download target. All paths are scanned for local models."
           }
         }
       }
@@ -7651,6 +7933,17 @@
         }
       }
     },
+    "server.section.network" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Network"
+          }
+        }
+      }
+    },
     "server.section.startup" : {
       "comment" : "Section heading for server launch behavior settings",
       "extractionState" : "manual",
@@ -7659,17 +7952,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Server Startup"
-          }
-        }
-      }
-    },
-    "server.section.network" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Network"
           }
         }
       }
@@ -8382,6 +8664,42 @@
         }
       }
     },
+    "settings.dflash.quant.activation.16" : {
+      "comment" : "DFlash draft quantization activation bits option",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "16-bit"
+          }
+        }
+      }
+    },
+    "settings.dflash.quant.activation.32" : {
+      "comment" : "DFlash draft quantization activation bits option",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "32-bit"
+          }
+        }
+      }
+    },
+    "settings.dflash.quant.activation.default" : {
+      "comment" : "DFlash draft quantization activation bits — use server default",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "default"
+          }
+        }
+      }
+    },
     "settings.dflash.quant.bf16" : {
       "comment" : "DFlash draft quantization option for bf16 (no quantization)",
       "extractionState" : "manual",
@@ -8390,6 +8708,114 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "bf16 (default)"
+          }
+        }
+      }
+    },
+    "settings.dflash.quant.group.default" : {
+      "comment" : "DFlash draft quantization group size — use server default",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "default"
+          }
+        }
+      }
+    },
+    "settings.dflash.quant.weight.2" : {
+      "comment" : "DFlash draft quantization weight bits option",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "2-bit"
+          }
+        }
+      }
+    },
+    "settings.dflash.quant.weight.4" : {
+      "comment" : "DFlash draft quantization weight bits option",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "4-bit"
+          }
+        }
+      }
+    },
+    "settings.dflash.quant.weight.8" : {
+      "comment" : "DFlash draft quantization weight bits option",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "8-bit"
+          }
+        }
+      }
+    },
+    "settings.dflash.verify_mode.adaptive" : {
+      "comment" : "DFlash verify mode: shrinks block size when acceptance drops",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "adaptive"
+          }
+        }
+      }
+    },
+    "settings.dflash.verify_mode.ddtree" : {
+      "comment" : "DFlash verify mode: DDTree verifier",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "ddtree"
+          }
+        }
+      }
+    },
+    "settings.dflash.verify_mode.default" : {
+      "comment" : "DFlash verify mode option meaning the server default is used",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "default (adaptive)"
+          }
+        }
+      }
+    },
+    "settings.dflash.verify_mode.dflash" : {
+      "comment" : "DFlash verify mode: standard dflash verifier",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "dflash"
+          }
+        }
+      }
+    },
+    "settings.dflash.verify_mode.off" : {
+      "comment" : "DFlash verify mode: disable speculative verify",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "off"
           }
         }
       }
@@ -8406,6 +8832,42 @@
         }
       }
     },
+    "settings.experimental.dflash.draft_quant_activation.label" : {
+      "comment" : "Row label for the DFlash draft quantization activation bits picker",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Activation Bits"
+          }
+        }
+      }
+    },
+    "settings.experimental.dflash.draft_quant_group.label" : {
+      "comment" : "Row label for the DFlash draft quantization group size picker",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Group Size"
+          }
+        }
+      }
+    },
+    "settings.experimental.dflash.draft_quant_weight.label" : {
+      "comment" : "Row label for the DFlash draft quantization weight bits picker",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Weight Bits"
+          }
+        }
+      }
+    },
     "settings.experimental.dflash.draft_quant.label" : {
       "comment" : "Row label for the DFlash draft-quantization picker",
       "extractionState" : "manual",
@@ -8414,6 +8876,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Draft Quantization"
+          }
+        }
+      }
+    },
+    "settings.experimental.dflash.draft_quant.sub" : {
+      "comment" : "Sublabel for the DFlash draft quantization toggle",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable quantization for the draft model (weight, activation bits & group size)."
           }
         }
       }
@@ -8478,6 +8952,30 @@
         }
       }
     },
+    "settings.experimental.dflash.mem_cache_entries.label" : {
+      "comment" : "Row label for the DFlash L1 in-memory cache max entries field",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cache Entries"
+          }
+        }
+      }
+    },
+    "settings.experimental.dflash.mem_cache_entries.sub" : {
+      "comment" : "Sublabel for the DFlash L1 cache max entries field",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Maximum prefix snapshots kept in RAM. Each entry stores KV + draft GDN state."
+          }
+        }
+      }
+    },
     "settings.experimental.dflash.mem_cache.label" : {
       "comment" : "Row label for the DFlash L1 in-memory cache toggle",
       "extractionState" : "manual",
@@ -8498,6 +8996,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "DFlash L1 prefix snapshot cache in RAM."
+          }
+        }
+      }
+    },
+    "settings.experimental.dflash.sink_size.label" : {
+      "comment" : "Row label for the DFlash attention-sink tokens field",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Draft Sink Size"
+          }
+        }
+      }
+    },
+    "settings.experimental.dflash.sink_size.sub" : {
+      "comment" : "Sublabel for the DFlash draft sink size field",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Attention-sink tokens always kept in the window. Empty = dflash default (64)."
+          }
+        }
+      }
+    },
+    "settings.experimental.dflash.ssd_cache_size.label" : {
+      "comment" : "Row label for the DFlash L2 SSD cache disk budget field",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "SSD Cache Size"
+          }
+        }
+      }
+    },
+    "settings.experimental.dflash.ssd_cache_size.sub" : {
+      "comment" : "Sublabel for the DFlash SSD cache size field",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disk budget for L2 spill; oldest entries are evicted when exceeded."
           }
         }
       }
@@ -8558,6 +9104,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Block-diffusion speculative decoding. Single-stream only (requests run one at a time)."
+          }
+        }
+      }
+    },
+    "settings.experimental.dflash.verify_mode.label" : {
+      "comment" : "Row label for the DFlash verifier algorithm picker",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Verify Mode"
+          }
+        }
+      }
+    },
+    "settings.experimental.dflash.verify_mode.sub" : {
+      "comment" : "Sublabel for the DFlash verify mode picker",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Verifier algorithm. \"adaptive\" shrinks block size when acceptance drops; \"off\" disables speculative verify."
+          }
+        }
+      }
+    },
+    "settings.experimental.dflash.window_size.label" : {
+      "comment" : "Row label for the DFlash draft sliding-attention window size field",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Draft Window Size"
+          }
+        }
+      }
+    },
+    "settings.experimental.dflash.window_size.sub" : {
+      "comment" : "Sublabel for the DFlash draft window size field",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Draft model sliding-attention window. Empty = dflash default (1024)."
           }
         }
       }
@@ -8718,6 +9312,78 @@
         }
       }
     },
+    "settings.experimental.vlm_mtp.block_size.label" : {
+      "comment" : "Row label for the VLM MTP draft block-size field",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Draft Block Size"
+          }
+        }
+      }
+    },
+    "settings.experimental.vlm_mtp.block_size.sub" : {
+      "comment" : "Sublabel for the VLM MTP draft block-size field",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tokens drafted per round. Empty uses the mlx-vlm default."
+          }
+        }
+      }
+    },
+    "settings.experimental.vlm_mtp.draft.label" : {
+      "comment" : "Row label for the VLM MTP draft-model picker",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VLM Draft Model"
+          }
+        }
+      }
+    },
+    "settings.experimental.vlm_mtp.draft.sub" : {
+      "comment" : "Sublabel for the VLM MTP draft-model picker",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Assistant drafter sharing the target's tokenizer."
+          }
+        }
+      }
+    },
+    "settings.experimental.vlm_mtp.label" : {
+      "comment" : "Row label for the VLM MTP toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VLM MTP"
+          }
+        }
+      }
+    },
+    "settings.experimental.vlm_mtp.sub" : {
+      "comment" : "Default sublabel for the VLM MTP toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Multi-token prediction for vision-language models via an assistant drafter."
+          }
+        }
+      }
+    },
     "settings.header.back_to_models" : {
       "comment" : "Back button label at the top of the per-model settings screen",
       "extractionState" : "manual",
@@ -8846,6 +9512,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Disable TurboQuant KV before enabling MTP."
+          }
+        }
+      }
+    },
+    "settings.mtp.conflict.vlm_mtp" : {
+      "comment" : "Tooltip / sublabel shown when native MTP can't be enabled because VLM MTP is on",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable VLM MTP before enabling Native MTP."
           }
         }
       }
@@ -9062,6 +9740,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "50% — Minimal (~1.5x)"
+          }
+        }
+      }
+    },
+    "settings.speculative.conflict.vlm_mtp" : {
+      "comment" : "Tooltip / sublabel shown when another speculative feature can't be enabled because VLM MTP is on",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable VLM MTP before enabling this feature."
           }
         }
       }
@@ -9290,6 +9980,66 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Top P must be in (0, 1]."
+          }
+        }
+      }
+    },
+    "settings.vlm_mtp.conflict.dflash" : {
+      "comment" : "Tooltip / sublabel shown when VLM MTP can't be enabled because DFlash is on",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable DFlash before enabling VLM MTP."
+          }
+        }
+      }
+    },
+    "settings.vlm_mtp.conflict.mtp" : {
+      "comment" : "Tooltip / sublabel shown when VLM MTP can't be enabled because native MTP is on",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable Native MTP before enabling VLM MTP."
+          }
+        }
+      }
+    },
+    "settings.vlm_mtp.conflict.specprefill" : {
+      "comment" : "Tooltip / sublabel shown when VLM MTP can't be enabled because SpecPrefill is on",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable SpecPrefill before enabling VLM MTP."
+          }
+        }
+      }
+    },
+    "settings.vlm_mtp.conflict.turboquant" : {
+      "comment" : "Tooltip / sublabel shown when VLM MTP can't be enabled because TurboQuant KV is on",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disable TurboQuant KV before enabling VLM MTP."
+          }
+        }
+      }
+    },
+    "settings.vlm_mtp.draft.placeholder" : {
+      "comment" : "Initial placeholder option in the VLM MTP draft-model picker",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select assistant drafter…"
           }
         }
       }
@@ -9725,9 +10475,6 @@
         }
       }
     },
-    "sk-omlx-…" : {
-
-    },
     "status.active_now.badge.generating" : {
       "comment" : "Active Now badge: model currently generating tokens",
       "extractionState" : "manual",
@@ -9844,6 +10591,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Clear"
+          }
+        }
+      }
+    },
+    "status.confirm.clear_hot" : {
+      "comment" : "Confirmation dialog title for clearing the hot (memory) KV cache",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear the in-memory KV cache for all loaded models? Subsequent requests will re-fault from SSD or recompute."
           }
         }
       }
@@ -9968,6 +10727,18 @@
         }
       }
     },
+    "status.runtime_cache.clear_hot" : {
+      "comment" : "Destructive button to clear the in-memory KV cache",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear Memory Cache"
+          }
+        }
+      }
+    },
     "status.runtime_cache.clear_ssd" : {
       "comment" : "Destructive button to clear all SSD cache files",
       "extractionState" : "manual",
@@ -10024,6 +10795,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Location"
+          }
+        }
+      }
+    },
+    "status.runtime_cache.memory" : {
+      "comment" : "Row label for the in-memory (hot) KV cache size gauge",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Memory Cache"
+          }
+        }
+      }
+    },
+    "status.runtime_cache.memory_entries" : {
+      "comment" : "Row label for the number of in-memory KV cache entries",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Memory Entries"
+          }
+        }
+      }
+    },
+    "status.runtime_cache.memory_entries.one" : {
+      "comment" : "Singular memory cache entry count",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "1 entry"
+          }
+        }
+      }
+    },
+    "status.runtime_cache.memory_entries.other" : {
+      "comment" : "Plural memory cache entry count; placeholder is the number of entries",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%lld entries"
           }
         }
       }
@@ -10253,17 +11072,6 @@
         }
       }
     },
-    "status.tile.cached" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cached Tokens"
-          }
-        }
-      }
-    },
     "status.tile.cache_efficiency" : {
       "comment" : "Stat tile label for cache efficiency percentage",
       "extractionState" : "manual",
@@ -10276,14 +11084,13 @@
         }
       }
     },
-    "status.tile.cached.sub" : {
-      "comment" : "Sub-label showing cache efficiency percentage on the cached tile; placeholder is a formatted percentage",
-      "extractionState" : "extracted_with_value",
+    "status.tile.cached" : {
+      "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%@%% efficiency"
+            "state" : "translated",
+            "value" : "Cached Tokens"
           }
         }
       }
@@ -10318,18 +11125,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Requests"
-          }
-        }
-      }
-    },
-    "status.tile.requests.sub" : {
-      "comment" : "Sub-label showing in-flight request count; placeholder is the number of active requests",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%lld in flight"
           }
         }
       }
@@ -10424,7 +11219,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "You have the current version · %@"
+            "value" : "Ready to download · %@"
           }
         }
       }
@@ -10460,6 +11255,42 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Check Now"
+          }
+        }
+      }
+    },
+    "status.updates.checking_button" : {
+      "comment" : "Updates action button label while a check is in progress",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Checking…"
+          }
+        }
+      }
+    },
+    "status.updates.checking_primary" : {
+      "comment" : "Primary update status line while a check is in progress",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Checking for updates…"
+          }
+        }
+      }
+    },
+    "status.updates.checking_secondary" : {
+      "comment" : "Secondary update status line while a check is in progress",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Checking GitHub releases…"
           }
         }
       }
@@ -10508,42 +11339,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Update check failed"
-          }
-        }
-      }
-    },
-    "status.updates.checking_button" : {
-      "comment" : "Updates action button label while a check is in progress",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checking…"
-          }
-        }
-      }
-    },
-    "status.updates.checking_primary" : {
-      "comment" : "Primary update status line while a check is in progress",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checking for updates…"
-          }
-        }
-      }
-    },
-    "status.updates.checking_secondary" : {
-      "comment" : "Secondary update status line while a check is in progress",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checking GitHub releases…"
           }
         }
       }
@@ -10638,6 +11433,66 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@ · build %2$@"
+          }
+        }
+      }
+    },
+    "update.channel.beta" : {
+      "comment" : "Display name for the Beta update channel",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beta"
+          }
+        }
+      }
+    },
+    "update.channel.dev" : {
+      "comment" : "Display name for the Dev update channel",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dev"
+          }
+        }
+      }
+    },
+    "update.channel.nightly" : {
+      "comment" : "Display name for the Nightly update channel",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nightly"
+          }
+        }
+      }
+    },
+    "update.channel.release_candidate" : {
+      "comment" : "Display name for the Release Candidate update channel",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Release Candidate"
+          }
+        }
+      }
+    },
+    "update.channel.stable" : {
+      "comment" : "Display name for the Stable update channel",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stable"
           }
         }
       }
@@ -10770,66 +11625,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Could not find the staged update. Try downloading again."
-          }
-        }
-      }
-    },
-    "update.channel.beta" : {
-      "comment" : "Display name for the Beta update channel",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beta"
-          }
-        }
-      }
-    },
-    "update.channel.dev" : {
-      "comment" : "Display name for the Dev update channel",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dev"
-          }
-        }
-      }
-    },
-    "update.channel.nightly" : {
-      "comment" : "Display name for the Nightly update channel",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nightly"
-          }
-        }
-      }
-    },
-    "update.channel.release_candidate" : {
-      "comment" : "Display name for the Release Candidate update channel",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Release Candidate"
-          }
-        }
-      }
-    },
-    "update.channel.stable" : {
-      "comment" : "Display name for the Stable update channel",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stable"
           }
         }
       }
@@ -11170,14 +11965,14 @@
         }
       }
     },
-    "welcome.header.tagline" : {
-      "comment" : "Sub-tagline under the Welcome wizard's main heading",
+    "welcome.header.meta" : {
+      "comment" : "Short metadata line on the Welcome intro page",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "macOS-native MLX server with smart caching.\nClaude Code, OpenClaw, and Cursor respond in 5 seconds, not 90."
+            "value" : "Apple Silicon · macOS-native · Apache 2.0"
           }
         }
       }
@@ -11194,14 +11989,14 @@
         }
       }
     },
-    "welcome.header.meta" : {
-      "comment" : "Short metadata line on the Welcome intro page",
+    "welcome.header.tagline" : {
+      "comment" : "Sub-tagline under the Welcome wizard's main heading",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Apple Silicon · macOS-native · Apache 2.0"
+            "value" : "macOS-native MLX server with smart caching.\nClaude Code, OpenClaw, and Cursor respond in 5 seconds, not 90."
           }
         }
       }
@@ -11242,14 +12037,14 @@
         }
       }
     },
-    "welcome.setup.title" : {
-      "comment" : "Heading on the Welcome setup page",
+    "welcome.setup.local.body" : {
+      "comment" : "Body for the local server setup card",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Set up your local server"
+            "value" : "oMLX binds to 127.0.0.1 on first run, so clients on this Mac can use it without exposing the server to your network."
           }
         }
       }
@@ -11266,14 +12061,14 @@
         }
       }
     },
-    "welcome.setup.local.body" : {
-      "comment" : "Body for the local server setup card",
+    "welcome.setup.title" : {
+      "comment" : "Heading on the Welcome setup page",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "oMLX binds to 127.0.0.1 on first run, so clients on this Mac can use it without exposing the server to your network."
+            "value" : "Set up your local server"
           }
         }
       }

--- a/apps/omlx-mac/Sources/AppView/AppView.swift
+++ b/apps/omlx-mac/Sources/AppView/AppView.swift
@@ -503,53 +503,28 @@ private struct ContentScaffold<Content: View>: View {
     @Environment(\.omlxTheme) private var theme
     @EnvironmentObject private var services: AppServices
 
-    /// Resolved section title, rendered as content (not via .navigationTitle)
-    /// because the window toolbar is hidden — Settings.app pattern.
     private var titleText: String { detailTitle ?? section.title }
-
-    @ViewBuilder
-    private func sectionTitleHeader() -> some View {
-        Text(titleText)
-            .font(.omlxText(28, weight: .bold))
-            .foregroundStyle(theme.text)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            // Match the 14pt horizontal padding screen cards apply
-            // internally so the title's left edge aligns with the
-            // cards' left edge inside the 720pt centered frame.
-            .padding(.horizontal, 14)
-            .padding(.top, 36)
-            .padding(.bottom, 6)
-    }
 
     var body: some View {
         Group {
             if section.fillsContentArea {
-                // Skip the outer ScrollView so the screen can claim the
-                // available height (Logs uses this for its monospace pane).
-                VStack(alignment: .leading, spacing: 0) {
-                    sectionTitleHeader()
-                    content()
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                }
-                .frame(maxWidth: 720, alignment: .topLeading)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                .padding(.bottom, 18)
-                .background(theme.windowBg)
+                content()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .frame(maxWidth: 720, alignment: .topLeading)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    .padding(.bottom, 18)
+                    .background(theme.windowBg)
             } else {
                 ScrollViewReader { proxy in
                     ScrollView {
-                        VStack(alignment: .leading, spacing: 0) {
-                            sectionTitleHeader()
-                            content()
-                                .padding(.top, 8)
-                        }
+                        content()
                         // Wrap title + content together in a single max-width
                         // frame so the section title and the cards share the
                         // same left edge (Settings.app pattern: large title
                         // sits flush with content, not offset).
-                        .frame(maxWidth: 720, alignment: .topLeading)
-                        .frame(maxWidth: .infinity, alignment: .top)
-                        .padding(.bottom, 36)
+                            .frame(maxWidth: 720, alignment: .topLeading)
+                            .frame(maxWidth: .infinity, alignment: .top)
+                            .padding(.bottom, 36)
                     }
                     // Deep-link scroll: when another screen (e.g. the
                     // per-model "Edit on Server →" link) requested a
@@ -575,11 +550,8 @@ private struct ContentScaffold<Content: View>: View {
                 }
             }
         }
+        .navigationTitle(titleText)
         .background(theme.windowBg)
-        // Title is rendered as content via sectionTitleHeader() — no
-        // .navigationTitle here because the window toolbar is hidden in
-        // AppView (matches the Settings.app pattern of inline titles on
-        // floating-glass sidebar layouts).
     }
 }
 

--- a/apps/omlx-mac/Sources/AppView/Screens/AboutScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/AboutScreen.swift
@@ -133,46 +133,6 @@ private struct ProjectSection: View {
     }
 }
 
-private struct LinkRow: View {
-    let label: String
-    let sublabel: String
-    let icon: String
-    let url: URL
-    var isLast: Bool = false
-
-    @Environment(\.omlxTheme) private var theme
-
-    var body: some View {
-        FreeRow(isLast: isLast) {
-            HStack(spacing: 10) {
-                Image(systemName: icon)
-                    .font(.system(size: 14))
-                    .foregroundStyle(theme.textSecondary)
-                    .frame(width: 18, alignment: .center)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(label)
-                        .font(.omlxText(13, weight: .medium))
-                        .foregroundStyle(theme.text)
-                    Text(sublabel)
-                        .font(.omlxText(11))
-                        .foregroundStyle(theme.textSecondary)
-                }
-                Spacer(minLength: 8)
-                Button {
-                    NSWorkspace.shared.open(url)
-                } label: {
-                    Label(String(localized: "common.open",
-                                 defaultValue: "Open",
-                                 comment: "Button label that opens the linked URL in the default browser"),
-                          systemImage: "arrow.up.right.square")
-                        .labelStyle(.titleAndIcon)
-                }
-                .buttonStyle(.omlx(.normal, size: .small))
-            }
-        }
-    }
-}
-
 // MARK: - License
 
 private struct LicenseSection: View {
@@ -265,29 +225,15 @@ private struct CreditsSection: View {
 
         ListGroup {
             ForEach(Array(credits.enumerated()), id: \.element.id) { idx, credit in
-                FreeRow(isLast: idx == credits.count - 1) {
-                    HStack(spacing: 10) {
-                        Squircle(systemSymbol: "cpu",
-                                 size: 26,
-                                 gradient: SquircleGradient.models)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(credit.name)
-                                .font(.omlxText(13, weight: .medium))
-                                .foregroundStyle(theme.text)
-                            Text(credit.role)
-                                .font(.omlxText(11))
-                                .foregroundStyle(theme.textSecondary)
-                                .lineLimit(2)
-                        }
-                        Spacer(minLength: 8)
-                        Button {
-                            NSWorkspace.shared.open(credit.url)
-                        } label: {
-                            Image(systemName: "arrow.up.right.square")
-                                .font(.system(size: 12))
-                        }
-                        .buttonStyle(.omlx(.plain, size: .small))
-                    }
+                LinkRow(
+                    label: credit.name,
+                    sublabel: credit.role,
+                    url: credit.url,
+                    isLast: idx == credits.count - 1
+                ) {
+                    Squircle(systemSymbol: "cpu",
+                             size: 26,
+                             gradient: SquircleGradient.models)
                 }
             }
         }

--- a/apps/omlx-mac/Sources/AppView/Screens/AccuracyBenchScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/AccuracyBenchScreen.swift
@@ -212,7 +212,6 @@ private struct ConfigurationSection: View {
                                  comment: "Sublabel under the Accuracy Bench batch-size selector")
             ) {
                 Segmented(selection: $batchSize, options: batchSizeOptions)
-                    .frame(width: 260)
             }
 
             Row(
@@ -320,15 +319,23 @@ private struct BenchmarkGrid: View {
     @Binding var selected: Set<String>
     @Binding var sampleSizes: [String: Int]
 
+    @State private var calculatedHeight: CGFloat = 334
+
+    private struct GridHeightKey: PreferenceKey {
+        static let defaultValue: CGFloat = 334
+        static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+            value = max(value, nextValue())
+        }
+    }
+
     var body: some View {
-        // 3-column grid on width > 600, 2-column otherwise. GeometryReader
-        // gives us the live width so we don't need a fixed window size.
         GeometryReader { geo in
             let cols = geo.size.width > 600 ? 3 : 2
             let layout = Array(
                 repeating: GridItem(.flexible(), spacing: 8),
                 count: cols
             )
+
             LazyVGrid(columns: layout, alignment: .leading, spacing: 8) {
                 ForEach(benchmarkCatalog) { entry in
                     BenchmarkCard(
@@ -337,26 +344,32 @@ private struct BenchmarkGrid: View {
                         sampleSize: binding(for: entry.key),
                         onToggle: { toggle(entry.key) }
                     )
+                    .frame(maxHeight: .infinity, alignment: .top)
+                }
+            }
+            .background {
+                GeometryReader { contentGeo in
+                    Color.clear
+                        .preference(key: GridHeightKey.self, value: contentGeo.size.height)
                 }
             }
         }
-        .frame(minHeight: gridHeight)
-    }
-
-    /// LazyVGrid inside a GeometryReader needs an explicit frame height —
-    /// otherwise it collapses to zero. Estimate generously: 8 rows × 64 pt
-    /// covers both 2-column (8 rows) and 3-column (6 rows) layouts.
-    private var gridHeight: CGFloat {
-        let rows = Double(benchmarkCatalog.count) / 2.0
-        return CGFloat((rows.rounded(.up)) * 66)
+        .frame(height: calculatedHeight)
+        .onPreferenceChange(GridHeightKey.self) { height in
+            withAnimation {
+                self.calculatedHeight = height
+            }
+        }
     }
 
     private func toggle(_ key: String) {
-        if selected.contains(key) {
-            selected.remove(key)
-        } else {
-            selected.insert(key)
-            if sampleSizes[key] == nil { sampleSizes[key] = 100 }
+        withAnimation {
+            if selected.contains(key) {
+                selected.remove(key)
+            } else {
+                selected.insert(key)
+                if sampleSizes[key] == nil { sampleSizes[key] = 100 }
+            }
         }
     }
 
@@ -380,9 +393,10 @@ private struct BenchmarkCard: View {
         VStack(alignment: .leading, spacing: 6) {
             Button(action: onToggle) {
                 HStack(alignment: .center, spacing: 8) {
-                    Image(systemName: isSelected ? "checkmark.square.fill" : "square")
-                        .font(.system(size: 13))
-                        .foregroundStyle(isSelected ? theme.accent : theme.textTertiary)
+                    Toggle(entry.displayName, isOn: Binding(
+                        get: { isSelected },
+                        set: { _ in onToggle() }
+                    ))
                     VStack(alignment: .leading, spacing: 1) {
                         Text(entry.displayName)
                             .font(.omlxText(12.5, weight: .medium))
@@ -825,7 +839,7 @@ private struct TextExportSection: View {
                                   : String(localized: "common.copy",
                                            defaultValue: "Copy",
                                            comment: "Generic Copy button label"),
-                                  systemImage: copied ? "checkmark" : "doc.on.doc")
+                                  systemImage: copied ? "checkmark" : "document.on.document")
                                 .labelStyle(.titleAndIcon)
                         }
                         .buttonStyle(.omlx(.normal, size: .small))

--- a/apps/omlx-mac/Sources/AppView/Screens/AccuracyBenchScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/AccuracyBenchScreen.swift
@@ -391,12 +391,11 @@ private struct BenchmarkCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Button(action: onToggle) {
-                HStack(alignment: .center, spacing: 8) {
-                    Toggle(entry.displayName, isOn: Binding(
-                        get: { isSelected },
-                        set: { _ in onToggle() }
-                    ))
+            Toggle(isOn: Binding(
+                get: { isSelected },
+                set: { _ in onToggle() }
+            )) {
+                HStack {
                     VStack(alignment: .leading, spacing: 1) {
                         Text(entry.displayName)
                             .font(.omlxText(12.5, weight: .medium))
@@ -405,11 +404,9 @@ private struct BenchmarkCard: View {
                             .font(.omlxText(10.5))
                             .foregroundStyle(theme.textTertiary)
                     }
-                    Spacer(minLength: 0)
+                    Spacer()
                 }
-                .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
 
             if isSelected {
                 HStack(spacing: 6) {

--- a/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
@@ -149,7 +149,6 @@ private struct SourceSwitcher: View {
                 selection: $source,
                 options: DownloadSource.allCases.map { ($0, $0.label) }
             )
-            .frame(width: 280)
             .disabled(!msAvailable)
             if !msAvailable {
                 Text(String(localized: "downloads.source.ms_unavailable",
@@ -664,7 +663,7 @@ private struct ActiveDownloadsSection: View {
                                              defaultValue: "Cancel",
                                              comment: "Tooltip on the X button that cancels or removes a download task"))
                             }
-                            ProgressBar(progress: task.progress / 100)
+                            ProgressBar(progress: task.progress / 100, colors: [Color(rgb24: 0x0A84FF), Color(rgb24: 0x5E5CE6)])
                             HStack(spacing: 12) {
                                 StatusChip(task: task)
                                 if !task.error.isEmpty {
@@ -717,31 +716,6 @@ private struct StatusChip: View {
             }
         }()
         StatusPill(status: .custom(color: cfg.0, label: cfg.1, fillBg: true))
-    }
-}
-
-private struct ProgressBar: View {
-    let progress: Double
-    @Environment(\.omlxTheme) private var theme
-
-    var body: some View {
-        GeometryReader { geo in
-            ZStack(alignment: .leading) {
-                RoundedRectangle(cornerRadius: 2, style: .continuous)
-                    .fill(theme.codeBg)
-                RoundedRectangle(cornerRadius: 2, style: .continuous)
-                    .fill(LinearGradient(
-                        colors: [
-                            Color(rgb24: 0x0A84FF),
-                            Color(rgb24: 0x5E5CE6),
-                        ],
-                        startPoint: .leading, endPoint: .trailing
-                    ))
-                    .frame(width: geo.size.width * max(0, min(progress, 1)))
-                    .animation(.easeOut(duration: 0.4), value: progress)
-            }
-        }
-        .frame(height: 4)
     }
 }
 

--- a/apps/omlx-mac/Sources/AppView/Screens/IntegrationsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/IntegrationsScreen.swift
@@ -70,7 +70,6 @@ private struct ClaudeCodeSection: View {
                                           comment: "Claude Code mode option: route to local server")),
                     ]
                 )
-                .frame(width: 160)
             }
             if vm.claudeMode == "local" {
                 Row(label: String(localized: "integrations.claude.opus",
@@ -260,7 +259,7 @@ private struct CopyButton: View {
                 copied = false
             }
         } label: {
-            Image(systemName: copied ? "checkmark" : "doc.on.doc")
+            Image(systemName: copied ? "checkmark" : "document.on.document")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(copied ? theme.successText : theme.textSecondary)
                 .padding(5)

--- a/apps/omlx-mac/Sources/AppView/Screens/LogsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/LogsScreen.swift
@@ -15,48 +15,13 @@ struct LogsScreen: View {
                                   defaultValue: "Server Logs",
                                   comment: "Section header above the log tail pane on the Logs screen"),
                           subtitle: vm.subtitle) {
-                HStack(spacing: 6) {
-                    Popup(
-                        selection: $vm.lines,
-                        width: 110,
-                        options: [
-                            (100,
-                             String(localized: "logs.lines.100",
-                                    defaultValue: "Last 100",
-                                    comment: "Popup option to show the most recent 100 log lines")),
-                            (500,
-                             String(localized: "logs.lines.500",
-                                    defaultValue: "Last 500",
-                                    comment: "Popup option to show the most recent 500 log lines")),
-                            (1000,
-                             String(localized: "logs.lines.1000",
-                                    defaultValue: "Last 1,000",
-                                    comment: "Popup option to show the most recent 1,000 log lines")),
-                            (5000,
-                             String(localized: "logs.lines.5000",
-                                    defaultValue: "Last 5,000",
-                                    comment: "Popup option to show the most recent 5,000 log lines")),
-                            (20000,
-                             String(localized: "logs.lines.20000",
-                                    defaultValue: "Last 20,000",
-                                    comment: "Popup option to show the most recent 20,000 log lines")),
-                        ]
-                    )
-                    Button {
-                        Task { await vm.reload() }
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
-                    }
-                    .buttonStyle(.omlx(.normal, size: .small))
-                    .disabled(vm.isLoading)
-                    Button(String(localized: "common.copy",
-                                  defaultValue: "Copy",
-                                  comment: "Button label to copy the visible log text to the pasteboard")) {
-                        vm.copyToPasteboard()
-                    }
-                        .buttonStyle(.omlx(.normal, size: .small))
-                        .disabled(vm.lines == 0 || vm.logText.isEmpty)
+                Button(String(localized: "common.copy",
+                              defaultValue: "Copy",
+                              comment: "Button label to copy the visible log text to the pasteboard")) {
+                    vm.copyToPasteboard()
                 }
+                              .buttonStyle(.omlx(.normal, size: .small))
+                              .disabled(vm.lines == 0 || vm.logText.isEmpty)
             }
 
             if vm.availableFiles.count > 1 {
@@ -89,12 +54,60 @@ struct LogsScreen: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .toolbar {
+            ToolbarItemGroup(placement: .primaryAction) {
+                logLinesPicker
+                reloadButton
+            }
+        }
         .task(id: vm.refreshKey) {
             await vm.start(client: services.client)
         }
         .onChange(of: vm.lines) { _, _ in vm.bumpRefreshKey() }
         .onChange(of: vm.selectedFile) { _, _ in vm.bumpRefreshKey() }
         .onDisappear { vm.stop() }
+    }
+
+    @ViewBuilder
+    private var logLinesPicker: some View {
+        let lineOptions = [
+            (100,
+             String(localized: "logs.lines.100",
+                    defaultValue: "Last 100",
+                    comment: "Popup option to show the most recent 100 log lines")),
+            (500,
+             String(localized: "logs.lines.500",
+                    defaultValue: "Last 500",
+                    comment: "Popup option to show the most recent 500 log lines")),
+            (1000,
+             String(localized: "logs.lines.1000",
+                    defaultValue: "Last 1,000",
+                    comment: "Popup option to show the most recent 1,000 log lines")),
+            (5000,
+             String(localized: "logs.lines.5000",
+                    defaultValue: "Last 5,000",
+                    comment: "Popup option to show the most recent 5,000 log lines")),
+            (20000,
+             String(localized: "logs.lines.20000",
+                    defaultValue: "Last 20,000",
+                    comment: "Popup option to show the most recent 20,000 log lines")),
+        ]
+
+        Popup(
+            selection: $vm.lines,
+            width: 110,
+            options: lineOptions
+        )
+    }
+
+    @ViewBuilder
+    private var reloadButton: some View {
+        Button {
+            Task { await vm.reload() }
+        } label: {
+            Image(systemName: "arrow.clockwise")
+        }
+        .disabled(vm.isLoading)
     }
 }
 

--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -1549,6 +1549,12 @@ final class ModelSettingsScreenVM: ObservableObject {
     static let diffusionConfigModelTypes: Set<String> = [
         "diffusion_gemma",
     ]
+    /// `config_model_type` values accepted by the HTML admin's VLM MTP
+    /// assistant-drafter picker. Mirrored from `dashboard.js`
+    /// (`VLM_MTP_DRAFTER_CONFIG_MODEL_TYPES`).
+    static let vlmMtpDrafterConfigModelTypes: Set<String> = [
+        "gemma4_assistant", "gemma4_unified_assistant", "qwen3_5_mtp",
+    ]
     static let diffusionUnsupportedCtKwargKeys: Set<String> = [
         "enable_thinking", "reasoning_effort", "preserve_thinking",
     ]
@@ -2034,9 +2040,9 @@ final class ModelSettingsScreenVM: ObservableObject {
     }
 
     /// Draft-model options for VLM MTP. mlx-vlm's MTP loop takes an
-    /// "assistant" drafter, so the picker filters to model ids containing
-    /// "assistant" (case-insensitive), matching the HTML editor's filter,
-    /// and drops the current model so it can't draft for itself.
+    /// assistant drafter. Match the HTML editor by accepting known
+    /// config-derived drafter types first, then falling back to names that
+    /// contain "assistant" or a standalone "mtp" token.
     ///
     /// The stored value is the model **id**, not its path: the server
     /// resolves the drafter by registry id (`engine_pool` looks it up in
@@ -2049,11 +2055,30 @@ final class ModelSettingsScreenVM: ObservableObject {
                         comment: "Initial placeholder option in the VLM MTP draft-model picker")),
         ]
         for m in allModels
-        where m.id != modelID
-            && m.id.range(of: "assistant", options: .caseInsensitive) != nil {
+        where Self.isVlmMtpDraftModelCandidate(m, currentModelID: modelID) {
             out.append((m.id, m.id))
         }
         return out
+    }
+
+    static func isVlmMtpDraftModelCandidate(_ model: ModelDTO, currentModelID: String) -> Bool {
+        guard model.id != currentModelID else { return false }
+
+        if let type = model.configModelType?.lowercased(),
+           vlmMtpDrafterConfigModelTypes.contains(type) {
+            return true
+        }
+
+        let searchText = [model.id, model.modelPath]
+            .compactMap { $0 }
+            .joined(separator: " ")
+        if searchText.range(of: "assistant", options: .caseInsensitive) != nil {
+            return true
+        }
+        return searchText.range(
+            of: #"(^|[-_/\s])mtp($|[-_/\s])"#,
+            options: [.regularExpression, .caseInsensitive]
+        ) != nil
     }
 
     var isDSAConfigModel: Bool {

--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -27,7 +27,7 @@ struct ModelSettingsScreen: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Header(model: vm.model, onBack: { services.modelDetailID = nil })
+            Header(model: vm.model)
 
             SectionPicker(selection: $vm.section)
 
@@ -61,7 +61,25 @@ struct ModelSettingsScreen: View {
                     .padding(.top, 8)
             }
         }
+        .toolbar {
+            ToolbarItem(placement: .navigation) {
+                backButton
+            }
+        }
         .task(id: modelID) { await vm.load(modelID: modelID, client: services.client) }
+    }
+
+    @ViewBuilder
+    private var backButton: some View {
+        Button {
+            services.modelDetailID = nil
+        } label: {
+            Label(String(localized: "settings.header.back_to_models",
+                         defaultValue: "Back to Models",
+                         comment: "Back button label at the top of the per-model settings screen"),
+                  systemImage: "chevron.left")
+                .labelStyle(.iconOnly)
+        }
     }
 }
 
@@ -69,8 +87,6 @@ struct ModelSettingsScreen: View {
 
 private struct Header: View {
     let model: ModelDTO?
-    let onBack: () -> Void
-
     @Environment(\.omlxTheme) private var theme
 
     var body: some View {
@@ -96,17 +112,7 @@ private struct Header: View {
                 }
             }
             .layoutPriority(1)
-            Spacer(minLength: 8)
-            Button {
-                onBack()
-            } label: {
-                Label(String(localized: "settings.header.back_to_models",
-                             defaultValue: "Back to Models",
-                             comment: "Back button label at the top of the per-model settings screen"),
-                      systemImage: "chevron.left")
-                    .labelStyle(.titleAndIcon)
-            }
-            .buttonStyle(.omlx(.plain, size: .small))
+            Spacer()
         }
         .padding(.horizontal, 14)
         .padding(.bottom, 10)
@@ -126,7 +132,6 @@ private struct SectionPicker: View {
                     ($0, $0.label)
                 }
             )
-            .frame(width: 320)
             Spacer()
         }
         .padding(.horizontal, 14)
@@ -1544,12 +1549,6 @@ final class ModelSettingsScreenVM: ObservableObject {
     static let diffusionConfigModelTypes: Set<String> = [
         "diffusion_gemma",
     ]
-    /// `config_model_type` values accepted by the HTML admin's VLM MTP
-    /// assistant-drafter picker. Mirrored from `dashboard.js`
-    /// (`VLM_MTP_DRAFTER_CONFIG_MODEL_TYPES`).
-    static let vlmMtpDrafterConfigModelTypes: Set<String> = [
-        "gemma4_assistant", "gemma4_unified_assistant", "qwen3_5_mtp",
-    ]
     static let diffusionUnsupportedCtKwargKeys: Set<String> = [
         "enable_thinking", "reasoning_effort", "preserve_thinking",
     ]
@@ -2035,9 +2034,9 @@ final class ModelSettingsScreenVM: ObservableObject {
     }
 
     /// Draft-model options for VLM MTP. mlx-vlm's MTP loop takes an
-    /// assistant drafter. Match the HTML editor by accepting known
-    /// config-derived drafter types first, then falling back to names that
-    /// contain "assistant" or a standalone "mtp" token.
+    /// "assistant" drafter, so the picker filters to model ids containing
+    /// "assistant" (case-insensitive), matching the HTML editor's filter,
+    /// and drops the current model so it can't draft for itself.
     ///
     /// The stored value is the model **id**, not its path: the server
     /// resolves the drafter by registry id (`engine_pool` looks it up in
@@ -2050,30 +2049,11 @@ final class ModelSettingsScreenVM: ObservableObject {
                         comment: "Initial placeholder option in the VLM MTP draft-model picker")),
         ]
         for m in allModels
-        where Self.isVlmMtpDraftModelCandidate(m, currentModelID: modelID) {
+        where m.id != modelID
+            && m.id.range(of: "assistant", options: .caseInsensitive) != nil {
             out.append((m.id, m.id))
         }
         return out
-    }
-
-    static func isVlmMtpDraftModelCandidate(_ model: ModelDTO, currentModelID: String) -> Bool {
-        guard model.id != currentModelID else { return false }
-
-        if let type = model.configModelType?.lowercased(),
-           vlmMtpDrafterConfigModelTypes.contains(type) {
-            return true
-        }
-
-        let searchText = [model.id, model.modelPath]
-            .compactMap { $0 }
-            .joined(separator: " ")
-        if searchText.range(of: "assistant", options: .caseInsensitive) != nil {
-            return true
-        }
-        return searchText.range(
-            of: #"(^|[-_/\s])mtp($|[-_/\s])"#,
-            options: [.regularExpression, .caseInsensitive]
-        ) != nil
     }
 
     var isDSAConfigModel: Bool {

--- a/apps/omlx-mac/Sources/AppView/Screens/ProfileViews.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ProfileViews.swift
@@ -470,7 +470,6 @@ struct SaveAsPopover: View {
                                      comment: "Scope label for per-model profiles")),
                 ]
             )
-            .frame(width: 140)
             TextInput(text: $name,
                       placeholder: String(localized: "profile.save_as.name.placeholder",
                                           defaultValue: "profile-name",

--- a/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
@@ -393,7 +393,6 @@ private struct AdvancedSection: View {
                             ("bfloat16", "bfloat16"),
                             ("float16",  "float16"),
                         ])
-                        .frame(width: 180)
                     }
                 }
             }
@@ -516,7 +515,7 @@ private struct QueueRow: View {
                                comment: "Tooltip on the X button for a terminal quant task"))
             }
             if task.isActive {
-                ProgressBar(progress: max(0, min(task.progress / 100, 1)))
+                ProgressBar(progress: max(0, min(task.progress / 100, 1)), colors: [Color(rgb24: 0xFF2D55), Color(rgb24: 0xAF52DE)])
                 HStack(spacing: 8) {
                     if !task.phase.isEmpty {
                         Text(task.phase)
@@ -600,28 +599,6 @@ private struct StatusChip: View {
             .padding(.vertical, 1)
             .background(cfg.0.opacity(0.12))
             .clipShape(Capsule())
-    }
-}
-
-private struct ProgressBar: View {
-    let progress: Double
-    @Environment(\.omlxTheme) private var theme
-
-    var body: some View {
-        GeometryReader { geo in
-            ZStack(alignment: .leading) {
-                RoundedRectangle(cornerRadius: 2, style: .continuous)
-                    .fill(theme.codeBg)
-                RoundedRectangle(cornerRadius: 2, style: .continuous)
-                    .fill(LinearGradient(
-                        colors: [Color(rgb24: 0xFF2D55), Color(rgb24: 0xAF52DE)],
-                        startPoint: .leading, endPoint: .trailing
-                    ))
-                    .frame(width: geo.size.width * progress)
-                    .animation(.easeOut(duration: 0.4), value: progress)
-            }
-        }
-        .frame(height: 4)
     }
 }
 
@@ -718,7 +695,7 @@ private struct UploadRow: View {
                                comment: "Tooltip on the X button for a terminal upload task"))
             }
             if task.isActive {
-                ProgressBar(progress: max(0, min(task.progress / 100, 1)))
+                ProgressBar(progress: max(0, min(task.progress / 100, 1)), colors: [Color(rgb24: 0xFF2D55), Color(rgb24: 0xAF52DE)])
                 HStack(spacing: 8) {
                     Text(task.repoId)
                         .font(.omlxMono(11))

--- a/apps/omlx-mac/Sources/AppView/Screens/SecurityScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/SecurityScreen.swift
@@ -103,7 +103,8 @@ private struct APIKeyEditorRow: View {
                           comment: "Row label for the API key editor"),
             sublabel: sublabel, isLast: true) {
             HStack(spacing: 6) {
-                field
+                TextInput("security.api_key.row_label", text: $draft, placeholder: "sk-omlx-…", isSecure: !showKey, mono: true, width: 260)
+                    .onSubmit { Task { await save() } }
                 iconButton(systemName: showKey ? "eye.slash" : "eye",
                            help: showKey
                                 ? String(localized: "security.api_key.hide",
@@ -121,7 +122,7 @@ private struct APIKeyEditorRow: View {
                     draft = APIKeyGenerator.random()
                     showKey = true
                 }
-                iconButton(systemName: copied ? "checkmark" : "doc.on.doc",
+                iconButton(systemName: copied ? "checkmark" : "document.on.document",
                            help: String(localized: "security.api_key.copy",
                                         defaultValue: "Copy to clipboard",
                                         comment: "Tooltip on the API key copy button"),
@@ -147,34 +148,6 @@ private struct APIKeyEditorRow: View {
         .task(id: loaded) {
             if !focused { draft = loaded }
         }
-    }
-
-    @ViewBuilder
-    private var field: some View {
-        Group {
-            if showKey {
-                TextField("sk-omlx-…", text: $draft)
-            } else {
-                SecureField("sk-omlx-…", text: $draft)
-            }
-        }
-        .focused($focused)
-        .textFieldStyle(.plain)
-        .font(.omlxMono(13, weight: .medium))
-        .foregroundStyle(theme.text)
-        .padding(.horizontal, 10)
-        .frame(height: 28)
-        .frame(width: 260)
-        .background(theme.inputBg)
-        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 7, style: .continuous)
-                .strokeBorder(
-                    focused ? theme.inputBorderFocus : theme.inputBorder,
-                    lineWidth: 0.5
-                )
-        )
-        .onSubmit { Task { await save() } }
     }
 
     @ViewBuilder

--- a/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
@@ -38,7 +38,6 @@ struct StatusScreen: View {
                                             defaultValue: "All Time",
                                             comment: "Segmented control option: all-time stats")),
                     ])
-                    .frame(width: 160)
                     Button {
                         showingClearStatsConfirm = true
                     } label: {
@@ -442,26 +441,6 @@ private struct AverageSpeedTilesRow: View {
 
 // MARK: - System rows
 
-/// Horizontal usage bar shared by the GPU memory + system RAM rows.
-/// 140pt × 4pt to match the JSX `.metric-bar` block in the redesign.
-private struct UsageBar: View {
-    let progress: Double
-    let tint: Color
-    @Environment(\.omlxTheme) private var theme
-
-    var body: some View {
-        ZStack(alignment: .leading) {
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
-                .fill(theme.codeBg)
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
-                .fill(tint)
-                .frame(width: 140 * max(0, min(progress, 1)))
-                .animation(.easeOut(duration: 0.4), value: progress)
-        }
-        .frame(width: 140, height: 4)
-    }
-}
-
 private struct GpuMemoryTrailing: View {
     let stats: StatsDTO?
     @Environment(\.omlxTheme) private var theme
@@ -470,7 +449,8 @@ private struct GpuMemoryTrailing: View {
         let used = stats?.activeModels.modelMemoryUsed
         let max = stats?.activeModels.modelMemoryMax
         HStack(spacing: 10) {
-            UsageBar(progress: progress, tint: theme.blueDot)
+            ProgressBar(progress: progress, tint: theme.blueDot)
+                .frame(width: 140)
             Text(labelText(used: used, max: max))
                 .font(.omlxMono(11))
                 .foregroundStyle(theme.textSecondary)
@@ -501,7 +481,8 @@ private struct SystemRamTrailing: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            UsageBar(progress: progress, tint: theme.text.opacity(0.7))
+            ProgressBar(progress: progress, tint: theme.text.opacity(0.7))
+                .frame(width: 140)
             Text(labelText)
                 .font(.omlxMono(11))
                 .foregroundStyle(theme.textSecondary)

--- a/apps/omlx-mac/Sources/AppView/Screens/ThroughputBenchScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ThroughputBenchScreen.swift
@@ -771,7 +771,7 @@ private struct UploadRow: View {
                 Spacer(minLength: 0)
             } else if let urlString = result.url, let url = URL(string: urlString) {
                 Image(systemName: result.duplicate == true
-                      ? "doc.on.doc"
+                      ? "document.on.document"
                       : "checkmark.circle.fill")
                     .font(.system(size: 11))
                     .foregroundStyle(result.duplicate == true ? theme.textTertiary : theme.greenDot)

--- a/apps/omlx-mac/Sources/Theme/Components/CodeChip.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/CodeChip.swift
@@ -19,7 +19,7 @@ struct CodeChip: View {
                     .foregroundStyle(theme.text)
                     .lineLimit(1)
                     .truncationMode(.middle)
-                Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                Image(systemName: copied ? "checkmark" : "document.on.document")
                     .font(.system(size: 10, weight: .medium))
                     .foregroundStyle(copied ? theme.successText : theme.textSecondary)
                     .animation(.easeOut(duration: 0.12), value: copied)
@@ -59,7 +59,7 @@ struct CopyIconButton: View {
 
     var body: some View {
         Button(action: copy) {
-            Image(systemName: copied ? "checkmark" : "doc.on.doc")
+            Image(systemName: copied ? "checkmark" : "document.on.document")
                 .font(.system(size: 10.5, weight: .medium))
                 .foregroundStyle(copied ? theme.successText : theme.textSecondary)
                 .frame(width: 22, height: 22)

--- a/apps/omlx-mac/Sources/Theme/Components/Popup.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/Popup.swift
@@ -10,67 +10,35 @@ struct PopupOption<Value: Hashable>: Identifiable {
 
 struct Popup<Value: Hashable>: View {
     @Binding var selection: Value
+    var titleKey: LocalizedStringKey
     let options: [PopupOption<Value>]
     let width: CGFloat?
 
     @Environment(\.omlxTheme) private var theme
 
-    init(selection: Binding<Value>, width: CGFloat? = nil, options: [PopupOption<Value>]) {
+    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, options: [PopupOption<Value>]) {
+        self.titleKey = titleKey
         self._selection = selection
         self.options = options
         self.width = width
     }
 
-    init(
-        selection: Binding<Value>,
-        width: CGFloat? = nil,
-        options: [(Value, String)]
-    ) {
+    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, options: [(Value, String)]) {
+        self.titleKey = titleKey
         self._selection = selection
         self.options = options.map { PopupOption(value: $0.0, label: $0.1) }
         self.width = width
     }
 
     var body: some View {
-        Menu {
+        Picker(titleKey, selection: $selection) {
             ForEach(options) { opt in
-                Button {
-                    selection = opt.value
-                } label: {
-                    HStack {
-                        Text(opt.label)
-                        if opt.value == selection {
-                            Spacer()
-                            Image(systemName: "checkmark")
-                        }
-                    }
-                }
+                Text(opt.label)
+                    .tag(opt.value)
             }
-        } label: {
-            HStack(spacing: 8) {
-                Text(currentLabel)
-                    .font(.omlxText(13, weight: .medium))
-                    .foregroundStyle(theme.text)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                Spacer(minLength: 4)
-                Image(systemName: "chevron.up.chevron.down")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundStyle(theme.textSecondary)
-            }
-            .padding(.horizontal, 10)
-            .frame(height: 28)
-            .frame(maxWidth: width)
-            .background(theme.inputBg)
-            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 7, style: .continuous)
-                    .strokeBorder(theme.inputBorder, lineWidth: 0.5)
-            )
-            .contentShape(Rectangle())
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
+        .labelsHidden()
+        .pickerStyle(.menu)
     }
 
     private var currentLabel: String {
@@ -81,7 +49,8 @@ struct Popup<Value: Hashable>: View {
 #Preview("Popup") {
     @Previewable @State var host = "127.0.0.1"
     @Previewable @State var quant = "q4"
-    return VStack(alignment: .leading, spacing: 14) {
+
+    VStack(alignment: .leading, spacing: 14) {
         Popup(selection: $host, width: 220, options: [
             ("127.0.0.1", "127.0.0.1 (Local only)"),
             ("0.0.0.0", "0.0.0.0 (All networks)"),

--- a/apps/omlx-mac/Sources/Theme/Components/ProgressBar.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/ProgressBar.swift
@@ -20,7 +20,7 @@ struct ProgressBar: View {
         self.progress = progress
         self._colors = State(initialValue: colors)
     }
-    
+
     var body: some View {
         ProgressView(value: progress)
             .progressViewStyle(OMLXLinearProgressViewStyle(colors: colors))
@@ -67,7 +67,7 @@ struct OMLXLinearProgressViewStyle: ProgressViewStyle {
         ProgressBar(progress: progress, tint: .red)
         ProgressBar(progress: progress, colors: downloadsColors)
         ProgressBar(progress: progress, colors: quantizationColors)
-    
+
         Slider(value: $progress, in: 0.0...1.0)
     }
     .padding()

--- a/apps/omlx-mac/Sources/Theme/Components/ProgressBar.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/ProgressBar.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct ProgressBar: View {
+    let progress: Double
+    @State var colors: [Color]? = nil
+    @Environment(\.omlxTheme) private var theme
+
+    init(progress: Double) {
+        self.progress = progress
+    }
+
+    init(progress: Double, tint: Color? = nil) {
+        self.progress = progress
+        if let color = tint {
+            self._colors = State(initialValue: [color])
+        }
+    }
+
+    init(progress: Double, colors: [Color]? = nil) {
+        self.progress = progress
+        self._colors = State(initialValue: colors)
+    }
+    
+    var body: some View {
+        ProgressView(value: progress)
+            .progressViewStyle(OMLXLinearProgressViewStyle(colors: colors))
+    }
+}
+
+struct OMLXLinearProgressViewStyle: ProgressViewStyle {
+    @Environment(\.omlxTheme) private var theme
+    var colors: [Color]? = nil
+    func makeBody(configuration: Configuration) -> some View {
+        let progress = configuration.fractionCompleted ?? 0
+        let progressShapeStyle: AnyShapeStyle = {
+            if let colors = colors {
+                return AnyShapeStyle(LinearGradient(
+                    colors: colors,
+                    startPoint: .leading,
+                    endPoint: .trailing
+                ))
+            } else {
+                return AnyShapeStyle(.tint)
+            }
+        }()
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(theme.codeBg)
+                Capsule()
+                    .fill(progressShapeStyle)
+                    .frame(width: geo.size.width * max(0, min(progress, 1)))
+                    .animation(.easeOut(duration: 0.4), value: progress)
+            }
+        }
+        .frame(height: 4)
+    }
+}
+
+#Preview {
+    @Previewable @State var progress = 0.3
+    let downloadsColors = [Color(rgb24: 0x0A84FF), Color(rgb24: 0x5E5CE6)]
+    let quantizationColors = [Color(rgb24: 0xFF2D55), Color(rgb24: 0xAF52DE)]
+
+    VStack(spacing: 20) {
+        ProgressBar(progress: progress)
+        ProgressBar(progress: progress, tint: .red)
+        ProgressBar(progress: progress, colors: downloadsColors)
+        ProgressBar(progress: progress, colors: quantizationColors)
+    
+        Slider(value: $progress, in: 0.0...1.0)
+    }
+    .padding()
+}

--- a/apps/omlx-mac/Sources/Theme/Components/Row.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/Row.swift
@@ -145,7 +145,7 @@ struct LinkRow<Icon: View>: View {
             HStack(spacing: 10) {
                 iconView
                     .foregroundStyle(theme.textSecondary)
-                
+
                 VStack(alignment: .leading, spacing: 2) {
                     Text(label)
                         .font(.omlxText(13, weight: .medium))
@@ -155,9 +155,9 @@ struct LinkRow<Icon: View>: View {
                         .foregroundStyle(theme.textSecondary)
                         .lineLimit(2)
                 }
-                
+
                 Spacer(minLength: 8)
-                
+
                 Button {
                     NSWorkspace.shared.open(url)
                 } label: {

--- a/apps/omlx-mac/Sources/Theme/Components/Row.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/Row.swift
@@ -98,6 +98,78 @@ struct FreeRow<Content: View>: View {
     }
 }
 
+struct LinkRow<Icon: View>: View {
+    let label: String
+    let sublabel: String
+    let url: URL
+    var isLast: Bool = false
+
+    private let iconView: Icon
+
+    @Environment(\.omlxTheme) private var theme
+
+    init(
+        label: String,
+        sublabel: String,
+        url: URL,
+        isLast: Bool = false,
+        @ViewBuilder iconView: () -> Icon
+    ) {
+        self.label = label
+        self.sublabel = sublabel
+        self.url = url
+        self.isLast = isLast
+        self.iconView = iconView()
+    }
+
+    init(
+        label: String,
+        sublabel: String,
+        icon: String,
+        url: URL,
+        isLast: Bool = false
+    ) where Icon == AnyView {
+        self.label = label
+        self.sublabel = sublabel
+        self.url = url
+        self.isLast = isLast
+        self.iconView = AnyView(
+            Image(systemName: icon)
+                .font(.system(size: 14))
+                .frame(width: 18, alignment: .center)
+        )
+    }
+
+    var body: some View {
+        FreeRow(isLast: isLast) {
+            HStack(spacing: 10) {
+                iconView
+                    .foregroundStyle(theme.textSecondary)
+                
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label)
+                        .font(.omlxText(13, weight: .medium))
+                        .foregroundStyle(theme.text)
+                    Text(sublabel)
+                        .font(.omlxText(11))
+                        .foregroundStyle(theme.textSecondary)
+                        .lineLimit(2)
+                }
+                
+                Spacer(minLength: 8)
+                
+                Button {
+                    NSWorkspace.shared.open(url)
+                } label: {
+                    Label("common.open", systemImage: "arrow.up.right.square")
+                        .labelStyle(.iconOnly)
+                }
+                .buttonStyle(.omlx(.plain, size: .small))
+            }
+        }
+    }
+}
+
 #Preview("Row in ListGroup") {
     @Previewable @State var autoStart = true
     @Previewable @State var requireKey = false

--- a/apps/omlx-mac/Sources/Theme/Components/Segmented.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/Segmented.swift
@@ -4,43 +4,20 @@ import SwiftUI
 
 struct Segmented<Value: Hashable>: View {
     @Binding var selection: Value
+    let titleKey: LocalizedStringKey = ""
     let options: [(value: Value, label: String)]
 
     @Environment(\.omlxTheme) private var theme
 
     var body: some View {
-        HStack(spacing: 0) {
-            ForEach(options.indices, id: \.self) { i in
-                let opt = options[i]
-                let isSelected = opt.value == selection
-                Button {
-                    selection = opt.value
-                } label: {
-                    Text(opt.label)
-                        .font(.omlxText(11.5, weight: .medium))
-                        .foregroundStyle(isSelected ? theme.text : theme.textSecondary)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 4)
-                        .frame(maxWidth: .infinity)
-                        .background(
-                            RoundedRectangle(cornerRadius: 5, style: .continuous)
-                                .fill(isSelected ? theme.controlBg : Color.clear)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 5, style: .continuous)
-                                        .strokeBorder(
-                                            isSelected ? theme.inputBorder : Color.clear,
-                                            lineWidth: 0.5
-                                        )
-                                )
-                        )
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
+        Picker(titleKey, selection: $selection) {
+            ForEach(options, id: \.value) { opt in
+                Text(opt.label)
+                    .tag(opt.value)
             }
         }
-        .padding(2)
-        .background(theme.inputBg)
-        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .pickerStyle(.segmented)
+        .labelsHidden()
     }
 }
 

--- a/apps/omlx-mac/Sources/Theme/Components/TextInput.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/TextInput.swift
@@ -4,68 +4,108 @@ import SwiftUI
 
 struct TextInput: View {
     @Binding var text: String
-    var placeholder: String = ""
-    var isSecure: Bool = false
-    var mono: Bool = false
-    var suffix: String? = nil
-    var width: CGFloat? = nil
+    var titleKey: LocalizedStringKey
+    var placeholder: String
+    var isSecure: Bool
+    var mono: Bool
+    var isNumeric: Bool
+    var range: ClosedRange<Double>?
+    var step: Double?
+    var suffix: String?
+    var width: CGFloat?
 
     @Environment(\.omlxTheme) private var theme
-    @FocusState private var isFocused: Bool
 
-    var body: some View {
-        HStack(spacing: 6) {
-            field
-                .focused($isFocused)
-                .textFieldStyle(.plain)
-                .font(mono ? .omlxMono(13, weight: .medium)
-                            : .omlxText(13, weight: .medium))
-                .foregroundStyle(theme.text)
-            if let suffix {
-                Text(suffix)
-                    .font(.omlxText(11))
-                    .foregroundStyle(theme.textSecondary)
-            }
-        }
-        .padding(.horizontal, 10)
-        .frame(height: 28)
-        .frame(maxWidth: width)
-        .background(theme.inputBg)
-        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 7, style: .continuous)
-                .strokeBorder(
-                    isFocused ? theme.inputBorderFocus : theme.inputBorder,
-                    lineWidth: 0.5
-                )
-        )
-        // Focus glow — softer than NSFocusRing but consistent with design.
-        .overlay(
-            RoundedRectangle(cornerRadius: 7, style: .continuous)
-                .stroke(theme.accent.opacity(isFocused ? 0.20 : 0), lineWidth: 3)
-                .padding(-2)
-                .allowsHitTesting(false)
-        )
-        .animation(.easeOut(duration: 0.08), value: isFocused)
+    init(_ titleKey: LocalizedStringKey = "", text: Binding<String>, placeholder: String = "", isSecure: Bool = false, mono: Bool = false, isNumeric: Bool = false, range: ClosedRange<Double>? = nil, step: Double? = nil, suffix: String? = nil, width: CGFloat? = nil) {
+        self._text = text
+        self.titleKey = titleKey
+        self.placeholder = placeholder
+        self.isSecure = isSecure
+        self.mono = mono
+        self.isNumeric = isNumeric
+        self.range = range
+        self.step = step
+        self.suffix = suffix
+        self.width = width
     }
 
-    @ViewBuilder
+    private var textAsDouble: Binding<Double> {
+        Binding(
+            get: { Double(text) ?? 0 },
+            set: { text = $0.formatted(.number.grouping(.never)) }
+        )
+    }
+
+    var body: some View {
+        field
+            .lineLimit(1)
+            .textFieldStyle(.roundedBorder)
+            .font(mono ? .omlxMono(13, weight: .medium) : .omlxText(13, weight: .medium))
+            .foregroundStyle(theme.text)
+            .overlay(alignment: .trailing) {
+                HStack(spacing: 0) {
+                    if let suffix {
+                        Text(suffix)
+                            .font(.omlxText(11))
+                            .foregroundStyle(theme.textSecondary)
+                            .padding(.horizontal, 10)
+                    }
+                    if isNumeric {
+                        stepper
+                    }
+                }
+            }
+            .frame(maxWidth: width)
+    }
+
     private var field: some View {
-        if isSecure {
-            SecureField(placeholder, text: $text)
-        } else {
-            TextField(placeholder, text: $text)
+        Group {
+            if isSecure {
+                SecureField(titleKey, text: $text, prompt: Text(placeholder))
+            } else {
+                TextField(titleKey, text: $text, prompt: Text(placeholder))
+            }
         }
+    }
+
+    private var stepper: some View {
+        Group {
+            switch (range, step) {
+            case let (range?, step?):
+                Stepper(titleKey, value: textAsDouble, in: range, step: step)
+            case let (range?, nil):
+                Stepper(titleKey, value: textAsDouble, in: range)
+            default:
+                Stepper(titleKey, value: textAsDouble)
+            }
+        }
+        .labelsHidden()
+        .controlSize(.small)
+        .padding(.trailing, 1)
     }
 }
 
 #Preview("TextInput") {
     @Previewable @State var port = "8000"
+    @Previewable @State var qty = "1024"
+    @Previewable @State var temperature = "0.3"
     @Previewable @State var pwd = "sk-omlx-2k4j8"
+    @Previewable @State var showKey = false
     @Previewable @State var alias = ""
-    return VStack(alignment: .leading, spacing: 14) {
+    VStack(alignment: .leading, spacing: 14) {
         TextInput(text: $port, placeholder: "Port", mono: true, width: 110)
-        TextInput(text: $pwd, placeholder: "Admin password", isSecure: true, width: 200)
+        TextInput(text: $qty, placeholder: "Quantity", isNumeric: true, suffix: "qty", width: 160)
+        TextInput(text: $temperature, placeholder: "Temperature", isNumeric: true, range: 0...2, step: 0.1, width: 160)
+        HStack {
+            TextInput(text: $pwd, placeholder: "Admin password", isSecure: !showKey, width: 200)
+            Button {
+                showKey.toggle()
+            } label: {
+                Image(systemName: "eye")
+                    .symbolVariant(showKey ? .slash : .none)
+            }
+            .buttonStyle(.plain)
+        }
         TextInput(text: $alias, placeholder: "model-id-suffix", mono: true,
                   suffix: "alias", width: 240)
     }

--- a/apps/omlx-mac/Sources/Welcome/WelcomeWindow.swift
+++ b/apps/omlx-mac/Sources/Welcome/WelcomeWindow.swift
@@ -384,7 +384,11 @@ final class WelcomeViewModel: ObservableObject {
     @discardableResult
     func openWebDashboard() -> Bool {
         guard let services else { return false }
-        guard let url = URL(string: "http://\(services.config.host):\(services.config.port)/admin/dashboard") else {
+        guard let url = AppConfig.httpURL(
+            host: services.config.host,
+            port: services.config.port,
+            path: "/admin/dashboard"
+        ) else {
             return false
         }
         NSWorkspace.shared.open(url)

--- a/apps/omlx-mac/Sources/Welcome/WelcomeWindow.swift
+++ b/apps/omlx-mac/Sources/Welcome/WelcomeWindow.swift
@@ -384,11 +384,7 @@ final class WelcomeViewModel: ObservableObject {
     @discardableResult
     func openWebDashboard() -> Bool {
         guard let services else { return false }
-        guard let url = AppConfig.httpURL(
-            host: services.config.host,
-            port: services.config.port,
-            path: "/admin/dashboard"
-        ) else {
+        guard let url = URL(string: "http://\(services.config.host):\(services.config.port)/admin/dashboard") else {
             return false
         }
         NSWorkspace.shared.open(url)
@@ -614,15 +610,14 @@ private struct WelcomeSetupBody: View {
                                          defaultValue: "This key is also your Web Dashboard login password.",
                                          comment: "Sublabel explaining API key usage")
                     ) {
-                        HStack(spacing: 8) {
-                            keyField($vm.apiKey)
+                        HStack(spacing: 0) {
+                            TextInput("welcome.api_key.placeholder", text: $vm.apiKey, placeholder: "sk-omlx-…", isSecure: !keyVisible, mono: true, width: 210)
                             Button {
                                 keyVisible.toggle()
                             } label: {
                                 Image(systemName: keyVisible ? "eye.slash" : "eye")
                                     .font(.system(size: 13, weight: .semibold))
                             }
-                            .buttonStyle(.omlx(.plain, size: .small))
                             .disabled(vm.isStarting)
                             .help(keyVisible
                                   ? String(localized: "welcome.api_key.hide",
@@ -631,7 +626,18 @@ private struct WelcomeSetupBody: View {
                                   : String(localized: "welcome.api_key.show",
                                            defaultValue: "Show key",
                                            comment: "Tooltip on the eye button that unmasks the API key field"))
+
+                            Button {
+                                vm.apiKey = APIKeyGenerator.random()
+                                keyVisible = true
+                            } label: {
+                                Image(systemName: "arrow.triangle.2.circlepath")
+                            }
+                            .help(String(localized: "security.api_key.generate",
+                                         defaultValue: "Generate a random key",
+                                         comment: "Tooltip on the API key regenerate button"))
                         }
+                        .buttonStyle(.omlx(.plain, size: .small))
                     }
                 }
                 .background(WelcomeStyle.panel)
@@ -654,19 +660,6 @@ private struct WelcomeSetupBody: View {
         .padding(.top, 18)
         .padding(.bottom, 6)
         .disabled(vm.isStarting)
-    }
-
-    @ViewBuilder
-    private func keyField(_ binding: Binding<String>) -> some View {
-        let placeholder = String(localized: "welcome.api_key.placeholder",
-                                 defaultValue: "Create an API key",
-                                 comment: "Placeholder text inside the API key text field")
-        if keyVisible {
-            TextInput(text: binding, placeholder: placeholder, mono: true, width: 210)
-        } else {
-            TextInput(text: binding, placeholder: placeholder,
-                      isSecure: true, mono: true, width: 210)
-        }
     }
 }
 

--- a/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
+++ b/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
@@ -23,14 +23,14 @@
 		2BB000000000000000000008 /* ListGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC000000000000000000008 /* ListGroup.swift */; };
 		2BB000000000000000000009 /* Row.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC000000000000000000009 /* Row.swift */; };
 		2BB00000000000000000000A /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC00000000000000000000A /* SectionHeader.swift */; };
-		2BB00000000000000000000D /* ScreenScaffold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC00000000000000000000D /* ScreenScaffold.swift */; };
 		2BB00000000000000000000B /* StatusPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC00000000000000000000B /* StatusPill.swift */; };
 		2BB00000000000000000000C /* CodeChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC00000000000000000000C /* CodeChip.swift */; };
+		2BB00000000000000000000D /* ScreenScaffold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC00000000000000000000D /* ScreenScaffold.swift */; };
 		3BB000000000000000000001 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000001 /* AppConfig.swift */; };
-		3BB000000000000000000004 /* ShellEnvWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000004 /* ShellEnvWriter.swift */; };
-		3BB000000000000000000005 /* APIKeyGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000005 /* APIKeyGenerator.swift */; };
 		3BB000000000000000000002 /* MenubarStatsPoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000002 /* MenubarStatsPoller.swift */; };
 		3BB000000000000000000003 /* MenubarVisibilityWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000003 /* MenubarVisibilityWatcher.swift */; };
+		3BB000000000000000000004 /* ShellEnvWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000004 /* ShellEnvWriter.swift */; };
+		3BB000000000000000000005 /* APIKeyGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000005 /* APIKeyGenerator.swift */; };
 		4BB000000000000000000001 /* PortConflictResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC000000000000000000001 /* PortConflictResolver.swift */; };
 		4BB000000000000000000002 /* SignalHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC000000000000000000002 /* SignalHandlers.swift */; };
 		4BB000000000000000000003 /* AppControlServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC000000000000000000003 /* AppControlServer.swift */; };
@@ -67,15 +67,13 @@
 		8BB000000000000000000008 /* ProfileViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC000000000000000000008 /* ProfileViews.swift */; };
 		8BB000000000000000000009 /* ProfileWorkingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC000000000000000000009 /* ProfileWorkingState.swift */; };
 		8BB00000000000000000000A /* MSTaskDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC00000000000000000000A /* MSTaskDTO.swift */; };
-		9BB000000000000000000005 /* PresetBundleDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000005 /* PresetBundleDTO.swift */; };
-		DBB000000000000000000101 /* ModelCardDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000101 /* ModelCardDTO.swift */; };
-		DBB000000000000000000102 /* ModelCardSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000102 /* ModelCardSheet.swift */; };
-		EBB000000000000000000001 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = ECC000000000000000000001 /* MarkdownUI */; };
-		9BB000000000000000000006 /* PresetBundleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000006 /* PresetBundleStore.swift */; };
 		9BB000000000000000000001 /* SubKeyDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000001 /* SubKeyDTO.swift */; };
 		9BB000000000000000000002 /* OQDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000002 /* OQDTO.swift */; };
 		9BB000000000000000000003 /* HFUploadDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000003 /* HFUploadDTO.swift */; };
 		9BB000000000000000000004 /* BenchDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000004 /* BenchDTO.swift */; };
+		9BB000000000000000000005 /* PresetBundleDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000005 /* PresetBundleDTO.swift */; };
+		9BB000000000000000000006 /* PresetBundleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000006 /* PresetBundleStore.swift */; };
+		AACFCBE42FE115A200B224C0 /* ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACFCBE32FE115A200B224C0 /* ProgressBar.swift */; };
 		ABB000000000000000000001 /* WelcomeWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACC000000000000000000001 /* WelcomeWindow.swift */; };
 		BBB000000000000000000002 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BCC000000000000000000002 /* Localizable.xcstrings */; };
 		BBB000000000000000000004 /* AppUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCC000000000000000000003 /* AppUpdater.swift */; };
@@ -96,12 +94,15 @@
 		DBB00000000000000000000E /* ServerProcessIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */; };
 		DBB00000000000000000000F /* LocalizationSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000F /* LocalizationSmokeTests.swift */; };
 		DBB000000000000000000100 /* MenubarControllerPortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000100 /* MenubarControllerPortTests.swift */; };
+		DBB000000000000000000101 /* ModelCardDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000101 /* ModelCardDTO.swift */; };
+		DBB000000000000000000102 /* ModelCardSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000102 /* ModelCardSheet.swift */; };
 		DBB000000000000000000103 /* ModelCardDTODecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000103 /* ModelCardDTODecodeTests.swift */; };
 		DBB000000000000000000104 /* ShellEnvWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000104 /* ShellEnvWriterTests.swift */; };
 		DBB000000000000000000105 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000105 /* ThemeTests.swift */; };
 		DBB000000000000000000106 /* ReleasesCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000106 /* ReleasesCheckerTests.swift */; };
 		DBB000000000000000000107 /* ModelsScreenSortingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000107 /* ModelsScreenSortingTests.swift */; };
 		DBB000000000000000000108 /* ModelSettingsScreenVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000108 /* ModelSettingsScreenVMTests.swift */; };
+		EBB000000000000000000001 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = ECC000000000000000000001 /* MarkdownUI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -110,7 +111,7 @@
 			containerPortal = 1AAAAAAAAAAAAAAAAAAAAAA1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 1AAAAAAAAAAAAAAAAAAAAAA2;
-			remoteInfo = "oMLX";
+			remoteInfo = oMLX;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -119,9 +120,9 @@
 		1CCCCCCCCCCCCCCCCCCCCCC2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1CCCCCCCCCCCCCCCCCCCCCC3 /* MenubarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarController.swift; sourceTree = "<group>"; };
 		1CCCCCCCCCCCCCCCCCCCCCC4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		1CCCCCCCCCCCCCCCCCCCCCC5 /* oMLX.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "oMLX.entitlements"; sourceTree = "<group>"; };
+		1CCCCCCCCCCCCCCCCCCCCCC5 /* oMLX.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = oMLX.entitlements; sourceTree = "<group>"; };
 		1CCCCCCCCCCCCCCCCCCCCCC6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		1CCCCCCCCCCCCCCCCCCCCCC7 /* oMLX.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "oMLX.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CCCCCCCCCCCCCCCCCCCCCC7 /* oMLX.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = oMLX.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CCCCCCCCCCCCCCCCCCCCCC8 /* PythonRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PythonRuntime.swift; sourceTree = "<group>"; };
 		1CCCCCCCCCCCCCCCCCCCCCC9 /* ServerProcess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerProcess.swift; sourceTree = "<group>"; };
 		2CC000000000000000000001 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -134,14 +135,14 @@
 		2CC000000000000000000008 /* ListGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListGroup.swift; sourceTree = "<group>"; };
 		2CC000000000000000000009 /* Row.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Row.swift; sourceTree = "<group>"; };
 		2CC00000000000000000000A /* SectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeader.swift; sourceTree = "<group>"; };
-		2CC00000000000000000000D /* ScreenScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenScaffold.swift; sourceTree = "<group>"; };
 		2CC00000000000000000000B /* StatusPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPill.swift; sourceTree = "<group>"; };
 		2CC00000000000000000000C /* CodeChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeChip.swift; sourceTree = "<group>"; };
+		2CC00000000000000000000D /* ScreenScaffold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenScaffold.swift; sourceTree = "<group>"; };
 		3CC000000000000000000001 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
-		3CC000000000000000000004 /* ShellEnvWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvWriter.swift; sourceTree = "<group>"; };
-		3CC000000000000000000005 /* APIKeyGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyGenerator.swift; sourceTree = "<group>"; };
 		3CC000000000000000000002 /* MenubarStatsPoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarStatsPoller.swift; sourceTree = "<group>"; };
 		3CC000000000000000000003 /* MenubarVisibilityWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarVisibilityWatcher.swift; sourceTree = "<group>"; };
+		3CC000000000000000000004 /* ShellEnvWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvWriter.swift; sourceTree = "<group>"; };
+		3CC000000000000000000005 /* APIKeyGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyGenerator.swift; sourceTree = "<group>"; };
 		4CC000000000000000000001 /* PortConflictResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortConflictResolver.swift; sourceTree = "<group>"; };
 		4CC000000000000000000002 /* SignalHandlers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalHandlers.swift; sourceTree = "<group>"; };
 		4CC000000000000000000003 /* AppControlServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppControlServer.swift; sourceTree = "<group>"; };
@@ -178,14 +179,13 @@
 		8CC000000000000000000008 /* ProfileViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViews.swift; sourceTree = "<group>"; };
 		8CC000000000000000000009 /* ProfileWorkingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileWorkingState.swift; sourceTree = "<group>"; };
 		8CC00000000000000000000A /* MSTaskDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSTaskDTO.swift; sourceTree = "<group>"; };
-		9CC000000000000000000005 /* PresetBundleDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetBundleDTO.swift; sourceTree = "<group>"; };
-		DCC000000000000000000101 /* ModelCardDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCardDTO.swift; sourceTree = "<group>"; };
-		DCC000000000000000000102 /* ModelCardSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCardSheet.swift; sourceTree = "<group>"; };
-		9CC000000000000000000006 /* PresetBundleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetBundleStore.swift; sourceTree = "<group>"; };
 		9CC000000000000000000001 /* SubKeyDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubKeyDTO.swift; sourceTree = "<group>"; };
 		9CC000000000000000000002 /* OQDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OQDTO.swift; sourceTree = "<group>"; };
 		9CC000000000000000000003 /* HFUploadDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HFUploadDTO.swift; sourceTree = "<group>"; };
 		9CC000000000000000000004 /* BenchDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchDTO.swift; sourceTree = "<group>"; };
+		9CC000000000000000000005 /* PresetBundleDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetBundleDTO.swift; sourceTree = "<group>"; };
+		9CC000000000000000000006 /* PresetBundleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetBundleStore.swift; sourceTree = "<group>"; };
+		AACFCBE32FE115A200B224C0 /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
 		ACC000000000000000000001 /* WelcomeWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeWindow.swift; sourceTree = "<group>"; };
 		BCC000000000000000000002 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BCC000000000000000000003 /* AppUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdater.swift; sourceTree = "<group>"; };
@@ -205,14 +205,16 @@
 		DCC00000000000000000000D /* DTOFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTOFixtureTests.swift; sourceTree = "<group>"; };
 		DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerProcessIntegrationTests.swift; sourceTree = "<group>"; };
 		DCC00000000000000000000F /* LocalizationSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationSmokeTests.swift; sourceTree = "<group>"; };
+		DCC000000000000000000010 /* oMLXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = oMLXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCC000000000000000000100 /* MenubarControllerPortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarControllerPortTests.swift; sourceTree = "<group>"; };
+		DCC000000000000000000101 /* ModelCardDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCardDTO.swift; sourceTree = "<group>"; };
+		DCC000000000000000000102 /* ModelCardSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCardSheet.swift; sourceTree = "<group>"; };
 		DCC000000000000000000103 /* ModelCardDTODecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCardDTODecodeTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000104 /* ShellEnvWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvWriterTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000105 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000106 /* ReleasesCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleasesCheckerTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000107 /* ModelsScreenSortingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsScreenSortingTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000108 /* ModelSettingsScreenVMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelSettingsScreenVMTests.swift; sourceTree = "<group>"; };
-		DCC000000000000000000010 /* oMLXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = oMLXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -234,7 +236,7 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1BBBBBBBBBBBBBBBBBBBBBB1 /* oMLX */ = {
+		1BBBBBBBBBBBBBBBBBBBBBB1 = {
 			isa = PBXGroup;
 			children = (
 				1BBBBBBBBBBBBBBBBBBBBBB2 /* Sources */,
@@ -242,43 +244,6 @@
 				1BBBBBBBBBBBBBBBBBBBBBB5 /* Resources */,
 				1BBBBBBBBBBBBBBBBBBBBBB6 /* Products */,
 			);
-			sourceTree = "<group>";
-		};
-		DEE000000000000000000001 /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				DEE000000000000000000002 /* oMLXTests */,
-			);
-			path = Tests;
-			sourceTree = "<group>";
-		};
-		DEE000000000000000000002 /* oMLXTests */ = {
-			isa = PBXGroup;
-			children = (
-				DCC000000000000000000001 /* AppServicesPathTests.swift */,
-				DCC000000000000000000002 /* AppConfigTests.swift */,
-				DCC000000000000000000003 /* ServerScreenVMStorageDiffTests.swift */,
-				DCC000000000000000000004 /* ProfileDTODecodeTests.swift */,
-				DCC000000000000000000005 /* SamplingValidatorTests.swift */,
-				DCC000000000000000000006 /* APIKeyGeneratorTests.swift */,
-				DCC000000000000000000007 /* ChatTemplateKwargsCodecTests.swift */,
-				DCC000000000000000000008 /* DflashByteSizeTests.swift */,
-				DCC000000000000000000009 /* GlobalSettingsSamplingTests.swift */,
-				DCC00000000000000000000A /* ProfileScopeTests.swift */,
-				DCC00000000000000000000B /* SystemMetricsTests.swift */,
-				DCC00000000000000000000C /* WelcomeViewModelTests.swift */,
-				DCC00000000000000000000D /* DTOFixtureTests.swift */,
-				DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */,
-				DCC00000000000000000000F /* LocalizationSmokeTests.swift */,
-				DCC000000000000000000100 /* MenubarControllerPortTests.swift */,
-				DCC000000000000000000103 /* ModelCardDTODecodeTests.swift */,
-				DCC000000000000000000104 /* ShellEnvWriterTests.swift */,
-				DCC000000000000000000105 /* ThemeTests.swift */,
-				DCC000000000000000000106 /* ReleasesCheckerTests.swift */,
-				DCC000000000000000000107 /* ModelsScreenSortingTests.swift */,
-				DCC000000000000000000108 /* ModelSettingsScreenVMTests.swift */,
-			);
-			path = oMLXTests;
 			sourceTree = "<group>";
 		};
 		1BBBBBBBBBBBBBBBBBBBBBB2 /* Sources */ = {
@@ -297,12 +262,94 @@
 			path = Sources;
 			sourceTree = "<group>";
 		};
-		AEE000000000000000000001 /* Welcome */ = {
+		1BBBBBBBBBBBBBBBBBBBBBB3 /* App */ = {
 			isa = PBXGroup;
 			children = (
-				ACC000000000000000000001 /* WelcomeWindow.swift */,
+				1CCCCCCCCCCCCCCCCCCCCCC1 /* oMLXApp.swift */,
+				1CCCCCCCCCCCCCCCCCCCCCC2 /* AppDelegate.swift */,
 			);
-			path = Welcome;
+			path = App;
+			sourceTree = "<group>";
+		};
+		1BBBBBBBBBBBBBBBBBBBBBB4 /* Menubar */ = {
+			isa = PBXGroup;
+			children = (
+				1CCCCCCCCCCCCCCCCCCCCCC3 /* MenubarController.swift */,
+				3CC000000000000000000002 /* MenubarStatsPoller.swift */,
+				3CC000000000000000000003 /* MenubarVisibilityWatcher.swift */,
+			);
+			path = Menubar;
+			sourceTree = "<group>";
+		};
+		1BBBBBBBBBBBBBBBBBBBBBB5 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				1CCCCCCCCCCCCCCCCCCCCCC4 /* Info.plist */,
+				1CCCCCCCCCCCCCCCCCCCCCC5 /* oMLX.entitlements */,
+				1CCCCCCCCCCCCCCCCCCCCCC6 /* Assets.xcassets */,
+				BCC000000000000000000002 /* Localizable.xcstrings */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		1BBBBBBBBBBBBBBBBBBBBBB6 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1CCCCCCCCCCCCCCCCCCCCCC7 /* oMLX.app */,
+				DCC000000000000000000010 /* oMLXTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		1BBBBBBBBBBBBBBBBBBBBBB7 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				1CCCCCCCCCCCCCCCCCCCCCC8 /* PythonRuntime.swift */,
+				1CCCCCCCCCCCCCCCCCCCCCC9 /* ServerProcess.swift */,
+				4CC000000000000000000001 /* PortConflictResolver.swift */,
+				4CC000000000000000000002 /* SignalHandlers.swift */,
+				4CC000000000000000000003 /* AppControlServer.swift */,
+			);
+			path = Server;
+			sourceTree = "<group>";
+		};
+		2EE000000000000000000001 /* Theme */ = {
+			isa = PBXGroup;
+			children = (
+				2CC000000000000000000001 /* Theme.swift */,
+				2CC000000000000000000002 /* Squircle.swift */,
+				2CC000000000000000000003 /* Glass.swift */,
+				2EE000000000000000000002 /* Components */,
+			);
+			path = Theme;
+			sourceTree = "<group>";
+		};
+		2EE000000000000000000002 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				2CC000000000000000000004 /* Button.swift */,
+				AACFCBE32FE115A200B224C0 /* ProgressBar.swift */,
+				2CC000000000000000000005 /* Popup.swift */,
+				2CC000000000000000000006 /* TextInput.swift */,
+				2CC000000000000000000007 /* Segmented.swift */,
+				2CC000000000000000000008 /* ListGroup.swift */,
+				2CC000000000000000000009 /* Row.swift */,
+				2CC00000000000000000000A /* SectionHeader.swift */,
+				2CC00000000000000000000B /* StatusPill.swift */,
+				2CC00000000000000000000C /* CodeChip.swift */,
+				2CC00000000000000000000D /* ScreenScaffold.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		3EE000000000000000000001 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				3CC000000000000000000001 /* AppConfig.swift */,
+				3CC000000000000000000004 /* ShellEnvWriter.swift */,
+				3CC000000000000000000005 /* APIKeyGenerator.swift */,
+			);
+			path = Config;
 			sourceTree = "<group>";
 		};
 		6EE000000000000000000001 /* AppView */ = {
@@ -315,6 +362,33 @@
 				6EE000000000000000000002 /* Screens */,
 			);
 			path = AppView;
+			sourceTree = "<group>";
+		};
+		6EE000000000000000000002 /* Screens */ = {
+			isa = PBXGroup;
+			children = (
+				6CC000000000000000000004 /* ServerScreen.swift */,
+				6CC000000000000000000005 /* StatusScreen.swift */,
+				6CC000000000000000000006 /* LogsScreen.swift */,
+				6CC000000000000000000007 /* ModelsScreen.swift */,
+				6CC000000000000000000008 /* DownloadsScreen.swift */,
+				8CC000000000000000000004 /* ModelSettingsScreen.swift */,
+				8CC000000000000000000005 /* ChatTemplateKwargs.swift */,
+				8CC000000000000000000006 /* DflashByteSize.swift */,
+				8CC000000000000000000007 /* SystemMetrics.swift */,
+				8CC000000000000000000008 /* ProfileViews.swift */,
+				8CC000000000000000000009 /* ProfileWorkingState.swift */,
+				6CC000000000000000000009 /* IntegrationsScreen.swift */,
+				6CC00000000000000000000A /* SecurityScreen.swift */,
+				6CC00000000000000000000B /* AboutScreen.swift */,
+				6CC00000000000000000000C /* QuantizationScreen.swift */,
+				6CC00000000000000000000D /* ThroughputBenchScreen.swift */,
+				6CC00000000000000000000E /* AccuracyBenchScreen.swift */,
+				6CC00000000000000000000F /* NetworkScreen.swift */,
+				6CC000000000000000000010 /* PerformanceScreen.swift */,
+				DCC000000000000000000102 /* ModelCardSheet.swift */,
+			);
+			path = Screens;
 			sourceTree = "<group>";
 		};
 		7EE000000000000000000001 /* Net */ = {
@@ -358,120 +432,49 @@
 			path = Updater;
 			sourceTree = "<group>";
 		};
-		6EE000000000000000000002 /* Screens */ = {
+		AEE000000000000000000001 /* Welcome */ = {
 			isa = PBXGroup;
 			children = (
-				6CC000000000000000000004 /* ServerScreen.swift */,
-				6CC000000000000000000005 /* StatusScreen.swift */,
-				6CC000000000000000000006 /* LogsScreen.swift */,
-				6CC000000000000000000007 /* ModelsScreen.swift */,
-				6CC000000000000000000008 /* DownloadsScreen.swift */,
-				8CC000000000000000000004 /* ModelSettingsScreen.swift */,
-				8CC000000000000000000005 /* ChatTemplateKwargs.swift */,
-				8CC000000000000000000006 /* DflashByteSize.swift */,
-				8CC000000000000000000007 /* SystemMetrics.swift */,
-				8CC000000000000000000008 /* ProfileViews.swift */,
-				8CC000000000000000000009 /* ProfileWorkingState.swift */,
-				6CC000000000000000000009 /* IntegrationsScreen.swift */,
-				6CC00000000000000000000A /* SecurityScreen.swift */,
-				6CC00000000000000000000B /* AboutScreen.swift */,
-				6CC00000000000000000000C /* QuantizationScreen.swift */,
-				6CC00000000000000000000D /* ThroughputBenchScreen.swift */,
-				6CC00000000000000000000E /* AccuracyBenchScreen.swift */,
-				6CC00000000000000000000F /* NetworkScreen.swift */,
-				6CC000000000000000000010 /* PerformanceScreen.swift */,
-				DCC000000000000000000102 /* ModelCardSheet.swift */,
+				ACC000000000000000000001 /* WelcomeWindow.swift */,
 			);
-			path = Screens;
+			path = Welcome;
 			sourceTree = "<group>";
 		};
-		3EE000000000000000000001 /* Config */ = {
+		DEE000000000000000000001 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				3CC000000000000000000001 /* AppConfig.swift */,
-				3CC000000000000000000004 /* ShellEnvWriter.swift */,
-				3CC000000000000000000005 /* APIKeyGenerator.swift */,
+				DEE000000000000000000002 /* oMLXTests */,
 			);
-			path = Config;
+			path = Tests;
 			sourceTree = "<group>";
 		};
-		2EE000000000000000000001 /* Theme */ = {
+		DEE000000000000000000002 /* oMLXTests */ = {
 			isa = PBXGroup;
 			children = (
-				2CC000000000000000000001 /* Theme.swift */,
-				2CC000000000000000000002 /* Squircle.swift */,
-				2CC000000000000000000003 /* Glass.swift */,
-				2EE000000000000000000002 /* Components */,
+				DCC000000000000000000001 /* AppServicesPathTests.swift */,
+				DCC000000000000000000002 /* AppConfigTests.swift */,
+				DCC000000000000000000003 /* ServerScreenVMStorageDiffTests.swift */,
+				DCC000000000000000000004 /* ProfileDTODecodeTests.swift */,
+				DCC000000000000000000005 /* SamplingValidatorTests.swift */,
+				DCC000000000000000000006 /* APIKeyGeneratorTests.swift */,
+				DCC000000000000000000007 /* ChatTemplateKwargsCodecTests.swift */,
+				DCC000000000000000000008 /* DflashByteSizeTests.swift */,
+				DCC000000000000000000009 /* GlobalSettingsSamplingTests.swift */,
+				DCC00000000000000000000A /* ProfileScopeTests.swift */,
+				DCC00000000000000000000B /* SystemMetricsTests.swift */,
+				DCC00000000000000000000C /* WelcomeViewModelTests.swift */,
+				DCC00000000000000000000D /* DTOFixtureTests.swift */,
+				DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */,
+				DCC00000000000000000000F /* LocalizationSmokeTests.swift */,
+				DCC000000000000000000100 /* MenubarControllerPortTests.swift */,
+				DCC000000000000000000103 /* ModelCardDTODecodeTests.swift */,
+				DCC000000000000000000104 /* ShellEnvWriterTests.swift */,
+				DCC000000000000000000105 /* ThemeTests.swift */,
+				DCC000000000000000000106 /* ReleasesCheckerTests.swift */,
+				DCC000000000000000000107 /* ModelsScreenSortingTests.swift */,
+				DCC000000000000000000108 /* ModelSettingsScreenVMTests.swift */,
 			);
-			path = Theme;
-			sourceTree = "<group>";
-		};
-		2EE000000000000000000002 /* Components */ = {
-			isa = PBXGroup;
-			children = (
-				2CC000000000000000000004 /* Button.swift */,
-				2CC000000000000000000005 /* Popup.swift */,
-				2CC000000000000000000006 /* TextInput.swift */,
-				2CC000000000000000000007 /* Segmented.swift */,
-				2CC000000000000000000008 /* ListGroup.swift */,
-				2CC000000000000000000009 /* Row.swift */,
-				2CC00000000000000000000A /* SectionHeader.swift */,
-				2CC00000000000000000000B /* StatusPill.swift */,
-				2CC00000000000000000000C /* CodeChip.swift */,
-				2CC00000000000000000000D /* ScreenScaffold.swift */,
-			);
-			path = Components;
-			sourceTree = "<group>";
-		};
-		1BBBBBBBBBBBBBBBBBBBBBB7 /* Server */ = {
-			isa = PBXGroup;
-			children = (
-				1CCCCCCCCCCCCCCCCCCCCCC8 /* PythonRuntime.swift */,
-				1CCCCCCCCCCCCCCCCCCCCCC9 /* ServerProcess.swift */,
-				4CC000000000000000000001 /* PortConflictResolver.swift */,
-				4CC000000000000000000002 /* SignalHandlers.swift */,
-				4CC000000000000000000003 /* AppControlServer.swift */,
-			);
-			path = Server;
-			sourceTree = "<group>";
-		};
-		1BBBBBBBBBBBBBBBBBBBBBB3 /* App */ = {
-			isa = PBXGroup;
-			children = (
-				1CCCCCCCCCCCCCCCCCCCCCC1 /* oMLXApp.swift */,
-				1CCCCCCCCCCCCCCCCCCCCCC2 /* AppDelegate.swift */,
-			);
-			path = App;
-			sourceTree = "<group>";
-		};
-		1BBBBBBBBBBBBBBBBBBBBBB4 /* Menubar */ = {
-			isa = PBXGroup;
-			children = (
-				1CCCCCCCCCCCCCCCCCCCCCC3 /* MenubarController.swift */,
-				3CC000000000000000000002 /* MenubarStatsPoller.swift */,
-				3CC000000000000000000003 /* MenubarVisibilityWatcher.swift */,
-			);
-			path = Menubar;
-			sourceTree = "<group>";
-		};
-		1BBBBBBBBBBBBBBBBBBBBBB5 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				1CCCCCCCCCCCCCCCCCCCCCC4 /* Info.plist */,
-				1CCCCCCCCCCCCCCCCCCCCCC5 /* oMLX.entitlements */,
-				1CCCCCCCCCCCCCCCCCCCCCC6 /* Assets.xcassets */,
-				BCC000000000000000000002 /* Localizable.xcstrings */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		1BBBBBBBBBBBBBBBBBBBBBB6 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				1CCCCCCCCCCCCCCCCCCCCCC7 /* oMLX.app */,
-				DCC000000000000000000010 /* oMLXTests.xctest */,
-			);
-			name = Products;
+			path = oMLXTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -489,11 +492,11 @@
 			);
 			dependencies = (
 			);
-			name = "oMLX";
+			name = oMLX;
 			packageProductDependencies = (
 				ECC000000000000000000001 /* MarkdownUI */,
 			);
-			productName = "oMLX";
+			productName = oMLX;
 			productReference = 1CCCCCCCCCCCCCCCCCCCCCC7 /* oMLX.app */;
 			productType = "com.apple.product-type.application";
 		};
@@ -629,6 +632,7 @@
 				DBB000000000000000000101 /* ModelCardDTO.swift in Sources */,
 				DBB000000000000000000102 /* ModelCardSheet.swift in Sources */,
 				9BB000000000000000000006 /* PresetBundleStore.swift in Sources */,
+				AACFCBE42FE115A200B224C0 /* ProgressBar.swift in Sources */,
 				8BB000000000000000000004 /* ModelSettingsScreen.swift in Sources */,
 				8BB000000000000000000005 /* ChatTemplateKwargs.swift in Sources */,
 				8BB000000000000000000006 /* DflashByteSize.swift in Sources */,
@@ -808,7 +812,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = "Resources/oMLX.entitlements";
+				CODE_SIGN_ENTITLEMENTS = Resources/oMLX.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -816,14 +820,14 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "Resources/Info.plist";
+				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 0.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = "app.omlx";
+				PRODUCT_BUNDLE_IDENTIFIER = app.omlx;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
@@ -834,7 +838,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = "Resources/oMLX.entitlements";
+				CODE_SIGN_ENTITLEMENTS = Resources/oMLX.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -842,14 +846,14 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = "Resources/Info.plist";
+				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 0.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = "app.omlx";
+				PRODUCT_BUNDLE_IDENTIFIER = app.omlx;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
@@ -865,7 +869,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "app.omlx.tests";
+				PRODUCT_BUNDLE_IDENTIFIER = app.omlx.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 6.0;
@@ -882,7 +886,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "app.omlx.tests";
+				PRODUCT_BUNDLE_IDENTIFIER = app.omlx.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 6.0;


### PR DESCRIPTION
This Pull Request addresses the requirements outlined in Issue #1632 by consolidating a sequence of refactoring and build changes aimed at removing hand-rolled UI primitives in favor of their first-party SwiftUI counterparts.

The app's visual language aligns more closely with macOS system conventions, and the component surface that needs ongoing maintenance shrinks substantially. No user-visible behavior is changed unless noted.

See the attached images below for the visual comparison before and after this refactoring (running on macOS 27 Golden Gate).

<img width="2560" height="1440" alt="Accuracy" src="https://github.com/user-attachments/assets/e85af7ed-acf3-433c-bb92-e3f2f9ea6f15" />
<img width="2560" height="1440" alt="Logs" src="https://github.com/user-attachments/assets/76d25157-ef83-4438-9f39-6da14d2aded7" />
<img width="2560" height="1440" alt="Model Settings" src="https://github.com/user-attachments/assets/d685fd24-5ac0-49cf-a2bf-dfd0ce242170" />
<img width="2560" height="1440" alt="Quantization" src="https://github.com/user-attachments/assets/b7572dc0-0232-446a-9fa8-8de370663c49" />
