### PR TITLE
fix(admin): always show the oQ sensitivity-model selector

### DIFF
--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -4368,10 +4368,16 @@
                 if (!this.oqSelectedModelPath) return [];
                 const source = this.oqModels.find(m => m.path === this.oqSelectedModelPath);
                 if (!source) return [];
+                // A usable proxy is a quantized build of the SAME base model.
+                // Matching model_type alone was too loose: it offered a quantized
+                // generative Qwen3 as a proxy for Qwen3-Embedding. Also require the
+                // candidate name to start with the source name (the standard
+                // "<base>-<quant>" layout), so only real siblings are listed.
                 return this.oqAllModels.filter(m =>
                     m.path !== this.oqSelectedModelPath &&
                     m.is_quantized &&
-                    m.model_type === source.model_type
+                    m.model_type === source.model_type &&
+                    m.name.startsWith(source.name)
                 );
             },
 

--- a/omlx/admin/templates/dashboard/_models.html
+++ b/omlx/admin/templates/dashboard/_models.html
@@ -1229,7 +1229,7 @@
                                         </select>
                                     </div>
                                     <!-- Sensitivity Model (optional, all models) -->
-                                    <div class="flex-1" x-show="oqSelectedModelPath && oqSensitivityModelCandidates().length > 0" x-cloak>
+                                    <div class="flex-1" x-show="oqSelectedModelPath" x-cloak>
                                         <div class="flex items-center gap-1.5 mb-1.5">
                                             <label class="block text-xs font-medium text-neutral-500 uppercase tracking-wider">Sensitivity Model</label>
                                             <span class="cursor-help" @mouseenter="$refs.sensTip.style.display='block'" @mouseleave="$refs.sensTip.style.display='none'">
@@ -1248,6 +1248,9 @@
                                                 <option :value="m.path" x-text="m.name + ' (' + m.size_formatted + ')'"></option>
                                             </template>
                                         </select>
+                                        <p x-show="oqSensitivityModelCandidates().length === 0" x-cloak class="mt-1.5 text-xs text-neutral-400 leading-relaxed">
+                                            No quantized version of this model was found on disk. Leave this as "None": oQ measures sensitivity on the source, or auto-builds a proxy when the source cannot be loaded directly (for example an embedding model).
+                                        </p>
                                     </div>
                                     <!-- oQ Level Selector -->
                                     <div class="w-40 shrink-0">


### PR DESCRIPTION
Closes #1978.

## Summary
- The quantizer hid the "Sensitivity Model" selector unless a quantized build of the same `model_type` was already on disk, so for most models (and every embedding model) the control vanished with no explanation.
- The candidate match was `model_type`-only, which offered a quantized generative Qwen3 as a proxy for a Qwen3-Embedding source.
- This shows the selector whenever a source model is selected, adds a hint for the no-sibling case, and tightens the match so only real siblings are listed.

## Why (root cause)
The selector is gated on `x-show="oqSelectedModelPath && oqSensitivityModelCandidates().length > 0"`. An empty candidate list hides it entirely, which is the common case. `oqSensitivityModelCandidates()` filters on `m.is_quantized && m.model_type === source.model_type`; model_type alone does not separate an embedding model from a generative one, so the wrong model could be listed.

## Changes
- `omlx/admin/templates/dashboard/_models.html`: gate the selector on `oqSelectedModelPath` alone, and add a hint shown when there are no candidates ("leave this on None; oQ measures on the source, or auto-builds a proxy when the source cannot be loaded directly, for example an embedding model").
- `omlx/admin/static/js/dashboard.js`: in `oqSensitivityModelCandidates()`, also require `m.name.startsWith(source.name)`, so a candidate must be a quantized build of the same base model.

## Safety / scope
- When candidates do exist, the dropdown is unchanged apart from the tighter filter, which only removes entries that were not real proxies of the source.
- The hint paragraph is its own `x-show` and only renders when the candidate list is empty.

## Verification (rendered in a browser)
There are no JS tests in the repo, so I verified the rendered behaviour with the actual Alpine runtime (`omlx/admin/static/js/alpine.min.js`), the exact markup from this PR, and the real `oqSensitivityModelCandidates()` function, with a Qwen3-Embedding source selected and the only quantized model on disk being a generative `Qwen3-4B-Instruct-4bit` (same model_type):

- before (main markup): the selector is not rendered at all.
- after (this PR): the selector renders with "Sensitivity Model" and a "None (use source model)" dropdown; the no-sibling hint shows; and the generative `Qwen3-4B-Instruct-4bit` is absent from the dropdown, so the tightened match correctly excludes it.
