### PR TITLE
Add Gemma vision soft-token plumbing

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -114,6 +114,7 @@ class ModelSettingsRequest(BaseModel):
     force_sampling: bool | None = None
     max_tool_result_tokens: int | None = None
     chat_template_kwargs: dict[str, Any] | None = None
+    vision_soft_tokens_per_image: int | None = None
     forced_ct_kwargs: list[str] | None = None
     ttl_seconds: int | None = None
     index_cache_freq: int | None = None
@@ -2152,6 +2153,13 @@ async def update_model_settings(
         )
     if "chat_template_kwargs" in sent:
         current_settings.chat_template_kwargs = request.chat_template_kwargs
+    if "vision_soft_tokens_per_image" in sent:
+        current_settings.vision_soft_tokens_per_image = (
+            request.vision_soft_tokens_per_image
+            if request.vision_soft_tokens_per_image
+            and request.vision_soft_tokens_per_image > 0
+            else None
+        )
     if "forced_ct_kwargs" in sent:
         current_settings.forced_ct_kwargs = request.forced_ct_kwargs
     if "ttl_seconds" in sent:

--- a/omlx/api/anthropic_models.py
+++ b/omlx/api/anthropic_models.py
@@ -200,6 +200,8 @@ class MessagesRequest(BaseModel):
     thinking: ThinkingConfig | None = None
     # Chat template kwargs (e.g. enable_thinking, reasoning_effort)
     chat_template_kwargs: dict[str, Any] | None = None
+    # VLM image soft-token budget per image (Gemma-style variable resolution)
+    vision_soft_tokens_per_image: int | None = None
 
 
 # =============================================================================

--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -298,6 +298,14 @@ class ChatCompletionRequest(BaseModel):
     guided_grammar: Optional[str] = None
     # Chat template kwargs (e.g. enable_thinking, reasoning_effort)
     chat_template_kwargs: Optional[Dict[str, Any]] = None
+    # VLM image soft-token budget per image (Gemma-style variable resolution)
+    vision_soft_tokens_per_image: Optional[int] = Field(
+        default=None,
+        ge=1,
+        validation_alias=AliasChoices(
+            "vision_soft_tokens_per_image", "max_soft_tokens"
+        ),
+    )
     # Thinking budget (max thinking tokens, None = unlimited)
     thinking_budget: Optional[int] = Field(default=None, ge=0)
     # SpecPrefill: per-request enable/disable (None = use model setting)

--- a/omlx/api/responses_models.py
+++ b/omlx/api/responses_models.py
@@ -121,6 +121,8 @@ class ResponsesRequest(BaseModel):
     conversation: Optional[Any] = None
     max_tool_calls: Optional[int] = None
     stream_options: Optional[Dict[str, Any]] = None
+    # VLM image soft-token budget per image (Gemma-style variable resolution)
+    vision_soft_tokens_per_image: Optional[int] = None
     # Seed for reproducible generation (best-effort)
     seed: Optional[int] = None
 

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -26,6 +26,7 @@ Usage:
 import asyncio
 import contextlib
 import copy
+import hashlib
 import importlib
 import inspect
 import json
@@ -843,6 +844,69 @@ def _derive_image_token_upper_bound(processor: Any) -> int:
     return _IMAGE_TOKEN_UPPER_BOUND_FALLBACK
 
 
