### PR TITLE
fix(mcp): support 'cwd' in MCPServerConfig for stdio transport

### DIFF
--- a/omlx/mcp/client.py
+++ b/omlx/mcp/client.py
@@ -139,6 +139,7 @@ class MCPClient:
             command=self.config.command,
             args=self.config.args or [],
             env=self.config.env,
+            cwd=self.config.cwd,
         )
 
         # Create stdio client context

--- a/omlx/mcp/types.py
+++ b/omlx/mcp/types.py
@@ -46,6 +46,12 @@ class MCPServerConfig:
     enabled: bool = True
     timeout: float = 30.0
 
+    # Working directory for the spawned stdio MCP subprocess, passed through
+    # to the MCP SDK's StdioServerParameters. Common in configs ported from
+    # other MCP hosts (Claude Desktop, LM Studio, etc.); see issue #1111.
+    # Appended after the existing fields so their positional order is stable.
+    cwd: Optional[str] = None
+
     def __post_init__(self):
         """Validate configuration."""
         if isinstance(self.transport, str):

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -287,6 +287,38 @@ class TestMCPClientConnect:
         assert streamable_http_client.state == MCPServerState.CONNECTED
 
     @pytest.mark.asyncio
+    async def test_connect_stdio_passes_cwd_to_sdk(self):
+        """cwd from the server config reaches StdioServerParameters (#1111).
+
+        Runs the real _connect_stdio with only the SDK's stdio_client and
+        ClientSession mocked, so the real StdioServerParameters also proves
+        the pinned SDK accepts the field.
+        """
+        mcp = pytest.importorskip("mcp")
+        config = MCPServerConfig(
+            name="cwd-test",
+            transport=MCPTransport.STDIO,
+            command="python",
+            args=["-m", "mcp_server"],
+            cwd="/tmp/mcp-workdir",
+        )
+        client = MCPClient(config)
+
+        fake_ctx = MagicMock()
+        fake_ctx.__aenter__.return_value = (MagicMock(), MagicMock())
+        with patch(
+            "mcp.client.stdio.stdio_client", return_value=fake_ctx
+        ) as mock_stdio, patch("mcp.ClientSession", return_value=MagicMock()):
+            await client._connect_stdio()
+
+        server_params = mock_stdio.call_args.args[0]
+        assert isinstance(server_params, mcp.StdioServerParameters)
+        assert server_params.cwd == "/tmp/mcp-workdir"
+        # Existing fields keep flowing through unchanged.
+        assert server_params.command == "python"
+        assert server_params.args == ["-m", "mcp_server"]
+
+    @pytest.mark.asyncio
     async def test_connect_failure(self, stdio_client: MCPClient):
         """Test connection failure sets error state."""
         with patch.object(

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -129,6 +129,26 @@ class TestValidateConfigServerLoading:
                 {"servers": {"fs": {"transport": "stdio", "command": "x", "bogus": 1}}}
             )
 
