### PR TITLE
fix(engine_core): reap output collectors orphaned by client disconnect

### DIFF
--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -234,6 +234,13 @@ class EngineCore:
         self._output_collectors: Dict[str, RequestOutputCollector] = {}
         self._stream_states: Dict[str, RequestStreamState] = {}
         self._finished_events: Dict[str, asyncio.Event] = {}
+        # Finish timestamps for orphan-collector reaping (#1154).
+        # Normally a consumer drains and removes its own collector, but if the
+        # client disconnects mid-stream the SSE generator chain is abandoned and
+        # its cleanup finally only runs at GC time, so the collector lingers and
+        # the dashboard keeps showing the request as "Generating".
+        self._finished_at: Dict[str, float] = {}
+        self._last_reap = 0.0
 
         # Engine state
         self._running = False
@@ -351,6 +358,12 @@ class EngineCore:
 
         while self._running:
             try:
+                # Sweep collectors orphaned by client disconnects (throttled).
+                now = time.monotonic()
+                if now - self._last_reap >= 1.0:
+                    self._last_reap = now
+                    self._reap_orphaned_collectors(now)
+
                 if self.scheduler.has_requests():
                     step_outputs = await loop.run_in_executor(
                         self._mlx_executor, self._step_burst
@@ -397,11 +410,11 @@ class EngineCore:
                                         state.mark_sent(req_output.completion_tokens)
 
                             if req_output.finished:
-                                event = events.get(rid)
-                                if event:
-                                    event.set()
-                                # Note: cleanup is handled by stream_outputs() finally block
-                                # _delayed_cleanup() was causing double cleanup race condition
+                                self._mark_request_finished(rid)
+                                # Cleanup normally happens in the consumer
+                                # (stream_outputs()/generate()); collectors left
+                                # behind by a disconnected client are swept by
+                                # _reap_orphaned_collectors() via _finished_at.
 
                     if distributed:
                         # Always yield to prevent event loop starvation.
@@ -485,9 +498,7 @@ class EngineCore:
                                 error=str(e),
                             )
                         )
-                    event = self._finished_events.get(rid)
-                    if event:
-                        event.set()
+                    self._mark_request_finished(rid)
                 await asyncio.sleep(0.1)
 
     async def add_request(
@@ -584,6 +595,21 @@ class EngineCore:
                 self._mlx_executor, self.scheduler.add_request, request
             )
         except BaseException:
+            # If the caller is cancelled here (e.g. the client disconnected
+            # before the SSE stream began) — or the insert fails — the request
+            # never reaches stream_outputs()/generate()'s try/finally, so
+            # nothing would mark it finished or clean it up. The collector
+            # created above would then linger forever as a phantom the reaper
+            # cannot see (it was never stamped _finished_at), and the dashboard
+            # would show it as "Generating" indefinitely (#1154).
+            # Drop the tracking and abort any partial scheduler insert (the
+            # deferred abort is idempotent and harmless if it never landed).
+            try:
+                self.scheduler.abort_request(request_id)
+            except Exception as abort_exc:  # noqa: BLE001
+                logger.debug(
+                    f"Abort of partial insert for {request_id} failed: {abort_exc}"
+                )
             self._cleanup_request(request_id)
             raise
         self._wake_engine_loop()
@@ -626,9 +652,7 @@ class EngineCore:
                     error="Request aborted",
                 )
             )
-        event = self._finished_events.get(request_id)
-        if event is not None:
-            event.set()
+        self._mark_request_finished(request_id)
         self._wake_engine_loop()
 
         return result
@@ -675,15 +699,60 @@ class EngineCore:
                         error=error_msg,
                     )
                 )
-            event = self._finished_events.get(rid)
-            if event is not None:
-                event.set()
+            self._mark_request_finished(rid)
         if request_ids:
             logger.warning(
                 f"Aborted {len(request_ids)} requests due to memory pressure"
             )
             self._wake_engine_loop()
         return len(request_ids)
