### PR TITLE
fix(thinking): stop budget-forced close from leaking a second </think> (#1864)

### DIFF
--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -28,6 +28,13 @@ _THINKING_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
 # Handle case where <think> is missing but </think> is present
 # (scheduler prepends <think>\n but the tag may be split)
 _THINKING_TAIL_PATTERN = re.compile(r'^(.*?)</think>', re.DOTALL)
+# Collapse the blank-line gap left after an orphan </think> tag is removed
+# (the forced close is written as ``\n</think>\n\n``).  Deliberately a simple
+# ``\n{3,}`` and NOT a pattern with a leading ``[ \t]*``/``\s*`` quantifier:
+# an unbounded whitespace prefix makes re.sub O(n^2) on a long run (quadratic
+# ReDoS), and model output is untrusted and can degenerate into whitespace
+# repetition. ``\n{3,}`` has no backtracking ambiguity and scans linearly.
+_COLLAPSE_BLANK_LINES = re.compile(r'\n{3,}')
 
 
 def _safe_tokenizer_attr(tokenizer, attr: str, default=None):
@@ -142,6 +149,26 @@ def prompt_opens_thinking(
     return True, think_tag
 
 
+def _strip_orphan_close_tags(content: str) -> str:
+    """Remove stray ``</think>`` tags left in answer content.
+
+    Called only after the thinking block(s) have already been extracted, so
+    any ``</think>`` still present is an orphan — most often the close the
+    model emits on its own after a budget-forced close (#1864).
+
+    Implemented as a linear ``str.replace`` plus a blank-line collapse rather
+    than a single regex: ``content`` is untrusted model output, and a regex
+    that tries to absorb the surrounding whitespace with a leading quantifier
+    backtracks quadratically on long whitespace runs (ReDoS).  Dropping the
+    literal tag turns the forced-close wrapper ``\\n</think>\\n\\n`` into a
+    ``\\n\\n\\n`` gap, which the collapse trims back to a paragraph break; a
+    bare inline ``</think>`` simply vanishes with no stray newline.
+    """
+    if '</think>' not in content:
+        return content
+    return _COLLAPSE_BLANK_LINES.sub('\n\n', content.replace('</think>', ''))
+
+
 def extract_thinking(text: str) -> Tuple[str, str]:
     """Extract thinking and content from complete text.
 
@@ -191,14 +218,14 @@ def extract_thinking(text: str) -> Tuple[str, str]:
 
     if thinking_parts:
         thinking = "\n".join(thinking_parts).strip()
-        return (thinking, remaining.strip())
+        return (thinking, _strip_orphan_close_tags(remaining).strip())
 
     # Handle partial: content before </think> without <think> tag
     if '</think>' in text and '<think>' not in text:
         match = _THINKING_TAIL_PATTERN.match(text)
         if match:
             thinking = match.group(1).strip()
-            remaining = text[match.end():].strip()
+            remaining = _strip_orphan_close_tags(text[match.end():]).strip()
             return (thinking, remaining)
 
     # Malformed: <think> opened but never closed. Drop the open tag and
@@ -392,8 +419,10 @@ class ThinkingBudgetProcessor:
     """Logits processor that enforces a thinking token budget.
 
     Counts tokens generated while in thinking mode.  When the budget is
-    exceeded, forces the close-think token(s) one at a time, then becomes
-    a no-op for the rest of generation.
+    exceeded, forces the close-think token(s) one at a time.  Afterwards,
+    for a single-token close, it masks that close token for the rest of
+    generation so the cut-off model cannot emit a second, literal
+    ``</think>`` into the answer (issue #1864); otherwise it is a no-op.
 
     Handles both single-token and multi-token close-think sequences, and
     supports alternative think markers (e.g. ``<longcat_think>``).
@@ -432,6 +461,14 @@ class ThinkingBudgetProcessor:
         self._force_idx: int = 0
         self._done: bool = False
         self._first_call: bool = True
+        # After a *forced* close, the model has been cut off mid-thought and
+        # tends to keep reasoning and then emit its own ``</think>``.  That
+        # second close leaks into the answer as a literal tag (issue #1864).
+        # Once we force the close, suppress further close-tag tokens until the
+        # model re-enters a thinking block, so it cannot emit a duplicate.
+        # Only set after a forced close — a natural close means the model
+        # finished on its own and needs no muzzle.
+        self._suppress_reclose: bool = False
         # Sliding window for multi-token end detection
         self._recent_tokens: List[int] = []
         self._last_token_utf8_complete: bool = True
@@ -453,6 +490,23 @@ class ThinkingBudgetProcessor:
 
         # If state changed by _update_state, handle immediately
         if self._done:
+            # After a forced close, mask the close-tag token so the model
+            # cannot emit a second, literal ``</think>`` into the answer
+            # (issue #1864).  Skip this if the model has re-entered thinking,
+            # where a legitimate close is expected again.
+            #
+            # Only for a single-token close: that token is a dedicated </think>
+            # sentinel, safe to ban for the rest of generation.  A multi-token
+            # close decomposes into ordinary subwords (e.g. "</", "think", ">")
+            # that recur in normal text, so masking them would corrupt the
+            # answer — those models fall back to the parser-side orphan strip
+            # in extract_thinking() instead.
+            if (
+                self._suppress_reclose
+                and not self._in_thinking
+                and len(self._think_end_ids) == 1
+            ):
+                return self._suppress_reclose_tokens(logits, mx)
             return logits
 
         if self._forcing:
@@ -484,6 +538,8 @@ class ThinkingBudgetProcessor:
                 self._done = False
                 self._thinking_tokens = 0
                 self._recent_tokens = []
+                # Re-entered thinking: a future close is legitimate again.
+                self._suppress_reclose = False
             return
 
         if self._forcing:
@@ -492,6 +548,9 @@ class ThinkingBudgetProcessor:
                 self._in_thinking = False
                 self._forcing = False
                 self._done = True
+                # Forced close finished — muzzle any further close tags so the
+                # model cannot leak a second ``</think>`` into the answer (#1864).
+                self._suppress_reclose = True
             return
 
         # Detect natural close-think via sliding window
@@ -521,6 +580,7 @@ class ThinkingBudgetProcessor:
         if not self._in_thinking and self._think_start_id and token_id == self._think_start_id:
             self._in_thinking = True
             self._done = False
+            self._suppress_reclose = False
             self._thinking_tokens = 0
             self._recent_tokens = []
 
@@ -557,6 +617,20 @@ class ThinkingBudgetProcessor:
         forced[..., target_id] = 0.0
         return forced
 
+    def _suppress_reclose_tokens(self, logits, mx):
+        """Mask the close-think token so a forced-closed block stays closed.
+
+        Sets only the close-tag id(s) to -inf (not the leading/trailing
+        whitespace tokens), leaving the rest of the distribution untouched so
+        the model still picks its real answer tokens normally.  Only reached
+        for a single-token close (see ``__call__``), so this never bans an
+        ordinary subword.  The assignment is in-place: the mlx-lm processor
+        chain passes a fresh logits array per step and does not alias it.
+        """
+        for tid in self._think_end_ids:
+            logits[..., tid] = float("-inf")
+        return logits
+
     # -- Speculative-decoding (vlm_mtp) support -----------------------------
     #
     # The vlm_mtp decode path applies this processor inside mlx-vlm's
@@ -575,6 +649,12 @@ class ThinkingBudgetProcessor:
         "_force_idx",
         "_done",
         "_first_call",
+        # Part of the post-forced-close muzzle (#1864): if this were left out
+        # of the snapshot, a rejected draft suffix would rewind every other
+        # field but keep the muzzle state from the discarded positions, so a
+        # forced close inside the rejected suffix would keep suppressing the
+        # close tag after the rewind (or vice versa).
+        "_suppress_reclose",
         "_recent_tokens",
         "_last_token_utf8_complete",
         "_pending_utf8",

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -112,6 +112,53 @@ class TestExtractThinking:
         assert thinking == "thought process"
         assert content == "visible answer"
 
+    def test_orphan_close_tag_stripped_from_content_with_open(self):
+        """Regression for #1864: after a thinking_budget force-close, the model
+        keeps reasoning and emits its OWN ``</think>`` later. With a leading
+        ``<think>``, the first pair is extracted but the second close was
+        leaking into the answer as a literal tag. It must be stripped."""
+        thinking, content = extract_thinking(
+            "<think>reasoning</think>spilled text\n</think>\n\nfinal answer"
+        )
+        assert thinking == "reasoning"
+        assert "</think>" not in content
+        assert content == "spilled text\n\nfinal answer"
+
+    def test_orphan_close_tag_stripped_from_content_tail_branch(self):
+        """Regression for #1864 on the partial-tail branch (prompt pre-opened
+        ``<think>``, no open tag in output): the model's second, self-emitted
+        ``</think>`` must not survive in the answer body."""
+        thinking, content = extract_thinking(
+            "reasoning</think>answer body\n</think>\n\nanswer body dup"
+        )
+        assert thinking == "reasoning"
+        assert "</think>" not in content
+        assert content == "answer body\n\nanswer body dup"
+
+    def test_orphan_close_tag_inline_stripped_without_stray_newline(self):
+        """A bare inline orphan ``</think>`` (no surrounding newlines) is
+        removed outright — it must not inject a stray newline mid-text."""
+        thinking, content = extract_thinking(
+            "<think>reasoning</think>foo</think>bar"
+        )
+        assert thinking == "reasoning"
+        assert content == "foobar"
+
+    def test_orphan_close_strip_is_linear_on_whitespace_runs(self):
+        """ReDoS guard: orphan-tag cleanup must stay linear on untrusted model
+        output. A leading ``[ \\t]*`` quantifier made this O(n^2) on long
+        whitespace runs (a degenerate-repetition / injection DoS). A 200k-char
+        run plus a ``</think>`` must finish near-instantly."""
+        import time
+
+        payload = "<think>x</think>" + (" " * 200_000) + "y</think>"
+        start = time.perf_counter()
+        _, content = extract_thinking(payload)
+        elapsed = time.perf_counter() - start
+        assert "</think>" not in content
+        # Linear scan is well under 100ms; the quadratic version took ~120s.
+        assert elapsed < 1.0, f"orphan strip too slow ({elapsed:.2f}s) — ReDoS?"
+
 
 class TestThinkingParser:
     """Tests for streaming ThinkingParser."""

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -82,7 +82,9 @@ class TestThinkingBudgetProcessor:
         assert other_logit == float("-inf")
 
     def test_done_after_forced_sequence(self):
-        """After forcing the close sequence, processor should become a no-op."""
+        """After forcing the close sequence the processor stops forcing and,
+        per #1864, masks only the close-think token (to block a duplicate
+        close) while leaving every other logit untouched."""
         proc = self._make_processor(budget=1)
 
         # Call 1 (first_call): budget=1, forcing starts → forces THINK_END_ID
@@ -94,7 +96,9 @@ class TestThinkingBudgetProcessor:
         logits = proc(_make_tokens(10, self.THINK_END_ID), _make_logits())
         assert proc._done
         assert not proc._forcing
-        assert mx.array_equal(logits, _make_logits())
+        # Close token masked; all other positions left as-is.
+        assert logits[0, self.THINK_END_ID].item() == float("-inf")
+        assert logits[0, 0].item() == 0.0
 
     def test_trailing_tokens_forced_after_end(self):
         """Trailing tokens (e.g. \\n) should be forced after </think>."""
@@ -111,10 +115,12 @@ class TestThinkingBudgetProcessor:
         assert proc._forcing
         assert logits1[0, self.NEWLINE_ID].item() == 0.0
 
-        # Call 3: _force_idx advances to 2 == len([42, 99]) → done
+        # Call 3: _force_idx advances to 2 == len([42, 99]) → done.
+        # Close token masked afterwards (#1864); trailing/other tokens free.
         logits2 = proc(_make_tokens(10, self.THINK_END_ID, self.NEWLINE_ID), _make_logits())
         assert proc._done
-        assert mx.array_equal(logits2, _make_logits())
+        assert logits2[0, self.THINK_END_ID].item() == float("-inf")
+        assert logits2[0, self.NEWLINE_ID].item() == 0.0
 
     def test_natural_end_before_budget(self):
         """If model produces </think> naturally, processor becomes no-op."""
@@ -131,6 +137,70 @@ class TestThinkingBudgetProcessor:
         original = _make_logits()
         result = proc(_make_tokens(10, self.THINK_END_ID, 50), original)
         assert mx.array_equal(result, original)
+
+    def test_suppresses_reclose_after_forced_close(self):
+        """Regression for #1864: after the budget force-closes thinking, the
+        model tends to keep reasoning and emit its OWN </think>, which leaks
+        into the answer. Once the forced close completes, the close-think
+        token must be masked to -inf so a duplicate can't be generated."""
+        proc = self._make_processor(budget=1)
+
+        # Call 1 (first_call): budget=1 → forces THINK_END_ID.
+        proc(_make_tokens(10), _make_logits())
+        assert proc._forcing
+        # Call 2: force_sequence = [THINK_END_ID] only → forcing completes.
+        proc(_make_tokens(10, self.THINK_END_ID), _make_logits())
+        assert proc._done
+        assert proc._suppress_reclose
+
+        # Subsequent calls must muzzle the close token while leaving the rest
+        # of the distribution untouched (model still picks real answer tokens).
+        result = proc(_make_tokens(10, self.THINK_END_ID, 70), _make_logits())
+        assert result[0, self.THINK_END_ID].item() == float("-inf")
+        assert result[0, 0].item() == 0.0  # other tokens unchanged
+
+    def test_natural_close_does_not_suppress_reclose(self):
+        """A natural close means the model finished on its own — it must NOT
+        be muzzled (only budget-forced closes are, per #1864)."""
+        proc = self._make_processor(budget=100)
+        proc(_make_tokens(10), _make_logits())
+        proc(_make_tokens(10, self.THINK_END_ID), _make_logits())
+        assert proc._done
+        assert not proc._suppress_reclose
+        original = _make_logits()
+        result = proc(_make_tokens(10, self.THINK_END_ID, 50), original)
+        assert mx.array_equal(result, original)
+
+    def test_reclose_suppression_clears_on_think_reentry(self):
+        """If the model re-opens a thinking block after a forced close, a
+        future close is legitimate again, so suppression must clear."""
+        proc = self._make_processor(budget=1)
+        proc(_make_tokens(10), _make_logits())
+        proc(_make_tokens(10, self.THINK_END_ID), _make_logits())
+        assert proc._suppress_reclose
+
+        # Model emits <think> again → re-entered thinking, suppression cleared.
+        proc(_make_tokens(10, self.THINK_END_ID, self.THINK_START_ID), _make_logits())
+        assert proc._in_thinking
+        assert not proc._suppress_reclose
+
+    def test_multi_token_close_is_not_suppressed(self):
+        """#1864 guard: a multi-token close (subwords like "</", "think", ">")
+        must NOT be masked after a forced close — banning those ids would
+        corrupt the answer. Multi-token models rely on the parser-side strip."""
+        end_ids = [50, 51, 52]
+        proc = self._make_processor(budget=1, end_ids=end_ids)
+        # Drive the full forced close: budget hit, then 50, 51, 52.
+        proc(_make_tokens(10), _make_logits())
+        proc(_make_tokens(10, 50), _make_logits())
+        proc(_make_tokens(10, 50, 51), _make_logits())
+        proc(_make_tokens(10, 50, 51, 52), _make_logits())
+        assert proc._done and proc._suppress_reclose
+
+        # Next step must leave every close-component logit untouched.
+        result = proc(_make_tokens(10, 50, 51, 52, 70), _make_logits())
+        for tid in end_ids:
+            assert result[0, tid].item() == 0.0
 
     def test_first_call_skips_state_update(self):
         """First call should not check tokens[-1] for state transitions."""
@@ -166,9 +236,14 @@ class TestThinkingBudgetProcessor:
         assert logits2[0, 52].item() == 0.0
 
         # Call 4: _force_idx advances to 3 == len(end_ids), then becomes done.
+        # A multi-token close decomposes into ordinary subwords, so the #1864
+        # re-close suppression is NOT applied here (it would ban real answer
+        # tokens) — the processor is a pure no-op afterwards.
         logits3 = proc(_make_tokens(10, 50, 51, 52), _make_logits())
         assert proc._done
         assert not proc._forcing
+        # Flag is set, but the single-token gate in __call__ skips masking.
+        assert proc._suppress_reclose
         assert mx.array_equal(logits3, _make_logits())
 
     def test_waits_for_utf8_completion_before_forcing(self):


### PR DESCRIPTION
Fixes #1864.

## The bug

With a `thinking_budget` set, a low budget force-closes the `<think>` block mid-thought. The model, unaware it was cut off, keeps reasoning and then emits its **own** `</think>` later. Because the reasoning/answer split happens at the *first* (forced) close, everything after it lands in the answer: the model's continued deliberation, a duplicated answer, and a literal `</think>` tag visible in `content`.

## Repro

Driven live on `Qwen3.6-35B-A3B-4bit` at `thinking_budget=128`, temp 0, via `/v1/chat/completions` and in-process `stream_generate`:

- Cyrillic and English math prompts both produced `content` ending with a literal `</think>` followed by a duplicated answer.
- Two refinements to the original report:
  - It is **not** Cyrillic-specific. It reproduces in English too. The real trigger is "natural thinking length much greater than budget", which low budgets guarantee.
  - The "UTF-8 boundary wait" hypothesis is not the cause here: on a byte-level BPE tokenizer the piece lookup returns a `str`, so `_is_utf8_complete` always returns `True` and that path is inert. The failure is the double close.

## The fix (two layers)

1. **`ThinkingBudgetProcessor`**: after a *forced* close completes, mask the close token for the rest of generation so the model cannot emit a duplicate `</think>`. Cleared when the model legitimately re-enters a thinking block. Gated to **single-token** closes, where the token is a dedicated `</think>` sentinel that is always safe to ban. Multi-token closes decompose into ordinary subwords (e.g. `"</"`, `"think"`, `">"`) that recur in normal text, so masking them would corrupt the answer; those models rely on layer 2 instead.
2. **`extract_thinking`**: strip any orphan `</think>` from answer content as a backstop (covers multi-token-close models and any non-suppressed path). Implemented as a linear `str.replace` plus a `\n{3,}` collapse rather than a regex with a leading whitespace quantifier, which backtracks quadratically on untrusted model output (ReDoS).

EOS is never masked, so termination and `max_tokens` are unaffected. The streaming `ThinkingParser` already consumed stray closes, so no change was needed there.

## Verification

- After the fix, the literal-tag leak and the answer duplication are both gone across the repro prompts (Cyrillic math, English math, Cyrillic poem, budget=64 explain).
- New regression tests: re-close suppression after a forced close, no suppression after a natural close, suppression cleared on re-entry, multi-token close left untouched, orphan-strip on both `extract_thinking` branches, inline strip without stray newline, and a ReDoS guard (200k-char whitespace payload completes well under 1s; the pre-fix regex took ~120s).
- Full suite: 5849 passed, 22 skipped.

Note: reasoning that spills after a hard cut still goes to the answer (inherent to truncating the model mid-thought); this PR removes the literal tag and the duplication, not the spilled text itself. The strip also removes a `</think>` a model legitimately wrote in its answer when a thinking block is also present, matching the existing streaming parser behavior.