### PR TITLE
fix(cache): serialize composite nstate elements (hybrid CacheList) to SSD prefix cache

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -1759,7 +1759,12 @@ class PagedSSDCacheManager(CacheManager):
             def _store_nstate_elements(prefix: str, elements):
                 """Write N elements as ``{prefix}_state_{k}`` keys with a
                 ``{prefix}_state_count`` count marker. Zero-dim shapes are
-                preserved via ``{prefix}_state_{k}_zero_dim``."""
+                preserved via ``{prefix}_state_{k}_zero_dim``. Composite
+                elements (a bare tuple/list or a nested ``__nstate__``
+                marker) recurse under a ``{elem_key}`` sub-prefix and record
+                a ``{elem_key}_nested`` marker; the flat ``{elem_key}``
+                tensor is deliberately omitted so an older reader hits its
+                ``Missing {elem_key} in arrays`` path and skips the block."""
                 cache_list_meta[f"{prefix}_state_count"] = str(len(elements))
                 for k, elem in enumerate(elements):
                     elem_key = f"{prefix}_state_{k}"
@@ -1774,7 +1779,31 @@ class PagedSSDCacheManager(CacheManager):
                         cache_list_meta[f"{elem_key}_zero_dim"] = _encode_shape(
                             elem.shape
                         )
+                    elif (
+                        isinstance(elem, tuple)
+                        and len(elem) >= 2
+                        and isinstance(elem[0], str)
+                        and elem[0] == "__nstate__"
+                    ):
+                        # Nested ``('__nstate__', class_name, [sub...])``
+                        # marker — recurse, no flat tensor written.
+                        cache_list_meta[f"{elem_key}_nested"] = "nstate"
+                        sub_class = elem[1] if len(elem) >= 2 else None
+                        sub_elements = elem[2] if len(elem) >= 3 else []
+                        if sub_class:
+                            cache_list_meta[f"{elem_key}_state_class_name"] = sub_class
+                        _store_nstate_elements(elem_key, sub_elements)
+                    elif isinstance(elem, (tuple, list)):
+                        # Bare tuple/list of sub-elements — recurse, no flat
+                        # tensor written.
+                        cache_list_meta[f"{elem_key}_nested"] = "tuple"
+                        _store_nstate_elements(elem_key, list(elem))
                     else:
+                        if not isinstance(elem, mx.array):
+                            raise TypeError(
+                                f"unsupported non-array nstate element "
+                                f"{elem_key}: {type(elem).__name__}"
+                            )
                         arrays[elem_key] = elem
 
             for i, layer_data in enumerate(cache_data):
@@ -2085,7 +2114,12 @@ class PagedSSDCacheManager(CacheManager):
         # downstream code must dispatch on.
         def _maybe_unwrap_legacy(marker: tuple) -> Any:
             _, _, elements = marker
-            if len(elements) == 2:
+            # Only the legacy plain ``(keys, values)`` shape unwraps. If
+            # either element is itself composite (a recursed sub-state), the
+            # ``__nstate__`` wrapper must survive so the shape matches save.
+            if len(elements) == 2 and not any(
+                isinstance(e, (tuple, list)) for e in elements
+            ):
                 return (elements[0], elements[1])
             return marker
 
@@ -2111,8 +2145,26 @@ class PagedSSDCacheManager(CacheManager):
                     elem_key = f"{prefix}_state_{k}"
                     none_marker = f"{elem_key}_none"
                     zd_marker = f"{elem_key}_zero_dim"
+                    nested_marker = f"{elem_key}_nested"
                     if file_metadata and none_marker in file_metadata:
                         elements.append(None)
+                        continue
+                    if file_metadata and nested_marker in file_metadata:
+                        # Composite element — recurse, then restore the same
+                        # shape it had on save (bare tuple vs __nstate__).
+                        sub = _load_nstate(elem_key, fallback_class=None)
+                        if sub is None:
+                            return None
+                        if file_metadata[nested_marker] == "tuple":
+                            elements.append(tuple(sub[2]))
+                        elif file_metadata[nested_marker] == "nstate":
+                            # Explicit marker on write — preserve the full
+                            # ('__nstate__', class_name, elements) as-is;
+                            # never unwrap (would drop the marker/class_name).
+                            elements.append(sub)
+                        else:
+                            # Corrupt/unknown nested marker — fail closed.
+                            return None
                         continue
                     if elem_key not in arrays:
                         logger.error(f"Missing {elem_key} in arrays")

--- a/tests/test_nested_nstate_serialization.py
+++ b/tests/test_nested_nstate_serialization.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Round-trip tests for nstate elements that are themselves composite.
+
+DeepSeek-V4-Flash layers are ``CacheList(RotatingKVCache, PoolingCache,
+PoolingCache)``. On the store path a layer can reach the paged-SSD serializer
+as an ``__nstate__`` marker whose *elements* are not flat ``mx.array`` values
+but composite sub-states:
+
+  - a 2-tuple of arrays ``(keys, values)`` (the rotating sub-state), and
+  - a nested ``('__nstate__', class_name, [None, None, pooled])`` marker (the
+    pooling sub-state, whose first two elements are ``None``).
+
+The pre-fix ``_store_nstate_elements`` assumed every element was an
+``mx.array`` and stored it directly, so ``_extract_tensor_bytes`` raised
+``'tuple' object has no attribute 'dtype'``. That failed the whole block save
+(and, via the caller's break-on-failure, every later block), which bled the
+prefix-cache hit rate down over a multi-turn conversation.
+
+These tests pin the contract: composite nstate elements round-trip
+byte-identically through ``save_block`` -> ``load_block``, including ``None``
+sub-elements and zero-*size* arrays (MLA stores an empty values tensor).
+"""
+
+from __future__ import annotations
+
+import time
+
+import mlx.core as mx
+
+from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
+
+
+def _make_manager(tmp_path):
+    return PagedSSDCacheManager(
+        cache_dir=tmp_path / "nested_nstate",
+        max_size_bytes=100 * 1024**2,
+    )
+
+
+def _wait_for_file(manager, block_hash):
+    for _ in range(100):
+        if manager._get_file_path(block_hash).exists():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def _eq(a, b):
+    return mx.max(mx.abs(a - b)).item() == 0.0
+
+
+class TestNestedNStateElements:
+    """An nstate element may itself be a composite sub-state."""
+
+    def test_element_is_tuple_of_arrays_round_trips(self, tmp_path):
+        """A layer nstate whose element is a 2-tuple ``(keys, values)`` of
+        arrays survives the round-trip with both arrays byte-identical."""
+        manager = _make_manager(tmp_path)
+        block_hash = b"nested_tuple_elem___"
+
+        keys = mx.arange(1 * 1 * 16 * 8, dtype=mx.float32).reshape(1, 1, 16, 8)
+        values = (mx.arange(1 * 1 * 16 * 8, dtype=mx.float32) + 7.0).reshape(1, 1, 16, 8)
+        mx.eval(keys, values)
+
+        layer_marker = ("__nstate__", "DeepSeekV4Composite", [(keys, values)])
+        manager.save_block(block_hash, [layer_marker], token_count=16)
+        assert _wait_for_file(manager, block_hash)
+
+        loaded = manager.load_block(block_hash)
+        assert loaded is not None
+        assert len(loaded) == 1
+        marker = loaded[0]
+        assert marker[0] == "__nstate__"
+        elements = marker[2]
+        assert len(elements) == 1
+        elem = elements[0]
+        assert isinstance(elem, (tuple, list)) and len(elem) == 2
+        assert _eq(elem[0], keys)
+        assert _eq(elem[1], values)
+
+        manager.close()
+
+    def test_element_is_nested_nstate_marker_round_trips(self, tmp_path):
+        """The real DeepSeek shape: an element that is a nested
+        ``('__nstate__', class, [None, None, pooled])`` marker."""
+        manager = _make_manager(tmp_path)
+        block_hash = b"nested_marker_elem__"
+
+        keys = mx.arange(1 * 1 * 16 * 8, dtype=mx.float32).reshape(1, 1, 16, 8)
+        values = mx.zeros((1, 1, 16, 8))
+        pooled = mx.arange(1 * 4 * 8, dtype=mx.float32).reshape(1, 4, 8) * 3.0
+        mx.eval(keys, values, pooled)
+
+        layer_marker = (
+            "__nstate__",
+            "DeepSeekV4Composite",
+            [
+                (keys, values),
+                ("__nstate__", "PoolingCache", [None, None, pooled]),
+            ],
+        )
+        manager.save_block(block_hash, [layer_marker], token_count=16)
+        assert _wait_for_file(manager, block_hash)
+
+        loaded = manager.load_block(block_hash)
+        assert loaded is not None
+        marker = loaded[0]
+        assert marker[0] == "__nstate__"
+        elements = marker[2]
+        assert len(elements) == 2
+
+        # element 0: tuple of arrays
+        assert _eq(elements[0][0], keys)
+        assert _eq(elements[0][1], values)
+
+        # element 1: nested __nstate__ marker, None positions preserved, pooled byte-equal
+        nested = elements[1]
+        assert isinstance(nested, tuple)
+        assert nested[0] == "__nstate__"
+        sub_elems = nested[2]
+        assert len(sub_elems) == 3
+        assert sub_elems[0] is None
+        assert sub_elems[1] is None
+        assert _eq(sub_elems[2], pooled)
+
+        manager.close()
+
+    def test_length2_nested_nstate_marker_stays_a_marker(self, tmp_path):
+        """A length-2, EXPLICITLY-marked nested ``__nstate__`` element must
+        round-trip as an ``__nstate__`` marker (class_name intact), not get
+        unwrapped to a bare 2-tuple. Length-2 is the heuristic-collision case
+        the length-3 tests miss; unwrapping it loses the marker and breaks
+        callers that index ``elem[2]``."""
+        manager = _make_manager(tmp_path)
+        block_hash = b"len2_nested_marker__"
+
+        c = (mx.arange(1 * 4 * 8, dtype=mx.float32) * 5.0).reshape(1, 4, 8)
+        mx.eval(c)
+
+        layer_marker = (
+            "__nstate__",
+            "DeepSeekV4Composite",
+            [("__nstate__", "PoolingCache", [None, c])],
+        )
+        manager.save_block(block_hash, [layer_marker], token_count=8)
+        assert _wait_for_file(manager, block_hash)
+
+        loaded = manager.load_block(block_hash)
+        assert loaded is not None
+        nested = loaded[0][2][0]
+        assert isinstance(nested, tuple)
+        assert nested[0] == "__nstate__", f"expected marker, got {nested!r}"
+        assert nested[1] == "PoolingCache"  # class_name preserved
+        assert len(nested[2]) == 2
+        assert nested[2][0] is None
+        assert _eq(nested[2][1], c)
+
+        manager.close()
+
+    def test_zero_size_array_element_round_trips(self, tmp_path):
+        """MLA stores an empty values tensor (a 0-length trailing axis).
+        Shape must be preserved across the round-trip."""
+        manager = _make_manager(tmp_path)
+        block_hash = b"zero_size_elem______"
+
+        keys = mx.arange(1 * 1 * 8 * 16, dtype=mx.float32).reshape(1, 1, 8, 16)
+        values = mx.zeros((1, 1, 8, 0))  # zero-size last axis, like MLA
+        mx.eval(keys, values)
+
+        layer_marker = ("__nstate__", "DeepSeekV4Composite", [(keys, values)])
+        manager.save_block(block_hash, [layer_marker], token_count=8)
+        assert _wait_for_file(manager, block_hash)
+
+        loaded = manager.load_block(block_hash)
+        assert loaded is not None
+        elem = loaded[0][2][0]
+        assert _eq(elem[0], keys)
+        assert tuple(elem[1].shape) == (1, 1, 8, 0)
+
+        manager.close()
+
+    def test_flat_three_tuple_still_works(self, tmp_path):
+        """Regression guard: a flat N-tuple of plain arrays (the existing
+        PoolingCache case) must keep working unchanged."""
+        manager = _make_manager(tmp_path)
+        block_hash = b"flat_three_tuple____"
+
+        e0 = mx.arange(1 * 4 * 8, dtype=mx.float32).reshape(1, 4, 8)
+        e1 = e0 * 2.0
+        e2 = e0 * 3.0
+        mx.eval(e0, e1, e2)
+
+        layer_marker = ("__nstate__", "PoolingCache", [e0, e1, e2])
+        manager.save_block(block_hash, [layer_marker], token_count=16)
+        assert _wait_for_file(manager, block_hash)
+
+        loaded = manager.load_block(block_hash)
+        assert loaded is not None
+        elements = loaded[0][2]
+        assert len(elements) == 3
+        assert _eq(elements[0], e0)
+        assert _eq(elements[1], e1)
+        assert _eq(elements[2], e2)
+
+        manager.close()
+
+    def test_format_version_unchanged(self):
+        """The fix is additive; existing v2/v3 caches stay readable and the
+        write version is not bumped (no mass cache invalidation)."""
+        from omlx.cache.paged_ssd_cache import (
+            _CACHE_FORMAT_VERSION,
+            _READABLE_CACHE_FORMAT_VERSIONS,
+        )
+
+        assert _CACHE_FORMAT_VERSION == "3"
+        assert {"2", "3"} <= set(_READABLE_CACHE_FORMAT_VERSIONS)


