### PR TITLE
fix(engine_pool): stop false 507s on back-to-back large-model swaps

### DIFF
--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -745,23 +745,53 @@ class EnginePool:
                         )
                         await self._unload_engine(victim)
                         continue
-                    # Nothing else to evict -- model cannot fit. Use
-                    # ModelTooLargeError when the model alone exceeds the
-                    # ceiling (no chance of fitting), InsufficientMemoryError
-                    # when the model would fit on a clean process but the
-                    # current usage leaves no room.
+                    # Nothing else to evict. Before failing, re-test against
+                    # the *tracked committed* baseline. The phys_footprint term
+                    # folded into `current` is the macOS kernel ledger, which
+                    # still counts reclaimable residue from models we just
+                    # evicted -- dirty file-backed (mmap'd weight) and
+                    # IOAccelerator pages the kernel has not reaped yet but
+                    # drops under allocation pressure (jetsam reclaims them
+                    # before OOM-killing). That residue caused false 507s on
+                    # back-to-back large-model swaps: eviction settled (both
+                    # mx.get_active_memory() and _current_model_memory dropped)
+                    # yet phys_footprint lagged hundreds of GB high, so a model
+                    # that fits cleanly on its own was rejected. The pool's
+                    # tracked accumulator excludes that residue, so once there
+                    # is nothing left to evict, trust it. Pinned/in-use models
+                    # that could not be evicted remain counted in
+                    # _current_model_memory, so this never over-admits past
+                    # genuinely committed memory (see #1623).
+                    committed = max(
+                        mx.get_active_memory(), self._current_model_memory
+                    )
+                    committed_projected = committed + entry.estimated_size
+                    if committed_projected <= ceiling:
+                        logger.info(
+                            f"Admitting '{model_id}': committed baseline "
+                            f"{format_size(committed_projected)} fits ceiling "
+                            f"{format_size(ceiling)} "
+                            f"(live footprint {format_size(projected)} included "
+                            "reclaimable residue from evicted models)"
+                        )
+                        break
+
+                    # Still over budget even discounting reclaimable residue --
+                    # a genuine shortfall. Use ModelTooLargeError when the model
+                    # alone exceeds the ceiling (no chance of fitting),
+                    # InsufficientMemoryError when committed usage leaves no room.
                     if entry.estimated_size > ceiling:
                         raise ModelTooLargeError(
                             model_id, entry.estimated_size, ceiling
                         )
                     raise InsufficientMemoryError(
                         required=entry.estimated_size,
-                        current=current,
+                        current=committed,
                         message=(
                             f"Cannot load {model_id}: projected memory "
-                            f"{format_size(projected)} would exceed the memory "
-                            f"ceiling {format_size(ceiling)} "
-                            f"(current: {format_size(current)}, "
+                            f"{format_size(committed_projected)} would exceed "
+                            f"the memory ceiling {format_size(ceiling)} "
+                            f"(committed: {format_size(committed)}, "
                             f"model: {format_size(entry.estimated_size)}). "
                             "Free system memory or lower memory_guard_tier."
                         ),

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -1246,6 +1246,72 @@ class TestEnginePoolEviction:
         assert pool._entries["model-b"].engine is not None
         assert pool.loaded_model_count == 1
 
+    @pytest.fixture
+    def residue_memory_pool(self, small_mock_model_dir, monkeypatch):
+        """Pool where phys_footprint lags high after an eviction.
+
+        Reproduces the false-507-on-swap bug: the macOS phys_footprint ledger
+        still counts reclaimable residue (dirty file-backed / IOAccelerator
+        pages from a just-evicted model) that the kernel has not yet reaped,
+        while both `mx.get_active_memory()` and the tracked accumulator
+        (`_current_model_memory`) have already dropped. We model that as a
+        high-water mark that never falls on its own.
+        """
+        pool = _make_pool(ceiling=2500)  # each model fits alone, not both
+        pool.discover_models(str(small_mock_model_dir))
+        hwm = {"v": 0}
+
+        def lagging_footprint():
+            hwm["v"] = max(hwm["v"], pool._current_model_memory)
+            return hwm["v"]
+
+        monkeypatch.setattr(
+            "omlx.engine_pool.get_phys_footprint", lagging_footprint
+        )
+        monkeypatch.setattr("omlx.engine_pool.mx.get_active_memory", lambda: 0)
+        return pool
+
+    @pytest.mark.asyncio
+    async def test_swap_admits_when_footprint_lags_after_eviction(
+        self, residue_memory_pool
+    ):
+        """A model that fits cleanly must load after eviction even when
+        phys_footprint still reflects the evicted model's reclaimable residue.
+
+        Without the committed-baseline recheck, admission sees
+        `current = max(0, lagging_footprint, 0)` still pinned at the evicted
+        model's size, projects past the ceiling with nothing left to evict, and
+        wrongly raises InsufficientMemoryError (the 507 on swap).
+        """
+        pool = residue_memory_pool
+
+        mock_engine_a = MagicMock()
+        mock_engine_a.start = AsyncMock()
+        mock_engine_a.stop = AsyncMock()
+        mock_engine_a.has_active_requests.return_value = False
+
+        mock_engine_b = MagicMock()
+        mock_engine_b.start = AsyncMock()
+        mock_engine_b.has_active_requests.return_value = False
+
+        def create_engine(*args, **kwargs):
+            if "model-a" in str(kwargs.get("model_name", args[0] if args else "")):
+                return mock_engine_a
+            return mock_engine_b
+
+        with patch("omlx.engine_pool.BatchedEngine", side_effect=create_engine):
+            await pool.get_engine("model-a")
+            assert pool.loaded_model_count == 1
+
+            # Swap to model-b: model-a is evicted, but phys_footprint still
+            # reports model-a's residue. model-b fits alone, so it must load.
+            await pool.get_engine("model-b")
+
+        mock_engine_a.stop.assert_called_once()
+        assert pool._entries["model-a"].engine is None
+        assert pool._entries["model-b"].engine is not None
+        assert pool.loaded_model_count == 1
+
     @pytest.mark.asyncio
     async def test_insufficient_memory_all_pinned(self, tight_memory_pool):
         """Test InsufficientMemoryError when all models are pinned."""


### PR DESCRIPTION
## Problem
Pre-load admission baselines on
`max(active_memory, get_phys_footprint(), _current_model_memory)`.
`phys_footprint` is the macOS kernel ledger, which keeps counting reclaimable
residue (dirty file-backed mmap'd weight pages and IOAccelerator allocations)
from a model that was just evicted until the kernel reaps it under pressure.

On a swap between two large models this inflated the baseline by hundreds of GB
even though the eviction had settled (both `active_memory` and
`_current_model_memory` dropped), so the incoming model was rejected with **507**
despite fitting cleanly.

## Fix
When eviction has exhausted every evictable model and admission is about to
fail, re-test against the tracked committed baseline
`max(active_memory, _current_model_memory)` — which excludes the reclaimable
residue — and admit if the model fits. Pinned / in-use models stay counted in
`_current_model_memory`, so this never over-admits past genuinely committed
memory (preserves the #1623 undercount guard).

## Tests
`tests/test_engine_pool.py` — 96 passing, incl. new regression
`test_swap_admits_when_footprint_lags_after_eviction` (fails without the fix,
passes with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