+def _processor_supports_vision_soft_tokens(processor: Any) -> bool:
+    """Return True only when the processor explicitly advertises this knob.
+
+    Older mlx-vlm processors may accept arbitrary ``**kwargs`` while ignoring
+    or failing to forward the budget to the image processor. Treating **kwargs
+    as support would make the request look successful while still using the
+    wrong image-token count.
+    """
+    call = getattr(processor, "__call__", None)
+    if call is None:
+        return False
+    try:
+        params = inspect.signature(call).parameters
+    except (TypeError, ValueError):
+        return False
+    return "vision_soft_tokens_per_image" in params or "max_soft_tokens" in params
+
+
+def _vision_soft_token_prepare_kwargs(
+    processor: Any,
+    vision_soft_tokens_per_image: int | None,
+    *,
+    num_images: int,
+) -> dict[str, int]:
+    if vision_soft_tokens_per_image is None or num_images <= 0:
+        return {}
+    if not _processor_supports_vision_soft_tokens(processor):
+        raise InvalidRequestError(
+            "vision_soft_tokens_per_image requires a newer mlx-vlm build whose "
+            "processor explicitly supports Gemma-style image soft-token budgets.",
+            field="vision_soft_tokens_per_image",
+        )
+    return {"vision_soft_tokens_per_image": int(vision_soft_tokens_per_image)}
+
+
+def _namespace_vision_cache_hash(
+    image_hash: str | None,
+    vision_soft_tokens_per_image: int | None,
+) -> str | None:
+    """Salt vision-feature cache hashes with processor-affecting options."""
+    if image_hash is None or vision_soft_tokens_per_image is None:
+        return image_hash
+    payload = json.dumps(
+        {
+            "image_hash": image_hash,
+            "vision_soft_tokens_per_image": int(vision_soft_tokens_per_image),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _vision_preflight_image_bound(
+    processor: Any,
+    vision_soft_tokens_per_image: int | None,
+) -> int:
+    bound = _derive_image_token_upper_bound(processor)
+    if vision_soft_tokens_per_image is not None:
+        bound = max(bound, int(vision_soft_tokens_per_image))
+    return bound
+
+
 def _count_image_tokens(
     messages: list[dict[str, Any]],
     per_image_upper_bound: int = _IMAGE_TOKEN_UPPER_BOUND_FALLBACK,
@@ -1658,7 +1722,10 @@ class VLMBatchedEngine(BaseEngine):
                             inspect.Parameter.POSITIONAL_OR_KEYWORD,
                         )
                     ]
-                    if image_position_ids is not None and len(positional_parameters) >= 2:
+                    if (
+                        image_position_ids is not None
+                        and len(positional_parameters) >= 2
+                    ):
                         return model.encode_image(pixel_values, image_position_ids)
 
             return model.encode_image(pixel_values)
@@ -1884,6 +1951,7 @@ class VLMBatchedEngine(BaseEngine):
         audio: list | None = None,
         chat_template_kwargs: dict[str, Any] | None = None,
         tools: list[dict] | None = None,
+        vision_soft_tokens_per_image: int | None = None,
     ) -> Tuple[
         List[int],
         Optional[mx.array],
@@ -1927,6 +1995,11 @@ class VLMBatchedEngine(BaseEngine):
 
         num_images = len(images)
         num_audios = len(audio) if audio else 0
+        vision_processor_kwargs = _vision_soft_token_prepare_kwargs(
+            self._processor,
+            vision_soft_tokens_per_image,
+            num_images=num_images,
+        )
 
         model_type = self.model_type or ""
         if model_type == COHERE2_MOE_MODEL_TYPE and (num_images > 0 or num_audios > 0):
@@ -2050,6 +2123,7 @@ class VLMBatchedEngine(BaseEngine):
             images=images if images else None,
             audio=audio if audio else None,
             prompts=[prompt] if isinstance(prompt, str) else prompt,
+            **vision_processor_kwargs,
         )
 
         input_ids = inputs["input_ids"]
@@ -2102,6 +2176,7 @@ class VLMBatchedEngine(BaseEngine):
                                 if isinstance(prefix_prompt, str)
                                 else prefix_prompt
                             ),
+                            **vision_processor_kwargs,
                         )
                         prefix_ids = prefix_inputs["input_ids"]
                         boundary_tokens = (
@@ -2111,7 +2186,10 @@ class VLMBatchedEngine(BaseEngine):
                         )
 
                     images_consumed += msg_num_images
