### PR TITLE
fix(model_discovery): warn + skip on duplicate model_id instead of silent overwrite

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -1052,6 +1052,12 @@ def _register_model(
     source_repo_id: str | None = None,
 ) -> None:
     """Try to register a single model directory into the models dict."""
+    if model_id in models:
+        logger.warning(
+            f"Duplicate model_id '{model_id}' found in {model_dir}, "
+            f"keeping version from {models[model_id].model_path}"
+        )
+        return
     try:
         if _is_unsupported_model(model_dir):
             logger.info(f"Skipping unsupported model: {model_id}")

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -2,6 +2,7 @@
 """Tests for model discovery functionality."""
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,7 @@ from omlx.model_discovery import (
     _is_adapter_dir,
     _is_unsupported_model,
     _read_model_context_length,
+    _register_model,
     _resolve_hf_cache_entry,
     detect_model_type,
     discover_models,
@@ -655,6 +657,35 @@ class TestDiscoverModels:
         assert "llama-3b" in models
         assert models["llama-3b"].model_type == "llm"
         assert models["llama-3b"].engine_type == "batched"
+
+    def test_register_model_skips_duplicate_id(self, tmp_path, caplog):
+        """Collision guard: a second model with an already-registered model_id is
+        skipped (first registration kept), not silently overwritten, and the
+        collision is logged naming both the kept and the skipped path."""
+        # A real, registerable model dir — without the guard this WOULD overwrite.
+        second = tmp_path / "dup"
+        second.mkdir()
+        (second / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        (second / "model.safetensors").write_bytes(b"0" * 1000)
+
+        original = DiscoveredModel(
+            model_id="dup",
+            model_path="/first/dup",
+            model_type="llm",
+            engine_type="batched",
+            estimated_size=123,
+        )
+        models = {"dup": original}
+        with caplog.at_level(logging.WARNING):
+            _register_model(models, second, "dup")
+
+        # Guard kept the first registration rather than overwriting it.
+        assert models["dup"] is original
+        assert models["dup"].model_path == "/first/dup"
+        # ...and surfaced the collision, naming both the kept and the skipped path.
+        assert "Duplicate model_id 'dup'" in caplog.text
+        assert "/first/dup" in caplog.text
+        assert str(second) in caplog.text
 
     def test_discover_model_dir_is_itself_a_model(self, tmp_path):
         """Test that pointing directly at a model directory works."""


### PR DESCRIPTION
## Summary

When two model directories under a served dir resolve to the same bare `model_id`, `_register_model` silently overwrote the earlier registration — so which model actually serves under that id was decided by scan position, with nothing logged. The common trigger is the same model published under two orgs: a flat `served/Qwen3-8B` alongside an org-folder child `served/mlx-community/Qwen3-8B` both register as `Qwen3-8B`, and one silently shadows the other.

## Root cause

`_register_model` (`model_discovery.py`) takes the bare leaf name as the id at every call site — `_register_model(models, subdir, subdir.name)` for a flat dir, `_register_model(models, child, child.name)` for an org-folder child — and ends with an unconditional `models[model_id] = DiscoveredModel(...)`. With no collision check, a second registration replaces the first with no signal.

(The directory scan is `sorted()`, so the outcome is stable run-to-run — this is silent *shadowing*, not nondeterminism. The surprising part is that a nested org-child can replace a top-level model the operator placed deliberately, and nothing says so.)

## Fix

Guard at the top of `_register_model`: if the `model_id` is already registered, log a warning naming both colliding paths and keep the first registration.

```python
if model_id in models:
    logger.warning(
        f"Duplicate model_id '{model_id}' found in {model_dir}, "
        f"keeping version from {models[model_id].model_path}"
    )
    return
```

This mirrors the rule `discover_models_from_dirs` already applies to **cross-directory** `model_id` conflicts (warn + keep the earlier directory's model). The PR closes the within-directory gap that precedent left open. The warning message matches the sibling's phrasing.

The survivor is the first entry in the sorted directory scan (`sorted(iterdir())`) — deterministic run-to-run, but ordered **by name, not by flat-vs-nested layout**. In the `Qwen3-8B` example the flat dir wins only because `Q` sorts before `mlx-community`; a lowercase flat name vs an uppercase org folder would flip the winner.

## Why warn + keep-first (not fail-fatal or last-wins)

- **Consistency** — `discover_models_from_dirs` already treats a same-`model_id` collision as an expected condition resolved by warn + keep-earlier; this makes the single-scan case behave the same way.
- **fail-fatal would be user-hostile** — a single benign bare-name collision (the very common "same model from two orgs" layout) would abort the entire discovery scan and refuse to serve *all* models. Discovery runs at startup / admin refresh, so crashing it is the wrong trade.
- **last-wins + warn** would keep the surprising winner and merely annotate it; since both keep-first and keep-last are "deterministic but arbitrary," consistency with the existing keep-first convention is the tie-breaker.

## Scope (honest blast radius)

- `_register_model` is the **sole** `DiscoveredModel` construction + dict-write site; all callers (flat, HF-cache, org-child, single-dir fallback) pass the same `models` dict, so the guard sees every prior registration in a scan.
- The `models` dict is **ephemeral per scan** (freshly built each `discover_models` call); the guard never touches persisted serving state (`EnginePool`), so it does not interfere with rescans or metadata refreshes.
- **Behavior change to call out** — for a layout that currently collides, this flips which model serves (the first registration in the sorted scan now wins instead of the last). The warning names both paths so the change is visible in the logs.
- Out of scope — `admin/routes.py::list_hf_models` has a parallel UI-only listing dedup; it never writes the serving registry, so it is untouched here.

## Tests

`tests/test_model_discovery.py::test_register_model_skips_duplicate_id` — pre-seeds a `model_id`, registers a second **valid** model dir under it, and asserts the first registration survives (RED without the guard: the second model overwrites) and that the warning is logged naming both the kept and the skipped path.

## Related

**#1188 (model directory & naming conventions).** The maintainer confirmed there that discovery already accepts `{owner}/{model}` subfolders, but the HF/ModelScope downloaders used to strip the org prefix and write flat — and has since fixed them to preserve the full path (`admin/hf_downloader.py` now writes `<model_dir>/<owner>/<model>`). That nesting is exactly what lets a freshly-downloaded `mlx-community/Qwen3-8B` collide on the bare leaf name with a legacy flat `Qwen3-8B`. This PR is the downstream safety net that makes that collision visible and deterministic; it does not change the directory convention or the bare-name id scheme.

**#1661 (display the org prefix in the model list)** is the user-visible motivation — its reporter notes correlation "works as long as we do not have duplicate names", and the duplicate case is exactly where it breaks.

**Non-goals.** This does not make two *distinct* same-named models both servable (the second is now skipped *loudly* rather than silently — both-servable would need org-qualified ids, a compat-breaking change), and it does not add the org-prefix *display* that #1661 asks for. It strictly turns a silent shadow into a visible, deterministic one.
