### PR TITLE
fix(settings): preserve symlinked config files on save (#1958)

### DIFF
--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -8,7 +8,6 @@ flags, and metadata.
 import copy
 import json
 import logging
-import os
 import threading
 from dataclasses import dataclass, field, fields
 from pathlib import Path
@@ -32,22 +31,39 @@ TEMPLATES_VERSION = 1
 
 
 def _atomic_write_json(target: Path, data: Any, **dump_kwargs: Any) -> None:
-    """Atomically write ``data`` as JSON to ``target`` (temp file + rename).
+    """Write ``data`` as JSON to ``target``, preserving linked config files.
 
-    If ``target`` is a symlink, write through to its real destination so the
-    link itself is preserved rather than clobbered by the rename (#1958 —
-    settings.json kept symlinks because it wrote in place; the model_settings/
-    profiles/templates files lost them via temp+replace). The temp file is
-    created alongside the resolved destination so the rename stays on one
-    filesystem and remains atomic; on first save (no link yet) this is
-    identical to the previous behavior.
+    Users keep ``~/.omlx`` config in a git repo and ``ln`` it into place (#1958).
+    The default path here is a temp file + atomic rename (crash-safe), but
+    ``os.replace`` swaps the directory entry to a *new* inode, which breaks
+    both a symlink (clobbers the link with a real file) and a hard link
+    (other names keep pointing at the old inode, so the repo file never sees
+    the edit). ``settings.json`` avoided this only because it writes in place.
+
+    So when ``target`` is a symlink or a hard-linked file, write in place
+    instead: an in-place write follows a symlink through to its destination
+    and rewrites a hard link's existing inode, keeping the link intact. This
+    trades atomicity for link preservation on those paths only, the same
+    tradeoff ``settings.json`` already makes, and only for files the user has
+    deliberately linked. The common, unlinked case keeps the atomic rename.
     """
-    dest = Path(os.path.realpath(target)) if target.is_symlink() else target
-    temp_file = dest.with_suffix(".tmp")
+    # st_nlink > 1 means another directory entry shares this inode (a hard
+    # link). On APFS/HFS+ a normal file is always nlink==1, and clones
+    # (clonefile, used by Finder copy/Time Machine local snapshots) get their
+    # own inode, so this does not false-positive on ordinary files.
+    is_linked = target.is_symlink() or (
+        target.exists() and target.stat().st_nlink > 1
+    )
+    if is_linked:
+        with open(target, "w", encoding="utf-8") as f:
+            json.dump(data, f, **dump_kwargs)
+        return
+
+    temp_file = target.with_suffix(".tmp")
     try:
         with open(temp_file, "w", encoding="utf-8") as f:
             json.dump(data, f, **dump_kwargs)
-        temp_file.replace(dest)
+        temp_file.replace(target)
     except Exception:
         temp_file.unlink(missing_ok=True)
         raise

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -8,6 +8,7 @@ flags, and metadata.
 import copy
 import json
 import logging
+import os
 import threading
 from dataclasses import dataclass, field, fields
 from pathlib import Path
@@ -28,6 +29,28 @@ logger = logging.getLogger(__name__)
 SETTINGS_VERSION = 1
 PROFILES_VERSION = 1
 TEMPLATES_VERSION = 1
+
+
+def _atomic_write_json(target: Path, data: Any, **dump_kwargs: Any) -> None:
+    """Atomically write ``data`` as JSON to ``target`` (temp file + rename).
+
+    If ``target`` is a symlink, write through to its real destination so the
+    link itself is preserved rather than clobbered by the rename (#1958 —
+    settings.json kept symlinks because it wrote in place; the model_settings/
+    profiles/templates files lost them via temp+replace). The temp file is
+    created alongside the resolved destination so the rename stays on one
+    filesystem and remains atomic; on first save (no link yet) this is
+    identical to the previous behavior.
+    """
+    dest = Path(os.path.realpath(target)) if target.is_symlink() else target
+    temp_file = dest.with_suffix(".tmp")
+    try:
+        with open(temp_file, "w", encoding="utf-8") as f:
+            json.dump(data, f, **dump_kwargs)
+        temp_file.replace(dest)
+    except Exception:
+        temp_file.unlink(missing_ok=True)
+        raise
 
 
 @dataclass
@@ -373,12 +396,9 @@ class ModelSettingsManager:
         }
 
         try:
-            # Write to temp file first, then rename for atomicity
-            temp_file = self.settings_file.with_suffix(".tmp")
-            with open(temp_file, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2, ensure_ascii=False)
-
-            temp_file.replace(self.settings_file)
+            _atomic_write_json(
+                self.settings_file, data, indent=2, ensure_ascii=False
+            )
             logger.debug(f"Saved settings for {len(self._settings)} models")
 
         except Exception as e:
@@ -580,15 +600,12 @@ class ModelSettingsManager:
     def _save_profiles(self) -> None:
         """Write profiles to disk atomically (temp file + rename)."""
         data = {"version": PROFILES_VERSION, "profiles": self._profiles}
-        temp_file = self.profiles_file.with_suffix(".tmp")
         try:
-            with open(temp_file, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2, ensure_ascii=False, default=str)
-            temp_file.replace(self.profiles_file)
+            _atomic_write_json(
+                self.profiles_file, data, indent=2, ensure_ascii=False, default=str
+            )
         except Exception as e:
             logger.error(f"Failed to save profiles file: {e}")
-            if temp_file.exists():
-                temp_file.unlink(missing_ok=True)
             raise
 
     @staticmethod
@@ -1079,10 +1096,9 @@ class ModelSettingsManager:
         """Must be called while holding the lock."""
         data = {"version": TEMPLATES_VERSION, "templates": self._templates}
         try:
-            temp_file = self.templates_file.with_suffix(".tmp")
-            with open(temp_file, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2, ensure_ascii=False, default=str)
-            temp_file.replace(self.templates_file)
+            _atomic_write_json(
+                self.templates_file, data, indent=2, ensure_ascii=False, default=str
+            )
         except Exception as e:
             logger.error(f"Failed to save templates file: {e}")
             raise

--- a/tests/test_model_settings_symlink.py
+++ b/tests/test_model_settings_symlink.py
@@ -1,0 +1,59 @@
+"""Atomic JSON writes must preserve symlinked config files (#1958).
+
+Users keep ~/.omlx config in a git repo and `ln` it into place. settings.json
+wrote in place and kept the link; model_settings/profiles/templates used a
+temp-file+rename that clobbered the link with a real file. All now route
+through _atomic_write_json, which writes through to the link target.
+"""
+
+import json
+import os
+
+from omlx.model_settings import (
+    ModelSettings,
+    ModelSettingsManager,
+    _atomic_write_json,
+)
+
+
+def test_atomic_write_json_writes_through_symlink(tmp_path):
+    real = tmp_path / "repo" / "data.json"
+    real.parent.mkdir()
+    real.write_text("{}")
+    link = tmp_path / "link.json"
+    link.symlink_to(real)
+
+    _atomic_write_json(link, {"x": 1}, indent=2)
+
+    assert link.is_symlink(), "rename clobbered the symlink with a real file"
+    assert os.path.realpath(link) == str(real)
+    assert json.loads(real.read_text()) == {"x": 1}
+    # no stray temp file left behind next to the resolved target
+    assert not (real.parent / "data.tmp").exists()
+
+
+def test_atomic_write_json_plain_file_unchanged(tmp_path):
+    # Refactor regression guard: non-symlink path still writes atomically.
+    target = tmp_path / "plain.json"
+    _atomic_write_json(target, {"y": 2}, indent=2)
+    assert not target.is_symlink()
+    assert json.loads(target.read_text()) == {"y": 2}
+
+
+def test_set_settings_preserves_symlinked_model_settings(tmp_path):
+    # Repro of #1958: model_settings.json as a symlink into a config repo.
+    real = tmp_path / "repo" / "model_settings.json"
+    real.parent.mkdir()
+    real.write_text('{"version": 1, "models": {}}')
+
+    cfg = tmp_path / "dotomlx"
+    cfg.mkdir()
+    link = cfg / "model_settings.json"
+    link.symlink_to(real)
+
+    mgr = ModelSettingsManager(cfg)
+    mgr.set_settings("my-model", ModelSettings(temperature=0.5))
+
+    assert link.is_symlink(), "save broke the symlink (#1958)"
+    assert os.path.realpath(link) == str(real)
+    assert "my-model" in real.read_text()

--- a/tests/test_model_settings_symlink.py
+++ b/tests/test_model_settings_symlink.py
@@ -1,9 +1,11 @@
-"""Atomic JSON writes must preserve symlinked config files (#1958).
+"""Atomic JSON writes must preserve linked config files (#1958).
 
-Users keep ~/.omlx config in a git repo and `ln` it into place. settings.json
-wrote in place and kept the link; model_settings/profiles/templates used a
-temp-file+rename that clobbered the link with a real file. All now route
-through _atomic_write_json, which writes through to the link target.
+Users keep ~/.omlx config in a git repo and `ln`/`ln -s` it into place.
+settings.json wrote in place and kept the link; model_settings/profiles/
+templates used a temp-file+rename whose os.replace swapped the directory
+entry to a new inode, breaking both symlinks (clobbered with a real file)
+and hard links (the repo file stopped seeing edits). All now route through
+_atomic_write_json, which writes in place for linked targets.
 """
 
 import json
@@ -32,6 +34,24 @@ def test_atomic_write_json_writes_through_symlink(tmp_path):
     assert not (real.parent / "data.tmp").exists()
 
 
+def test_atomic_write_json_preserves_hard_link(tmp_path):
+    # The issue repro uses `ln -f` (a hard link) + `ls -li` to check the inode.
+    real = tmp_path / "repo" / "data.json"
+    real.parent.mkdir()
+    real.write_text("{}")
+    link = tmp_path / "link.json"
+    os.link(real, link)  # hard link: link and real share one inode
+    inode = real.stat().st_ino
+
+    _atomic_write_json(link, {"x": 1}, indent=2)
+
+    assert link.stat().st_ino == inode, "rename broke the hard link (new inode)"
+    assert real.stat().st_ino == inode
+    # the whole point: the edit reaches the other name (the repo file)
+    assert json.loads(real.read_text()) == {"x": 1}
+    assert not (tmp_path / "link.tmp").exists()
+
+
 def test_atomic_write_json_plain_file_unchanged(tmp_path):
     # Refactor regression guard: non-symlink path still writes atomically.
     target = tmp_path / "plain.json"
@@ -57,3 +77,22 @@ def test_set_settings_preserves_symlinked_model_settings(tmp_path):
     assert link.is_symlink(), "save broke the symlink (#1958)"
     assert os.path.realpath(link) == str(real)
     assert "my-model" in real.read_text()
+
+
+def test_set_settings_preserves_hard_linked_model_settings(tmp_path):
+    # Repro of #1958 with a hard link (`ln -f`), the case the reporter showed.
+    real = tmp_path / "repo" / "model_settings.json"
+    real.parent.mkdir()
+    real.write_text('{"version": 1, "models": {}}')
+
+    cfg = tmp_path / "dotomlx"
+    cfg.mkdir()
+    link = cfg / "model_settings.json"
+    os.link(real, link)
+    inode = real.stat().st_ino
+
+    mgr = ModelSettingsManager(cfg)
+    mgr.set_settings("my-model", ModelSettings(temperature=0.5))
+
+    assert link.stat().st_ino == inode, "save broke the hard link (#1958)"
+    assert "my-model" in real.read_text(), "edit never reached the repo file"


### PR DESCRIPTION
## Problem

`~/.omlx/model_settings.json` (and `model_profiles.json`, `global_templates.json`) are written with a temp-file + `os.replace` rename. `os.replace` swaps the directory entry to a **new inode**, which breaks links a user has set up by keeping config in a git repo and `ln`-ing it into `~/.omlx/`:

- **symlink** (`ln -s`): the rename clobbers the link with a real file.
- **hard link** (`ln`): the other name (the repo file) keeps pointing at the old inode, so edits never reach it.

`settings.json` was unaffected only because its writer writes in place. Reported in #1958, whose repro uses `ln -f` (a hard link) and `ls -li` to verify the inode.

## Fix

Route all three writers through a shared `_atomic_write_json` helper. When the target is a symlink **or** a hard-linked file (`st_nlink > 1`), write in place, which follows a symlink through to its destination and rewrites a hard link's existing inode, preserving the link in both cases. The common, unlinked case keeps the temp-file + atomic rename.

### Tradeoff (deliberate)

In-place writing is **not crash-atomic**: a crash mid-write could leave a linked config file partially written. This is accepted because (a) it is the exact same tradeoff `settings.json` already makes, and (b) it only applies to files the user has deliberately linked. The default, unlinked path keeps the crash-safe atomic rename. File mode is not explicitly preserved on the unlinked rename path (umask default), which is pre-existing behavior unchanged here.

## Tests

`tests/test_model_settings_symlink.py`:
- symlink and hard-link write-through at the helper level (link survives, target/inode updated, no stray temp file)
- plain-file path unchanged (refactor regression guard)
- end-to-end `set_settings` on both a symlinked and a hard-linked `model_settings.json` (the #1958 repro, both link kinds)

Local run green: new file + existing `test_model_settings`, `test_model_settings_profiles`, `test_admin_profiles_api`, `test_settings` (350 passed).

No live-server test: this is a config file-write path with no model inference involved, and the `set_settings` integration tests exercise the real save flow end to end.