### PR TITLE
feat: accelerate GLM-5.2 with Sparse MLA and fused MoE DSA kernels

### DIFF
--- a/omlx/patches/glm_moe_dsa/__init__.py
+++ b/omlx/patches/glm_moe_dsa/__init__.py
@@ -1,57 +1,61 @@
 # SPDX-License-Identifier: Apache-2.0
 """GLM-5.2 ``glm_moe_dsa`` monkey-patch for mlx-lm.
 
-Brings ml-explore/mlx-lm#1410 into oMLX without modifying the pinned
-mlx-lm package. The upstream change turns the stock bare DeepSeek-V3.2
-subclass into a GLM-5.2-aware model with native DSA indexer sharing:
-full layers compute top-k indices, shared layers reuse the previous full
-layer's top-k, and shared layers carry no indexer KV cache.
+Vendors the oMLX GLM-5.2 optimized mlx-lm model code without modifying the
+pinned mlx-lm package. The public module name stays
+``mlx_lm.models.glm_moe_dsa`` so mlx-lm's normal model loader can find it, but
+the optimized helper modules remain private to ``omlx.patches.glm_moe_dsa`` and
+do not replace ``mlx_lm.models.deepseek_v32`` or the shared MoE layers used by
+other model families.
 """
 
 from __future__ import annotations
 
 import importlib
-import importlib.util
 import logging
 import sys
-from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-PR_HEAD_SHA = "3cb18b51892a7800678923116f5b4920a7666208"
-PR_URL = "https://github.com/ml-explore/mlx-lm/pull/1410"
+PATCH_SOURCE = "mlxlm-glm optimized-final mlx-lm snapshot"
+CUSTOM_MLX_REF = "https://github.com/jundot/mlx@v0.31.2-omlx"
 
 _APPLIED = False
 
 
-def _upstream_has_glm_moe_dsa_support() -> bool:
-    """Return True when the installed mlx-lm already has PR #1410 support."""
+def _missing_custom_mlx_symbols() -> list[str]:
+    """Return expected custom MLX symbols missing from the installed runtime."""
     try:
-        module = importlib.import_module("mlx_lm.models.glm_moe_dsa")
+        import mlx.core as mx
     except Exception:
-        return False
+        return []
 
-    fields = getattr(getattr(module, "ModelArgs", None), "__dataclass_fields__", {})
-    return "indexer_types" in fields and hasattr(module, "GlmMoeDsaModel")
+    required = (
+        "dsa_indexer_scores",
+        "dsa_topk_indices",
+        "glm_dsa_sparse_mla_attention",
+        "glm_dsa_q8_vup_flat",
+        "glm_moe_swiglu_down",
+        "glm_moe_weighted_sum",
+    )
+    return [name for name in required if not hasattr(mx.fast, name)]
 
 
 def _register_module() -> None:
     qualname = "mlx_lm.models.glm_moe_dsa"
-    here = Path(__file__).parent
-    file_path = here / "glm_moe_dsa_model.py"
-    spec = importlib.util.spec_from_file_location(qualname, str(file_path))
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Could not create spec for {qualname} from {file_path}")
+    existing = sys.modules.get(qualname)
+    if getattr(existing, "_OMLX_GLM_DSA_OPTIMIZED", False):
+        module = existing
+    else:
+        module = importlib.import_module(f"{__name__}.glm_moe_dsa_model")
+        module._OMLX_GLM_DSA_OPTIMIZED = True
 
-    module = importlib.util.module_from_spec(spec)
-    module.__package__ = "mlx_lm.models"
     sys.modules[qualname] = module
-    spec.loader.exec_module(module)
 
     import mlx_lm.models as models_pkg
 
     models_pkg.glm_moe_dsa = module
-    logger.info("Registered %s from %s", qualname, file_path.name)
+    logger.info("Registered %s from oMLX optimized vendored module", qualname)
 
 
 def apply_glm_moe_dsa_patch() -> bool:
@@ -59,9 +63,8 @@ def apply_glm_moe_dsa_patch() -> bool:
 
     Must run before ``mlx_lm.load()`` imports ``mlx_lm.models.glm_moe_dsa``.
 