+    def test_cwd_accepted_for_stdio_server(self):
+        """``cwd`` is a common key in stdio entries ported from other MCP
+        hosts (Claude Desktop, LM Studio). Before the #1111 fix the unknown
+        kwarg raised TypeError, surfaced as "Invalid config for server ...",
+        and disabled MCP for the whole config; it must load and carry the
+        value through instead."""
+        cfg = validate_config(
+            {
+                "mcpServers": {
+                    "lightroom": {
+                        "transport": "stdio",
+                        "command": "node",
+                        "args": ["build/index.js"],
+                        "cwd": "/Users/me/mcp/lightroom",
+                    }
+                }
+            }
+        )
+        assert cfg.servers["lightroom"].cwd == "/Users/me/mcp/lightroom"
+
     def test_claude_desktop_mcpServers_format_accepted(self):  # noqa: N802
         """Upstream chose to accept Claude Desktop's ``mcpServers`` key
         as an alias for oMLX's ``servers``. Drop this and Claude users

--- a/tests/test_mcp_types.py
+++ b/tests/test_mcp_types.py
@@ -124,6 +124,26 @@ class TestMCPServerConfig:
         )
         assert config.timeout == 120.0
 
+    def test_stdio_config_with_cwd(self):
+        """Test stdio config accepts a working directory (#1111)."""
+        config = MCPServerConfig(
+            name="cwd-server",
+            transport=MCPTransport.STDIO,
+            command="node",
+            args=["server.js"],
+            cwd="/srv/mcp/cwd-server",
+        )
+        assert config.cwd == "/srv/mcp/cwd-server"
+
+    def test_cwd_defaults_to_none(self):
+        """Test cwd defaults to None when omitted."""
+        config = MCPServerConfig(
+            name="no-cwd",
+            transport=MCPTransport.STDIO,
+            command="python",
+        )
+        assert config.cwd is None
+
 
 class TestMCPConfig:
     """Tests for MCPConfig dataclass."""
@@ -185,6 +205,25 @@ class TestMCPConfig:
         assert config.servers["web-server"].url == "http://localhost:3000/mcp"
         assert config.max_tool_calls == 20
         assert config.default_timeout == 45.0
+
+    def test_from_dict_server_with_cwd(self):
+        """Test 'cwd' survives the **server_data expansion (#1111).
+
+        Before the fix the unknown kwarg made MCPServerConfig raise
+        TypeError, which disabled MCP for the whole config.
+        """
+        data = {
+            "servers": {
+                "local-tools": {
+                    "transport": "stdio",
+                    "command": "node",
+                    "args": ["server.js"],
+                    "cwd": "/srv/mcp/local-tools",
+                },
+            },
+        }
+        config = MCPConfig.from_dict(data)
+        assert config.servers["local-tools"].cwd == "/srv/mcp/local-tools"
 
 
 class TestMCPTool:


### PR DESCRIPTION
Fixes #1111.

## Summary
- Add an optional `cwd` field to `MCPServerConfig` and pass it through to the MCP SDK's `StdioServerParameters` when connecting a stdio server.
- An MCP config with a `cwd` key on a stdio server previously crashed the whole MCP loader at startup; now the working directory is honored.

## Why
`cwd` is a standard stdio key in configs ported from other MCP hosts (Claude Desktop, LM Studio, Cursor). `MCPServerConfig` had no `cwd` field, and both config loaders build it by keyword-spread — `MCPServerConfig(**server_data)` in `validate_config()` (`omlx/mcp/config.py`) and `MCPConfig.from_dict()` (`omlx/mcp/types.py`). The unknown key raised `TypeError`, surfaced as the reported error, and disabled MCP for the *entire* config:

```
Invalid config for server 'lightroom': MCPServerConfig.__init__() got an
unexpected keyword argument 'cwd'. MCP features disabled. Fix your MCP config and restart.
```

The SDK's `StdioServerParameters` already supports `cwd`, so the correct fix is to pass the field through, not silently drop it (dropping it would discard the working directory the user configured).

## Changes
- `omlx/mcp/types.py`: add `cwd: Optional[str] = None` to `MCPServerConfig`, appended after the existing fields so positional order is unchanged.
- `omlx/mcp/client.py`: pass `cwd=self.config.cwd` to `StdioServerParameters` in `_connect_stdio()`.

## Why this is safe (no impact on existing servers)
- For any server that doesn't set `cwd`, the field defaults to `None`, so we pass `cwd=None`. `StdioServerParameters`'s own default for `cwd` is `None`, so `StdioServerParameters(command, args, env, cwd=None)` is **identical** to the previous `StdioServerParameters(command, args, env)` — verified with `model_dump()` equality. Zero behavioral change: the subprocess still launches in oMLX's working directory.
- `cwd` is a client-side launch parameter (like `env`/`args`); it is not part of the MCP handshake, so the server framework is irrelevant. Independent of whether the subprocess runs official FastMCP, standalone `fastmcp`, a Node server, etc.
- One field addition covers **both** kwargs-spread loaders (`config.py:validate_config` and `types.py:from_dict`); confirmed those are the only two construction sites.
- `cwd` is only consumed in `_connect_stdio()`. The SSE and Streamable-HTTP paths don't read it. Confirmed `StdioServerParameters(` has a single call site, so no sibling stdio path is missed.

## Tests
`pytest tests/test_mcp_types.py tests/test_mcp_config.py tests/test_mcp_client.py` → **106 passed**. All five new tests are added to the existing per-module files and fail when the fix is reverted:
- `test_mcp_types.py`: direct construction + the `**server_data` expansion in `MCPConfig.from_dict`.
- `test_mcp_config.py`: the exact `validate_config()` failure shape from the issue.
- `test_mcp_client.py`: runs the real `_connect_stdio` and asserts `cwd` reaches a real `StdioServerParameters` (the only mocks are the SDK's `stdio_client`/`ClientSession`).

Also verified end-to-end on the live server path: drove the real `init_mcp()` (`server.py`) against an on-disk `mcp.json` with `cwd` set, pointing at a real stdio MCP server.
- Without the fix: reproduced the issue's exact `MCP features disabled` failure.
- With the fix: `MCP initialized with 1 tools`; the MCP server subprocess actually spawned in the configured `cwd` (confirmed by a marker file it wrote *and* by a live `getcwd` tool call returning that directory).
