### PR TITLE
feat(server): add `--tool-call-parser none` to pass raw model tokens through to content

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -1111,6 +1111,14 @@ def _parse_tool_calls_impl(
     tools: Optional[List] = None,
 ) -> Tuple[str, Optional[List[ToolCall]]]:
     """parse_tool_calls body, pre-remap. See the public wrapper's docstring."""
+    # Operator opt-out (tool_call_parser=none): return the raw text untouched
+    # so no tool-call markup is extracted or stripped. The generic XML / Hermes
+    # / bracket fallbacks below run even without an injected parser, so the
+    # disabled sentinel must short-circuit before any of them. See
+    # https://github.com/jundot/omlx/issues/906.
+    if getattr(tokenizer, "tool_calls_disabled", False):
+        return text, None
+
     cleaned_text = text
 
     # Remove thinking tags if present (reasoning models)
@@ -1448,6 +1456,11 @@ class ToolCallStreamFilter:
     """
 
     def __init__(self, tokenizer: Any):
+        # Operator opt-out (tool_call_parser=none): when no parser was injected
+        # the filter must NOT suppress the built-in fallback envelopes
+        # (<tool_call> etc.) -- the raw tokens have to reach the client. See
+        # https://github.com/jundot/omlx/issues/906.
+        self._disabled = bool(getattr(tokenizer, "tool_calls_disabled", False))
         marker = getattr(tokenizer, "tool_call_start", None)
         marker_end = getattr(tokenizer, "tool_call_end", None)
         # Normalize None-like values but preserve empty strings.
@@ -1498,7 +1511,7 @@ class ToolCallStreamFilter:
     @property
     def active(self) -> bool:
         """Whether this filter should run for tool-enabled streams."""
-        return True
+        return not self._disabled
 
     def _find_start_envelope(
         self, text: str

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -851,6 +851,20 @@ Example directory structure:
         default=None,
         help="Max embedding inputs processed in one forward pass. Higher values increase throughput but use more memory. (default: 32)",
     )
+    serve_parser.add_argument(
+        "--tool-call-parser",
+        type=str,
+        default=None,
+        metavar="{auto,none,<name>}",
+        help=(
+            "Tool-call parser to use. 'auto' (default) selects a parser from "
+            "the model's chat template and extracts tool calls into the "
+            "structured OpenAI tool_calls field. 'none' (or 'off') disables "
+            "extraction so the raw model tokens pass through to the assistant "
+            "message content unchanged -- useful when a downstream system does "
+            "its own tool-call parsing."
+        ),
+    )
 
     # Memory guard options
     serve_parser.add_argument(

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -274,6 +274,22 @@ class BatchedEngine(BaseEngine):
             get_mlx_executor(), _load_model_sync
         )
 
+        # Operator opt-out: when the tool-call parser is set to "none"/"off",
+        # disable tool-call extraction so the raw model tokens pass straight
+        # through to the assistant message content. mlx-lm attaches the parser
+        # to the tokenizer at load time, so clear it here and flag the tokenizer
+        # for the server-side parse_tool_calls() / ToolCallStreamFilter checks.
+        # See https://github.com/jundot/omlx/issues/906.
+        parser_choice = getattr(self._scheduler_config, "tool_call_parser", None)
+        if (
+            self._tokenizer is not None
+            and parser_choice is not None
+            and parser_choice.lower() in ("none", "off")
+        ):
+            self._tokenizer.tool_calls_disabled = True
+            self._tokenizer.has_tool_calling = False
+            logger.info("Tool calling disabled: tool_call_parser=none")
+
         # Apply post-load transforms (e.g., IndexCache for DSA models)
         from ..utils.model_loading import (
             apply_post_load_transforms,

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1394,6 +1394,23 @@ class VLMBatchedEngine(BaseEngine):
         if not chat_template:
             return
 
+        # Operator opt-out: when the tool-call parser is set to "none"/"off",
+        # skip parser injection entirely. With no parser injected, tool-call
+        # extraction is bypassed on every path: parse_tool_calls() is a no-op
+        # without ``has_tool_calling`` (non-streaming + the structured
+        # ``tool_calls`` field), and ToolCallStreamFilter goes inactive when it
+        # sees ``tool_calls_disabled`` (streaming). The raw model tokens then
+        # pass straight through to the assistant message content -- for
+        # downstream systems that own their own tool-call parsing. See
+        # https://github.com/jundot/omlx/issues/906.
+        parser_choice = getattr(
+            self._scheduler_config, "tool_call_parser", None
+        )
+        if parser_choice is not None and parser_choice.lower() in ("none", "off"):
+            tokenizer.tool_calls_disabled = True
+            logger.info("VLM tool calling disabled: tool_call_parser=none")
+            return
+
         # Prefer mlx_vlm.tool_parsers (superset; knows about Gemma4 etc.)
         try:
             from mlx_vlm.tool_parsers import (

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1288,6 +1288,12 @@ class SchedulerConfig:
     # Model identification (for cache isolation between different models)
     model_name: str = ""  # OpenAI API model name (e.g., "mlx-community/Llama-3.2-3B")
 
+    # Tool-call parser selection. None means auto-select from the chat template
+    # (the default). "none"/"off" disables tool-call extraction entirely so the
+    # raw model tokens pass straight through to the assistant message content
+    # (for downstream systems that own their own tool-call parsing).
+    tool_call_parser: str | None = None
+
     # GC/cleanup settings (memory optimization)
     gc_cleanup_interval: int = 0  # Steps between gc.collect() calls (0=disabled)
     mlx_cache_cleanup_interval: int = 512  # Steps between mx.clear_cache() calls

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -263,6 +263,10 @@ class SchedulerSettings:
     # When True, long prefills are interleaved with decode steps.
     # Reduces TTFT for concurrent requests at the cost of per-step overhead.
     chunked_prefill: bool = False
+    # Tool-call parser selection. None = auto-select from the chat template
+    # (default). "none"/"off" disables tool-call extraction so raw model
+    # tokens pass through to the assistant message content unchanged.
+    tool_call_parser: Optional[str] = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
@@ -284,6 +288,7 @@ class SchedulerSettings:
             max_concurrent_requests=value,
             embedding_batch_size=embedding_batch_size,
             chunked_prefill=bool(data.get("chunked_prefill", False)),
+            tool_call_parser=data.get("tool_call_parser"),
         )
 
 
@@ -944,6 +949,8 @@ class GlobalSettings:
                 logger.warning(
                     f"Invalid OMLX_EMBEDDING_BATCH_SIZE value: {embedding_batch_size}"
                 )
+        if tool_call_parser := os.getenv("OMLX_TOOL_CALL_PARSER"):
+            self.scheduler.tool_call_parser = tool_call_parser
 
         # Cache settings
         if cache_enabled := os.getenv("OMLX_CACHE_ENABLED"):
@@ -1053,6 +1060,11 @@ class GlobalSettings:
             and args.embedding_batch_size is not None
         ):
             self.scheduler.embedding_batch_size = args.embedding_batch_size
+        if (
+            hasattr(args, "tool_call_parser")
+            and args.tool_call_parser is not None
+        ):
+            self.scheduler.tool_call_parser = args.tool_call_parser
 
         # Memory guard settings
         if hasattr(args, "memory_guard") and args.memory_guard is not None:
@@ -1425,6 +1437,7 @@ class GlobalSettings:
                 self.base_path
             ),
             hot_cache_max_size=self.cache.get_hot_cache_max_size_bytes(),
+            tool_call_parser=self.scheduler.tool_call_parser,
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -321,7 +321,27 @@ class TestSchedulerSettings:
             "max_concurrent_requests": 8,
             "embedding_batch_size": 32,
             "chunked_prefill": False,
+            "tool_call_parser": None,
         }
+
+    def test_tool_call_parser_default_is_none(self):
+        """tool_call_parser defaults to None (auto-select, unchanged behavior)."""
+        assert SchedulerSettings().tool_call_parser is None
+
+    def test_tool_call_parser_round_trip(self):
+        """tool_call_parser round-trips through from_dict / to_dict."""
+        settings = SchedulerSettings.from_dict({"tool_call_parser": "none"})
+        assert settings.tool_call_parser == "none"
+        assert settings.to_dict()["tool_call_parser"] == "none"
+
+    def test_tool_call_parser_threads_to_scheduler_config(self):
+        """GlobalSettings carries tool_call_parser into the engine SchedulerConfig."""
+        pytest.importorskip("mlx")  # to_scheduler_config imports the mlx-backed scheduler
+        gs = GlobalSettings()
+        gs.scheduler.tool_call_parser = "none"
+        assert gs.to_scheduler_config().tool_call_parser == "none"
+        # Default stays None (auto-select).
+        assert GlobalSettings().to_scheduler_config().tool_call_parser is None
 
     def test_from_dict(self):
         """Test creation from dictionary."""

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -700,6 +700,59 @@ def _make_tokenizer(tool_call_start=""):
     return tok
 
 
+def _make_disabled_tokenizer():
+    """Mock tokenizer with tool-call extraction disabled (tool_call_parser=none).
+
+    Mirrors the state ``VLMBatchedEngine._inject_tool_calling`` leaves the
+    tokenizer in when the operator passes ``--tool-call-parser none``: no
+    ``has_tool_calling`` / parser attributes are injected and the
+    ``tool_calls_disabled`` sentinel is set.
+    """
+    tok = MagicMock(spec=[])
+    tok.tool_calls_disabled = True
+    return tok
+
+
+class TestToolCallParserNone:
+    """tool_call_parser='none' opt-out (issue #906).
+
+    When the operator disables the parser, oMLX must pass the raw model
+    tokens through to the assistant content unchanged on every path:
+
+    * streaming  -> ToolCallStreamFilter must go inactive so the built-in
+      ``<tool_call>`` fallback envelopes are NOT suppressed;
+    * non-streaming -> parse_tool_calls() must be a no-op (no
+      ``has_tool_calling``) so the structured ``tool_calls`` field stays
+      empty and the raw text is returned verbatim.
+    """
+
+    def test_disabled_filter_is_inactive(self):
+        """A disabled tokenizer makes the stream filter inactive."""
+        f = ToolCallStreamFilter(_make_disabled_tokenizer())
+        assert f.active is False
+
+    def test_disabled_filter_passes_raw_tool_call_markup(self):
+        """Raw <tool_call> markup streams through untouched when disabled."""
+        f = ToolCallStreamFilter(_make_disabled_tokenizer())
+        raw = 'Answer<tool_call>{"name":"func","arguments":{}}</tool_call>'
+        out = f.feed(raw) + f.finish()
+        assert out == raw
+
+    def test_default_filter_still_suppresses_markup(self):
+        """Regression: without the opt-out the fallback envelope is suppressed."""
+        f = ToolCallStreamFilter(_make_tokenizer())
+        assert f.active is True
+        out = f.feed('Answer<tool_call>{"name":"func"}</tool_call>') + f.finish()
+        assert out == "Answer"
+
+    def test_disabled_non_streaming_extraction_is_noop(self):
+        """parse_tool_calls() leaves content untouched and finds no tool calls."""
+        raw = 'Answer<tool_call>{"name":"func","arguments":{}}</tool_call>'
+        cleaned, tool_calls = parse_tool_calls(raw, _make_disabled_tokenizer())
+        assert cleaned == raw
+        assert tool_calls is None
+
+
 class TestToolCallStreamFilter:
     """Tests for ToolCallStreamFilter."""
 


### PR DESCRIPTION

Closes #906.

## Summary

oMLX auto-selects a tool-call parser from the model's chat template and extracts tool calls into the structured OpenAI `tool_calls` field. For operators whose downstream already owns tool-call parsing (proxies, custom routers, Hermes-style pipelines), that auto-extraction silently consumes the model's raw `<tool_call>` tokens — the assistant `content` comes back empty/`null` and the tool never fires for the end user.

This PR adds an **opt-out** so operators can pass the raw decoded model tokens straight through to the assistant message `content`, with `tool_calls` left unset:

```bash
omlx serve --tool-call-parser none          # CLI flag
OMLX_TOOL_CALL_PARSER=none omlx serve        # env var
# or settings.json:  { "scheduler": { "tool_call_parser": "none" } }
```

`auto` (the implicit default) is unchanged — parsers are still auto-selected and tool calls still extracted — so **existing users are unaffected**. `none` and `off` are accepted as synonyms.

## Why a server flag (from the issue)

Downstream code can read `delta.tool_calls` and re-synthesize the native XML, but:
- Proxies targeting *multiple* backends (some raw, some extracted) have to carry both paths forever.
- One server flag scales cleaner than every downstream learning oMLX's split format.

## Design — disabled on every path

The whole tool-call subsystem keys off the tokenizer. The flag is threaded `CLI/env/settings → SchedulerSettings → SchedulerConfig → engine`, and the engine flags the tokenizer at load time (`tool_calls_disabled = True`). With that flag set:

- **Engine (load time):** `VLMBatchedEngine._inject_tool_calling` skips parser injection entirely; `BatchedEngine` clears the parser mlx-lm attached at load. `has_tool_calling` is therefore never set.
- **Non-streaming:** `parse_tool_calls()` short-circuits and returns the raw text untouched. This is required because the generic XML / Hermes / bracket fallbacks in `parse_tool_calls` run *even without* an injected parser — so skipping injection alone is not enough; the short-circuit is what truly passes content through.
- **Streaming:** `ToolCallStreamFilter` goes **inactive**. Today the filter has hardcoded fallback envelopes (`<tool_call>`, `<|tool_call_start|>`, …) and `active` always returns `True`, so it suppresses raw `<tool_call>` markup from streamed deltas regardless of whether a parser matched. Under `none` it must not — the raw deltas have to reach the client.

This covers both the streaming and non-streaming paths called out in the issue.

## Relationship to #1583

This is the **output-side complement** to the input-side fix merged for #1583 (#1597, "respect `tool_choice: none`"). That change stops tools being *injected* into the template on a per-request basis; this change stops tool calls being *extracted* out of the model output on a per-server basis. Both are operator opt-outs from oMLX's automatic tool handling, sitting on opposite ends of the same request.

## Tests

`tests/test_tool_calling.py::TestToolCallParserNone`:
- streaming filter is **inactive** when disabled and passes raw `<tool_call>` markup through verbatim;
- regression: the default filter still suppresses that markup;
- non-streaming `parse_tool_calls()` is a no-op (raw text returned, `tool_calls` is `None`).

`tests/test_settings.py::TestSchedulerSettings`:
- `tool_call_parser` default is `None` (auto), round-trips through `from_dict`/`to_dict`, and threads through `to_scheduler_config()` into the engine `SchedulerConfig`.

Existing `test_tool_calling.py` / `test_settings.py` suites pass (the only failures in the headless sandbox are pre-existing and due to optional `mlx` / `mlx_lm` / `httpx2` not being installed — identical with and without this change). `omlx serve --help` shows the new flag.

## Notes / scope

- The issue also floats an independent `--reasoning-parser none` for the `reasoning_content` split. That's a separate concern and is **out of scope** here — this PR is focused on tool-call extraction only.
- `--tool-call-parser` currently exposes `auto` (default) and `none`/`off`. Selecting a *specific* named parser by hand (overriding chat-template auto-detection) is a straightforward follow-up on the same plumbing if maintainers want it, but #906 only needs the opt-out.