-    Returns True when oMLX registered its vendored module, False when the
-    patch was already applied, mlx-lm is unavailable, or upstream already
-    ships equivalent support.
+    Returns True when oMLX registered its optimized vendored module, False when
+    the patch was already applied or mlx-lm is unavailable.
     """
     global _APPLIED
     if _APPLIED:
@@ -73,14 +76,20 @@ def apply_glm_moe_dsa_patch() -> bool:
         logger.debug("mlx_lm not importable - glm_moe_dsa patch skipped")
         return False
 
-    if _upstream_has_glm_moe_dsa_support():
-        _APPLIED = True
-        logger.debug("mlx_lm.models.glm_moe_dsa already supports GLM-5.2 sharing")
-        return False
-
     _register_module()
+    from .generate_patch import apply_glm_moe_dsa_generate_patch
+
+    apply_glm_moe_dsa_generate_patch()
     _APPLIED = True
-    logger.info("GLM MoE DSA mlx-lm patch applied (PR 1410 head %s)", PR_HEAD_SHA[:8])
+    missing = _missing_custom_mlx_symbols()
+    if missing:
+        logger.warning(
+            "GLM MoE DSA optimized patch applied, but custom MLX symbols are "
+            "missing: %s. Install %s for the accelerated path.",
+            ", ".join(missing),
+            CUSTOM_MLX_REF,
+        )
+    logger.info("GLM MoE DSA optimized mlx-lm patch applied")
     return True
 
 
@@ -88,4 +97,9 @@ def is_applied() -> bool:
     return _APPLIED
 
 
-__all__ = ["apply_glm_moe_dsa_patch", "is_applied", "PR_HEAD_SHA", "PR_URL"]
+__all__ = [
+    "apply_glm_moe_dsa_patch",
+    "is_applied",
+    "PATCH_SOURCE",
+    "CUSTOM_MLX_REF",
+]

--- a/omlx/patches/glm_moe_dsa/deepseek_v32.py
+++ b/omlx/patches/glm_moe_dsa/deepseek_v32.py
@@ -1,0 +1,1486 @@
+# Copyright © 2025 Apple Inc.
+
+import math
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
+
+from mlx_lm.models.activations import swiglu
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.cache import CacheList, KVCache
+from mlx_lm.models.mla import MultiLinear
+from mlx_lm.models.rope_utils import initialize_rope
+from .sparse_mla import (
+    block_scores_to_indices,
+    fused_indexer_topk_indices,
+    fused_indexer_scores_high_histogram,
+    fused_indexer_scores,
+    fused_topk_block_table_from_scores,
+    fused_topk_indices_with_high_histogram,
+    fused_index_score_reduce,
+    scores_to_block_indices,
+)
+from .switch_layers import SwitchGLU, use_fused_gate_up_switch
+
+
+def _use_load_fused_wk_weights_proj(args) -> bool:
+    env = os.environ.get("MLX_LM_GLM_DSA_LOAD_FUSED_WK_WEIGHTS_PROJ", "auto").lower()
+    if env in {"0", "false", "off", "no"}:
+        return False
+    if env in {"1", "true", "on", "yes"}:
+        return True
+    if getattr(args, "model_type", None) != "glm_moe_dsa":
+        return False
+    quantization = getattr(args, "quantization", None)
+    if not isinstance(quantization, dict):
+        return False
+
+    def is_indexer_q8(name):
+        spec = quantization.get(name)
+        return (
+            isinstance(spec, dict)
+            and spec.get("bits") == 8
+            and spec.get("group_size") == 64
+            and spec.get("mode", "affine") == "affine"
+        )
+
+    return any(
+        key.endswith(".self_attn.indexer.wk")
+        and is_indexer_q8(key)
+        and is_indexer_q8(key[:-2] + "weights_proj")
+        for key in quantization
+    )
+
+
+def _dequant_mla_proj_mode(args) -> str:
+    if getattr(args, "model_type", None) != "glm_moe_dsa":
+        return "0"
+    return os.environ.get("MLX_LM_GLM_DSA_DEQUANT_MLA_PROJ", "0").lower()
+
+
+def _use_glm_moe_fused_gate_up(args) -> bool:
+    env = os.environ.get("MLX_LM_GLM_MOE_FUSED_GATE_UP", "auto").lower()
+    if env in {"0", "false", "off", "no"}:
+        return False
+    if env in {"1", "true", "on", "yes"}:
+        return True
+    return getattr(args, "model_type", None) == "glm_moe_dsa"
+
+
+def _use_glm_moe_swiglu_down(args) -> bool:
+    env = os.environ.get("MLX_LM_GLM_MOE_SWIGLU_DOWN", "auto").lower()
+    if env in {"0", "false", "off", "no"}:
+        return False
+    if env in {"1", "true", "on", "yes"}:
+        return getattr(args, "model_type", None) == "glm_moe_dsa"
+    return getattr(args, "model_type", None) == "glm_moe_dsa"
+
+
+def _use_glm_shared_fused_gate_up(args) -> bool:
+    env = os.environ.get("MLX_LM_GLM_SHARED_FUSED_GATE_UP", "0").lower()
+    if env in {"0", "false", "off", "no"}:
+        return False
+    if env in {"1", "true", "on", "yes"}:
+        return getattr(args, "model_type", None) == "glm_moe_dsa"
+    return False
+
+
+def _use_glm_moe_weighted_sum(args) -> bool:
+    env = os.environ.get("MLX_LM_GLM_MOE_WEIGHTED_SUM", "auto").lower()
+    if env in {"0", "false", "off", "no"}:
+        return False
+    if env in {"1", "true", "on", "yes"}:
+        return getattr(args, "model_type", None) == "glm_moe_dsa"
+    return getattr(args, "model_type", None) == "glm_moe_dsa"
+
+
+def _use_glm_moe_inverse_scatter(args) -> bool:
+    env = os.environ.get("MLX_LM_GLM_MOE_INVERSE_SCATTER", "auto").lower()
+    if env in {"0", "false", "off", "no"}:
+        return False
+    if env in {"1", "true", "on", "yes"}:
+        return getattr(args, "model_type", None) == "glm_moe_dsa"
+    return getattr(args, "model_type", None) == "glm_moe_dsa"
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str = "deepseek_v32"
+    vocab_size: int = 102400
+    hidden_size: int = 4096
+    index_head_dim: int = 128
+    index_n_heads: int = 64
+    index_topk: int = 2048
+    intermediate_size: int = 11008
+    moe_intermediate_size: int = 1407
+    num_hidden_layers: int = 30
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 32
+    n_shared_experts: Optional[int] = None
+    n_routed_experts: Optional[int] = None
+    routed_scaling_factor: float = 1.0
+    kv_lora_rank: int = 512
+    q_lora_rank: int = 1536
+    qk_rope_head_dim: int = 64
+    v_head_dim: int = 128
+    qk_nope_head_dim: int = 128
+    topk_method: str = "noaux_tc"
+    scoring_func: str = "sigmoid"
+    norm_topk_prob: bool = True
+    n_group: int = 1
+    topk_group: int = 1
+    num_experts_per_tok: int = 1
+    moe_layer_freq: int = 1
+    first_k_dense_replace: int = 0
+    max_position_embeddings: int = 2048
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 10000.0
+    rope_scaling: Dict = None
+    attention_bias: bool = False
+
+
+class Indexer(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.dim = args.hidden_size
+        self.n_heads = args.index_n_heads
+        self.head_dim = args.index_head_dim
+        self.rope_head_dim = args.qk_rope_head_dim
+        self.index_topk = args.index_topk
+        self.q_lora_rank = args.q_lora_rank
+        self.wq_b = nn.Linear(
+            self.q_lora_rank, self.n_heads * self.head_dim, bias=False
+        )
+        self.load_fused_wk_weights_proj = _use_load_fused_wk_weights_proj(args)
+        if self.load_fused_wk_weights_proj:
+            self.wk = None
+            self.weights_proj = None
+            self.wk_weights_proj = nn.QuantizedLinear(
+                self.dim,
+                self.head_dim + self.n_heads,
+                bias=False,
+                group_size=64,
+                bits=8,
+                mode="affine",
+            )
+        else:
+            self.wk = nn.Linear(self.dim, self.head_dim, bias=False)
+            self.weights_proj = nn.Linear(self.dim, self.n_heads, bias=False)
+            self.wk_weights_proj = None
+        self.k_norm = nn.LayerNorm(self.head_dim)
+        self.softmax_scale = self.head_dim**-0.5
+        self.weight_scale = self.n_heads**-0.5 * self.softmax_scale
+        self._wk_weights_proj_cache = None
+        self.default_block_sparse_sdpa = args.model_type == "glm_moe_dsa"
+        self.rope = initialize_rope(
+            dims=args.qk_rope_head_dim,
+            base=args.rope_theta,
+            traditional=True,
+            max_position_embeddings=args.max_position_embeddings,
+            scaling_config=args.rope_scaling,
+        )
+
+    def _fused_wk_weights_proj(self, x: mx.array):
+        if self.wk_weights_proj is not None:
+            out = self.wk_weights_proj(x)
+            return mx.split(out, [self.head_dim], axis=-1)
+
+        if os.environ.get("MLX_LM_GLM_DSA_FUSED_WK_WEIGHTS_PROJ", "0") != "1":
+            return None
+
+        wk = self.wk
+        weights_proj = self.weights_proj
+        wk_weight = getattr(wk, "weight", None)
+        wp_weight = getattr(weights_proj, "weight", None)
+        if wk_weight is None or wp_weight is None:
+            return None
+
+        wk_scales = getattr(wk, "scales", None)
+        wp_scales = getattr(weights_proj, "scales", None)
+        is_quantized = wk_scales is not None and wp_scales is not None
+        if is_quantized:
+            if (
+                getattr(wk, "group_size", None) != getattr(weights_proj, "group_size", None)
+                or getattr(wk, "bits", None) != getattr(weights_proj, "bits", None)
+                or getattr(wk, "mode", None) != getattr(weights_proj, "mode", None)
+                or wk_weight.shape[1:] != wp_weight.shape[1:]
+                or wk_scales.shape[1:] != wp_scales.shape[1:]
+            ):
+                return None
+
+            wk_biases = getattr(wk, "biases", None)
+            wp_biases = getattr(weights_proj, "biases", None)
+            if (wk_biases is None) != (wp_biases is None):
+                return None
+
+            cache = self._wk_weights_proj_cache
+            if cache is None or cache[0] is not wk_weight or cache[1] is not wp_weight:
+                fused_weight = mx.concatenate([wk_weight, wp_weight], axis=0)
+                fused_scales = mx.concatenate([wk_scales, wp_scales], axis=0)
+                fused_biases = (
+                    None
+                    if wk_biases is None
+                    else mx.concatenate([wk_biases, wp_biases], axis=0)
+                )
+                cache = (
+                    wk_weight,
+                    wp_weight,
+                    fused_weight,
+                    fused_scales,
+                    fused_biases,
+                )
+                self._wk_weights_proj_cache = cache
+
+            out = mx.quantized_matmul(
+                x,
+                cache[2],
+                scales=cache[3],
+                biases=cache[4],
+                transpose=True,
+                group_size=wk.group_size,
+                bits=wk.bits,
+                mode=wk.mode,
+            )
+            return mx.split(out, [self.head_dim], axis=-1)
+
+        if (
+            wk_weight.shape[1:] != wp_weight.shape[1:]
+            or getattr(wk, "bias", None) is not None
+            or getattr(weights_proj, "bias", None) is not None
+        ):
+            return None
+
+        cache = self._wk_weights_proj_cache
+        if cache is None or cache[0] is not wk_weight or cache[1] is not wp_weight:
+            fused_weight = mx.concatenate([wk_weight, wp_weight], axis=0)
+            cache = (wk_weight, wp_weight, fused_weight)
+            self._wk_weights_proj_cache = cache
+        out = x @ cache[2].swapaxes(-1, -2)
+        return mx.split(out, [self.head_dim], axis=-1)
+
+    def __call__(
+        self,
+        x: mx.array,
+        qr: mx.array,
+        mask: Optional[mx.array],
+        cache: Optional[Any] = None,
+    ):
+        # Computes top_k indices for attention
+        b, s, _ = x.shape
+        q = self.wq_b(qr)
+        q = q.reshape(b, s, self.n_heads, self.head_dim).swapaxes(1, 2)
+        fused_kw = self._fused_wk_weights_proj(x)
+        if fused_kw is None:
+            k = self.wk(x)
+            weights_lh = self.weights_proj(x)
+        else:
+            k, weights_lh = fused_kw
+        k = self.k_norm(k)
+        k = mx.reshape(k, (b, 1, s, self.head_dim))
+
+        offset = cache.offset if cache is not None else 0
+
+        q = self.rope(q, offset=offset)
+        k = self.rope(k, offset=offset)
+
+        if cache is not None:
+            k, _ = cache.update_and_fetch(k, mx.zeros([b, 1, s, 0]))
+        if k.shape[2] <= self.index_topk:
+            return None
+        use_fast_topk = (
+            os.environ.get("MLX_LM_GLM_DSA_FAST_TOPK", "1") == "1"
+            and hasattr(mx.fast, "dsa_topk_indices")
+        )
+        sort_exact_topk = (
+            os.environ.get("MLX_LM_GLM_DSA_SORT_EXACT_TOPK", "1") == "1"
+        )
+        bucketed_topk = (
+            use_fast_topk
+            and s > 1
+            and os.environ.get("MLX_LM_GLM_DSA_BUCKETED_TOPK", "1") == "1"
+        )
+        causal_valid_prefix_topk = False
+        prefix_topk_rows = 0
+
+        def causal_prefix_topk(prefix_rows: int):
+            offset = k.shape[2] - s
+            slots = mx.arange(self.index_topk, dtype=mx.uint32).reshape(
+                1, 1, 1, self.index_topk
+            )
+            lengths = (
+                mx.arange(prefix_rows, dtype=mx.uint32).reshape(
+                    1, 1, prefix_rows, 1
+                )
+                + mx.array(offset + 1, dtype=mx.uint32)
+            )
+            prefix = mx.where(slots < lengths, slots, mx.array(0, dtype=mx.uint32))
+            return mx.broadcast_to(prefix, (b, 1, prefix_rows, self.index_topk))
+
+        def finish_topk_indices(indices, prefix_rows: int = 0):
+            if indices is not None:
+                indices = (
+                    mx.sort(indices, axis=-1)
+                    if sort_exact_topk and not bucketed_topk
+                    else indices
+                )
+            if prefix_rows > 0:
+                if (
+                    indices is not None
+                    and self.default_block_sparse_sdpa
+                    and os.environ.get(
+                        "MLX_LM_GLM_DSA_COMPACT_PREFIX_TOPK", "1"
+                    )
+                    == "1"
+                ):
+                    return indices, None, prefix_rows
+                prefix = causal_prefix_topk(prefix_rows)
+                return (
+                    prefix
+                    if indices is None
+                    else mx.concatenate([prefix, indices], axis=2)
+                )
+            return indices
+
+        def select_topk(
+            scores, prefix_rows: int = 0, causal_valid_prefix: Optional[bool] = None
+        ):
+            indices = None
+            if scores is not None and use_fast_topk:
+                topk_u16_env = os.environ.get("MLX_LM_GLM_DSA_TOPK_U16", "0").lower()
+                use_topk_u16 = (
+                    topk_u16_env in {"1", "true", "on", "yes"}
+                    or (
+                        topk_u16_env == "auto"
+                        and self.default_block_sparse_sdpa
+                    )
+                ) and scores.shape[-1] <= 65536 and hasattr(
+                    mx.fast, "dsa_topk_indices_u16"
+                )
+                topk_fn = (
+                    mx.fast.dsa_topk_indices_u16
+                    if use_topk_u16
+                    else mx.fast.dsa_topk_indices
+                )
+                indices = topk_fn(
+                    scores,
+                    self.index_topk,
+                    bucketed=bucketed_topk,
+                    causal_valid_prefix=(
+                        causal_valid_prefix_topk
+                        if causal_valid_prefix is None
+                        else causal_valid_prefix
+                    ),
+                )
+            elif scores is not None:
+                indices = mx.argpartition(scores, kth=-self.index_topk, axis=-1)[
+                    ..., -self.index_topk :
+                ]
+            return finish_topk_indices(indices, prefix_rows)
+
+        if s == 1:
+            scores = q @ k.swapaxes(-1, -2)
+            scores = mx.maximum(scores, 0)
+            weights = weights_lh * self.weight_scale
+            weights = weights.swapaxes(-1, -2)[..., None]
+            scores = scores * weights
+            scores = scores.sum(axis=1, keepdims=True)
+            if mask is not None:
+                scores = mx.where(mask, scores, -float("inf"))
+            return select_topk(scores)
+        weights_lh = weights_lh * self.weight_scale
+        fuse_causal_mask = (
+            mask is not None
+            and os.environ.get("MLX_LM_GLM_DSA_FUSED_INDEXER_CAUSAL", "1") == "1"
+        )
+        causal_valid_prefix_topk = (
+            fuse_causal_mask
+            and os.environ.get("MLX_LM_GLM_DSA_TOPK_CAUSAL_PREFIX_FASTPATH", "1")
+            == "1"
+        )
+        default_block_sdpa = "1" if self.default_block_sparse_sdpa else "0"
+        use_block_sdpa = os.environ.get(
+            "MLX_LM_GLM_DSA_BLOCK_SPARSE_SDPA",
+            os.environ.get("MLX_LM_GLM_DSA_BLOCK_UNION_SDPA", default_block_sdpa),
+        ) == "1"
+        prefill_mode = os.environ.get("MLX_LM_GLM_DSA_PREFILL_MODE", "").lower()
+        default_exact_prefill = (
+            self.default_block_sparse_sdpa
+            and prefill_mode == ""
+            and os.environ.get("MLX_LM_GLM_DSA_EXACT_PREFILL_DEFAULT", "1") != "0"
+        )
+        mode_exact = prefill_mode in {"exact", "strict"} or default_exact_prefill
+        mode_high = prefill_mode in {"high", "quality", "recall"}
+        use_exact_block_token_sdpa = (
+            os.environ.get(
+                "MLX_LM_GLM_DSA_EXACT_BLOCK_TOKEN_SDPA",
+                "1" if mode_exact else "0",
+            )
+            == "1"
+        )
+        if mode_high:
+            default_block_budget = "128"
+        else:
+            default_block_budget = "16" if use_block_sdpa else "0"
+        block_budget = int(
+            os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_SDPA_BUDGET",
+                os.environ.get(
+                    "MLX_LM_GLM_DSA_BLOCK_BUDGET", default_block_budget
+                ),
+            )
+        )
+        if block_budget > 0:
+            min_block_budget = int(
+                os.environ.get("MLX_LM_GLM_DSA_BLOCK_MIN_BUDGET", "16")
+            )
+            if self.default_block_sparse_sdpa:
+                min_block_budget = max(min_block_budget, 16)
+            block_budget = max(block_budget, min_block_budget)
+        q_block_size = int(
+            os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_SDPA_Q_BLOCK",
+                os.environ.get(
+                    "MLX_LM_GLM_DSA_BLOCK_BUDGET_Q_BLOCK",
+                    "32",
+                ),
+            )
+        )
+        k_block_size = int(
+            os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_SDPA_K_BLOCK",
+                os.environ.get(
+                    "MLX_LM_GLM_DSA_BLOCK_BUDGET_K_BLOCK",
+                    "16",
+                ),
+            )
+        )
+        # Sorting improves locality for shorter contexts, but at long GLM
+        # prefill lengths the sort overhead slightly outweighs that benefit.
+        default_sort = (
+            "0" if self.default_block_sparse_sdpa and k.shape[2] >= 18432 else "1"
+        )
+        sort_block_indices = (
+            os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_SDPA_SORT",
+                default_sort,
+            )
+            != "0"
+        )
+        recent_blocks = int(
+            os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_SDPA_RECENT_BLOCKS",
+                os.environ.get("MLX_LM_GLM_DSA_BLOCK_RECENT_BLOCKS", "0"),
+            )
+        )
+        if (
+            block_budget > 0
+            and s > 1
+            and use_block_sdpa
+            and not use_exact_block_token_sdpa
+            and (mask is None or fuse_causal_mask)
+            and os.environ.get(
+                "MLX_LM_GLM_DSA_FUSED_BLOCK_INDEXER",
+                "0",
+            )
+            == "1"
+            and k.shape[2]
+            >= int(os.environ.get("MLX_LM_GLM_DSA_FUSED_BLOCK_INDEXER_MIN_K", "8192"))
+        ):
+            block_scores = mx.fast.dsa_indexer_block_scores(
+                q,
+                k,
+                weights_lh,
+                q_block_size=q_block_size,
+                k_block_size=k_block_size,
+                causal=fuse_causal_mask,
+            )
+            block_indices = block_scores_to_indices(
+                block_scores,
+                block_budget=block_budget,
+                recent_blocks=recent_blocks,
+                q_block_size=q_block_size,
+                k_block_size=k_block_size,
+                query_length=s,
+                key_length=k.shape[2],
+                sort_indices=sort_block_indices,
+            )
+            if block_indices is not None:
+                return None, block_indices
+
+        scores = None
+        score_high_hist = None
+        block_table_mode = os.environ.get(
+            "MLX_LM_GLM_DSA_BLOCK_TABLE_SPARSE_MLA", "0"
+        ).lower()
+        if (
+            s > 1
+            and (mask is None or fuse_causal_mask)
+            and os.environ.get("MLX_LM_GLM_DSA_CORE_INDEXER_SCORES", "1") == "1"
+        ):
+            scores_feed_block_path = (
+                block_budget > 0
+                and use_block_sdpa
+                and not use_exact_block_token_sdpa
+            )
+            scores_feed_exact_topk = (
+                causal_valid_prefix_topk and not scores_feed_block_path
+            )
+            want_fused_exact_block_table = (
+                os.environ.get("MLX_LM_GLM_DSA_FUSED_TOPK_BLOCK_TABLE", "0")
+                == "1"
+                and use_fast_topk
+                and not scores_feed_block_path
+                and block_table_mode in {"1", "auto", "force"}
+                and (mask is None or fuse_causal_mask)
+            )
+            candidate_prefix_rows = 0
+            if (
+                use_fast_topk
+                and scores_feed_exact_topk
+                and not want_fused_exact_block_table
+            ):
+                candidate_prefix_rows = min(
+                    s, max(0, self.index_topk - (k.shape[2] - s))
+                )
+            if candidate_prefix_rows == s:
+                return select_topk(None, candidate_prefix_rows)
+            score_q = (
+                q[:, :, candidate_prefix_rows:, :] if candidate_prefix_rows else q
+            )
+            score_weights = (
+                weights_lh[:, candidate_prefix_rows:, :]
+                if candidate_prefix_rows
+                else weights_lh
+            )
+            default_chunk_mb = (
+                "128"
+                if self.default_block_sparse_sdpa and k.shape[2] <= 65536
+                else "0"
+            )
+            chunk_mb = int(
+                os.environ.get("MLX_LM_GLM_DSA_INDEXER_CHUNK_MB", default_chunk_mb)
+            )
+            chunked_topk = None
+            if (
+                os.environ.get("MLX_LM_GLM_DSA_FUSED_INDEXER_TOPK", "0") == "1"
+                and use_fast_topk
+                and not scores_feed_block_path
+            ):
+                fused_topk = fused_indexer_topk_indices(
+                    score_q,
+                    k,
+                    score_weights,
+                    self.index_topk,
+                    causal=fuse_causal_mask,
+                )
+                if fused_topk is not None:
+                    return finish_topk_indices(fused_topk, candidate_prefix_rows)
+            if (
+                chunk_mb > 0
+                and use_fast_topk
+                and not scores_feed_block_path
+                and score_q.shape[2] > 64
+            ):
+                bytes_per_score = 2
+                max_scores = max(1, (chunk_mb * 1024 * 1024) // bytes_per_score)
+                chunk_rows = max(64, (max_scores // k.shape[2]) // 64 * 64)
+                if chunk_rows < score_q.shape[2]:
+                    chunk_indices = []
+                    full_q_offset = k.shape[2] - s
+                    for row_start in range(0, score_q.shape[2], chunk_rows):
+                        row_end = min(score_q.shape[2], row_start + chunk_rows)
+                        chunk_scores = fused_indexer_scores(
+                            score_q[:, :, row_start:row_end, :],
+                            k,
+                            score_weights[:, row_start:row_end, :],
+                            causal=fuse_causal_mask,
+                            causal_q_offset=(
+                                full_q_offset + candidate_prefix_rows + row_start
+                                if fuse_causal_mask
+                                else -1
+                            ),
+                        )
+                        if chunk_scores is None:
+                            chunk_indices = []
+                            break
+                        chunk_indices.append(
+                            select_topk(
+                                chunk_scores,
+                                causal_valid_prefix=False,
+                            )
+                        )
+                    if chunk_indices:
+                        chunked_topk = mx.concatenate(chunk_indices, axis=2)
+                        return finish_topk_indices(
+                            chunked_topk, candidate_prefix_rows
+                        )
+            if chunked_topk is None:
+                use_score_high_hist = (
+                    os.environ.get("MLX_LM_GLM_DSA_SCORE_HIGH_HIST", "0") == "1"
+                    and use_fast_topk
+                    and not scores_feed_block_path
+                    and (mask is None or scores_feed_exact_topk)
+                )
+                if use_score_high_hist:
+                    score_hist_pair = fused_indexer_scores_high_histogram(
+                        score_q,
+                        k,
+                        score_weights,
+                        causal=fuse_causal_mask,
+                        skip_causal_future_store=scores_feed_exact_topk,
+                    )
+                    if score_hist_pair is not None:
+                        scores, score_high_hist = score_hist_pair
+                if scores is None:
+                    scores = fused_indexer_scores(
+                        score_q,
+                        k,
+                        score_weights,
+                        causal=fuse_causal_mask,
+                        skip_causal_future_store=scores_feed_exact_topk,
+                    )
+            if scores is not None:
+                prefix_topk_rows = candidate_prefix_rows
+
+        weights = weights_lh.swapaxes(-1, -2)[..., None]
+        head_scores = None
+        if (
+            scores is None
+            and s > 1
+            and os.environ.get("MLX_LM_GLM_DSA_FUSED_INDEXER_REDUCE", "1") == "1"
+        ):
+            head_scores = q @ k.swapaxes(-1, -2)
+            scores = fused_index_score_reduce(
+                head_scores,
+                weights,
+                causal=fuse_causal_mask,
+            )
+        if scores is None:
+            if head_scores is None:
+                head_scores = q @ k.swapaxes(-1, -2)
+            scores = mx.maximum(head_scores, 0)
+            scores = scores * weights
+            scores = scores.sum(axis=1, keepdims=True)
+            fuse_causal_mask = False
+        if mask is not None and not fuse_causal_mask:
+            scores = mx.where(mask, scores, -float("inf"))
+        if (
+            block_budget > 0
+            and s > 1
+            and use_block_sdpa
+            and not use_exact_block_token_sdpa
+        ):
+            block_indices = scores_to_block_indices(
+                scores,
+                block_budget=block_budget,
+                q_block_size=q_block_size,
+                k_block_size=k_block_size,
+                recent_blocks=recent_blocks,
+                sort_indices=sort_block_indices,
+            )
+            if block_indices is not None:
+                return None, block_indices
+        if scores is not None and score_high_hist is not None:
+            high_hist_indices = fused_topk_indices_with_high_histogram(
+                scores,
+                score_high_hist,
+                self.index_topk,
+                bucketed=bucketed_topk,
+                causal_valid_prefix=causal_valid_prefix_topk,
+            )
+            if high_hist_indices is not None:
+                return finish_topk_indices(high_hist_indices, prefix_topk_rows)
+        if (
+            scores is not None
+            and os.environ.get("MLX_LM_GLM_DSA_FUSED_TOPK_BLOCK_TABLE", "0") == "1"
+            and prefix_topk_rows == 0
+        ):
+            if block_table_mode in {"1", "auto", "force"}:
+                block_k = int(
+                    os.environ.get("MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_K_BLOCK", "8")
+                )
+                exact_block_table = fused_topk_block_table_from_scores(
+                    scores,
+                    self.index_topk,
+                    k.shape[2],
+                    k_block_size=block_k,
+                    bucketed=bucketed_topk,
+                    causal_valid_prefix=causal_valid_prefix_topk,
+                )
+                if exact_block_table is not None:
+                    return None, None, 0, exact_block_table
+        return select_topk(scores, prefix_topk_rows)
+
+
+class DeepseekV32Attention(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.max_position_embeddings = config.max_position_embeddings
+        self.rope_theta = config.rope_theta
+        self.q_lora_rank = config.q_lora_rank
+        self.qk_rope_head_dim = config.qk_rope_head_dim
+        self.kv_lora_rank = config.kv_lora_rank
+        self.v_head_dim = config.v_head_dim
+        self.qk_nope_head_dim = config.qk_nope_head_dim
+        self.q_head_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
+
+        self.scale = self.q_head_dim**-0.5
+
+        self.q_a_proj = nn.Linear(
+            self.hidden_size, self.q_lora_rank, bias=config.attention_bias
+        )
+        self.q_a_layernorm = nn.RMSNorm(self.q_lora_rank, eps=1e-6)
+        self.q_b_proj = nn.Linear(
+            self.q_lora_rank, self.num_heads * self.q_head_dim, bias=False
+        )
+
+        self.kv_a_proj_with_mqa = nn.Linear(
+            self.hidden_size,
+            self.kv_lora_rank + self.qk_rope_head_dim,
+            bias=config.attention_bias,
+        )
+        self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=1e-6)
+        self.embed_q = MultiLinear(
+            self.qk_nope_head_dim, self.kv_lora_rank, self.num_heads
+        )
+        self.unembed_out = MultiLinear(
+            self.kv_lora_rank, self.v_head_dim, self.num_heads
+        )
+
+        self.o_proj = nn.Linear(
+            self.num_heads * self.v_head_dim,
+            self.hidden_size,
+            bias=config.attention_bias,
+        )
+
+        if self.config.rope_scaling is not None:
+            mscale_all_dim = self.config.rope_scaling.get("mscale_all_dim", 0)
+            if mscale_all_dim:
+                scaling_factor = self.config.rope_scaling["factor"]
+                if scaling_factor > 1:
+                    s = 0.1 * mscale_all_dim * math.log(scaling_factor) + 1.0
+                    self.scale = self.scale * s * s
+
+        self.indexer = Indexer(config)
+        self.rope = initialize_rope(
+            dims=self.qk_rope_head_dim,
+            base=self.rope_theta,
+            traditional=True,
+            max_position_embeddings=self.max_position_embeddings,
+            scaling_config=self.config.rope_scaling,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        qr = self.q_a_layernorm(self.q_a_proj(x))
+        q = self.q_b_proj(qr)
+
+        q = q.reshape(B, L, self.num_heads, self.q_head_dim).transpose(0, 2, 1, 3)
+        q_nope, q_pe = mx.split(q, [self.qk_nope_head_dim], axis=-1)
+        compressed_kv = self.kv_a_proj_with_mqa(x)
+        compressed_kv, k_pe = mx.split(compressed_kv, [self.kv_lora_rank], axis=-1)
+        k_pe = k_pe.reshape(B, L, 1, self.qk_rope_head_dim).transpose(0, 2, 1, 3)
+        kv_latent = self.kv_a_layernorm(compressed_kv)
+
+        offset = cache[0].offset if cache is not None else 0
+        q_pe = self.rope(q_pe, offset)
+        k_pe = self.rope(k_pe, offset)
+
+        kv_latent = mx.expand_dims(kv_latent, axis=1)
+
+        if cache is not None:
+            kv_latent, k_pe = cache[0].update_and_fetch(kv_latent, k_pe)
+        else:
+            cache = [None] * 2
+
+        topk_indices = self.indexer(x, qr, mask, cache=cache[1])
+        if topk_indices is not None:
+            if L == 1:
+                idx = topk_indices[:, :, 0, :, None]
+                kv_latent = mx.take_along_axis(
+                    kv_latent,
+                    mx.broadcast_to(idx, idx.shape[:-1] + (kv_latent.shape[-1],)),
+                    axis=2,
+                )
+                k_pe = mx.take_along_axis(
+                    k_pe,
+                    mx.broadcast_to(idx, idx.shape[:-1] + (k_pe.shape[-1],)),
+                    axis=2,
+                )
+                if mask is not None:
+                    mask = mx.take_along_axis(mask, topk_indices, axis=-1)
+            else:
+                shape = list(topk_indices.shape)
+                shape[-1] = kv_latent.shape[2]
+                sparse_mask = mx.zeros(shape, dtype=mx.bool_)
+                sparse_mask = mx.put_along_axis(
+                    sparse_mask, topk_indices, mx.array(True), axis=-1
+                )
+                if mask is not None:
+                    sparse_mask = sparse_mask & mask
+                mask = sparse_mask
+        # Ensure the indexer cache is evaluated even if the topk_indices are unused
+        # to keep the graph from getting too large
+        if cache is not None and cache[0] is not None:
+            cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys, cache[1].values))
+
+        pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
+        if mask is not None:
+            pe_scores = mx.where(
+                mask,
+                pe_scores,
+                mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
+            )
+
+        if L == 1:
+            q_nope = self.embed_q(q_nope)
+            k = v = kv_latent
+        else:
+            k = self.embed_q(kv_latent, transpose=False)
+            v = self.unembed_out(kv_latent)
+
+        output = scaled_dot_product_attention(
+            q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
+        )
+        if L == 1:
+            output = self.unembed_out(output)
+
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class DeepseekV32MLP(nn.Module):
+    def __init__(
+        self,
+        config: ModelArgs,
+        hidden_size: int = None,
+        intermediate_size: int = None,
+        fused_gate_up: bool = False,
+    ):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size if hidden_size is None else hidden_size
+        self.intermediate_size = (
+            config.intermediate_size if intermediate_size is None else intermediate_size
+        )
+
+        if fused_gate_up:
+            self.gate_up_proj = nn.Linear(
+                self.hidden_size, self.intermediate_size * 2, bias=False
+            )
+        else:
+            self.gate_proj = nn.Linear(
+                self.hidden_size, self.intermediate_size, bias=False
+            )
+            self.up_proj = nn.Linear(
+                self.hidden_size, self.intermediate_size, bias=False
+            )
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+
+    def __call__(self, x):
+        if hasattr(self, "gate_up_proj"):
+            gate, up = mx.split(
+                self.gate_up_proj(x), [self.intermediate_size], axis=-1
+            )
+        else:
+            gate = self.gate_proj(x)
+            up = self.up_proj(x)
+        down_proj = self.down_proj(swiglu(gate, up))
+        return down_proj
+
+
+@mx.compile
+def group_expert_select(
+    gates,
+    e_score_correction_bias,
+    top_k,
+    n_group,
+    topk_group,
+    routed_scaling_factor,
+    norm_topk_prob,
+):
+
+    scores = mx.sigmoid(gates.astype(mx.float32))
+    orig_scores = scores
+    scores = scores + e_score_correction_bias
+    if n_group > 1:
+        scores = mx.unflatten(scores, axis=-1, shape=(n_group, -1))
+        group_scores = mx.topk(scores, 2, axis=-1).sum(axis=-1, keepdims=True)
+        k = n_group - topk_group
+        group_idx = mx.argpartition(group_scores, kth=k - 1, axis=-2)[..., :k, :]
+        scores = mx.put_along_axis(
+            scores, mx.stop_gradient(group_idx), mx.array(0.0), axis=-2
+        )
+        scores = mx.flatten(scores, -2, -1)
+
+    k = top_k
+    inds = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+    if top_k > 1 and norm_topk_prob:
+        denominator = scores.sum(axis=-1, keepdims=True)
+        scores = scores / denominator
+    scores = scores * routed_scaling_factor
+
+    return inds, scores
+
+
+class MoEGate(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.config = config
+        self.top_k = config.num_experts_per_tok
+        self.norm_topk_prob = config.norm_topk_prob
+        self.n_routed_experts = config.n_routed_experts
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.n_group = config.n_group
+        self.topk_group = config.topk_group
+        self.weight = mx.zeros((self.n_routed_experts, config.hidden_size))
+        self.e_score_correction_bias = mx.zeros((self.n_routed_experts,))
+        assert config.topk_method == "noaux_tc", "Unsupported topk method."
+
+    def __call__(self, x):
+        return group_expert_select(
+            x @ self.weight.T,
+            self.e_score_correction_bias,
+            self.top_k,
+            self.n_group,
+            self.topk_group,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+        )
+
+
+class DeepseekV32MoE(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.config = config
+        self.num_experts_per_tok = config.num_experts_per_tok
+        self.switch_mlp = SwitchGLU(
+            config.hidden_size,
+            config.moe_intermediate_size,
+            config.n_routed_experts,
+            fused_gate_up=_use_glm_moe_fused_gate_up(config),
+            fused_swiglu_down=_use_glm_moe_swiglu_down(config),
+            inverse_scatter=_use_glm_moe_inverse_scatter(config),
+        )
+
+        self.gate = MoEGate(config)
+        if config.n_shared_experts is not None:
+            intermediate_size = config.moe_intermediate_size * config.n_shared_experts
+            self.shared_experts = DeepseekV32MLP(
+                config=config,
+                intermediate_size=intermediate_size,
+                fused_gate_up=_use_glm_shared_fused_gate_up(config),
+            )
+
+        self.sharding_group = None
+
+    def __call__(self, x):
+        if self.sharding_group is not None:
+            x = sum_gradients(self.sharding_group)(x)
+
+        inds, scores = self.gate(x)
+        use_weighted_sum = (
+            _use_glm_moe_weighted_sum(self.config)
+            and inds.size >= 64
+            and hasattr(mx.fast, "glm_moe_weighted_sum")
+        )
+        y = self.switch_mlp(
+            x,
+            inds,
+            scores=scores if use_weighted_sum else None,
+            weighted_sum=use_weighted_sum,
+        )
+        if not use_weighted_sum:
+            y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        if self.config.n_shared_experts is not None:
+            y = y + self.shared_experts(x)
+
+        if self.sharding_group is not None:
+            y = mx.distributed.all_sum(y, group=self.sharding_group)
+
+        return y
+
+
+class DeepseekV32DecoderLayer(nn.Module):
+    def __init__(self, config: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.self_attn = DeepseekV32Attention(config)
+        self.mlp = (
+            DeepseekV32MoE(config)
+            if (
+                config.n_routed_experts is not None
+                and layer_idx >= config.first_k_dense_replace
+                and layer_idx % config.moe_layer_freq == 0
+            )
+            else DeepseekV32MLP(config)
+        )
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class DeepseekV32Model(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            DeepseekV32DecoderLayer(config, idx)
+            for idx in range(config.num_hidden_layers)
+        ]
+        self.start_idx = 0
+        self.end_idx = len(self.layers)
+        self.num_layers = self.end_idx
+
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pipeline_rank = 0
+        self.pipeline_size = 1
+
+    def pipeline(self, group):
+        # Split layers in reverse so rank=0 gets the last layers and
+        # rank=pipeline_size-1 gets the first
+        self.pipeline_rank = group.rank()
+        self.pipeline_size = group.size()
+        layers_per_rank = len(self.layers) // self.pipeline_size
+        extra = len(self.layers) - layers_per_rank * self.pipeline_size
+        if self.pipeline_rank < extra:
+            layers_per_rank += 1
+        self.start_idx = (self.pipeline_size - self.pipeline_rank - 1) * layers_per_rank
+        self.end_idx = self.start_idx + layers_per_rank
+        self.layers = self.layers[: self.end_idx]
+        self.layers[: self.start_idx] = [None] * self.start_idx
+        self.num_layers = len(self.layers) - self.start_idx
+
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        h = self.embed_tokens(x)
+
+        pipeline_rank = self.pipeline_rank
+        pipeline_size = self.pipeline_size
+
+        if cache is None:
+            cache = [None] * self.num_layers
+        mask = create_attention_mask(
+            h, cache[0][0] if cache[0] else None, return_array=True
+        )
+
+        # Receive from the previous process in the pipeline
+
+        if pipeline_rank < pipeline_size - 1:
+            h = mx.distributed.recv_like(h, (pipeline_rank + 1))
+
+        for i in range(self.num_layers):
+            h = self.layers[self.start_idx + i](h, mask, cache[i])
+
+        # Send to the next process in the pipeline
+        if pipeline_rank != 0:
+            h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
+            if cache[-1] is not None:
+                cache[-1][0].keys = mx.depends(cache[-1][0].keys, h)
+
+        # Broadcast h while keeping it in the graph
+        if pipeline_size > 1:
+            h = mx.distributed.all_gather(h)[: h.shape[0]]
+
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.args = config
+        self.model_type = config.model_type
+        self.model = DeepseekV32Model(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+    ):
+        out = self.model(inputs, cache)
+        return self.lm_head(out)
+
+    def update_quantization_config(self, config):
+        if _use_glm_shared_fused_gate_up(self.args):
+            for key in ("quantization", "quantization_config"):
+                quantization = config.get(key)
+                if not isinstance(quantization, dict):
+                    continue
+                for l in range(self.args.num_hidden_layers):
+                    prefix = f"model.layers.{l}.mlp.shared_experts"
+                    gate_path = f"{prefix}.gate_proj"
+                    up_path = f"{prefix}.up_proj"
+                    fused_path = f"{prefix}.gate_up_proj"
+                    gate_spec = quantization.get(gate_path)
+                    up_spec = quantization.get(up_path)
+                    if gate_spec is not None and gate_spec == up_spec:
+                        quantization[fused_path] = dict(gate_spec)
+                        quantization.pop(gate_path, None)
+                        quantization.pop(up_path, None)
+
+        dequant_mla_proj = _dequant_mla_proj_mode(self.args)
+        dequant_embed_q = dequant_mla_proj in {
+            "1",
+            "true",
+            "all",
+            "both",
+            "embed",
+            "embed_q",
+        }
+        dequant_unembed_out = dequant_mla_proj in {
+            "1",
+            "true",
+            "all",
+            "both",
+            "unembed",
+            "unembed_out",
+            "out",
+        }
+        if not (dequant_embed_q or dequant_unembed_out):
+            return
+        skip_quantization = config.setdefault("_skip_quantization_paths", set())
+        if not isinstance(skip_quantization, set):
+            skip_quantization = set(skip_quantization)
+            config["_skip_quantization_paths"] = skip_quantization
+        for key in ("quantization", "quantization_config"):
+            quantization = config.get(key)
+            if not isinstance(quantization, dict):
+                continue
+            for l in range(self.args.num_hidden_layers):
+                prefix = f"model.layers.{l}.self_attn"
+                if dequant_embed_q:
+                    path = f"{prefix}.embed_q"
+                    skip_quantization.add(path)
+                    quantization.pop(path, None)
+                if dequant_unembed_out:
+                    path = f"{prefix}.unembed_out"
+                    skip_quantization.add(path)
+                    quantization.pop(path, None)
+
+    def sanitize(self, weights):
+        # Remove multi-token prediction layers
+        mpt_layer = self.args.num_hidden_layers
+        new_weights = {}
+        for k, v in weights.items():
+            parts = k.split(".")
+            if len(parts) >= 3 and parts[1] == "layers" and int(parts[2]) >= mpt_layer:
+                continue
+            new_weights[k] = v
+        weights = new_weights
+
+        def dequant(weight, scale_inv):
+            dtype = mx.bfloat16
+            weight = mx.from_fp8(weight, dtype=mx.bfloat16)
+            bs = 128  # block size
+            m, n = weight.shape
+            pad_bottom = (-m) % bs
+            pad_side = (-n) % bs
+            weight = mx.pad(weight, ((0, pad_bottom), (0, pad_side)))
+            weight = weight.reshape(
+                ((m + pad_bottom) // bs, bs, (n + pad_side) // bs, bs)
+            )
+            weight = (weight * scale_inv[:, None, :, None]).reshape(
+                m + pad_bottom, n + pad_side
+            )
+            return weight[:m, :n].astype(dtype)
+
+        # Dequantize
+        new_weights = {}
+        for k, v in weights.items():
+            if "weight_scale_inv" in k:
+                scale_inv = v
+                wk = k.replace("_scale_inv", "")
+                weight = weights[wk]
+                weight = dequant(weight, scale_inv)
+                new_weights[wk] = weight
+            elif k not in new_weights:
+                new_weights[k] = v
+        weights = new_weights
+
+        if _use_load_fused_wk_weights_proj(self.args):
+            fused = {}
+            skip_keys = set()
+            for l in range(self.args.num_hidden_layers):
+                prefix = f"model.layers.{l}.self_attn.indexer"
+                wk_prefix = f"{prefix}.wk"
+                wp_prefix = f"{prefix}.weights_proj"
+                fused_prefix = f"{prefix}.wk_weights_proj"
+                if (
+                    f"{wk_prefix}.weight" not in weights
+                    or f"{wp_prefix}.weight" not in weights
+                ):
+                    continue
+                for suffix in ("weight", "scales", "biases"):
+                    wk_key = f"{wk_prefix}.{suffix}"
+                    wp_key = f"{wp_prefix}.{suffix}"
+                    if wk_key in weights and wp_key in weights:
+                        fused[f"{fused_prefix}.{suffix}"] = mx.concatenate(
+                            [weights[wk_key], weights[wp_key]], axis=0
+                        )
+                        skip_keys.add(wk_key)
+                        skip_keys.add(wp_key)
+                skip_keys.add(f"{wk_prefix}.bias")
+                skip_keys.add(f"{wp_prefix}.bias")
+            if fused:
+                weights = {
+                    k: v
+                    for k, v in weights.items()
+                    if k not in skip_keys
+                    and ".self_attn.indexer.wk." not in k
+                    and ".self_attn.indexer.weights_proj." not in k
+                }
+                weights.update(fused)
+
+        dequant_mla_proj = _dequant_mla_proj_mode(self.args)
+        dequant_embed_q = dequant_mla_proj in {"1", "true", "all", "both", "embed", "embed_q"}
+        dequant_unembed_out = dequant_mla_proj in {
+            "1",
+            "true",
+            "all",
+            "both",
+            "unembed",
+            "unembed_out",
+            "out",
+        }
+        if (dequant_embed_q or dequant_unembed_out) and isinstance(
+            getattr(self.args, "quantization", None), dict
+        ):
+            def dequant_mla_weight(path, input_dims):
+                weight_key = f"{path}.weight"
+                scales_key = f"{path}.scales"
+                biases_key = f"{path}.biases"
+                if weight_key not in weights:
+                    weights.pop(scales_key, None)
+                    weights.pop(biases_key, None)
+                    return
+                scales = weights.pop(scales_key, None)
+                biases = weights.pop(biases_key, None)
+                if scales is None:
+                    return
+                spec = self.args.quantization.get(path, {})
+                bits = spec.get("bits")
+                if bits is None:
+                    bits = (weights[weight_key].shape[-1] * 32) // input_dims
+                group_size = spec.get("group_size")
+                if group_size is None:
+                    group_size = input_dims // scales.shape[-1]
+                mode = spec.get("mode", "affine")
+                weights[weight_key] = mx.dequantize(
+                    weights[weight_key],
+                    scales,
+                    biases,
+                    group_size=group_size,
+                    bits=bits,
+                    mode=mode,
+                    dtype=mx.bfloat16,
+                )
+
+            for l in range(self.args.num_hidden_layers):
+                prefix = f"model.layers.{l}.self_attn"
+                if dequant_embed_q:
+                    dequant_mla_weight(
+                        f"{prefix}.embed_q", self.args.qk_nope_head_dim
+                    )
+                    self.args.quantization.pop(f"{prefix}.embed_q", None)
+                if dequant_unembed_out:
+                    dequant_mla_weight(
+                        f"{prefix}.unembed_out", self.args.kv_lora_rank
+                    )
+                    self.args.quantization.pop(f"{prefix}.unembed_out", None)
+
+        # Stack experts
+        for l in range(self.args.num_hidden_layers):
+            prefix = f"model.layers.{l}"
+            for n, m in [("w1", "gate_proj"), ("w2", "down_proj"), ("w3", "up_proj")]:
+                for k in ["weight", "scales", "biases"]:
+                    if f"{prefix}.mlp.experts.0.{m}.{k}" in weights:
+                        to_join = [
+                            weights.pop(f"{prefix}.mlp.experts.{e}.{m}.{k}")
+                            for e in range(self.args.n_routed_experts)
+                        ]
+                        weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(to_join)
+            if _use_glm_moe_fused_gate_up(self.args) or use_fused_gate_up_switch():
+                switch_prefix = f"{prefix}.mlp.switch_mlp"
+                for k in ["weight", "scales", "biases"]:
+                    gate_key = f"{switch_prefix}.gate_proj.{k}"
+                    up_key = f"{switch_prefix}.up_proj.{k}"
+                    if gate_key in weights and up_key in weights:
+                        weights[f"{switch_prefix}.gate_up_proj.{k}"] = mx.concatenate(
+                            [weights.pop(gate_key), weights.pop(up_key)],
+                            axis=1,
+                        )
+            if _use_glm_shared_fused_gate_up(self.args):
+                shared_prefix = f"{prefix}.mlp.shared_experts"
+                for k in ["weight", "scales", "biases"]:
+                    gate_key = f"{shared_prefix}.gate_proj.{k}"
+                    up_key = f"{shared_prefix}.up_proj.{k}"
+                    if gate_key in weights and up_key in weights:
+                        weights[f"{shared_prefix}.gate_up_proj.{k}"] = mx.concatenate(
+                            [weights.pop(gate_key), weights.pop(up_key)],
+                            axis=0,
+                        )
+            prefix = f"model.layers.{l}.self_attn"
+            if f"{prefix}.kv_b_proj.weight" in weights:
+                quantized = f"{prefix}.kv_b_proj.scales" in weights
+                v = weights.pop(f"{prefix}.kv_b_proj.weight")
+                head_dim = self.args.qk_nope_head_dim + self.args.v_head_dim
+
+                if quantized:
+                    dims = self.args.kv_lora_rank
+                    scales = weights.pop(f"{prefix}.kv_b_proj.scales")
+                    biases = weights.pop(f"{prefix}.kv_b_proj.biases")
+                    # Try to infer bits and group size
+                    bits = (v.shape[-1] * 32) // dims
+                    group_size = dims // scales.shape[-1]
+                    v = mx.dequantize(
+                        v, scales, biases, bits=bits, group_size=group_size
+                    )
+                num_heads = self.args.num_attention_heads
+                v = v.reshape(num_heads, head_dim, -1)
+                wk = mx.contiguous(
+                    v[:, : self.args.qk_nope_head_dim, :].swapaxes(-1, -2)
+                )
+                wv = mx.contiguous(v[:, self.args.qk_nope_head_dim :, :])
+                if quantized:
+                    if not dequant_embed_q:
+                        wk, wk_scales, wk_biases = mx.quantize(
+                            wk, bits=bits, group_size=group_size
+                        )
+                        weights[f"{prefix}.embed_q.scales"] = wk_scales
+                        weights[f"{prefix}.embed_q.biases"] = wk_biases
+                    if not dequant_unembed_out:
+                        wv, wv_scales, wv_biases = mx.quantize(
+                            wv, bits=bits, group_size=group_size
+                        )
+                        weights[f"{prefix}.unembed_out.scales"] = wv_scales
+                        weights[f"{prefix}.unembed_out.biases"] = wv_biases
+                weights[f"{prefix}.embed_q.weight"] = wk
+                weights[f"{prefix}.unembed_out.weight"] = wv
+
+        return weights
+
+    def shard(self, group: Optional[mx.distributed.Group] = None):
+        group = group or mx.distributed.init()
+        N = group.size()
+        rank = group.rank()
+        for layer in self.model.layers:
+            layer.self_attn.q_b_proj = shard_linear(
+                layer.self_attn.q_b_proj, "all-to-sharded", group=group
+            )
+
+            layer.self_attn.o_proj = shard_linear(
+                layer.self_attn.o_proj, "sharded-to-all", group=group
+            )
+            layer.self_attn.num_heads //= N
+            num_heads = layer.self_attn.num_heads
+            sh = rank * num_heads
+            eh = sh + num_heads
+
+            def shard_heads(w):
+                return w[sh:eh]
+
+            layer.self_attn.embed_q.apply(shard_heads)
+            layer.self_attn.unembed_out.apply(shard_heads)
+
+            # Shard the MLP
+            if isinstance(layer.mlp, DeepseekV32MLP):
+                layer.mlp.gate_proj = shard_linear(
+                    layer.mlp.gate_proj, "all-to-sharded", group=group
+                )
+                layer.mlp.down_proj = shard_linear(
+                    layer.mlp.down_proj, "sharded-to-all", group=group
+                )
+                layer.mlp.up_proj = shard_linear(
+                    layer.mlp.up_proj, "all-to-sharded", group=group
+                )
+
+            # Shard the MoE. Shard in place since the MoE should be responsible
+            # for aggregating the results.
+            else:
+                layer.mlp.sharding_group = group = group
+                if hasattr(layer.mlp.shared_experts, "gate_up_proj"):
+                    shard_inplace(
+                        layer.mlp.shared_experts.gate_up_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                else:
+                    shard_inplace(
+                        layer.mlp.shared_experts.gate_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                    shard_inplace(
+                        layer.mlp.shared_experts.up_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                shard_inplace(
+                    layer.mlp.shared_experts.down_proj, "sharded-to-all", group=group
+                )
+                if hasattr(layer.mlp.switch_mlp, "gate_up_proj"):
+                    shard_inplace(
+                        layer.mlp.switch_mlp.gate_up_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                else:
+                    shard_inplace(
+                        layer.mlp.switch_mlp.gate_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                    shard_inplace(
+                        layer.mlp.switch_mlp.up_proj, "all-to-sharded", group=group
+                    )
+                shard_inplace(
+                    layer.mlp.switch_mlp.down_proj, "sharded-to-all", group=group
+                )
+
+    @property
+    def layers(self):
+        return self.model.layers[self.model.start_idx : self.model.end_idx]
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            return "e_score_correction_bias" not in k
+
+        return predicate
+
+    def make_cache(self):
+        return [CacheList(KVCache(), KVCache()) for _ in self.layers]

--- a/omlx/patches/glm_moe_dsa/generate_patch.py
+++ b/omlx/patches/glm_moe_dsa/generate_patch.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GLM DSA adaptive prefill patches for ``mlx_lm.generate``.
+
+This ports the small GLM-specific prefill chunking change from the optimized
+mlx-lm snapshot without replacing the whole ``mlx_lm.generate`` module. The
+patch is intentionally inert for non-GLM models.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_APPLIED = False
+
+
+@dataclass(frozen=True)
+class _AdaptivePrefillConfig:
+    step_size: int
+    after: int
+    min_remaining: int
+
+
+def _glm_dsa_adaptive_prefill_config(
+    model: Any, prefill_step_size: int
+) -> _AdaptivePrefillConfig | None:
+    model_type = getattr(model, "model_type", None) or getattr(
+        getattr(model, "args", None), "model_type", None
+    )
+    if (
+        model_type != "glm_moe_dsa"
+        or prefill_step_size != 2048
+        or os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", "1") != "1"
+    ):
+        return None
+
+    return _AdaptivePrefillConfig(
+        step_size=int(
+            os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP_SIZE", "6144")
+        ),
+        after=int(os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_AFTER", "0")),
+        min_remaining=int(
+            os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_MIN_REMAINING", "0")
+        ),
+    )
+
+
+def _prefill_step_size_for_progress(
+    prefill_step_size: int,
+    processed_tokens: int,
+    remaining_tokens: int,
+    adaptive_prefill: _AdaptivePrefillConfig | None,
+) -> int:
+    if (
+        adaptive_prefill is not None
+        and processed_tokens >= adaptive_prefill.after
+        and remaining_tokens >= adaptive_prefill.min_remaining
+    ):
+        return adaptive_prefill.step_size
+    return prefill_step_size
+
+
+def apply_glm_moe_dsa_generate_patch() -> bool:
+    """Patch ``mlx_lm.generate`` with GLM-only adaptive prefill behavior."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        gen = importlib.import_module("mlx_lm.generate")
+    except Exception:
+        logger.debug("mlx_lm.generate not importable - GLM prefill patch skipped")
+        return False
+
+    PromptProcessingBatch = gen.PromptProcessingBatch
+    BatchGenerator = gen.BatchGenerator
+
+    if getattr(PromptProcessingBatch, "_omlx_glm_dsa_adaptive_patched", False):
+        _APPLIED = True
+        return False
+
+    original_ppb_init = PromptProcessingBatch.__init__
+    original_ppb_copy = PromptProcessingBatch._copy
+    original_ppb_split = PromptProcessingBatch.split
+    original_ppb_prompt = PromptProcessingBatch.prompt
+    original_bg_init = BatchGenerator.__init__
+    original_bg_next = BatchGenerator._next
+
+    def patched_ppb_init(self, *args, **kwargs):
+        original_ppb_init(self, *args, **kwargs)
+        model = getattr(self, "model", None)
+        prefill_step_size = getattr(self, "prefill_step_size", 2048)
+        self._omlx_glm_dsa_adaptive_prefill = _glm_dsa_adaptive_prefill_config(
+            model, prefill_step_size
+        )
+
+    def patched_ppb_copy(self):
+        new_batch = original_ppb_copy(self)
+        new_batch._omlx_glm_dsa_adaptive_prefill = getattr(
+            self, "_omlx_glm_dsa_adaptive_prefill", None
+        )
+        return new_batch
+
+    def patched_ppb_split(self, indices):
+        new_batch = original_ppb_split(self, indices)
+        if not hasattr(new_batch, "_omlx_glm_dsa_adaptive_prefill"):
+            new_batch._omlx_glm_dsa_adaptive_prefill = getattr(
+                self, "_omlx_glm_dsa_adaptive_prefill", None
+            )
+        return new_batch
+
+    def patched_ppb_prompt(self, tokens):
+        adaptive_prefill = getattr(self, "_omlx_glm_dsa_adaptive_prefill", None)
+        if adaptive_prefill is None:
+            return original_ppb_prompt(self, tokens)
+
+        if len(self.uids) != len(tokens):
+            raise ValueError("The batch length doesn't match the number of inputs")
+        if not tokens:
+            return None
+
+        processed_tokens = min(len(sti) for sti in self.tokens)
+        for sti, ti in zip(self.tokens, tokens):
+            sti += ti
+
+        lengths = [len(p) for p in tokens]
+        max_length = max(lengths)
+        padding = [max_length - length for length in lengths]
+        max_padding = max(padding)
+
+        if max_padding > 0:
+            tokens = gen._right_pad_prompts(tokens, max_length=max_length)
+            for cache in self.prompt_cache:
+                cache.prepare(lengths=lengths, right_padding=padding)
+        else:
+            tokens = mx.array(tokens)
+
+        while tokens.shape[1] > 0:
+            remaining = tokens.shape[1]
+            step_size = _prefill_step_size_for_progress(
+                self.prefill_step_size,
+                processed_tokens,
+                remaining,
+                adaptive_prefill,
+            )
+            n_to_process = min(step_size, remaining)
+            self.model(tokens[:, :n_to_process], cache=self.prompt_cache)
+            mx.eval([cache.state for cache in self.prompt_cache])
+            mx.clear_cache()
+            tokens = tokens[:, n_to_process:]
+            processed_tokens += n_to_process
+
+        if max_padding > 0:
+            for cache in self.prompt_cache:
+                cache.finalize()
+            mx.eval([cache.state for cache in self.prompt_cache])
+            mx.clear_cache()
+        return None
+
+    def patched_bg_init(self, *args, **kwargs):
+        original_bg_init(self, *args, **kwargs)
+        model = getattr(self, "model", None)
+        prefill_step_size = getattr(self, "prefill_step_size", 2048)
+        self._omlx_glm_dsa_adaptive_prefill = _glm_dsa_adaptive_prefill_config(
+            model, prefill_step_size
+        )
+        self._prompt_batch._omlx_glm_dsa_adaptive_prefill = (
+            self._omlx_glm_dsa_adaptive_prefill
+        )
+
+    def patched_bg_next(self):
+        adaptive_prefill = getattr(self, "_omlx_glm_dsa_adaptive_prefill", None)
+        if adaptive_prefill is None:
+            return original_bg_next(self)
+
+        generation_responses = []
+        prompt_responses = []
+
+        if len(self._generation_batch) > 0:
+            generation_responses = self._generation_batch.next()
+            self._gen_tokens_counter += len(generation_responses)
+            self._steps_counter += 1
+            if self._steps_counter % 512 == 0:
+                mx.clear_cache()
+
+        if len(self._generation_batch) >= self.completion_batch_size:
+            return prompt_responses, generation_responses
+
+        n = min(
+            self.prefill_batch_size - len(self._prompt_batch),
+            self.completion_batch_size - len(self._generation_batch),
+            len(self._unprocessed_sequences),
+        )
+        if n > 0:
+            self._prompt_batch.extend(self._make_batch(n))
+
+        keep = []
+        split = []
+        for i, seq in enumerate(self._currently_processing):
+            segments = seq[0]
+            if len(segments) == 1 and len(segments[0]) == 1:
+                split.append(i)
+            else:
+                keep.append(i)
+
+        if split:
+            last_inputs = [self._currently_processing[i][0][0] for i in split]
+            progress = [(self._currently_processing[i][2],) * 2 for i in split]
+            self._currently_processing = [self._currently_processing[i] for i in keep]
+            gen_batch = self._prompt_batch.split(split).generate(last_inputs)
+            for i, progress_item in enumerate(progress):
+                prompt_responses.append(
+                    gen.PromptProcessingBatch.Response(
+                        gen_batch.uids[i],
+                        progress_item,
+                        True,
+                        True,
+                    )
+                )
+            self._generation_batch.extend(gen_batch)
+
+        prompts = []
+        for i, seq in enumerate(self._currently_processing):
+            response = gen.PromptProcessingBatch.Response(
+                self._prompt_batch.uids[i], 0, False, False
+            )
+            segments = seq[0]
+            remaining = len(segments[0])
+            step_size = _prefill_step_size_for_progress(
+                self.prefill_step_size,
+                seq[1],
+                remaining,
+                adaptive_prefill,
+            )
+            n = min(remaining, step_size)
+            prompts.append(segments[0][:n])
+            segments[0] = segments[0][n:]
+            if len(segments[0]) == 0:
+                segments.pop(0)
+                response.end_of_segment = True
+            seq[1] += len(prompts[-1])
+            response.progress = (seq[1], seq[2])
+            prompt_responses.append(response)
+
+        self._prompt_tokens_counter += sum(len(prompt) for prompt in prompts)
+        tic = time.perf_counter()
+        self._prompt_batch.prompt(prompts)
+        toc = time.perf_counter()
+        self._prompt_time_counter += toc - tic
+
+        return prompt_responses, generation_responses
+
+    PromptProcessingBatch.__init__ = patched_ppb_init
+    PromptProcessingBatch._copy = patched_ppb_copy
+    PromptProcessingBatch.split = patched_ppb_split
+    PromptProcessingBatch.prompt = patched_ppb_prompt
+    BatchGenerator.__init__ = patched_bg_init
+    BatchGenerator._next = patched_bg_next
+
+    PromptProcessingBatch._omlx_glm_dsa_adaptive_patched = True
+    BatchGenerator._omlx_glm_dsa_adaptive_patched = True
+    _APPLIED = True
+    logger.info("GLM MoE DSA adaptive prefill patch applied to mlx_lm.generate")
+    return True
+
+
+__all__ = ["apply_glm_moe_dsa_generate_patch"]

