### PR TITLE
fix(cache): enforce SSD cache limit across model switches (#1915)

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -1332,9 +1332,16 @@ class PagedSSDCacheManager(CacheManager):
         """Scan cache directory for existing files and build the compatible index.
 
         Only blocks compatible with the currently loaded model/layout are
-        indexed. Incompatible blocks are left on disk so a shared SSD cache
+        indexed.  Incompatible blocks are left on disk so a shared SSD cache
         directory can safely serve multiple loaded models without one model's
         startup scan deleting another model's cache.
+
+        When the total disk usage of the cache directory exceeds the
+        configured limit, incompatible blocks are evicted (oldest first)
+        to reclaim space.  This prevents the runaway growth reported in
+        https://github.com/jundot/omlx/issues/1915 where switching models
+        causes the cache to exceed its configured limit because each model's
+        manager only tracks its own compatible blocks.
         """
         logger.info(f"Scanning SSD cache directory: {self._cache_dir}")
 
@@ -1343,6 +1350,8 @@ class PagedSSDCacheManager(CacheManager):
         skipped_incompatible = 0
         skipped_incompatible_bytes = 0
         errors = 0
+        # Collect incompatible blocks for potential cleanup (oldest first).
+        incompatible: list[PagedSSDBlockMetadata] = []
 
         for subdir in self.SUBDIR_CHARS:
             subdir_path = self._cache_dir / subdir
@@ -1358,6 +1367,7 @@ class PagedSSDCacheManager(CacheManager):
                     if not self._is_compatible_block(metadata):
                         skipped_incompatible += 1
                         skipped_incompatible_bytes += metadata.file_size
+                        incompatible.append(metadata)
                         continue
                     self._index.add(metadata)
                     indexed += 1
@@ -1375,6 +1385,74 @@ class PagedSSDCacheManager(CacheManager):
                 f"({format_bytes(skipped_incompatible_bytes)})"
             )
         logger.info(log_msg)
+
+        # If incompatible blocks push the cache directory over the configured
+        # limit, evict them (oldest last_access first) until within budget.
+        if incompatible:
+            self._cleanup_incompatible_blocks(incompatible)
+
+    def _cleanup_incompatible_blocks(
+        self,
+        incompatible: list[PagedSSDBlockMetadata],
+    ) -> None:
+        """Remove incompatible blocks when the cache directory is over limit.
+
+        Incompatible blocks are files left on disk by other models that are
+        not tracked in this manager's index.  Without cleanup they are
+        invisible to the LRU eviction logic and accumulate unboundedly when
+        switching between models (issue #1915).
+
+        Blocks are removed oldest-first (by ``last_access``) until the
+        on-disk usage drops to within the configured limit.
+        """
+        if self._cache_dir is None:
+            return
+
+        effective_max = self._get_effective_max_size()
+        # Derive total on-disk cache size: compatible blocks (in index)
+        # + incompatible blocks (from other models, passed in as argument).
+        total_on_disk = self._index.total_size + sum(
+            m.file_size for m in incompatible
+        )
+
+        if total_on_disk <= effective_max:
+            return  # Within budget, nothing to do.
+
+        # Sort incompatible blocks oldest-first so we evict the least
+        # recently used from other models first.
+        incompatible.sort(key=lambda m: m.last_access)
+
+        bytes_to_free = total_on_disk - effective_max
+        freed = 0
+        removed = 0
+        for metadata in incompatible:
+            if freed >= bytes_to_free:
+                break
+            try:
+                if metadata.file_path.exists():
+                    metadata.file_path.unlink()
+                    freed += metadata.file_size
+                    removed += 1
+                    logger.debug(
+                        f"Evicted incompatible SSD cache block: "
+                        f"{metadata.file_path.name} "
+                        f"({format_bytes(metadata.file_size)})"
+                    )
+            except OSError as e:
+                logger.warning(
+                    f"Failed to delete incompatible cache file "
+                    f"{metadata.file_path}: {e}"
+                )
+
+        if removed > 0:
+            logger.info(
+                f"Cleaned up {removed} incompatible SSD cache blocks, "
+                f"freed {format_bytes(freed)}"
+            )
+            # Invalidate disk usage cache so next effective_max reflects
+            # the reclaimed space.
+            with self._lock:
+                self._disk_usage_cache = None
 
     def _is_compatible_block(self, metadata: PagedSSDBlockMetadata) -> bool:
         """Return True when a block can be indexed for this manager."""
@@ -2932,9 +3010,10 @@ class PagedSSDCacheManager(CacheManager):
         """Get effective max size considering actual disk free space.
 
         Returns the minimum of configured max_size and 99% of disk space
-        available for cache (current cache size + disk free). This ensures
-        eviction triggers before the disk fills up even when other processes
-        consume disk space after the server started.
+        available for cache.  Uses ``shutil.disk_usage().used`` to account
+        for *all* files in the cache directory (including blocks from other
+        models that are not in this manager's index), so the limit is
+        enforced correctly even after switching models.
 
         Uses a 30-second TTL cache for shutil.disk_usage() results.
         """
@@ -2960,10 +3039,14 @@ class PagedSSDCacheManager(CacheManager):
                     )
                     return self._max_size
                 self._disk_usage_cache_time = now
-            disk_free = self._disk_usage_cache.free
+            usage = self._disk_usage_cache
 
