### PR TITLE
Fix VLM engine teardown memory reclaim

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1598,11 +1598,24 @@ class VLMBatchedEngine(BaseEngine):
 
     async def stop(self) -> None:
         """Stop the engine and cleanup resources."""
-        if self._engine:
-            await self._engine.stop()
-            if hasattr(self._engine, "engine") and self._engine.engine is not None:
+        engine = self._engine
+
+        # Drop wrapper-side references before EngineCore.close() performs its
+        # final worker-thread MLX reclaim. Otherwise the VLM wrapper can keep
+        # model weights alive until after the reclaim pass has already run.
+        self._engine = None
+        self._vlm_model = None
+        self._processor = None
+        self._adapter = None
+        self._tokenizer = None
+        self._vlm_mtp_drafter = None
+        self._diffusion_family = None
+
+        if engine:
+            await engine.stop()
+            if hasattr(engine, "engine") and engine.engine is not None:
                 try:
-                    self._engine.engine.close()
+                    engine.engine.close()
                 except Exception as e:
                     logger.warning(f"Error closing engine: {e}")
         if self._vision_cache is not None:
@@ -1611,13 +1624,6 @@ class VLMBatchedEngine(BaseEngine):
         for cancel_event in getattr(self, "_diffusion_cancel_events", ()):
             cancel_event.set()
         self._diffusion_cancel_events = set()
-        self._engine = None
-        self._vlm_model = None
-        self._processor = None
-        self._adapter = None
-        self._tokenizer = None
-        self._vlm_mtp_drafter = None
-        self._diffusion_family = None
         self._diffusion_active_requests = 0
         self._loaded = False
         logger.info("VLMBatchedEngine stopped")

--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -14,6 +14,7 @@ The design follows vLLM's engine architecture adapted for MLX.
 
 import asyncio
 import concurrent.futures
+import gc
 import logging
 import os
 import time
@@ -38,7 +39,7 @@ from .exceptions import PrefillMemoryExceededError
 from .model_registry import get_registry
 from .output_collector import RequestOutputCollector, RequestStreamState
 from .request import Request, RequestOutput, SamplingParams
-from .scheduler import Scheduler, SchedulerConfig
+from .scheduler import Scheduler, SchedulerConfig, _sync_and_clear_cache
 from .utils.compile_cache import (
     clear_thread_compile_cache,
     compile_cache_clear_available,
@@ -76,6 +77,13 @@ _global_mlx_executor: concurrent.futures.ThreadPoolExecutor | None = None
 # these stay empty and the worker threads shut down normally.
 _immortal_mlx_executors: list = []
 _immortal_mlx_streams: list = []
+
+
+def _final_engine_thread_reclaim(stream: Any) -> None:
+    """Drop Python cycles and reclaim MLX buffers on the engine worker thread."""
+    gc.collect()
+    _sync_and_clear_cache(stream)
+    gc.collect()
 
 
 def _init_mlx_thread() -> None:
@@ -1043,6 +1051,10 @@ class EngineCore:
                     exc_info=True,
                 )
 
+        # Drop the last bound-method reference from the teardown loop before
+        # the final GC/reclaim pass below.
+        fn = None
+
         # Guarantee the SSD cache manager is released even if shutdown() did not
         # reach its own close() above. The manager's writer thread holds a strong
         # reference to it, so an unclosed manager leaks until restart.
@@ -1057,8 +1069,57 @@ class EngineCore:
                     exc_info=True,
                 )
             self.scheduler.paged_ssd_cache_manager = None