-                    cumulative_hash = compute_image_hash(images[:images_consumed])
+                    cumulative_hash = _namespace_vision_cache_hash(
+                        compute_image_hash(images[:images_consumed]),
+                        vision_soft_tokens_per_image,
+                    )
                     image_cache_key_ranges.append((boundary_tokens, cumulative_hash))
 
                 image_cache_key_start = image_cache_key_ranges[0][0]
@@ -2145,7 +2223,10 @@ class VLMBatchedEngine(BaseEngine):
             image_hash = None
             image_token_count = None
             if num_images > 0:
-                image_hash = compute_image_hash(images)
+                image_hash = _namespace_vision_cache_hash(
+                    compute_image_hash(images),
+                    vision_soft_tokens_per_image,
+                )
                 image_token_count = self._image_token_count(input_ids)
 
             if (
@@ -2153,7 +2234,10 @@ class VLMBatchedEngine(BaseEngine):
                 and self._vision_cache is not None
                 and self._vision_cache_enabled
             ):
-                per_hashes = compute_per_image_hashes(images)
+                per_hashes = [
+                    _namespace_vision_cache_hash(h, vision_soft_tokens_per_image)
+                    for h in compute_per_image_hashes(images)
+                ]
                 cached_per_image = [
                     self._vision_cache.get(h, self._model_name) for h in per_hashes
                 ]
@@ -2705,6 +2789,7 @@ class VLMBatchedEngine(BaseEngine):
             return
         template_tools = convert_tools_for_template(tools) if tools else None
         ct_kwargs = kwargs.get("chat_template_kwargs")
+        vision_soft_tokens_per_image = kwargs.get("vision_soft_tokens_per_image")
         partial = kwargs.get("is_partial")
         # Strip image content-parts BEFORE templating. Modern HF chat
         # templates (Qwen2.5-VL, Gemma-Vision, Llama-3.2-Vision) render
@@ -2744,8 +2829,13 @@ class VLMBatchedEngine(BaseEngine):
         # ``text_messages`` no longer has the image content-parts).
         num_tokens += _count_image_tokens(
             messages,
-            per_image_upper_bound=_derive_image_token_upper_bound(
-                getattr(self, "_processor", None)
+            per_image_upper_bound=_vision_preflight_image_bound(
+                (
+                    getattr(self, "_processor", None)
+                    if hasattr(self, "_processor")
+                    else None
+                ),
+                vision_soft_tokens_per_image,
             ),
         )
         scheduler = getattr(getattr(self._engine, "engine", None), "scheduler", None)
@@ -2969,6 +3059,7 @@ class VLMBatchedEngine(BaseEngine):
         text_messages, images, audio = extract_images_from_messages(messages)
 
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
+        vision_soft_tokens_per_image = kwargs.pop("vision_soft_tokens_per_image", None)
 
         # Keep VLM-capable models on one prompt-rendering path, even before the
         # first image arrives. Otherwise the conversation switches prompt families
@@ -2988,6 +3079,7 @@ class VLMBatchedEngine(BaseEngine):
             audio=audio if audio else None,
             chat_template_kwargs=ct_kwargs,
             tools=template_tools,
+            vision_soft_tokens_per_image=vision_soft_tokens_per_image,
         )
 
         if images:

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -61,6 +61,7 @@ MODEL_SPECIFIC_PROFILE_FIELDS = (
     "dflash_draft_sink_size",
     "dflash_verify_mode",
     "mtp_enabled",
+    "vision_soft_tokens_per_image",
     "vlm_mtp_enabled",
     "vlm_mtp_draft_model",
     "vlm_mtp_draft_block_size",

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -9,7 +9,7 @@ import copy
 import json
 import logging
 import threading
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
@@ -46,6 +46,7 @@ class ModelSettings:
         force_sampling: Force sampling even with temperature=0.
         max_tool_result_tokens: Maximum tokens in tool result (None = use global default).
         chat_template_kwargs: Extra chat template keyword arguments.
+        vision_soft_tokens_per_image: Optional VLM image soft-token budget per image.
         forced_ct_kwargs: Keys in chat_template_kwargs that cannot be overridden.
         ttl_seconds: Auto-unload after idle seconds (None = no TTL).
         model_type_override: "llm", "vlm", "embedding", "reranker", or None (auto-detect).
@@ -114,6 +115,7 @@ class ModelSettings:
     force_sampling: bool = False
     max_tool_result_tokens: Optional[int] = None
     chat_template_kwargs: Optional[Dict[str, Any]] = None
+    vision_soft_tokens_per_image: Optional[int] = None
     forced_ct_kwargs: Optional[list[str]] = (
         None  # Keys that cannot be overridden by API requests
     )

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1400,6 +1400,15 @@ def get_model_settings_for_request(model_id: str | None):
     )
 
 
