### PR TITLE
fix(cohere2_moe): re-escape literal control chars in streamed tool arguments

### DIFF
--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -404,6 +404,19 @@ def _create_cohere2_moe_filter():
     return PyFilter(PyFilterOptions().cmd4().stream_tool_actions())
 
 
+def _reserialize_cohere_tool_arguments(args: str) -> str:
+    if not args:
+        return "{}"
+    try:
+        return json.dumps(
+            json.loads(args, strict=False),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    except (json.JSONDecodeError, ValueError):
+        return args or "{}"
+
+
 class Cohere2MoeOutputParserSession:
     """Parser session for Cohere2 MoE / Command-style Melody output."""
 
@@ -506,7 +519,7 @@ class Cohere2MoeOutputParserSession:
             {
                 "id": value["id"],
                 "name": value["name"],
-                "arguments": value["arguments"] or "{}",
+                "arguments": _reserialize_cohere_tool_arguments(value["arguments"]),
             }
             for _, value in sorted(self._tool_calls.items())
             if value["name"]

--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -233,6 +233,59 @@ class TestCohere2MoeOutputParserSession:
         ]
         assert final.finish_reason == "tool_calls"
 
+    def test_literal_newline_in_arguments_is_reescaped(self, monkeypatch):
+        """Melody may stream literal control chars when the model emits them inside
+        JSON string values (e.g. newlines inside code arguments).  finalize() must
+        re-serialize the accumulated arguments so they are valid JSON."""
+        # Build a fake Melody that returns arguments containing a literal newline
+        # (U+000A) inside the JSON string value, as the real model sometimes does.
+        literal_newline_args = '{"path":"f.py","code":"line1\nline2"}'  # literal \n
+
+        class _FakeMelodyFilterLiteralNewline:
+            def __init__(self, options):
+                pass
+
+            def write_decoded(self, decoded_text: str):
+                if decoded_text == "TC":
+                    tc = SimpleNamespace(
+                        index=0,
+                        id="call_1",
+                        name="edit",
+                        arguments=literal_newline_args,
+                    )
+                    return SimpleNamespace(content=None, reasoning=None, tool_calls=[tc])
+                return SimpleNamespace(content=None, reasoning=None, tool_calls=[])
+
+            def flush_partials(self):
+                return SimpleNamespace(content=None, reasoning=None, tool_calls=[])
+
+        import types, json as _json
+        module = types.ModuleType("cohere_melody")
+        module.PyFilter = _FakeMelodyFilterLiteralNewline
+        module.PyFilterOptions = _FakeMelodyOptions
+        monkeypatch.setitem(__import__("sys").modules, "cohere_melody", module)
+
+        tokenizer = CohereTokenizer({"TC": "TC"})
+        from omlx.adapter.output_parser import Cohere2MoeOutputParserSession
+        session = Cohere2MoeOutputParserSession.__new__(Cohere2MoeOutputParserSession)
+        session._tokenizer = tokenizer
+        session._melody = _FakeMelodyFilterLiteralNewline(None)
+        session._detokenizer = None
+        session._thinking_started = False
+        session._thinking_closed = False
+        session._tool_calls = {}
+
+        session.process_token("TC")
+        final = session.finalize()
+
+        assert len(final.tool_calls) == 1
+        args_str = final.tool_calls[0]["arguments"]
+        # Must be valid strict JSON (no literal control characters)
+        parsed = _json.loads(args_str)
+        assert parsed["code"] == "line1\nline2"
+        # The literal newline must have been escaped
+        assert "\n" not in args_str or "\\n" in args_str
+
 
 class TestGemma4OutputParserSession:
     def test_normal_reasoning_block(self):


### PR DESCRIPTION
## Problem

When `Cohere2MoeOutputParserSession.finalize()` returns tool call arguments, it passes the accumulated Melody string through verbatim:

```python
"arguments": value["arguments"] or "{}",
```

The Melody filter streams model output character-by-character. If the model emits a literal control character (e.g. U+000A newline) inside a JSON string value instead of the `\n` escape sequence, the accumulated `arguments` string fails pydantic's strict JSON validation and the request is rejected:

```
1 validation error for FunctionCall
arguments
  Value error, arguments must be valid JSON, got parse error: Expecting ','
  delimiter: line 1 column 343 (char 342). ...
  Received: '{"path": "parse_logs.py", "edits": [{"oldText": "LOG_RE = re.compile(\n    r\'...'
```

This surfaces as a hard failure on any task where the model writes multi-line content in a tool argument (e.g. `edit_file` with multi-line code).

## Fix

Add `_reserialize_cohere_tool_arguments()` which runs the accumulated string through `json.loads(strict=False)` + `json.dumps()` before `finalize()` returns it. `strict=False` tolerates literal control characters inside strings; `json.dumps()` re-serializes them with proper escape sequences.

This mirrors the identical fix already applied to the XML fallback parser path in `ToolCallStreamFilter` (commit `64a1b8c`).

## Tests

Added `test_literal_newline_in_arguments_is_reescaped` to `TestCohere2MoeOutputParserSession`. All 20 tests pass.