--- a/omlx/patches/glm_moe_dsa/glm_moe_dsa_model.py
+++ b/omlx/patches/glm_moe_dsa/glm_moe_dsa_model.py
@@ -1,27 +1,102 @@
-# Copyright (c) 2025 Apple Inc.
-# SPDX-License-Identifier: Apache-2.0
-"""GLM-5.2 ``glm_moe_dsa`` model for the pinned mlx-lm runtime.
+# Copyright © 2025 Apple Inc.
 
-Vendored from ml-explore/mlx-lm#1410 so oMLX can load GLM-5.2 checkpoints
-while the pinned mlx-lm still exposes ``glm_moe_dsa`` as a bare
-DeepSeek-V3.2 subclass.
-"""
-
-from __future__ import annotations
-
+import math
+import os
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 import mlx.core as mx
 
-from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
-from .cache import CacheList, KVCache
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.cache import CacheList, KVCache
 from .deepseek_v32 import (
     DeepseekV32Attention,
     DeepseekV32DecoderLayer,
     DeepseekV32Model,
 )
 from .deepseek_v32 import Model as DSV32Model
+from .sparse_mla import (
+    block_indices_to_block_mask,
+    q8_vup_flat,
+    sparse_mla_block_table_attention,
+    sparse_mla_qblock_attention,
+    sparse_mla_attention,
+    topk_indices_to_block_masks,
+)
+
+_SGLANG_GLM5_INDEX_TOPK_PATTERN = (
+    "FFSFSSSFSSFFFSSSFFFSFSSSSSSFFSFFSFFSSFFFFFFSFFFFFSFFSSSSSS"
+    "FSFFFSFSSSFSFFSFFSSS"
+)
+_BLOCK_STATS_SEEN = set()
+
+
+def _parse_topk_state(topk_state):
+    topk_indices = topk_state
+    block_indices = None
+    prefix_rows = 0
+    exact_block_table = None
+    if isinstance(topk_state, tuple):
+        if len(topk_state) == 4:
+            topk_indices, block_indices, prefix_rows, exact_block_table = topk_state
+        elif len(topk_state) == 3:
+            topk_indices, block_indices, prefix_rows = topk_state
+        else:
+            topk_indices, block_indices = topk_state
+    return topk_indices, block_indices, prefix_rows, exact_block_table
+
+
+def _maybe_log_block_index_stats(
+    block_indices: mx.array,
+    *,
+    layer_idx: int,
+    query_length: int,
+    key_length: int,
+    k_block_size: int,
+) -> None:
+    if os.environ.get("MLX_LM_GLM_DSA_BLOCK_STATS", "0") != "1":
+        return
+    if block_indices.ndim != 4 or block_indices.shape[1] != 1:
+        return
+
+    q_blocks = block_indices.shape[2]
+    budget = block_indices.shape[3]
+    k_blocks = (key_length + k_block_size - 1) // k_block_size
+    key = (layer_idx, query_length, key_length, q_blocks, budget)
+    if os.environ.get("MLX_LM_GLM_DSA_BLOCK_STATS_ONCE", "1") == "1":
+        if key in _BLOCK_STATS_SEEN:
+            return
+        _BLOCK_STATS_SEEN.add(key)
+
+    try:
+        rows = block_indices[0, 0].tolist()
+    except Exception as exc:
+        print(f"GLM_DSA_BLOCK_STATS layer={layer_idx} unavailable: {exc}")
+        return
+
+    row_counts = []
+    union = set()
+    total_valid = 0
+    for row in rows:
+        valid = [int(block) for block in row if int(block) < k_blocks]
+        row_counts.append(len(set(valid)))
+        union.update(valid)
+        total_valid += len(valid)
+
+    avg_row = sum(row_counts) / max(len(row_counts), 1)
+    coverage = len(union) / max(k_blocks, 1)
+    duplicate_ratio = 1.0 - (len(union) / max(total_valid, 1))
+    print(
+        "GLM_DSA_BLOCK_STATS "
+        f"layer={layer_idx} L={query_length} K={key_length} "
+        f"q_blocks={q_blocks} k_blocks={k_blocks} budget={budget} "
+        f"union={len(union)} coverage={coverage:.4f} "
+        f"avg_row_unique={avg_row:.2f} duplicate_ratio={duplicate_ratio:.4f}"
+    )
 
 
 @dataclass
