### PR TITLE
fix(server): keep chat stream reasoning out of content

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -4166,7 +4166,20 @@ async def stream_chat_completion(
     last_output = None
     accumulated_text = ""
     has_tools = bool(kwargs.get("tools"))
-    thinking_parser = ThinkingParser()
+    start_in_thinking = False
+    try:
+        tokenizer = getattr(engine, "tokenizer", None)
+        if tokenizer is not None:
+            template_kwargs = {"tokenize": False, "add_generation_prompt": True}
+            if kwargs.get("tools"):
+                template_kwargs["tools"] = kwargs["tools"]
+            if kwargs.get("chat_template_kwargs"):
+                template_kwargs.update(kwargs["chat_template_kwargs"])
+            prompt = tokenizer.apply_chat_template(messages, **template_kwargs)
+            start_in_thinking, _ = prompt_opens_thinking(tokenizer, prompt)
+    except Exception as exc:
+        logger.debug("Could not detect chat stream thinking state: %s", exc)
+    thinking_parser = ThinkingParser(start_in_thinking=start_in_thinking)
 
     # Reuse the id pre-minted by the caller (so the keepalive frame can share
     # it); otherwise mint one for direct/non-streaming callers.

--- a/tests/integration/test_e2e_streaming.py
+++ b/tests/integration/test_e2e_streaming.py
@@ -553,6 +553,90 @@ class TestStreamingHelperFunctions:
         assert data["choices"][0]["delta"].get("role") == "assistant"
 
     @pytest.mark.asyncio
+    async def test_stream_chat_completion_prompt_opened_thinking_streams_as_reasoning(self):
+        """If the rendered prompt opens <think>, initial deltas are reasoning."""
+        from omlx.server import stream_chat_completion
+        from omlx.api.openai_models import ChatCompletionRequest, Message
+
+        class PromptOpenedThinkingTokenizer(MockTokenizer):
+            think_start = "<think>"
+            think_end = "</think>"
+            think_start_id = 999
+            think_end_id = 998
+            unk_token_id = -1
+
+            def convert_tokens_to_ids(self, token: str):
+                if token == self.think_start:
+                    return self.think_start_id
+                if token == self.think_end:
+                    return self.think_end_id
+                return self.unk_token_id
+
+            def encode(self, text: str, add_special_tokens: bool = False) -> List[int]:
+                ids = [101]
+                if text.rstrip().endswith(self.think_start):
+                    ids.append(self.think_start_id)
+                return ids
+
+            def apply_chat_template(
+                self, messages: List[Dict], tokenize: bool = False, **kwargs
+            ) -> str:
+                return "user: Hi\nassistant:<think>"
+
+        engine = MockBaseEngine()
+        engine._tokenizer = PromptOpenedThinkingTokenizer()
+        engine.set_stream_outputs([
+            MockGenerationOutput(
+                text="Need to inspect first.",
+                new_text="Need to inspect first.",
+                completion_tokens=1,
+                finished=False,
+            ),
+            MockGenerationOutput(
+                text="Need to inspect first.</think>Done.",
+                new_text="</think>Done.",
+                completion_tokens=2,
+                finished=True,
+                finish_reason="stop",
+            ),
+        ])
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="Hi")],
+            stream=True,
+        )
+
+        payloads = []
+        messages = [{"role": "user", "content": "Hi"}]
+        async for event in stream_chat_completion(
+            engine,
+            messages,
+            request,
+            max_tokens=256,
+            temperature=0.7,
+            top_p=0.9,
+            top_k=40,
+        ):
+            if event.startswith("data: {"):
+                payloads.append(json.loads(event[6:-2]))
+
+        reasoning_deltas = []
+        content_deltas = []
+        for payload in payloads:
+            choices = payload.get("choices", [])
+            if not choices:
+                continue
+            delta = choices[0].get("delta", {})
+            if delta.get("reasoning_content"):
+                reasoning_deltas.append(delta["reasoning_content"])
+            if delta.get("content"):
+                content_deltas.append(delta["content"])
+
+        assert "".join(reasoning_deltas) == "Need to inspect first."
+        assert content_deltas == ["Done."]
+
+    @pytest.mark.asyncio
     async def test_stream_chat_completion_with_tools_streams_content_incrementally(self):
         """Tool availability must not force full buffering of normal text deltas."""
         from omlx.server import stream_chat_completion

--- a/tests/test_chat_stream_thinking_static.py
+++ b/tests/test_chat_stream_thinking_static.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Static guards for OpenAI chat streaming thinking separation."""
+
+import ast
+from pathlib import Path
+
+
+def _stream_chat_completion_node():
+    source = (Path(__file__).resolve().parents[1] / "omlx" / "server.py").read_text()
+    for node in ast.walk(ast.parse(source)):
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "stream_chat_completion"
+        ):
+            return node
+    raise AssertionError("stream_chat_completion not found in server.py")
+
+
+def test_stream_chat_completion_starts_parser_when_prompt_opens_thinking():
+    """Chat streaming must not leak prompt-opened thinking as content."""
+    node = _stream_chat_completion_node()
+    called = {
+        call.func.id
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+    }
+    assert "prompt_opens_thinking" in called, (
+        "stream_chat_completion must detect when the rendered chat prompt "
+        "already opens the thinking block; otherwise initial reasoning deltas "
+        "are emitted as public content."
+    )
+
+    thinking_parser_calls = [
+        call
+        for call in ast.walk(node)
+        if (
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == "ThinkingParser"
+        )
+    ]
+    assert any(
+        keyword.arg == "start_in_thinking"
+        for call in thinking_parser_calls
+        for keyword in call.keywords
+    ), (
+        "stream_chat_completion must pass start_in_thinking into "
+        "ThinkingParser so prompt-opened reasoning streams as "
+        "reasoning_content, not content."
+    )


### PR DESCRIPTION
## Summary

Fixes OpenAI chat-completions streaming for reasoning models whose rendered chat template already opens a `<think>` block before generation starts.

Previously, `stream_chat_completion()` always initialized `ThinkingParser()` with `start_in_thinking=False`. For Qwen/DeepSeek-style templates that leave the prompt inside an open thinking block, the
first generated reasoning tokens were streamed as `delta.content` until the model emitted `</think>`. That could leak reasoning text into clients that persist assistant content.

This changes chat streaming to mirror the prompt-aware behavior used elsewhere: render the chat prompt, call `prompt_opens_thinking()`, and pass the result to `ThinkingParser(start_in_thinking=...)`.

## Tests

- Added a functional streaming regression test for prompt-opened thinking.
- Added a static guard to ensure `stream_chat_completion()` continues wiring `prompt_opens_thinking()` into `ThinkingParser(start_in_thinking=...)`.
- Ran:
  - `tests/test_chat_stream_thinking_static.py`
  - `tests/test_thinking.py`

## Verification

Before the fix, the static regression guard fails because `stream_chat_completion()` does not call `prompt_opens_thinking()`.

After the fix, prompt-opened reasoning streams via `reasoning_content`, and only post-`</think>` answer text streams as `content`.