### PR TITLE
fix: allow uppercase letters in profile and template names

### DIFF
--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -181,19 +181,37 @@ class InvalidProfileNameError(ValueError):
     """Raised when a profile or template name fails validation."""
 
 
-_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+# Used for API-exposed names (model IDs, api_name) — must be lowercase slugs.
+_API_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+
+# Used for internal profile/template names — allows uppercase so users can
+# create names like "Gemma-4-OCR-32k" without hitting a 400 error.
+_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,31}$")
 
 
 def validate_profile_name(name: str) -> None:
-    """Raise InvalidProfileNameError if ``name`` is not a valid slug.
+    """Raise InvalidProfileNameError if ``name`` is not a valid profile identifier.
 
-    Valid: lowercase letters/digits, underscores, dashes. Must start with
-    a letter or digit. 1-32 characters.
+    Valid: letters (upper or lower), digits, underscores, dashes. Must start
+    with a letter or digit. 1-32 characters.
     """
     if not isinstance(name, str) or not _NAME_RE.match(name):
         raise InvalidProfileNameError(
             f"Invalid profile/template name: {name!r}. "
-            f"Must match ^[a-z0-9][a-z0-9_-]{{0,31}}$"
+            f"Must match ^[a-zA-Z0-9][a-zA-Z0-9_-]{{0,31}}$"
+        )
+
+
+def validate_profile_api_name(name: str) -> None:
+    """Raise InvalidProfileNameError if ``name`` is not a valid API slug.
+
+    API names are used in model IDs and URL paths, so they must be lowercase.
+    Valid: lowercase letters, digits, underscores, dashes. 1-32 characters.
+    """
+    if not isinstance(name, str) or not _API_NAME_RE.match(name):
+        raise InvalidProfileNameError(
+            f"Invalid profile API name: {name!r}. "
+            f"Must match ^[a-z0-9][a-z0-9_-]{{0,31}}$ (lowercase only)"
         )
 
 

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -373,12 +373,10 @@ class ModelSettingsManager:
         }
 
         try:
-            # Write to temp file first, then rename for atomicity
-            temp_file = self.settings_file.with_suffix(".tmp")
-            with open(temp_file, "w", encoding="utf-8") as f:
+            # Write in-place so symlinks and hard links are preserved, consistent
+            # with how settings.json is saved via GlobalSettings.save.
+            with open(self.settings_file, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
-
-            temp_file.replace(self.settings_file)
             logger.debug(f"Saved settings for {len(self._settings)} models")
 
         except Exception as e:

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -18,6 +18,7 @@ from .model_profiles import (
     filter_profile_fields,
     filter_universal_fields,
     slugify_profile_api_name,
+    validate_profile_api_name,
     validate_profile_name,
     utcnow,
 )
@@ -547,7 +548,7 @@ class ModelSettingsManager:
                     current_api_name = profile.get("api_name")
                     if current_api_name:
                         try:
-                            validate_profile_name(current_api_name)
+                            validate_profile_api_name(current_api_name)
                             base_api_name = current_api_name
                         except Exception:
                             base_api_name = slugify_profile_api_name(
@@ -591,7 +592,7 @@ class ModelSettingsManager:
 
     @staticmethod
     def _dedupe_profile_api_name(base: str, used: set[str]) -> str:
-        validate_profile_name(base)
+        validate_profile_api_name(base)
         candidate = base
         index = 2
         while candidate in used:
@@ -605,7 +606,7 @@ class ModelSettingsManager:
     @staticmethod
     def _profile_api_name(profile: Dict[str, Any]) -> str:
         api_name = profile.get("api_name") or profile["name"]
-        validate_profile_name(api_name)
+        validate_profile_api_name(api_name)
         return api_name
 
     def _allocate_profile_api_name_locked(
@@ -618,7 +619,7 @@ class ModelSettingsManager:
         exclude_name: str | None = None,
     ) -> str:
         if value:
-            validate_profile_name(value)
+            validate_profile_api_name(value)
             base = value
         else:
             base = slugify_profile_api_name(

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -374,10 +374,12 @@ class ModelSettingsManager:
         }
 
         try:
-            # Write in-place so symlinks and hard links are preserved, consistent
-            # with how settings.json is saved via GlobalSettings.save.
-            with open(self.settings_file, "w", encoding="utf-8") as f:
+            # Write to temp file first, then rename for atomicity
+            temp_file = self.settings_file.with_suffix(".tmp")
+            with open(temp_file, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
+
+            temp_file.replace(self.settings_file)
             logger.debug(f"Saved settings for {len(self._settings)} models")
 
         except Exception as e:


### PR DESCRIPTION
Fixes #1957 (partial — the Python/API side)

## Problem

Profile names like `'Gemma-4-OCR-32k'` were rejected with `HTTP 400`:

```
Invalid profile/template name: 'Gemma-4-OCR-32k'. Must match ^[a-z0-9][a-z0-9_-]{0,31}$
```

The `name` field is an internal identifier (dict key + URL path parameter). There is no technical reason to restrict it to lowercase — that restriction only makes sense for `api_name`, which is exposed in OpenAI-compatible model IDs.

## Fix

Split `validate_profile_name` into two functions:

| Function | Regex | Used for |
|---|---|---|
| `validate_profile_name` | `^[a-zA-Z0-9][a-zA-Z0-9_-]{0,31}$` | internal `name` / `new_name` fields |
| `validate_profile_api_name` | `^[a-z0-9][a-z0-9_-]{0,31}$` | `api_name` (exposed in model IDs, must stay lowercase) |

Update the 4 `api_name` call sites in `model_settings.py` to use the stricter `validate_profile_api_name`. All `name`/`new_name` call sites continue using `validate_profile_name`, which now accepts uppercase.

## Testing

```
✓ 'Gemma-4-OCR-32k'  as profile name → pass (was failing before)
✓ 'Gemma-4-OCR-32k'  as api_name     → fail (uppercase still rejected for api slugs)
✓ 'gemma-4-ocr-32k'  as profile name → pass
✓ 'gemma-4-ocr-32k'  as api_name     → pass
✓ 'Has Space'         as profile name → fail (spaces still invalid)
✓ 'Valid-Name_123'    as profile name → pass
✓ empty string        as profile name → fail
✓ 33-char string      as profile name → fail (length limit enforced)
```

## Note on #1957's second request (error UI location)

The request to show the validation error near the input field instead of at the bottom of the window is a SwiftUI change and not addressed here.