+def _resolve_vision_soft_tokens_per_image(request, settings) -> int | None:
+    """Resolve VLM image soft-token budget: request > model setting > None."""
+    value = getattr(settings, "vision_soft_tokens_per_image", None)
+    request_value = getattr(request, "vision_soft_tokens_per_image", None)
+    if request_value is not None:
+        value = request_value
+    return int(value) if value is not None else None
+
+
 def resolve_model_id(model_id: str | None) -> str | None:
     """Resolve a model alias to its real model ID.
 
@@ -3093,6 +3102,9 @@ async def create_chat_completion(
         reasoning_parser = None
         settings_guided_grammar = None
         ms = get_model_settings_for_request(request.model)
+        vision_soft_tokens_per_image = _resolve_vision_soft_tokens_per_image(
+            request, ms
+        )
         if ms:
             max_tool_result_tokens = ms.max_tool_result_tokens
             reasoning_parser = ms.reasoning_parser
@@ -3367,6 +3379,8 @@ async def create_chat_completion(
         # Add chat template kwargs
         if merged_ct_kwargs:
             chat_kwargs["chat_template_kwargs"] = merged_ct_kwargs
+        if vision_soft_tokens_per_image is not None:
+            chat_kwargs["vision_soft_tokens_per_image"] = vision_soft_tokens_per_image
 
         # Forward partial-mode decision to the engine explicitly
         chat_kwargs["is_partial"] = is_partial
@@ -4917,6 +4931,9 @@ async def create_anthropic_message(
         merged_ct_kwargs = {}
         forced_keys: set[str] = set()
         ms = get_model_settings_for_request(request.model)
+        vision_soft_tokens_per_image = _resolve_vision_soft_tokens_per_image(
+            request, ms
+        )
         if ms:
             max_tool_result_tokens = ms.max_tool_result_tokens
             if ms.chat_template_kwargs:
@@ -5103,6 +5120,8 @@ async def create_anthropic_message(
         # Add chat template kwargs
         if merged_ct_kwargs:
             chat_kwargs["chat_template_kwargs"] = merged_ct_kwargs
+        if vision_soft_tokens_per_image is not None:
+            chat_kwargs["vision_soft_tokens_per_image"] = vision_soft_tokens_per_image
 
         # Forward partial-mode decision to the engine explicitly
         chat_kwargs["is_partial"] = is_partial
@@ -5448,6 +5467,9 @@ async def create_response(
         merged_ct_kwargs = {}
         reasoning_parser = None
         ms = get_model_settings_for_request(request.model)
+        vision_soft_tokens_per_image = _resolve_vision_soft_tokens_per_image(
+            request, ms
+        )
         if ms:
             reasoning_parser = ms.reasoning_parser
             if ms.chat_template_kwargs:
@@ -5624,6 +5646,8 @@ async def create_response(
             chat_kwargs["tools"] = tools_for_template
         if merged_ct_kwargs:
             chat_kwargs["chat_template_kwargs"] = merged_ct_kwargs
+        if vision_soft_tokens_per_image is not None:
+            chat_kwargs["vision_soft_tokens_per_image"] = vision_soft_tokens_per_image
 
         # Pre-flight prefill memory guard — must precede any StreamingResponse
         # return so PrefillMemoryExceededError can be mapped to HTTP 400.

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -902,6 +902,43 @@ class TestChatCompletionEndpoint:
 
         assert response.status_code == 200
 
+    def test_chat_completion_forwards_vision_soft_tokens_override(
+        self, client, mock_llm_engine, tmp_path
+    ):
+        """Request vision soft-token budget overrides model settings."""
+        from omlx.model_settings import ModelSettings, ModelSettingsManager
+        from omlx.server import _server_state
+
+        manager = ModelSettingsManager(tmp_path)
+        manager.set_settings(
+            "test-model", ModelSettings(vision_soft_tokens_per_image=1024)
+        )
+
+        recorded_chat_kwargs = []
+
+        async def chat(messages, **kwargs):
+            recorded_chat_kwargs.append(kwargs)
+            return MockGenerationOutput(text="Chat response.")
+
+        mock_llm_engine.chat = chat
+        original_settings_manager = _server_state.settings_manager
+        try:
+            _server_state.settings_manager = manager
+            response = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "vision_soft_tokens_per_image": 2048,
+                },
+            )
+        finally:
+            _server_state.settings_manager = original_settings_manager
+
+        assert response.status_code == 200
+        assert recorded_chat_kwargs
+        assert recorded_chat_kwargs[0]["vision_soft_tokens_per_image"] == 2048
+
     def test_chat_completion_includes_cached_tokens_on_cache_hit(
         self, client, mock_llm_engine
     ):

--- a/tests/test_engine_preflight.py
+++ b/tests/test_engine_preflight.py
@@ -288,6 +288,41 @@ async def test_vlm_preflight_chat_adds_image_token_budget(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_vlm_preflight_chat_uses_requested_vision_soft_token_budget(monkeypatch):
+    """Explicit Gemma-style soft-token budgets must raise the image-token bound."""
+    from omlx.engine.vlm import VLMBatchedEngine
+
+    scheduler = _make_scheduler()
+    engine = _build_engine_with_stub_scheduler(VLMBatchedEngine, scheduler)
+    engine._tokenizer.encode = MagicMock(return_value=list(range(1000)))
+
+    seen: dict = {}
+
+    def _capture(num_prompt_tokens, **kwargs):
+        seen["num_prompt_tokens"] = num_prompt_tokens
+
+    scheduler.preflight_or_raise = _capture  # type: ignore[assignment]
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hello"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,..."},
+                },
+            ],
+        }
+    ]
+    await engine.preflight_chat(
+        messages=messages,
+        vision_soft_tokens_per_image=2048,
+    )
+    assert seen["num_prompt_tokens"] == 1000 + 2048
+
+
+@pytest.mark.asyncio
 async def test_vlm_preflight_chat_strips_images_before_template(monkeypatch):
     """Modern HF chat templates (Qwen2.5-VL, Gemma-Vision, Llama-3.2-Vision)
     render image content parts as literal placeholder strings inline with

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -5,8 +5,6 @@ import json
 import tempfile
 from pathlib import Path
 