+
+    def _mark_request_finished(self, request_id: str) -> None:
+        """Signal the consumer a request finished and stamp the finish time.
+
+        The timestamp lets _reap_orphaned_collectors() drop collectors whose
+        consumer never cleaned up (e.g. the client disconnected mid-stream and
+        the SSE generator chain was abandoned rather than closed).
+        """
+        self._finished_at.setdefault(request_id, time.monotonic())
+        event = self._finished_events.get(request_id)
+        if event is not None:
+            event.set()
+
+    def _reap_orphaned_collectors(self, now: float, grace: float = 5.0) -> int:
+        """Drop tracking for finished requests whose consumer never cleaned up.
+
+        stream_outputs()/generate() normally remove their own collector via
+        _cleanup_request() once the final output is drained. But when a client
+        disconnects mid-stream the SSE generator chain is abandoned instead of
+        closed, so that finally block only runs at non-deterministic GC time —
+        the collector lingers in _output_collectors and the request shows as
+        "Generating" forever on the dashboard (#1154).
+
+        This sweep removes the dict tracking for any request finished more than
+        ``grace`` seconds ago. It is intentionally pop-only and never calls
+        ``collector.clear()``: stream_outputs()/generate() hold their own
+        reference to the collector object, so dropping the dict entry cannot
+        truncate a slow-but-live consumer's output — only an over-eager clear()
+        could (which is what made the earlier _delayed_cleanup() approach race).
+        The grace period guarantees a live consumer (which drains in the same
+        event-loop turn the request finishes) has already self-cleaned.
+        """
+        if not self._finished_at:
+            return 0
+        stale = [rid for rid, ts in self._finished_at.items() if now - ts >= grace]
+        for rid in stale:
+            # pop-only — see docstring; never clear() the collector object.
+            self._output_collectors.pop(rid, None)
+            self._stream_states.pop(rid, None)
+            self._finished_events.pop(rid, None)
+            self._finished_at.pop(rid, None)
+        if stale:
+            logger.debug(
+                "Reaped %d orphaned output collector(s) after disconnect: %s",
+                len(stale), stale,
+            )
+        return len(stale)
 
     def _cleanup_request(self, request_id: str) -> None:
         """Clean up request tracking.
@@ -697,6 +766,7 @@ class EngineCore:
             collector.clear()
         self._stream_states.pop(request_id, None)
         self._finished_events.pop(request_id, None)
+        self._finished_at.pop(request_id, None)
 
     async def _delayed_cleanup(self, request_id: str, delay: float = 5.0) -> None:
         """
@@ -797,6 +867,15 @@ class EngineCore:
         if event is None:
             raise RuntimeError(f"No event for request {request_id}")
 
+        # Capture the collector reference BEFORE awaiting, mirroring
+        # stream_outputs(): the orphan reaper is pop-only and may drop the dict
+        # entry once the request is finished, but a held reference still drains.
+        # Re-fetching after the await would race the reaper if this coroutine is
+        # starved past the grace window under heavy load (#1154).
+        collector = self._output_collectors.get(request_id)
+        if collector is None:
+            raise RuntimeError(f"No collector for request {request_id}")
+
         try:
             # Wait for the request to finish
             await event.wait()
@@ -808,12 +887,7 @@ class EngineCore:
             self._cleanup_request(request_id)
             raise
 
-        # Get the final output from collector
-        collector = self._output_collectors.get(request_id)
-        if collector is None:
-            raise RuntimeError(f"No collector for request {request_id}")
-
-        # Drain all outputs and get the last one
+        # Drain all outputs and get the last one (using the captured reference)
         final_output = None
         while True:
             output = collector.get_nowait()
@@ -1022,6 +1096,7 @@ class EngineCore:
         self._output_collectors.clear()
         self._stream_states.clear()
         self._finished_events.clear()
+        self._finished_at.clear()
 
         # Release model and tokenizer references for GC
         self.model = None

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -20,6 +20,7 @@ import pytest
 
 from omlx.engine_core import AsyncEngineCore, EngineConfig, EngineCore
 from omlx.exceptions import PrefillMemoryExceededError
+from omlx.output_collector import RequestOutputCollector
 from omlx.request import RequestOutput, SamplingParams
 from omlx.scheduler import SchedulerConfig, SchedulerOutput
 
@@ -349,6 +350,36 @@ class TestEngineCoreAddRequest:
                 assert request_id in engine._output_collectors
                 assert request_id in engine._stream_states
                 assert request_id in engine._finished_events
+            finally:
+                await engine.stop()
+                engine.close()
+
+    @pytest.mark.asyncio
+    async def test_add_request_cleans_up_if_scheduler_insert_fails(self, mock_model, mock_tokenizer):
+        """If the scheduler insert fails/cancels after the collector is created,
+        add_request must drop the tracking (and abort) so no phantom collector
+        leaks that the reaper can't see — it was never stamped finished
+        (#1154). BaseException in the guard also covers the real
+        trigger: CancelledError when a client disconnects before streaming."""
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+            try:
+                await engine.start()
+                engine.scheduler.add_request = MagicMock(
+                    side_effect=RuntimeError("insert boom"))
+                engine.scheduler.abort_request = MagicMock(return_value=True)
+
+                with pytest.raises(RuntimeError):
+                    await engine.add_request(prompt="Hello")
+
+                # No phantom tracking left behind for any request.
+                assert engine._output_collectors == {}
+                assert engine._stream_states == {}
+                assert engine._finished_events == {}
+                assert engine._finished_at == {}
+                # The partial scheduler insert was aborted (idempotent).
+                engine.scheduler.abort_request.assert_called_once()
             finally:
                 await engine.stop()
                 engine.close()
