### PR TITLE
fix(loader): retry weight load with strict=False on mismatch (GLM-5.2)

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -232,6 +232,8 @@ class BatchedEngine(BaseEngine):
         from ..engine_core import AsyncEngineCore, EngineConfig
         from ..scheduler import SchedulerConfig
         from ..utils.model_loading import (
+            force_non_strict_weight_load,
+            is_weight_mismatch_error,
             maybe_apply_pre_load_patches,
             maybe_load_custom_quantization,
         )
@@ -263,11 +265,32 @@ class BatchedEngine(BaseEngine):
                 model, processor = custom_loaded
                 return model, getattr(processor, "tokenizer", processor)
 
-            return load(
-                self._model_name,
-                tokenizer_config=tokenizer_config,
-                trust_remote_code=self._trust_remote_code,
-            )
+            try:
+                return load(
+                    self._model_name,
+                    tokenizer_config=tokenizer_config,
+                    trust_remote_code=self._trust_remote_code,
+                )
+            except ValueError as exc:
+                # mlx-lm loads weights with strict=True and raises
+                # "Missing N parameters" when a checkpoint legitimately omits
+                # tied/optional weights (mlx nn.Module.load_weights). load()
+                # doesn't expose `strict`, so retry once forcing strict=False
+                # to skip the unmatched weights (mirrors the TTS engine).
+                if not is_weight_mismatch_error(exc):
+                    raise
+                logger.warning(
+                    "Strict weight loading failed for %s; retrying with "
+                    "strict=False so unmatched weights are skipped: %s",
+                    self._model_name,
+                    exc,
+                )
+                with force_non_strict_weight_load():
+                    return load(
+                        self._model_name,
+                        tokenizer_config=tokenizer_config,
+                        trust_remote_code=self._trust_remote_code,
+                    )
 
         loop = asyncio.get_running_loop()
         self._model, self._tokenizer = await loop.run_in_executor(

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 from pathlib import Path
@@ -16,6 +17,54 @@ logger = logging.getLogger(__name__)
 _VLM_TEXT_PREFIX = "language_model."
 
 _MLX_LM_LOAD_CONFIG_PATCHED = False
+
+
+def is_weight_mismatch_error(exc: BaseException) -> bool:
+    """True iff ``exc`` is an mlx strict weight-load mismatch.
+
+    mlx's ``nn.Module.load_weights(..., strict=True)`` raises ``ValueError``
+    for three mismatch shapes (see ``mlx/nn/layers/base.py``):
+
+    - ``"Missing N parameters: ..."``        — checkpoint omits model weights
+    - ``"Received N parameters not in model"`` — checkpoint has extra weights
+    - ``"Expected shape ... but received ..."`` — a weight has the wrong shape
+
+    All three are skipped when the same load runs with ``strict=False``.
+    """
+    if not isinstance(exc, ValueError):
+        return False
+    msg = str(exc)
+    return (
+        ("Missing" in msg and "parameters" in msg)
+        or "parameters not in model" in msg
+        or "Expected shape" in msg
+    )
+
+
+@contextlib.contextmanager
+def force_non_strict_weight_load():
+    """Force mlx-lm's ``load_model`` to skip unmatched weights for one load.
+
+    ``mlx_lm.load()`` does not expose ``strict``, and ``load_model`` defaults
+    to ``strict=True`` (``mlx_lm/utils.py``), so some converted/quantized
+    checkpoints that legitimately omit tied or optional weights crash with
+    ``"Missing N parameters"``. Wrapping the *current* ``load_model`` to force
+    ``strict=False`` lets those weights be skipped. Because it wraps whatever
+    ``load_model`` is bound at enter time, it composes with the other
+    ``load_model`` patches (e.g. DeepSeek V4). Restores the original on exit.
+    """
+    import mlx_lm.utils as _lu
+
+    original = _lu.load_model
+
+    def _non_strict(model_path, lazy=False, strict=True, **kwargs):
+        return original(model_path, lazy, strict=False, **kwargs)
+
+    _lu.load_model = _non_strict
+    try:
+        yield
+    finally:
+        _lu.load_model = original
 
 
 def expand_per_layer_quant_keys(cfg: dict) -> dict:

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -9,6 +9,8 @@ import pytest
 
 from omlx.utils import model_loading
 from omlx.utils.model_loading import (
+    force_non_strict_weight_load,
+    is_weight_mismatch_error,
     maybe_apply_pre_load_patches,
     maybe_load_custom_quantization,
 )
@@ -487,3 +489,67 @@ class TestCheckpointHasMtpWeights:
         )
 
         assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is True