-import pytest
-
 from omlx.model_settings import ModelSettings, ModelSettingsManager
 
 
@@ -158,6 +156,31 @@ class TestModelSettings:
         assert settings.temperature == 0.8
         assert settings.chat_template_kwargs == {"reasoning_effort": "high"}
 
+    def test_vision_soft_tokens_per_image_default(self):
+        """Test vision_soft_tokens_per_image defaults to None."""
+        settings = ModelSettings()
+        assert settings.vision_soft_tokens_per_image is None
+
+    def test_vision_soft_tokens_per_image_roundtrip(self):
+        """Test vision_soft_tokens_per_image survives to_dict -> from_dict."""
+        original = ModelSettings(vision_soft_tokens_per_image=2048)
+        d = original.to_dict()
+        assert d["vision_soft_tokens_per_image"] == 2048
+        restored = ModelSettings.from_dict(d)
+        assert restored.vision_soft_tokens_per_image == 2048
+
+    def test_chat_completion_request_accepts_vision_soft_tokens_alias(self):
+        """OpenAI chat requests accept max_soft_tokens as a compatibility alias."""
+        from omlx.api.openai_models import ChatCompletionRequest
+
+        request = ChatCompletionRequest.model_validate(
+            {
+                "model": "test-vlm",
+                "messages": [{"role": "user", "content": "describe"}],
+                "max_soft_tokens": 2048,
+            }
+        )
+        assert request.vision_soft_tokens_per_image == 2048
 
     def test_ttl_seconds_default(self):
         """Test ttl_seconds defaults to None."""

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -60,6 +60,26 @@ class MockVLMTokenizer:
         return "decoded text"
 
 
