### PR TITLE
fix(api): probe mid-system support with the leading-system block present (#1966)

### DIFF
--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -233,6 +233,7 @@ _TOOL_ROLE_CHECK_RE = re.compile(r"==\s*['\"]tool['\"]")
 _MID_SYSTEM_USER_MARKER = "__OMLX_MID_SYSTEM_PROBE_USER__"
 _MID_SYSTEM_MARKER = "__OMLX_MID_SYSTEM_PROBE_SYSTEM__"
 _MID_SYSTEM_ASSISTANT_MARKER = "__OMLX_MID_SYSTEM_PROBE_ASSISTANT__"
+_MID_SYSTEM_LEADING_MARKER = "__OMLX_MID_SYSTEM_PROBE_LEADING__"
 _MID_SYSTEM_PROBE_TOOL = [
     {
         "type": "function",
@@ -296,6 +297,7 @@ def _mid_system_probe_cache_key(
     chat_template_kwargs: dict[str, Any] | None,
     placement: str,
     is_partial: bool,
+    has_leading_system: bool,
 ) -> tuple[Any, ...]:
     chat_template = getattr(tokenizer, "chat_template", None)
     if isinstance(chat_template, str):
@@ -309,6 +311,7 @@ def _mid_system_probe_cache_key(
         _freeze_template_value(chat_template_kwargs or {}),
         placement,
         is_partial,
+        has_leading_system,
     )
 
 
@@ -355,12 +358,20 @@ def chat_template_preserves_mid_system(
     chat_template_kwargs: dict[str, Any] | None = None,
     placement: str = "tail",
     is_partial: bool = False,
+    has_leading_system: bool = False,
 ) -> bool:
     """Return whether the chat template renders a mid-system message in-place.
 
     This does not prove model-level semantics. It only verifies that the
     current tokenizer template keeps the system content after the preceding
     user turn instead of raising, dropping it, or moving it to the front.
+
+    When ``has_leading_system`` is True the probe is built with a leading
+    system block (``system, user, system[, assistant]``), matching the real
+    conversation shape. Some strict templates (e.g. Qwen3.6) accept a system
+    message after a user turn *only* when there is no leading system block, and
+    raise "System message must be at the beginning." otherwise. Probing without
+    the leading block hides that rejection and yields a false positive (#1966).
     """
     if tokenizer is None or not hasattr(tokenizer, "apply_chat_template"):
         return False
@@ -374,15 +385,19 @@ def chat_template_preserves_mid_system(
         chat_template_kwargs=chat_template_kwargs,
         placement=placement,
         is_partial=is_partial,
+        has_leading_system=has_leading_system,
     )
     cached = _MID_SYSTEM_PROBE_CACHE.get(cache_key)
     if cached is not None:
         return cached
 
-    probe_messages = [
-        {"role": "user", "content": _MID_SYSTEM_USER_MARKER},
-        {"role": "system", "content": _MID_SYSTEM_MARKER},
-    ]
+    probe_messages: list[dict] = []
+    if has_leading_system:
+        probe_messages.append(
+            {"role": "system", "content": _MID_SYSTEM_LEADING_MARKER}
+        )
+    probe_messages.append({"role": "user", "content": _MID_SYSTEM_USER_MARKER})
+    probe_messages.append({"role": "system", "content": _MID_SYSTEM_MARKER})
     if placement == "between":
         probe_messages.append(
             {"role": "assistant", "content": _MID_SYSTEM_ASSISTANT_MARKER}
@@ -407,6 +422,11 @@ def chat_template_preserves_mid_system(
     supported = user_idx >= 0 and system_idx > user_idx
     if placement == "between":
         supported = supported and assistant_idx > system_idx
+    if has_leading_system:
+        # The leading system block must still render first; a strict template
+        # that rejects the mid-system run (or relocates it) is not safe.
+        leading_idx = rendered.find(_MID_SYSTEM_LEADING_MARKER)
+        supported = supported and 0 <= leading_idx < user_idx
 
     _MID_SYSTEM_PROBE_CACHE[cache_key] = supported
     return supported
@@ -684,6 +704,9 @@ def prepare_system_messages_for_template(
     if is_partial:
         return strict_fallback()
 
+    has_leading_system = bool(messages) and _is_system_role(
+        messages[0].get("role")
+    )
     can_preserve = all(
         chat_template_preserves_mid_system(
             tokenizer,
@@ -691,6 +714,7 @@ def prepare_system_messages_for_template(
             chat_template_kwargs=chat_template_kwargs,
             placement=placement,
             is_partial=is_partial,
+            has_leading_system=has_leading_system,
         )
         for placement in placements
     )

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -3364,3 +3364,99 @@ class TestToolResultWithToolAwareTokenizer:
         assert result[0]["tool_calls"][0]["function"]["name"] == "get_weather"
         # Arguments are parsed into dict for the chat template.
         assert result[0]["tool_calls"][0]["function"]["arguments"] == {"city": "Seoul"}
+
+
+class TestMidSystemProbeLeadingSystem:
+    """Probe must replicate the leading-system precondition (#1966).
+
+    Strict templates (Qwen3.6) accept a system message after a user turn only
+    when there is no leading system block; with a leading block they raise
+    "System message must be at the beginning." The capability probe must build
+    the same shape (system, user, system) or it returns a false positive and
+    the mid-system message is preserved into a request the template rejects.
+    """
+
+    class StrictLeadingSystemTokenizer:
+        """Mimics Qwen3.6: a system message after the beginning is allowed only
+        when there is no leading system block; otherwise the template raises."""
+
+        chat_template = "strict-leading-system"
+
+        def apply_chat_template(self, messages, **kwargs):
+            has_leading = bool(messages) and messages[0]["role"] == "system"
+            seen_non_system = False
+            for msg in messages:
+                if msg["role"] == "system":
+                    if seen_non_system and has_leading:
+                        raise ValueError(
+                            "System message must be at the beginning."
+                        )
+                else:
+                    seen_non_system = True
+            return "\n".join(
+                f"{m['role']}:{m.get('content', '')}" for m in messages
+            )
+
+    def test_probe_detects_strict_leading_system_rejection(self):
+        from omlx.api.utils import chat_template_preserves_mid_system
+
+        tokenizer = self.StrictLeadingSystemTokenizer()
+
+        # Without a leading system block the [user, system] shape is accepted.
+        assert (
+            chat_template_preserves_mid_system(
+                tokenizer, has_leading_system=False
+            )
+            is True
+        )
+        # With a leading system block the strict template rejects the
+        # mid-system run, so the probe must report it as unsupported.
+        assert (
+            chat_template_preserves_mid_system(
+                tokenizer, has_leading_system=True
+            )
+            is False
+        )
+
+    def test_downgrades_mid_system_when_leading_block_present(self):
+        from omlx.api.utils import prepare_system_messages_for_template
+
+        # Real Qwen3.6 shape from #1966: a leading developer/system block, a
+        # user turn, then a later developer/system block.
+        messages = [
+            {"role": "system", "content": "Leading context"},
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "Later context"},
+        ]
+
+        result = prepare_system_messages_for_template(
+            messages,
+            self.StrictLeadingSystemTokenizer(),
+            unsupported_mid_system_policy="user_note_safe",
+        )
+
+        # The mid-system block must be downgraded into the user turn so the
+        # strict template no longer sees a system message after the beginning.
+        assert [m["role"] for m in result] == ["system", "user"]
+        assert result[0]["content"] == "Leading context"
+        assert "Later context" in result[1]["content"]
+        assert "[System note]" in result[1]["content"]
+
+    def test_no_leading_block_still_preserves_mid_system(self):
+        from omlx.api.utils import prepare_system_messages_for_template
+
+        # Without a leading system block the template accepts the mid-system
+        # turn, so it should still be preserved in place (not downgraded).
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "system", "content": "Plan mode"},
+        ]
+
+        result = prepare_system_messages_for_template(
+            messages,
+            self.StrictLeadingSystemTokenizer(),
+            unsupported_mid_system_policy="user_note_safe",
+        )
+
+        assert [m["role"] for m in result] == ["user", "system"]
+        assert result[1]["content"] == "Plan mode"


### PR DESCRIPTION

## Summary

Fixes #1966. On Qwen3.6, `/v1/responses` can fail with
`Chat template error: System message must be at the beginning.` when a request
has a leading developer/system block, a user/assistant turn, then a later
developer/system block — a common shape for agent clients that send initial
runtime context and later interrupt/continue events. OpenAI accepts this shape;
oMLX rejected it unless `server.preserve_mid_system_cache=false` was set.

## Root cause

`chat_template_preserves_mid_system` probed the template with only:

```python
[
    {"role": "user", "content": marker_user},
    {"role": "system", "content": marker_system},
]
```

Qwen3.6 accepts a system message after a user turn **when there is no leading
system block**, so the probe concluded mid-system preservation was safe. But the
real failing conversation begins with a leading system block, and Qwen3.6
rejects a later system message in that case. The capability probe was too weak —
it didn't replicate the leading-system precondition — so it returned a false
positive and the mid-system run was preserved into a request the template
rejects.

## Fix

Strengthen the probe. When the real conversation starts with a system block,
`prepare_system_messages_for_template` now passes `has_leading_system=True`, and
the probe:

1. builds the shape `[system, user, system(, assistant)]` (the actual failing
   shape), and
2. additionally requires the leading system marker to render **first**
   (`0 <= leading_idx < user_idx`).

A strict template that raises or relocates the mid-system run now fails the
probe, so the existing `user_note_safe` downgrade path moves the mid-system
content into the adjacent user turn instead of crashing. Conversations **without**
a leading system block keep the existing in-place preservation behavior
unchanged. `has_leading_system` is included in the probe cache key.

## Tests

Added `TestMidSystemProbeLeadingSystem` in `tests/test_api_utils.py` with a
`StrictLeadingSystemTokenizer` that mimics Qwen3.6 (accepts `[user, system]`,
raises when a system message follows a leading system block):

- probe returns `True` without a leading block, `False` with one;
- `[system, user, system]` is downgraded to `[system, user]` with the later
  system content merged into the user turn as a `[System note]`;
- a conversation without a leading block still preserves the mid-system turn
  in place (no regression).

Verified the new downgrade/probe tests **fail on `main`** (the
`[system, user, system]` shape survives unchanged) and pass with this change.

```
tests/test_api_utils.py: 226 passed (incl. 4 new)
```

## Notes

- New keyword arg `has_leading_system` defaults to `False`, so existing callers
  are unaffected.
- 6 pre-existing `tests/test_settings.py` failures in this sandbox are unrelated
  (runtime/`mlx`-dependent) and reproduce on clean `main`; `test_api_utils.py`
  is fully green.
