### PR TITLE
fix(admin): move chat action buttons below bubble to prevent cutoff (#1932)

### DIFF
--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -263,10 +263,12 @@
     .user-message {
         max-width: min(768px, 100%);
         align-self: flex-end;
+        padding-bottom: 32px;
     }
 
     .user-message.is-editing {
         width: min(768px, 100%);
+        padding-bottom: 0;
     }
 
     .user-message-bubble {
@@ -583,8 +585,10 @@
 
     .user-message-actions {
         position: absolute;
-        left: -96px;
-        top: 4px;
+        right: 0;
+        bottom: 0;
+        left: auto;
+        top: auto;
         display: flex;
         flex-direction: row;
         gap: 4px;
@@ -801,7 +805,8 @@
         }
 
         .user-message-actions {
-            left: -28px;
+            right: 0;
+            left: auto;
         }
 
         /* Prevent iOS auto-zoom on input focus (requires >= 16px) */


### PR DESCRIPTION
## Summary

The user-message action buttons (copy, edit, more) were absolutely positioned at `left: -96px`, i.e. in the empty margin to the **left** of the right-aligned chat bubble. On long prompts (>= 2 lines), narrow viewports, or with the chat history sidebar open, the bubble grows to fill the available width and that left margin disappears, so the buttons land **outside** `#messagesContainer`, where `overflow-x: hidden` clips them and makes them impossible to hover/click.

This adds a small reserved strip **below** the bubble and positions the buttons there (bottom-right), so they no longer depend on side margins and stay inside the scrollable chat container, clickable at any width, using the same "hover actions below the message" pattern found in other chat UIs (e.g. ChatGPT, Claude).

### Changes (`omlx/admin/templates/chat.html`, CSS only)
- `.user-message`: add `padding-bottom: 32px` to reserve a strip for the hover actions (and `padding-bottom: 0` while editing).
- `.user-message-actions`: reposition from `left: -96px; top: 4px` to `right: 0; bottom: 0` (with `left/top: auto`).
- Mobile `@media` override: stop pushing the buttons to `left: -28px`; keep them right-aligned.

No JavaScript or markup changes; the reserved strip prevents layout shift so the buttons just fade in on hover.

Fixes #1932.

## Screenshots

**Before**, on a narrow viewport with the sidebar open, the action buttons are clipped by the container and become inaccessible:

<img width="1552" height="982" alt="610426086-dfe6323b-8c5a-4621-b66e-0e23f4bdf05c" src="https://github.com/user-attachments/assets/0565fb09-31c3-4c46-912e-568f897a0656" />

**After**, the buttons now sit below the bubble (bottom-right) and stay fully visible at any width:

<img width="779" height="466" alt="Screenshot 2026-06-24 at 7 16 26 PM" src="https://github.com/user-attachments/assets/59417c20-f166-4415-9a15-4773bec8611e" />

## Test plan
- [x] Reproduced the bug: long prompt (>= 2 lines) with the sidebar open on a narrow window; the copy/edit/more buttons were clipped and unclickable.
- [x] After the fix: the buttons sit below the bubble and stay fully visible and clickable at every width tested (narrow, full screen, sidebar open or closed).
- [x] The "More actions" menu (Branch Here / Delete / Copy Markdown) still opens correctly.
- [x] CSS-only change: `git diff --check` clean, no linter errors, no JS / markup / Python behavior changed.


