### PR TITLE
fix(oq): build an embedding-aware sensitivity proxy for oQ

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -3002,6 +3002,15 @@ def quantize_oq_streaming(
             "OOM-prone paths will be skipped"
         )
 
+    # Embedding models (e.g. Qwen3-Embedding) ship as CausalLM checkpoints with
+    # no lm_head and bare weight keys, which mlx-lm cannot load. Both full-fp16
+    # measurement and the uniform mlx-lm proxy load through mlx-lm, so neither
+    # can rank an embedding model's sensitivity. They always need an
+    # embedding-aware proxy, regardless of how much RAM is available.
+    from omlx.model_discovery import detect_model_type as _detect_model_type
+
+    _is_embedding = _detect_model_type(source) == "embedding"
+
     cb("loading", 12.0)
 
     if sensitivity_map_path.exists():
@@ -3047,22 +3056,37 @@ def quantize_oq_streaming(
                 seq_length=256,
                 trust_remote_code=trust_remote_code,
             )
-        elif _model_exceeds_ram and auto_proxy_sensitivity:
-            logger.warning(
-                f"oQ{oq_level:g}: model size ({_model_bytes/1e9:.1f} GB) exceeds "
-                f"{int(_MAX_MODEL_RAM_FRACTION*100)}% of system RAM "
-                f"({_system_ram/1e9:.1f} GB). Auto-building a uniform "
-                f"{_PROXY_QUANT_BITS}-bit proxy on disk so sensitivity "
-                "measurement stays data-driven."
-            )
+        elif (_model_exceeds_ram or _is_embedding) and auto_proxy_sensitivity:
+            if _is_embedding:
+                logger.info(
+                    f"oQ{oq_level:g}: embedding model. mlx-lm cannot load the "
+                    "source checkpoint for sensitivity measurement, so "
+                    f"auto-building an embedding-aware {_PROXY_QUANT_BITS}-bit "
+                    "proxy on disk to keep oQ data-driven."
+                )
+            else:
+                logger.warning(
+                    f"oQ{oq_level:g}: model size ({_model_bytes/1e9:.1f} GB) exceeds "
+                    f"{int(_MAX_MODEL_RAM_FRACTION*100)}% of system RAM "
+                    f"({_system_ram/1e9:.1f} GB). Auto-building a uniform "
+                    f"{_PROXY_QUANT_BITS}-bit proxy on disk so sensitivity "
+                    "measurement stays data-driven."
+                )
             _proxy_dir: Path | None = None
             try:
-                _proxy_dir = _build_proxy_for_sensitivity(
-                    model_path,
-                    dtype=dtype,
-                    working_dir=str(output.parent),
-                    trust_remote_code=trust_remote_code,
-                )
+                if _is_embedding:
+                    _proxy_dir = _build_embedding_proxy_for_sensitivity(
+                        model_path,
+                        dtype=dtype,
+                        working_dir=str(output.parent),
+                    )
+                else:
+                    _proxy_dir = _build_proxy_for_sensitivity(
+                        model_path,
+                        dtype=dtype,
+                        working_dir=str(output.parent),
+                        trust_remote_code=trust_remote_code,
+                    )
                 logger.info(
                     f"oQ{oq_level:g}: proxy ready at {_proxy_dir}, measuring sensitivity"
                 )