+
+
+class TestWeightMismatchError:
+    """is_weight_mismatch_error() recognizes mlx's strict-load failures."""
+
+    def test_missing_parameters(self):
+        # The exact message mlx raises from nn.Module.load_weights.
+        exc = ValueError("Missing 285 parameters: \nfoo.bar,\nbaz.qux")
+        assert is_weight_mismatch_error(exc) is True
+
+    def test_extra_parameters_not_in_model(self):
+        exc = ValueError("Received 3 parameters not in model: \nx,\ny,\nz")
+        assert is_weight_mismatch_error(exc) is True
+
+    def test_shape_mismatch(self):
+        exc = ValueError(
+            "Expected shape (4,) but received shape (8,) for parameter w"
+        )
+        assert is_weight_mismatch_error(exc) is True
+
+    def test_unrelated_value_error_is_not_mismatch(self):
+        assert is_weight_mismatch_error(ValueError("Model type x not found")) is False
+
+    def test_non_value_error_is_not_mismatch(self):
+        # Must be a ValueError specifically; a RuntimeError with similar text
+        # should not be swallowed by the non-strict retry.
+        assert is_weight_mismatch_error(RuntimeError("Missing 285 parameters")) is False
+
+
+class TestForceNonStrictWeightLoad:
+    """force_non_strict_weight_load() forces strict=False and restores."""
+
+    def test_forces_strict_false_and_restores(self, monkeypatch):
+        import mlx_lm.utils as mlx_utils
+
+        captured = {}
+
+        def fake_load_model(model_path, lazy=False, strict=True, **kwargs):
+            captured["strict"] = strict
+            captured["kwargs"] = kwargs
+            return ("model", "config")
+
+        monkeypatch.setattr(mlx_utils, "load_model", fake_load_model)
+
+        with force_non_strict_weight_load():
+            # Wrapped: caller's strict=True default is overridden to False,
+            # and other kwargs (model_config) pass through untouched.
+            assert mlx_utils.load_model is not fake_load_model
+            result = mlx_utils.load_model("/path", False, model_config={"a": 1})
+
+        assert result == ("model", "config")
+        assert captured["strict"] is False
+        assert captured["kwargs"] == {"model_config": {"a": 1}}
+        # Original restored on exit.
+        assert mlx_utils.load_model is fake_load_model
+
+    def test_restores_on_exception(self, monkeypatch):
+        import mlx_lm.utils as mlx_utils
+
+        sentinel = mlx_utils.load_model
+        with pytest.raises(RuntimeError):
+            with force_non_strict_weight_load():
+                raise RuntimeError("boom")
+        assert mlx_utils.load_model is sentinel


### PR DESCRIPTION
## Problem
mlx-lm's `load()` loads weights with `strict=True` and raises `ValueError`
("Missing N parameters", "Received N parameters not in model", or
"Expected shape ...") for checkpoints that legitimately omit or add weights.

GLM-5.2 (`glm_moe_dsa`) is the motivating case: its DSA indexer sub-module
exists only on the `full` attention layers, but stock mlx-lm builds an indexer
for every layer, so every faithful quant aborts on load with
"Missing N parameters" for the `shared` layers. (Related: ml-explore/mlx-lm#879.)

## Fix
- `is_weight_mismatch_error()` — detects the three mlx strict-load mismatch shapes.
- `force_non_strict_weight_load()` — context manager that wraps the *current*
  `mlx_lm.utils.load_model` to force `strict=False`, composing with other
  load_model patches (e.g. DeepSeek V4) and restoring the original on exit.
- `BatchedEngine` retries the load once with strict=False when the strict load
  raises a weight-mismatch `ValueError`. The unmatched modules are never invoked
  at inference, so output is unaffected.

## Tests
`tests/test_model_loading.py` — 34 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