-        disk_available = self._index.total_size + disk_free
-        disk_limit = int(disk_available * self._DISK_SAFE_RATIO)
+        # ``disk_limit`` is the largest the cache is allowed to grow.
+        # Using ``used`` instead of ``index.total_size`` means blocks from
+        # other models that are on disk but not in *this* index are counted
+        # against the budget, preventing the runaway growth described in
+        # https://github.com/jundot/omlx/issues/1915.
+        disk_limit = int((usage.used + usage.free) * self._DISK_SAFE_RATIO)
         return min(self._max_size, disk_limit)
 
     def _enforce_size_limit_for_new_block(

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -1847,12 +1847,12 @@ class TestEffectiveMaxSize:
             max_size_bytes=110 * 1024**3,  # 110GB configured
         )
 
-        # Simulate: cache currently has 10GB, disk free is 90GB
-        # So disk_available = 10GB + 90GB = 100GB
+        # Simulate: total disk is 100GB, configured max is 110GB
+        # disk_limit = int(100GB * 0.99) = 99GB
         manager._index._total_size = 10 * 1024**3
 
         mock_usage = self._make_disk_usage(
-            total=500 * 1024**3, used=410 * 1024**3, free=90 * 1024**3
+            total=100 * 1024**3, used=10 * 1024**3, free=90 * 1024**3
         )
         with patch("shutil.disk_usage", return_value=mock_usage):
             effective = manager._get_effective_max_size()
@@ -1907,12 +1907,13 @@ class TestEffectiveMaxSize:
             max_size_bytes=100 * 1024**3,
         )
 
-        # Simulate: cache has 50GB, but disk only has 10GB free
-        # So disk_available = 50GB + 10GB = 60GB, disk_limit = ~59.4GB
+        # Simulate: total disk is 60GB, cache has 50GB indexed
+        # disk_limit = int(60GB * 0.99) = ~59.4GB
+        # effective_max = min(100GB, 59.4GB) = 59.4GB
         manager._index._total_size = 50 * 1024**3
 
         mock_usage = self._make_disk_usage(
-            total=200 * 1024**3, used=190 * 1024**3, free=10 * 1024**3
+            total=60 * 1024**3, used=50 * 1024**3, free=10 * 1024**3
         )
         with patch("shutil.disk_usage", return_value=mock_usage):
             stats = manager.get_stats_dict()
@@ -1949,9 +1950,9 @@ class TestEffectiveMaxSize:
             max_size_bytes=200 * 1024**3,
         )
 
-        # disk_available = 0 + 50GB = 50GB, disk_limit = ~49.5GB
+        # total disk = 50GB, disk_limit = int(50GB * 0.99) = ~49.5GB
         mock_usage = self._make_disk_usage(
-            total=500 * 1024**3, used=450 * 1024**3, free=50 * 1024**3
+            total=50 * 1024**3, used=0, free=50 * 1024**3
         )
         with patch("shutil.disk_usage", return_value=mock_usage):
             assert manager.max_size < 200 * 1024**3
@@ -1982,9 +1983,10 @@ class TestEffectiveMaxSize:
             max_size_bytes=100 * 1024**3,
         )
 
-        # Simulate nearly full disk: only 5GB free, cache has 0 bytes
+        # Simulate a tiny disk: total=10GB, so disk_limit = int(10GB * 0.99)
+        # = ~9.9GB which is < 10% of configured 100GB → triggers warning.
         mock_usage = self._make_disk_usage(
-            total=500 * 1024**3, used=495 * 1024**3, free=5 * 1024**3
+            total=10 * 1024**3, used=5 * 1024**3, free=5 * 1024**3
         )
         with (
             patch("shutil.disk_usage", return_value=mock_usage),


### PR DESCRIPTION
## Problem

SSD cache usage exceeds the configured limit when switching between models .

When switching models, each model creates a new `PagedSSDCacheManager` sharing the same SSD cache directory. Incompatible blocks from other models are left on disk but **not indexed**, making them invisible to the LRU eviction logic. This causes two issues:

1. **`_get_effective_max_size()` miscalculates the limit** — it uses `index.total_size + disk_free`, treating incompatible blocks' disk space as "available". The effective limit is inflated and eviction never triggers for those blocks.

2. **Incompatible blocks are never evicted** — `_enforce_size_limit_for_new_block()` only evicts indexed (compatible) blocks via `self._index.evict_until_size()`. Blocks from previous models accumulate unboundedly.

**Reproduction scenario from the issue:**
- 64GB SSD, 45GB cache limit configured
- Model A fills 30GB of cache → 30GB on disk
- Switch to Model B → index scans, total_size = 0 (Model A's blocks are incompatible)
- `disk_available = 0 + 34GB(free) = 34GB` → `effective_max = 33.6GB`
- Model B writes 33GB → **actual disk usage = 63GB**, far exceeding the 45GB limit

## Fix

Two changes in `omlx/cache/paged_ssd_cache.py`:

### 1. `_get_effective_max_size()` — use actual disk usage

```python
# Before (buggy):
disk_available = self._index.total_size + disk_free
disk_limit = int(disk_available * self._DISK_SAFE_RATIO)

# After (fixed):
disk_limit = int((usage.used + usage.free) * self._DISK_SAFE_RATIO)
```

Using `shutil.disk_usage().used + .free` accounts for **all** files in the cache directory, including incompatible blocks from other models that aren't in this manager's index.

### 2. `_scan_existing_files()` + new `_cleanup_incompatible_blocks()` — evict stale blocks

During startup scan, incompatible blocks are now collected. If the total on-disk cache (compatible + incompatible) exceeds the effective limit, incompatible blocks are evicted oldest-first to reclaim space.

## Tests

Updated 4 test cases in `test_paged_ssd_cache.py` to match the corrected disk space calculation. All 134 SSD cache tests pass.

Closes #1915