@@ -37,8 +112,8 @@ class ModelArgs(BaseModelArgs):
     num_hidden_layers: int
     num_attention_heads: int
     num_key_value_heads: int
-    n_shared_experts: int | None
-    n_routed_experts: int | None
+    n_shared_experts: Optional[int]
+    n_routed_experts: Optional[int]
     routed_scaling_factor: float
     kv_lora_rank: int
     q_lora_rank: int
@@ -55,53 +130,128 @@ class ModelArgs(BaseModelArgs):
     first_k_dense_replace: int
     max_position_embeddings: int
     rms_norm_eps: float
-    rope_parameters: dict
+    rope_parameters: Dict
     attention_bias: bool
-    rope_scaling: dict | None = None
-    rope_theta: float | None = None
-    indexer_types: list[str] | None = None
-    index_topk_pattern: Any | None = None
+    rope_scaling: Dict = None
+    rope_theta: Optional[float] = None
+    indexer_types: Optional[List[str]] = None
+    index_topk_pattern: Optional[Any] = None
     index_topk_freq: int = 1
     index_skip_topk_offset: int = 2
+    quantization: Optional[Dict[str, Any]] = None
+    quantization_config: Optional[Dict[str, Any]] = None
 
     def __post_init__(self):
         self.rope_scaling = self.rope_parameters
         self.rope_theta = self.rope_parameters["rope_theta"]
 
+        config_indexer_types = self.indexer_types
+        prefill_mode = os.environ.get("MLX_LM_GLM_DSA_PREFILL_MODE", "").lower()
+        indexcache_mode = os.environ.get("MLX_LM_GLM_DSA_INDEXCACHE", "").lower()
+        env_pattern = os.environ.get("MLX_LM_GLM_DSA_INDEX_TOPK_PATTERN")
+        indexcache_disabled = indexcache_mode in {
+            "0",
+            "false",
+            "off",
+            "none",
+            "disable",
+            "disabled",
+        }
+        indexcache_requested = (
+            prefill_mode in {"sglang", "indexcache"}
+            or indexcache_mode in {"1", "true", "sglang", "glm5", "glm-5"}
+        )
+        pattern_is_sglang = (
+            env_pattern is not None
+            and env_pattern.strip().lower()
+            in {"sglang", "glm5", "glm-5", "recommended"}
+        )
+        indexcache_recall_risk_allowed = os.environ.get(
+            "MLX_LM_GLM_DSA_ALLOW_INDEXCACHE_RECALL_RISK", "0"
+        ).lower() in {"1", "true", "yes", "on"}
+        if (
+            not indexcache_disabled
+            and (indexcache_requested or pattern_is_sglang)
+            and not indexcache_recall_risk_allowed
+        ):
+            raise ValueError(
+                "SGLang-style GLM DSA IndexCache is disabled by default because "
+                "it failed a 32K multi-needle recall test on GLM-5.2-oQ4. "
+                "Set MLX_LM_GLM_DSA_ALLOW_INDEXCACHE_RECALL_RISK=1 to enable "
+                "this speed/recall-risk mode explicitly."
+            )
+        if not env_pattern and not indexcache_disabled and indexcache_requested:
+            env_pattern = "sglang"
+        if env_pattern:
+            env_pattern = env_pattern.strip()
+            if env_pattern.lower() in {"sglang", "glm5", "glm-5", "recommended"}:
+                env_pattern = _SGLANG_GLM5_INDEX_TOPK_PATTERN
+            self.index_topk_pattern = env_pattern
+            self.indexer_types = None
+        if "MLX_LM_GLM_DSA_INDEX_TOPK_FREQ" in os.environ:
+            self.index_topk_freq = int(os.environ["MLX_LM_GLM_DSA_INDEX_TOPK_FREQ"])
+            self.index_topk_pattern = None
+            if config_indexer_types is not None and os.environ.get(
+                "MLX_LM_GLM_DSA_ALLOW_NEW_INDEXERS", "0"
+            ) != "1":
+                freq = max(self.index_topk_freq, 1)
+                full_count = 0
+                indexer_types = []
+                for layer_type in config_indexer_types:
+                    if layer_type == "full":
+                        indexer_types.append(
+                            "full" if full_count % freq == 0 else "shared"
+                        )
+                        full_count += 1
+                    else:
+                        indexer_types.append("shared")
+                self.indexer_types = indexer_types
+            else:
+                self.indexer_types = None
+        if "MLX_LM_GLM_DSA_INDEX_SKIP_TOPK_OFFSET" in os.environ:
+            self.index_skip_topk_offset = int(
+                os.environ["MLX_LM_GLM_DSA_INDEX_SKIP_TOPK_OFFSET"]
+            )
+            if self.index_topk_pattern is None:
+                self.indexer_types = None
+
         if self.indexer_types is None:
             if self.index_topk_pattern is not None:
                 pattern = self.index_topk_pattern
                 if isinstance(pattern, str):
-                    self.indexer_types = [
+                    if len(pattern) != self.num_hidden_layers:
+                        raise ValueError(
+                            "index_topk_pattern length must match "
+                            f"num_hidden_layers ({len(pattern)} != "
+                            f"{self.num_hidden_layers})."
+                        )
+                    pattern_types = [
                         {"F": "full", "S": "shared"}[c] for c in pattern
                     ]
                 else:
-                    self.indexer_types = list(pattern)
+                    pattern_types = list(pattern)
+                if config_indexer_types is not None and os.environ.get(
+                    "MLX_LM_GLM_DSA_ALLOW_NEW_INDEXERS", "0"
+                ) != "1":
+                    self.indexer_types = [
+                        "full" if base == "full" and selected == "full" else "shared"
+                        for base, selected in zip(config_indexer_types, pattern_types)
+                    ]
+                else:
+                    self.indexer_types = pattern_types
             else:
-                freq = max(int(self.index_topk_freq), 1)
-                offset = int(self.index_skip_topk_offset)
+                freq = max(self.index_topk_freq, 1)
+                offset = self.index_skip_topk_offset
                 self.indexer_types = [
                     "full" if (max(i - offset + 1, 0) % freq) == 0 else "shared"
                     for i in range(self.num_hidden_layers)
                 ]
-        else:
-            self.indexer_types = list(self.indexer_types)
-
-        if len(self.indexer_types) != self.num_hidden_layers:
-            raise ValueError(
-                "`indexer_types` must have one entry per hidden layer, "
-                f"got {len(self.indexer_types)} for {self.num_hidden_layers} layers."
-            )
-        invalid = sorted(set(self.indexer_types) - {"full", "shared"})
-        if invalid:
-            raise ValueError(f"Unsupported GLM MoE DSA indexer types: {invalid}")
-        if self.indexer_types and self.indexer_types[0] != "full":
-            raise ValueError("The first GLM MoE DSA layer must be a full indexer layer.")
 
 
 class GlmMoeDsaAttention(DeepseekV32Attention):
     def __init__(self, config: ModelArgs, layer_idx: int):
         super().__init__(config)
+        self.layer_idx = layer_idx
         self.skip_topk = config.indexer_types[layer_idx] == "shared"
         if self.skip_topk:
             self.indexer = None
@@ -109,24 +259,20 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
     def __call__(
         self,
         x: mx.array,
-        mask: mx.array | None = None,
-        cache: Any | None = None,
-        prev_topk_indices: mx.array | None = None,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        prev_topk_indices: Optional[mx.array] = None,
     ):
-        batch_size, seq_len, _hidden_dim = x.shape
+        B, L, D = x.shape
 
         qr = self.q_a_layernorm(self.q_a_proj(x))
         q = self.q_b_proj(qr)
 
-        q = q.reshape(
-            batch_size, seq_len, self.num_heads, self.q_head_dim
-        ).transpose(0, 2, 1, 3)
+        q = q.reshape(B, L, self.num_heads, self.q_head_dim).transpose(0, 2, 1, 3)
         q_nope, q_pe = mx.split(q, [self.qk_nope_head_dim], axis=-1)
         compressed_kv = self.kv_a_proj_with_mqa(x)
         compressed_kv, k_pe = mx.split(compressed_kv, [self.kv_lora_rank], axis=-1)
-        k_pe = k_pe.reshape(
-            batch_size, seq_len, 1, self.qk_rope_head_dim
-        ).transpose(0, 2, 1, 3)
+        k_pe = k_pe.reshape(B, L, 1, self.qk_rope_head_dim).transpose(0, 2, 1, 3)
         kv_latent = self.kv_a_layernorm(compressed_kv)
 
         offset = cache[0].offset if cache is not None else 0
@@ -141,12 +287,13 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
             cache = [None] * 2
 
         if self.indexer is not None:
-            topk_indices = self.indexer(x, qr, mask, cache=cache[1])
+            topk_state = self.indexer(x, qr, mask, cache=cache[1])
         else:
-            topk_indices = prev_topk_indices
+            topk_state = prev_topk_indices
 
-        if topk_indices is not None:
-            if seq_len == 1:
+        if L == 1:
+            topk_indices, _, _, _ = _parse_topk_state(topk_state)
+            if topk_indices is not None:
                 idx = topk_indices[:, :, 0, :, None]
                 kv_latent = mx.take_along_axis(
                     kv_latent,
@@ -160,19 +307,390 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
                 )
                 if mask is not None:
                     mask = mx.take_along_axis(mask, topk_indices, axis=-1)
-            else:
-                shape = list(topk_indices.shape)
-                shape[-1] = kv_latent.shape[2]
-                sparse_mask = mx.zeros(shape, dtype=mx.bool_)
-                sparse_mask = mx.put_along_axis(
-                    sparse_mask, topk_indices, mx.array(True), axis=-1
-                )
-                if mask is not None:
-                    sparse_mask = sparse_mask & mask
-                mask = sparse_mask
 
+            # Ensure the indexer cache is evaluated even if the topk_indices are unused
+            # to keep the graph from getting too large.
+            if self.indexer is not None and cache is not None and cache[0] is not None:
+                cache[0].keys = mx.depends(
+                    cache[0].keys, (cache[1].keys, cache[1].values)
+                )
+
+            pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
+            if mask is not None:
+                pe_scores = mx.where(
+                    mask,
+                    pe_scores,
+                    mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
+                )
+            q_nope = self.embed_q(q_nope)
+            output = scaled_dot_product_attention(
+                q_nope,
+                kv_latent,
+                kv_latent,
+                cache=cache,
+                scale=self.scale,
+                mask=pe_scores,
+            )
+            output = self.unembed_out(output)
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+            return self.o_proj(output), topk_state
+
+        topk_indices, block_indices, topk_prefix_rows, exact_block_table = (
+            _parse_topk_state(topk_state)
+        )
+
+        # Ensure the indexer cache is evaluated even if the topk_indices are unused
+        # to keep the graph from getting too large
         if self.indexer is not None and cache is not None and cache[0] is not None:
             cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys, cache[1].values))
