### PR TITLE
fix: preserve symlinks and hard links when saving model_settings.json

### DIFF
--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -373,12 +373,10 @@ class ModelSettingsManager:
         }
 
         try:
-            # Write to temp file first, then rename for atomicity
-            temp_file = self.settings_file.with_suffix(".tmp")
-            with open(temp_file, "w", encoding="utf-8") as f:
+            # Write in-place so symlinks and hard links are preserved, consistent
+            # with how settings.json is saved via GlobalSettings.save.
+            with open(self.settings_file, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
-
-            temp_file.replace(self.settings_file)
             logger.debug(f"Saved settings for {len(self._settings)} models")
 
         except Exception as e:

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -373,10 +373,31 @@ class ModelSettingsManager:
         }
 
         try:
-            # Write in-place so symlinks and hard links are preserved, consistent
-            # with how settings.json is saved via GlobalSettings.save.
-            with open(self.settings_file, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2, ensure_ascii=False)
+            # Serialize first so any JSON encoding errors surface before we
+            # touch the filesystem — avoids writing a partial/corrupt file.
+            serialized = json.dumps(data, indent=2, ensure_ascii=False)
+
+            # Write to a temp file first for crash-safety.  If this step fails
+            # or the process is killed, the original file is untouched.
+            temp_file = self.settings_file.with_suffix(".tmp")
+            temp_file.write_text(serialized, encoding="utf-8")
+
+            try:
+                # Write to the original path in-place so the inode is preserved.
+                # This keeps symlinks and hard links valid — atomic rename would
+                # unlink the original inode and break them (see issue #1958).
+                with open(self.settings_file, "w", encoding="utf-8") as f:
+                    f.write(serialized)
+            except Exception:
+                # temp_file holds the complete, valid serialization and can be
+                # used for manual recovery if the in-place write failed.
+                logger.warning(
+                    f"In-place write failed; recovery backup at {temp_file}"
+                )
+                raise
+            else:
+                temp_file.unlink(missing_ok=True)
+
             logger.debug(f"Saved settings for {len(self._settings)} models")
 
         except Exception as e:

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -592,3 +592,76 @@ class TestModelSettingsManager:
                 t.join()
 
             assert len(errors) == 0
+
+
+class TestModelSettingsManagerSave:
+    """Tests for _save link-preservation and crash-safety (issue #1958)."""
+
+    def test_symlink_preserved_after_save(self):
+        """Saving must write through a symlink, not replace it with a regular file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            real_file = Path(tmpdir) / "real_model_settings.json"
+            link_file = Path(tmpdir) / "model_settings.json"
+
+            real_file.write_text("{}", encoding="utf-8")
+            link_file.symlink_to(real_file)
+
+            manager = ModelSettingsManager(Path(tmpdir))
+            manager.set_settings("mymodel", ModelSettings(temperature=0.7))
+
+            assert link_file.is_symlink(), "symlink was replaced with a regular file"
+            assert link_file.resolve() == real_file.resolve(), (
+                "symlink target changed after save"
+            )
+            saved = json.loads(real_file.read_text())
+            assert "mymodel" in saved["models"]
+
+    def test_hard_link_preserved_after_save(self):
+        """Saving must write through a hard link (shared inode), not break it."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_file = Path(tmpdir) / "model_settings.json"
+            hard_link = Path(tmpdir) / "model_settings_backup.json"
+
+            settings_file.write_text("{}", encoding="utf-8")
+            hard_link.hardlink_to(settings_file)
+
+            manager = ModelSettingsManager(Path(tmpdir))
+            manager.set_settings("mymodel", ModelSettings(temperature=0.5))
+
+            assert settings_file.stat().st_ino == hard_link.stat().st_ino, (
+                "hard link inode changed — atomic rename broke the link"
+            )
+            saved = json.loads(hard_link.read_text())
+            assert "mymodel" in saved["models"]
+
+    def test_temp_file_cleaned_up_on_success(self):
+        """The .tmp backup file must be removed after a successful save."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ModelSettingsManager(Path(tmpdir))
+            manager.set_settings("mymodel", ModelSettings(temperature=0.3))
+
+            tmp_path = Path(tmpdir) / "model_settings.tmp"
+            assert not tmp_path.exists(), ".tmp file was not cleaned up after save"
+
+    def test_serialization_error_leaves_file_untouched(self):
+        """A JSON encoding error must not corrupt the existing settings file."""
+        import unittest.mock as mock
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ModelSettingsManager(Path(tmpdir))
+            manager.set_settings("mymodel", ModelSettings(temperature=0.9))
+
+            settings_file = Path(tmpdir) / "model_settings.json"
+            original_content = settings_file.read_text()
+
+            # Make json.dumps raise before any file is touched
+            with mock.patch(
+                "omlx.model_settings.json.dumps",
+                side_effect=TypeError("not serializable"),
+            ):
+                with pytest.raises(Exception):
+                    manager.set_settings("another", ModelSettings())
+
+            # Original file must be unchanged and no stray temp file
+            assert settings_file.read_text() == original_content
+            assert not (Path(tmpdir) / "model_settings.tmp").exists()


### PR DESCRIPTION
Fixes #1958

## Problem

`ModelSettingsManager._save` writes to a temp file then calls `temp_file.replace(self.settings_file)`. `Path.replace()` replaces the directory entry itself, which destroys any symlink or hard link at that path — exactly the inconsistency reported in #1958.

`GlobalSettings.save` (which handles `settings.json`) uses a plain `open(path, 'w')` write, so it writes through symlinks and hard links without breaking them.

## Fix

Switch `_save` to the same `open()`-in-place pattern so both settings files behave consistently:

```python
# Before
temp_file = self.settings_file.with_suffix(".tmp")
with open(temp_file, "w", encoding="utf-8") as f:
    json.dump(data, f, indent=2, ensure_ascii=False)
temp_file.replace(self.settings_file)

# After
with open(self.settings_file, "w", encoding="utf-8") as f:
    json.dump(data, f, indent=2, ensure_ascii=False)
```

## Testing

Verified with a Python script that simulates both `ln -s` (symlink) and `ln` (hard link) setups:

- **symlink**: real file updated ✓, link still readable ✓
- **hard link**: real file updated ✓, link still readable ✓

Both failed before this change and pass after.

## Trade-off

The atomic rename guaranteed no partial-write corruption. The in-place write does not. In practice, `model_settings.json` is small (~5 KB) and written infrequently, so the corruption window is negligible — and it matches the existing behaviour of `settings.json`.