### PR TITLE
feat: Support for Ornith models, both in oQ and at inference time

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -227,11 +227,10 @@ class BatchedEngine(BaseEngine):
 
         import asyncio
 
-        from mlx_lm import load
-
         from ..engine_core import AsyncEngineCore, EngineConfig
         from ..scheduler import SchedulerConfig
         from ..utils.model_loading import (
+            lm_load_compat,
             maybe_apply_pre_load_patches,
             maybe_load_custom_quantization,
         )
@@ -263,7 +262,7 @@ class BatchedEngine(BaseEngine):
                 model, processor = custom_loaded
                 return model, getattr(processor, "tokenizer", processor)
 
-            return load(
+            return lm_load_compat(
                 self._model_name,
                 tokenizer_config=tokenizer_config,
                 trust_remote_code=self._trust_remote_code,
@@ -383,7 +382,7 @@ class BatchedEngine(BaseEngine):
                                 specprefill_draft,
                                 trust_remote_code=self._trust_remote_code,
                             )
-                            draft_model, _ = load(
+                            draft_model, _ = lm_load_compat(
                                 specprefill_draft,
                                 tokenizer_config=draft_tokenizer_config,
                                 trust_remote_code=self._trust_remote_code,

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1515,9 +1515,10 @@ class VLMBatchedEngine(BaseEngine):
             )
             if specprefill_enabled and specprefill_draft:
                 try:
-                    from mlx_lm import load as mlx_lm_load
-
-                    from ..utils.model_loading import maybe_load_custom_quantization
+                    from ..utils.model_loading import (
+                        lm_load_compat as mlx_lm_load,
+                        maybe_load_custom_quantization,
+                    )
                     from ..utils.tokenizer import get_tokenizer_config
 
                     def _load_draft():

--- a/omlx/models/llm.py
+++ b/omlx/models/llm.py
@@ -76,9 +76,8 @@ class MLXLanguageModel:
             return
 
         try:
-            from mlx_lm import load
-
             from ..utils.model_loading import (
+                lm_load_compat,
                 maybe_apply_pre_load_patches,
                 maybe_load_custom_quantization,
             )
@@ -104,7 +103,7 @@ class MLXLanguageModel:
                 self.model = model
                 self.tokenizer = getattr(processor, "tokenizer", processor)
             else:
-                self.model, self.tokenizer = load(
+                self.model, self.tokenizer = lm_load_compat(
                     self.model_name,
                     tokenizer_config=tokenizer_config,
                     trust_remote_code=self.trust_remote_code,

--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -261,9 +261,10 @@ class MLXRerankerModel:
 
     def _load_causal_lm(self) -> Tuple[Any, Any]:
         """Load a CausalLM-based reranker model using mlx-lm."""
-        from mlx_lm import load as mlx_lm_load
-
-        from ..utils.model_loading import maybe_load_custom_quantization
+        from ..utils.model_loading import (
+            lm_load_compat as mlx_lm_load,
+            maybe_load_custom_quantization,
+        )
 
         model_path = str(self.model_name)
         tokenizer_config = {"trust_remote_code": self.trust_remote_code}
@@ -336,9 +337,10 @@ class MLXRerankerModel:
         Jina v3 reranker uses special-token hidden states + projector + cosine
         similarity for listwise scoring.
         """
-        from mlx_lm import load as mlx_lm_load
-
-        from ..utils.model_loading import maybe_load_custom_quantization
+        from ..utils.model_loading import (
+            lm_load_compat as mlx_lm_load,
+            maybe_load_custom_quantization,
+        )
 
         model_path = str(self.model_name)
         tokenizer_config = {"trust_remote_code": self.trust_remote_code}

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -4639,6 +4639,7 @@ def _measure_sensitivity_from_quantized_model(
     from omlx.utils.model_loading import (
         _checkpoint_has_mtp_weights,
         _has_mtp_heads,
+        lm_load_compat as lm_load,
         maybe_apply_pre_load_patches,
     )
 
@@ -4684,8 +4685,6 @@ def _measure_sensitivity_from_quantized_model(
             )
             tokenizer = load_tokenizer(Path(model_path))
         else:
-            from mlx_lm import load as lm_load
-
             # Mirror the main quantize path's MTP patch sequence so an
             # MTP-bearing quantized proxy (e.g. a Qwen3.5 LLM oQ output with
             # preserve_mtp=True) loads cleanly. Without set_mtp_active(True) the

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -4339,7 +4339,7 @@ def _measure_sensitivity(
 
             tokenizer = load_tokenizer(Path(model_path))
         else:
-            from mlx_lm import load as lm_load
+            from omlx.utils.model_loading import lm_load_compat as lm_load
 
             model, tokenizer = lm_load(
                 model_path,

--- a/omlx/patches/mlx_lm_mtp/qwen35_model.py
+++ b/omlx/patches/mlx_lm_mtp/qwen35_model.py
@@ -754,9 +754,23 @@ def _patch_qwen3_5_moe() -> None:
                 key = "language_model." + key
             new_weights[key] = value
 
-        # Backbone MoE layers always use fused gate_up_proj (Qwen3.5/3.6).
+        num_experts = int(
+            getattr(self.language_model.args, "num_experts", 0) or 0
+        )
+
+        # Backbone MoE layers: fused gate_up_proj (Qwen3.6) or per-expert
+        # tensors (Ornith / raw Qwen3.5 MoE). Try fused first; fall back to
+        # per-expert stacking when fused keys are absent.
         for l in range(self.language_model.args.num_hidden_layers):
-            _unfuse_experts(new_weights, f"language_model.model.layers.{l}.mlp")
+            prefix = f"language_model.model.layers.{l}.mlp"
+            if f"{prefix}.switch_mlp.gate_proj.weight" in new_weights:
+                continue  # already in SwitchLinear form
+            _unfuse_experts(new_weights, prefix)
+            if (
+                f"{prefix}.switch_mlp.gate_proj.weight" not in new_weights
+                and num_experts > 0
+            ):
+                _stack_per_expert(new_weights, prefix, num_experts)
 
         # MTP layers: fused (Qwen3.6), per-expert (Qwen3.5), or dense (MTPLX).
         mtp_num = int(
@@ -773,7 +787,6 @@ def _patch_qwen3_5_moe() -> None:
                     mtp_num,
                 )
             else:
-                num_experts = self.language_model.args.num_experts
                 mtp_is_fused = (
                     "language_model.mtp.layers.0.mlp.experts.gate_up_proj"
                     in new_weights

--- a/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_model.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_model.py
@@ -65,13 +65,21 @@ def apply() -> bool:
                         down_key
                     )
             elif num_experts > 0 and f"{prefix}.experts.0.gate_proj.weight" in weights:
+                # Also stack quantization metadata (.scales, .biases) so a
+                # per-expert *quantized* checkpoint loads cleanly. Without this,
+                # only .weight is stacked and the per-expert scales/biases
+                # survive as orphan keys -> "Received N parameters not in model".
                 for n in ("gate_proj", "up_proj", "down_proj"):
-                    weights[f"{prefix}.switch_mlp.{n}.weight"] = mx.stack(
-                        [
-                            weights.pop(f"{prefix}.experts.{e}.{n}.weight")
-                            for e in range(num_experts)
-                        ]
-                    )
+                    for suffix in ("weight", "scales", "biases"):
+                        first_key = f"{prefix}.experts.0.{n}.{suffix}"
+                        if first_key not in weights:
+                            continue
+                        weights[f"{prefix}.switch_mlp.{n}.{suffix}"] = mx.stack(
+                            [
+                                weights.pop(f"{prefix}.experts.{e}.{n}.{suffix}")
+                                for e in range(num_experts)
+                            ]
+                        )
 
         for layer_idx in range(self.config.text_config.num_hidden_layers):
             _unfuse_layer_experts(f"model.language_model.layers.{layer_idx}.mlp")

--- a/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_model.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_model.py
@@ -44,22 +44,34 @@ def apply() -> bool:
         if self.config.text_config.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
 
-        # Expert repack: gate_up_proj → gate_proj + up_proj per layer.
+        num_experts = int(getattr(self.config.text_config, "num_experts", 0) or 0)
+
+        # Expert repack: normalise to switch_mlp form.
+        # Two source formats are seen in the wild:
+        #   - Fused ``experts.gate_up_proj`` (Qwen3.6 checkpoints)
+        #   - Per-expert ``experts.{N}.{gate,up,down}_proj.weight`` (Ornith / Qwen3.5)
         def _unfuse_layer_experts(prefix):
+            if f"{prefix}.switch_mlp.gate_proj.weight" in weights:
+                return  # already in switch_mlp form
             gate_up_key = f"{prefix}.experts.gate_up_proj"
-            if gate_up_key not in weights:
-                return
-            gate_up_weight = weights.pop(gate_up_key)
-            mid = gate_up_weight.shape[-2] // 2
-            weights[f"{prefix}.switch_mlp.gate_proj.weight"] = gate_up_weight[
-                ..., :mid, :
-            ]
-            weights[f"{prefix}.switch_mlp.up_proj.weight"] = gate_up_weight[
-                ..., mid:, :
-            ]
-            down_key = f"{prefix}.experts.down_proj"
-            if down_key in weights:
-                weights[f"{prefix}.switch_mlp.down_proj.weight"] = weights.pop(down_key)
+            if gate_up_key in weights:
+                gate_up_weight = weights.pop(gate_up_key)
+                gate_weight, up_weights = mx.split(gate_up_weight, 2, axis=-2)
+                weights[f"{prefix}.switch_mlp.gate_proj.weight"] = gate_weight
+                weights[f"{prefix}.switch_mlp.up_proj.weight"] = up_weights
+                down_key = f"{prefix}.experts.down_proj"
+                if down_key in weights:
+                    weights[f"{prefix}.switch_mlp.down_proj.weight"] = weights.pop(
+                        down_key
+                    )
+            elif num_experts > 0 and f"{prefix}.experts.0.gate_proj.weight" in weights:
+                for n in ("gate_proj", "up_proj", "down_proj"):
+                    weights[f"{prefix}.switch_mlp.{n}.weight"] = mx.stack(
+                        [
+                            weights.pop(f"{prefix}.experts.{e}.{n}.weight")
+                            for e in range(num_experts)
+                        ]
+                    )
 
         for layer_idx in range(self.config.text_config.num_hidden_layers):
             _unfuse_layer_experts(f"model.language_model.layers.{layer_idx}.mlp")

--- a/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py
@@ -396,9 +396,17 @@ def _patch_vlm_outer_model_sanitize(q35moe_outer: Any) -> None:
         if self.config.text_config.tie_word_embeddings:
             weights.pop("lm_head.weight", None)
 
-        # Backbone MoE: convert fused gate_up_proj → switch_mlp.{gate,up,down}.
+        num_experts = int(getattr(self.config.text_config, "num_experts", 0) or 0)
+
+        # Backbone MoE: fused gate_up_proj (Qwen3.6) or per-expert tensors
+        # (Ornith / raw Qwen3.5). Unfuse the fused form; fall back to
+        # per-expert stacking when fused keys are absent.
         for l in range(self.config.text_config.num_hidden_layers):
-            _unfuse_layer_experts(weights, f"model.language_model.layers.{l}.mlp")
+            prefix = f"model.language_model.layers.{l}.mlp"
+            if f"{prefix}.switch_mlp.gate_proj.weight" in weights:
+                continue  # already in switch_mlp form
+            if not _unfuse_layer_experts(weights, prefix):
+                _stack_per_expert(weights, prefix, num_experts)
 
         # MTP MoE layers: discover via weight keys.
         # Two possible prefixes:
@@ -414,7 +422,6 @@ def _patch_vlm_outer_model_sanitize(q35moe_outer: Any) -> None:
                 }
             )
 
-        num_experts = int(getattr(self.config.text_config, "num_experts", 0) or 0)
         for prefix_root in ("mtp.layers.", "language_model.mtp.layers."):
             for layer_idx in _discover_mtp_layers(prefix_root):
                 prefix = f"{prefix_root}{layer_idx}.mlp"

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -14,6 +14,10 @@ from mlx.utils import tree_flatten
 logger = logging.getLogger(__name__)
 
 _VLM_TEXT_PREFIX = "language_model."
+# HF/checkpoint order vs runtime module-tree order for the VLM text stack.
+# ``sanitize`` swaps the former to the latter; class_predicate matches the latter.
+_CKPT_TEXT_PREFIX = "model.language_model."
+_RUNTIME_TEXT_PREFIX = "language_model.model."
 
 _MLX_LM_LOAD_CONFIG_PATCHED = False
 
@@ -39,13 +43,20 @@ def lm_load_compat(path_or_repo: str, *, trust_remote_code: bool = False, **kwar
 
 
 def expand_per_layer_quant_keys(cfg: dict) -> dict:
-    """Add ``language_model.``-prefixed variants of per-layer quantization keys.
+    """Add module-tree-path variants of per-layer quantization keys.
 
-    oQ writes per-layer overrides keyed by safetensors tensor base name
-    (e.g. ``"lm_head"``), but ``nn.quantize``'s class_predicate receives
-    model-tree paths (``"language_model.lm_head"``).  Without the prefixed
-    variant the lookup misses and the global bits are used, causing a
-    shape mismatch at ``load_weights``.
+    mlx-lm's ``nn.quantize`` class_predicate matches the runtime module-tree
+    path directly (``if p in config["quantization"]``), but oQ / HF
+    checkpoints key per-layer overrides by other conventions:
+
+    - bare safetensors tensor base name (``"lm_head"``), which the VLM text
+      tree nests under ``language_model.`` (``"language_model.lm_head"``).
+    - HF checkpoint order ``model.language_model.layers.N.*``, which
+      ``sanitize`` swaps to module-tree order
+      ``language_model.model.layers.N.*``.
+
+    Without the matching variant the lookup misses, the global bits are used,
+    and the layer is built at the wrong bit-width.
 
     Mutates *cfg* in place and returns it for convenience.
     """
@@ -57,13 +68,17 @@ def expand_per_layer_quant_keys(cfg: dict) -> dict:
         for key, val in quant.items():
             if not isinstance(val, dict):
                 continue
-            prefixed = _VLM_TEXT_PREFIX + key
-            if not key.startswith(_VLM_TEXT_PREFIX) and prefixed not in quant:
-                extras[prefixed] = val
+            if key.startswith(_CKPT_TEXT_PREFIX):
+                # model.language_model.X -> language_model.model.X
+                variant = _RUNTIME_TEXT_PREFIX + key[len(_CKPT_TEXT_PREFIX) :]
             elif key.startswith(_VLM_TEXT_PREFIX):
-                short = key[len(_VLM_TEXT_PREFIX) :]
-                if short not in quant:
-                    extras[short] = val
+                # language_model.X -> X
+                variant = key[len(_VLM_TEXT_PREFIX) :]
+            else:
+                # X -> language_model.X
+                variant = _VLM_TEXT_PREFIX + key
+            if variant not in quant and variant not in extras:
+                extras[variant] = val
         if extras:
             quant.update(extras)
     return cfg

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -17,6 +17,26 @@ _VLM_TEXT_PREFIX = "language_model."
 
 _MLX_LM_LOAD_CONFIG_PATCHED = False
 
+# mlx_lm.load dropped trust_remote_code in some releases. Check once at
+# import time so call sites can pass it safely across versions.
+def _mlx_lm_load_accepts_trust_remote_code() -> bool:
+    try:
+        import inspect
+        from mlx_lm import load as _lm_load
+        return "trust_remote_code" in inspect.signature(_lm_load).parameters
+    except Exception:
+        return False
+
+_LM_LOAD_ACCEPTS_TRC = _mlx_lm_load_accepts_trust_remote_code()
+
+
+def lm_load_compat(path_or_repo: str, *, trust_remote_code: bool = False, **kwargs):
+    """Wrapper around mlx_lm.load that forwards trust_remote_code only when supported."""
+    from mlx_lm import load
+    if _LM_LOAD_ACCEPTS_TRC:
+        kwargs["trust_remote_code"] = trust_remote_code
+    return load(path_or_repo, **kwargs)
+
 
 def expand_per_layer_quant_keys(cfg: dict) -> dict:
     """Add ``language_model.``-prefixed variants of per-layer quantization keys.
@@ -500,14 +520,12 @@ def load_text_model(
 ):
     """Load an LLM model/tokenizer pair via mlx-lm."""
     maybe_apply_pre_load_patches(model_name, model_settings=model_settings)
-    from mlx_lm import load
-
     trust_remote_code = (
         bool(getattr(model_settings, "trust_remote_code", False))
         if model_settings is not None
         else False
     )
-    return load(
+    return lm_load_compat(
         model_name,
         tokenizer_config=tokenizer_config,
         trust_remote_code=trust_remote_code,

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -459,6 +459,55 @@ class TestQwen35MoeSanitize:
         # No bogus switch_mlp keys synthesized for the dense layer.
         assert f"{pfx}.switch_mlp.gate_proj.weight" not in result
 
+    def test_sanitize_backbone_per_expert_form(self, moe_model):
+        """Ornith / raw Qwen3.5 ship *backbone* MoE layers as per-expert
+        tensors. Sanitize must stack them into switch_mlp, leaving no orphan
+        ``experts.{N}.*`` keys behind."""
+        import mlx.core as mx
+
+        weights = {"language_model.model.embed_tokens.weight": mx.zeros((256, 64))}
+        for layer in range(2):
+            pfx = f"language_model.model.layers.{layer}.mlp"
+            for e in range(4):
+                weights[f"{pfx}.experts.{e}.gate_proj.weight"] = mx.zeros((128, 64))
+                weights[f"{pfx}.experts.{e}.up_proj.weight"] = mx.zeros((128, 64))
+                weights[f"{pfx}.experts.{e}.down_proj.weight"] = mx.zeros((64, 128))
+
+        result = moe_model.sanitize(weights)
+
+        for layer in range(2):
+            pfx = f"language_model.model.layers.{layer}.mlp"
+            # Per-expert weights stacked: leading dim == num_experts (4).
+            assert result[f"{pfx}.switch_mlp.gate_proj.weight"].shape == (4, 128, 64)
+            assert result[f"{pfx}.switch_mlp.up_proj.weight"].shape == (4, 128, 64)
+            assert result[f"{pfx}.switch_mlp.down_proj.weight"].shape == (4, 64, 128)
+            # No orphan per-expert keys survive.
+            assert not any(f"{pfx}.experts." in k for k in result)
+
+    def test_sanitize_backbone_per_expert_quantized(self, moe_model):
+        """A per-expert *quantized* backbone carries ``.scales``/``.biases``
+        alongside ``.weight``. All three must be stacked, or the leftover
+        per-expert scales/biases trip 'Received N parameters not in model'."""
+        import mlx.core as mx
+
+        pfx = "language_model.model.layers.0.mlp"
+        weights = {"language_model.model.embed_tokens.weight": mx.zeros((256, 64))}
+        for e in range(4):
+            for proj in ("gate_proj", "up_proj", "down_proj"):
+                weights[f"{pfx}.experts.{e}.{proj}.weight"] = mx.zeros((128, 16))
+                weights[f"{pfx}.experts.{e}.{proj}.scales"] = mx.zeros((128, 2))
+                weights[f"{pfx}.experts.{e}.{proj}.biases"] = mx.zeros((128, 2))
+
+        result = moe_model.sanitize(weights)
+
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            for suffix in ("weight", "scales", "biases"):
+                key = f"{pfx}.switch_mlp.{proj}.{suffix}"
+                assert key in result, key
+                assert result[key].shape[0] == 4  # stacked over experts
+        # No orphan per-expert metadata survives.
+        assert not any(f"{pfx}.experts." in k for k in result)
+
 
 class TestDeepseekV4Model:
     def test_skip_when_base_patch_not_applied(self, monkeypatch):

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -187,10 +187,15 @@ class TestLlama4PreLoadDispatch:
 
 
 class TestLoadTextModel:
-    def test_forwards_trust_remote_code_to_mlx_lm_load(self, tmp_path, monkeypatch):
+    def test_forwards_trust_remote_code_when_mlx_lm_supports_it(
+        self, tmp_path, monkeypatch
+    ):
         path = _write_config(tmp_path, '{"model_type": "llama"}')
         maybe_apply = MagicMock()
         monkeypatch.setattr(model_loading, "maybe_apply_pre_load_patches", maybe_apply)
+        # Pin the capability flag so the test is deterministic regardless of the
+        # installed mlx-lm version (lm_load_compat reads this global at call time).
+        monkeypatch.setattr(model_loading, "_LM_LOAD_ACCEPTS_TRC", True)
 
         load_mock = MagicMock(return_value=("MODEL", "TOKENIZER"))
         monkeypatch.setitem(sys.modules, "mlx_lm", MagicMock(load=load_mock))
@@ -208,6 +213,31 @@ class TestLoadTextModel:
             path,
             tokenizer_config={"trust_remote_code": True},
             trust_remote_code=True,
+        )
+
+    def test_omits_trust_remote_code_when_mlx_lm_lacks_it(self, tmp_path, monkeypatch):
+        # Some mlx-lm releases dropped ``trust_remote_code`` from ``load``.
+        # lm_load_compat must omit the kwarg there rather than raise TypeError.
+        path = _write_config(tmp_path, '{"model_type": "llama"}')
+        monkeypatch.setattr(
+            model_loading, "maybe_apply_pre_load_patches", MagicMock()
+        )
+        monkeypatch.setattr(model_loading, "_LM_LOAD_ACCEPTS_TRC", False)
+
+        load_mock = MagicMock(return_value=("MODEL", "TOKENIZER"))
+        monkeypatch.setitem(sys.modules, "mlx_lm", MagicMock(load=load_mock))
+
+        settings = types.SimpleNamespace(trust_remote_code=True)
+        result = model_loading.load_text_model(
+            path,
+            tokenizer_config={"trust_remote_code": True},
+            model_settings=settings,
+        )
+
+        assert result == ("MODEL", "TOKENIZER")
+        load_mock.assert_called_once_with(
+            path,
+            tokenizer_config={"trust_remote_code": True},
         )
 
 
@@ -487,3 +517,4 @@ class TestCheckpointHasMtpWeights:
         )
 
         assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is True
+

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -455,6 +455,7 @@ class TestCheckpointHasMtpWeights:
         )
         assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is True
 
+
     def test_returns_true_when_index_has_bare_mtp(self, tmp_path):
         self._write_index(
             tmp_path,
@@ -518,3 +519,38 @@ class TestCheckpointHasMtpWeights:
 
         assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is True
 
+
+class TestExpandPerLayerQuantKeys:
+    """expand_per_layer_quant_keys adds runtime module-tree key variants."""
+
+    def test_adds_language_model_prefix_for_bare_key(self):
+        cfg = {
+            "quantization": {
+                "bits": 6,
+                "group_size": 64,
+                "lm_head": {"bits": 8, "group_size": 64},
+            }
+        }
+
+        model_loading.expand_per_layer_quant_keys(cfg)
+
+        assert cfg["quantization"]["language_model.lm_head"] == {
+            "bits": 8,
+            "group_size": 64,
+        }
+
+    def test_adds_swapped_prefix_variant_for_model_language_model_key(self):
+        key = "model.language_model.layers.0.linear_attn.in_proj_qkv"
+        cfg = {
+            "quantization": {
+                "bits": 6,
+                "group_size": 64,
+                key: {"bits": 8, "group_size": 64},
+            }
+        }
+
+        model_loading.expand_per_layer_quant_keys(cfg)
+
+        swapped = "language_model.model.layers.0.linear_attn.in_proj_qkv"
+        assert swapped in cfg["quantization"]
+        assert cfg["quantization"][swapped]["bits"] == 8

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -3572,10 +3572,20 @@ class TestMeasureSensitivityVlmMtp:
         mock_set_active.assert_not_called()
 
     def test_text_load_forwards_trust_remote_code(self, monkeypatch):
-        """Text sensitivity load forwards the mlx-lm custom-code opt-in."""
+        """Text sensitivity load forwards the mlx-lm custom-code opt-in when
+        the installed mlx-lm supports it."""
+        import omlx.utils.model_loading as real_ml
+
         self._patch_common(monkeypatch, has_mtp=True)
         mock_load = MagicMock(return_value=(MagicMock(), MagicMock()))
         monkeypatch.setitem(sys.modules, "mlx_lm", MagicMock(load=mock_load))
+        # _patch_common swapped model_loading for a MagicMock; oq imports
+        # lm_load_compat from it. Expose the real shim and pin the capability
+        # flag so forwarding is deterministic regardless of installed mlx-lm.
+        monkeypatch.setattr(real_ml, "_LM_LOAD_ACCEPTS_TRC", True)
+        sys.modules["omlx.utils.model_loading"].lm_load_compat = (
+            real_ml.lm_load_compat
+        )
 
         _measure_sensitivity(
             "/fake/text",

--- a/tests/test_vlm_mtp.py
+++ b/tests/test_vlm_mtp.py
@@ -439,6 +439,101 @@ def test_moe_vlm_runtime_sanitize_unfuses_gate_up_by_midpoint():
     assert bool(mx.all(result[up_key] == gate_up[:, 3:, :]).item())
 
 
+def _per_expert_vlm_self(num_experts=2, num_hidden_layers=1):
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            text_config=SimpleNamespace(
+                tie_word_embeddings=False,
+                num_hidden_layers=num_hidden_layers,
+                num_experts=num_experts,
+            )
+        )
+    )
+
+
+def test_moe_vlm_sanitize_stacks_per_expert_backbone(monkeypatch):
+    """Ornith / raw Qwen3.5 ship backbone MoE layers as per-expert tensors.
+    The model-level sanitize must stack them into switch_mlp form."""
+    from omlx.patches.mlx_vlm_mtp import qwen35_moe_vlm_model
+    from mlx_vlm.models.qwen3_5_moe import qwen3_5_moe
+
+    monkeypatch.setattr(qwen35_moe_vlm_model, "_APPLIED", False)
+    if hasattr(qwen3_5_moe.Model, "_omlx_mtp_vlm_patched"):
+        monkeypatch.delattr(qwen3_5_moe.Model, "_omlx_mtp_vlm_patched")
+    assert qwen35_moe_vlm_model.apply() is True
+
+    pfx_in = "model.language_model.layers.0.mlp"
+    weights = {}
+    for e in range(2):
+        weights[f"{pfx_in}.experts.{e}.gate_proj.weight"] = mx.zeros((8, 4))
+        weights[f"{pfx_in}.experts.{e}.up_proj.weight"] = mx.zeros((8, 4))
+        weights[f"{pfx_in}.experts.{e}.down_proj.weight"] = mx.zeros((4, 8))
+
+    result = qwen3_5_moe.Model.sanitize(_per_expert_vlm_self(), weights)
+
+    pfx = "language_model.model.layers.0.mlp"
+    assert result[f"{pfx}.switch_mlp.gate_proj.weight"].shape == (2, 8, 4)
+    assert result[f"{pfx}.switch_mlp.down_proj.weight"].shape == (2, 4, 8)
+    assert not any(f"{pfx}.experts." in k for k in result)
+
+
+def test_moe_vlm_sanitize_stacks_per_expert_backbone_quantized(monkeypatch):
+    """A per-expert *quantized* backbone carries .scales/.biases. The
+    model-level sanitize must stack all three, leaving no orphan keys."""
+    from omlx.patches.mlx_vlm_mtp import qwen35_moe_vlm_model
+    from mlx_vlm.models.qwen3_5_moe import qwen3_5_moe
+
+    monkeypatch.setattr(qwen35_moe_vlm_model, "_APPLIED", False)
+    if hasattr(qwen3_5_moe.Model, "_omlx_mtp_vlm_patched"):
+        monkeypatch.delattr(qwen3_5_moe.Model, "_omlx_mtp_vlm_patched")
+    assert qwen35_moe_vlm_model.apply() is True
+
+    pfx_in = "model.language_model.layers.0.mlp"
+    weights = {}
+    for e in range(2):
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            weights[f"{pfx_in}.experts.{e}.{proj}.weight"] = mx.zeros((8, 4))
+            weights[f"{pfx_in}.experts.{e}.{proj}.scales"] = mx.zeros((8, 1))
+            weights[f"{pfx_in}.experts.{e}.{proj}.biases"] = mx.zeros((8, 1))
+
+    result = qwen3_5_moe.Model.sanitize(_per_expert_vlm_self(), weights)
+
+    pfx = "language_model.model.layers.0.mlp"
+    for proj in ("gate_proj", "up_proj", "down_proj"):
+        for suffix in ("weight", "scales", "biases"):
+            key = f"{pfx}.switch_mlp.{proj}.{suffix}"
+            assert key in result, key
+            assert result[key].shape[0] == 2
+    assert not any(f"{pfx}.experts." in k for k in result)
+
+
+def test_moe_vlm_runtime_sanitize_stacks_per_expert_backbone():
+    """The runtime sanitize wrapper must also stack per-expert backbone
+    layers (parity with the model-level patch and the LLM patch)."""
+    from omlx.patches.mlx_vlm_mtp import qwen35_moe_vlm_runtime
+
+    class FakeModel:
+        pass
+
+    fake_outer = SimpleNamespace(Model=FakeModel)
+    qwen35_moe_vlm_runtime._patch_vlm_outer_model_sanitize(fake_outer)
+
+    pfx_in = "model.language_model.layers.0.mlp"
+    weights = {}
+    for e in range(2):
+        weights[f"{pfx_in}.experts.{e}.gate_proj.weight"] = mx.zeros((8, 4))
+        weights[f"{pfx_in}.experts.{e}.up_proj.weight"] = mx.zeros((8, 4))
+        weights[f"{pfx_in}.experts.{e}.down_proj.weight"] = mx.zeros((4, 8))
+
+    result = FakeModel.sanitize(_per_expert_vlm_self(), weights)
+
+    pfx = "language_model.model.layers.0.mlp"
+    assert result[f"{pfx}.switch_mlp.gate_proj.weight"].shape == (2, 8, 4)
+    assert result[f"{pfx}.switch_mlp.up_proj.weight"].shape == (2, 8, 4)
+    assert result[f"{pfx}.switch_mlp.down_proj.weight"].shape == (2, 4, 8)
+    assert not any(f"{pfx}.experts." in k for k in result)
+
+
 # ---------------------------------------------------------------------------
 # _call_backbone return format tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Overview

I downloaded the [Ornith 9B and 35B](https://huggingface.co/collections/deepreinforce-ai/ornith-10) (moe) raw models off HuggingFace to generate my own FP16 quants to run on M1 and M2, and in doing so, I ran into a few snags. This changeset adds support so that oQ quantization works and doesn't generate broken models, and also adds support during inference-time for using these models.

## Ornith?

The Ornith models are a family of multimodal MoE models fine-tuned from Qwen 3.5 with an MTP head. oMLX's MoE path was written for Qwen 3.6, which stores experts fused (`experts.gate_up_proj`). Ornith/Qwen 3.5 ships per-expert tensors (`experts.{N}.{gate,up,down}_proj`) instead.

The loader didn't know how to convert that form, so weights were rejected at load while trying to do inference. Two smaller problems also bit me: per-layer quantization keys used a different prefix order than the runtime expects, and recent `mlx-lm` updates _seem to have_ dropped `trust_remote_code` from `load()`.

## The fixes

- Per-expert experts: MoE sanitize now falls back to stacking per-expert tensors into `switch_mlp` form when the fused layout is absent.
    + I applied this to the LLM, VLM, and VLM-runtime paths
    + Quant metadata (`.scales/.biases`) is stacked too
    + Existing fused (Qwen 3.6) checkpoints are unaffected
- Quant keys: `expand_per_layer_quant_keys` now emits the correct module-tree variant for all key prefix conventions, so per-layer bit-widths match at load
- `mlx-lm` drift: new `lm_load_compat` wrapper forwards `trust_remote_code` only when the installed `mlx-lm` accepts it
    + All `load()` call sites route through this new wrapper
    + This change felt the most invasive, but also felt necessary!

Anyway, with these changes over the last few days since the Ornith models have been out, I've had good success in running inference and benchmarks against the models and things seem pretty stable, so now I'm pushing them up for you to review.