+
+        if exact_block_table is not None and L > 1:
+            block_k = int(
+                os.environ.get("MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_K_BLOCK", "8")
+            )
+            q_latent = self.embed_q(q_nope)
+            block_table = (
+                exact_block_table
+                if exact_block_table.dtype == mx.uint32
+                else exact_block_table.astype(mx.uint32)
+            )
+            output = sparse_mla_block_table_attention(
+                q_latent,
+                q_pe,
+                kv_latent,
+                k_pe,
+                block_table,
+                self.scale,
+                k_block_size=block_k,
+            )
+            if output is not None:
+                output_flat = q8_vup_flat(
+                    output, self.unembed_out, key_length=kv_latent.shape[2]
+                )
+                if output_flat is None:
+                    output = self.unembed_out(output)
+                    output_flat = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                output = output_flat
+                return self.o_proj(output), topk_state
+
+        if block_indices is not None and L > 1:
+            use_block_sdpa = os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_SPARSE_SDPA",
+                os.environ.get("MLX_LM_GLM_DSA_BLOCK_UNION_SDPA", "1"),
+            ) == "1" and L > 8
+            if use_block_sdpa:
+                use_block_index_sdpa = (
+                    os.environ.get("MLX_LM_GLM_DSA_BLOCK_INDEX_SDPA", "1") == "1"
+                )
+                if use_block_index_sdpa:
+                    block_indices_u32 = (
+                        block_indices
+                        if block_indices.dtype == mx.uint32
+                        else block_indices.astype(mx.uint32)
+                    )
+                    stats_k_block_size = int(
+                        os.environ.get(
+                            "MLX_LM_GLM_DSA_BLOCK_SDPA_K_BLOCK",
+                            os.environ.get(
+                                "MLX_LM_GLM_DSA_BLOCK_BUDGET_K_BLOCK", "16"
+                            ),
+                        )
+                    )
+                    _maybe_log_block_index_stats(
+                        block_indices_u32,
+                        layer_idx=self.layer_idx,
+                        query_length=L,
+                        key_length=kv_latent.shape[2],
+                        k_block_size=stats_k_block_size,
+                    )
+                    k = self.embed_q(kv_latent, transpose=False)
+                    v = self.unembed_out(kv_latent)
+                    split_qk_max_k = int(
+                        os.environ.get("MLX_LM_GLM_DSA_SPLIT_QK_MAX_K", "65536")
+                    )
+                    if (
+                        os.environ.get("MLX_LM_GLM_DSA_SPLIT_QK_SDPA", "0") == "1"
+                        and kv_latent.shape[2] <= split_qk_max_k
+                        and hasattr(mx.fast, "glm_dsa_attention")
+                    ):
+                        output = mx.fast.glm_dsa_attention(
+                            q_nope,
+                            q_pe,
+                            k,
+                            k_pe,
+                            v,
+                            block_indices_u32,
+                            self.scale,
+                        )
+                    else:
+                        k_pe_heads = mx.broadcast_to(
+                            k_pe, k.shape[:-1] + k_pe.shape[-1:]
+                        )
+                        q = mx.concatenate([q_nope, q_pe], axis=-1)
+                        k = mx.concatenate([k, k_pe_heads], axis=-1)
+                        output = mx.fast.scaled_dot_product_attention(
+                            q,
+                            k,
+                            v,
+                            scale=self.scale,
+                            mask="causal",
+                            block_indices=block_indices_u32,
+                        )
+                    output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                    return self.o_proj(output), topk_state
+                q_block_size = int(
+                    os.environ.get(
+                        "MLX_LM_GLM_DSA_BLOCK_SDPA_Q_BLOCK",
+                        os.environ.get("MLX_LM_GLM_DSA_BLOCK_BUDGET_Q_BLOCK", "32"),
+                    )
+                )
+                k_block_size = int(
+                    os.environ.get(
+                        "MLX_LM_GLM_DSA_BLOCK_SDPA_K_BLOCK",
+                        os.environ.get("MLX_LM_GLM_DSA_BLOCK_BUDGET_K_BLOCK", "16"),
+                    )
+                )
+                k = self.embed_q(kv_latent, transpose=False)
+                v = self.unembed_out(kv_latent)
+                k_pe_heads = mx.broadcast_to(k_pe, k.shape[:-1] + k_pe.shape[-1:])
+                q = mx.concatenate([q_nope, q_pe], axis=-1)
+                k = mx.concatenate([k, k_pe_heads], axis=-1)
+                block_mask = block_indices_to_block_mask(
+                    block_indices,
+                    L=L,
+                    K=kv_latent.shape[2],
+                    q_block_size=q_block_size,
+                    k_block_size=k_block_size,
+                )
+                if block_mask is not None:
+                    output = mx.fast.scaled_dot_product_attention(
+                        q,
+                        k,
+                        v,
+                        scale=self.scale,
+                        mask="causal",
+                        block_mask=block_mask,
+                    )
+                    output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                    return self.o_proj(output), topk_state
+
+        prefill_mode = os.environ.get("MLX_LM_GLM_DSA_PREFILL_MODE", "").lower()
+        default_exact_prefill = (
+            prefill_mode == ""
+            and os.environ.get("MLX_LM_GLM_DSA_EXACT_PREFILL_DEFAULT", "1") != "0"
+        )
+        exact_prefill = prefill_mode in {"exact", "strict"} or default_exact_prefill
+        # Exact block-token SDPA is still slightly faster around 10K, while
+        # direct sparse MLA wins from 12K+ on the retained GLM-5.2 path.
+        direct_sparse_mla_min_k = int(
+            os.environ.get("MLX_LM_GLM_DSA_DIRECT_SPARSE_MLA_MIN_K", "11264")
+        )
+        direct_sparse_mla_default = (
+            "1"
+            if exact_prefill and kv_latent.shape[2] >= direct_sparse_mla_min_k
+            else "0"
+        )
+        direct_sparse_mla_requested = (
+            topk_indices is not None
+            and L > 1
+            and os.environ.get(
+                "MLX_LM_GLM_DSA_DIRECT_SPARSE_MLA", direct_sparse_mla_default
+            )
+            == "1"
+        )
+        if direct_sparse_mla_requested:
+            fast_topk_indices = (
+                os.environ.get("MLX_LM_GLM_DSA_FAST_TOPK", "1") == "1"
+                and hasattr(mx.fast, "dsa_topk_indices")
+            )
+            causal_prefix_indices = (
+                fast_topk_indices
+                and os.environ.get("MLX_LM_GLM_DSA_TOPK_CAUSAL_PREFIX_FASTPATH", "1")
+                == "1"
+            )
+            q_latent = self.embed_q(q_nope)
+            if (
+                os.environ.get("MLX_LM_GLM_DSA_QBLOCK_UNION_MLA", "0") == "1"
+                and hasattr(mx.fast, "dsa_topk_qblock_union")
+                and hasattr(mx.fast, "glm_dsa_sparse_mla_qblock_attention")
+            ):
+                qblock_size = int(
+                    os.environ.get("MLX_LM_GLM_DSA_QBLOCK_UNION_MLA_Q_BLOCK", "4")
+                )
+                qblock_capacity = int(
+                    os.environ.get("MLX_LM_GLM_DSA_QBLOCK_UNION_MLA_CAPACITY", "4096")
+                )
+                output = sparse_mla_qblock_attention(
+                    q_latent,
+                    q_pe,
+                    kv_latent,
+                    k_pe,
+                    topk_indices,
+                    self.scale,
+                    topk_valid_prefix=fast_topk_indices,
+                    causal_prefix_indices=causal_prefix_indices,
+                    causal_prefix_rows=topk_prefix_rows,
+                    q_block_size=qblock_size,
+                    capacity=qblock_capacity,
+                )
+                if output is not None:
+                    output_flat = q8_vup_flat(
+                        output, self.unembed_out, key_length=kv_latent.shape[2]
+                    )
+                    if output_flat is None:
+                        output = self.unembed_out(output)
+                        output_flat = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                    output = output_flat
+                    return self.o_proj(output), topk_state
+            block_table_mode = os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_TABLE_SPARSE_MLA", "0"
+            ).lower()
+            use_block_table_mla = (
+                topk_prefix_rows == 0
+                and block_table_mode in {"1", "auto", "force"}
+                and hasattr(mx.fast, "dsa_topk_to_block_table")
+            )
+            if use_block_table_mla:
+                block_k = int(
+                    os.environ.get("MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_K_BLOCK", "8")
+                )
+                if block_table_mode != "force":
+                    k_blocks = max(1, (kv_latent.shape[2] + block_k - 1) // block_k)
+                    topk_size = max(1, topk_indices.shape[-1])
+                    expected_blocks = k_blocks * (
+                        1.0 - math.exp(topk_size * math.log1p(-1.0 / k_blocks))
+                    )
+                    expected_expansion = expected_blocks * block_k / topk_size
+                    max_expansion = float(
+                        os.environ.get(
+                            "MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_MAX_EXPANSION",
+                            "1.5",
+                        )
+                    )
+                    use_block_table_mla = expected_expansion <= max_expansion
+
+            if use_block_table_mla:
+                packed_block_table = (
+                    block_k <= 16
+                    and os.environ.get(
+                        "MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_PACKED", "1"
+                    )
+                    == "1"
+                )
+                block_table = mx.fast.dsa_topk_to_block_table(
+                    topk_indices,
+                    kv_latent.shape[2],
+                    k_block_size=block_k,
+                    causal=True,
+                    packed=packed_block_table,
+                )
+                output = sparse_mla_block_table_attention(
+                    q_latent,
+                    q_pe,
+                    kv_latent,
+                    k_pe,
+                    block_table,
+                    self.scale,
+                    k_block_size=block_k,
+                )
+                if output is not None:
+                    output_flat = q8_vup_flat(
+                        output, self.unembed_out, key_length=kv_latent.shape[2]
+                    )
+                    if output_flat is None:
+                        output = self.unembed_out(output)
+                        output_flat = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                    output = output_flat
+                    return self.o_proj(output), topk_state
+            output = sparse_mla_attention(
+                q_latent,
+                q_pe,
+                kv_latent,
+                k_pe,
+                topk_indices,
+                self.scale,
+                topk_valid_prefix=fast_topk_indices,
+                causal_prefix_indices=causal_prefix_indices,
+                causal_prefix_rows=topk_prefix_rows,
+            )
+            if output is not None:
+                output_flat = q8_vup_flat(
+                    output, self.unembed_out, key_length=kv_latent.shape[2]
+                )
+                if output_flat is None:
+                    output = self.unembed_out(output)
+                    output_flat = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                output = output_flat
+                return self.o_proj(output), topk_state
+
+        if (
+            topk_indices is not None
+            and L > 8
+            and os.environ.get(
+                "MLX_LM_GLM_DSA_EXACT_BLOCK_TOKEN_SDPA",
+                "1" if exact_prefill else "0",
+            )
+            == "1"
+        ):
+            k = self.embed_q(kv_latent, transpose=False)
+            k_pe_heads = mx.broadcast_to(k_pe, k.shape[:-1] + k_pe.shape[-1:])
+            q = mx.concatenate([q_nope, q_pe], axis=-1)
+            k = mx.concatenate([k, k_pe_heads], axis=-1)
+            v = self.unembed_out(kv_latent)
+            q_block_size = int(
+                os.environ.get(
+                    "MLX_LM_GLM_DSA_EXACT_BLOCK_SDPA_Q_BLOCK",
+                    os.environ.get("MLX_LM_GLM_DSA_BLOCK_SDPA_Q_BLOCK", "32"),
+                )
+            )
+            k_block_size = int(
+                os.environ.get(
+                    "MLX_LM_GLM_DSA_EXACT_BLOCK_SDPA_K_BLOCK",
+                    os.environ.get(
+                        "MLX_LM_GLM_DSA_BLOCK_SDPA_K_BLOCK",
+                        os.environ.get("MLX_LM_GLM_DSA_BLOCK_BUDGET_K_BLOCK", "8"),
+                    ),
+                )
+            )
+            block_masks = topk_indices_to_block_masks(
+                topk_indices,
+                L=L,
+                K=kv_latent.shape[2],
+                q_block_size=q_block_size,
+                k_block_size=k_block_size,
+                causal_prefix_indices=(
+                    os.environ.get("MLX_LM_GLM_DSA_FAST_TOPK", "1") == "1"
+                    and os.environ.get(
+                        "MLX_LM_GLM_DSA_TOPK_CAUSAL_PREFIX_FASTPATH", "1"
+                    )
+                    == "1"
+                ),
+                causal_prefix_rows=topk_prefix_rows,
+            )
+            if block_masks is not None:
+                block_mask, block_token_mask = block_masks
+                output = mx.fast.scaled_dot_product_attention(
+                    q,
+                    k,
+                    v,
+                    scale=self.scale,
+                    mask="causal",
+                    block_mask=block_mask,
+                    block_token_mask=block_token_mask,
+                )
+                output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                return self.o_proj(output), topk_state
+
+        if direct_sparse_mla_requested:
+            shape = list(topk_indices.shape)
+            shape[-1] = kv_latent.shape[2]
+            sparse_mask = mx.zeros(shape, dtype=mx.bool_)
+            sparse_mask = mx.put_along_axis(
+                sparse_mask, topk_indices, mx.array(True), axis=-1
+            )
+            if mask is not None:
+                sparse_mask = sparse_mask & mask
+            mask = sparse_mask
 
         pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
         if mask is not None:
@@ -182,7 +700,7 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if seq_len == 1:
+        if L == 1:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -192,11 +710,11 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
-        if seq_len == 1:
+        if L == 1:
             output = self.unembed_out(output)
 
-        output = output.transpose(0, 2, 1, 3).reshape(batch_size, seq_len, -1)
-        return self.o_proj(output), topk_indices
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output), topk_state
 
 
 class GlmMoeDsaDecoderLayer(DeepseekV32DecoderLayer):
@@ -207,9 +725,9 @@ class GlmMoeDsaDecoderLayer(DeepseekV32DecoderLayer):
     def __call__(
         self,
         x: mx.array,
-        mask: mx.array | None = None,
-        cache: Any | None = None,
-        prev_topk_indices: mx.array | None = None,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        prev_topk_indices: Optional[mx.array] = None,
     ):
         r, topk_indices = self.self_attn(
             self.input_layernorm(x), mask, cache, prev_topk_indices
@@ -230,7 +748,7 @@ class GlmMoeDsaModel(DeepseekV32Model):
     def __call__(
         self,
         x: mx.array,
-        cache: Any | None = None,
+        cache: Optional[Any] = None,
     ) -> mx.array:
         h = self.embed_tokens(x)
 
@@ -243,6 +761,7 @@ class GlmMoeDsaModel(DeepseekV32Model):
             h, cache[0][0] if cache[0] else None, return_array=True
         )
 
+        # Receive from the previous process in the pipeline
         if pipeline_rank < pipeline_size - 1:
             h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
@@ -252,11 +771,13 @@ class GlmMoeDsaModel(DeepseekV32Model):
                 h, mask, cache[i], prev_topk_indices
             )
 
+        # Send to the next process in the pipeline
         if pipeline_rank != 0:
             h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
             if cache[-1] is not None:
                 cache[-1][0].keys = mx.depends(cache[-1][0].keys, h)
 
+        # Broadcast h while keeping it in the graph
         if pipeline_size > 1:
             h = mx.distributed.all_gather(h)[: h.shape[0]]
 
@@ -268,7 +789,23 @@ class Model(DSV32Model):
         super().__init__(config)
         self.model = GlmMoeDsaModel(config)
 
+    def sanitize(self, weights):
+        weights = super().sanitize(weights)
+        skip_prefixes = [
+            f"model.layers.{i}.self_attn.indexer."
+            for i, layer in enumerate(self.model.layers)
+            if getattr(layer.self_attn, "skip_topk", False)
+        ]
+        if skip_prefixes:
+            weights = {
+                k: v
+                for k, v in weights.items()
+                if not any(k.startswith(prefix) for prefix in skip_prefixes)
+            }
+        return weights
+
     def make_cache(self):
+        # Shared layers run no indexer, so they get no indexer KVCache.
         caches = []
         for layer in self.layers:
             if getattr(layer.self_attn, "skip_topk", False):