+        manager = None
+
+        # Clear output collectors before dropping model/scheduler references so
+        # any request-side caches they retain are eligible for the final reclaim.
+        for collector in self._output_collectors.values():
+            collector.clear()
+        self._output_collectors.clear()
+        self._stream_states.clear()
+        self._finished_events.clear()
+        self._finished_at.clear()
+
+        release_model_resources = getattr(self.model, "release_resources", None)
+        if callable(release_model_resources):
+            try:
+                release_model_resources()
+            except Exception:
+                logger.warning(
+                    "Engine %s: model resource release failed during close()",
+                    self._engine_id,
+                    exc_info=True,
+                )
+        release_model_resources = None
+
+        # Release model, tokenizer, and scheduler references before the final
+        # MLX reclaim. The reclaim must run on this engine's worker thread and
+        # stream; clearing on the global executor cannot reliably return this
+        # thread/stream-local Metal memory to MLX.
+        self.model = None
+        self.tokenizer = None
+        self.scheduler = None
 
         if self._mlx_executor is not None:
+            try:
+                self._mlx_executor.submit(
+                    _final_engine_thread_reclaim, self._mlx_stream
+                ).result(timeout=FATAL_TEARDOWN_TIMEOUT_S)
+            except concurrent.futures.TimeoutError:
+                fatal_exit(
+                    f"Engine teardown timed out after "
+                    f"{FATAL_TEARDOWN_TIMEOUT_S:.0f}s while reclaiming "
+                    f"MLX memory for engine {self._engine_id}"
+                )
+            except RuntimeError:
+                pass
+            except Exception:
+                logger.warning(
+                    "Engine %s: final MLX reclaim raised during close()",
+                    self._engine_id,
+                    exc_info=True,
+                )
+
             # MLX's @mx.compile cache is a C++ thread_local CompilerCache. If
             # this worker thread exits with a non-empty cache, ~CompilerCache
             # frees the cached graphs' Python objects from a thread-exit handler
@@ -1089,19 +1150,6 @@ class EngineCore:
                 _immortal_mlx_executors.append(self._mlx_executor)
                 _immortal_mlx_streams.append(self._mlx_stream)
             self._mlx_executor = None
-
-        # Clear output collectors
-        for collector in self._output_collectors.values():
-            collector.clear()
-        self._output_collectors.clear()
-        self._stream_states.clear()
-        self._finished_events.clear()
-        self._finished_at.clear()
-
-        # Release model and tokenizer references for GC
-        self.model = None
-        self.tokenizer = None
-        self.scheduler = None
 
         logger.debug(f"Engine {self._engine_id} closed")
 

--- a/omlx/models/vlm.py
+++ b/omlx/models/vlm.py
@@ -68,6 +68,15 @@ class VLMModelAdapter(nn.Module):
         self._uid_rope_deltas: Dict[int, float] = {}
         self._batch_rope_deltas: Optional[mx.array] = None
 
