### PR TITLE
fix(oq): expose embed_audio on the VLM sanitize proxy for gemma4_unified

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -2109,7 +2109,16 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
 
             def _vlm_sanitize(weights):
                 class _Proxy:
+                    # The audio-presence guard differs by arch: gemma4 checks
+                    # ``self.audio_tower``; gemma4_unified checks
+                    # ``self.embed_audio``. Expose BOTH (sentinel iff the source
+                    # config carries audio) so sanitize keeps the audio modality
+                    # for either. Missing ``embed_audio`` made gemma4_unified's
+                    # sanitize raise AttributeError, silently dropping the whole
+                    # sanitize pass → oQ shipped raw ``model.``-prefixed keys
+                    # that omlx could not load.
                     audio_tower = _AUDIO_SENTINEL
+                    embed_audio = _AUDIO_SENTINEL
 
                 proxy = _Proxy()
                 proxy.config = model_config

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -3010,6 +3010,77 @@ class TestBuildModelSanitizerTextOnly:
 
 
 # =============================================================================
+# Test _vlm_sanitize proxy exposes the gemma-4 audio-guard attributes
+# =============================================================================
+
+
+class TestVlmSanitizeProxyAudioAttrs:
+    """oq's _vlm_sanitize _Proxy must expose BOTH audio-guard attributes the
+    gemma-4 family reads: gemma4 guards audio weights on ``self.audio_tower``,
+    gemma4_unified on ``self.embed_audio``. A proxy missing the attribute a
+    model's ``sanitize()`` reads raises AttributeError, aborting sanitize so oQ
+    ships raw ``model.``-prefixed VLM keys that mlx-vlm cannot load.
+    """
+
+    @pytest.mark.parametrize("audio_attr", ["audio_tower", "embed_audio"])
+    def test_proxy_exposes_audio_guard_attr(self, monkeypatch, audio_attr):
+        pytest.importorskip("mlx_vlm.utils")
+        from types import SimpleNamespace
+
+        from omlx.oq import _build_model_sanitizer
+
+        class _Cfg:
+            def __init__(self, **fields):
+                self.__dict__.update(fields)
+
+            @classmethod
+            def from_dict(cls, fields):
+                return cls(**fields)
+
+        class _FakeModel:
+            @staticmethod
+            def sanitize(proxy, weights):
+                # The real Gemma4(Unified).sanitize reads this guard attr off
+                # self; the proxy must expose it or getattr raises AttributeError
+                # and oq's whole sanitize pass is silently dropped.
+                getattr(proxy, audio_attr)
+                return weights
+
+        fake_module = SimpleNamespace(
+            Model=_FakeModel,
+            ModelConfig=_Cfg,
+            VisionConfig=_Cfg,
+            TextConfig=_Cfg,
+            VisionModel=object,
+            LanguageModel=object,
+        )
+        monkeypatch.setattr(
+            "mlx_vlm.utils.get_model_and_args",
+            lambda config: (fake_module, None),
+        )
+        monkeypatch.setattr(
+            "mlx_vlm.utils.sanitize_weights",
+            lambda _model, weights, _config: weights,
+        )
+
+        config = {
+            "architectures": ["Gemma4UnifiedForConditionalGeneration"],
+            "model_type": "gemma4_unified",
+            "text_config": {"num_hidden_layers": 4, "hidden_size": 64},
+            "vision_config": {"hidden_size": 32},
+            "audio_config": {"hidden_size": 16},
+        }
+
+        sanitize = _build_model_sanitizer(config, text_only=False)
+        assert sanitize is not None
+
+        # Before the fix the proxy lacked ``embed_audio`` → this call raised
+        # AttributeError for the gemma4_unified guard, dropping the sanitize pass.
+        weights = {"model.embed_audio.proj.weight": 1}
+        assert sanitize(weights) == weights
+
+
+# =============================================================================
 # Test _build_proxy_for_sensitivity MTP patch integration
 # =============================================================================
 


### PR DESCRIPTION
Refs #1645 — this fixes the **oQ-quantization** path for `gemma4_unified`. It does *not* add the base mlx-vlm "model type not supported" support that #1645 also needs, so it's a partial address, not a close.

## Summary
- oQ's VLM sanitize proxy now exposes `embed_audio` alongside the existing `audio_tower`, so `gemma4_unified.sanitize()` no longer aborts mid-quant.
- Before this, oQ produced a quant that passed the structural scan but could not be loaded or served (`model.`-prefixed keys mlx-vlm rejects).

## Why (root cause)
`oq._build_model_sanitizer` builds a lightweight `_Proxy` and calls the model's real `Model.sanitize(proxy, weights)` during quantization. The gemma-4 family guards its audio weights on an instance attribute, but the **attribute name differs by arch**:

- `gemma4` reads `self.audio_tower` — already exposed on the proxy
- `gemma4_unified` reads `self.embed_audio` (mlx-vlm `models/gemma4_unified/gemma4_unified.py`, in `sanitize`) — **not** exposed

So for `gemma4_unified` the proxy raised `AttributeError`, the surrounding `try/except` swallowed it, and the entire sanitize pass was skipped. The quant was then written with raw checkpoint keys, which mlx-vlm refuses on load:

```
Received 1339 parameters not in model: model.vision_embedder.pos_norm.weight
```

This is the same shape as the recently-merged #1881 (expose `language_model` on this proxy for nested VLMs) — same proxy, sibling attribute.

## Changes
- `omlx/oq.py`: add `embed_audio = _AUDIO_SENTINEL` to the sanitize `_Proxy`. The sentinel is truthy iff the source `config` carries `audio_config`, so audio weights survive sanitize when present and are correctly dropped when absent — identical semantics to the existing `audio_tower` guard.
- `tests/test_oq.py`: regression test parametrized over both guard attributes (`audio_tower`, `embed_audio`), driving `_build_model_sanitizer` with a `gemma4_unified`-style config.

## Sibling-path sweep
Checked every VLM `Model.sanitize` in the pinned mlx-vlm for instance-attribute guards:
- gemma-4 family is now complete: `gemma4` → `self.audio_tower` (pre-existing), `gemma4_unified` → `self.embed_audio` (this fix).
- Other arches whose top-level `sanitize` reads instance attributes (`phi4mm`, `step3p7`, …) are pre-existing gaps, out of scope here. The fix is deliberately an explicit named attribute, **not** a blanket `__getattr__` sentinel, so those arches' `is None` guards keep behaving correctly.

## Tests
```
python -m pytest tests/test_oq.py -q   # 245 passed
```
The new test fails with `AttributeError: '_Proxy' object has no attribute 'embed_audio'` when the fix is reverted.

### End-to-end verification (live `omlx serve`)
An oQ-quantized `gemma-4-12B-it` (`gemma4_unified`, 7.2 GB) loads cleanly — **no "parameters not in model"** — and produces correct, non-blank output across every mode, including gemma-4's harmony-style thinking channels (`<|channel>thought … <channel|>` → `reasoning_content`, final → `content`):

| Mode | `content` | `reasoning_content` |
|---|---|---|
| Text, non-stream | ✓ | — |
| Vision (image description), non-stream | ✓ (no placeholder-token leak) | — |
| Streaming, no-think | ✓ | — |
| Thinking, non-stream | ✓ (not blank) | ✓ |
| Thinking + streaming | ✓ (not blank) | ✓ |

The vision path exercises the `embed_vision`/`vision_embedder` keys that were malformed before the fix; `content` is populated in all modes (i.e. no thinking-channel blanking).
