### PR TITLE
fix(vlm): preflight counts real image tokens, not the max_pixels ceiling

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -868,6 +868,118 @@ def _count_image_tokens(
     return image_parts * per_image_upper_bound
 
 
+def _smart_resize_tokens(
+    h: int, w: int, patch_size: int, merge_size: int,
+    min_pixels: int, max_pixels: int,
+) -> int:
+    """Real merged-token count for one image of pixel size (h, w), mirroring
+    the Qwen image processor's ``smart_resize`` -> grid_thw ->
+    ``(t*h*w)//merge**2`` pipeline (t=1 for a still image). Pure arithmetic;
+    no pixel decode. This is the *exact* count the real chat path produces, so
+    it never under-counts the prefill-memory guard."""
+    import math
+
+    factor = patch_size * merge_size
+    if h <= 0 or w <= 0:
+        return 0
+    h_bar = max(factor, round(h / factor) * factor)
+    w_bar = max(factor, round(w / factor) * factor)
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((h * w) / max_pixels)
+        h_bar = max(factor, math.floor(h / beta / factor) * factor)
+        w_bar = max(factor, math.floor(w / beta / factor) * factor)
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (h * w))
+        h_bar = math.ceil(h * beta / factor) * factor
+        w_bar = math.ceil(w * beta / factor) * factor
+    return (h_bar // patch_size) * (w_bar // patch_size) // (merge_size ** 2)
+
+
+def _read_image_dims(part: dict) -> Optional[tuple]:
+    """Best-effort, decode-free ``(width, height)`` for an OpenAI image part.
+
+    Handles ``data:`` base64 URIs, raw base64, and local file paths via a lazy
+    ``PIL.Image.open`` (reads the header only, not pixels). Returns ``None`` for
+    anything that would need a network fetch or that fails to parse, so callers
+    fall back to the conservative per-image upper bound."""
+    import base64 as _b64
+    import binascii
+    import io as _io
+
+    from PIL import Image as _Image
+
+    obj = part.get("image_url")
+    if obj is None:
+        obj = part.get("input_image") or part.get("image")
+    url = obj if isinstance(obj, str) else (obj.get("url") if isinstance(obj, dict) else None)
+    if not isinstance(url, str) or not url:
+        return None
+
+    raw = None
+    s = url.strip()
+    if s.startswith("data:"):
+        _, sep, encoded = s.partition(",")
+        if sep == ",":
+            try:
+                raw = _b64.b64decode(encoded, validate=True)
+            except (binascii.Error, ValueError):
+                return None
+    elif s.startswith(("http://", "https://")):
+        return None  # no network in preflight
+    else:
+        try:
+            raw = _b64.b64decode(s, validate=True)
+        except (binascii.Error, ValueError):
+            raw = None  # not base64 -> treat as path below
+
+    try:
+        if raw is not None:
+            with _Image.open(_io.BytesIO(raw)) as im:
+                return im.size  # (width, height)
+        with _Image.open(s) as im:
+            return im.size
+    except Exception:
+        return None
+
+
+def _count_image_tokens_real(
+    messages: list[dict[str, Any]],
+    processor: Any,
+    *,
+    upper_bound: int = _IMAGE_TOKEN_UPPER_BOUND_FALLBACK,
+) -> int:
+    """Sum the *real* per-image token contribution from actual image
+    dimensions, instead of charging every image the model's ``max_pixels``
+    ceiling. Falls back to ``upper_bound`` per image when the dimensions can't
+    be read decode-free or the processor isn't a Qwen-style one, so the guard
+    still never under-counts."""
+    ip = getattr(processor, "image_processor", None) or processor
+    ps = getattr(ip, "patch_size", None)
+    ms = getattr(ip, "merge_size", None)
+    minp = getattr(ip, "min_pixels", None)
+    maxp = getattr(ip, "max_pixels", None)
+    qwen_ok = all(
+        isinstance(x, int) and x > 0 for x in (ps, ms, minp, maxp)
+    )
+
+    total = 0
+    for msg in messages:
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") not in ("image_url", "image", "input_image"):
+                continue
+            wh = _read_image_dims(part) if qwen_ok else None
+            if wh is None:
+                total += upper_bound
+            else:
+                total += _smart_resize_tokens(wh[1], wh[0], ps, ms, minp, maxp)
+    return total
+
+
 class VLMBatchedEngine(BaseEngine):
     """
     VLM engine with continuous batching, tiered KV cache, and boundary snapshots.
@@ -2742,9 +2854,10 @@ class VLMBatchedEngine(BaseEngine):
             return
         # Count images from the ORIGINAL messages (the stripped
         # ``text_messages`` no longer has the image content-parts).
-        num_tokens += _count_image_tokens(
+        num_tokens += _count_image_tokens_real(
             messages,
-            per_image_upper_bound=_derive_image_token_upper_bound(
+            getattr(self, "_processor", None),
+            upper_bound=_derive_image_token_upper_bound(
                 getattr(self, "_processor", None)
             ),
         )

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -10,6 +10,7 @@ Tests cover:
 - Engine stop safety (close() exception guard)
 """
 
+import base64
 import io
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1865,3 +1866,120 @@ class TestStopSafety:
         await engine.stop()
 
         mock_inner_engine.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# TestPreflightImageTokenCount
+# ---------------------------------------------------------------------------
+
+
+# Qwen3.x-VL / Qwen2.5-VL image-processor defaults used across these tests.
+_QWEN_IP = SimpleNamespace(
+    patch_size=16, merge_size=2, min_pixels=65536, max_pixels=16777216
+)
+_QWEN_PROC = SimpleNamespace(image_processor=_QWEN_IP)
+
+
+def _png_data_uri(width: int, height: int) -> str:
+    """Build a ``data:`` base64 PNG of the given pixel size."""
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height)).save(buf, format="PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+
+def _image_part(width: int, height: int) -> dict:
+    return {"type": "image_url", "image_url": {"url": _png_data_uri(width, height)}}
+
+
+class TestSmartResizeTokens:
+    """`_smart_resize_tokens` must match the Qwen processor's grid -> token math."""
+
+    @pytest.mark.parametrize(
+        "w,h,expected",
+        [
+            (512, 512, 256),     # exact multiple of patch*merge (32)
+            (336, 336, 100),     # 336 -> 336 grid 21x21 -> 441//4... rounds via factor
+            (510, 680, 336),     # non-multiple, rounded to nearest factor
+            (100, 100, 64),      # below min_pixels -> upscaled to min
+            (4000, 3000, 11750),  # above max_pixels -> downscaled to cap
+        ],
+    )
+    def test_matches_known_grid(self, w, h, expected):
+        from omlx.engine.vlm import _smart_resize_tokens
+
+        got = _smart_resize_tokens(
+            h, w, _QWEN_IP.patch_size, _QWEN_IP.merge_size,
+            _QWEN_IP.min_pixels, _QWEN_IP.max_pixels,
+        )
+        assert got == expected
+
+    def test_zero_dims_return_zero(self):
+        from omlx.engine.vlm import _smart_resize_tokens
+
+        assert _smart_resize_tokens(0, 512, 16, 2, 65536, 16777216) == 0
+
+
+class TestReadImageDims:
+    """`_read_image_dims` reads dimensions decode-free, or returns None safely."""
+
+    def test_reads_data_uri(self):
+        from omlx.engine.vlm import _read_image_dims
+
+        assert _read_image_dims(_image_part(640, 480)) == (640, 480)
+
+    def test_http_url_returns_none(self):
+        from omlx.engine.vlm import _read_image_dims
+
+        part = {"type": "image_url",
+                "image_url": {"url": "https://example.com/x.jpg"}}
+        assert _read_image_dims(part) is None
+
+    def test_garbage_returns_none(self):
+        from omlx.engine.vlm import _read_image_dims
+
+        part = {"type": "image_url",
+                "image_url": {"url": "data:image/png;base64,not-base64!!"}}
+        assert _read_image_dims(part) is None
+
+
+class TestCountImageTokensReal:
+    """`_count_image_tokens_real` charges actual size, not the max_pixels ceiling."""
+
+    def test_counts_real_size_not_upper_bound(self):
+        from omlx.engine.vlm import _count_image_tokens_real
+
+        # 20 down-sized 512x512 frames (livestream client shape).
+        content = [_image_part(512, 512) for _ in range(20)]
+        content.append({"type": "text", "text": "describe"})
+        messages = [{"role": "user", "content": content}]
+
+        total = _count_image_tokens_real(messages, _QWEN_PROC, upper_bound=16384)
+        assert total == 20 * 256  # 5120, not 20 * 16384 = 327680
+
+    def test_falls_back_to_upper_bound_for_unreadable(self):
+        from omlx.engine.vlm import _count_image_tokens_real
+
+        messages = [{"role": "user", "content": [
+            {"type": "image_url",
+             "image_url": {"url": "https://example.com/x.jpg"}},
+            {"type": "text", "text": "hi"},
+        ]}]
+        total = _count_image_tokens_real(messages, _QWEN_PROC, upper_bound=16384)
+        assert total == 16384
+
+    def test_falls_back_when_processor_not_qwen_style(self):
+        from omlx.engine.vlm import _count_image_tokens_real
+
+        # Processor missing patch/merge/min/max -> never under-count.
+        messages = [{"role": "user", "content": [_image_part(512, 512)]}]
+        total = _count_image_tokens_real(messages, SimpleNamespace(),
+                                         upper_bound=16384)
+        assert total == 16384
+
+    def test_no_images_returns_zero(self):
+        from omlx.engine.vlm import _count_image_tokens_real
+
+        messages = [{"role": "user", "content": "just text"}]
+        assert _count_image_tokens_real(messages, _QWEN_PROC) == 0


### PR DESCRIPTION
## Summary

`VLMBatchedEngine.preflight_chat` estimates prompt size by charging **every
image the model's `max_pixels`-derived per-image ceiling**
(`_derive_image_token_upper_bound`), independent of the image's actual size.
For any client that down-sizes frames before sending (video / livestream
analysis, thumbnailing, etc.) this massively over-counts and produces **false
`prefill_memory_exceeded` (HTTP 400) rejections** for prompts that run fine.

This is the *token-count* side of the head_dim=256 prefill story; it stacks on
top of the (correct) O(kv_len) SDPA fallback term from #1797 / #1863 — those
fixed the *formula*, this fixes the *kv_len fed into it*.

## Root cause

```python
# preflight_chat
num_tokens += _count_image_tokens(
    messages,
    per_image_upper_bound=_derive_image_token_upper_bound(self._processor),
)
# _count_image_tokens         -> image_parts * per_image_upper_bound  (dim-agnostic)
# _derive_image_token_upper_bound -> max_pixels // (patch**2 * merge**2)
```

The real chat path already derives the exact per-image token count from
`image_grid_thw` (`(t*h*w)//merge_sq`); only preflight uses the ceiling.

## Measurement (omlx 0.4.4, MLX 0.31.2, Qwen3.6-35B-A3B-oQ4)

Processor: `max_pixels=16777216, patch_size=16, merge_size=2`.

| | per image | x20 frames |
|---|---:|---:|
| preflight charged (`_derive_image_token_upper_bound`) | 16,384 | 327,680 |
| real (512x512 frame, grid `(1,32,32)`=1024 patches) | 256 | 5,120 |
| **over-count** | **64x** | **64x** |

`_smart_resize_tokens` matches the real `Qwen image_processor` grid exactly
across sizes:

| WxH | predicted | real processor |
|---|---:|---:|
| 512x512 | 256 | 256 |
| 510x680 | 336 | 336 |
| 1280x720 | 880 | 880 |
| 100x100 (clamped to min_pixels) | 64 | 64 |
| 4000x3000 (clamped to max_pixels) | 11750 | 11750 |

## Impact (live, brew 0.4.4 + this patch, M-series, Qwen3.6-35B-A3B-oQ4, head_dim=256)

A 20-frame 512x512 livestream-analysis request:

| | before | after |
|---|---|---|
| preflight image tokens | 327,680 | 5,120 |
| outcome | **400** `prefill_memory_exceeded` (`current 22.0 GB + KV+SDPA 22.1 GB > 43.1 GB ceiling`) | **200**, `prompt: 5187`, completed in 6.5s |

The 22.1 GB "KV+SDPA" was correct arithmetic (`n_q·chunk·kv_len·2B`) on a
64x-inflated `kv_len`; with the real count the prefill transient is well under
1 GB. The request was always runnable — only the estimate rejected it.

## Why this stays safe (never under-counts)

- `_smart_resize_tokens` reproduces the processor's deterministic
  `smart_resize` -> grid -> token math, so it returns the **exact** count the
  real path will produce, not an optimistic lower bound.
- `_read_image_dims` is decode-free (lazy `PIL.Image.open(...).size`, header
  only) and returns `None` for network URLs or unparseable data; those parts
  fall back to the existing `_derive_image_token_upper_bound` ceiling.
- Non-Qwen processors (no `patch_size`/`merge_size`/`min_pixels`/`max_pixels`)
  also fall back to the per-image ceiling. So the guard's "never under-count"
  property — the thing protecting against the Metal IOGPU OOM/SIGABRT path — is
  preserved; this only removes the over-count.

## Changes

- `omlx/engine/vlm.py`: add `_smart_resize_tokens`, `_read_image_dims`,
  `_count_image_tokens_real`; `preflight_chat` uses the latter (still passing
  `_derive_image_token_upper_bound(...)` as the fallback bound).
- `tests/test_vlm_engine.py`: `TestSmartResizeTokens` (grid math incl. min/max
  clamping), `TestReadImageDims` (data-uri / http / garbage), and
  `TestCountImageTokensReal` (real-size count, and fallbacks for unreadable
  parts / non-Qwen processors).

Inference is untouched — this only changes the admission-time estimate.

## Test plan

- `pytest tests/test_vlm_engine.py` — 86/86 pass (13 new).
- Live-validated on brew 0.4.4 (MLX 0.31.2), Qwen3.6-35B-A3B-oQ4: the 20-frame
  request goes 400 -> 200; server log shows `prompt: 5187`, no preflight
  rejection, no OOM.

## Out of scope

The orthogonal chunk-tier observation (preflight evaluates the SDPA term at the
configured `prefill_step_size` rather than the lowest tier the adaptive
throttle can reach, so genuine long-context head_dim=256 requests that *would*
complete with chunk throttling can still be rejected) is left to #1797 where it
was raised.

Refines #1797 / #1863.
