### PR TITLE
fix(omlx-mac): align About docs link with website

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/AboutScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/AboutScreen.swift
@@ -116,7 +116,7 @@ private struct ProjectSection: View {
                                  defaultValue: "Setup, model management, integrations",
                                  comment: "Sublabel under the Documentation link on the About screen"),
                 icon: "book.closed",
-                url: URL(string: "https://omlx.app/docs")!
+                url: URL(string: "https://github.com/jundot/omlx")!
             )
             LinkRow(
                 label: String(localized: "about.project.issue.label",


### PR DESCRIPTION
## Summary

Replace the dead Documentation link in the macOS About screen with the same documentation destination used by the omlx.ai website.

Fixes #1947

## Verification

- Confirmed the replacement URL returns HTTP 200
- Built the native macOS app successfully
- Ran `git diff --check`