--- a/omlx/patches/glm_moe_dsa/sparse_mla.py
+++ b/omlx/patches/glm_moe_dsa/sparse_mla.py
@@ -1,0 +1,1232 @@
+# Copyright © 2026 Apple Inc.
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Optional
+
+import mlx.core as mx
+
+
+def scores_to_block_indices(
+    scores: mx.array,
+    *,
+    block_budget: int,
+    q_block_size: int = 8,
+    k_block_size: int = 16,
+    recent_blocks: int = 0,
+    sort_indices: bool = True,
+) -> Optional[mx.array]:
+    """Select a fixed K-block table from dense DSA indexer scores.
+
+    The result is a page table shaped [B, 1, q_blocks, block_budget]. Each row
+    contains K-block ids, not token ids. This mirrors the sparse MLA metadata
+    consumed by CUDA serving engines while keeping the workspace bounded.
+    """
+
+    if scores.ndim != 4 or scores.shape[1] != 1 or block_budget <= 0:
+        return None
+
+    B, _, L, K = scores.shape
+    q_blocks = (L + q_block_size - 1) // q_block_size
+    k_blocks = (K + k_block_size - 1) // k_block_size
+    block_budget = min(block_budget, k_blocks)
+
+    pad_value = mx.array(mx.finfo(scores.dtype).min, scores.dtype)
+    if K != k_blocks * k_block_size:
+        scores = mx.pad(
+            scores,
+            [(0, 0), (0, 0), (0, 0), (0, k_blocks * k_block_size - K)],
+            constant_values=pad_value,
+        )
+    block_scores = mx.max(
+        scores.reshape(B, 1, L, k_blocks, k_block_size),
+        axis=-1,
+    )
+    if L != q_blocks * q_block_size:
+        block_scores = mx.pad(
+            block_scores,
+            [(0, 0), (0, 0), (0, q_blocks * q_block_size - L), (0, 0)],
+            constant_values=pad_value,
+        )
+    block_scores = block_scores.reshape(B, 1, q_blocks, q_block_size, k_blocks)
+    block_scores = mx.max(block_scores, axis=3)
+
+    return block_scores_to_indices(
+        block_scores,
+        block_budget=block_budget,
+        recent_blocks=recent_blocks,
+        q_block_size=q_block_size,
+        k_block_size=k_block_size,
+        query_length=L,
+        key_length=K,
+        sort_indices=sort_indices,
+    )
+
+
+def _boost_recent_block_scores(
+    block_scores: mx.array,
+    *,
+    recent_blocks: int,
+    q_block_size: int,
+    k_block_size: int,
+    query_length: int,
+    key_length: int,
+) -> mx.array:
+    if recent_blocks <= 0:
+        return block_scores
+
+    q_blocks = block_scores.shape[-2]
+    k_blocks = block_scores.shape[-1]
+    recent_blocks = min(recent_blocks, k_blocks)
+
+    q_block = mx.arange(q_blocks, dtype=mx.uint32)[:, None]
+    k_block = mx.arange(k_blocks, dtype=mx.uint32)[None, :]
+    q_end_local = mx.minimum(
+        (q_block + 1) * q_block_size,
+        mx.array(query_length, dtype=mx.uint32),
+    ) - 1
+    q_abs_end = q_end_local + (key_length - query_length)
+    end_block = q_abs_end // k_block_size
+    recent_mask = (k_block <= end_block) & (k_block + recent_blocks > end_block)
+    recent_mask = mx.reshape(recent_mask, (1, 1, q_blocks, k_blocks))
+    boost_value = mx.array(mx.finfo(block_scores.dtype).max, block_scores.dtype)
+    return mx.where(recent_mask, boost_value, block_scores)
+
+
+def block_scores_to_indices(
+    block_scores: mx.array,
+    *,
+    block_budget: int,
+    recent_blocks: int = 0,
+    q_block_size: Optional[int] = None,
+    k_block_size: Optional[int] = None,
+    query_length: Optional[int] = None,
+    key_length: Optional[int] = None,
+    sort_indices: bool = True,
+) -> Optional[mx.array]:
+    """Select block ids from pre-reduced [B, 1, q_blocks, k_blocks] scores."""
+
+    if block_scores.ndim != 4 or block_scores.shape[1] != 1 or block_budget <= 0:
+        return None
+
+    block_budget = min(block_budget, block_scores.shape[-1])
+    if recent_blocks > 0:
+        if (
+            q_block_size is None
+            or k_block_size is None
+            or query_length is None
+            or key_length is None
+        ):
+            return None
+        recent_blocks = min(recent_blocks, block_budget)
+        block_scores = _boost_recent_block_scores(
+            block_scores,
+            recent_blocks=recent_blocks,
+            q_block_size=q_block_size,
+            k_block_size=k_block_size,
+            query_length=query_length,
+            key_length=key_length,
+        )
+    indices = mx.argpartition(block_scores, kth=-block_budget, axis=-1)[
+        ..., -block_budget:
+    ].astype(mx.uint32)
+    if sort_indices:
+        indices = mx.sort(indices, axis=-1)
+    return indices
+
+
+@lru_cache(maxsize=None)
+def _make_block_indices_to_block_mask_kernel():
+    if not mx.metal.is_available():
+        return None
+
+    source = r"""
+        const uint elem = thread_position_in_grid.x;
+        const uint total = B * Q_BLOCKS * BUDGET;
+        if (elem >= total) {
+          return;
+        }
+
+        const uint q_block = (elem / BUDGET) % Q_BLOCKS;
+        const uint b = elem / (BUDGET * Q_BLOCKS);
+
+        const uint k_block = block_indices[elem];
+        if (k_block >= K_BLOCKS) {
+          return;
+        }
+
+        const uint q_end_local = (q_block + 1) * Q_BLOCK < L
+            ? (q_block + 1) * Q_BLOCK
+            : L;
+        const uint q_block_end = (K - L) + q_end_local - 1;
+        const uint k_block_start = k_block * K_BLOCK;
+        if (k_block_start <= q_block_end) {
+          block_mask[((b * Q_BLOCKS + q_block) * K_BLOCKS) + k_block] = true;
+        }
+    """
+
+    return mx.fast.metal_kernel(
+        name="glm_dsa_block_indices_to_block_mask",
+        input_names=["block_indices"],
+        output_names=["block_mask"],
+        source=source,
+    )
+
+
+def block_indices_to_block_mask(
+    block_indices: mx.array,
+    *,
+    L: Optional[int] = None,
+    K: int,
+    q_block_size: int = 32,
+    k_block_size: int = 16,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Expand a fixed block table into the Steel SDPA block mask layout."""
+
+    if block_indices.ndim != 4 or block_indices.shape[1] != 1:
+        return None
+
+    B, _, q_blocks, budget = block_indices.shape
+    k_blocks = (K + k_block_size - 1) // k_block_size
+
+    kernel = _make_block_indices_to_block_mask_kernel()
+    if kernel is not None and L is not None:
+        return kernel(
+            inputs=[block_indices.astype(mx.uint32)],
+            template=[
+                ("B", B),
+                ("L", L),
+                ("K", K),
+                ("BUDGET", budget),
+                ("Q_BLOCK", q_block_size),
+                ("K_BLOCK", k_block_size),
+                ("Q_BLOCKS", q_blocks),
+                ("K_BLOCKS", k_blocks),
+            ],
+            grid=(B * q_blocks * budget, 1, 1),
+            threadgroup=(256, 1, 1),
+            output_shapes=[(B, 1, q_blocks, k_blocks)],
+            output_dtypes=[mx.bool_],
+            init_value=0,
+            stream=stream or mx.gpu,
+        )[0]
+
+    block_mask = mx.zeros((B, 1, q_blocks, k_blocks), dtype=mx.bool_)
+    return mx.put_along_axis(
+        block_mask,
+        block_indices.astype(mx.uint32),
+        mx.array(True),
+        axis=-1,
+    )
+
+
+@lru_cache(maxsize=None)
+def _make_topk_indices_to_block_masks_kernel():
+    if not mx.metal.is_available():
+        return None
+
+    source = r"""
+        const uint elem = thread_position_in_grid.x;
+        const uint total = B * L * TOPK;
+        if (elem >= total) {
+          return;
+        }
+
+        const uint j = elem % TOPK;
+        const uint q_pos = (elem / TOPK) % L;
+        const uint b = elem / (TOPK * L);
+
+        const uint q_abs = (K - L) + q_pos;
+        if (CAUSAL_PREFIX_INDICES && q_pos < PREFIX_ROWS) {
+          const uint valid_length = min(uint(K), q_abs + 1);
+          const uint prefix_blocks =
+              (valid_length + uint(K_BLOCK) - 1) / uint(K_BLOCK);
+          if (j >= prefix_blocks) {
+            return;
+          }
+
+          const uint q_block = q_pos / Q_BLOCK;
+          const uint k_block = j;
+          if (q_block >= Q_BLOCKS || k_block >= K_BLOCKS) {
+            return;
+          }
+
+          const uint block_idx = (b * Q_BLOCKS + q_block) * K_BLOCKS + k_block;
+          block_mask[block_idx] = true;
+
+          const uint block_start = k_block * uint(K_BLOCK);
+          const uint tokens_in_block =
+              min(uint(K_BLOCK), valid_length - block_start);
+          const uint full_bits =
+              K_BLOCK == 32 ? 0xffffffffu : ((1u << K_BLOCK) - 1u);
+          const uint bits = tokens_in_block == K_BLOCK
+              ? full_bits
+              : ((1u << tokens_in_block) - 1u);
+          const uint token_idx = (b * L + q_pos) * K_BLOCKS + k_block;
+          block_token_mask[token_idx] = bits;
+          return;
+        }
+
+        const uint topk_row = COMPACT_PREFIX_TOPK ? q_pos - PREFIX_ROWS : q_pos;
+        const uint topk_elem = (b * TOPK_ROWS + topk_row) * TOPK + j;
+        const uint k_pos = topk_indices[topk_elem];
+        if (k_pos >= K) {
+          return;
+        }
+
+        if (CAUSAL && k_pos > q_abs) {
+          return;
+        }
+
+        const uint q_block = q_pos / Q_BLOCK;
+        const uint k_block = k_pos / K_BLOCK;
+        if (q_block >= Q_BLOCKS || k_block >= K_BLOCKS) {
+          return;
+        }
+
+        const uint block_idx = (b * Q_BLOCKS + q_block) * K_BLOCKS + k_block;
+        block_mask[block_idx] = true;
+
+        const uint bit = 1u << (k_pos - k_block * K_BLOCK);
+        const uint token_idx = (b * L + q_pos) * K_BLOCKS + k_block;
+        device atomic_uint* atomic_token_mask =
+            reinterpret_cast<device atomic_uint*>(block_token_mask);
+        atomic_fetch_or_explicit(
+            &atomic_token_mask[token_idx],
+            bit,
+            memory_order_relaxed);
+    """
+
+    return mx.fast.metal_kernel(
+        name="glm_dsa_topk_indices_to_block_masks",
+        input_names=["topk_indices"],
+        output_names=["block_mask", "block_token_mask"],
+        source=source,
+    )
+
+
+def topk_indices_to_block_masks(
+    topk_indices: mx.array,
+    *,
+    L: Optional[int] = None,
+    K: int,
+    q_block_size: int = 32,
+    k_block_size: int = 16,
+    causal: bool = True,
+    causal_prefix_indices: bool = False,
+    causal_prefix_rows: int = 0,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[tuple[mx.array, mx.array]]:
+    """Build block and token-bit masks for exact top-k Steel SDPA.
+
+    ``block_mask`` is shaped [B, 1, q_blocks, k_blocks]. ``block_token_mask`` is
+    shaped [B, 1, L, k_blocks] and stores one uint32 bitset per K block. This
+    preserves per-token top-k semantics while letting Steel SDPA skip K blocks
+    whose bitset would be empty for the corresponding query block.
+    """
+
+    if (
+        topk_indices.ndim != 4
+        or topk_indices.shape[1] != 1
+        or k_block_size <= 0
+        or k_block_size > 32
+        or q_block_size <= 0
+    ):
+        return None
+
+    B, _, L_in, topk = topk_indices.shape
+    L = L_in if L is None else L
+    causal_prefix_rows = max(0, min(causal_prefix_rows, L))
+    compact_prefix_topk = (
+        causal_prefix_indices
+        and causal_prefix_rows > 0
+        and L_in == L - causal_prefix_rows
+    )
+    if (L != L_in and not compact_prefix_topk) or K <= 0 or topk <= 0:
+        return None
+
+    q_blocks = (L + q_block_size - 1) // q_block_size
+    k_blocks = (K + k_block_size - 1) // k_block_size
+
+    kernel = _make_topk_indices_to_block_masks_kernel()
+    if kernel is None:
+        return None
+
+    block_mask, block_token_mask = kernel(
+        inputs=[topk_indices.astype(mx.uint32)],
+        template=[
+            ("B", B),
+            ("L", L),
+            ("K", K),
+            ("TOPK", topk),
+            ("TOPK_ROWS", L_in),
+            ("Q_BLOCK", q_block_size),
+            ("K_BLOCK", k_block_size),
+            ("Q_BLOCKS", q_blocks),
+            ("K_BLOCKS", k_blocks),
+            ("CAUSAL", causal),
+            ("CAUSAL_PREFIX_INDICES", causal_prefix_indices),
+            ("PREFIX_ROWS", causal_prefix_rows),
+            ("COMPACT_PREFIX_TOPK", compact_prefix_topk),
+        ],
+        grid=(B * L * topk, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[
+            (B, 1, q_blocks, k_blocks),
+            (B, 1, L, k_blocks),
+        ],
+        output_dtypes=[mx.bool_, mx.uint32],
+        init_value=0,
+        stream=stream or mx.gpu,
+    )
+    return block_mask, block_token_mask
+
+
+@lru_cache(maxsize=None)
+def _make_index_score_reduce_kernel():
+    if not mx.metal.is_available():
+        return None
+
+    source = r"""
+        const uint elem = thread_position_in_grid.x;
+        const uint total = B * L * K;
+        if (elem >= total) {
+          return;
+        }
+
+        const uint k_pos = elem % K;
+        const uint q_pos = (elem / K) % L;
+        const uint b = elem / (L * K);
+
+        if (CAUSAL && k_pos > K - L + q_pos) {
+          out[elem] = static_cast<T>(-INFINITY);
+          return;
+        }
+
+        float acc = 0.0f;
+        #pragma clang loop unroll(full)
+        for (uint h = 0; h < H; ++h) {
+          const uint score_idx = ((b * H + h) * L + q_pos) * K + k_pos;
+          const uint weight_idx = (b * H + h) * L + q_pos;
+          const float s = static_cast<float>(head_scores[score_idx]);
+          const float w = static_cast<float>(weights[weight_idx]);
+          acc += metal::max(s, 0.0f) * w;
+        }
+        out[elem] = static_cast<T>(acc);
+    """
+
+    return mx.fast.metal_kernel(
+        name="glm_dsa_index_score_reduce",
+        input_names=["head_scores", "weights"],
+        output_names=["out"],
+        source=source,
+    )
+
+
+def fused_index_score_reduce(
+    head_scores: mx.array,
+    weights: mx.array,
+    *,
+    causal: bool = False,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Fuse ReLU, per-head weighting, causal fill, and head reduction."""
+
+    kernel = _make_index_score_reduce_kernel()
+    if (
+        kernel is None
+        or head_scores.ndim != 4
+        or weights.ndim != 4
+        or weights.shape[-1] != 1
+        or head_scores.shape[:3] != weights.shape[:3]
+    ):
+        return None
+
+    B, H, L, K = head_scores.shape
+    short_k_threadgroup = int(
+        os.environ.get("MLX_LM_GLM_DSA_INDEX_REDUCE_THREADGROUP_SIZE", "512")
+    )
+    long_k_threshold = int(
+        os.environ.get("MLX_LM_GLM_DSA_INDEX_REDUCE_LONG_K_THRESHOLD", "32768")
+    )
+    long_k_threadgroup = int(
+        os.environ.get("MLX_LM_GLM_DSA_INDEX_REDUCE_LONG_K_THREADGROUP_SIZE", "256")
+    )
+    threadgroup_size = (
+        long_k_threadgroup if K > long_k_threshold else short_k_threadgroup
+    )
+    return kernel(
+        inputs=[head_scores, weights],
+        template=[
+            ("T", head_scores.dtype),
+            ("B", B),
+            ("H", H),
+            ("L", L),
+            ("K", K),
+            ("CAUSAL", causal),
+        ],
+        grid=(B * L * K, 1, 1),
+        threadgroup=(threadgroup_size, 1, 1),
+        output_shapes=[(B, 1, L, K)],
+        output_dtypes=[head_scores.dtype],
+        stream=stream or mx.gpu,
+    )[0]
+
+
+def fused_indexer_scores(
+    queries: mx.array,
+    keys: mx.array,
+    weights: mx.array,
+    *,
+    causal: bool = False,
+    unused_causal_prefix_topk: int = 0,
+    skip_causal_future_store: bool = False,
+    causal_q_offset: int = -1,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Compute GLM DSA indexer logits without materializing per-head scores.
+
+    This is the MLX equivalent of the vLLM/SGLang MQA-logits indexer path:
+    the Steel kernel computes ``sum_h relu(q_h @ k.T) * weight_h`` directly
+    into [B, 1, L, K]. The Metal kernel is specialized for GLM-5.2's
+    [H=32, D=128] indexer and 64-token M/N tiles, so non-multiple prompt
+    lengths are padded and sliced back exactly.
+    """
+
+    if (
+        not hasattr(mx.fast, "dsa_indexer_scores")
+        or queries.ndim != 4
+        or keys.ndim != 4
+        or weights.ndim != 3
+        or queries.shape[0] != keys.shape[0]
+        or queries.shape[0] != weights.shape[0]
+        or queries.shape[1] != 32
+        or keys.shape[1] != 1
+        or queries.shape[2] != weights.shape[1]
+        or queries.shape[1] != weights.shape[2]
+        or queries.shape[3] != 128
+        or keys.shape[3] != 128
+        or keys.shape[2]
+        < int(os.environ.get("MLX_LM_GLM_DSA_INDEXER_MIN_K", "4096"))
+        or queries.dtype != keys.dtype
+        or queries.dtype != weights.dtype
+    ):
+        return None
+
+    B, H, L, D = queries.shape
+    K = keys.shape[2]
+    q_pad = (-L) % 64
+    k_pad = (-K) % 64
+
+    q = queries
+    k = keys
+    w = weights
+    if q_pad:
+        q = mx.pad(q, [(0, 0), (0, 0), (0, q_pad), (0, 0)])
+        w = mx.pad(w, [(0, 0), (0, q_pad), (0, 0)])
+    if k_pad:
+        k = mx.pad(k, [(0, 0), (0, 0), (0, k_pad), (0, 0)])
+    if q_pad or k_pad:
+        unused_causal_prefix_topk = 0
+
+    scores = mx.fast.dsa_indexer_scores(
+        q,
+        k,
+        w,
+        causal=causal,
+        unused_causal_prefix_topk=unused_causal_prefix_topk,
+        skip_causal_future_store=skip_causal_future_store,
+        causal_q_offset=causal_q_offset,
+        stream=stream or mx.gpu,
+    )
+    if q_pad or k_pad:
+        scores = scores[:, :, :L, :K]
+    return scores
+
+
+def fused_indexer_scores_high_histogram(
+    queries: mx.array,
+    keys: mx.array,
+    weights: mx.array,
+    *,
+    causal: bool = False,
+    unused_causal_prefix_topk: int = 0,
+    skip_causal_future_store: bool = False,
+    causal_q_offset: int = -1,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[tuple[mx.array, mx.array]]:
+    """Compute exact indexer scores plus high-byte top-k histogram state."""
+
+    required = (
+        "dsa_indexer_scores_high_histogram",
+        "dsa_topk_indices_with_high_state",
+    )
+    if (
+        not all(hasattr(mx.fast, name) for name in required)
+        or queries.ndim != 4
+        or keys.ndim != 4
+        or weights.ndim != 3
+        or queries.shape[0] != keys.shape[0]
+        or queries.shape[0] != weights.shape[0]
+        or queries.shape[1] != 32
+        or keys.shape[1] != 1
+        or queries.shape[2] != weights.shape[1]
+        or queries.shape[1] != weights.shape[2]
+        or queries.shape[3] != 128
+        or keys.shape[3] != 128
+        or queries.shape[2] % 64 != 0
+        or keys.shape[2] % 64 != 0
+        or keys.shape[2]
+        < int(os.environ.get("MLX_LM_GLM_DSA_INDEXER_MIN_K", "4096"))
+        or queries.dtype != keys.dtype
+        or queries.dtype != weights.dtype
+    ):
+        return None
+
+    scores, high_hist = mx.fast.dsa_indexer_scores_high_histogram(
+        queries,
+        keys,
+        weights,
+        causal=causal,
+        unused_causal_prefix_topk=unused_causal_prefix_topk,
+        skip_causal_future_store=skip_causal_future_store,
+        causal_q_offset=causal_q_offset,
+        stream=stream or mx.gpu,
+    )
+    return scores, high_hist
+
+
+def _dsa_histogram_threshold(hist: mx.array, topk: int) -> mx.array:
+    rev_cumsum = mx.cumsum(hist[..., ::-1], axis=-1)
+    target = mx.array(topk, dtype=mx.uint32)
+    rev_idx = mx.argmax((rev_cumsum >= target).astype(mx.uint32), axis=-1)
+    threshold_hi = (mx.array(255, dtype=mx.uint32) - rev_idx).astype(mx.uint32)
+
+    prev_idx = mx.maximum(
+        rev_idx.astype(mx.int32) - mx.array(1, dtype=mx.int32),
+        mx.array(0, dtype=mx.int32),
+    ).astype(mx.uint32)
+    prev = mx.take_along_axis(rev_cumsum, prev_idx[..., None], axis=-1)[..., 0]
+    greater = mx.where(
+        rev_idx > mx.array(0, dtype=mx.uint32),
+        prev,
+        mx.array(0, dtype=mx.uint32),
+    )
+    return mx.stack([threshold_hi, greater.astype(mx.uint32)], axis=-1)
+
+
+def _dsa_low_histogram_threshold(
+    high_state: mx.array, low_hist: mx.array, topk: int
+) -> mx.array:
+    greater_hi = high_state[..., 1]
+    target = mx.array(topk, dtype=mx.uint32) - greater_hi
+    rev_cumsum = mx.cumsum(low_hist[..., ::-1], axis=-1)
+    rev_idx = mx.argmax((rev_cumsum >= target[..., None]).astype(mx.uint32), axis=-1)
+    threshold_lo = (mx.array(255, dtype=mx.uint32) - rev_idx).astype(mx.uint32)
+
+    prev_idx = mx.maximum(
+        rev_idx.astype(mx.int32) - mx.array(1, dtype=mx.int32),
+        mx.array(0, dtype=mx.int32),
+    ).astype(mx.uint32)
+    prev = mx.take_along_axis(rev_cumsum, prev_idx[..., None], axis=-1)[..., 0]
+    greater_low = mx.where(
+        rev_idx > mx.array(0, dtype=mx.uint32),
+        prev,
+        mx.array(0, dtype=mx.uint32),
+    )
+    threshold_key = high_state[..., 0] * mx.array(256, dtype=mx.uint32) + threshold_lo
+    greater = greater_hi + greater_low.astype(mx.uint32)
+    return mx.stack([threshold_key.astype(mx.uint32), greater.astype(mx.uint32)], axis=-1)
+
+
+def fused_indexer_topk_indices(
+    queries: mx.array,
+    keys: mx.array,
+    weights: mx.array,
+    topk: int,
+    *,
+    causal: bool = False,
+    causal_q_offset: int = -1,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Exact GLM DSA indexer top-k without a materialized score matrix.
+
+    The implementation mirrors the existing 16-bit radix top-k, but moves the
+    score production into Steel MMA passes: high-byte histogram, low-byte
+    histogram for the threshold bucket, then index emission. It preserves exact
+    top-k semantics up to normal equal-score tie freedom.
+    """
+
+    required = (
+        "dsa_indexer_score_histogram",
+        "dsa_indexer_score_low_histogram",
+        "dsa_indexer_topk_emit",
+    )
+    if (
+        not all(hasattr(mx.fast, name) for name in required)
+        or queries.ndim != 4
+        or keys.ndim != 4
+        or weights.ndim != 3
+        or queries.shape[0] != keys.shape[0]
+        or queries.shape[0] != weights.shape[0]
+        or queries.shape[1] != 32
+        or keys.shape[1] != 1
+        or queries.shape[2] != weights.shape[1]
+        or queries.shape[1] != weights.shape[2]
+        or queries.shape[3] != 128
+        or keys.shape[3] != 128
+        or queries.shape[2] % 64 != 0
+        or keys.shape[2] % 64 != 0
+        or keys.shape[2] < topk
+        or keys.shape[2]
+        < int(os.environ.get("MLX_LM_GLM_DSA_INDEXER_MIN_K", "4096"))
+        or queries.dtype != keys.dtype
+        or queries.dtype != weights.dtype
+    ):
+        return None
+
+    s = stream or mx.gpu
+    high_hist = mx.fast.dsa_indexer_score_histogram(
+        queries,
+        keys,
+        weights,
+        causal=causal,
+        causal_q_offset=causal_q_offset,
+        stream=s,
+    )
+    high_state = _dsa_histogram_threshold(high_hist, topk)
+    low_hist = mx.fast.dsa_indexer_score_low_histogram(
+        queries,
+        keys,
+        weights,
+        high_state,
+        causal=causal,
+        causal_q_offset=causal_q_offset,
+        stream=s,
+    )
+    threshold = _dsa_low_histogram_threshold(high_state, low_hist, topk)
+    return mx.fast.dsa_indexer_topk_emit(
+        queries,
+        keys,
+        weights,
+        threshold,
+        topk,
+        causal=causal,
+        causal_q_offset=causal_q_offset,
+        stream=s,
+    )
+
+
+def fused_topk_indices_with_high_histogram(
+    scores: mx.array,
+    high_hist: mx.array,
+    topk: int,
+    *,
+    bucketed: bool = False,
+    causal_valid_prefix: bool = False,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    if (
+        not hasattr(mx.fast, "dsa_topk_indices_with_high_state")
+        or scores.ndim != 4
+        or scores.shape[1] != 1
+        or high_hist.ndim != 3
+        or high_hist.shape[0] != scores.shape[0]
+        or high_hist.shape[1] != scores.shape[2]
+        or high_hist.shape[2] != 256
+        or high_hist.dtype != mx.uint32
+    ):
+        return None
+    s = stream or mx.gpu
+    high_state = _dsa_histogram_threshold(high_hist, topk)
+    return mx.fast.dsa_topk_indices_with_high_state(
+        scores,
+        high_state,
+        topk,
+        bucketed=bucketed,
+        causal_valid_prefix=causal_valid_prefix,
+        stream=s,
+    )
+
+
+def fused_topk_block_table_from_scores(
+    scores: mx.array,
+    topk: int,
+    key_length: int,
+    *,
+    k_block_size: int = 8,
+    bucketed: bool = False,
+    causal_valid_prefix: bool = False,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    if (
+        not hasattr(mx.fast, "dsa_topk_block_table_from_scores")
+        or scores.ndim != 4
+        or scores.shape[1] != 1
+        or scores.shape[-1] != key_length
+        or k_block_size not in (8, 16)
+    ):
+        return None
+    return mx.fast.dsa_topk_block_table_from_scores(
+        scores,
+        topk,
+        key_length,
+        k_block_size=k_block_size,
+        bucketed=bucketed,
+        causal_valid_prefix=causal_valid_prefix,
+        stream=stream or mx.gpu,
+    )
+
+
+@lru_cache(maxsize=None)
+def _make_sparse_mla_prefill_kernel():
+    if not mx.metal.is_available():
+        return None
+
+    source = r"""
+        constexpr int QGROUP = 8;
+        constexpr int QD = (D_LATENT + 31) / 32;
+        constexpr int PED = (D_PE + 31) / 32;
+
+        const uint lane = thread_index_in_simdgroup;
+        const uint sg = simdgroup_index_in_threadgroup;
+
+        const uint q_pos = threadgroup_position_in_grid.x * QGROUP + sg;
+        const uint h = threadgroup_position_in_grid.y;
+        const uint b = threadgroup_position_in_grid.z;
+        if (q_pos >= L) {
+          return;
+        }
+
+        const uint q_abs = K - L + q_pos;
+
+        const uint q_base = ((b * H + h) * L + q_pos) * D_LATENT;
+        thread float q_vals[QD];
+        for (uint i = 0; i < QD; ++i) {
+          const uint d = i * 32 + lane;
+          q_vals[i] = d < D_LATENT
+              ? static_cast<float>(q_latent[q_base + d])
+              : 0.0f;
+        }
+
+        const uint qpe_base = ((b * H + h) * L + q_pos) * D_PE;
+        thread float qpe_vals[PED];
+        for (uint i = 0; i < PED; ++i) {
+          const uint d = i * 32 + lane;
+          qpe_vals[i] = d < D_PE
+              ? static_cast<float>(q_pe[qpe_base + d])
+              : 0.0f;
+        }
+
+        thread float out_vals[QD];
+        for (uint i = 0; i < QD; ++i) {
+          out_vals[i] = 0.0f;
+        }
+
+        const uint topk_base = (b * L + q_pos) * TOPK;
+        float max_score = -INFINITY;
+        float sum_exp = 0.0f;
+
+        for (uint j = 0; j < TOPK; ++j) {
+          const uint k_pos = topk[topk_base + j];
+          const bool valid = (k_pos < K) && (k_pos <= q_abs);
+
+          float score = -INFINITY;
+          if (valid) {
+            float part = 0.0f;
+
+            const uint k_base = (b * K + k_pos) * D_LATENT;
+            for (uint i = 0; i < QD; ++i) {
+              const uint d = i * 32 + lane;
+              if (d < D_LATENT) {
+                part += q_vals[i] * static_cast<float>(kv_latent[k_base + d]);
+              }
+            }
+
+            const uint kpe_base = (b * K + k_pos) * D_PE;
+            for (uint i = 0; i < PED; ++i) {
+              const uint d = i * 32 + lane;
+              if (d < D_PE) {
+                part += qpe_vals[i] * static_cast<float>(k_pe[kpe_base + d]);
+              }
+            }
+
+            score = simd_sum(part) * static_cast<float>(scale);
+          }
+
+          if (valid) {
+            const float new_max = max(max_score, score);
+            const float old_scale = fast::exp(max_score - new_max);
+            const float exp_score = fast::exp(score - new_max);
+
+            const uint v_base = (b * K + k_pos) * D_LATENT;
+            for (uint i = 0; i < QD; ++i) {
+              const uint d = i * 32 + lane;
+              if (d < D_LATENT) {
+                out_vals[i] = out_vals[i] * old_scale +
+                    exp_score * static_cast<float>(kv_latent[v_base + d]);
+              }
+            }
+
+            sum_exp = sum_exp * old_scale + exp_score;
+            max_score = new_max;
+          }
+        }
+
+        const uint out_base = ((b * H + h) * L + q_pos) * D_LATENT;
+        for (uint i = 0; i < QD; ++i) {
+          const uint d = i * 32 + lane;
+          if (d < D_LATENT) {
+            const float normalized =
+                sum_exp == 0.0f ? 0.0f : out_vals[i] / sum_exp;
+            out[out_base + d] = static_cast<T>(normalized);
+          }
+        }
+    """
+
+    return mx.fast.metal_kernel(
+        name="glm_dsa_sparse_mla_prefill",
+        input_names=["q_latent", "q_pe", "kv_latent", "k_pe", "topk", "scale"],
+        output_names=["out"],
+        source=source,
+    )
+
+
+def sparse_mla_attention(
+    q_latent: mx.array,
+    q_pe: mx.array,
+    kv_latent: mx.array,
+    k_pe: mx.array,
+    topk_indices: mx.array,
+    scale: float,
+    *,
+    topk_valid_prefix: bool = False,
+    causal_prefix_indices: bool = False,
+    topk_length: Optional[mx.array] = None,
+    causal_prefix_rows: int = 0,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Sparse MLA prefill over per-query DSA top-k indices.
+
+    This mirrors the FlashMLA sparse prefill contract used by vLLM/SGLang:
+    attention scores are computed over [latent, rope] keys, values are the
+    latent KV cache, and the caller applies the MLA output projection after.
+
+    Shapes:
+      q_latent: [B, H, L, 512]
+      q_pe: [B, H, L, 64]
+      kv_latent: [B, 1, K, 512]
+      k_pe: [B, 1, K, 64]
+      topk_indices: [B, 1, L, TOPK]
+      topk_length: optional [B, L] or [B, 1, L] valid prefix length
+    """
+
+    if (
+        q_latent.ndim != 4
+        or q_pe.ndim != 4
+        or kv_latent.ndim != 4
+        or k_pe.ndim != 4
+        or topk_indices.ndim != 4
+        or kv_latent.shape[1] != 1
+        or k_pe.shape[1] != 1
+    ):
+        return None
+
+    B, H, L, D_LATENT = q_latent.shape
+    K = kv_latent.shape[2]
+    D_PE = q_pe.shape[-1]
+    TOPK = topk_indices.shape[-1]
+    topk_rows = topk_indices.shape[2]
+    compact_prefix = causal_prefix_rows > 0 and topk_rows != L
+
+    if (
+        L <= 1
+        or q_pe.shape[:3] != (B, H, L)
+        or kv_latent.shape[:3] != (B, 1, K)
+        or k_pe.shape[:3] != (B, 1, K)
+        or topk_indices.shape[:2] != (B, 1)
+        or not (
+            topk_rows == L
+            or (
+                compact_prefix
+                and topk_rows + causal_prefix_rows == L
+                and causal_prefix_indices
+                and topk_valid_prefix
+            )
+        )
+        or kv_latent.shape[-1] != D_LATENT
+        or k_pe.shape[-1] != D_PE
+        or D_LATENT != 512
+        or D_PE != 64
+        or q_latent.dtype not in (mx.float16, mx.bfloat16)
+        or q_pe.dtype != q_latent.dtype
+        or kv_latent.dtype != q_latent.dtype
+        or k_pe.dtype != q_latent.dtype
+    ):
+        return None
+
+    if hasattr(mx.fast, "glm_dsa_sparse_mla_attention"):
+        topk = (
+            topk_indices
+            if topk_indices.dtype in (mx.uint32, mx.uint16)
+            else topk_indices.astype(mx.uint32)
+        )
+        if (
+            os.environ.get("MLX_LM_GLM_DSA_TOPK_PAGE_PACK", "0") == "1"
+            and hasattr(mx.fast, "dsa_topk_page_pack")
+            and topk.shape[-1] == 2048
+        ):
+            page_size = int(os.environ.get("MLX_LM_GLM_DSA_TOPK_PAGE_SIZE", "64"))
+            topk = mx.fast.dsa_topk_page_pack(
+                topk,
+                K,
+                page_size=page_size,
+                stream=stream or mx.gpu,
+            )
+        if topk_length is not None and topk_length.dtype != mx.uint32:
+            topk_length = topk_length.astype(mx.uint32)
+        return mx.fast.glm_dsa_sparse_mla_attention(
+            q_latent,
+            q_pe,
+            kv_latent,
+            k_pe,
+            topk,
+            scale,
+            topk_valid_prefix=topk_valid_prefix,
+            causal_prefix_indices=causal_prefix_indices,
+            topk_length=topk_length,
+            causal_prefix_rows=causal_prefix_rows,
+            stream=stream or mx.gpu,
+        )
+
+    kernel = _make_sparse_mla_prefill_kernel()
+    if kernel is None:
+        return None
+
+    qgroup = 8
+    return kernel(
+        inputs=[q_latent, q_pe, kv_latent, k_pe, topk_indices, scale],
+        template=[
+            ("T", q_latent.dtype),
+            ("B", B),
+            ("H", H),
+            ("L", L),
+            ("K", K),
+            ("D_LATENT", D_LATENT),
+            ("D_PE", D_PE),
+            ("TOPK", TOPK),
+        ],
+        grid=(256 * ((L + qgroup - 1) // qgroup), H, B),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(B, H, L, D_LATENT)],
+        output_dtypes=[q_latent.dtype],
+        stream=stream or mx.gpu,
+    )[0]
+
+
+def sparse_mla_block_table_attention(
+    q_latent: mx.array,
+    q_pe: mx.array,
+    kv_latent: mx.array,
+    k_pe: mx.array,
+    block_table: mx.array,
+    scale: float,
+    *,
+    k_block_size: int = 16,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Sparse MLA prefill over compact block-token tables."""
+
+    packed_table = block_table.ndim == 4
+
+    if (
+        not hasattr(mx.fast, "glm_dsa_sparse_mla_block_table_attention")
+        or q_latent.ndim != 4
+        or q_pe.ndim != 4
+        or kv_latent.ndim != 4
+        or k_pe.ndim != 4
+        or block_table.ndim not in (4, 5)
+        or kv_latent.shape[1] != 1
+        or k_pe.shape[1] != 1
+        or block_table.shape[1] != 1
+        or (not packed_table and block_table.shape[-1] != 2)
+    ):
+        return None
+
+    B, H, L, D_LATENT = q_latent.shape
+    K = kv_latent.shape[2]
+    D_PE = q_pe.shape[-1]
+    if (
+        L <= 1
+        or q_pe.shape[:3] != (B, H, L)
+        or kv_latent.shape[:3] != (B, 1, K)
+        or k_pe.shape[:3] != (B, 1, K)
+        or block_table.shape[:3] != (B, 1, L)
+        or kv_latent.shape[-1] != D_LATENT
+        or k_pe.shape[-1] != D_PE
+        or D_LATENT != 512
+        or D_PE != 64
+        or q_latent.dtype not in (mx.float16, mx.bfloat16)
+        or q_pe.dtype != q_latent.dtype
+        or kv_latent.dtype != q_latent.dtype
+        or k_pe.dtype != q_latent.dtype
+        or k_block_size not in (8, 16, 32)
+        or (packed_table and k_block_size > 16)
+    ):
+        return None
+
+    table = (
+        block_table if block_table.dtype == mx.uint32 else block_table.astype(mx.uint32)
+    )
+    return mx.fast.glm_dsa_sparse_mla_block_table_attention(
+        q_latent,
+        q_pe,
+        kv_latent,
+        k_pe,
+        table,
+        scale,
+        k_block_size=k_block_size,
+        stream=stream or mx.gpu,
+    )
+
+
+def sparse_mla_qblock_attention(
+    q_latent: mx.array,
+    q_pe: mx.array,
+    kv_latent: mx.array,
+    k_pe: mx.array,
+    topk_indices: mx.array,
+    scale: float,
+    *,
+    topk_valid_prefix: bool = False,
+    causal_prefix_indices: bool = False,
+    causal_prefix_rows: int = 0,
+    q_block_size: int = 4,
+    capacity: int = 4096,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Exact sparse MLA over q-block union metadata."""
+
+    if (
+        not hasattr(mx.fast, "dsa_topk_qblock_union")
+        or not hasattr(mx.fast, "glm_dsa_sparse_mla_qblock_attention")
+        or q_latent.ndim != 4
+        or q_pe.ndim != 4
+        or kv_latent.ndim != 4
+        or k_pe.ndim != 4
+        or topk_indices.ndim != 4
+        or kv_latent.shape[1] != 1
+        or k_pe.shape[1] != 1
+        or topk_indices.shape[1] != 1
+    ):
+        return None
+
+    B, H, L, D_LATENT = q_latent.shape
+    K = kv_latent.shape[2]
+    D_PE = q_pe.shape[-1]
+    compact_prefix = causal_prefix_rows > 0 and topk_indices.shape[2] != L
+    if (
+        L <= 1
+        or q_pe.shape[:3] != (B, H, L)
+        or kv_latent.shape[:3] != (B, 1, K)
+        or k_pe.shape[:3] != (B, 1, K)
+        or topk_indices.shape[:2] != (B, 1)
+        or not (
+            topk_indices.shape[2] == L
+            or (
+                compact_prefix
+                and topk_indices.shape[2] + causal_prefix_rows == L
+                and causal_prefix_indices
+                and topk_valid_prefix
+            )
+        )
+        or kv_latent.shape[-1] != D_LATENT
+        or k_pe.shape[-1] != D_PE
+        or D_LATENT != 512
+        or D_PE != 64
+        or q_latent.dtype not in (mx.float16, mx.bfloat16)
+        or q_pe.dtype != q_latent.dtype
+        or kv_latent.dtype != q_latent.dtype
+        or k_pe.dtype != q_latent.dtype
+        or topk_indices.dtype != mx.uint32
+        or q_block_size not in (2, 4)
+        or capacity not in (4096, 8192)
+    ):
+        return None
+
+    union_tokens, row_bits, lengths, _ = mx.fast.dsa_topk_qblock_union(
+        topk_indices,
+        K,
+        query_length=L,
+        q_block_size=q_block_size,
+        capacity=capacity,
+        causal=True,
+        topk_valid_prefix=topk_valid_prefix,
+        causal_prefix_indices=causal_prefix_indices,
+        causal_prefix_rows=causal_prefix_rows,
+        stream=stream or mx.gpu,
+    )
+    return mx.fast.glm_dsa_sparse_mla_qblock_attention(
+        q_latent,
+        q_pe,
+        kv_latent,
+        k_pe,
+        union_tokens,
+        row_bits,
+        lengths,
+        scale,
+        q_block_size=q_block_size,
+        capacity=capacity,
+        stream=stream or mx.gpu,
+    )
+
+
+def q8_vup_flat(
+    x: mx.array,
+    unembed_out,
+    *,
+    key_length: Optional[int] = None,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Project GLM sparse MLA latent output directly to [B, L, H * 256]."""
+
+    env = os.environ.get("MLX_LM_GLM_DSA_Q8_VUP_FLAT", "auto").lower()
+    if env in {"0", "false", "off", "no"}:
+        return None
+    if env in {"auto", ""} and (
+        key_length is None or key_length < 32768 or key_length > 65536
+    ):
+        return None
+    if env not in {"1", "true", "on", "yes", "auto", ""}:
+        return None
+
+    if (
+        not hasattr(mx.fast, "glm_dsa_q8_vup_flat")
+        or x.ndim != 4
+        or x.shape[1] != 64
+        or x.shape[-1] != 512
+        or getattr(unembed_out, "bits", None) != 8
+        or getattr(unembed_out, "group_size", None) != 64
+        or getattr(unembed_out, "mode", None) != "affine"
+        or not hasattr(unembed_out, "weight")
+        or not hasattr(unembed_out, "scales")
+    ):
+        return None
+
+    biases = unembed_out.get("biases") if hasattr(unembed_out, "get") else None
+    if biases is None:
+        return None
+    weight = unembed_out["weight"]
+    scales = unembed_out["scales"]
+    if weight.shape != (64, 256, 128) or scales.shape != (64, 256, 8):
+        return None
+    return mx.fast.glm_dsa_q8_vup_flat(
+        x,
+        weight,
+        scales,
+        biases,
+        stream=stream or mx.gpu,
+    )

--- a/omlx/patches/glm_moe_dsa/switch_layers.py
+++ b/omlx/patches/glm_moe_dsa/switch_layers.py
@@ -1,0 +1,346 @@
+# Copyright © 2023-2024 Apple Inc.
+
+import math
+import os
+from functools import partial
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.activations import swiglu
+
+
+def _env_flag(name, default="0"):
+    return os.environ.get(name, default).lower() in {"1", "true", "on", "yes"}
+
+
+def use_fused_gate_up_switch():
+    return _env_flag("MLX_LM_SWITCH_FUSED_GATE_UP")
+
+
+def use_fused_swiglu_down_switch():
+    return _env_flag("MLX_LM_GLM_MOE_SWIGLU_DOWN")
+
+
+def use_fused_swiglu_gate_up_switch():
+    return _env_flag("MLX_LM_GLM_MOE_SWIGLU_GATE_UP")
+
+
+def _inverse_permutation(order, inverse_scatter=False):
+    if inverse_scatter or _env_flag("MLX_LM_SWITCH_INVERSE_SCATTER"):
+        return mx.put_along_axis(
+            mx.zeros_like(order),
+            order,
+            mx.arange(order.size, dtype=order.dtype),
+            axis=0,
+        )
+    return mx.argsort(order)
+
+
+def _gather_sort(x, indices, inverse_scatter=False):
+    *_, M = indices.shape
+    indices = indices.flatten()
+    order = mx.argsort(indices)
+    inv_order = _inverse_permutation(order, inverse_scatter)
+    lhs_indices = order // M
+    x = x.flatten(0, -3)
+    return x[lhs_indices], indices[order], inv_order
+
+
+def _scatter_unsort(x, inv_order, shape=None):
+    x = x[inv_order]
+    if shape is not None:
+        x = mx.unflatten(x, 0, shape)
+    return x
+
+
+class QuantizedSwitchLinear(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        output_dims: int,
+        num_experts: int,
+        bias: bool = True,
+        group_size: int = 64,
+        bits: int = 4,
+        mode: str = "affine",
+    ):
+        super().__init__()
+
+        scale = math.sqrt(1 / input_dims)
+        self.weight, self.scales, *biases = mx.quantize(
+            mx.random.uniform(
+                low=-scale,
+                high=scale,
+                shape=(num_experts, output_dims, input_dims),
+            ),
+            group_size=group_size,
+            bits=bits,
+            mode=mode,
+        )
+        self.biases = biases[0] if biases else None
+
+        if bias:
+            self.bias = mx.zeros((num_experts, output_dims))
+
+        self.group_size = group_size
+        self.bits = bits
+        self.mode = mode
+
+        # Freeze this model's parameters
+        self.freeze()
+
+    @property
+    def input_dims(self):
+        return self.scales.shape[2] * self.group_size
+
+    @property
+    def output_dims(self):
+        return self.weight.shape[1]
+
+    @property
+    def num_experts(self):
+        return self.weight.shape[0]
+
+    def __call__(self, x, indices, sorted_indices=False):
+        x = mx.gather_qmm(
+            x,
+            self["weight"],
+            self["scales"],
+            self.get("biases"),
+            rhs_indices=indices,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+            sorted_indices=sorted_indices,
+        )
+        if "bias" in self:
+            x = x + mx.expand_dims(self["bias"][indices], -2)
+        return x
+
+
+class SwitchLinear(nn.Module):
+    def __init__(
+        self, input_dims: int, output_dims: int, num_experts: int, bias: bool = True
+    ):
+        super().__init__()
+        scale = math.sqrt(1 / input_dims)
+        self.weight = mx.random.uniform(
+            low=-scale,
+            high=scale,
+            shape=(num_experts, output_dims, input_dims),
+        )
+
+        if bias:
+            self.bias = mx.zeros((num_experts, output_dims))
+
+    @property
+    def input_dims(self):
+        return self.weight.shape[2]
+
+    @property
+    def output_dims(self):
+        return self.weight.shape[1]
+
+    @property
+    def num_experts(self):
+        return self.weight.shape[0]
+
+    def __call__(self, x, indices, sorted_indices=False):
+        x = mx.gather_mm(
+            x,
+            self["weight"].swapaxes(-1, -2),
+            rhs_indices=indices,
+            sorted_indices=sorted_indices,
+        )
+        if "bias" in self:
+            x = x + mx.expand_dims(self["bias"][indices], -2)
+        return x
+
+    def to_quantized(self, group_size: int = 64, bits: int = 4, mode: str = "affine"):
+        num_experts, output_dims, input_dims = self.weight.shape
+        ql = QuantizedSwitchLinear(
+            input_dims,
+            output_dims,
+            num_experts,
+            False,
+            group_size,
+            bits,
+            mode=mode,
+        )
+        ql.weight, ql.scales, *biases = mx.quantize(
+            self.weight, group_size, bits, mode=mode
+        )
+        ql.biases = biases[0] if biases else None
+
+        if "bias" in self:
+            ql.bias = self.bias
+        return ql
+
+
+class SwiGLU(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def __call__(self, x, gate):
+        return swiglu(gate, x)
+
+
+class SwitchGLU(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=SwiGLU(),
+        bias: bool = False,
+        fused_gate_up: bool = False,
+        fused_swiglu_down: bool = False,
+        inverse_scatter: bool = False,
+    ):
+        super().__init__()
+
+        self.gate_proj = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.up_proj = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.down_proj = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
+        self.activation = activation
+        self.fused_swiglu_down = fused_swiglu_down
+        self.inverse_scatter = inverse_scatter
+        if fused_gate_up or use_fused_gate_up_switch():
+            self.gate_up_proj = SwitchLinear(
+                input_dims, hidden_dims * 2, num_experts, bias=bias
+            )
+            del self.gate_proj
+            del self.up_proj
+
+    def __call__(
+        self,
+        x,
+        indices,
+        scores: mx.array | None = None,
+        weighted_sum: bool = False,
+    ) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+
+        # When we have many tokens, then sort them to make sure that the access
+        # of different experts is in order.
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(
+                x, indices, inverse_scatter=self.inverse_scatter
+            )
+        if self.training:
+            idx = mx.stop_gradient(idx)
+        if hasattr(self, "gate_up_proj"):
+            if (
+                use_fused_swiglu_gate_up_switch()
+                and do_sort
+                and isinstance(self.activation, SwiGLU)
+                and isinstance(self.gate_up_proj, QuantizedSwitchLinear)
+                and isinstance(self.down_proj, QuantizedSwitchLinear)
+                and hasattr(mx.fast, "glm_moe_swiglu_gate_up")
+            ):
+                x = mx.fast.glm_moe_swiglu_gate_up(
+                    x,
+                    self.gate_up_proj["weight"],
+                    self.gate_up_proj["scales"],
+                    self.gate_up_proj.get("biases"),
+                    idx,
+                    self.gate_up_proj.group_size,
+                    self.gate_up_proj.bits,
+                    self.gate_up_proj.mode,
+                )
+                x = self.down_proj(
+                    x,
+                    idx,
+                    sorted_indices=do_sort,
+                )
+            else:
+                x_gate_up = self.gate_up_proj(x, idx, sorted_indices=do_sort)
+                if (
+                    (self.fused_swiglu_down or use_fused_swiglu_down_switch())
+                    and do_sort
+                    and isinstance(self.activation, SwiGLU)
+                    and isinstance(self.down_proj, QuantizedSwitchLinear)
+                    and hasattr(mx.fast, "glm_moe_swiglu_down")
+                ):
+                    x = mx.fast.glm_moe_swiglu_down(
+                        x_gate_up,
+                        self.down_proj["weight"],
+                        self.down_proj["scales"],
+                        self.down_proj.get("biases"),
+                        idx,
+                        self.down_proj.group_size,
+                        self.down_proj.bits,
+                        self.down_proj.mode,
+                    )
+                    if "bias" in self.down_proj:
+                        x = x + mx.expand_dims(self.down_proj["bias"][idx], -2)
+                else:
+                    x_gate, x_up = mx.split(x_gate_up, 2, axis=-1)
+                    x = self.down_proj(
+                        self.activation(x_up, x_gate),
+                        idx,
+                        sorted_indices=do_sort,
+                    )
+        else:
+            x_up = self.up_proj(x, idx, sorted_indices=do_sort)
+            x_gate = self.gate_proj(x, idx, sorted_indices=do_sort)
+            x = self.down_proj(
+                self.activation(x_up, x_gate),
+                idx,
+                sorted_indices=do_sort,
+            )
+
+        if (
+            weighted_sum
+            and scores is not None
+            and do_sort
+            and hasattr(mx.fast, "glm_moe_weighted_sum")
+        ):
+            return mx.fast.glm_moe_weighted_sum(x, inv_order, scores)
+
+        if do_sort:
+            x = _scatter_unsort(x, inv_order, indices.shape)
+
+        return x.squeeze(-2)
+
+
+class SwitchMLP(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=nn.GELU(approx="precise"),
+        bias: bool = False,
+    ):
+        super().__init__()
+
+        self.fc1 = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.fc2 = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
+        self.activation = activation
+
+    def __call__(self, x, indices) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+
+        # When we have many tokens, then sort them to make sure that the access
+        # of different experts is in order.
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(x, indices)
+        if self.training:
+            idx = mx.stop_gradient(idx)
+        x = self.fc1(x, idx, sorted_indices=do_sort)
+        x = self.activation(x)
+        x = self.fc2(x, idx, sorted_indices=do_sort)
+
+        if do_sort:
+            x = _scatter_unsort(x, inv_order, indices.shape)
+
+        return x.squeeze(-2)

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -884,6 +884,10 @@ def _patched_ppb_split(self, indices):
         new_batch.logits_processors = lps
         new_batch.state_machines = self.state_machines
         new_batch.max_tokens = self.max_tokens
+        if hasattr(self, "_omlx_glm_dsa_adaptive_prefill"):
+            new_batch._omlx_glm_dsa_adaptive_prefill = (
+                self._omlx_glm_dsa_adaptive_prefill
+            )
 
         self.uids = []
         self.prompt_cache = []
@@ -1447,6 +1451,25 @@ class Scheduler:
         self._turboquant_skip_last: bool = True
         # Memoized MLA-architecture detection (see _model_uses_mla / #1613).
         self._mla_model: bool | None = None
+        self._glm_dsa_adaptive_prefill = None
+        try:
+            from .patches.glm_moe_dsa.generate_patch import (
+                _glm_dsa_adaptive_prefill_config,
+            )
+
+            self._glm_dsa_adaptive_prefill = _glm_dsa_adaptive_prefill_config(
+                model, self.config.prefill_step_size
+            )
+        except Exception:
+            logger.debug("GLM DSA adaptive prefill config unavailable", exc_info=True)
+        if self._glm_dsa_adaptive_prefill is not None:
+            logger.info(
+                "GLM DSA adaptive scheduler prefill enabled: step=%d after=%d "
+                "min_remaining=%d",
+                self._glm_dsa_adaptive_prefill.step_size,
+                self._glm_dsa_adaptive_prefill.after,
+                self._glm_dsa_adaptive_prefill.min_remaining,
+            )
 
         # Request management - following vLLM's design
         self.waiting: deque[Request] = deque()  # Waiting queue (FCFS)
@@ -2870,13 +2893,15 @@ class Scheduler:
 
         input_arr = mx.array(prefill_tokens)[None]  # (1, seq_len)
         processed_tokens = 0
-        prefill_step_size = self.config.prefill_step_size
         uid = self.request_id_to_uid.get(request.request_id)
 
         emitted_boundaries: dict[int, int] = {}
 
         while input_arr.shape[1] > 0:
             remaining = input_arr.shape[1]
+            prefill_step_size = self._prefill_step_size_for_progress(
+                processed_tokens, remaining
+            )
             n_to_process = min(prefill_step_size, remaining)
 
             if processed_tokens == 0:
@@ -3744,6 +3769,24 @@ class Scheduler:
     # Chunked prefill helpers (used when config.chunked_prefill=True)
     # ------------------------------------------------------------------
 
+    def _prefill_step_size_for_progress(
+        self, processed_tokens: int, remaining_tokens: int
+    ) -> int:
+        """Return the scheduler prefill chunk size for the current progress."""
+        adaptive_prefill = self._glm_dsa_adaptive_prefill
+        if adaptive_prefill is None:
+            return self.config.prefill_step_size
+        from .patches.glm_moe_dsa.generate_patch import (
+            _prefill_step_size_for_progress,
+        )
+
+        return _prefill_step_size_for_progress(
+            self.config.prefill_step_size,
+            processed_tokens,
+            remaining_tokens,
+            adaptive_prefill,
+        )
+
     def _begin_prefill(
         self,
         request: "Request",
@@ -3819,7 +3862,11 @@ class Scheduler:
         if state.tokens_remaining.shape[1] == 0:
             return True
 
-        n = min(self.config.prefill_step_size, state.tokens_remaining.shape[1])
+        remaining = state.tokens_remaining.shape[1]
+        prefill_step_size = self._prefill_step_size_for_progress(
+            state.tokens_processed, remaining
+        )
+        n = min(prefill_step_size, remaining)
 
         if state.tokens_processed == 0:
             _sync_and_clear_cache(self._stream)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "mlx>=0.31.2",
+    # oMLX GLM-5.2 custom kernels based on MLX v0.31.2.
+    "mlx @ git+https://github.com/jundot/mlx.git@v0.31.2-omlx",
     # mlx-lm from commit (2c008fd, v0.31.3) - trust_remote_code load gate,
     # transformers 5.7.0 compatibility, and prior BatchGenerator/cache fixes.
     "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@2c008fd0252b2c569227d12568356ab88ab0560a",
@@ -197,9 +198,10 @@ include = ["omlx*"]
 "omlx.eval" = ["data/*.jsonl"]
 
 [tool.uv]
-# mlx-lm is pinned to a git commit; override transitive pins
-# (e.g. mlx-audio → mlx-lm==0.31.1) so the resolver accepts it.
+# mlx and mlx-lm are git-pinned; override transitive pins
+# (e.g. mlx-audio -> mlx-lm==0.31.1) so the resolver accepts them.
 override-dependencies = [
+    "mlx @ git+https://github.com/jundot/mlx.git@v0.31.2-omlx",
     "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@2c008fd0252b2c569227d12568356ab88ab0560a",
 ]
 

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -95,6 +96,76 @@ def test_pre_load_dispatch_applies_glm_patch(tmp_path, monkeypatch):
     apply_mock.assert_called_once_with()
 
 
+def test_glm_adaptive_prefill_config_defaults_and_gates(monkeypatch):
+    from omlx.patches.glm_moe_dsa.generate_patch import (
+        _glm_dsa_adaptive_prefill_config,
+        _prefill_step_size_for_progress,
+    )
+
+    env_names = [
+        "MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP",
+        "MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP_SIZE",
+        "MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_AFTER",
+        "MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_MIN_REMAINING",
+    ]
+    for name in env_names:
+        monkeypatch.delenv(name, raising=False)
+
+    model = SimpleNamespace(model_type="glm_moe_dsa")
+    cfg = _glm_dsa_adaptive_prefill_config(model, 2048)
+    assert cfg is not None
+    assert cfg.step_size == 6144
+    assert cfg.after == 0
+    assert cfg.min_remaining == 0
+    assert _prefill_step_size_for_progress(2048, 0, 8192, cfg) == 6144
+
+    assert _glm_dsa_adaptive_prefill_config(model, 1024) is None
+    assert (
+        _glm_dsa_adaptive_prefill_config(
+            SimpleNamespace(model_type="deepseek_v32"), 2048
+        )
+        is None
+    )
+
+    monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", "0")
+    assert _glm_dsa_adaptive_prefill_config(model, 2048) is None
+
+
+def test_glm_adaptive_prefill_config_env_overrides(monkeypatch):
+    from omlx.patches.glm_moe_dsa.generate_patch import (
+        _glm_dsa_adaptive_prefill_config,
+        _prefill_step_size_for_progress,
+    )
+
+    monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", "1")
+    monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP_SIZE", "4096")
+    monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_AFTER", "8192")
+    monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_MIN_REMAINING", "2048")
+
+    cfg = _glm_dsa_adaptive_prefill_config(
+        SimpleNamespace(args=SimpleNamespace(model_type="glm_moe_dsa")), 2048
+    )
+    assert cfg is not None
+    assert cfg.step_size == 4096
+    assert cfg.after == 8192
+    assert cfg.min_remaining == 2048
+    assert _prefill_step_size_for_progress(2048, 4096, 4096, cfg) == 2048
+    assert _prefill_step_size_for_progress(2048, 8192, 1024, cfg) == 2048
+    assert _prefill_step_size_for_progress(2048, 8192, 2048, cfg) == 4096
+
+
+def test_glm_patch_keeps_vendored_helpers_private():
+    glm_moe_dsa = _load_patched_glm_module()
+
+    from omlx.patches.glm_moe_dsa import deepseek_v32 as vendored_deepseek_v32
+    from mlx_lm.models import deepseek_v32 as upstream_deepseek_v32
+
+    assert getattr(glm_moe_dsa, "_OMLX_GLM_DSA_OPTIMIZED", False)
+    assert sys.modules["mlx_lm.models.glm_moe_dsa"] is glm_moe_dsa
+    assert glm_moe_dsa.DeepseekV32Model is vendored_deepseek_v32.DeepseekV32Model
+    assert upstream_deepseek_v32 is not vendored_deepseek_v32
+
+
 def test_glm_patch_installs_native_indexer_schedule():
     glm_moe_dsa = _load_patched_glm_module()
 
@@ -113,9 +184,14 @@ def test_glm_patch_installs_native_indexer_schedule():
     ]
 
     model = glm_moe_dsa.Model(args)
-    assert [
-        layer.self_attn.indexer is not None for layer in model.model.layers
-    ] == [True, False, True, False, True, False]
+    assert [layer.self_attn.indexer is not None for layer in model.model.layers] == [
+        True,
+        False,
+        True,
+        False,
+        True,
+        False,
+    ]
     assert [len(c.caches) for c in model.make_cache()] == [2, 1, 2, 1, 2, 1]
 
 

--- a/tests/test_scheduler_chunked_prefill.py
+++ b/tests/test_scheduler_chunked_prefill.py
@@ -90,6 +90,32 @@ def _make_prefill_state(
     return state
 
 
+class _RecordingModel:
+    def __init__(self, model_type: str):
+        self.model_type = model_type
+        self.layers = []
+        self.chunk_lengths: list[int] = []
+
+    def __call__(self, tokens, cache=None):
+        self.chunk_lengths.append(int(tokens.shape[1]))
+
+
+def _make_recording_scheduler(model_type: str) -> tuple[Scheduler, _RecordingModel]:
+    model = _RecordingModel(model_type)
+    tokenizer = MagicMock()
+    tokenizer.eos_token_id = 2
+    scheduler = Scheduler(
+        model=model,
+        tokenizer=tokenizer,
+        config=SchedulerConfig(
+            prefill_step_size=2048,
+            chunked_prefill=True,
+            paged_cache_block_size=0,
+        ),
+    )
+    return scheduler, model
+
+
 # ---------------------------------------------------------------------------
 # SchedulerConfig
 # ---------------------------------------------------------------------------
@@ -209,6 +235,46 @@ class TestGetStats:
         sched.prefilling.append(_make_request("r1"))
         sched.prefilling.append(_make_request("r2"))
         assert sched.get_stats()["num_prefilling"] == 2
+
+
+# ---------------------------------------------------------------------------
+# GLM adaptive chunked prefill
+# ---------------------------------------------------------------------------
+
+
+class TestGLMAdaptiveChunkedPrefill:
+    def test_glm_uses_adaptive_prefill_chunk_size(self, monkeypatch):
+        monkeypatch.delenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", raising=False)
+        monkeypatch.delenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP_SIZE", raising=False)
+        monkeypatch.delenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_AFTER", raising=False)
+        monkeypatch.delenv(
+            "MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_MIN_REMAINING", raising=False
+        )
+
+        sched, model = _make_recording_scheduler("glm_moe_dsa")
+        req = _make_request("glm", n_tokens=8193)
+        state = _make_prefill_state(sched, req, n_remaining=8192)
+
+        with patch("omlx.scheduler._sync_and_clear_cache"):
+            done = sched._step_prefill_chunk(state)
+
+        assert not done
+        assert model.chunk_lengths == [6144]
+        assert state.tokens_processed == 6144
+
+    def test_non_glm_keeps_configured_prefill_chunk_size(self, monkeypatch):
+        monkeypatch.delenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", raising=False)
+
+        sched, model = _make_recording_scheduler("deepseek_v32")
+        req = _make_request("deepseek", n_tokens=8193)
+        state = _make_prefill_state(sched, req, n_remaining=8192)
+
+        with patch("omlx.scheduler._sync_and_clear_cache"):
+            done = sched._step_prefill_chunk(state)
+
+        assert not done
+        assert model.chunk_lengths == [2048]
+        assert state.tokens_processed == 2048
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Direct-Link Notice: Please Follow PR #1984

If you arrived here through a direct link, please check #1984 instead

PR #1984 continues this work on the improved vanilla MLX dependency path, without requiring the forked MLX package used by this draft.

## Summary

- pin oMLX to the custom MLX fork branch with GLM MoE DSA kernels
- vendor the optimized GLM-5.2 `glm_moe_dsa` mlx-lm implementation under `omlx.patches.glm_moe_dsa`
- keep DeepSeek V3.2, Sparse MLA, and switch-layer helpers private to the oMLX patch package instead of replacing shared `mlx_lm.models` modules
- add GLM-only adaptive prefill for both `mlx_lm.generate` and oMLX scheduler external/chunked prefill paths

## Benchmark

Model: GLM-5.2-oQ4 (418.1 GB)  
Machine: Mac Studio, M3 Ultra, 512 GB unified memory  
Workload: single request, 128 generated tokens

### Throughput

| Context | Baseline PP | Optimized PP | PP speedup | Baseline TG | Optimized TG | TG delta |
|---:|---:|---:|---:|---:|---:|---:|
| 1k | 186.8 tok/s | 190.4 tok/s | 1.02x (+1.9%) | 15.6 tok/s | 15.6 tok/s | +0.0% |
| 4k | 187.4 tok/s | 212.1 tok/s | 1.13x (+13.2%) | 14.7 tok/s | 14.9 tok/s | +1.4% |
| 8k | 164.1 tok/s | 181.8 tok/s | 1.11x (+10.8%) | 14.4 tok/s | 14.9 tok/s | +3.5% |
| 16k | 128.1 tok/s | 179.3 tok/s | 1.40x (+40.0%) | 14.4 tok/s | 14.5 tok/s | +0.7% |
| 32k | 87.7 tok/s | 172.7 tok/s | 1.97x (+96.9%) | 14.1 tok/s | 14.4 tok/s | +2.1% |

### Peak Memory

| Context | Baseline peak mem | Optimized peak mem | Peak mem delta |
|---:|---:|---:|---:|
| 1k | 399.5 GB | 399.48 GB | -0.02 GB |
| 4k | 402.1 GB | 401.39 GB | -0.71 GB |
| 8k | 404.9 GB | 401.67 GB | -3.23 GB |
| 16k | 410.8 GB | 402.25 GB | -8.55 GB |
| 32k | 423.3 GB | 403.90 GB | -19.40 GB |

Highlights:
- 16k PP improves from 128.1 to 179.3 tok/s, a 1.40x gain, while TG stays effectively flat.
- 32k PP improves from 87.7 to 172.7 tok/s, a 1.97x gain, with 19.4 GB lower peak memory.
- TG remains in the same band across the tested context range.

## Validation

- `python -m compileall -q omlx/scheduler.py tests/test_scheduler_chunked_prefill.py omlx/patches/glm_moe_dsa`
- `python -m pytest tests/test_scheduler_chunked_prefill.py tests/test_glm_moe_dsa_patch.py`
- `python -m pytest tests/test_singleton_cache_passthrough.py`
- `python -m pip install --dry-run .`
