### PR TITLE
fix: cli honors bootstrap base-path if exists

### DIFF
--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -42,6 +42,33 @@ SETTINGS_VERSION = "1.0"
 # Default base path
 DEFAULT_BASE_PATH = Path.home() / ".omlx"
 
+# One-line bootstrap file the macOS app writes when the user moves their data root
+BASE_PATH_BOOTSTRAP_FILE = (
+    Path.home() / "Library" / "Application Support" / "oMLX" / "base-path"
+)
+
+
+def resolve_default_base_path() -> Path:
+    """
+    Resolve the base path to use when none was passed explicitly.
+
+    Priority: ``OMLX_BASE_PATH`` env var > the macOS app's bootstrap file >
+    ``~/.omlx``. This matches AppConfig.currentBasePath() in the Swift app
+    so the CLI and GUI agree on where settings.json lives.
+    """
+    env_value = os.environ.get("OMLX_BASE_PATH")
+    if env_value:
+        return Path(env_value).expanduser().resolve()
+
+    try:
+        raw = BASE_PATH_BOOTSTRAP_FILE.read_text(encoding="utf-8").strip()
+    except OSError:
+        raw = ""
+    if raw:
+        return Path(raw).expanduser().resolve()
+
+    return DEFAULT_BASE_PATH
+
 
 def get_system_memory() -> int:
     """
@@ -785,7 +812,9 @@ class GlobalSettings:
         Load settings with priority hierarchy: CLI > env > file > defaults.
 
         Args:
-            base_path: Base directory for oMLX (default: ~/.omlx).
+            base_path: Base directory for oMLX (default: resolved via
+                OMLX_BASE_PATH env var, the macOS app's bootstrap file,
+                then ~/.omlx).
             cli_args: Argparse namespace with CLI arguments.
 
         Returns:
@@ -795,7 +824,7 @@ class GlobalSettings:
         if base_path:
             resolved_base = Path(base_path).expanduser().resolve()
         else:
-            resolved_base = DEFAULT_BASE_PATH
+            resolved_base = resolve_default_base_path()
 
         # Start with defaults
         settings = cls(base_path=resolved_base)
@@ -1450,7 +1479,9 @@ def init_settings(
     Initialize global settings (call once at startup).
 
     Args:
-        base_path: Base directory for oMLX (default: ~/.omlx).
+        base_path: Base directory for oMLX (default: resolved via
+                OMLX_BASE_PATH env var, the macOS app's bootstrap file,
+                then ~/.omlx).
         cli_args: Argparse namespace with CLI arguments.
 
     Returns:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -33,6 +33,7 @@ from omlx.settings import (
     get_system_memory,
     init_settings,
     reset_settings,
+    resolve_default_base_path,
 )
 
 
@@ -1669,6 +1670,57 @@ class TestHelperFunctions:
         """Test SSD capacity with tilde path expansion."""
         capacity = get_ssd_capacity("~/")
         assert capacity > 0
+
+
+class TestResolveDefaultBasePath:
+    """Tests for resolve_default_base_path()."""
+
+    def test_falls_back_to_default_when_nothing_configured(self, monkeypatch):
+        monkeypatch.delenv("OMLX_BASE_PATH", raising=False)
+        monkeypatch.setattr(
+            "omlx.settings.BASE_PATH_BOOTSTRAP_FILE",
+            Path("/nonexistent/oMLX/base-path"),
+        )
+        assert resolve_default_base_path() == Path.home() / ".omlx"
+
+    def test_uses_bootstrap_file_when_present(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("OMLX_BASE_PATH", raising=False)
+        custom_base = tmp_path / "external-ssd" / "omlx-data"
+        bootstrap_file = tmp_path / "base-path"
+        bootstrap_file.write_text(f"{custom_base}\n", encoding="utf-8")
+        monkeypatch.setattr("omlx.settings.BASE_PATH_BOOTSTRAP_FILE", bootstrap_file)
+
+        assert resolve_default_base_path() == custom_base.resolve()
+
+    def test_env_var_wins_over_bootstrap_file(self, monkeypatch, tmp_path):
+        env_base = tmp_path / "env-base"
+        bootstrap_base = tmp_path / "bootstrap-base"
+        bootstrap_file = tmp_path / "base-path"
+        bootstrap_file.write_text(str(bootstrap_base), encoding="utf-8")
+        monkeypatch.setattr("omlx.settings.BASE_PATH_BOOTSTRAP_FILE", bootstrap_file)
+        monkeypatch.setenv("OMLX_BASE_PATH", str(env_base))
+
+        assert resolve_default_base_path() == env_base.resolve()
+
+    def test_empty_bootstrap_file_falls_back_to_default(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("OMLX_BASE_PATH", raising=False)
+        bootstrap_file = tmp_path / "base-path"
+        bootstrap_file.write_text("   \n", encoding="utf-8")
+        monkeypatch.setattr("omlx.settings.BASE_PATH_BOOTSTRAP_FILE", bootstrap_file)
+
+        assert resolve_default_base_path() == Path.home() / ".omlx"
+
+    def test_global_settings_load_uses_resolver_when_no_base_path_given(
+        self, monkeypatch, tmp_path
+    ):
+        resolved = tmp_path / "resolved-base"
+        monkeypatch.setattr(
+            "omlx.settings.resolve_default_base_path", lambda: resolved
+        )
+
+        settings = GlobalSettings.load()
+
+        assert settings.base_path == resolved
 
 
 class TestSettingsVersionMigration:


### PR DESCRIPTION
Fixes non-default install paths by making GlobalSettings.load() resolve the same base-path bootstrap file that the macOS app already uses, if exists.