@@ -3085,13 +3109,18 @@ def quantize_oq_streaming(
                 if _proxy_dir is not None and _proxy_dir.exists():
                     shutil.rmtree(_proxy_dir, ignore_errors=True)
                     logger.info(f"oQ{oq_level:g}: cleaned up proxy at {_proxy_dir}")
-        elif _model_exceeds_ram:
+        elif _model_exceeds_ram or _is_embedding:
+            _reason = (
+                "is an embedding model mlx-lm cannot load for full-fp16 "
+                "sensitivity measurement"
+                if _is_embedding
+                else f"exceeds {int(_MAX_MODEL_RAM_FRACTION*100)}% of system RAM"
+            )
             raise RuntimeError(
-                f"oQ{oq_level:g}: model exceeds {int(_MAX_MODEL_RAM_FRACTION*100)}% "
-                "of system RAM and auto_proxy_sensitivity is disabled. "
-                "Enable auto_proxy_sensitivity, pass sensitivity_model_path "
-                "with a pre-quantized version of this model, or run on a "
-                "machine with enough RAM."
+                f"oQ{oq_level:g}: model {_reason} and auto_proxy_sensitivity is "
+                "disabled. Enable auto_proxy_sensitivity, or pass "
+                "sensitivity_model_path with a pre-quantized version of this "
+                "model."
             )
         else:
             logger.info(
@@ -4152,6 +4181,56 @@ def _build_proxy_for_sensitivity(
         dtype=dtype,
         trust_remote_code=trust_remote_code,
     )
+    return proxy_dir
+
+
+def _build_embedding_proxy_for_sensitivity(
+    model_path: str,
+    *,
+    dtype: str,
+    working_dir: str | None = None,
+) -> Path:
+    """Build a temporary quantized proxy for an embedding model's sensitivity.
+
+    Embedding checkpoints (e.g. Qwen3-Embedding) ship as CausalLM models with
+    no lm_head and bare weight keys, so mlx-lm cannot load them and the uniform
+    mlx-lm proxy from ``_build_proxy_for_sensitivity`` fails at conversion. This
+    builds the proxy with mlx-embeddings' converter instead, which is
+    embedding-aware: it re-keys the weights to the layout mlx-lm expects, so the
+    proxy loads through the normal ``_measure_sensitivity_from_quantized_model``
+    path. The proxy is tied (lm_head -> embed_tokens) so mlx-lm does not reject
+    the missing lm_head at load; sensitivity only reads the decoder layers, so
+    the tie is load-only and harmless.
+
+    mlx-embeddings' converter loads lazily and donates weights as it writes, so
+    its peak memory stays near half the source size, matching the OOM-safety the
+    uniform proxy provides for the RAM-exceeding case.
+
+    The caller is responsible for deleting the returned directory.
+    """
+    from mlx_embeddings import convert as _mlx_embeddings_convert
+
+    proxy_dir = Path(tempfile.mkdtemp(prefix="omlx_oq_emb_proxy_", dir=working_dir))
+    shutil.rmtree(proxy_dir)
+    _mlx_embeddings_convert(
+        hf_path=model_path,
+        mlx_path=str(proxy_dir),
+        quantize=True,
+        q_bits=_PROXY_QUANT_BITS,
+        q_group_size=_PROXY_QUANT_GROUP_SIZE,
+        q_mode="affine",
+        dtype=dtype,
+    )
+
+    config_path = proxy_dir / "config.json"
+    with open(config_path) as f:
+        proxy_config = json.load(f)
+    if not proxy_config.get("tie_word_embeddings"):
+        proxy_config["tie_word_embeddings"] = True
+        tmp_path = config_path.with_suffix(".json.tmp")
+        with open(tmp_path, "w") as f:
+            json.dump(proxy_config, f, indent=2)
+        tmp_path.replace(config_path)
     return proxy_dir
 
 

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -3619,3 +3619,72 @@ class TestQuantizeOqStreamingOq25:
             tensors.update(mx.load(str(sf)))
         assert "model.layers.0.mlp.switch_mlp.down_proj.scales" in tensors
         assert "model.layers.0.mlp.switch_mlp.gate_proj.scales" in tensors
+
+
+class TestBuildEmbeddingProxyForSensitivity:
+    """Tests for the embedding-aware sensitivity proxy.
+
+    Embedding checkpoints (e.g. Qwen3-Embedding) cannot be loaded by mlx-lm, so
+    the uniform proxy in _build_proxy_for_sensitivity fails on them. The
+    embedding proxy is built with mlx-embeddings' converter, which re-keys the
+    weights so the proxy loads through the normal sensitivity path, and is tied
+    so mlx-lm does not reject the missing lm_head.
+    """
+
+    def test_builds_via_mlx_embeddings_and_ties(self, tmp_path, monkeypatch):
+        """Uses mlx-embeddings' converter (not mlx-lm) and ties the output."""
+        from omlx import oq as _oq
+
+        calls = {}
+
+        def _fake_convert(
+            hf_path, mlx_path, quantize, q_bits, q_group_size, q_mode, dtype
+        ):
+            calls.update(
+                hf_path=hf_path,
+                quantize=quantize,
+                q_bits=q_bits,
+                q_group_size=q_group_size,
+                q_mode=q_mode,
+                dtype=dtype,
+            )
+            Path(mlx_path).mkdir(parents=True, exist_ok=True)
+            # An embedding source ships tie_word_embeddings False and no lm_head.
+            (Path(mlx_path) / "config.json").write_text(
+                json.dumps({"tie_word_embeddings": False})
+            )
+
+        monkeypatch.setattr("mlx_embeddings.convert", _fake_convert)
+        proxy_dir = _oq._build_embedding_proxy_for_sensitivity(
+            "/src/embed-model", dtype="bfloat16", working_dir=str(tmp_path)
+        )
+
+        # The embedding-aware converter is used, with affine quantization at the
+        # proxy bit width (not mlx-lm's converter, which cannot load the source).
+        assert calls["hf_path"] == "/src/embed-model"
+        assert calls["quantize"] is True
+        assert calls["q_bits"] == _oq._PROXY_QUANT_BITS
+        assert calls["q_group_size"] == _oq._PROXY_QUANT_GROUP_SIZE
+        assert calls["q_mode"] == "affine"
+        assert calls["dtype"] == "bfloat16"
+        # The proxy is tied so mlx-lm loads it without the missing lm_head.
+        cfg = json.loads((proxy_dir / "config.json").read_text())
+        assert cfg["tie_word_embeddings"] is True
+
+    def test_preserves_an_already_tied_config(self, tmp_path, monkeypatch):
+        """A source that is already tied is left tied (no spurious rewrite)."""
+        from omlx import oq as _oq
+
+        def _fake_convert(hf_path, mlx_path, **_kwargs):
+            Path(mlx_path).mkdir(parents=True, exist_ok=True)
+            (Path(mlx_path) / "config.json").write_text(
+                json.dumps({"tie_word_embeddings": True, "marker": 1})
+            )
+
+        monkeypatch.setattr("mlx_embeddings.convert", _fake_convert)
+        proxy_dir = _oq._build_embedding_proxy_for_sensitivity(
+            "/src/embed-model", dtype="float16", working_dir=str(tmp_path)
+        )
+        cfg = json.loads((proxy_dir / "config.json").read_text())
+        assert cfg["tie_word_embeddings"] is True
+        assert cfg["marker"] == 1


### PR DESCRIPTION
Closes #1976.

## Summary
- oQ on an embedding model fails with "sensitivity measurement produced no scores", before any output is written. Embedding checkpoints cannot be loaded by mlx-lm, and both sensitivity paths go through mlx-lm.
- This detects embedding models and auto-builds the sensitivity proxy with mlx-embeddings' converter (embedding-aware) instead of the mlx-lm one, so oQ on an embedding model works with the default settings.

## Why (root cause)
Embedding checkpoints like Qwen3-Embedding declare a CausalLM architecture but ship no `lm_head` and store weights with bare keys (`embed_tokens.weight`, `layers.0...`) instead of mlx-lm's `model.`-prefixed layout. Both sensitivity paths load through mlx-lm:

- under the RAM gate, `_measure_sensitivity` calls `mlx_lm.load`, which rejects the bare keys ("Received N parameters not in model");
- over the RAM gate, `_build_proxy_for_sensitivity` converts through mlx-lm and fails the same way.

So the inner measurement returns `{}`, and `quantize_oq_streaming` raises at its "no scores" guard. The RAM gate is irrelevant here; the load fails at any size. (Same surface error as #1309, different cause: that was the MTP head plus mlx-vlm sanitize stripping `mtp.*`; this is the embedding key layout.)

## Changes
- `omlx/oq.py`:
  - Detect embedding models once via `model_discovery.detect_model_type(source) == "embedding"`.
  - The auto-proxy branch now also fires for embedding models, regardless of RAM (the fp16 path cannot load them either), and builds the proxy with the embedding-aware path. The RAM-exceeding generic path keeps its existing builder and message.
  - New `_build_embedding_proxy_for_sensitivity`: builds the proxy with `mlx_embeddings.convert` (which re-keys the weights to mlx-lm's layout) and ties the output (`lm_head -> embed_tokens`) so mlx-lm loads it without the missing head. mlx-embeddings' converter loads lazily and donates weights, so peak memory stays near half the source size, matching the OOM-safety of the uniform proxy.
- `tests/test_oq.py`: `TestBuildEmbeddingProxyForSensitivity`.

## Safety / scope
- Non-embedding models are unaffected: `_is_embedding` is False, the new branch conditions do not fire, and the existing RAM and full-fp16 paths run exactly as before. The 253 oQ tests pass unchanged.
- `auto_proxy_sensitivity=False` still raises for an embedding model, now with a message that names the real reason and points to `sensitivity_model_path`.
- Composes with #1975 (sensitivity micro-batch): a large embedding model's proxy goes through the same `_measure_sensitivity_from_quantized_model`, so the micro-batch option there bounds its memory.

## Tests
```
python -m pytest tests/ -m "not slow and not integration"
```
5859 passed, 0 failed (verified locally in fresh-process batches: the full suite in one process exhausts this 16 GB machine around the 30% mark, which is unrelated to the change). The 253 oQ tests pass directly as well.
- `TestBuildEmbeddingProxyForSensitivity` asserts the embedding builder uses mlx-embeddings' converter (not mlx-lm's) with affine quantization at the proxy bit width and ties the output config; a second case checks that an already-tied source is left untouched.
- Revert-proof: the test calls `_build_embedding_proxy_for_sensitivity`, so reverting the feature removes the symbol and the test errors.
- The change is contained to the oQ sensitivity dispatch. For a non-embedding model `_is_embedding` is False, the new branch conditions do not fire, and every existing path runs unchanged.

### Real-world verification (before/after, same model, real branch code)
`quantize_oq_streaming("Qwen/Qwen3-Embedding-0.6B", oq_level=4, auto_proxy_sensitivity=True)` with no explicit proxy:

| | result |
|---|---|
| before (main) | `RuntimeError: oQ4: sensitivity measurement produced no scores` (preceded by mlx-lm "Received 398 parameters not in model: embed_tokens.weight, ...") |
| after (this branch) | quantize succeeds; the output is a 1024-d oQ4 model with a real mixed-precision plan (37 modules at 5-bit, 8 at 6-bit) and embeds correctly (paraphrase cosine 0.72) |
