### PR TITLE
fix(tool_calling): treat explicit json_schema=None as absent in JSON output paths

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -2071,7 +2071,7 @@ def parse_json_output(
 
     # json_schema - validate against schema
     if format_type == "json_schema":
-        json_schema_spec = rf_dict.get("json_schema", {})
+        json_schema_spec = rf_dict.get("json_schema") or {}
         schema = json_schema_spec.get("schema", {})
 
         if schema:
@@ -2128,7 +2128,7 @@ def build_json_system_prompt(
         )
 
     if format_type == "json_schema":
-        json_schema_spec = rf_dict.get("json_schema", {})
+        json_schema_spec = rf_dict.get("json_schema") or {}
         schema = json_schema_spec.get("schema", {})
         name = json_schema_spec.get("name", "response")
         description = json_schema_spec.get("description", "")

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -353,6 +353,44 @@ class TestParseJsonOutput:
         assert error is not None
         assert "validation failed" in error.lower()
 
+    def test_json_schema_format_explicit_none_schema(self):
+        """Explicit json_schema=None must behave like a missing key.
+
+        Regression test: clients may send
+        response_format={"type": "json_schema", "json_schema": null}; the
+        explicit null bypasses dict.get()'s default and previously raised
+        AttributeError ('NoneType' has no attribute 'get'). With no schema
+        available, the output is treated like json_object: extracted but
+        not validated.
+        """
+        text = '{"name": "John"}'
+        response_format = {"type": "json_schema", "json_schema": None}
+
+        cleaned, parsed, is_valid, error = parse_json_output(text, response_format)
+
+        assert cleaned == text
+        assert parsed == {"name": "John"}
+        assert is_valid is True
+        assert error is None
+
+    def test_json_schema_format_explicit_none_schema_wire_path(self):
+        """Explicit json_schema=None via the ResponseFormat object (real wire path).
+
+        A real client request arrives as a ResponseFormat, not a raw dict, so it
+        takes the isinstance branch, which sets rf_dict["json_schema"] to None.
+        The raw-dict test above skips that normalization, so this pins the
+        production path directly: it must degrade like a missing schema, not raise.
+        """
+        text = '{"name": "John"}'
+        response_format = ResponseFormat(type="json_schema", json_schema=None)
+
+        cleaned, parsed, is_valid, error = parse_json_output(text, response_format)
+
+        assert cleaned == text
+        assert parsed == {"name": "John"}
+        assert is_valid is True
+        assert error is None
+
     def test_json_schema_with_pydantic_model(self):
         """Test with ResponseFormat Pydantic model."""
         text = '{"message": "hello"}'
@@ -431,6 +469,34 @@ class TestBuildJsonSystemPrompt:
         assert result is not None
         assert "person" in result
         assert "A person object" in result
+
+    def test_json_schema_format_explicit_none_schema(self):
+        """Explicit json_schema=None must behave like a missing key.
+
+        Regression test: the explicit null bypasses dict.get()'s default
+        and previously raised AttributeError. The prompt falls back to the
+        default schema name 'response' with an empty schema.
+        """
+        response_format = {"type": "json_schema", "json_schema": None}
+
+        result = build_json_system_prompt(response_format)
+
+        assert result is not None
+        assert "response" in result
+
+    def test_json_schema_format_explicit_none_schema_wire_path(self):
+        """Explicit json_schema=None via the ResponseFormat object (real wire path).
+
+        A real client request arrives as a ResponseFormat whose isinstance branch
+        sets rf_dict["json_schema"] to None; the raw-dict test above skips that
+        normalization. Falls back to the default schema name 'response'.
+        """
+        response_format = ResponseFormat(type="json_schema", json_schema=None)
+
+        result = build_json_system_prompt(response_format)
+
+        assert result is not None
+        assert "response" in result
 
     def test_json_schema_format_with_pydantic(self):
         """Test with ResponseFormat Pydantic model."""


### PR DESCRIPTION
## Summary

`POST /v1/chat/completions` with `response_format={"type": "json_schema", "json_schema": null}` returns a 500. The explicit `null` is a natural wire shape — any client that always emits the `json_schema` field, or serializes an unset optional as `null`, produces it — and Pydantic accepts it (`ResponseFormat.json_schema` is `Optional[...] = None`, no 422), so the request reaches the handler and crashes.

## Root cause

`parse_json_output` reads the schema spec with a chained `.get()`:

```python
json_schema_spec = rf_dict.get("json_schema", {})   # key present → returns None, not {}
schema = json_schema_spec.get("schema", {})          # None.get(...) → AttributeError
```

Because the key **exists** (with value `null`), `dict.get("json_schema", {})` returns `None` rather than the `{}` default, and the next `.get("schema")` raises `AttributeError: 'NoneType' object has no attribute 'get'` → 500. The `ResponseFormat` normalization a few lines up *re-injects* this: it sets `rf_dict["json_schema"]` to a dict only when the inbound schema is truthy, otherwise leaves it `None` — so the object (wire) path and the raw-dict path both hit it.

## Fix

Coerce an explicit `null` to `{}` so it is handled exactly like a missing key — two single-token edits, in `parse_json_output` and `build_json_system_prompt`:

```python
-    json_schema_spec = rf_dict.get("json_schema", {})
+    json_schema_spec = rf_dict.get("json_schema") or {}
```

A null `json_schema` then degrades like "no schema provided": `parse_json_output` extracts the JSON without schema-validating (same as `json_object`), and `build_json_system_prompt` falls back to the default schema name `response`.

## Why degrade, not reject

The 500 is an *accidental* `AttributeError` over a chained `.get()`, not a deliberate validation guard — so this restores graceful handling rather than choosing to accept bad input. Degrading is also what the rest of the subsystem already does for a no-schema `json_schema`:

- `_response_format_requests_grammar` / `_build_format_element` (`server.py`) already treat a `json_schema` carrying no schema as mapping to nothing — it earns no grammar element and *must not even warn* (issue #1241, implemented via #1564). The grammar path's `_build_format_element` already guards this with `if js is not None`.
- #1564 (merged) deliberately **declined** to turn an unenforceable `response_format` into a 400, choosing to signal + return 200.

A 422/400 would reverse those decisions, and architecturally can't live in these leaf helpers (they return a 4-tuple / a `str`, not an HTTP response) — request-level validation already accepts `json_schema=null` by design. This patch simply makes the two crashing leaf readers consistent with the policy already in the tree.

## Scope (honest blast radius)

- **`parse_json_output`** — this is the live, externally-reproducible 500 (it's called on the chat-completions path gated only by `if response_format and not tool_calls`, both streaming and non-streaming).
- **`build_json_system_prompt`** — the identical unguarded pattern, fixed for symmetry. It is a public exported reader, but this exact input can't currently reach it: its `server.py:3218` call is gated by `_response_format_requests_grammar` (False for a no-schema `json_schema`), and its `server.py:5499` (`/v1/responses`) call reconstructs `json_schema` as a dict. Hardened to keep the two readers consistent, not because it crashes today.
- `rg` confirms these were the **only two** unguarded chained `json_schema` derefs in the tree.
- `or {}` only differs from `, {}` when the value is falsy, which was exactly the crashing case — every other `json_schema` value (a valid schema, an empty `{}`, a missing key) is byte-identical to before. Other falsy values (`false`, `0`, `""`, `[]`, reachable as raw dicts via the `Union`) likewise go from a 500 to the same graceful degrade; none was ever a useful result.

## Tests

Added to the existing `TestParseJsonOutput` / `TestBuildJsonSystemPrompt` classes in `tests/test_tool_calling.py`:

- `test_json_schema_format_explicit_none_schema` (×2) — the raw-dict wire shape `{"type": "json_schema", "json_schema": None}`.
- `test_json_schema_format_explicit_none_schema_wire_path` (×2) — the production object shape `ResponseFormat(type="json_schema", json_schema=None)`, exercising the `isinstance` normalization branch that sets `json_schema` to `None`.

All four are RED on `main` (`AttributeError` at the patched lines) and green with the fix; full `tests/test_tool_calling.py` is 234/234.

## Reproduction

```bash
curl -s http://127.0.0.1:8000/v1/chat/completions -H 'content-type: application/json' -d '{
  "model": "<any>",
  "messages": [{"role": "user", "content": "hi"}],
  "response_format": {"type": "json_schema", "json_schema": null}
}'
# before: 500 (AttributeError: 'NoneType' object has no attribute 'get')
# after:  200, best-effort JSON (degrades like a missing schema)
```