### PR DESCRIPTION
## Summary

Hybrid-MLA models build each layer as `CacheList(RotatingKVCache, PoolingCache, PoolingCache)`. On the SSD-store path such a layer reaches `PagedSSDCacheManager._store_nstate_elements` as an `__nstate__` marker whose **elements are not flat `mx.array` values** but composite sub-states:

- a 2-tuple `(keys, values)` (the rotating sub-state), and
- a nested `('__nstate__', class_name, [None, None, pooled])` marker (the pooling sub-state).

`_store_nstate_elements` assumed every element was an `mx.array` and passed it straight to `_extract_tensor_bytes`, which raised:

```
ERROR - Failed to prepare block for SSD cache: 'tuple' object has no attribute 'dtype'
```

That fails the **whole block save**, and via the caller's break-on-failure, every later block too — so the prefix cache silently stops persisting. Over a growing multi-turn conversation the hit rate bleeds from ~97% down to ~74%, and warm turns fall back to full re-prefill (95–124 s/turn on an M2 Mac Pro with DeepSeek-V4-Flash-3bit-DQ).

## Fix

Route composite elements through the same recursion the serializer already uses for `__cache_list__`:

- **store**: a nested `__nstate__` element records `{key}_nested="nstate"` (+ class name) and recurses; a bare tuple/list records `{key}_nested="tuple"` and recurses. No flat tensor is written, so an *older* reader hits its existing `Missing {key} in arrays` skip path (forward/backward safe). A genuinely unsupported (non-array, non-composite) element now raises a clear `TypeError` the caller catches and skips cleanly, instead of an opaque `.dtype` `AttributeError`.
- **load**: a `{key}_nested` marker recurses and restores the original shape — `"tuple"` rebuilds a bare tuple, `"nstate"` preserves the full `('__nstate__', class_name, elements)` wrapper as-is.
- `_maybe_unwrap_legacy` now only collapses the legacy plain `(keys, values)` pair when neither element is itself composite, so a **length-2 nested marker keeps its wrapper and class_name** (the heuristic-collision case).

