### PR TITLE
feat: add GLM-5.2 native custom kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 
 # C extensions
 *.so
+*.dylib
+*.metallib
 
 # Distribution / packaging
 .Python

--- a/omlx/patches/glm_moe_dsa/__init__.py
+++ b/omlx/patches/glm_moe_dsa/__init__.py
@@ -15,30 +15,26 @@ import importlib
 import logging
 import sys
 
+from .kernels import fast as glm_fast
+
 logger = logging.getLogger(__name__)
 
 PATCH_SOURCE = "mlxlm-glm optimized-final mlx-lm snapshot"
-CUSTOM_MLX_REF = "https://github.com/jundot/mlx@v0.31.2-omlx"
+NATIVE_KERNELS_PACKAGE = "omlx_glm_kernels"
 
 _APPLIED = False
 
 
-def _missing_custom_mlx_symbols() -> list[str]:
-    """Return expected custom MLX symbols missing from the installed runtime."""
-    try:
-        import mlx.core as mx
-    except Exception:
-        return []
-
+def _missing_fast_symbols() -> list[str]:
+    """Return expected fast symbols missing from native or patched MLX runtime."""
     required = (
         "dsa_indexer_scores",
         "dsa_topk_indices",
         "glm_dsa_sparse_mla_attention",
         "glm_dsa_q8_vup_flat",
-        "glm_moe_swiglu_down",
         "glm_moe_weighted_sum",
     )
-    return [name for name in required if not hasattr(mx.fast, name)]
+    return glm_fast.missing(required)
 
 
 def _register_module() -> None:
@@ -81,13 +77,19 @@ def apply_glm_moe_dsa_patch() -> bool:
 
     apply_glm_moe_dsa_generate_patch()
     _APPLIED = True
-    missing = _missing_custom_mlx_symbols()
+    missing = _missing_fast_symbols()
     if missing:
         logger.warning(
-            "GLM MoE DSA optimized patch applied, but custom MLX symbols are "
-            "missing: %s. Install %s for the accelerated path.",
+            "GLM MoE DSA optimized patch applied, but fast kernel symbols are "
+            "missing from %s and mx.fast: %s. Build the native extension for "
+            "the accelerated path.",
+            NATIVE_KERNELS_PACKAGE,
             ", ".join(missing),
-            CUSTOM_MLX_REF,
+        )
+    elif glm_fast.native_available():
+        logger.info(
+            "GLM MoE DSA native kernels available from %s",
+            NATIVE_KERNELS_PACKAGE,
         )
     logger.info("GLM MoE DSA optimized mlx-lm patch applied")
     return True
@@ -101,5 +103,5 @@ __all__ = [
     "apply_glm_moe_dsa_patch",
     "is_applied",
     "PATCH_SOURCE",
-    "CUSTOM_MLX_REF",
+    "NATIVE_KERNELS_PACKAGE",
 ]

--- a/omlx/patches/glm_moe_dsa/__init__.py
+++ b/omlx/patches/glm_moe_dsa/__init__.py
@@ -1,57 +1,61 @@
 # SPDX-License-Identifier: Apache-2.0
 """GLM-5.2 ``glm_moe_dsa`` monkey-patch for mlx-lm.
 
-Brings ml-explore/mlx-lm#1410 into oMLX without modifying the pinned
-mlx-lm package. The upstream change turns the stock bare DeepSeek-V3.2
-subclass into a GLM-5.2-aware model with native DSA indexer sharing:
-full layers compute top-k indices, shared layers reuse the previous full
-layer's top-k, and shared layers carry no indexer KV cache.
+Vendors the oMLX GLM-5.2 optimized mlx-lm model code without modifying the
+pinned mlx-lm package. The public module name stays
+``mlx_lm.models.glm_moe_dsa`` so mlx-lm's normal model loader can find it, but
+the optimized helper modules remain private to ``omlx.patches.glm_moe_dsa`` and
+do not replace ``mlx_lm.models.deepseek_v32`` or the shared MoE layers used by
+other model families.
 """
 
 from __future__ import annotations
 
 import importlib
-import importlib.util
 import logging
 import sys
-from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-PR_HEAD_SHA = "3cb18b51892a7800678923116f5b4920a7666208"
-PR_URL = "https://github.com/ml-explore/mlx-lm/pull/1410"
+PATCH_SOURCE = "mlxlm-glm optimized-final mlx-lm snapshot"
+CUSTOM_MLX_REF = "https://github.com/jundot/mlx@v0.31.2-omlx"
 
 _APPLIED = False
 
 
-def _upstream_has_glm_moe_dsa_support() -> bool:
-    """Return True when the installed mlx-lm already has PR #1410 support."""
+def _missing_custom_mlx_symbols() -> list[str]:
+    """Return expected custom MLX symbols missing from the installed runtime."""
     try:
-        module = importlib.import_module("mlx_lm.models.glm_moe_dsa")
+        import mlx.core as mx
     except Exception:
-        return False
+        return []
 
-    fields = getattr(getattr(module, "ModelArgs", None), "__dataclass_fields__", {})
-    return "indexer_types" in fields and hasattr(module, "GlmMoeDsaModel")
+    required = (
+        "dsa_indexer_scores",
+        "dsa_topk_indices",
+        "glm_dsa_sparse_mla_attention",
+        "glm_dsa_q8_vup_flat",
+        "glm_moe_swiglu_down",
+        "glm_moe_weighted_sum",
+    )
+    return [name for name in required if not hasattr(mx.fast, name)]
 
 
 def _register_module() -> None:
     qualname = "mlx_lm.models.glm_moe_dsa"
-    here = Path(__file__).parent
-    file_path = here / "glm_moe_dsa_model.py"
-    spec = importlib.util.spec_from_file_location(qualname, str(file_path))
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Could not create spec for {qualname} from {file_path}")
+    existing = sys.modules.get(qualname)
+    if getattr(existing, "_OMLX_GLM_DSA_OPTIMIZED", False):
+        module = existing
+    else:
+        module = importlib.import_module(f"{__name__}.glm_moe_dsa_model")
+        module._OMLX_GLM_DSA_OPTIMIZED = True
 
-    module = importlib.util.module_from_spec(spec)
-    module.__package__ = "mlx_lm.models"
     sys.modules[qualname] = module
-    spec.loader.exec_module(module)
 
     import mlx_lm.models as models_pkg
 
     models_pkg.glm_moe_dsa = module
-    logger.info("Registered %s from %s", qualname, file_path.name)
+    logger.info("Registered %s from oMLX optimized vendored module", qualname)
 
 
 def apply_glm_moe_dsa_patch() -> bool:
@@ -59,9 +63,8 @@ def apply_glm_moe_dsa_patch() -> bool:
 
     Must run before ``mlx_lm.load()`` imports ``mlx_lm.models.glm_moe_dsa``.
 
-    Returns True when oMLX registered its vendored module, False when the
-    patch was already applied, mlx-lm is unavailable, or upstream already
-    ships equivalent support.
+    Returns True when oMLX registered its optimized vendored module, False when
+    the patch was already applied or mlx-lm is unavailable.
     """
     global _APPLIED
     if _APPLIED:
@@ -73,14 +76,20 @@ def apply_glm_moe_dsa_patch() -> bool:
         logger.debug("mlx_lm not importable - glm_moe_dsa patch skipped")
         return False
 
-    if _upstream_has_glm_moe_dsa_support():
-        _APPLIED = True
-        logger.debug("mlx_lm.models.glm_moe_dsa already supports GLM-5.2 sharing")
-        return False
-
     _register_module()
+    from .generate_patch import apply_glm_moe_dsa_generate_patch
+
+    apply_glm_moe_dsa_generate_patch()
     _APPLIED = True
-    logger.info("GLM MoE DSA mlx-lm patch applied (PR 1410 head %s)", PR_HEAD_SHA[:8])
+    missing = _missing_custom_mlx_symbols()
+    if missing:
+        logger.warning(
+            "GLM MoE DSA optimized patch applied, but custom MLX symbols are "
+            "missing: %s. Install %s for the accelerated path.",
+            ", ".join(missing),
+            CUSTOM_MLX_REF,
+        )
+    logger.info("GLM MoE DSA optimized mlx-lm patch applied")
     return True
 
 
@@ -88,4 +97,9 @@ def is_applied() -> bool:
     return _APPLIED
 
 
-__all__ = ["apply_glm_moe_dsa_patch", "is_applied", "PR_HEAD_SHA", "PR_URL"]
+__all__ = [
+    "apply_glm_moe_dsa_patch",
+    "is_applied",
+    "PATCH_SOURCE",
+    "CUSTOM_MLX_REF",
+]

--- a/omlx/patches/glm_moe_dsa/deepseek_v32.py
+++ b/omlx/patches/glm_moe_dsa/deepseek_v32.py
@@ -18,12 +18,12 @@ from mlx_lm.models.base import (
 from mlx_lm.models.cache import CacheList, KVCache
 from mlx_lm.models.mla import MultiLinear
 from mlx_lm.models.rope_utils import initialize_rope
+from .kernels import fast as glm_fast
 from .sparse_mla import (
     block_scores_to_indices,
     fused_indexer_topk_indices,
     fused_indexer_scores_high_histogram,
     fused_indexer_scores,
-    fused_topk_block_table_from_scores,
     fused_topk_indices_with_high_histogram,
     fused_index_score_reduce,
     scores_to_block_indices,
@@ -208,7 +208,8 @@ class Indexer(nn.Module):
         is_quantized = wk_scales is not None and wp_scales is not None
         if is_quantized:
             if (
-                getattr(wk, "group_size", None) != getattr(weights_proj, "group_size", None)
+                getattr(wk, "group_size", None)
+                != getattr(weights_proj, "group_size", None)
                 or getattr(wk, "bits", None) != getattr(weights_proj, "bits", None)
                 or getattr(wk, "mode", None) != getattr(weights_proj, "mode", None)
                 or wk_weight.shape[1:] != wp_weight.shape[1:]
@@ -295,13 +296,10 @@ class Indexer(nn.Module):
             k, _ = cache.update_and_fetch(k, mx.zeros([b, 1, s, 0]))
         if k.shape[2] <= self.index_topk:
             return None
-        use_fast_topk = (
-            os.environ.get("MLX_LM_GLM_DSA_FAST_TOPK", "1") == "1"
-            and hasattr(mx.fast, "dsa_topk_indices")
-        )
-        sort_exact_topk = (
-            os.environ.get("MLX_LM_GLM_DSA_SORT_EXACT_TOPK", "1") == "1"
-        )
+        use_fast_topk = os.environ.get(
+            "MLX_LM_GLM_DSA_FAST_TOPK", "1"
+        ) == "1" and hasattr(glm_fast, "dsa_topk_indices")
+        sort_exact_topk = os.environ.get("MLX_LM_GLM_DSA_SORT_EXACT_TOPK", "1") == "1"
         bucketed_topk = (
             use_fast_topk
             and s > 1
@@ -315,12 +313,9 @@ class Indexer(nn.Module):
             slots = mx.arange(self.index_topk, dtype=mx.uint32).reshape(
                 1, 1, 1, self.index_topk
             )
-            lengths = (
-                mx.arange(prefix_rows, dtype=mx.uint32).reshape(
-                    1, 1, prefix_rows, 1
-                )
-                + mx.array(offset + 1, dtype=mx.uint32)
-            )
+            lengths = mx.arange(prefix_rows, dtype=mx.uint32).reshape(
+                1, 1, prefix_rows, 1
+            ) + mx.array(offset + 1, dtype=mx.uint32)
             prefix = mx.where(slots < lengths, slots, mx.array(0, dtype=mx.uint32))
             return mx.broadcast_to(prefix, (b, 1, prefix_rows, self.index_topk))
 
@@ -335,10 +330,7 @@ class Indexer(nn.Module):
                 if (
                     indices is not None
                     and self.default_block_sparse_sdpa
-                    and os.environ.get(
-                        "MLX_LM_GLM_DSA_COMPACT_PREFIX_TOPK", "1"
-                    )
-                    == "1"
+                    and os.environ.get("MLX_LM_GLM_DSA_COMPACT_PREFIX_TOPK", "1") == "1"
                 ):
                     return indices, None, prefix_rows
                 prefix = causal_prefix_topk(prefix_rows)
@@ -353,23 +345,14 @@ class Indexer(nn.Module):
             scores, prefix_rows: int = 0, causal_valid_prefix: Optional[bool] = None
         ):
             indices = None
-            if scores is not None and use_fast_topk:
-                topk_u16_env = os.environ.get("MLX_LM_GLM_DSA_TOPK_U16", "0").lower()
-                use_topk_u16 = (
-                    topk_u16_env in {"1", "true", "on", "yes"}
-                    or (
-                        topk_u16_env == "auto"
-                        and self.default_block_sparse_sdpa
-                    )
-                ) and scores.shape[-1] <= 65536 and hasattr(
-                    mx.fast, "dsa_topk_indices_u16"
-                )
-                topk_fn = (
-                    mx.fast.dsa_topk_indices_u16
-                    if use_topk_u16
-                    else mx.fast.dsa_topk_indices
-                )
-                indices = topk_fn(
+            use_native_topk = (
+                use_fast_topk
+                and self.index_topk == 2048
+                and scores is not None
+                and scores.shape[-1] >= 2048
+            )
+            if use_native_topk:
+                indices = glm_fast.dsa_topk_indices(
                     scores,
                     self.index_topk,
                     bucketed=bucketed_topk,
@@ -402,14 +385,16 @@ class Indexer(nn.Module):
         )
         causal_valid_prefix_topk = (
             fuse_causal_mask
-            and os.environ.get("MLX_LM_GLM_DSA_TOPK_CAUSAL_PREFIX_FASTPATH", "1")
-            == "1"
+            and os.environ.get("MLX_LM_GLM_DSA_TOPK_CAUSAL_PREFIX_FASTPATH", "1") == "1"
         )
         default_block_sdpa = "1" if self.default_block_sparse_sdpa else "0"
-        use_block_sdpa = os.environ.get(
-            "MLX_LM_GLM_DSA_BLOCK_SPARSE_SDPA",
-            os.environ.get("MLX_LM_GLM_DSA_BLOCK_UNION_SDPA", default_block_sdpa),
-        ) == "1"
+        use_block_sdpa = (
+            os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_SPARSE_SDPA",
+                os.environ.get("MLX_LM_GLM_DSA_BLOCK_UNION_SDPA", default_block_sdpa),
+            )
+            == "1"
+        )
         prefill_mode = os.environ.get("MLX_LM_GLM_DSA_PREFILL_MODE", "").lower()
         default_exact_prefill = (
             self.default_block_sparse_sdpa
@@ -432,9 +417,7 @@ class Indexer(nn.Module):
         block_budget = int(
             os.environ.get(
                 "MLX_LM_GLM_DSA_BLOCK_SDPA_BUDGET",
-                os.environ.get(
-                    "MLX_LM_GLM_DSA_BLOCK_BUDGET", default_block_budget
-                ),
+                os.environ.get("MLX_LM_GLM_DSA_BLOCK_BUDGET", default_block_budget),
             )
         )
         if block_budget > 0:
@@ -494,7 +477,7 @@ class Indexer(nn.Module):
             and k.shape[2]
             >= int(os.environ.get("MLX_LM_GLM_DSA_FUSED_BLOCK_INDEXER_MIN_K", "8192"))
         ):
-            block_scores = mx.fast.dsa_indexer_block_scores(
+            block_scores = glm_fast.dsa_indexer_block_scores(
                 q,
                 k,
                 weights_lh,
@@ -517,53 +500,32 @@ class Indexer(nn.Module):
 
         scores = None
         score_high_hist = None
-        block_table_mode = os.environ.get(
-            "MLX_LM_GLM_DSA_BLOCK_TABLE_SPARSE_MLA", "0"
-        ).lower()
         if (
             s > 1
             and (mask is None or fuse_causal_mask)
             and os.environ.get("MLX_LM_GLM_DSA_CORE_INDEXER_SCORES", "1") == "1"
         ):
             scores_feed_block_path = (
-                block_budget > 0
-                and use_block_sdpa
-                and not use_exact_block_token_sdpa
+                block_budget > 0 and use_block_sdpa and not use_exact_block_token_sdpa
             )
             scores_feed_exact_topk = (
                 causal_valid_prefix_topk and not scores_feed_block_path
             )
-            want_fused_exact_block_table = (
-                os.environ.get("MLX_LM_GLM_DSA_FUSED_TOPK_BLOCK_TABLE", "0")
-                == "1"
-                and use_fast_topk
-                and not scores_feed_block_path
-                and block_table_mode in {"1", "auto", "force"}
-                and (mask is None or fuse_causal_mask)
-            )
             candidate_prefix_rows = 0
-            if (
-                use_fast_topk
-                and scores_feed_exact_topk
-                and not want_fused_exact_block_table
-            ):
+            if use_fast_topk and scores_feed_exact_topk:
                 candidate_prefix_rows = min(
                     s, max(0, self.index_topk - (k.shape[2] - s))
                 )
             if candidate_prefix_rows == s:
                 return select_topk(None, candidate_prefix_rows)
-            score_q = (
-                q[:, :, candidate_prefix_rows:, :] if candidate_prefix_rows else q
-            )
+            score_q = q[:, :, candidate_prefix_rows:, :] if candidate_prefix_rows else q
             score_weights = (
                 weights_lh[:, candidate_prefix_rows:, :]
                 if candidate_prefix_rows
                 else weights_lh
             )
             default_chunk_mb = (
-                "128"
-                if self.default_block_sparse_sdpa and k.shape[2] <= 65536
-                else "0"
+                "128" if self.default_block_sparse_sdpa and k.shape[2] <= 65536 else "0"
             )
             chunk_mb = int(
                 os.environ.get("MLX_LM_GLM_DSA_INDEXER_CHUNK_MB", default_chunk_mb)
@@ -619,9 +581,7 @@ class Indexer(nn.Module):
                         )
                     if chunk_indices:
                         chunked_topk = mx.concatenate(chunk_indices, axis=2)
-                        return finish_topk_indices(
-                            chunked_topk, candidate_prefix_rows
-                        )
+                        return finish_topk_indices(chunked_topk, candidate_prefix_rows)
             if chunked_topk is None:
                 use_score_high_hist = (
                     os.environ.get("MLX_LM_GLM_DSA_SCORE_HIGH_HIST", "0") == "1"
@@ -698,25 +658,6 @@ class Indexer(nn.Module):
             )
             if high_hist_indices is not None:
                 return finish_topk_indices(high_hist_indices, prefix_topk_rows)
-        if (
-            scores is not None
-            and os.environ.get("MLX_LM_GLM_DSA_FUSED_TOPK_BLOCK_TABLE", "0") == "1"
-            and prefix_topk_rows == 0
-        ):
-            if block_table_mode in {"1", "auto", "force"}:
-                block_k = int(
-                    os.environ.get("MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_K_BLOCK", "8")
-                )
-                exact_block_table = fused_topk_block_table_from_scores(
-                    scores,
-                    self.index_topk,
-                    k.shape[2],
-                    k_block_size=block_k,
-                    bucketed=bucketed_topk,
-                    causal_valid_prefix=causal_valid_prefix_topk,
-                )
-                if exact_block_table is not None:
-                    return None, None, 0, exact_block_table
         return select_topk(scores, prefix_topk_rows)
 
 
@@ -896,9 +837,7 @@ class DeepseekV32MLP(nn.Module):
 
     def __call__(self, x):
         if hasattr(self, "gate_up_proj"):
-            gate, up = mx.split(
-                self.gate_up_proj(x), [self.intermediate_size], axis=-1
-            )
+            gate, up = mx.split(self.gate_up_proj(x), [self.intermediate_size], axis=-1)
         else:
             gate = self.gate_proj(x)
             up = self.up_proj(x)
@@ -1000,7 +939,7 @@ class DeepseekV32MoE(nn.Module):
         use_weighted_sum = (
             _use_glm_moe_weighted_sum(self.config)
             and inds.size >= 64
-            and hasattr(mx.fast, "glm_moe_weighted_sum")
+            and hasattr(glm_fast, "glm_moe_weighted_sum")
         )
         y = self.switch_mlp(
             x,
@@ -1266,7 +1205,14 @@ class Model(nn.Module):
                 weights.update(fused)
 
         dequant_mla_proj = _dequant_mla_proj_mode(self.args)
-        dequant_embed_q = dequant_mla_proj in {"1", "true", "all", "both", "embed", "embed_q"}
+        dequant_embed_q = dequant_mla_proj in {
+            "1",
+            "true",
+            "all",
+            "both",
+            "embed",
+            "embed_q",
+        }
         dequant_unembed_out = dequant_mla_proj in {
             "1",
             "true",
@@ -1279,6 +1225,7 @@ class Model(nn.Module):
         if (dequant_embed_q or dequant_unembed_out) and isinstance(
             getattr(self.args, "quantization", None), dict
         ):
+
             def dequant_mla_weight(path, input_dims):
                 weight_key = f"{path}.weight"
                 scales_key = f"{path}.scales"
@@ -1312,14 +1259,10 @@ class Model(nn.Module):
             for l in range(self.args.num_hidden_layers):
                 prefix = f"model.layers.{l}.self_attn"
                 if dequant_embed_q:
-                    dequant_mla_weight(
-                        f"{prefix}.embed_q", self.args.qk_nope_head_dim
-                    )
+                    dequant_mla_weight(f"{prefix}.embed_q", self.args.qk_nope_head_dim)
                     self.args.quantization.pop(f"{prefix}.embed_q", None)
                 if dequant_unembed_out:
-                    dequant_mla_weight(
-                        f"{prefix}.unembed_out", self.args.kv_lora_rank
-                    )
+                    dequant_mla_weight(f"{prefix}.unembed_out", self.args.kv_lora_rank)
                     self.args.quantization.pop(f"{prefix}.unembed_out", None)
 
         # Stack experts

--- a/omlx/patches/glm_moe_dsa/deepseek_v32.py
+++ b/omlx/patches/glm_moe_dsa/deepseek_v32.py
@@ -1,0 +1,1486 @@
+# Copyright © 2025 Apple Inc.
+
+import math
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
+
+from mlx_lm.models.activations import swiglu
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.cache import CacheList, KVCache
+from mlx_lm.models.mla import MultiLinear
+from mlx_lm.models.rope_utils import initialize_rope
+from .sparse_mla import (
+    block_scores_to_indices,
+    fused_indexer_topk_indices,
+    fused_indexer_scores_high_histogram,
+    fused_indexer_scores,
+    fused_topk_block_table_from_scores,
+    fused_topk_indices_with_high_histogram,
+    fused_index_score_reduce,
+    scores_to_block_indices,
+)
+from .switch_layers import SwitchGLU, use_fused_gate_up_switch
+
+
+def _use_load_fused_wk_weights_proj(args) -> bool:
+    env = os.environ.get("MLX_LM_GLM_DSA_LOAD_FUSED_WK_WEIGHTS_PROJ", "auto").lower()
+    if env in {"0", "false", "off", "no"}:
+        return False
+    if env in {"1", "true", "on", "yes"}:
+        return True
+    if getattr(args, "model_type", None) != "glm_moe_dsa":
+        return False
+    quantization = getattr(args, "quantization", None)
+    if not isinstance(quantization, dict):
+        return False
+
+    def is_indexer_q8(name):
+        spec = quantization.get(name)
+        return (
+            isinstance(spec, dict)
+            and spec.get("bits") == 8
+            and spec.get("group_size") == 64
+            and spec.get("mode", "affine") == "affine"
+        )
+
+    return any(
+        key.endswith(".self_attn.indexer.wk")
+        and is_indexer_q8(key)
+        and is_indexer_q8(key[:-2] + "weights_proj")
+        for key in quantization
+    )
+
+
+def _dequant_mla_proj_mode(args) -> str:
+    if getattr(args, "model_type", None) != "glm_moe_dsa":
+        return "0"
+    return os.environ.get("MLX_LM_GLM_DSA_DEQUANT_MLA_PROJ", "0").lower()
+
+
+def _use_glm_moe_fused_gate_up(args) -> bool:
+    env = os.environ.get("MLX_LM_GLM_MOE_FUSED_GATE_UP", "auto").lower()
+    if env in {"0", "false", "off", "no"}:
+        return False
+    if env in {"1", "true", "on", "yes"}:
+        return True
+    return getattr(args, "model_type", None) == "glm_moe_dsa"
+
+
+def _use_glm_moe_swiglu_down(args) -> bool:
+    env = os.environ.get("MLX_LM_GLM_MOE_SWIGLU_DOWN", "auto").lower()
+    if env in {"0", "false", "off", "no"}:
+        return False
+    if env in {"1", "true", "on", "yes"}:
+        return getattr(args, "model_type", None) == "glm_moe_dsa"
+    return getattr(args, "model_type", None) == "glm_moe_dsa"
+
+
+def _use_glm_shared_fused_gate_up(args) -> bool:
+    env = os.environ.get("MLX_LM_GLM_SHARED_FUSED_GATE_UP", "0").lower()
+    if env in {"0", "false", "off", "no"}:
+        return False
+    if env in {"1", "true", "on", "yes"}:
+        return getattr(args, "model_type", None) == "glm_moe_dsa"
+    return False
+
+
+def _use_glm_moe_weighted_sum(args) -> bool:
+    env = os.environ.get("MLX_LM_GLM_MOE_WEIGHTED_SUM", "auto").lower()
+    if env in {"0", "false", "off", "no"}:
+        return False
+    if env in {"1", "true", "on", "yes"}:
+        return getattr(args, "model_type", None) == "glm_moe_dsa"
+    return getattr(args, "model_type", None) == "glm_moe_dsa"
+
+
+def _use_glm_moe_inverse_scatter(args) -> bool:
+    env = os.environ.get("MLX_LM_GLM_MOE_INVERSE_SCATTER", "auto").lower()
+    if env in {"0", "false", "off", "no"}:
+        return False
+    if env in {"1", "true", "on", "yes"}:
+        return getattr(args, "model_type", None) == "glm_moe_dsa"
+    return getattr(args, "model_type", None) == "glm_moe_dsa"
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str = "deepseek_v32"
+    vocab_size: int = 102400
+    hidden_size: int = 4096
+    index_head_dim: int = 128
+    index_n_heads: int = 64
+    index_topk: int = 2048
+    intermediate_size: int = 11008
+    moe_intermediate_size: int = 1407
+    num_hidden_layers: int = 30
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 32
+    n_shared_experts: Optional[int] = None
+    n_routed_experts: Optional[int] = None
+    routed_scaling_factor: float = 1.0
+    kv_lora_rank: int = 512
+    q_lora_rank: int = 1536
+    qk_rope_head_dim: int = 64
+    v_head_dim: int = 128
+    qk_nope_head_dim: int = 128
+    topk_method: str = "noaux_tc"
+    scoring_func: str = "sigmoid"
+    norm_topk_prob: bool = True
+    n_group: int = 1
+    topk_group: int = 1
+    num_experts_per_tok: int = 1
+    moe_layer_freq: int = 1
+    first_k_dense_replace: int = 0
+    max_position_embeddings: int = 2048
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 10000.0
+    rope_scaling: Dict = None
+    attention_bias: bool = False
+
+
+class Indexer(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.dim = args.hidden_size
+        self.n_heads = args.index_n_heads
+        self.head_dim = args.index_head_dim
+        self.rope_head_dim = args.qk_rope_head_dim
+        self.index_topk = args.index_topk
+        self.q_lora_rank = args.q_lora_rank
+        self.wq_b = nn.Linear(
+            self.q_lora_rank, self.n_heads * self.head_dim, bias=False
+        )
+        self.load_fused_wk_weights_proj = _use_load_fused_wk_weights_proj(args)
+        if self.load_fused_wk_weights_proj:
+            self.wk = None
+            self.weights_proj = None
+            self.wk_weights_proj = nn.QuantizedLinear(
+                self.dim,
+                self.head_dim + self.n_heads,
+                bias=False,
+                group_size=64,
+                bits=8,
+                mode="affine",
+            )
+        else:
+            self.wk = nn.Linear(self.dim, self.head_dim, bias=False)
+            self.weights_proj = nn.Linear(self.dim, self.n_heads, bias=False)
+            self.wk_weights_proj = None
+        self.k_norm = nn.LayerNorm(self.head_dim)
+        self.softmax_scale = self.head_dim**-0.5
+        self.weight_scale = self.n_heads**-0.5 * self.softmax_scale
+        self._wk_weights_proj_cache = None
+        self.default_block_sparse_sdpa = args.model_type == "glm_moe_dsa"
+        self.rope = initialize_rope(
+            dims=args.qk_rope_head_dim,
+            base=args.rope_theta,
+            traditional=True,
+            max_position_embeddings=args.max_position_embeddings,
+            scaling_config=args.rope_scaling,
+        )
+
+    def _fused_wk_weights_proj(self, x: mx.array):
+        if self.wk_weights_proj is not None:
+            out = self.wk_weights_proj(x)
+            return mx.split(out, [self.head_dim], axis=-1)
+
+        if os.environ.get("MLX_LM_GLM_DSA_FUSED_WK_WEIGHTS_PROJ", "0") != "1":
+            return None
+
+        wk = self.wk
+        weights_proj = self.weights_proj
+        wk_weight = getattr(wk, "weight", None)
+        wp_weight = getattr(weights_proj, "weight", None)
+        if wk_weight is None or wp_weight is None:
+            return None
+
+        wk_scales = getattr(wk, "scales", None)
+        wp_scales = getattr(weights_proj, "scales", None)
+        is_quantized = wk_scales is not None and wp_scales is not None
+        if is_quantized:
+            if (
+                getattr(wk, "group_size", None) != getattr(weights_proj, "group_size", None)
+                or getattr(wk, "bits", None) != getattr(weights_proj, "bits", None)
+                or getattr(wk, "mode", None) != getattr(weights_proj, "mode", None)
+                or wk_weight.shape[1:] != wp_weight.shape[1:]
+                or wk_scales.shape[1:] != wp_scales.shape[1:]
+            ):
+                return None
+
+            wk_biases = getattr(wk, "biases", None)
+            wp_biases = getattr(weights_proj, "biases", None)
+            if (wk_biases is None) != (wp_biases is None):
+                return None
+
+            cache = self._wk_weights_proj_cache
+            if cache is None or cache[0] is not wk_weight or cache[1] is not wp_weight:
+                fused_weight = mx.concatenate([wk_weight, wp_weight], axis=0)
+                fused_scales = mx.concatenate([wk_scales, wp_scales], axis=0)
+                fused_biases = (
+                    None
+                    if wk_biases is None
+                    else mx.concatenate([wk_biases, wp_biases], axis=0)
+                )
+                cache = (
+                    wk_weight,
+                    wp_weight,
+                    fused_weight,
+                    fused_scales,
+                    fused_biases,
+                )
+                self._wk_weights_proj_cache = cache
+
+            out = mx.quantized_matmul(
+                x,
+                cache[2],
+                scales=cache[3],
+                biases=cache[4],
+                transpose=True,
+                group_size=wk.group_size,
+                bits=wk.bits,
+                mode=wk.mode,
+            )
+            return mx.split(out, [self.head_dim], axis=-1)
+
+        if (
+            wk_weight.shape[1:] != wp_weight.shape[1:]
+            or getattr(wk, "bias", None) is not None
+            or getattr(weights_proj, "bias", None) is not None
+        ):
+            return None
+
+        cache = self._wk_weights_proj_cache
+        if cache is None or cache[0] is not wk_weight or cache[1] is not wp_weight:
+            fused_weight = mx.concatenate([wk_weight, wp_weight], axis=0)
+            cache = (wk_weight, wp_weight, fused_weight)
+            self._wk_weights_proj_cache = cache
+        out = x @ cache[2].swapaxes(-1, -2)
+        return mx.split(out, [self.head_dim], axis=-1)
+
+    def __call__(
+        self,
+        x: mx.array,
+        qr: mx.array,
+        mask: Optional[mx.array],
+        cache: Optional[Any] = None,
+    ):
+        # Computes top_k indices for attention
+        b, s, _ = x.shape
+        q = self.wq_b(qr)
+        q = q.reshape(b, s, self.n_heads, self.head_dim).swapaxes(1, 2)
+        fused_kw = self._fused_wk_weights_proj(x)
+        if fused_kw is None:
+            k = self.wk(x)
+            weights_lh = self.weights_proj(x)
+        else:
+            k, weights_lh = fused_kw
+        k = self.k_norm(k)
+        k = mx.reshape(k, (b, 1, s, self.head_dim))
+
+        offset = cache.offset if cache is not None else 0
+
+        q = self.rope(q, offset=offset)
+        k = self.rope(k, offset=offset)
+
+        if cache is not None:
+            k, _ = cache.update_and_fetch(k, mx.zeros([b, 1, s, 0]))
+        if k.shape[2] <= self.index_topk:
+            return None
+        use_fast_topk = (
+            os.environ.get("MLX_LM_GLM_DSA_FAST_TOPK", "1") == "1"
+            and hasattr(mx.fast, "dsa_topk_indices")
+        )
+        sort_exact_topk = (
+            os.environ.get("MLX_LM_GLM_DSA_SORT_EXACT_TOPK", "1") == "1"
+        )
+        bucketed_topk = (
+            use_fast_topk
+            and s > 1
+            and os.environ.get("MLX_LM_GLM_DSA_BUCKETED_TOPK", "1") == "1"
+        )
+        causal_valid_prefix_topk = False
+        prefix_topk_rows = 0
+
+        def causal_prefix_topk(prefix_rows: int):
+            offset = k.shape[2] - s
+            slots = mx.arange(self.index_topk, dtype=mx.uint32).reshape(
+                1, 1, 1, self.index_topk
+            )
+            lengths = (
+                mx.arange(prefix_rows, dtype=mx.uint32).reshape(
+                    1, 1, prefix_rows, 1
+                )
+                + mx.array(offset + 1, dtype=mx.uint32)
+            )
+            prefix = mx.where(slots < lengths, slots, mx.array(0, dtype=mx.uint32))
+            return mx.broadcast_to(prefix, (b, 1, prefix_rows, self.index_topk))
+
+        def finish_topk_indices(indices, prefix_rows: int = 0):
+            if indices is not None:
+                indices = (
+                    mx.sort(indices, axis=-1)
+                    if sort_exact_topk and not bucketed_topk
+                    else indices
+                )
+            if prefix_rows > 0:
+                if (
+                    indices is not None
+                    and self.default_block_sparse_sdpa
+                    and os.environ.get(
+                        "MLX_LM_GLM_DSA_COMPACT_PREFIX_TOPK", "1"
+                    )
+                    == "1"
+                ):
+                    return indices, None, prefix_rows
+                prefix = causal_prefix_topk(prefix_rows)
+                return (
+                    prefix
+                    if indices is None
+                    else mx.concatenate([prefix, indices], axis=2)
+                )
+            return indices
+
+        def select_topk(
+            scores, prefix_rows: int = 0, causal_valid_prefix: Optional[bool] = None
+        ):
+            indices = None
+            if scores is not None and use_fast_topk:
+                topk_u16_env = os.environ.get("MLX_LM_GLM_DSA_TOPK_U16", "0").lower()
+                use_topk_u16 = (
+                    topk_u16_env in {"1", "true", "on", "yes"}
+                    or (
+                        topk_u16_env == "auto"
+                        and self.default_block_sparse_sdpa
+                    )
+                ) and scores.shape[-1] <= 65536 and hasattr(
+                    mx.fast, "dsa_topk_indices_u16"
+                )
+                topk_fn = (
+                    mx.fast.dsa_topk_indices_u16
+                    if use_topk_u16
+                    else mx.fast.dsa_topk_indices
+                )
+                indices = topk_fn(
+                    scores,
+                    self.index_topk,
+                    bucketed=bucketed_topk,
+                    causal_valid_prefix=(
+                        causal_valid_prefix_topk
+                        if causal_valid_prefix is None
+                        else causal_valid_prefix
+                    ),
+                )
+            elif scores is not None:
+                indices = mx.argpartition(scores, kth=-self.index_topk, axis=-1)[
+                    ..., -self.index_topk :
+                ]
+            return finish_topk_indices(indices, prefix_rows)
+
+        if s == 1:
+            scores = q @ k.swapaxes(-1, -2)
+            scores = mx.maximum(scores, 0)
+            weights = weights_lh * self.weight_scale
+            weights = weights.swapaxes(-1, -2)[..., None]
+            scores = scores * weights
+            scores = scores.sum(axis=1, keepdims=True)
+            if mask is not None:
+                scores = mx.where(mask, scores, -float("inf"))
+            return select_topk(scores)
+        weights_lh = weights_lh * self.weight_scale
+        fuse_causal_mask = (
+            mask is not None
+            and os.environ.get("MLX_LM_GLM_DSA_FUSED_INDEXER_CAUSAL", "1") == "1"
+        )
+        causal_valid_prefix_topk = (
+            fuse_causal_mask
+            and os.environ.get("MLX_LM_GLM_DSA_TOPK_CAUSAL_PREFIX_FASTPATH", "1")
+            == "1"
+        )
+        default_block_sdpa = "1" if self.default_block_sparse_sdpa else "0"
+        use_block_sdpa = os.environ.get(
+            "MLX_LM_GLM_DSA_BLOCK_SPARSE_SDPA",
+            os.environ.get("MLX_LM_GLM_DSA_BLOCK_UNION_SDPA", default_block_sdpa),
+        ) == "1"
+        prefill_mode = os.environ.get("MLX_LM_GLM_DSA_PREFILL_MODE", "").lower()
+        default_exact_prefill = (
+            self.default_block_sparse_sdpa
+            and prefill_mode == ""
+            and os.environ.get("MLX_LM_GLM_DSA_EXACT_PREFILL_DEFAULT", "1") != "0"
+        )
+        mode_exact = prefill_mode in {"exact", "strict"} or default_exact_prefill
+        mode_high = prefill_mode in {"high", "quality", "recall"}
+        use_exact_block_token_sdpa = (
+            os.environ.get(
+                "MLX_LM_GLM_DSA_EXACT_BLOCK_TOKEN_SDPA",
+                "1" if mode_exact else "0",
+            )
+            == "1"
+        )
+        if mode_high:
+            default_block_budget = "128"
+        else:
+            default_block_budget = "16" if use_block_sdpa else "0"
+        block_budget = int(
+            os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_SDPA_BUDGET",
+                os.environ.get(
+                    "MLX_LM_GLM_DSA_BLOCK_BUDGET", default_block_budget
+                ),
+            )
+        )
+        if block_budget > 0:
+            min_block_budget = int(
+                os.environ.get("MLX_LM_GLM_DSA_BLOCK_MIN_BUDGET", "16")
+            )
+            if self.default_block_sparse_sdpa:
+                min_block_budget = max(min_block_budget, 16)
+            block_budget = max(block_budget, min_block_budget)
+        q_block_size = int(
+            os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_SDPA_Q_BLOCK",
+                os.environ.get(
+                    "MLX_LM_GLM_DSA_BLOCK_BUDGET_Q_BLOCK",
+                    "32",
+                ),
+            )
+        )
+        k_block_size = int(
+            os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_SDPA_K_BLOCK",
+                os.environ.get(
+                    "MLX_LM_GLM_DSA_BLOCK_BUDGET_K_BLOCK",
+                    "16",
+                ),
+            )
+        )
+        # Sorting improves locality for shorter contexts, but at long GLM
+        # prefill lengths the sort overhead slightly outweighs that benefit.
+        default_sort = (
+            "0" if self.default_block_sparse_sdpa and k.shape[2] >= 18432 else "1"
+        )
+        sort_block_indices = (
+            os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_SDPA_SORT",
+                default_sort,
+            )
+            != "0"
+        )
+        recent_blocks = int(
+            os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_SDPA_RECENT_BLOCKS",
+                os.environ.get("MLX_LM_GLM_DSA_BLOCK_RECENT_BLOCKS", "0"),
+            )
+        )
+        if (
+            block_budget > 0
+            and s > 1
+            and use_block_sdpa
+            and not use_exact_block_token_sdpa
+            and (mask is None or fuse_causal_mask)
+            and os.environ.get(
+                "MLX_LM_GLM_DSA_FUSED_BLOCK_INDEXER",
+                "0",
+            )
+            == "1"
+            and k.shape[2]
+            >= int(os.environ.get("MLX_LM_GLM_DSA_FUSED_BLOCK_INDEXER_MIN_K", "8192"))
+        ):
+            block_scores = mx.fast.dsa_indexer_block_scores(
+                q,
+                k,
+                weights_lh,
+                q_block_size=q_block_size,
+                k_block_size=k_block_size,
+                causal=fuse_causal_mask,
+            )
+            block_indices = block_scores_to_indices(
+                block_scores,
+                block_budget=block_budget,
+                recent_blocks=recent_blocks,
+                q_block_size=q_block_size,
+                k_block_size=k_block_size,
+                query_length=s,
+                key_length=k.shape[2],
+                sort_indices=sort_block_indices,
+            )
+            if block_indices is not None:
+                return None, block_indices
+
+        scores = None
+        score_high_hist = None
+        block_table_mode = os.environ.get(
+            "MLX_LM_GLM_DSA_BLOCK_TABLE_SPARSE_MLA", "0"
+        ).lower()
+        if (
+            s > 1
+            and (mask is None or fuse_causal_mask)
+            and os.environ.get("MLX_LM_GLM_DSA_CORE_INDEXER_SCORES", "1") == "1"
+        ):
+            scores_feed_block_path = (
+                block_budget > 0
+                and use_block_sdpa
+                and not use_exact_block_token_sdpa
+            )
+            scores_feed_exact_topk = (
+                causal_valid_prefix_topk and not scores_feed_block_path
+            )
+            want_fused_exact_block_table = (
+                os.environ.get("MLX_LM_GLM_DSA_FUSED_TOPK_BLOCK_TABLE", "0")
+                == "1"
+                and use_fast_topk
+                and not scores_feed_block_path
+                and block_table_mode in {"1", "auto", "force"}
+                and (mask is None or fuse_causal_mask)
+            )
+            candidate_prefix_rows = 0
+            if (
+                use_fast_topk
+                and scores_feed_exact_topk
+                and not want_fused_exact_block_table
+            ):
+                candidate_prefix_rows = min(
+                    s, max(0, self.index_topk - (k.shape[2] - s))
+                )
+            if candidate_prefix_rows == s:
+                return select_topk(None, candidate_prefix_rows)
+            score_q = (
+                q[:, :, candidate_prefix_rows:, :] if candidate_prefix_rows else q
+            )
+            score_weights = (
+                weights_lh[:, candidate_prefix_rows:, :]
+                if candidate_prefix_rows
+                else weights_lh
+            )
+            default_chunk_mb = (
+                "128"
+                if self.default_block_sparse_sdpa and k.shape[2] <= 65536
+                else "0"
+            )
+            chunk_mb = int(
+                os.environ.get("MLX_LM_GLM_DSA_INDEXER_CHUNK_MB", default_chunk_mb)
+            )
+            chunked_topk = None
+            if (
+                os.environ.get("MLX_LM_GLM_DSA_FUSED_INDEXER_TOPK", "0") == "1"
+                and use_fast_topk
+                and not scores_feed_block_path
+            ):
+                fused_topk = fused_indexer_topk_indices(
+                    score_q,
+                    k,
+                    score_weights,
+                    self.index_topk,
+                    causal=fuse_causal_mask,
+                )
+                if fused_topk is not None:
+                    return finish_topk_indices(fused_topk, candidate_prefix_rows)
+            if (
+                chunk_mb > 0
+                and use_fast_topk
+                and not scores_feed_block_path
+                and score_q.shape[2] > 64
+            ):
+                bytes_per_score = 2
+                max_scores = max(1, (chunk_mb * 1024 * 1024) // bytes_per_score)
+                chunk_rows = max(64, (max_scores // k.shape[2]) // 64 * 64)
+                if chunk_rows < score_q.shape[2]:
+                    chunk_indices = []
+                    full_q_offset = k.shape[2] - s
+                    for row_start in range(0, score_q.shape[2], chunk_rows):
+                        row_end = min(score_q.shape[2], row_start + chunk_rows)
+                        chunk_scores = fused_indexer_scores(
+                            score_q[:, :, row_start:row_end, :],
+                            k,
+                            score_weights[:, row_start:row_end, :],
+                            causal=fuse_causal_mask,
+                            causal_q_offset=(
+                                full_q_offset + candidate_prefix_rows + row_start
+                                if fuse_causal_mask
+                                else -1
+                            ),
+                        )
+                        if chunk_scores is None:
+                            chunk_indices = []
+                            break
+                        chunk_indices.append(
+                            select_topk(
+                                chunk_scores,
+                                causal_valid_prefix=False,
+                            )
+                        )
+                    if chunk_indices:
+                        chunked_topk = mx.concatenate(chunk_indices, axis=2)
+                        return finish_topk_indices(
+                            chunked_topk, candidate_prefix_rows
+                        )
+            if chunked_topk is None:
+                use_score_high_hist = (
+                    os.environ.get("MLX_LM_GLM_DSA_SCORE_HIGH_HIST", "0") == "1"
+                    and use_fast_topk
+                    and not scores_feed_block_path
+                    and (mask is None or scores_feed_exact_topk)
+                )
+                if use_score_high_hist:
+                    score_hist_pair = fused_indexer_scores_high_histogram(
+                        score_q,
+                        k,
+                        score_weights,
+                        causal=fuse_causal_mask,
+                        skip_causal_future_store=scores_feed_exact_topk,
+                    )
+                    if score_hist_pair is not None:
+                        scores, score_high_hist = score_hist_pair
+                if scores is None:
+                    scores = fused_indexer_scores(
+                        score_q,
+                        k,
+                        score_weights,
+                        causal=fuse_causal_mask,
+                        skip_causal_future_store=scores_feed_exact_topk,
+                    )
+            if scores is not None:
+                prefix_topk_rows = candidate_prefix_rows
+
+        weights = weights_lh.swapaxes(-1, -2)[..., None]
+        head_scores = None
+        if (
+            scores is None
+            and s > 1
+            and os.environ.get("MLX_LM_GLM_DSA_FUSED_INDEXER_REDUCE", "1") == "1"
+        ):
+            head_scores = q @ k.swapaxes(-1, -2)
+            scores = fused_index_score_reduce(
+                head_scores,
+                weights,
+                causal=fuse_causal_mask,
+            )
+        if scores is None:
+            if head_scores is None:
+                head_scores = q @ k.swapaxes(-1, -2)
+            scores = mx.maximum(head_scores, 0)
+            scores = scores * weights
+            scores = scores.sum(axis=1, keepdims=True)
+            fuse_causal_mask = False
+        if mask is not None and not fuse_causal_mask:
+            scores = mx.where(mask, scores, -float("inf"))
+        if (
+            block_budget > 0
+            and s > 1
+            and use_block_sdpa
+            and not use_exact_block_token_sdpa
+        ):
+            block_indices = scores_to_block_indices(
+                scores,
+                block_budget=block_budget,
+                q_block_size=q_block_size,
+                k_block_size=k_block_size,
+                recent_blocks=recent_blocks,
+                sort_indices=sort_block_indices,
+            )
+            if block_indices is not None:
+                return None, block_indices
+        if scores is not None and score_high_hist is not None:
+            high_hist_indices = fused_topk_indices_with_high_histogram(
+                scores,
+                score_high_hist,
+                self.index_topk,
+                bucketed=bucketed_topk,
+                causal_valid_prefix=causal_valid_prefix_topk,
+            )
+            if high_hist_indices is not None:
+                return finish_topk_indices(high_hist_indices, prefix_topk_rows)
+        if (
+            scores is not None
+            and os.environ.get("MLX_LM_GLM_DSA_FUSED_TOPK_BLOCK_TABLE", "0") == "1"
+            and prefix_topk_rows == 0
+        ):
+            if block_table_mode in {"1", "auto", "force"}:
+                block_k = int(
+                    os.environ.get("MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_K_BLOCK", "8")
+                )
+                exact_block_table = fused_topk_block_table_from_scores(
+                    scores,
+                    self.index_topk,
+                    k.shape[2],
+                    k_block_size=block_k,
+                    bucketed=bucketed_topk,
+                    causal_valid_prefix=causal_valid_prefix_topk,
+                )
+                if exact_block_table is not None:
+                    return None, None, 0, exact_block_table
+        return select_topk(scores, prefix_topk_rows)
+
+
+class DeepseekV32Attention(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.max_position_embeddings = config.max_position_embeddings
+        self.rope_theta = config.rope_theta
+        self.q_lora_rank = config.q_lora_rank
+        self.qk_rope_head_dim = config.qk_rope_head_dim
+        self.kv_lora_rank = config.kv_lora_rank
+        self.v_head_dim = config.v_head_dim
+        self.qk_nope_head_dim = config.qk_nope_head_dim
+        self.q_head_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
+
+        self.scale = self.q_head_dim**-0.5
+
+        self.q_a_proj = nn.Linear(
+            self.hidden_size, self.q_lora_rank, bias=config.attention_bias
+        )
+        self.q_a_layernorm = nn.RMSNorm(self.q_lora_rank, eps=1e-6)
+        self.q_b_proj = nn.Linear(
+            self.q_lora_rank, self.num_heads * self.q_head_dim, bias=False
+        )
+
+        self.kv_a_proj_with_mqa = nn.Linear(
+            self.hidden_size,
+            self.kv_lora_rank + self.qk_rope_head_dim,
+            bias=config.attention_bias,
+        )
+        self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=1e-6)
+        self.embed_q = MultiLinear(
+            self.qk_nope_head_dim, self.kv_lora_rank, self.num_heads
+        )
+        self.unembed_out = MultiLinear(
+            self.kv_lora_rank, self.v_head_dim, self.num_heads
+        )
+
+        self.o_proj = nn.Linear(
+            self.num_heads * self.v_head_dim,
+            self.hidden_size,
+            bias=config.attention_bias,
+        )
+
+        if self.config.rope_scaling is not None:
+            mscale_all_dim = self.config.rope_scaling.get("mscale_all_dim", 0)
+            if mscale_all_dim:
+                scaling_factor = self.config.rope_scaling["factor"]
+                if scaling_factor > 1:
+                    s = 0.1 * mscale_all_dim * math.log(scaling_factor) + 1.0
+                    self.scale = self.scale * s * s
+
+        self.indexer = Indexer(config)
+        self.rope = initialize_rope(
+            dims=self.qk_rope_head_dim,
+            base=self.rope_theta,
+            traditional=True,
+            max_position_embeddings=self.max_position_embeddings,
+            scaling_config=self.config.rope_scaling,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        qr = self.q_a_layernorm(self.q_a_proj(x))
+        q = self.q_b_proj(qr)
+
+        q = q.reshape(B, L, self.num_heads, self.q_head_dim).transpose(0, 2, 1, 3)
+        q_nope, q_pe = mx.split(q, [self.qk_nope_head_dim], axis=-1)
+        compressed_kv = self.kv_a_proj_with_mqa(x)
+        compressed_kv, k_pe = mx.split(compressed_kv, [self.kv_lora_rank], axis=-1)
+        k_pe = k_pe.reshape(B, L, 1, self.qk_rope_head_dim).transpose(0, 2, 1, 3)
+        kv_latent = self.kv_a_layernorm(compressed_kv)
+
+        offset = cache[0].offset if cache is not None else 0
+        q_pe = self.rope(q_pe, offset)
+        k_pe = self.rope(k_pe, offset)
+
+        kv_latent = mx.expand_dims(kv_latent, axis=1)
+
+        if cache is not None:
+            kv_latent, k_pe = cache[0].update_and_fetch(kv_latent, k_pe)
+        else:
+            cache = [None] * 2
+
+        topk_indices = self.indexer(x, qr, mask, cache=cache[1])
+        if topk_indices is not None:
+            if L == 1:
+                idx = topk_indices[:, :, 0, :, None]
+                kv_latent = mx.take_along_axis(
+                    kv_latent,
+                    mx.broadcast_to(idx, idx.shape[:-1] + (kv_latent.shape[-1],)),
+                    axis=2,
+                )
+                k_pe = mx.take_along_axis(
+                    k_pe,
+                    mx.broadcast_to(idx, idx.shape[:-1] + (k_pe.shape[-1],)),
+                    axis=2,
+                )
+                if mask is not None:
+                    mask = mx.take_along_axis(mask, topk_indices, axis=-1)
+            else:
+                shape = list(topk_indices.shape)
+                shape[-1] = kv_latent.shape[2]
+                sparse_mask = mx.zeros(shape, dtype=mx.bool_)
+                sparse_mask = mx.put_along_axis(
+                    sparse_mask, topk_indices, mx.array(True), axis=-1
+                )
+                if mask is not None:
+                    sparse_mask = sparse_mask & mask
+                mask = sparse_mask
+        # Ensure the indexer cache is evaluated even if the topk_indices are unused
+        # to keep the graph from getting too large
+        if cache is not None and cache[0] is not None:
+            cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys, cache[1].values))
+
+        pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
+        if mask is not None:
+            pe_scores = mx.where(
+                mask,
+                pe_scores,
+                mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
+            )
+
+        if L == 1:
+            q_nope = self.embed_q(q_nope)
+            k = v = kv_latent
+        else:
+            k = self.embed_q(kv_latent, transpose=False)
+            v = self.unembed_out(kv_latent)
+
+        output = scaled_dot_product_attention(
+            q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
+        )
+        if L == 1:
+            output = self.unembed_out(output)
+
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class DeepseekV32MLP(nn.Module):
+    def __init__(
+        self,
+        config: ModelArgs,
+        hidden_size: int = None,
+        intermediate_size: int = None,
+        fused_gate_up: bool = False,
+    ):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size if hidden_size is None else hidden_size
+        self.intermediate_size = (
+            config.intermediate_size if intermediate_size is None else intermediate_size
+        )
+
+        if fused_gate_up:
+            self.gate_up_proj = nn.Linear(
+                self.hidden_size, self.intermediate_size * 2, bias=False
+            )
+        else:
+            self.gate_proj = nn.Linear(
+                self.hidden_size, self.intermediate_size, bias=False
+            )
+            self.up_proj = nn.Linear(
+                self.hidden_size, self.intermediate_size, bias=False
+            )
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+
+    def __call__(self, x):
+        if hasattr(self, "gate_up_proj"):
+            gate, up = mx.split(
+                self.gate_up_proj(x), [self.intermediate_size], axis=-1
+            )
+        else:
+            gate = self.gate_proj(x)
+            up = self.up_proj(x)
+        down_proj = self.down_proj(swiglu(gate, up))
+        return down_proj
+
+
+@mx.compile
+def group_expert_select(
+    gates,
+    e_score_correction_bias,
+    top_k,
+    n_group,
+    topk_group,
+    routed_scaling_factor,
+    norm_topk_prob,
+):
+
+    scores = mx.sigmoid(gates.astype(mx.float32))
+    orig_scores = scores
+    scores = scores + e_score_correction_bias
+    if n_group > 1:
+        scores = mx.unflatten(scores, axis=-1, shape=(n_group, -1))
+        group_scores = mx.topk(scores, 2, axis=-1).sum(axis=-1, keepdims=True)
+        k = n_group - topk_group
+        group_idx = mx.argpartition(group_scores, kth=k - 1, axis=-2)[..., :k, :]
+        scores = mx.put_along_axis(
+            scores, mx.stop_gradient(group_idx), mx.array(0.0), axis=-2
+        )
+        scores = mx.flatten(scores, -2, -1)
+
+    k = top_k
+    inds = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+    if top_k > 1 and norm_topk_prob:
+        denominator = scores.sum(axis=-1, keepdims=True)
+        scores = scores / denominator
+    scores = scores * routed_scaling_factor
+
+    return inds, scores
+
+
+class MoEGate(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.config = config
+        self.top_k = config.num_experts_per_tok
+        self.norm_topk_prob = config.norm_topk_prob
+        self.n_routed_experts = config.n_routed_experts
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.n_group = config.n_group
+        self.topk_group = config.topk_group
+        self.weight = mx.zeros((self.n_routed_experts, config.hidden_size))
+        self.e_score_correction_bias = mx.zeros((self.n_routed_experts,))
+        assert config.topk_method == "noaux_tc", "Unsupported topk method."
+
+    def __call__(self, x):
+        return group_expert_select(
+            x @ self.weight.T,
+            self.e_score_correction_bias,
+            self.top_k,
+            self.n_group,
+            self.topk_group,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+        )
+
+
+class DeepseekV32MoE(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.config = config
+        self.num_experts_per_tok = config.num_experts_per_tok
+        self.switch_mlp = SwitchGLU(
+            config.hidden_size,
+            config.moe_intermediate_size,
+            config.n_routed_experts,
+            fused_gate_up=_use_glm_moe_fused_gate_up(config),
+            fused_swiglu_down=_use_glm_moe_swiglu_down(config),
+            inverse_scatter=_use_glm_moe_inverse_scatter(config),
+        )
+
+        self.gate = MoEGate(config)
+        if config.n_shared_experts is not None:
+            intermediate_size = config.moe_intermediate_size * config.n_shared_experts
+            self.shared_experts = DeepseekV32MLP(
+                config=config,
+                intermediate_size=intermediate_size,
+                fused_gate_up=_use_glm_shared_fused_gate_up(config),
+            )
+
+        self.sharding_group = None
+
+    def __call__(self, x):
+        if self.sharding_group is not None:
+            x = sum_gradients(self.sharding_group)(x)
+
+        inds, scores = self.gate(x)
+        use_weighted_sum = (
+            _use_glm_moe_weighted_sum(self.config)
+            and inds.size >= 64
+            and hasattr(mx.fast, "glm_moe_weighted_sum")
+        )
+        y = self.switch_mlp(
+            x,
+            inds,
+            scores=scores if use_weighted_sum else None,
+            weighted_sum=use_weighted_sum,
+        )
+        if not use_weighted_sum:
+            y = (y * scores[..., None]).sum(axis=-2).astype(y.dtype)
+        if self.config.n_shared_experts is not None:
+            y = y + self.shared_experts(x)
+
+        if self.sharding_group is not None:
+            y = mx.distributed.all_sum(y, group=self.sharding_group)
+
+        return y
+
+
+class DeepseekV32DecoderLayer(nn.Module):
+    def __init__(self, config: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.self_attn = DeepseekV32Attention(config)
+        self.mlp = (
+            DeepseekV32MoE(config)
+            if (
+                config.n_routed_experts is not None
+                and layer_idx >= config.first_k_dense_replace
+                and layer_idx % config.moe_layer_freq == 0
+            )
+            else DeepseekV32MLP(config)
+        )
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class DeepseekV32Model(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            DeepseekV32DecoderLayer(config, idx)
+            for idx in range(config.num_hidden_layers)
+        ]
+        self.start_idx = 0
+        self.end_idx = len(self.layers)
+        self.num_layers = self.end_idx
+
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pipeline_rank = 0
+        self.pipeline_size = 1
+
+    def pipeline(self, group):
+        # Split layers in reverse so rank=0 gets the last layers and
+        # rank=pipeline_size-1 gets the first
+        self.pipeline_rank = group.rank()
+        self.pipeline_size = group.size()
+        layers_per_rank = len(self.layers) // self.pipeline_size
+        extra = len(self.layers) - layers_per_rank * self.pipeline_size
+        if self.pipeline_rank < extra:
+            layers_per_rank += 1
+        self.start_idx = (self.pipeline_size - self.pipeline_rank - 1) * layers_per_rank
+        self.end_idx = self.start_idx + layers_per_rank
+        self.layers = self.layers[: self.end_idx]
+        self.layers[: self.start_idx] = [None] * self.start_idx
+        self.num_layers = len(self.layers) - self.start_idx
+
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        h = self.embed_tokens(x)
+
+        pipeline_rank = self.pipeline_rank
+        pipeline_size = self.pipeline_size
+
+        if cache is None:
+            cache = [None] * self.num_layers
+        mask = create_attention_mask(
+            h, cache[0][0] if cache[0] else None, return_array=True
+        )
+
+        # Receive from the previous process in the pipeline
+
+        if pipeline_rank < pipeline_size - 1:
+            h = mx.distributed.recv_like(h, (pipeline_rank + 1))
+
+        for i in range(self.num_layers):
+            h = self.layers[self.start_idx + i](h, mask, cache[i])
+
+        # Send to the next process in the pipeline
+        if pipeline_rank != 0:
+            h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
+            if cache[-1] is not None:
+                cache[-1][0].keys = mx.depends(cache[-1][0].keys, h)
+
+        # Broadcast h while keeping it in the graph
+        if pipeline_size > 1:
+            h = mx.distributed.all_gather(h)[: h.shape[0]]
+
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        self.args = config
+        self.model_type = config.model_type
+        self.model = DeepseekV32Model(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+    ):
+        out = self.model(inputs, cache)
+        return self.lm_head(out)
+
+    def update_quantization_config(self, config):
+        if _use_glm_shared_fused_gate_up(self.args):
+            for key in ("quantization", "quantization_config"):
+                quantization = config.get(key)
+                if not isinstance(quantization, dict):
+                    continue
+                for l in range(self.args.num_hidden_layers):
+                    prefix = f"model.layers.{l}.mlp.shared_experts"
+                    gate_path = f"{prefix}.gate_proj"
+                    up_path = f"{prefix}.up_proj"
+                    fused_path = f"{prefix}.gate_up_proj"
+                    gate_spec = quantization.get(gate_path)
+                    up_spec = quantization.get(up_path)
+                    if gate_spec is not None and gate_spec == up_spec:
+                        quantization[fused_path] = dict(gate_spec)
+                        quantization.pop(gate_path, None)
+                        quantization.pop(up_path, None)
+
+        dequant_mla_proj = _dequant_mla_proj_mode(self.args)
+        dequant_embed_q = dequant_mla_proj in {
+            "1",
+            "true",
+            "all",
+            "both",
+            "embed",
+            "embed_q",
+        }
+        dequant_unembed_out = dequant_mla_proj in {
+            "1",
+            "true",
+            "all",
+            "both",
+            "unembed",
+            "unembed_out",
+            "out",
+        }
+        if not (dequant_embed_q or dequant_unembed_out):
+            return
+        skip_quantization = config.setdefault("_skip_quantization_paths", set())
+        if not isinstance(skip_quantization, set):
+            skip_quantization = set(skip_quantization)
+            config["_skip_quantization_paths"] = skip_quantization
+        for key in ("quantization", "quantization_config"):
+            quantization = config.get(key)
+            if not isinstance(quantization, dict):
+                continue
+            for l in range(self.args.num_hidden_layers):
+                prefix = f"model.layers.{l}.self_attn"
+                if dequant_embed_q:
+                    path = f"{prefix}.embed_q"
+                    skip_quantization.add(path)
+                    quantization.pop(path, None)
+                if dequant_unembed_out:
+                    path = f"{prefix}.unembed_out"
+                    skip_quantization.add(path)
+                    quantization.pop(path, None)
+
+    def sanitize(self, weights):
+        # Remove multi-token prediction layers
+        mpt_layer = self.args.num_hidden_layers
+        new_weights = {}
+        for k, v in weights.items():
+            parts = k.split(".")
+            if len(parts) >= 3 and parts[1] == "layers" and int(parts[2]) >= mpt_layer:
+                continue
+            new_weights[k] = v
+        weights = new_weights
+
+        def dequant(weight, scale_inv):
+            dtype = mx.bfloat16
+            weight = mx.from_fp8(weight, dtype=mx.bfloat16)
+            bs = 128  # block size
+            m, n = weight.shape
+            pad_bottom = (-m) % bs
+            pad_side = (-n) % bs
+            weight = mx.pad(weight, ((0, pad_bottom), (0, pad_side)))
+            weight = weight.reshape(
+                ((m + pad_bottom) // bs, bs, (n + pad_side) // bs, bs)
+            )
+            weight = (weight * scale_inv[:, None, :, None]).reshape(
+                m + pad_bottom, n + pad_side
+            )
+            return weight[:m, :n].astype(dtype)
+
+        # Dequantize
+        new_weights = {}
+        for k, v in weights.items():
+            if "weight_scale_inv" in k:
+                scale_inv = v
+                wk = k.replace("_scale_inv", "")
+                weight = weights[wk]
+                weight = dequant(weight, scale_inv)
+                new_weights[wk] = weight
+            elif k not in new_weights:
+                new_weights[k] = v
+        weights = new_weights
+
+        if _use_load_fused_wk_weights_proj(self.args):
+            fused = {}
+            skip_keys = set()
+            for l in range(self.args.num_hidden_layers):
+                prefix = f"model.layers.{l}.self_attn.indexer"
+                wk_prefix = f"{prefix}.wk"
+                wp_prefix = f"{prefix}.weights_proj"
+                fused_prefix = f"{prefix}.wk_weights_proj"
+                if (
+                    f"{wk_prefix}.weight" not in weights
+                    or f"{wp_prefix}.weight" not in weights
+                ):
+                    continue
+                for suffix in ("weight", "scales", "biases"):
+                    wk_key = f"{wk_prefix}.{suffix}"
+                    wp_key = f"{wp_prefix}.{suffix}"
+                    if wk_key in weights and wp_key in weights:
+                        fused[f"{fused_prefix}.{suffix}"] = mx.concatenate(
+                            [weights[wk_key], weights[wp_key]], axis=0
+                        )
+                        skip_keys.add(wk_key)
+                        skip_keys.add(wp_key)
+                skip_keys.add(f"{wk_prefix}.bias")
+                skip_keys.add(f"{wp_prefix}.bias")
+            if fused:
+                weights = {
+                    k: v
+                    for k, v in weights.items()
+                    if k not in skip_keys
+                    and ".self_attn.indexer.wk." not in k
+                    and ".self_attn.indexer.weights_proj." not in k
+                }
+                weights.update(fused)
+
+        dequant_mla_proj = _dequant_mla_proj_mode(self.args)
+        dequant_embed_q = dequant_mla_proj in {"1", "true", "all", "both", "embed", "embed_q"}
+        dequant_unembed_out = dequant_mla_proj in {
+            "1",
+            "true",
+            "all",
+            "both",
+            "unembed",
+            "unembed_out",
+            "out",
+        }
+        if (dequant_embed_q or dequant_unembed_out) and isinstance(
+            getattr(self.args, "quantization", None), dict
+        ):
+            def dequant_mla_weight(path, input_dims):
+                weight_key = f"{path}.weight"
+                scales_key = f"{path}.scales"
+                biases_key = f"{path}.biases"
+                if weight_key not in weights:
+                    weights.pop(scales_key, None)
+                    weights.pop(biases_key, None)
+                    return
+                scales = weights.pop(scales_key, None)
+                biases = weights.pop(biases_key, None)
+                if scales is None:
+                    return
+                spec = self.args.quantization.get(path, {})
+                bits = spec.get("bits")
+                if bits is None:
+                    bits = (weights[weight_key].shape[-1] * 32) // input_dims
+                group_size = spec.get("group_size")
+                if group_size is None:
+                    group_size = input_dims // scales.shape[-1]
+                mode = spec.get("mode", "affine")
+                weights[weight_key] = mx.dequantize(
+                    weights[weight_key],
+                    scales,
+                    biases,
+                    group_size=group_size,
+                    bits=bits,
+                    mode=mode,
+                    dtype=mx.bfloat16,
+                )
+
+            for l in range(self.args.num_hidden_layers):
+                prefix = f"model.layers.{l}.self_attn"
+                if dequant_embed_q:
+                    dequant_mla_weight(
+                        f"{prefix}.embed_q", self.args.qk_nope_head_dim
+                    )
+                    self.args.quantization.pop(f"{prefix}.embed_q", None)
+                if dequant_unembed_out:
+                    dequant_mla_weight(
+                        f"{prefix}.unembed_out", self.args.kv_lora_rank
+                    )
+                    self.args.quantization.pop(f"{prefix}.unembed_out", None)
+
+        # Stack experts
+        for l in range(self.args.num_hidden_layers):
+            prefix = f"model.layers.{l}"
+            for n, m in [("w1", "gate_proj"), ("w2", "down_proj"), ("w3", "up_proj")]:
+                for k in ["weight", "scales", "biases"]:
+                    if f"{prefix}.mlp.experts.0.{m}.{k}" in weights:
+                        to_join = [
+                            weights.pop(f"{prefix}.mlp.experts.{e}.{m}.{k}")
+                            for e in range(self.args.n_routed_experts)
+                        ]
+                        weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(to_join)
+            if _use_glm_moe_fused_gate_up(self.args) or use_fused_gate_up_switch():
+                switch_prefix = f"{prefix}.mlp.switch_mlp"
+                for k in ["weight", "scales", "biases"]:
+                    gate_key = f"{switch_prefix}.gate_proj.{k}"
+                    up_key = f"{switch_prefix}.up_proj.{k}"
+                    if gate_key in weights and up_key in weights:
+                        weights[f"{switch_prefix}.gate_up_proj.{k}"] = mx.concatenate(
+                            [weights.pop(gate_key), weights.pop(up_key)],
+                            axis=1,
+                        )
+            if _use_glm_shared_fused_gate_up(self.args):
+                shared_prefix = f"{prefix}.mlp.shared_experts"
+                for k in ["weight", "scales", "biases"]:
+                    gate_key = f"{shared_prefix}.gate_proj.{k}"
+                    up_key = f"{shared_prefix}.up_proj.{k}"
+                    if gate_key in weights and up_key in weights:
+                        weights[f"{shared_prefix}.gate_up_proj.{k}"] = mx.concatenate(
+                            [weights.pop(gate_key), weights.pop(up_key)],
+                            axis=0,
+                        )
+            prefix = f"model.layers.{l}.self_attn"
+            if f"{prefix}.kv_b_proj.weight" in weights:
+                quantized = f"{prefix}.kv_b_proj.scales" in weights
+                v = weights.pop(f"{prefix}.kv_b_proj.weight")
+                head_dim = self.args.qk_nope_head_dim + self.args.v_head_dim
+
+                if quantized:
+                    dims = self.args.kv_lora_rank
+                    scales = weights.pop(f"{prefix}.kv_b_proj.scales")
+                    biases = weights.pop(f"{prefix}.kv_b_proj.biases")
+                    # Try to infer bits and group size
+                    bits = (v.shape[-1] * 32) // dims
+                    group_size = dims // scales.shape[-1]
+                    v = mx.dequantize(
+                        v, scales, biases, bits=bits, group_size=group_size
+                    )
+                num_heads = self.args.num_attention_heads
+                v = v.reshape(num_heads, head_dim, -1)
+                wk = mx.contiguous(
+                    v[:, : self.args.qk_nope_head_dim, :].swapaxes(-1, -2)
+                )
+                wv = mx.contiguous(v[:, self.args.qk_nope_head_dim :, :])
+                if quantized:
+                    if not dequant_embed_q:
+                        wk, wk_scales, wk_biases = mx.quantize(
+                            wk, bits=bits, group_size=group_size
+                        )
+                        weights[f"{prefix}.embed_q.scales"] = wk_scales
+                        weights[f"{prefix}.embed_q.biases"] = wk_biases
+                    if not dequant_unembed_out:
+                        wv, wv_scales, wv_biases = mx.quantize(
+                            wv, bits=bits, group_size=group_size
+                        )
+                        weights[f"{prefix}.unembed_out.scales"] = wv_scales
+                        weights[f"{prefix}.unembed_out.biases"] = wv_biases
+                weights[f"{prefix}.embed_q.weight"] = wk
+                weights[f"{prefix}.unembed_out.weight"] = wv
+
+        return weights
+
+    def shard(self, group: Optional[mx.distributed.Group] = None):
+        group = group or mx.distributed.init()
+        N = group.size()
+        rank = group.rank()
+        for layer in self.model.layers:
+            layer.self_attn.q_b_proj = shard_linear(
+                layer.self_attn.q_b_proj, "all-to-sharded", group=group
+            )
+
+            layer.self_attn.o_proj = shard_linear(
+                layer.self_attn.o_proj, "sharded-to-all", group=group
+            )
+            layer.self_attn.num_heads //= N
+            num_heads = layer.self_attn.num_heads
+            sh = rank * num_heads
+            eh = sh + num_heads
+
+            def shard_heads(w):
+                return w[sh:eh]
+
+            layer.self_attn.embed_q.apply(shard_heads)
+            layer.self_attn.unembed_out.apply(shard_heads)
+
+            # Shard the MLP
+            if isinstance(layer.mlp, DeepseekV32MLP):
+                layer.mlp.gate_proj = shard_linear(
+                    layer.mlp.gate_proj, "all-to-sharded", group=group
+                )
+                layer.mlp.down_proj = shard_linear(
+                    layer.mlp.down_proj, "sharded-to-all", group=group
+                )
+                layer.mlp.up_proj = shard_linear(
+                    layer.mlp.up_proj, "all-to-sharded", group=group
+                )
+
+            # Shard the MoE. Shard in place since the MoE should be responsible
+            # for aggregating the results.
+            else:
+                layer.mlp.sharding_group = group = group
+                if hasattr(layer.mlp.shared_experts, "gate_up_proj"):
+                    shard_inplace(
+                        layer.mlp.shared_experts.gate_up_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                else:
+                    shard_inplace(
+                        layer.mlp.shared_experts.gate_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                    shard_inplace(
+                        layer.mlp.shared_experts.up_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                shard_inplace(
+                    layer.mlp.shared_experts.down_proj, "sharded-to-all", group=group
+                )
+                if hasattr(layer.mlp.switch_mlp, "gate_up_proj"):
+                    shard_inplace(
+                        layer.mlp.switch_mlp.gate_up_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                else:
+                    shard_inplace(
+                        layer.mlp.switch_mlp.gate_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                    shard_inplace(
+                        layer.mlp.switch_mlp.up_proj, "all-to-sharded", group=group
+                    )
+                shard_inplace(
+                    layer.mlp.switch_mlp.down_proj, "sharded-to-all", group=group
+                )
+
+    @property
+    def layers(self):
+        return self.model.layers[self.model.start_idx : self.model.end_idx]
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            return "e_score_correction_bias" not in k
+
+        return predicate
+
+    def make_cache(self):
+        return [CacheList(KVCache(), KVCache()) for _ in self.layers]

--- a/omlx/patches/glm_moe_dsa/generate_patch.py
+++ b/omlx/patches/glm_moe_dsa/generate_patch.py
@@ -44,7 +44,7 @@ def _glm_dsa_adaptive_prefill_config(
 
     return _AdaptivePrefillConfig(
         step_size=int(
-            os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP_SIZE", "6144")
+            os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP_SIZE", "8192")
         ),
         after=int(os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_AFTER", "0")),
         min_remaining=int(
@@ -83,7 +83,10 @@ def apply_glm_moe_dsa_generate_patch() -> bool:
     PromptProcessingBatch = gen.PromptProcessingBatch
     BatchGenerator = gen.BatchGenerator
 
-    if getattr(PromptProcessingBatch, "_omlx_glm_dsa_adaptive_patched", False):
+    if (
+        getattr(PromptProcessingBatch, "_omlx_glm_dsa_adaptive_patched", False)
+        and getattr(gen.generate_step, "_omlx_glm_dsa_adaptive_patched", False)
+    ):
         _APPLIED = True
         return False
 
@@ -93,6 +96,7 @@ def apply_glm_moe_dsa_generate_patch() -> bool:
     original_ppb_prompt = PromptProcessingBatch.prompt
     original_bg_init = BatchGenerator.__init__
     original_bg_next = BatchGenerator._next
+    original_generate_step = gen.generate_step
 
     def patched_ppb_init(self, *args, **kwargs):
         original_ppb_init(self, *args, **kwargs)
@@ -258,12 +262,27 @@ def apply_glm_moe_dsa_generate_patch() -> bool:
 
         return prompt_responses, generation_responses
 
+    def patched_generate_step(prompt, model, *args, **kwargs):
+        prefill_step_size = kwargs.get("prefill_step_size", 2048)
+        adaptive_prefill = _glm_dsa_adaptive_prefill_config(
+            model, prefill_step_size
+        )
+        if (
+            adaptive_prefill is not None
+            and adaptive_prefill.after == 0
+            and adaptive_prefill.min_remaining == 0
+        ):
+            kwargs["prefill_step_size"] = adaptive_prefill.step_size
+        return original_generate_step(prompt, model, *args, **kwargs)
+
     PromptProcessingBatch.__init__ = patched_ppb_init
     PromptProcessingBatch._copy = patched_ppb_copy
     PromptProcessingBatch.split = patched_ppb_split
     PromptProcessingBatch.prompt = patched_ppb_prompt
     BatchGenerator.__init__ = patched_bg_init
     BatchGenerator._next = patched_bg_next
+    patched_generate_step._omlx_glm_dsa_adaptive_patched = True
+    gen.generate_step = patched_generate_step
 
     PromptProcessingBatch._omlx_glm_dsa_adaptive_patched = True
     BatchGenerator._omlx_glm_dsa_adaptive_patched = True

--- a/omlx/patches/glm_moe_dsa/generate_patch.py
+++ b/omlx/patches/glm_moe_dsa/generate_patch.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GLM DSA adaptive prefill patches for ``mlx_lm.generate``.
+
+This ports the small GLM-specific prefill chunking change from the optimized
+mlx-lm snapshot without replacing the whole ``mlx_lm.generate`` module. The
+patch is intentionally inert for non-GLM models.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_APPLIED = False
+
+
+@dataclass(frozen=True)
+class _AdaptivePrefillConfig:
+    step_size: int
+    after: int
+    min_remaining: int
+
+
+def _glm_dsa_adaptive_prefill_config(
+    model: Any, prefill_step_size: int
+) -> _AdaptivePrefillConfig | None:
+    model_type = getattr(model, "model_type", None) or getattr(
+        getattr(model, "args", None), "model_type", None
+    )
+    if (
+        model_type != "glm_moe_dsa"
+        or prefill_step_size != 2048
+        or os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", "1") != "1"
+    ):
+        return None
+
+    return _AdaptivePrefillConfig(
+        step_size=int(
+            os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP_SIZE", "6144")
+        ),
+        after=int(os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_AFTER", "0")),
+        min_remaining=int(
+            os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_MIN_REMAINING", "0")
+        ),
+    )
+
+
+def _prefill_step_size_for_progress(
+    prefill_step_size: int,
+    processed_tokens: int,
+    remaining_tokens: int,
+    adaptive_prefill: _AdaptivePrefillConfig | None,
+) -> int:
+    if (
+        adaptive_prefill is not None
+        and processed_tokens >= adaptive_prefill.after
+        and remaining_tokens >= adaptive_prefill.min_remaining
+    ):
+        return adaptive_prefill.step_size
+    return prefill_step_size
+
+
+def apply_glm_moe_dsa_generate_patch() -> bool:
+    """Patch ``mlx_lm.generate`` with GLM-only adaptive prefill behavior."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        gen = importlib.import_module("mlx_lm.generate")
+    except Exception:
+        logger.debug("mlx_lm.generate not importable - GLM prefill patch skipped")
+        return False
+
+    PromptProcessingBatch = gen.PromptProcessingBatch
+    BatchGenerator = gen.BatchGenerator
+
+    if getattr(PromptProcessingBatch, "_omlx_glm_dsa_adaptive_patched", False):
+        _APPLIED = True
+        return False
+
+    original_ppb_init = PromptProcessingBatch.__init__
+    original_ppb_copy = PromptProcessingBatch._copy
+    original_ppb_split = PromptProcessingBatch.split
+    original_ppb_prompt = PromptProcessingBatch.prompt
+    original_bg_init = BatchGenerator.__init__
+    original_bg_next = BatchGenerator._next
+
+    def patched_ppb_init(self, *args, **kwargs):
+        original_ppb_init(self, *args, **kwargs)
+        model = getattr(self, "model", None)
+        prefill_step_size = getattr(self, "prefill_step_size", 2048)
+        self._omlx_glm_dsa_adaptive_prefill = _glm_dsa_adaptive_prefill_config(
+            model, prefill_step_size
+        )
+
+    def patched_ppb_copy(self):
+        new_batch = original_ppb_copy(self)
+        new_batch._omlx_glm_dsa_adaptive_prefill = getattr(
+            self, "_omlx_glm_dsa_adaptive_prefill", None
+        )
+        return new_batch
+
+    def patched_ppb_split(self, indices):
+        new_batch = original_ppb_split(self, indices)
+        if not hasattr(new_batch, "_omlx_glm_dsa_adaptive_prefill"):
+            new_batch._omlx_glm_dsa_adaptive_prefill = getattr(
+                self, "_omlx_glm_dsa_adaptive_prefill", None
+            )
+        return new_batch
+
+    def patched_ppb_prompt(self, tokens):
+        adaptive_prefill = getattr(self, "_omlx_glm_dsa_adaptive_prefill", None)
+        if adaptive_prefill is None:
+            return original_ppb_prompt(self, tokens)
+
+        if len(self.uids) != len(tokens):
+            raise ValueError("The batch length doesn't match the number of inputs")
+        if not tokens:
+            return None
+
+        processed_tokens = min(len(sti) for sti in self.tokens)
+        for sti, ti in zip(self.tokens, tokens):
+            sti += ti
+
+        lengths = [len(p) for p in tokens]
+        max_length = max(lengths)
+        padding = [max_length - length for length in lengths]
+        max_padding = max(padding)
+
+        if max_padding > 0:
+            tokens = gen._right_pad_prompts(tokens, max_length=max_length)
+            for cache in self.prompt_cache:
+                cache.prepare(lengths=lengths, right_padding=padding)
+        else:
+            tokens = mx.array(tokens)
+
+        while tokens.shape[1] > 0:
+            remaining = tokens.shape[1]
+            step_size = _prefill_step_size_for_progress(
+                self.prefill_step_size,
+                processed_tokens,
+                remaining,
+                adaptive_prefill,
+            )
+            n_to_process = min(step_size, remaining)
+            self.model(tokens[:, :n_to_process], cache=self.prompt_cache)
+            mx.eval([cache.state for cache in self.prompt_cache])
+            mx.clear_cache()
+            tokens = tokens[:, n_to_process:]
+            processed_tokens += n_to_process
+
+        if max_padding > 0:
+            for cache in self.prompt_cache:
+                cache.finalize()
+            mx.eval([cache.state for cache in self.prompt_cache])
+            mx.clear_cache()
+        return None
+
+    def patched_bg_init(self, *args, **kwargs):
+        original_bg_init(self, *args, **kwargs)
+        model = getattr(self, "model", None)
+        prefill_step_size = getattr(self, "prefill_step_size", 2048)
+        self._omlx_glm_dsa_adaptive_prefill = _glm_dsa_adaptive_prefill_config(
+            model, prefill_step_size
+        )
+        self._prompt_batch._omlx_glm_dsa_adaptive_prefill = (
+            self._omlx_glm_dsa_adaptive_prefill
+        )
+
+    def patched_bg_next(self):
+        adaptive_prefill = getattr(self, "_omlx_glm_dsa_adaptive_prefill", None)
+        if adaptive_prefill is None:
+            return original_bg_next(self)
+
+        generation_responses = []
+        prompt_responses = []
+
+        if len(self._generation_batch) > 0:
+            generation_responses = self._generation_batch.next()
+            self._gen_tokens_counter += len(generation_responses)
+            self._steps_counter += 1
+            if self._steps_counter % 512 == 0:
+                mx.clear_cache()
+
+        if len(self._generation_batch) >= self.completion_batch_size:
+            return prompt_responses, generation_responses
+
+        n = min(
+            self.prefill_batch_size - len(self._prompt_batch),
+            self.completion_batch_size - len(self._generation_batch),
+            len(self._unprocessed_sequences),
+        )
+        if n > 0:
+            self._prompt_batch.extend(self._make_batch(n))
+
+        keep = []
+        split = []
+        for i, seq in enumerate(self._currently_processing):
+            segments = seq[0]
+            if len(segments) == 1 and len(segments[0]) == 1:
+                split.append(i)
+            else:
+                keep.append(i)
+
+        if split:
+            last_inputs = [self._currently_processing[i][0][0] for i in split]
+            progress = [(self._currently_processing[i][2],) * 2 for i in split]
+            self._currently_processing = [self._currently_processing[i] for i in keep]
+            gen_batch = self._prompt_batch.split(split).generate(last_inputs)
+            for i, progress_item in enumerate(progress):
+                prompt_responses.append(
+                    gen.PromptProcessingBatch.Response(
+                        gen_batch.uids[i],
+                        progress_item,
+                        True,
+                        True,
+                    )
+                )
+            self._generation_batch.extend(gen_batch)
+
+        prompts = []
+        for i, seq in enumerate(self._currently_processing):
+            response = gen.PromptProcessingBatch.Response(
+                self._prompt_batch.uids[i], 0, False, False
+            )
+            segments = seq[0]
+            remaining = len(segments[0])
+            step_size = _prefill_step_size_for_progress(
+                self.prefill_step_size,
+                seq[1],
+                remaining,
+                adaptive_prefill,
+            )
+            n = min(remaining, step_size)
+            prompts.append(segments[0][:n])
+            segments[0] = segments[0][n:]
+            if len(segments[0]) == 0:
+                segments.pop(0)
+                response.end_of_segment = True
+            seq[1] += len(prompts[-1])
+            response.progress = (seq[1], seq[2])
+            prompt_responses.append(response)
+
+        self._prompt_tokens_counter += sum(len(prompt) for prompt in prompts)
+        tic = time.perf_counter()
+        self._prompt_batch.prompt(prompts)
+        toc = time.perf_counter()
+        self._prompt_time_counter += toc - tic
+
+        return prompt_responses, generation_responses
+
+    PromptProcessingBatch.__init__ = patched_ppb_init
+    PromptProcessingBatch._copy = patched_ppb_copy
+    PromptProcessingBatch.split = patched_ppb_split
+    PromptProcessingBatch.prompt = patched_ppb_prompt
+    BatchGenerator.__init__ = patched_bg_init
+    BatchGenerator._next = patched_bg_next
+
+    PromptProcessingBatch._omlx_glm_dsa_adaptive_patched = True
+    BatchGenerator._omlx_glm_dsa_adaptive_patched = True
+    _APPLIED = True
+    logger.info("GLM MoE DSA adaptive prefill patch applied to mlx_lm.generate")
+    return True
+
+
+__all__ = ["apply_glm_moe_dsa_generate_patch"]

--- a/omlx/patches/glm_moe_dsa/glm_moe_dsa_model.py
+++ b/omlx/patches/glm_moe_dsa/glm_moe_dsa_model.py
@@ -1,6 +1,5 @@
 # Copyright © 2025 Apple Inc.
 
-import math
 import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -13,6 +12,7 @@ from mlx_lm.models.base import (
     scaled_dot_product_attention,
 )
 from mlx_lm.models.cache import CacheList, KVCache
+from .kernels import fast as glm_fast
 from .deepseek_v32 import (
     DeepseekV32Attention,
     DeepseekV32DecoderLayer,
@@ -20,83 +20,29 @@ from .deepseek_v32 import (
 )
 from .deepseek_v32 import Model as DSV32Model
 from .sparse_mla import (
-    block_indices_to_block_mask,
     q8_vup_flat,
-    sparse_mla_block_table_attention,
-    sparse_mla_qblock_attention,
     sparse_mla_attention,
-    topk_indices_to_block_masks,
 )
 
 _SGLANG_GLM5_INDEX_TOPK_PATTERN = (
-    "FFSFSSSFSSFFFSSSFFFSFSSSSSSFFSFFSFFSSFFFFFFSFFFFFSFFSSSSSS"
-    "FSFFFSFSSSFSFFSFFSSS"
+    "FFSFSSSFSSFFFSSSFFFSFSSSSSSFFSFFSFFSSFFFFFFSFFFFFSFFSSSSSS" "FSFFFSFSSSFSFFSFFSSS"
 )
-_BLOCK_STATS_SEEN = set()
+
+
+def _native_sparse_mla_default_min_k() -> str:
+    """Use native sparse MLA for all GLM-5.2 prefill chunks when available."""
+    return "0" if glm_fast.has("glm_dsa_sparse_mla_attention") else "11264"
 
 
 def _parse_topk_state(topk_state):
     topk_indices = topk_state
-    block_indices = None
     prefix_rows = 0
-    exact_block_table = None
     if isinstance(topk_state, tuple):
-        if len(topk_state) == 4:
-            topk_indices, block_indices, prefix_rows, exact_block_table = topk_state
-        elif len(topk_state) == 3:
-            topk_indices, block_indices, prefix_rows = topk_state
+        if len(topk_state) == 3:
+            topk_indices, _, prefix_rows = topk_state
         else:
-            topk_indices, block_indices = topk_state
-    return topk_indices, block_indices, prefix_rows, exact_block_table
-
-
-def _maybe_log_block_index_stats(
-    block_indices: mx.array,
-    *,
-    layer_idx: int,
-    query_length: int,
-    key_length: int,
-    k_block_size: int,
-) -> None:
-    if os.environ.get("MLX_LM_GLM_DSA_BLOCK_STATS", "0") != "1":
-        return
-    if block_indices.ndim != 4 or block_indices.shape[1] != 1:
-        return
-
-    q_blocks = block_indices.shape[2]
-    budget = block_indices.shape[3]
-    k_blocks = (key_length + k_block_size - 1) // k_block_size
-    key = (layer_idx, query_length, key_length, q_blocks, budget)
-    if os.environ.get("MLX_LM_GLM_DSA_BLOCK_STATS_ONCE", "1") == "1":
-        if key in _BLOCK_STATS_SEEN:
-            return
-        _BLOCK_STATS_SEEN.add(key)
-
-    try:
-        rows = block_indices[0, 0].tolist()
-    except Exception as exc:
-        print(f"GLM_DSA_BLOCK_STATS layer={layer_idx} unavailable: {exc}")
-        return
-
-    row_counts = []
-    union = set()
-    total_valid = 0
-    for row in rows:
-        valid = [int(block) for block in row if int(block) < k_blocks]
-        row_counts.append(len(set(valid)))
-        union.update(valid)
-        total_valid += len(valid)
-
-    avg_row = sum(row_counts) / max(len(row_counts), 1)
-    coverage = len(union) / max(k_blocks, 1)
-    duplicate_ratio = 1.0 - (len(union) / max(total_valid, 1))
-    print(
-        "GLM_DSA_BLOCK_STATS "
-        f"layer={layer_idx} L={query_length} K={key_length} "
-        f"q_blocks={q_blocks} k_blocks={k_blocks} budget={budget} "
-        f"union={len(union)} coverage={coverage:.4f} "
-        f"avg_row_unique={avg_row:.2f} duplicate_ratio={duplicate_ratio:.4f}"
-    )
+            topk_indices, _ = topk_state
+    return topk_indices, prefix_rows
 
 
 @dataclass
@@ -157,15 +103,16 @@ class ModelArgs(BaseModelArgs):
             "disable",
             "disabled",
         }
-        indexcache_requested = (
-            prefill_mode in {"sglang", "indexcache"}
-            or indexcache_mode in {"1", "true", "sglang", "glm5", "glm-5"}
-        )
-        pattern_is_sglang = (
-            env_pattern is not None
-            and env_pattern.strip().lower()
-            in {"sglang", "glm5", "glm-5", "recommended"}
-        )
+        indexcache_requested = prefill_mode in {
+            "sglang",
+            "indexcache",
+        } or indexcache_mode in {"1", "true", "sglang", "glm5", "glm-5"}
+        pattern_is_sglang = env_pattern is not None and env_pattern.strip().lower() in {
+            "sglang",
+            "glm5",
+            "glm-5",
+            "recommended",
+        }
         indexcache_recall_risk_allowed = os.environ.get(
             "MLX_LM_GLM_DSA_ALLOW_INDEXCACHE_RECALL_RISK", "0"
         ).lower() in {"1", "true", "yes", "on"}
@@ -191,9 +138,10 @@ class ModelArgs(BaseModelArgs):
         if "MLX_LM_GLM_DSA_INDEX_TOPK_FREQ" in os.environ:
             self.index_topk_freq = int(os.environ["MLX_LM_GLM_DSA_INDEX_TOPK_FREQ"])
             self.index_topk_pattern = None
-            if config_indexer_types is not None and os.environ.get(
-                "MLX_LM_GLM_DSA_ALLOW_NEW_INDEXERS", "0"
-            ) != "1":
+            if (
+                config_indexer_types is not None
+                and os.environ.get("MLX_LM_GLM_DSA_ALLOW_NEW_INDEXERS", "0") != "1"
+            ):
                 freq = max(self.index_topk_freq, 1)
                 full_count = 0
                 indexer_types = []
@@ -225,14 +173,13 @@ class ModelArgs(BaseModelArgs):
                             f"num_hidden_layers ({len(pattern)} != "
                             f"{self.num_hidden_layers})."
                         )
-                    pattern_types = [
-                        {"F": "full", "S": "shared"}[c] for c in pattern
-                    ]
+                    pattern_types = [{"F": "full", "S": "shared"}[c] for c in pattern]
                 else:
                     pattern_types = list(pattern)
-                if config_indexer_types is not None and os.environ.get(
-                    "MLX_LM_GLM_DSA_ALLOW_NEW_INDEXERS", "0"
-                ) != "1":
+                if (
+                    config_indexer_types is not None
+                    and os.environ.get("MLX_LM_GLM_DSA_ALLOW_NEW_INDEXERS", "0") != "1"
+                ):
                     self.indexer_types = [
                         "full" if base == "full" and selected == "full" else "shared"
                         for base, selected in zip(config_indexer_types, pattern_types)
@@ -292,7 +239,7 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
             topk_state = prev_topk_indices
 
         if L == 1:
-            topk_indices, _, _, _ = _parse_topk_state(topk_state)
+            topk_indices, _ = _parse_topk_state(topk_state)
             if topk_indices is not None:
                 idx = topk_indices[:, :, 0, :, None]
                 kv_latent = mx.take_along_axis(
@@ -335,144 +282,12 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
             output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
             return self.o_proj(output), topk_state
 
-        topk_indices, block_indices, topk_prefix_rows, exact_block_table = (
-            _parse_topk_state(topk_state)
-        )
+        topk_indices, topk_prefix_rows = _parse_topk_state(topk_state)
 
         # Ensure the indexer cache is evaluated even if the topk_indices are unused
         # to keep the graph from getting too large
         if self.indexer is not None and cache is not None and cache[0] is not None:
             cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys, cache[1].values))
-
-        if exact_block_table is not None and L > 1:
-            block_k = int(
-                os.environ.get("MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_K_BLOCK", "8")
-            )
-            q_latent = self.embed_q(q_nope)
-            block_table = (
-                exact_block_table
-                if exact_block_table.dtype == mx.uint32
-                else exact_block_table.astype(mx.uint32)
-            )
-            output = sparse_mla_block_table_attention(
-                q_latent,
-                q_pe,
-                kv_latent,
-                k_pe,
-                block_table,
-                self.scale,
-                k_block_size=block_k,
-            )
-            if output is not None:
-                output_flat = q8_vup_flat(
-                    output, self.unembed_out, key_length=kv_latent.shape[2]
-                )
-                if output_flat is None:
-                    output = self.unembed_out(output)
-                    output_flat = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-                output = output_flat
-                return self.o_proj(output), topk_state
-
-        if block_indices is not None and L > 1:
-            use_block_sdpa = os.environ.get(
-                "MLX_LM_GLM_DSA_BLOCK_SPARSE_SDPA",
-                os.environ.get("MLX_LM_GLM_DSA_BLOCK_UNION_SDPA", "1"),
-            ) == "1" and L > 8
-            if use_block_sdpa:
-                use_block_index_sdpa = (
-                    os.environ.get("MLX_LM_GLM_DSA_BLOCK_INDEX_SDPA", "1") == "1"
-                )
-                if use_block_index_sdpa:
-                    block_indices_u32 = (
-                        block_indices
-                        if block_indices.dtype == mx.uint32
-                        else block_indices.astype(mx.uint32)
-                    )
-                    stats_k_block_size = int(
-                        os.environ.get(
-                            "MLX_LM_GLM_DSA_BLOCK_SDPA_K_BLOCK",
-                            os.environ.get(
-                                "MLX_LM_GLM_DSA_BLOCK_BUDGET_K_BLOCK", "16"
-                            ),
-                        )
-                    )
-                    _maybe_log_block_index_stats(
-                        block_indices_u32,
-                        layer_idx=self.layer_idx,
-                        query_length=L,
-                        key_length=kv_latent.shape[2],
-                        k_block_size=stats_k_block_size,
-                    )
-                    k = self.embed_q(kv_latent, transpose=False)
-                    v = self.unembed_out(kv_latent)
-                    split_qk_max_k = int(
-                        os.environ.get("MLX_LM_GLM_DSA_SPLIT_QK_MAX_K", "65536")
-                    )
-                    if (
-                        os.environ.get("MLX_LM_GLM_DSA_SPLIT_QK_SDPA", "0") == "1"
-                        and kv_latent.shape[2] <= split_qk_max_k
-                        and hasattr(mx.fast, "glm_dsa_attention")
-                    ):
-                        output = mx.fast.glm_dsa_attention(
-                            q_nope,
-                            q_pe,
-                            k,
-                            k_pe,
-                            v,
-                            block_indices_u32,
-                            self.scale,
-                        )
-                    else:
-                        k_pe_heads = mx.broadcast_to(
-                            k_pe, k.shape[:-1] + k_pe.shape[-1:]
-                        )
-                        q = mx.concatenate([q_nope, q_pe], axis=-1)
-                        k = mx.concatenate([k, k_pe_heads], axis=-1)
-                        output = mx.fast.scaled_dot_product_attention(
-                            q,
-                            k,
-                            v,
-                            scale=self.scale,
-                            mask="causal",
-                            block_indices=block_indices_u32,
-                        )
-                    output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-                    return self.o_proj(output), topk_state
-                q_block_size = int(
-                    os.environ.get(
-                        "MLX_LM_GLM_DSA_BLOCK_SDPA_Q_BLOCK",
-                        os.environ.get("MLX_LM_GLM_DSA_BLOCK_BUDGET_Q_BLOCK", "32"),
-                    )
-                )
-                k_block_size = int(
-                    os.environ.get(
-                        "MLX_LM_GLM_DSA_BLOCK_SDPA_K_BLOCK",
-                        os.environ.get("MLX_LM_GLM_DSA_BLOCK_BUDGET_K_BLOCK", "16"),
-                    )
-                )
-                k = self.embed_q(kv_latent, transpose=False)
-                v = self.unembed_out(kv_latent)
-                k_pe_heads = mx.broadcast_to(k_pe, k.shape[:-1] + k_pe.shape[-1:])
-                q = mx.concatenate([q_nope, q_pe], axis=-1)
-                k = mx.concatenate([k, k_pe_heads], axis=-1)
-                block_mask = block_indices_to_block_mask(
-                    block_indices,
-                    L=L,
-                    K=kv_latent.shape[2],
-                    q_block_size=q_block_size,
-                    k_block_size=k_block_size,
-                )
-                if block_mask is not None:
-                    output = mx.fast.scaled_dot_product_attention(
-                        q,
-                        k,
-                        v,
-                        scale=self.scale,
-                        mask="causal",
-                        block_mask=block_mask,
-                    )
-                    output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-                    return self.o_proj(output), topk_state
 
         prefill_mode = os.environ.get("MLX_LM_GLM_DSA_PREFILL_MODE", "").lower()
         default_exact_prefill = (
@@ -480,18 +295,27 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
             and os.environ.get("MLX_LM_GLM_DSA_EXACT_PREFILL_DEFAULT", "1") != "0"
         )
         exact_prefill = prefill_mode in {"exact", "strict"} or default_exact_prefill
-        # Exact block-token SDPA is still slightly faster around 10K, while
-        # direct sparse MLA wins from 12K+ on the retained GLM-5.2 path.
         direct_sparse_mla_min_k = int(
-            os.environ.get("MLX_LM_GLM_DSA_DIRECT_SPARSE_MLA_MIN_K", "11264")
+            os.environ.get(
+                "MLX_LM_GLM_DSA_DIRECT_SPARSE_MLA_MIN_K",
+                _native_sparse_mla_default_min_k(),
+            )
         )
         direct_sparse_mla_default = (
             "1"
             if exact_prefill and kv_latent.shape[2] >= direct_sparse_mla_min_k
             else "0"
         )
-        direct_sparse_mla_requested = (
+        native_sparse_mla_shape = (
             topk_indices is not None
+            and self.num_heads == 64
+            and q_pe.shape[-1] == 64
+            and kv_latent.shape[-1] == 512
+            and k_pe.shape[-1] == 64
+            and topk_indices.shape[-1] == 2048
+        )
+        direct_sparse_mla_requested = (
+            native_sparse_mla_shape
             and L > 1
             and os.environ.get(
                 "MLX_LM_GLM_DSA_DIRECT_SPARSE_MLA", direct_sparse_mla_default
@@ -499,109 +323,15 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
             == "1"
         )
         if direct_sparse_mla_requested:
-            fast_topk_indices = (
-                os.environ.get("MLX_LM_GLM_DSA_FAST_TOPK", "1") == "1"
-                and hasattr(mx.fast, "dsa_topk_indices")
-            )
+            fast_topk_indices = os.environ.get(
+                "MLX_LM_GLM_DSA_FAST_TOPK", "1"
+            ) == "1" and hasattr(glm_fast, "dsa_topk_indices")
             causal_prefix_indices = (
                 fast_topk_indices
                 and os.environ.get("MLX_LM_GLM_DSA_TOPK_CAUSAL_PREFIX_FASTPATH", "1")
                 == "1"
             )
             q_latent = self.embed_q(q_nope)
-            if (
-                os.environ.get("MLX_LM_GLM_DSA_QBLOCK_UNION_MLA", "0") == "1"
-                and hasattr(mx.fast, "dsa_topk_qblock_union")
-                and hasattr(mx.fast, "glm_dsa_sparse_mla_qblock_attention")
-            ):
-                qblock_size = int(
-                    os.environ.get("MLX_LM_GLM_DSA_QBLOCK_UNION_MLA_Q_BLOCK", "4")
-                )
-                qblock_capacity = int(
-                    os.environ.get("MLX_LM_GLM_DSA_QBLOCK_UNION_MLA_CAPACITY", "4096")
-                )
-                output = sparse_mla_qblock_attention(
-                    q_latent,
-                    q_pe,
-                    kv_latent,
-                    k_pe,
-                    topk_indices,
-                    self.scale,
-                    topk_valid_prefix=fast_topk_indices,
-                    causal_prefix_indices=causal_prefix_indices,
-                    causal_prefix_rows=topk_prefix_rows,
-                    q_block_size=qblock_size,
-                    capacity=qblock_capacity,
-                )
-                if output is not None:
-                    output_flat = q8_vup_flat(
-                        output, self.unembed_out, key_length=kv_latent.shape[2]
-                    )
-                    if output_flat is None:
-                        output = self.unembed_out(output)
-                        output_flat = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-                    output = output_flat
-                    return self.o_proj(output), topk_state
-            block_table_mode = os.environ.get(
-                "MLX_LM_GLM_DSA_BLOCK_TABLE_SPARSE_MLA", "0"
-            ).lower()
-            use_block_table_mla = (
-                topk_prefix_rows == 0
-                and block_table_mode in {"1", "auto", "force"}
-                and hasattr(mx.fast, "dsa_topk_to_block_table")
-            )
-            if use_block_table_mla:
-                block_k = int(
-                    os.environ.get("MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_K_BLOCK", "8")
-                )
-                if block_table_mode != "force":
-                    k_blocks = max(1, (kv_latent.shape[2] + block_k - 1) // block_k)
-                    topk_size = max(1, topk_indices.shape[-1])
-                    expected_blocks = k_blocks * (
-                        1.0 - math.exp(topk_size * math.log1p(-1.0 / k_blocks))
-                    )
-                    expected_expansion = expected_blocks * block_k / topk_size
-                    max_expansion = float(
-                        os.environ.get(
-                            "MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_MAX_EXPANSION",
-                            "1.5",
-                        )
-                    )
-                    use_block_table_mla = expected_expansion <= max_expansion
-
-            if use_block_table_mla:
-                packed_block_table = (
-                    block_k <= 16
-                    and os.environ.get(
-                        "MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_PACKED", "1"
-                    )
-                    == "1"
-                )
-                block_table = mx.fast.dsa_topk_to_block_table(
-                    topk_indices,
-                    kv_latent.shape[2],
-                    k_block_size=block_k,
-                    causal=True,
-                    packed=packed_block_table,
-                )
-                output = sparse_mla_block_table_attention(
-                    q_latent,
-                    q_pe,
-                    kv_latent,
-                    k_pe,
-                    block_table,
-                    self.scale,
-                    k_block_size=block_k,
-                )
-                if output is not None:
-                    output_flat = q8_vup_flat(
-                        output, self.unembed_out, key_length=kv_latent.shape[2]
-                    )
-                    if output_flat is None:
-                        output = self.unembed_out(output)
-                        output_flat = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-                    output = output_flat
-                    return self.o_proj(output), topk_state
             output = sparse_mla_attention(
                 q_latent,
                 q_pe,
@@ -622,75 +352,10 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
                     output_flat = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
                 output = output_flat
                 return self.o_proj(output), topk_state
-
-        if (
-            topk_indices is not None
-            and L > 8
-            and os.environ.get(
-                "MLX_LM_GLM_DSA_EXACT_BLOCK_TOKEN_SDPA",
-                "1" if exact_prefill else "0",
+            raise RuntimeError(
+                "GLM direct sparse MLA was requested, but no native kernel "
+                "handled the current shape."
             )
-            == "1"
-        ):
-            k = self.embed_q(kv_latent, transpose=False)
-            k_pe_heads = mx.broadcast_to(k_pe, k.shape[:-1] + k_pe.shape[-1:])
-            q = mx.concatenate([q_nope, q_pe], axis=-1)
-            k = mx.concatenate([k, k_pe_heads], axis=-1)
-            v = self.unembed_out(kv_latent)
-            q_block_size = int(
-                os.environ.get(
-                    "MLX_LM_GLM_DSA_EXACT_BLOCK_SDPA_Q_BLOCK",
-                    os.environ.get("MLX_LM_GLM_DSA_BLOCK_SDPA_Q_BLOCK", "32"),
-                )
-            )
-            k_block_size = int(
-                os.environ.get(
-                    "MLX_LM_GLM_DSA_EXACT_BLOCK_SDPA_K_BLOCK",
-                    os.environ.get(
-                        "MLX_LM_GLM_DSA_BLOCK_SDPA_K_BLOCK",
-                        os.environ.get("MLX_LM_GLM_DSA_BLOCK_BUDGET_K_BLOCK", "8"),
-                    ),
-                )
-            )
-            block_masks = topk_indices_to_block_masks(
-                topk_indices,
-                L=L,
-                K=kv_latent.shape[2],
-                q_block_size=q_block_size,
-                k_block_size=k_block_size,
-                causal_prefix_indices=(
-                    os.environ.get("MLX_LM_GLM_DSA_FAST_TOPK", "1") == "1"
-                    and os.environ.get(
-                        "MLX_LM_GLM_DSA_TOPK_CAUSAL_PREFIX_FASTPATH", "1"
-                    )
-                    == "1"
-                ),
-                causal_prefix_rows=topk_prefix_rows,
-            )
-            if block_masks is not None:
-                block_mask, block_token_mask = block_masks
-                output = mx.fast.scaled_dot_product_attention(
-                    q,
-                    k,
-                    v,
-                    scale=self.scale,
-                    mask="causal",
-                    block_mask=block_mask,
-                    block_token_mask=block_token_mask,
-                )
-                output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
-                return self.o_proj(output), topk_state
-
-        if direct_sparse_mla_requested:
-            shape = list(topk_indices.shape)
-            shape[-1] = kv_latent.shape[2]
-            sparse_mask = mx.zeros(shape, dtype=mx.bool_)
-            sparse_mask = mx.put_along_axis(
-                sparse_mask, topk_indices, mx.array(True), axis=-1
-            )
-            if mask is not None:
-                sparse_mask = sparse_mask & mask
-            mask = sparse_mask
 
         pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
         if mask is not None:

--- a/omlx/patches/glm_moe_dsa/glm_moe_dsa_model.py
+++ b/omlx/patches/glm_moe_dsa/glm_moe_dsa_model.py
@@ -1,27 +1,102 @@
-# Copyright (c) 2025 Apple Inc.
-# SPDX-License-Identifier: Apache-2.0
-"""GLM-5.2 ``glm_moe_dsa`` model for the pinned mlx-lm runtime.
+# Copyright © 2025 Apple Inc.
 
-Vendored from ml-explore/mlx-lm#1410 so oMLX can load GLM-5.2 checkpoints
-while the pinned mlx-lm still exposes ``glm_moe_dsa`` as a bare
-DeepSeek-V3.2 subclass.
-"""
-
-from __future__ import annotations
-
+import math
+import os
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 import mlx.core as mx
 
-from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
-from .cache import CacheList, KVCache
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.cache import CacheList, KVCache
 from .deepseek_v32 import (
     DeepseekV32Attention,
     DeepseekV32DecoderLayer,
     DeepseekV32Model,
 )
 from .deepseek_v32 import Model as DSV32Model
+from .sparse_mla import (
+    block_indices_to_block_mask,
+    q8_vup_flat,
+    sparse_mla_block_table_attention,
+    sparse_mla_qblock_attention,
+    sparse_mla_attention,
+    topk_indices_to_block_masks,
+)
+
+_SGLANG_GLM5_INDEX_TOPK_PATTERN = (
+    "FFSFSSSFSSFFFSSSFFFSFSSSSSSFFSFFSFFSSFFFFFFSFFFFFSFFSSSSSS"
+    "FSFFFSFSSSFSFFSFFSSS"
+)
+_BLOCK_STATS_SEEN = set()
+
+
+def _parse_topk_state(topk_state):
+    topk_indices = topk_state
+    block_indices = None
+    prefix_rows = 0
+    exact_block_table = None
+    if isinstance(topk_state, tuple):
+        if len(topk_state) == 4:
+            topk_indices, block_indices, prefix_rows, exact_block_table = topk_state
+        elif len(topk_state) == 3:
+            topk_indices, block_indices, prefix_rows = topk_state
+        else:
+            topk_indices, block_indices = topk_state
+    return topk_indices, block_indices, prefix_rows, exact_block_table
+
+
+def _maybe_log_block_index_stats(
+    block_indices: mx.array,
+    *,
+    layer_idx: int,
+    query_length: int,
+    key_length: int,
+    k_block_size: int,
+) -> None:
+    if os.environ.get("MLX_LM_GLM_DSA_BLOCK_STATS", "0") != "1":
+        return
+    if block_indices.ndim != 4 or block_indices.shape[1] != 1:
+        return
+
+    q_blocks = block_indices.shape[2]
+    budget = block_indices.shape[3]
+    k_blocks = (key_length + k_block_size - 1) // k_block_size
+    key = (layer_idx, query_length, key_length, q_blocks, budget)
+    if os.environ.get("MLX_LM_GLM_DSA_BLOCK_STATS_ONCE", "1") == "1":
+        if key in _BLOCK_STATS_SEEN:
+            return
+        _BLOCK_STATS_SEEN.add(key)
+
+    try:
+        rows = block_indices[0, 0].tolist()
+    except Exception as exc:
+        print(f"GLM_DSA_BLOCK_STATS layer={layer_idx} unavailable: {exc}")
+        return
+
+    row_counts = []
+    union = set()
+    total_valid = 0
+    for row in rows:
+        valid = [int(block) for block in row if int(block) < k_blocks]
+        row_counts.append(len(set(valid)))
+        union.update(valid)
+        total_valid += len(valid)
+
+    avg_row = sum(row_counts) / max(len(row_counts), 1)
+    coverage = len(union) / max(k_blocks, 1)
+    duplicate_ratio = 1.0 - (len(union) / max(total_valid, 1))
+    print(
+        "GLM_DSA_BLOCK_STATS "
+        f"layer={layer_idx} L={query_length} K={key_length} "
+        f"q_blocks={q_blocks} k_blocks={k_blocks} budget={budget} "
+        f"union={len(union)} coverage={coverage:.4f} "
+        f"avg_row_unique={avg_row:.2f} duplicate_ratio={duplicate_ratio:.4f}"
+    )
 
 
 @dataclass
@@ -37,8 +112,8 @@ class ModelArgs(BaseModelArgs):
     num_hidden_layers: int
     num_attention_heads: int
     num_key_value_heads: int
-    n_shared_experts: int | None
-    n_routed_experts: int | None
+    n_shared_experts: Optional[int]
+    n_routed_experts: Optional[int]
     routed_scaling_factor: float
     kv_lora_rank: int
     q_lora_rank: int
@@ -55,53 +130,128 @@ class ModelArgs(BaseModelArgs):
     first_k_dense_replace: int
     max_position_embeddings: int
     rms_norm_eps: float
-    rope_parameters: dict
+    rope_parameters: Dict
     attention_bias: bool
-    rope_scaling: dict | None = None
-    rope_theta: float | None = None
-    indexer_types: list[str] | None = None
-    index_topk_pattern: Any | None = None
+    rope_scaling: Dict = None
+    rope_theta: Optional[float] = None
+    indexer_types: Optional[List[str]] = None
+    index_topk_pattern: Optional[Any] = None
     index_topk_freq: int = 1
     index_skip_topk_offset: int = 2
+    quantization: Optional[Dict[str, Any]] = None
+    quantization_config: Optional[Dict[str, Any]] = None
 
     def __post_init__(self):
         self.rope_scaling = self.rope_parameters
         self.rope_theta = self.rope_parameters["rope_theta"]
 
+        config_indexer_types = self.indexer_types
+        prefill_mode = os.environ.get("MLX_LM_GLM_DSA_PREFILL_MODE", "").lower()
+        indexcache_mode = os.environ.get("MLX_LM_GLM_DSA_INDEXCACHE", "").lower()
+        env_pattern = os.environ.get("MLX_LM_GLM_DSA_INDEX_TOPK_PATTERN")
+        indexcache_disabled = indexcache_mode in {
+            "0",
+            "false",
+            "off",
+            "none",
+            "disable",
+            "disabled",
+        }
+        indexcache_requested = (
+            prefill_mode in {"sglang", "indexcache"}
+            or indexcache_mode in {"1", "true", "sglang", "glm5", "glm-5"}
+        )
+        pattern_is_sglang = (
+            env_pattern is not None
+            and env_pattern.strip().lower()
+            in {"sglang", "glm5", "glm-5", "recommended"}
+        )
+        indexcache_recall_risk_allowed = os.environ.get(
+            "MLX_LM_GLM_DSA_ALLOW_INDEXCACHE_RECALL_RISK", "0"
+        ).lower() in {"1", "true", "yes", "on"}
+        if (
+            not indexcache_disabled
+            and (indexcache_requested or pattern_is_sglang)
+            and not indexcache_recall_risk_allowed
+        ):
+            raise ValueError(
+                "SGLang-style GLM DSA IndexCache is disabled by default because "
+                "it failed a 32K multi-needle recall test on GLM-5.2-oQ4. "
+                "Set MLX_LM_GLM_DSA_ALLOW_INDEXCACHE_RECALL_RISK=1 to enable "
+                "this speed/recall-risk mode explicitly."
+            )
+        if not env_pattern and not indexcache_disabled and indexcache_requested:
+            env_pattern = "sglang"
+        if env_pattern:
+            env_pattern = env_pattern.strip()
+            if env_pattern.lower() in {"sglang", "glm5", "glm-5", "recommended"}:
+                env_pattern = _SGLANG_GLM5_INDEX_TOPK_PATTERN
+            self.index_topk_pattern = env_pattern
+            self.indexer_types = None
+        if "MLX_LM_GLM_DSA_INDEX_TOPK_FREQ" in os.environ:
+            self.index_topk_freq = int(os.environ["MLX_LM_GLM_DSA_INDEX_TOPK_FREQ"])
+            self.index_topk_pattern = None
+            if config_indexer_types is not None and os.environ.get(
+                "MLX_LM_GLM_DSA_ALLOW_NEW_INDEXERS", "0"
+            ) != "1":
+                freq = max(self.index_topk_freq, 1)
+                full_count = 0
+                indexer_types = []
+                for layer_type in config_indexer_types:
+                    if layer_type == "full":
+                        indexer_types.append(
+                            "full" if full_count % freq == 0 else "shared"
+                        )
+                        full_count += 1
+                    else:
+                        indexer_types.append("shared")
+                self.indexer_types = indexer_types
+            else:
+                self.indexer_types = None
+        if "MLX_LM_GLM_DSA_INDEX_SKIP_TOPK_OFFSET" in os.environ:
+            self.index_skip_topk_offset = int(
+                os.environ["MLX_LM_GLM_DSA_INDEX_SKIP_TOPK_OFFSET"]
+            )
+            if self.index_topk_pattern is None:
+                self.indexer_types = None
+
         if self.indexer_types is None:
             if self.index_topk_pattern is not None:
                 pattern = self.index_topk_pattern
                 if isinstance(pattern, str):
-                    self.indexer_types = [
+                    if len(pattern) != self.num_hidden_layers:
+                        raise ValueError(
+                            "index_topk_pattern length must match "
+                            f"num_hidden_layers ({len(pattern)} != "
+                            f"{self.num_hidden_layers})."
+                        )
+                    pattern_types = [
                         {"F": "full", "S": "shared"}[c] for c in pattern
                     ]
                 else:
-                    self.indexer_types = list(pattern)
+                    pattern_types = list(pattern)
+                if config_indexer_types is not None and os.environ.get(
+                    "MLX_LM_GLM_DSA_ALLOW_NEW_INDEXERS", "0"
+                ) != "1":
+                    self.indexer_types = [
+                        "full" if base == "full" and selected == "full" else "shared"
+                        for base, selected in zip(config_indexer_types, pattern_types)
+                    ]
+                else:
+                    self.indexer_types = pattern_types
             else:
-                freq = max(int(self.index_topk_freq), 1)
-                offset = int(self.index_skip_topk_offset)
+                freq = max(self.index_topk_freq, 1)
+                offset = self.index_skip_topk_offset
                 self.indexer_types = [
                     "full" if (max(i - offset + 1, 0) % freq) == 0 else "shared"
                     for i in range(self.num_hidden_layers)
                 ]
-        else:
-            self.indexer_types = list(self.indexer_types)
-
-        if len(self.indexer_types) != self.num_hidden_layers:
-            raise ValueError(
-                "`indexer_types` must have one entry per hidden layer, "
-                f"got {len(self.indexer_types)} for {self.num_hidden_layers} layers."
-            )
-        invalid = sorted(set(self.indexer_types) - {"full", "shared"})
-        if invalid:
-            raise ValueError(f"Unsupported GLM MoE DSA indexer types: {invalid}")
-        if self.indexer_types and self.indexer_types[0] != "full":
-            raise ValueError("The first GLM MoE DSA layer must be a full indexer layer.")
 
 
 class GlmMoeDsaAttention(DeepseekV32Attention):
     def __init__(self, config: ModelArgs, layer_idx: int):
         super().__init__(config)
+        self.layer_idx = layer_idx
         self.skip_topk = config.indexer_types[layer_idx] == "shared"
         if self.skip_topk:
             self.indexer = None
@@ -109,24 +259,20 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
     def __call__(
         self,
         x: mx.array,
-        mask: mx.array | None = None,
-        cache: Any | None = None,
-        prev_topk_indices: mx.array | None = None,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        prev_topk_indices: Optional[mx.array] = None,
     ):
-        batch_size, seq_len, _hidden_dim = x.shape
+        B, L, D = x.shape
 
         qr = self.q_a_layernorm(self.q_a_proj(x))
         q = self.q_b_proj(qr)
 
-        q = q.reshape(
-            batch_size, seq_len, self.num_heads, self.q_head_dim
-        ).transpose(0, 2, 1, 3)
+        q = q.reshape(B, L, self.num_heads, self.q_head_dim).transpose(0, 2, 1, 3)
         q_nope, q_pe = mx.split(q, [self.qk_nope_head_dim], axis=-1)
         compressed_kv = self.kv_a_proj_with_mqa(x)
         compressed_kv, k_pe = mx.split(compressed_kv, [self.kv_lora_rank], axis=-1)
-        k_pe = k_pe.reshape(
-            batch_size, seq_len, 1, self.qk_rope_head_dim
-        ).transpose(0, 2, 1, 3)
+        k_pe = k_pe.reshape(B, L, 1, self.qk_rope_head_dim).transpose(0, 2, 1, 3)
         kv_latent = self.kv_a_layernorm(compressed_kv)
 
         offset = cache[0].offset if cache is not None else 0
@@ -141,12 +287,13 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
             cache = [None] * 2
 
         if self.indexer is not None:
-            topk_indices = self.indexer(x, qr, mask, cache=cache[1])
+            topk_state = self.indexer(x, qr, mask, cache=cache[1])
         else:
-            topk_indices = prev_topk_indices
+            topk_state = prev_topk_indices
 
-        if topk_indices is not None:
-            if seq_len == 1:
+        if L == 1:
+            topk_indices, _, _, _ = _parse_topk_state(topk_state)
+            if topk_indices is not None:
                 idx = topk_indices[:, :, 0, :, None]
                 kv_latent = mx.take_along_axis(
                     kv_latent,
@@ -160,19 +307,390 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
                 )
                 if mask is not None:
                     mask = mx.take_along_axis(mask, topk_indices, axis=-1)
-            else:
-                shape = list(topk_indices.shape)
-                shape[-1] = kv_latent.shape[2]
-                sparse_mask = mx.zeros(shape, dtype=mx.bool_)
-                sparse_mask = mx.put_along_axis(
-                    sparse_mask, topk_indices, mx.array(True), axis=-1
-                )
-                if mask is not None:
-                    sparse_mask = sparse_mask & mask
-                mask = sparse_mask
 
+            # Ensure the indexer cache is evaluated even if the topk_indices are unused
+            # to keep the graph from getting too large.
+            if self.indexer is not None and cache is not None and cache[0] is not None:
+                cache[0].keys = mx.depends(
+                    cache[0].keys, (cache[1].keys, cache[1].values)
+                )
+
+            pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
+            if mask is not None:
+                pe_scores = mx.where(
+                    mask,
+                    pe_scores,
+                    mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
+                )
+            q_nope = self.embed_q(q_nope)
+            output = scaled_dot_product_attention(
+                q_nope,
+                kv_latent,
+                kv_latent,
+                cache=cache,
+                scale=self.scale,
+                mask=pe_scores,
+            )
+            output = self.unembed_out(output)
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+            return self.o_proj(output), topk_state
+
+        topk_indices, block_indices, topk_prefix_rows, exact_block_table = (
+            _parse_topk_state(topk_state)
+        )
+
+        # Ensure the indexer cache is evaluated even if the topk_indices are unused
+        # to keep the graph from getting too large
         if self.indexer is not None and cache is not None and cache[0] is not None:
             cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys, cache[1].values))
+
+        if exact_block_table is not None and L > 1:
+            block_k = int(
+                os.environ.get("MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_K_BLOCK", "8")
+            )
+            q_latent = self.embed_q(q_nope)
+            block_table = (
+                exact_block_table
+                if exact_block_table.dtype == mx.uint32
+                else exact_block_table.astype(mx.uint32)
+            )
+            output = sparse_mla_block_table_attention(
+                q_latent,
+                q_pe,
+                kv_latent,
+                k_pe,
+                block_table,
+                self.scale,
+                k_block_size=block_k,
+            )
+            if output is not None:
+                output_flat = q8_vup_flat(
+                    output, self.unembed_out, key_length=kv_latent.shape[2]
+                )
+                if output_flat is None:
+                    output = self.unembed_out(output)
+                    output_flat = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                output = output_flat
+                return self.o_proj(output), topk_state
+
+        if block_indices is not None and L > 1:
+            use_block_sdpa = os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_SPARSE_SDPA",
+                os.environ.get("MLX_LM_GLM_DSA_BLOCK_UNION_SDPA", "1"),
+            ) == "1" and L > 8
+            if use_block_sdpa:
+                use_block_index_sdpa = (
+                    os.environ.get("MLX_LM_GLM_DSA_BLOCK_INDEX_SDPA", "1") == "1"
+                )
+                if use_block_index_sdpa:
+                    block_indices_u32 = (
+                        block_indices
+                        if block_indices.dtype == mx.uint32
+                        else block_indices.astype(mx.uint32)
+                    )
+                    stats_k_block_size = int(
+                        os.environ.get(
+                            "MLX_LM_GLM_DSA_BLOCK_SDPA_K_BLOCK",
+                            os.environ.get(
+                                "MLX_LM_GLM_DSA_BLOCK_BUDGET_K_BLOCK", "16"
+                            ),
+                        )
+                    )
+                    _maybe_log_block_index_stats(
+                        block_indices_u32,
+                        layer_idx=self.layer_idx,
+                        query_length=L,
+                        key_length=kv_latent.shape[2],
+                        k_block_size=stats_k_block_size,
+                    )
+                    k = self.embed_q(kv_latent, transpose=False)
+                    v = self.unembed_out(kv_latent)
+                    split_qk_max_k = int(
+                        os.environ.get("MLX_LM_GLM_DSA_SPLIT_QK_MAX_K", "65536")
+                    )
+                    if (
+                        os.environ.get("MLX_LM_GLM_DSA_SPLIT_QK_SDPA", "0") == "1"
+                        and kv_latent.shape[2] <= split_qk_max_k
+                        and hasattr(mx.fast, "glm_dsa_attention")
+                    ):
+                        output = mx.fast.glm_dsa_attention(
+                            q_nope,
+                            q_pe,
+                            k,
+                            k_pe,
+                            v,
+                            block_indices_u32,
+                            self.scale,
+                        )
+                    else:
+                        k_pe_heads = mx.broadcast_to(
+                            k_pe, k.shape[:-1] + k_pe.shape[-1:]
+                        )
+                        q = mx.concatenate([q_nope, q_pe], axis=-1)
+                        k = mx.concatenate([k, k_pe_heads], axis=-1)
+                        output = mx.fast.scaled_dot_product_attention(
+                            q,
+                            k,
+                            v,
+                            scale=self.scale,
+                            mask="causal",
+                            block_indices=block_indices_u32,
+                        )
+                    output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                    return self.o_proj(output), topk_state
+                q_block_size = int(
+                    os.environ.get(
+                        "MLX_LM_GLM_DSA_BLOCK_SDPA_Q_BLOCK",
+                        os.environ.get("MLX_LM_GLM_DSA_BLOCK_BUDGET_Q_BLOCK", "32"),
+                    )
+                )
+                k_block_size = int(
+                    os.environ.get(
+                        "MLX_LM_GLM_DSA_BLOCK_SDPA_K_BLOCK",
+                        os.environ.get("MLX_LM_GLM_DSA_BLOCK_BUDGET_K_BLOCK", "16"),
+                    )
+                )
+                k = self.embed_q(kv_latent, transpose=False)
+                v = self.unembed_out(kv_latent)
+                k_pe_heads = mx.broadcast_to(k_pe, k.shape[:-1] + k_pe.shape[-1:])
+                q = mx.concatenate([q_nope, q_pe], axis=-1)
+                k = mx.concatenate([k, k_pe_heads], axis=-1)
+                block_mask = block_indices_to_block_mask(
+                    block_indices,
+                    L=L,
+                    K=kv_latent.shape[2],
+                    q_block_size=q_block_size,
+                    k_block_size=k_block_size,
+                )
+                if block_mask is not None:
+                    output = mx.fast.scaled_dot_product_attention(
+                        q,
+                        k,
+                        v,
+                        scale=self.scale,
+                        mask="causal",
+                        block_mask=block_mask,
+                    )
+                    output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                    return self.o_proj(output), topk_state
+
+        prefill_mode = os.environ.get("MLX_LM_GLM_DSA_PREFILL_MODE", "").lower()
+        default_exact_prefill = (
+            prefill_mode == ""
+            and os.environ.get("MLX_LM_GLM_DSA_EXACT_PREFILL_DEFAULT", "1") != "0"
+        )
+        exact_prefill = prefill_mode in {"exact", "strict"} or default_exact_prefill
+        # Exact block-token SDPA is still slightly faster around 10K, while
+        # direct sparse MLA wins from 12K+ on the retained GLM-5.2 path.
+        direct_sparse_mla_min_k = int(
+            os.environ.get("MLX_LM_GLM_DSA_DIRECT_SPARSE_MLA_MIN_K", "11264")
+        )
+        direct_sparse_mla_default = (
+            "1"
+            if exact_prefill and kv_latent.shape[2] >= direct_sparse_mla_min_k
+            else "0"
+        )
+        direct_sparse_mla_requested = (
+            topk_indices is not None
+            and L > 1
+            and os.environ.get(
+                "MLX_LM_GLM_DSA_DIRECT_SPARSE_MLA", direct_sparse_mla_default
+            )
+            == "1"
+        )
+        if direct_sparse_mla_requested:
+            fast_topk_indices = (
+                os.environ.get("MLX_LM_GLM_DSA_FAST_TOPK", "1") == "1"
+                and hasattr(mx.fast, "dsa_topk_indices")
+            )
+            causal_prefix_indices = (
+                fast_topk_indices
+                and os.environ.get("MLX_LM_GLM_DSA_TOPK_CAUSAL_PREFIX_FASTPATH", "1")
+                == "1"
+            )
+            q_latent = self.embed_q(q_nope)
+            if (
+                os.environ.get("MLX_LM_GLM_DSA_QBLOCK_UNION_MLA", "0") == "1"
+                and hasattr(mx.fast, "dsa_topk_qblock_union")
+                and hasattr(mx.fast, "glm_dsa_sparse_mla_qblock_attention")
+            ):
+                qblock_size = int(
+                    os.environ.get("MLX_LM_GLM_DSA_QBLOCK_UNION_MLA_Q_BLOCK", "4")
+                )
+                qblock_capacity = int(
+                    os.environ.get("MLX_LM_GLM_DSA_QBLOCK_UNION_MLA_CAPACITY", "4096")
+                )
+                output = sparse_mla_qblock_attention(
+                    q_latent,
+                    q_pe,
+                    kv_latent,
+                    k_pe,
+                    topk_indices,
+                    self.scale,
+                    topk_valid_prefix=fast_topk_indices,
+                    causal_prefix_indices=causal_prefix_indices,
+                    causal_prefix_rows=topk_prefix_rows,
+                    q_block_size=qblock_size,
+                    capacity=qblock_capacity,
+                )
+                if output is not None:
+                    output_flat = q8_vup_flat(
+                        output, self.unembed_out, key_length=kv_latent.shape[2]
+                    )
+                    if output_flat is None:
+                        output = self.unembed_out(output)
+                        output_flat = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                    output = output_flat
+                    return self.o_proj(output), topk_state
+            block_table_mode = os.environ.get(
+                "MLX_LM_GLM_DSA_BLOCK_TABLE_SPARSE_MLA", "0"
+            ).lower()
+            use_block_table_mla = (
+                topk_prefix_rows == 0
+                and block_table_mode in {"1", "auto", "force"}
+                and hasattr(mx.fast, "dsa_topk_to_block_table")
+            )
+            if use_block_table_mla:
+                block_k = int(
+                    os.environ.get("MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_K_BLOCK", "8")
+                )
+                if block_table_mode != "force":
+                    k_blocks = max(1, (kv_latent.shape[2] + block_k - 1) // block_k)
+                    topk_size = max(1, topk_indices.shape[-1])
+                    expected_blocks = k_blocks * (
+                        1.0 - math.exp(topk_size * math.log1p(-1.0 / k_blocks))
+                    )
+                    expected_expansion = expected_blocks * block_k / topk_size
+                    max_expansion = float(
+                        os.environ.get(
+                            "MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_MAX_EXPANSION",
+                            "1.5",
+                        )
+                    )
+                    use_block_table_mla = expected_expansion <= max_expansion
+
+            if use_block_table_mla:
+                packed_block_table = (
+                    block_k <= 16
+                    and os.environ.get(
+                        "MLX_LM_GLM_DSA_BLOCK_TABLE_MLA_PACKED", "1"
+                    )
+                    == "1"
+                )
+                block_table = mx.fast.dsa_topk_to_block_table(
+                    topk_indices,
+                    kv_latent.shape[2],
+                    k_block_size=block_k,
+                    causal=True,
+                    packed=packed_block_table,
+                )
+                output = sparse_mla_block_table_attention(
+                    q_latent,
+                    q_pe,
+                    kv_latent,
+                    k_pe,
+                    block_table,
+                    self.scale,
+                    k_block_size=block_k,
+                )
+                if output is not None:
+                    output_flat = q8_vup_flat(
+                        output, self.unembed_out, key_length=kv_latent.shape[2]
+                    )
+                    if output_flat is None:
+                        output = self.unembed_out(output)
+                        output_flat = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                    output = output_flat
+                    return self.o_proj(output), topk_state
+            output = sparse_mla_attention(
+                q_latent,
+                q_pe,
+                kv_latent,
+                k_pe,
+                topk_indices,
+                self.scale,
+                topk_valid_prefix=fast_topk_indices,
+                causal_prefix_indices=causal_prefix_indices,
+                causal_prefix_rows=topk_prefix_rows,
+            )
+            if output is not None:
+                output_flat = q8_vup_flat(
+                    output, self.unembed_out, key_length=kv_latent.shape[2]
+                )
+                if output_flat is None:
+                    output = self.unembed_out(output)
+                    output_flat = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                output = output_flat
+                return self.o_proj(output), topk_state
+
+        if (
+            topk_indices is not None
+            and L > 8
+            and os.environ.get(
+                "MLX_LM_GLM_DSA_EXACT_BLOCK_TOKEN_SDPA",
+                "1" if exact_prefill else "0",
+            )
+            == "1"
+        ):
+            k = self.embed_q(kv_latent, transpose=False)
+            k_pe_heads = mx.broadcast_to(k_pe, k.shape[:-1] + k_pe.shape[-1:])
+            q = mx.concatenate([q_nope, q_pe], axis=-1)
+            k = mx.concatenate([k, k_pe_heads], axis=-1)
+            v = self.unembed_out(kv_latent)
+            q_block_size = int(
+                os.environ.get(
+                    "MLX_LM_GLM_DSA_EXACT_BLOCK_SDPA_Q_BLOCK",
+                    os.environ.get("MLX_LM_GLM_DSA_BLOCK_SDPA_Q_BLOCK", "32"),
+                )
+            )
+            k_block_size = int(
+                os.environ.get(
+                    "MLX_LM_GLM_DSA_EXACT_BLOCK_SDPA_K_BLOCK",
+                    os.environ.get(
+                        "MLX_LM_GLM_DSA_BLOCK_SDPA_K_BLOCK",
+                        os.environ.get("MLX_LM_GLM_DSA_BLOCK_BUDGET_K_BLOCK", "8"),
+                    ),
+                )
+            )
+            block_masks = topk_indices_to_block_masks(
+                topk_indices,
+                L=L,
+                K=kv_latent.shape[2],
+                q_block_size=q_block_size,
+                k_block_size=k_block_size,
+                causal_prefix_indices=(
+                    os.environ.get("MLX_LM_GLM_DSA_FAST_TOPK", "1") == "1"
+                    and os.environ.get(
+                        "MLX_LM_GLM_DSA_TOPK_CAUSAL_PREFIX_FASTPATH", "1"
+                    )
+                    == "1"
+                ),
+                causal_prefix_rows=topk_prefix_rows,
+            )
+            if block_masks is not None:
+                block_mask, block_token_mask = block_masks
+                output = mx.fast.scaled_dot_product_attention(
+                    q,
+                    k,
+                    v,
+                    scale=self.scale,
+                    mask="causal",
+                    block_mask=block_mask,
+                    block_token_mask=block_token_mask,
+                )
+                output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                return self.o_proj(output), topk_state
+
+        if direct_sparse_mla_requested:
+            shape = list(topk_indices.shape)
+            shape[-1] = kv_latent.shape[2]
+            sparse_mask = mx.zeros(shape, dtype=mx.bool_)
+            sparse_mask = mx.put_along_axis(
+                sparse_mask, topk_indices, mx.array(True), axis=-1
+            )
+            if mask is not None:
+                sparse_mask = sparse_mask & mask
+            mask = sparse_mask
 
         pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
         if mask is not None:
@@ -182,7 +700,7 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if seq_len == 1:
+        if L == 1:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -192,11 +710,11 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
-        if seq_len == 1:
+        if L == 1:
             output = self.unembed_out(output)
 
-        output = output.transpose(0, 2, 1, 3).reshape(batch_size, seq_len, -1)
-        return self.o_proj(output), topk_indices
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output), topk_state
 
 
 class GlmMoeDsaDecoderLayer(DeepseekV32DecoderLayer):
@@ -207,9 +725,9 @@ class GlmMoeDsaDecoderLayer(DeepseekV32DecoderLayer):
     def __call__(
         self,
         x: mx.array,
-        mask: mx.array | None = None,
-        cache: Any | None = None,
-        prev_topk_indices: mx.array | None = None,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        prev_topk_indices: Optional[mx.array] = None,
     ):
         r, topk_indices = self.self_attn(
             self.input_layernorm(x), mask, cache, prev_topk_indices
@@ -230,7 +748,7 @@ class GlmMoeDsaModel(DeepseekV32Model):
     def __call__(
         self,
         x: mx.array,
-        cache: Any | None = None,
+        cache: Optional[Any] = None,
     ) -> mx.array:
         h = self.embed_tokens(x)
 
@@ -243,6 +761,7 @@ class GlmMoeDsaModel(DeepseekV32Model):
             h, cache[0][0] if cache[0] else None, return_array=True
         )
 
+        # Receive from the previous process in the pipeline
         if pipeline_rank < pipeline_size - 1:
             h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
@@ -252,11 +771,13 @@ class GlmMoeDsaModel(DeepseekV32Model):
                 h, mask, cache[i], prev_topk_indices
             )
 
+        # Send to the next process in the pipeline
         if pipeline_rank != 0:
             h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
             if cache[-1] is not None:
                 cache[-1][0].keys = mx.depends(cache[-1][0].keys, h)
 
+        # Broadcast h while keeping it in the graph
         if pipeline_size > 1:
             h = mx.distributed.all_gather(h)[: h.shape[0]]
 
@@ -268,7 +789,23 @@ class Model(DSV32Model):
         super().__init__(config)
         self.model = GlmMoeDsaModel(config)
 
+    def sanitize(self, weights):
+        weights = super().sanitize(weights)
+        skip_prefixes = [
+            f"model.layers.{i}.self_attn.indexer."
+            for i, layer in enumerate(self.model.layers)
+            if getattr(layer.self_attn, "skip_topk", False)
+        ]
+        if skip_prefixes:
+            weights = {
+                k: v
+                for k, v in weights.items()
+                if not any(k.startswith(prefix) for prefix in skip_prefixes)
+            }
+        return weights
+
     def make_cache(self):
+        # Shared layers run no indexer, so they get no indexer KVCache.
         caches = []
         for layer in self.layers:
             if getattr(layer.self_attn, "skip_topk", False):

--- a/omlx/patches/glm_moe_dsa/kernels.py
+++ b/omlx/patches/glm_moe_dsa/kernels.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fast-kernel dispatch for the GLM MoE DSA monkey patch."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+try:
+    import omlx_glm_kernels.fast as _native_fast
+except Exception as exc:  # pragma: no cover - depends on native extension build
+    _native_fast = None
+    _native_import_error = exc
+else:
+    _native_import_error = None
+
+
+class _FastDispatch:
+    def __getattr__(self, name: str) -> Any:
+        if _native_fast is not None and _native_fast.has_symbol(name):
+            try:
+                return getattr(_native_fast, name)
+            except AttributeError:
+                pass
+        return getattr(mx.fast, name)
+
+    def __dir__(self) -> list[str]:
+        names = set(dir(mx.fast))
+        if _native_fast is not None:
+            names.update(dir(_native_fast))
+        return sorted(names)
+
+    def has(self, name: str) -> bool:
+        return (
+            (_native_fast is not None and _native_fast.has_symbol(name))
+            or hasattr(mx.fast, name)
+        )
+
+    def missing(self, required: tuple[str, ...]) -> list[str]:
+        return [name for name in required if not self.has(name)]
+
+    def native_available(self) -> bool:
+        return _native_fast is not None and _native_fast.is_native_available()
+
+    def native_import_error(self) -> Exception | None:
+        if _native_fast is not None:
+            return _native_fast.import_error()
+        return _native_import_error
+
+
+fast = _FastDispatch()
+
+__all__ = ["fast"]

--- a/omlx/patches/glm_moe_dsa/sparse_mla.py
+++ b/omlx/patches/glm_moe_dsa/sparse_mla.py
@@ -8,6 +8,8 @@ from typing import Optional
 
 import mlx.core as mx
 
+from .kernels import fast as glm_fast
+
 
 def scores_to_block_indices(
     scores: mx.array,
@@ -83,10 +85,13 @@ def _boost_recent_block_scores(
 
     q_block = mx.arange(q_blocks, dtype=mx.uint32)[:, None]
     k_block = mx.arange(k_blocks, dtype=mx.uint32)[None, :]
-    q_end_local = mx.minimum(
-        (q_block + 1) * q_block_size,
-        mx.array(query_length, dtype=mx.uint32),
-    ) - 1
+    q_end_local = (
+        mx.minimum(
+            (q_block + 1) * q_block_size,
+            mx.array(query_length, dtype=mx.uint32),
+        )
+        - 1
+    )
     q_abs_end = q_end_local + (key_length - query_length)
     end_block = q_abs_end // k_block_size
     recent_mask = (k_block <= end_block) & (k_block + recent_blocks > end_block)
@@ -138,254 +143,6 @@ def block_scores_to_indices(
 
 
 @lru_cache(maxsize=None)
-def _make_block_indices_to_block_mask_kernel():
-    if not mx.metal.is_available():
-        return None
-
-    source = r"""
-        const uint elem = thread_position_in_grid.x;
-        const uint total = B * Q_BLOCKS * BUDGET;
-        if (elem >= total) {
-          return;
-        }
-
-        const uint q_block = (elem / BUDGET) % Q_BLOCKS;
-        const uint b = elem / (BUDGET * Q_BLOCKS);
-
-        const uint k_block = block_indices[elem];
-        if (k_block >= K_BLOCKS) {
-          return;
-        }
-
-        const uint q_end_local = (q_block + 1) * Q_BLOCK < L
-            ? (q_block + 1) * Q_BLOCK
-            : L;
-        const uint q_block_end = (K - L) + q_end_local - 1;
-        const uint k_block_start = k_block * K_BLOCK;
-        if (k_block_start <= q_block_end) {
-          block_mask[((b * Q_BLOCKS + q_block) * K_BLOCKS) + k_block] = true;
-        }
-    """
-
-    return mx.fast.metal_kernel(
-        name="glm_dsa_block_indices_to_block_mask",
-        input_names=["block_indices"],
-        output_names=["block_mask"],
-        source=source,
-    )
-
-
-def block_indices_to_block_mask(
-    block_indices: mx.array,
-    *,
-    L: Optional[int] = None,
-    K: int,
-    q_block_size: int = 32,
-    k_block_size: int = 16,
-    stream: Optional[mx.Stream] = None,
-) -> Optional[mx.array]:
-    """Expand a fixed block table into the Steel SDPA block mask layout."""
-
-    if block_indices.ndim != 4 or block_indices.shape[1] != 1:
-        return None
-
-    B, _, q_blocks, budget = block_indices.shape
-    k_blocks = (K + k_block_size - 1) // k_block_size
-
-    kernel = _make_block_indices_to_block_mask_kernel()
-    if kernel is not None and L is not None:
-        return kernel(
-            inputs=[block_indices.astype(mx.uint32)],
-            template=[
-                ("B", B),
-                ("L", L),
-                ("K", K),
-                ("BUDGET", budget),
-                ("Q_BLOCK", q_block_size),
-                ("K_BLOCK", k_block_size),
-                ("Q_BLOCKS", q_blocks),
-                ("K_BLOCKS", k_blocks),
-            ],
-            grid=(B * q_blocks * budget, 1, 1),
-            threadgroup=(256, 1, 1),
-            output_shapes=[(B, 1, q_blocks, k_blocks)],
-            output_dtypes=[mx.bool_],
-            init_value=0,
-            stream=stream or mx.gpu,
-        )[0]
-
-    block_mask = mx.zeros((B, 1, q_blocks, k_blocks), dtype=mx.bool_)
-    return mx.put_along_axis(
-        block_mask,
-        block_indices.astype(mx.uint32),
-        mx.array(True),
-        axis=-1,
-    )
-
-
-@lru_cache(maxsize=None)
-def _make_topk_indices_to_block_masks_kernel():
-    if not mx.metal.is_available():
-        return None
-
-    source = r"""
-        const uint elem = thread_position_in_grid.x;
-        const uint total = B * L * TOPK;
-        if (elem >= total) {
-          return;
-        }
-
-        const uint j = elem % TOPK;
-        const uint q_pos = (elem / TOPK) % L;
-        const uint b = elem / (TOPK * L);
-
-        const uint q_abs = (K - L) + q_pos;
-        if (CAUSAL_PREFIX_INDICES && q_pos < PREFIX_ROWS) {
-          const uint valid_length = min(uint(K), q_abs + 1);
-          const uint prefix_blocks =
-              (valid_length + uint(K_BLOCK) - 1) / uint(K_BLOCK);
-          if (j >= prefix_blocks) {
-            return;
-          }
-
-          const uint q_block = q_pos / Q_BLOCK;
-          const uint k_block = j;
-          if (q_block >= Q_BLOCKS || k_block >= K_BLOCKS) {
-            return;
-          }
-
-          const uint block_idx = (b * Q_BLOCKS + q_block) * K_BLOCKS + k_block;
-          block_mask[block_idx] = true;
-
-          const uint block_start = k_block * uint(K_BLOCK);
-          const uint tokens_in_block =
-              min(uint(K_BLOCK), valid_length - block_start);
-          const uint full_bits =
-              K_BLOCK == 32 ? 0xffffffffu : ((1u << K_BLOCK) - 1u);
-          const uint bits = tokens_in_block == K_BLOCK
-              ? full_bits
-              : ((1u << tokens_in_block) - 1u);
-          const uint token_idx = (b * L + q_pos) * K_BLOCKS + k_block;
-          block_token_mask[token_idx] = bits;
-          return;
-        }
-
-        const uint topk_row = COMPACT_PREFIX_TOPK ? q_pos - PREFIX_ROWS : q_pos;
-        const uint topk_elem = (b * TOPK_ROWS + topk_row) * TOPK + j;
-        const uint k_pos = topk_indices[topk_elem];
-        if (k_pos >= K) {
-          return;
-        }
-
-        if (CAUSAL && k_pos > q_abs) {
-          return;
-        }
-
-        const uint q_block = q_pos / Q_BLOCK;
-        const uint k_block = k_pos / K_BLOCK;
-        if (q_block >= Q_BLOCKS || k_block >= K_BLOCKS) {
-          return;
-        }
-
-        const uint block_idx = (b * Q_BLOCKS + q_block) * K_BLOCKS + k_block;
-        block_mask[block_idx] = true;
-
-        const uint bit = 1u << (k_pos - k_block * K_BLOCK);
-        const uint token_idx = (b * L + q_pos) * K_BLOCKS + k_block;
-        device atomic_uint* atomic_token_mask =
-            reinterpret_cast<device atomic_uint*>(block_token_mask);
-        atomic_fetch_or_explicit(
-            &atomic_token_mask[token_idx],
-            bit,
-            memory_order_relaxed);
-    """
-
-    return mx.fast.metal_kernel(
-        name="glm_dsa_topk_indices_to_block_masks",
-        input_names=["topk_indices"],
-        output_names=["block_mask", "block_token_mask"],
-        source=source,
-    )
-
-
-def topk_indices_to_block_masks(
-    topk_indices: mx.array,
-    *,
-    L: Optional[int] = None,
-    K: int,
-    q_block_size: int = 32,
-    k_block_size: int = 16,
-    causal: bool = True,
-    causal_prefix_indices: bool = False,
-    causal_prefix_rows: int = 0,
-    stream: Optional[mx.Stream] = None,
-) -> Optional[tuple[mx.array, mx.array]]:
-    """Build block and token-bit masks for exact top-k Steel SDPA.
-
-    ``block_mask`` is shaped [B, 1, q_blocks, k_blocks]. ``block_token_mask`` is
-    shaped [B, 1, L, k_blocks] and stores one uint32 bitset per K block. This
-    preserves per-token top-k semantics while letting Steel SDPA skip K blocks
-    whose bitset would be empty for the corresponding query block.
-    """
-
-    if (
-        topk_indices.ndim != 4
-        or topk_indices.shape[1] != 1
-        or k_block_size <= 0
-        or k_block_size > 32
-        or q_block_size <= 0
-    ):
-        return None
-
-    B, _, L_in, topk = topk_indices.shape
-    L = L_in if L is None else L
-    causal_prefix_rows = max(0, min(causal_prefix_rows, L))
-    compact_prefix_topk = (
-        causal_prefix_indices
-        and causal_prefix_rows > 0
-        and L_in == L - causal_prefix_rows
-    )
-    if (L != L_in and not compact_prefix_topk) or K <= 0 or topk <= 0:
-        return None
-
-    q_blocks = (L + q_block_size - 1) // q_block_size
-    k_blocks = (K + k_block_size - 1) // k_block_size
-
-    kernel = _make_topk_indices_to_block_masks_kernel()
-    if kernel is None:
-        return None
-
-    block_mask, block_token_mask = kernel(
-        inputs=[topk_indices.astype(mx.uint32)],
-        template=[
-            ("B", B),
-            ("L", L),
-            ("K", K),
-            ("TOPK", topk),
-            ("TOPK_ROWS", L_in),
-            ("Q_BLOCK", q_block_size),
-            ("K_BLOCK", k_block_size),
-            ("Q_BLOCKS", q_blocks),
-            ("K_BLOCKS", k_blocks),
-            ("CAUSAL", causal),
-            ("CAUSAL_PREFIX_INDICES", causal_prefix_indices),
-            ("PREFIX_ROWS", causal_prefix_rows),
-            ("COMPACT_PREFIX_TOPK", compact_prefix_topk),
-        ],
-        grid=(B * L * topk, 1, 1),
-        threadgroup=(256, 1, 1),
-        output_shapes=[
-            (B, 1, q_blocks, k_blocks),
-            (B, 1, L, k_blocks),
-        ],
-        output_dtypes=[mx.bool_, mx.uint32],
-        init_value=0,
-        stream=stream or mx.gpu,
-    )
-    return block_mask, block_token_mask
-
-
-@lru_cache(maxsize=None)
 def _make_index_score_reduce_kernel():
     if not mx.metal.is_available():
         return None
@@ -418,7 +175,7 @@ def _make_index_score_reduce_kernel():
         out[elem] = static_cast<T>(acc);
     """
 
-    return mx.fast.metal_kernel(
+    return glm_fast.metal_kernel(
         name="glm_dsa_index_score_reduce",
         input_names=["head_scores", "weights"],
         output_names=["out"],
@@ -497,7 +254,7 @@ def fused_indexer_scores(
     """
 
     if (
-        not hasattr(mx.fast, "dsa_indexer_scores")
+        not hasattr(glm_fast, "dsa_indexer_scores")
         or queries.ndim != 4
         or keys.ndim != 4
         or weights.ndim != 3
@@ -509,8 +266,7 @@ def fused_indexer_scores(
         or queries.shape[1] != weights.shape[2]
         or queries.shape[3] != 128
         or keys.shape[3] != 128
-        or keys.shape[2]
-        < int(os.environ.get("MLX_LM_GLM_DSA_INDEXER_MIN_K", "4096"))
+        or keys.shape[2] < int(os.environ.get("MLX_LM_GLM_DSA_INDEXER_MIN_K", "4096"))
         or queries.dtype != keys.dtype
         or queries.dtype != weights.dtype
     ):
@@ -532,7 +288,7 @@ def fused_indexer_scores(
     if q_pad or k_pad:
         unused_causal_prefix_topk = 0
 
-    scores = mx.fast.dsa_indexer_scores(
+    scores = glm_fast.dsa_indexer_scores(
         q,
         k,
         w,
@@ -565,7 +321,7 @@ def fused_indexer_scores_high_histogram(
         "dsa_topk_indices_with_high_state",
     )
     if (
-        not all(hasattr(mx.fast, name) for name in required)
+        not all(hasattr(glm_fast, name) for name in required)
         or queries.ndim != 4
         or keys.ndim != 4
         or weights.ndim != 3
@@ -579,14 +335,13 @@ def fused_indexer_scores_high_histogram(
         or keys.shape[3] != 128
         or queries.shape[2] % 64 != 0
         or keys.shape[2] % 64 != 0
-        or keys.shape[2]
-        < int(os.environ.get("MLX_LM_GLM_DSA_INDEXER_MIN_K", "4096"))
+        or keys.shape[2] < int(os.environ.get("MLX_LM_GLM_DSA_INDEXER_MIN_K", "4096"))
         or queries.dtype != keys.dtype
         or queries.dtype != weights.dtype
     ):
         return None
 
-    scores, high_hist = mx.fast.dsa_indexer_scores_high_histogram(
+    scores, high_hist = glm_fast.dsa_indexer_scores_high_histogram(
         queries,
         keys,
         weights,
@@ -639,7 +394,9 @@ def _dsa_low_histogram_threshold(
     )
     threshold_key = high_state[..., 0] * mx.array(256, dtype=mx.uint32) + threshold_lo
     greater = greater_hi + greater_low.astype(mx.uint32)
-    return mx.stack([threshold_key.astype(mx.uint32), greater.astype(mx.uint32)], axis=-1)
+    return mx.stack(
+        [threshold_key.astype(mx.uint32), greater.astype(mx.uint32)], axis=-1
+    )
 
 
 def fused_indexer_topk_indices(
@@ -666,7 +423,7 @@ def fused_indexer_topk_indices(
         "dsa_indexer_topk_emit",
     )
     if (
-        not all(hasattr(mx.fast, name) for name in required)
+        not all(hasattr(glm_fast, name) for name in required)
         or queries.ndim != 4
         or keys.ndim != 4
         or weights.ndim != 3
@@ -681,15 +438,14 @@ def fused_indexer_topk_indices(
         or queries.shape[2] % 64 != 0
         or keys.shape[2] % 64 != 0
         or keys.shape[2] < topk
-        or keys.shape[2]
-        < int(os.environ.get("MLX_LM_GLM_DSA_INDEXER_MIN_K", "4096"))
+        or keys.shape[2] < int(os.environ.get("MLX_LM_GLM_DSA_INDEXER_MIN_K", "4096"))
         or queries.dtype != keys.dtype
         or queries.dtype != weights.dtype
     ):
         return None
 
     s = stream or mx.gpu
-    high_hist = mx.fast.dsa_indexer_score_histogram(
+    high_hist = glm_fast.dsa_indexer_score_histogram(
         queries,
         keys,
         weights,
@@ -698,7 +454,7 @@ def fused_indexer_topk_indices(
         stream=s,
     )
     high_state = _dsa_histogram_threshold(high_hist, topk)
-    low_hist = mx.fast.dsa_indexer_score_low_histogram(
+    low_hist = glm_fast.dsa_indexer_score_low_histogram(
         queries,
         keys,
         weights,
@@ -708,7 +464,7 @@ def fused_indexer_topk_indices(
         stream=s,
     )
     threshold = _dsa_low_histogram_threshold(high_state, low_hist, topk)
-    return mx.fast.dsa_indexer_topk_emit(
+    return glm_fast.dsa_indexer_topk_emit(
         queries,
         keys,
         weights,
@@ -730,7 +486,7 @@ def fused_topk_indices_with_high_histogram(
     stream: Optional[mx.Stream] = None,
 ) -> Optional[mx.array]:
     if (
-        not hasattr(mx.fast, "dsa_topk_indices_with_high_state")
+        not hasattr(glm_fast, "dsa_topk_indices_with_high_state")
         or scores.ndim != 4
         or scores.shape[1] != 1
         or high_hist.ndim != 3
@@ -742,156 +498,13 @@ def fused_topk_indices_with_high_histogram(
         return None
     s = stream or mx.gpu
     high_state = _dsa_histogram_threshold(high_hist, topk)
-    return mx.fast.dsa_topk_indices_with_high_state(
+    return glm_fast.dsa_topk_indices_with_high_state(
         scores,
         high_state,
         topk,
         bucketed=bucketed,
         causal_valid_prefix=causal_valid_prefix,
         stream=s,
-    )
-
-
-def fused_topk_block_table_from_scores(
-    scores: mx.array,
-    topk: int,
-    key_length: int,
-    *,
-    k_block_size: int = 8,
-    bucketed: bool = False,
-    causal_valid_prefix: bool = False,
-    stream: Optional[mx.Stream] = None,
-) -> Optional[mx.array]:
-    if (
-        not hasattr(mx.fast, "dsa_topk_block_table_from_scores")
-        or scores.ndim != 4
-        or scores.shape[1] != 1
-        or scores.shape[-1] != key_length
-        or k_block_size not in (8, 16)
-    ):
-        return None
-    return mx.fast.dsa_topk_block_table_from_scores(
-        scores,
-        topk,
-        key_length,
-        k_block_size=k_block_size,
-        bucketed=bucketed,
-        causal_valid_prefix=causal_valid_prefix,
-        stream=stream or mx.gpu,
-    )
-
-
-@lru_cache(maxsize=None)
-def _make_sparse_mla_prefill_kernel():
-    if not mx.metal.is_available():
-        return None
-
-    source = r"""
-        constexpr int QGROUP = 8;
-        constexpr int QD = (D_LATENT + 31) / 32;
-        constexpr int PED = (D_PE + 31) / 32;
-
-        const uint lane = thread_index_in_simdgroup;
-        const uint sg = simdgroup_index_in_threadgroup;
-
-        const uint q_pos = threadgroup_position_in_grid.x * QGROUP + sg;
-        const uint h = threadgroup_position_in_grid.y;
-        const uint b = threadgroup_position_in_grid.z;
-        if (q_pos >= L) {
-          return;
-        }
-
-        const uint q_abs = K - L + q_pos;
-
-        const uint q_base = ((b * H + h) * L + q_pos) * D_LATENT;
-        thread float q_vals[QD];
-        for (uint i = 0; i < QD; ++i) {
-          const uint d = i * 32 + lane;
-          q_vals[i] = d < D_LATENT
-              ? static_cast<float>(q_latent[q_base + d])
-              : 0.0f;
-        }
-
-        const uint qpe_base = ((b * H + h) * L + q_pos) * D_PE;
-        thread float qpe_vals[PED];
-        for (uint i = 0; i < PED; ++i) {
-          const uint d = i * 32 + lane;
-          qpe_vals[i] = d < D_PE
-              ? static_cast<float>(q_pe[qpe_base + d])
-              : 0.0f;
-        }
-
-        thread float out_vals[QD];
-        for (uint i = 0; i < QD; ++i) {
-          out_vals[i] = 0.0f;
-        }
-
-        const uint topk_base = (b * L + q_pos) * TOPK;
-        float max_score = -INFINITY;
-        float sum_exp = 0.0f;
-
-        for (uint j = 0; j < TOPK; ++j) {
-          const uint k_pos = topk[topk_base + j];
-          const bool valid = (k_pos < K) && (k_pos <= q_abs);
-
-          float score = -INFINITY;
-          if (valid) {
-            float part = 0.0f;
-
-            const uint k_base = (b * K + k_pos) * D_LATENT;
-            for (uint i = 0; i < QD; ++i) {
-              const uint d = i * 32 + lane;
-              if (d < D_LATENT) {
-                part += q_vals[i] * static_cast<float>(kv_latent[k_base + d]);
-              }
-            }
-
-            const uint kpe_base = (b * K + k_pos) * D_PE;
-            for (uint i = 0; i < PED; ++i) {
-              const uint d = i * 32 + lane;
-              if (d < D_PE) {
-                part += qpe_vals[i] * static_cast<float>(k_pe[kpe_base + d]);
-              }
-            }
-
-            score = simd_sum(part) * static_cast<float>(scale);
-          }
-
-          if (valid) {
-            const float new_max = max(max_score, score);
-            const float old_scale = fast::exp(max_score - new_max);
-            const float exp_score = fast::exp(score - new_max);
-
-            const uint v_base = (b * K + k_pos) * D_LATENT;
-            for (uint i = 0; i < QD; ++i) {
-              const uint d = i * 32 + lane;
-              if (d < D_LATENT) {
-                out_vals[i] = out_vals[i] * old_scale +
-                    exp_score * static_cast<float>(kv_latent[v_base + d]);
-              }
-            }
-
-            sum_exp = sum_exp * old_scale + exp_score;
-            max_score = new_max;
-          }
-        }
-
-        const uint out_base = ((b * H + h) * L + q_pos) * D_LATENT;
-        for (uint i = 0; i < QD; ++i) {
-          const uint d = i * 32 + lane;
-          if (d < D_LATENT) {
-            const float normalized =
-                sum_exp == 0.0f ? 0.0f : out_vals[i] / sum_exp;
-            out[out_base + d] = static_cast<T>(normalized);
-          }
-        }
-    """
-
-    return mx.fast.metal_kernel(
-        name="glm_dsa_sparse_mla_prefill",
-        input_names=["q_latent", "q_pe", "kv_latent", "k_pe", "topk", "scale"],
-        output_names=["out"],
-        source=source,
     )
 
 
@@ -938,7 +551,6 @@ def sparse_mla_attention(
     B, H, L, D_LATENT = q_latent.shape
     K = kv_latent.shape[2]
     D_PE = q_pe.shape[-1]
-    TOPK = topk_indices.shape[-1]
     topk_rows = topk_indices.shape[2]
     compact_prefix = causal_prefix_rows > 0 and topk_rows != L
 
@@ -968,218 +580,27 @@ def sparse_mla_attention(
     ):
         return None
 
-    if hasattr(mx.fast, "glm_dsa_sparse_mla_attention"):
-        topk = (
-            topk_indices
-            if topk_indices.dtype in (mx.uint32, mx.uint16)
-            else topk_indices.astype(mx.uint32)
-        )
-        if (
-            os.environ.get("MLX_LM_GLM_DSA_TOPK_PAGE_PACK", "0") == "1"
-            and hasattr(mx.fast, "dsa_topk_page_pack")
-            and topk.shape[-1] == 2048
-        ):
-            page_size = int(os.environ.get("MLX_LM_GLM_DSA_TOPK_PAGE_SIZE", "64"))
-            topk = mx.fast.dsa_topk_page_pack(
-                topk,
-                K,
-                page_size=page_size,
-                stream=stream or mx.gpu,
-            )
-        if topk_length is not None and topk_length.dtype != mx.uint32:
-            topk_length = topk_length.astype(mx.uint32)
-        return mx.fast.glm_dsa_sparse_mla_attention(
-            q_latent,
-            q_pe,
-            kv_latent,
-            k_pe,
-            topk,
-            scale,
-            topk_valid_prefix=topk_valid_prefix,
-            causal_prefix_indices=causal_prefix_indices,
-            topk_length=topk_length,
-            causal_prefix_rows=causal_prefix_rows,
-            stream=stream or mx.gpu,
-        )
-
-    kernel = _make_sparse_mla_prefill_kernel()
-    if kernel is None:
+    if not hasattr(glm_fast, "glm_dsa_sparse_mla_attention"):
         return None
 
-    qgroup = 8
-    return kernel(
-        inputs=[q_latent, q_pe, kv_latent, k_pe, topk_indices, scale],
-        template=[
-            ("T", q_latent.dtype),
-            ("B", B),
-            ("H", H),
-            ("L", L),
-            ("K", K),
-            ("D_LATENT", D_LATENT),
-            ("D_PE", D_PE),
-            ("TOPK", TOPK),
-        ],
-        grid=(256 * ((L + qgroup - 1) // qgroup), H, B),
-        threadgroup=(256, 1, 1),
-        output_shapes=[(B, H, L, D_LATENT)],
-        output_dtypes=[q_latent.dtype],
-        stream=stream or mx.gpu,
-    )[0]
-
-
-def sparse_mla_block_table_attention(
-    q_latent: mx.array,
-    q_pe: mx.array,
-    kv_latent: mx.array,
-    k_pe: mx.array,
-    block_table: mx.array,
-    scale: float,
-    *,
-    k_block_size: int = 16,
-    stream: Optional[mx.Stream] = None,
-) -> Optional[mx.array]:
-    """Sparse MLA prefill over compact block-token tables."""
-
-    packed_table = block_table.ndim == 4
-
-    if (
-        not hasattr(mx.fast, "glm_dsa_sparse_mla_block_table_attention")
-        or q_latent.ndim != 4
-        or q_pe.ndim != 4
-        or kv_latent.ndim != 4
-        or k_pe.ndim != 4
-        or block_table.ndim not in (4, 5)
-        or kv_latent.shape[1] != 1
-        or k_pe.shape[1] != 1
-        or block_table.shape[1] != 1
-        or (not packed_table and block_table.shape[-1] != 2)
-    ):
-        return None
-
-    B, H, L, D_LATENT = q_latent.shape
-    K = kv_latent.shape[2]
-    D_PE = q_pe.shape[-1]
-    if (
-        L <= 1
-        or q_pe.shape[:3] != (B, H, L)
-        or kv_latent.shape[:3] != (B, 1, K)
-        or k_pe.shape[:3] != (B, 1, K)
-        or block_table.shape[:3] != (B, 1, L)
-        or kv_latent.shape[-1] != D_LATENT
-        or k_pe.shape[-1] != D_PE
-        or D_LATENT != 512
-        or D_PE != 64
-        or q_latent.dtype not in (mx.float16, mx.bfloat16)
-        or q_pe.dtype != q_latent.dtype
-        or kv_latent.dtype != q_latent.dtype
-        or k_pe.dtype != q_latent.dtype
-        or k_block_size not in (8, 16, 32)
-        or (packed_table and k_block_size > 16)
-    ):
-        return None
-
-    table = (
-        block_table if block_table.dtype == mx.uint32 else block_table.astype(mx.uint32)
+    topk = (
+        topk_indices
+        if topk_indices.dtype == mx.uint32
+        else topk_indices.astype(mx.uint32)
     )
-    return mx.fast.glm_dsa_sparse_mla_block_table_attention(
+    if topk_length is not None and topk_length.dtype != mx.uint32:
+        topk_length = topk_length.astype(mx.uint32)
+    return glm_fast.glm_dsa_sparse_mla_attention(
         q_latent,
         q_pe,
         kv_latent,
         k_pe,
-        table,
+        topk,
         scale,
-        k_block_size=k_block_size,
-        stream=stream or mx.gpu,
-    )
-
-
-def sparse_mla_qblock_attention(
-    q_latent: mx.array,
-    q_pe: mx.array,
-    kv_latent: mx.array,
-    k_pe: mx.array,
-    topk_indices: mx.array,
-    scale: float,
-    *,
-    topk_valid_prefix: bool = False,
-    causal_prefix_indices: bool = False,
-    causal_prefix_rows: int = 0,
-    q_block_size: int = 4,
-    capacity: int = 4096,
-    stream: Optional[mx.Stream] = None,
-) -> Optional[mx.array]:
-    """Exact sparse MLA over q-block union metadata."""
-
-    if (
-        not hasattr(mx.fast, "dsa_topk_qblock_union")
-        or not hasattr(mx.fast, "glm_dsa_sparse_mla_qblock_attention")
-        or q_latent.ndim != 4
-        or q_pe.ndim != 4
-        or kv_latent.ndim != 4
-        or k_pe.ndim != 4
-        or topk_indices.ndim != 4
-        or kv_latent.shape[1] != 1
-        or k_pe.shape[1] != 1
-        or topk_indices.shape[1] != 1
-    ):
-        return None
-
-    B, H, L, D_LATENT = q_latent.shape
-    K = kv_latent.shape[2]
-    D_PE = q_pe.shape[-1]
-    compact_prefix = causal_prefix_rows > 0 and topk_indices.shape[2] != L
-    if (
-        L <= 1
-        or q_pe.shape[:3] != (B, H, L)
-        or kv_latent.shape[:3] != (B, 1, K)
-        or k_pe.shape[:3] != (B, 1, K)
-        or topk_indices.shape[:2] != (B, 1)
-        or not (
-            topk_indices.shape[2] == L
-            or (
-                compact_prefix
-                and topk_indices.shape[2] + causal_prefix_rows == L
-                and causal_prefix_indices
-                and topk_valid_prefix
-            )
-        )
-        or kv_latent.shape[-1] != D_LATENT
-        or k_pe.shape[-1] != D_PE
-        or D_LATENT != 512
-        or D_PE != 64
-        or q_latent.dtype not in (mx.float16, mx.bfloat16)
-        or q_pe.dtype != q_latent.dtype
-        or kv_latent.dtype != q_latent.dtype
-        or k_pe.dtype != q_latent.dtype
-        or topk_indices.dtype != mx.uint32
-        or q_block_size not in (2, 4)
-        or capacity not in (4096, 8192)
-    ):
-        return None
-
-    union_tokens, row_bits, lengths, _ = mx.fast.dsa_topk_qblock_union(
-        topk_indices,
-        K,
-        query_length=L,
-        q_block_size=q_block_size,
-        capacity=capacity,
-        causal=True,
         topk_valid_prefix=topk_valid_prefix,
         causal_prefix_indices=causal_prefix_indices,
+        topk_length=topk_length,
         causal_prefix_rows=causal_prefix_rows,
-        stream=stream or mx.gpu,
-    )
-    return mx.fast.glm_dsa_sparse_mla_qblock_attention(
-        q_latent,
-        q_pe,
-        kv_latent,
-        k_pe,
-        union_tokens,
-        row_bits,
-        lengths,
-        scale,
-        q_block_size=q_block_size,
-        capacity=capacity,
         stream=stream or mx.gpu,
     )
 
@@ -1204,7 +625,7 @@ def q8_vup_flat(
         return None
 
     if (
-        not hasattr(mx.fast, "glm_dsa_q8_vup_flat")
+        not hasattr(glm_fast, "glm_dsa_q8_vup_flat")
         or x.ndim != 4
         or x.shape[1] != 64
         or x.shape[-1] != 512
@@ -1223,7 +644,7 @@ def q8_vup_flat(
     scales = unembed_out["scales"]
     if weight.shape != (64, 256, 128) or scales.shape != (64, 256, 8):
         return None
-    return mx.fast.glm_dsa_q8_vup_flat(
+    return glm_fast.glm_dsa_q8_vup_flat(
         x,
         weight,
         scales,

--- a/omlx/patches/glm_moe_dsa/sparse_mla.py
+++ b/omlx/patches/glm_moe_dsa/sparse_mla.py
@@ -1,0 +1,1232 @@
+# Copyright © 2026 Apple Inc.
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Optional
+
+import mlx.core as mx
+
+
+def scores_to_block_indices(
+    scores: mx.array,
+    *,
+    block_budget: int,
+    q_block_size: int = 8,
+    k_block_size: int = 16,
+    recent_blocks: int = 0,
+    sort_indices: bool = True,
+) -> Optional[mx.array]:
+    """Select a fixed K-block table from dense DSA indexer scores.
+
+    The result is a page table shaped [B, 1, q_blocks, block_budget]. Each row
+    contains K-block ids, not token ids. This mirrors the sparse MLA metadata
+    consumed by CUDA serving engines while keeping the workspace bounded.
+    """
+
+    if scores.ndim != 4 or scores.shape[1] != 1 or block_budget <= 0:
+        return None
+
+    B, _, L, K = scores.shape
+    q_blocks = (L + q_block_size - 1) // q_block_size
+    k_blocks = (K + k_block_size - 1) // k_block_size
+    block_budget = min(block_budget, k_blocks)
+
+    pad_value = mx.array(mx.finfo(scores.dtype).min, scores.dtype)
+    if K != k_blocks * k_block_size:
+        scores = mx.pad(
+            scores,
+            [(0, 0), (0, 0), (0, 0), (0, k_blocks * k_block_size - K)],
+            constant_values=pad_value,
+        )
+    block_scores = mx.max(
+        scores.reshape(B, 1, L, k_blocks, k_block_size),
+        axis=-1,
+    )
+    if L != q_blocks * q_block_size:
+        block_scores = mx.pad(
+            block_scores,
+            [(0, 0), (0, 0), (0, q_blocks * q_block_size - L), (0, 0)],
+            constant_values=pad_value,
+        )
+    block_scores = block_scores.reshape(B, 1, q_blocks, q_block_size, k_blocks)
+    block_scores = mx.max(block_scores, axis=3)
+
+    return block_scores_to_indices(
+        block_scores,
+        block_budget=block_budget,
+        recent_blocks=recent_blocks,
+        q_block_size=q_block_size,
+        k_block_size=k_block_size,
+        query_length=L,
+        key_length=K,
+        sort_indices=sort_indices,
+    )
+
+
+def _boost_recent_block_scores(
+    block_scores: mx.array,
+    *,
+    recent_blocks: int,
+    q_block_size: int,
+    k_block_size: int,
+    query_length: int,
+    key_length: int,
+) -> mx.array:
+    if recent_blocks <= 0:
+        return block_scores
+
+    q_blocks = block_scores.shape[-2]
+    k_blocks = block_scores.shape[-1]
+    recent_blocks = min(recent_blocks, k_blocks)
+
+    q_block = mx.arange(q_blocks, dtype=mx.uint32)[:, None]
+    k_block = mx.arange(k_blocks, dtype=mx.uint32)[None, :]
+    q_end_local = mx.minimum(
+        (q_block + 1) * q_block_size,
+        mx.array(query_length, dtype=mx.uint32),
+    ) - 1
+    q_abs_end = q_end_local + (key_length - query_length)
+    end_block = q_abs_end // k_block_size
+    recent_mask = (k_block <= end_block) & (k_block + recent_blocks > end_block)
+    recent_mask = mx.reshape(recent_mask, (1, 1, q_blocks, k_blocks))
+    boost_value = mx.array(mx.finfo(block_scores.dtype).max, block_scores.dtype)
+    return mx.where(recent_mask, boost_value, block_scores)
+
+
+def block_scores_to_indices(
+    block_scores: mx.array,
+    *,
+    block_budget: int,
+    recent_blocks: int = 0,
+    q_block_size: Optional[int] = None,
+    k_block_size: Optional[int] = None,
+    query_length: Optional[int] = None,
+    key_length: Optional[int] = None,
+    sort_indices: bool = True,
+) -> Optional[mx.array]:
+    """Select block ids from pre-reduced [B, 1, q_blocks, k_blocks] scores."""
+
+    if block_scores.ndim != 4 or block_scores.shape[1] != 1 or block_budget <= 0:
+        return None
+
+    block_budget = min(block_budget, block_scores.shape[-1])
+    if recent_blocks > 0:
+        if (
+            q_block_size is None
+            or k_block_size is None
+            or query_length is None
+            or key_length is None
+        ):
+            return None
+        recent_blocks = min(recent_blocks, block_budget)
+        block_scores = _boost_recent_block_scores(
+            block_scores,
+            recent_blocks=recent_blocks,
+            q_block_size=q_block_size,
+            k_block_size=k_block_size,
+            query_length=query_length,
+            key_length=key_length,
+        )
+    indices = mx.argpartition(block_scores, kth=-block_budget, axis=-1)[
+        ..., -block_budget:
+    ].astype(mx.uint32)
+    if sort_indices:
+        indices = mx.sort(indices, axis=-1)
+    return indices
+
+
+@lru_cache(maxsize=None)
+def _make_block_indices_to_block_mask_kernel():
+    if not mx.metal.is_available():
+        return None
+
+    source = r"""
+        const uint elem = thread_position_in_grid.x;
+        const uint total = B * Q_BLOCKS * BUDGET;
+        if (elem >= total) {
+          return;
+        }
+
+        const uint q_block = (elem / BUDGET) % Q_BLOCKS;
+        const uint b = elem / (BUDGET * Q_BLOCKS);
+
+        const uint k_block = block_indices[elem];
+        if (k_block >= K_BLOCKS) {
+          return;
+        }
+
+        const uint q_end_local = (q_block + 1) * Q_BLOCK < L
+            ? (q_block + 1) * Q_BLOCK
+            : L;
+        const uint q_block_end = (K - L) + q_end_local - 1;
+        const uint k_block_start = k_block * K_BLOCK;
+        if (k_block_start <= q_block_end) {
+          block_mask[((b * Q_BLOCKS + q_block) * K_BLOCKS) + k_block] = true;
+        }
+    """
+
+    return mx.fast.metal_kernel(
+        name="glm_dsa_block_indices_to_block_mask",
+        input_names=["block_indices"],
+        output_names=["block_mask"],
+        source=source,
+    )
+
+
+def block_indices_to_block_mask(
+    block_indices: mx.array,
+    *,
+    L: Optional[int] = None,
+    K: int,
+    q_block_size: int = 32,
+    k_block_size: int = 16,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Expand a fixed block table into the Steel SDPA block mask layout."""
+
+    if block_indices.ndim != 4 or block_indices.shape[1] != 1:
+        return None
+
+    B, _, q_blocks, budget = block_indices.shape
+    k_blocks = (K + k_block_size - 1) // k_block_size
+
+    kernel = _make_block_indices_to_block_mask_kernel()
+    if kernel is not None and L is not None:
+        return kernel(
+            inputs=[block_indices.astype(mx.uint32)],
+            template=[
+                ("B", B),
+                ("L", L),
+                ("K", K),
+                ("BUDGET", budget),
+                ("Q_BLOCK", q_block_size),
+                ("K_BLOCK", k_block_size),
+                ("Q_BLOCKS", q_blocks),
+                ("K_BLOCKS", k_blocks),
+            ],
+            grid=(B * q_blocks * budget, 1, 1),
+            threadgroup=(256, 1, 1),
+            output_shapes=[(B, 1, q_blocks, k_blocks)],
+            output_dtypes=[mx.bool_],
+            init_value=0,
+            stream=stream or mx.gpu,
+        )[0]
+
+    block_mask = mx.zeros((B, 1, q_blocks, k_blocks), dtype=mx.bool_)
+    return mx.put_along_axis(
+        block_mask,
+        block_indices.astype(mx.uint32),
+        mx.array(True),
+        axis=-1,
+    )
+
+
+@lru_cache(maxsize=None)
+def _make_topk_indices_to_block_masks_kernel():
+    if not mx.metal.is_available():
+        return None
+
+    source = r"""
+        const uint elem = thread_position_in_grid.x;
+        const uint total = B * L * TOPK;
+        if (elem >= total) {
+          return;
+        }
+
+        const uint j = elem % TOPK;
+        const uint q_pos = (elem / TOPK) % L;
+        const uint b = elem / (TOPK * L);
+
+        const uint q_abs = (K - L) + q_pos;
+        if (CAUSAL_PREFIX_INDICES && q_pos < PREFIX_ROWS) {
+          const uint valid_length = min(uint(K), q_abs + 1);
+          const uint prefix_blocks =
+              (valid_length + uint(K_BLOCK) - 1) / uint(K_BLOCK);
+          if (j >= prefix_blocks) {
+            return;
+          }
+
+          const uint q_block = q_pos / Q_BLOCK;
+          const uint k_block = j;
+          if (q_block >= Q_BLOCKS || k_block >= K_BLOCKS) {
+            return;
+          }
+
+          const uint block_idx = (b * Q_BLOCKS + q_block) * K_BLOCKS + k_block;
+          block_mask[block_idx] = true;
+
+          const uint block_start = k_block * uint(K_BLOCK);
+          const uint tokens_in_block =
+              min(uint(K_BLOCK), valid_length - block_start);
+          const uint full_bits =
+              K_BLOCK == 32 ? 0xffffffffu : ((1u << K_BLOCK) - 1u);
+          const uint bits = tokens_in_block == K_BLOCK
+              ? full_bits
+              : ((1u << tokens_in_block) - 1u);
+          const uint token_idx = (b * L + q_pos) * K_BLOCKS + k_block;
+          block_token_mask[token_idx] = bits;
+          return;
+        }
+
+        const uint topk_row = COMPACT_PREFIX_TOPK ? q_pos - PREFIX_ROWS : q_pos;
+        const uint topk_elem = (b * TOPK_ROWS + topk_row) * TOPK + j;
+        const uint k_pos = topk_indices[topk_elem];
+        if (k_pos >= K) {
+          return;
+        }
+
+        if (CAUSAL && k_pos > q_abs) {
+          return;
+        }
+
+        const uint q_block = q_pos / Q_BLOCK;
+        const uint k_block = k_pos / K_BLOCK;
+        if (q_block >= Q_BLOCKS || k_block >= K_BLOCKS) {
+          return;
+        }
+
+        const uint block_idx = (b * Q_BLOCKS + q_block) * K_BLOCKS + k_block;
+        block_mask[block_idx] = true;
+
+        const uint bit = 1u << (k_pos - k_block * K_BLOCK);
+        const uint token_idx = (b * L + q_pos) * K_BLOCKS + k_block;
+        device atomic_uint* atomic_token_mask =
+            reinterpret_cast<device atomic_uint*>(block_token_mask);
+        atomic_fetch_or_explicit(
+            &atomic_token_mask[token_idx],
+            bit,
+            memory_order_relaxed);
+    """
+
+    return mx.fast.metal_kernel(
+        name="glm_dsa_topk_indices_to_block_masks",
+        input_names=["topk_indices"],
+        output_names=["block_mask", "block_token_mask"],
+        source=source,
+    )
+
+
+def topk_indices_to_block_masks(
+    topk_indices: mx.array,
+    *,
+    L: Optional[int] = None,
+    K: int,
+    q_block_size: int = 32,
+    k_block_size: int = 16,
+    causal: bool = True,
+    causal_prefix_indices: bool = False,
+    causal_prefix_rows: int = 0,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[tuple[mx.array, mx.array]]:
+    """Build block and token-bit masks for exact top-k Steel SDPA.
+
+    ``block_mask`` is shaped [B, 1, q_blocks, k_blocks]. ``block_token_mask`` is
+    shaped [B, 1, L, k_blocks] and stores one uint32 bitset per K block. This
+    preserves per-token top-k semantics while letting Steel SDPA skip K blocks
+    whose bitset would be empty for the corresponding query block.
+    """
+
+    if (
+        topk_indices.ndim != 4
+        or topk_indices.shape[1] != 1
+        or k_block_size <= 0
+        or k_block_size > 32
+        or q_block_size <= 0
+    ):
+        return None
+
+    B, _, L_in, topk = topk_indices.shape
+    L = L_in if L is None else L
+    causal_prefix_rows = max(0, min(causal_prefix_rows, L))
+    compact_prefix_topk = (
+        causal_prefix_indices
+        and causal_prefix_rows > 0
+        and L_in == L - causal_prefix_rows
+    )
+    if (L != L_in and not compact_prefix_topk) or K <= 0 or topk <= 0:
+        return None
+
+    q_blocks = (L + q_block_size - 1) // q_block_size
+    k_blocks = (K + k_block_size - 1) // k_block_size
+
+    kernel = _make_topk_indices_to_block_masks_kernel()
+    if kernel is None:
+        return None
+
+    block_mask, block_token_mask = kernel(
+        inputs=[topk_indices.astype(mx.uint32)],
+        template=[
+            ("B", B),
+            ("L", L),
+            ("K", K),
+            ("TOPK", topk),
+            ("TOPK_ROWS", L_in),
+            ("Q_BLOCK", q_block_size),
+            ("K_BLOCK", k_block_size),
+            ("Q_BLOCKS", q_blocks),
+            ("K_BLOCKS", k_blocks),
+            ("CAUSAL", causal),
+            ("CAUSAL_PREFIX_INDICES", causal_prefix_indices),
+            ("PREFIX_ROWS", causal_prefix_rows),
+            ("COMPACT_PREFIX_TOPK", compact_prefix_topk),
+        ],
+        grid=(B * L * topk, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[
+            (B, 1, q_blocks, k_blocks),
+            (B, 1, L, k_blocks),
+        ],
+        output_dtypes=[mx.bool_, mx.uint32],
+        init_value=0,
+        stream=stream or mx.gpu,
+    )
+    return block_mask, block_token_mask
+
+
+@lru_cache(maxsize=None)
+def _make_index_score_reduce_kernel():
+    if not mx.metal.is_available():
+        return None
+
+    source = r"""
+        const uint elem = thread_position_in_grid.x;
+        const uint total = B * L * K;
+        if (elem >= total) {
+          return;
+        }
+
+        const uint k_pos = elem % K;
+        const uint q_pos = (elem / K) % L;
+        const uint b = elem / (L * K);
+
+        if (CAUSAL && k_pos > K - L + q_pos) {
+          out[elem] = static_cast<T>(-INFINITY);
+          return;
+        }
+
+        float acc = 0.0f;
+        #pragma clang loop unroll(full)
+        for (uint h = 0; h < H; ++h) {
+          const uint score_idx = ((b * H + h) * L + q_pos) * K + k_pos;
+          const uint weight_idx = (b * H + h) * L + q_pos;
+          const float s = static_cast<float>(head_scores[score_idx]);
+          const float w = static_cast<float>(weights[weight_idx]);
+          acc += metal::max(s, 0.0f) * w;
+        }
+        out[elem] = static_cast<T>(acc);
+    """
+
+    return mx.fast.metal_kernel(
+        name="glm_dsa_index_score_reduce",
+        input_names=["head_scores", "weights"],
+        output_names=["out"],
+        source=source,
+    )
+
+
+def fused_index_score_reduce(
+    head_scores: mx.array,
+    weights: mx.array,
+    *,
+    causal: bool = False,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Fuse ReLU, per-head weighting, causal fill, and head reduction."""
+
+    kernel = _make_index_score_reduce_kernel()
+    if (
+        kernel is None
+        or head_scores.ndim != 4
+        or weights.ndim != 4
+        or weights.shape[-1] != 1
+        or head_scores.shape[:3] != weights.shape[:3]
+    ):
+        return None
+
+    B, H, L, K = head_scores.shape
+    short_k_threadgroup = int(
+        os.environ.get("MLX_LM_GLM_DSA_INDEX_REDUCE_THREADGROUP_SIZE", "512")
+    )
+    long_k_threshold = int(
+        os.environ.get("MLX_LM_GLM_DSA_INDEX_REDUCE_LONG_K_THRESHOLD", "32768")
+    )
+    long_k_threadgroup = int(
+        os.environ.get("MLX_LM_GLM_DSA_INDEX_REDUCE_LONG_K_THREADGROUP_SIZE", "256")
+    )
+    threadgroup_size = (
+        long_k_threadgroup if K > long_k_threshold else short_k_threadgroup
+    )
+    return kernel(
+        inputs=[head_scores, weights],
+        template=[
+            ("T", head_scores.dtype),
+            ("B", B),
+            ("H", H),
+            ("L", L),
+            ("K", K),
+            ("CAUSAL", causal),
+        ],
+        grid=(B * L * K, 1, 1),
+        threadgroup=(threadgroup_size, 1, 1),
+        output_shapes=[(B, 1, L, K)],
+        output_dtypes=[head_scores.dtype],
+        stream=stream or mx.gpu,
+    )[0]
+
+
+def fused_indexer_scores(
+    queries: mx.array,
+    keys: mx.array,
+    weights: mx.array,
+    *,
+    causal: bool = False,
+    unused_causal_prefix_topk: int = 0,
+    skip_causal_future_store: bool = False,
+    causal_q_offset: int = -1,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Compute GLM DSA indexer logits without materializing per-head scores.
+
+    This is the MLX equivalent of the vLLM/SGLang MQA-logits indexer path:
+    the Steel kernel computes ``sum_h relu(q_h @ k.T) * weight_h`` directly
+    into [B, 1, L, K]. The Metal kernel is specialized for GLM-5.2's
+    [H=32, D=128] indexer and 64-token M/N tiles, so non-multiple prompt
+    lengths are padded and sliced back exactly.
+    """
+
+    if (
+        not hasattr(mx.fast, "dsa_indexer_scores")
+        or queries.ndim != 4
+        or keys.ndim != 4
+        or weights.ndim != 3
+        or queries.shape[0] != keys.shape[0]
+        or queries.shape[0] != weights.shape[0]
+        or queries.shape[1] != 32
+        or keys.shape[1] != 1
+        or queries.shape[2] != weights.shape[1]
+        or queries.shape[1] != weights.shape[2]
+        or queries.shape[3] != 128
+        or keys.shape[3] != 128
+        or keys.shape[2]
+        < int(os.environ.get("MLX_LM_GLM_DSA_INDEXER_MIN_K", "4096"))
+        or queries.dtype != keys.dtype
+        or queries.dtype != weights.dtype
+    ):
+        return None
+
+    B, H, L, D = queries.shape
+    K = keys.shape[2]
+    q_pad = (-L) % 64
+    k_pad = (-K) % 64
+
+    q = queries
+    k = keys
+    w = weights
+    if q_pad:
+        q = mx.pad(q, [(0, 0), (0, 0), (0, q_pad), (0, 0)])
+        w = mx.pad(w, [(0, 0), (0, q_pad), (0, 0)])
+    if k_pad:
+        k = mx.pad(k, [(0, 0), (0, 0), (0, k_pad), (0, 0)])
+    if q_pad or k_pad:
+        unused_causal_prefix_topk = 0
+
+    scores = mx.fast.dsa_indexer_scores(
+        q,
+        k,
+        w,
+        causal=causal,
+        unused_causal_prefix_topk=unused_causal_prefix_topk,
+        skip_causal_future_store=skip_causal_future_store,
+        causal_q_offset=causal_q_offset,
+        stream=stream or mx.gpu,
+    )
+    if q_pad or k_pad:
+        scores = scores[:, :, :L, :K]
+    return scores
+
+
+def fused_indexer_scores_high_histogram(
+    queries: mx.array,
+    keys: mx.array,
+    weights: mx.array,
+    *,
+    causal: bool = False,
+    unused_causal_prefix_topk: int = 0,
+    skip_causal_future_store: bool = False,
+    causal_q_offset: int = -1,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[tuple[mx.array, mx.array]]:
+    """Compute exact indexer scores plus high-byte top-k histogram state."""
+
+    required = (
+        "dsa_indexer_scores_high_histogram",
+        "dsa_topk_indices_with_high_state",
+    )
+    if (
+        not all(hasattr(mx.fast, name) for name in required)
+        or queries.ndim != 4
+        or keys.ndim != 4
+        or weights.ndim != 3
+        or queries.shape[0] != keys.shape[0]
+        or queries.shape[0] != weights.shape[0]
+        or queries.shape[1] != 32
+        or keys.shape[1] != 1
+        or queries.shape[2] != weights.shape[1]
+        or queries.shape[1] != weights.shape[2]
+        or queries.shape[3] != 128
+        or keys.shape[3] != 128
+        or queries.shape[2] % 64 != 0
+        or keys.shape[2] % 64 != 0
+        or keys.shape[2]
+        < int(os.environ.get("MLX_LM_GLM_DSA_INDEXER_MIN_K", "4096"))
+        or queries.dtype != keys.dtype
+        or queries.dtype != weights.dtype
+    ):
+        return None
+
+    scores, high_hist = mx.fast.dsa_indexer_scores_high_histogram(
+        queries,
+        keys,
+        weights,
+        causal=causal,
+        unused_causal_prefix_topk=unused_causal_prefix_topk,
+        skip_causal_future_store=skip_causal_future_store,
+        causal_q_offset=causal_q_offset,
+        stream=stream or mx.gpu,
+    )
+    return scores, high_hist
+
+
+def _dsa_histogram_threshold(hist: mx.array, topk: int) -> mx.array:
+    rev_cumsum = mx.cumsum(hist[..., ::-1], axis=-1)
+    target = mx.array(topk, dtype=mx.uint32)
+    rev_idx = mx.argmax((rev_cumsum >= target).astype(mx.uint32), axis=-1)
+    threshold_hi = (mx.array(255, dtype=mx.uint32) - rev_idx).astype(mx.uint32)
+
+    prev_idx = mx.maximum(
+        rev_idx.astype(mx.int32) - mx.array(1, dtype=mx.int32),
+        mx.array(0, dtype=mx.int32),
+    ).astype(mx.uint32)
+    prev = mx.take_along_axis(rev_cumsum, prev_idx[..., None], axis=-1)[..., 0]
+    greater = mx.where(
+        rev_idx > mx.array(0, dtype=mx.uint32),
+        prev,
+        mx.array(0, dtype=mx.uint32),
+    )
+    return mx.stack([threshold_hi, greater.astype(mx.uint32)], axis=-1)
+
+
+def _dsa_low_histogram_threshold(
+    high_state: mx.array, low_hist: mx.array, topk: int
+) -> mx.array:
+    greater_hi = high_state[..., 1]
+    target = mx.array(topk, dtype=mx.uint32) - greater_hi
+    rev_cumsum = mx.cumsum(low_hist[..., ::-1], axis=-1)
+    rev_idx = mx.argmax((rev_cumsum >= target[..., None]).astype(mx.uint32), axis=-1)
+    threshold_lo = (mx.array(255, dtype=mx.uint32) - rev_idx).astype(mx.uint32)
+
+    prev_idx = mx.maximum(
+        rev_idx.astype(mx.int32) - mx.array(1, dtype=mx.int32),
+        mx.array(0, dtype=mx.int32),
+    ).astype(mx.uint32)
+    prev = mx.take_along_axis(rev_cumsum, prev_idx[..., None], axis=-1)[..., 0]
+    greater_low = mx.where(
+        rev_idx > mx.array(0, dtype=mx.uint32),
+        prev,
+        mx.array(0, dtype=mx.uint32),
+    )
+    threshold_key = high_state[..., 0] * mx.array(256, dtype=mx.uint32) + threshold_lo
+    greater = greater_hi + greater_low.astype(mx.uint32)
+    return mx.stack([threshold_key.astype(mx.uint32), greater.astype(mx.uint32)], axis=-1)
+
+
+def fused_indexer_topk_indices(
+    queries: mx.array,
+    keys: mx.array,
+    weights: mx.array,
+    topk: int,
+    *,
+    causal: bool = False,
+    causal_q_offset: int = -1,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Exact GLM DSA indexer top-k without a materialized score matrix.
+
+    The implementation mirrors the existing 16-bit radix top-k, but moves the
+    score production into Steel MMA passes: high-byte histogram, low-byte
+    histogram for the threshold bucket, then index emission. It preserves exact
+    top-k semantics up to normal equal-score tie freedom.
+    """
+
+    required = (
+        "dsa_indexer_score_histogram",
+        "dsa_indexer_score_low_histogram",
+        "dsa_indexer_topk_emit",
+    )
+    if (
+        not all(hasattr(mx.fast, name) for name in required)
+        or queries.ndim != 4
+        or keys.ndim != 4
+        or weights.ndim != 3
+        or queries.shape[0] != keys.shape[0]
+        or queries.shape[0] != weights.shape[0]
+        or queries.shape[1] != 32
+        or keys.shape[1] != 1
+        or queries.shape[2] != weights.shape[1]
+        or queries.shape[1] != weights.shape[2]
+        or queries.shape[3] != 128
+        or keys.shape[3] != 128
+        or queries.shape[2] % 64 != 0
+        or keys.shape[2] % 64 != 0
+        or keys.shape[2] < topk
+        or keys.shape[2]
+        < int(os.environ.get("MLX_LM_GLM_DSA_INDEXER_MIN_K", "4096"))
+        or queries.dtype != keys.dtype
+        or queries.dtype != weights.dtype
+    ):
+        return None
+
+    s = stream or mx.gpu
+    high_hist = mx.fast.dsa_indexer_score_histogram(
+        queries,
+        keys,
+        weights,
+        causal=causal,
+        causal_q_offset=causal_q_offset,
+        stream=s,
+    )
+    high_state = _dsa_histogram_threshold(high_hist, topk)
+    low_hist = mx.fast.dsa_indexer_score_low_histogram(
+        queries,
+        keys,
+        weights,
+        high_state,
+        causal=causal,
+        causal_q_offset=causal_q_offset,
+        stream=s,
+    )
+    threshold = _dsa_low_histogram_threshold(high_state, low_hist, topk)
+    return mx.fast.dsa_indexer_topk_emit(
+        queries,
+        keys,
+        weights,
+        threshold,
+        topk,
+        causal=causal,
+        causal_q_offset=causal_q_offset,
+        stream=s,
+    )
+
+
+def fused_topk_indices_with_high_histogram(
+    scores: mx.array,
+    high_hist: mx.array,
+    topk: int,
+    *,
+    bucketed: bool = False,
+    causal_valid_prefix: bool = False,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    if (
+        not hasattr(mx.fast, "dsa_topk_indices_with_high_state")
+        or scores.ndim != 4
+        or scores.shape[1] != 1
+        or high_hist.ndim != 3
+        or high_hist.shape[0] != scores.shape[0]
+        or high_hist.shape[1] != scores.shape[2]
+        or high_hist.shape[2] != 256
+        or high_hist.dtype != mx.uint32
+    ):
+        return None
+    s = stream or mx.gpu
+    high_state = _dsa_histogram_threshold(high_hist, topk)
+    return mx.fast.dsa_topk_indices_with_high_state(
+        scores,
+        high_state,
+        topk,
+        bucketed=bucketed,
+        causal_valid_prefix=causal_valid_prefix,
+        stream=s,
+    )
+
+
+def fused_topk_block_table_from_scores(
+    scores: mx.array,
+    topk: int,
+    key_length: int,
+    *,
+    k_block_size: int = 8,
+    bucketed: bool = False,
+    causal_valid_prefix: bool = False,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    if (
+        not hasattr(mx.fast, "dsa_topk_block_table_from_scores")
+        or scores.ndim != 4
+        or scores.shape[1] != 1
+        or scores.shape[-1] != key_length
+        or k_block_size not in (8, 16)
+    ):
+        return None
+    return mx.fast.dsa_topk_block_table_from_scores(
+        scores,
+        topk,
+        key_length,
+        k_block_size=k_block_size,
+        bucketed=bucketed,
+        causal_valid_prefix=causal_valid_prefix,
+        stream=stream or mx.gpu,
+    )
+
+
+@lru_cache(maxsize=None)
+def _make_sparse_mla_prefill_kernel():
+    if not mx.metal.is_available():
+        return None
+
+    source = r"""
+        constexpr int QGROUP = 8;
+        constexpr int QD = (D_LATENT + 31) / 32;
+        constexpr int PED = (D_PE + 31) / 32;
+
+        const uint lane = thread_index_in_simdgroup;
+        const uint sg = simdgroup_index_in_threadgroup;
+
+        const uint q_pos = threadgroup_position_in_grid.x * QGROUP + sg;
+        const uint h = threadgroup_position_in_grid.y;
+        const uint b = threadgroup_position_in_grid.z;
+        if (q_pos >= L) {
+          return;
+        }
+
+        const uint q_abs = K - L + q_pos;
+
+        const uint q_base = ((b * H + h) * L + q_pos) * D_LATENT;
+        thread float q_vals[QD];
+        for (uint i = 0; i < QD; ++i) {
+          const uint d = i * 32 + lane;
+          q_vals[i] = d < D_LATENT
+              ? static_cast<float>(q_latent[q_base + d])
+              : 0.0f;
+        }
+
+        const uint qpe_base = ((b * H + h) * L + q_pos) * D_PE;
+        thread float qpe_vals[PED];
+        for (uint i = 0; i < PED; ++i) {
+          const uint d = i * 32 + lane;
+          qpe_vals[i] = d < D_PE
+              ? static_cast<float>(q_pe[qpe_base + d])
+              : 0.0f;
+        }
+
+        thread float out_vals[QD];
+        for (uint i = 0; i < QD; ++i) {
+          out_vals[i] = 0.0f;
+        }
+
+        const uint topk_base = (b * L + q_pos) * TOPK;
+        float max_score = -INFINITY;
+        float sum_exp = 0.0f;
+
+        for (uint j = 0; j < TOPK; ++j) {
+          const uint k_pos = topk[topk_base + j];
+          const bool valid = (k_pos < K) && (k_pos <= q_abs);
+
+          float score = -INFINITY;
+          if (valid) {
+            float part = 0.0f;
+
+            const uint k_base = (b * K + k_pos) * D_LATENT;
+            for (uint i = 0; i < QD; ++i) {
+              const uint d = i * 32 + lane;
+              if (d < D_LATENT) {
+                part += q_vals[i] * static_cast<float>(kv_latent[k_base + d]);
+              }
+            }
+
+            const uint kpe_base = (b * K + k_pos) * D_PE;
+            for (uint i = 0; i < PED; ++i) {
+              const uint d = i * 32 + lane;
+              if (d < D_PE) {
+                part += qpe_vals[i] * static_cast<float>(k_pe[kpe_base + d]);
+              }
+            }
+
+            score = simd_sum(part) * static_cast<float>(scale);
+          }
+
+          if (valid) {
+            const float new_max = max(max_score, score);
+            const float old_scale = fast::exp(max_score - new_max);
+            const float exp_score = fast::exp(score - new_max);
+
+            const uint v_base = (b * K + k_pos) * D_LATENT;
+            for (uint i = 0; i < QD; ++i) {
+              const uint d = i * 32 + lane;
+              if (d < D_LATENT) {
+                out_vals[i] = out_vals[i] * old_scale +
+                    exp_score * static_cast<float>(kv_latent[v_base + d]);
+              }
+            }
+
+            sum_exp = sum_exp * old_scale + exp_score;
+            max_score = new_max;
+          }
+        }
+
+        const uint out_base = ((b * H + h) * L + q_pos) * D_LATENT;
+        for (uint i = 0; i < QD; ++i) {
+          const uint d = i * 32 + lane;
+          if (d < D_LATENT) {
+            const float normalized =
+                sum_exp == 0.0f ? 0.0f : out_vals[i] / sum_exp;
+            out[out_base + d] = static_cast<T>(normalized);
+          }
+        }
+    """
+
+    return mx.fast.metal_kernel(
+        name="glm_dsa_sparse_mla_prefill",
+        input_names=["q_latent", "q_pe", "kv_latent", "k_pe", "topk", "scale"],
+        output_names=["out"],
+        source=source,
+    )
+
+
+def sparse_mla_attention(
+    q_latent: mx.array,
+    q_pe: mx.array,
+    kv_latent: mx.array,
+    k_pe: mx.array,
+    topk_indices: mx.array,
+    scale: float,
+    *,
+    topk_valid_prefix: bool = False,
+    causal_prefix_indices: bool = False,
+    topk_length: Optional[mx.array] = None,
+    causal_prefix_rows: int = 0,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Sparse MLA prefill over per-query DSA top-k indices.
+
+    This mirrors the FlashMLA sparse prefill contract used by vLLM/SGLang:
+    attention scores are computed over [latent, rope] keys, values are the
+    latent KV cache, and the caller applies the MLA output projection after.
+
+    Shapes:
+      q_latent: [B, H, L, 512]
+      q_pe: [B, H, L, 64]
+      kv_latent: [B, 1, K, 512]
+      k_pe: [B, 1, K, 64]
+      topk_indices: [B, 1, L, TOPK]
+      topk_length: optional [B, L] or [B, 1, L] valid prefix length
+    """
+
+    if (
+        q_latent.ndim != 4
+        or q_pe.ndim != 4
+        or kv_latent.ndim != 4
+        or k_pe.ndim != 4
+        or topk_indices.ndim != 4
+        or kv_latent.shape[1] != 1
+        or k_pe.shape[1] != 1
+    ):
+        return None
+
+    B, H, L, D_LATENT = q_latent.shape
+    K = kv_latent.shape[2]
+    D_PE = q_pe.shape[-1]
+    TOPK = topk_indices.shape[-1]
+    topk_rows = topk_indices.shape[2]
+    compact_prefix = causal_prefix_rows > 0 and topk_rows != L
+
+    if (
+        L <= 1
+        or q_pe.shape[:3] != (B, H, L)
+        or kv_latent.shape[:3] != (B, 1, K)
+        or k_pe.shape[:3] != (B, 1, K)
+        or topk_indices.shape[:2] != (B, 1)
+        or not (
+            topk_rows == L
+            or (
+                compact_prefix
+                and topk_rows + causal_prefix_rows == L
+                and causal_prefix_indices
+                and topk_valid_prefix
+            )
+        )
+        or kv_latent.shape[-1] != D_LATENT
+        or k_pe.shape[-1] != D_PE
+        or D_LATENT != 512
+        or D_PE != 64
+        or q_latent.dtype not in (mx.float16, mx.bfloat16)
+        or q_pe.dtype != q_latent.dtype
+        or kv_latent.dtype != q_latent.dtype
+        or k_pe.dtype != q_latent.dtype
+    ):
+        return None
+
+    if hasattr(mx.fast, "glm_dsa_sparse_mla_attention"):
+        topk = (
+            topk_indices
+            if topk_indices.dtype in (mx.uint32, mx.uint16)
+            else topk_indices.astype(mx.uint32)
+        )
+        if (
+            os.environ.get("MLX_LM_GLM_DSA_TOPK_PAGE_PACK", "0") == "1"
+            and hasattr(mx.fast, "dsa_topk_page_pack")
+            and topk.shape[-1] == 2048
+        ):
+            page_size = int(os.environ.get("MLX_LM_GLM_DSA_TOPK_PAGE_SIZE", "64"))
+            topk = mx.fast.dsa_topk_page_pack(
+                topk,
+                K,
+                page_size=page_size,
+                stream=stream or mx.gpu,
+            )
+        if topk_length is not None and topk_length.dtype != mx.uint32:
+            topk_length = topk_length.astype(mx.uint32)
+        return mx.fast.glm_dsa_sparse_mla_attention(
+            q_latent,
+            q_pe,
+            kv_latent,
+            k_pe,
+            topk,
+            scale,
+            topk_valid_prefix=topk_valid_prefix,
+            causal_prefix_indices=causal_prefix_indices,
+            topk_length=topk_length,
+            causal_prefix_rows=causal_prefix_rows,
+            stream=stream or mx.gpu,
+        )
+
+    kernel = _make_sparse_mla_prefill_kernel()
+    if kernel is None:
+        return None
+
+    qgroup = 8
+    return kernel(
+        inputs=[q_latent, q_pe, kv_latent, k_pe, topk_indices, scale],
+        template=[
+            ("T", q_latent.dtype),
+            ("B", B),
+            ("H", H),
+            ("L", L),
+            ("K", K),
+            ("D_LATENT", D_LATENT),
+            ("D_PE", D_PE),
+            ("TOPK", TOPK),
+        ],
+        grid=(256 * ((L + qgroup - 1) // qgroup), H, B),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(B, H, L, D_LATENT)],
+        output_dtypes=[q_latent.dtype],
+        stream=stream or mx.gpu,
+    )[0]
+
+
+def sparse_mla_block_table_attention(
+    q_latent: mx.array,
+    q_pe: mx.array,
+    kv_latent: mx.array,
+    k_pe: mx.array,
+    block_table: mx.array,
+    scale: float,
+    *,
+    k_block_size: int = 16,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Sparse MLA prefill over compact block-token tables."""
+
+    packed_table = block_table.ndim == 4
+
+    if (
+        not hasattr(mx.fast, "glm_dsa_sparse_mla_block_table_attention")
+        or q_latent.ndim != 4
+        or q_pe.ndim != 4
+        or kv_latent.ndim != 4
+        or k_pe.ndim != 4
+        or block_table.ndim not in (4, 5)
+        or kv_latent.shape[1] != 1
+        or k_pe.shape[1] != 1
+        or block_table.shape[1] != 1
+        or (not packed_table and block_table.shape[-1] != 2)
+    ):
+        return None
+
+    B, H, L, D_LATENT = q_latent.shape
+    K = kv_latent.shape[2]
+    D_PE = q_pe.shape[-1]
+    if (
+        L <= 1
+        or q_pe.shape[:3] != (B, H, L)
+        or kv_latent.shape[:3] != (B, 1, K)
+        or k_pe.shape[:3] != (B, 1, K)
+        or block_table.shape[:3] != (B, 1, L)
+        or kv_latent.shape[-1] != D_LATENT
+        or k_pe.shape[-1] != D_PE
+        or D_LATENT != 512
+        or D_PE != 64
+        or q_latent.dtype not in (mx.float16, mx.bfloat16)
+        or q_pe.dtype != q_latent.dtype
+        or kv_latent.dtype != q_latent.dtype
+        or k_pe.dtype != q_latent.dtype
+        or k_block_size not in (8, 16, 32)
+        or (packed_table and k_block_size > 16)
+    ):
+        return None
+
+    table = (
+        block_table if block_table.dtype == mx.uint32 else block_table.astype(mx.uint32)
+    )
+    return mx.fast.glm_dsa_sparse_mla_block_table_attention(
+        q_latent,
+        q_pe,
+        kv_latent,
+        k_pe,
+        table,
+        scale,
+        k_block_size=k_block_size,
+        stream=stream or mx.gpu,
+    )
+
+
+def sparse_mla_qblock_attention(
+    q_latent: mx.array,
+    q_pe: mx.array,
+    kv_latent: mx.array,
+    k_pe: mx.array,
+    topk_indices: mx.array,
+    scale: float,
+    *,
+    topk_valid_prefix: bool = False,
+    causal_prefix_indices: bool = False,
+    causal_prefix_rows: int = 0,
+    q_block_size: int = 4,
+    capacity: int = 4096,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Exact sparse MLA over q-block union metadata."""
+
+    if (
+        not hasattr(mx.fast, "dsa_topk_qblock_union")
+        or not hasattr(mx.fast, "glm_dsa_sparse_mla_qblock_attention")
+        or q_latent.ndim != 4
+        or q_pe.ndim != 4
+        or kv_latent.ndim != 4
+        or k_pe.ndim != 4
+        or topk_indices.ndim != 4
+        or kv_latent.shape[1] != 1
+        or k_pe.shape[1] != 1
+        or topk_indices.shape[1] != 1
+    ):
+        return None
+
+    B, H, L, D_LATENT = q_latent.shape
+    K = kv_latent.shape[2]
+    D_PE = q_pe.shape[-1]
+    compact_prefix = causal_prefix_rows > 0 and topk_indices.shape[2] != L
+    if (
+        L <= 1
+        or q_pe.shape[:3] != (B, H, L)
+        or kv_latent.shape[:3] != (B, 1, K)
+        or k_pe.shape[:3] != (B, 1, K)
+        or topk_indices.shape[:2] != (B, 1)
+        or not (
+            topk_indices.shape[2] == L
+            or (
+                compact_prefix
+                and topk_indices.shape[2] + causal_prefix_rows == L
+                and causal_prefix_indices
+                and topk_valid_prefix
+            )
+        )
+        or kv_latent.shape[-1] != D_LATENT
+        or k_pe.shape[-1] != D_PE
+        or D_LATENT != 512
+        or D_PE != 64
+        or q_latent.dtype not in (mx.float16, mx.bfloat16)
+        or q_pe.dtype != q_latent.dtype
+        or kv_latent.dtype != q_latent.dtype
+        or k_pe.dtype != q_latent.dtype
+        or topk_indices.dtype != mx.uint32
+        or q_block_size not in (2, 4)
+        or capacity not in (4096, 8192)
+    ):
+        return None
+
+    union_tokens, row_bits, lengths, _ = mx.fast.dsa_topk_qblock_union(
+        topk_indices,
+        K,
+        query_length=L,
+        q_block_size=q_block_size,
+        capacity=capacity,
+        causal=True,
+        topk_valid_prefix=topk_valid_prefix,
+        causal_prefix_indices=causal_prefix_indices,
+        causal_prefix_rows=causal_prefix_rows,
+        stream=stream or mx.gpu,
+    )
+    return mx.fast.glm_dsa_sparse_mla_qblock_attention(
+        q_latent,
+        q_pe,
+        kv_latent,
+        k_pe,
+        union_tokens,
+        row_bits,
+        lengths,
+        scale,
+        q_block_size=q_block_size,
+        capacity=capacity,
+        stream=stream or mx.gpu,
+    )
+
+
+def q8_vup_flat(
+    x: mx.array,
+    unembed_out,
+    *,
+    key_length: Optional[int] = None,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Project GLM sparse MLA latent output directly to [B, L, H * 256]."""
+
+    env = os.environ.get("MLX_LM_GLM_DSA_Q8_VUP_FLAT", "auto").lower()
+    if env in {"0", "false", "off", "no"}:
+        return None
+    if env in {"auto", ""} and (
+        key_length is None or key_length < 32768 or key_length > 65536
+    ):
+        return None
+    if env not in {"1", "true", "on", "yes", "auto", ""}:
+        return None
+
+    if (
+        not hasattr(mx.fast, "glm_dsa_q8_vup_flat")
+        or x.ndim != 4
+        or x.shape[1] != 64
+        or x.shape[-1] != 512
+        or getattr(unembed_out, "bits", None) != 8
+        or getattr(unembed_out, "group_size", None) != 64
+        or getattr(unembed_out, "mode", None) != "affine"
+        or not hasattr(unembed_out, "weight")
+        or not hasattr(unembed_out, "scales")
+    ):
+        return None
+
+    biases = unembed_out.get("biases") if hasattr(unembed_out, "get") else None
+    if biases is None:
+        return None
+    weight = unembed_out["weight"]
+    scales = unembed_out["scales"]
+    if weight.shape != (64, 256, 128) or scales.shape != (64, 256, 8):
+        return None
+    return mx.fast.glm_dsa_q8_vup_flat(
+        x,
+        weight,
+        scales,
+        biases,
+        stream=stream or mx.gpu,
+    )

--- a/omlx/patches/glm_moe_dsa/switch_layers.py
+++ b/omlx/patches/glm_moe_dsa/switch_layers.py
@@ -8,6 +8,7 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from mlx_lm.models.activations import swiglu
+from .kernels import fast as glm_fast
 
 
 def _env_flag(name, default="0"):
@@ -241,9 +242,9 @@ class SwitchGLU(nn.Module):
                 and isinstance(self.activation, SwiGLU)
                 and isinstance(self.gate_up_proj, QuantizedSwitchLinear)
                 and isinstance(self.down_proj, QuantizedSwitchLinear)
-                and hasattr(mx.fast, "glm_moe_swiglu_gate_up")
+                and hasattr(glm_fast, "glm_moe_swiglu_gate_up")
             ):
-                x = mx.fast.glm_moe_swiglu_gate_up(
+                x = glm_fast.glm_moe_swiglu_gate_up(
                     x,
                     self.gate_up_proj["weight"],
                     self.gate_up_proj["scales"],
@@ -265,9 +266,9 @@ class SwitchGLU(nn.Module):
                     and do_sort
                     and isinstance(self.activation, SwiGLU)
                     and isinstance(self.down_proj, QuantizedSwitchLinear)
-                    and hasattr(mx.fast, "glm_moe_swiglu_down")
+                    and hasattr(glm_fast, "glm_moe_swiglu_down")
                 ):
-                    x = mx.fast.glm_moe_swiglu_down(
+                    x = glm_fast.glm_moe_swiglu_down(
                         x_gate_up,
                         self.down_proj["weight"],
                         self.down_proj["scales"],
@@ -299,9 +300,9 @@ class SwitchGLU(nn.Module):
             weighted_sum
             and scores is not None
             and do_sort
-            and hasattr(mx.fast, "glm_moe_weighted_sum")
+            and hasattr(glm_fast, "glm_moe_weighted_sum")
         ):
-            return mx.fast.glm_moe_weighted_sum(x, inv_order, scores)
+            return glm_fast.glm_moe_weighted_sum(x, inv_order, scores)
 
         if do_sort:
             x = _scatter_unsort(x, inv_order, indices.shape)

--- a/omlx/patches/glm_moe_dsa/switch_layers.py
+++ b/omlx/patches/glm_moe_dsa/switch_layers.py
@@ -1,0 +1,346 @@
+# Copyright © 2023-2024 Apple Inc.
+
+import math
+import os
+from functools import partial
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.activations import swiglu
+
+
+def _env_flag(name, default="0"):
+    return os.environ.get(name, default).lower() in {"1", "true", "on", "yes"}
+
+
+def use_fused_gate_up_switch():
+    return _env_flag("MLX_LM_SWITCH_FUSED_GATE_UP")
+
+
+def use_fused_swiglu_down_switch():
+    return _env_flag("MLX_LM_GLM_MOE_SWIGLU_DOWN")
+
+
+def use_fused_swiglu_gate_up_switch():
+    return _env_flag("MLX_LM_GLM_MOE_SWIGLU_GATE_UP")
+
+
+def _inverse_permutation(order, inverse_scatter=False):
+    if inverse_scatter or _env_flag("MLX_LM_SWITCH_INVERSE_SCATTER"):
+        return mx.put_along_axis(
+            mx.zeros_like(order),
+            order,
+            mx.arange(order.size, dtype=order.dtype),
+            axis=0,
+        )
+    return mx.argsort(order)
+
+
+def _gather_sort(x, indices, inverse_scatter=False):
+    *_, M = indices.shape
+    indices = indices.flatten()
+    order = mx.argsort(indices)
+    inv_order = _inverse_permutation(order, inverse_scatter)
+    lhs_indices = order // M
+    x = x.flatten(0, -3)
+    return x[lhs_indices], indices[order], inv_order
+
+
+def _scatter_unsort(x, inv_order, shape=None):
+    x = x[inv_order]
+    if shape is not None:
+        x = mx.unflatten(x, 0, shape)
+    return x
+
+
+class QuantizedSwitchLinear(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        output_dims: int,
+        num_experts: int,
+        bias: bool = True,
+        group_size: int = 64,
+        bits: int = 4,
+        mode: str = "affine",
+    ):
+        super().__init__()
+
+        scale = math.sqrt(1 / input_dims)
+        self.weight, self.scales, *biases = mx.quantize(
+            mx.random.uniform(
+                low=-scale,
+                high=scale,
+                shape=(num_experts, output_dims, input_dims),
+            ),
+            group_size=group_size,
+            bits=bits,
+            mode=mode,
+        )
+        self.biases = biases[0] if biases else None
+
+        if bias:
+            self.bias = mx.zeros((num_experts, output_dims))
+
+        self.group_size = group_size
+        self.bits = bits
+        self.mode = mode
+
+        # Freeze this model's parameters
+        self.freeze()
+
+    @property
+    def input_dims(self):
+        return self.scales.shape[2] * self.group_size
+
+    @property
+    def output_dims(self):
+        return self.weight.shape[1]
+
+    @property
+    def num_experts(self):
+        return self.weight.shape[0]
+
+    def __call__(self, x, indices, sorted_indices=False):
+        x = mx.gather_qmm(
+            x,
+            self["weight"],
+            self["scales"],
+            self.get("biases"),
+            rhs_indices=indices,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+            sorted_indices=sorted_indices,
+        )
+        if "bias" in self:
+            x = x + mx.expand_dims(self["bias"][indices], -2)
+        return x
+
+
+class SwitchLinear(nn.Module):
+    def __init__(
+        self, input_dims: int, output_dims: int, num_experts: int, bias: bool = True
+    ):
+        super().__init__()
+        scale = math.sqrt(1 / input_dims)
+        self.weight = mx.random.uniform(
+            low=-scale,
+            high=scale,
+            shape=(num_experts, output_dims, input_dims),
+        )
+
+        if bias:
+            self.bias = mx.zeros((num_experts, output_dims))
+
+    @property
+    def input_dims(self):
+        return self.weight.shape[2]
+
+    @property
+    def output_dims(self):
+        return self.weight.shape[1]
+
+    @property
+    def num_experts(self):
+        return self.weight.shape[0]
+
+    def __call__(self, x, indices, sorted_indices=False):
+        x = mx.gather_mm(
+            x,
+            self["weight"].swapaxes(-1, -2),
+            rhs_indices=indices,
+            sorted_indices=sorted_indices,
+        )
+        if "bias" in self:
+            x = x + mx.expand_dims(self["bias"][indices], -2)
+        return x
+
+    def to_quantized(self, group_size: int = 64, bits: int = 4, mode: str = "affine"):
+        num_experts, output_dims, input_dims = self.weight.shape
+        ql = QuantizedSwitchLinear(
+            input_dims,
+            output_dims,
+            num_experts,
+            False,
+            group_size,
+            bits,
+            mode=mode,
+        )
+        ql.weight, ql.scales, *biases = mx.quantize(
+            self.weight, group_size, bits, mode=mode
+        )
+        ql.biases = biases[0] if biases else None
+
+        if "bias" in self:
+            ql.bias = self.bias
+        return ql
+
+
+class SwiGLU(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def __call__(self, x, gate):
+        return swiglu(gate, x)
+
+
+class SwitchGLU(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=SwiGLU(),
+        bias: bool = False,
+        fused_gate_up: bool = False,
+        fused_swiglu_down: bool = False,
+        inverse_scatter: bool = False,
+    ):
+        super().__init__()
+
+        self.gate_proj = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.up_proj = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.down_proj = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
+        self.activation = activation
+        self.fused_swiglu_down = fused_swiglu_down
+        self.inverse_scatter = inverse_scatter
+        if fused_gate_up or use_fused_gate_up_switch():
+            self.gate_up_proj = SwitchLinear(
+                input_dims, hidden_dims * 2, num_experts, bias=bias
+            )
+            del self.gate_proj
+            del self.up_proj
+
+    def __call__(
+        self,
+        x,
+        indices,
+        scores: mx.array | None = None,
+        weighted_sum: bool = False,
+    ) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+
+        # When we have many tokens, then sort them to make sure that the access
+        # of different experts is in order.
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(
+                x, indices, inverse_scatter=self.inverse_scatter
+            )
+        if self.training:
+            idx = mx.stop_gradient(idx)
+        if hasattr(self, "gate_up_proj"):
+            if (
+                use_fused_swiglu_gate_up_switch()
+                and do_sort
+                and isinstance(self.activation, SwiGLU)
+                and isinstance(self.gate_up_proj, QuantizedSwitchLinear)
+                and isinstance(self.down_proj, QuantizedSwitchLinear)
+                and hasattr(mx.fast, "glm_moe_swiglu_gate_up")
+            ):
+                x = mx.fast.glm_moe_swiglu_gate_up(
+                    x,
+                    self.gate_up_proj["weight"],
+                    self.gate_up_proj["scales"],
+                    self.gate_up_proj.get("biases"),
+                    idx,
+                    self.gate_up_proj.group_size,
+                    self.gate_up_proj.bits,
+                    self.gate_up_proj.mode,
+                )
+                x = self.down_proj(
+                    x,
+                    idx,
+                    sorted_indices=do_sort,
+                )
+            else:
+                x_gate_up = self.gate_up_proj(x, idx, sorted_indices=do_sort)
+                if (
+                    (self.fused_swiglu_down or use_fused_swiglu_down_switch())
+                    and do_sort
+                    and isinstance(self.activation, SwiGLU)
+                    and isinstance(self.down_proj, QuantizedSwitchLinear)
+                    and hasattr(mx.fast, "glm_moe_swiglu_down")
+                ):
+                    x = mx.fast.glm_moe_swiglu_down(
+                        x_gate_up,
+                        self.down_proj["weight"],
+                        self.down_proj["scales"],
+                        self.down_proj.get("biases"),
+                        idx,
+                        self.down_proj.group_size,
+                        self.down_proj.bits,
+                        self.down_proj.mode,
+                    )
+                    if "bias" in self.down_proj:
+                        x = x + mx.expand_dims(self.down_proj["bias"][idx], -2)
+                else:
+                    x_gate, x_up = mx.split(x_gate_up, 2, axis=-1)
+                    x = self.down_proj(
+                        self.activation(x_up, x_gate),
+                        idx,
+                        sorted_indices=do_sort,
+                    )
+        else:
+            x_up = self.up_proj(x, idx, sorted_indices=do_sort)
+            x_gate = self.gate_proj(x, idx, sorted_indices=do_sort)
+            x = self.down_proj(
+                self.activation(x_up, x_gate),
+                idx,
+                sorted_indices=do_sort,
+            )
+
+        if (
+            weighted_sum
+            and scores is not None
+            and do_sort
+            and hasattr(mx.fast, "glm_moe_weighted_sum")
+        ):
+            return mx.fast.glm_moe_weighted_sum(x, inv_order, scores)
+
+        if do_sort:
+            x = _scatter_unsort(x, inv_order, indices.shape)
+
+        return x.squeeze(-2)
+
+
+class SwitchMLP(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=nn.GELU(approx="precise"),
+        bias: bool = False,
+    ):
+        super().__init__()
+
+        self.fc1 = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.fc2 = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
+        self.activation = activation
+
+    def __call__(self, x, indices) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+
+        # When we have many tokens, then sort them to make sure that the access
+        # of different experts is in order.
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(x, indices)
+        if self.training:
+            idx = mx.stop_gradient(idx)
+        x = self.fc1(x, idx, sorted_indices=do_sort)
+        x = self.activation(x)
+        x = self.fc2(x, idx, sorted_indices=do_sort)
+
+        if do_sort:
+            x = _scatter_unsort(x, inv_order, indices.shape)
+
+        return x.squeeze(-2)

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -884,6 +884,10 @@ def _patched_ppb_split(self, indices):
         new_batch.logits_processors = lps
         new_batch.state_machines = self.state_machines
         new_batch.max_tokens = self.max_tokens
+        if hasattr(self, "_omlx_glm_dsa_adaptive_prefill"):
+            new_batch._omlx_glm_dsa_adaptive_prefill = (
+                self._omlx_glm_dsa_adaptive_prefill
+            )
 
         self.uids = []
         self.prompt_cache = []
@@ -1447,6 +1451,25 @@ class Scheduler:
         self._turboquant_skip_last: bool = True
         # Memoized MLA-architecture detection (see _model_uses_mla / #1613).
         self._mla_model: bool | None = None
+        self._glm_dsa_adaptive_prefill = None
+        try:
+            from .patches.glm_moe_dsa.generate_patch import (
+                _glm_dsa_adaptive_prefill_config,
+            )
+
+            self._glm_dsa_adaptive_prefill = _glm_dsa_adaptive_prefill_config(
+                model, self.config.prefill_step_size
+            )
+        except Exception:
+            logger.debug("GLM DSA adaptive prefill config unavailable", exc_info=True)
+        if self._glm_dsa_adaptive_prefill is not None:
+            logger.info(
+                "GLM DSA adaptive scheduler prefill enabled: step=%d after=%d "
+                "min_remaining=%d",
+                self._glm_dsa_adaptive_prefill.step_size,
+                self._glm_dsa_adaptive_prefill.after,
+                self._glm_dsa_adaptive_prefill.min_remaining,
+            )
 
         # Request management - following vLLM's design
         self.waiting: deque[Request] = deque()  # Waiting queue (FCFS)
@@ -2870,13 +2893,15 @@ class Scheduler:
 
         input_arr = mx.array(prefill_tokens)[None]  # (1, seq_len)
         processed_tokens = 0
-        prefill_step_size = self.config.prefill_step_size
         uid = self.request_id_to_uid.get(request.request_id)
 
         emitted_boundaries: dict[int, int] = {}
 
         while input_arr.shape[1] > 0:
             remaining = input_arr.shape[1]
+            prefill_step_size = self._prefill_step_size_for_progress(
+                processed_tokens, remaining
+            )
             n_to_process = min(prefill_step_size, remaining)
 
             if processed_tokens == 0:
@@ -3744,6 +3769,24 @@ class Scheduler:
     # Chunked prefill helpers (used when config.chunked_prefill=True)
     # ------------------------------------------------------------------
 
+    def _prefill_step_size_for_progress(
+        self, processed_tokens: int, remaining_tokens: int
+    ) -> int:
+        """Return the scheduler prefill chunk size for the current progress."""
+        adaptive_prefill = self._glm_dsa_adaptive_prefill
+        if adaptive_prefill is None:
+            return self.config.prefill_step_size
+        from .patches.glm_moe_dsa.generate_patch import (
+            _prefill_step_size_for_progress,
+        )
+
+        return _prefill_step_size_for_progress(
+            self.config.prefill_step_size,
+            processed_tokens,
+            remaining_tokens,
+            adaptive_prefill,
+        )
+
     def _begin_prefill(
         self,
         request: "Request",
@@ -3819,7 +3862,11 @@ class Scheduler:
         if state.tokens_remaining.shape[1] == 0:
             return True
 
-        n = min(self.config.prefill_step_size, state.tokens_remaining.shape[1])
+        remaining = state.tokens_remaining.shape[1]
+        prefill_step_size = self._prefill_step_size_for_progress(
+            state.tokens_processed, remaining
+        )
+        n = min(prefill_step_size, remaining)
 
         if state.tokens_processed == 0:
             _sync_and_clear_cache(self._stream)

--- a/omlx_glm_kernels/__init__.py
+++ b/omlx_glm_kernels/__init__.py
@@ -1,0 +1,5 @@
+"""Native GLM kernel extensions used by oMLX monkey patches."""
+
+from . import fast
+
+__all__ = ["fast"]

--- a/omlx_glm_kernels/csrc/CMakeLists.txt
+++ b/omlx_glm_kernels/csrc/CMakeLists.txt
@@ -1,0 +1,115 @@
+cmake_minimum_required(VERSION 3.27)
+
+project(omlx_glm_kernels LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+option(BUILD_SHARED_LIBS "Build extensions as a shared library" ON)
+
+find_package(
+  Python 3.8
+  COMPONENTS Interpreter Development.Module
+  REQUIRED)
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m mlx --cmake-dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE MLX_ROOT)
+find_package(MLX CONFIG REQUIRED)
+list(GET MLX_INCLUDE_DIRS 0 OMLX_GLM_MLX_INCLUDE_DIR)
+
+add_library(omlx_glm_kernel_ops)
+target_sources(
+  omlx_glm_kernel_ops
+  PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/dsa_indexer.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/fused_moe.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/sparse_mla.cpp)
+target_include_directories(
+  omlx_glm_kernel_ops
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_compile_definitions(
+  omlx_glm_kernel_ops
+  PUBLIC OMLX_GLM_KERNEL_SOURCE_DIR="${CMAKE_CURRENT_LIST_DIR}"
+         OMLX_GLM_MLX_INCLUDE_DIR="${OMLX_GLM_MLX_INCLUDE_DIR}")
+target_link_libraries(omlx_glm_kernel_ops PUBLIC mlx)
+
+if(MLX_BUILD_METAL)
+  set(OMLX_GLM_METAL_SOURCES
+      ${CMAKE_CURRENT_LIST_DIR}/dsa_indexer.metal
+      ${CMAKE_CURRENT_LIST_DIR}/fused_moe.metal
+      ${CMAKE_CURRENT_LIST_DIR}/sparse_mla.metal)
+  file(GLOB_RECURSE OMLX_GLM_METAL_HEADERS CONFIGURE_DEPENDS
+       ${CMAKE_CURRENT_LIST_DIR}/*.h)
+  set(OMLX_GLM_METAL_FLAGS
+      -x
+      metal
+      -Wall
+      -Wextra
+      -fno-fast-math
+      -Wno-c++17-extensions
+      -Wno-c++20-extensions)
+  if(MLX_METAL_DEBUG)
+    set(OMLX_GLM_METAL_FLAGS ${OMLX_GLM_METAL_FLAGS} -gline-tables-only
+                             -frecord-sources)
+  endif()
+  if(NOT CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+    set(OMLX_GLM_METAL_FLAGS
+        ${OMLX_GLM_METAL_FLAGS}
+        "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+  endif()
+  set(OMLX_GLM_METAL_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}
+                                  ${MLX_INCLUDE_DIRS})
+  set(OMLX_GLM_METAL_INCLUDE_ARGS)
+  foreach(INCLUDE_DIR IN LISTS OMLX_GLM_METAL_INCLUDE_DIRS)
+    list(APPEND OMLX_GLM_METAL_INCLUDE_ARGS -I${INCLUDE_DIR})
+  endforeach()
+  set(OMLX_GLM_METAL_AIR)
+  foreach(SRCFILE IN LISTS OMLX_GLM_METAL_SOURCES)
+    get_filename_component(TARGET_NAME ${SRCFILE} NAME_WE)
+    set(AIR_FILE ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}.air)
+    add_custom_command(
+      OUTPUT ${AIR_FILE}
+      COMMAND xcrun -sdk macosx metal ${OMLX_GLM_METAL_FLAGS} -c ${SRCFILE}
+              ${OMLX_GLM_METAL_INCLUDE_ARGS} -o ${AIR_FILE}
+      DEPENDS ${SRCFILE} ${OMLX_GLM_METAL_HEADERS}
+      COMMENT "Building ${TARGET_NAME}.air"
+      VERBATIM)
+    list(APPEND OMLX_GLM_METAL_AIR ${AIR_FILE})
+  endforeach()
+
+  set(OMLX_GLM_METALLIB
+      ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/omlx_glm_kernels.metallib)
+  add_custom_command(
+    OUTPUT ${OMLX_GLM_METALLIB}
+    COMMAND xcrun -sdk macosx metal ${OMLX_GLM_METAL_AIR} -o
+            ${OMLX_GLM_METALLIB}
+    DEPENDS ${OMLX_GLM_METAL_AIR}
+    COMMENT "Building omlx_glm_kernels.metallib"
+    VERBATIM)
+  add_custom_target(omlx_glm_kernels_metallib DEPENDS ${OMLX_GLM_METALLIB})
+
+  add_dependencies(omlx_glm_kernel_ops omlx_glm_kernels_metallib)
+endif()
+
+nanobind_add_module(
+  _ext
+  NB_STATIC
+  STABLE_ABI
+  LTO
+  NOMINSIZE
+  NB_DOMAIN
+  mlx
+  ${CMAKE_CURRENT_LIST_DIR}/bindings.cpp)
+target_link_libraries(_ext PRIVATE omlx_glm_kernel_ops)
+
+if(BUILD_SHARED_LIBS)
+  target_link_options(_ext PRIVATE -Wl,-rpath,@loader_path)
+endif()

--- a/omlx_glm_kernels/csrc/bindings.cpp
+++ b/omlx_glm_kernels/csrc/bindings.cpp
@@ -1,0 +1,65 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/variant.h>
+
+#include "dsa_indexer.h"
+#include "fused_moe.h"
+#include "sparse_mla.h"
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+NB_MODULE(_ext, m) {
+  m.doc() = "Native GLM kernels for oMLX";
+
+  m.def(
+      "dsa_indexer_scores",
+      &omlx::glm_kernels::dsa_indexer_scores,
+      "queries"_a,
+      "keys"_a,
+      "weights"_a,
+      "causal"_a = true,
+      "unused_causal_prefix_topk"_a = 0,
+      "skip_causal_future_store"_a = false,
+      "causal_q_offset"_a = -1,
+      "stream"_a = nb::none());
+  m.def(
+      "dsa_topk_indices",
+      &omlx::glm_kernels::dsa_topk_indices,
+      "scores"_a,
+      "topk"_a,
+      "bucketed"_a = false,
+      "causal_valid_prefix"_a = false,
+      "stream"_a = nb::none());
+  m.def(
+      "glm_dsa_sparse_mla_attention",
+      &omlx::glm_kernels::glm_dsa_sparse_mla_attention,
+      "q_latent"_a,
+      "q_pe"_a,
+      "kv_latent"_a,
+      "k_pe"_a,
+      "topk_indices"_a,
+      "scale"_a,
+      "causal"_a = true,
+      "topk_valid_prefix"_a = false,
+      "causal_prefix_indices"_a = false,
+      "topk_length"_a = nb::none(),
+      "causal_prefix_rows"_a = 0,
+      "stream"_a = nb::none());
+  m.def(
+      "glm_dsa_q8_vup_flat",
+      &omlx::glm_kernels::glm_dsa_q8_vup_flat,
+      "x"_a,
+      "weight"_a,
+      "scales"_a,
+      "biases"_a,
+      "stream"_a = nb::none());
+  m.def(
+      "glm_moe_weighted_sum",
+      &omlx::glm_kernels::glm_moe_weighted_sum,
+      "x_sorted"_a,
+      "inv_order"_a,
+      "scores"_a,
+      "stream"_a = nb::none());
+}

--- a/omlx_glm_kernels/csrc/dsa_indexer.cpp
+++ b/omlx_glm_kernels/csrc/dsa_indexer.cpp
@@ -1,0 +1,500 @@
+#include "dsa_indexer.h"
+
+#include <cstdlib>
+#include <dlfcn.h>
+#include <filesystem>
+#include <sstream>
+
+#include "mlx/backend/common/utils.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/kernels/steel/gemm/params.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/ops.h"
+#include "mlx/utils.h"
+
+namespace omlx::glm_kernels {
+
+namespace {
+
+using namespace mlx::core;
+
+std::string current_binary_dir() {
+  static std::string binary_dir = []() {
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<void*>(&current_binary_dir), &info)) {
+      throw std::runtime_error("Unable to get omlx_glm_kernels binary dir.");
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().string();
+  }();
+  return binary_dir;
+}
+
+struct DSATopKParams {
+  int rows;
+  int L;
+  int K;
+  int topk;
+  bool causal_valid_prefix;
+};
+
+struct DSATopKBlockTableParams {
+  int rows;
+  int L;
+  int K;
+  int topk;
+  int k_block_size;
+  int causal;
+};
+
+bool row_contiguous(const array& arr) {
+  return arr.flags().row_contiguous && arr.strides(-1) == 1;
+}
+
+class DSAIndexerScoresPrimitive : public Primitive {
+ public:
+  DSAIndexerScoresPrimitive(
+      Stream stream,
+      bool causal,
+      bool weights_lh,
+      int unused_causal_prefix_topk,
+      bool skip_causal_future_store,
+      int causal_q_offset)
+      : Primitive(stream),
+        causal_(causal),
+        weights_lh_(weights_lh),
+        unused_causal_prefix_topk_(unused_causal_prefix_topk),
+        skip_causal_future_store_(skip_causal_future_store),
+        causal_q_offset_(causal_q_offset) {}
+
+  static bool unsupported(
+      const array& q,
+      const array& k,
+      const array& weights,
+      Stream s) {
+    if (s.device == Device::cpu) {
+      return true;
+    }
+    if (q.dtype() != k.dtype() || q.dtype() != weights.dtype()) {
+      return true;
+    }
+    if (q.dtype() != float16 && q.dtype() != bfloat16) {
+      return true;
+    }
+    if (!row_contiguous(q) || !row_contiguous(k) || !row_contiguous(weights)) {
+      return true;
+    }
+    if (q.ndim() != 4 || k.ndim() != 4 ||
+        (weights.ndim() != 3 && weights.ndim() != 4)) {
+      return true;
+    }
+    const bool weights_lh = weights.ndim() == 3;
+    if (q.shape(1) != 32 || k.shape(1) != 1) {
+      return true;
+    }
+    if (weights_lh) {
+      if (weights.shape(1) != q.shape(2) || weights.shape(2) != q.shape(1)) {
+        return true;
+      }
+    } else {
+      if (weights.shape(1) != q.shape(1) || weights.shape(2) != q.shape(2) ||
+          weights.shape(3) != 1) {
+        return true;
+      }
+    }
+    if (q.shape(3) != 128 || k.shape(3) != 128) {
+      return true;
+    }
+    if (q.shape(2) % 64 != 0 || k.shape(2) % 64 != 0 ||
+        q.shape(3) % 16 != 0) {
+      return true;
+    }
+    const char* min_k_env = std::getenv("MLX_LM_GLM_DSA_INDEXER_MIN_K");
+    const int min_k = min_k_env == nullptr ? 4096 : std::atoi(min_k_env);
+    return k.shape(2) < min_k;
+  }
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("DSAIndexerScoresPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    auto& out = outputs[0];
+
+    const auto& q = inputs[0];
+    const auto& k = inputs[1];
+    const auto& weights = inputs[2];
+
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    constexpr int bm = 64;
+    constexpr int bn = 64;
+    constexpr int bk = 16;
+    constexpr int wm = 2;
+    constexpr int wn = 2;
+
+    const int B = q.shape(0);
+    const int H = q.shape(1);
+    const int M = q.shape(2);
+    const int N = k.shape(2);
+    const int D = q.shape(3);
+    const int tiles_m = (M + bm - 1) / bm;
+    const int tiles_n = (N + bn - 1) / bn;
+
+    mlx::steel::GEMMParams params{
+        /* const int M = */ M,
+        /* const int N = */ N,
+        /* const int K = */ D,
+        /* const int lda = */ D,
+        /* const int ldb = */ D,
+        /* const int ldd = */ N,
+        /* const int tiles_n = */ tiles_n,
+        /* const int tiles_m = */ tiles_m,
+        /* const int64_t batch_stride_a = */ int64_t(H) * M * D,
+        /* const int64_t batch_stride_b = */ int64_t(N) * D,
+        /* const int64_t batch_stride_d = */ int64_t(M) * N,
+        /* const int swizzle_log = */ 0,
+        /* const int gemm_k_iterations_aligned = */ D / bk,
+        /* const int batch_ndim = */ 1};
+
+    bool do_causal = causal_;
+    bool use_weights_lh = weights_lh_;
+    bool pair_heads =
+        H % 2 == 0 &&
+        std::getenv("MLX_LM_GLM_DSA_INDEXER_PAIR_HEADS") != nullptr &&
+        std::string(std::getenv("MLX_LM_GLM_DSA_INDEXER_PAIR_HEADS")) == "1";
+    bool emit_high_histogram = false;
+    metal::MTLFCList func_consts = {
+        {&do_causal, MTL::DataType::DataTypeBool, 300},
+        {&use_weights_lh, MTL::DataType::DataTypeBool, 301},
+        {&pair_heads, MTL::DataType::DataTypeBool, 304},
+        {&emit_high_histogram, MTL::DataType::DataTypeBool, 305},
+    };
+
+    std::string base_name;
+    concatenate(
+        base_name,
+        "steel_dsa_indexer_score_",
+        type_to_name(q),
+        "_bm",
+        bm,
+        "_bn",
+        bn,
+        "_bk",
+        bk,
+        "_wm",
+        wm,
+        "_wn",
+        wn);
+
+    std::string hash_name;
+    concatenate(
+        hash_name,
+        base_name,
+        "_causal_",
+        (do_causal ? 't' : 'n'),
+        "_wlh_",
+        (use_weights_lh ? 't' : 'n'),
+        "_pairh_",
+        (pair_heads ? 't' : 'n'),
+        "_hh_n");
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto& compute_encoder = metal::get_command_encoder(s);
+    auto kernel = d.get_kernel(base_name, lib, hash_name, func_consts);
+    compute_encoder.set_compute_pipeline_state(kernel);
+
+    compute_encoder.set_input_array(q, 0);
+    compute_encoder.set_input_array(k, 1);
+    compute_encoder.set_input_array(weights, 2);
+    compute_encoder.set_output_array(out, 3);
+    compute_encoder.set_bytes(params, 4);
+    compute_encoder.set_bytes(H, 5);
+    compute_encoder.set_bytes(unused_causal_prefix_topk_, 6);
+    compute_encoder.set_bytes(skip_causal_future_store_, 7);
+    compute_encoder.set_bytes(causal_q_offset_, 8);
+
+    MTL::Size group_dims = MTL::Size(wm * wn * 32, 1, 1);
+    MTL::Size grid_dims = MTL::Size(tiles_n, tiles_m, B);
+    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  }
+
+  DEFINE_NAME(OMLXDSAIndexerScores)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs = static_cast<const DSAIndexerScoresPrimitive&>(other);
+    return causal_ == rhs.causal_ && weights_lh_ == rhs.weights_lh_ &&
+        unused_causal_prefix_topk_ == rhs.unused_causal_prefix_topk_ &&
+        skip_causal_future_store_ == rhs.skip_causal_future_store_ &&
+        causal_q_offset_ == rhs.causal_q_offset_;
+  }
+  auto state() const {
+    return std::make_tuple(
+        causal_,
+        weights_lh_,
+        unused_causal_prefix_topk_,
+        skip_causal_future_store_,
+        causal_q_offset_);
+  }
+
+ private:
+  bool causal_;
+  bool weights_lh_;
+  int unused_causal_prefix_topk_;
+  bool skip_causal_future_store_;
+  int causal_q_offset_;
+};
+
+class DSATopKIndicesPrimitive : public Primitive {
+ public:
+  DSATopKIndicesPrimitive(
+      Stream stream,
+      int topk,
+      bool bucketed,
+      bool causal_valid_prefix)
+      : Primitive(stream),
+        topk_(topk),
+        bucketed_(bucketed),
+        causal_valid_prefix_(causal_valid_prefix) {}
+
+  static bool unsupported(const array& scores, int topk, Stream s) {
+    if (s.device == Device::cpu) {
+      return true;
+    }
+    if (scores.dtype() != float16 && scores.dtype() != bfloat16) {
+      return true;
+    }
+    if (!row_contiguous(scores)) {
+      return true;
+    }
+    if (scores.ndim() != 4 || scores.shape(1) != 1) {
+      return true;
+    }
+    if (topk != 2048) {
+      return true;
+    }
+    return scores.shape(-1) < topk;
+  }
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("DSATopKIndicesPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    auto& out = outputs[0];
+
+    const auto& scores = inputs[0];
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    constexpr int threads = 1024;
+
+    const int B = scores.shape(0);
+    const int L = scores.shape(2);
+    const int K = scores.shape(3);
+    const int rows = B * L;
+
+    std::string base_name;
+    concatenate(
+        base_name,
+        "steel_dsa_topk_indices_",
+        type_to_name(scores),
+        "_topk",
+        topk_,
+        "_t",
+        threads);
+
+    bool bucketed = bucketed_;
+    metal::MTLFCList func_consts = {
+        {&bucketed, MTL::DataType::DataTypeBool, 302},
+    };
+
+    std::string hash_name;
+    concatenate(
+        hash_name,
+        base_name,
+        "_bucketed_",
+        (bucketed ? 't' : 'n'));
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto& compute_encoder = metal::get_command_encoder(s);
+    auto kernel = d.get_kernel(base_name, lib, hash_name, func_consts);
+    compute_encoder.set_compute_pipeline_state(kernel);
+
+    DSATopKParams params{
+        /* int rows = */ rows,
+        /* int L = */ L,
+        /* int K = */ K,
+        /* int topk = */ topk_,
+        /* bool causal_valid_prefix = */ causal_valid_prefix_};
+
+    compute_encoder.set_input_array(scores, 0);
+    compute_encoder.set_output_array(out, 1);
+    compute_encoder.set_bytes(params, 2);
+
+    MTL::Size group_dims = MTL::Size(threads, 1, 1);
+    MTL::Size grid_dims = MTL::Size(rows, 1, 1);
+    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  }
+
+  DEFINE_NAME(OMLXDSATopKIndices)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs = static_cast<const DSATopKIndicesPrimitive&>(other);
+    return topk_ == rhs.topk_ && bucketed_ == rhs.bucketed_ &&
+        causal_valid_prefix_ == rhs.causal_valid_prefix_;
+  }
+  auto state() const {
+    return std::make_tuple(topk_, bucketed_, causal_valid_prefix_);
+  }
+
+ private:
+  int topk_;
+  bool bucketed_;
+  bool causal_valid_prefix_;
+};
+
+array dsa_topk_indices_impl(
+    const array& scores,
+    int topk,
+    bool bucketed,
+    bool causal_valid_prefix,
+    StreamOrDevice s) {
+  if (scores.ndim() != 4 || scores.shape(1) != 1) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.dsa_topk_indices] expected scores with shape "
+        << "[B, 1, L, K], got " << scores.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (topk <= 0 || topk > scores.shape(-1)) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.dsa_topk_indices] invalid topk " << topk
+        << " for scores with shape " << scores.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto stream = to_stream(s);
+  std::vector<array> inputs = {scores};
+  if (DSATopKIndicesPrimitive::unsupported(scores, topk, stream)) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.dsa_topk_indices] unsupported M3 GLM shape.");
+  }
+
+  Shape out_shape{scores.shape(0), 1, scores.shape(2), topk};
+  return array(
+      std::move(out_shape),
+      uint32,
+      std::make_shared<DSATopKIndicesPrimitive>(
+          stream, topk, bucketed, causal_valid_prefix),
+      std::move(inputs));
+}
+
+} // namespace
+
+array dsa_indexer_scores(
+    const array& queries,
+    const array& keys,
+    const array& weights,
+    bool causal,
+    int unused_causal_prefix_topk,
+    bool skip_causal_future_store,
+    int causal_q_offset,
+    StreamOrDevice s) {
+  if (queries.ndim() != 4 || keys.ndim() != 4 ||
+      (weights.ndim() != 3 && weights.ndim() != 4)) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.dsa_indexer_scores] expected q/k rank 4 and "
+        << "weights rank 3 or 4, got " << queries.shape() << ", "
+        << keys.shape() << ", " << weights.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (keys.shape(1) != 1) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.dsa_indexer_scores] keys must have a singleton "
+        "indexer head axis.");
+  }
+  const bool weights_lh = weights.ndim() == 3;
+  bool weights_match = false;
+  if (weights_lh) {
+    weights_match = weights.shape(1) == queries.shape(2) &&
+        weights.shape(2) == queries.shape(1);
+  } else {
+    weights_match = weights.shape(1) == queries.shape(1) &&
+        weights.shape(2) == queries.shape(2) && weights.shape(3) == 1;
+  }
+  if (queries.shape(0) != keys.shape(0) ||
+      queries.shape(0) != weights.shape(0) || !weights_match ||
+      queries.shape(3) != keys.shape(3)) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.dsa_indexer_scores] incompatible q, k, "
+        << "weights shapes: " << queries.shape() << ", " << keys.shape()
+        << ", " << weights.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto final_type = result_type(queries, keys, weights);
+  if (final_type != float16 && final_type != bfloat16) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.dsa_indexer_scores] expected float16 or "
+        << "bfloat16 inputs, got " << final_type << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (unused_causal_prefix_topk < 0) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.dsa_indexer_scores] "
+        << "unused_causal_prefix_topk must be non-negative, got "
+        << unused_causal_prefix_topk << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (causal_q_offset < -1) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.dsa_indexer_scores] causal_q_offset must be "
+        << "-1 or non-negative, got " << causal_q_offset << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto stream = to_stream(s);
+  auto q = astype(queries, final_type, stream);
+  auto k = astype(keys, final_type, stream);
+  auto w = astype(weights, final_type, stream);
+
+  std::vector<array> inputs = {q, k, w};
+  if (DSAIndexerScoresPrimitive::unsupported(q, k, w, stream)) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.dsa_indexer_scores] unsupported M3 GLM shape.");
+  }
+
+  Shape out_shape{q.shape(0), 1, q.shape(2), k.shape(2)};
+  return array(
+      std::move(out_shape),
+      final_type,
+      std::make_shared<DSAIndexerScoresPrimitive>(
+          stream,
+          causal,
+          weights_lh,
+          unused_causal_prefix_topk,
+          skip_causal_future_store,
+          causal_q_offset),
+      std::move(inputs));
+}
+
+array dsa_topk_indices(
+    const array& scores,
+    int topk,
+    bool bucketed,
+    bool causal_valid_prefix,
+    StreamOrDevice s) {
+  return dsa_topk_indices_impl(scores, topk, bucketed, causal_valid_prefix, s);
+}
+
+} // namespace omlx::glm_kernels

--- a/omlx_glm_kernels/csrc/dsa_indexer.h
+++ b/omlx_glm_kernels/csrc/dsa_indexer.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "mlx/array.h"
+#include "mlx/stream.h"
+#include "mlx/utils.h"
+
+namespace mx = mlx::core;
+
+namespace omlx::glm_kernels {
+
+mx::array dsa_indexer_scores(
+    const mx::array& queries,
+    const mx::array& keys,
+    const mx::array& weights,
+    bool causal = true,
+    int unused_causal_prefix_topk = 0,
+    bool skip_causal_future_store = false,
+    int causal_q_offset = -1,
+    mx::StreamOrDevice s = {});
+
+mx::array dsa_topk_indices(
+    const mx::array& scores,
+    int topk,
+    bool bucketed = false,
+    bool causal_valid_prefix = false,
+    mx::StreamOrDevice s = {});
+
+} // namespace omlx::glm_kernels

--- a/omlx_glm_kernels/csrc/dsa_indexer.metal
+++ b/omlx_glm_kernels/csrc/dsa_indexer.metal
@@ -1,0 +1,68 @@
+#include "mlx/backend/metal/kernels/utils.h"
+#include "mlx/backend/metal/kernels/steel/gemm/gemm.h"
+
+namespace mlx {
+namespace steel {
+
+struct OMLXDSATopKParams {
+  int rows;
+  int L;
+  int K;
+  int topk;
+  bool causal_valid_prefix;
+};
+
+struct OMLXDSATopKBlockTableParams {
+  int rows;
+  int L;
+  int K;
+  int topk;
+  int k_block_size;
+  int causal;
+};
+
+struct OMLXDSATopKQBlockUnionParams {
+  int blocks;
+  int L;
+  int K;
+  int topk_rows;
+  int topk;
+  int q_block_size;
+  int capacity;
+  int causal;
+  int topk_valid_prefix;
+  int causal_prefix_indices;
+  int causal_prefix_rows;
+};
+
+} // namespace steel
+} // namespace mlx
+
+#define DSATopKParams OMLXDSATopKParams
+#define DSATopKBlockTableParams OMLXDSATopKBlockTableParams
+#define DSATopKQBlockUnionParams OMLXDSATopKQBlockUnionParams
+#include "kernels/steel_dsa_indexer_score.h"
+#undef DSATopKQBlockUnionParams
+#undef DSATopKBlockTableParams
+#undef DSATopKParams
+
+#define instantiate_dsa_indexer_score(iname, itype, bm, bn, bk, wm, wn) \
+  instantiate_kernel(                                                   \
+      "steel_dsa_indexer_score_" #iname                                 \
+      "_bm" #bm "_bn" #bn "_bk" #bk "_wm" #wm "_wn" #wn,              \
+      dsa_indexer_score, itype, bm, bn, bk, wm, wn)
+
+#define instantiate_dsa_topk_indices(iname, itype, topk, threads)       \
+  instantiate_kernel(                                                   \
+      "steel_dsa_topk_indices_" #iname "_topk" #topk "_t" #threads,    \
+      dsa_topk_indices_16bit,                                           \
+      itype,                                                            \
+      uint,                                                             \
+      topk,                                                             \
+      threads)
+
+instantiate_dsa_indexer_score(float16, half, 64, 64, 16, 2, 2);
+instantiate_dsa_indexer_score(bfloat16, bfloat16_t, 64, 64, 16, 2, 2);
+
+instantiate_dsa_topk_indices(float16, half, 2048, 1024);
+instantiate_dsa_topk_indices(bfloat16, bfloat16_t, 2048, 1024);

--- a/omlx_glm_kernels/csrc/fused_moe.cpp
+++ b/omlx_glm_kernels/csrc/fused_moe.cpp
@@ -1,0 +1,432 @@
+#include "fused_moe.h"
+
+#include <cstdlib>
+#include <dlfcn.h>
+#include <filesystem>
+#include <sstream>
+#include <string>
+
+#include "mlx/backend/common/utils.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/ops.h"
+#include "mlx/utils.h"
+
+namespace omlx::glm_kernels {
+
+namespace {
+
+using namespace mlx::core;
+
+std::string current_binary_dir() {
+  static std::string binary_dir = []() {
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<void*>(&current_binary_dir), &info)) {
+      throw std::runtime_error("Unable to get omlx_glm_kernels binary dir.");
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().string();
+  }();
+  return binary_dir;
+}
+
+bool row_contiguous(const array& arr) {
+  return arr.flags().row_contiguous && arr.strides(-1) == 1;
+}
+
+std::string glm_type_name(Dtype dtype) {
+  if (dtype == float16) {
+    return "float16_t";
+  }
+  if (dtype == bfloat16) {
+    return "bfloat16_t";
+  }
+  std::ostringstream msg;
+  msg << "Unsupported GLM fused kernel dtype: " << dtype << ".";
+  throw std::invalid_argument(msg.str());
+}
+
+class GlmDsaQ8VupFlatPrimitive : public Primitive {
+ public:
+  explicit GlmDsaQ8VupFlatPrimitive(Stream stream) : Primitive(stream) {}
+
+  static bool unsupported(
+      const array& x,
+      const array& weight,
+      const array& scales,
+      const array& biases,
+      Stream s) {
+    if (s.device == Device::cpu) {
+      return true;
+    }
+    if (x.dtype() != float16 && x.dtype() != bfloat16) {
+      return true;
+    }
+    if (weight.dtype() != uint32 || scales.dtype() != x.dtype() ||
+        biases.dtype() != x.dtype()) {
+      return true;
+    }
+    if (x.ndim() != 4 || weight.ndim() != 3 || scales.ndim() != 3 ||
+        biases.ndim() != 3) {
+      return true;
+    }
+    if (!row_contiguous(x) || !row_contiguous(weight) ||
+        !row_contiguous(scales) || !row_contiguous(biases)) {
+      return true;
+    }
+
+    constexpr int bits = 8;
+    constexpr int group_size = 64;
+    constexpr int pack_factor = 32 / bits;
+    const int H = x.shape(1);
+    const int K = x.shape(3);
+    const int N = weight.shape(1);
+    if (H != 64 || K != 512 || N != 256) {
+      return true;
+    }
+    if (weight.shape(0) != H || scales.shape(0) != H ||
+        biases.shape(0) != H || scales.shape(1) != N ||
+        biases.shape(1) != N || weight.shape(2) * pack_factor != K ||
+        scales.shape(2) != K / group_size ||
+        biases.shape(2) != K / group_size) {
+      return true;
+    }
+    return false;
+  }
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("GlmDsaQ8VupFlatPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    auto& out = outputs[0];
+
+    const auto& x = inputs[0];
+    const auto& weight = inputs[1];
+    const auto& scales = inputs[2];
+    const auto& biases = inputs[3];
+
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    constexpr int group_size = 64;
+    constexpr int bits = 8;
+    constexpr int bm = 32;
+    constexpr int bn = 32;
+
+    const int B = x.shape(0);
+    const int H = x.shape(1);
+    const int M = x.shape(2);
+    const int K = x.shape(3);
+    const int N = weight.shape(1);
+
+    std::string kname;
+    concatenate(
+        kname,
+        "affine_qmm_t_head_flat_",
+        glm_type_name(x.dtype()),
+        "_gs_",
+        group_size,
+        "_b_",
+        bits,
+        "_alN_true");
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto kernel = d.get_kernel(kname, lib);
+    auto& compute_encoder = metal::get_command_encoder(s);
+    compute_encoder.set_compute_pipeline_state(kernel);
+    compute_encoder.set_input_array(weight, 0);
+    compute_encoder.set_input_array(scales, 1);
+    compute_encoder.set_input_array(biases, 2);
+    compute_encoder.set_input_array(x, 3);
+    compute_encoder.set_output_array(out, 4);
+    compute_encoder.set_bytes(K, 5);
+    compute_encoder.set_bytes(N, 6);
+    compute_encoder.set_bytes(M, 7);
+    compute_encoder.set_bytes(H, 8);
+
+    MTL::Size grid_dims((N + bn - 1) / bn, (M + bm - 1) / bm, B * H);
+    MTL::Size group_dims(32, 2, 2);
+    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  }
+
+  DEFINE_NAME(GlmDsaQ8VupFlatPrimitive)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& /* other */) const override {
+    return true;
+  }
+  auto state() const {
+    return std::make_tuple(nullptr);
+  }
+
+};
+
+class GlmMoeWeightedSumPrimitive : public Primitive {
+ public:
+  explicit GlmMoeWeightedSumPrimitive(Stream stream) : Primitive(stream) {}
+
+  static bool unsupported(
+      const array& x_sorted,
+      const array& inv_order,
+      const array& scores,
+      Stream s) {
+    if (s.device == Device::cpu) {
+      return true;
+    }
+    if (x_sorted.dtype() != float16 && x_sorted.dtype() != bfloat16) {
+      return true;
+    }
+    if (scores.dtype() != float32 || inv_order.dtype() != uint32) {
+      return true;
+    }
+    if (x_sorted.ndim() != 3 || x_sorted.shape(-2) != 1 ||
+        scores.ndim() < 2 || inv_order.ndim() != 1) {
+      return true;
+    }
+    if (!row_contiguous(x_sorted) || !row_contiguous(inv_order) ||
+        !row_contiguous(scores)) {
+      return true;
+    }
+    if (scores.shape(-1) != 8 || x_sorted.shape(0) != scores.size() ||
+        inv_order.size() != scores.size()) {
+      return true;
+    }
+    return false;
+  }
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("GlmMoeWeightedSumPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    auto& out = outputs[0];
+
+    const auto& x_sorted = inputs[0];
+    const auto& inv_order = inputs[1];
+    const auto& scores = inputs[2];
+
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    const int topk = scores.shape(-1);
+    const int tokens = scores.size() / topk;
+    const int D = x_sorted.shape(-1);
+
+    bool use_tiled = true;
+    if (const char* tiled_env = std::getenv("MLX_LM_GLM_MOE_WEIGHTED_SUM_TILED")) {
+      use_tiled = std::string(tiled_env) != "0";
+    }
+    int tiled_threads = 256;
+    if (const char* tiled_threads_env =
+            std::getenv("MLX_LM_GLM_MOE_WEIGHTED_SUM_TILED_THREADS")) {
+      tiled_threads = std::atoi(tiled_threads_env);
+    }
+    if (tiled_threads != 128 && tiled_threads != 256 && tiled_threads != 512) {
+      tiled_threads = 256;
+    }
+    int vec = 4;
+    if (const char* legacy_vec4_env =
+            std::getenv("MLX_LM_GLM_MOE_WEIGHTED_SUM_VEC4")) {
+      if (std::string(legacy_vec4_env) == "0") {
+        vec = 1;
+      }
+    }
+    if (const char* vec_env = std::getenv("MLX_LM_GLM_MOE_WEIGHTED_SUM_VEC")) {
+      vec = std::atoi(vec_env);
+    }
+    if (!((vec == 4 || vec == 8 || vec == 16) && D % vec == 0)) {
+      vec = 1;
+    }
+
+    std::string kname;
+    if (use_tiled) {
+      concatenate(
+          kname,
+          "moe_weighted_sum_tiled_",
+          glm_type_name(x_sorted.dtype()),
+          "_score_float_topk_",
+          topk,
+          "_t_",
+          tiled_threads);
+    } else {
+      concatenate(
+          kname,
+          vec == 1 ? "moe_weighted_sum_" : "moe_weighted_sum_vec",
+          vec == 1 ? "" : std::to_string(vec),
+          vec == 1 ? "" : "_",
+          glm_type_name(x_sorted.dtype()),
+          "_score_float_topk_",
+          topk);
+    }
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto kernel = d.get_kernel(kname, lib);
+    auto& compute_encoder = metal::get_command_encoder(s);
+    compute_encoder.set_compute_pipeline_state(kernel);
+    compute_encoder.set_input_array(x_sorted, 0);
+    compute_encoder.set_input_array(inv_order, 1);
+    compute_encoder.set_input_array(scores, 2);
+    compute_encoder.set_output_array(out, 3);
+    compute_encoder.set_bytes(tokens, 4);
+    compute_encoder.set_bytes(D, 5);
+
+    const int threads = use_tiled ? tiled_threads : 256;
+    const int total = vec == 1 ? tokens * D : tokens * ((D + vec - 1) / vec);
+    MTL::Size group_dims(threads, 1, 1);
+    MTL::Size grid_dims(
+        use_tiled ? tokens : (total + threads - 1) / threads, 1, 1);
+    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  }
+
+  DEFINE_NAME(GlmMoeWeightedSumPrimitive)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& /* other */) const override {
+    return true;
+  }
+  auto state() const {
+    return std::make_tuple(nullptr);
+  }
+
+};
+
+} // namespace
+
+array glm_dsa_q8_vup_flat(
+    const array& x,
+    const array& weight,
+    const array& scales,
+    const array& biases,
+    StreamOrDevice s /* = {} */) {
+  if (x.ndim() != 4 || weight.ndim() != 3 || scales.ndim() != 3 ||
+      biases.ndim() != 3) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_dsa_q8_vup_flat] expected x rank 4 and "
+        << "quantized weights rank 3, got " << x.shape() << ", "
+        << weight.shape() << ", " << scales.shape() << ", " << biases.shape()
+        << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  const int B = x.shape(0);
+  const int H = x.shape(1);
+  const int L = x.shape(2);
+  constexpr int bits = 8;
+  constexpr int group_size = 64;
+  constexpr int pack_factor = 32 / bits;
+  const int V = weight.shape(1);
+  const int K = weight.shape(2) * pack_factor;
+  if (H != weight.shape(0) || H != scales.shape(0) ||
+      H != biases.shape(0) || V != scales.shape(1) ||
+      V != biases.shape(1) || x.shape(3) != K ||
+      scales.shape(2) != K / group_size ||
+      biases.shape(2) != K / group_size) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_dsa_q8_vup_flat] incompatible shapes: "
+        << x.shape() << ", " << weight.shape() << ", " << scales.shape()
+        << ", " << biases.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (x.dtype() != float16 && x.dtype() != bfloat16) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_dsa_q8_vup_flat] expected float16 or "
+        << "bfloat16 input, got " << x.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (weight.dtype() != uint32 || scales.dtype() != x.dtype() ||
+      biases.dtype() != x.dtype()) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_dsa_q8_vup_flat] expected uint32 weight and "
+        << "scale/bias dtype " << x.dtype() << ", got " << weight.dtype()
+        << ", " << scales.dtype() << ", " << biases.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto stream = to_stream(s);
+  std::vector<array> inputs = {x, weight, scales, biases};
+  if (GlmDsaQ8VupFlatPrimitive::unsupported(x, weight, scales, biases, stream)) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.glm_dsa_q8_vup_flat] unsupported M3 GLM shape.");
+  }
+
+  Shape out_shape{B, L, H * V};
+  return array(
+      std::move(out_shape),
+      x.dtype(),
+      std::make_shared<GlmDsaQ8VupFlatPrimitive>(stream),
+      std::move(inputs));
+}
+
+array glm_moe_weighted_sum(
+    const array& x_sorted,
+    const array& inv_order,
+    const array& scores,
+    StreamOrDevice s /* = {} */) {
+  if (x_sorted.ndim() != 3 || x_sorted.shape(-2) != 1) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_moe_weighted_sum] expected x_sorted shape "
+        << "[N, 1, D], got " << x_sorted.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (scores.ndim() < 2) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_moe_weighted_sum] expected scores rank >= 2, "
+        << "got " << scores.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (inv_order.ndim() != 1 || inv_order.dtype() != uint32) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_moe_weighted_sum] expected uint32 inv_order "
+        << "rank 1, got " << inv_order.shape() << " dtype "
+        << inv_order.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  const int topk = scores.shape(-1);
+  const int64_t routed_rows = scores.size();
+  const int D = x_sorted.shape(-1);
+  if (x_sorted.shape(0) != routed_rows || inv_order.size() != routed_rows) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_moe_weighted_sum] incompatible shapes: "
+        << x_sorted.shape() << ", " << inv_order.shape() << ", "
+        << scores.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (topk <= 0 || D <= 0) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_moe_weighted_sum] invalid topk or hidden "
+        << "dim: topk=" << topk << ", D=" << D << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (!issubdtype(x_sorted.dtype(), floating)) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_moe_weighted_sum] expected floating "
+        << "x_sorted, got " << x_sorted.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto stream = to_stream(s);
+  std::vector<array> inputs = {x_sorted, inv_order, scores};
+  Shape out_shape = scores.shape();
+  out_shape.pop_back();
+  out_shape.push_back(D);
+  if (GlmMoeWeightedSumPrimitive::unsupported(
+          x_sorted, inv_order, scores, stream)) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.glm_moe_weighted_sum] unsupported M3 GLM shape.");
+  }
+  return array(
+      std::move(out_shape),
+      x_sorted.dtype(),
+      std::make_shared<GlmMoeWeightedSumPrimitive>(stream),
+      std::move(inputs));
+}
+
+} // namespace omlx::glm_kernels

--- a/omlx_glm_kernels/csrc/fused_moe.h
+++ b/omlx_glm_kernels/csrc/fused_moe.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "mlx/array.h"
+#include "mlx/stream.h"
+#include "mlx/utils.h"
+
+namespace mx = mlx::core;
+
+namespace omlx::glm_kernels {
+
+mx::array glm_dsa_q8_vup_flat(
+    const mx::array& x,
+    const mx::array& weight,
+    const mx::array& scales,
+    const mx::array& biases,
+    mx::StreamOrDevice s = {});
+
+mx::array glm_moe_weighted_sum(
+    const mx::array& x_sorted,
+    const mx::array& inv_order,
+    const mx::array& scores,
+    mx::StreamOrDevice s = {});
+
+} // namespace omlx::glm_kernels

--- a/omlx_glm_kernels/csrc/fused_moe.metal
+++ b/omlx_glm_kernels/csrc/fused_moe.metal
@@ -1,0 +1,34 @@
+#include "mlx/backend/metal/kernels/utils.h"
+#include "mlx/backend/metal/kernels/steel/gemm/gemm.h"
+#include "kernels/quantized_glm.h"
+
+#define instantiate_quantized_head_flat(name, type, group_size, bits, aligned) \
+  instantiate_kernel(                                                          \
+      #name "_" #type "_gs_" #group_size "_b_" #bits "_alN_" #aligned,         \
+      name,                                                                    \
+      type,                                                                    \
+      group_size,                                                              \
+      bits,                                                                    \
+      aligned,                                                                 \
+      true)
+
+#define instantiate_moe_weighted_sum_tiled(type, score_type, topk, threads)    \
+  instantiate_kernel(                                                          \
+      "moe_weighted_sum_tiled_" #type "_score_" #score_type "_topk_" #topk     \
+      "_t_" #threads,                                                          \
+      moe_weighted_sum_tiled,                                                  \
+      type,                                                                    \
+      score_type,                                                              \
+      topk,                                                                    \
+      threads)
+
+instantiate_quantized_head_flat(affine_qmm_t_head_flat, float16_t, 64, 8, true);
+instantiate_quantized_head_flat(
+    affine_qmm_t_head_flat,
+    bfloat16_t,
+    64,
+    8,
+    true);
+
+instantiate_moe_weighted_sum_tiled(float16_t, float, 8, 256);
+instantiate_moe_weighted_sum_tiled(bfloat16_t, float, 8, 256);

--- a/omlx_glm_kernels/csrc/kernels/quantized_glm.h
+++ b/omlx_glm_kernels/csrc/kernels/quantized_glm.h
@@ -1,0 +1,2826 @@
+// Copyright © 2023-2024 Apple Inc.
+
+#include <metal_simdgroup>
+#include <metal_stdlib>
+
+constant bool align_M [[function_constant(200)]];
+constant bool align_N [[function_constant(201)]];
+constant bool align_K [[function_constant(202)]];
+
+using namespace metal;
+
+#define MLX_MTL_CONST static constant constexpr const
+
+MLX_MTL_CONST int SIMD_SIZE = 32;
+MLX_MTL_CONST int QUAD_SIZE = 4;
+
+template <int bits, int wsize = 8>
+inline constexpr short get_pack_factor() {
+  return (bits == 3 || bits == 5) ? 8 : (bits == 6 ? 4 : wsize / bits);
+}
+
+template <int bits, int wsize = 8>
+inline constexpr short get_bytes_per_pack() {
+  constexpr int power_of_2_bits = (bits & (bits - 1)) == 0;
+  return power_of_2_bits ? (wsize / 8) : (bits == 5 ? 5 : 3);
+}
+
+template <typename T, typename U, int values_per_thread, int bits>
+inline U load_vector(const device T* x, thread U* x_thread) {
+  static_assert(
+      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
+          bits == 8,
+      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+
+  U sum = 0;
+
+  if (bits == 2) {
+    for (int i = 0; i < values_per_thread; i += 4) {
+      sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
+      x_thread[i] = x[i];
+      x_thread[i + 1] = x[i + 1] / 4.0f;
+      x_thread[i + 2] = x[i + 2] / 16.0f;
+      x_thread[i + 3] = x[i + 3] / 64.0f;
+    }
+  }
+
+  else if (bits == 3) {
+    for (int i = 0; i < values_per_thread; i += 8) {
+      sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3] + x[i + 4] + x[i + 5] +
+          x[i + 6] + x[i + 7];
+      x_thread[i] = x[i];
+      x_thread[i + 1] = x[i + 1] / 8.0f;
+      x_thread[i + 2] = x[i + 2] / 64.0f;
+      x_thread[i + 3] = x[i + 3] / 2.0f;
+      x_thread[i + 4] = x[i + 4] / 16.0f;
+      x_thread[i + 5] = x[i + 5] / 128.0f;
+      x_thread[i + 6] = x[i + 6] / 4.0f;
+      x_thread[i + 7] = x[i + 7] / 32.0f;
+    }
+  }
+
+  else if (bits == 4) {
+    for (int i = 0; i < values_per_thread; i += 4) {
+      sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
+      x_thread[i] = x[i];
+      x_thread[i + 1] = x[i + 1] / 16.0f;
+      x_thread[i + 2] = x[i + 2] / 256.0f;
+      x_thread[i + 3] = x[i + 3] / 4096.0f;
+    }
+  }
+
+  else if (bits == 5) {
+    for (int i = 0; i < values_per_thread; i += 8) {
+      sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3] + x[i + 4] + x[i + 5] +
+          x[i + 6] + x[i + 7];
+      x_thread[i] = x[i];
+      x_thread[i + 1] = x[i + 1] / 32.0f;
+      x_thread[i + 2] = x[i + 2] / 4.0f;
+      x_thread[i + 3] = x[i + 3] / 128.0f;
+      x_thread[i + 4] = x[i + 4] / 16.0f;
+      x_thread[i + 5] = x[i + 5] / 2.0f;
+      x_thread[i + 6] = x[i + 6] / 64.0f;
+      x_thread[i + 7] = x[i + 7] / 8.0f;
+    }
+  }
+
+  else if (bits == 6) {
+    for (int i = 0; i < values_per_thread; i += 4) {
+      sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
+      x_thread[i] = x[i];
+      x_thread[i + 1] = x[i + 1] / 64.0f;
+      x_thread[i + 2] = x[i + 2] / 16.0f;
+      x_thread[i + 3] = x[i + 3] / 4.0f;
+    }
+  }
+
+  else if (bits == 8) {
+    for (int i = 0; i < values_per_thread; i++) {
+      sum += x[i];
+      x_thread[i] = x[i];
+    }
+  }
+
+  return sum;
+}
+
+template <typename T, typename U, int values_per_thread, int bits>
+inline U load_vector_safe(const device T* x, thread U* x_thread, int N) {
+  static_assert(
+      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
+          bits == 8,
+      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+
+  U sum = 0;
+
+  if (bits == 2) {
+    for (int i = 0; i < N; i += 4) {
+      sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
+      x_thread[i] = x[i];
+      x_thread[i + 1] = x[i + 1] / 4.0f;
+      x_thread[i + 2] = x[i + 2] / 16.0f;
+      x_thread[i + 3] = x[i + 3] / 64.0f;
+    }
+  }
+
+  else if (bits == 3) {
+    for (int i = 0; i < N; i += 8) {
+      sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3] + x[i + 4] + x[i + 5] +
+          x[i + 6] + x[i + 7];
+
+      x_thread[i] = x[i];
+      x_thread[i + 1] = x[i + 1] / 8.0f;
+      x_thread[i + 2] = x[i + 2] / 64.0f;
+      x_thread[i + 3] = x[i + 3] / 2.0f;
+      x_thread[i + 4] = x[i + 4] / 16.0f;
+      x_thread[i + 5] = x[i + 5] / 128.0f;
+      x_thread[i + 6] = x[i + 6] / 4.0f;
+      x_thread[i + 7] = x[i + 7] / 32.0f;
+    }
+  }
+
+  else if (bits == 4) {
+    for (int i = 0; i < N; i += 4) {
+      sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
+      x_thread[i] = x[i];
+      x_thread[i + 1] = x[i + 1] / 16.0f;
+      x_thread[i + 2] = x[i + 2] / 256.0f;
+      x_thread[i + 3] = x[i + 3] / 4096.0f;
+    }
+  }
+
+  else if (bits == 5) {
+    for (int i = 0; i < N; i += 8) {
+      sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3] + x[i + 4] + x[i + 5] +
+          x[i + 6] + x[i + 7];
+      x_thread[i] = x[i];
+      x_thread[i + 1] = x[i + 1] / 32.0f;
+      x_thread[i + 2] = x[i + 2] / 4.0f;
+      x_thread[i + 3] = x[i + 3] / 128.0f;
+      x_thread[i + 4] = x[i + 4] / 16.0f;
+      x_thread[i + 5] = x[i + 5] / 2.0f;
+      x_thread[i + 6] = x[i + 6] / 64.0f;
+      x_thread[i + 7] = x[i + 7] / 8.0f;
+    }
+  }
+
+  else if (bits == 6) {
+    for (int i = 0; i < N; i += 4) {
+      sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
+      x_thread[i] = x[i];
+      x_thread[i + 1] = x[i + 1] / 64.0f;
+      x_thread[i + 2] = x[i + 2] / 16.0f;
+      x_thread[i + 3] = x[i + 3] / 4.0f;
+    }
+  }
+
+  else if (bits == 8) {
+    for (int i = 0; i < N; i++) {
+      sum += x[i];
+      x_thread[i] = x[i];
+    }
+  }
+
+  for (int i = N; i < values_per_thread; i++) {
+    x_thread[i] = 0;
+  }
+
+  return sum;
+}
+
+template <typename U, int values_per_thread, int bits>
+inline U qdot(
+    const device uint8_t* w,
+    const thread U* x_thread,
+    U scale,
+    U bias,
+    U sum) {
+  static_assert(
+      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
+          bits == 8,
+      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+
+  U accum = 0;
+
+  if (bits == 2) {
+    for (int i = 0; i < (values_per_thread / 4); i++) {
+      accum +=
+          (x_thread[4 * i] * (w[i] & 0x03) +
+           x_thread[4 * i + 1] * (w[i] & 0x0c) +
+           x_thread[4 * i + 2] * (w[i] & 0x30) +
+           x_thread[4 * i + 3] * (w[i] & 0xc0));
+    }
+  }
+
+  else if (bits == 3) {
+    for (int i = 0; i < (values_per_thread / 8); i++) {
+      x_thread += 8 * i;
+      w += 3 * i;
+
+      accum += (w[0] & 0x07) * x_thread[0];
+      accum += (w[0] & 0x38) * x_thread[1];
+      accum += (w[0] & 0xc0) * x_thread[2];
+      accum += (w[1] & 0x01) * (x_thread[2] * 256.0f);
+
+      accum += (w[1] & 0x0e) * x_thread[3];
+      accum += (w[1] & 0x70) * x_thread[4];
+      accum += (w[1] & 0x80) * x_thread[5];
+      accum += (w[2] & 0x03) * (x_thread[5] * 256.0f);
+
+      accum += (w[2] & 0x1c) * x_thread[6];
+      accum += (w[2] & 0xe0) * x_thread[7];
+    }
+  }
+
+  else if (bits == 4) {
+    const device uint16_t* ws = (const device uint16_t*)w;
+    for (int i = 0; i < (values_per_thread / 4); i++) {
+      accum +=
+          (x_thread[4 * i] * (ws[i] & 0x000f) +
+           x_thread[4 * i + 1] * (ws[i] & 0x00f0) +
+           x_thread[4 * i + 2] * (ws[i] & 0x0f00) +
+           x_thread[4 * i + 3] * (ws[i] & 0xf000));
+    }
+  }
+
+  else if (bits == 5) {
+    for (int i = 0; i < (values_per_thread / 8); i++) {
+      x_thread += 8 * i;
+      w += 5 * i;
+
+      accum += (w[0] & 0x1f) * x_thread[0];
+      accum += (w[0] & 0xe0) * x_thread[1];
+      accum += (w[1] & 0x3) * (x_thread[1] * 256.0f);
+      accum += (w[1] & 0x7c) * x_thread[2];
+      accum += (w[1] & 0x80) * x_thread[3];
+      accum += (w[2] & 0xf) * (x_thread[3] * 256.0f);
+      accum += (w[2] & 0xf0) * x_thread[4];
+      accum += (w[3] & 0x1) * (x_thread[4] * 256.0f);
+      accum += (w[3] & 0x3e) * x_thread[5];
+      accum += (w[3] & 0xc0) * x_thread[6];
+      accum += (w[4] & 0x7) * (x_thread[6] * 256.0f);
+      accum += (w[4] & 0xf8) * x_thread[7];
+    }
+  }
+
+  else if (bits == 6) {
+    for (int i = 0; i < (values_per_thread / 4); i++) {
+      x_thread += 4 * i;
+      w += 3 * i;
+
+      accum += (w[0] & 0x3f) * x_thread[0];
+
+      accum += (w[0] & 0xc0) * x_thread[1];
+      accum += (w[1] & 0x0f) * (x_thread[1] * 256.0f);
+
+      accum += (w[1] & 0xf0) * x_thread[2];
+      accum += (w[2] & 0x03) * (x_thread[2] * 256.0f);
+
+      accum += (w[2] & 0xfc) * x_thread[3];
+    }
+  }
+
+  else if (bits == 8) {
+    for (int i = 0; i < values_per_thread; i++) {
+      accum += x_thread[i] * w[i];
+    }
+  }
+
+  return scale * accum + sum * bias;
+}
+
+template <typename U, int values_per_thread, int bits>
+inline U qdot_safe(
+    const device uint8_t* w,
+    const thread U* x_thread,
+    U scale,
+    U bias,
+    U sum,
+    int N) {
+  static_assert(
+      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
+          bits == 8,
+      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+
+  U accum = 0;
+
+  if (bits == 2) {
+    for (int i = 0; i < (N / 4); i++) {
+      accum +=
+          (x_thread[4 * i] * (w[i] & 0x03) +
+           x_thread[4 * i + 1] * (w[i] & 0x0c) +
+           x_thread[4 * i + 2] * (w[i] & 0x30) +
+           x_thread[4 * i + 3] * (w[i] & 0xc0));
+    }
+  }
+
+  else if (bits == 3) {
+    for (int i = 0; i < (N / 8); i++) {
+      x_thread += 8 * i;
+      w += 3 * i;
+
+      accum += (w[0] & 0x07) * x_thread[0];
+      accum += (w[0] & 0x38) * x_thread[1];
+      accum += (w[0] & 0xc0) * x_thread[2];
+      accum += (w[1] & 0x01) * (x_thread[2] * 256.0f);
+
+      accum += (w[1] & 0x0e) * x_thread[3];
+      accum += (w[1] & 0x70) * x_thread[4];
+      accum += (w[1] & 0x80) * x_thread[5];
+      accum += (w[2] & 0x03) * (x_thread[5] * 256.0f);
+
+      accum += (w[2] & 0x1c) * x_thread[6];
+      accum += (w[2] & 0xe0) * x_thread[7];
+    }
+  }
+
+  else if (bits == 4) {
+    const device uint16_t* ws = (const device uint16_t*)w;
+    for (int i = 0; i < (N / 4); i++) {
+      accum +=
+          (x_thread[4 * i] * (ws[i] & 0x000f) +
+           x_thread[4 * i + 1] * (ws[i] & 0x00f0) +
+           x_thread[4 * i + 2] * (ws[i] & 0x0f00) +
+           x_thread[4 * i + 3] * (ws[i] & 0xf000));
+    }
+  }
+
+  else if (bits == 5) {
+    for (int i = 0; i < (N / 8); i++) {
+      x_thread += 8 * i;
+      w += 5 * i;
+
+      accum += (w[0] & 0x1f) * x_thread[0];
+      accum += (w[0] & 0xe0) * x_thread[1];
+      accum += (w[1] & 0x3) * (x_thread[1] * 256.0f);
+      accum += (w[1] & 0x7c) * x_thread[2];
+      accum += (w[1] & 0x80) * x_thread[3];
+      accum += (w[2] & 0xf) * (x_thread[3] * 256.0f);
+      accum += (w[2] & 0xf0) * x_thread[4];
+      accum += (w[3] & 0x1) * (x_thread[4] * 256.0f);
+      accum += (w[3] & 0x3e) * x_thread[5];
+      accum += (w[3] & 0xc0) * x_thread[6];
+      accum += (w[4] & 0x7) * (x_thread[6] * 256.0f);
+      accum += (w[4] & 0xf8) * x_thread[7];
+    }
+  }
+
+  else if (bits == 6) {
+    for (int i = 0; i < (N / 4); i++) {
+      x_thread += 4 * i;
+      w += 3 * i;
+
+      accum += (w[0] & 0x3f) * x_thread[0];
+
+      accum += (w[0] & 0xc0) * x_thread[1];
+      accum += (w[1] & 0x0f) * (x_thread[1] * 256.0f);
+
+      accum += (w[1] & 0xf0) * x_thread[2];
+      accum += (w[2] & 0x03) * (x_thread[2] * 256.0f);
+
+      accum += (w[2] & 0xfc) * x_thread[3];
+    }
+  }
+
+  else if (bits == 8) {
+    for (int i = 0; i < N; i++) {
+      accum += x_thread[i] * w[i];
+    }
+  }
+
+  return scale * accum + sum * bias;
+}
+
+template <typename U, int values_per_thread, int bits>
+inline void
+qouter(const thread uint8_t* w, U x, U scale, U bias, thread U* result) {
+  static_assert(
+      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
+          bits == 8,
+      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+
+  if (bits == 2) {
+    U s[4] = {scale, scale / 4.0f, scale / 16.0f, scale / 64.0f};
+    for (int i = 0; i < (values_per_thread / 4); i++) {
+      result[4 * i] += x * (s[0] * (w[i] & 0x03) + bias);
+      result[4 * i + 1] += x * (s[1] * (w[i] & 0x0c) + bias);
+      result[4 * i + 2] += x * (s[2] * (w[i] & 0x30) + bias);
+      result[4 * i + 3] += x * (s[3] * (w[i] & 0xc0) + bias);
+    }
+  }
+
+  else if (bits == 3) {
+    for (int i = 0; i < (values_per_thread / 8); i++) {
+      uint8_t w0 = w[3 * i];
+      uint8_t w1 = w[3 * i + 1];
+      uint8_t w2 = w[3 * i + 2];
+
+      result[8 * i] += x * ((w0 & 0x7) * scale + bias);
+      result[8 * i + 1] += x * (((w0 & 0x38) >> 3) * scale + bias);
+      result[8 * i + 2] +=
+          x * ((((w0 & 0xc0) >> 6) + ((w1 & 0x1) << 2)) * scale + bias);
+      result[8 * i + 3] += x * (((w1 & 0xe) >> 1) * scale + bias);
+      result[8 * i + 4] += x * (((w1 & 0x70) >> 4) * scale + bias);
+      result[8 * i + 5] +=
+          x * ((((w1 & 0x80) >> 7) + ((w2 & 0x3) << 1)) * scale + bias);
+      result[8 * i + 6] += x * (((w2 & 0x1c) >> 2) * scale + bias);
+      result[8 * i + 7] += x * (((w2 & 0xe0) >> 5) * scale + bias);
+    }
+  }
+
+  else if (bits == 4) {
+    U s[2] = {scale, scale / 16.0f};
+    for (int i = 0; i < (values_per_thread / 2); i++) {
+      result[2 * i] += x * (s[0] * (w[i] & 0x0f) + bias);
+      result[2 * i + 1] += x * (s[1] * (w[i] & 0xf0) + bias);
+    }
+  }
+
+  else if (bits == 5) {
+    for (int i = 0; i < (values_per_thread / 8); i++) {
+      uint8_t w0 = w[5 * i];
+      uint8_t w1 = w[5 * i + 1];
+      uint8_t w2 = w[5 * i + 2];
+      uint8_t w3 = w[5 * i + 3];
+      uint8_t w4 = w[5 * i + 4];
+      result[8 * i] += x * ((w0 & 0x1f) * scale + bias);
+      result[8 * i + 1] +=
+          x * ((((w0 & 0xe0) >> 5) + ((w1 & 0x3) << 3)) * scale + bias);
+      result[8 * i + 2] += x * (((w1 & 0x7c) >> 2) * scale + bias);
+      result[8 * i + 3] +=
+          x * ((((w1 & 0x80) >> 7) + ((w2 & 0xf) << 1)) * scale + bias);
+      result[8 * i + 4] +=
+          x * ((((w2 & 0xf0) >> 4) + ((w3 & 0x1) << 4)) * scale + bias);
+      result[8 * i + 5] += x * (((w3 & 0x3e) >> 1) * scale + bias);
+      result[8 * i + 6] +=
+          x * ((((w3 & 0xc0) >> 6) + ((w4 & 0x7) << 2)) * scale + bias);
+      result[8 * i + 7] += x * (((w4 & 0xf8) >> 3) * scale + bias);
+    }
+  }
+
+  else if (bits == 6) {
+    for (int i = 0; i < (values_per_thread / 4); i++) {
+      uint8_t w0 = w[3 * i];
+      uint8_t w1 = w[3 * i + 1];
+      uint8_t w2 = w[3 * i + 2];
+
+      result[4 * i] += x * ((w0 & 0x3f) * scale + bias);
+      result[4 * i + 1] +=
+          x * ((((w0 >> 6) & 0x03) + ((w1 & 0x0f) << 2)) * scale + bias);
+      result[4 * i + 2] +=
+          x * ((((w1 >> 4) & 0x0f) + ((w2 & 0x03) << 4)) * scale + bias);
+      result[4 * i + 3] += x * (((w2 >> 2) & 0x3f) * scale + bias);
+    }
+  }
+
+  else if (bits == 8) {
+    for (int i = 0; i < values_per_thread; i++) {
+      result[i] += x * (scale * w[i] + bias);
+    }
+  }
+}
+
+template <typename U, int N, int bits>
+inline void
+dequantize(const device uint8_t* w, U scale, U bias, threadgroup U* w_local) {
+  static_assert(
+      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
+          bits == 8,
+      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+
+  if (bits == 2) {
+    U s[4] = {
+        scale,
+        scale / static_cast<U>(4.0f),
+        scale / static_cast<U>(16.0f),
+        scale / static_cast<U>(64.0f)};
+    for (int i = 0; i < (N / 4); i++) {
+      w_local[4 * i] = s[0] * (w[i] & 0x03) + bias;
+      w_local[4 * i + 1] = s[1] * (w[i] & 0x0c) + bias;
+      w_local[4 * i + 2] = s[2] * (w[i] & 0x30) + bias;
+      w_local[4 * i + 3] = s[3] * (w[i] & 0xc0) + bias;
+    }
+  }
+
+  else if (bits == 3) {
+    for (int i = 0; i < (N / 8); i++) {
+      w_local += 8 * i;
+      w += 3 * i;
+
+      w_local[0] = (w[0] & 0x7) * scale + bias;
+      w_local[1] = ((w[0] & 0x38) >> 3) * scale + bias;
+      w_local[2] = (((w[0] & 0xc0) >> 6) + ((w[1] & 0x1) << 2)) * scale + bias;
+      w_local[3] = ((w[1] & 0xe) >> 1) * scale + bias;
+      w_local[4] = ((w[1] & 0x70) >> 4) * scale + bias;
+      w_local[5] = (((w[1] & 0x80) >> 7) + ((w[2] & 0x3) << 1)) * scale + bias;
+      w_local[6] = ((w[2] & 0x1c) >> 2) * scale + bias;
+      w_local[7] = ((w[2] & 0xe0) >> 5) * scale + bias;
+    }
+  }
+
+  else if (bits == 4) {
+    U s[2] = {scale, scale / static_cast<U>(16.0f)};
+    for (int i = 0; i < (N / 2); i++) {
+      w_local[2 * i] = s[0] * (w[i] & 0x0f) + bias;
+      w_local[2 * i + 1] = s[1] * (w[i] & 0xf0) + bias;
+    }
+  }
+
+  else if (bits == 5) {
+    for (int i = 0; i < (N / 8); i++) {
+      w_local += 8 * i;
+      w += 5 * i;
+
+      w_local[0] = (w[0] & 0x1f) * scale + bias;
+      w_local[1] = (((w[0] & 0xe0) >> 5) + ((w[1] & 0x3) << 3)) * scale + bias;
+      w_local[2] = ((w[1] & 0x7c) >> 2) * scale + bias;
+      w_local[3] = (((w[1] & 0x80) >> 7) + ((w[2] & 0xf) << 1)) * scale + bias;
+      w_local[4] = (((w[2] & 0xf0) >> 4) + ((w[3] & 0x1) << 4)) * scale + bias;
+      w_local[5] = ((w[3] & 0x3e) >> 1) * scale + bias;
+      w_local[6] = (((w[3] & 0xc0) >> 6) + ((w[4] & 0x7) << 2)) * scale + bias;
+      w_local[7] = ((w[4] & 0xf8) >> 3) * scale + bias;
+    }
+  }
+
+  else if (bits == 6) {
+    for (int i = 0; i < (N / 4); i++) {
+      w_local += 4 * i;
+      w += 3 * i;
+      w_local[0] = (w[0] & 0x3f) * scale + bias;
+      w_local[1] = (((w[0] >> 6) & 0x03) + ((w[1] & 0x0f) << 2)) * scale + bias;
+      w_local[2] = (((w[1] >> 4) & 0x0f) + ((w[2] & 0x03) << 4)) * scale + bias;
+      w_local[3] = ((w[2] >> 2) & 0x3f) * scale + bias;
+    }
+  }
+
+  else if (bits == 8) {
+    for (int i = 0; i < N; i++) {
+      w_local[i] = scale * w[i] + bias;
+    }
+  }
+}
+
+template <
+    typename T,
+    short BROWS,
+    short BCOLS,
+    short dst_ld,
+    short reduction_dim,
+    short tgp_size,
+    short group_size,
+    short bits>
+struct QuantizedBlockLoader {
+  static_assert(
+      BCOLS <= group_size,
+      "The group size should be larger than the columns");
+  static_assert(
+      group_size % BCOLS == 0,
+      "The group size should be divisible by the columns");
+  static_assert(
+      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
+          bits == 8,
+      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+
+  MLX_MTL_CONST short pack_factor = get_pack_factor<bits, 8>();
+  MLX_MTL_CONST short bytes_per_pack = get_bytes_per_pack<bits>();
+  MLX_MTL_CONST short BCOLS_PACKED = BCOLS / pack_factor;
+  MLX_MTL_CONST short n_reads =
+      (BCOLS_PACKED * BROWS < tgp_size) ? 1 : (BCOLS_PACKED * BROWS) / tgp_size;
+  MLX_MTL_CONST short group_steps = group_size / BCOLS;
+
+  const int src_ld;
+  const int tile_stride;
+  short group_step_cnt;
+  const int group_stride;
+
+  const short thread_idx;
+  const short bi;
+  const short bj;
+
+  threadgroup T* dst;
+  const device uint8_t* src;
+  const device T* scales;
+  const device T* biases;
+
+  QuantizedBlockLoader(
+      const device uint8_t* src_,
+      const device T* scales_,
+      const device T* biases_,
+      const int src_ld_,
+      threadgroup T* dst_,
+      ushort simd_group_id [[simdgroup_index_in_threadgroup]],
+      ushort simd_lane_id [[thread_index_in_simdgroup]])
+      : src_ld(src_ld_),
+        tile_stride(
+            reduction_dim ? BCOLS_PACKED * bytes_per_pack
+                          : BROWS * src_ld * bytes_per_pack / pack_factor),
+        group_step_cnt(0),
+        group_stride(BROWS * src_ld / group_size),
+        thread_idx(simd_group_id * 32 + simd_lane_id),
+        bi(n_reads * thread_idx / BCOLS_PACKED),
+        bj((n_reads * thread_idx) % BCOLS_PACKED),
+        dst(dst_ + bi * dst_ld + bj * pack_factor),
+        src(src_ + bi * src_ld * bytes_per_pack / pack_factor +
+            bj * bytes_per_pack),
+        scales(scales_ + bi * src_ld / group_size),
+        biases(biases_ + bi * src_ld / group_size) {}
+
+  void load_unsafe() const {
+    if (BCOLS_PACKED * BROWS < tgp_size && bi >= BROWS) {
+      return;
+    }
+
+    T scale = *scales;
+    T bias = *biases;
+    for (int i = 0; i < n_reads; i++) {
+      dequantize<T, pack_factor, bits>(
+          src + i * bytes_per_pack, scale, bias, dst + i * pack_factor);
+    }
+  }
+
+  void load_safe(short2 src_tile_dim) const {
+    if (BCOLS_PACKED * BROWS < tgp_size && bi >= BROWS) {
+      return;
+    }
+
+    if (reduction_dim == 1 && bi >= src_tile_dim.x) {
+      for (int i = 0; i < n_reads * pack_factor; i++) {
+        dst[i] = T(0);
+      }
+      return;
+    }
+
+    if (reduction_dim == 0 && bi >= src_tile_dim.y) {
+      for (int i = 0; i < n_reads * pack_factor; i++) {
+        dst[i] = T(0);
+      }
+      return;
+    }
+
+    T scale = *scales;
+    T bias = *biases;
+    for (int i = 0; i < n_reads; i++) {
+      dequantize<T, pack_factor, bits>(
+          (device uint8_t*)(src + i * bytes_per_pack),
+          scale,
+          bias,
+          dst + i * pack_factor);
+    }
+  }
+
+  void next() {
+    src += tile_stride;
+    if (reduction_dim == 1) {
+      if (group_steps > 1) {
+        group_step_cnt++;
+        if (group_step_cnt == group_steps) {
+          group_step_cnt = 0;
+          scales++;
+          biases++;
+        }
+      } else {
+        scales++;
+        biases++;
+      }
+    } else {
+      scales += group_stride;
+      biases += group_stride;
+    }
+  }
+};
+
+template <typename T, int group_size, int bits, int D>
+METAL_FUNC void qmv_quad_impl(
+    const device uint32_t* w,
+    const device T* scales,
+    const device T* biases,
+    const device T* x,
+    device T* y,
+    constant int& in_vec_size,
+    const constant int& out_vec_size,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint quad_gid [[quadgroup_index_in_threadgroup]],
+    uint quad_lid [[thread_index_in_quadgroup]]) {
+  constexpr int quads_per_simd = SIMD_SIZE / QUAD_SIZE;
+  constexpr int pack_factor = 32 / bits;
+  constexpr int values_per_thread = D / QUAD_SIZE;
+  constexpr int packs_per_thread = values_per_thread / pack_factor;
+  constexpr int scale_step_per_thread = group_size / values_per_thread;
+  constexpr int results_per_quadgroup = 8;
+
+  typedef float U;
+
+  thread U x_thread[values_per_thread];
+  thread U result[results_per_quadgroup] = {0};
+
+  // Adjust positions
+  const int in_vec_size_w = in_vec_size / pack_factor;
+  const int in_vec_size_g = in_vec_size / group_size;
+  const int out_row = tid.y * quads_per_simd * results_per_quadgroup + quad_gid;
+
+  w += out_row * in_vec_size_w + quad_lid * packs_per_thread;
+  scales += out_row * in_vec_size_g + quad_lid / scale_step_per_thread;
+  biases += out_row * in_vec_size_g + quad_lid / scale_step_per_thread;
+  x += tid.x * in_vec_size + quad_lid * values_per_thread;
+  y += tid.x * out_vec_size + out_row;
+
+  U sum = load_vector<T, U, values_per_thread, bits>(x, x_thread);
+
+  for (int row = 0; row < results_per_quadgroup; row++) {
+    auto wl = (const device uint8_t*)(w + row * in_vec_size_w * quads_per_simd);
+    const device T* sl = scales + row * in_vec_size_g * quads_per_simd;
+    const device T* bl = biases + row * in_vec_size_g * quads_per_simd;
+
+    U s = sl[0];
+    U b = bl[0];
+    if (row * quads_per_simd + out_row < out_vec_size) {
+      result[row] += qdot<U, values_per_thread, bits>(wl, x_thread, s, b, sum);
+    }
+  }
+
+  for (int row = 0; row < results_per_quadgroup; row++) {
+    result[row] = quad_sum(result[row]);
+    if (quad_lid == 0 && row * quads_per_simd + out_row < out_vec_size) {
+      y[row * quads_per_simd] = static_cast<T>(result[row]);
+    }
+  }
+}
+
+template <typename T, int group_size, int bits>
+METAL_FUNC void qmv_fast_impl(
+    const device uint32_t* w,
+    const device T* scales,
+    const device T* biases,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int packs_per_thread = bits == 2 ? 1 : 2;
+  constexpr int num_simdgroups = 2;
+  constexpr int results_per_simdgroup = 4;
+  constexpr int pack_factor = get_pack_factor<bits, 32>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<bits, 32>();
+  constexpr int values_per_thread = pack_factor * packs_per_thread;
+  constexpr int block_size = values_per_thread * SIMD_SIZE;
+  constexpr int scale_step_per_thread = group_size / values_per_thread;
+
+  const device uint8_t* ws = (const device uint8_t*)w;
+
+  typedef float U;
+
+  thread U x_thread[values_per_thread];
+  thread U result[results_per_simdgroup] = {0};
+
+  // Adjust positions
+  const int in_vec_size_w = in_vec_size * bytes_per_pack / pack_factor;
+  const int in_vec_size_g = in_vec_size / group_size;
+  const int out_row = tid.y * (num_simdgroups * results_per_simdgroup) +
+      simd_gid * results_per_simdgroup;
+
+  ws += out_row * in_vec_size_w + simd_lid * packs_per_thread * bytes_per_pack;
+  scales += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+  biases += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+  x += tid.x * in_vec_size + simd_lid * values_per_thread;
+  y += tid.x * out_vec_size + out_row;
+
+  for (int k = 0; k < in_vec_size; k += block_size) {
+    U sum = load_vector<T, U, values_per_thread, bits>(x, x_thread);
+
+    for (int row = 0; row < results_per_simdgroup; row++) {
+      auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+      const device T* sl = scales + row * in_vec_size_g;
+      const device T* bl = biases + row * in_vec_size_g;
+
+      U s = sl[0];
+      U b = bl[0];
+      result[row] += qdot<U, values_per_thread, bits>(wl, x_thread, s, b, sum);
+    }
+
+    ws += block_size * bytes_per_pack / pack_factor;
+    scales += block_size / group_size;
+    biases += block_size / group_size;
+    x += block_size;
+  }
+
+  for (int row = 0; row < results_per_simdgroup; row++) {
+    result[row] = simd_sum(result[row]);
+    if (simd_lid == 0) {
+      y[row] = static_cast<T>(result[row]);
+    }
+  }
+}
+
+template <typename T, int group_size, int bits>
+METAL_FUNC void qmv_impl(
+    const device uint32_t* w,
+    const device T* scales,
+    const device T* biases,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int num_simdgroups = 2;
+  constexpr int results_per_simdgroup = 4;
+  constexpr int packs_per_thread = 1;
+  constexpr int pack_factor = get_pack_factor<bits, 32>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<bits, 32>();
+
+  constexpr int values_per_thread = pack_factor * packs_per_thread;
+  constexpr int block_size = values_per_thread * SIMD_SIZE;
+  constexpr int scale_step_per_thread = group_size / values_per_thread;
+
+  const device uint8_t* ws = (const device uint8_t*)w;
+
+  typedef float U;
+
+  thread U x_thread[values_per_thread];
+  thread U result[results_per_simdgroup] = {0};
+
+  // Adjust positions
+  const int in_vec_size_w = in_vec_size * bytes_per_pack / pack_factor;
+  const int in_vec_size_g = in_vec_size / group_size;
+  const int out_row = tid.y * (num_simdgroups * results_per_simdgroup) +
+      simd_gid * results_per_simdgroup;
+  const int used_out_row = min(out_vec_size - results_per_simdgroup, out_row);
+
+  if (out_row >= out_vec_size) {
+    return;
+  }
+
+  // In this case we need to properly guard all our reads because there isn't
+  // even 1 tile in the matrix
+  if (out_vec_size < (num_simdgroups * results_per_simdgroup)) {
+    ws +=
+        out_row * in_vec_size_w + simd_lid * packs_per_thread * bytes_per_pack;
+    scales += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+    biases += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+    x += tid.x * in_vec_size + simd_lid * values_per_thread;
+    y += tid.x * out_vec_size + out_row;
+
+    int k = 0;
+    for (; k < in_vec_size - block_size; k += block_size) {
+      U sum = load_vector<T, U, values_per_thread, bits>(x, x_thread);
+
+      for (int row = 0;
+           row < results_per_simdgroup && out_row + row < out_vec_size;
+           row++) {
+        auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+        const device T* sl = scales + row * in_vec_size_g;
+        const device T* bl = biases + row * in_vec_size_g;
+
+        U s = sl[0];
+        U b = bl[0];
+        result[row] +=
+            qdot<U, values_per_thread, bits>(wl, x_thread, s, b, sum);
+      }
+
+      ws += block_size * bytes_per_pack / pack_factor;
+      scales += block_size / group_size;
+      biases += block_size / group_size;
+      x += block_size;
+    }
+    const int remaining = clamp(
+        static_cast<int>(in_vec_size - k - simd_lid * values_per_thread),
+        0,
+        values_per_thread);
+    if (remaining > 0) {
+      U sum = load_vector_safe<T, U, values_per_thread, bits>(
+          x, x_thread, remaining);
+
+      for (int row = 0;
+           row < results_per_simdgroup && out_row + row < out_vec_size;
+           row++) {
+        auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+        const device T* sl = scales + row * in_vec_size_g;
+        const device T* bl = biases + row * in_vec_size_g;
+
+        U s = sl[0];
+        U b = bl[0];
+        result[row] += qdot_safe<U, values_per_thread, bits>(
+            wl, x_thread, s, b, sum, remaining);
+      }
+    }
+
+    for (int row = 0;
+         row < results_per_simdgroup && out_row + row < out_vec_size;
+         row++) {
+      result[row] = simd_sum(result[row]);
+      if (simd_lid == 0) {
+        y[row] = static_cast<T>(result[row]);
+      }
+    }
+  }
+
+  // In this case the last tile is moved back to redo some output values
+  else {
+    ws += used_out_row * in_vec_size_w +
+        simd_lid * packs_per_thread * bytes_per_pack;
+    scales += used_out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+    biases += used_out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+    x += tid.x * in_vec_size + simd_lid * values_per_thread;
+    y += tid.x * out_vec_size + used_out_row;
+
+    int k = 0;
+    for (; k < in_vec_size - block_size; k += block_size) {
+      U sum = load_vector<T, U, values_per_thread, bits>(x, x_thread);
+
+      for (int row = 0; row < results_per_simdgroup; row++) {
+        auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+        const device T* sl = scales + row * in_vec_size_g;
+        const device T* bl = biases + row * in_vec_size_g;
+
+        U s = sl[0];
+        U b = bl[0];
+        result[row] +=
+            qdot<U, values_per_thread, bits>(wl, x_thread, s, b, sum);
+      }
+
+      ws += block_size * bytes_per_pack / pack_factor;
+      scales += block_size / group_size;
+      biases += block_size / group_size;
+      x += block_size;
+    }
+    const int remaining = clamp(
+        static_cast<int>(in_vec_size - k - simd_lid * values_per_thread),
+        0,
+        values_per_thread);
+    if (remaining > 0) {
+      U sum = load_vector_safe<T, U, values_per_thread, bits>(
+          x, x_thread, remaining);
+
+      for (int row = 0; row < results_per_simdgroup; row++) {
+        auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+        const device T* sl = scales + row * in_vec_size_g;
+        const device T* bl = biases + row * in_vec_size_g;
+
+        U s = sl[0];
+        U b = bl[0];
+        result[row] += qdot_safe<U, values_per_thread, bits>(
+            wl, x_thread, s, b, sum, remaining);
+      }
+    }
+    for (int row = 0; row < results_per_simdgroup; row++) {
+      result[row] = simd_sum(result[row]);
+      if (simd_lid == 0) {
+        y[row] = static_cast<T>(result[row]);
+      }
+    }
+  }
+}
+
+template <typename T, const int group_size, const int bits>
+METAL_FUNC void qvm_impl(
+    const device uint32_t* w,
+    const device T* scales,
+    const device T* biases,
+    const device T* x,
+    device T* y,
+    const int in_vec_size,
+    const int out_vec_size,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int power_of_2_bits = (bits & (bits - 1)) == 0;
+  constexpr int num_simdgroups = 2;
+  constexpr int pack_factor = get_pack_factor<bits, 32>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<bits>();
+
+  constexpr int tn = 32 / pack_factor;
+  constexpr int block_size = SIMD_SIZE;
+
+  using W_T =
+      typename ConditionalType<power_of_2_bits, uint32_t, uint8_t>::type;
+  const device W_T* ws = (const device W_T*)w;
+
+  typedef float U;
+  typedef struct {
+    W_T wi[tn * bytes_per_pack];
+  } vec_w;
+
+  thread vec_w w_local;
+  thread U result[tn * pack_factor] = {0};
+  thread U scale = 1;
+  thread U bias = 0;
+  thread U x_local = 0;
+
+  // Adjust positions
+  const int out_vec_size_w = out_vec_size * bytes_per_pack / pack_factor;
+  const int out_vec_size_g = out_vec_size / group_size;
+  int out_col = pack_factor * tn * (tid.y * num_simdgroups + simd_gid);
+  ws += out_col * bytes_per_pack / pack_factor + simd_lid * out_vec_size_w;
+  scales += out_col / group_size + simd_lid * out_vec_size_g;
+  biases += out_col / group_size + simd_lid * out_vec_size_g;
+  x += tid.x * in_vec_size + simd_lid;
+  y += tid.x * out_vec_size + out_col;
+
+  if (out_col >= out_vec_size) {
+    return;
+  }
+
+  // Loop over in_vec in blocks of block_size
+  int remaining = in_vec_size % block_size;
+  if (remaining == 0) {
+    for (int i = 0; i < in_vec_size; i += block_size) {
+      x_local = *x;
+      scale = *scales;
+      bias = *biases;
+      w_local = *((device vec_w*)ws);
+      qouter<U, tn * pack_factor, bits>(
+          (thread uint8_t*)&w_local, x_local, scale, bias, result);
+
+      x += block_size;
+      scales += block_size * out_vec_size_g;
+      biases += block_size * out_vec_size_g;
+      ws += block_size * out_vec_size_w;
+    }
+  } else {
+    for (int i = block_size; i < in_vec_size; i += block_size) {
+      x_local = *x;
+      scale = *scales;
+      bias = *biases;
+      w_local = *((device vec_w*)ws);
+
+      qouter<U, tn * pack_factor, bits>(
+          (thread uint8_t*)&w_local, x_local, scale, bias, result);
+
+      x += block_size;
+      scales += block_size * out_vec_size_g;
+      biases += block_size * out_vec_size_g;
+      ws += block_size * out_vec_size_w;
+    }
+    if (static_cast<int>(simd_lid) < remaining) {
+      x_local = *x;
+      scale = *scales;
+      bias = *biases;
+      w_local = *((device vec_w*)ws);
+    } else {
+      x_local = 0;
+      scale = 0;
+      bias = 0;
+    }
+    qouter<U, tn * pack_factor, bits>(
+        (thread uint8_t*)&w_local, x_local, scale, bias, result);
+  }
+
+// Accumulate in the simdgroup
+#pragma clang loop unroll(full)
+  for (int k = 0; k < tn * pack_factor; k++) {
+    result[k] = simd_sum(result[k]);
+  }
+
+  // Store the result
+  if (simd_lid == 0) {
+#pragma clang loop unroll(full)
+    for (int k = 0; k < tn * pack_factor; k++) {
+      y[k] = static_cast<T>(result[k]);
+    }
+  }
+}
+
+template <
+    typename T,
+    const int group_size,
+    const int bits,
+    const bool aligned_N,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+METAL_FUNC void qmm_t_impl(
+    const device uint32_t* w,
+    const device T* scales,
+    const device T* biases,
+    const device T* x,
+    device T* y,
+    threadgroup T* Xs,
+    threadgroup T* Ws,
+    const constant int& K,
+    const constant int& N,
+    const constant int& M,
+    const constant int& K_eff,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  static_assert(BK >= SIMD_SIZE, "BK should be larger than SIMD_SIZE");
+  static_assert(BK % SIMD_SIZE == 0, "BK should be divisible by SIMD_SIZE");
+
+  (void)lid;
+
+  constexpr int WM = 2;
+  constexpr int WN = 2;
+  constexpr int pack_factor = get_pack_factor<bits, 8>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<bits>();
+
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+
+  // Instantiate the appropriate BlockMMA and Loader
+  using mma_t = mlx::steel::
+      BlockMMA<T, T, BM, BN, BK, WM, WN, false, true, BK_padded, BK_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t = QuantizedBlockLoader<
+      T,
+      BN,
+      BK,
+      BK_padded,
+      1,
+      WM * WN * SIMD_SIZE,
+      group_size,
+      bits>;
+
+  // Set the block
+  const int K_w = K * bytes_per_pack / pack_factor;
+  const int K_g = K / group_size;
+  const int y_row = tid.y * BM;
+  const int y_col = tid.x * BN;
+
+  auto wl = (const device uint8_t*)w;
+
+  x += y_row * static_cast<int64_t>(K);
+  wl += y_col * K_w;
+  scales += y_col * K_g;
+  biases += y_col * K_g;
+  y += y_row * static_cast<int64_t>(N) + y_col;
+
+  // Make the x loader and mma operation
+  const short num_els = min(BM, M - y_row);
+  const short num_outs = min(BN, N - y_col);
+  loader_x_t loader_x(x, K, Xs, simd_gid, simd_lid);
+  loader_w_t loader_w(wl, scales, biases, K, Ws, simd_gid, simd_lid);
+  mma_t mma_op(simd_gid, simd_lid);
+
+  if (num_els < BM) {
+    if (!aligned_N && num_outs < BN) {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_safe(short2(BK, num_outs));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    } else {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    }
+  } else {
+    if (!aligned_N && num_outs < BN) {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_safe(short2(BK, num_outs));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    } else {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    }
+  }
+
+  // Store results to device memory
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (num_els < BM || num_outs < BN) {
+    mma_op.store_result_safe(y, N, short2(num_outs, num_els));
+  } else {
+    mma_op.store_result(y, N);
+  }
+}
+
+template <
+    typename T,
+    const int group_size,
+    const int bits,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+METAL_FUNC void qmm_n_impl(
+    const device uint32_t* w,
+    const device T* scales,
+    const device T* biases,
+    const device T* x,
+    device T* y,
+    threadgroup T* Xs,
+    threadgroup T* Ws,
+    const constant int& K,
+    const constant int& N,
+    const constant int& M,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  static_assert(BK >= SIMD_SIZE, "BK should be larger than SIMD_SIZE");
+  static_assert(BK % SIMD_SIZE == 0, "BK should be divisible by SIMD_SIZE");
+
+  (void)lid;
+
+  constexpr int WM = 2;
+  constexpr int WN = 2;
+  constexpr int pack_factor = get_pack_factor<bits, 8>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<bits>();
+
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  constexpr int BN_padded = (BN + 16 / sizeof(T));
+
+  // Instantiate the appropriate BlockMMA and Loader
+  using mma_t = mlx::steel::
+      BlockMMA<T, T, BM, BN, BK, WM, WN, false, false, BK_padded, BN_padded>;
+  using loader_x_t = mlx::steel::
+      BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE, 1, 4>;
+  using loader_w_t = QuantizedBlockLoader<
+      T,
+      BK,
+      BN,
+      BN_padded,
+      0,
+      WM * WN * SIMD_SIZE,
+      group_size,
+      bits>;
+
+  auto wl = (const device uint8_t*)w;
+
+  // Set the block
+  const int y_row = tid.y * BM;
+  const int y_col = tid.x * BN;
+  x += y_row * static_cast<int64_t>(K);
+  wl += y_col * bytes_per_pack / pack_factor;
+  scales += y_col / group_size;
+  biases += y_col / group_size;
+  y += y_row * static_cast<int64_t>(N) + y_col;
+
+  // Make the x loader and mma operation
+  const short num_els = min(BM, M - y_row);
+  loader_x_t loader_x(x, K, Xs, simd_gid, simd_lid);
+  loader_w_t loader_w(wl, scales, biases, N, Ws, simd_gid, simd_lid);
+  mma_t mma_op(simd_gid, simd_lid);
+
+  if (num_els < BM) {
+    if ((K % BK) != 0) {
+      const int k_blocks = K / BK;
+      for (int k = 0; k < k_blocks; k++) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+      const short num_k = K - k_blocks * BK;
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      loader_x.load_safe(short2(num_k, num_els));
+      loader_w.load_safe(short2(BN, num_k));
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      mma_op.mma(Xs, Ws);
+    } else {
+      for (int k = 0; k < K; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    }
+  } else {
+    if ((K % BK) != 0) {
+      const int k_blocks = K / BK;
+      for (int k = 0; k < k_blocks; k++) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+      const short num_k = K - k_blocks * BK;
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      loader_x.load_safe(short2(num_k, BM));
+      loader_w.load_safe(short2(BN, num_k));
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      mma_op.mma(Xs, Ws);
+    } else {
+      for (int k = 0; k < K; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    }
+  }
+
+  // Store results to device memory
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (num_els < BM) {
+    mma_op.store_result_safe(y, N, short2(BN, num_els));
+  } else {
+    mma_op.store_result(y, N);
+  }
+}
+
+template <typename T>
+METAL_FUNC void adjust_matrix_offsets(
+    const device T*& x,
+    const device uint32_t*& w,
+    const device T*& scales,
+    const device T*& biases,
+    device T*& y,
+    int output_stride,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    const constant int64_t* b_strides,
+    uint3 tid [[threadgroup_position_in_grid]]) {
+  // Set the input/output matrices
+  uint32_t x_idx = tid.z;
+  uint32_t w_idx = tid.z;
+  if (x_batch_ndims == 1) {
+    x += x_idx * x_strides[0];
+  } else {
+    x += elem_to_loc(x_idx, x_shape, x_strides, x_batch_ndims);
+  }
+  if (w_batch_ndims == 1) {
+    w += w_idx * w_strides[0];
+    scales += w_idx * s_strides[0];
+    biases += w_idx * b_strides[0];
+  } else {
+    ulong3 idx = elem_to_loc_broadcast(
+        w_idx, w_shape, w_strides, s_strides, b_strides, w_batch_ndims);
+    w += idx.x;
+    scales += idx.y;
+    biases += idx.z;
+  }
+  y += tid.z * output_stride;
+}
+
+template <typename T>
+METAL_FUNC void adjust_matrix_offsets(
+    const device T*& x,
+    const device uint32_t*& w,
+    const device T*& scales,
+    const device T*& biases,
+    const device uint32_t* lhs_indices,
+    const device uint32_t* rhs_indices,
+    device T*& y,
+    int output_stride,
+    const constant int& batch_ndims,
+    const constant int* batch_shape,
+    const constant int64_t* lhs_strides,
+    const constant int64_t* rhs_strides,
+    const constant int& x_batch_ndims,
+    const constant int* x_shape,
+    const constant int64_t* x_strides,
+    const constant int& w_batch_ndims,
+    const constant int* w_shape,
+    const constant int64_t* w_strides,
+    const constant int64_t* s_strides,
+    const constant int64_t* b_strides,
+    uint3 tid [[threadgroup_position_in_grid]]) {
+  // Set the input/output matrices
+  uint32_t x_idx;
+  uint32_t w_idx;
+  if (batch_ndims == 1) {
+    x_idx = lhs_indices[tid.z * lhs_strides[0]];
+    w_idx = rhs_indices[tid.z * rhs_strides[0]];
+  } else {
+    ulong2 idx = elem_to_loc_broadcast(
+        tid.z, batch_shape, lhs_strides, rhs_strides, batch_ndims);
+    x_idx = lhs_indices[idx.x];
+    w_idx = rhs_indices[idx.y];
+  }
+  if (x_batch_ndims == 1) {
+    x += x_idx * x_strides[0];
+  } else {
+    x += elem_to_loc(x_idx, x_shape, x_strides, x_batch_ndims);
+  }
+  if (w_batch_ndims == 1) {
+    w += w_idx * w_strides[0];
+    scales += w_idx * s_strides[0];
+    biases += w_idx * b_strides[0];
+  } else {
+    ulong3 idx = elem_to_loc_broadcast(
+        w_idx, w_shape, w_strides, s_strides, b_strides, w_batch_ndims);
+    w += idx.x;
+    scales += idx.y;
+    biases += idx.z;
+  }
+  y += tid.z * output_stride;
+}
+
+template <typename T, int group_size, int bits, int D, bool batched>
+[[kernel]] void affine_qmv_quad(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    device T* y [[buffer(4)]],
+    const constant int& in_vec_size [[buffer(5)]],
+    const constant int& out_vec_size [[buffer(6)]],
+    const constant int& x_batch_ndims [[buffer(7)]],
+    const constant int* x_shape [[buffer(8)]],
+    const constant int64_t* x_strides [[buffer(9)]],
+    const constant int& w_batch_ndims [[buffer(10)]],
+    const constant int* w_shape [[buffer(11)]],
+    const constant int64_t* w_strides [[buffer(12)]],
+    const constant int64_t* s_strides [[buffer(13)]],
+    const constant int64_t* b_strides [[buffer(14)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint quad_gid [[quadgroup_index_in_threadgroup]],
+    uint quad_lid [[thread_index_in_quadgroup]]) {
+  if (batched) {
+    int M = x_shape[x_batch_ndims];
+    adjust_matrix_offsets<T>(
+        x,
+        w,
+        scales,
+        biases,
+        y,
+        out_vec_size * M,
+        x_batch_ndims,
+        x_shape,
+        x_strides,
+        w_batch_ndims,
+        w_shape,
+        w_strides,
+        s_strides,
+        b_strides,
+        tid);
+  }
+  qmv_quad_impl<T, group_size, bits, D>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      in_vec_size,
+      out_vec_size,
+      tid,
+      quad_gid,
+      quad_lid);
+}
+
+template <typename T, int group_size, int bits, bool batched>
+[[kernel]] void affine_qmv_fast(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    device T* y [[buffer(4)]],
+    const constant int& in_vec_size [[buffer(5)]],
+    const constant int& out_vec_size [[buffer(6)]],
+    const constant int& x_batch_ndims [[buffer(7)]],
+    const constant int* x_shape [[buffer(8)]],
+    const constant int64_t* x_strides [[buffer(9)]],
+    const constant int& w_batch_ndims [[buffer(10)]],
+    const constant int* w_shape [[buffer(11)]],
+    const constant int64_t* w_strides [[buffer(12)]],
+    const constant int64_t* s_strides [[buffer(13)]],
+    const constant int64_t* b_strides [[buffer(14)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  if (batched) {
+    int M = x_shape[x_batch_ndims];
+    adjust_matrix_offsets<T>(
+        x,
+        w,
+        scales,
+        biases,
+        y,
+        out_vec_size * M,
+        x_batch_ndims,
+        x_shape,
+        x_strides,
+        w_batch_ndims,
+        w_shape,
+        w_strides,
+        s_strides,
+        b_strides,
+        tid);
+  }
+  qmv_fast_impl<T, group_size, bits>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      in_vec_size,
+      out_vec_size,
+      tid,
+      simd_gid,
+      simd_lid);
+}
+
+template <typename T, const int group_size, const int bits, bool batched>
+[[kernel]] void affine_qmv(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    device T* y [[buffer(4)]],
+    const constant int& in_vec_size [[buffer(5)]],
+    const constant int& out_vec_size [[buffer(6)]],
+    const constant int& x_batch_ndims [[buffer(7)]],
+    const constant int* x_shape [[buffer(8)]],
+    const constant int64_t* x_strides [[buffer(9)]],
+    const constant int& w_batch_ndims [[buffer(10)]],
+    const constant int* w_shape [[buffer(11)]],
+    const constant int64_t* w_strides [[buffer(12)]],
+    const constant int64_t* s_strides [[buffer(13)]],
+    const constant int64_t* b_strides [[buffer(14)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  if (batched) {
+    int M = x_shape[x_batch_ndims];
+    adjust_matrix_offsets<T>(
+        x,
+        w,
+        scales,
+        biases,
+        y,
+        out_vec_size * M,
+        x_batch_ndims,
+        x_shape,
+        x_strides,
+        w_batch_ndims,
+        w_shape,
+        w_strides,
+        s_strides,
+        b_strides,
+        tid);
+  }
+  qmv_impl<T, group_size, bits>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      in_vec_size,
+      out_vec_size,
+      tid,
+      simd_gid,
+      simd_lid);
+}
+
+template <typename T, const int group_size, const int bits, bool batched>
+[[kernel]] void affine_qvm(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    device T* y [[buffer(4)]],
+    const constant int& in_vec_size [[buffer(5)]],
+    const constant int& out_vec_size [[buffer(6)]],
+    const constant int& x_batch_ndims [[buffer(7)]],
+    const constant int* x_shape [[buffer(8)]],
+    const constant int64_t* x_strides [[buffer(9)]],
+    const constant int& w_batch_ndims [[buffer(10)]],
+    const constant int* w_shape [[buffer(11)]],
+    const constant int64_t* w_strides [[buffer(12)]],
+    const constant int64_t* s_strides [[buffer(13)]],
+    const constant int64_t* b_strides [[buffer(14)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  if (batched) {
+    int M = x_shape[x_batch_ndims];
+    adjust_matrix_offsets<T>(
+        x,
+        w,
+        scales,
+        biases,
+        y,
+        out_vec_size * M,
+        x_batch_ndims,
+        x_shape,
+        x_strides,
+        w_batch_ndims,
+        w_shape,
+        w_strides,
+        s_strides,
+        b_strides,
+        tid);
+  }
+  qvm_impl<T, group_size, bits>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      in_vec_size,
+      out_vec_size,
+      tid,
+      simd_gid,
+      simd_lid);
+}
+
+template <typename T, const int group_size, const int bits, int split_k = 32>
+[[kernel]] void affine_qvm_split_k(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    device T* y [[buffer(4)]],
+    const constant int& in_vec_size [[buffer(5)]],
+    const constant int& out_vec_size [[buffer(6)]],
+    const constant int& x_batch_ndims [[buffer(7)]],
+    const constant int* x_shape [[buffer(8)]],
+    const constant int64_t* x_strides [[buffer(9)]],
+    const constant int& w_batch_ndims [[buffer(10)]],
+    const constant int* w_shape [[buffer(11)]],
+    const constant int64_t* w_strides [[buffer(12)]],
+    const constant int64_t* s_strides [[buffer(13)]],
+    const constant int64_t* b_strides [[buffer(14)]],
+    const constant int& final_block_size [[buffer(15)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  int M = x_shape[x_batch_ndims];
+  adjust_matrix_offsets<T>(
+      x,
+      w,
+      scales,
+      biases,
+      y,
+      out_vec_size * M,
+      x_batch_ndims,
+      x_shape,
+      x_strides,
+      w_batch_ndims,
+      w_shape,
+      w_strides,
+      s_strides,
+      b_strides,
+      tid);
+
+  // When (in_vec_size % split_k != 0) the final block needs to be smaller
+  int in_vec_size_adj =
+      tid.z % split_k == split_k - 1 ? final_block_size : in_vec_size;
+
+  qvm_impl<T, group_size, bits>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      in_vec_size_adj,
+      out_vec_size,
+      tid,
+      simd_gid,
+      simd_lid);
+}
+
+template <
+    typename T,
+    const int group_size,
+    const int bits,
+    const bool aligned_N,
+    const bool batched,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+[[kernel]] void affine_qmm_t(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    device T* y [[buffer(4)]],
+    const constant int& K [[buffer(5)]],
+    const constant int& N [[buffer(6)]],
+    const constant int& M [[buffer(7)]],
+    const constant int& x_batch_ndims [[buffer(8)]],
+    const constant int* x_shape [[buffer(9)]],
+    const constant int64_t* x_strides [[buffer(10)]],
+    const constant int& w_batch_ndims [[buffer(11)]],
+    const constant int* w_shape [[buffer(12)]],
+    const constant int64_t* w_strides [[buffer(13)]],
+    const constant int64_t* s_strides [[buffer(14)]],
+    const constant int64_t* b_strides [[buffer(15)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  (void)lid;
+
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  if (batched) {
+    adjust_matrix_offsets<T>(
+        x,
+        w,
+        scales,
+        biases,
+        y,
+        M * N,
+        x_batch_ndims,
+        x_shape,
+        x_strides,
+        w_batch_ndims,
+        w_shape,
+        w_strides,
+        s_strides,
+        b_strides,
+        tid);
+  }
+  qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      Xs,
+      Ws,
+      K,
+      N,
+      M,
+      K,
+      tid,
+      lid,
+      simd_gid,
+      simd_lid);
+}
+
+template <
+    typename T,
+    int group_size,
+    int bits,
+    const bool aligned_N,
+    const bool batched,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+[[kernel]] void affine_qmm_t_head_flat(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    device T* y [[buffer(4)]],
+    const constant int& K [[buffer(5)]],
+    const constant int& N [[buffer(6)]],
+    const constant int& M [[buffer(7)]],
+    const constant int& H [[buffer(8)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  (void)batched;
+  (void)lid;
+
+  constexpr int WM = 2;
+  constexpr int WN = 2;
+  constexpr int pack_factor = get_pack_factor<bits, 8>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<bits>();
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+
+  using mma_t = mlx::steel::
+      BlockMMA<T, T, BM, BN, BK, WM, WN, false, true, BK_padded, BK_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t = QuantizedBlockLoader<
+      T,
+      BN,
+      BK,
+      BK_padded,
+      1,
+      WM * WN * SIMD_SIZE,
+      group_size,
+      bits>;
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  const int K_eff = ceildiv(K, BK) * BK;
+  const int K_w = K * bytes_per_pack / pack_factor;
+  const int K_g = K / group_size;
+  const int y_row = tid.y * BM;
+  const int y_col = tid.x * BN;
+  const int h = tid.z % uint(H);
+  const int b = tid.z / uint(H);
+  const int ldy = H * N;
+
+  const device T* x_head = x + (size_t(b) * H + h) * M * K;
+  const device uint8_t* wl =
+      (const device uint8_t*)w + (size_t(h) * N + y_col) * K_w;
+  const device T* scales_h = scales + (size_t(h) * N + y_col) * K_g;
+  const device T* biases_h = biases + (size_t(h) * N + y_col) * K_g;
+  device T* y_head = y + size_t(b) * M * H * N + size_t(h) * N;
+
+  x_head += y_row * static_cast<int64_t>(K);
+  y_head += y_row * static_cast<int64_t>(ldy) + y_col;
+
+  const short num_els = min(BM, M - y_row);
+  const short num_outs = min(BN, N - y_col);
+
+  loader_x_t loader_x(x_head, K, Xs, simd_gid, simd_lid);
+  loader_w_t loader_w(wl, scales_h, biases_h, K, Ws, simd_gid, simd_lid);
+  mma_t mma_op(simd_gid, simd_lid);
+
+  if (num_els < BM) {
+    if (!aligned_N && num_outs < BN) {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_safe(short2(BK, num_outs));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    } else {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_safe(short2(BK, num_els));
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    }
+  } else {
+    if (!aligned_N && num_outs < BN) {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_safe(short2(BK, num_outs));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    } else {
+      for (int k = 0; k < K_eff; k += BK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_x.load_unsafe();
+        loader_w.load_unsafe();
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(Xs, Ws);
+        loader_x.next();
+        loader_w.next();
+      }
+    }
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (num_els < BM || num_outs < BN) {
+    mma_op.store_result_safe(y_head, ldy, short2(num_outs, num_els));
+  } else {
+    mma_op.store_result(y_head, ldy);
+  }
+}
+
+template <
+    typename T,
+    const int group_size,
+    const int bits,
+    const bool aligned_N,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+[[kernel]] void affine_qmm_t_splitk(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    device T* y [[buffer(4)]],
+    const constant int& K [[buffer(5)]],
+    const constant int& N [[buffer(6)]],
+    const constant int& M [[buffer(7)]],
+    const constant int& k_partition_size [[buffer(8)]],
+    const constant int& split_k_partition_stride [[buffer(9)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  (void)lid;
+
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  constexpr int pack_factor = get_pack_factor<bits, 8>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<bits>();
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  const int k_start = tid.z * k_partition_size;
+  x += k_start;
+
+  auto wl = (const device uint8_t*)w;
+  wl += k_start * bytes_per_pack / pack_factor;
+  scales += k_start / group_size;
+  biases += k_start / group_size;
+  y += tid.z * static_cast<int64_t>(split_k_partition_stride);
+
+  qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN>(
+      (const device uint32_t*)wl,
+      scales,
+      biases,
+      x,
+      y,
+      Xs,
+      Ws,
+      K,
+      N,
+      M,
+      k_partition_size,
+      tid,
+      lid,
+      simd_gid,
+      simd_lid);
+}
+
+template <
+    typename T,
+    const int group_size,
+    const int bits,
+    const bool batched,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+[[kernel]] void affine_qmm_n(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    device T* y [[buffer(4)]],
+    const constant int& K [[buffer(5)]],
+    const constant int& N [[buffer(6)]],
+    const constant int& M [[buffer(7)]],
+    const constant int& x_batch_ndims [[buffer(8)]],
+    const constant int* x_shape [[buffer(9)]],
+    const constant int64_t* x_strides [[buffer(10)]],
+    const constant int& w_batch_ndims [[buffer(11)]],
+    const constant int* w_shape [[buffer(12)]],
+    const constant int64_t* w_strides [[buffer(13)]],
+    const constant int64_t* s_strides [[buffer(14)]],
+    const constant int64_t* b_strides [[buffer(15)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  (void)lid;
+
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  constexpr int BN_padded = (BN + 16 / sizeof(T));
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BK * BN_padded];
+
+  if (batched) {
+    adjust_matrix_offsets<T>(
+        x,
+        w,
+        scales,
+        biases,
+        y,
+        M * N,
+        x_batch_ndims,
+        x_shape,
+        x_strides,
+        w_batch_ndims,
+        w_shape,
+        w_strides,
+        s_strides,
+        b_strides,
+        tid);
+  }
+
+  qmm_n_impl<T, group_size, bits, BM, BK, BN>(
+      w, scales, biases, x, y, Xs, Ws, K, N, M, tid, lid, simd_gid, simd_lid);
+}
+
+template <typename T, int group_size, int bits>
+[[kernel]] void affine_gather_qmv_fast(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    const device uint32_t* lhs_indices [[buffer(4)]],
+    const device uint32_t* rhs_indices [[buffer(5)]],
+    device T* y [[buffer(6)]],
+    const constant int& in_vec_size [[buffer(7)]],
+    const constant int& out_vec_size [[buffer(8)]],
+    const constant int& x_batch_ndims [[buffer(9)]],
+    const constant int* x_shape [[buffer(10)]],
+    const constant int64_t* x_strides [[buffer(11)]],
+    const constant int& w_batch_ndims [[buffer(12)]],
+    const constant int* w_shape [[buffer(13)]],
+    const constant int64_t* w_strides [[buffer(14)]],
+    const constant int64_t* s_strides [[buffer(15)]],
+    const constant int64_t* b_strides [[buffer(16)]],
+    const constant int& batch_ndims [[buffer(17)]],
+    const constant int* batch_shape [[buffer(18)]],
+    const constant int64_t* lhs_strides [[buffer(19)]],
+    const constant int64_t* rhs_strides [[buffer(20)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  int M = x_shape[x_batch_ndims];
+  adjust_matrix_offsets<T>(
+      x,
+      w,
+      scales,
+      biases,
+      lhs_indices,
+      rhs_indices,
+      y,
+      out_vec_size * M,
+      batch_ndims,
+      batch_shape,
+      lhs_strides,
+      rhs_strides,
+      x_batch_ndims,
+      x_shape,
+      x_strides,
+      w_batch_ndims,
+      w_shape,
+      w_strides,
+      s_strides,
+      b_strides,
+      tid);
+  qmv_fast_impl<T, group_size, bits>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      in_vec_size,
+      out_vec_size,
+      tid,
+      simd_gid,
+      simd_lid);
+}
+
+template <typename T, int group_size, int bits>
+[[kernel]] void affine_gather_qmv(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    const device uint32_t* lhs_indices [[buffer(4)]],
+    const device uint32_t* rhs_indices [[buffer(5)]],
+    device T* y [[buffer(6)]],
+    const constant int& in_vec_size [[buffer(7)]],
+    const constant int& out_vec_size [[buffer(8)]],
+    const constant int& x_batch_ndims [[buffer(9)]],
+    const constant int* x_shape [[buffer(10)]],
+    const constant int64_t* x_strides [[buffer(11)]],
+    const constant int& w_batch_ndims [[buffer(12)]],
+    const constant int* w_shape [[buffer(13)]],
+    const constant int64_t* w_strides [[buffer(14)]],
+    const constant int64_t* s_strides [[buffer(15)]],
+    const constant int64_t* b_strides [[buffer(16)]],
+    const constant int& batch_ndims [[buffer(17)]],
+    const constant int* batch_shape [[buffer(18)]],
+    const constant int64_t* lhs_strides [[buffer(19)]],
+    const constant int64_t* rhs_strides [[buffer(20)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  int M = x_shape[x_batch_ndims];
+  adjust_matrix_offsets<T>(
+      x,
+      w,
+      scales,
+      biases,
+      lhs_indices,
+      rhs_indices,
+      y,
+      out_vec_size * M,
+      batch_ndims,
+      batch_shape,
+      lhs_strides,
+      rhs_strides,
+      x_batch_ndims,
+      x_shape,
+      x_strides,
+      w_batch_ndims,
+      w_shape,
+      w_strides,
+      s_strides,
+      b_strides,
+      tid);
+  qmv_impl<T, group_size, bits>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      in_vec_size,
+      out_vec_size,
+      tid,
+      simd_gid,
+      simd_lid);
+}
+
+template <typename T, int group_size, int bits>
+[[kernel]] void affine_gather_qvm(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    const device uint32_t* lhs_indices [[buffer(4)]],
+    const device uint32_t* rhs_indices [[buffer(5)]],
+    device T* y [[buffer(6)]],
+    const constant int& in_vec_size [[buffer(7)]],
+    const constant int& out_vec_size [[buffer(8)]],
+    const constant int& x_batch_ndims [[buffer(9)]],
+    const constant int* x_shape [[buffer(10)]],
+    const constant int64_t* x_strides [[buffer(11)]],
+    const constant int& w_batch_ndims [[buffer(12)]],
+    const constant int* w_shape [[buffer(13)]],
+    const constant int64_t* w_strides [[buffer(14)]],
+    const constant int64_t* s_strides [[buffer(15)]],
+    const constant int64_t* b_strides [[buffer(16)]],
+    const constant int& batch_ndims [[buffer(17)]],
+    const constant int* batch_shape [[buffer(18)]],
+    const constant int64_t* lhs_strides [[buffer(19)]],
+    const constant int64_t* rhs_strides [[buffer(20)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  int M = x_shape[x_batch_ndims];
+  adjust_matrix_offsets<T>(
+      x,
+      w,
+      scales,
+      biases,
+      lhs_indices,
+      rhs_indices,
+      y,
+      out_vec_size * M,
+      batch_ndims,
+      batch_shape,
+      lhs_strides,
+      rhs_strides,
+      x_batch_ndims,
+      x_shape,
+      x_strides,
+      w_batch_ndims,
+      w_shape,
+      w_strides,
+      s_strides,
+      b_strides,
+      tid);
+  qvm_impl<T, group_size, bits>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      in_vec_size,
+      out_vec_size,
+      tid,
+      simd_gid,
+      simd_lid);
+}
+
+template <
+    typename T,
+    const int group_size,
+    const int bits,
+    const bool aligned_N,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+[[kernel]] void affine_gather_qmm_t(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    const device uint32_t* lhs_indices [[buffer(4)]],
+    const device uint32_t* rhs_indices [[buffer(5)]],
+    device T* y [[buffer(6)]],
+    const constant int& K [[buffer(7)]],
+    const constant int& N [[buffer(8)]],
+    const constant int& M [[buffer(9)]],
+    const constant int& x_batch_ndims [[buffer(10)]],
+    const constant int* x_shape [[buffer(11)]],
+    const constant int64_t* x_strides [[buffer(12)]],
+    const constant int& w_batch_ndims [[buffer(13)]],
+    const constant int* w_shape [[buffer(14)]],
+    const constant int64_t* w_strides [[buffer(15)]],
+    const constant int64_t* s_strides [[buffer(16)]],
+    const constant int64_t* b_strides [[buffer(17)]],
+    const constant int& batch_ndims [[buffer(18)]],
+    const constant int* batch_shape [[buffer(19)]],
+    const constant int64_t* lhs_strides [[buffer(20)]],
+    const constant int64_t* rhs_strides [[buffer(21)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  (void)lid;
+
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  adjust_matrix_offsets<T>(
+      x,
+      w,
+      scales,
+      biases,
+      lhs_indices,
+      rhs_indices,
+      y,
+      M * N,
+      batch_ndims,
+      batch_shape,
+      lhs_strides,
+      rhs_strides,
+      x_batch_ndims,
+      x_shape,
+      x_strides,
+      w_batch_ndims,
+      w_shape,
+      w_strides,
+      s_strides,
+      b_strides,
+      tid);
+  qmm_t_impl<T, group_size, bits, aligned_N, BM, BK, BN>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      Xs,
+      Ws,
+      K,
+      N,
+      M,
+      K,
+      tid,
+      lid,
+      simd_gid,
+      simd_lid);
+}
+
+template <
+    typename T,
+    const int group_size,
+    const int bits,
+    const int BM = 32,
+    const int BK = 32,
+    const int BN = 32>
+[[kernel]] void affine_gather_qmm_n(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    const device uint32_t* lhs_indices [[buffer(4)]],
+    const device uint32_t* rhs_indices [[buffer(5)]],
+    device T* y [[buffer(6)]],
+    const constant int& K [[buffer(7)]],
+    const constant int& N [[buffer(8)]],
+    const constant int& M [[buffer(9)]],
+    const constant int& x_batch_ndims [[buffer(10)]],
+    const constant int* x_shape [[buffer(11)]],
+    const constant int64_t* x_strides [[buffer(12)]],
+    const constant int& w_batch_ndims [[buffer(13)]],
+    const constant int* w_shape [[buffer(14)]],
+    const constant int64_t* w_strides [[buffer(15)]],
+    const constant int64_t* s_strides [[buffer(16)]],
+    const constant int64_t* b_strides [[buffer(17)]],
+    const constant int& batch_ndims [[buffer(18)]],
+    const constant int* batch_shape [[buffer(19)]],
+    const constant int64_t* lhs_strides [[buffer(20)]],
+    const constant int64_t* rhs_strides [[buffer(21)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  (void)lid;
+
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  constexpr int BN_padded = (BN + 16 / sizeof(T));
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BK * BN_padded];
+
+  adjust_matrix_offsets<T>(
+      x,
+      w,
+      scales,
+      biases,
+      lhs_indices,
+      rhs_indices,
+      y,
+      M * N,
+      batch_ndims,
+      batch_shape,
+      lhs_strides,
+      rhs_strides,
+      x_batch_ndims,
+      x_shape,
+      x_strides,
+      w_batch_ndims,
+      w_shape,
+      w_strides,
+      s_strides,
+      b_strides,
+      tid);
+  qmm_n_impl<T, group_size, bits, BM, BK, BN>(
+      w, scales, biases, x, y, Xs, Ws, K, N, M, tid, lid, simd_gid, simd_lid);
+}
+
+template <
+    typename T,
+    int group_size,
+    int bits,
+    int BM,
+    int BN,
+    int BK,
+    int WM,
+    int WN,
+    bool transpose>
+[[kernel]] void affine_gather_qmm_rhs(
+    const device T* x [[buffer(0)]],
+    const device uint32_t* w [[buffer(1)]],
+    const device T* scales [[buffer(2)]],
+    const device T* biases [[buffer(3)]],
+    const device uint32_t* indices [[buffer(4)]],
+    device T* y [[buffer(5)]],
+    const constant int& M [[buffer(6)]],
+    const constant int& N [[buffer(7)]],
+    const constant int& K [[buffer(8)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]]) {
+  constexpr int pack_factor = get_pack_factor<bits, 8>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<bits>();
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  constexpr int BN_padded = (BN + 16 / sizeof(T));
+
+  using mma_t = mlx::steel::BlockMMA<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      transpose,
+      BK_padded,
+      transpose ? BK_padded : BN_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t = QuantizedBlockLoader<
+      T,
+      transpose ? BN : BK,
+      transpose ? BK : BN,
+      transpose ? BK_padded : BN_padded,
+      transpose,
+      WM * WN * SIMD_SIZE,
+      group_size,
+      bits>;
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[transpose ? BN * BK_padded : BK * BN_padded];
+
+  // Compute the block
+  const int K_w = K * bytes_per_pack / pack_factor;
+  const int K_g = K / group_size;
+  const int N_w = N * bytes_per_pack / pack_factor;
+  const int N_g = N / group_size;
+  const int K_it = K / BK;
+  const size_t stride_w = transpose ? N * K_w : K * N_w;
+  const size_t stride_s = transpose ? N * K_g : K * N_g;
+  const int y_row = tid.y * BM;
+  const int y_col = tid.x * BN;
+  const size_t y_row_long = size_t(y_row);
+  const size_t y_col_long = size_t(y_col);
+
+  // Prepare threadgroup bounds
+  const short tgp_bm = align_M ? BM : short(min(BM, M - y_row));
+  const short tgp_bn = align_N ? BN : short(min(BN, N - y_col));
+
+  // Calculate the final tiles in the case that K is not aligned
+  const int k_remain = K - K_it * BK;
+  const short2 tile_x = short2(k_remain, tgp_bm);
+  const short2 tile_w =
+      transpose ? short2(k_remain, tgp_bn) : short2(tgp_bn, k_remain);
+
+  // Move x and output to the correct block
+  auto wl = (const device uint8_t*)w;
+  x += y_row_long * K;
+  y += y_row_long * N + y_col_long;
+  wl += transpose ? y_col_long * K_w : y_col * bytes_per_pack / pack_factor;
+  scales += transpose ? y_col_long * K_g : y_col / group_size;
+  biases += transpose ? y_col_long * K_g : y_col / group_size;
+
+  // Do as many matmuls as necessary
+  uint32_t index;
+  short offset;
+  uint32_t index_next = indices[y_row];
+  short offset_next = 0;
+  int n = 0;
+  while (n < tgp_bm) {
+    n++;
+    offset = offset_next;
+    index = index_next;
+    offset_next = tgp_bm;
+    for (; n < tgp_bm; n++) {
+      if (indices[y_row + n] != index) {
+        offset_next = n;
+        index_next = indices[y_row + n];
+        break;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_none);
+
+    // Prepare threadgroup mma operation
+    thread mma_t mma_op(simd_group_id, simd_lane_id);
+
+    // Prepare threadgroup loading operations
+    thread loader_x_t loader_x(x, K, Xs, simd_group_id, simd_lane_id);
+    thread loader_w_t loader_w(
+        wl + index * stride_w,
+        scales + index * stride_s,
+        biases + index * stride_s,
+        transpose ? K : N,
+        Ws,
+        simd_group_id,
+        simd_lane_id);
+
+    // Matrices are all aligned check nothing
+    if (align_M && align_N) {
+      gemm_loop_aligned(Xs, Ws, mma_op, loader_x, loader_w, K_it);
+      if (!align_K) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+      }
+
+      // Store results to device memory
+      if (offset_next - offset == BM) {
+        mma_op.store_result(y, N);
+      } else {
+        mma_op.store_result_slice(
+            y, N, short2(0, offset), short2(BN, offset_next));
+      }
+    } else {
+      // Tile aligned so check outside of the hot loop
+      if ((align_M || tgp_bm == BM) && (align_N || tgp_bn == BN)) {
+        gemm_loop_aligned(Xs, Ws, mma_op, loader_x, loader_w, K_it);
+        if (!align_K) {
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          gemm_loop_finalize(
+              Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+        }
+
+        // Store results to device memory
+        if (offset_next - offset == BM) {
+          mma_op.store_result(y, N);
+        } else {
+          mma_op.store_result_slice(
+              y, N, short2(0, offset), short2(BN, offset_next));
+        }
+      }
+
+      // Tile partially aligned check rows
+      else if (align_N || tgp_bn == BN) {
+        gemm_loop_unaligned<false, true, transpose>(
+            Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+        if (!align_K) {
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          gemm_loop_finalize(
+              Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+        }
+        mma_op.store_result_slice(
+            y, N, short2(0, offset), short2(BN, offset_next));
+      }
+
+      // Tile partially aligned check cols
+      else if (align_M || tgp_bm == BM) {
+        gemm_loop_unaligned<true, false, transpose>(
+            Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+        if (!align_K) {
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          gemm_loop_finalize(
+              Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+        }
+        mma_op.store_result_slice(
+            y, N, short2(0, offset), short2(tgp_bn, offset_next));
+      }
+
+      // Nothing aligned so check both rows and cols
+      else {
+        gemm_loop_unaligned<false, false, transpose>(
+            Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+        if (!align_K) {
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          gemm_loop_finalize(
+              Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+        }
+        mma_op.store_result_slice(
+            y, N, short2(0, offset), short2(tgp_bn, offset_next));
+      }
+    }
+  }
+}
+
+template <typename T, typename S, int TOPK>
+[[kernel]] void moe_weighted_sum(
+    const device T* x_sorted [[buffer(0)]],
+    const device uint32_t* inv_order [[buffer(1)]],
+    const device S* scores [[buffer(2)]],
+    device T* y [[buffer(3)]],
+    const constant int& tokens [[buffer(4)]],
+    const constant int& D [[buffer(5)]],
+    uint elem [[thread_position_in_grid]]) {
+  const uint total = uint(tokens * D);
+  if (elem >= total) {
+    return;
+  }
+
+  const int token = elem / D;
+  const int d = elem - token * D;
+  const int route_base = token * TOPK;
+  float acc = 0.0f;
+  for (int k = 0; k < TOPK; ++k) {
+    const uint32_t row = inv_order[route_base + k];
+    acc += float(x_sorted[row * D + d]) * float(scores[route_base + k]);
+  }
+  y[elem] = T(acc);
+}
+
+template <typename T, typename S, int TOPK, int VEC>
+[[kernel]] void moe_weighted_sum_vec(
+    const device T* x_sorted [[buffer(0)]],
+    const device uint32_t* inv_order [[buffer(1)]],
+    const device S* scores [[buffer(2)]],
+    device T* y [[buffer(3)]],
+    const constant int& tokens [[buffer(4)]],
+    const constant int& D [[buffer(5)]],
+    uint elem [[thread_position_in_grid]]) {
+  const int Dv = (D + VEC - 1) / VEC;
+  const uint total = uint(tokens * Dv);
+  if (elem >= total) {
+    return;
+  }
+
+  const int token = elem / Dv;
+  const int d0 = (elem - token * Dv) * VEC;
+  const int route_base = token * TOPK;
+  float acc[VEC];
+  for (int v = 0; v < VEC; ++v) {
+    acc[v] = 0.0f;
+  }
+
+  for (int k = 0; k < TOPK; ++k) {
+    const uint32_t row = inv_order[route_base + k];
+    const float score = float(scores[route_base + k]);
+    const int base = int(row) * D + d0;
+    for (int v = 0; v < VEC; ++v) {
+      const int d = d0 + v;
+      if (d < D) {
+        acc[v] += float(x_sorted[base + v]) * score;
+      }
+    }
+  }
+
+  const int out_base = token * D + d0;
+  for (int v = 0; v < VEC; ++v) {
+    const int d = d0 + v;
+    if (d < D) {
+      y[out_base + v] = T(acc[v]);
+    }
+  }
+}
+
+template <typename T, typename S, int TOPK, int THREADS>
+[[kernel]] void moe_weighted_sum_tiled(
+    const device T* x_sorted [[buffer(0)]],
+    const device uint32_t* inv_order [[buffer(1)]],
+    const device S* scores [[buffer(2)]],
+    device T* y [[buffer(3)]],
+    const constant int& tokens [[buffer(4)]],
+    const constant int& D [[buffer(5)]],
+    uint token [[threadgroup_position_in_grid]],
+    uint lid [[thread_index_in_threadgroup]]) {
+  if (token >= uint(tokens)) {
+    return;
+  }
+
+  threadgroup uint rows[TOPK];
+  threadgroup float score_tg[TOPK];
+  const int route_base = int(token) * TOPK;
+  if (lid < TOPK) {
+    rows[lid] = inv_order[route_base + lid];
+    score_tg[lid] = float(scores[route_base + lid]);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (int d = int(lid); d < D; d += THREADS) {
+    float acc = 0.0f;
+    for (int k = 0; k < TOPK; ++k) {
+      acc += float(x_sorted[rows[k] * D + d]) * score_tg[k];
+    }
+    y[int(token) * D + d] = T(acc);
+  }
+}
+
+template <typename T, const int group_size, const int bits>
+[[kernel]] void affine_quantize(
+    const device T* w [[buffer(0)]],
+    device uint8_t* out [[buffer(1)]],
+    device T* scales [[buffer(2)]],
+    device T* biases [[buffer(3)]],
+    uint2 index [[thread_position_in_grid]],
+    uint2 grid_dim [[threads_per_grid]]) {
+  constexpr float eps = 1e-7;
+  constexpr int simd_size = 32;
+  constexpr float n_bins = (1 << bits) - 1;
+  constexpr int pack_factor = get_pack_factor<bits, 8>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<bits>();
+  constexpr int values_per_reduce = group_size / simd_size;
+  constexpr int writes_per_reduce = pack_factor / values_per_reduce;
+  constexpr int writes_per_pack =
+      writes_per_reduce > 1 ? 1 : values_per_reduce / pack_factor;
+  constexpr int power_of_2_bits = (bits & (bits - 1)) == 0;
+
+  static_assert(
+      group_size % simd_size == 0,
+      "Group size must be divisible by simd size.");
+
+  size_t offset = index.x + grid_dim.x * size_t(index.y);
+  size_t in_index = offset * values_per_reduce;
+  size_t out_index = power_of_2_bits
+      ? offset * writes_per_pack
+      : offset * bytes_per_pack / writes_per_reduce;
+
+  float w_thread[values_per_reduce];
+  float w_min = Limits<T>::max;
+  float w_max = 0;
+
+#pragma clang loop unroll(full)
+  for (int i = 0; i < values_per_reduce; i++) {
+    float val = w[in_index + i];
+    w_thread[i] = val;
+    w_min = min(w_min, val);
+    w_max = max(w_max, val);
+  }
+
+  w_min = simd_min(w_min);
+  w_max = simd_max(w_max);
+
+  float scale = max((w_max - w_min) / n_bins, eps);
+  bool side = abs(w_min) > abs(w_max);
+  scale = side ? scale : -scale;
+  float edge = side ? w_min : w_max;
+  float q0 = round(edge / scale);
+  bool at_zero = q0 == 0.0f;
+  scale = at_zero ? scale : edge / q0;
+  float bias = at_zero ? 0 : edge;
+
+  // Write out the scales and biases
+  size_t gindex = in_index / group_size;
+  if (in_index % group_size == 0) {
+    scales[gindex] = static_cast<T>(scale);
+    biases[gindex] = static_cast<T>(bias);
+  }
+
+  using OutType = metal::conditional_t<bits == 5, uint64_t, uint32_t>;
+  OutType output = 0;
+
+#pragma clang loop unroll(full)
+  for (int i = 0; i < values_per_reduce; i++) {
+    uint8_t val = min(round((w_thread[i] - bias) / scale), n_bins);
+    if (bits == 8) {
+      output = val;
+    } else {
+      output |= val << (bits * (i % pack_factor));
+    }
+
+    if (pack_factor < values_per_reduce && i % pack_factor == pack_factor - 1) {
+      out[out_index + i / pack_factor] = output;
+      output = 0;
+    } else {
+#pragma clang loop unroll(full)
+      for (int j = 1; j < writes_per_reduce; j++) {
+        uint8_t sval = simd_shuffle_down(val, j);
+        output |= static_cast<OutType>(sval)
+            << (bits * (j * values_per_reduce + i));
+      }
+    }
+  }
+  if (bits == 3 || bits == 6) {
+    if (in_index % pack_factor == 0 && out_index % bytes_per_pack == 0) {
+      out[out_index] = output & 0xff;
+      out[out_index + 1] = (output & 0xff00) >> 8;
+      out[out_index + 2] = (output & 0xff0000) >> 16;
+    }
+  } else if (bits == 5) {
+    if (in_index % pack_factor == 0 && out_index % bytes_per_pack == 0) {
+      out[out_index] = output & 0xff;
+      out[out_index + 1] = (output & 0xff00) >> 8;
+      out[out_index + 2] = (output & 0xff0000) >> 16;
+      out[out_index + 3] = (output & 0xff000000) >> 24;
+      out[out_index + 4] = (output & 0xff00000000) >> 32;
+    }
+  } else {
+    if (writes_per_reduce > 0 && out_index % writes_per_reduce == 0) {
+      out[out_index / writes_per_reduce] = output;
+    }
+  }
+}
+
+template <typename T, const int group_size, const int bits>
+[[kernel]] void affine_dequantize(
+    const device uint8_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    device T* out [[buffer(3)]],
+    uint2 index [[thread_position_in_grid]],
+    uint2 grid_dim [[threads_per_grid]]) {
+  constexpr int pack_factor = get_pack_factor<bits, 8>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<bits>();
+
+  size_t offset = index.x + grid_dim.x * size_t(index.y);
+  size_t oindex = offset * pack_factor;
+  size_t gindex = oindex / group_size;
+  T scale = scales[gindex];
+  T bias = biases[gindex];
+
+  out += oindex;
+
+  if (bits == 3) {
+    w += offset * bytes_per_pack;
+    out[0] = (w[0] & 0x7) * scale + bias;
+    out[1] = ((w[0] & 0x38) >> 3) * scale + bias;
+    out[2] = (((w[0] & 0xc0) >> 6) + ((w[1] & 0x1) << 2)) * scale + bias;
+    out[3] = ((w[1] & 0xe) >> 1) * scale + bias;
+    out[4] = ((w[1] & 0x70) >> 4) * scale + bias;
+    out[5] = (((w[1] & 0x80) >> 7) + ((w[2] & 0x3) << 1)) * scale + bias;
+    out[6] = ((w[2] & 0x1c) >> 2) * scale + bias;
+    out[7] = ((w[2] & 0xe0) >> 5) * scale + bias;
+  } else if (bits == 5) {
+    w += offset * bytes_per_pack;
+    out[0] = (w[0] & 0x1f) * scale + bias;
+    out[1] = (((w[0] & 0xe0) >> 5) + ((w[1] & 0x3) << 3)) * scale + bias;
+    out[2] = ((w[1] & 0x7c) >> 2) * scale + bias;
+    out[3] = (((w[1] & 0x80) >> 7) + ((w[2] & 0xf) << 1)) * scale + bias;
+    out[4] = (((w[2] & 0xf0) >> 4) + ((w[3] & 0x1) << 4)) * scale + bias;
+    out[5] = ((w[3] & 0x3e) >> 1) * scale + bias;
+    out[6] = (((w[3] & 0xc0) >> 6) + ((w[4] & 0x7) << 2)) * scale + bias;
+    out[7] = ((w[4] & 0xf8) >> 3) * scale + bias;
+  } else if (bits == 6) {
+    w += offset * bytes_per_pack;
+    out[0] = (w[0] & 0x3f) * scale + bias;
+    out[1] = (((w[0] >> 6) & 0x03) + ((w[1] & 0x0f) << 2)) * scale + bias;
+    out[2] = (((w[1] >> 4) & 0x0f) + ((w[2] & 0x03) << 4)) * scale + bias;
+    out[3] = ((w[2] >> 2) & 0x3f) * scale + bias;
+  } else {
+    uint val = w[offset];
+#pragma clang loop unroll(full)
+    for (int i = 0; i < pack_factor; i++) {
+      uint8_t d;
+      if (bits == 2) {
+        d = (val >> (bits * i)) & 0x03;
+      } else if (bits == 4) {
+        d = (val >> (bits * i)) & 0x0f;
+      } else if (bits == 8) {
+        d = val;
+      }
+      out[i] = scale * d + bias;
+    }
+  }
+}

--- a/omlx_glm_kernels/csrc/kernels/steel_dsa_indexer_score.h
+++ b/omlx_glm_kernels/csrc/kernels/steel_dsa_indexer_score.h
@@ -1,0 +1,1770 @@
+// Copyright © 2026 Apple Inc.
+
+#pragma once
+
+#include "mlx/backend/metal/kernels/steel/gemm/gemm.h"
+
+using namespace mlx::steel;
+
+constant bool do_causal [[function_constant(300)]];
+constant bool weights_lh [[function_constant(301)]];
+constant bool bucketed_topk_output [[function_constant(302)]];
+constant bool packed_block_table_output [[function_constant(303)]];
+constant bool pair_head_indexer_score [[function_constant(304)]];
+constant bool emit_high_histogram [[function_constant(305)]];
+
+template <typename T>
+METAL_FUNC uint dsa_ordered_key_16(T x) {
+  const ushort bits = as_type<ushort>(x);
+  return (bits & 0x8000) ? uint((~bits) & 0xffff) : uint(bits | 0x8000);
+}
+
+template <typename T, typename O, int TOPK, int THREADS>
+[[kernel, max_total_threads_per_threadgroup(THREADS)]] void dsa_topk_indices_16bit(
+    const device T* scores [[buffer(0)]],
+    device O* out [[buffer(1)]],
+    const constant DSATopKParams* params [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint row [[threadgroup_position_in_grid]]) {
+  if (row >= uint(params->rows)) {
+    return;
+  }
+
+  threadgroup atomic_uint hist[256];
+  threadgroup atomic_uint counters[2];
+  threadgroup uint state[4];
+
+  if (tid < 256) {
+    atomic_store_explicit(&hist[tid], 0, memory_order_relaxed);
+  }
+  if (tid < 2) {
+    atomic_store_explicit(&counters[tid], 0, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const device T* row_scores = scores + size_t(row) * params->K;
+  device O* row_out = out + size_t(row) * TOPK;
+
+  int scan_limit = params->K;
+  if (params->causal_valid_prefix) {
+    const int q = int(row % uint(params->L));
+    const int valid_length =
+        metal::min(params->K, metal::max(0, params->K - params->L + q + 1));
+    if (valid_length <= TOPK) {
+      for (int i = int(tid); i < TOPK; i += THREADS) {
+        row_out[i] = O(i < valid_length ? i : 0);
+      }
+      return;
+    }
+    scan_limit = valid_length;
+  }
+
+  for (int i = int(tid); i < scan_limit; i += THREADS) {
+    const uint key = dsa_ordered_key_16(row_scores[i]);
+    atomic_fetch_add_explicit(&hist[key >> 8], 1, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid == 0) {
+    uint greater = 0;
+    uint threshold_hi = 0;
+    for (int h = 255; h >= 0; --h) {
+      const uint count = atomic_load_explicit(&hist[h], memory_order_relaxed);
+      if (greater + count >= uint(TOPK)) {
+        threshold_hi = uint(h);
+        break;
+      }
+      greater += count;
+    }
+    state[0] = threshold_hi;
+    state[1] = greater;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid < 256) {
+    atomic_store_explicit(&hist[tid], 0, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const uint threshold_hi = state[0];
+  for (int i = int(tid); i < scan_limit; i += THREADS) {
+    const uint key = dsa_ordered_key_16(row_scores[i]);
+    if ((key >> 8) == threshold_hi) {
+      atomic_fetch_add_explicit(&hist[key & 0xff], 1, memory_order_relaxed);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid == 0) {
+    uint greater = state[1];
+    uint threshold_lo = 0;
+    for (int l = 255; l >= 0; --l) {
+      const uint count = atomic_load_explicit(&hist[l], memory_order_relaxed);
+      if (greater + count >= uint(TOPK)) {
+        threshold_lo = uint(l);
+        break;
+      }
+      greater += count;
+    }
+    const uint threshold_key = (threshold_hi << 8) | threshold_lo;
+    state[2] = threshold_key;
+    state[3] = greater;
+    atomic_store_explicit(&counters[0], 0, memory_order_relaxed);
+    atomic_store_explicit(&counters[1], greater, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const uint threshold_key = state[2];
+  if (bucketed_topk_output) {
+    for (int base = 0; base < scan_limit; base += THREADS) {
+      const int i = base + int(tid);
+      if (i < scan_limit) {
+        const uint key = dsa_ordered_key_16(row_scores[i]);
+        if (key > threshold_key) {
+          const uint pos =
+              atomic_fetch_add_explicit(&counters[0], 1, memory_order_relaxed);
+          if (pos < uint(TOPK)) {
+            row_out[pos] = O(i);
+          }
+        } else if (key == threshold_key) {
+          const uint pos =
+              atomic_fetch_add_explicit(&counters[1], 1, memory_order_relaxed);
+          if (pos < uint(TOPK)) {
+            row_out[pos] = O(i);
+          }
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  } else {
+    for (int i = int(tid); i < scan_limit; i += THREADS) {
+      const uint key = dsa_ordered_key_16(row_scores[i]);
+      if (key > threshold_key) {
+        const uint pos =
+            atomic_fetch_add_explicit(&counters[0], 1, memory_order_relaxed);
+        if (pos < uint(TOPK)) {
+          row_out[pos] = O(i);
+        }
+      } else if (key == threshold_key) {
+        const uint pos =
+            atomic_fetch_add_explicit(&counters[1], 1, memory_order_relaxed);
+        if (pos < uint(TOPK)) {
+          row_out[pos] = O(i);
+        }
+      }
+    }
+  }
+}
+
+template <typename T, int TOPK, int THREADS>
+[[kernel, max_total_threads_per_threadgroup(THREADS)]] void
+dsa_topk_indices_16bit_split_hist(
+    const device T* scores [[buffer(0)]],
+    device uint* out [[buffer(1)]],
+    const constant DSATopKParams* params [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint row [[threadgroup_position_in_grid]]) {
+  if (row >= uint(params->rows)) {
+    return;
+  }
+
+  constexpr int SGS = THREADS / 32;
+  constexpr int HIST_SGS = SGS > 16 ? 16 : SGS;
+  threadgroup atomic_uint hist[HIST_SGS * 256];
+  threadgroup atomic_uint counters[2];
+  threadgroup uint state[4];
+
+  for (int i = int(tid); i < HIST_SGS * 256; i += THREADS) {
+    atomic_store_explicit(&hist[i], 0, memory_order_relaxed);
+  }
+  if (tid < 2) {
+    atomic_store_explicit(&counters[tid], 0, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const uint sg = (tid / 32) % HIST_SGS;
+  const device T* row_scores = scores + size_t(row) * params->K;
+  device uint* row_out = out + size_t(row) * TOPK;
+
+  int scan_limit = params->K;
+  if (params->causal_valid_prefix) {
+    const int q = int(row % uint(params->L));
+    const int valid_length =
+        metal::min(params->K, metal::max(0, params->K - params->L + q + 1));
+    if (valid_length <= TOPK) {
+      for (int i = int(tid); i < TOPK; i += THREADS) {
+        row_out[i] = uint(i < valid_length ? i : 0);
+      }
+      return;
+    }
+    scan_limit = valid_length;
+  }
+
+  for (int i = int(tid); i < scan_limit; i += THREADS) {
+    const uint key = dsa_ordered_key_16(row_scores[i]);
+    atomic_fetch_add_explicit(
+        &hist[sg * 256 + (key >> 8)], 1, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid == 0) {
+    uint greater = 0;
+    uint threshold_hi = 0;
+    for (int h = 255; h >= 0; --h) {
+      uint count = 0;
+      STEEL_PRAGMA_UNROLL
+      for (int g = 0; g < HIST_SGS; ++g) {
+        count += atomic_load_explicit(&hist[g * 256 + h], memory_order_relaxed);
+      }
+      if (greater + count >= uint(TOPK)) {
+        threshold_hi = uint(h);
+        break;
+      }
+      greater += count;
+    }
+    state[0] = threshold_hi;
+    state[1] = greater;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (int i = int(tid); i < HIST_SGS * 256; i += THREADS) {
+    atomic_store_explicit(&hist[i], 0, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const uint threshold_hi = state[0];
+  for (int i = int(tid); i < scan_limit; i += THREADS) {
+    const uint key = dsa_ordered_key_16(row_scores[i]);
+    if ((key >> 8) == threshold_hi) {
+      atomic_fetch_add_explicit(
+          &hist[sg * 256 + (key & 0xff)], 1, memory_order_relaxed);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid == 0) {
+    uint greater = state[1];
+    uint threshold_lo = 0;
+    for (int l = 255; l >= 0; --l) {
+      uint count = 0;
+      STEEL_PRAGMA_UNROLL
+      for (int g = 0; g < HIST_SGS; ++g) {
+        count += atomic_load_explicit(&hist[g * 256 + l], memory_order_relaxed);
+      }
+      if (greater + count >= uint(TOPK)) {
+        threshold_lo = uint(l);
+        break;
+      }
+      greater += count;
+    }
+    const uint threshold_key = (threshold_hi << 8) | threshold_lo;
+    state[2] = threshold_key;
+    state[3] = greater;
+    atomic_store_explicit(&counters[0], 0, memory_order_relaxed);
+    atomic_store_explicit(&counters[1], greater, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const uint threshold_key = state[2];
+  if (bucketed_topk_output) {
+    for (int base = 0; base < scan_limit; base += THREADS) {
+      const int i = base + int(tid);
+      if (i < scan_limit) {
+        const uint key = dsa_ordered_key_16(row_scores[i]);
+        if (key > threshold_key) {
+          const uint pos =
+              atomic_fetch_add_explicit(&counters[0], 1, memory_order_relaxed);
+          if (pos < uint(TOPK)) {
+            row_out[pos] = uint(i);
+          }
+        } else if (key == threshold_key) {
+          const uint pos =
+              atomic_fetch_add_explicit(&counters[1], 1, memory_order_relaxed);
+          if (pos < uint(TOPK)) {
+            row_out[pos] = uint(i);
+          }
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  } else {
+    for (int i = int(tid); i < scan_limit; i += THREADS) {
+      const uint key = dsa_ordered_key_16(row_scores[i]);
+      if (key > threshold_key) {
+        const uint pos =
+            atomic_fetch_add_explicit(&counters[0], 1, memory_order_relaxed);
+        if (pos < uint(TOPK)) {
+          row_out[pos] = uint(i);
+        }
+      } else if (key == threshold_key) {
+        const uint pos =
+            atomic_fetch_add_explicit(&counters[1], 1, memory_order_relaxed);
+        if (pos < uint(TOPK)) {
+          row_out[pos] = uint(i);
+        }
+      }
+    }
+  }
+}
+
+template <typename T, int TOPK, int THREADS>
+[[kernel, max_total_threads_per_threadgroup(THREADS)]] void
+dsa_topk_indices_16bit_with_high_state(
+    const device T* scores [[buffer(0)]],
+    const device uint* high_state [[buffer(1)]],
+    device uint* out [[buffer(2)]],
+    const constant DSATopKParams* params [[buffer(3)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint row [[threadgroup_position_in_grid]]) {
+  if (row >= uint(params->rows)) {
+    return;
+  }
+
+  threadgroup atomic_uint hist[256];
+  threadgroup atomic_uint counters[2];
+  threadgroup uint state[4];
+
+  if (tid < 256) {
+    atomic_store_explicit(&hist[tid], 0, memory_order_relaxed);
+  }
+  if (tid < 2) {
+    atomic_store_explicit(&counters[tid], 0, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const device T* row_scores = scores + size_t(row) * params->K;
+  device uint* row_out = out + size_t(row) * TOPK;
+
+  int scan_limit = params->K;
+  if (params->causal_valid_prefix) {
+    const int q = int(row % uint(params->L));
+    const int valid_length =
+        metal::min(params->K, metal::max(0, params->K - params->L + q + 1));
+    if (valid_length <= TOPK) {
+      for (int i = int(tid); i < TOPK; i += THREADS) {
+        row_out[i] = uint(i < valid_length ? i : 0);
+      }
+      return;
+    }
+    scan_limit = valid_length;
+  }
+
+  const uint threshold_hi = high_state[size_t(row) * 2];
+  const uint greater_hi = high_state[size_t(row) * 2 + 1];
+  for (int i = int(tid); i < scan_limit; i += THREADS) {
+    const uint key = dsa_ordered_key_16(row_scores[i]);
+    if ((key >> 8) == threshold_hi) {
+      atomic_fetch_add_explicit(&hist[key & 0xff], 1, memory_order_relaxed);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid == 0) {
+    uint greater = greater_hi;
+    uint threshold_lo = 0;
+    for (int l = 255; l >= 0; --l) {
+      const uint count = atomic_load_explicit(&hist[l], memory_order_relaxed);
+      if (greater + count >= uint(TOPK)) {
+        threshold_lo = uint(l);
+        break;
+      }
+      greater += count;
+    }
+    const uint threshold_key = (threshold_hi << 8) | threshold_lo;
+    state[0] = threshold_key;
+    state[1] = greater;
+    atomic_store_explicit(&counters[0], 0, memory_order_relaxed);
+    atomic_store_explicit(&counters[1], greater, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const uint threshold_key = state[0];
+  if (bucketed_topk_output) {
+    for (int base = 0; base < scan_limit; base += THREADS) {
+      const int i = base + int(tid);
+      if (i < scan_limit) {
+        const uint key = dsa_ordered_key_16(row_scores[i]);
+        if (key > threshold_key) {
+          const uint pos =
+              atomic_fetch_add_explicit(&counters[0], 1, memory_order_relaxed);
+          if (pos < uint(TOPK)) {
+            row_out[pos] = uint(i);
+          }
+        } else if (key == threshold_key) {
+          const uint pos =
+              atomic_fetch_add_explicit(&counters[1], 1, memory_order_relaxed);
+          if (pos < uint(TOPK)) {
+            row_out[pos] = uint(i);
+          }
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  } else {
+    for (int i = int(tid); i < scan_limit; i += THREADS) {
+      const uint key = dsa_ordered_key_16(row_scores[i]);
+      if (key > threshold_key) {
+        const uint pos =
+            atomic_fetch_add_explicit(&counters[0], 1, memory_order_relaxed);
+        if (pos < uint(TOPK)) {
+          row_out[pos] = uint(i);
+        }
+      } else if (key == threshold_key) {
+        const uint pos =
+            atomic_fetch_add_explicit(&counters[1], 1, memory_order_relaxed);
+        if (pos < uint(TOPK)) {
+          row_out[pos] = uint(i);
+        }
+      }
+    }
+  }
+}
+
+template <typename T, int TOPK, int K_BLOCK, int THREADS>
+[[kernel, max_total_threads_per_threadgroup(THREADS)]] void
+dsa_topk_block_table_from_scores_16bit(
+    const device T* scores [[buffer(0)]],
+    device uint* table [[buffer(1)]],
+    const constant DSATopKParams* params [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint row [[threadgroup_position_in_grid]]) {
+  if (row >= uint(params->rows)) {
+    return;
+  }
+
+  constexpr uint empty = uint(-1);
+  constexpr uint bit_mask =
+      uint(K_BLOCK == 32 ? 0xffffffffull : ((1ull << K_BLOCK) - 1ull));
+  threadgroup atomic_uint hist[256];
+  threadgroup atomic_uint counters[2];
+  threadgroup atomic_uint block_slots[TOPK];
+  threadgroup atomic_uint bit_slots[TOPK];
+  threadgroup atomic_uint out_count;
+  threadgroup uint state[4];
+
+  if (tid < 256) {
+    atomic_store_explicit(&hist[tid], 0, memory_order_relaxed);
+  }
+  for (uint slot = tid; slot < uint(TOPK); slot += THREADS) {
+    atomic_store_explicit(&block_slots[slot], empty, memory_order_relaxed);
+    atomic_store_explicit(&bit_slots[slot], 0, memory_order_relaxed);
+  }
+  if (tid < 2) {
+    atomic_store_explicit(&counters[tid], 0, memory_order_relaxed);
+  }
+  if (tid == 0) {
+    atomic_store_explicit(&out_count, 0, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const device T* row_scores = scores + size_t(row) * params->K;
+  device uint* row_table = table + size_t(row) * TOPK;
+
+  int scan_limit = params->K;
+  if (params->causal_valid_prefix) {
+    const int q = int(row % uint(params->L));
+    scan_limit =
+        metal::min(params->K, metal::max(0, params->K - params->L + q + 1));
+  }
+
+  for (int i = int(tid); i < scan_limit; i += THREADS) {
+    const uint key = dsa_ordered_key_16(row_scores[i]);
+    atomic_fetch_add_explicit(&hist[key >> 8], 1, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid == 0) {
+    uint greater = 0;
+    uint threshold_hi = 0;
+    const uint target = uint(metal::min(TOPK, scan_limit));
+    for (int h = 255; h >= 0; --h) {
+      const uint count = atomic_load_explicit(&hist[h], memory_order_relaxed);
+      if (greater + count >= target) {
+        threshold_hi = uint(h);
+        break;
+      }
+      greater += count;
+    }
+    state[0] = threshold_hi;
+    state[1] = greater;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid < 256) {
+    atomic_store_explicit(&hist[tid], 0, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const uint threshold_hi = state[0];
+  for (int i = int(tid); i < scan_limit; i += THREADS) {
+    const uint key = dsa_ordered_key_16(row_scores[i]);
+    if ((key >> 8) == threshold_hi) {
+      atomic_fetch_add_explicit(&hist[key & 0xff], 1, memory_order_relaxed);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid == 0) {
+    uint greater = state[1];
+    uint threshold_lo = 0;
+    const uint target = uint(metal::min(TOPK, scan_limit));
+    for (int l = 255; l >= 0; --l) {
+      const uint count = atomic_load_explicit(&hist[l], memory_order_relaxed);
+      if (greater + count >= target) {
+        threshold_lo = uint(l);
+        break;
+      }
+      greater += count;
+    }
+    const uint threshold_key = (threshold_hi << 8) | threshold_lo;
+    state[2] = threshold_key;
+    state[3] = greater;
+    atomic_store_explicit(&counters[0], 0, memory_order_relaxed);
+    atomic_store_explicit(&counters[1], greater, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const uint threshold_key = state[2];
+  const auto add_block = [&](uint k_pos) {
+    const uint block = k_pos / uint(K_BLOCK);
+    const uint bit = 1u << (k_pos - block * uint(K_BLOCK));
+    const uint hash = (block * 2654435761u) % uint(TOPK);
+    for (uint probe = 0; probe < uint(TOPK); ++probe) {
+      const uint slot = (hash + probe) % uint(TOPK);
+      uint expected = empty;
+      if (atomic_compare_exchange_weak_explicit(
+              &block_slots[slot],
+              &expected,
+              block,
+              memory_order_relaxed,
+              memory_order_relaxed) ||
+          expected == block) {
+        atomic_fetch_or_explicit(
+            &bit_slots[slot], bit & bit_mask, memory_order_relaxed);
+        break;
+      }
+    }
+  };
+
+  if (bucketed_topk_output) {
+    for (int base = 0; base < scan_limit; base += THREADS) {
+      const int i = base + int(tid);
+      if (i < scan_limit) {
+        const uint key = dsa_ordered_key_16(row_scores[i]);
+        if (key > threshold_key) {
+          const uint pos =
+              atomic_fetch_add_explicit(&counters[0], 1, memory_order_relaxed);
+          if (pos < uint(TOPK)) {
+            add_block(uint(i));
+          }
+        } else if (key == threshold_key) {
+          const uint pos =
+              atomic_fetch_add_explicit(&counters[1], 1, memory_order_relaxed);
+          if (pos < uint(TOPK)) {
+            add_block(uint(i));
+          }
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  } else {
+    for (int i = int(tid); i < scan_limit; i += THREADS) {
+      const uint key = dsa_ordered_key_16(row_scores[i]);
+      if (key > threshold_key) {
+        const uint pos =
+            atomic_fetch_add_explicit(&counters[0], 1, memory_order_relaxed);
+        if (pos < uint(TOPK)) {
+          add_block(uint(i));
+        }
+      } else if (key == threshold_key) {
+        const uint pos =
+            atomic_fetch_add_explicit(&counters[1], 1, memory_order_relaxed);
+        if (pos < uint(TOPK)) {
+          add_block(uint(i));
+        }
+      }
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint slot = tid; slot < uint(TOPK); slot += THREADS) {
+    const uint block =
+        atomic_load_explicit(&block_slots[slot], memory_order_relaxed);
+    const uint bits =
+        atomic_load_explicit(&bit_slots[slot], memory_order_relaxed);
+    if (block != empty && bits != 0) {
+      const uint out_slot =
+          atomic_fetch_add_explicit(&out_count, 1, memory_order_relaxed);
+      if (out_slot < uint(TOPK)) {
+        row_table[out_slot] = uint((ulong(block) << K_BLOCK) | ulong(bits));
+      }
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  uint final_count = 0;
+  if (tid == 0) {
+    final_count = atomic_load_explicit(&out_count, memory_order_relaxed);
+    state[0] = final_count;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  final_count = state[0];
+
+  for (uint slot = final_count + tid; slot < uint(TOPK); slot += THREADS) {
+    row_table[slot] = empty;
+  }
+}
+
+template <int TOPK, int K_BLOCK, int THREADS>
+[[kernel, max_total_threads_per_threadgroup(THREADS)]] void
+dsa_topk_to_block_table(
+    const device uint* topk [[buffer(0)]],
+    device uint* table [[buffer(1)]],
+    const constant DSATopKBlockTableParams* params [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint row [[threadgroup_position_in_grid]]) {
+  if (row >= uint(params->rows)) {
+    return;
+  }
+
+  constexpr uint empty = uint(-1);
+  const uint table_base = packed_block_table_output ? row * uint(TOPK)
+                                                    : row * uint(TOPK) * 2;
+  threadgroup atomic_uint block_slots[TOPK];
+  threadgroup atomic_uint bit_slots[TOPK];
+  threadgroup atomic_uint out_count;
+  threadgroup uint final_count;
+
+  for (uint slot = tid; slot < uint(TOPK); slot += THREADS) {
+    atomic_store_explicit(&block_slots[slot], empty, memory_order_relaxed);
+    atomic_store_explicit(&bit_slots[slot], 0, memory_order_relaxed);
+  }
+  if (tid == 0) {
+    atomic_store_explicit(&out_count, 0, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const int q_pos = int(row % uint(params->L));
+  const int q_abs = params->K - params->L + q_pos;
+  const device uint* row_topk = topk + size_t(row) * TOPK;
+
+  for (uint j = tid; j < uint(TOPK); j += THREADS) {
+    const uint k_pos = row_topk[j];
+    if (k_pos >= uint(params->K)) {
+      continue;
+    }
+    if (params->causal && int(k_pos) > q_abs) {
+      continue;
+    }
+
+    const uint block = k_pos / uint(K_BLOCK);
+    const uint bit = 1u << (k_pos - block * uint(K_BLOCK));
+    const uint hash = (block * 2654435761u) % uint(TOPK);
+
+    for (uint probe = 0; probe < uint(TOPK); ++probe) {
+      const uint slot = (hash + probe) % uint(TOPK);
+      uint expected = empty;
+      if (atomic_compare_exchange_weak_explicit(
+              &block_slots[slot],
+              &expected,
+              block,
+              memory_order_relaxed,
+              memory_order_relaxed) ||
+          expected == block) {
+        atomic_fetch_or_explicit(&bit_slots[slot], bit, memory_order_relaxed);
+        break;
+      }
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint slot = tid; slot < uint(TOPK); slot += THREADS) {
+    const uint block =
+        atomic_load_explicit(&block_slots[slot], memory_order_relaxed);
+    const uint bits =
+        atomic_load_explicit(&bit_slots[slot], memory_order_relaxed);
+    if (block != empty && bits != 0) {
+      const uint out_slot =
+          atomic_fetch_add_explicit(&out_count, 1, memory_order_relaxed);
+      if (packed_block_table_output) {
+        table[table_base + out_slot] =
+            uint((ulong(block) << K_BLOCK) | ulong(bits));
+      } else {
+        table[table_base + out_slot * 2] = block;
+        table[table_base + out_slot * 2 + 1] = bits;
+      }
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid == 0) {
+    final_count = atomic_load_explicit(&out_count, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint slot = final_count + tid; slot < uint(TOPK); slot += THREADS) {
+    if (packed_block_table_output) {
+      table[table_base + slot] = empty;
+    } else {
+      table[table_base + slot * 2] = empty;
+      table[table_base + slot * 2 + 1] = 0;
+    }
+  }
+}
+
+template <int TOPK, int PAGE_SIZE, int PAGE_BINS, int THREADS>
+[[kernel, max_total_threads_per_threadgroup(THREADS)]] void
+dsa_topk_page_pack(
+    const device uint* topk [[buffer(0)]],
+    device uint* out [[buffer(1)]],
+    const constant int& key_length [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint row [[threadgroup_position_in_grid]]) {
+  threadgroup atomic_uint hist[PAGE_BINS];
+  threadgroup atomic_uint counters[PAGE_BINS];
+  threadgroup uint offsets[PAGE_BINS];
+
+  for (uint i = tid; i < uint(PAGE_BINS); i += THREADS) {
+    atomic_store_explicit(&hist[i], 0, memory_order_relaxed);
+    atomic_store_explicit(&counters[i], 0, memory_order_relaxed);
+    offsets[i] = 0;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const device uint* row_topk = topk + size_t(row) * TOPK;
+  device uint* row_out = out + size_t(row) * TOPK;
+  const uint max_page =
+      uint(metal::min(PAGE_BINS - 1, (key_length + PAGE_SIZE - 1) / PAGE_SIZE));
+
+  for (uint i = tid; i < uint(TOPK); i += THREADS) {
+    const uint token = row_topk[i];
+    const uint page = metal::min(token / uint(PAGE_SIZE), max_page);
+    atomic_fetch_add_explicit(&hist[page], 1, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (tid == 0) {
+    uint offset = 0;
+    for (uint page = 0; page < uint(PAGE_BINS); ++page) {
+      offsets[page] = offset;
+      offset += atomic_load_explicit(&hist[page], memory_order_relaxed);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint i = tid; i < uint(TOPK); i += THREADS) {
+    const uint token = row_topk[i];
+    const uint page = metal::min(token / uint(PAGE_SIZE), max_page);
+    const uint pos =
+        atomic_fetch_add_explicit(&counters[page], 1, memory_order_relaxed);
+    row_out[offsets[page] + pos] = token;
+  }
+}
+
+template <int TOPK, int Q_BLOCK, int CAPACITY, int THREADS>
+[[kernel, max_total_threads_per_threadgroup(THREADS)]] void
+dsa_topk_qblock_union(
+    const device uint* topk [[buffer(0)]],
+    device atomic_uint* union_tokens [[buffer(1)]],
+    device atomic_uint* row_bits [[buffer(2)]],
+    device atomic_uint* lengths [[buffer(3)]],
+    device atomic_uint* overflow [[buffer(4)]],
+    const constant DSATopKQBlockUnionParams* params [[buffer(5)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint block_id [[threadgroup_position_in_grid]]) {
+  if (block_id >= uint(params->blocks)) {
+    return;
+  }
+
+  constexpr uint empty = uint(-1);
+  const int q_blocks = (params->L + Q_BLOCK - 1) / Q_BLOCK;
+  const int b = int(block_id) / q_blocks;
+  const int qb = int(block_id) - b * q_blocks;
+  const int q_start = qb * Q_BLOCK;
+  const size_t out_base = size_t(block_id) * CAPACITY;
+
+  for (uint slot = tid; slot < uint(CAPACITY); slot += THREADS) {
+    atomic_store_explicit(
+        &union_tokens[out_base + slot], empty, memory_order_relaxed);
+    atomic_store_explicit(
+        &row_bits[out_base + slot], 0, memory_order_relaxed);
+  }
+  if (tid == 0) {
+    atomic_store_explicit(&lengths[block_id], 0, memory_order_relaxed);
+    atomic_store_explicit(&overflow[block_id], 0, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const bool compact_prefix = params->causal_prefix_rows > 0 &&
+      params->topk_rows + params->causal_prefix_rows == params->L &&
+      params->causal_prefix_indices && params->topk_valid_prefix;
+
+  for (int q_local = 0; q_local < Q_BLOCK; ++q_local) {
+    const int q_pos = q_start + q_local;
+    if (q_pos >= params->L) {
+      continue;
+    }
+    const int q_abs = params->K - params->L + q_pos;
+    const int valid_slots = params->topk_valid_prefix
+        ? metal::min(params->topk, q_abs + 1)
+        : params->topk;
+    const bool implicit = params->causal_prefix_indices &&
+        params->topk_valid_prefix &&
+        ((compact_prefix && q_pos < params->causal_prefix_rows) ||
+         q_abs < params->topk);
+    const int topk_row = compact_prefix ? q_pos - params->causal_prefix_rows
+                                        : q_pos;
+    const bool has_topk_row = !implicit && topk_row >= 0 &&
+        topk_row < params->topk_rows;
+    const int safe_topk_row = has_topk_row ? topk_row : 0;
+    const device uint* row_topk =
+        topk + (size_t(b) * params->topk_rows + safe_topk_row) * TOPK;
+
+    for (uint j = tid; j < uint(valid_slots); j += THREADS) {
+      uint token = implicit ? j : (has_topk_row ? row_topk[j] : empty);
+      if (token >= uint(params->K)) {
+        continue;
+      }
+      if (params->causal && int(token) > q_abs) {
+        continue;
+      }
+
+      const uint q_bit = 1u << uint(q_local);
+      const uint hash = (token * 2654435761u) % uint(CAPACITY);
+      bool inserted_or_found = false;
+      for (uint probe = 0; probe < uint(CAPACITY); ++probe) {
+        const uint pos = (hash + probe) % uint(CAPACITY);
+        uint expected = empty;
+        if (atomic_compare_exchange_weak_explicit(
+                &union_tokens[out_base + pos],
+                &expected,
+                token,
+                memory_order_relaxed,
+                memory_order_relaxed)) {
+          atomic_fetch_or_explicit(
+              &row_bits[out_base + pos], q_bit, memory_order_relaxed);
+          atomic_fetch_add_explicit(&lengths[block_id], 1, memory_order_relaxed);
+          inserted_or_found = true;
+          break;
+        }
+        if (expected == token) {
+          atomic_fetch_or_explicit(
+              &row_bits[out_base + pos], q_bit, memory_order_relaxed);
+          inserted_or_found = true;
+          break;
+        }
+      }
+      if (!inserted_or_found) {
+        atomic_store_explicit(&overflow[block_id], 1, memory_order_relaxed);
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+}
+
+template <int CAPACITY, int THREADS>
+[[kernel, max_total_threads_per_threadgroup(THREADS)]] void
+dsa_qblock_union_compact(
+    const device atomic_uint* hash_tokens [[buffer(0)]],
+    const device atomic_uint* hash_row_bits [[buffer(1)]],
+    device uint* compact_tokens [[buffer(2)]],
+    device uint* compact_row_bits [[buffer(3)]],
+    device atomic_uint* lengths [[buffer(4)]],
+    const constant DSATopKQBlockUnionParams* params [[buffer(5)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint block_id [[threadgroup_position_in_grid]]) {
+  if (block_id >= uint(params->blocks)) {
+    return;
+  }
+
+  constexpr uint empty = uint(-1);
+  const size_t base = size_t(block_id) * CAPACITY;
+
+  if (tid == 0) {
+    atomic_store_explicit(&lengths[block_id], 0, memory_order_relaxed);
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (uint slot = tid; slot < uint(CAPACITY); slot += THREADS) {
+    const uint token =
+        atomic_load_explicit(&hash_tokens[base + slot], memory_order_relaxed);
+    const uint bits =
+        atomic_load_explicit(&hash_row_bits[base + slot], memory_order_relaxed);
+    if (token != empty && bits != 0) {
+      const uint out_slot =
+          atomic_fetch_add_explicit(&lengths[block_id], 1, memory_order_relaxed);
+      if (out_slot < uint(CAPACITY)) {
+        compact_tokens[base + out_slot] = token;
+        compact_row_bits[base + out_slot] = bits;
+      }
+    }
+  }
+}
+
+template <typename T, int BM, int BN, int BK, int WM, int WN>
+[[kernel, max_total_threads_per_threadgroup(WM* WN * 32)]] void
+dsa_indexer_score_histogram(
+    const device T* Q [[buffer(0)]],
+    const device T* K [[buffer(1)]],
+    const device T* W [[buffer(2)]],
+    device uint* Hist [[buffer(3)]],
+    const constant GEMMParams* params [[buffer(4)]],
+    const constant int& H [[buffer(5)]],
+    const constant int& causal_q_offset [[buffer(6)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 lid [[thread_position_in_threadgroup]]) {
+  (void)lid;
+
+  using gemm_kernel = GEMMKernel<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      true,
+      true,
+      true,
+      float>;
+
+  using loader_a_t = typename gemm_kernel::loader_a_t;
+  using loader_b_t = typename gemm_kernel::loader_b_t;
+  using mma_t = typename gemm_kernel::mma_t;
+
+  const int tid_y = ((tid.y) << params->swizzle_log) +
+      ((tid.x) & ((1 << params->swizzle_log) - 1));
+  const int tid_x = (tid.x) >> params->swizzle_log;
+
+  if (params->tiles_n <= tid_x || params->tiles_m <= tid_y) {
+    return;
+  }
+
+  const int c_row = tid_y * BM;
+  const int c_col = tid_x * BN;
+
+  const int M = params->M;
+  const int N = params->N;
+  const int D = params->K;
+  const int q_offset = causal_q_offset >= 0 ? causal_q_offset : N - M;
+
+  if (do_causal) {
+    const int row_limit = metal::min(c_row + BM, M);
+    if (c_col > q_offset + row_limit - 1) {
+      return;
+    }
+  }
+
+  Q += size_t(tid.z) * H * M * D;
+  K += size_t(tid.z) * N * D;
+  W += size_t(tid.z) * H * M;
+  Hist += size_t(tid.z) * M * 256 + size_t(c_row) * 256;
+
+  threadgroup T As[gemm_kernel::tgp_mem_size_a];
+  threadgroup T Bs[gemm_kernel::tgp_mem_size_b];
+
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+
+  float accum[decltype(mma_op.Ctile)::kElemsPerTile];
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < decltype(mma_op.Ctile)::kElemsPerTile; ++i) {
+    accum[i] = 0.0f;
+  }
+
+  if (pair_head_indexer_score) {
+    thread mma_t mma_op_1(simd_group_id, simd_lane_id);
+    for (int h = 0; h < H; h += 2) {
+      mma_op.Ctile.clear();
+      mma_op_1.Ctile.clear();
+
+      const device T* A0 = Q + size_t(h) * M * D + size_t(c_row) * D;
+      const device T* A1 = Q + size_t(h + 1) * M * D + size_t(c_row) * D;
+      const device T* B = K + size_t(c_col) * D;
+
+      thread loader_a_t loader_a0(
+          A0, params->lda, As, simd_group_id, simd_lane_id);
+      thread loader_a_t loader_a1(
+          A1, params->lda, As, simd_group_id, simd_lane_id);
+      thread loader_b_t loader_b(B, params->ldb, Bs, simd_group_id, simd_lane_id);
+
+      for (int d = 0; d < params->gemm_k_iterations_aligned; ++d) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_a0.load_unsafe();
+        loader_b.load_unsafe();
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(As, Bs);
+        loader_a0.next();
+
+        if (h + 1 < H) {
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          loader_a1.load_unsafe();
+
+          threadgroup_barrier(mem_flags::mem_threadgroup);
+          mma_op_1.mma(As, Bs);
+          loader_a1.next();
+        }
+        loader_b.next();
+      }
+
+      threadgroup_barrier(mem_flags::mem_none);
+
+      short ai = 0;
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
+        const int row = c_row + mma_op.sm + i * mma_t::TM_stride;
+        const float weight = weights_lh
+            ? static_cast<float>(W[size_t(row) * H + h])
+            : static_cast<float>(W[size_t(h) * M + row]);
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
+          thread const auto& frag = mma_op.Ctile.frag_at(i, j);
+          STEEL_PRAGMA_UNROLL
+          for (short e = 0; e < decltype(mma_op.Ctile)::kElemsPerFrag; ++e) {
+            accum[ai++] += max(frag[e], 0.0f) * weight;
+          }
+        }
+      }
+
+      if (h + 1 < H) {
+        ai = 0;
+        STEEL_PRAGMA_UNROLL
+        for (short i = 0; i < decltype(mma_op_1.Ctile)::kTileRows; ++i) {
+          const int row = c_row + mma_op_1.sm + i * mma_t::TM_stride;
+          const float weight = weights_lh
+              ? static_cast<float>(W[size_t(row) * H + h + 1])
+              : static_cast<float>(W[size_t(h + 1) * M + row]);
+          STEEL_PRAGMA_UNROLL
+          for (short j = 0; j < decltype(mma_op_1.Ctile)::kTileCols; ++j) {
+            thread const auto& frag = mma_op_1.Ctile.frag_at(i, j);
+            STEEL_PRAGMA_UNROLL
+            for (short e = 0; e < decltype(mma_op_1.Ctile)::kElemsPerFrag; ++e) {
+              accum[ai++] += max(frag[e], 0.0f) * weight;
+            }
+          }
+        }
+      }
+    }
+  } else {
+    for (int h = 0; h < H; ++h) {
+      mma_op.Ctile.clear();
+
+      const device T* A = Q + size_t(h) * M * D + size_t(c_row) * D;
+      const device T* B = K + size_t(c_col) * D;
+
+      thread loader_a_t loader_a(A, params->lda, As, simd_group_id, simd_lane_id);
+      thread loader_b_t loader_b(B, params->ldb, Bs, simd_group_id, simd_lane_id);
+
+      for (int d = 0; d < params->gemm_k_iterations_aligned; ++d) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        loader_a.load_unsafe();
+        loader_b.load_unsafe();
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        mma_op.mma(As, Bs);
+
+        loader_a.next();
+        loader_b.next();
+      }
+
+      threadgroup_barrier(mem_flags::mem_none);
+
+      short ai = 0;
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
+        const int row = c_row + mma_op.sm + i * mma_t::TM_stride;
+        const float weight = weights_lh
+            ? static_cast<float>(W[size_t(row) * H + h])
+            : static_cast<float>(W[size_t(h) * M + row]);
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
+          thread const auto& frag = mma_op.Ctile.frag_at(i, j);
+          STEEL_PRAGMA_UNROLL
+          for (short e = 0; e < decltype(mma_op.Ctile)::kElemsPerFrag; ++e) {
+            accum[ai++] += max(frag[e], 0.0f) * weight;
+          }
+        }
+      }
+    }
+  }
+
+  device atomic_uint* atomic_hist = reinterpret_cast<device atomic_uint*>(Hist);
+  short ai = 0;
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
+    const int row = c_row + mma_op.sm + i * mma_t::TM_stride;
+    STEEL_PRAGMA_UNROLL
+    for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
+      const int col_base = c_col + mma_op.sn + j * mma_t::TN_stride;
+      STEEL_PRAGMA_UNROLL
+      for (short e = 0; e < decltype(mma_op.Ctile)::kElemsPerFrag; ++e) {
+        const int col = col_base + e;
+        if (row < M && col < N && (!do_causal || col <= q_offset + row)) {
+          const uint key = dsa_ordered_key_16(static_cast<T>(accum[ai]));
+          atomic_fetch_add_explicit(
+              &atomic_hist[size_t(row - c_row) * 256 + (key >> 8)],
+              1,
+              memory_order_relaxed);
+        }
+        ai++;
+      }
+    }
+  }
+}
+
+template <typename T, int BM, int BN, int BK, int WM, int WN>
+[[kernel, max_total_threads_per_threadgroup(WM* WN * 32)]] void
+dsa_indexer_score_low_histogram(
+    const device T* Q [[buffer(0)]],
+    const device T* K [[buffer(1)]],
+    const device T* W [[buffer(2)]],
+    const device uint* ThresholdHi [[buffer(3)]],
+    device uint* Hist [[buffer(4)]],
+    const constant GEMMParams* params [[buffer(5)]],
+    const constant int& H [[buffer(6)]],
+    const constant int& causal_q_offset [[buffer(7)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 lid [[thread_position_in_threadgroup]]) {
+  (void)lid;
+
+  using gemm_kernel = GEMMKernel<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      true,
+      true,
+      true,
+      float>;
+
+  using loader_a_t = typename gemm_kernel::loader_a_t;
+  using loader_b_t = typename gemm_kernel::loader_b_t;
+  using mma_t = typename gemm_kernel::mma_t;
+
+  const int tid_y = ((tid.y) << params->swizzle_log) +
+      ((tid.x) & ((1 << params->swizzle_log) - 1));
+  const int tid_x = (tid.x) >> params->swizzle_log;
+
+  if (params->tiles_n <= tid_x || params->tiles_m <= tid_y) {
+    return;
+  }
+
+  const int c_row = tid_y * BM;
+  const int c_col = tid_x * BN;
+
+  const int M = params->M;
+  const int N = params->N;
+  const int D = params->K;
+  const int q_offset = causal_q_offset >= 0 ? causal_q_offset : N - M;
+
+  if (do_causal) {
+    const int row_limit = metal::min(c_row + BM, M);
+    if (c_col > q_offset + row_limit - 1) {
+      return;
+    }
+  }
+
+  Q += size_t(tid.z) * H * M * D;
+  K += size_t(tid.z) * N * D;
+  W += size_t(tid.z) * H * M;
+  ThresholdHi += size_t(tid.z) * M * 2 + size_t(c_row) * 2;
+  Hist += size_t(tid.z) * M * 256 + size_t(c_row) * 256;
+
+  threadgroup T As[gemm_kernel::tgp_mem_size_a];
+  threadgroup T Bs[gemm_kernel::tgp_mem_size_b];
+
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+
+  float accum[decltype(mma_op.Ctile)::kElemsPerTile];
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < decltype(mma_op.Ctile)::kElemsPerTile; ++i) {
+    accum[i] = 0.0f;
+  }
+
+  for (int h = 0; h < H; ++h) {
+    mma_op.Ctile.clear();
+
+    const device T* A = Q + size_t(h) * M * D + size_t(c_row) * D;
+    const device T* B = K + size_t(c_col) * D;
+
+    thread loader_a_t loader_a(A, params->lda, As, simd_group_id, simd_lane_id);
+    thread loader_b_t loader_b(B, params->ldb, Bs, simd_group_id, simd_lane_id);
+
+    for (int d = 0; d < params->gemm_k_iterations_aligned; ++d) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      loader_a.load_unsafe();
+      loader_b.load_unsafe();
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      mma_op.mma(As, Bs);
+
+      loader_a.next();
+      loader_b.next();
+    }
+
+    threadgroup_barrier(mem_flags::mem_none);
+
+    short ai = 0;
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
+      const int row = c_row + mma_op.sm + i * mma_t::TM_stride;
+      const float weight = weights_lh
+          ? static_cast<float>(W[size_t(row) * H + h])
+          : static_cast<float>(W[size_t(h) * M + row]);
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
+        thread const auto& frag = mma_op.Ctile.frag_at(i, j);
+        STEEL_PRAGMA_UNROLL
+        for (short e = 0; e < decltype(mma_op.Ctile)::kElemsPerFrag; ++e) {
+          accum[ai++] += max(frag[e], 0.0f) * weight;
+        }
+      }
+    }
+  }
+
+  device atomic_uint* atomic_hist = reinterpret_cast<device atomic_uint*>(Hist);
+  short ai = 0;
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
+    const int row = c_row + mma_op.sm + i * mma_t::TM_stride;
+    STEEL_PRAGMA_UNROLL
+    for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
+      const int col_base = c_col + mma_op.sn + j * mma_t::TN_stride;
+      STEEL_PRAGMA_UNROLL
+      for (short e = 0; e < decltype(mma_op.Ctile)::kElemsPerFrag; ++e) {
+        const int col = col_base + e;
+        if (row < M && col < N && (!do_causal || col <= q_offset + row)) {
+          const uint threshold_hi = ThresholdHi[size_t(row - c_row) * 2];
+          const uint key = dsa_ordered_key_16(static_cast<T>(accum[ai]));
+          if ((key >> 8) == threshold_hi) {
+            atomic_fetch_add_explicit(
+                &atomic_hist[size_t(row - c_row) * 256 + (key & 0xff)],
+                1,
+                memory_order_relaxed);
+          }
+        }
+        ai++;
+      }
+    }
+  }
+}
+
+template <typename T, int TOPK, int BM, int BN, int BK, int WM, int WN>
+[[kernel, max_total_threads_per_threadgroup(WM* WN * 32)]] void
+dsa_indexer_topk_emit(
+    const device T* Q [[buffer(0)]],
+    const device T* K [[buffer(1)]],
+    const device T* W [[buffer(2)]],
+    const device uint* Threshold [[buffer(3)]],
+    device uint* O [[buffer(4)]],
+    device uint* Counters [[buffer(5)]],
+    const constant GEMMParams* params [[buffer(6)]],
+    const constant int& H [[buffer(7)]],
+    const constant int& causal_q_offset [[buffer(8)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 lid [[thread_position_in_threadgroup]]) {
+  (void)lid;
+
+  using gemm_kernel = GEMMKernel<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      true,
+      true,
+      true,
+      float>;
+
+  using loader_a_t = typename gemm_kernel::loader_a_t;
+  using loader_b_t = typename gemm_kernel::loader_b_t;
+  using mma_t = typename gemm_kernel::mma_t;
+
+  const int tid_y = ((tid.y) << params->swizzle_log) +
+      ((tid.x) & ((1 << params->swizzle_log) - 1));
+  const int tid_x = (tid.x) >> params->swizzle_log;
+
+  if (params->tiles_n <= tid_x || params->tiles_m <= tid_y) {
+    return;
+  }
+
+  const int c_row = tid_y * BM;
+  const int c_col = tid_x * BN;
+
+  const int M = params->M;
+  const int N = params->N;
+  const int D = params->K;
+  const int q_offset = causal_q_offset >= 0 ? causal_q_offset : N - M;
+
+  if (do_causal) {
+    const int row_limit = metal::min(c_row + BM, M);
+    if (c_col > q_offset + row_limit - 1) {
+      return;
+    }
+  }
+
+  Q += size_t(tid.z) * H * M * D;
+  K += size_t(tid.z) * N * D;
+  W += size_t(tid.z) * H * M;
+  Threshold += size_t(tid.z) * M * 2 + size_t(c_row) * 2;
+  O += size_t(tid.z) * M * TOPK + size_t(c_row) * TOPK;
+  Counters += size_t(tid.z) * M * 2 + size_t(c_row) * 2;
+
+  threadgroup T As[gemm_kernel::tgp_mem_size_a];
+  threadgroup T Bs[gemm_kernel::tgp_mem_size_b];
+
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+
+  float accum[decltype(mma_op.Ctile)::kElemsPerTile];
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < decltype(mma_op.Ctile)::kElemsPerTile; ++i) {
+    accum[i] = 0.0f;
+  }
+
+  for (int h = 0; h < H; ++h) {
+    mma_op.Ctile.clear();
+
+    const device T* A = Q + size_t(h) * M * D + size_t(c_row) * D;
+    const device T* B = K + size_t(c_col) * D;
+
+    thread loader_a_t loader_a(A, params->lda, As, simd_group_id, simd_lane_id);
+    thread loader_b_t loader_b(B, params->ldb, Bs, simd_group_id, simd_lane_id);
+
+    for (int d = 0; d < params->gemm_k_iterations_aligned; ++d) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      loader_a.load_unsafe();
+      loader_b.load_unsafe();
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      mma_op.mma(As, Bs);
+
+      loader_a.next();
+      loader_b.next();
+    }
+
+    threadgroup_barrier(mem_flags::mem_none);
+
+    short ai = 0;
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
+      const int row = c_row + mma_op.sm + i * mma_t::TM_stride;
+      const float weight = weights_lh
+          ? static_cast<float>(W[size_t(row) * H + h])
+          : static_cast<float>(W[size_t(h) * M + row]);
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
+        thread const auto& frag = mma_op.Ctile.frag_at(i, j);
+        STEEL_PRAGMA_UNROLL
+        for (short e = 0; e < decltype(mma_op.Ctile)::kElemsPerFrag; ++e) {
+          accum[ai++] += max(frag[e], 0.0f) * weight;
+        }
+      }
+    }
+  }
+
+  device atomic_uint* atomic_counters =
+      reinterpret_cast<device atomic_uint*>(Counters);
+  short ai = 0;
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
+    const int row = c_row + mma_op.sm + i * mma_t::TM_stride;
+    STEEL_PRAGMA_UNROLL
+    for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
+      const int col_base = c_col + mma_op.sn + j * mma_t::TN_stride;
+      STEEL_PRAGMA_UNROLL
+      for (short e = 0; e < decltype(mma_op.Ctile)::kElemsPerFrag; ++e) {
+        const int col = col_base + e;
+        if (row < M && col < N && (!do_causal || col <= q_offset + row)) {
+          const uint threshold_key = Threshold[size_t(row - c_row) * 2];
+          const uint greater_count = Threshold[size_t(row - c_row) * 2 + 1];
+          device uint* row_out = O + size_t(row - c_row) * TOPK;
+          device atomic_uint* row_counters =
+              atomic_counters + size_t(row - c_row) * 2;
+          const uint key = dsa_ordered_key_16(static_cast<T>(accum[ai]));
+          if (key > threshold_key) {
+            const uint pos = atomic_fetch_add_explicit(
+                &row_counters[0], 1, memory_order_relaxed);
+            if (pos < uint(TOPK)) {
+              row_out[pos] = uint(col);
+            }
+          } else if (key == threshold_key) {
+            const uint pos = greater_count +
+                atomic_fetch_add_explicit(
+                    &row_counters[1], 1, memory_order_relaxed);
+            if (pos < uint(TOPK)) {
+              row_out[pos] = uint(col);
+            }
+          }
+        }
+        ai++;
+      }
+    }
+  }
+}
+
+template <typename T, int BM, int BN, int BK, int WM, int WN>
+[[kernel, max_total_threads_per_threadgroup(WM* WN * 32)]] void
+dsa_indexer_score(
+    const device T* Q [[buffer(0)]],
+    const device T* K [[buffer(1)]],
+    const device T* W [[buffer(2)]],
+    device T* O [[buffer(3)]],
+    const constant GEMMParams* params [[buffer(4)]],
+    const constant int& H [[buffer(5)]],
+    const constant int& unused_causal_prefix_topk [[buffer(6)]],
+    const constant bool& skip_causal_future_store [[buffer(7)]],
+    const constant int& causal_q_offset [[buffer(8)]],
+    device uint* Hist [[buffer(9), function_constant(emit_high_histogram)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 lid [[thread_position_in_threadgroup]]) {
+  (void)lid;
+
+  using gemm_kernel = GEMMKernel<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      true,
+      true,
+      true,
+      float>;
+
+  using loader_a_t = typename gemm_kernel::loader_a_t;
+  using loader_b_t = typename gemm_kernel::loader_b_t;
+  using mma_t = typename gemm_kernel::mma_t;
+
+  const int tid_y = ((tid.y) << params->swizzle_log) +
+      ((tid.x) & ((1 << params->swizzle_log) - 1));
+  const int tid_x = (tid.x) >> params->swizzle_log;
+
+  if (params->tiles_n <= tid_x || params->tiles_m <= tid_y) {
+    return;
+  }
+
+  const int c_row = tid_y * BM;
+  const int c_col = tid_x * BN;
+
+  const int M = params->M;
+  const int N = params->N;
+  const int D = params->K;
+  const int q_offset = causal_q_offset >= 0 ? causal_q_offset : N - M;
+  constexpr int THREADS = WM * WN * 32;
+  const int thread_idx = int(simd_group_id) * 32 + int(simd_lane_id);
+
+  if (do_causal) {
+    const int row_limit = metal::min(c_row + BM, M);
+    if (c_col > q_offset + row_limit - 1) {
+      if (skip_causal_future_store) {
+        return;
+      }
+      device T* Dst = O + size_t(tid.z) * M * N + size_t(c_row) * params->ldd +
+          c_col;
+      device atomic_uint* atomic_hist = nullptr;
+      if (emit_high_histogram) {
+        atomic_hist = reinterpret_cast<device atomic_uint*>(
+            Hist + size_t(tid.z) * M * 256 + size_t(c_row) * 256);
+      }
+      const uint neg_inf_hi = dsa_ordered_key_16(static_cast<T>(-INFINITY)) >> 8;
+      for (int e = thread_idx; e < BM * BN; e += THREADS) {
+        const int row = e / BN;
+        const int col = e - row * BN;
+        if (c_row + row < M && c_col + col < N) {
+          Dst[size_t(row) * params->ldd + col] = static_cast<T>(-INFINITY);
+          if (emit_high_histogram) {
+            atomic_fetch_add_explicit(
+                &atomic_hist[size_t(row) * 256 + neg_inf_hi],
+                1,
+                memory_order_relaxed);
+          }
+        }
+      }
+      return;
+    }
+  }
+
+  if (do_causal && unused_causal_prefix_topk > 0) {
+    const int row_limit = metal::min(c_row + BM, M);
+    if (q_offset + row_limit <= unused_causal_prefix_topk) {
+      return;
+    }
+  }
+
+  Q += size_t(tid.z) * H * M * D;
+  K += size_t(tid.z) * N * D;
+  W += size_t(tid.z) * H * M;
+  O += size_t(tid.z) * M * N + size_t(c_row) * params->ldd + c_col;
+  if (emit_high_histogram) {
+    Hist += size_t(tid.z) * M * 256 + size_t(c_row) * 256;
+  }
+
+  threadgroup T As[gemm_kernel::tgp_mem_size_a];
+  threadgroup T Bs[gemm_kernel::tgp_mem_size_b];
+
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+
+  float accum[decltype(mma_op.Ctile)::kElemsPerTile];
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < decltype(mma_op.Ctile)::kElemsPerTile; ++i) {
+    accum[i] = 0.0f;
+  }
+
+  for (int h = 0; h < H; ++h) {
+    mma_op.Ctile.clear();
+
+    const device T* A = Q + size_t(h) * M * D + size_t(c_row) * D;
+    const device T* B = K + size_t(c_col) * D;
+
+    thread loader_a_t loader_a(A, params->lda, As, simd_group_id, simd_lane_id);
+    thread loader_b_t loader_b(B, params->ldb, Bs, simd_group_id, simd_lane_id);
+
+    for (int d = 0; d < params->gemm_k_iterations_aligned; ++d) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      loader_a.load_unsafe();
+      loader_b.load_unsafe();
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      mma_op.mma(As, Bs);
+
+      loader_a.next();
+      loader_b.next();
+    }
+
+    threadgroup_barrier(mem_flags::mem_none);
+
+    short ai = 0;
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
+      const int row = c_row + mma_op.sm + i * mma_t::TM_stride;
+      const float weight = weights_lh
+          ? static_cast<float>(W[size_t(row) * H + h])
+          : static_cast<float>(W[size_t(h) * M + row]);
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
+        thread const auto& frag = mma_op.Ctile.frag_at(i, j);
+        STEEL_PRAGMA_UNROLL
+        for (short e = 0; e < decltype(mma_op.Ctile)::kElemsPerFrag; ++e) {
+          accum[ai++] += max(frag[e], 0.0f) * weight;
+        }
+      }
+    }
+  }
+
+  device T* Dst = O + size_t(mma_op.sm) * params->ldd + mma_op.sn;
+  device atomic_uint* atomic_hist = nullptr;
+  if (emit_high_histogram) {
+    atomic_hist = reinterpret_cast<device atomic_uint*>(Hist);
+  }
+  short ai = 0;
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
+    const int row = c_row + mma_op.sm + i * mma_t::TM_stride;
+    STEEL_PRAGMA_UNROLL
+    for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
+      const int col_base = c_col + mma_op.sn + j * mma_t::TN_stride;
+      const int out_base =
+          (i * decltype(mma_op.Ctile)::kFragRows) * WM * params->ldd +
+          (j * decltype(mma_op.Ctile)::kFragCols) * WN;
+      STEEL_PRAGMA_UNROLL
+      for (short e = 0; e < decltype(mma_op.Ctile)::kElemsPerFrag; ++e) {
+        const int col = col_base + e;
+        const bool valid = row < M && col < N;
+        const bool future = do_causal && col > q_offset + row;
+        const T value = future ? static_cast<T>(-INFINITY)
+                               : static_cast<T>(accum[ai]);
+        Dst[out_base + e] = value;
+        if (emit_high_histogram && valid &&
+            (!skip_causal_future_store || !future)) {
+          const uint key = dsa_ordered_key_16(value);
+          atomic_fetch_add_explicit(
+              &atomic_hist[size_t(row - c_row) * 256 + (key >> 8)],
+              1,
+              memory_order_relaxed);
+        }
+        ai++;
+      }
+    }
+  }
+}
+
+template <typename T, int BM, int BN, int BK, int WM, int WN>
+[[kernel, max_total_threads_per_threadgroup(WM* WN * 32)]] void
+dsa_indexer_block_score(
+    const device T* Q [[buffer(0)]],
+    const device T* K [[buffer(1)]],
+    const device T* W [[buffer(2)]],
+    device float* O [[buffer(3)]],
+    const constant GEMMParams* params [[buffer(4)]],
+    const constant int& H [[buffer(5)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 lid [[thread_position_in_threadgroup]]) {
+  (void)lid;
+
+  constexpr int Q_BLOCK = 32;
+  constexpr int K_BLOCK = 16;
+  constexpr int SUB_M = BM / Q_BLOCK;
+  constexpr int SUB_N = BN / K_BLOCK;
+  constexpr int SUB_BLOCKS = SUB_M * SUB_N;
+  constexpr int THREADS = WM * WN * 32;
+
+  using gemm_kernel = GEMMKernel<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      true,
+      true,
+      true,
+      float>;
+
+  using loader_a_t = typename gemm_kernel::loader_a_t;
+  using loader_b_t = typename gemm_kernel::loader_b_t;
+  using mma_t = typename gemm_kernel::mma_t;
+
+  const int tid_y = ((tid.y) << params->swizzle_log) +
+      ((tid.x) & ((1 << params->swizzle_log) - 1));
+  const int tid_x = (tid.x) >> params->swizzle_log;
+
+  if (params->tiles_n <= tid_x || params->tiles_m <= tid_y) {
+    return;
+  }
+
+  const int c_row = tid_y * BM;
+  const int c_col = tid_x * BN;
+
+  const int M = params->M;
+  const int N = params->N;
+  const int D = params->K;
+  const int q_blocks = (M + Q_BLOCK - 1) / Q_BLOCK;
+  const int k_blocks = (N + K_BLOCK - 1) / K_BLOCK;
+
+  Q += size_t(tid.z) * H * M * D;
+  K += size_t(tid.z) * N * D;
+  W += size_t(tid.z) * H * M;
+  O += size_t(tid.z) * q_blocks * k_blocks;
+
+  threadgroup T As[gemm_kernel::tgp_mem_size_a];
+  threadgroup T Bs[gemm_kernel::tgp_mem_size_b];
+  threadgroup float partial[SUB_BLOCKS * THREADS];
+
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+
+  float accum[decltype(mma_op.Ctile)::kElemsPerTile];
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < decltype(mma_op.Ctile)::kElemsPerTile; ++i) {
+    accum[i] = 0.0f;
+  }
+
+  for (int h = 0; h < H; ++h) {
+    mma_op.Ctile.clear();
+
+    const device T* A = Q + size_t(h) * M * D + size_t(c_row) * D;
+    const device T* B = K + size_t(c_col) * D;
+
+    thread loader_a_t loader_a(A, params->lda, As, simd_group_id, simd_lane_id);
+    thread loader_b_t loader_b(B, params->ldb, Bs, simd_group_id, simd_lane_id);
+
+    for (int d = 0; d < params->gemm_k_iterations_aligned; ++d) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      loader_a.load_unsafe();
+      loader_b.load_unsafe();
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      mma_op.mma(As, Bs);
+
+      loader_a.next();
+      loader_b.next();
+    }
+
+    threadgroup_barrier(mem_flags::mem_none);
+
+    short ai = 0;
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
+      const int row = c_row + mma_op.sm + i * mma_t::TM_stride;
+      const float weight = weights_lh
+          ? static_cast<float>(W[size_t(row) * H + h])
+          : static_cast<float>(W[size_t(h) * M + row]);
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
+        thread const auto& frag = mma_op.Ctile.frag_at(i, j);
+        STEEL_PRAGMA_UNROLL
+        for (short e = 0; e < decltype(mma_op.Ctile)::kElemsPerFrag; ++e) {
+          accum[ai++] += max(frag[e], 0.0f) * weight;
+        }
+      }
+    }
+  }
+
+  float local_max[SUB_BLOCKS];
+  const int thread_idx = simd_group_id * 32 + simd_lane_id;
+  STEEL_PRAGMA_UNROLL
+  for (short s = 0; s < SUB_BLOCKS; ++s) {
+    local_max[s] = -INFINITY;
+  }
+
+  const int offset = N - M;
+  short ai = 0;
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
+    const int row = c_row + mma_op.sm + i * mma_t::TM_stride;
+    STEEL_PRAGMA_UNROLL
+    for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
+      const int col_base = c_col + mma_op.sn + j * mma_t::TN_stride;
+      STEEL_PRAGMA_UNROLL
+      for (short e = 0; e < decltype(mma_op.Ctile)::kElemsPerFrag; ++e) {
+        const int col = col_base + e;
+        if (row < M && col < N && (!do_causal || col <= offset + row)) {
+          const int sub_m = (row - c_row) / Q_BLOCK;
+          const int sub_n = (col - c_col) / K_BLOCK;
+          const int sub_idx = sub_m * SUB_N + sub_n;
+          local_max[sub_idx] = max(local_max[sub_idx], accum[ai]);
+        }
+        ai++;
+      }
+    }
+  }
+
+  STEEL_PRAGMA_UNROLL
+  for (short s = 0; s < SUB_BLOCKS; ++s) {
+    partial[s * THREADS + thread_idx] = local_max[s];
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  if (thread_idx < SUB_BLOCKS) {
+    float block_max = -INFINITY;
+    for (short t = 0; t < THREADS; ++t) {
+      block_max = max(block_max, partial[thread_idx * THREADS + t]);
+    }
+    const int out_q_block = c_row / Q_BLOCK + thread_idx / SUB_N;
+    const int out_k_block = c_col / K_BLOCK + thread_idx % SUB_N;
+    if (out_q_block < q_blocks && out_k_block < k_blocks) {
+      O[out_q_block * k_blocks + out_k_block] = block_max;
+    }
+  }
+}

--- a/omlx_glm_kernels/csrc/kernels/steel_sparse_mla.h
+++ b/omlx_glm_kernels/csrc/kernels/steel_sparse_mla.h
@@ -1,0 +1,1248 @@
+// Copyright © 2026 Apple Inc.
+
+#pragma once
+
+#include "mlx/backend/metal/kernels/steel/attn/attn.h"
+
+using namespace mlx::steel;
+
+constant bool packed_block_table [[function_constant(306)]];
+constant bool sparse_mla_direct_q_load [[function_constant(307)]];
+
+struct SparseMlaMaxOp {
+  template <typename T>
+  METAL_FUNC static constexpr T apply(T x, T y) {
+    return metal::max(x, y);
+  }
+};
+
+struct SparseMlaSumOp {
+  template <typename T>
+  METAL_FUNC static constexpr T apply(T x, T y) {
+    return x + y;
+  }
+};
+
+struct SparseMlaMulOp {
+  template <typename T>
+  METAL_FUNC static constexpr T apply(T x, T y) {
+    return x * y;
+  }
+};
+
+struct SparseMlaExpSubOp {
+  template <typename T>
+  METAL_FUNC static constexpr T apply(T x, T y) {
+    return fast::exp2(x - y);
+  }
+};
+
+struct SparseMlaDivOp {
+  template <typename T>
+  METAL_FUNC static constexpr T apply(T x, T y) {
+    return x / y;
+  }
+};
+
+template <typename IndexT>
+METAL_FUNC int sparse_mla_topk_token(
+    const device IndexT* Topk,
+    const device uint* TopkLength,
+    const constant GlmDsaSparseMlaParams* params,
+    int b,
+    int q_pos,
+    int slot) {
+  if (q_pos < 0 || q_pos >= params->qL || slot < 0) {
+    return -1;
+  }
+
+  const int q_abs = params->qL_off + q_pos;
+  const int length_limit = params->has_topk_length
+      ? int(TopkLength[size_t(b) * params->TopkLength_strides[0] +
+                       size_t(q_pos) * params->TopkLength_strides[1]])
+      : params->topk;
+  const int causal_prefix_limit = params->topk_valid_prefix
+      ? metal::min(params->topk, q_abs + 1)
+      : params->topk;
+  const int topk_limit =
+      metal::min(params->topk, metal::min(length_limit, causal_prefix_limit));
+  if (slot >= topk_limit) {
+    return -1;
+  }
+
+  const bool prefix_row = params->causal_prefix_indices &&
+      params->topk_valid_prefix && q_pos < params->causal_prefix_rows;
+  const bool implicit_causal_prefix = params->causal_prefix_indices &&
+      params->topk_valid_prefix && (prefix_row || q_abs < params->topk) &&
+      length_limit >= q_abs + 1;
+  int k_pos = implicit_causal_prefix ? slot
+                                     : int(Topk[size_t(b) * params->Topk_strides[0] +
+                                                size_t(q_pos -
+                                                       params->causal_prefix_rows) *
+                                                    params->Topk_strides[2] +
+                                                slot]);
+  if (k_pos < 0 || k_pos >= params->kL || (do_causal && k_pos > q_abs)) {
+    k_pos = -1;
+  }
+  return k_pos;
+}
+
+// clang-format off
+template <
+    typename T,
+    int BK,
+    int DC,
+    int H,
+    int D_LATENT,
+    int D_PE,
+    int WM,
+    typename IndexT,
+    typename AccumType = float>
+[[kernel, max_total_threads_per_threadgroup(WM * 32)]] void sparse_mla_attention(
+    const device T* Q_latent [[buffer(0)]],
+    const device T* Q_pe [[buffer(1)]],
+    const device T* KV_latent [[buffer(2)]],
+    const device T* K_pe [[buffer(3)]],
+    const device IndexT* Topk [[buffer(4)]],
+    const device uint* TopkLength [[buffer(5)]],
+    device T* O [[buffer(6)]],
+    const constant GlmDsaSparseMlaParams* params [[buffer(7)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]]) { // clang-format on
+
+  constexpr short kFragSize = 8;
+  constexpr short padQ = 16 / sizeof(T);
+  constexpr short padK = 16 / sizeof(T);
+  constexpr short padV = 16 / sizeof(T);
+
+  constexpr short LDQ = DC + padQ;
+  constexpr short LDK = BK + padK;
+  constexpr short LDV = DC + padV;
+
+  constexpr int kNWarps = WM;
+  constexpr int TQ = H / (kNWarps * kFragSize);
+  constexpr int TK = BK / kFragSize;
+  constexpr int TDC = DC / kFragSize;
+  constexpr int TD_LATENT = D_LATENT / kFragSize;
+  constexpr int D_TOTAL = D_LATENT + D_PE;
+  constexpr int D_CHUNKS = D_TOTAL / DC;
+  constexpr int V_CHUNKS = D_LATENT / DC;
+
+  static_assert(TQ >= 1, "Sparse MLA kernel expects at least one head tile.");
+  static_assert(
+      H % (kNWarps * kFragSize) == 0,
+      "Sparse MLA head count must divide evenly across simdgroups.");
+  static_assert(BK % kFragSize == 0, "BK must be a multiple of 8.");
+  static_assert(DC % kFragSize == 0, "DC must be a multiple of 8.");
+  static_assert(D_TOTAL % DC == 0, "QK total dimension must divide DC.");
+  static_assert(D_LATENT % DC == 0, "Latent value dimension must divide DC.");
+
+  constexpr int tgp_size = WM * 32;
+  const int lane = int(simd_group_id * 32 + simd_lane_id);
+
+  const int q_pos = int(tid.x);
+  const int b = int(tid.y);
+  const int q_abs = params->qL_off + q_pos;
+
+  threadgroup T Qs[H * LDQ];
+  threadgroup T KVs[(BK * LDV > DC * LDK) ? BK * LDV : DC * LDK];
+  threadgroup int selected[BK];
+
+  using MMAFragAcc = BaseMMAFrag<AccumType, kFragSize, kFragSize>;
+  MMATile<AccumType, TQ, 1, MMAFragAcc> Qtile;
+  MMATile<AccumType, 1, TK, MMAFragAcc> Ktile;
+  MMATile<AccumType, TQ, TK, MMAFragAcc> Stile;
+  MMATile<AccumType, 1, 1, MMAFragAcc> Vtile;
+  MMATile<AccumType, TQ, TD_LATENT, MMAFragAcc> Otile;
+
+  Otile.clear();
+
+  const short2 simd_coord = MMAFragAcc::get_coord(simd_lane_id);
+  const short sm = simd_coord.y;
+  const short sn = simd_coord.x;
+  const short tm = kFragSize * TQ * simd_group_id;
+
+  const short Qs_offset = (tm + sm) * LDQ + sn;
+  const short Ks_offset = sm * LDK + sn;
+  const short Vs_offset = sm * LDV + sn;
+
+  const AccumType scale = AccumType(params->scale * M_LOG2E_F);
+
+  constexpr short rows_per_thread = decltype(Stile)::kRowsPerThread;
+  AccumType max_score[rows_per_thread];
+  AccumType sum_score[rows_per_thread] = {0};
+
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < rows_per_thread; ++i) {
+    max_score[i] = Limits<AccumType>::finite_min;
+  }
+
+  const device T* q_latent_base = Q_latent +
+      size_t(b) * params->Q_latent_strides[0] +
+      size_t(q_pos) * params->Q_latent_strides[2];
+  const device T* q_pe_base = Q_pe + size_t(b) * params->Q_pe_strides[0] +
+      size_t(q_pos) * params->Q_pe_strides[2];
+  const device T* kv_latent_base =
+      KV_latent + size_t(b) * params->KV_latent_strides[0];
+  const device T* k_pe_base = K_pe + size_t(b) * params->K_pe_strides[0];
+  const bool prefix_row = params->causal_prefix_indices &&
+      params->topk_valid_prefix && q_pos < params->causal_prefix_rows;
+  const int topk_row = prefix_row ? 0 : q_pos - params->causal_prefix_rows;
+  const device IndexT* topk_base =
+      Topk + size_t(b) * params->Topk_strides[0] +
+      size_t(topk_row) * params->Topk_strides[2];
+
+  const int length_limit = params->has_topk_length
+      ? int(TopkLength[size_t(b) * params->TopkLength_strides[0] +
+                       size_t(q_pos) * params->TopkLength_strides[1]])
+      : params->topk;
+  const int causal_prefix_limit = params->topk_valid_prefix
+      ? metal::min(params->topk, q_abs + 1)
+      : params->topk;
+  const int topk_limit =
+      metal::min(params->topk, metal::min(length_limit, causal_prefix_limit));
+  const bool implicit_causal_prefix = params->causal_prefix_indices &&
+      params->topk_valid_prefix && (prefix_row || q_abs < params->topk) &&
+      length_limit >= q_abs + 1;
+  const int n_tiles = (topk_limit + BK - 1) / BK;
+
+  for (int ktile = 0; ktile < n_tiles; ++ktile) {
+    const int topk_off = ktile * BK;
+
+    for (int k = lane; k < BK; k += tgp_size) {
+      const int slot = topk_off + k;
+      int k_pos = -1;
+      if (slot < topk_limit) {
+        k_pos = implicit_causal_prefix ? slot : int(topk_base[slot]);
+        if (k_pos < 0 || k_pos >= params->kL || (do_causal && k_pos > q_abs)) {
+          k_pos = -1;
+        }
+      }
+      selected[k] = k_pos;
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    Stile.clear();
+
+    STEEL_PRAGMA_UNROLL
+    for (short dchunk = 0; dchunk < D_CHUNKS; ++dchunk) {
+      const int dbase = int(dchunk) * DC;
+
+      if (!sparse_mla_direct_q_load) {
+        for (int elem = lane; elem < H * DC; elem += tgp_size) {
+          const int h = elem / DC;
+          const int d = elem - h * DC;
+          Qs[h * LDQ + d] = dbase < D_LATENT
+              ? q_latent_base[size_t(h) * params->Q_latent_strides[1] + dbase + d]
+              : q_pe_base[size_t(h) * params->Q_pe_strides[1] +
+                          (dbase - D_LATENT) + d];
+        }
+      }
+
+      for (int elem = lane; elem < BK * DC; elem += tgp_size) {
+        const int k = elem / DC;
+        const int d = elem - k * DC;
+        const int k_pos = selected[k];
+        T value = T(0);
+        if (k_pos >= 0) {
+          value = dbase < D_LATENT
+              ? kv_latent_base[size_t(k_pos) * params->KV_latent_strides[2] +
+                               dbase + d]
+              : k_pe_base[size_t(k_pos) * params->K_pe_strides[2] +
+                          (dbase - D_LATENT) + d];
+        }
+        KVs[k + d * LDK] = value;
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      STEEL_PRAGMA_UNROLL
+      for (short dd = 0; dd < TDC; ++dd) {
+        simdgroup_barrier(mem_flags::mem_none);
+        if (sparse_mla_direct_q_load) {
+          if (dbase < D_LATENT) {
+            const device T* q_src = q_latent_base +
+                size_t(tm + sm) * params->Q_latent_strides[1] + dbase +
+                dd * kFragSize + sn;
+            Qtile.template load<T, 1, 1>(
+                q_src, int(params->Q_latent_strides[1]));
+          } else {
+            const device T* q_src = q_pe_base +
+                size_t(tm + sm) * params->Q_pe_strides[1] +
+                (dbase - D_LATENT) + dd * kFragSize + sn;
+            Qtile.template load<T, 1, 1>(
+                q_src, int(params->Q_pe_strides[1]));
+          }
+        } else {
+          Qtile.template load<T, 1, 1, LDQ, 1>(&Qs[Qs_offset + dd * kFragSize]);
+        }
+        Ktile.template load<T, 1, 1, LDK, 1>(
+            &KVs[Ks_offset + dd * kFragSize * LDK]);
+        simdgroup_barrier(mem_flags::mem_none);
+        tile_matmad(Stile, Qtile, Ktile, Stile);
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    STEEL_PRAGMA_UNROLL
+    for (short ii = 0; ii < decltype(Stile)::kElemsPerTile; ++ii) {
+      Stile.elems()[ii] *= scale;
+    }
+
+    {
+      using stile_t = decltype(Stile);
+      using selem_t = typename stile_t::elem_type;
+      constexpr auto neg_inf = Limits<selem_t>::finite_min;
+
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < stile_t::kTileRows; ++i) {
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < stile_t::kTileCols; ++j) {
+          const short col_pos = sn + j * stile_t::kFragCols;
+          STEEL_PRAGMA_UNROLL
+          for (short jj = 0; jj < stile_t::MMAFrag_t::kElemCols; ++jj) {
+            if (selected[col_pos + jj] < 0) {
+              Stile.frag_at(i, j)[jj] = neg_inf;
+            }
+          }
+        }
+      }
+    }
+
+    AccumType new_max[rows_per_thread];
+    AccumType factor[rows_per_thread];
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      new_max[i] = max_score[i];
+    }
+
+    Stile.template row_reduce<SparseMlaMaxOp>(new_max);
+    Stile.template row_bin_op<SparseMlaExpSubOp>(new_max);
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      factor[i] = fast::exp2(max_score[i] - new_max[i]);
+      max_score[i] = new_max[i];
+    }
+
+    AccumType sum_score_tmp[rows_per_thread] = {0};
+    Stile.template row_reduce<SparseMlaSumOp>(sum_score_tmp);
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      sum_score[i] = sum_score[i] * factor[i] + sum_score_tmp[i];
+    }
+
+    Otile.template row_bin_op<SparseMlaMulOp>(factor);
+
+    STEEL_PRAGMA_UNROLL
+    for (short vchunk = 0; vchunk < V_CHUNKS; ++vchunk) {
+      const int dbase = int(vchunk) * DC;
+
+      for (int elem = lane; elem < BK * DC; elem += tgp_size) {
+        const int k = elem / DC;
+        const int d = elem - k * DC;
+        const int k_pos = selected[k];
+        KVs[k * LDV + d] = k_pos >= 0
+            ? kv_latent_base[size_t(k_pos) * params->KV_latent_strides[2] +
+                             dbase + d]
+            : T(0);
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      STEEL_PRAGMA_UNROLL
+      for (short iq = 0; iq < TQ; ++iq) {
+        STEEL_PRAGMA_UNROLL
+        for (short id = 0; id < TDC; ++id) {
+          STEEL_PRAGMA_UNROLL
+          for (short ik = 0; ik < TK; ++ik) {
+            const short kk = ik * kFragSize;
+            const short dd = id * kFragSize;
+            Vtile.template load<T, 1, 1, LDV, 1>(
+                &KVs[Vs_offset + kk * LDV + dd]);
+            MMAFragAcc::mma(
+                Otile.frag_at(iq, vchunk * TDC + id),
+                Stile.frag_at(iq, ik),
+                Vtile.frag_at(0, 0),
+                Otile.frag_at(iq, vchunk * TDC + id));
+          }
+        }
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  }
+
+  Otile.template row_bin_op<SparseMlaDivOp>(sum_score);
+
+  device T* out = O + size_t(b) * params->O_strides[0] +
+      size_t(q_pos) * params->O_strides[2] +
+      size_t(tm + sm) * params->O_strides[1] + sn;
+  Otile.template store<T, 1, 1>(out, params->O_strides[1]);
+}
+
+// clang-format off
+template <
+    typename T,
+    int BK,
+    int DC,
+    int H,
+    int D_LATENT,
+    int D_PE,
+    int WM,
+    typename AccumType = float>
+[[kernel, max_total_threads_per_threadgroup(WM * 32)]] void
+sparse_mla_attention_q2(
+    const device T* Q_latent [[buffer(0)]],
+    const device T* Q_pe [[buffer(1)]],
+    const device T* KV_latent [[buffer(2)]],
+    const device T* K_pe [[buffer(3)]],
+    const device uint* Topk [[buffer(4)]],
+    const device uint* TopkLength [[buffer(5)]],
+    device T* O [[buffer(6)]],
+    const constant GlmDsaSparseMlaParams* params [[buffer(7)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]]) { // clang-format on
+
+  constexpr short kFragSize = 8;
+  constexpr int QG = 2;
+  constexpr int WQ = WM / QG;
+  constexpr int K_UNION = BK * QG;
+  constexpr short padQ = 16 / sizeof(T);
+  constexpr short padK = 16 / sizeof(T);
+  constexpr short padV = 16 / sizeof(T);
+
+  constexpr short LDQ = DC + padQ;
+  constexpr short LDK = K_UNION + padK;
+  constexpr short LDV = DC + padV;
+
+  constexpr int TQ = H / (WQ * kFragSize);
+  constexpr int TK = K_UNION / kFragSize;
+  constexpr int TDC = DC / kFragSize;
+  constexpr int TD_LATENT = D_LATENT / kFragSize;
+  constexpr int D_TOTAL = D_LATENT + D_PE;
+  constexpr int D_CHUNKS = D_TOTAL / DC;
+  constexpr int V_CHUNKS = D_LATENT / DC;
+
+  static_assert(WM % QG == 0, "q2 sparse MLA expects an even simdgroup count.");
+  static_assert(TQ >= 1, "q2 sparse MLA expects at least one head tile.");
+  static_assert(
+      H % (WQ * kFragSize) == 0,
+      "q2 sparse MLA head count must divide evenly across per-query simdgroups.");
+  static_assert(BK % kFragSize == 0, "BK must be a multiple of 8.");
+  static_assert(DC % kFragSize == 0, "DC must be a multiple of 8.");
+  static_assert(D_TOTAL % DC == 0, "QK total dimension must divide DC.");
+  static_assert(D_LATENT % DC == 0, "Latent value dimension must divide DC.");
+
+  constexpr int tgp_size = WM * 32;
+  const int lane = int(simd_group_id * 32 + simd_lane_id);
+  const int q_local = int(simd_group_id) / WQ;
+  const int local_sg = int(simd_group_id) - q_local * WQ;
+  const int q_pos_base = int(tid.x) * QG;
+  const int q_pos = q_pos_base + q_local;
+  const int b = int(tid.y);
+
+  threadgroup T KVs[(K_UNION * LDV > DC * LDK) ? K_UNION * LDV : DC * LDK];
+  threadgroup int selected[K_UNION];
+  threadgroup uchar valid[QG * K_UNION];
+
+  using MMAFragAcc = BaseMMAFrag<AccumType, kFragSize, kFragSize>;
+  MMATile<AccumType, TQ, 1, MMAFragAcc> Qtile;
+  MMATile<AccumType, 1, TK, MMAFragAcc> Ktile;
+  MMATile<AccumType, TQ, TK, MMAFragAcc> Stile;
+  MMATile<AccumType, 1, 1, MMAFragAcc> Vtile;
+  MMATile<AccumType, TQ, TD_LATENT, MMAFragAcc> Otile;
+
+  Otile.clear();
+
+  const short2 simd_coord = MMAFragAcc::get_coord(simd_lane_id);
+  const short sm = simd_coord.y;
+  const short sn = simd_coord.x;
+  const short tm = kFragSize * TQ * local_sg;
+
+  const short Ks_offset = sm * LDK + sn;
+  const short Vs_offset = sm * LDV + sn;
+
+  const AccumType scale = AccumType(params->scale * M_LOG2E_F);
+
+  constexpr short rows_per_thread = decltype(Stile)::kRowsPerThread;
+  AccumType max_score[rows_per_thread];
+  AccumType sum_score[rows_per_thread] = {0};
+
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < rows_per_thread; ++i) {
+    max_score[i] = Limits<AccumType>::finite_min;
+  }
+
+  const device T* q_latent_base = Q_latent +
+      size_t(b) * params->Q_latent_strides[0];
+  const device T* q_pe_base = Q_pe + size_t(b) * params->Q_pe_strides[0];
+  const device T* kv_latent_base =
+      KV_latent + size_t(b) * params->KV_latent_strides[0];
+  const device T* k_pe_base = K_pe + size_t(b) * params->K_pe_strides[0];
+
+  const int n_tiles = (params->topk + BK - 1) / BK;
+  for (int ktile = 0; ktile < n_tiles; ++ktile) {
+    const int topk_off = ktile * BK;
+
+    for (int i = lane; i < K_UNION; i += tgp_size) {
+      selected[i] = -1;
+      valid[i] = 0;
+      valid[K_UNION + i] = 0;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (int k = lane; k < BK; k += tgp_size) {
+      const int token =
+          sparse_mla_topk_token(Topk, TopkLength, params, b, q_pos_base, topk_off + k);
+      selected[k] = token;
+      valid[k] = token >= 0;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (int k = lane; k < BK; k += tgp_size) {
+      const int token = sparse_mla_topk_token(
+          Topk, TopkLength, params, b, q_pos_base + 1, topk_off + k);
+      if (token >= 0) {
+        int duplicate = -1;
+        for (int j = 0; j < BK; ++j) {
+          if (selected[j] == token) {
+            duplicate = j;
+            break;
+          }
+        }
+        if (duplicate >= 0) {
+          valid[K_UNION + duplicate] = 1;
+        } else {
+          const int pos = BK + k;
+          selected[pos] = token;
+          valid[K_UNION + pos] = 1;
+        }
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    Stile.clear();
+
+    STEEL_PRAGMA_UNROLL
+    for (short dchunk = 0; dchunk < D_CHUNKS; ++dchunk) {
+      const int dbase = int(dchunk) * DC;
+
+      for (int elem = lane; elem < K_UNION * DC; elem += tgp_size) {
+        const int k = elem / DC;
+        const int d = elem - k * DC;
+        const int k_pos = selected[k];
+        T value = T(0);
+        if (k_pos >= 0) {
+          value = dbase < D_LATENT
+              ? kv_latent_base[size_t(k_pos) * params->KV_latent_strides[2] +
+                               dbase + d]
+              : k_pe_base[size_t(k_pos) * params->K_pe_strides[2] +
+                          (dbase - D_LATENT) + d];
+        }
+        KVs[k + d * LDK] = value;
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      STEEL_PRAGMA_UNROLL
+      for (short dd = 0; dd < TDC; ++dd) {
+        simdgroup_barrier(mem_flags::mem_none);
+        if (q_pos < params->qL) {
+          if (dbase < D_LATENT) {
+            const device T* q_src = q_latent_base +
+                size_t(tm + sm) * params->Q_latent_strides[1] +
+                size_t(q_pos) * params->Q_latent_strides[2] + dbase +
+                dd * kFragSize + sn;
+            Qtile.template load<T, 1, 1>(
+                q_src, int(params->Q_latent_strides[1]));
+          } else {
+            const device T* q_src = q_pe_base +
+                size_t(tm + sm) * params->Q_pe_strides[1] +
+                size_t(q_pos) * params->Q_pe_strides[2] +
+                (dbase - D_LATENT) + dd * kFragSize + sn;
+            Qtile.template load<T, 1, 1>(
+                q_src, int(params->Q_pe_strides[1]));
+          }
+        } else {
+          Qtile.clear();
+        }
+        Ktile.template load<T, 1, 1, LDK, 1>(
+            &KVs[Ks_offset + dd * kFragSize * LDK]);
+        simdgroup_barrier(mem_flags::mem_none);
+        tile_matmad(Stile, Qtile, Ktile, Stile);
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    STEEL_PRAGMA_UNROLL
+    for (short ii = 0; ii < decltype(Stile)::kElemsPerTile; ++ii) {
+      Stile.elems()[ii] *= scale;
+    }
+
+    {
+      using stile_t = decltype(Stile);
+      using selem_t = typename stile_t::elem_type;
+      constexpr auto neg_inf = Limits<selem_t>::finite_min;
+
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < stile_t::kTileRows; ++i) {
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < stile_t::kTileCols; ++j) {
+          const short col_pos = sn + j * stile_t::kFragCols;
+          STEEL_PRAGMA_UNROLL
+          for (short jj = 0; jj < stile_t::MMAFrag_t::kElemCols; ++jj) {
+            const int col = col_pos + jj;
+            if (q_pos >= params->qL || selected[col] < 0 ||
+                valid[q_local * K_UNION + col] == 0) {
+              Stile.frag_at(i, j)[jj] = neg_inf;
+            }
+          }
+        }
+      }
+    }
+
+    AccumType new_max[rows_per_thread];
+    AccumType factor[rows_per_thread];
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      new_max[i] = max_score[i];
+    }
+
+    Stile.template row_reduce<SparseMlaMaxOp>(new_max);
+    Stile.template row_bin_op<SparseMlaExpSubOp>(new_max);
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      factor[i] = fast::exp2(max_score[i] - new_max[i]);
+      max_score[i] = new_max[i];
+    }
+
+    AccumType sum_score_tmp[rows_per_thread] = {0};
+    Stile.template row_reduce<SparseMlaSumOp>(sum_score_tmp);
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      sum_score[i] = sum_score[i] * factor[i] + sum_score_tmp[i];
+    }
+
+    Otile.template row_bin_op<SparseMlaMulOp>(factor);
+
+    STEEL_PRAGMA_UNROLL
+    for (short vchunk = 0; vchunk < V_CHUNKS; ++vchunk) {
+      const int dbase = int(vchunk) * DC;
+
+      for (int elem = lane; elem < K_UNION * DC; elem += tgp_size) {
+        const int k = elem / DC;
+        const int d = elem - k * DC;
+        const int k_pos = selected[k];
+        KVs[k * LDV + d] = k_pos >= 0
+            ? kv_latent_base[size_t(k_pos) * params->KV_latent_strides[2] +
+                             dbase + d]
+            : T(0);
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      STEEL_PRAGMA_UNROLL
+      for (short iq = 0; iq < TQ; ++iq) {
+        STEEL_PRAGMA_UNROLL
+        for (short id = 0; id < TDC; ++id) {
+          STEEL_PRAGMA_UNROLL
+          for (short ik = 0; ik < TK; ++ik) {
+            const short kk = ik * kFragSize;
+            const short dd = id * kFragSize;
+            Vtile.template load<T, 1, 1, LDV, 1>(
+                &KVs[Vs_offset + kk * LDV + dd]);
+            MMAFragAcc::mma(
+                Otile.frag_at(iq, vchunk * TDC + id),
+                Stile.frag_at(iq, ik),
+                Vtile.frag_at(0, 0),
+                Otile.frag_at(iq, vchunk * TDC + id));
+          }
+        }
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  }
+
+  if (q_pos < params->qL) {
+    Otile.template row_bin_op<SparseMlaDivOp>(sum_score);
+    device T* out = O + size_t(b) * params->O_strides[0] +
+        size_t(q_pos) * params->O_strides[2] +
+        size_t(tm + sm) * params->O_strides[1] + sn;
+    Otile.template store<T, 1, 1>(out, params->O_strides[1]);
+  }
+}
+
+// clang-format off
+template <
+    typename T,
+    int Q_BLOCK,
+    int BK,
+    int DC,
+    int H,
+    int D_LATENT,
+    int D_PE,
+    int WM,
+    typename AccumType = float>
+[[kernel, max_total_threads_per_threadgroup(WM * 32)]] void
+sparse_mla_qblock_attention(
+    const device T* Q_latent [[buffer(0)]],
+    const device T* Q_pe [[buffer(1)]],
+    const device T* KV_latent [[buffer(2)]],
+    const device T* K_pe [[buffer(3)]],
+    const device uint* UnionTokens [[buffer(4)]],
+    const device uint* RowBits [[buffer(5)]],
+    const device uint* Lengths [[buffer(6)]],
+    device T* O [[buffer(7)]],
+    const constant GlmDsaSparseMlaQBlockParams* params [[buffer(8)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]]) { // clang-format on
+
+  constexpr short kFragSize = 8;
+  constexpr int WQ = WM / Q_BLOCK;
+  constexpr short padK = 16 / sizeof(T);
+  constexpr short padV = 16 / sizeof(T);
+
+  constexpr short LDK = BK + padK;
+  constexpr short LDV = DC + padV;
+
+  constexpr int TQ = H / (WQ * kFragSize);
+  constexpr int TK = BK / kFragSize;
+  constexpr int TDC = DC / kFragSize;
+  constexpr int TD_LATENT = D_LATENT / kFragSize;
+  constexpr int D_TOTAL = D_LATENT + D_PE;
+  constexpr int D_CHUNKS = D_TOTAL / DC;
+  constexpr int V_CHUNKS = D_LATENT / DC;
+
+  static_assert(Q_BLOCK > 0, "Q_BLOCK must be positive.");
+  static_assert(WM % Q_BLOCK == 0, "q-block sparse MLA expects WM divisible by Q_BLOCK.");
+  static_assert(TQ >= 1, "q-block sparse MLA expects at least one head tile.");
+  static_assert(
+      H % (WQ * kFragSize) == 0,
+      "q-block sparse MLA head count must divide evenly.");
+  static_assert(BK % kFragSize == 0, "BK must be a multiple of 8.");
+  static_assert(DC % kFragSize == 0, "DC must be a multiple of 8.");
+  static_assert(D_TOTAL % DC == 0, "QK total dimension must divide DC.");
+  static_assert(D_LATENT % DC == 0, "Latent value dimension must divide DC.");
+
+  constexpr int tgp_size = WM * 32;
+  const int lane = int(simd_group_id * 32 + simd_lane_id);
+  const int q_local = int(simd_group_id) / WQ;
+  const int local_sg = int(simd_group_id) - q_local * WQ;
+  const int qb = int(tid.x);
+  const int b = int(tid.y);
+  const int q_pos = qb * Q_BLOCK + q_local;
+  const int q_abs = params->qL_off + q_pos;
+
+  threadgroup T KVs[(BK * LDV > DC * LDK) ? BK * LDV : DC * LDK];
+  threadgroup int selected[BK];
+  threadgroup uchar valid[Q_BLOCK * BK];
+
+  using MMAFragAcc = BaseMMAFrag<AccumType, kFragSize, kFragSize>;
+  MMATile<AccumType, TQ, 1, MMAFragAcc> Qtile;
+  MMATile<AccumType, 1, TK, MMAFragAcc> Ktile;
+  MMATile<AccumType, TQ, TK, MMAFragAcc> Stile;
+  MMATile<AccumType, 1, 1, MMAFragAcc> Vtile;
+  MMATile<AccumType, TQ, TD_LATENT, MMAFragAcc> Otile;
+
+  Otile.clear();
+
+  const short2 simd_coord = MMAFragAcc::get_coord(simd_lane_id);
+  const short sm = simd_coord.y;
+  const short sn = simd_coord.x;
+  const short tm = kFragSize * TQ * local_sg;
+
+  const short Ks_offset = sm * LDK + sn;
+  const short Vs_offset = sm * LDV + sn;
+
+  const AccumType scale = AccumType(params->scale * M_LOG2E_F);
+
+  constexpr short rows_per_thread = decltype(Stile)::kRowsPerThread;
+  AccumType max_score[rows_per_thread];
+  AccumType sum_score[rows_per_thread] = {0};
+
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < rows_per_thread; ++i) {
+    max_score[i] = Limits<AccumType>::finite_min;
+  }
+
+  const device T* q_latent_base = Q_latent +
+      size_t(b) * params->Q_latent_strides[0];
+  const device T* q_pe_base = Q_pe + size_t(b) * params->Q_pe_strides[0];
+  const device T* kv_latent_base =
+      KV_latent + size_t(b) * params->KV_latent_strides[0];
+  const device T* k_pe_base = K_pe + size_t(b) * params->K_pe_strides[0];
+  const device uint* union_base =
+      UnionTokens + size_t(b) * params->Union_strides[0] +
+      size_t(qb) * params->Union_strides[1];
+  const device uint* row_bits_base =
+      RowBits + size_t(b) * params->RowBits_strides[0] +
+      size_t(qb) * params->RowBits_strides[1];
+  const int union_len =
+      int(Lengths[size_t(b) * params->Length_strides[0] +
+                  size_t(qb) * params->Length_strides[1]]);
+  const int n_tiles = (union_len + BK - 1) / BK;
+
+  for (int ktile = 0; ktile < n_tiles; ++ktile) {
+    const int union_off = ktile * BK;
+
+    for (int k = lane; k < BK; k += tgp_size) {
+      const int slot = union_off + k;
+      int k_pos = -1;
+      uint bits = 0;
+      if (slot < union_len) {
+        const uint token = union_base[size_t(slot) * params->Union_strides[2]];
+        bits = row_bits_base[size_t(slot) * params->RowBits_strides[2]];
+        if (token < uint(params->kL)) {
+          k_pos = int(token);
+        }
+      }
+      selected[k] = k_pos;
+      STEEL_PRAGMA_UNROLL
+      for (int qr = 0; qr < Q_BLOCK; ++qr) {
+        const int qp = qb * Q_BLOCK + qr;
+        const bool row_valid = qp < params->qL;
+        const bool token_valid =
+            k_pos >= 0 && row_valid && ((bits & (1u << uint(qr))) != 0) &&
+            (!do_causal || k_pos <= params->qL_off + qp);
+        valid[qr * BK + k] = token_valid ? 1 : 0;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    Stile.clear();
+
+    STEEL_PRAGMA_UNROLL
+    for (short dchunk = 0; dchunk < D_CHUNKS; ++dchunk) {
+      const int dbase = int(dchunk) * DC;
+
+      for (int elem = lane; elem < BK * DC; elem += tgp_size) {
+        const int k = elem / DC;
+        const int d = elem - k * DC;
+        const int k_pos = selected[k];
+        T value = T(0);
+        if (k_pos >= 0) {
+          value = dbase < D_LATENT
+              ? kv_latent_base[size_t(k_pos) * params->KV_latent_strides[2] +
+                               dbase + d]
+              : k_pe_base[size_t(k_pos) * params->K_pe_strides[2] +
+                          (dbase - D_LATENT) + d];
+        }
+        KVs[k + d * LDK] = value;
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      STEEL_PRAGMA_UNROLL
+      for (short dd = 0; dd < TDC; ++dd) {
+        simdgroup_barrier(mem_flags::mem_none);
+        if (q_pos < params->qL) {
+          if (dbase < D_LATENT) {
+            const device T* q_src = q_latent_base +
+                size_t(tm + sm) * params->Q_latent_strides[1] +
+                size_t(q_pos) * params->Q_latent_strides[2] + dbase +
+                dd * kFragSize + sn;
+            Qtile.template load<T, 1, 1>(
+                q_src, int(params->Q_latent_strides[1]));
+          } else {
+            const device T* q_src = q_pe_base +
+                size_t(tm + sm) * params->Q_pe_strides[1] +
+                size_t(q_pos) * params->Q_pe_strides[2] +
+                (dbase - D_LATENT) + dd * kFragSize + sn;
+            Qtile.template load<T, 1, 1>(
+                q_src, int(params->Q_pe_strides[1]));
+          }
+        } else {
+          Qtile.clear();
+        }
+        Ktile.template load<T, 1, 1, LDK, 1>(
+            &KVs[Ks_offset + dd * kFragSize * LDK]);
+        simdgroup_barrier(mem_flags::mem_none);
+        tile_matmad(Stile, Qtile, Ktile, Stile);
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    STEEL_PRAGMA_UNROLL
+    for (short ii = 0; ii < decltype(Stile)::kElemsPerTile; ++ii) {
+      Stile.elems()[ii] *= scale;
+    }
+
+    {
+      using stile_t = decltype(Stile);
+      using selem_t = typename stile_t::elem_type;
+      constexpr auto neg_inf = Limits<selem_t>::finite_min;
+
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < stile_t::kTileRows; ++i) {
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < stile_t::kTileCols; ++j) {
+          const short col_pos = sn + j * stile_t::kFragCols;
+          STEEL_PRAGMA_UNROLL
+          for (short jj = 0; jj < stile_t::MMAFrag_t::kElemCols; ++jj) {
+            const int col = col_pos + jj;
+            if (q_pos >= params->qL || selected[col] < 0 ||
+                valid[q_local * BK + col] == 0) {
+              Stile.frag_at(i, j)[jj] = neg_inf;
+            }
+          }
+        }
+      }
+    }
+
+    AccumType new_max[rows_per_thread];
+    AccumType factor[rows_per_thread];
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      new_max[i] = max_score[i];
+    }
+
+    Stile.template row_reduce<SparseMlaMaxOp>(new_max);
+    Stile.template row_bin_op<SparseMlaExpSubOp>(new_max);
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      factor[i] = fast::exp2(max_score[i] - new_max[i]);
+      max_score[i] = new_max[i];
+    }
+
+    AccumType sum_score_tmp[rows_per_thread] = {0};
+    Stile.template row_reduce<SparseMlaSumOp>(sum_score_tmp);
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      sum_score[i] = sum_score[i] * factor[i] + sum_score_tmp[i];
+    }
+
+    Otile.template row_bin_op<SparseMlaMulOp>(factor);
+
+    STEEL_PRAGMA_UNROLL
+    for (short vchunk = 0; vchunk < V_CHUNKS; ++vchunk) {
+      const int dbase = int(vchunk) * DC;
+
+      for (int elem = lane; elem < BK * DC; elem += tgp_size) {
+        const int k = elem / DC;
+        const int d = elem - k * DC;
+        const int k_pos = selected[k];
+        KVs[k * LDV + d] = k_pos >= 0
+            ? kv_latent_base[size_t(k_pos) * params->KV_latent_strides[2] +
+                             dbase + d]
+            : T(0);
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      STEEL_PRAGMA_UNROLL
+      for (short iq = 0; iq < TQ; ++iq) {
+        STEEL_PRAGMA_UNROLL
+        for (short id = 0; id < TDC; ++id) {
+          STEEL_PRAGMA_UNROLL
+          for (short ik = 0; ik < TK; ++ik) {
+            const short kk = ik * kFragSize;
+            const short dd = id * kFragSize;
+            Vtile.template load<T, 1, 1, LDV, 1>(
+                &KVs[Vs_offset + kk * LDV + dd]);
+            MMAFragAcc::mma(
+                Otile.frag_at(iq, vchunk * TDC + id),
+                Stile.frag_at(iq, ik),
+                Vtile.frag_at(0, 0),
+                Otile.frag_at(iq, vchunk * TDC + id));
+          }
+        }
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  }
+
+  if (q_pos < params->qL) {
+    Otile.template row_bin_op<SparseMlaDivOp>(sum_score);
+    device T* out = O + size_t(b) * params->O_strides[0] +
+        size_t(q_pos) * params->O_strides[2] +
+        size_t(tm + sm) * params->O_strides[1] + sn;
+    Otile.template store<T, 1, 1>(out, params->O_strides[1]);
+  }
+}
+
+// clang-format off
+template <
+    typename T,
+    int K_BLOCK,
+    int DC,
+    int H,
+    int D_LATENT,
+    int D_PE,
+    int WM,
+    typename AccumType = float>
+[[kernel, max_total_threads_per_threadgroup(WM * 32)]] void
+sparse_mla_block_table_attention(
+    const device T* Q_latent [[buffer(0)]],
+    const device T* Q_pe [[buffer(1)]],
+    const device T* KV_latent [[buffer(2)]],
+    const device T* K_pe [[buffer(3)]],
+    const device uint* BlockTable [[buffer(4)]],
+    device T* O [[buffer(5)]],
+    const constant GlmDsaSparseMlaBlockTableParams* params [[buffer(6)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]]) { // clang-format on
+
+  constexpr short kFragSize = 8;
+  constexpr short padQ = 16 / sizeof(T);
+  constexpr short padK = 16 / sizeof(T);
+  constexpr short padV = 16 / sizeof(T);
+
+  constexpr short LDQ = DC + padQ;
+  constexpr short LDK = K_BLOCK + padK;
+  constexpr short LDV = DC + padV;
+
+  constexpr int kNWarps = WM;
+  constexpr int TQ = H / (kNWarps * kFragSize);
+  constexpr int TK = K_BLOCK / kFragSize;
+  constexpr int TDC = DC / kFragSize;
+  constexpr int TD_LATENT = D_LATENT / kFragSize;
+  constexpr int D_TOTAL = D_LATENT + D_PE;
+  constexpr int D_CHUNKS = D_TOTAL / DC;
+  constexpr int V_CHUNKS = D_LATENT / DC;
+
+  static_assert(TQ >= 1, "Sparse MLA block-table kernel expects head tiles.");
+  static_assert(
+      H % (kNWarps * kFragSize) == 0,
+      "Sparse MLA head count must divide evenly across simdgroups.");
+  static_assert(K_BLOCK % kFragSize == 0, "K_BLOCK must be a multiple of 8.");
+  static_assert(DC % kFragSize == 0, "DC must be a multiple of 8.");
+  static_assert(D_TOTAL % DC == 0, "QK total dimension must divide DC.");
+  static_assert(D_LATENT % DC == 0, "Latent value dimension must divide DC.");
+
+  constexpr int tgp_size = WM * 32;
+  const int lane = int(simd_group_id * 32 + simd_lane_id);
+
+  const int q_pos = int(tid.x);
+  const int b = int(tid.y);
+  const int q_abs = params->qL_off + q_pos;
+
+  threadgroup T Qs[H * LDQ];
+  threadgroup T KVs[(K_BLOCK * LDV > DC * LDK) ? K_BLOCK * LDV : DC * LDK];
+  threadgroup int selected[K_BLOCK];
+
+  using MMAFragAcc = BaseMMAFrag<AccumType, kFragSize, kFragSize>;
+  MMATile<AccumType, TQ, 1, MMAFragAcc> Qtile;
+  MMATile<AccumType, 1, TK, MMAFragAcc> Ktile;
+  MMATile<AccumType, TQ, TK, MMAFragAcc> Stile;
+  MMATile<AccumType, 1, 1, MMAFragAcc> Vtile;
+  MMATile<AccumType, TQ, TD_LATENT, MMAFragAcc> Otile;
+
+  Otile.clear();
+
+  const short2 simd_coord = MMAFragAcc::get_coord(simd_lane_id);
+  const short sm = simd_coord.y;
+  const short sn = simd_coord.x;
+  const short tm = kFragSize * TQ * simd_group_id;
+
+  const short Qs_offset = (tm + sm) * LDQ + sn;
+  const short Ks_offset = sm * LDK + sn;
+  const short Vs_offset = sm * LDV + sn;
+
+  const AccumType scale = AccumType(params->scale * M_LOG2E_F);
+
+  constexpr short rows_per_thread = decltype(Stile)::kRowsPerThread;
+  AccumType max_score[rows_per_thread];
+  AccumType sum_score[rows_per_thread] = {0};
+
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < rows_per_thread; ++i) {
+    max_score[i] = Limits<AccumType>::finite_min;
+  }
+
+  const device T* q_latent_base = Q_latent +
+      size_t(b) * params->Q_latent_strides[0] +
+      size_t(q_pos) * params->Q_latent_strides[2];
+  const device T* q_pe_base = Q_pe + size_t(b) * params->Q_pe_strides[0] +
+      size_t(q_pos) * params->Q_pe_strides[2];
+  const device T* kv_latent_base =
+      KV_latent + size_t(b) * params->KV_latent_strides[0];
+  const device T* k_pe_base = K_pe + size_t(b) * params->K_pe_strides[0];
+  const device uint* table_base =
+      BlockTable + size_t(b) * params->BlockTable_strides[0] +
+      size_t(q_pos) * params->BlockTable_strides[1];
+
+  for (int entry = 0; entry < params->table_size; ++entry) {
+    const uint encoded =
+        table_base[size_t(entry) * params->BlockTable_strides[2]];
+    constexpr uint mask =
+        uint(K_BLOCK == 32 ? 0xffffffffull : ((1ull << K_BLOCK) - 1ull));
+    const uint block = packed_block_table
+        ? uint(ulong(encoded) >> uint(K_BLOCK))
+        : encoded;
+    const uint bits = packed_block_table
+        ? encoded & mask
+        : table_base[size_t(entry) * params->BlockTable_strides[2] +
+                     params->BlockTable_strides[3]];
+    if (block == uint(-1) || bits == 0) {
+      break;
+    }
+
+    for (int k = lane; k < K_BLOCK; k += tgp_size) {
+      const int k_pos = int(block) * params->k_block_size + k;
+      const bool valid_bit = (bits & (1u << uint(k))) != 0;
+      selected[k] =
+          valid_bit && k_pos < params->kL && (!do_causal || k_pos <= q_abs)
+          ? k_pos
+          : -1;
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    Stile.clear();
+
+    STEEL_PRAGMA_UNROLL
+    for (short dchunk = 0; dchunk < D_CHUNKS; ++dchunk) {
+      const int dbase = int(dchunk) * DC;
+
+      for (int elem = lane; elem < H * DC; elem += tgp_size) {
+        const int h = elem / DC;
+        const int d = elem - h * DC;
+        Qs[h * LDQ + d] = dbase < D_LATENT
+            ? q_latent_base[size_t(h) * params->Q_latent_strides[1] + dbase + d]
+            : q_pe_base[size_t(h) * params->Q_pe_strides[1] +
+                        (dbase - D_LATENT) + d];
+      }
+
+      for (int elem = lane; elem < K_BLOCK * DC; elem += tgp_size) {
+        const int k = elem / DC;
+        const int d = elem - k * DC;
+        const int k_pos = selected[k];
+        T value = T(0);
+        if (k_pos >= 0) {
+          value = dbase < D_LATENT
+              ? kv_latent_base[size_t(k_pos) * params->KV_latent_strides[2] +
+                               dbase + d]
+              : k_pe_base[size_t(k_pos) * params->K_pe_strides[2] +
+                          (dbase - D_LATENT) + d];
+        }
+        KVs[k + d * LDK] = value;
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      STEEL_PRAGMA_UNROLL
+      for (short dd = 0; dd < TDC; ++dd) {
+        simdgroup_barrier(mem_flags::mem_none);
+        Qtile.template load<T, 1, 1, LDQ, 1>(&Qs[Qs_offset + dd * kFragSize]);
+        Ktile.template load<T, 1, 1, LDK, 1>(
+            &KVs[Ks_offset + dd * kFragSize * LDK]);
+        simdgroup_barrier(mem_flags::mem_none);
+        tile_matmad(Stile, Qtile, Ktile, Stile);
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    STEEL_PRAGMA_UNROLL
+    for (short ii = 0; ii < decltype(Stile)::kElemsPerTile; ++ii) {
+      Stile.elems()[ii] *= scale;
+    }
+
+    {
+      using stile_t = decltype(Stile);
+      using selem_t = typename stile_t::elem_type;
+      constexpr auto neg_inf = Limits<selem_t>::finite_min;
+
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < stile_t::kTileRows; ++i) {
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < stile_t::kTileCols; ++j) {
+          const short col_pos = sn + j * stile_t::kFragCols;
+          STEEL_PRAGMA_UNROLL
+          for (short jj = 0; jj < stile_t::MMAFrag_t::kElemCols; ++jj) {
+            if (selected[col_pos + jj] < 0) {
+              Stile.frag_at(i, j)[jj] = neg_inf;
+            }
+          }
+        }
+      }
+    }
+
+    AccumType new_max[rows_per_thread];
+    AccumType factor[rows_per_thread];
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      new_max[i] = max_score[i];
+    }
+
+    Stile.template row_reduce<SparseMlaMaxOp>(new_max);
+    Stile.template row_bin_op<SparseMlaExpSubOp>(new_max);
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      factor[i] = fast::exp2(max_score[i] - new_max[i]);
+      max_score[i] = new_max[i];
+    }
+
+    AccumType sum_score_tmp[rows_per_thread] = {0};
+    Stile.template row_reduce<SparseMlaSumOp>(sum_score_tmp);
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      sum_score[i] = sum_score[i] * factor[i] + sum_score_tmp[i];
+    }
+
+    Otile.template row_bin_op<SparseMlaMulOp>(factor);
+
+    STEEL_PRAGMA_UNROLL
+    for (short vchunk = 0; vchunk < V_CHUNKS; ++vchunk) {
+      const int dbase = int(vchunk) * DC;
+
+      for (int elem = lane; elem < K_BLOCK * DC; elem += tgp_size) {
+        const int k = elem / DC;
+        const int d = elem - k * DC;
+        const int k_pos = selected[k];
+        KVs[k * LDV + d] = k_pos >= 0
+            ? kv_latent_base[size_t(k_pos) * params->KV_latent_strides[2] +
+                             dbase + d]
+            : T(0);
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      STEEL_PRAGMA_UNROLL
+      for (short iq = 0; iq < TQ; ++iq) {
+        STEEL_PRAGMA_UNROLL
+        for (short id = 0; id < TDC; ++id) {
+          STEEL_PRAGMA_UNROLL
+          for (short ik = 0; ik < TK; ++ik) {
+            const short kk = ik * kFragSize;
+            const short dd = id * kFragSize;
+            Vtile.template load<T, 1, 1, LDV, 1>(
+                &KVs[Vs_offset + kk * LDV + dd]);
+            MMAFragAcc::mma(
+                Otile.frag_at(iq, vchunk * TDC + id),
+                Stile.frag_at(iq, ik),
+                Vtile.frag_at(0, 0),
+                Otile.frag_at(iq, vchunk * TDC + id));
+          }
+        }
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  }
+
+  Otile.template row_bin_op<SparseMlaDivOp>(sum_score);
+
+  device T* out = O + size_t(b) * params->O_strides[0] +
+      size_t(q_pos) * params->O_strides[2] +
+      size_t(tm + sm) * params->O_strides[1] + sn;
+  Otile.template store<T, 1, 1>(out, params->O_strides[1]);
+}

--- a/omlx_glm_kernels/csrc/mlx/backend/metal/kernels/steel/attn/params.h
+++ b/omlx_glm_kernels/csrc/mlx/backend/metal/kernels/steel/attn/params.h
@@ -1,0 +1,148 @@
+// Copyright © 2024 Apple Inc.
+
+#pragma once
+
+///////////////////////////////////////////////////////////////////////////////
+// Attn param classes
+///////////////////////////////////////////////////////////////////////////////
+
+namespace mlx {
+namespace steel {
+
+struct AttnParams {
+  int B; ///< Batch Size
+  int H; ///< Heads
+  int D; ///< Head Dim
+
+  int qL; ///< Query Sequence Length
+  int kL; ///< Key Sequence Length
+
+  int gqa_factor; ///< Group Query factor
+  float scale; ///< Attention scale
+
+  int NQ; ///< Number of query blocks
+  int NK; ///< Number of key/value blocks
+
+  int NQ_aligned; ///< Number of full query blocks
+  int NK_aligned; ///< Number of full key/value blocks
+
+  int qL_rem; ///< Remainder in last query block
+  int kL_rem; ///< Remainder in last key/value block
+  int qL_off; ///< Offset in query sequence start
+
+  int64_t Q_strides[3]; ///< Query  strides (B, H, L, D = 1)
+  int64_t K_strides[3]; ///< Key    strides (B, H, L, D = 1)
+  int64_t V_strides[3]; ///< Value  strides (B, H, L, D = 1)
+  int64_t O_strides[3]; ///< Output strides (B, H, L, D = 1)
+};
+
+struct AttnMaskParams {
+  int64_t M_strides[3]; ///< Mask  strides (B, H, qL, kL = 1)
+};
+
+struct AttnBlockMaskParams {
+  int64_t BM_strides[3]; ///< Block mask strides (B, H, qBlock, kBlock = 1)
+};
+
+struct AttnBlockTokenMaskParams {
+  int64_t BTM_strides[3]; ///< Token mask strides (B, H, qL, kBlock = 1)
+};
+
+struct AttnBlockIndexParams {
+  int64_t BI_strides[3]; ///< Block index strides (B, H, qBlock, budget = 1)
+  int budget; ///< Number of selected K blocks per query block
+};
+
+struct AttnSplitQKParams {
+  int B; ///< Batch Size
+  int H; ///< Heads
+  int D; ///< Head Dim
+
+  int qL; ///< Query Sequence Length
+  int kL; ///< Key Sequence Length
+
+  float scale; ///< Attention scale
+
+  int NQ; ///< Number of query blocks
+  int NK; ///< Number of key/value blocks
+
+  int NQ_aligned; ///< Number of full query blocks
+  int NK_aligned; ///< Number of full key/value blocks
+
+  int qL_rem; ///< Remainder in last query block
+  int kL_rem; ///< Remainder in last key/value block
+  int qL_off; ///< Offset in query sequence start
+
+  int64_t Q_nope_strides[3]; ///< Query no-PE strides (B, H, L, D = 1)
+  int64_t Q_pe_strides[3]; ///< Query PE strides (B, H, L, D = 1)
+  int64_t K_nope_strides[3]; ///< Key no-PE strides (B, H, L, D = 1)
+  int64_t K_pe_strides[3]; ///< Key PE strides (B, 1, L, D = 1)
+  int64_t V_strides[3]; ///< Value strides (B, H, L, D = 1)
+  int64_t O_strides[3]; ///< Output strides (B, H, L, D = 1)
+};
+
+struct GlmDsaSparseMlaParams {
+  int B; ///< Batch Size
+  int H; ///< Query heads
+  int qL; ///< Query sequence length
+  int kL; ///< Key/value sequence length
+  int topk; ///< Number of selected tokens per query
+  int topk_valid_prefix; ///< Whether valid causal top-k entries precede invalids
+  int causal_prefix_indices; ///< Whether early causal rows use implicit 0..q indices
+  int has_topk_length; ///< Whether a per-query valid top-k prefix length exists
+  int causal_prefix_rows; ///< Number of leading query rows omitted from top-k
+
+  float scale; ///< Attention scale
+  int qL_off; ///< Offset in query sequence start
+
+  int64_t Q_latent_strides[3]; ///< Query latent strides (B, H, L, D = 1)
+  int64_t Q_pe_strides[3]; ///< Query PE strides (B, H, L, D = 1)
+  int64_t KV_latent_strides[3]; ///< KV latent strides (B, 1, L, D = 1)
+  int64_t K_pe_strides[3]; ///< Key PE strides (B, 1, L, D = 1)
+  int64_t Topk_strides[3]; ///< Top-k strides (B, 1, L, topk = 1)
+  int64_t TopkLength_strides[2]; ///< Top-k length strides (B, L)
+  int64_t O_strides[3]; ///< Output strides (B, H, L, D = 1)
+};
+
+struct GlmDsaSparseMlaBlockTableParams {
+  int B; ///< Batch size
+  int H; ///< Query heads
+  int qL; ///< Query sequence length
+  int kL; ///< Key/value sequence length
+  int table_size; ///< Number of block-table entries per query
+  int k_block_size; ///< Number of tokens represented by one table bitset
+
+  float scale; ///< Attention scale
+  int qL_off; ///< Offset in query sequence start
+
+  int64_t Q_latent_strides[3]; ///< Query latent strides (B, H, L, D = 1)
+  int64_t Q_pe_strides[3]; ///< Query PE strides (B, H, L, D = 1)
+  int64_t KV_latent_strides[3]; ///< KV latent strides (B, 1, L, D = 1)
+  int64_t K_pe_strides[3]; ///< Key PE strides (B, 1, L, D = 1)
+  int64_t BlockTable_strides[4]; ///< Block table strides (B, L, slot, pair)
+  int64_t O_strides[3]; ///< Output strides (B, H, L, D = 1)
+};
+
+struct GlmDsaSparseMlaQBlockParams {
+  int B; ///< Batch size
+  int H; ///< Query heads
+  int qL; ///< Query sequence length
+  int kL; ///< Key/value sequence length
+  int q_block_size; ///< Number of query rows represented by one union row
+  int capacity; ///< Union-token capacity per query block
+
+  float scale; ///< Attention scale
+  int qL_off; ///< Offset in query sequence start
+
+  int64_t Q_latent_strides[3]; ///< Query latent strides (B, H, L, D = 1)
+  int64_t Q_pe_strides[3]; ///< Query PE strides (B, H, L, D = 1)
+  int64_t KV_latent_strides[3]; ///< KV latent strides (B, 1, L, D = 1)
+  int64_t K_pe_strides[3]; ///< Key PE strides (B, 1, L, D = 1)
+  int64_t Union_strides[3]; ///< Union token strides (B, qBlock, capacity)
+  int64_t RowBits_strides[3]; ///< Row-bit strides (B, qBlock, capacity)
+  int64_t Length_strides[2]; ///< Union length strides (B, qBlock)
+  int64_t O_strides[3]; ///< Output strides (B, H, L, D = 1)
+};
+
+} // namespace steel
+} // namespace mlx

--- a/omlx_glm_kernels/csrc/sparse_mla.cpp
+++ b/omlx_glm_kernels/csrc/sparse_mla.cpp
@@ -1,0 +1,457 @@
+#include "sparse_mla.h"
+
+#include <cstdlib>
+#include <dlfcn.h>
+#include <filesystem>
+#include <sstream>
+
+#include "mlx/backend/common/utils.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/ops.h"
+#include "mlx/utils.h"
+
+namespace omlx::glm_kernels {
+
+namespace {
+
+using namespace mlx::core;
+
+std::string current_binary_dir() {
+  static std::string binary_dir = []() {
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<void*>(&current_binary_dir), &info)) {
+      throw std::runtime_error("Unable to get omlx_glm_kernels binary dir.");
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().string();
+  }();
+  return binary_dir;
+}
+
+inline int64_t bcast_stride(const array& a, int axis) {
+  return a.shape(axis) == 1 ? 0 : a.strides(axis);
+}
+
+bool last_dim_contiguous(const array& arr) {
+  return arr.strides(-1) == 1;
+}
+
+struct GlmDsaSparseMlaParams {
+  int B;
+  int H;
+  int qL;
+  int kL;
+  int topk;
+  int topk_valid_prefix;
+  int causal_prefix_indices;
+  int has_topk_length;
+  int causal_prefix_rows;
+
+  float scale;
+  int qL_off;
+
+  int64_t Q_latent_strides[3];
+  int64_t Q_pe_strides[3];
+  int64_t KV_latent_strides[3];
+  int64_t K_pe_strides[3];
+  int64_t Topk_strides[3];
+  int64_t TopkLength_strides[2];
+  int64_t O_strides[3];
+};
+
+class GlmDsaSparseMlaAttentionPrimitive : public Primitive {
+ public:
+  GlmDsaSparseMlaAttentionPrimitive(
+      Stream stream,
+      float scale,
+      bool do_causal,
+      bool topk_valid_prefix,
+      bool causal_prefix_indices,
+      bool has_topk_length,
+      int causal_prefix_rows)
+      : Primitive(stream),
+        scale_(scale),
+        do_causal_(do_causal),
+        topk_valid_prefix_(topk_valid_prefix),
+        causal_prefix_indices_(causal_prefix_indices),
+        has_topk_length_(has_topk_length),
+        causal_prefix_rows_(causal_prefix_rows) {}
+
+  static bool unsupported(
+      const array& q_latent,
+      const array& q_pe,
+      const array& kv_latent,
+      const array& k_pe,
+      const array& topk_indices,
+      const std::optional<array>& topk_length,
+      bool topk_valid_prefix,
+      bool causal_prefix_indices,
+      int causal_prefix_rows,
+      bool do_causal,
+      Stream s) {
+    if (s.device == Device::cpu || !do_causal) {
+      return true;
+    }
+    if (q_latent.dtype() != q_pe.dtype() ||
+        q_latent.dtype() != kv_latent.dtype() ||
+        q_latent.dtype() != k_pe.dtype()) {
+      return true;
+    }
+    if (q_latent.dtype() != float16 && q_latent.dtype() != bfloat16) {
+      return true;
+    }
+    if (q_latent.ndim() != 4 || q_pe.ndim() != 4 || kv_latent.ndim() != 4 ||
+        k_pe.ndim() != 4 || topk_indices.ndim() != 4) {
+      return true;
+    }
+    if (!last_dim_contiguous(q_latent) || !last_dim_contiguous(q_pe) ||
+        !last_dim_contiguous(kv_latent) || !last_dim_contiguous(k_pe) ||
+        !last_dim_contiguous(topk_indices)) {
+      return true;
+    }
+    if (q_latent.shape(1) != 64 || kv_latent.shape(1) != 1 ||
+        k_pe.shape(1) != 1 || topk_indices.shape(1) != 1) {
+      return true;
+    }
+    if (q_latent.shape(3) != 512 || kv_latent.shape(3) != 512 ||
+        q_pe.shape(3) != 64 || k_pe.shape(3) != 64) {
+      return true;
+    }
+    if (q_latent.shape(2) <= 1 || topk_indices.shape(3) < 16 ||
+        topk_indices.dtype() != uint32) {
+      return true;
+    }
+    if (causal_prefix_rows < 0 || causal_prefix_rows > q_latent.shape(2)) {
+      return true;
+    }
+    const bool compact_prefix =
+        causal_prefix_rows > 0 && topk_indices.shape(2) != q_latent.shape(2);
+    if (compact_prefix) {
+      if (!causal_prefix_indices || !topk_valid_prefix ||
+          topk_indices.shape(2) + causal_prefix_rows != q_latent.shape(2)) {
+        return true;
+      }
+    } else if (topk_indices.shape(2) != q_latent.shape(2)) {
+      return true;
+    }
+    if (topk_length.has_value() &&
+        (topk_length->dtype() != uint32 ||
+         (topk_length->ndim() != 2 && topk_length->ndim() != 3))) {
+      return true;
+    }
+    return false;
+  }
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error(
+        "GlmDsaSparseMlaAttentionPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+
+    const auto& q_latent = inputs[0];
+    const auto& q_pe = inputs[1];
+    const auto& kv_latent = inputs[2];
+    const auto& k_pe = inputs[3];
+    const auto& topk = inputs[4];
+    const bool has_topk_length = inputs.size() > 5;
+    const array& topk_length = has_topk_length ? inputs[5] : topk;
+    auto& o = outputs[0];
+
+    constexpr int bk = 256;
+    constexpr int dc = 32;
+    constexpr int h = 64;
+    constexpr int d_latent = 512;
+    constexpr int d_pe = 64;
+    constexpr int wm = 8;
+
+    const int B = q_latent.shape(0);
+    const int H = q_latent.shape(1);
+    const int qL = q_latent.shape(2);
+    const int kL = kv_latent.shape(2);
+    int64_t topk_length_strides[2] = {0, 0};
+    if (has_topk_length) {
+      topk_length_strides[0] = topk_length.strides(0);
+      topk_length_strides[1] =
+          topk_length.ndim() == 3 ? topk_length.strides(2)
+                                  : topk_length.strides(1);
+    }
+
+    int64_t str_oD = 1;
+    int64_t str_oL = o.shape(3);
+    int64_t str_oH = o.shape(2) * str_oL;
+    int64_t str_oB = o.shape(1) * str_oH;
+    size_t data_size = o.shape(0) * str_oB;
+
+    array::Flags flags{
+        /* bool contiguous = */ 1,
+        /* bool row_contiguous = */ 1,
+        /* bool col_contiguous = */ 0,
+    };
+
+    o.set_data(
+        allocator::malloc(o.nbytes()),
+        data_size,
+        {str_oB, str_oH, str_oL, str_oD},
+        flags);
+
+    const bool do_causal = do_causal_;
+    const bool direct_q_load =
+        std::getenv("MLX_LM_GLM_DSA_SPARSE_MLA_DIRECT_Q_LOAD") != nullptr &&
+        std::string(std::getenv("MLX_LM_GLM_DSA_SPARSE_MLA_DIRECT_Q_LOAD")) ==
+            "1";
+    metal::MTLFCList func_consts = {
+        {&do_causal, MTL::DataType::DataTypeBool, 301},
+        {&direct_q_load, MTL::DataType::DataTypeBool, 307}};
+
+    std::string base_name;
+    concatenate(
+        base_name,
+        "steel_sparse_mla_",
+        type_to_name(q_latent),
+        "_bk",
+        bk,
+        "_dc",
+        dc,
+        "_h",
+        h,
+        "_d",
+        d_latent,
+        "_pe",
+        d_pe,
+        "_wm",
+        wm);
+
+    std::string hash_name;
+    concatenate(
+        hash_name,
+        base_name,
+        "_do_causal_",
+        (do_causal ? 't' : 'n'),
+        "_direct_q_",
+        (direct_q_load ? 't' : 'n'));
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto& compute_encoder = metal::get_command_encoder(s);
+    auto kernel = d.get_kernel(base_name, lib, hash_name, func_consts);
+    compute_encoder.set_compute_pipeline_state(kernel);
+
+    GlmDsaSparseMlaParams params{
+        /* int B = */ B,
+        /* int H = */ H,
+        /* int qL = */ qL,
+        /* int kL = */ kL,
+        /* int topk = */ topk.shape(3),
+        /* int topk_valid_prefix = */ topk_valid_prefix_,
+        /* int causal_prefix_indices = */ causal_prefix_indices_,
+        /* int has_topk_length = */ has_topk_length,
+        /* int causal_prefix_rows = */ causal_prefix_rows_,
+
+        /* float scale = */ scale_,
+        /* int qL_off = */ kL - qL,
+
+        /* int64_t Q_latent_strides[3] = */ {
+            q_latent.strides(0), q_latent.strides(1), q_latent.strides(2)},
+        /* int64_t Q_pe_strides[3] = */ {
+            q_pe.strides(0), q_pe.strides(1), q_pe.strides(2)},
+        /* int64_t KV_latent_strides[3] = */ {
+            kv_latent.strides(0),
+            bcast_stride(kv_latent, 1),
+            kv_latent.strides(2)},
+        /* int64_t K_pe_strides[3] = */ {
+            k_pe.strides(0), bcast_stride(k_pe, 1), k_pe.strides(2)},
+        /* int64_t Topk_strides[3] = */ {
+            topk.strides(0), bcast_stride(topk, 1), topk.strides(2)},
+        /* int64_t TopkLength_strides[2] = */ {
+            topk_length_strides[0], topk_length_strides[1]},
+        /* int64_t O_strides[3] = */ {
+            o.strides(0), o.strides(1), o.strides(2)}};
+
+    compute_encoder.set_input_array(q_latent, 0);
+    compute_encoder.set_input_array(q_pe, 1);
+    compute_encoder.set_input_array(kv_latent, 2);
+    compute_encoder.set_input_array(k_pe, 3);
+    compute_encoder.set_input_array(topk, 4);
+    compute_encoder.set_input_array(topk_length, 5);
+    compute_encoder.set_output_array(o, 6);
+    compute_encoder.set_bytes(params, 7);
+
+    MTL::Size grid_dims = MTL::Size(qL, B, 1);
+    MTL::Size group_dims = MTL::Size(32, wm, 1);
+    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  }
+
+  DEFINE_NAME(OMLXGlmDsaSparseMlaAttention)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs =
+        static_cast<const GlmDsaSparseMlaAttentionPrimitive&>(other);
+    return scale_ == rhs.scale_ && do_causal_ == rhs.do_causal_ &&
+        topk_valid_prefix_ == rhs.topk_valid_prefix_ &&
+        causal_prefix_indices_ == rhs.causal_prefix_indices_ &&
+        has_topk_length_ == rhs.has_topk_length_ &&
+        causal_prefix_rows_ == rhs.causal_prefix_rows_;
+  }
+  auto state() const {
+    return std::make_tuple(
+        nullptr,
+        scale_,
+        do_causal_,
+        topk_valid_prefix_,
+        causal_prefix_indices_,
+        has_topk_length_,
+        causal_prefix_rows_);
+  }
+
+ private:
+  float scale_;
+  bool do_causal_;
+  bool topk_valid_prefix_;
+  bool causal_prefix_indices_;
+  bool has_topk_length_;
+  int causal_prefix_rows_;
+};
+
+} // namespace
+
+array glm_dsa_sparse_mla_attention(
+    const array& q_latent,
+    const array& q_pe,
+    const array& kv_latent,
+    const array& k_pe,
+    const array& topk_indices,
+    float scale,
+    bool causal,
+    bool topk_valid_prefix,
+    bool causal_prefix_indices,
+    const std::optional<array>& topk_length,
+    int causal_prefix_rows,
+    StreamOrDevice s) {
+  for (const auto& tensor : {q_latent, q_pe, kv_latent, k_pe}) {
+    if (tensor.ndim() != 4) {
+      std::ostringstream msg;
+      msg << "[omlx_glm_kernels.glm_dsa_sparse_mla_attention] input with shape "
+          << tensor.shape() << " expected to be rank 4.";
+      throw std::invalid_argument(msg.str());
+    }
+  }
+  if (topk_indices.ndim() != 4) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_dsa_sparse_mla_attention] topk_indices with "
+        << "shape " << topk_indices.shape() << " expected to be rank 4.";
+    throw std::invalid_argument(msg.str());
+  }
+  if (causal_prefix_rows < 0 || causal_prefix_rows > q_latent.shape(2)) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_dsa_sparse_mla_attention] "
+        << "causal_prefix_rows must be in [0, L], got "
+        << causal_prefix_rows << " for L=" << q_latent.shape(2) << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  const bool compact_prefix_topk =
+      causal_prefix_rows > 0 && topk_indices.shape(2) != q_latent.shape(2);
+  const bool topk_length_ok = topk_indices.shape(2) == q_latent.shape(2) ||
+      (compact_prefix_topk &&
+       topk_indices.shape(2) + causal_prefix_rows == q_latent.shape(2) &&
+       causal_prefix_indices && topk_valid_prefix);
+  if (q_latent.shape(0) != q_pe.shape(0) ||
+      q_latent.shape(0) != kv_latent.shape(0) ||
+      q_latent.shape(0) != k_pe.shape(0) ||
+      q_latent.shape(0) != topk_indices.shape(0) ||
+      q_latent.shape(1) != q_pe.shape(1) || kv_latent.shape(1) != 1 ||
+      k_pe.shape(1) != 1 || topk_indices.shape(1) != 1 ||
+      q_latent.shape(2) != q_pe.shape(2) || !topk_length_ok ||
+      kv_latent.shape(2) != k_pe.shape(2) ||
+      q_latent.shape(3) != kv_latent.shape(3) ||
+      q_pe.shape(3) != k_pe.shape(3)) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_dsa_sparse_mla_attention] incompatible "
+        << "shapes: " << q_latent.shape() << ", " << q_pe.shape() << ", "
+        << kv_latent.shape() << ", " << k_pe.shape() << ", "
+        << topk_indices.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (topk_indices.dtype() != uint32) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_dsa_sparse_mla_attention] topk_indices must "
+        << "be uint32, got " << topk_indices.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (topk_length.has_value()) {
+    const auto& lengths = *topk_length;
+    const bool rank_ok = lengths.ndim() == 2 || lengths.ndim() == 3;
+    const bool shape_ok = rank_ok && lengths.shape(0) == q_latent.shape(0) &&
+        lengths.shape(lengths.ndim() - 1) == q_latent.shape(2) &&
+        (lengths.ndim() == 2 || lengths.shape(1) == 1);
+    if (!shape_ok) {
+      std::ostringstream msg;
+      msg << "[omlx_glm_kernels.glm_dsa_sparse_mla_attention] topk_length "
+          << "with shape " << lengths.shape() << " expected [B, L] or "
+          << "[B, 1, L].";
+      throw std::invalid_argument(msg.str());
+    }
+    if (lengths.dtype() != uint32) {
+      std::ostringstream msg;
+      msg << "[omlx_glm_kernels.glm_dsa_sparse_mla_attention] topk_length must "
+          << "be uint32, got " << lengths.dtype() << ".";
+      throw std::invalid_argument(msg.str());
+    }
+  }
+
+  auto final_type =
+      result_type(std::vector<array>{q_latent, q_pe, kv_latent, k_pe});
+  if (final_type != float16 && final_type != bfloat16 && final_type != float32) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_dsa_sparse_mla_attention] expected floating "
+        << "inputs, got " << final_type << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto stream = to_stream(s);
+  auto ql = astype(q_latent, final_type, stream);
+  auto qp = astype(q_pe, final_type, stream);
+  auto kv = astype(kv_latent, final_type, stream);
+  auto kp = astype(k_pe, final_type, stream);
+
+  std::vector<array> inputs = {ql, qp, kv, kp, topk_indices};
+  if (topk_length.has_value()) {
+    inputs.push_back(*topk_length);
+  }
+  if (GlmDsaSparseMlaAttentionPrimitive::unsupported(
+          ql,
+          qp,
+          kv,
+          kp,
+          topk_indices,
+          topk_length,
+          topk_valid_prefix,
+          causal_prefix_indices,
+          causal_prefix_rows,
+          causal,
+          stream)) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.glm_dsa_sparse_mla_attention] unsupported M3 GLM shape.");
+  }
+
+  Shape out_shape{ql.shape(0), ql.shape(1), ql.shape(2), kv.shape(3)};
+  return array(
+      std::move(out_shape),
+      final_type,
+      std::make_shared<GlmDsaSparseMlaAttentionPrimitive>(
+          stream,
+          scale,
+          causal,
+          topk_valid_prefix,
+          causal_prefix_indices,
+          topk_length.has_value(),
+          causal_prefix_rows),
+      std::move(inputs));
+}
+
+} // namespace omlx::glm_kernels

--- a/omlx_glm_kernels/csrc/sparse_mla.h
+++ b/omlx_glm_kernels/csrc/sparse_mla.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <optional>
+
+#include "mlx/array.h"
+#include "mlx/stream.h"
+#include "mlx/utils.h"
+
+namespace mx = mlx::core;
+
+namespace omlx::glm_kernels {
+
+mx::array glm_dsa_sparse_mla_attention(
+    const mx::array& q_latent,
+    const mx::array& q_pe,
+    const mx::array& kv_latent,
+    const mx::array& k_pe,
+    const mx::array& topk_indices,
+    float scale,
+    bool causal = true,
+    bool topk_valid_prefix = false,
+    bool causal_prefix_indices = false,
+    const std::optional<mx::array>& topk_length = std::nullopt,
+    int causal_prefix_rows = 0,
+    mx::StreamOrDevice s = {});
+
+} // namespace omlx::glm_kernels

--- a/omlx_glm_kernels/csrc/sparse_mla.metal
+++ b/omlx_glm_kernels/csrc/sparse_mla.metal
@@ -1,0 +1,21 @@
+#include "mlx/backend/metal/kernels/utils.h"
+#include "mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h"
+#include "kernels/steel_sparse_mla.h"
+
+#define instantiate_sparse_mla(tname, dtype, bk, dc, h, d, pe, wm)      \
+  instantiate_kernel(                                                   \
+      "steel_sparse_mla_" #tname "_bk" #bk "_dc" #dc "_h" #h           \
+      "_d" #d "_pe" #pe "_wm" #wm,                                     \
+      sparse_mla_attention,                                             \
+      dtype,                                                            \
+      bk,                                                               \
+      dc,                                                               \
+      h,                                                                \
+      d,                                                                \
+      pe,                                                               \
+      wm,                                                               \
+      uint,                                                             \
+      float)
+
+instantiate_sparse_mla(float16, half, 256, 32, 64, 512, 64, 8);
+instantiate_sparse_mla(bfloat16, bfloat16_t, 256, 32, 64, 512, 64, 8);

--- a/omlx_glm_kernels/fast.py
+++ b/omlx_glm_kernels/fast.py
@@ -1,0 +1,229 @@
+"""Fast GLM kernels with a fallback to patched ``mlx.core.fast`` symbols."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+try:
+    from . import _ext
+except Exception as exc:  # pragma: no cover - depends on local native build
+    _ext = None
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
+
+
+NATIVE_SYMBOLS = (
+    "dsa_indexer_scores",
+    "dsa_topk_indices",
+    "glm_dsa_sparse_mla_attention",
+    "glm_dsa_q8_vup_flat",
+    "glm_moe_weighted_sum",
+)
+
+
+def is_native_available() -> bool:
+    return _ext is not None
+
+
+def import_error() -> Exception | None:
+    return _IMPORT_ERROR
+
+
+def has_symbol(name: str) -> bool:
+    return hasattr(_ext, name) or hasattr(mx.fast, name)
+
+
+def native_symbols() -> tuple[str, ...]:
+    if _ext is None:
+        return ()
+    return tuple(name for name in NATIVE_SYMBOLS if hasattr(_ext, name))
+
+
+def missing_symbols(required: tuple[str, ...]) -> list[str]:
+    return [name for name in required if not has_symbol(name)]
+
+
+def _native_stream_kwargs(stream) -> dict[str, object]:
+    """Accept the same stream shorthand that mlx.fast kernels accept."""
+    if (
+        stream is None
+        or isinstance(stream, mx.DeviceType)
+        or isinstance(stream, mx.Device)
+    ):
+        return {}
+    if isinstance(stream, mx.DeviceType):
+        return {}
+    return {"stream": stream}
+
+
+def dsa_indexer_scores(
+    queries: mx.array,
+    keys: mx.array,
+    weights: mx.array,
+    causal: bool = True,
+    unused_causal_prefix_topk: int = 0,
+    skip_causal_future_store: bool = False,
+    causal_q_offset: int = -1,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is not None:
+        return _ext.dsa_indexer_scores(
+            queries,
+            keys,
+            weights,
+            causal=causal,
+            unused_causal_prefix_topk=unused_causal_prefix_topk,
+            skip_causal_future_store=skip_causal_future_store,
+            causal_q_offset=causal_q_offset,
+            **_native_stream_kwargs(stream),
+        )
+    return mx.fast.dsa_indexer_scores(
+        queries,
+        keys,
+        weights,
+        causal=causal,
+        unused_causal_prefix_topk=unused_causal_prefix_topk,
+        skip_causal_future_store=skip_causal_future_store,
+        causal_q_offset=causal_q_offset,
+        stream=stream or mx.gpu,
+    )
+
+
+def dsa_topk_indices(
+    scores: mx.array,
+    topk: int,
+    bucketed: bool = False,
+    causal_valid_prefix: bool = False,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is not None:
+        return _ext.dsa_topk_indices(
+            scores,
+            topk,
+            bucketed=bucketed,
+            causal_valid_prefix=causal_valid_prefix,
+            **_native_stream_kwargs(stream),
+        )
+    return mx.fast.dsa_topk_indices(
+        scores,
+        topk,
+        bucketed=bucketed,
+        causal_valid_prefix=causal_valid_prefix,
+        stream=stream or mx.gpu,
+    )
+
+
+def glm_dsa_sparse_mla_attention(
+    q_latent: mx.array,
+    q_pe: mx.array,
+    kv_latent: mx.array,
+    k_pe: mx.array,
+    topk_indices: mx.array,
+    scale: float,
+    causal: bool = True,
+    topk_valid_prefix: bool = False,
+    causal_prefix_indices: bool = False,
+    topk_length: mx.array | None = None,
+    causal_prefix_rows: int = 0,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is not None:
+        return _ext.glm_dsa_sparse_mla_attention(
+            q_latent,
+            q_pe,
+            kv_latent,
+            k_pe,
+            topk_indices,
+            scale,
+            causal=causal,
+            topk_valid_prefix=topk_valid_prefix,
+            causal_prefix_indices=causal_prefix_indices,
+            topk_length=topk_length,
+            causal_prefix_rows=causal_prefix_rows,
+            **_native_stream_kwargs(stream),
+        )
+    return mx.fast.glm_dsa_sparse_mla_attention(
+        q_latent,
+        q_pe,
+        kv_latent,
+        k_pe,
+        topk_indices,
+        scale,
+        causal=causal,
+        topk_valid_prefix=topk_valid_prefix,
+        causal_prefix_indices=causal_prefix_indices,
+        topk_length=topk_length,
+        causal_prefix_rows=causal_prefix_rows,
+        stream=stream or mx.gpu,
+    )
+
+
+def glm_dsa_q8_vup_flat(
+    x: mx.array,
+    weight: mx.array,
+    scales: mx.array,
+    biases: mx.array,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is not None and hasattr(_ext, "glm_dsa_q8_vup_flat"):
+        return _ext.glm_dsa_q8_vup_flat(
+            x,
+            weight,
+            scales,
+            biases,
+            **_native_stream_kwargs(stream),
+        )
+    return mx.fast.glm_dsa_q8_vup_flat(
+        x,
+        weight,
+        scales,
+        biases,
+        stream=stream or mx.gpu,
+    )
+
+
+def glm_moe_weighted_sum(
+    x_sorted: mx.array,
+    inv_order: mx.array,
+    scores: mx.array,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is not None and hasattr(_ext, "glm_moe_weighted_sum"):
+        return _ext.glm_moe_weighted_sum(
+            x_sorted,
+            inv_order,
+            scores,
+            **_native_stream_kwargs(stream),
+        )
+    return mx.fast.glm_moe_weighted_sum(
+        x_sorted,
+        inv_order,
+        scores,
+        stream=stream or mx.gpu,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    if _ext is not None and hasattr(_ext, name):
+        return getattr(_ext, name)
+    return getattr(mx.fast, name)
+
+
+def __dir__() -> list[str]:
+    names = set(globals())
+    names.update(NATIVE_SYMBOLS)
+    names.update(dir(mx.fast))
+    if _ext is not None:
+        names.update(dir(_ext))
+    return sorted(names)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,11 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = [
+    "setuptools>=61.0",
+    "wheel",
+    "cmake>=3.27",
+    "nanobind",
+    "mlx==0.31.2",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -28,8 +34,8 @@ classifiers = [
 ]
 
 dependencies = [
-    # oMLX GLM-5.2 custom kernels based on MLX v0.31.2.
-    "mlx @ git+https://github.com/jundot/mlx.git@v0.31.2-omlx",
+    # Vanilla MLX v0.31.2; GLM-5.2 kernels are provided by omlx_glm_kernels.
+    "mlx==0.31.2",
     # mlx-lm from commit (2c008fd, v0.31.3) - trust_remote_code load gate,
     # transformers 5.7.0 compatibility, and prior BatchGenerator/cache fixes.
     "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@2c008fd0252b2c569227d12568356ab88ab0560a",
@@ -190,18 +196,19 @@ version = {attr = "omlx._version.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["omlx*"]
+include = ["omlx*", "omlx_glm_kernels*"]
 
 [tool.setuptools.package-data]
 "omlx" = ["oq_calibration_data.json"]
 "omlx.admin" = ["templates/**/*.html", "static/**/*", "i18n/*.json"]
 "omlx.eval" = ["data/*.jsonl"]
+"omlx_glm_kernels" = ["*.metallib", "*.dylib", "*.so"]
 
 [tool.uv]
 # mlx and mlx-lm are git-pinned; override transitive pins
 # (e.g. mlx-audio -> mlx-lm==0.31.1) so the resolver accepts them.
 override-dependencies = [
-    "mlx @ git+https://github.com/jundot/mlx.git@v0.31.2-omlx",
+    "mlx==0.31.2",
     "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@2c008fd0252b2c569227d12568356ab88ab0560a",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "mlx>=0.31.2",
+    # oMLX GLM-5.2 custom kernels based on MLX v0.31.2.
+    "mlx @ git+https://github.com/jundot/mlx.git@v0.31.2-omlx",
     # mlx-lm from commit (2c008fd, v0.31.3) - trust_remote_code load gate,
     # transformers 5.7.0 compatibility, and prior BatchGenerator/cache fixes.
     "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@2c008fd0252b2c569227d12568356ab88ab0560a",
@@ -197,9 +198,10 @@ include = ["omlx*"]
 "omlx.eval" = ["data/*.jsonl"]
 
 [tool.uv]
-# mlx-lm is pinned to a git commit; override transitive pins
-# (e.g. mlx-audio → mlx-lm==0.31.1) so the resolver accepts it.
+# mlx and mlx-lm are git-pinned; override transitive pins
+# (e.g. mlx-audio -> mlx-lm==0.31.1) so the resolver accepts them.
 override-dependencies = [
+    "mlx @ git+https://github.com/jundot/mlx.git@v0.31.2-omlx",
     "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@2c008fd0252b2c569227d12568356ab88ab0560a",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+from mlx import extension
+
+
+if __name__ == "__main__":
+    setup(
+        ext_modules=[
+            extension.CMakeExtension(
+                "omlx_glm_kernels._ext",
+                sourcedir="omlx_glm_kernels/csrc",
+            )
+        ],
+        cmdclass={"build_ext": extension.CMakeBuild},
+    )

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -114,10 +114,10 @@ def test_glm_adaptive_prefill_config_defaults_and_gates(monkeypatch):
     model = SimpleNamespace(model_type="glm_moe_dsa")
     cfg = _glm_dsa_adaptive_prefill_config(model, 2048)
     assert cfg is not None
-    assert cfg.step_size == 6144
+    assert cfg.step_size == 8192
     assert cfg.after == 0
     assert cfg.min_remaining == 0
-    assert _prefill_step_size_for_progress(2048, 0, 8192, cfg) == 6144
+    assert _prefill_step_size_for_progress(2048, 0, 8192, cfg) == 8192
 
     assert _glm_dsa_adaptive_prefill_config(model, 1024) is None
     assert (
@@ -193,6 +193,112 @@ def test_glm_patch_installs_native_indexer_schedule():
         False,
     ]
     assert [len(c.caches) for c in model.make_cache()] == [2, 1, 2, 1, 2, 1]
+
+
+def test_glm_native_fused_kernels_match_reference(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+
+    try:
+        import omlx_glm_kernels.fast as fast
+    except Exception as exc:  # pragma: no cover - depends on local native build
+        pytest.skip(f"omlx_glm_kernels is unavailable: {exc}")
+
+    if not fast.is_native_available():
+        pytest.skip("omlx_glm_kernels native extension is unavailable")
+
+    mx.random.seed(7)
+
+    tokens, topk, dims = 8, 8, 64
+    x_sorted = mx.random.normal((tokens * topk, 1, dims), dtype=mx.float16)
+    inv_order = mx.array(list(range(tokens * topk - 1, -1, -1)), dtype=mx.uint32)
+    scores = mx.softmax(
+        mx.random.normal((tokens, topk), dtype=mx.float32),
+        axis=-1,
+    )
+    y_native = fast.glm_moe_weighted_sum(x_sorted, inv_order, scores)
+    x_ref = mx.squeeze(x_sorted, -2)
+    x_ref = mx.take(x_ref, inv_order, axis=0)
+    x_ref = mx.reshape(x_ref, scores.shape + (dims,))
+    y_ref = mx.sum(x_ref * mx.expand_dims(scores, -1), axis=-2).astype(mx.float16)
+    mx.eval(y_native, y_ref)
+    assert float(mx.max(mx.abs(y_native - y_ref)).item()) == 0.0
+
+    batch, heads, length, latent, values = 1, 64, 1, 512, 256
+    x = mx.random.normal((batch, heads, length, latent), dtype=mx.float16)
+    w_float = mx.random.normal((heads, values, latent), dtype=mx.float16)
+    weight, scales, biases = mx.quantize(
+        w_float,
+        group_size=64,
+        bits=8,
+        mode="affine",
+    )
+    y_native = fast.glm_dsa_q8_vup_flat(x, weight, scales, biases)
+    y_ref = mx.quantized_matmul(
+        x,
+        weight,
+        scales,
+        biases,
+        True,
+        64,
+        8,
+        "affine",
+    )
+    y_ref = mx.transpose(y_ref, (0, 2, 1, 3))
+    y_ref = mx.reshape(y_ref, (batch, length, heads * values))
+    mx.eval(y_native, y_ref)
+    assert float(mx.max(mx.abs(y_native - y_ref)).item()) <= 0.125
+
+    batch, heads, q_len, k_len, latent, pe = 1, 64, 2, 32, 512, 64
+    scale = 0.05
+    q_latent = mx.random.normal((batch, heads, q_len, latent), dtype=mx.float16)
+    q_pe = mx.random.normal((batch, heads, q_len, pe), dtype=mx.float16)
+    kv_latent = mx.random.normal((batch, 1, k_len, latent), dtype=mx.float16)
+    k_pe = mx.random.normal((batch, 1, k_len, pe), dtype=mx.float16)
+    topk_indices = mx.broadcast_to(
+        mx.reshape(mx.arange(0, k_len, dtype=mx.uint32), (1, 1, 1, k_len)),
+        (batch, 1, q_len, k_len),
+    )
+    y_native = fast.glm_dsa_sparse_mla_attention(
+        q_latent,
+        q_pe,
+        kv_latent,
+        k_pe,
+        topk_indices,
+        scale,
+        causal=True,
+    )
+    scores = mx.sum(
+        mx.expand_dims(q_latent, 3) * mx.expand_dims(kv_latent, 1),
+        axis=-1,
+    )
+    scores = scores + mx.sum(
+        mx.expand_dims(q_pe, 3) * mx.expand_dims(k_pe, 1),
+        axis=-1,
+    )
+    scores = scores * scale
+    q_pos = mx.reshape(
+        mx.arange(k_len - q_len, k_len, dtype=mx.uint32),
+        (1, 1, q_len, 1),
+    )
+    k_pos = mx.reshape(mx.arange(0, k_len, dtype=mx.uint32), (1, 1, 1, k_len))
+    scores = mx.where(k_pos <= q_pos, scores, mx.array(-65504.0, scores.dtype))
+    probs = mx.softmax(scores, axis=-1)
+    y_ref = mx.sum(
+        mx.expand_dims(probs, -1) * mx.expand_dims(kv_latent, 1),
+        axis=3,
+    )
+    mx.eval(y_native, y_ref)
+    assert float(mx.max(mx.abs(y_native - y_ref)).item()) <= 0.02
+
+    scores = mx.random.normal((1, 1, 2, 2048), dtype=mx.float16)
+    topk_indices = fast.dsa_topk_indices(
+        scores,
+        2048,
+        bucketed=False,
+        causal_valid_prefix=True,
+    )
+    mx.eval(topk_indices)
+    assert topk_indices.shape == (1, 1, 2, 2048)
 
 
 def test_glm_patch_forward_sparse_path_and_cache_state():

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -95,6 +96,76 @@ def test_pre_load_dispatch_applies_glm_patch(tmp_path, monkeypatch):
     apply_mock.assert_called_once_with()
 
 
+def test_glm_adaptive_prefill_config_defaults_and_gates(monkeypatch):
+    from omlx.patches.glm_moe_dsa.generate_patch import (
+        _glm_dsa_adaptive_prefill_config,
+        _prefill_step_size_for_progress,
+    )
+
+    env_names = [
+        "MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP",
+        "MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP_SIZE",
+        "MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_AFTER",
+        "MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_MIN_REMAINING",
+    ]
+    for name in env_names:
+        monkeypatch.delenv(name, raising=False)
+
+    model = SimpleNamespace(model_type="glm_moe_dsa")
+    cfg = _glm_dsa_adaptive_prefill_config(model, 2048)
+    assert cfg is not None
+    assert cfg.step_size == 6144
+    assert cfg.after == 0
+    assert cfg.min_remaining == 0
+    assert _prefill_step_size_for_progress(2048, 0, 8192, cfg) == 6144
+
+    assert _glm_dsa_adaptive_prefill_config(model, 1024) is None
+    assert (
+        _glm_dsa_adaptive_prefill_config(
+            SimpleNamespace(model_type="deepseek_v32"), 2048
+        )
+        is None
+    )
+
+    monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", "0")
+    assert _glm_dsa_adaptive_prefill_config(model, 2048) is None
+
+
+def test_glm_adaptive_prefill_config_env_overrides(monkeypatch):
+    from omlx.patches.glm_moe_dsa.generate_patch import (
+        _glm_dsa_adaptive_prefill_config,
+        _prefill_step_size_for_progress,
+    )
+
+    monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", "1")
+    monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP_SIZE", "4096")
+    monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_AFTER", "8192")
+    monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_MIN_REMAINING", "2048")
+
+    cfg = _glm_dsa_adaptive_prefill_config(
+        SimpleNamespace(args=SimpleNamespace(model_type="glm_moe_dsa")), 2048
+    )
+    assert cfg is not None
+    assert cfg.step_size == 4096
+    assert cfg.after == 8192
+    assert cfg.min_remaining == 2048
+    assert _prefill_step_size_for_progress(2048, 4096, 4096, cfg) == 2048
+    assert _prefill_step_size_for_progress(2048, 8192, 1024, cfg) == 2048
+    assert _prefill_step_size_for_progress(2048, 8192, 2048, cfg) == 4096
+
+
+def test_glm_patch_keeps_vendored_helpers_private():
+    glm_moe_dsa = _load_patched_glm_module()
+
+    from omlx.patches.glm_moe_dsa import deepseek_v32 as vendored_deepseek_v32
+    from mlx_lm.models import deepseek_v32 as upstream_deepseek_v32
+
+    assert getattr(glm_moe_dsa, "_OMLX_GLM_DSA_OPTIMIZED", False)
+    assert sys.modules["mlx_lm.models.glm_moe_dsa"] is glm_moe_dsa
+    assert glm_moe_dsa.DeepseekV32Model is vendored_deepseek_v32.DeepseekV32Model
+    assert upstream_deepseek_v32 is not vendored_deepseek_v32
+
+
 def test_glm_patch_installs_native_indexer_schedule():
     glm_moe_dsa = _load_patched_glm_module()
 
@@ -113,9 +184,14 @@ def test_glm_patch_installs_native_indexer_schedule():
     ]
 
     model = glm_moe_dsa.Model(args)
-    assert [
-        layer.self_attn.indexer is not None for layer in model.model.layers
-    ] == [True, False, True, False, True, False]
+    assert [layer.self_attn.indexer is not None for layer in model.model.layers] == [
+        True,
+        False,
+        True,
+        False,
+        True,
+        False,
+    ]
     assert [len(c.caches) for c in model.make_cache()] == [2, 1, 2, 1, 2, 1]
 
 

--- a/tests/test_scheduler_chunked_prefill.py
+++ b/tests/test_scheduler_chunked_prefill.py
@@ -252,15 +252,15 @@ class TestGLMAdaptiveChunkedPrefill:
         )
 
         sched, model = _make_recording_scheduler("glm_moe_dsa")
-        req = _make_request("glm", n_tokens=8193)
-        state = _make_prefill_state(sched, req, n_remaining=8192)
+        req = _make_request("glm", n_tokens=8194)
+        state = _make_prefill_state(sched, req, n_remaining=8193)
 
         with patch("omlx.scheduler._sync_and_clear_cache"):
             done = sched._step_prefill_chunk(state)
 
         assert not done
-        assert model.chunk_lengths == [6144]
-        assert state.tokens_processed == 6144
+        assert model.chunk_lengths == [8192]
+        assert state.tokens_processed == 8192
 
     def test_non_glm_keeps_configured_prefill_chunk_size(self, monkeypatch):
         monkeypatch.delenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", raising=False)

--- a/tests/test_scheduler_chunked_prefill.py
+++ b/tests/test_scheduler_chunked_prefill.py
@@ -90,6 +90,32 @@ def _make_prefill_state(
     return state
 
 
+class _RecordingModel:
+    def __init__(self, model_type: str):
+        self.model_type = model_type
+        self.layers = []
+        self.chunk_lengths: list[int] = []
+
+    def __call__(self, tokens, cache=None):
+        self.chunk_lengths.append(int(tokens.shape[1]))
+
+
+def _make_recording_scheduler(model_type: str) -> tuple[Scheduler, _RecordingModel]:
+    model = _RecordingModel(model_type)
+    tokenizer = MagicMock()
+    tokenizer.eos_token_id = 2
+    scheduler = Scheduler(
+        model=model,
+        tokenizer=tokenizer,
+        config=SchedulerConfig(
+            prefill_step_size=2048,
+            chunked_prefill=True,
+            paged_cache_block_size=0,
+        ),
+    )
+    return scheduler, model
+
+
 # ---------------------------------------------------------------------------
 # SchedulerConfig
 # ---------------------------------------------------------------------------
@@ -209,6 +235,46 @@ class TestGetStats:
         sched.prefilling.append(_make_request("r1"))
         sched.prefilling.append(_make_request("r2"))
         assert sched.get_stats()["num_prefilling"] == 2
+
+
+# ---------------------------------------------------------------------------
+# GLM adaptive chunked prefill
+# ---------------------------------------------------------------------------
+
+
+class TestGLMAdaptiveChunkedPrefill:
+    def test_glm_uses_adaptive_prefill_chunk_size(self, monkeypatch):
+        monkeypatch.delenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", raising=False)
+        monkeypatch.delenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP_SIZE", raising=False)
+        monkeypatch.delenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_AFTER", raising=False)
+        monkeypatch.delenv(
+            "MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_MIN_REMAINING", raising=False
+        )
+
+        sched, model = _make_recording_scheduler("glm_moe_dsa")
+        req = _make_request("glm", n_tokens=8193)
+        state = _make_prefill_state(sched, req, n_remaining=8192)
+
+        with patch("omlx.scheduler._sync_and_clear_cache"):
+            done = sched._step_prefill_chunk(state)
+
+        assert not done
+        assert model.chunk_lengths == [6144]
+        assert state.tokens_processed == 6144
+
+    def test_non_glm_keeps_configured_prefill_chunk_size(self, monkeypatch):
+        monkeypatch.delenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", raising=False)
+
+        sched, model = _make_recording_scheduler("deepseek_v32")
+        req = _make_request("deepseek", n_tokens=8193)
+        state = _make_prefill_state(sched, req, n_remaining=8192)
+
+        with patch("omlx.scheduler._sync_and_clear_cache"):
+            done = sched._step_prefill_chunk(state)
+
+        assert not done
+        assert model.chunk_lengths == [2048]
+        assert state.tokens_processed == 2048
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a native `omlx_glm_kernels` extension for the GLM-5.2 DSA path on Apple Silicon.
- Route the GLM MoE DSA monkey patch through native kernels when available, while retaining the existing MLX/Python path when the extension is absent.
- Pin the project back to vanilla `mlx==0.31.2` so the custom MLX fork is no longer required for this path.

## Validation
- `python setup.py build_ext --inplace --force`
- `python -m pytest tests/test_glm_moe_dsa_patch.py tests/test_scheduler_chunked_prefill.py::TestGLMAdaptiveChunkedPrefill`
- Direct oMLX pp16384/tg128 smoke, memory_guard=False: 178.5 PP, 15.0 TG, 433.06 GB peak

This is a draft PR because I want to keep iterating on packaging and release gating before merging.