+    def release_resources(self) -> None:
+        """Drop references to VLM-owned MLX arrays before engine teardown reclaim."""
+        self._pending_embeds = None
+        self._pending_kwargs = {}
+        self._uid_rope_deltas.clear()
+        self._batch_rope_deltas = None
+        self._language_model = None
+        self._vlm_model = None
+
     @property
     def layers(self):
         """Expose language model layers for cache creation.

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -684,7 +684,12 @@ class TestEngineCoreClose:
             timeout_future = MagicMock()
             timeout_future.result.side_effect = concurrent.futures.TimeoutError
             executor = MagicMock()
-            executor.submit.side_effect = [ok_future, ok_future, timeout_future]
+            executor.submit.side_effect = [
+                ok_future,
+                ok_future,
+                ok_future,
+                timeout_future,
+            ]
             engine._mlx_executor = executor
 
             with (

--- a/tests/test_per_engine_threads.py
+++ b/tests/test_per_engine_threads.py
@@ -157,15 +157,32 @@ class TestPerEngineExecutor:
 
         with patch("omlx.engine_core.get_registry") as mock_registry, patch(
             "omlx.engine_core.compile_cache_clear_available", return_value=True
-        ), patch("omlx.engine_core.clear_thread_compile_cache") as mock_clear:
+        ), patch("omlx.engine_core.clear_thread_compile_cache") as mock_clear, patch(
+            "omlx.engine_core._final_engine_thread_reclaim"
+        ) as mock_reclaim:
             mock_registry.return_value.acquire.return_value = True
 
             engine = EngineCore(mock_model, mock_tokenizer)
             executor = engine._mlx_executor
+            events = []
+
+            def reclaim_side_effect(_stream):
+                events.append("reclaim")
+                assert engine.model is None
+                assert engine.tokenizer is None
+                assert engine.scheduler is None
+
+            mock_model.release_resources.side_effect = lambda: events.append("release")
+            mock_reclaim.side_effect = reclaim_side_effect
+            mock_clear.side_effect = lambda: events.append("compile")
             engine.close()
 
-            # Cache cleared on the worker thread, then thread shut down.
+            # Memory is reclaimed after dropping engine refs, then the compile
+            # cache is cleared on the worker thread before thread shutdown.
+            mock_model.release_resources.assert_called_once_with()
+            mock_reclaim.assert_called_once_with(engine._mlx_stream)
             mock_clear.assert_called()
+            assert events == ["release", "reclaim", "compile"]
             assert engine._mlx_executor is None
             assert executor._shutdown
             assert executor not in ec._immortal_mlx_executors

--- a/tests/test_vlm_model_adapter.py
+++ b/tests/test_vlm_model_adapter.py
@@ -55,6 +55,26 @@ class TestVLMModelAdapter:
         assert adapter._pending_embeds is None
         assert adapter._embed_offset == 0
 
+    def test_release_resources_drops_model_references(self):
+        """release_resources drops raw VLM/language model and pending arrays."""
+        from omlx.models.vlm import VLMModelAdapter
+
+        vlm = self._make_mock_vlm_model()
+        adapter = VLMModelAdapter(vlm)
+        adapter._pending_embeds = MockMXArray()
+        adapter._pending_kwargs = {"position_ids": MockMXArray()}
+        adapter._uid_rope_deltas[1] = 2.0
+        adapter._batch_rope_deltas = MockMXArray()
+
+        adapter.release_resources()
+
+        assert adapter._vlm_model is None
+        assert adapter._language_model is None
+        assert adapter._pending_embeds is None
+        assert adapter._pending_kwargs == {}
+        assert adapter._uid_rope_deltas == {}
+        assert adapter._batch_rope_deltas is None
+
     def test_layers_property(self):
         """Test layers property delegates to language_model.model.layers."""
         from omlx.models.vlm import VLMModelAdapter


### PR DESCRIPTION
## Summary
- release VLM wrapper/model references before the final EngineCore teardown reclaim
- add a final worker-thread MLX reclaim after dropping engine-owned model/tokenizer/scheduler references
- clear VLM adapter-owned pending arrays and raw model references during teardown

Fixes #2004

Related reproduction: #1691, specifically https://github.com/jundot/omlx/issues/1691#issuecomment-4809293896

## Problem analysis
The related #1691 comment shows the same class of retained Metal memory on oMLX 0.4.4 after a successful long-context completion, not only after a failed prefill or mid-stream fallback. In that run, oMLX reported no active or waiting requests, unloaded every real model, and `POST /admin/api/hot-cache/clear` reclaimed 0 bytes, while `vmmap -summary` still showed tens of GB of `IOAccelerator (graphics)` memory. Restarting the Python/oMLX process released it.

That points to process-lifetime MLX/Metal allocations surviving engine teardown after the request/model state is no longer visible through model accounting, request status, or the hot-cache admin surface. This patch narrows the fix to normal teardown mechanics: drop VLM wrapper/adapter references and then perform the final MLX reclaim on the same engine worker thread/stream before shutting down the executor.

## Tests
- `.venv/bin/python -m pytest tests/test_per_engine_threads.py::TestPerEngineExecutor::test_close_clears_compile_cache_then_shuts_down tests/test_engine_core.py::TestEngineCoreClose tests/test_vlm_model_adapter.py::TestVLMModelAdapter::test_release_resources_drops_model_references -q`
- `.venv/bin/python -m pytest tests/test_vlm_engine.py::TestStopSafety -q`