### PR TITLE
fix(build): pin nanobind==2.12.0 to match MLX 0.31.2 ABI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,12 @@ requires = [
     "setuptools>=61.0",
     "wheel",
     "cmake>=3.27",
-    "nanobind",
+    # Pin nanobind to match the ABI version MLX 0.31.2 was built with
+    # (MLX pins nanobind v2.12.0 / ABI v19 via FetchContent in its CMakeLists.txt).
+    # A newer nanobind (e.g. 2.13.0 / ABI v20) isolates the `mlx` NB_DOMAIN, so
+    # custom kernel extensions (omlx.custom_kernels.*) reject every mlx.core.array
+    # at the type caster with `incompatible function arguments`.
+    "nanobind==2.12.0",
     "mlx==0.31.2",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Problem

Building oMLX from source with `OMLX_WITH_CUSTOM_KERNEL=1` against MLX 0.31.2 produces native kernel extensions (`omlx.custom_kernels.glm_moe_dsa._ext`, `omlx.custom_kernels.minimax_m3._ext`) whose `mlx.core.array` type casters reject **every** `mx.array` argument at call time:

```
TypeError: dsa_indexer_scores(): incompatible function arguments.
Invoked with types: mlx.core.array, mlx.core.array, mlx.core.array, bool, int, bool, int
```

This makes the native GLM-5.2 DSA kernels from #1984 completely unusable (and there is no `mx.fast.dsa_indexer_scores` fallback), so local GLM-5.2 inference fails on every prefill/decode step. The same caster rejection hits all six native symbols (`dsa_indexer_scores`, `dsa_topk_indices`, `glm_dsa_sparse_mla_attention`, `glm_dsa_exact_block_attention`, `glm_dsa_q8_vup_flat`, `glm_moe_weighted_sum`).

## Root cause

A **nanobind ABI-version skew** between `mlx.core` and the custom-kernel `_ext`:

- MLX 0.31.2's wheel is built with **nanobind v2.12.0 (ABI v19)** — MLX pins it via `FetchContent_Declare(nanobind ... GIT_TAG v2.12.0)` in its root `CMakeLists.txt` (https://github.com/ml-explore/mlx/blob/v0.31.2/CMakeLists.txt).
- oMLX's `pyproject.toml` declares **unpinned `nanobind`**, so the build resolves pip's latest (**2.13.0 / ABI v20**, released 2026-06-18).
- The custom-kernel extensions use `NB_DOMAIN mlx` to share `mlx.core.array`/`mlx.core.Stream` casters with `mlx.core`. nanobind's docs are explicit: *"both modules must use the same nanobind ABI version, or they will be isolated from each other."* ABI v19 vs v20 isolates the `mlx` domain, so `_ext`'s array caster cannot see `mlx.core`'s `array` type and rejects all `mx.array` arguments — even a minimal 3-arg call `_ext.dsa_indexer_scores(q, k, w)` with plain float32 arrays fails, while `mlx.core`'s own bindings accept the same arrays fine.

Direct evidence of the skew in the compiled binaries: `mlx.core.so` contains `nanobind.nb_type_%zu` / `nanobind.nb_ndarray`, while an `_ext.so` built with 2.13.0 contains `nanobind.nb_type`.

## Fix

Pin the build dependency to `nanobind==2.12.0` so any source build against MLX 0.31.2 produces an ABI-compatible extension. This matches the version MLX itself uses for its 0.31.2 release.

## Verification

Built and tested end-to-end on Apple Silicon (MLX 0.31.2, omlx 0.4.5.dev1):

- With the pin, the build resolves `Selecting: nanobind==2.12.0` (was `2.13.0` before).
- `_ext.dsa_indexer_scores(q, k, w)` now executes the kernel's own shape validation instead of rejecting `mx.array` at the caster; a second symbol (`glm_dsa_q8_vup_flat`) likewise binds — confirming the ABI fix is global across all native symbols.
- Live `POST /v1/chat/completions` to `GLM-5.2-mxfp4` (371 GB loaded, native DSA kernels active) succeeds for **both streaming and non-streaming**, with zero `incompatible function arguments` / `TypeError` / engine-loop errors in the server log. `GLM MoE DSA native kernels available` is logged at model load.

## Notes

- The pin should track MLX's `FetchContent` nanobind tag whenever MLX is bumped. When oMLX moves to a future MLX release built with a newer nanobind, this pin needs to move with it.
- `uv tool install --build-constraints` did **not** reliably constrain nanobind for this case (uv still selected 2.13.0); pinning in `build-system.requires` is the reliable path, which is what this PR does.