@@ -1581,3 +1612,140 @@ class TestStepBurst:
             assert len(outs) == 1
         finally:
             engine.close()
+
+
+class TestOrphanedCollectorReaping:
+    """Reaping of output collectors orphaned by a client disconnect (#1154).
+
+    When a client disconnects mid-stream the SSE generator chain is abandoned
+    rather than closed, so stream_outputs()'s cleanup finally only runs at GC
+    time and the collector lingers in _output_collectors — the dashboard then
+    shows the request as "Generating" indefinitely. _reap_orphaned_collectors()
+    drops such orphans after a grace period.
+    """
+
+    def test_reaps_only_stale_finished_collectors(self, mock_model, mock_tokenizer):
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+            try:
+                now = 1000.0
+
+                # orphan: finished long ago, consumer never cleaned up.
+                orphan = RequestOutputCollector()
+                orphan.put(RequestOutput(
+                    request_id="orphan", finished=True,
+                    finish_reason="abort", new_text="partial",
+                ))
+                engine._output_collectors["orphan"] = orphan
+                engine._finished_events["orphan"] = asyncio.Event()
+                engine._finished_at["orphan"] = now - 100.0
+
+                # fresh: just finished, still within grace (consumer may drain).
+                engine._output_collectors["fresh"] = RequestOutputCollector()
+                engine._finished_events["fresh"] = asyncio.Event()
+                engine._finished_at["fresh"] = now - 1.0
+
+                # active: still generating, never marked finished.
+                engine._output_collectors["active"] = RequestOutputCollector()
+                engine._finished_events["active"] = asyncio.Event()
+
+                reaped = engine._reap_orphaned_collectors(now=now, grace=5.0)
+
+                assert reaped == 1
+                # stale orphan dropped from every tracking dict
+                assert "orphan" not in engine._output_collectors
+                assert "orphan" not in engine._finished_events
+                assert "orphan" not in engine._finished_at
+                # within-grace and still-active requests are retained
+                assert "fresh" in engine._output_collectors
+                assert "active" in engine._output_collectors
+                # pop-only: a consumer still holding the orphan reference keeps
+                # its buffered output — the reaper must NOT clear() it.
+                assert orphan.output is not None
+                assert orphan.output.new_text == "partial"
+            finally:
+                engine.close()
+
+    def test_mark_request_finished_stamps_once_and_signals(self, mock_model, mock_tokenizer):
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+            try:
+                event = asyncio.Event()
+                engine._finished_events["r1"] = event
+
+                engine._mark_request_finished("r1")
+                assert event.is_set()
+                assert "r1" in engine._finished_at
+                first = engine._finished_at["r1"]
+
+                # setdefault semantics: a repeated signal must not reset the
+                # grace clock (otherwise an orphan could never age out).
+                engine._mark_request_finished("r1")
+                assert engine._finished_at["r1"] == first
+            finally:
+                engine.close()
+
+    def test_cleanup_request_removes_finished_stamp(self, mock_model, mock_tokenizer):
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+            try:
+                engine._output_collectors["r1"] = RequestOutputCollector()
+                engine._finished_events["r1"] = asyncio.Event()
+                engine._finished_at["r1"] = 123.0
+
+                engine._cleanup_request("r1")
+
+                # normal consumer cleanup also clears the finish stamp so the
+                # reaper never revisits a request the consumer already handled.
+                assert "r1" not in engine._finished_at
+                assert "r1" not in engine._output_collectors
+            finally:
+                engine.close()
+
+    @pytest.mark.asyncio
+    async def test_generate_drains_via_held_reference_if_reaped(
+        self, mock_model, mock_tokenizer
+    ):
+        """generate() captures the collector BEFORE awaiting, so the pop-only
+        reaper removing the dict entry once the request finishes cannot lose a
+        completed result when generate() is slow to resume under load (#1154).
+        Without the early capture, the post-await re-fetch would return None and
+        raise — the streaming path was already safe; this extends it to generate().
+        """
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+            try:
+                await engine.start()
+                engine.scheduler.has_requests = lambda: False
+
+                task = asyncio.create_task(
+                    engine.generate(
+                        prompt="Hello",
+                        sampling_params=SamplingParams(max_tokens=5),
+                    )
+                )
+                # Let generate() add the request and capture the collector
+                # reference (it captures before awaiting the finished event).
+                await asyncio.sleep(0.05)
+                request_id = list(engine._output_collectors.keys())[0]
+                collector = engine._output_collectors[request_id]
+
+                # Deliver the completed result, then simulate the reaper popping
+                # the dict entry BEFORE generate() resumes to drain it.
+                collector.put(RequestOutput(
+                    request_id=request_id, finished=True,
+                    finish_reason="stop", new_text="done",
+                ))
+                engine._output_collectors.pop(request_id)
+                engine._finished_events[request_id].set()
+
+                result = await task
+                assert result is not None
+                assert result.new_text == "done"
+            finally:
+                await engine.stop()
+                engine.close()

