### PR TITLE
feat: add adapter_path support for LoRA fine-tuned models

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -254,6 +254,10 @@ class BatchedEngine(BaseEngine):
         # while ensuring no concurrent Metal operations. See issue #85.
         from ..engine_core import get_mlx_executor
 
+        adapter_path = None
+        if self._model_settings is not None:
+            adapter_path = getattr(self._model_settings, "adapter_path", None)
+
         def _load_model_sync():
             custom_loaded = maybe_load_custom_quantization(
                 self._model_name,
@@ -266,6 +270,7 @@ class BatchedEngine(BaseEngine):
             return load(
                 self._model_name,
                 tokenizer_config=tokenizer_config,
+                adapter_path=adapter_path,
                 trust_remote_code=self._trust_remote_code,
             )
 

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -84,6 +84,8 @@ EXCLUDED_FROM_PROFILES = frozenset(
         "ttl_seconds",
         # Security flag must be explicit per model — never propagated via profiles.
         "trust_remote_code",
+        # LoRA adapter path is a model-specific filesystem path, not a profile tunable.
+        "adapter_path",
     }
 )
 

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -100,6 +100,7 @@ class ModelSettings:
         display_name: Human-readable name for UI display.
         description: Optional description of the model.
         active_profile_name: Name of the currently-applied profile (None = no profile).
+        adapter_path: Path to LoRA adapter weights for fine-tuned models (None = no adapter).
     """
 
     # Sampling parameters (None means use global default)
@@ -213,6 +214,9 @@ class ModelSettings:
     # loaders are allowed to execute custom Python from the model repository
     # (modeling_*.py, tokenization_*.py). Off by default — see issue #926.
     trust_remote_code: bool = False
+
+    # LoRA adapters
+    adapter_path: Optional[str] = None  # Path to LoRA adapter weights for fine-tuned models
 
     # Metadata
     display_name: Optional[str] = None

--- a/omlx/models/llm.py
+++ b/omlx/models/llm.py
@@ -53,6 +53,7 @@ class MLXLanguageModel:
         model_name: str,
         tokenizer_name: str | None = None,
         trust_remote_code: bool = False,
+        adapter_path: str | None = None,
     ):
         """
         Initialize the MLX language model.
@@ -61,10 +62,12 @@ class MLXLanguageModel:
             model_name: HuggingFace model name or local path
             tokenizer_name: Optional separate tokenizer name
             trust_remote_code: Whether to trust remote code
+            adapter_path: Optional path to LoRA adapter weights
         """
         self.model_name = model_name
         self.tokenizer_name = tokenizer_name or model_name
         self.trust_remote_code = trust_remote_code
+        self.adapter_path = adapter_path
 
         self.model = None
         self.tokenizer = None
@@ -107,6 +110,7 @@ class MLXLanguageModel:
                 self.model, self.tokenizer = load(
                     self.model_name,
                     tokenizer_config=tokenizer_config,
+                    adapter_path=self.adapter_path,
                     trust_remote_code=self.trust_remote_code,
                 )
 


### PR DESCRIPTION
## Summary

Adds `adapter_path` support to oMLX per-model settings, allowing LoRA adapter weights to be loaded alongside a base model without requiring a separate fused checkpoint.

## Changes

**`omlx/model_settings.py`** — Added `adapter_path: Optional[str] = None` field to `ModelSettings` dataclass, with docstring entry.

**`omlx/engine/batched.py`** — Reads `adapter_path` from `model_settings` before the load closure and passes it through to `mlx_lm.load()`.

**`omlx/models/llm.py`** — Added `adapter_path` parameter to `MLXLanguageModel.__init__()` and passes it through to `mlx_lm.load()`, so external callers using the public API can also load LoRA adapters.

**`omlx/model_profiles.py`** — Excluded `adapter_path` from profile application, as it is a model-specific filesystem path, not a profile-tunable parameter.

## Usage

Configure in `model_settings.json`:
```json
{
  "org/model-name": {
    "adapter_path": "/path/to/lora/adapters"
  }
}
```

Where the model directory contains the base weights and `adapter_path` points to a directory with `adapters.safetensors` and `adapter_config.json` (standard mlx-lm LoRA output format).

## Testing

- All 224 model discovery, settings, and profile classification tests pass
- End-to-end verified: loaded a 27GB 6-bit quantized base model + LoRA adapters successfully via oMLX