### PR TITLE
fix(api): generate Mistral-compliant tool-call ids

### DIFF
--- a/omlx/api/anthropic_utils.py
+++ b/omlx/api/anthropic_utils.py
@@ -23,6 +23,7 @@ from .anthropic_models import (
     SystemContent,
 )
 from .openai_models import ToolCall
+from .shared_models import generate_tool_call_id
 
 _PRESERVE_ROLE_BOUNDARY = "_preserve_role_boundary"
 logger = logging.getLogger(__name__)
@@ -271,7 +272,7 @@ def convert_anthropic_to_internal(
                             tool_calls.append(
                                 {
                                     "id": block_dict.get(
-                                        "id", f"call_{uuid.uuid4().hex[:8]}"
+                                        "id", generate_tool_call_id()
                                     ),
                                     "function": {
                                         "name": block_dict.get("name", ""),
@@ -513,7 +514,7 @@ def convert_anthropic_to_internal_harmony(
 
                 elif block_type == "tool_use":
                     # Tool use in assistant message - preserve as tool_calls
-                    tool_id = block_dict.get("id", f"call_{uuid.uuid4().hex[:8]}")
+                    tool_id = block_dict.get("id", generate_tool_call_id())
                     tool_name = block_dict.get("name", "")
                     tool_input = block_dict.get("input", {})
                     # input should be dict for chat_template |tojson

--- a/omlx/api/responses_utils.py
+++ b/omlx/api/responses_utils.py
@@ -4,7 +4,6 @@
 import copy
 import json
 import logging
-import uuid
 from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -17,7 +16,7 @@ from .responses_models import (
     ResponsesTool,
     ResponseUsage,
 )
-from .shared_models import IDPrefix, generate_id
+from .shared_models import IDPrefix, generate_id, generate_tool_call_id
 
 logger = logging.getLogger(__name__)
 
@@ -259,7 +258,7 @@ def convert_responses_input_to_messages(
 
         elif item.type == "function_call":
             # Assistant's tool call — accumulate for grouping
-            call_id = item.call_id or item.id or f"call_{uuid.uuid4().hex[:8]}"
+            call_id = item.call_id or item.id or generate_tool_call_id()
             pending_tool_calls.append(
                 {
                     "id": call_id,
@@ -664,7 +663,7 @@ def normalize_response_output_to_messages(
                 pending_reasoning = ""
             messages.append(msg_dict)
         elif item_type == "function_call":
-            call_id = item.get("call_id", f"call_{uuid.uuid4().hex[:8]}")
+            call_id = item.get("call_id", generate_tool_call_id())
             pending_tool_calls.append(
                 {
                     "id": call_id,

--- a/omlx/api/shared_models.py
+++ b/omlx/api/shared_models.py
@@ -43,6 +43,22 @@ def generate_id(prefix: IDPrefix, length: int = 8) -> str:
     return f"{prefix.value}-{uuid.uuid4().hex[:length]}"
 
 
+def generate_tool_call_id() -> str:
+    """Generate a tool-call id valid across every supported tokenizer.
+
+    Mistral / tekken (``MistralCommonBackend``) validates ``tool_call_id``
+    against ``[a-zA-Z0-9]`` with a length of *exactly* 9, and rejects the id
+    when the assistant turn is replayed otherwise (HTTP 500 on multi-turn tool
+    loops). ``"call"`` + 5 hex characters is exactly 9 alphanumeric characters:
+    accepted by Mistral and still an opaque, recognizable id for OpenAI /
+    Anthropic clients, which treat the id as opaque.
+
+    Returns:
+        A 9-character alphanumeric id, e.g. ``"call1a2b3"``.
+    """
+    return f"call{uuid.uuid4().hex[:5]}"
+
+
 def get_unix_timestamp() -> int:
     """Get current Unix timestamp.
 

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -21,7 +21,6 @@ import bisect
 import json
 import logging
 import re
-import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -29,6 +28,7 @@ import regex
 from jsonschema import ValidationError, validate
 
 from .openai_models import FunctionCall, ResponseFormat, ToolCall
+from .shared_models import generate_tool_call_id
 
 logger = logging.getLogger(__name__)
 
@@ -155,7 +155,7 @@ def _parse_xml_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
             arguments = parsed.get("arguments", {})
             tool_calls.append(
                 ToolCall(
-                    id=f"call_{uuid.uuid4().hex[:8]}",
+                    id=generate_tool_call_id(),
                     type="function",
                     function=FunctionCall(
                         name=name,
@@ -184,7 +184,7 @@ def _parse_xml_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
                     arguments[key] = val
             tool_calls.append(
                 ToolCall(
-                    id=f"call_{uuid.uuid4().hex[:8]}",
+                    id=generate_tool_call_id(),
                     type="function",
                     function=FunctionCall(
                         name=func_name,
@@ -214,7 +214,7 @@ def _parse_xml_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
                     arguments[k] = v
             tool_calls.append(
                 ToolCall(
-                    id=f"call_{uuid.uuid4().hex[:8]}",
+                    id=generate_tool_call_id(),
                     type="function",
                     function=FunctionCall(
                         name=func_name,
@@ -269,7 +269,7 @@ def _parse_namespaced_tool_calls(
                     arguments[key] = val
             tool_calls.append(
                 ToolCall(
-                    id=f"call_{uuid.uuid4().hex[:8]}",
+                    id=generate_tool_call_id(),
                     type="function",
                     function=FunctionCall(
                         name=func_name,
@@ -316,7 +316,7 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
             if name:
                 tool_calls.append(
                     ToolCall(
-                        id=f"call_{uuid.uuid4().hex[:8]}",
+                        id=generate_tool_call_id(),
                         type="function",
                         function=FunctionCall(
                             name=name,
@@ -359,7 +359,7 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
 
             tool_calls.append(
                 ToolCall(
-                    id=f"call_{uuid.uuid4().hex[:8]}",
+                    id=generate_tool_call_id(),
                     type="function",
                     function=FunctionCall(
                         name=func_name,
@@ -401,7 +401,7 @@ def _parse_bracket_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]
             arguments = {"raw": args_str}
         tool_calls.append(
             ToolCall(
-                id=f"call_{uuid.uuid4().hex[:8]}",
+                id=generate_tool_call_id(),
                 type="function",
                 function=FunctionCall(
                     name=name,
@@ -421,7 +421,7 @@ def _parse_bracket_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]
         name = match.group(1)
         tool_calls.append(
             ToolCall(
-                id=f"call_{uuid.uuid4().hex[:8]}",
+                id=generate_tool_call_id(),
                 type="function",
                 function=FunctionCall(
                     name=name,
@@ -1152,7 +1152,7 @@ def _parse_tool_calls_impl(
                         arguments = p.get("arguments", {})
                         tool_calls.append(
                             ToolCall(
-                                id=f"call_{uuid.uuid4().hex[:8]}",
+                                id=generate_tool_call_id(),
                                 type="function",
                                 function=FunctionCall(
                                     name=name,
@@ -1184,7 +1184,7 @@ def _parse_tool_calls_impl(
                                 arguments = p.get("arguments", {})
                                 tool_calls.append(
                                     ToolCall(
-                                        id=f"call_{uuid.uuid4().hex[:8]}",
+                                        id=generate_tool_call_id(),
                                         type="function",
                                         function=FunctionCall(
                                             name=name,

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -153,6 +153,7 @@ from .api.responses_utils import (
     format_sse_event,
     normalize_response_output_to_messages,
 )
+from .api.shared_models import generate_tool_call_id
 from .api.thinking import ThinkingParser, extract_thinking, prompt_opens_thinking
 from .api.tool_calling import (
     ToolCallStreamFilter,
@@ -207,7 +208,7 @@ def _convert_parser_tool_calls(tool_calls: list[dict] | None) -> list[ToolCall]:
             ToolCall(
                 id=tool_call.get("id")
                 or tool_call.get("call_id")
-                or f"call_{uuid.uuid4().hex[:8]}",
+                or generate_tool_call_id(),
                 type="function",
                 function=FunctionCall(
                     name=tool_call.get("name", ""),
@@ -5738,7 +5739,7 @@ async def create_response(
                         arguments = tc.function.arguments
                     elif isinstance(tc, dict):
                         call_id = tc.get(
-                            "call_id", tc.get("id", f"call_{uuid.uuid4().hex[:8]}")
+                            "call_id", tc.get("id", generate_tool_call_id())
                         )
                         name = tc.get("name", "")
                         arguments = tc.get("arguments", "{}")
@@ -6273,7 +6274,7 @@ async def stream_responses_api(
                 arguments = tc.function.arguments
             elif isinstance(tc, dict):
                 call_id = tc.get(
-                    "call_id", tc.get("id", f"call_{uuid.uuid4().hex[:8]}")
+                    "call_id", tc.get("id", generate_tool_call_id())
                 )
                 name = tc.get("name", "")
                 arguments = tc.get("arguments", "{}")

--- a/tests/test_shared_models.py
+++ b/tests/test_shared_models.py
@@ -9,6 +9,7 @@ import pytest
 from omlx.api.shared_models import (
     IDPrefix,
     generate_id,
+    generate_tool_call_id,
     get_unix_timestamp,
     BaseUsage,
 )
@@ -243,3 +244,29 @@ class TestBaseUsage:
         data = usage.model_dump()
         assert data["input_tokens"] == 100
         assert data["output_tokens"] == 50
+
+
+class TestGenerateToolCallId:
+    """Tool-call ids must satisfy Mistral/tekken: exactly 9 alphanumeric chars."""
+
+    def test_length_is_nine(self):
+        assert len(generate_tool_call_id()) == 9
+
+    def test_matches_mistral_constraint(self):
+        # Mistral rejects any tool_call_id not matching [a-zA-Z0-9] of length 9.
+        for _ in range(1000):
+            tid = generate_tool_call_id()
+            assert len(tid) == 9
+            assert tid.isascii() and tid.isalnum()
+
+    def test_no_underscore(self):
+        # The legacy "call_<8hex>" form (underscore, length 13) is what broke.
+        assert "_" not in generate_tool_call_id()
+
+    def test_has_call_prefix(self):
+        assert generate_tool_call_id().startswith("call")
+
+    def test_ids_are_unique(self):
+        ids = {generate_tool_call_id() for _ in range(1000)}
+        # 16**5 ~= 1M space; collisions across 1000 draws are vanishingly rare.
+        assert len(ids) >= 995


### PR DESCRIPTION
Fixes #1995.

## Problem

omlx generates tool-call ids as `call_<8 hex>` (e.g. `call_49c89af0`). Mistral /
tekken (`MistralCommonBackend`) validates `tool_call_id` against `[a-zA-Z0-9]`
with a length of **exactly 9** and rejects anything else when the assistant turn
is replayed on the next request:

```
HTTP 500: Tool call id was call_49c89af0 but must be a-z, A-Z, 0-9,
with a length of 9
```

So the first turn works and the second 500s — on the id the server itself
generated. Every multi-turn tool loop with Devstral / Mistral-Small breaks.

## Fix

Centralize id creation in `shared_models.generate_tool_call_id()`:

```python
return f"call{uuid.uuid4().hex[:5]}"   # "call" + 5 hex = exactly 9 alphanumeric
```

Valid for Mistral and still an opaque, recognizable id for OpenAI / Anthropic
clients (which treat the id as opaque — nothing in the codebase matches on the
`call_` prefix). Replaces all **17** inline `f"call_{uuid.uuid4().hex[:8]}"`
sites across `tool_calling.py` (10), `server.py` (3), `anthropic_utils.py` (2)
and `responses_utils.py` (2), and drops the now-unused `uuid` import where it was
only used for ids.

## Tests

`tests/test_shared_models.py::TestGenerateToolCallId` — asserts the id is exactly
9 chars, matches `[a-zA-Z0-9]`, has no underscore, and is unique across many
draws.