+class VisionSoftTokenProcessor:
+    """Processor stub whose signature advertises soft-token budget support."""
+
+    def __init__(self, tokenizer=None):
+        self.tokenizer = tokenizer or MockVLMTokenizer()
+
+    def apply_chat_template(self, messages, **kwargs):
+        return "<vision prompt>"
+
+    def __call__(self, *args, vision_soft_tokens_per_image=None, **kwargs):
+        return {}
+
+
+class KwargsOnlyProcessor(VisionSoftTokenProcessor):
+    """Processor stub that accepts arbitrary kwargs but advertises no support."""
+
+    def __call__(self, *args, **kwargs):
+        return {}
+
+
 def _make_engine(**overrides):
     """Create a VLMBatchedEngine instance without loading a model."""
     from omlx.engine.vlm import VLMBatchedEngine
@@ -986,7 +1006,29 @@ class TestProcessChatMessages:
             audio=None,
             chat_template_kwargs=None,
             tools=None,
+            vision_soft_tokens_per_image=None,
         )
+
+    def test_vision_soft_tokens_forwarded_to_prepare_vision(self):
+        """Request-level vision soft-token budget reaches VLM preprocessing."""
+        from omlx.engine import vlm as vlm_module
+
+        text_msgs = [{"role": "user", "content": "Hello"}]
+        engine = _make_loaded_engine()
+        engine._prepare_vision_inputs = MagicMock(
+            return_value=([1, 2, 3], None, None, None, 0, [])
+        )
+
+        with patch.object(vlm_module, "extract_images_from_messages") as mock_extract:
+            mock_extract.return_value = (text_msgs, [], [])
+            engine._process_chat_messages(
+                [{"role": "user", "content": "Hello"}],
+                tools=None,
+                kwargs={"vision_soft_tokens_per_image": 2048},
+            )
+
+        call_kwargs = engine._prepare_vision_inputs.call_args[1]
+        assert call_kwargs["vision_soft_tokens_per_image"] == 2048
 
     @patch("omlx.engine.vlm.extract_images_from_messages")
     def test_text_only_passes_tools_to_prepare_vision(self, mock_extract):
