### PR TITLE
Fix spaCy model wheel install

### DIFF
--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -85,8 +85,11 @@ class Omlx < Formula
     end
 
     # Install the spaCy English model required by misaki for Kokoro TTS.
-    system libexec/"bin/pip", "install", "--no-deps",
-           resource("en-core-web-sm").cached_download
+    spacy_resource = resource("en-core-web-sm")
+    spacy_wheel = buildpath/File.basename(spacy_resource.url)
+    spacy_resource.fetch unless spacy_resource.downloaded?
+    cp spacy_resource.cached_download, spacy_wheel
+    system libexec/"bin/pip", "install", "--no-deps", spacy_wheel
     system libexec/"bin/python", "-c",
            "import spacy; spacy.load('en_core_web_sm')"
 


### PR DESCRIPTION
- The Homebrew formula currently passes the cached `en-core-web-sm` resource path directly to `pip install`.
- That can fail because Homebrew stores downloaded resources with cache-prefixed filenames.
- `pip` validates wheel filenames before installing them, so it rejects that cache filename even though the downloaded wheel itself is valid.
- This change copies the resource into the build directory using the original wheel filename from the resource URL, then installs that copy.
- It also fetches the resource first if it is not already present in Homebrew's cache.