### PR TITLE
fix(reranker): recover scoring frame from chat template, gate built-in fallback to Qwen3

### DIFF
--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -296,26 +296,90 @@ class MLXRerankerModel:
                 "This model may not be a compatible CausalLM reranker."
             )
 
-        # Pre-compute prefix and suffix tokens for the prompt template.
-        # Use apply_chat_template() for portability across tokenizer formats,
-        # then split on a sentinel to extract prefix/suffix boundaries.
+        # Pre-compute the static prompt prefix/suffix (the document content is
+        # spliced between them at scoring time). The Qwen3-Reranker frame opens a
+        # user turn, then prefills an empty think block before the yes/no logit:
+        #   prefix = "<|im_start|>system\n{SYS}<|im_end|>\n<|im_start|>user\n"
+        #   suffix = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+        # We first try to recover the frame from the tokenizer's chat template, so
+        # a model shipping its own system prompt or framing is honored. We fall
+        # back to the built-in Qwen frame only when the template cannot provide it
+        # (absent, unrenderable, or role-specific templates that drop the user
+        # content, as shipped by MLX-converted Qwen3-Reranker repos).
         _SENTINEL = "<<__CONTENT_SENTINEL__>>"
-        messages = [
-            {"role": "system", "content": self._CAUSAL_LM_SYSTEM_PROMPT},
-            {"role": "user", "content": _SENTINEL},
-        ]
-        template_str = tokenizer.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=True
-        )
-        parts = template_str.split(_SENTINEL)
-        if len(parts) != 2:
-            raise ValueError(
-                f"Chat template produced unexpected format; "
-                f"could not split on sentinel. Template: {template_str!r}"
+        _THINK_PREFILL = "<think>\n\n</think>\n\n"
+
+        prefix = suffix = None
+        if getattr(tokenizer, "chat_template", None):
+            messages = [
+                {"role": "system", "content": self._CAUSAL_LM_SYSTEM_PROMPT},
+                {"role": "user", "content": _SENTINEL},
+            ]
+            try:
+                template_str = tokenizer.apply_chat_template(
+                    messages, tokenize=False, add_generation_prompt=True
+                )
+            except (MemoryError, RecursionError):
+                raise
+            except Exception as e:
+                logger.warning(
+                    "Could not render the CausalLM reranker chat template for %s; "
+                    "falling back to the built-in scoring prompt: %s",
+                    self.model_name,
+                    e,
+                )
+                template_str = None
+
+            if template_str is not None:
+                head, sentinel, tail = template_str.partition(_SENTINEL)
+                if sentinel:
+                    prefix = head
+                    # Some chat templates already emit the empty-think prefill via
+                    # add_generation_prompt; only append it when the exact prefill
+                    # is absent. Matching the full sequence (not just "</think>")
+                    # avoids both a duplicated prefill and a doubled opening tag
+                    # when a template emits only "<think>\n".
+                    suffix = tail if _THINK_PREFILL in tail else tail + _THINK_PREFILL
+                else:
+                    logger.warning(
+                        "CausalLM reranker chat template for %s did not preserve "
+                        "user content; falling back to the built-in scoring prompt.",
+                        self.model_name,
+                    )
+
+        if prefix is None or suffix is None:
+            # The built-in fallback frame is Qwen3-Reranker specific. Other CausalLM
+            # reranker architectures must surface a clear error rather than be scored
+            # through a frame that does not match their tokenizer. When adding a new
+            # arch to CAUSAL_LM_RERANKER_ARCHITECTURES that needs a built-in frame,
+            # extend this gate together with its fallback.
+            arch = self._get_architecture()
+            if arch != "Qwen3ForCausalLM":
+                raise ValueError(
+                    f"CausalLM reranker {self.model_name} has no usable chat "
+                    f"template, and no built-in scoring frame exists for "
+                    f"architecture {arch!r}. Only Qwen3-Reranker models have a "
+                    "built-in fallback frame."
+                )
+            prefix = (
+                f"<|im_start|>system\n{self._CAUSAL_LM_SYSTEM_PROMPT}<|im_end|>\n"
+                "<|im_start|>user\n"
             )
-        prefix = parts[0]
-        # Append <think> block for models that use thinking-then-answering format
-        suffix = parts[1] + "<think>\n\n</think>\n\n"
+            suffix = f"<|im_end|>\n<|im_start|>assistant\n{_THINK_PREFILL}"
+
+        # The scoring frame relies on ChatML control tokens. If the tokenizer does
+        # not map them to dedicated ids, they are silently split into ordinary text,
+        # producing a prompt that loads but scores incorrectly. Fail loudly instead.
+        for marker in ("<|im_start|>", "<|im_end|>"):
+            if marker in prefix or marker in suffix:
+                marker_ids = tokenizer.encode(marker, add_special_tokens=False)
+                if len(marker_ids) != 1:
+                    raise ValueError(
+                        f"Tokenizer for {self.model_name} does not map ChatML "
+                        f"control token {marker!r} to a single id (got "
+                        f"{marker_ids}); its tokenizer is incompatible with the "
+                        "CausalLM reranker scoring frame."
+                    )
 
         self._prefix_tokens = tokenizer.encode(prefix, add_special_tokens=False)
         self._suffix_tokens = tokenizer.encode(suffix, add_special_tokens=False)

--- a/tests/test_reranker_causal_lm.py
+++ b/tests/test_reranker_causal_lm.py
@@ -2,6 +2,9 @@
 """Tests for CausalLM-based reranker support."""
 
 import json
+import sys
+from contextlib import ExitStack
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -10,6 +13,7 @@ from safetensors.numpy import save_file
 
 try:
     import mlx.core as mx
+
     HAS_MLX = True
 except ImportError:
     HAS_MLX = False
@@ -61,16 +65,191 @@ class TestXLMRobertaReranker:
 class TestCausalLMReranker:
     """Tests for CausalLM reranker (e.g., Qwen3-Reranker) functionality."""
 
-    def _make_model_dir(self, tmp_path, name="Qwen3-Reranker-0.6B"):
+    def _make_model_dir(
+        self,
+        tmp_path,
+        name="Qwen3-Reranker-0.6B",
+        architecture="Qwen3ForCausalLM",
+        model_type="qwen3",
+    ):
         """Create a mock model directory with CausalLM reranker config."""
         model_dir = tmp_path / name
         model_dir.mkdir()
         config = {
-            "model_type": "qwen3",
-            "architectures": ["Qwen3ForCausalLM"],
+            "model_type": model_type,
+            "architectures": [architecture],
         }
         (model_dir / "config.json").write_text(json.dumps(config))
         return model_dir
+
+    def _load_with_tokenizer(self, tmp_path, tokenizer, **model_dir_kwargs):
+        model_dir = self._make_model_dir(tmp_path, **model_dir_kwargs)
+        model = MLXRerankerModel(str(model_dir))
+        wrapper = SimpleNamespace(_tokenizer=tokenizer)
+        fake_mlx_lm = SimpleNamespace(
+            load=MagicMock(return_value=(MagicMock(), wrapper))
+        )
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "omlx.utils.model_loading.maybe_load_custom_quantization",
+                    return_value=None,
+                )
+            )
+            stack.enter_context(patch.dict(sys.modules, {"mlx_lm": fake_mlx_lm}))
+            model._load_causal_lm()
+
+        return model
+
+    def _make_causal_tokenizer(self):
+        tokenizer = MagicMock()
+        tokenizer.convert_tokens_to_ids.side_effect = {"yes": 1, "no": 2}.get
+        tokenizer.encode.side_effect = lambda text, add_special_tokens=False: [text]
+        return tokenizer
+
+    def test_load_causal_lm_preserves_echoing_chat_template(self, tmp_path):
+        tokenizer = self._make_causal_tokenizer()
+        sentinel = "<<__CONTENT_SENTINEL__>>"
+        tokenizer.apply_chat_template.return_value = f"prefix{sentinel}suffix"
+
+        model = self._load_with_tokenizer(tmp_path, tokenizer)
+
+        assert model._prefix_tokens == ["prefix"]
+        assert model._suffix_tokens == ["suffix<think>\n\n</think>\n\n"]
+
+    def test_load_causal_lm_falls_back_when_template_transforms_content(self, tmp_path):
+        tokenizer = self._make_causal_tokenizer()
+        tokenizer.apply_chat_template.return_value = (
+            "<|im_start|>system\nJudge whether the Document meets the requirements "
+            "based on the Query and the Instruct provided. Note that the answer can "
+            'only be "yes" or "no".<|im_end|>\n<|im_start|>user\n'
+            "<Instruct>: instruction\n<Query>: \n<Document>: <|im_end|>\n"
+            "<|im_start|>assistant\n<think>\n\n</think>\n\n"
+        )
+
+        model = self._load_with_tokenizer(tmp_path, tokenizer)
+
+        assert model._prefix_tokens == [
+            "<|im_start|>system\n"
+            f"{model._CAUSAL_LM_SYSTEM_PROMPT}<|im_end|>\n"
+            "<|im_start|>user\n"
+        ]
+        assert model._suffix_tokens == [
+            "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+        ]
+
+    _QWEN_FALLBACK_PREFIX = (
+        "<|im_start|>system\n"
+        "Judge whether the Document meets the requirements based on the "
+        "Query and the Instruct provided. Note that the answer can only be "
+        '"yes" or "no".'
+        "<|im_end|>\n<|im_start|>user\n"
+    )
+    _QWEN_FALLBACK_SUFFIX = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+
+    def test_load_causal_lm_falls_back_when_template_rendering_raises(self, tmp_path):
+        tokenizer = self._make_causal_tokenizer()
+        tokenizer.apply_chat_template.side_effect = ValueError("bad template")
+
+        model = self._load_with_tokenizer(tmp_path, tokenizer)
+
+        assert model._prefix_tokens == [self._QWEN_FALLBACK_PREFIX]
+        assert model._suffix_tokens == [self._QWEN_FALLBACK_SUFFIX]
+
+    def test_load_causal_lm_falls_back_when_no_chat_template(self, tmp_path):
+        tokenizer = self._make_causal_tokenizer()
+        tokenizer.chat_template = None
+
+        model = self._load_with_tokenizer(tmp_path, tokenizer)
+
+        assert model._prefix_tokens == [self._QWEN_FALLBACK_PREFIX]
+        assert model._suffix_tokens == [self._QWEN_FALLBACK_SUFFIX]
+        tokenizer.apply_chat_template.assert_not_called()
+
+    def test_load_causal_lm_raises_for_non_qwen_without_usable_template(self, tmp_path):
+        tokenizer = self._make_causal_tokenizer()
+        tokenizer.chat_template = None
+
+        with pytest.raises(ValueError, match="no built-in scoring frame"):
+            self._load_with_tokenizer(
+                tmp_path,
+                tokenizer,
+                name="reranker_v2_6b",
+                architecture="MistralForCausalLM",
+                model_type="mistral",
+            )
+
+    def test_load_causal_lm_propagates_unexpected_render_error(self, tmp_path):
+        tokenizer = self._make_causal_tokenizer()
+        tokenizer.apply_chat_template.side_effect = MemoryError("oom")
+
+        with pytest.raises(MemoryError):
+            self._load_with_tokenizer(tmp_path, tokenizer)
+
+    def test_load_causal_lm_does_not_duplicate_think_prefill(self, tmp_path):
+        tokenizer = self._make_causal_tokenizer()
+        sentinel = "<<__CONTENT_SENTINEL__>>"
+        # Template already emits the empty-think prefill via add_generation_prompt.
+        tokenizer.apply_chat_template.return_value = (
+            f"P{sentinel}T<think>\n\n</think>\n\n"
+        )
+
+        model = self._load_with_tokenizer(tmp_path, tokenizer)
+
+        assert model._prefix_tokens == ["P"]
+        assert model._suffix_tokens == ["T<think>\n\n</think>\n\n"]
+
+    def test_load_causal_lm_appends_prefill_on_partial_think_in_tail(self, tmp_path):
+        tokenizer = self._make_causal_tokenizer()
+        sentinel = "<<__CONTENT_SENTINEL__>>"
+        # "</think>" appears in the tail but not as the empty-think prefill, so the
+        # prefill must still be appended (no false-positive suppression).
+        tokenizer.apply_chat_template.return_value = f"P{sentinel}T</think> extra"
+
+        model = self._load_with_tokenizer(tmp_path, tokenizer)
+
+        assert model._prefix_tokens == ["P"]
+        assert model._suffix_tokens == ["T</think> extra<think>\n\n</think>\n\n"]
+
+    def test_load_causal_lm_rejects_tokenizer_without_chatml_tokens(self, tmp_path):
+        tokenizer = self._make_causal_tokenizer()
+        tokenizer.chat_template = None  # force the built-in ChatML frame
+
+        def encode(text, add_special_tokens=False):
+            # Simulate a tokenizer that does not know ChatML control tokens and
+            # splits them into multiple ordinary-text pieces.
+            if text in ("<|im_start|>", "<|im_end|>"):
+                return [0, 0]
+            return [text]
+
+        tokenizer.encode.side_effect = encode
+
+        with pytest.raises(ValueError, match="ChatML control token"):
+            self._load_with_tokenizer(tmp_path, tokenizer)
+
+    def test_load_causal_lm_rejects_bad_tokenizer_when_sentinel_survives(
+        self, tmp_path
+    ):
+        # The ChatML-token validation must also run on the template-derived frame,
+        # not only the built-in fallback. Here the sentinel survives (template path)
+        # but the tokenizer does not know the control tokens.
+        tokenizer = self._make_causal_tokenizer()
+        sentinel = "<<__CONTENT_SENTINEL__>>"
+        tokenizer.apply_chat_template.return_value = (
+            f"<|im_start|>system\nSYS<|im_end|>\n<|im_start|>user\n{sentinel}"
+            "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+        )
+
+        def encode(text, add_special_tokens=False):
+            if text in ("<|im_start|>", "<|im_end|>"):
+                return [0, 0]
+            return [text]
+
+        tokenizer.encode.side_effect = encode
+
+        with pytest.raises(ValueError, match="ChatML control token"):
+            self._load_with_tokenizer(tmp_path, tokenizer)
 
     def test_validate_architecture_accepts_causal_lm_reranker(self, tmp_path):
         """CausalLM architecture is accepted when directory name contains 'reranker'."""
@@ -133,7 +312,9 @@ class TestCausalLMReranker:
 
         model.model = MagicMock(side_effect=mock_forward)
 
-        result = model._rerank_causal_lm("test query", ["relevant doc", "irrelevant doc"])
+        result = model._rerank_causal_lm(
+            "test query", ["relevant doc", "irrelevant doc"]
+        )
 
         assert isinstance(result, RerankOutput)
         assert len(result.scores) == 2
@@ -165,7 +346,9 @@ class TestCausalLMReranker:
         model._loaded = True
 
         mock_result = RerankOutput(scores=[0.9], indices=[0], total_tokens=10)
-        with patch.object(model, "_rerank_causal_lm", return_value=mock_result) as mock_method:
+        with patch.object(
+            model, "_rerank_causal_lm", return_value=mock_result
+        ) as mock_method:
             result = model.rerank("query", ["doc"])
             mock_method.assert_called_once()
             assert result.scores == [0.9]
@@ -178,7 +361,9 @@ class TestCausalLMReranker:
         model._loaded = True
 
         mock_result = RerankOutput(scores=[0.5], indices=[0], total_tokens=10)
-        with patch.object(model, "_rerank_causal_lm", return_value=mock_result) as mock_method:
+        with patch.object(
+            model, "_rerank_causal_lm", return_value=mock_result
+        ) as mock_method:
             model.rerank("query", ["doc"])
             # max_length=None should use default 8192 for CausalLM
             args, _ = mock_method.call_args
@@ -192,7 +377,9 @@ class TestCausalLMReranker:
         model._loaded = True
 
         mock_result = RerankOutput(scores=[0.5], indices=[0], total_tokens=10)
-        with patch.object(model, "_rerank_causal_lm", return_value=mock_result) as mock_method:
+        with patch.object(
+            model, "_rerank_causal_lm", return_value=mock_result
+        ) as mock_method:
             model.rerank("query", ["doc"], max_length=1024)
             args, _ = mock_method.call_args
             assert args[2] == 1024
@@ -205,7 +392,9 @@ class TestCausalLMReranker:
         model._loaded = True
 
         mock_result = RerankOutput(scores=[0.5], indices=[0], total_tokens=10)
-        with patch.object(model, "_rerank_causal_lm", return_value=mock_result) as mock_method:
+        with patch.object(
+            model, "_rerank_causal_lm", return_value=mock_result
+        ) as mock_method:
             model.rerank("query", ["doc"], max_length=512)
             args, _ = mock_method.call_args
             assert args[2] == 512
@@ -516,9 +705,7 @@ class TestRerankerCompileFallback:
         model._loaded = True
         model._is_causal_lm = False
         model._is_compiled = True
-        model._compiled_seq_logits = MagicMock(
-            side_effect=RuntimeError("compile fail")
-        )
+        model._compiled_seq_logits = MagicMock(side_effect=RuntimeError("compile fail"))
 
         # Mock processor
         mock_processor = MagicMock()


### PR DESCRIPTION
## Summary

Qwen3-Reranker models fail to load on `/v1/rerank` for MLX-converted repos like `mlx-community/Qwen3-Reranker-*`. The failure is at load time, so the model never serves a request — every call returns HTTP 500.

## Why (root cause)

To score a query/document pair, the loader needs the static text that wraps the document — a `prefix` and a `suffix`, together the scoring **frame**. It found these by rendering the chat template with a sentinel standing in for the content, then splitting on the sentinel — which only works if the template echoes the content back verbatim.

MLX-converted Qwen3-Reranker repos ship a role-specific template that renders `query`/`document` roles and ignores a plain `user` message. The sentinel is never emitted, the split fails, and load aborts:

```
ValueError: Chat template produced unexpected format; could not split on sentinel
```

The official `Qwen/Qwen3-Reranker-*` template echoes content and is unaffected.

## Reproduction

No weights needed — the tokenizer alone shows the dropped sentinel that the old loader split on:

```python
from transformers import AutoTokenizer

tok = AutoTokenizer.from_pretrained("mlx-community/Qwen3-Reranker-0.6B-4bit")
SENTINEL = "<<__CONTENT_SENTINEL__>>"
msgs = [
    {"role": "system", "content": "Judge whether the Document meets the requirements..."},
    {"role": "user", "content": SENTINEL},
]
rendered = tok.apply_chat_template(msgs, tokenize=False, add_generation_prompt=True)
print(SENTINEL in rendered)           # False -> sentinel dropped
print(len(rendered.split(SENTINEL)))  # 1     -> old loader raises here
```

## Changes

The loader now derives the frame from the chat template when it can, and uses a guarded built-in Qwen fallback when it can't:

- **Use the template** when it preserves the sentinel (unchanged for the official Qwen template).
- **Fall back to the built-in Qwen frame** when the template is missing, fails to render, or drops the content — the case that used to be fatal.
- **Gate the fallback to `Qwen3ForCausalLM`.** The frame is Qwen-specific; other architectures raise a clear error instead of being scored through a mismatched frame.
- **Validate the ChatML control tokens** map to single ids, so a tokenizer that doesn't know them fails loudly instead of scoring on mis-tokenized text.
- **Don't duplicate the `<think>` prefill** if the template already emitted one.
- **Narrow error handling:** skip rendering when no template is set; let unexpected errors (e.g. `MemoryError`) propagate.

## Tests

```
python -m pytest tests/test_reranker_causal_lm.py -q   # 31 passed
```

Covers each path: template preserved, content dropped, no template, render error, non-Qwen architecture, already-present think prefill, and unknown ChatML tokens.

## Notes for reviewers

The built-in frame was checked against the published Qwen3-Reranker MLX recipe and the `mlx-community/Qwen3-Reranker-0.6B-4bit` model card, and verified end-to-end on real weights (`Qwen3-Reranker-0.6B`): the model loads via the fallback and scores a relevant document at 0.997 vs 0.0 for an irrelevant one. The fallback only rescues the architecture it was validated against; everything else still fails fast.