@@ -1124,6 +1166,74 @@ class TestPrepareVisionInputs:
         engine._processor = mock_processor
 
         return engine
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    @patch("mlx_vlm.prompt_utils.apply_chat_template")
+    def test_vision_soft_tokens_passed_to_prepare_inputs(
+        self, mock_vlm_act, mock_prepare
+    ):
+        """Compatible processors receive the explicit image soft-token budget."""
+        engine = self._setup_engine_for_vision(model_type="gemma4")
+        engine._processor = VisionSoftTokenProcessor(engine._tokenizer)
+
+        mock_vlm_act.return_value = [{"role": "user", "content": "formatted"}]
+        mock_prepare.return_value = {
+            "input_ids": mx.array([[1, 2, 3]]),
+            "pixel_values": None,
+        }
+
+        from PIL import Image
+
+        images = [Image.new("RGB", (4, 4), "red")]
+        engine._prepare_vision_inputs(
+            [{"role": "user", "content": "Describe"}],
+            images,
+            vision_soft_tokens_per_image=2048,
+        )
+
+        call_kwargs = mock_prepare.call_args[1]
+        assert call_kwargs["vision_soft_tokens_per_image"] == 2048
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    @patch("mlx_vlm.prompt_utils.apply_chat_template")
+    def test_vision_soft_tokens_rejected_without_explicit_processor_support(
+        self, mock_vlm_act, mock_prepare
+    ):
+        """Do not silently accept the knob on old mlx-vlm processors."""
+        from omlx.exceptions import InvalidRequestError
+
+        engine = self._setup_engine_for_vision(model_type="gemma4")
+        engine._processor = KwargsOnlyProcessor(engine._tokenizer)
+        mock_vlm_act.return_value = [{"role": "user", "content": "formatted"}]
+        mock_prepare.return_value = {
+            "input_ids": mx.array([[1, 2, 3]]),
+            "pixel_values": None,
+        }
+
+        from PIL import Image
+
+        images = [Image.new("RGB", (4, 4), "red")]
+        with pytest.raises(InvalidRequestError, match="newer mlx-vlm"):
+            engine._prepare_vision_inputs(
+                [{"role": "user", "content": "Describe"}],
+                images,
+                vision_soft_tokens_per_image=2048,
+            )
+
+        mock_prepare.assert_not_called()
+
+    def test_vision_soft_tokens_namespace_cache_hashes(self):
+        """Feature cache keys vary with explicit soft-token budgets."""
+        from omlx.engine.vlm import _namespace_vision_cache_hash
+
+        raw_hash = "abc123"
+        assert _namespace_vision_cache_hash(raw_hash, None) == raw_hash
+        assert _namespace_vision_cache_hash(raw_hash, 1024) != raw_hash
+        assert _namespace_vision_cache_hash(raw_hash, 1024) != (
+            _namespace_vision_cache_hash(raw_hash, 2048)
+        )
 
     @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
     @patch("mlx_vlm.utils.prepare_inputs")


### PR DESCRIPTION
## Summary
- Add a model/request-level vision_soft_tokens_per_image setting, with max_soft_tokens accepted as an OpenAI chat compatibility alias.
- Forward the setting through OpenAI Chat, Anthropic Messages, and Responses API chat paths into VLM preprocessing and preflight accounting.
- Gate runtime use on processors that explicitly advertise support, and namespace vision-feature cache keys by the requested soft-token budget.

## Notes
- This is designed to coexist safely with the current pinned mlx-vlm: requests that set vision_soft_tokens_per_image against an older processor fail with a clear InvalidRequestError instead of silently using the wrong image budget.
- Runtime support depends on Blaizzy/mlx-vlm#1426 or an equivalent mlx-vlm release/pin bump.
- Refs #1023.

## Tests
- .venv/bin/python -m py_compile omlx/model_settings.py omlx/model_profiles.py omlx/api/openai_models.py omlx/api/anthropic_models.py omlx/api/responses_models.py omlx/admin/routes.py omlx/engine/vlm.py omlx/server.py tests/test_model_settings.py tests/test_vlm_engine.py tests/test_engine_preflight.py tests/integration/test_server_endpoints.py
- .venv/bin/python -m ruff check --select F,E9 omlx/model_settings.py omlx/model_profiles.py omlx/api/openai_models.py omlx/api/anthropic_models.py omlx/api/responses_models.py omlx/admin/routes.py omlx/engine/vlm.py omlx/server.py tests/test_model_settings.py tests/test_vlm_engine.py tests/test_engine_preflight.py tests/integration/test_server_endpoints.py
- .venv/bin/python -m pytest tests/test_model_settings.py tests/test_vlm_engine.py tests/test_engine_preflight.py tests/test_admin_profiles_api.py tests/test_model_settings_profiles.py tests/integration/test_server_endpoints.py -q