### PR TITLE
fix: change VLM MTP draft block_size default from 4 to 3

### DIFF
--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -957,7 +957,7 @@
                                                min="1"
                                                max="16"
                                                x-model.number="modelSettings.vlm_mtp_draft_block_size"
-                                               placeholder="4"
+                                               placeholder="3"
                                                class="w-full px-3 py-2 text-sm border border-neutral-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-black" />
                                     </div>
                                 </div>

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6099,7 +6099,7 @@ class Scheduler:
             return
         total_accepted = sum(lens)
         block_size = self._vlm_mtp_draft_block_size or int(
-            getattr(drafter.model.config, "block_size", 4)
+            getattr(drafter.model.config, "block_size", 3)
         )
         max_per_round = max(1, block_size - 1)
         acceptance_rate = total_accepted / (rounds * max_per_round)


### PR DESCRIPTION
## Problem

The backend fallback and frontend placeholder for `vlm_mtp_draft_block_size` were hardcoded to 4, but benchmark data shows 4 is suboptimal for all tested models. When a draft model's config lacks a `block_size` field (e.g. `gemma-4-26B-A4B-it-assistant`), the fallback value of 4 causes an 8% throughput regression vs the optimal value.

Some draft models (e.g. Qwen3.6-35B-A3B-MTP) provide `block_size` in their config and are unaffected by this fallback. Others (e.g. gemma-4-26B-A4B-it-assistant) do not, making 3 a safer default.

## Benchmark Results

**Target: Qwen3.6-35B-A3B-UD-MLX-4bit** (drafter: Qwen3.6-35B-A3B-MTP-bf16, config has `block_size=3`)

| block_size | accept rate | tokens/round | speed (tok/s) | delta |
|:---:|:---:|:---:|:---:|:---:|
| 2 | 86.1% | 1.86 | ~109 | -13% |
| **3** | **76.2%** | **2.52** | **~125** | **baseline** |
| 4 | 61.5% | 2.84 | ~118 | -6% |
| 5 | 51.2% | 3.05 | ~110 | -12% |

**Target: gemma-4-26B-A4B-it-MLX-4bit** (drafter: gemma-4-26B-A4B-it-assistant-bf16, config has no `block_size`)

| block_size | accept rate | tokens/round | speed (tok/s) | delta |
|:---:|:---:|:---:|:---:|:---:|
| **2** | **71.1%** | **1.71** | **~109** | **baseline** |
| 3 | 60.9% | 2.22 | ~108 | -1% |
| 4 | 50.8% | 2.52 | ~100 | -8% |

## Changes

- `omlx/scheduler.py`: fallback `4` → `3`
- `omlx/admin/templates/dashboard/_modal_model_settings.html`: placeholder `4` → `3`
