### PR TITLE
fix(engine): enable tool calling for MistralCommon (tekken) tokenizers

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -274,6 +274,11 @@ class BatchedEngine(BaseEngine):
             get_mlx_executor(), _load_model_sync
         )
 
+        # MistralCommon (tekken) tokenizers expose no jinja chat_template, so
+        # mlx_lm's load() can't infer a tool parser and has_tool_calling stays
+        # False -> the server never parses [TOOL_CALLS]. Attach it explicitly.
+        self._ensure_mistral_tool_parser()
+
         # Apply post-load transforms (e.g., IndexCache for DSA models)
         from ..utils.model_loading import (
             apply_post_load_transforms,
@@ -476,6 +481,81 @@ class BatchedEngine(BaseEngine):
             prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
             return prompt + "\nassistant:"
 
+    def _is_mistral_common(self) -> bool:
+        """True if the loaded tokenizer is backed by mistral-common (tekken)."""
+        if self._tokenizer is None:
+            return False
+        inner = getattr(self._tokenizer, "_tokenizer", self._tokenizer)
+        return type(inner).__name__ == "MistralCommonBackend"
+
+    def _ensure_mistral_tool_parser(self) -> None:
+        """Attach mlx_lm's mistral tool parser for MistralCommon tokenizers.
+
+        MistralCommon exposes no jinja ``chat_template``, so mlx_lm's ``load()``
+        cannot infer a tool parser and ``has_tool_calling`` stays ``False``. The
+        model still emits ``[TOOL_CALLS]``; without a parser the server returns it
+        as raw text instead of structured ``tool_calls``.
+        """
+        tokenizer = self._tokenizer
+        if tokenizer is None or not self._is_mistral_common():
+            return
+        if getattr(tokenizer, "has_tool_calling", False):
+            return
+        try:
+            from mlx_lm.tool_parsers import mistral as mistral_parser
+        except ImportError:
+            logger.warning(
+                "mlx_lm.tool_parsers.mistral not found; tool calling "
+                "disabled for MistralCommon tokenizer"
+            )
+            return
+        tokenizer._tool_call_start = mistral_parser.tool_call_start
+        tokenizer._tool_call_end = mistral_parser.tool_call_end
+        tokenizer._tool_parser = mistral_parser.parse_tool_call
+        logger.info("LLM tool calling enabled: parser=mistral (MistralCommon)")
+
+    def _prompt_ids_for_mistral_common(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None,
+        chat_template_kwargs: dict[str, Any] | None,
+        is_partial: bool | None,
+        fallback_prompt,
+    ):
+        """Tokenize directly to ids for MistralCommon tokenizers.
+
+        ``apply_chat_template(..., tokenize=False)`` renders control tokens
+        (``[INST]``, ``[AVAILABLE_TOOLS]``, ``[TOOL_CALLS]``, ...) as literal text;
+        re-encoding that string turns them into ASCII brackets, so the model sees an
+        out-of-distribution prompt and emits EOS immediately. Tokenizing directly to
+        ids preserves the control tokens. Returns ``fallback_prompt`` unchanged for
+        every other tokenizer.
+        """
+        if not self._is_mistral_common():
+            return fallback_prompt
+        kw = {"tokenize": True, "add_generation_prompt": not bool(is_partial)}
+        if is_partial:
+            kw["continue_final_message"] = True
+        if tools:
+            kw["tools"] = tools
+        if chat_template_kwargs:
+            kw.update(chat_template_kwargs)
+        try:
+            ids = self._tokenizer.apply_chat_template(messages, **kw)
+        except TypeError:
+            # Older mistral-common rejects unknown kwargs (e.g. enable_thinking).
+            if chat_template_kwargs:
+                for key in chat_template_kwargs:
+                    kw.pop(key, None)
+            ids = self._tokenizer.apply_chat_template(messages, **kw)
+        except Exception as e:
+            logger.warning(
+                f"MistralCommon direct tokenize failed ({e}); "
+                "falling back to string prompt"
+            )
+            return fallback_prompt
+        return list(ids)
+
     def count_chat_tokens(
         self,
         messages: list[dict[str, Any]],
@@ -553,9 +633,9 @@ class BatchedEngine(BaseEngine):
             presence_penalty=presence_penalty,
             frequency_penalty=kwargs.get("frequency_penalty", 0.0),
             stop=stop or [],
-            thinking_budget=kwargs.get("thinking_budget", None),
-            compiled_grammar=kwargs.get("compiled_grammar", None),
-            seed=kwargs.get("seed", None),
+            thinking_budget=kwargs.get("thinking_budget"),
+            compiled_grammar=kwargs.get("compiled_grammar"),
+            seed=kwargs.get("seed"),
         )
 
         output = await self._engine.generate(
@@ -622,9 +702,9 @@ class BatchedEngine(BaseEngine):
             presence_penalty=presence_penalty,
             frequency_penalty=kwargs.get("frequency_penalty", 0.0),
             stop=stop or [],
-            thinking_budget=kwargs.get("thinking_budget", None),
-            compiled_grammar=kwargs.get("compiled_grammar", None),
-            seed=kwargs.get("seed", None),
+            thinking_budget=kwargs.get("thinking_budget"),
+            compiled_grammar=kwargs.get("compiled_grammar"),
+            seed=kwargs.get("seed"),
         )
 
         # SpecPrefill: pass per-request overrides to engine
@@ -738,6 +818,11 @@ class BatchedEngine(BaseEngine):
             template_tools,
             chat_template_kwargs=ct_kwargs,
             is_partial=partial,
+        )
+        # MistralCommon: tokenize directly to ids so control tokens survive
+        # (no-op string passthrough for every other tokenizer).
+        prompt = self._prompt_ids_for_mistral_common(
+            messages, template_tools, ct_kwargs, partial, prompt
         )
 
         return await self.generate(
@@ -915,6 +1000,12 @@ class BatchedEngine(BaseEngine):
                         kwargs["specprefill_system_end"] = system_end
                 except Exception as e:
                     logger.debug(f"SpecPrefill: system_end calc failed: {e}")
+
+        # MistralCommon: tokenize directly to ids so control tokens survive.
+        # Done after SpecPrefill's string-based token counting above.
+        prompt = self._prompt_ids_for_mistral_common(
+            messages, template_tools, ct_kwargs, partial, prompt
+        )
 
         async for output in self.stream_generate(
             prompt=prompt,

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -781,3 +781,127 @@ class TestApplyChatTemplatePartialMode:
         # continue_final_message=True (not add_generation_prompt=True).
         assert count_kwargs["continue_final_message"] is True
         assert count_kwargs["add_generation_prompt"] is False
+
+
+class TestBatchedEngineMistralCommon:
+    """Tool-calling support for MistralCommon (tekken) tokenizers (#1992)."""
+
+    def _mistral_tokenizer(self, **attrs):
+        """Build a fake tokenizer whose inner backend is 'MistralCommonBackend'."""
+        MistralCommonBackend = type("MistralCommonBackend", (), {})
+        return SimpleNamespace(_tokenizer=MistralCommonBackend(), **attrs)
+
+    def test_is_mistral_common_true(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        engine._tokenizer = self._mistral_tokenizer()
+        assert engine._is_mistral_common() is True
+
+    def test_is_mistral_common_false_for_regular(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        engine._tokenizer = SimpleNamespace(_tokenizer=object())
+        assert engine._is_mistral_common() is False
+
+    def test_is_mistral_common_false_when_none(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        engine._tokenizer = None
+        assert engine._is_mistral_common() is False
+
+    def test_prompt_ids_returns_ids_for_mistral_common(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        tok = self._mistral_tokenizer()
+        tok.apply_chat_template = MagicMock(return_value=[1, 5, 1091])
+        engine._tokenizer = tok
+
+        result = engine._prompt_ids_for_mistral_common(
+            [{"role": "user", "content": "hi"}], None, None, False, "FALLBACK"
+        )
+
+        assert result == [1, 5, 1091]
+        kw = tok.apply_chat_template.call_args[1]
+        assert kw["tokenize"] is True
+        assert kw["add_generation_prompt"] is True
+
+    def test_prompt_ids_passes_tools(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        tok = self._mistral_tokenizer()
+        tok.apply_chat_template = MagicMock(return_value=[1, 5])
+        engine._tokenizer = tok
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+
+        engine._prompt_ids_for_mistral_common(
+            [{"role": "user", "content": "hi"}], tools, None, False, "FALLBACK"
+        )
+
+        assert tok.apply_chat_template.call_args[1]["tools"] == tools
+
+    def test_prompt_ids_passthrough_for_non_mistral(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        engine._tokenizer = SimpleNamespace(_tokenizer=object())
+
+        result = engine._prompt_ids_for_mistral_common(
+            [{"role": "user", "content": "hi"}], None, None, False, "FALLBACK"
+        )
+
+        assert result == "FALLBACK"
+
+    def test_prompt_ids_falls_back_on_error(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        tok = self._mistral_tokenizer()
+        tok.apply_chat_template = MagicMock(side_effect=RuntimeError("boom"))
+        engine._tokenizer = tok
+
+        result = engine._prompt_ids_for_mistral_common(
+            [{"role": "user", "content": "hi"}], None, None, False, "FALLBACK"
+        )
+
+        assert result == "FALLBACK"
+
+    def test_ensure_mistral_tool_parser_attaches(self):
+        mp = pytest.importorskip("mlx_lm.tool_parsers.mistral")
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        tok = self._mistral_tokenizer(has_tool_calling=False)
+        engine._tokenizer = tok
+
+        engine._ensure_mistral_tool_parser()
+
+        assert tok._tool_parser is mp.parse_tool_call
+        assert tok._tool_call_start == mp.tool_call_start
+        assert tok._tool_call_end == mp.tool_call_end
+
+    def test_ensure_mistral_tool_parser_skips_when_enabled(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        tok = self._mistral_tokenizer(has_tool_calling=True)
+        engine._tokenizer = tok
+
+        engine._ensure_mistral_tool_parser()
+
+        assert not hasattr(tok, "_tool_parser")
+
+    def test_ensure_mistral_tool_parser_noop_for_non_mistral(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        tok = SimpleNamespace(_tokenizer=object(), has_tool_calling=False)
+        engine._tokenizer = tok
+
+        engine._ensure_mistral_tool_parser()
+
+        assert not hasattr(tok, "_tool_parser")


### PR DESCRIPTION
Fixes #1992.

## Problem

Models with a **MistralCommon / tekken** tokenizer (Devstral, Mistral-Small, …)
on the LLM batched-engine path return an **empty assistant message** when a
request includes `tools`:

```json
{ "choices": [ { "message": { "role": "assistant" }, "finish_reason": "stop" } ],
  "usage": { "prompt_tokens": 106, "completion_tokens": 0 } }
```

`completion_tokens: 0` — the model emits EOS immediately and no `tool_calls` are
produced. These tokenizers have **no jinja `chat_template`** and represent
`[INST]`, `[AVAILABLE_TOOLS]`, `[TOOL_CALLS]` as **single control-token ids**.

## Two root causes (both gated on MistralCommon)

**1. Control tokens destroyed by a string round-trip.** `_apply_chat_template()`
renders with `tokenize=False` and the engine re-encodes the resulting string.
For MistralCommon that is lossy — control tokens become literal ASCII brackets:

```python
ids_direct = tok.apply_chat_template(msgs, tools=tools, tokenize=True,  add_generation_prompt=True)
ids_string = tok.encode(tok.apply_chat_template(msgs, tools=tools, tokenize=False, add_generation_prompt=True))
len(ids_direct)  # 86   first ids [1, 5, ...]     (5 == [AVAILABLE_TOOLS])
len(ids_string)  # 106  first ids [1, 1060, ...]  (literal "[AVAILABLE_TOOLS]" text)
```

The live server's `prompt_tokens: 106` matches the mis-encoded path exactly. The
prompt is out-of-distribution, so the model emits EOS.

**2. Tool parser never attached.** `mlx_lm.load()` infers the tool parser from
`tokenizer.chat_template`, which is `None` for MistralCommon, so
`has_tool_calling` stays `False` and `[TOOL_CALLS]` is never parsed.

## Fix

Both changes are scoped by `_is_mistral_common()`; no other model path changes.

1. Tokenize directly to ids for MistralCommon in `chat()` / `stream_chat()`
   (`engine_core` already accepts `List[int]`). String/token-counting paths
   (e.g. SpecPrefill) keep using the string form.
2. Attach `mlx_lm.tool_parsers.mistral` after load when the inner tokenizer is
   `MistralCommonBackend` and `has_tool_calling` is `False`.

## Result

```json
{ "finish_reason": "tool_calls",
  "usage": { "prompt_tokens": 86, "completion_tokens": 11 },
  "message": { "tool_calls": [ { "type": "function",
    "function": { "name": "get_weather", "arguments": "{\"city\": \"Tokyo\"}" } } ] } }
```

`prompt_tokens` 106 → 86 (control tokens restored), the model emits
`[TOOL_CALLS]`, and it parses into a structured tool call. Verified end-to-end
against Devstral-Small-2-24B on omlx 0.4.4.

## Tests

`tests/test_batched_engine.py::TestBatchedEngineMistralCommon` — unit tests for
`_is_mistral_common`, `_ensure_mistral_tool_parser`, and
`_prompt_ids_for_mistral_common` (detection, id passthrough, tool passing,
error fallback, parser attach/skip), using a stub tokenizer.