--- a/tests/test_engine_preflight.py
+++ b/tests/test_engine_preflight.py
@@ -578,6 +578,7 @@ async def test_engine_core_add_request_cleans_up_on_scheduler_raise(
     core._output_collectors = {}
     core._stream_states = {}
     core._finished_events = {}
+    core._finished_at = {}
 
     class _Cfg:
         stream_interval = 1


### PR DESCRIPTION
Fixes #1154.

## Summary
A client that cancels an in-flight request (e.g. Zed, which aggressively cancels predictions) leaves its `RequestOutputCollector` in `_output_collectors` until GC, so the dashboard shows the request as "Generating…" indefinitely even though the engine already aborted/completed it. This adds a grace-gated reaper to drop such orphans, plus guards that keep every consumer path safe.

## Why (root cause)
When a client disconnects mid-stream, Python's `async for` doesn't propagate `aclose()` into the inner `stream_outputs()` generator, so its cleanup `finally` — the only path that removes the collector — runs only at non-deterministic GC time. The dashboard's active count is `len(self._output_collectors)`, so the request lingers as "Generating…" until then (GPU/slot are already freed; it's purely stale tracking). The reporter suggested exactly a periodic reaping pass as a backstop.

## Changes
- **Grace-gated reaper.** `_mark_request_finished()` stamps a finish time on every terminal event; the engine loop calls `_reap_orphaned_collectors()` (throttled ~1/s, 5 s grace) to drop tracking for requests finished past the window. It is **pop-only** — never `collector.clear()` — so a slow-but-live consumer that holds its own collector reference is unaffected (an over-eager `clear()` is what made the earlier `_delayed_cleanup()` approach race).
- **add_request guard.** Aborts the partial scheduler insert (deferred + idempotent) and cleans up if the caller is cancelled before streaming begins — the disconnect-before-generation phantom the reaper can't see (never stamped `_finished_at`).
- **generate() symmetry.** The non-streaming path now captures its collector reference **before** awaiting, mirroring `stream_outputs()`. Without it, the post-await re-fetch could race the reaper and raise on an already-completed request if the coroutine was starved past the grace window under load.
- **Consistency.** `close()` also clears `_finished_at`; the partial-engine (`__new__`) regression test in `tests/test_engine_preflight.py` now sets `_finished_at`, since `_cleanup_request` manages it.

## Safety / sibling sweep
- The load-bearing invariant is pop-only + held-reference; both consumer paths (`stream_outputs`, `generate`) hold their reference before awaiting, so dropping the dict entry can never truncate a live consumer.
- VLM / batched / DFlash engines consume the same `EngineCore` API (they read the inner `_output_collectors` through the shared methods), so the central fix covers them — no per-engine special-casing.
- The dashboard count and `has_active_requests()` read the same dict; after a disconnect they now go stale-True for at most ~grace+throttle (~6 s) instead of until GC — a strict improvement over the status quo.
- **Out of scope (named):** `_delayed_cleanup()` is pre-existing dead code on `main` (no callers) — left for a separate cleanup rather than bundled here. The reaper grace is a fixed 5 s (no new user tunable); the `generate()` capture makes its exact value non-safety-critical.

## Tests
```
python -m pytest tests/test_engine_core.py tests/test_engine_preflight.py -q   # 92 passed
```
- New `TestOrphanedCollectorReaping` (reaps-only-stale, stamp-once, cleanup-clears-stamp, generate-drains-via-held-reference-if-reaped) and `test_add_request_cleans_up_if_scheduler_insert_fails`, exercising the real reaper/mark/cleanup methods.
- Full smoke (`pytest -m "not slow and not integration"`): **5935 passed**.
- Revert-proof: the reaper tests fail on `main` (`AttributeError: '_finished_at'`); the `generate()` test fails with `RuntimeError: No collector for request …` when the early capture is reverted.
