### PR TITLE
fix(responses): merge leading system messages in user_note_safe fallback

### DIFF
--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -666,6 +666,10 @@ def prepare_system_messages_for_template(
         if unsupported_mid_system_policy == "user_note_safe":
             prepared = _downgrade_mid_system_to_user_notes(messages)
             if prepared is not None:
+                # _downgrade preserves leading system blocks as-is; merge
+                # consecutive system messages so strict templates (Qwen3.6+)
+                # that require a single leading system message don't fail.
+                prepared = _merge_consecutive_system_messages(prepared)
                 if merge_consecutive_roles:
                     prepared = _merge_consecutive_roles(prepared)
                 return prepared

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -2369,6 +2369,44 @@ class TestPrepareSystemMessagesForTemplate:
         assert [m["role"] for m in result] == ["system", "user"]
         assert result[0]["content"] == "Runtime tip"
 
+    def test_user_note_policy_merges_leading_system_messages(self):
+        """Multiple leading system messages must be merged even when a
+        mid-system message triggers the user_note_safe downgrade path.
+
+        Regression test for: Codex App Desktop sends ``instructions`` plus a
+        system/developer message in ``input``, producing two leading system
+        messages.  When a later mid-system message triggers
+        ``_downgrade_mid_system_to_user_notes``, the leading block was
+        preserved as-is (two separate system messages), causing strict
+        templates like Qwen3.6 to reject with
+        "System message must be at the beginning."
+        """
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant"},
+            {"role": "system", "content": "Be concise"},
+            {"role": "user", "content": "Hello"},
+            {"role": "system", "content": "Remember this"},
+            {"role": "user", "content": "Continue"},
+        ]
+
+        result = prepare_system_messages_for_template(
+            messages,
+            self.ErrorTokenizer(),
+            unsupported_mid_system_policy="user_note_safe",
+        )
+
+        # All leading system messages must be merged into one
+        assert result[0]["role"] == "system"
+        assert "You are a helpful assistant" in result[0]["content"]
+        assert "Be concise" in result[0]["content"]
+        # No second system message at position 1 — strict templates
+        # (Qwen3.6) require a single system message at the beginning.
+        assert result[1]["role"] != "system", (
+            "Leading system messages were not merged — Qwen3.6-style "
+            "templates would reject this with "
+            "'System message must be at the beginning.'"
+        )
+
     def test_falls_back_for_unsupported_mid_system_placement(self):
         messages = [
             {"role": "user", "content": "Hello"},


### PR DESCRIPTION
## Problem

When Codex App Desktop sends `/v1/responses` requests with both `instructions` and a `system`/`developer` message in `input`, two leading system messages are produced. If the conversation also contains a mid-system message (e.g. via `previous_response_id` chain or multi-turn input), the `user_note_safe` downgrade path in `prepare_system_messages_for_template` preserves the leading system block as-is without merging.

Since `_merge_consecutive_roles` only merges `user`/`assistant` roles, the two consecutive system messages survive into the chat template. Strict templates like Qwen3.6 validate that system messages can only appear at the first position, causing:

```
POST /v1/responses -> 400: Chat template error: System message must be at the beginning.
```

## Root Cause

In `omlx/api/utils.py`, `_downgrade_mid_system_to_user_notes` preserves leading system blocks via `rewritten.extend(messages[start:i])` at line 601-602. The caller `unsupported_fallback` then only applies `_merge_consecutive_roles`, which doesn't touch system messages.

## Fix

Call `_merge_consecutive_system_messages` in `unsupported_fallback` before `_merge_consecutive_roles` when the `user_note_safe` path succeeds. This merges consecutive leading system messages into one, satisfying strict template validation.

## Reproduction

```python
from omlx.api.utils import prepare_system_messages_for_template

class Qwen36Tokenizer:
    def apply_chat_template(self, messages, **kw):
        for i, msg in enumerate(messages):
            if msg.get('role') == 'system' and i > 0:
                raise Exception('System message must be at the beginning.')
        return 'ok'

messages = [
    {"role": "system", "content": "You are a helpful assistant"},  # from instructions
    {"role": "system", "content": "Be concise"},                   # from input
    {"role": "user", "content": "Hello"},
    {"role": "system", "content": "Remember this"},                # mid-system
    {"role": "user", "content": "Continue"},
]

result = prepare_system_messages_for_template(
    messages, Qwen36Tokenizer(), unsupported_mid_system_policy="user_note_safe")
# Before fix: ['system', 'system', 'user'] → template error
# After fix:  ['system', 'user']           → OK
```

Closes #1908