### PR TITLE
feat(oq): micro-batch sensitivity calibration for low-memory machines

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -2909,6 +2909,7 @@ def quantize_oq_streaming(
     dtype: str = "bfloat16",
     preserve_mtp: bool = False,
     auto_proxy_sensitivity: bool = True,
+    sensitivity_micro_batch: int = 0,
     trust_remote_code: bool = False,
 ) -> None:
     """Tensor-by-tensor quantization. Memory: ~3-4GB regardless of model size.
@@ -2941,6 +2942,12 @@ def quantize_oq_streaming(
             False, the quantization aborts on RAM-exceeding models with a
             RuntimeError so callers always get a real sensitivity-driven
             output. Ignored if sensitivity_model_path is set explicitly.
+        sensitivity_micro_batch: When > 0, process the sensitivity
+            calibration set in sample-chunks of this size instead of all at
+            once, bounding peak activation memory so the measurement fits a
+            smaller machine. The per-layer score is a mean over samples, so
+            chunking is numerically equivalent; only peak memory differs.
+            0 (default) keeps the single-batch behaviour.
         trust_remote_code: Forwarded to mlx-lm/mlx-vlm model loads when a
             checkpoint requires custom model code.
     """
@@ -3022,6 +3029,7 @@ def quantize_oq_streaming(
                 oq_level,
                 num_samples=128,
                 seq_length=256,
+                micro_batch=sensitivity_micro_batch,
                 trust_remote_code=trust_remote_code,
             )
         elif (
@@ -3045,6 +3053,7 @@ def quantize_oq_streaming(
                 oq_level,
                 num_samples=128,
                 seq_length=256,
+                micro_batch=sensitivity_micro_batch,
                 trust_remote_code=trust_remote_code,
             )
         elif _model_exceeds_ram and auto_proxy_sensitivity:
@@ -3072,6 +3081,7 @@ def quantize_oq_streaming(
                     oq_level,
                     num_samples=128,
                     seq_length=256,
+                    micro_batch=sensitivity_micro_batch,
                     trust_remote_code=trust_remote_code,
                 )
             except Exception as e:
@@ -3103,6 +3113,7 @@ def quantize_oq_streaming(
                 oq_level,
                 num_samples=128,
                 seq_length=256,
+                micro_batch=sensitivity_micro_batch,
                 trust_remote_code=trust_remote_code,
             )
 
@@ -3935,6 +3946,7 @@ def _measure_sensitivity_from_model(
     calib_dataset="code_multilingual",
     num_samples=32,
     seq_length=256,
+    micro_batch=0,
 ):
     """Measure per-layer quantization sensitivity on an already-loaded model.
 
@@ -3956,6 +3968,11 @@ def _measure_sensitivity_from_model(
     embed_fn, layers = _find_model_layers(model)
     if embed_fn is None or layers is None:
         return {}
+
+    if micro_batch and micro_batch > 0:
+        return _measure_sensitivity_from_model_microbatched(
+            model, config, oq_level, embed_fn, layers, calib_data, micro_batch
+        )
 
     inputs = embed_fn(calib_data)
     inputs, layer_masks, position_ids = _prepare_layer_inputs(
@@ -4014,6 +4031,101 @@ def _measure_sensitivity_from_model(
     return sensitivity
 
 
+def _measure_sensitivity_from_model_microbatched(
+    model,
+    config,
+    oq_level,
+    embed_fn,
+    layers,
+    calib_data,
+    micro_batch,
+):
+    """Memory-bounded variant of the _measure_sensitivity_from_model loop.
+
+    Runs the calibration set through the layers in sample-chunks of
+    ``micro_batch``, accumulating each layer's squared-error and magnitude sums
+    and dividing at the end. A per-layer score is a mean over samples and a mean
+    is associative, so the result matches the single-batch loop within float
+    noise; only peak activation memory differs.
+    """
+    err_sum: dict = {}
+    mag_sum: dict = {}
+    count: dict = {}
+    n_total = int(calib_data.shape[0])
+    n_chunks = (n_total + micro_batch - 1) // micro_batch
+
+    for chunk_idx, start in enumerate(range(0, n_total, micro_batch)):
+        chunk = calib_data[start : start + micro_batch]
+        inputs = embed_fn(chunk)
+        inputs, layer_masks, position_ids = _prepare_layer_inputs(
+            model, layers, chunk, inputs
+        )
+        logger.info(f"oQ{oq_level:g}: sensitivity chunk {chunk_idx + 1}/{n_chunks}")
+
+        for layer_idx, block in enumerate(layers):
+            layer_mask = (
+                layer_masks[layer_idx] if layer_idx < len(layer_masks) else None
+            )
+            prev_aux = (
+                position_ids.get("prev_topk_indices")
+                if isinstance(position_ids, dict)
+                and position_ids.get("kind") == "glm_moe_dsa"
+                else None
+            )
+            out_float, baseline_aux = _forward_layer_result(
+                block, inputs, layer_mask, position_ids
+            )
+            if out_float is None:
+                continue
+
+            saved = _temporary_quantize_block(
+                block, config, oq_level, _OQ_DEFAULT_GROUP_SIZE
+            )
+            if (
+                isinstance(position_ids, dict)
+                and position_ids.get("kind") == "glm_moe_dsa"
+            ):
+                position_ids["prev_topk_indices"] = prev_aux
+            out_quant, _ = _forward_layer_result(
+                block, inputs, layer_mask, position_ids
+            )
+            if out_quant is not None:
+                # float32 reduction: float16 squared sums overflow on long runs.
+                of32 = out_float.astype(mx.float32)
+                oq32 = out_quant.astype(mx.float32)
+                err = ((of32 - oq32) ** 2).sum()
+                mag = (of32**2).sum()
+                mx.eval(err, mag)
+                err_sum[layer_idx] = err_sum.get(layer_idx, 0.0) + err.item()
+                mag_sum[layer_idx] = mag_sum.get(layer_idx, 0.0) + mag.item()
+                count[layer_idx] = count.get(layer_idx, 0) + int(of32.size)
+
+            _restore_saved_weights(block, saved)
+            if (
+                isinstance(position_ids, dict)
+                and position_ids.get("kind") == "glm_moe_dsa"
+            ):
+                position_ids["prev_topk_indices"] = baseline_aux
+            inputs = out_float
+            mx.synchronize()
+            mx.clear_cache()
+
+    sensitivity = {}
+    for layer_idx, total_err in err_sum.items():
+        n = max(count.get(layer_idx, 0), 1)
+        mean_mag = mag_sum.get(layer_idx, 0.0) / n
+        sensitivity[layer_idx] = (total_err / n) / max(mean_mag, 1e-10)
+
+    if sensitivity:
+        ranked = sorted(sensitivity.items(), key=lambda x: -x[1])
+        logger.info(
+            f"oQ{oq_level:g}: layer sensitivity (descending): "
+            + ", ".join(f"L{i}={s:.4f}" for i, s in ranked)
+        )
+
+    return sensitivity
+
+
 def _measure_sensitivity(
     model_path: str,
     config: dict,
@@ -4021,6 +4133,7 @@ def _measure_sensitivity(
     calib_dataset="code_multilingual",
     num_samples=32,
     seq_length=256,
+    micro_batch=0,
     trust_remote_code: bool = False,
 ):
     """Measure sensitivity by loading model temporarily. Used by streaming path."""
@@ -4103,6 +4216,7 @@ def _measure_sensitivity(
         calib_dataset,
         num_samples,
         seq_length,
+        micro_batch,
     )
 
     del model, tokenizer
@@ -4376,6 +4490,7 @@ def _measure_sensitivity_from_quantized_model(
     calib_dataset="code_multilingual",
     num_samples=32,
     seq_length=256,
+    micro_batch=0,
     trust_remote_code: bool = False,
 ):
     """Measure sensitivity via re-quantization on a quantized model.
@@ -4459,6 +4574,15 @@ def _measure_sensitivity_from_quantized_model(
         mx.synchronize()
         mx.clear_cache()
         return {}
+
+    if micro_batch and micro_batch > 0:
+        sensitivity = _measure_sensitivity_from_quantized_model_microbatched(
+            model, config, oq_level, embed_fn, layers, calib_data, micro_batch
+        )
+        del model, tokenizer
+        mx.synchronize()
+        mx.clear_cache()
+        return sensitivity
 
     inputs = embed_fn(calib_data)
     inputs, layer_masks, position_ids = _prepare_layer_inputs(
@@ -4568,6 +4692,149 @@ def _measure_sensitivity_from_quantized_model(
     del model, tokenizer
     mx.synchronize()
     mx.clear_cache()
+
+    if sensitivity:
+        ranked = sorted(sensitivity.items(), key=lambda x: -x[1])
+        logger.info(
+            f"oQ{oq_level:g}: proxy sensitivity (descending): "
+            + ", ".join(f"L{i}={s:.4f}" for i, s in ranked)
+        )
+
+    return sensitivity
+
+
+def _measure_sensitivity_from_quantized_model_microbatched(
+    model,
+    config,
+    oq_level,
+    embed_fn,
+    layers,
+    calib_data,
+    micro_batch,
+):
+    """Memory-bounded variant of the _measure_sensitivity_from_quantized_model loop.
+
+    Same per-layer re-quantization perturbation as the single-batch loop, but the
+    calibration set runs through the layers in sample-chunks of ``micro_batch``,
+    accumulating each layer's squared-error and magnitude sums and dividing at the
+    end. The score is a mean over samples and a mean is associative, so the result
+    matches the single-batch loop within float noise; only peak activation memory
+    differs.
+    """
+    err_sum: dict = {}
+    mag_sum: dict = {}
+    count: dict = {}
+    n_total = int(calib_data.shape[0])
+    n_chunks = (n_total + micro_batch - 1) // micro_batch
+
+    for chunk_idx, start in enumerate(range(0, n_total, micro_batch)):
+        chunk = calib_data[start : start + micro_batch]
+        inputs = embed_fn(chunk)
+        inputs, layer_masks, position_ids = _prepare_layer_inputs(
+            model, layers, chunk, inputs
+        )
+        logger.info(
+            f"oQ{oq_level:g}: proxy sensitivity chunk {chunk_idx + 1}/{n_chunks}"
+        )
+
+        for layer_idx, block in enumerate(layers):
+            layer_mask = (
+                layer_masks[layer_idx] if layer_idx < len(layer_masks) else None
+            )
+            prev_aux = (
+                position_ids.get("prev_topk_indices")
+                if isinstance(position_ids, dict)
+                and position_ids.get("kind") == "glm_moe_dsa"
+                else None
+            )
+            out_baseline, baseline_aux = _forward_layer_result(
+                block, inputs, layer_mask, position_ids
+            )
+            if out_baseline is None:
+                continue
+            mx.eval(out_baseline)
+
+            saved = {}
+            for p, m in tree_flatten(block.leaf_modules(), is_leaf=nn.Module.is_module):
+                if not hasattr(m, "scales") or not hasattr(m, "weight"):
+                    continue
+                bits = getattr(m, "bits", 4)
+                gs = getattr(m, "group_size", 64)
+                mode = getattr(m, "mode", "affine")
+                perturb_bits = _perturb_bits_for(bits)
+                if perturb_bits is None:
+                    continue
+                w_float = mx.dequantize(
+                    m.weight,
+                    m.scales,
+                    getattr(m, "biases", None),
+                    group_size=gs,
+                    bits=bits,
+                    mode=mode,
+                )
+                saved[p] = (m.weight, m.scales, getattr(m, "biases", None), bits, mode)
+                qw, sc, *rest = mx.quantize(
+                    w_float, group_size=gs, bits=perturb_bits, mode="affine"
+                )
+                m.weight = qw
+                m.scales = sc
+                m.biases = rest[0] if rest else None
+                m.bits = perturb_bits
+                m.mode = "affine"
+                if m.biases is not None:
+                    mx.eval(m.weight, m.scales, m.biases)
+                else:
+                    mx.eval(m.weight, m.scales)
+
+            if (
+                isinstance(position_ids, dict)
+                and position_ids.get("kind") == "glm_moe_dsa"
+            ):
+                position_ids["prev_topk_indices"] = prev_aux
+            out_perturbed, _ = _forward_layer_result(
+                block, inputs, layer_mask, position_ids
+            )
+
+            modules_by_path = dict(
+                tree_flatten(block.leaf_modules(), is_leaf=nn.Module.is_module)
+            )
+            for p, (w, s, b, orig_bits, orig_mode) in saved.items():
+                if p in modules_by_path:
+                    mod = modules_by_path[p]
+                    mod.weight = w
+                    mod.scales = s
+                    if b is not None:
+                        mod.biases = b
+                    elif hasattr(mod, "biases"):
+                        del mod.biases
+                    mod.bits = orig_bits
+                    mod.mode = orig_mode
+
+            if out_perturbed is not None:
+                ob32 = out_baseline.astype(mx.float32)
+                op32 = out_perturbed.astype(mx.float32)
+                err = ((ob32 - op32) ** 2).sum()
+                mag = (ob32**2).sum()
+                mx.eval(err, mag)
+                err_sum[layer_idx] = err_sum.get(layer_idx, 0.0) + err.item()
+                mag_sum[layer_idx] = mag_sum.get(layer_idx, 0.0) + mag.item()
+                count[layer_idx] = count.get(layer_idx, 0) + int(ob32.size)
+
+            if (
+                isinstance(position_ids, dict)
+                and position_ids.get("kind") == "glm_moe_dsa"
+            ):
+                position_ids["prev_topk_indices"] = baseline_aux
+            inputs = out_baseline
+            mx.eval(inputs)
+            mx.synchronize()
+            mx.clear_cache()
+
+    sensitivity = {}
+    for layer_idx, total_err in err_sum.items():
+        n = max(count.get(layer_idx, 0), 1)
+        mean_mag = mag_sum.get(layer_idx, 0.0) / n
+        sensitivity[layer_idx] = (total_err / n) / max(mean_mag, 1e-10)
 
     if sensitivity:
         ranked = sorted(sensitivity.items(), key=lambda x: -x[1])

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -2,6 +2,7 @@
 """Tests for oQ (oMLX Universal Dynamic Quantization)."""
 
 import json
+import math
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -3619,3 +3620,94 @@ class TestQuantizeOqStreamingOq25:
             tensors.update(mx.load(str(sf)))
         assert "model.layers.0.mlp.switch_mlp.down_proj.scales" in tensors
         assert "model.layers.0.mlp.switch_mlp.gate_proj.scales" in tensors
+
+
+class TestSensitivityMicroBatch:
+    """Micro-batched sensitivity must match the single-batch result.
+
+    Chunking the calibration set changes only peak activation memory: a per-layer
+    score is a mean over samples, so pooling the squared-error and magnitude sums
+    and dividing once is numerically identical. The samples here carry distinct
+    magnitudes and the chunk sizes do not divide the sample count, so an
+    implementation that averaged per-chunk scores instead of pooling would
+    diverge and fail this test.
+    """
+
+    @pytest.mark.skipif(not HAS_MLX, reason="requires mlx")
+    def test_microbatch_matches_single_batch(self):
+        from omlx import oq
+
+        n_samples, seq, hidden, n_layers = 8, 4, 6, 3
+        # Each row's token id IS its sample index, so a chunk slice carries its
+        # own samples. Distinct magnitude per sample (index + 1) means an
+        # implementation that averaged per-chunk scores would diverge.
+        calib = mx.broadcast_to(
+            mx.arange(n_samples).reshape(n_samples, 1), (n_samples, seq)
+        ).astype(mx.int32)
+
+        def embed(ids):
+            magnitude = ids[:, 0].reshape(-1, 1, 1).astype(mx.float32) + 1.0
+            return mx.broadcast_to(magnitude, (ids.shape[0], seq, hidden))
+
+        class Block:
+            def __init__(self, shift):
+                self.shift = shift
+                self.q = False
+
+        layers = [Block(0.1 * (i + 1)) for i in range(n_layers)]
+
+        def find_layers(_model):
+            return embed, layers
+
+        def prepare(_model, _layers, _calib, inputs):
+            return inputs, [None] * len(layers), {}
+
+        def forward(block, inputs, _mask, _pos):
+            # Baseline returns the input; the temporary quantize shifts it.
+            return inputs + (block.shift if block.q else 0.0), None
+
+        def quantize(block, _config, _level, _gs):
+            block.q = True
+            return block
+
+        def restore(block, _saved):
+            block.q = False
+
+        def run(micro_batch):
+            for b in layers:
+                b.q = False
+            # Spy on _prepare_layer_inputs: the single-batch path prepares once,
+            # the chunked path once per chunk. Counting it proves the chunked
+            # code is actually taken (an equivalence check alone would silently
+            # pass a dispatch that ignored micro_batch and ran single-batch).
+            prepare_spy = MagicMock(side_effect=prepare)
+            with (
+                patch.object(oq, "_load_calibration_data", return_value=calib),
+                patch.object(oq, "_find_model_layers", side_effect=find_layers),
+                patch.object(oq, "_prepare_layer_inputs", prepare_spy),
+                patch.object(oq, "_forward_layer_result", side_effect=forward),
+                patch.object(oq, "_temporary_quantize_block", side_effect=quantize),
+                patch.object(oq, "_restore_saved_weights", side_effect=restore),
+            ):
+                result = oq._measure_sensitivity_from_model(
+                    object(),
+                    object(),
+                    {},
+                    4,
+                    num_samples=n_samples,
+                    seq_length=seq,
+                    micro_batch=micro_batch,
+                )
+            return result, prepare_spy.call_count
+
+        single, single_calls = run(0)
+        assert single, "single-batch sensitivity should be non-empty"
+        assert single_calls == 1
+
+        # Cover max chunking (1), divisors, non-divisors, == count, and > count.
+        for chunk in (1, 2, 3, 5, 8, 16):
+            chunked, chunk_calls = run(chunk)
+            assert chunk_calls == math.ceil(n_samples / chunk)
+            assert set(chunked) == set(single)
+            for layer_idx in single:
+                assert chunked[layer_idx] == pytest.approx(single[layer_idx], abs=1e-5)


### PR DESCRIPTION
Closes #1974. Relates to #777 (this is the sensitivity-measurement half of that request; the weight-streaming half landed in #1094).

## Summary
- oQ's sensitivity pass runs the whole 128-sample calibration set through every layer in one batch. On a memory-constrained Mac the activations for that batch are what exhaust memory, so an 8B proxy sensitivity pass gets killed before quantization starts.
- This adds a `sensitivity_micro_batch` option that runs the calibration in sample-chunks and pools the per-layer sums, cutting peak activation memory while producing the identical result. The default `0` keeps the current behaviour untouched.

## Why (root cause)
`quantize_oq_streaming` already reads weights one tensor at a time, so the weights never sit in memory together (that was #1094). The remaining cost is sensitivity measurement: both `_measure_sensitivity_from_model` (full-fp16) and `_measure_sensitivity_from_quantized_model` (quantized proxy) call `embed_fn(calib_data)` on all 128 samples and walk every layer once. Attention activations are quadratic in sequence length, so that single batch is the peak, sitting on top of the proxy or model weights. On 16 GB an 8B proxy pass reaches it and the process is killed at the load to sensitivity transition, before any output is written.

A per-layer score is `mean((baseline - perturbed)^2) / mean(baseline^2)` over the calibration elements. A mean is associative, so the same score is recoverable by accumulating squared-error and magnitude sums across sample-chunks and dividing once at the end. Chunking changes only peak memory, not the result.

## Changes
- `omlx/oq.py`: add `sensitivity_micro_batch` to `quantize_oq_streaming`, threaded to both measurement paths. Each path gets a chunked sibling that accumulates per-layer `err`/`mag` sums and divides once. The GLM-MoE-DSA `prev_topk_indices` threading is preserved per chunk, and the reduction runs in float32 (the proxy path already does this to avoid long-sequence overflow). Each chunk logs `sensitivity chunk i/N`, so the phase is no longer silent (today it jumps 12% to 15% with no signal).
- `tests/test_oq.py`: `TestSensitivityMicroBatch`.

## Safety / scope
- `sensitivity_micro_batch=0` (the default) takes the original code path unchanged. The 246 existing `test_oq.py` cases and the full suite pass without modification.
- Both sensitivity paths are covered. The proxy path's GLM sample cap and every existing per-layer guard still apply, because the chunk loop wraps the same per-layer body rather than replacing it.
- Wired as a function parameter only. No new env var or CLI flag, and the GUI control is deliberately left for a follow-up so this stays a focused backend change.

## Tests
```
python -m pytest tests/ -m "not slow and not integration"   # 5945 passed, 22 skipped
```
- `TestSensitivityMicroBatch` pools the same deterministic forwards through chunk sizes 1/2/3/5/8/16 (max chunking, divisors, non-divisors, equal to count, greater than count) with distinct per-sample magnitudes, and asserts the chunked scores match the single batch. The varying magnitudes and non-dividing sizes are deliberate: an implementation that averaged per-chunk scores instead of pooling would diverge and fail. It also asserts `_prepare_layer_inputs` runs once per chunk, so a dispatch that ignored `micro_batch` and silently fell back to single-batch would fail as well.
- Revert-proof: the test passes `micro_batch=`, so reverting the feature (removing the parameter) makes it error rather than pass.

### Real-world verification (this branch, real model)
Ran `_measure_sensitivity_from_quantized_model` from this branch on `mlx-community/Qwen2.5-0.5B-Instruct-4bit`, 64 calibration samples, single-batch vs `micro_batch=4`:

| comparison | layers | max relative diff | top-10 ranking |
|---|---|---|---|
| micro_batch 0 vs 4 | 24 | 0.000390 | identical (10/10) |

Motivating case: a Qwen3-Embedding-8B oQ4 is killed during the single-batch sensitivity pass on a 16 GB M1 Pro, and completes once the calibration is chunked; the resulting model embeds correctly.