Additive and fail-closed: **no cache-format-version bump**, existing v2/v3 caches stay readable, and any malformed nested marker returns `None` (block skipped) rather than reconstructing a corrupt cache.

## Tests

`tests/test_nested_nstate_serialization.py` (6 tests) pins the contract via real `save_block` → `load_block` file I/O: tuple-of-arrays element, nested `__nstate__` element with `None` sub-elements, the length-2 marker-stays-a-marker regression, zero-size (MLA empty-values) array, the flat-N-tuple guard, and format-version-unchanged. The existing `tests/test_paged_ssd_cache.py` (134 tests) stays green.

## Live validation (DeepSeek-V4-Flash-3bit-DQ, M2 Mac Pro)

A 12-turn, 16k→40k-token, thinking-ON flood:

| | before | after |
|---|---|---|
| cache hit, warm turns | 97% → **74%** (degrades) | **97–98% flat** |
| warm-turn wall | 95–124 s (re-prefill) | **7–13 s** |
| serializer errors in window | 132 | **0** |
| blocks persisted to SSD | aborts on first crash | **89, zero errors** |

## Related issues

- #1128 (ds v4 frequent cache corruption) — same model/agent setup; this is the root cause behind the "cache corruption, client never sees the stream" symptom there.
- #1866 (cache hit rate 95% → 51%) — same degradation signature; likely the same store-path abort for that model's layer shape.
- #1106 (closed; `_extract_tensor_bytes` crash on a hybrid model) — prior report of the same call site, distinct (GC-race) hypothesis; this PR addresses the non-array-element variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)