### PR TITLE
feat: accelerate DeepSeek V4 with bundled MXFP4 MoE and sparse attention kernels

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
@@ -249,9 +249,11 @@ private struct SourceModelSection: View {
         return opts
     }
 
-    // 2 / 3 / 3.5 / 4 / 5 / 6 / 8 — mirrors the HTML <option>s.
+    // Mirrors the HTML <option>s.
     static let levelOptions: [PopupOption<Double>] = [
         PopupOption(value: 2,   label: "oQ2"),
+        PopupOption(value: 2.5, label: "oQ2.5"),
+        PopupOption(value: 2.8, label: "oQ2.8"),
         PopupOption(value: 3,   label: "oQ3"),
         PopupOption(value: 3.5, label: "oQ3.5"),
         PopupOption(value: 4,   label: "oQ4"),

--- a/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
@@ -253,6 +253,7 @@ private struct SourceModelSection: View {
     static let levelOptions: [PopupOption<Double>] = [
         PopupOption(value: 2,   label: "oQ2"),
         PopupOption(value: 2.5, label: "oQ2.5"),
+        PopupOption(value: 2.7, label: "oQ2.7"),
         PopupOption(value: 2.8, label: "oQ2.8"),
         PopupOption(value: 3,   label: "oQ3"),
         PopupOption(value: 3.5, label: "oQ3.5"),

--- a/apps/omlx-mac/Sources/Net/OMLXClient.swift
+++ b/apps/omlx-mac/Sources/Net/OMLXClient.swift
@@ -366,7 +366,7 @@ final class OMLXClient: ObservableObject {
         oqLevel: Double,
         preserveMtp: Bool = false
     ) async throws -> OQEstimateResponse {
-        // `oq_level` accepts ints (2,3,4,5,6,8) and 3.5. Send it without a
+        // `oq_level` accepts ints and fractional levels. Send it without a
         // trailing `.0` so the server parses an int when the user picked one.
         let levelStr: String = (oqLevel.rounded() == oqLevel)
             ? String(Int(oqLevel))

--- a/docs/oQ_Quantization.md
+++ b/docs/oQ_Quantization.md
@@ -29,6 +29,9 @@ Quantization should not be exclusive to any particular inference server. oQ prod
 | Level | Base Bits | Target bpw | Description |
 |-------|-----------|------------|-------------|
 | oQ2 | 2 | ~2.9 | Extreme compression |
+| oQ2.5 | 2 | ~3.2 | Extra routed down-projection protection |
+| oQ2.7 | 2 | ~3.3 | Sensitivity-selected routed layer boosts |
+| oQ2.8 | 2 | ~3.4 | Higher-budget routed layer boosts |
 | oQ3 | 3 | ~3.5 | Balanced |
 | oQ3.5 | 3 | ~3.8 | Quality balanced |
 | oQ4 | 4 | ~4.6 | Recommended |

--- a/docs/oQ_Quantization.md
+++ b/docs/oQ_Quantization.md
@@ -29,9 +29,8 @@ Quantization should not be exclusive to any particular inference server. oQ prod
 | Level | Base Bits | Target bpw | Description |
 |-------|-----------|------------|-------------|
 | oQ2 | 2 | ~2.9 | Extreme compression |
-| oQ2.5 | 2 | ~3.2 | Lower-budget routed layer boosts |
-| oQ2.7 | 2 | ~3.3 | Sensitivity-selected routed layer boosts |
-| oQ2.8 | 2 | ~3.4 | Higher-budget routed layer boosts |
+| oQ2.5 | 2 | ~3.2 | Code-preserving routed down-projection boosts |
+| oQ2.7 | 2 | ~3.3 | Higher-budget code-preserving routed boosts |
 | oQ3 | 3 | ~3.5 | Balanced |
 | oQ3.5 | 3 | ~3.8 | Quality balanced |
 | oQ4 | 4 | ~4.6 | Recommended |

--- a/docs/oQ_Quantization.md
+++ b/docs/oQ_Quantization.md
@@ -29,7 +29,7 @@ Quantization should not be exclusive to any particular inference server. oQ prod
 | Level | Base Bits | Target bpw | Description |
 |-------|-----------|------------|-------------|
 | oQ2 | 2 | ~2.9 | Extreme compression |
-| oQ2.5 | 2 | ~3.2 | Extra routed down-projection protection |
+| oQ2.5 | 2 | ~3.2 | Lower-budget routed layer boosts |
 | oQ2.7 | 2 | ~3.3 | Sensitivity-selected routed layer boosts |
 | oQ2.8 | 2 | ~3.4 | Higher-budget routed layer boosts |
 | oQ3 | 3 | ~3.5 | Balanced |

--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -152,10 +152,7 @@ def _is_cohere2_moe_model(
     model_name: str,
     model_config: dict[str, Any] | None = None,
 ) -> bool:
-    return (
-        model_config is not None
-        and model_config.get("model_type") == "cohere2_moe"
-    )
+    return model_config is not None and model_config.get("model_type") == "cohere2_moe"
 
 
 _MINIMAX_M3_MODEL_TYPES = {"minimax_m3", "minimax_m3_vl"}
@@ -165,6 +162,26 @@ _MINIMAX_EOS_TOKEN = "[e~["
 _MINIMAX_SPECIAL_TOKENS = (_MINIMAX_EOS_TOKEN, "]~b]", "]~!b[", "]!p~[", "]!d~[")
 _MINIMAX_TOOL_CALL_START = "]<]minimax[>[<tool_call>"
 _MINIMAX_TOOL_CALL_END = "]<]minimax[>[</tool_call>"
+_DEEPSEEK_V4_TOOL_CALL_START = "<｜DSML｜tool_calls>"
+_DEEPSEEK_V4_TOOL_CALL_END = "</｜DSML｜tool_calls>"
+
+
+def _is_deepseek_v4_model(
+    model_name: str,
+    tokenizer: Any,
+    model_config: dict[str, Any] | None = None,
+) -> bool:
+    model_type = str(model_config.get("model_type", "")) if model_config else ""
+    if model_type.startswith("deepseek_v4"):
+        return True
+
+    if (
+        getattr(tokenizer, "tool_call_start", None) == _DEEPSEEK_V4_TOOL_CALL_START
+        and getattr(tokenizer, "tool_call_end", None) == _DEEPSEEK_V4_TOOL_CALL_END
+    ):
+        return True
+
+    return "deepseek-v4" in model_name.lower() or "deepseek_v4" in model_name.lower()
 
 
 def _serialize_minimax_tool_arguments(arguments: Any) -> str:
@@ -264,6 +281,126 @@ def _token_id_for_text(tokenizer: Any, text: str) -> int | None:
         except (TypeError, ValueError):
             return None
     return None
+
+
+class DeepSeekV4OutputParserSession:
+    """Parser session for DeepSeek V4 DSML tool-call output.
+
+    A completed DSML tool-call block ends the assistant turn. Without a
+    parser-owned stop, batched decode keeps the row alive after
+    ``</｜DSML｜tool_calls>`` and the model may emit additional or malformed
+    DSML fragments as visible assistant text.
+    """
+
+    def __init__(self, tokenizer: Any, model_path: str | None = None):
+        self._tokenizer = tokenizer
+        self._raw_text = ""
+        self._stopped = False
+        self._detokenizer = create_streaming_detokenizer(tokenizer, model_path)
+        if self._detokenizer is not None:
+            self._detokenizer.reset()
+
+        try:
+            from ..api.tool_calling import ToolCallStreamFilter
+
+            self._stream_filter = ToolCallStreamFilter(tokenizer)
+            self._visible_filter = ToolCallStreamFilter(tokenizer)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("DeepSeek V4 stream filter unavailable: %s", e)
+            self._stream_filter = None
+            self._visible_filter = None
+
+    def _decode_token(self, token_id: int) -> str:
+        if self._detokenizer is not None:
+            self._detokenizer.add_token(token_id)
+            return self._detokenizer.last_segment
+        try:
+            return self._tokenizer.decode([token_id], skip_special_tokens=False)
+        except TypeError:
+            return self._tokenizer.decode([token_id])
+
+    def _filtered_text(self, text: str, tool_filter: Any) -> str:
+        if not text:
+            return ""
+        if tool_filter is not None:
+            return tool_filter.feed(text)
+        return text
+
+    def _finish_filtered_text(self, tool_filter: Any) -> str:
+        if tool_filter is None:
+            return ""
+        return tool_filter.finish()
+
+    def _trim_at_first_tool_block_end(self, text: str) -> tuple[str, bool]:
+        start_idx = text.find(_DEEPSEEK_V4_TOOL_CALL_START)
+        if start_idx < 0:
+            return text, False
+        end_idx = text.find(_DEEPSEEK_V4_TOOL_CALL_END, start_idx)
+        if end_idx < 0:
+            return text, False
+        cutoff = end_idx + len(_DEEPSEEK_V4_TOOL_CALL_END)
+        return text[:cutoff], True
+
+    def process_token(self, token_id: int) -> OutputParserTokenResult:
+        if self._stopped:
+            return OutputParserTokenResult(is_stop=True, record_token=False)
+
+        decoded_text = self._decode_token(token_id)
+        combined = self._raw_text + decoded_text
+        trimmed, is_stop = self._trim_at_first_tool_block_end(combined)
+
+        feed_text = trimmed[len(self._raw_text) :]
+        self._raw_text = trimmed
+        self._stopped = is_stop
+
+        return OutputParserTokenResult(
+            stream_text=self._filtered_text(feed_text, self._stream_filter),
+            visible_text=self._filtered_text(feed_text, self._visible_filter),
+            is_stop=is_stop,
+            record_token=True,
+        )
+
+    def finalize(self) -> OutputParserFinalizeResult:
+        stream_text = ""
+        visible_text = ""
+        if self._detokenizer is not None and not self._stopped:
+            self._detokenizer.finalize()
+            final_text = self._detokenizer.last_segment
+            if final_text:
+                prev_len = len(self._raw_text)
+                combined = self._raw_text + final_text
+                self._raw_text, self._stopped = self._trim_at_first_tool_block_end(
+                    combined
+                )
+                final_text = self._raw_text[prev_len:]
+                stream_text += self._filtered_text(final_text, self._stream_filter)
+                visible_text += self._filtered_text(final_text, self._visible_filter)
+
+        stream_text += self._finish_filtered_text(self._stream_filter)
+        visible_text += self._finish_filtered_text(self._visible_filter)
+
+        tool_calls: list[dict[str, str]] = []
+        try:
+            from ..api.tool_calling import parse_tool_calls
+
+            _, parsed_calls = parse_tool_calls(self._raw_text, self._tokenizer)
+            for call in parsed_calls or []:
+                tool_calls.append(
+                    {
+                        "id": getattr(call, "id", ""),
+                        "name": call.function.name,
+                        "arguments": call.function.arguments,
+                    }
+                )
+        except Exception as e:  # noqa: BLE001
+            logger.debug("DeepSeek V4 tool-call parse failed: %s", e)
+
+        return OutputParserFinalizeResult(
+            stream_text=stream_text,
+            visible_text=visible_text,
+            tool_calls=tool_calls,
+            finish_reason="tool_calls" if tool_calls else None,
+        )
 
 
 class MiniMaxM3OutputParserSession:
@@ -583,6 +720,20 @@ def detect_output_parser(
                 _TURN_END_MARKER,
                 _TOOL_RESPONSE_OPEN,
                 _TOOL_RESPONSE_CLOSE,
+            ),
+        )
+
+    if _is_deepseek_v4_model(model_name, tokenizer, model_config):
+        return OutputParserFactory(
+            kind="deepseek_v4",
+            create_session=lambda session_tokenizer: DeepSeekV4OutputParserSession(
+                session_tokenizer,
+                model_path=model_name,
+            ),
+            stop_token_ids=set(),
+            protocol_marker_texts=(
+                _DEEPSEEK_V4_TOOL_CALL_START,
+                _DEEPSEEK_V4_TOOL_CALL_END,
             ),
         )
 

--- a/omlx/admin/oq_manager.py
+++ b/omlx/admin/oq_manager.py
@@ -625,8 +625,10 @@ class OQManager:
                 if time.time() - getattr(task, "_last_progress_callback_at", 0.0) < 5:
                     continue
                 if task.status == QuantStatus.QUANTIZING:
+                    if self._has_explicit_quant_progress(task):
+                        continue
                     fraction = min(elapsed / estimated_total, 0.95)
-                    task.progress = 30.0 + fraction * 60.0
+                    task.progress = max(task.progress, 30.0 + fraction * 60.0)
                 elif task.status == QuantStatus.SAVING:
                     # During save, poll output dir size
                     output = Path(task.output_path)
@@ -636,9 +638,20 @@ class OQManager:
                         expected = task.source_size * task.oq_level / 16
                         if expected > 0:
                             save_frac = min(current / expected, 0.99)
-                            task.progress = 90.0 + save_frac * 10.0
+                            task.progress = max(task.progress, 90.0 + save_frac * 10.0)
         except asyncio.CancelledError:
             pass
+
+    @staticmethod
+    def _has_explicit_quant_progress(task: QuantTask) -> bool:
+        """Return True once the quantizer emits byte-level progress."""
+        meta = task.progress_meta if isinstance(task.progress_meta, dict) else {}
+        try:
+            total_bytes = int(meta.get("total_bytes") or 0)
+            processed_bytes = int(meta.get("processed_bytes") or 0)
+        except (TypeError, ValueError):
+            return False
+        return total_bytes > 0 and processed_bytes >= 0
 
     @staticmethod
     def _phase_label(phase: str, oq_level: float, enhanced: bool = False) -> str:

--- a/omlx/admin/oq_manager.py
+++ b/omlx/admin/oq_manager.py
@@ -264,7 +264,7 @@ class OQManager:
 
         Args:
             model_path: Path to source model directory.
-            oq_level: oQ level (2, 3, 4, 6, or 8).
+            oq_level: oQ level from OQ_LEVELS.
             dtype: Target fp dtype for non-quantized weights and quant
                 scales/biases. "bfloat16" (default) or "float16".
 

--- a/omlx/admin/templates/dashboard/_models.html
+++ b/omlx/admin/templates/dashboard/_models.html
@@ -1259,7 +1259,6 @@
                                             <option value="2" x-text="oqLevelLabel(2)"></option>
                                             <option value="2.5" x-text="oqLevelLabel(2.5)"></option>
                                             <option value="2.7" x-text="oqLevelLabel(2.7)"></option>
-                                            <option value="2.8" x-text="oqLevelLabel(2.8)"></option>
                                             <option value="3" x-text="oqLevelLabel(3)"></option>
                                             <option value="3.5" x-text="oqLevelLabel(3.5)"></option>
                                             <option value="4" selected x-text="oqLevelLabel(4)"></option>

--- a/omlx/admin/templates/dashboard/_models.html
+++ b/omlx/admin/templates/dashboard/_models.html
@@ -1258,6 +1258,7 @@
                                                 class="w-full px-4 py-2.5 bg-white border border-neutral-300 rounded-xl text-sm text-neutral-900 focus:outline-none focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
                                             <option value="2" x-text="oqLevelLabel(2)"></option>
                                             <option value="2.5" x-text="oqLevelLabel(2.5)"></option>
+                                            <option value="2.7" x-text="oqLevelLabel(2.7)"></option>
                                             <option value="2.8" x-text="oqLevelLabel(2.8)"></option>
                                             <option value="3" x-text="oqLevelLabel(3)"></option>
                                             <option value="3.5" x-text="oqLevelLabel(3.5)"></option>

--- a/omlx/cache/type_handlers.py
+++ b/omlx/cache/type_handlers.py
@@ -963,9 +963,11 @@ class CacheListHandler(CacheTypeHandler):
     ) -> Any:
         """Reconstruct CacheList from stored state.
 
-        Tries new mlx-lm CacheList.from_state() first, then falls back to
-        manual sub-cache reconstruction using CacheTypeRegistry (local import
-        to avoid circular dependency).
+        Rebuild sub-caches through omlx handlers before falling back to
+        upstream ``CacheList.from_state()``. The handler route is required for
+        restored nested caches whose local contracts differ from mlx-lm's raw
+        constructor, notably RotatingKVCache snapshots that must be trimmed into
+        PrefillReadyRotatingKVCache before reuse.
 
         Args:
             state: Dict with 'sub_states' key containing per-sub-cache states.
@@ -996,28 +998,6 @@ class CacheListHandler(CacheTypeHandler):
             )
             return None
 
-        # Sanitize sub_meta_states for sub-cache types that don't support
-        # meta_state (inherit _BaseCache's strict setter which rejects
-        # truthy values).  Use "" to match _BaseCache.meta_state getter.
-        no_meta_state_types = frozenset(
-            {"KVCache", "ConcatenateKVCache", "ArraysCache"}
-        )
-        sanitized_sub_meta_states = [
-            "" if cls_name in no_meta_state_types else sub_meta
-            for cls_name, sub_meta in zip(class_names, sub_meta_states)
-        ]
-
-        # Try new mlx-lm CacheList.from_state() first
-        try:
-            from mlx_lm.models.cache import CacheList
-
-            return CacheList.from_state(
-                sub_states, (class_names, sanitized_sub_meta_states)
-            )
-        except (ImportError, AttributeError, TypeError, KeyError, Exception) as e:
-            logger.debug(f"CacheList.from_state() unavailable or failed: {e}")
-
-        # Fallback: manually reconstruct sub-caches
         # NOTE: CacheTypeRegistry must be imported locally to avoid circular import
         # (type_handlers.py is imported by type_registry.py)
         try:
@@ -1028,53 +1008,83 @@ class CacheListHandler(CacheTypeHandler):
 
         from .type_registry import CacheTypeRegistry as _Registry  # local import
 
+        handler_reconstruct_failed = False
         sub_caches = []
-        for sub_state, cls_name, sub_meta in zip(
-            sub_states, class_names, sub_meta_states
-        ):
-            # Normalize class name for handler lookup
-            normalized_name = self._CLASS_NAME_NORMALIZE.get(cls_name, cls_name)
-            sub_handler = _Registry.get_handler_by_class_name(normalized_name)
+        try:
+            for sub_state, cls_name, sub_meta in zip(
+                sub_states, class_names, sub_meta_states
+            ):
+                # Normalize class name for handler lookup
+                normalized_name = self._CLASS_NAME_NORMALIZE.get(cls_name, cls_name)
+                sub_handler = _Registry.get_handler_by_class_name(normalized_name)
 
-            try:
-                if normalized_name in ("ArraysCache", "SizedArraysCache"):
-                    sub_cache = sub_handler.reconstruct_cache(
-                        {"states": list(sub_state)}, sub_meta
+                try:
+                    if normalized_name in ("ArraysCache", "SizedArraysCache"):
+                        sub_cache = sub_handler.reconstruct_cache(
+                            {"states": list(sub_state)}, sub_meta
+                        )
+                    elif isinstance(sub_state, (list, tuple)):
+                        # Generic N-tuple dispatch via the new deserialize_state
+                        # interface. Handlers that have a 3-tuple state (e.g.
+                        # PoolingCache: buf_kv, buf_gate, pooled) override
+                        # deserialize_state to consume all elements; default
+                        # implementation maps the first two to (keys, values)
+                        # which matches the legacy contract for KVCache /
+                        # RotatingKVCache.
+                        sub_cache = sub_handler.deserialize_state(
+                            tuple(sub_state), sub_meta
+                        )
+                    else:
+                        logger.debug(
+                            f"CacheList handler reconstruction skipped: "
+                            f"unexpected sub_state format for {cls_name}"
+                        )
+                        handler_reconstruct_failed = True
+                        break
+                except Exception as e:
+                    logger.debug(
+                        f"CacheList handler reconstruction failed for {cls_name}: {e}"
                     )
-                elif isinstance(sub_state, (list, tuple)):
-                    # Generic N-tuple dispatch via the new deserialize_state
-                    # interface. Handlers that have a 3-tuple state (e.g.
-                    # PoolingCache: buf_kv, buf_gate, pooled) override
-                    # deserialize_state to consume all elements; default
-                    # implementation maps the first two to (keys, values)
-                    # which matches the legacy contract for KVCache /
-                    # RotatingKVCache.
-                    sub_cache = sub_handler.deserialize_state(
-                        tuple(sub_state), sub_meta
+                    handler_reconstruct_failed = True
+                    break
+
+                if sub_cache is None:
+                    logger.debug(
+                        f"CacheList handler reconstruction failed: "
+                        f"sub-cache {cls_name} returned None"
                     )
-                else:
-                    logger.error(
-                        f"CacheList fallback: unexpected sub_state format "
-                        f"for {cls_name}"
-                    )
-                    return None
-            except Exception as e:
-                logger.error(
-                    f"CacheList fallback: failed to reconstruct {cls_name}: {e}"
-                )
-                return None
+                    handler_reconstruct_failed = True
+                    break
 
-            if sub_cache is None:
-                logger.error(f"CacheList fallback: sub-cache {cls_name} returned None")
-                return None
+                # Unwrap SizedArraysCache for CacheList (CacheList expects raw ArraysCache)
+                if isinstance(sub_cache, SizedArraysCache):
+                    sub_cache = sub_cache._inner
 
-            # Unwrap SizedArraysCache for CacheList (CacheList expects raw ArraysCache)
-            if isinstance(sub_cache, SizedArraysCache):
-                sub_cache = sub_cache._inner
+                sub_caches.append(sub_cache)
+        except Exception as e:
+            logger.debug(f"CacheList handler reconstruction failed: {e}")
+            handler_reconstruct_failed = True
 
-            sub_caches.append(sub_cache)
+        if not handler_reconstruct_failed:
+            return CacheList(*sub_caches)
 
-        return CacheList(*sub_caches)
+        # Last-resort compatibility path for unknown CacheList sub-caches.
+        # This bypasses omlx handlers, so it must not be the preferred path.
+        no_meta_state_types = frozenset(
+            {"KVCache", "ConcatenateKVCache", "ArraysCache"}
+        )
+        sanitized_sub_meta_states = [
+            "" if cls_name in no_meta_state_types else sub_meta
+            for cls_name, sub_meta in zip(class_names, sub_meta_states)
+        ]
+
+        try:
+            return CacheList.from_state(
+                sub_states, (class_names, sanitized_sub_meta_states)
+            )
+        except Exception as e:
+            logger.error(f"CacheList.from_state() fallback failed: {e}")
+            return None
 
     def _get_state_keys(self) -> tuple[str, ...]:
         return ("sub_states", "sub_class_names", "sub_meta_states")
@@ -1236,13 +1246,9 @@ class MiniMaxM3KVCacheHandler(_MiniMaxM3CacheHandlerBase):
             return {}
 
         keys_list = [s.get("keys") for s in states if s.get("keys") is not None]
-        values_list = [
-            s.get("values") for s in states if s.get("values") is not None
-        ]
+        values_list = [s.get("values") for s in states if s.get("values") is not None]
         index_list = [
-            s.get("index_keys")
-            for s in states
-            if s.get("index_keys") is not None
+            s.get("index_keys") for s in states if s.get("index_keys") is not None
         ]
         if not keys_list or not values_list:
             return {}

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/CMakeLists.txt
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(
   omlx_glm_kernel_ops
   PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/dsa_indexer.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/deepseek_v4_sparse_attention.cpp
   ${CMAKE_CURRENT_LIST_DIR}/exact_block_attention.cpp
   ${CMAKE_CURRENT_LIST_DIR}/fused_moe.cpp
   ${CMAKE_CURRENT_LIST_DIR}/sparse_mla.cpp)
@@ -44,6 +45,8 @@ target_link_libraries(omlx_glm_kernel_ops PUBLIC mlx)
 
 if(MLX_BUILD_METAL)
   set(OMLX_GLM_METAL_SOURCES
+      ${CMAKE_CURRENT_LIST_DIR}/deepseek_moe.metal
+      ${CMAKE_CURRENT_LIST_DIR}/deepseek_v4_sparse_attention.metal
       ${CMAKE_CURRENT_LIST_DIR}/dsa_indexer.metal
       ${CMAKE_CURRENT_LIST_DIR}/exact_block_attention.metal
       ${CMAKE_CURRENT_LIST_DIR}/fused_moe.metal

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
@@ -4,6 +4,7 @@
 #include <nanobind/stl/variant.h>
 
 #include "dsa_indexer.h"
+#include "deepseek_v4_sparse_attention.h"
 #include "exact_block_attention.h"
 #include "fused_moe.h"
 #include "sparse_mla.h"
@@ -60,6 +61,19 @@ NB_MODULE(_ext, m) {
       "causal"_a = true,
       "stream"_a = nb::none());
   m.def(
+      "deepseek_v4_sparse_attention",
+      &omlx::glm_kernels::deepseek_v4_sparse_attention,
+      "q"_a,
+      "local_kv"_a,
+      "pooled"_a,
+      "topk_indices"_a,
+      "sinks"_a,
+      "scale"_a,
+      "q_offset"_a,
+      "compress_ratio"_a,
+      "local_window"_a,
+      "stream"_a = nb::none());
+  m.def(
       "glm_dsa_q8_vup_flat",
       &omlx::glm_kernels::glm_dsa_q8_vup_flat,
       "x"_a,
@@ -73,5 +87,48 @@ NB_MODULE(_ext, m) {
       "x_sorted"_a,
       "inv_order"_a,
       "scores"_a,
+      "stream"_a = nb::none());
+  m.def(
+      "deepseek_mxfp4_gather_qmm_blocks",
+      &omlx::glm_kernels::deepseek_mxfp4_gather_qmm_blocks,
+      "x"_a,
+      "weight"_a,
+      "scales"_a,
+      "block_meta"_a,
+      "block_count"_a,
+      "variant"_a = 0,
+      "stream"_a = nb::none());
+  m.def(
+      "deepseek_mxfp4_gather_qmm_pair_blocks",
+      &omlx::glm_kernels::deepseek_mxfp4_gather_qmm_pair_blocks,
+      "x"_a,
+      "weight0"_a,
+      "scales0"_a,
+      "weight1"_a,
+      "scales1"_a,
+      "block_meta"_a,
+      "block_count"_a,
+      "variant"_a = 0,
+      "stream"_a = nb::none());
+  m.def(
+      "deepseek_mxfp4_gather_qmm_pair_concat_blocks",
+      &omlx::glm_kernels::deepseek_mxfp4_gather_qmm_pair_concat_blocks,
+      "x"_a,
+      "weight0"_a,
+      "scales0"_a,
+      "weight1"_a,
+      "scales1"_a,
+      "block_meta"_a,
+      "block_count"_a,
+      "variant"_a = 0,
+      "stream"_a = nb::none());
+  m.def(
+      "deepseek_mxfp4_gather_qmm_expert",
+      &omlx::glm_kernels::deepseek_mxfp4_gather_qmm_expert,
+      "x"_a,
+      "weight"_a,
+      "scales"_a,
+      "indices"_a,
+      "variant"_a = 0,
       "stream"_a = nb::none());
 }

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
@@ -123,6 +123,35 @@ NB_MODULE(_ext, m) {
       "variant"_a = 0,
       "stream"_a = nb::none());
   m.def(
+      "deepseek_affine_gather_qmm_blocks",
+      &omlx::glm_kernels::deepseek_affine_gather_qmm_blocks,
+      "x"_a,
+      "weight"_a,
+      "scales"_a,
+      "biases"_a,
+      "block_meta"_a,
+      "block_count"_a,
+      "group_size"_a,
+      "bits"_a,
+      "variant"_a = 0,
+      "stream"_a = nb::none());
+  m.def(
+      "deepseek_affine_gather_qmm_pair_concat_blocks",
+      &omlx::glm_kernels::deepseek_affine_gather_qmm_pair_concat_blocks,
+      "x"_a,
+      "weight0"_a,
+      "scales0"_a,
+      "biases0"_a,
+      "weight1"_a,
+      "scales1"_a,
+      "biases1"_a,
+      "block_meta"_a,
+      "block_count"_a,
+      "group_size"_a,
+      "bits"_a,
+      "variant"_a = 0,
+      "stream"_a = nb::none());
+  m.def(
       "deepseek_mxfp4_gather_qmm_expert",
       &omlx::glm_kernels::deepseek_mxfp4_gather_qmm_expert,
       "x"_a,

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_moe.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_moe.metal
@@ -1,0 +1,660 @@
+#include "mlx/backend/metal/kernels/utils.h"
+#include "mlx/backend/metal/kernels/steel/gemm/gemm.h"
+#include "mlx/backend/metal/kernels/fp_quantized.h"
+#include "mlx/backend/metal/kernels/quantized_utils.h"
+
+template <
+    typename T,
+    int BM,
+    int BN,
+    int BK,
+    int WM,
+    int WN>
+[[kernel]] void deepseek_mxfp4_gather_blocks_rhs(
+    const device T* x [[buffer(0)]],
+    const device uint32_t* w [[buffer(1)]],
+    const device uint8_t* scales [[buffer(2)]],
+    const device int32_t* block_meta [[buffer(3)]],
+    const device int32_t* block_count [[buffer(4)]],
+    device T* y [[buffer(5)]],
+    const constant int& max_blocks [[buffer(6)]],
+    const constant int& M [[buffer(7)]],
+    const constant int& N [[buffer(8)]],
+    const constant int& K [[buffer(9)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]]) {
+  (void)M;
+  constexpr int group_size = 32;
+  constexpr int bits = 4;
+  constexpr int pack_factor = get_pack_factor<8, bits>();
+  constexpr int bytes_per_pack = get_bytes_per_pack();
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+  constexpr int BN_padded = (BN + 16 / sizeof(T));
+
+  using mma_t = mlx::steel::BlockMMA<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      true,
+      BK_padded,
+      BK_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t = QuantizedBlockLoader<
+      T,
+      BN,
+      BK,
+      BK_padded,
+      true,
+      WM * WN * SIMD_SIZE,
+      group_size,
+      bits>;
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  const int block_id = int(tid.y);
+  const int nblocks = block_count[0];
+  if (block_id >= max_blocks || block_id >= nblocks) {
+    return;
+  }
+
+  const int y_col = int(tid.x) * BN;
+  if (y_col >= N) {
+    return;
+  }
+
+  const int row_start = block_meta[block_id * 3 + 0];
+  const int expert = block_meta[block_id * 3 + 1];
+  const int rows = block_meta[block_id * 3 + 2];
+  if (rows <= 0) {
+    return;
+  }
+
+  const short tgp_bm = short(min(BM, rows));
+  const short tgp_bn = short(min(BN, N - y_col));
+  const int K_it = K / BK;
+  const int k_remain = K - K_it * BK;
+  const short2 tile_x = short2(k_remain, tgp_bm);
+  const short2 tile_w = short2(k_remain, tgp_bn);
+
+  const int K_w = K * bytes_per_pack / pack_factor;
+  const int K_g = K / group_size;
+  const size_t stride_w = size_t(N) * K_w;
+  const size_t stride_s = size_t(N) * K_g;
+
+  const device T* xl = x + size_t(row_start) * K;
+  device T* yl = y + size_t(row_start) * N + y_col;
+  const device uint8_t* wl =
+      ((const device uint8_t*)w) + size_t(expert) * stride_w +
+      size_t(y_col) * K_w;
+  const device uint8_t* sl =
+      scales + size_t(expert) * stride_s + size_t(y_col) * K_g;
+
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+  thread loader_x_t loader_x(xl, K, Xs, simd_group_id, simd_lane_id);
+  thread loader_w_t loader_w(wl, sl, K, Ws, simd_group_id, simd_lane_id);
+
+  if (rows == BM && tgp_bn == BN) {
+    gemm_loop_aligned(Xs, Ws, mma_op, loader_x, loader_w, K_it);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result(yl, N);
+  } else if (tgp_bn == BN) {
+    gemm_loop_unaligned<false, true, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N, short2(0, 0), short2(BN, tgp_bm));
+  } else if (rows == BM) {
+    gemm_loop_unaligned<true, false, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N, short2(0, 0), short2(tgp_bn, BM));
+  } else {
+    gemm_loop_unaligned<false, false, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N, short2(0, 0), short2(tgp_bn, tgp_bm));
+  }
+}
+
+#define instantiate_deepseek_mxfp4_blocks(type, bm, bn, bk, wm, wn)            \
+  instantiate_kernel(                                                          \
+      "deepseek_mxfp4_gather_blocks_rhs_" #type "_bm_" #bm "_bn_" #bn         \
+      "_bk_" #bk "_wm_" #wm "_wn_" #wn,                                       \
+      deepseek_mxfp4_gather_blocks_rhs,                                        \
+      type,                                                                    \
+      bm,                                                                      \
+      bn,                                                                      \
+      bk,                                                                      \
+      wm,                                                                      \
+      wn)
+
+instantiate_deepseek_mxfp4_blocks(float16_t, 8, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_blocks(float16_t, 16, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_blocks(float16_t, 32, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_blocks(float16_t, 16, 64, 32, 1, 2);
+instantiate_deepseek_mxfp4_blocks(float16_t, 32, 64, 32, 1, 2);
+
+instantiate_deepseek_mxfp4_blocks(bfloat16_t, 8, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_blocks(bfloat16_t, 16, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_blocks(bfloat16_t, 32, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_blocks(bfloat16_t, 16, 64, 32, 1, 2);
+instantiate_deepseek_mxfp4_blocks(bfloat16_t, 32, 64, 32, 1, 2);
+
+template <
+    typename T,
+    int BM,
+    int BN,
+    int BK,
+    int WM,
+    int WN>
+[[kernel]] void deepseek_mxfp4_gather_pair_blocks_rhs(
+    const device T* x [[buffer(0)]],
+    const device uint32_t* w0 [[buffer(1)]],
+    const device uint8_t* scales0 [[buffer(2)]],
+    const device uint32_t* w1 [[buffer(3)]],
+    const device uint8_t* scales1 [[buffer(4)]],
+    const device int32_t* block_meta [[buffer(5)]],
+    const device int32_t* block_count [[buffer(6)]],
+    device T* y [[buffer(7)]],
+    const constant int& max_blocks [[buffer(8)]],
+    const constant int& M [[buffer(9)]],
+    const constant int& N [[buffer(10)]],
+    const constant int& K [[buffer(11)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]]) {
+  constexpr int group_size = 32;
+  constexpr int bits = 4;
+  constexpr int pack_factor = get_pack_factor<8, bits>();
+  constexpr int bytes_per_pack = get_bytes_per_pack();
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+
+  using mma_t = mlx::steel::BlockMMA<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      true,
+      BK_padded,
+      BK_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t = QuantizedBlockLoader<
+      T,
+      BN,
+      BK,
+      BK_padded,
+      true,
+      WM * WN * SIMD_SIZE,
+      group_size,
+      bits>;
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  const int pair_id = int(tid.z);
+  const int block_id = int(tid.y);
+  const int nblocks = block_count[0];
+  if (pair_id >= 2 || block_id >= max_blocks || block_id >= nblocks) {
+    return;
+  }
+
+  const int y_col = int(tid.x) * BN;
+  if (y_col >= N) {
+    return;
+  }
+
+  const int row_start = block_meta[block_id * 3 + 0];
+  const int expert = block_meta[block_id * 3 + 1];
+  const int rows = block_meta[block_id * 3 + 2];
+  if (rows <= 0) {
+    return;
+  }
+
+  const short tgp_bm = short(min(BM, rows));
+  const short tgp_bn = short(min(BN, N - y_col));
+  const int K_it = K / BK;
+  const int k_remain = K - K_it * BK;
+  const short2 tile_x = short2(k_remain, tgp_bm);
+  const short2 tile_w = short2(k_remain, tgp_bn);
+
+  const int K_w = K * bytes_per_pack / pack_factor;
+  const int K_g = K / group_size;
+  const size_t stride_w = size_t(N) * K_w;
+  const size_t stride_s = size_t(N) * K_g;
+
+  const device uint32_t* w = pair_id == 0 ? w0 : w1;
+  const device uint8_t* scales = pair_id == 0 ? scales0 : scales1;
+
+  const device T* xl = x + size_t(row_start) * K;
+  device T* yl = y + size_t(pair_id) * size_t(M) * N +
+      size_t(row_start) * N + y_col;
+  const device uint8_t* wl =
+      ((const device uint8_t*)w) + size_t(expert) * stride_w +
+      size_t(y_col) * K_w;
+  const device uint8_t* sl =
+      scales + size_t(expert) * stride_s + size_t(y_col) * K_g;
+
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+  thread loader_x_t loader_x(xl, K, Xs, simd_group_id, simd_lane_id);
+  thread loader_w_t loader_w(wl, sl, K, Ws, simd_group_id, simd_lane_id);
+
+  if (rows == BM && tgp_bn == BN) {
+    gemm_loop_aligned(Xs, Ws, mma_op, loader_x, loader_w, K_it);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result(yl, N);
+  } else if (tgp_bn == BN) {
+    gemm_loop_unaligned<false, true, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N, short2(0, 0), short2(BN, tgp_bm));
+  } else if (rows == BM) {
+    gemm_loop_unaligned<true, false, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N, short2(0, 0), short2(tgp_bn, BM));
+  } else {
+    gemm_loop_unaligned<false, false, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N, short2(0, 0), short2(tgp_bn, tgp_bm));
+  }
+}
+
+#define instantiate_deepseek_mxfp4_pair_blocks(type, bm, bn, bk, wm, wn)       \
+  instantiate_kernel(                                                          \
+      "deepseek_mxfp4_gather_pair_blocks_rhs_" #type "_bm_" #bm "_bn_" #bn    \
+      "_bk_" #bk "_wm_" #wm "_wn_" #wn,                                       \
+      deepseek_mxfp4_gather_pair_blocks_rhs,                                   \
+      type,                                                                    \
+      bm,                                                                      \
+      bn,                                                                      \
+      bk,                                                                      \
+      wm,                                                                      \
+      wn)
+
+instantiate_deepseek_mxfp4_pair_blocks(float16_t, 8, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_blocks(float16_t, 16, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_blocks(float16_t, 32, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_blocks(float16_t, 16, 64, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_blocks(float16_t, 32, 64, 32, 1, 2);
+
+instantiate_deepseek_mxfp4_pair_blocks(bfloat16_t, 8, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_blocks(bfloat16_t, 16, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_blocks(bfloat16_t, 32, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_blocks(bfloat16_t, 16, 64, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_blocks(bfloat16_t, 32, 64, 32, 1, 2);
+
+template <
+    typename T,
+    int BM,
+    int BN,
+    int BK,
+    int WM,
+    int WN>
+[[kernel]] void deepseek_mxfp4_gather_pair_concat_blocks_rhs(
+    const device T* x [[buffer(0)]],
+    const device uint32_t* w0 [[buffer(1)]],
+    const device uint8_t* scales0 [[buffer(2)]],
+    const device uint32_t* w1 [[buffer(3)]],
+    const device uint8_t* scales1 [[buffer(4)]],
+    const device int32_t* block_meta [[buffer(5)]],
+    const device int32_t* block_count [[buffer(6)]],
+    device T* y [[buffer(7)]],
+    const constant int& max_blocks [[buffer(8)]],
+    const constant int& M [[buffer(9)]],
+    const constant int& N [[buffer(10)]],
+    const constant int& K [[buffer(11)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]]) {
+  (void)M;
+  constexpr int group_size = 32;
+  constexpr int bits = 4;
+  constexpr int pack_factor = get_pack_factor<8, bits>();
+  constexpr int bytes_per_pack = get_bytes_per_pack();
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+
+  using mma_t = mlx::steel::BlockMMA<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      true,
+      BK_padded,
+      BK_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t = QuantizedBlockLoader<
+      T,
+      BN,
+      BK,
+      BK_padded,
+      true,
+      WM * WN * SIMD_SIZE,
+      group_size,
+      bits>;
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  const int block_id = int(tid.y);
+  const int nblocks = block_count[0];
+  if (block_id >= max_blocks || block_id >= nblocks) {
+    return;
+  }
+
+  const int y_col_concat = int(tid.x) * BN;
+  if (y_col_concat >= 2 * N) {
+    return;
+  }
+
+  const int pair_id = y_col_concat >= N ? 1 : 0;
+  const int y_col = pair_id == 0 ? y_col_concat : y_col_concat - N;
+  if (y_col >= N) {
+    return;
+  }
+
+  const int row_start = block_meta[block_id * 3 + 0];
+  const int expert = block_meta[block_id * 3 + 1];
+  const int rows = block_meta[block_id * 3 + 2];
+  if (rows <= 0) {
+    return;
+  }
+
+  const short tgp_bm = short(min(BM, rows));
+  const short tgp_bn = short(min(BN, N - y_col));
+  const int K_it = K / BK;
+  const int k_remain = K - K_it * BK;
+  const short2 tile_x = short2(k_remain, tgp_bm);
+  const short2 tile_w = short2(k_remain, tgp_bn);
+
+  const int K_w = K * bytes_per_pack / pack_factor;
+  const int K_g = K / group_size;
+  const size_t stride_w = size_t(N) * K_w;
+  const size_t stride_s = size_t(N) * K_g;
+  const int N_out = 2 * N;
+
+  const device uint32_t* w = pair_id == 0 ? w0 : w1;
+  const device uint8_t* scales = pair_id == 0 ? scales0 : scales1;
+
+  const device T* xl = x + size_t(row_start) * K;
+  device T* yl = y + size_t(row_start) * N_out +
+      size_t(pair_id) * N + y_col;
+  const device uint8_t* wl =
+      ((const device uint8_t*)w) + size_t(expert) * stride_w +
+      size_t(y_col) * K_w;
+  const device uint8_t* sl =
+      scales + size_t(expert) * stride_s + size_t(y_col) * K_g;
+
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+  thread loader_x_t loader_x(xl, K, Xs, simd_group_id, simd_lane_id);
+  thread loader_w_t loader_w(wl, sl, K, Ws, simd_group_id, simd_lane_id);
+
+  if (rows == BM && tgp_bn == BN) {
+    gemm_loop_aligned(Xs, Ws, mma_op, loader_x, loader_w, K_it);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result(yl, N_out);
+  } else if (tgp_bn == BN) {
+    gemm_loop_unaligned<false, true, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N_out, short2(0, 0), short2(BN, tgp_bm));
+  } else if (rows == BM) {
+    gemm_loop_unaligned<true, false, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N_out, short2(0, 0), short2(tgp_bn, BM));
+  } else {
+    gemm_loop_unaligned<false, false, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N_out, short2(0, 0), short2(tgp_bn, tgp_bm));
+  }
+}
+
+#define instantiate_deepseek_mxfp4_pair_concat_blocks(type, bm, bn, bk, wm, wn) \
+  instantiate_kernel(                                                          \
+      "deepseek_mxfp4_gather_pair_concat_blocks_rhs_" #type "_bm_" #bm         \
+      "_bn_" #bn "_bk_" #bk "_wm_" #wm "_wn_" #wn,                           \
+      deepseek_mxfp4_gather_pair_concat_blocks_rhs,                            \
+      type,                                                                    \
+      bm,                                                                      \
+      bn,                                                                      \
+      bk,                                                                      \
+      wm,                                                                      \
+      wn)
+
+instantiate_deepseek_mxfp4_pair_concat_blocks(float16_t, 8, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_concat_blocks(float16_t, 16, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_concat_blocks(float16_t, 32, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_concat_blocks(float16_t, 16, 64, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_concat_blocks(float16_t, 32, 64, 32, 1, 2);
+
+instantiate_deepseek_mxfp4_pair_concat_blocks(bfloat16_t, 8, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_concat_blocks(bfloat16_t, 16, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_concat_blocks(bfloat16_t, 32, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_concat_blocks(bfloat16_t, 16, 64, 32, 1, 2);
+instantiate_deepseek_mxfp4_pair_concat_blocks(bfloat16_t, 32, 64, 32, 1, 2);
+
+template <
+    typename T,
+    int BM,
+    int BN,
+    int BK,
+    int WM,
+    int WN>
+[[kernel]] void deepseek_mxfp4_gather_expert_rhs(
+    const device T* x [[buffer(0)]],
+    const device uint32_t* w [[buffer(1)]],
+    const device uint8_t* scales [[buffer(2)]],
+    const device uint32_t* indices [[buffer(3)]],
+    device T* y [[buffer(4)]],
+    const constant int& M [[buffer(5)]],
+    const constant int& N [[buffer(6)]],
+    const constant int& K [[buffer(7)]],
+    const constant int& E [[buffer(8)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]]) {
+  constexpr int group_size = 32;
+  constexpr int bits = 4;
+  constexpr int pack_factor = get_pack_factor<8, bits>();
+  constexpr int bytes_per_pack = get_bytes_per_pack();
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+
+  using mma_t = mlx::steel::BlockMMA<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      true,
+      BK_padded,
+      BK_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t = QuantizedBlockLoader<
+      T,
+      BN,
+      BK,
+      BK_padded,
+      true,
+      WM * WN * SIMD_SIZE,
+      group_size,
+      bits>;
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  const int y_col = int(tid.x) * BN;
+  const int expert = int(tid.y);
+  if (y_col >= N || expert >= E) {
+    return;
+  }
+
+  int lo = 0;
+  int hi = M;
+  while (lo < hi) {
+    const int mid = (lo + hi) >> 1;
+    if (indices[mid] < uint32_t(expert)) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  const int start = lo;
+
+  hi = M;
+  while (lo < hi) {
+    const int mid = (lo + hi) >> 1;
+    if (indices[mid] <= uint32_t(expert)) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  const int end = lo;
+  if (start >= end) {
+    return;
+  }
+
+  const int K_it = K / BK;
+  const int k_remain = K - K_it * BK;
+  const int K_w = K * bytes_per_pack / pack_factor;
+  const int K_g = K / group_size;
+  const size_t stride_w = size_t(N) * K_w;
+  const size_t stride_s = size_t(N) * K_g;
+  const short tgp_bn = short(min(BN, N - y_col));
+  const short2 tile_w = short2(k_remain, tgp_bn);
+
+  const device uint8_t* wl =
+      ((const device uint8_t*)w) + size_t(expert) * stride_w +
+      size_t(y_col) * K_w;
+  const device uint8_t* sl =
+      scales + size_t(expert) * stride_s + size_t(y_col) * K_g;
+
+  for (int row = start; row < end; row += BM) {
+    const int rows = min(BM, end - row);
+    const short tgp_bm = short(rows);
+    const short2 tile_x = short2(k_remain, tgp_bm);
+
+    const device T* xl = x + size_t(row) * K;
+    device T* yl = y + size_t(row) * N + y_col;
+
+    thread mma_t mma_op(simd_group_id, simd_lane_id);
+    thread loader_x_t loader_x(xl, K, Xs, simd_group_id, simd_lane_id);
+    thread loader_w_t loader_w(wl, sl, K, Ws, simd_group_id, simd_lane_id);
+
+    if (rows == BM && tgp_bn == BN) {
+      gemm_loop_aligned(Xs, Ws, mma_op, loader_x, loader_w, K_it);
+      if (k_remain != 0) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+      }
+      mma_op.store_result(yl, N);
+    } else if (tgp_bn == BN) {
+      gemm_loop_unaligned<false, true, true>(
+          Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+      if (k_remain != 0) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+      }
+      mma_op.store_result_slice(yl, N, short2(0, 0), short2(BN, tgp_bm));
+    } else if (rows == BM) {
+      gemm_loop_unaligned<true, false, true>(
+          Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+      if (k_remain != 0) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+      }
+      mma_op.store_result_slice(yl, N, short2(0, 0), short2(tgp_bn, BM));
+    } else {
+      gemm_loop_unaligned<false, false, true>(
+          Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+      if (k_remain != 0) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+      }
+      mma_op.store_result_slice(yl, N, short2(0, 0), short2(tgp_bn, tgp_bm));
+    }
+  }
+}
+
+#define instantiate_deepseek_mxfp4_expert(type, bm, bn, bk, wm, wn)            \
+  instantiate_kernel(                                                          \
+      "deepseek_mxfp4_gather_expert_rhs_" #type "_bm_" #bm "_bn_" #bn         \
+      "_bk_" #bk "_wm_" #wm "_wn_" #wn,                                       \
+      deepseek_mxfp4_gather_expert_rhs,                                        \
+      type,                                                                    \
+      bm,                                                                      \
+      bn,                                                                      \
+      bk,                                                                      \
+      wm,                                                                      \
+      wn)
+
+instantiate_deepseek_mxfp4_expert(float16_t, 8, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_expert(float16_t, 16, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_expert(float16_t, 32, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_expert(float16_t, 16, 64, 32, 1, 2);
+instantiate_deepseek_mxfp4_expert(float16_t, 32, 64, 32, 1, 2);
+
+instantiate_deepseek_mxfp4_expert(bfloat16_t, 8, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_expert(bfloat16_t, 16, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_expert(bfloat16_t, 32, 32, 32, 1, 2);
+instantiate_deepseek_mxfp4_expert(bfloat16_t, 16, 64, 32, 1, 2);
+instantiate_deepseek_mxfp4_expert(bfloat16_t, 32, 64, 32, 1, 2);

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_moe.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_moe.metal
@@ -3,6 +3,188 @@
 #include "mlx/backend/metal/kernels/fp_quantized.h"
 #include "mlx/backend/metal/kernels/quantized_utils.h"
 
+template <int bits, int wsize = 8>
+inline constexpr short deepseek_affine_pack_factor() {
+  return (bits == 3 || bits == 5) ? 8 : (bits == 6 ? 4 : wsize / bits);
+}
+
+template <int bits, int wsize = 8>
+inline constexpr short deepseek_affine_bytes_per_pack() {
+  constexpr int power_of_2_bits = (bits & (bits - 1)) == 0;
+  return power_of_2_bits ? (wsize / 8) : (bits == 5 ? 5 : 3);
+}
+
+template <typename U, int N, int bits>
+inline void deepseek_affine_dequantize(
+    const device uint8_t* w,
+    U scale,
+    U bias,
+    threadgroup U* w_local) {
+  static_assert(
+      bits == 2 || bits == 3 || bits == 4 || bits == 8,
+      "DeepSeek affine MoE supports bits in {2, 3, 4, 8}");
+
+  if (bits == 2) {
+    U s[4] = {
+        scale,
+        scale / static_cast<U>(4.0f),
+        scale / static_cast<U>(16.0f),
+        scale / static_cast<U>(64.0f)};
+    for (int i = 0; i < (N / 4); i++) {
+      w_local[4 * i] = s[0] * (w[i] & 0x03) + bias;
+      w_local[4 * i + 1] = s[1] * (w[i] & 0x0c) + bias;
+      w_local[4 * i + 2] = s[2] * (w[i] & 0x30) + bias;
+      w_local[4 * i + 3] = s[3] * (w[i] & 0xc0) + bias;
+    }
+  } else if (bits == 3) {
+    for (int i = 0; i < (N / 8); i++) {
+      const device uint8_t* wp = w + 3 * i;
+      threadgroup U* out = w_local + 8 * i;
+      out[0] = (wp[0] & 0x7) * scale + bias;
+      out[1] = ((wp[0] & 0x38) >> 3) * scale + bias;
+      out[2] = (((wp[0] & 0xc0) >> 6) + ((wp[1] & 0x1) << 2)) * scale + bias;
+      out[3] = ((wp[1] & 0xe) >> 1) * scale + bias;
+      out[4] = ((wp[1] & 0x70) >> 4) * scale + bias;
+      out[5] = (((wp[1] & 0x80) >> 7) + ((wp[2] & 0x3) << 1)) * scale + bias;
+      out[6] = ((wp[2] & 0x1c) >> 2) * scale + bias;
+      out[7] = ((wp[2] & 0xe0) >> 5) * scale + bias;
+    }
+  } else if (bits == 4) {
+    U s[2] = {scale, scale / static_cast<U>(16.0f)};
+    for (int i = 0; i < (N / 2); i++) {
+      w_local[2 * i] = s[0] * (w[i] & 0x0f) + bias;
+      w_local[2 * i + 1] = s[1] * (w[i] & 0xf0) + bias;
+    }
+  } else if (bits == 8) {
+    for (int i = 0; i < N; i++) {
+      w_local[i] = scale * w[i] + bias;
+    }
+  }
+}
+
+template <
+    typename T,
+    short BROWS,
+    short BCOLS,
+    short dst_ld,
+    short reduction_dim,
+    short tgp_size,
+    short group_size,
+    short bits>
+struct DeepseekAffineBlockLoader {
+  static_assert(BCOLS <= group_size, "group_size must cover BCOLS");
+  static_assert(group_size % BCOLS == 0, "group_size must divide BCOLS");
+  static_assert(
+      bits == 2 || bits == 3 || bits == 4 || bits == 8,
+      "DeepSeek affine MoE supports bits in {2, 3, 4, 8}");
+
+  static constant constexpr const short pack_factor =
+      deepseek_affine_pack_factor<bits, 8>();
+  static constant constexpr const short bytes_per_pack =
+      deepseek_affine_bytes_per_pack<bits, 8>();
+  static constant constexpr const short BCOLS_PACKED = BCOLS / pack_factor;
+  static constant constexpr const short n_reads =
+      (BCOLS_PACKED * BROWS < tgp_size) ? 1 : (BCOLS_PACKED * BROWS) / tgp_size;
+  static constant constexpr const short group_steps = group_size / BCOLS;
+
+  const int src_ld;
+  const int tile_stride;
+  short group_step_cnt;
+  const int group_stride;
+
+  const short thread_idx;
+  const short bi;
+  const short bj;
+
+  threadgroup T* dst;
+  const device uint8_t* src;
+  const device T* scales;
+  const device T* biases;
+
+  DeepseekAffineBlockLoader(
+      const device uint8_t* src_,
+      const device T* scales_,
+      const device T* biases_,
+      const int src_ld_,
+      threadgroup T* dst_,
+      ushort simd_group_id [[simdgroup_index_in_threadgroup]],
+      ushort simd_lane_id [[thread_index_in_simdgroup]])
+      : src_ld(src_ld_),
+        tile_stride(
+            reduction_dim ? BCOLS_PACKED * bytes_per_pack
+                          : BROWS * src_ld * bytes_per_pack / pack_factor),
+        group_step_cnt(0),
+        group_stride(BROWS * src_ld / group_size),
+        thread_idx(simd_group_id * 32 + simd_lane_id),
+        bi(n_reads * thread_idx / BCOLS_PACKED),
+        bj((n_reads * thread_idx) % BCOLS_PACKED),
+        dst(dst_ + bi * dst_ld + bj * pack_factor),
+        src(src_ + bi * src_ld * bytes_per_pack / pack_factor +
+            bj * bytes_per_pack),
+        scales(scales_ + bi * src_ld / group_size),
+        biases(biases_ + bi * src_ld / group_size) {}
+
+  void load_unsafe() const {
+    if (BCOLS_PACKED * BROWS < tgp_size && bi >= BROWS) {
+      return;
+    }
+
+    const T scale = *scales;
+    const T bias = *biases;
+    for (int i = 0; i < n_reads; i++) {
+      deepseek_affine_dequantize<T, pack_factor, bits>(
+          src + i * bytes_per_pack, scale, bias, dst + i * pack_factor);
+    }
+  }
+
+  void load_safe(short2 src_tile_dim) const {
+    if (BCOLS_PACKED * BROWS < tgp_size && bi >= BROWS) {
+      return;
+    }
+
+    if (reduction_dim == 1 && bi >= src_tile_dim.x) {
+      for (int i = 0; i < n_reads * pack_factor; i++) {
+        dst[i] = T(0);
+      }
+      return;
+    }
+
+    if (reduction_dim == 0 && bi >= src_tile_dim.y) {
+      for (int i = 0; i < n_reads * pack_factor; i++) {
+        dst[i] = T(0);
+      }
+      return;
+    }
+
+    const T scale = *scales;
+    const T bias = *biases;
+    for (int i = 0; i < n_reads; i++) {
+      deepseek_affine_dequantize<T, pack_factor, bits>(
+          src + i * bytes_per_pack, scale, bias, dst + i * pack_factor);
+    }
+  }
+
+  void next() {
+    src += tile_stride;
+    if (reduction_dim == 1) {
+      if (group_steps > 1) {
+        group_step_cnt++;
+        if (group_step_cnt == group_steps) {
+          group_step_cnt = 0;
+          scales++;
+          biases++;
+        }
+      } else {
+        scales++;
+        biases++;
+      }
+    } else {
+      scales += group_stride;
+      biases += group_stride;
+    }
+  }
+};
+
 template <
     typename T,
     int BM,
@@ -30,7 +212,6 @@ template <
   constexpr int pack_factor = get_pack_factor<8, bits>();
   constexpr int bytes_per_pack = get_bytes_per_pack();
   constexpr int BK_padded = (BK + 16 / sizeof(T));
-  constexpr int BN_padded = (BN + 16 / sizeof(T));
 
   using mma_t = mlx::steel::BlockMMA<
       T,
@@ -487,6 +668,339 @@ instantiate_deepseek_mxfp4_pair_concat_blocks(bfloat16_t, 16, 32, 32, 1, 2);
 instantiate_deepseek_mxfp4_pair_concat_blocks(bfloat16_t, 32, 32, 32, 1, 2);
 instantiate_deepseek_mxfp4_pair_concat_blocks(bfloat16_t, 16, 64, 32, 1, 2);
 instantiate_deepseek_mxfp4_pair_concat_blocks(bfloat16_t, 32, 64, 32, 1, 2);
+
+template <
+    typename T,
+    int BM,
+    int BN,
+    int BK,
+    int WM,
+    int WN,
+    int GROUP_SIZE,
+    int BITS>
+[[kernel]] void deepseek_affine_gather_blocks_rhs(
+    const device T* x [[buffer(0)]],
+    const device uint32_t* w [[buffer(1)]],
+    const device T* scales [[buffer(2)]],
+    const device T* biases [[buffer(3)]],
+    const device int32_t* block_meta [[buffer(4)]],
+    const device int32_t* block_count [[buffer(5)]],
+    device T* y [[buffer(6)]],
+    const constant int& max_blocks [[buffer(7)]],
+    const constant int& M [[buffer(8)]],
+    const constant int& N [[buffer(9)]],
+    const constant int& K [[buffer(10)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]]) {
+  (void)M;
+  constexpr int pack_factor = deepseek_affine_pack_factor<BITS, 8>();
+  constexpr int bytes_per_pack = deepseek_affine_bytes_per_pack<BITS, 8>();
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+
+  using mma_t = mlx::steel::BlockMMA<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      true,
+      BK_padded,
+      BK_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t = DeepseekAffineBlockLoader<
+      T,
+      BN,
+      BK,
+      BK_padded,
+      1,
+      WM * WN * SIMD_SIZE,
+      GROUP_SIZE,
+      BITS>;
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  const int block_id = int(tid.y);
+  const int nblocks = block_count[0];
+  if (block_id >= max_blocks || block_id >= nblocks) {
+    return;
+  }
+
+  const int y_col = int(tid.x) * BN;
+  if (y_col >= N) {
+    return;
+  }
+
+  const int row_start = block_meta[block_id * 3 + 0];
+  const int expert = block_meta[block_id * 3 + 1];
+  const int rows = block_meta[block_id * 3 + 2];
+  if (rows <= 0) {
+    return;
+  }
+
+  const short tgp_bm = short(min(BM, rows));
+  const short tgp_bn = short(min(BN, N - y_col));
+  const int K_it = K / BK;
+  const int k_remain = K - K_it * BK;
+  const short2 tile_x = short2(k_remain, tgp_bm);
+  const short2 tile_w = short2(k_remain, tgp_bn);
+
+  const int K_w = K * bytes_per_pack / pack_factor;
+  const int K_g = K / GROUP_SIZE;
+  const size_t stride_w = size_t(N) * K_w;
+  const size_t stride_s = size_t(N) * K_g;
+
+  const device T* xl = x + size_t(row_start) * K;
+  device T* yl = y + size_t(row_start) * N + y_col;
+  const device uint8_t* wl =
+      ((const device uint8_t*)w) + size_t(expert) * stride_w +
+      size_t(y_col) * K_w;
+  const device T* sl =
+      scales + size_t(expert) * stride_s + size_t(y_col) * K_g;
+  const device T* bl =
+      biases + size_t(expert) * stride_s + size_t(y_col) * K_g;
+
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+  thread loader_x_t loader_x(xl, K, Xs, simd_group_id, simd_lane_id);
+  thread loader_w_t loader_w(wl, sl, bl, K, Ws, simd_group_id, simd_lane_id);
+
+  if (rows == BM && tgp_bn == BN) {
+    gemm_loop_aligned(Xs, Ws, mma_op, loader_x, loader_w, K_it);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result(yl, N);
+  } else if (tgp_bn == BN) {
+    gemm_loop_unaligned<false, true, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N, short2(0, 0), short2(BN, tgp_bm));
+  } else if (rows == BM) {
+    gemm_loop_unaligned<true, false, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N, short2(0, 0), short2(tgp_bn, BM));
+  } else {
+    gemm_loop_unaligned<false, false, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N, short2(0, 0), short2(tgp_bn, tgp_bm));
+  }
+}
+
+#define instantiate_deepseek_affine_blocks(type, bm, bn, bk, wm, wn, gs, bits) \
+  instantiate_kernel(                                                          \
+      "deepseek_affine_gather_blocks_rhs_" #type "_gs_" #gs "_b_" #bits       \
+      "_bm_" #bm "_bn_" #bn "_bk_" #bk "_wm_" #wm "_wn_" #wn,              \
+      deepseek_affine_gather_blocks_rhs,                                       \
+      type,                                                                    \
+      bm,                                                                      \
+      bn,                                                                      \
+      bk,                                                                      \
+      wm,                                                                      \
+      wn,                                                                      \
+      gs,                                                                      \
+      bits)
+
+instantiate_deepseek_affine_blocks(float16_t, 16, 32, 32, 1, 2, 64, 2);
+instantiate_deepseek_affine_blocks(float16_t, 32, 32, 32, 1, 2, 64, 2);
+instantiate_deepseek_affine_blocks(float16_t, 16, 32, 32, 1, 2, 64, 3);
+instantiate_deepseek_affine_blocks(float16_t, 32, 32, 32, 1, 2, 64, 3);
+
+instantiate_deepseek_affine_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 2);
+instantiate_deepseek_affine_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 2);
+instantiate_deepseek_affine_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 3);
+instantiate_deepseek_affine_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 3);
+
+template <
+    typename T,
+    int BM,
+    int BN,
+    int BK,
+    int WM,
+    int WN,
+    int GROUP_SIZE,
+    int BITS>
+[[kernel]] void deepseek_affine_gather_pair_concat_blocks_rhs(
+    const device T* x [[buffer(0)]],
+    const device uint32_t* w0 [[buffer(1)]],
+    const device T* scales0 [[buffer(2)]],
+    const device T* biases0 [[buffer(3)]],
+    const device uint32_t* w1 [[buffer(4)]],
+    const device T* scales1 [[buffer(5)]],
+    const device T* biases1 [[buffer(6)]],
+    const device int32_t* block_meta [[buffer(7)]],
+    const device int32_t* block_count [[buffer(8)]],
+    device T* y [[buffer(9)]],
+    const constant int& max_blocks [[buffer(10)]],
+    const constant int& M [[buffer(11)]],
+    const constant int& N [[buffer(12)]],
+    const constant int& K [[buffer(13)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]]) {
+  (void)M;
+  constexpr int pack_factor = deepseek_affine_pack_factor<BITS, 8>();
+  constexpr int bytes_per_pack = deepseek_affine_bytes_per_pack<BITS, 8>();
+  constexpr int BK_padded = (BK + 16 / sizeof(T));
+
+  using mma_t = mlx::steel::BlockMMA<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      true,
+      BK_padded,
+      BK_padded>;
+  using loader_x_t =
+      mlx::steel::BlockLoader<T, BM, BK, BK_padded, 1, WM * WN * SIMD_SIZE>;
+  using loader_w_t = DeepseekAffineBlockLoader<
+      T,
+      BN,
+      BK,
+      BK_padded,
+      1,
+      WM * WN * SIMD_SIZE,
+      GROUP_SIZE,
+      BITS>;
+
+  threadgroup T Xs[BM * BK_padded];
+  threadgroup T Ws[BN * BK_padded];
+
+  const int block_id = int(tid.y);
+  const int nblocks = block_count[0];
+  if (block_id >= max_blocks || block_id >= nblocks) {
+    return;
+  }
+
+  const int y_col_concat = int(tid.x) * BN;
+  if (y_col_concat >= 2 * N) {
+    return;
+  }
+
+  const int pair_id = y_col_concat >= N ? 1 : 0;
+  const int y_col = pair_id == 0 ? y_col_concat : y_col_concat - N;
+  if (y_col >= N) {
+    return;
+  }
+
+  const int row_start = block_meta[block_id * 3 + 0];
+  const int expert = block_meta[block_id * 3 + 1];
+  const int rows = block_meta[block_id * 3 + 2];
+  if (rows <= 0) {
+    return;
+  }
+
+  const short tgp_bm = short(min(BM, rows));
+  const short tgp_bn = short(min(BN, N - y_col));
+  const int K_it = K / BK;
+  const int k_remain = K - K_it * BK;
+  const short2 tile_x = short2(k_remain, tgp_bm);
+  const short2 tile_w = short2(k_remain, tgp_bn);
+
+  const int K_w = K * bytes_per_pack / pack_factor;
+  const int K_g = K / GROUP_SIZE;
+  const size_t stride_w = size_t(N) * K_w;
+  const size_t stride_s = size_t(N) * K_g;
+  const int N_out = 2 * N;
+
+  const device uint32_t* w = pair_id == 0 ? w0 : w1;
+  const device T* scales = pair_id == 0 ? scales0 : scales1;
+  const device T* biases = pair_id == 0 ? biases0 : biases1;
+
+  const device T* xl = x + size_t(row_start) * K;
+  device T* yl = y + size_t(row_start) * N_out +
+      size_t(pair_id) * N + y_col;
+  const device uint8_t* wl =
+      ((const device uint8_t*)w) + size_t(expert) * stride_w +
+      size_t(y_col) * K_w;
+  const device T* sl =
+      scales + size_t(expert) * stride_s + size_t(y_col) * K_g;
+  const device T* bl =
+      biases + size_t(expert) * stride_s + size_t(y_col) * K_g;
+
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+  thread loader_x_t loader_x(xl, K, Xs, simd_group_id, simd_lane_id);
+  thread loader_w_t loader_w(wl, sl, bl, K, Ws, simd_group_id, simd_lane_id);
+
+  if (rows == BM && tgp_bn == BN) {
+    gemm_loop_aligned(Xs, Ws, mma_op, loader_x, loader_w, K_it);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result(yl, N_out);
+  } else if (tgp_bn == BN) {
+    gemm_loop_unaligned<false, true, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N_out, short2(0, 0), short2(BN, tgp_bm));
+  } else if (rows == BM) {
+    gemm_loop_unaligned<true, false, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N_out, short2(0, 0), short2(tgp_bn, BM));
+  } else {
+    gemm_loop_unaligned<false, false, true>(
+        Xs, Ws, mma_op, loader_x, loader_w, K_it, tgp_bm, tgp_bn, BK);
+    if (k_remain != 0) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      gemm_loop_finalize(Xs, Ws, mma_op, loader_x, loader_w, tile_x, tile_w);
+    }
+    mma_op.store_result_slice(yl, N_out, short2(0, 0), short2(tgp_bn, tgp_bm));
+  }
+}
+
+#define instantiate_deepseek_affine_pair_concat_blocks(                        \
+    type, bm, bn, bk, wm, wn, gs, bits)                                        \
+  instantiate_kernel(                                                          \
+      "deepseek_affine_gather_pair_concat_blocks_rhs_" #type "_gs_" #gs       \
+      "_b_" #bits "_bm_" #bm "_bn_" #bn "_bk_" #bk "_wm_" #wm              \
+      "_wn_" #wn,                                                             \
+      deepseek_affine_gather_pair_concat_blocks_rhs,                           \
+      type,                                                                    \
+      bm,                                                                      \
+      bn,                                                                      \
+      bk,                                                                      \
+      wm,                                                                      \
+      wn,                                                                      \
+      gs,                                                                      \
+      bits)
+
+instantiate_deepseek_affine_pair_concat_blocks(float16_t, 16, 32, 32, 1, 2, 64, 2);
+instantiate_deepseek_affine_pair_concat_blocks(float16_t, 32, 32, 32, 1, 2, 64, 2);
+instantiate_deepseek_affine_pair_concat_blocks(float16_t, 16, 32, 32, 1, 2, 64, 3);
+instantiate_deepseek_affine_pair_concat_blocks(float16_t, 32, 32, 32, 1, 2, 64, 3);
+
+instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 2);
+instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 2);
+instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 3);
+instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 3);
 
 template <
     typename T,

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_v4_sparse_attention.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_v4_sparse_attention.cpp
@@ -1,0 +1,313 @@
+#include "deepseek_v4_sparse_attention.h"
+
+#include <dlfcn.h>
+#include <filesystem>
+#include <sstream>
+
+#include "mlx/backend/common/utils.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/kernels/steel/attn/params.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/ops.h"
+#include "mlx/utils.h"
+
+namespace omlx::glm_kernels {
+
+namespace {
+
+using namespace mlx::core;
+using namespace mlx::steel;
+
+std::string current_binary_dir() {
+  static std::string binary_dir = []() {
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<void*>(&current_binary_dir), &info)) {
+      throw std::runtime_error("Unable to get omlx_glm_kernels binary dir.");
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().string();
+  }();
+  return binary_dir;
+}
+
+inline int64_t bcast_stride(const array& a, int axis) {
+  return a.shape(axis) == 1 ? 0 : a.strides(axis);
+}
+
+bool last_dim_contiguous(const array& arr) {
+  return arr.strides(-1) == 1;
+}
+
+class DeepseekV4SparseAttentionPrimitive : public Primitive {
+ public:
+  DeepseekV4SparseAttentionPrimitive(
+      Stream stream,
+      float scale,
+      int q_offset,
+      int compress_ratio,
+      int local_window)
+      : Primitive(stream),
+        scale_(scale),
+        q_offset_(q_offset),
+        compress_ratio_(compress_ratio),
+        local_window_(local_window) {}
+
+  static bool unsupported(
+      const array& q,
+      const array& local_kv,
+      const array& pooled,
+      const array& topk_indices,
+      const array& sinks,
+      int q_offset,
+      int compress_ratio,
+      int local_window,
+      Stream s) {
+    if (s.device == Device::cpu) {
+      return true;
+    }
+    if (q.dtype() != local_kv.dtype() || q.dtype() != pooled.dtype() ||
+        q.dtype() != sinks.dtype()) {
+      return true;
+    }
+    if (q.dtype() != float16 && q.dtype() != bfloat16) {
+      return true;
+    }
+    if (q.ndim() != 4 || local_kv.ndim() != 4 || pooled.ndim() != 3 ||
+        topk_indices.ndim() != 4 || sinks.ndim() != 1) {
+      return true;
+    }
+    if (!last_dim_contiguous(q) || !last_dim_contiguous(local_kv) ||
+        !last_dim_contiguous(pooled) || !last_dim_contiguous(topk_indices) ||
+        !last_dim_contiguous(sinks)) {
+      return true;
+    }
+    if (q.shape(0) != local_kv.shape(0) || q.shape(0) != pooled.shape(0) ||
+        q.shape(0) != topk_indices.shape(0) || q.shape(1) != 64 ||
+        q.shape(3) != 512 || local_kv.shape(1) != 1 ||
+        local_kv.shape(3) != 512 || pooled.shape(2) != 512 ||
+        topk_indices.shape(1) != 1 || topk_indices.shape(2) != q.shape(2) ||
+        sinks.shape(0) != q.shape(1)) {
+      return true;
+    }
+    if (q.shape(2) <= 1 || local_kv.shape(2) < q.shape(2) ||
+        pooled.shape(1) <= 0 || topk_indices.shape(3) <= 0 ||
+        topk_indices.dtype() != uint32) {
+      return true;
+    }
+    if (q_offset < 0 || compress_ratio <= 0 || local_window <= 0) {
+      return true;
+    }
+    return false;
+  }
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error(
+        "DeepseekV4SparseAttentionPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+
+    const auto& q = inputs[0];
+    const auto& local_kv = inputs[1];
+    const auto& pooled = inputs[2];
+    const auto& topk = inputs[3];
+    const auto& sinks = inputs[4];
+    auto& o = outputs[0];
+
+    constexpr int bk = 256;
+    constexpr int dc = 32;
+    constexpr int h = 64;
+    constexpr int dim = 512;
+    constexpr int wm = 8;
+
+    const int B = q.shape(0);
+    const int H = q.shape(1);
+    const int qL = q.shape(2);
+    const int localL = local_kv.shape(2);
+    const int pooledL = pooled.shape(1);
+    const int topkN = topk.shape(3);
+
+    int64_t str_oD = 1;
+    int64_t str_oL = o.shape(3);
+    int64_t str_oH = o.shape(2) * str_oL;
+    int64_t str_oB = o.shape(1) * str_oH;
+    size_t data_size = o.shape(0) * str_oB;
+    array::Flags flags{
+        /* bool contiguous = */ 1,
+        /* bool row_contiguous = */ 1,
+        /* bool col_contiguous = */ 0,
+    };
+    o.set_data(
+        allocator::malloc(o.nbytes()),
+        data_size,
+        {str_oB, str_oH, str_oL, str_oD},
+        flags);
+
+    std::string base_name;
+    concatenate(
+        base_name,
+        "deepseek_v4_sparse_attention_",
+        type_to_name(q),
+        "_bk",
+        bk,
+        "_dc",
+        dc,
+        "_h",
+        h,
+        "_d",
+        dim,
+        "_wm",
+        wm);
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto& compute_encoder = metal::get_command_encoder(s);
+    auto kernel = d.get_kernel(base_name, lib);
+    compute_encoder.set_compute_pipeline_state(kernel);
+
+    DeepseekV4SparseAttentionParams params{
+        /* int B = */ B,
+        /* int H = */ H,
+        /* int qL = */ qL,
+        /* int localL = */ localL,
+        /* int pooledL = */ pooledL,
+        /* int topk = */ topkN,
+        /* int local_window = */ local_window_,
+        /* int compress_ratio = */ compress_ratio_,
+        /* int q_offset = */ q_offset_,
+
+        /* float scale = */ scale_,
+
+        /* int64_t Q_strides[3] = */ {
+            q.strides(0), q.strides(1), q.strides(2)},
+        /* int64_t Local_strides[3] = */ {
+            local_kv.strides(0),
+            bcast_stride(local_kv, 1),
+            local_kv.strides(2)},
+        /* int64_t Pooled_strides[2] = */ {
+            pooled.strides(0), pooled.strides(1)},
+        /* int64_t Topk_strides[3] = */ {
+            topk.strides(0), bcast_stride(topk, 1), topk.strides(2)},
+        /* int64_t O_strides[3] = */ {
+            o.strides(0), o.strides(1), o.strides(2)}};
+
+    compute_encoder.set_input_array(q, 0);
+    compute_encoder.set_input_array(local_kv, 1);
+    compute_encoder.set_input_array(pooled, 2);
+    compute_encoder.set_input_array(topk, 3);
+    compute_encoder.set_input_array(sinks, 4);
+    compute_encoder.set_output_array(o, 5);
+    compute_encoder.set_bytes(params, 6);
+
+    MTL::Size grid_dims = MTL::Size(qL, B, 1);
+    MTL::Size group_dims = MTL::Size(32, wm, 1);
+    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  }
+
+  DEFINE_NAME(OMLXDeepseekV4SparseAttention)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs =
+        static_cast<const DeepseekV4SparseAttentionPrimitive&>(other);
+    return scale_ == rhs.scale_ && q_offset_ == rhs.q_offset_ &&
+        compress_ratio_ == rhs.compress_ratio_ &&
+        local_window_ == rhs.local_window_;
+  }
+  auto state() const {
+    return std::make_tuple(
+        nullptr, scale_, q_offset_, compress_ratio_, local_window_);
+  }
+
+ private:
+  float scale_;
+  int q_offset_;
+  int compress_ratio_;
+  int local_window_;
+};
+
+} // namespace
+
+array deepseek_v4_sparse_attention(
+    const array& q,
+    const array& local_kv,
+    const array& pooled,
+    const array& topk_indices,
+    const array& sinks,
+    float scale,
+    int q_offset,
+    int compress_ratio,
+    int local_window,
+    StreamOrDevice s) {
+  if (q.ndim() != 4 || local_kv.ndim() != 4 || pooled.ndim() != 3 ||
+      topk_indices.ndim() != 4 || sinks.ndim() != 1) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_v4_sparse_attention] incompatible "
+        << "ranks: " << q.shape() << ", " << local_kv.shape() << ", "
+        << pooled.shape() << ", " << topk_indices.shape() << ", "
+        << sinks.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (q.shape(0) != local_kv.shape(0) || q.shape(0) != pooled.shape(0) ||
+      q.shape(0) != topk_indices.shape(0) || q.shape(1) != 64 ||
+      q.shape(3) != 512 || local_kv.shape(1) != 1 ||
+      local_kv.shape(3) != 512 || pooled.shape(2) != 512 ||
+      topk_indices.shape(1) != 1 || topk_indices.shape(2) != q.shape(2) ||
+      sinks.shape(0) != q.shape(1)) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_v4_sparse_attention] incompatible "
+        << "shapes: " << q.shape() << ", " << local_kv.shape() << ", "
+        << pooled.shape() << ", " << topk_indices.shape() << ", "
+        << sinks.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (topk_indices.dtype() != uint32) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_v4_sparse_attention] topk_indices "
+        << "must be uint32, got " << topk_indices.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto final_type = result_type(std::vector<array>{q, local_kv, pooled});
+  if (final_type != float16 && final_type != bfloat16) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_v4_sparse_attention] expected fp16 or "
+        << "bf16 inputs, got " << final_type << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto stream = to_stream(s);
+  auto q_cast = astype(q, final_type, stream);
+  auto local_cast = astype(local_kv, final_type, stream);
+  auto pooled_cast = astype(pooled, final_type, stream);
+  auto sinks_cast = astype(sinks, final_type, stream);
+
+  if (DeepseekV4SparseAttentionPrimitive::unsupported(
+          q_cast,
+          local_cast,
+          pooled_cast,
+          topk_indices,
+          sinks_cast,
+          q_offset,
+          compress_ratio,
+          local_window,
+          stream)) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.deepseek_v4_sparse_attention] unsupported DeepSeek V4 sparse attention shape.");
+  }
+
+  Shape out_shape{q_cast.shape(0), q_cast.shape(1), q_cast.shape(2), q_cast.shape(3)};
+  std::vector<array> inputs = {
+      q_cast, local_cast, pooled_cast, topk_indices, sinks_cast};
+  return array(
+      std::move(out_shape),
+      final_type,
+      std::make_shared<DeepseekV4SparseAttentionPrimitive>(
+          stream, scale, q_offset, compress_ratio, local_window),
+      std::move(inputs));
+}
+
+} // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_v4_sparse_attention.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_v4_sparse_attention.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "mlx/array.h"
+#include "mlx/stream.h"
+#include "mlx/utils.h"
+
+namespace mx = mlx::core;
+
+namespace omlx::glm_kernels {
+
+mx::array deepseek_v4_sparse_attention(
+    const mx::array& q,
+    const mx::array& local_kv,
+    const mx::array& pooled,
+    const mx::array& topk_indices,
+    const mx::array& sinks,
+    float scale,
+    int q_offset,
+    int compress_ratio,
+    int local_window,
+    mx::StreamOrDevice s = {});
+
+} // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_v4_sparse_attention.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_v4_sparse_attention.metal
@@ -1,0 +1,20 @@
+#include "mlx/backend/metal/kernels/utils.h"
+#include "mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h"
+#include "kernels/steel_deepseek_v4_sparse_attention.h"
+
+#define instantiate_deepseek_v4_sparse_attention(tname, dtype, bk, dc, h, d, wm) \
+  instantiate_kernel(                                                            \
+      "deepseek_v4_sparse_attention_" #tname "_bk" #bk "_dc" #dc "_h" #h       \
+      "_d" #d "_wm" #wm,                                                        \
+      deepseek_v4_sparse_attention,                                              \
+      dtype,                                                                     \
+      bk,                                                                        \
+      dc,                                                                        \
+      h,                                                                         \
+      d,                                                                         \
+      wm,                                                                        \
+      uint,                                                                      \
+      float)
+
+instantiate_deepseek_v4_sparse_attention(float16, half, 256, 32, 64, 512, 8);
+instantiate_deepseek_v4_sparse_attention(bfloat16, bfloat16_t, 256, 32, 64, 512, 8);

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
@@ -85,7 +85,7 @@ class DSAIndexerScoresPrimitive : public Primitive {
       return true;
     }
     const bool weights_lh = weights.ndim() == 3;
-    if (q.shape(1) != 32 || k.shape(1) != 1) {
+    if ((q.shape(1) != 32 && q.shape(1) != 64) || k.shape(1) != 1) {
       return true;
     }
     if (weights_lh) {
@@ -105,7 +105,7 @@ class DSAIndexerScoresPrimitive : public Primitive {
         q.shape(3) % 16 != 0) {
       return true;
     }
-    return k.shape(2) < 4096;
+    return k.shape(2) < 64;
   }
 
   void eval_cpu(
@@ -260,7 +260,7 @@ class DSATopKIndicesPrimitive : public Primitive {
     if (scores.ndim() != 4 || scores.shape(1) != 1) {
       return true;
     }
-    if (topk != 2048) {
+    if (topk != 512 && topk != 2048) {
       return true;
     }
     return scores.shape(-1) < topk;

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.metal
@@ -39,3 +39,5 @@ instantiate_dsa_indexer_score(bfloat16, bfloat16_t, 64, 64, 16, 2, 2);
 
 instantiate_dsa_topk_indices(float16, half, 2048, 1024);
 instantiate_dsa_topk_indices(bfloat16, bfloat16_t, 2048, 1024);
+instantiate_dsa_topk_indices(float16, half, 512, 1024);
+instantiate_dsa_topk_indices(bfloat16, bfloat16_t, 512, 1024);

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.cpp
@@ -33,6 +33,34 @@ bool row_contiguous(const array& arr) {
   return arr.flags().row_contiguous && arr.strides(-1) == 1;
 }
 
+struct Mxfp4BlocksVariant {
+  int bm;
+  int bn;
+  int bk;
+  int wm;
+  int wn;
+};
+
+Mxfp4BlocksVariant mxfp4_blocks_variant(int variant) {
+  switch (variant) {
+    case 0:
+      return {/* bm = */ 8, /* bn = */ 32, /* bk = */ 32, /* wm = */ 1, /* wn = */ 2};
+    case 1:
+      return {/* bm = */ 16, /* bn = */ 32, /* bk = */ 32, /* wm = */ 1, /* wn = */ 2};
+    case 2:
+      return {/* bm = */ 32, /* bn = */ 32, /* bk = */ 32, /* wm = */ 1, /* wn = */ 2};
+    case 3:
+      return {/* bm = */ 16, /* bn = */ 64, /* bk = */ 32, /* wm = */ 1, /* wn = */ 2};
+    case 4:
+      return {/* bm = */ 32, /* bn = */ 64, /* bk = */ 32, /* wm = */ 1, /* wn = */ 2};
+    default: {
+      std::ostringstream msg;
+      msg << "Unsupported DeepSeek MXFP4 block-list variant " << variant << ".";
+      throw std::invalid_argument(msg.str());
+    }
+  }
+}
+
 std::string glm_type_name(Dtype dtype) {
   if (dtype == float16) {
     return "float16_t";
@@ -191,7 +219,8 @@ class GlmMoeWeightedSumPrimitive : public Primitive {
         !row_contiguous(scores)) {
       return true;
     }
-    if (scores.shape(-1) != 8 || x_sorted.shape(0) != scores.size() ||
+    const int topk = scores.shape(-1);
+    if ((topk != 6 && topk != 8) || x_sorted.shape(0) != scores.size() ||
         inv_order.size() != scores.size()) {
       return true;
     }
@@ -274,6 +303,416 @@ class GlmMoeWeightedSumPrimitive : public Primitive {
     return std::make_tuple(nullptr);
   }
 
+};
+
+class DeepseekMxfp4GatherBlocksPrimitive : public Primitive {
+ public:
+  explicit DeepseekMxfp4GatherBlocksPrimitive(Stream stream, int variant)
+      : Primitive(stream), variant_(variant) {
+    (void)mxfp4_blocks_variant(variant_);
+  }
+
+  static bool unsupported(
+      const array& x,
+      const array& weight,
+      const array& scales,
+      const array& block_meta,
+      const array& block_count,
+      Stream s) {
+    if (s.device == Device::cpu) {
+      return true;
+    }
+    if (x.dtype() != float16 && x.dtype() != bfloat16) {
+      return true;
+    }
+    if (weight.dtype() != uint32 || scales.dtype() != uint8 ||
+        block_meta.dtype() != int32 || block_count.dtype() != int32) {
+      return true;
+    }
+    if (x.ndim() != 3 || x.shape(1) != 1 || weight.ndim() != 3 ||
+        scales.ndim() != 3 || block_meta.ndim() != 2 ||
+        block_meta.shape(1) != 3 || block_count.size() != 1) {
+      return true;
+    }
+    if (!row_contiguous(x) || !row_contiguous(weight) ||
+        !row_contiguous(scales) || !row_contiguous(block_meta) ||
+        !row_contiguous(block_count)) {
+      return true;
+    }
+
+    constexpr int bits = 4;
+    constexpr int group_size = 32;
+    constexpr int values_per_uint32 = 32 / bits;
+    const int K = x.shape(2);
+    const int E = weight.shape(0);
+    const int N = weight.shape(1);
+    if (x.shape(0) <= 0 || K <= 0 || N <= 0 || E <= 0 ||
+        block_meta.shape(0) <= 0) {
+      return true;
+    }
+    if (weight.shape(2) * values_per_uint32 != K || scales.shape(0) != E ||
+        scales.shape(1) != N || scales.shape(2) != K / group_size) {
+      return true;
+    }
+    return false;
+  }
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error(
+        "DeepseekMxfp4GatherBlocksPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    auto& out = outputs[0];
+
+    const auto& x = inputs[0];
+    const auto& weight = inputs[1];
+    const auto& scales = inputs[2];
+    const auto& block_meta = inputs[3];
+    const auto& block_count = inputs[4];
+
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    const auto cfg = mxfp4_blocks_variant(variant_);
+    const int max_blocks = block_meta.shape(0);
+    const int M = x.shape(0);
+    const int K = x.shape(2);
+    const int N = weight.shape(1);
+
+    std::string kname;
+    concatenate(
+        kname,
+        "deepseek_mxfp4_gather_blocks_rhs_",
+        glm_type_name(x.dtype()),
+        "_bm_",
+        cfg.bm,
+        "_bn_",
+        cfg.bn,
+        "_bk_",
+        cfg.bk,
+        "_wm_",
+        cfg.wm,
+        "_wn_",
+        cfg.wn);
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto kernel = d.get_kernel(kname, lib);
+    auto& compute_encoder = metal::get_command_encoder(s);
+    compute_encoder.set_compute_pipeline_state(kernel);
+    compute_encoder.set_input_array(x, 0);
+    compute_encoder.set_input_array(weight, 1);
+    compute_encoder.set_input_array(scales, 2);
+    compute_encoder.set_input_array(block_meta, 3);
+    compute_encoder.set_input_array(block_count, 4);
+    compute_encoder.set_output_array(out, 5);
+    compute_encoder.set_bytes(max_blocks, 6);
+    compute_encoder.set_bytes(M, 7);
+    compute_encoder.set_bytes(N, 8);
+    compute_encoder.set_bytes(K, 9);
+
+    MTL::Size grid_dims((N + cfg.bn - 1) / cfg.bn, max_blocks, 1);
+    MTL::Size group_dims(cfg.wm * cfg.wn * 32, 1, 1);
+    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  }
+
+  DEFINE_NAME(DeepseekMxfp4GatherBlocksPrimitive)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs =
+        static_cast<const DeepseekMxfp4GatherBlocksPrimitive&>(other);
+    return variant_ == rhs.variant_;
+  }
+  auto state() const {
+    return std::make_tuple(variant_);
+  }
+
+ private:
+  int variant_;
+};
+
+class DeepseekMxfp4GatherPairBlocksPrimitive : public Primitive {
+ public:
+  explicit DeepseekMxfp4GatherPairBlocksPrimitive(
+      Stream stream,
+      int variant,
+      bool concat_output = false)
+      : Primitive(stream), variant_(variant), concat_output_(concat_output) {
+    (void)mxfp4_blocks_variant(variant_);
+  }
+
+  static bool unsupported(
+      const array& x,
+      const array& weight0,
+      const array& scales0,
+      const array& weight1,
+      const array& scales1,
+      const array& block_meta,
+      const array& block_count,
+      Stream s) {
+    if (s.device == Device::cpu) {
+      return true;
+    }
+    if (x.dtype() != float16 && x.dtype() != bfloat16) {
+      return true;
+    }
+    if (weight0.dtype() != uint32 || scales0.dtype() != uint8 ||
+        weight1.dtype() != uint32 || scales1.dtype() != uint8 ||
+        block_meta.dtype() != int32 || block_count.dtype() != int32) {
+      return true;
+    }
+    if (x.ndim() != 3 || x.shape(1) != 1 || weight0.ndim() != 3 ||
+        scales0.ndim() != 3 || weight1.ndim() != 3 || scales1.ndim() != 3 ||
+        block_meta.ndim() != 2 || block_meta.shape(1) != 3 ||
+        block_count.size() != 1) {
+      return true;
+    }
+    if (!row_contiguous(x) || !row_contiguous(weight0) ||
+        !row_contiguous(scales0) || !row_contiguous(weight1) ||
+        !row_contiguous(scales1) || !row_contiguous(block_meta) ||
+        !row_contiguous(block_count)) {
+      return true;
+    }
+
+    constexpr int bits = 4;
+    constexpr int group_size = 32;
+    constexpr int values_per_uint32 = 32 / bits;
+    const int K = x.shape(2);
+    const int E = weight0.shape(0);
+    const int N = weight0.shape(1);
+    if (x.shape(0) <= 0 || K <= 0 || N <= 0 || E <= 0 ||
+        block_meta.shape(0) <= 0) {
+      return true;
+    }
+    if (weight1.shape() != weight0.shape() || scales1.shape() != scales0.shape()) {
+      return true;
+    }
+    if (weight0.shape(2) * values_per_uint32 != K ||
+        scales0.shape(0) != E || scales0.shape(1) != N ||
+        scales0.shape(2) != K / group_size) {
+      return true;
+    }
+    return false;
+  }
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error(
+        "DeepseekMxfp4GatherPairBlocksPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    auto& out = outputs[0];
+
+    const auto& x = inputs[0];
+    const auto& weight0 = inputs[1];
+    const auto& scales0 = inputs[2];
+    const auto& weight1 = inputs[3];
+    const auto& scales1 = inputs[4];
+    const auto& block_meta = inputs[5];
+    const auto& block_count = inputs[6];
+
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    const auto cfg = mxfp4_blocks_variant(variant_);
+    const int max_blocks = block_meta.shape(0);
+    const int M = x.shape(0);
+    const int K = x.shape(2);
+    const int N = weight0.shape(1);
+
+    std::string kname;
+    concatenate(
+        kname,
+        concat_output_ ? "deepseek_mxfp4_gather_pair_concat_blocks_rhs_"
+                       : "deepseek_mxfp4_gather_pair_blocks_rhs_",
+        glm_type_name(x.dtype()),
+        "_bm_",
+        cfg.bm,
+        "_bn_",
+        cfg.bn,
+        "_bk_",
+        cfg.bk,
+        "_wm_",
+        cfg.wm,
+        "_wn_",
+        cfg.wn);
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto kernel = d.get_kernel(kname, lib);
+    auto& compute_encoder = metal::get_command_encoder(s);
+    compute_encoder.set_compute_pipeline_state(kernel);
+    compute_encoder.set_input_array(x, 0);
+    compute_encoder.set_input_array(weight0, 1);
+    compute_encoder.set_input_array(scales0, 2);
+    compute_encoder.set_input_array(weight1, 3);
+    compute_encoder.set_input_array(scales1, 4);
+    compute_encoder.set_input_array(block_meta, 5);
+    compute_encoder.set_input_array(block_count, 6);
+    compute_encoder.set_output_array(out, 7);
+    compute_encoder.set_bytes(max_blocks, 8);
+    compute_encoder.set_bytes(M, 9);
+    compute_encoder.set_bytes(N, 10);
+    compute_encoder.set_bytes(K, 11);
+
+    const int grid_n = concat_output_ ? 2 * N : N;
+    MTL::Size grid_dims(
+        (grid_n + cfg.bn - 1) / cfg.bn,
+        max_blocks,
+        concat_output_ ? 1 : 2);
+    MTL::Size group_dims(cfg.wm * cfg.wn * 32, 1, 1);
+    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  }
+
+  DEFINE_NAME(DeepseekMxfp4GatherPairBlocksPrimitive)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs =
+        static_cast<const DeepseekMxfp4GatherPairBlocksPrimitive&>(other);
+    return variant_ == rhs.variant_ && concat_output_ == rhs.concat_output_;
+  }
+  auto state() const {
+    return std::make_tuple(variant_, concat_output_);
+  }
+
+ private:
+  int variant_;
+  bool concat_output_;
+};
+
+class DeepseekMxfp4GatherExpertPrimitive : public Primitive {
+ public:
+  explicit DeepseekMxfp4GatherExpertPrimitive(Stream stream, int variant)
+      : Primitive(stream), variant_(variant) {
+    (void)mxfp4_blocks_variant(variant_);
+  }
+
+  static bool unsupported(
+      const array& x,
+      const array& weight,
+      const array& scales,
+      const array& indices,
+      Stream s) {
+    if (s.device == Device::cpu) {
+      return true;
+    }
+    if (x.dtype() != float16 && x.dtype() != bfloat16) {
+      return true;
+    }
+    if (weight.dtype() != uint32 || scales.dtype() != uint8 ||
+        (indices.dtype() != uint32 && indices.dtype() != int32)) {
+      return true;
+    }
+    if (x.ndim() != 3 || x.shape(1) != 1 || weight.ndim() != 3 ||
+        scales.ndim() != 3 || indices.ndim() != 1 ||
+        indices.size() != x.shape(0)) {
+      return true;
+    }
+    if (!row_contiguous(x) || !row_contiguous(weight) ||
+        !row_contiguous(scales) || !row_contiguous(indices)) {
+      return true;
+    }
+
+    constexpr int bits = 4;
+    constexpr int group_size = 32;
+    constexpr int values_per_uint32 = 32 / bits;
+    const int K = x.shape(2);
+    const int E = weight.shape(0);
+    const int N = weight.shape(1);
+    if (x.shape(0) <= 0 || K <= 0 || N <= 0 || E <= 0) {
+      return true;
+    }
+    if (weight.shape(2) * values_per_uint32 != K || scales.shape(0) != E ||
+        scales.shape(1) != N || scales.shape(2) != K / group_size) {
+      return true;
+    }
+    return false;
+  }
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error(
+        "DeepseekMxfp4GatherExpertPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    auto& out = outputs[0];
+
+    const auto& x = inputs[0];
+    const auto& weight = inputs[1];
+    const auto& scales = inputs[2];
+    const auto& indices = inputs[3];
+
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    const auto cfg = mxfp4_blocks_variant(variant_);
+    const int M = x.shape(0);
+    const int K = x.shape(2);
+    const int E = weight.shape(0);
+    const int N = weight.shape(1);
+
+    std::string kname;
+    concatenate(
+        kname,
+        "deepseek_mxfp4_gather_expert_rhs_",
+        glm_type_name(x.dtype()),
+        "_bm_",
+        cfg.bm,
+        "_bn_",
+        cfg.bn,
+        "_bk_",
+        cfg.bk,
+        "_wm_",
+        cfg.wm,
+        "_wn_",
+        cfg.wn);
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto kernel = d.get_kernel(kname, lib);
+    auto& compute_encoder = metal::get_command_encoder(s);
+    compute_encoder.set_compute_pipeline_state(kernel);
+    compute_encoder.set_input_array(x, 0);
+    compute_encoder.set_input_array(weight, 1);
+    compute_encoder.set_input_array(scales, 2);
+    compute_encoder.set_input_array(indices, 3);
+    compute_encoder.set_output_array(out, 4);
+    compute_encoder.set_bytes(M, 5);
+    compute_encoder.set_bytes(N, 6);
+    compute_encoder.set_bytes(K, 7);
+    compute_encoder.set_bytes(E, 8);
+
+    MTL::Size grid_dims((N + cfg.bn - 1) / cfg.bn, E, 1);
+    MTL::Size group_dims(cfg.wm * cfg.wn * 32, 1, 1);
+    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  }
+
+  DEFINE_NAME(DeepseekMxfp4GatherExpertPrimitive)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs =
+        static_cast<const DeepseekMxfp4GatherExpertPrimitive&>(other);
+    return variant_ == rhs.variant_;
+  }
+  auto state() const {
+    return std::make_tuple(variant_);
+  }
+
+ private:
+  int variant_;
 };
 
 } // namespace
@@ -404,6 +843,251 @@ array glm_moe_weighted_sum(
       std::move(out_shape),
       x_sorted.dtype(),
       std::make_shared<GlmMoeWeightedSumPrimitive>(stream),
+      std::move(inputs));
+}
+
+array deepseek_mxfp4_gather_qmm_blocks(
+    const array& x,
+    const array& weight,
+    const array& scales,
+    const array& block_meta,
+    const array& block_count,
+    int variant,
+    StreamOrDevice s /* = {} */) {
+  (void)mxfp4_blocks_variant(variant);
+
+  if (x.ndim() != 3 || x.shape(1) != 1 || weight.ndim() != 3 ||
+      scales.ndim() != 3 || block_meta.ndim() != 2 ||
+      block_meta.shape(1) != 3 || block_count.size() != 1) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_blocks] expected "
+        << "x [M,1,K], weight [E,N,K/8], scales [E,N,K/32], "
+        << "block_meta [B,3], block_count [1], got " << x.shape() << ", "
+        << weight.shape() << ", " << scales.shape() << ", "
+        << block_meta.shape() << ", " << block_count.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  constexpr int bits = 4;
+  constexpr int group_size = 32;
+  constexpr int values_per_uint32 = 32 / bits;
+  const int K = x.shape(2);
+  const int E = weight.shape(0);
+  const int N = weight.shape(1);
+  if (weight.shape(2) * values_per_uint32 != K || scales.shape(0) != E ||
+      scales.shape(1) != N || scales.shape(2) != K / group_size) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_blocks] "
+        << "incompatible shapes: " << x.shape() << ", " << weight.shape()
+        << ", " << scales.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (x.dtype() != float16 && x.dtype() != bfloat16) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_blocks] expected "
+        << "float16 or bfloat16 input, got " << x.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (weight.dtype() != uint32 || scales.dtype() != uint8 ||
+      block_meta.dtype() != int32 || block_count.dtype() != int32) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_blocks] expected "
+        << "uint32 weight, uint8 scales, int32 block_meta/count, got "
+        << weight.dtype() << ", " << scales.dtype() << ", "
+        << block_meta.dtype() << ", " << block_count.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto stream = to_stream(s);
+  std::vector<array> inputs = {x, weight, scales, block_meta, block_count};
+  if (DeepseekMxfp4GatherBlocksPrimitive::unsupported(
+          x, weight, scales, block_meta, block_count, stream)) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_blocks] unsupported shape.");
+  }
+
+  Shape out_shape{x.shape(0), 1, N};
+  return array(
+      std::move(out_shape),
+      x.dtype(),
+      std::make_shared<DeepseekMxfp4GatherBlocksPrimitive>(stream, variant),
+      std::move(inputs));
+}
+
+array deepseek_mxfp4_gather_qmm_pair_blocks(
+    const array& x,
+    const array& weight0,
+    const array& scales0,
+    const array& weight1,
+    const array& scales1,
+    const array& block_meta,
+    const array& block_count,
+    int variant,
+    StreamOrDevice s /* = {} */) {
+  (void)mxfp4_blocks_variant(variant);
+
+  if (x.ndim() != 3 || x.shape(1) != 1 || weight0.ndim() != 3 ||
+      scales0.ndim() != 3 || weight1.ndim() != 3 || scales1.ndim() != 3 ||
+      block_meta.ndim() != 2 || block_meta.shape(1) != 3 ||
+      block_count.size() != 1) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_pair_blocks] "
+        << "expected x [M,1,K], two weights [E,N,K/8], two scales "
+        << "[E,N,K/32], block_meta [B,3], block_count [1], got "
+        << x.shape() << ", " << weight0.shape() << ", " << scales0.shape()
+        << ", " << weight1.shape() << ", " << scales1.shape() << ", "
+        << block_meta.shape() << ", " << block_count.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  constexpr int bits = 4;
+  constexpr int group_size = 32;
+  constexpr int values_per_uint32 = 32 / bits;
+  const int K = x.shape(2);
+  const int E = weight0.shape(0);
+  const int N = weight0.shape(1);
+  if (weight1.shape() != weight0.shape() || scales1.shape() != scales0.shape() ||
+      weight0.shape(2) * values_per_uint32 != K || scales0.shape(0) != E ||
+      scales0.shape(1) != N || scales0.shape(2) != K / group_size) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_pair_blocks] "
+        << "incompatible shapes: " << x.shape() << ", " << weight0.shape()
+        << ", " << scales0.shape() << ", " << weight1.shape() << ", "
+        << scales1.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (x.dtype() != float16 && x.dtype() != bfloat16) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_pair_blocks] expected "
+        << "float16 or bfloat16 input, got " << x.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (weight0.dtype() != uint32 || scales0.dtype() != uint8 ||
+      weight1.dtype() != uint32 || scales1.dtype() != uint8 ||
+      block_meta.dtype() != int32 || block_count.dtype() != int32) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_pair_blocks] expected "
+        << "uint32 weights, uint8 scales, int32 block_meta/count, got "
+        << weight0.dtype() << ", " << scales0.dtype() << ", "
+        << weight1.dtype() << ", " << scales1.dtype() << ", "
+        << block_meta.dtype() << ", " << block_count.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto stream = to_stream(s);
+  std::vector<array> inputs = {
+      x, weight0, scales0, weight1, scales1, block_meta, block_count};
+  if (DeepseekMxfp4GatherPairBlocksPrimitive::unsupported(
+          x, weight0, scales0, weight1, scales1, block_meta, block_count, stream)) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_pair_blocks] unsupported shape.");
+  }
+
+  Shape out_shape{2, x.shape(0), 1, N};
+  return array(
+      std::move(out_shape),
+      x.dtype(),
+      std::make_shared<DeepseekMxfp4GatherPairBlocksPrimitive>(stream, variant),
+      std::move(inputs));
+}
+
+array deepseek_mxfp4_gather_qmm_pair_concat_blocks(
+    const array& x,
+    const array& weight0,
+    const array& scales0,
+    const array& weight1,
+    const array& scales1,
+    const array& block_meta,
+    const array& block_count,
+    int variant,
+    StreamOrDevice s /* = {} */) {
+  const auto cfg = mxfp4_blocks_variant(variant);
+  auto stream = to_stream(s);
+  if (DeepseekMxfp4GatherPairBlocksPrimitive::unsupported(
+          x, weight0, scales0, weight1, scales1, block_meta, block_count, stream)) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_pair_concat_blocks] unsupported shape.");
+  }
+  const int N = weight0.shape(1);
+  if (N % cfg.bn != 0) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_pair_concat_blocks] "
+        "output dimension must be divisible by the block N.");
+  }
+  std::vector<array> inputs = {
+      x, weight0, scales0, weight1, scales1, block_meta, block_count};
+  Shape out_shape{x.shape(0), 1, 2 * N};
+  return array(
+      std::move(out_shape),
+      x.dtype(),
+      std::make_shared<DeepseekMxfp4GatherPairBlocksPrimitive>(
+          stream, variant, true),
+      std::move(inputs));
+}
+
+array deepseek_mxfp4_gather_qmm_expert(
+    const array& x,
+    const array& weight,
+    const array& scales,
+    const array& indices,
+    int variant,
+    StreamOrDevice s /* = {} */) {
+  (void)mxfp4_blocks_variant(variant);
+
+  if (x.ndim() != 3 || x.shape(1) != 1 || weight.ndim() != 3 ||
+      scales.ndim() != 3 || indices.ndim() != 1 ||
+      indices.size() != x.shape(0)) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_expert] expected "
+        << "x [M,1,K], weight [E,N,K/8], scales [E,N,K/32], "
+        << "indices [M], got " << x.shape() << ", " << weight.shape() << ", "
+        << scales.shape() << ", " << indices.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  constexpr int bits = 4;
+  constexpr int group_size = 32;
+  constexpr int values_per_uint32 = 32 / bits;
+  const int K = x.shape(2);
+  const int E = weight.shape(0);
+  const int N = weight.shape(1);
+  if (weight.shape(2) * values_per_uint32 != K || scales.shape(0) != E ||
+      scales.shape(1) != N || scales.shape(2) != K / group_size) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_expert] "
+        << "incompatible shapes: " << x.shape() << ", " << weight.shape()
+        << ", " << scales.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (x.dtype() != float16 && x.dtype() != bfloat16) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_expert] expected "
+        << "float16 or bfloat16 input, got " << x.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (weight.dtype() != uint32 || scales.dtype() != uint8 ||
+      (indices.dtype() != uint32 && indices.dtype() != int32)) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_expert] expected "
+        << "uint32 weight, uint8 scales, uint32/int32 indices, got "
+        << weight.dtype() << ", " << scales.dtype() << ", "
+        << indices.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto stream = to_stream(s);
+  std::vector<array> inputs = {x, weight, scales, indices};
+  if (DeepseekMxfp4GatherExpertPrimitive::unsupported(
+          x, weight, scales, indices, stream)) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_expert] unsupported shape.");
+  }
+
+  Shape out_shape{x.shape(0), 1, N};
+  return array(
+      std::move(out_shape),
+      x.dtype(),
+      std::make_shared<DeepseekMxfp4GatherExpertPrimitive>(stream, variant),
       std::move(inputs));
 }
 

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.cpp
@@ -61,6 +61,49 @@ Mxfp4BlocksVariant mxfp4_blocks_variant(int variant) {
   }
 }
 
+int affine_pack_factor(int bits) {
+  switch (bits) {
+    case 2:
+      return 4;
+    case 3:
+      return 8;
+    case 4:
+      return 2;
+    case 8:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+int affine_bytes_per_pack(int bits) {
+  switch (bits) {
+    case 2:
+      return 1;
+    case 3:
+      return 3;
+    case 4:
+      return 1;
+    case 8:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+bool supported_deepseek_affine(int group_size, int bits) {
+  return group_size == 64 && (bits == 2 || bits == 3);
+}
+
+int affine_packed_row_bytes(int K, int bits) {
+  const int pack_factor = affine_pack_factor(bits);
+  const int bytes_per_pack = affine_bytes_per_pack(bits);
+  if (pack_factor == 0 || bytes_per_pack == 0 || K % pack_factor != 0) {
+    return -1;
+  }
+  return K * bytes_per_pack / pack_factor;
+}
+
 std::string glm_type_name(Dtype dtype) {
   if (dtype == float16) {
     return "float16_t";
@@ -589,6 +632,332 @@ class DeepseekMxfp4GatherPairBlocksPrimitive : public Primitive {
   bool concat_output_;
 };
 
+class DeepseekAffineGatherBlocksPrimitive : public Primitive {
+ public:
+  explicit DeepseekAffineGatherBlocksPrimitive(
+      Stream stream,
+      int group_size,
+      int bits,
+      int variant)
+      : Primitive(stream),
+        group_size_(group_size),
+        bits_(bits),
+        variant_(variant) {
+    (void)mxfp4_blocks_variant(variant_);
+    if (!supported_deepseek_affine(group_size_, bits_)) {
+      throw std::invalid_argument(
+          "Unsupported DeepSeek affine block-list quantization.");
+    }
+  }
+
+  static bool unsupported(
+      const array& x,
+      const array& weight,
+      const array& scales,
+      const array& biases,
+      const array& block_meta,
+      const array& block_count,
+      int group_size,
+      int bits,
+      Stream s) {
+    if (s.device == Device::cpu || !supported_deepseek_affine(group_size, bits)) {
+      return true;
+    }
+    if (x.dtype() != float16 && x.dtype() != bfloat16) {
+      return true;
+    }
+    if (weight.dtype() != uint32 || scales.dtype() != x.dtype() ||
+        biases.dtype() != x.dtype() || block_meta.dtype() != int32 ||
+        block_count.dtype() != int32) {
+      return true;
+    }
+    if (x.ndim() != 3 || x.shape(1) != 1 || weight.ndim() != 3 ||
+        scales.ndim() != 3 || biases.ndim() != 3 || block_meta.ndim() != 2 ||
+        block_meta.shape(1) != 3 || block_count.size() != 1) {
+      return true;
+    }
+    if (!row_contiguous(x) || !row_contiguous(weight) ||
+        !row_contiguous(scales) || !row_contiguous(biases) ||
+        !row_contiguous(block_meta) || !row_contiguous(block_count)) {
+      return true;
+    }
+
+    const int K = x.shape(2);
+    const int E = weight.shape(0);
+    const int N = weight.shape(1);
+    const int packed_bytes = affine_packed_row_bytes(K, bits);
+    if (x.shape(0) <= 0 || K <= 0 || N <= 0 || E <= 0 ||
+        block_meta.shape(0) <= 0 || packed_bytes <= 0) {
+      return true;
+    }
+    if (weight.shape(2) * static_cast<int>(sizeof(uint32_t)) != packed_bytes ||
+        scales.shape(0) != E || scales.shape(1) != N ||
+        scales.shape(2) != K / group_size || biases.shape() != scales.shape()) {
+      return true;
+    }
+    return false;
+  }
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error(
+        "DeepseekAffineGatherBlocksPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    auto& out = outputs[0];
+
+    const auto& x = inputs[0];
+    const auto& weight = inputs[1];
+    const auto& scales = inputs[2];
+    const auto& biases = inputs[3];
+    const auto& block_meta = inputs[4];
+    const auto& block_count = inputs[5];
+
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    const auto cfg = mxfp4_blocks_variant(variant_);
+    const int max_blocks = block_meta.shape(0);
+    const int M = x.shape(0);
+    const int K = x.shape(2);
+    const int N = weight.shape(1);
+
+    std::string kname;
+    concatenate(
+        kname,
+        "deepseek_affine_gather_blocks_rhs_",
+        glm_type_name(x.dtype()),
+        "_gs_",
+        group_size_,
+        "_b_",
+        bits_,
+        "_bm_",
+        cfg.bm,
+        "_bn_",
+        cfg.bn,
+        "_bk_",
+        cfg.bk,
+        "_wm_",
+        cfg.wm,
+        "_wn_",
+        cfg.wn);
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto kernel = d.get_kernel(kname, lib);
+    auto& compute_encoder = metal::get_command_encoder(s);
+    compute_encoder.set_compute_pipeline_state(kernel);
+    compute_encoder.set_input_array(x, 0);
+    compute_encoder.set_input_array(weight, 1);
+    compute_encoder.set_input_array(scales, 2);
+    compute_encoder.set_input_array(biases, 3);
+    compute_encoder.set_input_array(block_meta, 4);
+    compute_encoder.set_input_array(block_count, 5);
+    compute_encoder.set_output_array(out, 6);
+    compute_encoder.set_bytes(max_blocks, 7);
+    compute_encoder.set_bytes(M, 8);
+    compute_encoder.set_bytes(N, 9);
+    compute_encoder.set_bytes(K, 10);
+
+    MTL::Size grid_dims((N + cfg.bn - 1) / cfg.bn, max_blocks, 1);
+    MTL::Size group_dims(cfg.wm * cfg.wn * 32, 1, 1);
+    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  }
+
+  DEFINE_NAME(DeepseekAffineGatherBlocksPrimitive)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs =
+        static_cast<const DeepseekAffineGatherBlocksPrimitive&>(other);
+    return group_size_ == rhs.group_size_ && bits_ == rhs.bits_ &&
+        variant_ == rhs.variant_;
+  }
+  auto state() const {
+    return std::make_tuple(group_size_, bits_, variant_);
+  }
+
+ private:
+  int group_size_;
+  int bits_;
+  int variant_;
+};
+
+class DeepseekAffineGatherPairBlocksPrimitive : public Primitive {
+ public:
+  explicit DeepseekAffineGatherPairBlocksPrimitive(
+      Stream stream,
+      int group_size,
+      int bits,
+      int variant)
+      : Primitive(stream),
+        group_size_(group_size),
+        bits_(bits),
+        variant_(variant) {
+    (void)mxfp4_blocks_variant(variant_);
+    if (!supported_deepseek_affine(group_size_, bits_)) {
+      throw std::invalid_argument(
+          "Unsupported DeepSeek affine pair block-list quantization.");
+    }
+  }
+
+  static bool unsupported(
+      const array& x,
+      const array& weight0,
+      const array& scales0,
+      const array& biases0,
+      const array& weight1,
+      const array& scales1,
+      const array& biases1,
+      const array& block_meta,
+      const array& block_count,
+      int group_size,
+      int bits,
+      Stream s) {
+    if (s.device == Device::cpu || !supported_deepseek_affine(group_size, bits)) {
+      return true;
+    }
+    if (x.dtype() != float16 && x.dtype() != bfloat16) {
+      return true;
+    }
+    if (weight0.dtype() != uint32 || weight1.dtype() != uint32 ||
+        scales0.dtype() != x.dtype() || scales1.dtype() != x.dtype() ||
+        biases0.dtype() != x.dtype() || biases1.dtype() != x.dtype() ||
+        block_meta.dtype() != int32 || block_count.dtype() != int32) {
+      return true;
+    }
+    if (x.ndim() != 3 || x.shape(1) != 1 || weight0.ndim() != 3 ||
+        scales0.ndim() != 3 || biases0.ndim() != 3 || weight1.ndim() != 3 ||
+        scales1.ndim() != 3 || biases1.ndim() != 3 || block_meta.ndim() != 2 ||
+        block_meta.shape(1) != 3 || block_count.size() != 1) {
+      return true;
+    }
+    if (!row_contiguous(x) || !row_contiguous(weight0) ||
+        !row_contiguous(scales0) || !row_contiguous(biases0) ||
+        !row_contiguous(weight1) || !row_contiguous(scales1) ||
+        !row_contiguous(biases1) || !row_contiguous(block_meta) ||
+        !row_contiguous(block_count)) {
+      return true;
+    }
+
+    const int K = x.shape(2);
+    const int E = weight0.shape(0);
+    const int N = weight0.shape(1);
+    const int packed_bytes = affine_packed_row_bytes(K, bits);
+    if (x.shape(0) <= 0 || K <= 0 || N <= 0 || E <= 0 ||
+        block_meta.shape(0) <= 0 || packed_bytes <= 0) {
+      return true;
+    }
+    if (weight1.shape() != weight0.shape() || scales1.shape() != scales0.shape() ||
+        biases1.shape() != biases0.shape()) {
+      return true;
+    }
+    if (weight0.shape(2) * static_cast<int>(sizeof(uint32_t)) != packed_bytes ||
+        scales0.shape(0) != E || scales0.shape(1) != N ||
+        scales0.shape(2) != K / group_size ||
+        biases0.shape() != scales0.shape()) {
+      return true;
+    }
+    return false;
+  }
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error(
+        "DeepseekAffineGatherPairBlocksPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    auto& out = outputs[0];
+
+    const auto& x = inputs[0];
+    const auto& weight0 = inputs[1];
+    const auto& scales0 = inputs[2];
+    const auto& biases0 = inputs[3];
+    const auto& weight1 = inputs[4];
+    const auto& scales1 = inputs[5];
+    const auto& biases1 = inputs[6];
+    const auto& block_meta = inputs[7];
+    const auto& block_count = inputs[8];
+
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    const auto cfg = mxfp4_blocks_variant(variant_);
+    const int max_blocks = block_meta.shape(0);
+    const int M = x.shape(0);
+    const int K = x.shape(2);
+    const int N = weight0.shape(1);
+
+    std::string kname;
+    concatenate(
+        kname,
+        "deepseek_affine_gather_pair_concat_blocks_rhs_",
+        glm_type_name(x.dtype()),
+        "_gs_",
+        group_size_,
+        "_b_",
+        bits_,
+        "_bm_",
+        cfg.bm,
+        "_bn_",
+        cfg.bn,
+        "_bk_",
+        cfg.bk,
+        "_wm_",
+        cfg.wm,
+        "_wn_",
+        cfg.wn);
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto kernel = d.get_kernel(kname, lib);
+    auto& compute_encoder = metal::get_command_encoder(s);
+    compute_encoder.set_compute_pipeline_state(kernel);
+    compute_encoder.set_input_array(x, 0);
+    compute_encoder.set_input_array(weight0, 1);
+    compute_encoder.set_input_array(scales0, 2);
+    compute_encoder.set_input_array(biases0, 3);
+    compute_encoder.set_input_array(weight1, 4);
+    compute_encoder.set_input_array(scales1, 5);
+    compute_encoder.set_input_array(biases1, 6);
+    compute_encoder.set_input_array(block_meta, 7);
+    compute_encoder.set_input_array(block_count, 8);
+    compute_encoder.set_output_array(out, 9);
+    compute_encoder.set_bytes(max_blocks, 10);
+    compute_encoder.set_bytes(M, 11);
+    compute_encoder.set_bytes(N, 12);
+    compute_encoder.set_bytes(K, 13);
+
+    MTL::Size grid_dims((2 * N + cfg.bn - 1) / cfg.bn, max_blocks, 1);
+    MTL::Size group_dims(cfg.wm * cfg.wn * 32, 1, 1);
+    compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+  }
+
+  DEFINE_NAME(DeepseekAffineGatherPairBlocksPrimitive)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs =
+        static_cast<const DeepseekAffineGatherPairBlocksPrimitive&>(other);
+    return group_size_ == rhs.group_size_ && bits_ == rhs.bits_ &&
+        variant_ == rhs.variant_;
+  }
+  auto state() const {
+    return std::make_tuple(group_size_, bits_, variant_);
+  }
+
+ private:
+  int group_size_;
+  int bits_;
+  int variant_;
+};
+
 class DeepseekMxfp4GatherExpertPrimitive : public Primitive {
  public:
   explicit DeepseekMxfp4GatherExpertPrimitive(Stream stream, int variant)
@@ -1022,6 +1391,155 @@ array deepseek_mxfp4_gather_qmm_pair_concat_blocks(
       x.dtype(),
       std::make_shared<DeepseekMxfp4GatherPairBlocksPrimitive>(
           stream, variant, true),
+      std::move(inputs));
+}
+
+array deepseek_affine_gather_qmm_blocks(
+    const array& x,
+    const array& weight,
+    const array& scales,
+    const array& biases,
+    const array& block_meta,
+    const array& block_count,
+    int group_size,
+    int bits,
+    int variant,
+    StreamOrDevice s /* = {} */) {
+  (void)mxfp4_blocks_variant(variant);
+
+  if (x.ndim() != 3 || x.shape(1) != 1 || weight.ndim() != 3 ||
+      scales.ndim() != 3 || biases.ndim() != 3 || block_meta.ndim() != 2 ||
+      block_meta.shape(1) != 3 || block_count.size() != 1) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_affine_gather_qmm_blocks] expected "
+        << "x [M,1,K], weight [E,N,packed_words], scales/biases "
+        << "[E,N,K/group_size], block_meta [B,3], block_count [1], got "
+        << x.shape() << ", " << weight.shape() << ", " << scales.shape()
+        << ", " << biases.shape() << ", " << block_meta.shape() << ", "
+        << block_count.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  if (!supported_deepseek_affine(group_size, bits)) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_affine_gather_qmm_blocks] unsupported "
+        << "affine quantization group_size=" << group_size << " bits=" << bits
+        << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  const int K = x.shape(2);
+  const int E = weight.shape(0);
+  const int N = weight.shape(1);
+  const int packed_bytes = affine_packed_row_bytes(K, bits);
+  if (packed_bytes <= 0 ||
+      weight.shape(2) * static_cast<int>(sizeof(uint32_t)) != packed_bytes ||
+      scales.shape(0) != E || scales.shape(1) != N ||
+      scales.shape(2) != K / group_size || biases.shape() != scales.shape()) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_affine_gather_qmm_blocks] "
+        << "incompatible shapes: " << x.shape() << ", " << weight.shape()
+        << ", " << scales.shape() << ", " << biases.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (x.dtype() != float16 && x.dtype() != bfloat16) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_affine_gather_qmm_blocks] expected "
+        << "float16 or bfloat16 input, got " << x.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (weight.dtype() != uint32 || scales.dtype() != x.dtype() ||
+      biases.dtype() != x.dtype() || block_meta.dtype() != int32 ||
+      block_count.dtype() != int32) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.deepseek_affine_gather_qmm_blocks] expected "
+        << "uint32 weight, scales/biases matching input dtype, int32 "
+        << "block_meta/count, got " << weight.dtype() << ", "
+        << scales.dtype() << ", " << biases.dtype() << ", "
+        << block_meta.dtype() << ", " << block_count.dtype() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto stream = to_stream(s);
+  std::vector<array> inputs = {
+      x, weight, scales, biases, block_meta, block_count};
+  if (DeepseekAffineGatherBlocksPrimitive::unsupported(
+          x,
+          weight,
+          scales,
+          biases,
+          block_meta,
+          block_count,
+          group_size,
+          bits,
+          stream)) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.deepseek_affine_gather_qmm_blocks] unsupported shape.");
+  }
+
+  Shape out_shape{x.shape(0), 1, N};
+  return array(
+      std::move(out_shape),
+      x.dtype(),
+      std::make_shared<DeepseekAffineGatherBlocksPrimitive>(
+          stream, group_size, bits, variant),
+      std::move(inputs));
+}
+
+array deepseek_affine_gather_qmm_pair_concat_blocks(
+    const array& x,
+    const array& weight0,
+    const array& scales0,
+    const array& biases0,
+    const array& weight1,
+    const array& scales1,
+    const array& biases1,
+    const array& block_meta,
+    const array& block_count,
+    int group_size,
+    int bits,
+    int variant,
+    StreamOrDevice s /* = {} */) {
+  const auto cfg = mxfp4_blocks_variant(variant);
+  auto stream = to_stream(s);
+  if (DeepseekAffineGatherPairBlocksPrimitive::unsupported(
+          x,
+          weight0,
+          scales0,
+          biases0,
+          weight1,
+          scales1,
+          biases1,
+          block_meta,
+          block_count,
+          group_size,
+          bits,
+          stream)) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.deepseek_affine_gather_qmm_pair_concat_blocks] unsupported shape.");
+  }
+  const int N = weight0.shape(1);
+  if (N % cfg.bn != 0) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.deepseek_affine_gather_qmm_pair_concat_blocks] "
+        "output dimension must be divisible by the block N.");
+  }
+  std::vector<array> inputs = {
+      x,
+      weight0,
+      scales0,
+      biases0,
+      weight1,
+      scales1,
+      biases1,
+      block_meta,
+      block_count};
+  Shape out_shape{x.shape(0), 1, 2 * N};
+  return array(
+      std::move(out_shape),
+      x.dtype(),
+      std::make_shared<DeepseekAffineGatherPairBlocksPrimitive>(
+          stream, group_size, bits, variant),
       std::move(inputs));
 }
 

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.h
@@ -21,4 +21,43 @@ mx::array glm_moe_weighted_sum(
     const mx::array& scores,
     mx::StreamOrDevice s = {});
 
+mx::array deepseek_mxfp4_gather_qmm_blocks(
+    const mx::array& x,
+    const mx::array& weight,
+    const mx::array& scales,
+    const mx::array& block_meta,
+    const mx::array& block_count,
+    int variant = 0,
+    mx::StreamOrDevice s = {});
+
+mx::array deepseek_mxfp4_gather_qmm_pair_blocks(
+    const mx::array& x,
+    const mx::array& weight0,
+    const mx::array& scales0,
+    const mx::array& weight1,
+    const mx::array& scales1,
+    const mx::array& block_meta,
+    const mx::array& block_count,
+    int variant = 0,
+    mx::StreamOrDevice s = {});
+
+mx::array deepseek_mxfp4_gather_qmm_pair_concat_blocks(
+    const mx::array& x,
+    const mx::array& weight0,
+    const mx::array& scales0,
+    const mx::array& weight1,
+    const mx::array& scales1,
+    const mx::array& block_meta,
+    const mx::array& block_count,
+    int variant = 0,
+    mx::StreamOrDevice s = {});
+
+mx::array deepseek_mxfp4_gather_qmm_expert(
+    const mx::array& x,
+    const mx::array& weight,
+    const mx::array& scales,
+    const mx::array& indices,
+    int variant = 0,
+    mx::StreamOrDevice s = {});
+
 } // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.h
@@ -52,6 +52,33 @@ mx::array deepseek_mxfp4_gather_qmm_pair_concat_blocks(
     int variant = 0,
     mx::StreamOrDevice s = {});
 
+mx::array deepseek_affine_gather_qmm_blocks(
+    const mx::array& x,
+    const mx::array& weight,
+    const mx::array& scales,
+    const mx::array& biases,
+    const mx::array& block_meta,
+    const mx::array& block_count,
+    int group_size,
+    int bits,
+    int variant = 0,
+    mx::StreamOrDevice s = {});
+
+mx::array deepseek_affine_gather_qmm_pair_concat_blocks(
+    const mx::array& x,
+    const mx::array& weight0,
+    const mx::array& scales0,
+    const mx::array& biases0,
+    const mx::array& weight1,
+    const mx::array& scales1,
+    const mx::array& biases1,
+    const mx::array& block_meta,
+    const mx::array& block_count,
+    int group_size,
+    int bits,
+    int variant = 0,
+    mx::StreamOrDevice s = {});
+
 mx::array deepseek_mxfp4_gather_qmm_expert(
     const mx::array& x,
     const mx::array& weight,

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.metal
@@ -32,3 +32,5 @@ instantiate_quantized_head_flat(
 
 instantiate_moe_weighted_sum_tiled(float16_t, float, 8, 256);
 instantiate_moe_weighted_sum_tiled(bfloat16_t, float, 8, 256);
+instantiate_moe_weighted_sum_tiled(float16_t, float, 6, 256);
+instantiate_moe_weighted_sum_tiled(bfloat16_t, float, 6, 256);

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/steel_deepseek_v4_sparse_attention.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/steel_deepseek_v4_sparse_attention.h
@@ -1,0 +1,327 @@
+// Copyright © 2026 OpenAI
+
+#pragma once
+
+#include "mlx/backend/metal/kernels/steel/attn/attn.h"
+#include "mlx/backend/metal/kernels/steel/attn/params.h"
+
+using namespace mlx::steel;
+
+struct DeepseekV4SparseMaxOp {
+  template <typename T>
+  METAL_FUNC static constexpr T apply(T x, T y) {
+    return metal::max(x, y);
+  }
+};
+
+struct DeepseekV4SparseSumOp {
+  template <typename T>
+  METAL_FUNC static constexpr T apply(T x, T y) {
+    return x + y;
+  }
+};
+
+struct DeepseekV4SparseMulOp {
+  template <typename T>
+  METAL_FUNC static constexpr T apply(T x, T y) {
+    return x * y;
+  }
+};
+
+struct DeepseekV4SparseExpSubOp {
+  template <typename T>
+  METAL_FUNC static constexpr T apply(T x, T y) {
+    return fast::exp2(x - y);
+  }
+};
+
+struct DeepseekV4SparseDivOp {
+  template <typename T>
+  METAL_FUNC static constexpr T apply(T x, T y) {
+    return x / y;
+  }
+};
+
+// clang-format off
+template <
+    typename T,
+    int BK,
+    int DC,
+    int H,
+    int D,
+    int WM,
+    typename IndexT,
+    typename AccumType = float>
+[[kernel, max_total_threads_per_threadgroup(WM * 32)]] void deepseek_v4_sparse_attention(
+    const device T* Q [[buffer(0)]],
+    const device T* LocalKV [[buffer(1)]],
+    const device T* PooledKV [[buffer(2)]],
+    const device IndexT* Topk [[buffer(3)]],
+    const device T* Sinks [[buffer(4)]],
+    device T* O [[buffer(5)]],
+    const constant DeepseekV4SparseAttentionParams* params [[buffer(6)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]]) { // clang-format on
+
+  constexpr short kFragSize = 8;
+  constexpr short padQ = 16 / sizeof(T);
+  constexpr short padK = 16 / sizeof(T);
+  constexpr short padV = 16 / sizeof(T);
+
+  constexpr short LDQ = DC + padQ;
+  constexpr short LDK = BK + padK;
+  constexpr short LDV = DC + padV;
+
+  constexpr int kNWarps = WM;
+  constexpr int TQ = H / (kNWarps * kFragSize);
+  constexpr int TK = BK / kFragSize;
+  constexpr int TDC = DC / kFragSize;
+  constexpr int D_CHUNKS = D / DC;
+
+  static_assert(TQ >= 1, "DeepSeek sparse attention needs a head tile.");
+  static_assert(
+      H % (kNWarps * kFragSize) == 0,
+      "Head count must divide evenly across simdgroups.");
+  static_assert(BK % kFragSize == 0, "BK must be a multiple of 8.");
+  static_assert(DC % kFragSize == 0, "DC must be a multiple of 8.");
+  static_assert(D % DC == 0, "Head dimension must divide DC.");
+
+  constexpr int tgp_size = WM * 32;
+  const int lane = int(simd_group_id * 32 + simd_lane_id);
+
+  const int q_pos = int(tid.x);
+  const int b = int(tid.y);
+
+  threadgroup T Qs[H * LDQ];
+  threadgroup T KVs[(BK * LDV > DC * LDK) ? BK * LDV : DC * LDK];
+  threadgroup int selected[BK];
+
+  using MMAFragAcc = BaseMMAFrag<AccumType, kFragSize, kFragSize>;
+  MMATile<AccumType, TQ, 1, MMAFragAcc> Qtile;
+  MMATile<AccumType, 1, TK, MMAFragAcc> Ktile;
+  MMATile<AccumType, TQ, TK, MMAFragAcc> Stile;
+  MMATile<AccumType, 1, 1, MMAFragAcc> Vtile;
+  MMATile<AccumType, TQ, D_CHUNKS * TDC, MMAFragAcc> Otile;
+
+  Otile.clear();
+
+  const short2 simd_coord = MMAFragAcc::get_coord(simd_lane_id);
+  const short sm = simd_coord.y;
+  const short sn = simd_coord.x;
+  const short tm = kFragSize * TQ * simd_group_id;
+
+  const short Qs_offset = (tm + sm) * LDQ + sn;
+  const short Ks_offset = sm * LDK + sn;
+  const short Vs_offset = sm * LDV + sn;
+
+  const AccumType scale = AccumType(params->scale * M_LOG2E_F);
+
+  constexpr short rows_per_thread = decltype(Stile)::kRowsPerThread;
+  AccumType max_score[rows_per_thread];
+  AccumType sum_score[rows_per_thread] = {0};
+
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < rows_per_thread; ++i) {
+    const int head = int(tm + sm + i * kFragSize);
+    if (head < params->H) {
+      max_score[i] = AccumType(M_LOG2E_F) * AccumType(Sinks[head]);
+      sum_score[i] = AccumType(1);
+    } else {
+      max_score[i] = Limits<AccumType>::finite_min;
+    }
+  }
+
+  const device T* q_base = Q + size_t(b) * params->Q_strides[0] +
+      size_t(q_pos) * params->Q_strides[2];
+  const device T* local_base =
+      LocalKV + size_t(b) * params->Local_strides[0];
+  const device T* pooled_base =
+      PooledKV + size_t(b) * params->Pooled_strides[0];
+  const device IndexT* topk_base =
+      Topk + size_t(b) * params->Topk_strides[0] +
+      size_t(q_pos) * params->Topk_strides[2];
+
+  const int local_offset = params->localL - params->qL;
+  const int local_end =
+      metal::min(params->localL, local_offset + q_pos + 1);
+  const int local_start =
+      metal::max(0, local_end - params->local_window);
+  const int local_count = metal::max(0, local_end - local_start);
+  const int local_tiles = (local_count + BK - 1) / BK;
+  const int pooled_tiles = (params->topk + BK - 1) / BK;
+  const int pooled_valid = metal::min(
+      params->pooledL,
+      (params->q_offset + q_pos + 1) / params->compress_ratio);
+  const int total_tiles = local_tiles + pooled_tiles;
+
+  for (int ktile = 0; ktile < total_tiles; ++ktile) {
+    const bool is_pooled_tile = ktile >= local_tiles;
+    const int tile_slot = is_pooled_tile ? (ktile - local_tiles) : ktile;
+    const int slot_base = tile_slot * BK;
+
+    for (int k = lane; k < BK; k += tgp_size) {
+      const int slot = slot_base + k;
+      int k_pos = -1;
+      if (is_pooled_tile) {
+        if (slot < params->topk) {
+          const int pooled_pos = int(topk_base[slot]);
+          if (pooled_pos >= 0 && pooled_pos < pooled_valid) {
+            k_pos = pooled_pos;
+          }
+        }
+      } else {
+        if (slot < local_count) {
+          k_pos = local_start + slot;
+        }
+      }
+      selected[k] = k_pos;
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    Stile.clear();
+
+    STEEL_PRAGMA_UNROLL
+    for (short dchunk = 0; dchunk < D_CHUNKS; ++dchunk) {
+      const int dbase = int(dchunk) * DC;
+
+      for (int elem = lane; elem < H * DC; elem += tgp_size) {
+        const int h = elem / DC;
+        const int d = elem - h * DC;
+        Qs[h * LDQ + d] =
+            q_base[size_t(h) * params->Q_strides[1] + dbase + d];
+      }
+
+      for (int elem = lane; elem < BK * DC; elem += tgp_size) {
+        const int k = elem / DC;
+        const int d = elem - k * DC;
+        const int k_pos = selected[k];
+        T value = T(0);
+        if (k_pos >= 0) {
+          value = is_pooled_tile
+              ? pooled_base[size_t(k_pos) * params->Pooled_strides[1] +
+                            dbase + d]
+              : local_base[size_t(k_pos) * params->Local_strides[2] +
+                           dbase + d];
+        }
+        KVs[k + d * LDK] = value;
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      STEEL_PRAGMA_UNROLL
+      for (short dd = 0; dd < TDC; ++dd) {
+        simdgroup_barrier(mem_flags::mem_none);
+        Qtile.template load<T, 1, 1, LDQ, 1>(&Qs[Qs_offset + dd * kFragSize]);
+        Ktile.template load<T, 1, 1, LDK, 1>(
+            &KVs[Ks_offset + dd * kFragSize * LDK]);
+        simdgroup_barrier(mem_flags::mem_none);
+        tile_matmad(Stile, Qtile, Ktile, Stile);
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    STEEL_PRAGMA_UNROLL
+    for (short ii = 0; ii < decltype(Stile)::kElemsPerTile; ++ii) {
+      Stile.elems()[ii] *= scale;
+    }
+
+    {
+      using stile_t = decltype(Stile);
+      using selem_t = typename stile_t::elem_type;
+      constexpr auto neg_inf = Limits<selem_t>::finite_min;
+
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < stile_t::kTileRows; ++i) {
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < stile_t::kTileCols; ++j) {
+          const short col_pos = sn + j * stile_t::kFragCols;
+          STEEL_PRAGMA_UNROLL
+          for (short jj = 0; jj < stile_t::MMAFrag_t::kElemCols; ++jj) {
+            if (selected[col_pos + jj] < 0) {
+              Stile.frag_at(i, j)[jj] = neg_inf;
+            }
+          }
+        }
+      }
+    }
+
+    AccumType new_max[rows_per_thread];
+    AccumType factor[rows_per_thread];
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      new_max[i] = max_score[i];
+    }
+
+    Stile.template row_reduce<DeepseekV4SparseMaxOp>(new_max);
+    Stile.template row_bin_op<DeepseekV4SparseExpSubOp>(new_max);
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      factor[i] = fast::exp2(max_score[i] - new_max[i]);
+      max_score[i] = new_max[i];
+    }
+
+    AccumType sum_score_tmp[rows_per_thread] = {0};
+    Stile.template row_reduce<DeepseekV4SparseSumOp>(sum_score_tmp);
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      sum_score[i] = sum_score[i] * factor[i] + sum_score_tmp[i];
+    }
+
+    Otile.template row_bin_op<DeepseekV4SparseMulOp>(factor);
+
+    STEEL_PRAGMA_UNROLL
+    for (short vchunk = 0; vchunk < D_CHUNKS; ++vchunk) {
+      const int dbase = int(vchunk) * DC;
+
+      for (int elem = lane; elem < BK * DC; elem += tgp_size) {
+        const int k = elem / DC;
+        const int d = elem - k * DC;
+        const int k_pos = selected[k];
+        T value = T(0);
+        if (k_pos >= 0) {
+          value = is_pooled_tile
+              ? pooled_base[size_t(k_pos) * params->Pooled_strides[1] +
+                            dbase + d]
+              : local_base[size_t(k_pos) * params->Local_strides[2] +
+                           dbase + d];
+        }
+        KVs[k * LDV + d] = value;
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+
+      STEEL_PRAGMA_UNROLL
+      for (short iq = 0; iq < TQ; ++iq) {
+        STEEL_PRAGMA_UNROLL
+        for (short id = 0; id < TDC; ++id) {
+          STEEL_PRAGMA_UNROLL
+          for (short ik = 0; ik < TK; ++ik) {
+            const short kk = ik * kFragSize;
+            const short dd = id * kFragSize;
+            Vtile.template load<T, 1, 1, LDV, 1>(
+                &KVs[Vs_offset + kk * LDV + dd]);
+            MMAFragAcc::mma(
+                Otile.frag_at(iq, vchunk * TDC + id),
+                Stile.frag_at(iq, ik),
+                Vtile.frag_at(0, 0),
+                Otile.frag_at(iq, vchunk * TDC + id));
+          }
+        }
+      }
+
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  }
+
+  Otile.template row_bin_op<DeepseekV4SparseDivOp>(sum_score);
+
+  device T* out = O + size_t(b) * params->O_strides[0] +
+      size_t(q_pos) * params->O_strides[2] +
+      size_t(tm + sm) * params->O_strides[1] + sn;
+  Otile.template store<T, 1, 1>(out, params->O_strides[1]);
+}

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/mlx/backend/metal/kernels/steel/attn/params.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/mlx/backend/metal/kernels/steel/attn/params.h
@@ -144,5 +144,25 @@ struct GlmDsaSparseMlaQBlockParams {
   int64_t O_strides[3]; ///< Output strides (B, H, L, D = 1)
 };
 
+struct DeepseekV4SparseAttentionParams {
+  int B; ///< Batch size
+  int H; ///< Query heads
+  int qL; ///< Query sequence length
+  int localL; ///< Local rotating KV length
+  int pooledL; ///< Number of pooled KV tokens
+  int topk; ///< Number of selected pooled tokens per query
+  int local_window; ///< Sliding-window size for local KV
+  int compress_ratio; ///< Pooled compression ratio
+  int q_offset; ///< Absolute query offset before this chunk
+
+  float scale; ///< Attention scale
+
+  int64_t Q_strides[3]; ///< Query strides (B, H, L, D = 1)
+  int64_t Local_strides[3]; ///< Local KV strides (B, 1, L, D = 1)
+  int64_t Pooled_strides[2]; ///< Pooled KV strides (B, L, D = 1)
+  int64_t Topk_strides[3]; ///< Top-k strides (B, 1, L, topk = 1)
+  int64_t O_strides[3]; ///< Output strides (B, H, L, D = 1)
+};
+
 } // namespace steel
 } // namespace mlx

--- a/omlx/custom_kernels/glm_moe_dsa/fast.py
+++ b/omlx/custom_kernels/glm_moe_dsa/fast.py
@@ -23,8 +23,13 @@ NATIVE_SYMBOLS = (
     "dsa_topk_indices",
     "glm_dsa_sparse_mla_attention",
     "glm_dsa_exact_block_attention",
+    "deepseek_v4_sparse_attention",
     "glm_dsa_q8_vup_flat",
     "glm_moe_weighted_sum",
+    "deepseek_mxfp4_gather_qmm_blocks",
+    "deepseek_mxfp4_gather_qmm_pair_blocks",
+    "deepseek_mxfp4_gather_qmm_pair_concat_blocks",
+    "deepseek_mxfp4_gather_qmm_expert",
 )
 
 
@@ -196,6 +201,35 @@ def glm_dsa_exact_block_attention(
     )
 
 
+def deepseek_v4_sparse_attention(
+    q: mx.array,
+    local_kv: mx.array,
+    pooled: mx.array,
+    topk_indices: mx.array,
+    sinks: mx.array,
+    scale: float,
+    q_offset: int,
+    compress_ratio: int,
+    local_window: int,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is not None and hasattr(_ext, "deepseek_v4_sparse_attention"):
+        return _ext.deepseek_v4_sparse_attention(
+            q,
+            local_kv,
+            pooled,
+            topk_indices,
+            sinks,
+            scale,
+            q_offset,
+            compress_ratio,
+            local_window,
+            **_native_stream_kwargs(stream),
+        )
+    raise RuntimeError("deepseek_v4_sparse_attention native kernel is unavailable")
+
+
 def glm_dsa_q8_vup_flat(
     x: mx.array,
     weight: mx.array,
@@ -241,6 +275,110 @@ def glm_moe_weighted_sum(
         scores,
         stream=stream or mx.gpu,
     )
+
+
+def deepseek_mxfp4_gather_qmm_blocks(
+    x: mx.array,
+    weight: mx.array,
+    scales: mx.array,
+    block_meta: mx.array,
+    block_count: mx.array,
+    variant: int = 0,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is not None and hasattr(_ext, "deepseek_mxfp4_gather_qmm_blocks"):
+        return _ext.deepseek_mxfp4_gather_qmm_blocks(
+            x,
+            weight,
+            scales,
+            block_meta,
+            block_count,
+            variant,
+            **_native_stream_kwargs(stream),
+        )
+    raise RuntimeError("deepseek_mxfp4_gather_qmm_blocks native kernel is unavailable")
+
+
+def deepseek_mxfp4_gather_qmm_pair_blocks(
+    x: mx.array,
+    weight0: mx.array,
+    scales0: mx.array,
+    weight1: mx.array,
+    scales1: mx.array,
+    block_meta: mx.array,
+    block_count: mx.array,
+    variant: int = 0,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is not None and hasattr(_ext, "deepseek_mxfp4_gather_qmm_pair_blocks"):
+        return _ext.deepseek_mxfp4_gather_qmm_pair_blocks(
+            x,
+            weight0,
+            scales0,
+            weight1,
+            scales1,
+            block_meta,
+            block_count,
+            variant,
+            **_native_stream_kwargs(stream),
+        )
+    raise RuntimeError(
+        "deepseek_mxfp4_gather_qmm_pair_blocks native kernel is unavailable"
+    )
+
+
+def deepseek_mxfp4_gather_qmm_pair_concat_blocks(
+    x: mx.array,
+    weight0: mx.array,
+    scales0: mx.array,
+    weight1: mx.array,
+    scales1: mx.array,
+    block_meta: mx.array,
+    block_count: mx.array,
+    variant: int = 0,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is not None and hasattr(
+        _ext, "deepseek_mxfp4_gather_qmm_pair_concat_blocks"
+    ):
+        return _ext.deepseek_mxfp4_gather_qmm_pair_concat_blocks(
+            x,
+            weight0,
+            scales0,
+            weight1,
+            scales1,
+            block_meta,
+            block_count,
+            variant,
+            **_native_stream_kwargs(stream),
+        )
+    raise RuntimeError(
+        "deepseek_mxfp4_gather_qmm_pair_concat_blocks native kernel is unavailable"
+    )
+
+
+def deepseek_mxfp4_gather_qmm_expert(
+    x: mx.array,
+    weight: mx.array,
+    scales: mx.array,
+    indices: mx.array,
+    variant: int = 0,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is not None and hasattr(_ext, "deepseek_mxfp4_gather_qmm_expert"):
+        return _ext.deepseek_mxfp4_gather_qmm_expert(
+            x,
+            weight,
+            scales,
+            indices,
+            variant,
+            **_native_stream_kwargs(stream),
+        )
+    raise RuntimeError("deepseek_mxfp4_gather_qmm_expert native kernel is unavailable")
 
 
 def __getattr__(name: str) -> Any:

--- a/omlx/custom_kernels/glm_moe_dsa/fast.py
+++ b/omlx/custom_kernels/glm_moe_dsa/fast.py
@@ -30,6 +30,8 @@ NATIVE_SYMBOLS = (
     "deepseek_mxfp4_gather_qmm_pair_blocks",
     "deepseek_mxfp4_gather_qmm_pair_concat_blocks",
     "deepseek_mxfp4_gather_qmm_expert",
+    "deepseek_affine_gather_qmm_blocks",
+    "deepseek_affine_gather_qmm_pair_concat_blocks",
 )
 
 
@@ -379,6 +381,74 @@ def deepseek_mxfp4_gather_qmm_expert(
             **_native_stream_kwargs(stream),
         )
     raise RuntimeError("deepseek_mxfp4_gather_qmm_expert native kernel is unavailable")
+
+
+def deepseek_affine_gather_qmm_blocks(
+    x: mx.array,
+    weight: mx.array,
+    scales: mx.array,
+    biases: mx.array,
+    block_meta: mx.array,
+    block_count: mx.array,
+    group_size: int,
+    bits: int,
+    variant: int = 0,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is not None and hasattr(_ext, "deepseek_affine_gather_qmm_blocks"):
+        return _ext.deepseek_affine_gather_qmm_blocks(
+            x,
+            weight,
+            scales,
+            biases,
+            block_meta,
+            block_count,
+            group_size,
+            bits,
+            variant,
+            **_native_stream_kwargs(stream),
+        )
+    raise RuntimeError("deepseek_affine_gather_qmm_blocks native kernel is unavailable")
+
+
+def deepseek_affine_gather_qmm_pair_concat_blocks(
+    x: mx.array,
+    weight0: mx.array,
+    scales0: mx.array,
+    biases0: mx.array,
+    weight1: mx.array,
+    scales1: mx.array,
+    biases1: mx.array,
+    block_meta: mx.array,
+    block_count: mx.array,
+    group_size: int,
+    bits: int,
+    variant: int = 0,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is not None and hasattr(
+        _ext, "deepseek_affine_gather_qmm_pair_concat_blocks"
+    ):
+        return _ext.deepseek_affine_gather_qmm_pair_concat_blocks(
+            x,
+            weight0,
+            scales0,
+            biases0,
+            weight1,
+            scales1,
+            biases1,
+            block_meta,
+            block_count,
+            group_size,
+            bits,
+            variant,
+            **_native_stream_kwargs(stream),
+        )
+    raise RuntimeError(
+        "deepseek_affine_gather_qmm_pair_concat_blocks native kernel is unavailable"
+    )
 
 
 def __getattr__(name: str) -> Any:

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -4,9 +4,10 @@
 Mixed-precision quantization combining GGUF K-quant layer position strategy,
 unsloth Dynamic 2.0 selective non-quantization, and BnB MSE-optimal clipping.
 
-Supported levels: oQ2, oQ2.5, oQ2.7, oQ2.8, oQ3, oQ3.5, oQ4, oQ5, oQ6, oQ8
+Supported levels: oQ2, oQ2.5, oQ2.7, oQ3, oQ3.5, oQ4, oQ5, oQ6, oQ8
 (base bits differ, same predicate). Fractional levels keep the lower level's
-base bits and add targeted routed-expert protection plus a higher bpw budget.
+base bits and add targeted code-preserving routed-expert protection plus a
+higher bpw budget.
 """
 
 import hashlib
@@ -36,7 +37,7 @@ from omlx.model_discovery import _has_vision_subconfig
 
 logger = logging.getLogger(__name__)
 
-OQ_LEVELS = {2, 2.5, 2.7, 2.8, 3, 3.5, 4, 5, 6, 8}
+OQ_LEVELS = {2, 2.5, 2.7, 3, 3.5, 4, 5, 6, 8}
 
 OQ_DTYPES: tuple[str, ...] = ("bfloat16", "float16")
 
@@ -54,7 +55,6 @@ _LEVEL_BITS: dict[float, int] = {
     2: 2,
     2.5: 2,
     2.7: 2,
-    2.8: 2,
     3: 3,
     3.5: 3,
     4: 4,
@@ -67,7 +67,6 @@ _LEVEL_PROTECTION: dict[float, str] = {
     2: "full",
     2.5: "full",
     2.7: "full",
-    2.8: "full",
     3: "full",
     3.5: "full",
     4: "full",
@@ -85,7 +84,6 @@ _OQ_BPW_TARGETS: dict[float, tuple[float, float]] = {
     2: (2.8, 3.0),
     2.5: (3.1, 3.3),
     2.7: (3.25, 3.35),
-    2.8: (3.35, 3.45),
     3: (3.5, 3.7),
     3.5: (3.8, 4.0),
     4: (4.6, 4.7),
@@ -93,7 +91,8 @@ _OQ_BPW_TARGETS: dict[float, tuple[float, float]] = {
     6: (6.5, 6.7),
 }
 
-_ROUTED_LAYER_BOOST_LEVELS = {2.5, 2.7, 2.8}
+_ROUTED_LAYER_BOOST_LEVELS = {2.5, 2.7}
+_CODE_PRESERVE_FRACTIONAL_LEVELS = {2.5, 2.7}
 _VALID_QUANT_BITS = (2, 3, 4, 5, 6, 8)
 
 
@@ -158,9 +157,10 @@ def universal_quant_predicate(
 
     Protection levels vary by oQ level:
         oQ2: minimal protection (router fp16, lm_head 4-bit only) → ~2.5 bpw
-        oQ2.5/oQ2.7/oQ2.8: base 2-bit + routed layer boosts selected by layer
-            sensitivity; routed w2/down_proj first, then w1/w3 as paired
-            layer-wide boosts while staying under the bpw cap
+        oQ2.5/oQ2.7: base 2-bit + code-preserving routed layer boosts
+            selected by layer sensitivity and late-layer position; routed
+            w2/down_proj first, then w1/w3 as paired layer-wide boosts while
+            staying under the bpw cap
         oQ3.5: base 3-bit with routed expert down_proj protected above base per
             _LEVEL_EXPERT_DOWN_BOOST (Super Weights protection)
         oQ3: base 3-bit + full protection → ~3.5 bpw
@@ -539,6 +539,40 @@ def _routed_expert_projection(path: str) -> str | None:
     return None
 
 
+def _num_layers_from_config(config: dict, default: int = 32) -> int:
+    tc = config.get("text_config", {})
+    return int(
+        config.get("num_hidden_layers")
+        or (tc.get("num_hidden_layers") if isinstance(tc, dict) else None)
+        or default
+    )
+
+
+def _code_preserve_layer_score(
+    *,
+    layer_idx: int,
+    layer_score: float,
+    max_layer_score: float,
+    num_layers: int,
+    oq_level: float,
+) -> float:
+    """Raise generation-critical edge/late layers for aggressive 2-bit levels."""
+    if oq_level not in _CODE_PRESERVE_FRACTIONAL_LEVELS:
+        return layer_score
+    if layer_idx < 0 or num_layers <= 1:
+        return layer_score
+
+    anchor = max(max_layer_score, 1e-12)
+    pos = layer_idx / max(num_layers - 1, 1)
+    if pos >= 0.80:
+        return layer_score + 0.50 * anchor
+    if pos >= 0.65:
+        return layer_score + 0.25 * anchor
+    if pos < 0.125:
+        return layer_score + 0.20 * anchor
+    return layer_score
+
+
 _MANDATORY_BOOST_PATTERNS = {
     "lm_head": {"bits": 8, "group_size": 64, "mode": "affine"},
     "embeddings": {"bits": 8, "group_size": 64, "mode": "affine"},
@@ -581,9 +615,9 @@ def _apply_routed_layer_boosts(
     """Boost routed expert modules by layer while staying MLX-loader portable.
 
     MLX's QuantizedSwitchLinear stores one bit-width per fused expert projection,
-    not per expert. For oQ2.5/oQ2.7/oQ2.8 we therefore rank layers by
-    sensitivity and boost whole routed projection modules: down/w2 first,
-    then gate+up as a pair.
+    not per expert. For oQ2.5/oQ2.7 we therefore rank layers by sensitivity
+    plus a small late-layer generation prior, then boost whole routed projection
+    modules: down/w2 first, then gate+up as a pair.
     """
     if oq_level not in _ROUTED_LAYER_BOOST_LEVELS or base_bits >= 3:
         return total_bits_f, current_bpw
@@ -591,6 +625,8 @@ def _apply_routed_layer_boosts(
     from collections import defaultdict
 
     layer_scores = config.get("_oq_sensitivity_map") or {}
+    max_layer_score = max(layer_scores.values(), default=0.0)
+    num_layers = _num_layers_from_config(config)
     grouped: dict[tuple[int, str], list[tuple[str, tuple]]] = defaultdict(list)
     for path, shape in named_shapes.items():
         if path in fixed_overrides:
@@ -605,7 +641,14 @@ def _apply_routed_layer_boosts(
         grouped[(layer_idx, phase)].append((path, shape))
 
     def group_score(layer_idx: int) -> float:
-        return float(layer_scores.get(str(layer_idx), 0.0))
+        layer_score = float(layer_scores.get(str(layer_idx), 0.0))
+        return _code_preserve_layer_score(
+            layer_idx=layer_idx,
+            layer_score=layer_score,
+            max_layer_score=max_layer_score,
+            num_layers=num_layers,
+            oq_level=oq_level,
+        )
 
     def try_boost_group(items: list[tuple[str, tuple]]) -> bool:
         nonlocal total_bits_f, current_bpw
@@ -672,9 +715,10 @@ def _build_quant_plan(
 
     Strategy:
     1. Mandatory pre-allocation: consensus-critical tensors (lm_head → 8-bit)
-    2. Data-driven: all non-expert tensors compete equally, ranked by
-       layer sensitivity score. Higher sensitivity → more bits.
-    3. Routed experts always stay at base bits (93-98% of params).
+    2. For oQ2.5/oQ2.7, routed expert down/gate/up boosts get the remaining
+       target budget before opportunistic non-expert boosts.
+    3. Data-driven: remaining non-expert tensors compete by sensitivity and
+       layer-position score. Higher score → more bits.
 
     fixed_overrides marks tensors whose output format is fixed up front
     (pre-quantized source tensors passed through as mxfp4/mxfp8). They are
@@ -689,6 +733,8 @@ def _build_quant_plan(
 
     layer_scores = config.get("_oq_sensitivity_map") or {}
     max_layer_score = max(layer_scores.values(), default=0.0)
+    num_layers = _num_layers_from_config(config)
+    routed_first = oq_level in _CODE_PRESERVE_FRACTIONAL_LEVELS
 
     total_params = 0
     expert_params = 0
@@ -807,38 +853,69 @@ def _build_quant_plan(
         total_bits_f += delta
         current_bpw = next_bpw
 
+    # Aggressive 2-bit fractional levels are most prone to code-generation
+    # regressions when routed expert output paths stay at the base width.
+    # Reserve the remaining target budget for routed down_proj first, then
+    # paired gate/up, before opportunistic non-expert sensitivity boosts.
+    if routed_first and current_bpw < target_bpw:
+        total_bits_f, current_bpw = _apply_routed_layer_boosts(
+            named_shapes,
+            config,
+            oq_level,
+            boost_map,
+            fixed_overrides,
+            base_bits,
+            base_group_size,
+            base_mode,
+            total_bits_f,
+            total_params,
+            current_bpw,
+            target_bpw,
+            hard_cap_bpw,
+        )
+
     # Sensitivity-based greedy boost: boost tensors from their current bits
     # (which may already be elevated by the protection floor) using remaining
     # budget up to hard_cap_bpw.
     candidates = []
-    for path, shape in named_shapes.items():
-        if _is_routed_expert(path) or path in fixed_overrides:
-            continue
-        pred = universal_quant_predicate(
-            path, module, {**config, "_oq_boost_map": {}}, oq_level
-        )
-        if pred is False:
-            continue
-        layer_idx = _extract_layer_index(path)
-        if layer_idx < 0:
-            continue
-        layer_score = float(layer_scores.get(str(layer_idx), 0.0))
-        # Current bits (floor or base)
-        cur_bits = boost_map[path]["bits"] if path in boost_map else base_bits
-        cur_gs = _gs_for_mode(cur_bits, _OQ_DEFAULT_GROUP_SIZE)
-        cur_mode = _mode_for_bits(cur_bits)
-        cur_cost = _tensor_quantized_bytes(shape, cur_bits, cur_gs, cur_mode)
-        # Max target based on sensitivity
-        ratio = layer_score / max_layer_score if max_layer_score > 0 else 0
-        if ratio >= 0.5:
-            max_target = 8
-        elif ratio >= 0.2:
-            max_target = min(cur_bits + 2, 8)
-        else:
-            max_target = min(cur_bits + 1, 8)
-        if max_target <= cur_bits:
-            continue
-        candidates.append((layer_score, path, shape, cur_bits, cur_cost, max_target))
+    if not (routed_first and current_bpw >= target_bpw):
+        for path, shape in named_shapes.items():
+            if _is_routed_expert(path) or path in fixed_overrides:
+                continue
+            pred = universal_quant_predicate(
+                path, module, {**config, "_oq_boost_map": {}}, oq_level
+            )
+            if pred is False:
+                continue
+            layer_idx = _extract_layer_index(path)
+            if layer_idx < 0:
+                continue
+            layer_score = float(layer_scores.get(str(layer_idx), 0.0))
+            priority_score = _code_preserve_layer_score(
+                layer_idx=layer_idx,
+                layer_score=layer_score,
+                max_layer_score=max_layer_score,
+                num_layers=num_layers,
+                oq_level=oq_level,
+            )
+            # Current bits (floor or base)
+            cur_bits = boost_map[path]["bits"] if path in boost_map else base_bits
+            cur_gs = _gs_for_mode(cur_bits, _OQ_DEFAULT_GROUP_SIZE)
+            cur_mode = _mode_for_bits(cur_bits)
+            cur_cost = _tensor_quantized_bytes(shape, cur_bits, cur_gs, cur_mode)
+            # Max target based on sensitivity
+            ratio = layer_score / max_layer_score if max_layer_score > 0 else 0
+            if ratio >= 0.5:
+                max_target = 8
+            elif ratio >= 0.2:
+                max_target = min(cur_bits + 2, 8)
+            else:
+                max_target = min(cur_bits + 1, 8)
+            if max_target <= cur_bits:
+                continue
+            candidates.append(
+                (priority_score, path, shape, cur_bits, cur_cost, max_target)
+            )
 
     for _score, path, shape, cur_bits, cur_cost, max_target in sorted(
         candidates, key=lambda x: x[0], reverse=True
@@ -883,7 +960,16 @@ def _build_quant_plan(
             cur_cost = _tensor_quantized_bytes(shape, cur_bits, cur_gs, cur_mode)
             layer_idx = _extract_layer_index(path)
             layer_score = float(layer_scores.get(str(layer_idx), 0.0))
-            fallback_candidates.append((layer_score, path, shape, cur_bits, cur_cost))
+            priority_score = _code_preserve_layer_score(
+                layer_idx=layer_idx,
+                layer_score=layer_score,
+                max_layer_score=max_layer_score,
+                num_layers=num_layers,
+                oq_level=oq_level,
+            )
+            fallback_candidates.append(
+                (priority_score, path, shape, cur_bits, cur_cost)
+            )
 
         for _score, path, shape, cur_bits, cur_cost in sorted(
             fallback_candidates, key=lambda x: x[0], reverse=True
@@ -913,7 +999,7 @@ def _build_quant_plan(
             if current_bpw >= target_bpw:
                 break
 
-    if current_bpw < target_bpw:
+    if not routed_first and current_bpw < target_bpw:
         total_bits_f, current_bpw = _apply_routed_layer_boosts(
             named_shapes,
             config,
@@ -934,8 +1020,16 @@ def _build_quant_plan(
         from collections import Counter
 
         bits_dist = Counter(v["bits"] for v in boost_map.values())
+        route_dist = Counter()
         layer_bits = {}
         for k, v in boost_map.items():
+            projection = _routed_expert_projection(k)
+            if projection is not None:
+                route_dist[f"{projection}:{v['bits']}bit"] += 1
+            elif _is_routed_expert(k):
+                route_dist[f"routed_other:{v['bits']}bit"] += 1
+            else:
+                route_dist[f"non_expert:{v['bits']}bit"] += 1
             idx = _extract_layer_index(k)
             label = f"L{idx}" if idx >= 0 else k.split(".")[-1]
             if label not in layer_bits:
@@ -947,7 +1041,13 @@ def _build_quant_plan(
         )
         top_layers = sorted(layer_bits.items(), key=lambda x: -x[1])[:8]
         top_str = ", ".join(f"{l}={b}b" for l, b in top_layers)
-        logger.info(f"  plan detail: {bits_summary} | top: {top_str}")
+        route_summary = ", ".join(
+            f"{name}×{count}" for name, count in sorted(route_dist.items())
+        )
+        logger.info(
+            f"  plan detail: {bits_summary} | routes: {route_summary} | "
+            f"top: {top_str}"
+        )
 
     return QuantPlan(
         boost_map=boost_map,
@@ -3392,7 +3492,7 @@ def _source_imatrix_signature(
                 ch.update(block)
         calib_hash = ch.hexdigest()
     return {
-        "format": "omlx-oqe-imatrix-v1",
+        "format": _OQE_IMATRIX_FORMAT,
         "model_name": source.name,
         "source_hash": h.hexdigest(),
         "calib_dataset": calib_dataset,
@@ -3442,6 +3542,24 @@ def _load_oqe_imatrix(path: Path) -> OQImatrixData:
 
 def _oqe_cache_matches(cache: OQImatrixData, expected: dict[str, Any]) -> bool:
     return all(cache.metadata.get(k) == v for k, v in expected.items())
+
+
+def _oqe_cache_has_required_expert_coverage(
+    cache: OQImatrixData,
+) -> bool:
+    collection = cache.metadata.get("collection")
+    require_expert_counts = bool(cache.metadata.get("requires_expert_counts", False))
+    if isinstance(collection, dict):
+        require_expert_counts = bool(
+            collection.get("requires_expert_counts", require_expert_counts)
+        )
+    if not require_expert_counts:
+        return True
+    coverage = cache.metadata.get("expert_coverage")
+    if not isinstance(coverage, dict):
+        if isinstance(collection, dict):
+            coverage = collection.get("coverage")
+    return isinstance(coverage, dict) and bool(coverage.get("has_expert_counts", False))
 
 
 def _normalised_imatrix_values(entry: OQImatrixEntry) -> np.ndarray:
@@ -3514,9 +3632,42 @@ def _imatrix_expert_coverage_stats(
     }
 
 
-def _imatrix_expert_coverage_sufficient(stats: dict[str, Any]) -> bool:
+def _config_expects_moe_expert_counts(config: dict) -> bool:
+    """Return True when the model config describes routed MoE experts."""
+    configs = [config]
+    text_config = config.get("text_config")
+    if isinstance(text_config, dict):
+        configs.append(text_config)
+    ffn_config = config.get("ffn_config")
+    if isinstance(ffn_config, dict):
+        configs.append(ffn_config)
+
+    for cfg in configs:
+        for key in (
+            "n_routed_experts",
+            "num_experts",
+            "num_local_experts",
+            "moe_num_experts",
+        ):
+            try:
+                if int(cfg.get(key) or 0) > 1:
+                    return True
+            except (TypeError, ValueError):
+                continue
+    return False
+
+
+def _imatrix_requires_expert_counts(config: dict, switch_capture_modules: int) -> bool:
+    return switch_capture_modules > 0 and _config_expects_moe_expert_counts(config)
+
+
+def _imatrix_expert_coverage_sufficient(
+    stats: dict[str, Any],
+    *,
+    require_expert_counts: bool = False,
+) -> bool:
     if not stats.get("has_expert_counts", False):
-        return True
+        return not require_expert_counts
     required_key = f"p{_OQE_MIN_EXPERT_COUNT_PERCENTILE:02d}_count"
     return (
         int(stats.get("zero_count_experts", 0)) == 0
@@ -4352,7 +4503,7 @@ def quantize_oq_streaming(
         processed_bytes += tensor_bytes
         elapsed = _time.monotonic() - start_time
         frac = min(max(processed_bytes / max(total_bytes, 1), 0.0), 1.0)
-        pct = 15.0 + frac * 75.0
+        pct = 20.0 + frac * 70.0
         display_pct = min(100, max(0, int(frac * 100)))
         if (
             display_pct != last_quant_display_pct
@@ -4527,10 +4678,12 @@ def quantize_oq_streaming(
 _SENS_NUM_SAMPLES = 128
 _SENS_SEQ_LENGTH = 256
 _OQE_CALIB_DATASET = "oqe_code_multilingual"
+_OQE_IMATRIX_FORMAT = "omlx-oqe-imatrix-cache"
 _OQE_MAX_SAMPLE_MULTIPLIER = 8
 _OQE_MAX_ADAPTIVE_SAMPLES = 1024
 _OQE_MIN_EXPERT_COUNT = 16
 _OQE_MIN_EXPERT_COUNT_PERCENTILE = 5
+_OQE_SWITCH_LINEAR_CLASSES = {"SwitchLinear", "QuantizedSwitchLinear"}
 _OQ_CODE_MULTILINGUAL_KEYS = (
     "code",
     "en",
@@ -5005,7 +5158,10 @@ class _ImatrixCaptureWrapper(nn.Module):
 
     def __call__(self, *args, **kwargs):
         if args:
-            if type(self._module).__name__ == "SwitchLinear" and len(args) >= 2:
+            if (
+                type(self._module).__name__ in _OQE_SWITCH_LINEAR_CLASSES
+                and len(args) >= 2
+            ):
                 self._collector.collect_switch(
                     self._name, self._module, args[0], args[1]
                 )
@@ -5020,11 +5176,13 @@ class OQImatrixCollector:
     def __init__(self):
         self.entries: dict[str, OQImatrixEntry] = {}
         self._original_modules: dict[str, Any] = {}
+        self.capture_module_classes: dict[str, int] = {}
+        self.switch_capture_modules = 0
 
     @staticmethod
     def _is_capture_module(module) -> bool:
         cls = type(module).__name__
-        if cls == "SwitchLinear":
+        if cls in _OQE_SWITCH_LINEAR_CLASSES:
             return hasattr(module, "weight") and getattr(module.weight, "ndim", 0) == 3
         return (
             cls == "Linear"
@@ -5037,6 +5195,12 @@ class OQImatrixCollector:
         for name, module in model.named_modules():
             if not name or not self._is_capture_module(module):
                 continue
+            cls = type(module).__name__
+            self.capture_module_classes[cls] = (
+                self.capture_module_classes.get(cls, 0) + 1
+            )
+            if cls in _OQE_SWITCH_LINEAR_CLASSES:
+                self.switch_capture_modules += 1
             self._original_modules[name] = module
             replacements.append((name, _ImatrixCaptureWrapper(module, name, self)))
         if replacements:
@@ -5106,7 +5270,9 @@ class OQImatrixCollector:
 
     def collect_switch(self, name: str, module, x, indices) -> None:
         try:
-            n_experts, _, in_dim = (int(v) for v in module.weight.shape)
+            weight_shape = getattr(module.weight, "shape", ())
+            n_experts = int(getattr(module, "num_experts", weight_shape[0]))
+            in_dim = int(getattr(module, "input_dims", weight_shape[-1]))
             if getattr(x, "shape", ()) and int(x.shape[-1]) != in_dim:
                 return
             mx.eval(x, indices)
@@ -5202,6 +5368,9 @@ def _collect_imatrix_from_model(
     processed_samples = 0
     micro_batches = 0
     rounds: list[dict[str, Any]] = []
+    require_expert_counts = _imatrix_requires_expert_counts(
+        config, collector.switch_capture_modules
+    )
     coverage = _imatrix_expert_coverage_stats(collector.entries)
     logger.info(
         "oQe imatrix: adaptive max=%d, step=%d, micro-batch=%d "
@@ -5254,7 +5423,12 @@ def _collect_imatrix_from_model(
                 processed_samples = micro_next
                 micro_batches += 1
                 coverage = _imatrix_expert_coverage_stats(collector.entries)
-                sufficient = _imatrix_expert_coverage_sufficient(coverage)
+                coverage_sufficient = _imatrix_expert_coverage_sufficient(
+                    coverage, require_expert_counts=require_expert_counts
+                )
+                collection_sufficient = (
+                    processed_samples >= int(num_samples) and coverage_sufficient
+                )
                 frac = min(max(processed_samples / max(max_samples, 1), 0.0), 1.0)
                 pct = progress_start + frac * (progress_end - progress_start)
                 detail = (
@@ -5273,20 +5447,23 @@ def _collect_imatrix_from_model(
                         "requested_samples": int(num_samples),
                         "micro_batch_size": micro_batch_size,
                         "micro_batches": micro_batches,
-                        "coverage_sufficient": sufficient,
+                        "coverage_sufficient": coverage_sufficient,
+                        "collection_sufficient": collection_sufficient,
+                        "requires_expert_counts": require_expert_counts,
                         "coverage": coverage,
                     },
                 )
                 logger.info(
                     "oQe imatrix: %d/%d samples, zero experts=%d, "
-                    "p05=%.1f, sufficient=%s",
+                    "p05=%.1f, expert_coverage=%s, sufficient=%s",
                     processed_samples,
                     max_samples,
                     int(coverage.get("zero_count_experts", 0)),
                     float(coverage.get("p05_count", 0.0)),
-                    sufficient,
+                    coverage_sufficient,
+                    collection_sufficient,
                 )
-                if processed_samples >= int(num_samples) and sufficient:
+                if collection_sufficient:
                     break
                 mx.synchronize()
                 mx.clear_cache()
@@ -5294,20 +5471,38 @@ def _collect_imatrix_from_model(
             if int(processed_samples) == 0:
                 break
             coverage = _imatrix_expert_coverage_stats(collector.entries)
-            sufficient = _imatrix_expert_coverage_sufficient(coverage)
+            coverage_sufficient = _imatrix_expert_coverage_sufficient(
+                coverage, require_expert_counts=require_expert_counts
+            )
+            collection_sufficient = (
+                processed_samples >= int(num_samples) and coverage_sufficient
+            )
             rounds.append(
                 {
                     "processed_samples": processed_samples,
-                    "coverage_sufficient": sufficient,
+                    "coverage_sufficient": coverage_sufficient,
+                    "collection_sufficient": collection_sufficient,
                     "coverage": coverage,
                 }
             )
-            if processed_samples >= int(num_samples) and sufficient:
+            if collection_sufficient:
                 break
             mx.synchronize()
             mx.clear_cache()
     finally:
         collector.restore(model)
+
+    coverage_sufficient = _imatrix_expert_coverage_sufficient(
+        coverage, require_expert_counts=require_expert_counts
+    )
+    collection_sufficient = (
+        processed_samples >= int(num_samples) and coverage_sufficient
+    )
+    if require_expert_counts and not coverage.get("has_expert_counts", False):
+        logger.warning(
+            "oQe imatrix: model config expects routed experts, but no expert "
+            "activation counts were captured"
+        )
 
     metadata = {
         "dataset": calib_dataset,
@@ -5322,7 +5517,13 @@ def _collect_imatrix_from_model(
         "batch_plan": batch_plan,
         "processed_samples": processed_samples,
         "installed_modules": installed,
-        "coverage_sufficient": _imatrix_expert_coverage_sufficient(coverage),
+        "capture_module_classes": dict(
+            sorted(collector.capture_module_classes.items())
+        ),
+        "switch_capture_modules": int(collector.switch_capture_modules),
+        "requires_expert_counts": require_expert_counts,
+        "coverage_sufficient": coverage_sufficient,
+        "collection_sufficient": collection_sufficient,
         "coverage": coverage,
         "rounds": rounds,
     }
@@ -5456,17 +5657,24 @@ def _load_or_collect_imatrix(
     if reuse_cache and path.exists():
         cache = _load_oqe_imatrix(path)
         if _oqe_cache_matches(cache, expected):
-            cache.reused = True
-            logger.info("oQe imatrix: using cache %s", path)
-            _emit_progress(
-                progress_callback,
-                "imatrix",
-                progress_end,
-                f"Using oQe imatrix cache ({len(cache.entries)} entries)",
-                {"cache_path": str(path), "entry_count": len(cache.entries)},
+            if _oqe_cache_has_required_expert_coverage(cache):
+                cache.reused = True
+                logger.info("oQe imatrix: using cache %s", path)
+                _emit_progress(
+                    progress_callback,
+                    "imatrix",
+                    progress_end,
+                    f"Using oQe imatrix cache ({len(cache.entries)} entries)",
+                    {"cache_path": str(path), "entry_count": len(cache.entries)},
+                )
+                return cache
+            logger.info(
+                "oQe imatrix: cache missing required expert coverage, "
+                "recollecting %s",
+                path,
             )
-            return cache
-        logger.info("oQe imatrix: cache metadata mismatch, recollecting %s", path)
+        else:
+            logger.info("oQe imatrix: cache metadata mismatch, recollecting %s", path)
 
     logger.info(
         "oQe imatrix: collecting %d samples x %d tokens from %s",
@@ -5492,6 +5700,9 @@ def _load_or_collect_imatrix(
         "entry_count": len(entries),
         "collection": collection_metadata,
         "expert_coverage": collection_metadata.get("coverage", {}),
+        "requires_expert_counts": bool(
+            collection_metadata.get("requires_expert_counts", False)
+        ),
         "processed_samples": int(collection_metadata.get("processed_samples", 0)),
     }
     _save_oqe_imatrix(path, entries, metadata)

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -4,7 +4,7 @@
 Mixed-precision quantization combining GGUF K-quant layer position strategy,
 unsloth Dynamic 2.0 selective non-quantization, and BnB MSE-optimal clipping.
 
-Supported levels: oQ2, oQ2.5, oQ2.8, oQ3, oQ3.5, oQ4, oQ5, oQ6, oQ8
+Supported levels: oQ2, oQ2.5, oQ2.7, oQ2.8, oQ3, oQ3.5, oQ4, oQ5, oQ6, oQ8
 (base bits differ, same predicate). Fractional levels keep the lower level's
 base bits and add targeted routed-expert protection plus a higher bpw budget.
 """
@@ -36,7 +36,7 @@ from omlx.model_discovery import _has_vision_subconfig
 
 logger = logging.getLogger(__name__)
 
-OQ_LEVELS = {2, 2.5, 2.8, 3, 3.5, 4, 5, 6, 8}
+OQ_LEVELS = {2, 2.5, 2.7, 2.8, 3, 3.5, 4, 5, 6, 8}
 
 OQ_DTYPES: tuple[str, ...] = ("bfloat16", "float16")
 
@@ -53,6 +53,7 @@ _PROXY_QUANT_GROUP_SIZE = 64
 _LEVEL_BITS: dict[float, int] = {
     2: 2,
     2.5: 2,
+    2.7: 2,
     2.8: 2,
     3: 3,
     3.5: 3,
@@ -65,6 +66,7 @@ _LEVEL_BITS: dict[float, int] = {
 _LEVEL_PROTECTION: dict[float, str] = {
     2: "full",
     2.5: "full",
+    2.7: "full",
     2.8: "full",
     3: "full",
     3.5: "full",
@@ -82,6 +84,7 @@ _LEVEL_EXPERT_DOWN_BOOST: dict[float, int] = {2.5: 1, 3.5: 1}
 _OQ_BPW_TARGETS: dict[float, tuple[float, float]] = {
     2: (2.8, 3.0),
     2.5: (3.1, 3.3),
+    2.7: (3.25, 3.35),
     2.8: (3.35, 3.45),
     3: (3.5, 3.7),
     3.5: (3.8, 4.0),
@@ -90,7 +93,7 @@ _OQ_BPW_TARGETS: dict[float, tuple[float, float]] = {
     6: (6.5, 6.7),
 }
 
-_ROUTED_LAYER_BOOST_LEVELS = {2.8}
+_ROUTED_LAYER_BOOST_LEVELS = {2.7, 2.8}
 _VALID_QUANT_BITS = (2, 3, 4, 5, 6, 8)
 
 
@@ -158,7 +161,7 @@ def universal_quant_predicate(
         oQ2.5/oQ3.5: fractional levels — lower level's base bits,
             routed expert down_proj protected above base per
             _LEVEL_EXPERT_DOWN_BOOST (Super Weights protection)
-        oQ2.8: base 2-bit + routed layer boosts selected by layer
+        oQ2.7/oQ2.8: base 2-bit + routed layer boosts selected by layer
             sensitivity; routed w2/down_proj first, then w1/w3 as paired
             layer-wide boosts while staying under the bpw cap
         oQ3: base 3-bit + full protection → ~3.5 bpw
@@ -579,7 +582,7 @@ def _apply_routed_layer_boosts(
     """Boost routed expert modules by layer while staying MLX-loader portable.
 
     MLX's QuantizedSwitchLinear stores one bit-width per fused expert projection,
-    not per expert. For oQ2.8 we therefore rank layers by sensitivity and boost
+    not per expert. For oQ2.7/oQ2.8 we therefore rank layers by sensitivity and boost
     whole routed projection modules: down/w2 first, then gate+up as a pair.
     """
     if oq_level not in _ROUTED_LAYER_BOOST_LEVELS or base_bits >= 3:

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -6,8 +6,7 @@ unsloth Dynamic 2.0 selective non-quantization, and BnB MSE-optimal clipping.
 
 Supported levels: oQ2, oQ2.5, oQ2.7, oQ3, oQ3.5, oQ4, oQ5, oQ6, oQ8
 (base bits differ, same predicate). Fractional levels keep the lower level's
-base bits and add targeted code-preserving routed-expert protection plus a
-higher bpw budget.
+base bits and add targeted routed-expert protection plus a higher bpw budget.
 """
 
 import hashlib
@@ -75,9 +74,8 @@ _LEVEL_PROTECTION: dict[float, str] = {
     8: "full",
 }
 
-# Mandatory protection for routed expert down_proj on fractional levels that
-# reserve a blanket Super Weights floor instead of sensitivity-selected routing.
-# 3.5 -> 4-bit.
+# Fractional levels that reserve a blanket Super Weights floor.
+# 3.5 -> routed expert down_proj 4-bit.
 _LEVEL_EXPERT_DOWN_BOOST: dict[float, int] = {3.5: 1}
 
 _OQ_BPW_TARGETS: dict[float, tuple[float, float]] = {
@@ -92,7 +90,6 @@ _OQ_BPW_TARGETS: dict[float, tuple[float, float]] = {
 }
 
 _ROUTED_LAYER_BOOST_LEVELS = {2.5, 2.7}
-_CODE_PRESERVE_FRACTIONAL_LEVELS = {2.5, 2.7}
 _VALID_QUANT_BITS = (2, 3, 4, 5, 6, 8)
 
 
@@ -157,10 +154,9 @@ def universal_quant_predicate(
 
     Protection levels vary by oQ level:
         oQ2: minimal protection (router fp16, lm_head 4-bit only) → ~2.5 bpw
-        oQ2.5/oQ2.7: base 2-bit + code-preserving routed layer boosts
-            selected by layer sensitivity and late-layer position; routed
-            w2/down_proj first, then w1/w3 as paired layer-wide boosts while
-            staying under the bpw cap
+        oQ2.5/oQ2.7: base 2-bit + routed layer boosts selected by layer
+            sensitivity; routed w2/down_proj first, then w1/w3 as paired
+            layer-wide boosts while staying under the bpw cap
         oQ3.5: base 3-bit with routed expert down_proj protected above base per
             _LEVEL_EXPERT_DOWN_BOOST (Super Weights protection)
         oQ3: base 3-bit + full protection → ~3.5 bpw
@@ -539,40 +535,6 @@ def _routed_expert_projection(path: str) -> str | None:
     return None
 
 
-def _num_layers_from_config(config: dict, default: int = 32) -> int:
-    tc = config.get("text_config", {})
-    return int(
-        config.get("num_hidden_layers")
-        or (tc.get("num_hidden_layers") if isinstance(tc, dict) else None)
-        or default
-    )
-
-
-def _code_preserve_layer_score(
-    *,
-    layer_idx: int,
-    layer_score: float,
-    max_layer_score: float,
-    num_layers: int,
-    oq_level: float,
-) -> float:
-    """Raise generation-critical edge/late layers for aggressive 2-bit levels."""
-    if oq_level not in _CODE_PRESERVE_FRACTIONAL_LEVELS:
-        return layer_score
-    if layer_idx < 0 or num_layers <= 1:
-        return layer_score
-
-    anchor = max(max_layer_score, 1e-12)
-    pos = layer_idx / max(num_layers - 1, 1)
-    if pos >= 0.80:
-        return layer_score + 0.50 * anchor
-    if pos >= 0.65:
-        return layer_score + 0.25 * anchor
-    if pos < 0.125:
-        return layer_score + 0.20 * anchor
-    return layer_score
-
-
 _MANDATORY_BOOST_PATTERNS = {
     "lm_head": {"bits": 8, "group_size": 64, "mode": "affine"},
     "embeddings": {"bits": 8, "group_size": 64, "mode": "affine"},
@@ -616,8 +578,8 @@ def _apply_routed_layer_boosts(
 
     MLX's QuantizedSwitchLinear stores one bit-width per fused expert projection,
     not per expert. For oQ2.5/oQ2.7 we therefore rank layers by sensitivity
-    plus a small late-layer generation prior, then boost whole routed projection
-    modules: down/w2 first, then gate+up as a pair.
+    and boost whole routed projection modules: down/w2 first, then gate+up as
+    a pair.
     """
     if oq_level not in _ROUTED_LAYER_BOOST_LEVELS or base_bits >= 3:
         return total_bits_f, current_bpw
@@ -625,8 +587,6 @@ def _apply_routed_layer_boosts(
     from collections import defaultdict
 
     layer_scores = config.get("_oq_sensitivity_map") or {}
-    max_layer_score = max(layer_scores.values(), default=0.0)
-    num_layers = _num_layers_from_config(config)
     grouped: dict[tuple[int, str], list[tuple[str, tuple]]] = defaultdict(list)
     for path, shape in named_shapes.items():
         if path in fixed_overrides:
@@ -641,14 +601,7 @@ def _apply_routed_layer_boosts(
         grouped[(layer_idx, phase)].append((path, shape))
 
     def group_score(layer_idx: int) -> float:
-        layer_score = float(layer_scores.get(str(layer_idx), 0.0))
-        return _code_preserve_layer_score(
-            layer_idx=layer_idx,
-            layer_score=layer_score,
-            max_layer_score=max_layer_score,
-            num_layers=num_layers,
-            oq_level=oq_level,
-        )
+        return float(layer_scores.get(str(layer_idx), 0.0))
 
     def try_boost_group(items: list[tuple[str, tuple]]) -> bool:
         nonlocal total_bits_f, current_bpw
@@ -715,10 +668,10 @@ def _build_quant_plan(
 
     Strategy:
     1. Mandatory pre-allocation: consensus-critical tensors (lm_head → 8-bit)
-    2. For oQ2.5/oQ2.7, routed expert down/gate/up boosts get the remaining
-       target budget before opportunistic non-expert boosts.
-    3. Data-driven: remaining non-expert tensors compete by sensitivity and
-       layer-position score. Higher score → more bits.
+    2. Data-driven: all non-expert tensors compete equally, ranked by
+       layer sensitivity score. Higher sensitivity → more bits.
+    3. Routed experts stay at base bits except explicit fractional floors and
+       the oQ2.5/oQ2.7 fallback routed-layer boost.
 
     fixed_overrides marks tensors whose output format is fixed up front
     (pre-quantized source tensors passed through as mxfp4/mxfp8). They are
@@ -733,8 +686,6 @@ def _build_quant_plan(
 
     layer_scores = config.get("_oq_sensitivity_map") or {}
     max_layer_score = max(layer_scores.values(), default=0.0)
-    num_layers = _num_layers_from_config(config)
-    routed_first = oq_level in _CODE_PRESERVE_FRACTIONAL_LEVELS
 
     total_params = 0
     expert_params = 0
@@ -785,8 +736,8 @@ def _build_quant_plan(
                     current_bpw = next_bpw
                 break
 
-    # Mandatory expert down_proj boost above base bits (Super Weights
-    # protection) for fractional levels that reserve a blanket floor.
+    # Fractional levels with a blanket Super Weights floor: mandatory expert
+    # down_proj boost above base bits.
     _down_boost = _LEVEL_EXPERT_DOWN_BOOST.get(oq_level)
     if _down_boost:
         for path, shape in named_shapes.items():
@@ -853,69 +804,38 @@ def _build_quant_plan(
         total_bits_f += delta
         current_bpw = next_bpw
 
-    # Aggressive 2-bit fractional levels are most prone to code-generation
-    # regressions when routed expert output paths stay at the base width.
-    # Reserve the remaining target budget for routed down_proj first, then
-    # paired gate/up, before opportunistic non-expert sensitivity boosts.
-    if routed_first and current_bpw < target_bpw:
-        total_bits_f, current_bpw = _apply_routed_layer_boosts(
-            named_shapes,
-            config,
-            oq_level,
-            boost_map,
-            fixed_overrides,
-            base_bits,
-            base_group_size,
-            base_mode,
-            total_bits_f,
-            total_params,
-            current_bpw,
-            target_bpw,
-            hard_cap_bpw,
-        )
-
     # Sensitivity-based greedy boost: boost tensors from their current bits
     # (which may already be elevated by the protection floor) using remaining
     # budget up to hard_cap_bpw.
     candidates = []
-    if not (routed_first and current_bpw >= target_bpw):
-        for path, shape in named_shapes.items():
-            if _is_routed_expert(path) or path in fixed_overrides:
-                continue
-            pred = universal_quant_predicate(
-                path, module, {**config, "_oq_boost_map": {}}, oq_level
-            )
-            if pred is False:
-                continue
-            layer_idx = _extract_layer_index(path)
-            if layer_idx < 0:
-                continue
-            layer_score = float(layer_scores.get(str(layer_idx), 0.0))
-            priority_score = _code_preserve_layer_score(
-                layer_idx=layer_idx,
-                layer_score=layer_score,
-                max_layer_score=max_layer_score,
-                num_layers=num_layers,
-                oq_level=oq_level,
-            )
-            # Current bits (floor or base)
-            cur_bits = boost_map[path]["bits"] if path in boost_map else base_bits
-            cur_gs = _gs_for_mode(cur_bits, _OQ_DEFAULT_GROUP_SIZE)
-            cur_mode = _mode_for_bits(cur_bits)
-            cur_cost = _tensor_quantized_bytes(shape, cur_bits, cur_gs, cur_mode)
-            # Max target based on sensitivity
-            ratio = layer_score / max_layer_score if max_layer_score > 0 else 0
-            if ratio >= 0.5:
-                max_target = 8
-            elif ratio >= 0.2:
-                max_target = min(cur_bits + 2, 8)
-            else:
-                max_target = min(cur_bits + 1, 8)
-            if max_target <= cur_bits:
-                continue
-            candidates.append(
-                (priority_score, path, shape, cur_bits, cur_cost, max_target)
-            )
+    for path, shape in named_shapes.items():
+        if _is_routed_expert(path) or path in fixed_overrides:
+            continue
+        pred = universal_quant_predicate(
+            path, module, {**config, "_oq_boost_map": {}}, oq_level
+        )
+        if pred is False:
+            continue
+        layer_idx = _extract_layer_index(path)
+        if layer_idx < 0:
+            continue
+        layer_score = float(layer_scores.get(str(layer_idx), 0.0))
+        # Current bits (floor or base)
+        cur_bits = boost_map[path]["bits"] if path in boost_map else base_bits
+        cur_gs = _gs_for_mode(cur_bits, _OQ_DEFAULT_GROUP_SIZE)
+        cur_mode = _mode_for_bits(cur_bits)
+        cur_cost = _tensor_quantized_bytes(shape, cur_bits, cur_gs, cur_mode)
+        # Max target based on sensitivity
+        ratio = layer_score / max_layer_score if max_layer_score > 0 else 0
+        if ratio >= 0.5:
+            max_target = 8
+        elif ratio >= 0.2:
+            max_target = min(cur_bits + 2, 8)
+        else:
+            max_target = min(cur_bits + 1, 8)
+        if max_target <= cur_bits:
+            continue
+        candidates.append((layer_score, path, shape, cur_bits, cur_cost, max_target))
 
     for _score, path, shape, cur_bits, cur_cost, max_target in sorted(
         candidates, key=lambda x: x[0], reverse=True
@@ -960,16 +880,7 @@ def _build_quant_plan(
             cur_cost = _tensor_quantized_bytes(shape, cur_bits, cur_gs, cur_mode)
             layer_idx = _extract_layer_index(path)
             layer_score = float(layer_scores.get(str(layer_idx), 0.0))
-            priority_score = _code_preserve_layer_score(
-                layer_idx=layer_idx,
-                layer_score=layer_score,
-                max_layer_score=max_layer_score,
-                num_layers=num_layers,
-                oq_level=oq_level,
-            )
-            fallback_candidates.append(
-                (priority_score, path, shape, cur_bits, cur_cost)
-            )
+            fallback_candidates.append((layer_score, path, shape, cur_bits, cur_cost))
 
         for _score, path, shape, cur_bits, cur_cost in sorted(
             fallback_candidates, key=lambda x: x[0], reverse=True
@@ -999,7 +910,7 @@ def _build_quant_plan(
             if current_bpw >= target_bpw:
                 break
 
-    if not routed_first and current_bpw < target_bpw:
+    if current_bpw < target_bpw:
         total_bits_f, current_bpw = _apply_routed_layer_boosts(
             named_shapes,
             config,

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -76,10 +76,10 @@ _LEVEL_PROTECTION: dict[float, str] = {
     8: "full",
 }
 
-# Fractional levels: mandatory protection for routed expert down_proj
-# (Super Weights), expressed as bits above the level's base bits.
-# 2.5 -> 3-bit, 3.5 -> 4-bit.
-_LEVEL_EXPERT_DOWN_BOOST: dict[float, int] = {2.5: 1, 3.5: 1}
+# Mandatory protection for routed expert down_proj on fractional levels that
+# reserve a blanket Super Weights floor instead of sensitivity-selected routing.
+# 3.5 -> 4-bit.
+_LEVEL_EXPERT_DOWN_BOOST: dict[float, int] = {3.5: 1}
 
 _OQ_BPW_TARGETS: dict[float, tuple[float, float]] = {
     2: (2.8, 3.0),
@@ -93,7 +93,7 @@ _OQ_BPW_TARGETS: dict[float, tuple[float, float]] = {
     6: (6.5, 6.7),
 }
 
-_ROUTED_LAYER_BOOST_LEVELS = {2.7, 2.8}
+_ROUTED_LAYER_BOOST_LEVELS = {2.5, 2.7, 2.8}
 _VALID_QUANT_BITS = (2, 3, 4, 5, 6, 8)
 
 
@@ -158,12 +158,11 @@ def universal_quant_predicate(
 
     Protection levels vary by oQ level:
         oQ2: minimal protection (router fp16, lm_head 4-bit only) → ~2.5 bpw
-        oQ2.5/oQ3.5: fractional levels — lower level's base bits,
-            routed expert down_proj protected above base per
-            _LEVEL_EXPERT_DOWN_BOOST (Super Weights protection)
-        oQ2.7/oQ2.8: base 2-bit + routed layer boosts selected by layer
+        oQ2.5/oQ2.7/oQ2.8: base 2-bit + routed layer boosts selected by layer
             sensitivity; routed w2/down_proj first, then w1/w3 as paired
             layer-wide boosts while staying under the bpw cap
+        oQ3.5: base 3-bit with routed expert down_proj protected above base per
+            _LEVEL_EXPERT_DOWN_BOOST (Super Weights protection)
         oQ3: base 3-bit + full protection → ~3.5 bpw
         oQ4-oQ6: base N-bit + full protection
         oQ7: base 8-bit + full protection
@@ -341,8 +340,8 @@ def universal_quant_predicate(
         if is_routed_expert:
             down_boost = _LEVEL_EXPERT_DOWN_BOOST.get(oq_level)
             if down_boost:
-                # Fractional levels protect routed expert down_proj above
-                # the base bits (Super Weights protection).
+                # Mandatory fractional levels protect routed expert down_proj
+                # above the base bits (Super Weights protection).
                 return bits(base_bits + down_boost)
             return True
         if sensitive:
@@ -582,8 +581,9 @@ def _apply_routed_layer_boosts(
     """Boost routed expert modules by layer while staying MLX-loader portable.
 
     MLX's QuantizedSwitchLinear stores one bit-width per fused expert projection,
-    not per expert. For oQ2.7/oQ2.8 we therefore rank layers by sensitivity and boost
-    whole routed projection modules: down/w2 first, then gate+up as a pair.
+    not per expert. For oQ2.5/oQ2.7/oQ2.8 we therefore rank layers by
+    sensitivity and boost whole routed projection modules: down/w2 first,
+    then gate+up as a pair.
     """
     if oq_level not in _ROUTED_LAYER_BOOST_LEVELS or base_bits >= 3:
         return total_bits_f, current_bpw
@@ -739,8 +739,8 @@ def _build_quant_plan(
                     current_bpw = next_bpw
                 break
 
-    # Fractional levels (oQ2.5 / oQ3.5): mandatory expert down_proj
-    # boost above base bits (Super Weights protection).
+    # Mandatory expert down_proj boost above base bits (Super Weights
+    # protection) for fractional levels that reserve a blanket floor.
     _down_boost = _LEVEL_EXPERT_DOWN_BOOST.get(oq_level)
     if _down_boost:
         for path, shape in named_shapes.items():

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -160,8 +160,8 @@ def universal_quant_predicate(
             _LEVEL_EXPERT_DOWN_BOOST (Super Weights protection)
         oQ2.8: base 2-bit + routed layer boosts selected by layer
             sensitivity; routed w2/down_proj first, then w1/w3 as paired
-            layer modules
-        oQ3: base 2-bit + full protection → ~3.3 bpw
+            layer-wide boosts while staying under the bpw cap
+        oQ3: base 3-bit + full protection → ~3.5 bpw
         oQ4-oQ6: base N-bit + full protection
         oQ7: base 8-bit + full protection
         oQ8: near-uniform 8-bit (router fp16 only) → ~8.0 bpw
@@ -3818,7 +3818,7 @@ def quantize_oq_streaming(
     Args:
         model_path: Path to source model directory.
         output_path: Path for output (must not exist).
-        oq_level: Quantization level (2, 3, 4, 6, or 8).
+        oq_level: Quantization level from OQ_LEVELS.
         group_size: Default quantization group size.
         progress_callback: Optional fn(phase_name, progress_pct) for updates.
         text_only: Skip vision encoder weights for VLM models.

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -15,7 +15,10 @@ from .cache import CacheList, PoolingCache, RotatingKVCache
 from .hyper_connection import HyperConnection, HyperHead, hc_expand
 from .mla import MultiLinear
 from .pipeline import PipelineMixin
-from .switch_layers import SwitchGLU
+from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
+
+_DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = False
+_DEEPSEEK_V4_INDEXER_NATIVE_DISABLED = False
 
 
 def _materialize_cache_arrays(cache: Optional[Any]) -> None:
@@ -360,8 +363,51 @@ def _sparse_pooled_attention(
     pooled_mask: Optional[mx.array],
     scale: float,
     sinks: Optional[mx.array],
+    q_offset: Optional[Union[int, mx.array]] = None,
+    compress_ratio: Optional[int] = None,
+    local_window: Optional[int] = None,
 ) -> mx.array:
+    global _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED
+
     B, H, L, D = q.shape
+    if (
+        not _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED
+        and q_offset is not None
+        and compress_ratio is not None
+        and local_window is not None
+        and sinks is not None
+        and not isinstance(q_offset, mx.array)
+        and q.dtype in (mx.float16, mx.bfloat16)
+        and topk.dtype == mx.uint32
+        and B >= 1
+        and H == 64
+        and L > 1
+        and D == 512
+        and local_kv.ndim == 4
+        and local_kv.shape[1] == 1
+        and local_kv.shape[-1] == D
+        and pooled.ndim == 3
+        and pooled.shape[-1] == D
+        and topk.ndim == 3
+    ):
+        try:
+            from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+
+            if glm_fast.has_symbol("deepseek_v4_sparse_attention"):
+                return glm_fast.deepseek_v4_sparse_attention(
+                    q,
+                    local_kv,
+                    pooled,
+                    topk[:, None],
+                    sinks,
+                    scale,
+                    int(q_offset),
+                    int(compress_ratio),
+                    int(local_window),
+                )
+        except Exception:
+            _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = True
+
     idx = topk[:, None, :, :, None]
     pooled = mx.take_along_axis(
         mx.broadcast_to(pooled[:, None, None], (B, 1, L, pooled.shape[1], D)),
@@ -484,8 +530,9 @@ class DeepseekV4MoE(nn.Module):
             x = sum_gradients(self.sharding_group)(x)
 
         inds, scores = self.gate(x, input_ids)
-        y = self.switch_mlp(x, inds)
-        y = (y * scores[..., None].astype(y.dtype)).sum(-2)
+        y = self.switch_mlp(x, inds, scores=scores)
+        if y.ndim == scores.ndim + 1:
+            y = (y * scores[..., None].astype(y.dtype)).sum(-2)
         y = y + self.shared_experts(x)
 
         if self.sharding_group is not None:
@@ -574,6 +621,8 @@ class Indexer(nn.Module):
         pool_cache: Optional[PoolingCache],
         offset: Union[int, mx.array],
     ):
+        global _DEEPSEEK_V4_INDEXER_NATIVE_DISABLED
+
         B, L, _ = x.shape
         pooled = self.compressor(x, pool_cache, offset)
         if pooled.shape[1] == 0:
@@ -583,20 +632,61 @@ class Indexer(nn.Module):
         q = q.transpose(0, 2, 1, 3)
         q = position_rope(q, offset)
 
+        pmask = pool_cache.make_mask(L, offset) if pool_cache is not None else None
+        k = min(self.index_topk, pooled.shape[1])
+
+        if (
+            not _DEEPSEEK_V4_INDEXER_NATIVE_DISABLED
+            and pooled.shape[1] > self.index_topk
+            and k == self.index_topk
+            and L > 1
+            and L % 64 == 0
+            and pooled.shape[1] % 64 == 0
+            and self.n_heads in (32, 64)
+            and self.head_dim == 128
+            and q.dtype in (mx.float16, mx.bfloat16)
+        ):
+            try:
+                from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+
+                if glm_fast.has_symbol("dsa_indexer_scores") and glm_fast.has_symbol(
+                    "dsa_topk_indices"
+                ):
+                    weights = self.weights_proj(x).astype(q.dtype) * (
+                        (self.n_heads**-0.5) * self.scale
+                    )
+                    scores4 = glm_fast.dsa_indexer_scores(
+                        q,
+                        pooled[:, None],
+                        weights,
+                        causal=False,
+                    )
+                    if pmask is not None:
+                        scores4 = mx.where(
+                            (pmask[:, None] if pmask.ndim == 3 else pmask[None, None]),
+                            scores4,
+                            mx.finfo(scores4.dtype).min,
+                        )
+                    return glm_fast.dsa_topk_indices(
+                        scores4,
+                        self.index_topk,
+                        bucketed=True,
+                    )[:, 0]
+            except Exception:
+                _DEEPSEEK_V4_INDEXER_NATIVE_DISABLED = True
+
         scores = q.astype(mx.float32) @ pooled[:, None].swapaxes(-1, -2).astype(
             mx.float32
         )
         scores = mx.maximum(scores, 0) * self.scale
         weights = self.weights_proj(x).astype(mx.float32) * (self.n_heads**-0.5)
         scores = (scores * weights.swapaxes(-1, -2)[..., None]).sum(axis=1)
-        pmask = pool_cache.make_mask(L, offset) if pool_cache is not None else None
         if pmask is not None:
             scores = mx.where(
                 pmask if pmask.ndim == 3 else pmask[None],
                 scores,
                 mx.finfo(scores.dtype).min,
             )
-        k = min(self.index_topk, pooled.shape[1])
         return mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
 
 
@@ -907,6 +997,9 @@ class SparseCompressedAttention(nn.Module):
                 sparse_mask,
                 self.scale,
                 sinks,
+                q_offset=offset,
+                compress_ratio=self.compress_ratio,
+                local_window=self.config.sliding_window,
             )
 
         out = self.rope(out, offset, inverse=True)

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -522,6 +522,7 @@ class DeepseekV4MoE(nn.Module):
         self.shared_experts = DeepseekV4MLP(
             config,
             intermediate_size=config.moe_intermediate_size * config.n_shared_experts,
+            swiglu_limit=config.swiglu_limit,
         )
         self.sharding_group = None
 

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -1257,6 +1257,22 @@ class Model(nn.Module):
                             f"model.layers.{layer_idx}.ffn.switch_mlp.{dst}.{suffix}"
                         ] = mx.stack(stacked)
 
+        for key, value in list(weights.items()):
+            if (
+                ".ffn.switch_mlp." not in key
+                or not key.endswith((".scales", ".biases"))
+                or value.dtype != mx.bfloat16
+            ):
+                continue
+            stem = key.rsplit(".", 1)[0]
+            if (
+                stem + ".weight" in weights
+                and stem + ".scales" in weights
+                and stem + ".biases" in weights
+                and weights[stem + ".weight"].dtype == mx.uint32
+            ):
+                weights[key] = value.astype(mx.float16)
+
         # Reshape wo_a from nn.Linear (2D) to MultiLinear (3D) for all layers
         for layer_idx in range(n_layers):
             prefix = f"model.layers.{layer_idx}.attn.wo_a"

--- a/omlx/patches/deepseek_v4/switch_layers.py
+++ b/omlx/patches/deepseek_v4/switch_layers.py
@@ -1,0 +1,460 @@
+# Copyright (c) 2026 Apple Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepSeek V4 switch layers with an experimental MXFP4 block-list MoE GEMM."""
+
+from __future__ import annotations
+
+import math
+from functools import lru_cache
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.activations import swiglu
+from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+
+
+_DEEPSEEK_MXFP4_SMALL_BLOCK_BM = 16
+_DEEPSEEK_MXFP4_SMALL_BLOCK_VARIANT = 1
+_DEEPSEEK_MXFP4_LARGE_BLOCK_BM = 32
+_DEEPSEEK_MXFP4_LARGE_BLOCK_VARIANT = 2
+_DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES = 8192
+
+
+def _gather_sort(x, indices):
+    *_, M = indices.shape
+    indices = indices.flatten()
+    order = mx.argsort(indices)
+    inv_order = mx.argsort(order)
+    return x.flatten(0, -3)[order // M], indices[order], inv_order
+
+
+def _scatter_unsort(x, inv_order, shape=None):
+    x = x[inv_order]
+    if shape is not None:
+        x = mx.unflatten(x, 0, shape)
+    return x
+
+
+@lru_cache(maxsize=None)
+def _mxfp4_block_builder(num_experts: int, bm: int):
+    source = r"""
+        const uint expert = thread_index_in_threadgroup;
+
+        threadgroup atomic_int local_count;
+        if (expert == 0) {
+            atomic_store_explicit(&local_count, 0, memory_order_relaxed);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (expert >= NUM_EXPERTS) {
+            return;
+        }
+
+        int lo = 0;
+        int hi = M;
+        while (lo < hi) {
+            int mid = (lo + hi) >> 1;
+            if (indices[mid] < int(expert)) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        const int start = lo;
+
+        hi = M;
+        while (lo < hi) {
+            int mid = (lo + hi) >> 1;
+            if (indices[mid] <= int(expert)) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        const int end = lo;
+
+        for (int row = start; row < end; row += BM) {
+            const int rows = min(BM, end - row);
+            const int slot = atomic_fetch_add_explicit(
+                &local_count, 1, memory_order_relaxed);
+            if (slot < MAX_BLOCKS) {
+                block_meta[slot * 3 + 0] = row;
+                block_meta[slot * 3 + 1] = int(expert);
+                block_meta[slot * 3 + 2] = rows;
+            }
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (expert == 0) {
+            block_count[0] = atomic_load_explicit(
+                &local_count, memory_order_relaxed);
+        }
+    """
+
+    return mx.fast.metal_kernel(
+        name=f"deepseek_v4_mxfp4_block_builder_e{num_experts}_bm{bm}",
+        input_names=["indices"],
+        output_names=["block_meta", "block_count"],
+        source=source,
+        ensure_row_contiguous=True,
+    )
+
+
+def _build_mxfp4_blocks(indices: mx.array, num_experts: int, bm: int):
+    indices = indices.astype(mx.int32)
+    max_blocks = (indices.size + bm - 1) // bm + num_experts
+    builder = _mxfp4_block_builder(num_experts, bm)
+    return builder(
+        inputs=[indices],
+        template=[
+            ("NUM_EXPERTS", num_experts),
+            ("BM", bm),
+            ("M", indices.size),
+            ("MAX_BLOCKS", max_blocks),
+        ],
+        grid=(num_experts, 1, 1),
+        threadgroup=(num_experts, 1, 1),
+        output_shapes=[(max_blocks, 3), (1,)],
+        output_dtypes=[mx.int32, mx.int32],
+    )
+
+
+def _mxfp4_block_config(num_routes: int) -> tuple[int, int]:
+    if num_routes >= _DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES:
+        return (
+            _DEEPSEEK_MXFP4_LARGE_BLOCK_BM,
+            _DEEPSEEK_MXFP4_LARGE_BLOCK_VARIANT,
+        )
+    return (
+        _DEEPSEEK_MXFP4_SMALL_BLOCK_BM,
+        _DEEPSEEK_MXFP4_SMALL_BLOCK_VARIANT,
+    )
+
+
+def _unpack_mxfp4_block_plan(block_plan):
+    if len(block_plan) == 3:
+        return block_plan
+    block_meta, block_count = block_plan
+    return block_meta, block_count, _DEEPSEEK_MXFP4_SMALL_BLOCK_VARIANT
+
+
+class QuantizedSwitchLinear(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        output_dims: int,
+        num_experts: int,
+        bias: bool = True,
+        group_size: int = 64,
+        bits: int = 4,
+        mode: str = "affine",
+    ):
+        super().__init__()
+
+        scale = math.sqrt(1 / input_dims)
+        self.weight, self.scales, *biases = mx.quantize(
+            mx.random.uniform(
+                low=-scale,
+                high=scale,
+                shape=(num_experts, output_dims, input_dims),
+            ),
+            group_size=group_size,
+            bits=bits,
+            mode=mode,
+        )
+        self.biases = biases[0] if biases else None
+
+        if bias:
+            self.bias = mx.zeros((num_experts, output_dims))
+
+        self.group_size = group_size
+        self.bits = bits
+        self.mode = mode
+
+        self.freeze()
+
+    @property
+    def input_dims(self):
+        return self.scales.shape[2] * self.group_size
+
+    @property
+    def output_dims(self):
+        return self.weight.shape[1]
+
+    @property
+    def num_experts(self):
+        return self.weight.shape[0]
+
+    def _can_use_mxfp4_blocks(self, x, sorted_indices: bool) -> bool:
+        return (
+            sorted_indices
+            and x.ndim == 3
+            and x.shape[-2] == 1
+            and self.group_size == 32
+            and self.bits == 4
+            and self.mode == "mxfp4"
+            and self.get("biases") is None
+            and "bias" not in self
+            and self["weight"].dtype == mx.uint32
+            and self["scales"].dtype == mx.uint8
+            and glm_fast.has_symbol("deepseek_mxfp4_gather_qmm_blocks")
+        )
+
+    def __call__(self, x, indices, sorted_indices=False, block_plan=None):
+        if self._can_use_mxfp4_blocks(x, sorted_indices):
+            if block_plan is None:
+                block_bm, block_variant = _mxfp4_block_config(indices.size)
+                block_meta, block_count = _build_mxfp4_blocks(
+                    indices,
+                    self.num_experts,
+                    block_bm,
+                )
+            else:
+                block_meta, block_count, block_variant = _unpack_mxfp4_block_plan(
+                    block_plan
+                )
+            x = glm_fast.deepseek_mxfp4_gather_qmm_blocks(
+                x,
+                self["weight"],
+                self["scales"],
+                block_meta,
+                block_count,
+                block_variant,
+            )
+        else:
+            x = mx.gather_qmm(
+                x,
+                self["weight"],
+                self["scales"],
+                self.get("biases"),
+                rhs_indices=indices,
+                transpose=True,
+                group_size=self.group_size,
+                bits=self.bits,
+                mode=self.mode,
+                sorted_indices=sorted_indices,
+            )
+        if "bias" in self:
+            x = x + mx.expand_dims(self["bias"][indices], -2)
+        return x
+
+
+class SwitchLinear(nn.Module):
+    def __init__(
+        self, input_dims: int, output_dims: int, num_experts: int, bias: bool = True
+    ):
+        super().__init__()
+        scale = math.sqrt(1 / input_dims)
+        self.weight = mx.random.uniform(
+            low=-scale,
+            high=scale,
+            shape=(num_experts, output_dims, input_dims),
+        )
+
+        if bias:
+            self.bias = mx.zeros((num_experts, output_dims))
+
+    @property
+    def input_dims(self):
+        return self.weight.shape[2]
+
+    @property
+    def output_dims(self):
+        return self.weight.shape[1]
+
+    @property
+    def num_experts(self):
+        return self.weight.shape[0]
+
+    def __call__(self, x, indices, sorted_indices=False):
+        x = mx.gather_mm(
+            x,
+            self["weight"].swapaxes(-1, -2),
+            rhs_indices=indices,
+            sorted_indices=sorted_indices,
+        )
+        if "bias" in self:
+            x = x + mx.expand_dims(self["bias"][indices], -2)
+        return x
+
+    def to_quantized(self, group_size: int = 64, bits: int = 4, mode: str = "affine"):
+        num_experts, output_dims, input_dims = self.weight.shape
+        ql = QuantizedSwitchLinear(
+            input_dims,
+            output_dims,
+            num_experts,
+            False,
+            group_size,
+            bits,
+            mode=mode,
+        )
+        ql.weight, ql.scales, *biases = mx.quantize(
+            self.weight, group_size, bits, mode=mode
+        )
+        ql.biases = biases[0] if biases else None
+
+        if "bias" in self:
+            ql.bias = self.bias
+        return ql
+
+
+class SwiGLU(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def __call__(self, x, gate):
+        return swiglu(gate, x)
+
+
+class SwitchGLU(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=SwiGLU(),
+        bias: bool = False,
+    ):
+        super().__init__()
+
+        self.gate_proj = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.up_proj = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.down_proj = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
+        self.activation = activation
+
+    def __call__(self, x, indices, scores=None) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+        original_dtype = x.dtype
+
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(x, indices)
+        if self.training:
+            idx = mx.stop_gradient(idx)
+
+        block_plan = None
+        projections = (self.up_proj, self.gate_proj, self.down_proj)
+        if (
+            do_sort
+            and all(isinstance(p, QuantizedSwitchLinear) for p in projections)
+            and all(p._can_use_mxfp4_blocks(x, do_sort) for p in projections)
+        ):
+            block_bm, block_variant = _mxfp4_block_config(idx.size)
+            block_meta, block_count = _build_mxfp4_blocks(
+                idx,
+                self.up_proj.num_experts,
+                block_bm,
+            )
+            block_plan = (block_meta, block_count, block_variant)
+
+        use_f16_moe = block_plan is not None and x.dtype == mx.bfloat16
+        if use_f16_moe:
+            x = x.astype(mx.float16)
+
+        use_pair_proj = (
+            block_plan is not None
+            and glm_fast.has_symbol("deepseek_mxfp4_gather_qmm_pair_blocks")
+            and self.up_proj.output_dims == self.gate_proj.output_dims
+            and self.up_proj.num_experts == self.gate_proj.num_experts
+        )
+        if use_pair_proj:
+            block_meta, block_count, block_variant = _unpack_mxfp4_block_plan(
+                block_plan
+            )
+            if glm_fast.has_symbol("deepseek_mxfp4_gather_qmm_pair_concat_blocks"):
+                x_pair = glm_fast.deepseek_mxfp4_gather_qmm_pair_concat_blocks(
+                    x,
+                    self.up_proj["weight"],
+                    self.up_proj["scales"],
+                    self.gate_proj["weight"],
+                    self.gate_proj["scales"],
+                    block_meta,
+                    block_count,
+                    block_variant,
+                )
+                hidden_dims = self.up_proj.output_dims
+                x_up = x_pair[..., :hidden_dims]
+                x_gate = x_pair[..., hidden_dims:]
+            else:
+                x_pair = glm_fast.deepseek_mxfp4_gather_qmm_pair_blocks(
+                    x,
+                    self.up_proj["weight"],
+                    self.up_proj["scales"],
+                    self.gate_proj["weight"],
+                    self.gate_proj["scales"],
+                    block_meta,
+                    block_count,
+                    block_variant,
+                )
+                x_up = x_pair[0]
+                x_gate = x_pair[1]
+        else:
+            x_up = self.up_proj(
+                x, idx, sorted_indices=do_sort, block_plan=block_plan
+            )
+            x_gate = self.gate_proj(
+                x, idx, sorted_indices=do_sort, block_plan=block_plan
+            )
+        x = self.down_proj(
+            self.activation(x_up, x_gate),
+            idx,
+            sorted_indices=do_sort,
+            block_plan=block_plan,
+        )
+
+        if do_sort:
+            if (
+                scores is not None
+                and scores.shape[-1] in (6, 8)
+                and glm_fast.has_symbol("glm_moe_weighted_sum")
+            ):
+                return glm_fast.glm_moe_weighted_sum(
+                    x,
+                    inv_order.astype(mx.uint32),
+                    scores,
+                ).astype(original_dtype)
+            x = _scatter_unsort(x, inv_order, indices.shape)
+
+        x = x.squeeze(-2)
+        if use_f16_moe:
+            x = x.astype(original_dtype)
+        return x
+
+
+class SwitchMLP(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=nn.GELU(approx="precise"),
+        bias: bool = False,
+    ):
+        super().__init__()
+
+        self.fc1 = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.fc2 = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
+        self.activation = activation
+
+    def __call__(self, x, indices) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(x, indices)
+        if self.training:
+            idx = mx.stop_gradient(idx)
+        x = self.fc1(x, idx, sorted_indices=do_sort)
+        x = self.activation(x)
+        x = self.fc2(x, idx, sorted_indices=do_sort)
+
+        if do_sort:
+            x = _scatter_unsort(x, inv_order, indices.shape)
+
+        return x.squeeze(-2)

--- a/omlx/patches/deepseek_v4/switch_layers.py
+++ b/omlx/patches/deepseek_v4/switch_layers.py
@@ -14,7 +14,6 @@ import mlx.nn as nn
 from mlx_lm.models.activations import swiglu
 from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
 
-
 _DEEPSEEK_MXFP4_SMALL_BLOCK_BM = 16
 _DEEPSEEK_MXFP4_SMALL_BLOCK_VARIANT = 1
 _DEEPSEEK_MXFP4_LARGE_BLOCK_BM = 32
@@ -268,7 +267,7 @@ class SwitchLinear(nn.Module):
     def num_experts(self):
         return self.weight.shape[0]
 
-    def __call__(self, x, indices, sorted_indices=False):
+    def __call__(self, x, indices, sorted_indices=False, block_plan=None):
         x = mx.gather_mm(
             x,
             self["weight"].swapaxes(-1, -2),
@@ -393,9 +392,7 @@ class SwitchGLU(nn.Module):
                 x_up = x_pair[0]
                 x_gate = x_pair[1]
         else:
-            x_up = self.up_proj(
-                x, idx, sorted_indices=do_sort, block_plan=block_plan
-            )
+            x_up = self.up_proj(x, idx, sorted_indices=do_sort, block_plan=block_plan)
             x_gate = self.gate_proj(
                 x, idx, sorted_indices=do_sort, block_plan=block_plan
             )
@@ -407,16 +404,10 @@ class SwitchGLU(nn.Module):
         )
 
         if do_sort:
-            if (
-                scores is not None
-                and scores.shape[-1] in (6, 8)
-                and glm_fast.has_symbol("glm_moe_weighted_sum")
-            ):
-                return glm_fast.glm_moe_weighted_sum(
-                    x,
-                    inv_order.astype(mx.uint32),
-                    scores,
-                ).astype(original_dtype)
+            # Keep the reference scatter path for DeepSeek V4. The fused
+            # weighted-sum kernel changes long-context prefix snapshot state
+            # enough to make greedy cache-hit decoding diverge from fresh
+            # prefill, while the MXFP4 expert GEMM path remains stable.
             x = _scatter_unsort(x, inv_order, indices.shape)
 
         x = x.squeeze(-2)

--- a/omlx/patches/deepseek_v4/switch_layers.py
+++ b/omlx/patches/deepseek_v4/switch_layers.py
@@ -201,8 +201,35 @@ class QuantizedSwitchLinear(nn.Module):
             and glm_fast.has_symbol("deepseek_mxfp4_gather_qmm_blocks")
         )
 
-    def __call__(self, x, indices, sorted_indices=False, block_plan=None):
+    def _can_use_affine_blocks(self, x, sorted_indices: bool, dtype=None) -> bool:
+        dtype = dtype or x.dtype
+        biases = self.get("biases")
+        return (
+            sorted_indices
+            and x.ndim == 3
+            and x.shape[-2] == 1
+            and dtype in (mx.float16, mx.bfloat16)
+            and self.group_size == 64
+            and self.bits in (2, 3)
+            and self.mode == "affine"
+            and biases is not None
+            and "bias" not in self
+            and self["weight"].dtype == mx.uint32
+            and self["scales"].dtype == dtype
+            and biases.dtype == dtype
+            and glm_fast.has_symbol("deepseek_affine_gather_qmm_blocks")
+        )
+
+    def _native_block_kind(self, x, sorted_indices: bool, dtype=None) -> str | None:
         if self._can_use_mxfp4_blocks(x, sorted_indices):
+            return "mxfp4"
+        if self._can_use_affine_blocks(x, sorted_indices, dtype=dtype):
+            return "affine"
+        return None
+
+    def __call__(self, x, indices, sorted_indices=False, block_plan=None):
+        native_kind = self._native_block_kind(x, sorted_indices)
+        if native_kind is not None:
             if block_plan is None:
                 block_bm, block_variant = _mxfp4_block_config(indices.size)
                 block_meta, block_count = _build_mxfp4_blocks(
@@ -214,14 +241,27 @@ class QuantizedSwitchLinear(nn.Module):
                 block_meta, block_count, block_variant = _unpack_mxfp4_block_plan(
                     block_plan
                 )
-            x = glm_fast.deepseek_mxfp4_gather_qmm_blocks(
-                x,
-                self["weight"],
-                self["scales"],
-                block_meta,
-                block_count,
-                block_variant,
-            )
+            if native_kind == "mxfp4":
+                x = glm_fast.deepseek_mxfp4_gather_qmm_blocks(
+                    x,
+                    self["weight"],
+                    self["scales"],
+                    block_meta,
+                    block_count,
+                    block_variant,
+                )
+            else:
+                x = glm_fast.deepseek_affine_gather_qmm_blocks(
+                    x,
+                    self["weight"],
+                    self["scales"],
+                    self["biases"],
+                    block_meta,
+                    block_count,
+                    self.group_size,
+                    self.bits,
+                    block_variant,
+                )
         else:
             x = mx.gather_qmm(
                 x,
@@ -268,6 +308,7 @@ class SwitchLinear(nn.Module):
         return self.weight.shape[0]
 
     def __call__(self, x, indices, sorted_indices=False, block_plan=None):
+        del block_plan
         x = mx.gather_mm(
             x,
             self["weight"].swapaxes(-1, -2),
@@ -336,29 +377,52 @@ class SwitchGLU(nn.Module):
             idx = mx.stop_gradient(idx)
 
         block_plan = None
+        native_kinds = None
+        use_f16_moe = False
         projections = (self.up_proj, self.gate_proj, self.down_proj)
-        if (
-            do_sort
-            and all(isinstance(p, QuantizedSwitchLinear) for p in projections)
-            and all(p._can_use_mxfp4_blocks(x, do_sort) for p in projections)
-        ):
-            block_bm, block_variant = _mxfp4_block_config(idx.size)
-            block_meta, block_count = _build_mxfp4_blocks(
-                idx,
-                self.up_proj.num_experts,
-                block_bm,
-            )
-            block_plan = (block_meta, block_count, block_variant)
+        if do_sort and all(isinstance(p, QuantizedSwitchLinear) for p in projections):
+            native_kinds = tuple(p._native_block_kind(x, do_sort) for p in projections)
+            if x.dtype == mx.bfloat16:
+                f16_native_kinds = tuple(
+                    p._native_block_kind(x, do_sort, dtype=mx.float16)
+                    for p in projections
+                )
+                if all(kind == "mxfp4" for kind in f16_native_kinds) or all(
+                    kind == "affine" for kind in f16_native_kinds
+                ):
+                    native_kinds = f16_native_kinds
+                    use_f16_moe = True
+            if all(kind is not None for kind in native_kinds):
+                block_bm, block_variant = _mxfp4_block_config(idx.size)
+                block_meta, block_count = _build_mxfp4_blocks(
+                    idx,
+                    self.up_proj.num_experts,
+                    block_bm,
+                )
+                block_plan = (block_meta, block_count, block_variant)
 
-        use_f16_moe = block_plan is not None and x.dtype == mx.bfloat16
         if use_f16_moe:
             x = x.astype(mx.float16)
 
         use_pair_proj = (
             block_plan is not None
+            and native_kinds is not None
+            and native_kinds[0] == "mxfp4"
+            and native_kinds[1] == "mxfp4"
             and glm_fast.has_symbol("deepseek_mxfp4_gather_qmm_pair_blocks")
             and self.up_proj.output_dims == self.gate_proj.output_dims
             and self.up_proj.num_experts == self.gate_proj.num_experts
+        )
+        use_affine_pair_proj = (
+            block_plan is not None
+            and native_kinds is not None
+            and native_kinds[0] == "affine"
+            and native_kinds[1] == "affine"
+            and self.up_proj.group_size == self.gate_proj.group_size
+            and self.up_proj.bits == self.gate_proj.bits
+            and self.up_proj.output_dims == self.gate_proj.output_dims
+            and self.up_proj.num_experts == self.gate_proj.num_experts
+            and glm_fast.has_symbol("deepseek_affine_gather_qmm_pair_concat_blocks")
         )
         if use_pair_proj:
             block_meta, block_count, block_variant = _unpack_mxfp4_block_plan(
@@ -391,23 +455,50 @@ class SwitchGLU(nn.Module):
                 )
                 x_up = x_pair[0]
                 x_gate = x_pair[1]
+        elif use_affine_pair_proj:
+            block_meta, block_count, block_variant = _unpack_mxfp4_block_plan(
+                block_plan
+            )
+            x_pair = glm_fast.deepseek_affine_gather_qmm_pair_concat_blocks(
+                x,
+                self.up_proj["weight"],
+                self.up_proj["scales"],
+                self.up_proj["biases"],
+                self.gate_proj["weight"],
+                self.gate_proj["scales"],
+                self.gate_proj["biases"],
+                block_meta,
+                block_count,
+                self.up_proj.group_size,
+                self.up_proj.bits,
+                block_variant,
+            )
+            hidden_dims = self.up_proj.output_dims
+            x_up = x_pair[..., :hidden_dims]
+            x_gate = x_pair[..., hidden_dims:]
         else:
             x_up = self.up_proj(x, idx, sorted_indices=do_sort, block_plan=block_plan)
             x_gate = self.gate_proj(
                 x, idx, sorted_indices=do_sort, block_plan=block_plan
             )
+        x = self.activation(x_up, x_gate)
+        if (
+            block_plan is not None
+            and native_kinds is not None
+            and native_kinds[2] == "affine"
+            and isinstance(self.down_proj, QuantizedSwitchLinear)
+            and x.dtype != self.down_proj["scales"].dtype
+            and self.down_proj["scales"].dtype in (mx.float16, mx.bfloat16)
+        ):
+            x = x.astype(self.down_proj["scales"].dtype)
         x = self.down_proj(
-            self.activation(x_up, x_gate),
+            x,
             idx,
             sorted_indices=do_sort,
             block_plan=block_plan,
         )
 
         if do_sort:
-            # Keep the reference scatter path for DeepSeek V4. The fused
-            # weighted-sum kernel changes long-context prefix snapshot state
-            # enough to make greedy cache-hit decoding diverge from fresh
-            # prefill, while the MXFP4 expert GEMM path remains stable.
             x = _scatter_unsort(x, inv_order, indices.shape)
 
         x = x.squeeze(-2)

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1300,7 +1300,7 @@ class SchedulerConfig:
     completion_batch_size: int = 32
     # Per-forward embedding input chunk size
     embedding_batch_size: int = 32
-    prefill_step_size: int = 512
+    prefill_step_size: int = 2048
     # When True, long prefills are processed one chunk per step() call,
     # interleaved with decode steps for already-running requests. This
     # reduces TTFT for concurrent requests but adds per-step overhead.

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1300,7 +1300,7 @@ class SchedulerConfig:
     completion_batch_size: int = 32
     # Per-forward embedding input chunk size
     embedding_batch_size: int = 32
-    prefill_step_size: int = 2048
+    prefill_step_size: int = 512
     # When True, long prefills are processed one chunk per step() call,
     # interleaved with decode steps for already-running requests. This
     # reduces TTFT for concurrent requests but adds per-step overhead.

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -5200,6 +5200,246 @@ class Scheduler:
                 merged.append(bc)
         return merged
 
+    @staticmethod
+    def _is_empty_boundary_placeholder(layer_state: Any) -> bool:
+        if not isinstance(layer_state, dict):
+            return False
+        state = layer_state.get("state", ())
+        return isinstance(state, tuple) and len(state) == 0
+
+    @staticmethod
+    def _extracted_layer_type_name(layer_state: dict[str, Any]) -> str:
+        class_name = str(layer_state.get("class_name") or "")
+        if class_name:
+            return class_name
+        return str(layer_state.get("cache_type") or "")
+
+    @staticmethod
+    def _is_sliceable_extracted_layer(layer_state: dict[str, Any]) -> bool:
+        type_name = Scheduler._extracted_layer_type_name(layer_state)
+        if type_name in _KNOWN_SLICEABLE_CACHE_TYPES:
+            return True
+
+        if HAS_CACHE_TYPE_HANDLERS and CacheTypeRegistry is not None and type_name:
+            try:
+                if type_name not in CacheTypeRegistry.list_known_class_names():
+                    return False
+                handler = CacheTypeRegistry.get_handler_by_class_name(type_name)
+                return bool(handler.supports_block_slicing)
+            except Exception:
+                return False
+
+        return False
+
+    def _fill_boundary_placeholders_from_live_cache(
+        self,
+        boundary_cache: list[dict[str, Any]],
+        live_cache: list[dict[str, Any]],
+    ) -> list[dict[str, Any]] | None:
+        """Fill boundary placeholders only with proven sliceable live layers."""
+        if (
+            not boundary_cache
+            or not live_cache
+            or len(boundary_cache) != len(live_cache)
+        ):
+            return None
+
+        merged: list[dict[str, Any]] = []
+        for layer_idx, (boundary_layer, live_layer) in enumerate(
+            zip(boundary_cache, live_cache)
+        ):
+            if not self._is_empty_boundary_placeholder(boundary_layer):
+                merged.append(boundary_layer)
+                continue
+
+            if not isinstance(
+                live_layer, dict
+            ) or not self._is_sliceable_extracted_layer(live_layer):
+                logger.debug(
+                    "Cannot fill boundary placeholder for layer %s from non-sliceable "
+                    "live cache type %s",
+                    layer_idx,
+                    (
+                        self._extracted_layer_type_name(live_layer)
+                        if isinstance(live_layer, dict)
+                        else type(live_layer).__name__
+                    ),
+                )
+                return None
+
+            merged.append(live_layer)
+
+        if any(self._is_empty_boundary_placeholder(layer) for layer in merged):
+            return None
+        return merged
+
+    def _extract_live_request_cache_for_store(
+        self,
+        request_id: str,
+        uid: int,
+        expected_tokens: list[int],
+    ) -> tuple[list[dict[str, Any]], Optional["ModelCacheConfig"]] | None:
+        """Extract live cache only when its token prefix matches exactly."""
+        if self.batch_generator is None or uid is None or uid < 0:
+            return None
+
+        try:
+            _safe_sync_stream(self._stream)
+            with mx.stream(self._stream):
+                result = self.batch_generator.extract_cache([uid])
+            if uid not in result:
+                logger.debug(
+                    "Cannot extract live cache for %s: uid %s not present",
+                    request_id,
+                    uid,
+                )
+                return None
+
+            live_cache, live_tokens = result[uid]
+            live_tokens_list = list(live_tokens) if live_tokens is not None else []
+            if len(live_tokens_list) < len(expected_tokens) or (
+                live_tokens_list[: len(expected_tokens)] != expected_tokens
+            ):
+                logger.debug(
+                    "Skipping parser-stop cache store for %s: live cache tokens do "
+                    "not match prompt boundary prefix (%s/%s tokens)",
+                    request_id,
+                    min(len(live_tokens_list), len(expected_tokens)),
+                    len(expected_tokens),
+                )
+                return None
+
+            extracted_cache, model_cache_config = self._extract_cache_states(live_cache)
+            if not extracted_cache:
+                return None
+            return extracted_cache, model_cache_config
+        except Exception as e:
+            logger.debug(
+                "Failed to extract live cache for parser-stop cache store %s: %s",
+                request_id,
+                e,
+            )
+            return None
+
+    def _prepare_prompt_boundary_cache_store(
+        self,
+        request_id: str,
+        request: Request,
+        uid: int,
+    ) -> (
+        tuple[
+            list[int],
+            list[dict[str, Any]],
+            Optional["ModelCacheConfig"],
+            Any | None,
+        ]
+        | None
+    ):
+        """Prepare a prompt-only cache payload when a scheduler stop skipped it.
+
+        Parser-side stops (for example tool-call end markers) can finish a request
+        after a normal streaming token response. That response has no
+        ``prompt_cache``, so the usual final-response cache extraction never runs.
+        This fallback stores only prompt tokens up to a prefill block boundary,
+        never generated output tokens.
+        """
+        if self.block_aware_cache is None:
+            return None
+        if request.specprefill_indices is not None:
+            return None
+
+        block_size = self.config.paged_cache_block_size
+        if block_size <= 0:
+            return None
+
+        prompt_tokens = list(request.prompt_token_ids or [])
+        boundary_len = (len(prompt_tokens) // block_size) * block_size
+        if boundary_len <= 0:
+            return None
+
+        token_sequence = prompt_tokens[:boundary_len]
+
+        boundary_override = self._get_boundary_store_override(request_id, prompt_tokens)
+        if boundary_override is not None:
+            (
+                token_sequence,
+                boundary_cache,
+                boundary_model_config,
+                intermediate_snapshots,
+            ) = boundary_override
+
+            live_payload = None
+            if any(
+                self._is_empty_boundary_placeholder(layer) for layer in boundary_cache
+            ):
+                live_payload = self._extract_live_request_cache_for_store(
+                    request_id,
+                    uid,
+                    token_sequence,
+                )
+                if live_payload is None:
+                    return None
+                live_cache, live_model_config = live_payload
+                cache_to_store = self._fill_boundary_placeholders_from_live_cache(
+                    boundary_cache,
+                    live_cache,
+                )
+                if cache_to_store is None:
+                    return None
+                model_cache_config = boundary_model_config or live_model_config
+            else:
+                cache_to_store = boundary_cache
+                model_cache_config = boundary_model_config
+
+            logger.info(
+                "Using prompt boundary cache snapshot for %s: storing %s/%s prompt "
+                "tokens after scheduler-side stop (skipping output tokens, %s "
+                "intermediate snapshots)",
+                request_id,
+                len(token_sequence),
+                len(prompt_tokens),
+                len(intermediate_snapshots) if intermediate_snapshots else 0,
+            )
+            return (
+                token_sequence,
+                cache_to_store,
+                model_cache_config,
+                intermediate_snapshots,
+            )
+
+        # Pure sliceable cache models do not need boundary snapshots. For models
+        # that do need snapshots, a missing snapshot means the non-sliceable state
+        # at this boundary is unavailable, so skip rather than storing an unsafe
+        # live decode tail.
+        if self._detect_boundary_snapshot_need():
+            return None
+
+        live_payload = self._extract_live_request_cache_for_store(
+            request_id,
+            uid,
+            token_sequence,
+        )
+        if live_payload is None:
+            return None
+
+        live_cache, live_model_config = live_payload
+        if not all(self._is_sliceable_extracted_layer(layer) for layer in live_cache):
+            logger.debug(
+                "Skipping parser-stop cache store for %s: live cache has "
+                "non-sliceable layers but no boundary snapshot",
+                request_id,
+            )
+            return None
+
+        logger.info(
+            "Using live prompt cache for %s: storing %s/%s prompt tokens after "
+            "scheduler-side stop (skipping output tokens)",
+            request_id,
+            len(token_sequence),
+            len(prompt_tokens),
+        )
+        return token_sequence, live_cache, live_model_config, None
+
     def _validate_cache(self, cache: Any) -> bool:
         """
         Validate that a cache object is usable.
@@ -8593,31 +8833,48 @@ class Scheduler:
                         hasattr(request, "_extracted_cache")
                         and request._extracted_cache is not None
                     ):
+                        prompt_boundary_store = None
+                    else:
+                        uid_for_store = self.request_id_to_uid.get(request_id, -1)
+                        prompt_boundary_store = (
+                            self._prepare_prompt_boundary_cache_store(
+                                request_id,
+                                request,
+                                uid_for_store,
+                            )
+                        )
+
+                    if (
+                        hasattr(request, "_extracted_cache")
+                        and request._extracted_cache is not None
+                    ) or prompt_boundary_store is not None:
                         try:
                             full_token_sequence = list(request.prompt_token_ids) + list(
                                 request.output_token_ids
                             )
-                            # For reasoning models, only cache prompt tokens.
-                            # Output contains <think> tokens that the API layer
-                            # strips before the next turn, so they never match.
-                            if getattr(request, "needs_think_prefix", False):
-                                cacheable_sequence = list(request.prompt_token_ids)
+
+                            if prompt_boundary_store is not None:
+                                (
+                                    token_sequence_to_store,
+                                    cache_to_store,
+                                    model_cache_config,
+                                    intermediate_snapshots,
+                                ) = prompt_boundary_store
+                                cacheable_sequence = list(token_sequence_to_store)
                             else:
-                                cacheable_sequence = full_token_sequence
-                            token_sequence_to_store = cacheable_sequence
-                            # DEBUG-only divergence probe (issue #1003)
-                            if logger.isEnabledFor(logging.DEBUG):
-                                self._cache_probe_seqs.append(
-                                    (
-                                        request.request_id,
-                                        list(token_sequence_to_store),
-                                    )
+                                # For reasoning models, only cache prompt tokens.
+                                # Output contains <think> tokens that the API layer
+                                # strips before the next turn, so they never match.
+                                if getattr(request, "needs_think_prefix", False):
+                                    cacheable_sequence = list(request.prompt_token_ids)
+                                else:
+                                    cacheable_sequence = full_token_sequence
+                                token_sequence_to_store = cacheable_sequence
+                                cache_to_store = request._extracted_cache
+                                model_cache_config = getattr(
+                                    request, "_model_cache_config", None
                                 )
-                            cache_to_store = request._extracted_cache
-                            model_cache_config = getattr(
-                                request, "_model_cache_config", None
-                            )
-                            intermediate_snapshots = None
+                                intermediate_snapshots = None
 
                             # Inference-thread store_cache prep, timed as
                             # three sub-phases (boundary / collect / dispatch)
@@ -8631,34 +8888,48 @@ class Scheduler:
                             # -> SIGABRT. See the dispatch-phase comment below.
                             with mx.stream(self._stream):
                                 with self._phase_timer("store_cache_main_boundary"):
-                                    boundary_override = (
-                                        self._get_boundary_store_override(
-                                            request_id,
-                                            cacheable_sequence,
-                                        )
-                                    )
-                                    if boundary_override is not None:
-                                        (
-                                            token_sequence_to_store,
-                                            boundary_cache,
-                                            boundary_model_config,
-                                            intermediate_snapshots,
-                                        ) = boundary_override
-                                        cache_to_store = (
-                                            self._merge_boundary_with_full_cache(
-                                                boundary_cache, request._extracted_cache
+                                    if prompt_boundary_store is None:
+                                        boundary_override = (
+                                            self._get_boundary_store_override(
+                                                request_id,
+                                                cacheable_sequence,
                                             )
                                         )
-                                        if boundary_model_config is not None:
-                                            model_cache_config = boundary_model_config
-                                        logger.info(
-                                            f"Using boundary cache snapshot for {request_id}: "
-                                            f"storing {len(token_sequence_to_store)}/"
-                                            f"{len(full_token_sequence)} tokens "
-                                            f"(skipping trailing partial block, "
-                                            f"{len(intermediate_snapshots) if intermediate_snapshots else 0} "
-                                            f"intermediate snapshots)"
+                                        if boundary_override is not None:
+                                            (
+                                                token_sequence_to_store,
+                                                boundary_cache,
+                                                boundary_model_config,
+                                                intermediate_snapshots,
+                                            ) = boundary_override
+                                            cache_to_store = (
+                                                self._merge_boundary_with_full_cache(
+                                                    boundary_cache,
+                                                    request._extracted_cache,
+                                                )
+                                            )
+                                            if boundary_model_config is not None:
+                                                model_cache_config = (
+                                                    boundary_model_config
+                                                )
+                                            logger.info(
+                                                f"Using boundary cache snapshot for {request_id}: "
+                                                f"storing {len(token_sequence_to_store)}/"
+                                                f"{len(full_token_sequence)} tokens "
+                                                f"(skipping trailing partial block, "
+                                                f"{len(intermediate_snapshots) if intermediate_snapshots else 0} "
+                                                f"intermediate snapshots)"
+                                            )
+                                # DEBUG-only divergence probe (issue #1003).
+                                # Record the exact token sequence submitted to
+                                # store_cache, including boundary truncation.
+                                if logger.isEnabledFor(logging.DEBUG):
+                                    self._cache_probe_seqs.append(
+                                        (
+                                            request.request_id,
+                                            list(token_sequence_to_store),
                                         )
+                                    )
                                 with self._phase_timer("store_cache_main_collect"):
                                     pre_eval_arrays = (
                                         self._collect_arrays_from_extracted_cache(

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -4727,12 +4727,13 @@ class Scheduler:
         if think_start_id is not None:
             think_start_ids = [think_start_id]
         else:
-            think_start_text = self._get_output_parser_thinking_start_text() or "<think>"
+            think_start_text = (
+                self._get_output_parser_thinking_start_text() or "<think>"
+            )
             try:
                 token_id = self.tokenizer.convert_tokens_to_ids(think_start_text)
-                if (
-                    isinstance(token_id, int)
-                    and token_id != getattr(self.tokenizer, "unk_token_id", None)
+                if isinstance(token_id, int) and token_id != getattr(
+                    self.tokenizer, "unk_token_id", None
                 ):
                     think_start_ids = [token_id]
             except (AttributeError, KeyError, TypeError):
@@ -5457,12 +5458,49 @@ class Scheduler:
                                 "CacheList"
                             )
                             state_dict = handler.extract_state(layer_cache)
+                            sub_states = list(state_dict.get("sub_states", []))
+                            sub_class_names = list(
+                                state_dict.get("sub_class_names", [])
+                            )
+                            sub_meta_states = list(
+                                state_dict.get("sub_meta_states", [])
+                            )
+
+                            sub_caches = getattr(layer_cache, "caches", ())
+                            for sub_idx, sub_cache in enumerate(sub_caches):
+                                if sub_idx >= len(sub_states):
+                                    break
+
+                                sub_class_name = type(sub_cache).__name__
+                                if sub_class_name in (
+                                    "RotatingKVCache",
+                                    "BatchRotatingKVCache",
+                                    "PrefillReadyRotatingKVCache",
+                                ):
+                                    normalized_state, normalized_meta = (
+                                        self._normalize_rotating_snapshot_state(
+                                            sub_cache,
+                                            sub_states[sub_idx],
+                                            (
+                                                sub_meta_states[sub_idx]
+                                                if sub_idx < len(sub_meta_states)
+                                                else getattr(
+                                                    sub_cache, "meta_state", ()
+                                                )
+                                            ),
+                                            layer_idx=layer_idx,
+                                        )
+                                    )
+                                    sub_states[sub_idx] = normalized_state
+                                    if sub_idx < len(sub_meta_states):
+                                        sub_meta_states[sub_idx] = normalized_meta
+
                             extracted.append(
                                 {
-                                    "state": state_dict.get("sub_states", []),
+                                    "state": sub_states,
                                     "meta_state": (
-                                        state_dict.get("sub_class_names", []),
-                                        state_dict.get("sub_meta_states", []),
+                                        sub_class_names,
+                                        sub_meta_states,
                                     ),
                                     "class_name": "CacheList",
                                     "cache_type": "CacheList",
@@ -5513,6 +5551,8 @@ class Scheduler:
                     is_rotating_cache = class_name in (
                         "RotatingKVCache",
                         "BatchRotatingKVCache",
+                        "PrefillReadyRotatingKVCache",
+                        "BufferedRotatingKVCache",
                     )
                     if HAS_CACHE_TYPE_HANDLERS and CacheTypeRegistry is not None:
                         is_rotating_cache = (
@@ -5719,8 +5759,7 @@ class Scheduler:
             return None
         if not (
             best_common >= self._CACHE_FRESHNESS_WAIT_MIN_COMMON_TOKENS
-            or best_common / len(prompt)
-            >= self._CACHE_FRESHNESS_WAIT_MIN_PROMPT_RATIO
+            or best_common / len(prompt) >= self._CACHE_FRESHNESS_WAIT_MIN_PROMPT_RATIO
         ):
             return None
 
@@ -6628,10 +6667,7 @@ class Scheduler:
         prompt_tokens = request.prompt_token_ids or []
         if not cache_list or block_table is None or not block_table.block_ids:
             return False
-        if (
-            block_table.num_tokens <= 0
-            or block_table.num_tokens >= len(prompt_tokens)
-        ):
+        if block_table.num_tokens <= 0 or block_table.num_tokens >= len(prompt_tokens):
             return False
 
         minimax_m3_names = frozenset({"MiniMaxM3KVCache"})
@@ -7541,9 +7577,7 @@ class Scheduler:
                         rejected_outputs.append(stalled)
                 else:
                     if self.waiting:
-                        self._clear_memory_admission_blocker(
-                            self.waiting[0].request_id
-                        )
+                        self._clear_memory_admission_blocker(self.waiting[0].request_id)
                     stalled = self._store_cache_admission_stall_output(
                         "store_cache_backpressure",
                         gate_in_flight=gate.in_flight,
@@ -8352,8 +8386,7 @@ class Scheduler:
                         prefix_text = think_tag + "\n"
                     else:
                         prefix_text = (
-                            self._get_output_parser_thinking_start_output_text()
-                            or ""
+                            self._get_output_parser_thinking_start_output_text() or ""
                         )
                     if prefix_text:
                         new_text = prefix_text + new_text

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -4650,8 +4650,22 @@ async def stream_anthropic_messages(
     message_id = f"msg_{uuid.uuid4().hex[:24]}"
     accumulated_text = ""
 
-    # Track content blocks with thinking separation
-    thinking_parser = ThinkingParser()
+    # Track content blocks with thinking separation. Some templates open the
+    # thinking block in the prompt itself, so the generated text starts with
+    # reasoning body and only later emits </think>.
+    start_in_thinking = False
+    try:
+        tokenizer = getattr(engine, "tokenizer", None)
+        if tokenizer is not None:
+            prompt, prompt_token_ids = _render_chat_prompt_for_thinking_detection(
+                engine, messages, kwargs
+            )
+            start_in_thinking, _ = prompt_opens_thinking(
+                tokenizer, prompt, prompt_token_ids=prompt_token_ids
+            )
+    except Exception as exc:
+        logger.debug("Could not detect Anthropic stream thinking state: %s", exc)
+    thinking_parser = ThinkingParser(start_in_thinking=start_in_thinking)
     thinking_block_started = False
     text_block_started = False
     block_index = 0

--- a/scripts/replay_anthropic_payload.py
+++ b/scripts/replay_anthropic_payload.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Replay a captured Anthropic /v1/messages payload against an oMLX server."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+DSML_MARKERS = (
+    "<｜DSML｜tool_calls>",
+    "</｜DSML｜tool_calls>",
+    "<｜DSML｜invoke",
+    "</｜DSML｜invoke>",
+    "<｜DSML｜parameter",
+    "</｜DSML｜parameter>",
+)
+
+
+def _apply_overrides(payload: dict[str, Any], args: argparse.Namespace) -> None:
+    if args.model is not None:
+        payload["model"] = args.model
+    if args.max_tokens is not None:
+        payload["max_tokens"] = args.max_tokens
+    if args.temperature is not None:
+        payload["temperature"] = args.temperature
+    if args.top_p is not None:
+        payload["top_p"] = args.top_p
+    if args.stream is not None:
+        payload["stream"] = args.stream
+
+
+def _extract_text_from_event(event: dict[str, Any]) -> str:
+    pieces: list[str] = []
+    delta = event.get("delta")
+    if isinstance(delta, dict):
+        text = delta.get("text") or delta.get("thinking")
+        if isinstance(text, str):
+            pieces.append(text)
+    block = event.get("content_block")
+    if isinstance(block, dict):
+        text = block.get("text") or block.get("thinking")
+        if isinstance(text, str):
+            pieces.append(text)
+    content = event.get("content")
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    pieces.append(text)
+    return "".join(pieces)
+
+
+def _first_marker_excerpt(text: str, radius: int = 160) -> str:
+    positions = [text.find(marker) for marker in DSML_MARKERS if marker in text]
+    if not positions:
+        return ""
+    pos = min(positions)
+    start = max(0, pos - radius)
+    end = min(len(text), pos + radius)
+    return text[start:end].replace("\n", "\\n")
+
+
+def _summarize(
+    name: str, raw: str, text: str, elapsed: float, error: str = ""
+) -> dict[str, Any]:
+    combined = text or raw
+    return {
+        "name": name,
+        "elapsed_s": round(elapsed, 3),
+        "error": error,
+        "text_chars": len(text),
+        "raw_chars": len(raw),
+        "dsml_marker_count": sum(combined.count(marker) for marker in DSML_MARKERS),
+        "orphan_command_param": '<｜DSML｜parameter name="command" string="true"></｜DSML｜parameter>'
+        in combined,
+        "first_marker_excerpt": _first_marker_excerpt(combined),
+    }
+
+
+def _post_once(
+    *,
+    name: str,
+    url: str,
+    payload: dict[str, Any],
+    api_key: str | None,
+    output_dir: Path,
+    timeout: float,
+) -> dict[str, Any]:
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream" if payload.get("stream") else "application/json",
+    }
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+
+    raw_parts: list[str] = []
+    text_parts: list[str] = []
+    started = time.monotonic()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            for raw_line in resp:
+                line = raw_line.decode("utf-8", errors="replace")
+                raw_parts.append(line)
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:].strip()
+                if not data or data == "[DONE]":
+                    continue
+                try:
+                    event = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                text_parts.append(_extract_text_from_event(event))
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        elapsed = time.monotonic() - started
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / f"{name}.raw.txt").write_text(raw, encoding="utf-8")
+        return _summarize(name, raw, "", elapsed, error=f"HTTP {exc.code}")
+    except Exception as exc:  # noqa: BLE001 - diagnostic script
+        elapsed = time.monotonic() - started
+        return _summarize(
+            name, "".join(raw_parts), "".join(text_parts), elapsed, error=repr(exc)
+        )
+
+    elapsed = time.monotonic() - started
+    raw = "".join(raw_parts)
+    text = "".join(text_parts)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / f"{name}.raw.txt").write_text(raw, encoding="utf-8")
+    (output_dir / f"{name}.text.txt").write_text(text, encoding="utf-8")
+    return _summarize(name, raw, text, elapsed)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--payload", required=True, type=Path)
+    parser.add_argument("--url", default="http://127.0.0.1:18150/v1/messages")
+    parser.add_argument("--api-key")
+    parser.add_argument(
+        "--output-dir", default=Path("/tmp/omlx_repro_outputs"), type=Path
+    )
+    parser.add_argument("--repeat", default=1, type=int)
+    parser.add_argument("--concurrency", default=1, type=int)
+    parser.add_argument("--stagger-s", default=0.0, type=float)
+    parser.add_argument("--timeout-s", default=1800.0, type=float)
+    parser.add_argument("--model")
+    parser.add_argument("--max-tokens", type=int)
+    parser.add_argument("--temperature", type=float)
+    parser.add_argument("--top-p", type=float)
+    stream_group = parser.add_mutually_exclusive_group()
+    stream_group.add_argument("--stream", dest="stream", action="store_true")
+    stream_group.add_argument("--no-stream", dest="stream", action="store_false")
+    parser.set_defaults(stream=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    payload = json.loads(args.payload.read_text(encoding="utf-8"))
+    _apply_overrides(payload, args)
+
+    print(
+        json.dumps(
+            {
+                "url": args.url,
+                "payload": str(args.payload),
+                "model": payload.get("model"),
+                "messages": len(payload.get("messages") or []),
+                "tools": len(payload.get("tools") or []),
+                "max_tokens": payload.get("max_tokens"),
+                "temperature": payload.get("temperature", "<server-default>"),
+                "top_p": payload.get("top_p", "<server-default>"),
+                "stream": payload.get("stream"),
+                "repeat": args.repeat,
+                "concurrency": args.concurrency,
+            },
+            ensure_ascii=False,
+        )
+    )
+
+    def run(index: int) -> dict[str, Any]:
+        if args.stagger_s > 0:
+            time.sleep(args.stagger_s * index)
+        return _post_once(
+            name=f"run_{index:03d}",
+            url=args.url,
+            payload=dict(payload),
+            api_key=args.api_key,
+            output_dir=args.output_dir,
+            timeout=args.timeout_s,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=args.concurrency
+    ) as executor:
+        futures = [executor.submit(run, i) for i in range(args.repeat)]
+        for future in concurrent.futures.as_completed(futures):
+            print(json.dumps(future.result(), ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_e2e_streaming.py
+++ b/tests/integration/test_e2e_streaming.py
@@ -1136,6 +1136,91 @@ class TestStreamingHelperFunctions:
         assert "tool_use" in stop_reasons
 
     @pytest.mark.asyncio
+    async def test_stream_anthropic_messages_starts_parser_when_prompt_opens_thinking(self):
+        """Prompt-opened thinking must stream as thinking, not public text."""
+        from omlx.server import stream_anthropic_messages
+        from omlx.api.anthropic_models import MessagesRequest
+
+        class PromptOpenedThinkingTokenizer(MockTokenizer):
+            think_start = "<think>"
+            think_end = "</think>"
+            think_start_id = 9001
+            think_end_id = 9002
+
+            def encode(self, text: str, add_special_tokens: bool = False) -> List[int]:
+                if text.rstrip().endswith(self.think_start):
+                    return [101, self.think_start_id]
+                return [101]
+
+            def apply_chat_template(
+                self, messages: List[Dict], tokenize: bool = False, **kwargs
+            ) -> str:
+                return "system: hidden\nuser: hi\nassistant:<think>"
+
+        engine = MockBaseEngine()
+        engine._tokenizer = PromptOpenedThinkingTokenizer()
+        engine.set_stream_outputs([
+            MockGenerationOutput(
+                text="The user asked a simple informational question.</think>",
+                new_text="The user asked a simple informational question.</think>",
+                completion_tokens=1,
+                finished=False,
+            ),
+            MockGenerationOutput(
+                text=(
+                    "The user asked a simple informational question.</think>"
+                    "Visible answer."
+                ),
+                new_text="Visible answer.",
+                completion_tokens=2,
+                finished=True,
+                finish_reason="stop",
+            ),
+        ])
+
+        request = MessagesRequest(
+            model="test-model",
+            max_tokens=256,
+            messages=[{"role": "user", "content": "Hi"}],
+            stream=True,
+        )
+
+        events = []
+        async for event in stream_anthropic_messages(
+            engine,
+            [{"role": "user", "content": "Hi"}],
+            request,
+            max_tokens=256,
+            temperature=0.7,
+            top_p=0.9,
+            top_k=40,
+        ):
+            events.append(event)
+
+        parsed_events = []
+        for event in events:
+            for line in event.split("\n"):
+                if line.startswith("data: "):
+                    parsed_events.append(json.loads(line[6:]))
+
+        thinking_deltas = []
+        text_deltas = []
+        for event in parsed_events:
+            if event.get("type") != "content_block_delta":
+                continue
+            delta = event.get("delta", {})
+            if delta.get("type") == "thinking_delta":
+                thinking_deltas.append(delta["thinking"])
+            elif delta.get("type") == "text_delta":
+                text_deltas.append(delta["text"])
+
+        streamed_thinking = "".join(thinking_deltas)
+        streamed_text = "".join(text_deltas)
+        assert "The user asked a simple informational question." in streamed_thinking
+        assert "The user asked a simple informational question." not in streamed_text
+        assert streamed_text == "Visible answer."
+
+    @pytest.mark.asyncio
     async def test_anthropic_tool_only_stream_starts_with_tool_use_block(self):
         """A tool-only response should not emit an empty text block before tool_use."""
         from omlx.server import stream_anthropic_messages

--- a/tests/test_cache_type_handlers.py
+++ b/tests/test_cache_type_handlers.py
@@ -160,6 +160,7 @@ class TestKVCacheHandlerWithMLX:
         """Import MLX or skip."""
         try:
             import mlx.core as mx
+
             return mx
         except ImportError:
             pytest.skip("MLX not available")
@@ -524,6 +525,7 @@ class TestRotatingKVCacheHandlerWithMLX:
         """Import MLX or skip."""
         try:
             import mlx.core as mx
+
             return mx
         except ImportError:
             pytest.skip("MLX not available")
@@ -1181,6 +1183,7 @@ class TestCacheListHandlerWithMLX:
         """Import MLX or skip."""
         try:
             import mlx.core as mx
+
             return mx
         except ImportError:
             pytest.skip("MLX not available")
@@ -1211,9 +1214,8 @@ class TestCacheListHandlerWithMLX:
         assert hasattr(cache, "caches")
         assert len(cache.caches) == 2
 
-    def test_reconstruct_cache_kvcache_no_fallback(self, handler, mx):
-        """Test CacheList with KVCache sub-caches succeeds via from_state()
-        without falling back to manual reconstruction (GLM-5 scenario)."""
+    def test_reconstruct_cache_kvcache_subs_via_handlers(self, handler, mx):
+        """Test CacheList with KVCache sub-caches succeeds via local handlers."""
         keys1 = mx.zeros((1, 8, 64, 64))
         values1 = mx.zeros((1, 8, 64, 64))
         keys2 = mx.zeros((1, 8, 64, 64))
@@ -1229,20 +1231,42 @@ class TestCacheListHandlerWithMLX:
             ["", ""],
         )
 
-        import logging
-        from unittest.mock import patch
-
-        with patch.object(
-            logging.getLogger("omlx.cache.type_handlers"), "debug"
-        ) as mock_debug:
-            cache = handler.reconstruct_cache(state, meta_state)
+        cache = handler.reconstruct_cache(state, meta_state)
 
         assert cache is not None
         assert hasattr(cache, "caches")
         assert len(cache.caches) == 2
-        # Verify from_state() succeeded without fallback
-        for call_args in mock_debug.call_args_list:
-            assert "from_state() unavailable or failed" not in str(call_args)
+
+    def test_reconstruct_cache_rotating_sub_cache_uses_handler(self, handler, mx):
+        """Nested RotatingKVCache restores as trimmed PrefillReadyRotatingKVCache."""
+        from omlx.cache._rotating_subclass import PrefillReadyRotatingKVCache
+
+        keys = mx.arange(255).reshape(1, 1, 255, 1)
+        values = mx.arange(1000, 1255).reshape(1, 1, 255, 1)
+        expected_keys = keys[..., -128:, :]
+        expected_values = values[..., -128:, :]
+
+        state = {
+            "sub_states": [(keys, values)],
+        }
+        meta_state = (
+            ["RotatingKVCache"],
+            [("0", "128", "1280", "255")],
+        )
+
+        cache = handler.reconstruct_cache(state, meta_state)
+
+        assert cache is not None
+        assert hasattr(cache, "caches")
+        assert len(cache.caches) == 1
+        sub_cache = cache.caches[0]
+        assert isinstance(sub_cache, PrefillReadyRotatingKVCache)
+        assert sub_cache.keys.shape == (1, 1, 128, 1)
+        assert sub_cache.values.shape == (1, 1, 128, 1)
+        assert bool(mx.all(sub_cache.keys == expected_keys).item())
+        assert bool(mx.all(sub_cache.values == expected_values).item())
+        assert sub_cache.offset == 1280
+        assert sub_cache._idx == 128
 
     def test_reconstruct_cache_mixed_types(self, handler, mx):
         """Test reconstructing CacheList with ArraysCache + KVCache."""

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -784,6 +784,65 @@ class TestCacheMaterialization:
         assert loop_pos < materialize_pos < pipeline_send_pos
 
 
+class TestDeepseekV4SwitchGLU:
+    """DeepSeek-V4 SwitchGLU execution guards."""
+
+    def test_skips_fused_weighted_sum_for_cache_stability(
+        self, applied_patch, monkeypatch
+    ):
+        mx = pytest.importorskip("mlx.core")
+        from omlx.patches.deepseek_v4 import switch_layers
+
+        monkeypatch.setattr(
+            switch_layers.glm_fast,
+            "has_symbol",
+            lambda name: name == "glm_moe_weighted_sum",
+        )
+
+        def fail_weighted_sum(*args, **kwargs):
+            raise AssertionError("DeepSeek V4 must not use fused weighted sum")
+
+        monkeypatch.setattr(
+            switch_layers.glm_fast,
+            "glm_moe_weighted_sum",
+            fail_weighted_sum,
+            raising=False,
+        )
+
+        mx.random.seed(11)
+        layer = switch_layers.SwitchGLU(
+            input_dims=16,
+            hidden_dims=32,
+            num_experts=4,
+            bias=False,
+        )
+        x = mx.random.normal((1, 8, 16), dtype=mx.float32)
+        indices = mx.array(
+            [
+                [
+                    [0, 1, 2, 3, 0, 1, 2, 3],
+                    [1, 2, 3, 0, 1, 2, 3, 0],
+                    [2, 3, 0, 1, 2, 3, 0, 1],
+                    [3, 0, 1, 2, 3, 0, 1, 2],
+                    [0, 2, 1, 3, 0, 2, 1, 3],
+                    [1, 3, 2, 0, 1, 3, 2, 0],
+                    [2, 0, 3, 1, 2, 0, 3, 1],
+                    [3, 1, 0, 2, 3, 1, 0, 2],
+                ]
+            ],
+            dtype=mx.int32,
+        )
+        scores = mx.softmax(
+            mx.random.normal((1, 8, 8), dtype=mx.float32),
+            axis=-1,
+        )
+
+        y = layer(x, indices, scores=scores)
+        mx.eval(y)
+
+        assert y.shape == (1, 8, 8, 16)
+
+
 class TestPreLoadDispatch:
     """maybe_apply_pre_load_patches gates correctly on config.json model_type."""
 

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -787,6 +787,36 @@ class TestCacheMaterialization:
 class TestDeepseekV4SwitchGLU:
     """DeepSeek-V4 SwitchGLU execution guards."""
 
+    def test_shared_expert_uses_configured_swiglu_limit(self, applied_patch):
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+
+        config = dsv4.ModelArgs(
+            vocab_size=16,
+            hidden_size=8,
+            intermediate_size=16,
+            moe_intermediate_size=4,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            n_shared_experts=1,
+            n_routed_experts=2,
+            num_experts_per_tok=1,
+            num_hash_layers=0,
+            q_lora_rank=0,
+            qk_rope_head_dim=4,
+            head_dim=4,
+            o_lora_rank=0,
+            index_n_heads=2,
+            index_head_dim=4,
+            index_topk=2,
+            swiglu_limit=10.0,
+        )
+
+        moe = dsv4.DeepseekV4MoE(config, layer_idx=0)
+
+        assert moe.switch_mlp.activation.limit == config.swiglu_limit
+        assert moe.shared_experts.swiglu_limit == config.swiglu_limit
+
     def test_skips_fused_weighted_sum_for_cache_stability(
         self, applied_patch, monkeypatch
     ):

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -4,6 +4,7 @@
 import importlib
 import inspect
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -959,6 +960,63 @@ class TestMakeQuantizationConfigMtp:
 
         qcfg = dsv4.make_quantization_config(_ModelStub())
         assert not any(k.startswith("mtp.") for k in qcfg)
+
+
+class TestDeepSeekV4SanitizeAffineSwitchMLP:
+    """Sanitize should enable the FP16 affine routed-MoE fast path."""
+
+    def test_affine_switch_mlp_scale_bias_cast_to_fp16(self, applied_patch):
+        mx = pytest.importorskip("mlx.core")
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        fake_model = SimpleNamespace(
+            args=SimpleNamespace(
+                num_hidden_layers=1,
+                n_routed_experts=2,
+                o_groups=1,
+                o_lora_rank=1,
+            )
+        )
+        weights = {
+            "model.layers.0.ffn.switch_mlp.up_proj.weight": mx.zeros(
+                (2, 4, 2), dtype=mx.uint32
+            ),
+            "model.layers.0.ffn.switch_mlp.up_proj.scales": mx.zeros(
+                (2, 4, 1), dtype=mx.bfloat16
+            ),
+            "model.layers.0.ffn.switch_mlp.up_proj.biases": mx.zeros(
+                (2, 4, 1), dtype=mx.bfloat16
+            ),
+            "model.layers.0.ffn.switch_mlp.down_proj.weight": mx.zeros(
+                (2, 4, 2), dtype=mx.uint32
+            ),
+            "model.layers.0.ffn.switch_mlp.down_proj.scales": mx.zeros(
+                (2, 4, 1), dtype=mx.bfloat16
+            ),
+            "model.layers.0.ffn.switch_mlp.down_proj.biases": mx.zeros(
+                (2, 4, 1), dtype=mx.bfloat16
+            ),
+            "model.layers.0.ffn.shared_experts.up_proj.scales": mx.zeros(
+                (4, 1), dtype=mx.bfloat16
+            ),
+        }
+
+        out = dsv4.Model.sanitize(fake_model, dict(weights))
+
+        assert out["model.layers.0.ffn.switch_mlp.up_proj.scales"].dtype == mx.float16
+        assert out["model.layers.0.ffn.switch_mlp.up_proj.biases"].dtype == mx.float16
+        assert (
+            out["model.layers.0.ffn.switch_mlp.down_proj.scales"].dtype
+            == mx.float16
+        )
+        assert (
+            out["model.layers.0.ffn.switch_mlp.down_proj.biases"].dtype
+            == mx.float16
+        )
+        assert (
+            out["model.layers.0.ffn.shared_experts.up_proj.scales"].dtype
+            == mx.bfloat16
+        )
 
 
 class TestMtpSanitizeWoAReshape:

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -636,6 +636,281 @@ def test_glm_native_fused_kernels_match_reference(monkeypatch):
     assert topk_indices.shape == (1, 1, 2, 2048)
 
 
+def test_deepseek_affine_block_moe_kernels_match_gather_qmm():
+    mx = pytest.importorskip("mlx.core")
+
+    try:
+        from omlx.custom_kernels.glm_moe_dsa import fast
+    except Exception as exc:  # pragma: no cover - depends on local native build
+        pytest.skip(f"omlx.custom_kernels.glm_moe_dsa is unavailable: {exc}")
+
+    if not fast.is_native_available():
+        pytest.skip("GLM MoE DSA native extension is unavailable")
+    if not fast.has_symbol("deepseek_affine_gather_qmm_blocks"):
+        pytest.skip("DeepSeek affine block-list kernels are unavailable")
+
+    from omlx.patches.deepseek_v4.switch_layers import (
+        _build_mxfp4_blocks,
+        _mxfp4_block_config,
+    )
+
+    mx.random.seed(11)
+    experts, output_dims, input_dims, routes = 8, 64, 128, 192
+    indices = mx.array(
+        sorted((i * 7) % experts for i in range(routes)),
+        dtype=mx.int32,
+    )
+    block_bm, block_variant = _mxfp4_block_config(indices.size)
+    block_meta, block_count = _build_mxfp4_blocks(indices, experts, block_bm)
+
+    for dtype in (mx.bfloat16, mx.float16):
+        x = mx.random.normal((routes, 1, input_dims), dtype=dtype)
+        for bits in (2, 3):
+            w0 = mx.random.normal(
+                (experts, output_dims, input_dims),
+                dtype=dtype,
+            )
+            w1 = mx.random.normal(
+                (experts, output_dims, input_dims),
+                dtype=dtype,
+            )
+            q0, s0, b0 = mx.quantize(
+                w0,
+                group_size=64,
+                bits=bits,
+                mode="affine",
+            )
+            q1, s1, b1 = mx.quantize(
+                w1,
+                group_size=64,
+                bits=bits,
+                mode="affine",
+            )
+
+            y_ref = mx.gather_qmm(
+                x,
+                q0,
+                s0,
+                b0,
+                rhs_indices=indices,
+                transpose=True,
+                group_size=64,
+                bits=bits,
+                mode="affine",
+                sorted_indices=True,
+            )
+            y_native = fast.deepseek_affine_gather_qmm_blocks(
+                x,
+                q0,
+                s0,
+                b0,
+                block_meta,
+                block_count,
+                64,
+                bits,
+                block_variant,
+            )
+            y_pair = fast.deepseek_affine_gather_qmm_pair_concat_blocks(
+                x,
+                q0,
+                s0,
+                b0,
+                q1,
+                s1,
+                b1,
+                block_meta,
+                block_count,
+                64,
+                bits,
+                block_variant,
+            )
+            y1_ref = mx.gather_qmm(
+                x,
+                q1,
+                s1,
+                b1,
+                rhs_indices=indices,
+                transpose=True,
+                group_size=64,
+                bits=bits,
+                mode="affine",
+                sorted_indices=True,
+            )
+
+            y0_pair = y_pair[..., :output_dims]
+            y1_pair = y_pair[..., output_dims:]
+            mx.eval(y_ref, y_native, y0_pair, y1_ref, y1_pair)
+            assert float(mx.max(mx.abs(y_ref - y_native)).item()) == 0.0
+            assert float(mx.max(mx.abs(y_ref - y0_pair)).item()) == 0.0
+            assert float(mx.max(mx.abs(y1_ref - y1_pair)).item()) == 0.0
+
+
+def test_deepseek_switchglu_uses_affine_block_kernels(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+
+    try:
+        from omlx.custom_kernels.glm_moe_dsa import fast
+    except Exception as exc:  # pragma: no cover - depends on local native build
+        pytest.skip(f"omlx.custom_kernels.glm_moe_dsa is unavailable: {exc}")
+
+    if not fast.is_native_available():
+        pytest.skip("GLM MoE DSA native extension is unavailable")
+    if not fast.has_symbol("deepseek_affine_gather_qmm_pair_concat_blocks"):
+        pytest.skip("DeepSeek affine block-list kernels are unavailable")
+
+    from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
+
+    mx.random.seed(13)
+
+    def quantized_affine(layer):
+        layer = layer.to_quantized(
+            group_size=64,
+            bits=3,
+            mode="affine",
+        )
+        layer.scales = layer.scales.astype(mx.bfloat16)
+        layer.biases = layer.biases.astype(mx.bfloat16)
+        return layer
+
+    model = SwitchGLU(128, 64, 8)
+    model.gate_proj = quantized_affine(model.gate_proj)
+    model.up_proj = quantized_affine(model.up_proj)
+    model.down_proj = quantized_affine(model.down_proj)
+
+    calls = {"pair": 0, "single": 0}
+    orig_pair = fast.deepseek_affine_gather_qmm_pair_concat_blocks
+    orig_single = fast.deepseek_affine_gather_qmm_blocks
+
+    def pair_spy(*args, **kwargs):
+        calls["pair"] += 1
+        return orig_pair(*args, **kwargs)
+
+    def single_spy(*args, **kwargs):
+        calls["single"] += 1
+        return orig_single(*args, **kwargs)
+
+    monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_pair_concat_blocks", pair_spy)
+    monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_blocks", single_spy)
+
+    x = mx.random.normal((1, 32, 128), dtype=mx.bfloat16)
+    indices = mx.array(
+        [[[(i + j) % 8 for j in range(2)] for i in range(32)]],
+        dtype=mx.int32,
+    )
+    y = model(x, indices)
+    mx.eval(y)
+
+    assert y.shape == (1, 32, 2, 128)
+    assert calls == {"pair": 1, "single": 1}
+
+
+def test_deepseek_switchglu_uses_fp16_affine_blocks_for_bf16_inputs(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+
+    try:
+        from omlx.custom_kernels.glm_moe_dsa import fast
+    except Exception as exc:  # pragma: no cover - depends on local native build
+        pytest.skip(f"omlx.custom_kernels.glm_moe_dsa is unavailable: {exc}")
+
+    if not fast.is_native_available():
+        pytest.skip("GLM MoE DSA native extension is unavailable")
+    if not fast.has_symbol("deepseek_affine_gather_qmm_pair_concat_blocks"):
+        pytest.skip("DeepSeek affine block-list kernels are unavailable")
+
+    from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
+
+    mx.random.seed(19)
+
+    def quantized_affine(layer):
+        layer = layer.to_quantized(
+            group_size=64,
+            bits=3,
+            mode="affine",
+        )
+        layer.scales = layer.scales.astype(mx.float16)
+        layer.biases = layer.biases.astype(mx.float16)
+        return layer
+
+    model = SwitchGLU(128, 64, 8)
+    model.gate_proj = quantized_affine(model.gate_proj)
+    model.up_proj = quantized_affine(model.up_proj)
+    model.down_proj = quantized_affine(model.down_proj)
+
+    calls = {"pair": 0, "single": 0, "pair_dtype": None, "single_dtype": None}
+    orig_pair = fast.deepseek_affine_gather_qmm_pair_concat_blocks
+    orig_single = fast.deepseek_affine_gather_qmm_blocks
+
+    def pair_spy(x, *args, **kwargs):
+        calls["pair"] += 1
+        calls["pair_dtype"] = x.dtype
+        return orig_pair(x, *args, **kwargs)
+
+    def single_spy(x, *args, **kwargs):
+        calls["single"] += 1
+        calls["single_dtype"] = x.dtype
+        return orig_single(x, *args, **kwargs)
+
+    monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_pair_concat_blocks", pair_spy)
+    monkeypatch.setattr(fast, "deepseek_affine_gather_qmm_blocks", single_spy)
+
+    x = mx.random.normal((1, 32, 128), dtype=mx.bfloat16)
+    indices = mx.array(
+        [[[(i + j) % 8 for j in range(2)] for i in range(32)]],
+        dtype=mx.int32,
+    )
+    y = model(x, indices)
+    mx.eval(y)
+
+    assert y.dtype == mx.bfloat16
+    assert y.shape == (1, 32, 2, 128)
+    assert calls == {
+        "pair": 1,
+        "single": 1,
+        "pair_dtype": mx.float16,
+        "single_dtype": mx.float16,
+    }
+
+
+def test_deepseek_switchglu_does_not_use_native_weighted_sum(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+
+    from omlx.custom_kernels.glm_moe_dsa import fast
+    from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
+
+    orig_has_symbol = fast.has_symbol
+    calls = {"weighted_sum": 0}
+
+    def has_symbol(name):
+        if name == "glm_moe_weighted_sum":
+            return True
+        return orig_has_symbol(name)
+
+    def weighted_sum_spy(*args, **kwargs):
+        calls["weighted_sum"] += 1
+        raise AssertionError("DeepSeek V4 must use the reference scatter path")
+
+    monkeypatch.setattr(fast, "has_symbol", has_symbol)
+    monkeypatch.setattr(fast, "glm_moe_weighted_sum", weighted_sum_spy)
+
+    mx.random.seed(17)
+    model = SwitchGLU(16, 8, 8)
+    x = mx.random.normal((1, 11, 16), dtype=mx.bfloat16)
+    indices = mx.array(
+        [[[(i + j) % 8 for j in range(6)] for i in range(11)]],
+        dtype=mx.int32,
+    )
+    scores = mx.softmax(
+        mx.random.normal(indices.shape, dtype=mx.float32),
+        axis=-1,
+    )
+
+    y = model(x, indices, scores=scores)
+    mx.eval(y)
+
+    assert y.shape == (1, 11, 6, 16)
+    assert calls["weighted_sum"] == 0
+
+
 def test_glm_direct_sparse_mla_threshold_requires_native(monkeypatch):
     glm_moe_dsa = _load_patched_glm_module()
 

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -345,20 +345,25 @@ def test_glm_native_fused_kernels_match_reference(monkeypatch):
 
     mx.random.seed(7)
 
-    tokens, topk, dims = 8, 8, 64
-    x_sorted = mx.random.normal((tokens * topk, 1, dims), dtype=mx.float16)
-    inv_order = mx.array(list(range(tokens * topk - 1, -1, -1)), dtype=mx.uint32)
-    scores = mx.softmax(
-        mx.random.normal((tokens, topk), dtype=mx.float32),
-        axis=-1,
-    )
-    y_native = fast.glm_moe_weighted_sum(x_sorted, inv_order, scores)
-    x_ref = mx.squeeze(x_sorted, -2)
-    x_ref = mx.take(x_ref, inv_order, axis=0)
-    x_ref = mx.reshape(x_ref, scores.shape + (dims,))
-    y_ref = mx.sum(x_ref * mx.expand_dims(scores, -1), axis=-2).astype(mx.float16)
-    mx.eval(y_native, y_ref)
-    assert float(mx.max(mx.abs(y_native - y_ref)).item()) == 0.0
+    tokens, dims = 8, 64
+    for topk in (8, 6):
+        x_sorted = mx.random.normal((tokens * topk, 1, dims), dtype=mx.float16)
+        inv_order = mx.array(
+            list(range(tokens * topk - 1, -1, -1)), dtype=mx.uint32
+        )
+        scores = mx.softmax(
+            mx.random.normal((tokens, topk), dtype=mx.float32),
+            axis=-1,
+        )
+        y_native = fast.glm_moe_weighted_sum(x_sorted, inv_order, scores)
+        x_ref = mx.squeeze(x_sorted, -2)
+        x_ref = mx.take(x_ref, inv_order, axis=0)
+        x_ref = mx.reshape(x_ref, scores.shape + (dims,))
+        y_ref = mx.sum(x_ref * mx.expand_dims(scores, -1), axis=-2).astype(
+            mx.float16
+        )
+        mx.eval(y_native, y_ref)
+        assert float(mx.max(mx.abs(y_native - y_ref)).item()) == 0.0
 
     batch, heads, length, latent, values = 1, 64, 1, 512, 256
     x = mx.random.normal((batch, heads, length, latent), dtype=mx.float16)

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -30,6 +30,7 @@ from omlx.oq import (
     _build_proxy_for_sensitivity,
     _build_quant_plan,
     _build_streaming_proxy_for_sensitivity,
+    _config_expects_moe_expert_counts,
     _discover_sanitize_plan,
     _DiscoveredPlan,
     _extract_layer_index,
@@ -40,6 +41,7 @@ from omlx.oq import (
     _ImatrixCaptureWrapper,
     _imatrix_expert_coverage_stats,
     _imatrix_expert_coverage_sufficient,
+    _imatrix_requires_expert_counts,
     _is_audio_tensor,
     _is_moe_router,
     _is_vision_tensor,
@@ -1009,17 +1011,16 @@ class TestLevelBudgetPlan:
     def test_bpw_targets_for_level_returns_correct_values(self):
         assert _bpw_targets_for_level(2.5) == (3.1, 3.3)
         assert _bpw_targets_for_level(2.7) == (3.25, 3.35)
-        assert _bpw_targets_for_level(2.8) == (3.35, 3.45)
         assert _bpw_targets_for_level(3) == (3.5, 3.7)
         assert _bpw_targets_for_level(3.5) == (3.8, 4.0)
         assert _bpw_targets_for_level(4) == (4.6, 4.7)
         assert _bpw_targets_for_level(5) == (5.5, 5.7)
         assert _bpw_targets_for_level(6) == (6.5, 6.7)
+        assert _bpw_targets_for_level(2.8) is None
 
     def test_oq2_fractional_base_bits_are_2(self):
         assert _LEVEL_BITS[2.5] == 2
         assert _LEVEL_BITS[2.7] == 2
-        assert _LEVEL_BITS[2.8] == 2
 
     def test_oq35_mandatory_expert_down_proj_boost(self):
         """oQ3.5 protects routed expert down_proj above base bits
@@ -1057,9 +1058,9 @@ class TestLevelBudgetPlan:
         assert isinstance(result, dict)
         assert result["bits"] == 4
 
-    @pytest.mark.parametrize("oq_level", [2.5, 2.7, 2.8])
+    @pytest.mark.parametrize("oq_level", [2.5, 2.7])
     def test_oq2x_predicate_keeps_routed_down_proj_at_base_without_plan(self, oq_level):
-        """oQ2.5/oQ2.7/oQ2.8 use budget-planned routed boosts."""
+        """oQ2.5/oQ2.7 use budget-planned routed boosts."""
         config = {
             "num_hidden_layers": 32,
             "num_experts": 8,
@@ -1082,10 +1083,12 @@ class TestLevelBudgetPlan:
         assert _bpw_targets_for_level(2) == (2.8, 3.0)
 
     def test_oq2_fractional_levels_use_routed_layer_boosts(self):
-        for level in (2.5, 2.7, 2.8):
+        for level in (2.5, 2.7):
             assert level in OQ_LEVELS
             assert level in _ROUTED_LAYER_BOOST_LEVELS
             assert level not in _LEVEL_EXPERT_DOWN_BOOST
+        assert 2.8 not in OQ_LEVELS
+        assert 2.8 not in _ROUTED_LAYER_BOOST_LEVELS
 
     def test_budget_plan_oq8_not_enabled(self):
         assert 8 not in _OQ_BPW_TARGETS
@@ -1191,9 +1194,9 @@ class TestLevelBudgetPlan:
         for k in plan.boost_map:
             assert "switch_mlp" not in k
 
-    @pytest.mark.parametrize("oq_level", [2.5, 2.7, 2.8])
+    @pytest.mark.parametrize("oq_level", [2.5, 2.7])
     def test_oq2x_boosts_routed_down_proj_by_layer_sensitivity(self, oq_level):
-        """oQ2.5/oQ2.7/oQ2.8 boost routed projections by whole layer modules."""
+        """oQ2.5/oQ2.7 boost routed projections by whole layer modules."""
         named_shapes = {}
         for i in range(2):
             named_shapes[f"model.layers.{i}.ffn.switch_mlp.gate_proj"] = (8, 64, 64)
@@ -1210,9 +1213,9 @@ class TestLevelBudgetPlan:
         assert plan.boost_map["model.layers.0.ffn.switch_mlp.down_proj"]["bits"] == 3
         assert "model.layers.1.ffn.switch_mlp.down_proj" not in plan.boost_map
 
-    @pytest.mark.parametrize("oq_level", [2.5, 2.7, 2.8])
+    @pytest.mark.parametrize("oq_level", [2.5, 2.7])
     def test_oq2x_boosts_gate_up_pair_after_routed_down_proj(self, oq_level):
-        """After routed w2/down_proj, oQ2.5/oQ2.7/oQ2.8 boost gate+up as a pair."""
+        """After routed w2/down_proj, oQ2.5/oQ2.7 boost gate+up as a pair."""
         named_shapes = {
             "model.layers.0.ffn.switch_mlp.gate_proj": (8, 64, 64),
             "model.layers.0.ffn.switch_mlp.up_proj": (8, 64, 64),
@@ -1229,6 +1232,24 @@ class TestLevelBudgetPlan:
         assert plan.boost_map["model.layers.0.ffn.switch_mlp.down_proj"]["bits"] == 3
         assert plan.boost_map["model.layers.0.ffn.switch_mlp.gate_proj"]["bits"] == 3
         assert plan.boost_map["model.layers.0.ffn.switch_mlp.up_proj"]["bits"] == 3
+
+    @pytest.mark.parametrize("oq_level", [2.5, 2.7])
+    def test_oq2x_prioritizes_routed_down_before_dense_greedy(self, oq_level):
+        """Code-preserving 2-bit levels spend target budget on routed down first."""
+        named_shapes = {
+            "model.layers.0.ffn.switch_mlp.down_proj": (8, 64, 64),
+            "model.layers.0.mlp.gate_proj": (8, 64, 64),
+        }
+        config = {
+            "num_hidden_layers": 2,
+            "_oq_use_budget_plan": True,
+            "_oq_sensitivity_map": {"0": 1.0, "1": 0.1},
+        }
+        plan = _build_quant_plan(
+            named_shapes, config, oq_level, target_bpw=3.0, hard_cap_bpw=3.01
+        )
+        assert plan.boost_map["model.layers.0.ffn.switch_mlp.down_proj"]["bits"] == 3
+        assert "model.layers.0.mlp.gate_proj" not in plan.boost_map
 
     def test_oq2_budget_plan_respects_cap(self):
         """oQ2 with budget plan should stay within hard cap."""
@@ -1712,6 +1733,52 @@ class TestOQImatrixCollector:
         assert stats["zero_count_experts"] == 0
         assert stats["p05_count"] >= 16
         assert _imatrix_expert_coverage_sufficient(stats) is True
+
+    def test_expert_coverage_requires_counts_for_moe_config(self):
+        dense_only = {
+            "dense": OQImatrixEntry(
+                in_sum2=np.zeros((8,), dtype=np.float32),
+                counts=np.array([1024], dtype=np.int64),
+            )
+        }
+        stats = _imatrix_expert_coverage_stats(dense_only)
+
+        assert stats["has_expert_counts"] is False
+        assert _imatrix_expert_coverage_sufficient(stats) is True
+        assert (
+            _imatrix_expert_coverage_sufficient(stats, require_expert_counts=True)
+            is False
+        )
+        assert _config_expects_moe_expert_counts({"n_routed_experts": 256}) is True
+        assert _imatrix_requires_expert_counts({"n_routed_experts": 256}, 0) is False
+        assert _imatrix_requires_expert_counts({"n_routed_experts": 256}, 3) is True
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not installed")
+    def test_quantized_switch_linear_capture_uses_logical_input_dims(self):
+        class QuantizedSwitchLinear:
+            weight = mx.zeros((3, 2, 1), dtype=mx.uint32)
+
+            @property
+            def input_dims(self):
+                return 4
+
+            @property
+            def num_experts(self):
+                return 3
+
+        module = QuantizedSwitchLinear()
+        collector = OQImatrixCollector()
+        x = mx.array([[[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]])
+        indices = mx.array([[[0, 2], [2, 1]]], dtype=mx.int32)
+
+        assert collector._is_capture_module(module) is True
+        collector.collect_switch("experts", module, x, indices)
+
+        entry = collector.entries["experts"]
+        np.testing.assert_array_equal(entry.counts, np.array([1, 1, 2]))
+        np.testing.assert_allclose(entry.in_sum2[0], np.array([1.0, 4.0, 9.0, 16.0]))
+        np.testing.assert_allclose(entry.in_sum2[1], np.array([25.0, 36.0, 49.0, 64.0]))
+        np.testing.assert_allclose(entry.in_sum2[2], np.array([26.0, 40.0, 58.0, 80.0]))
 
 
 class TestOQECalibrationData:

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -19,10 +19,12 @@ except ImportError:
 
 from omlx.oq import (
     _LEVEL_BITS,
+    _LEVEL_EXPERT_DOWN_BOOST,
     _MAX_MODEL_RAM_FRACTION,
     _OQ_BPW_TARGETS,
     _PROXY_QUANT_BITS,
     _PROXY_QUANT_GROUP_SIZE,
+    _ROUTED_LAYER_BOOST_LEVELS,
     OQ_LEVELS,
     _bpw_targets_for_level,
     _build_proxy_for_sensitivity,
@@ -1006,6 +1008,7 @@ class TestLevelBudgetPlan:
 
     def test_bpw_targets_for_level_returns_correct_values(self):
         assert _bpw_targets_for_level(2.5) == (3.1, 3.3)
+        assert _bpw_targets_for_level(2.7) == (3.25, 3.35)
         assert _bpw_targets_for_level(2.8) == (3.35, 3.45)
         assert _bpw_targets_for_level(3) == (3.5, 3.7)
         assert _bpw_targets_for_level(3.5) == (3.8, 4.0)
@@ -1013,8 +1016,9 @@ class TestLevelBudgetPlan:
         assert _bpw_targets_for_level(5) == (5.5, 5.7)
         assert _bpw_targets_for_level(6) == (6.5, 6.7)
 
-    def test_oq25_base_bits_is_2(self):
+    def test_oq2_fractional_base_bits_are_2(self):
         assert _LEVEL_BITS[2.5] == 2
+        assert _LEVEL_BITS[2.7] == 2
         assert _LEVEL_BITS[2.8] == 2
 
     @pytest.mark.parametrize("oq_level,expected_bits", [(2.5, 3), (3.5, 4)])
@@ -1054,15 +1058,16 @@ class TestLevelBudgetPlan:
         assert isinstance(result, dict)
         assert result["bits"] == expected_bits
 
-    def test_oq28_predicate_keeps_routed_down_proj_at_base_without_plan(self):
-        """oQ2.8 uses budget-planned routed boosts, not a blanket predicate floor."""
+    @pytest.mark.parametrize("oq_level", [2.7, 2.8])
+    def test_oq2x_predicate_keeps_routed_down_proj_at_base_without_plan(self, oq_level):
+        """oQ2.7/oQ2.8 use budget-planned routed boosts, not a blanket floor."""
         config = {
             "num_hidden_layers": 32,
             "num_experts": 8,
             "hidden_size": 1024,
         }
         result = universal_quant_predicate(
-            "model.layers.5.mlp.switch_mlp.down_proj", None, config, 2.8
+            "model.layers.5.mlp.switch_mlp.down_proj", None, config, oq_level
         )
         assert result is True
 
@@ -1076,6 +1081,11 @@ class TestLevelBudgetPlan:
     def test_budget_plan_oq2_enabled(self):
         assert 2 in _OQ_BPW_TARGETS
         assert _bpw_targets_for_level(2) == (2.8, 3.0)
+
+    def test_oq27_uses_routed_layer_boosts(self):
+        assert 2.7 in OQ_LEVELS
+        assert 2.7 in _ROUTED_LAYER_BOOST_LEVELS
+        assert 2.7 not in _LEVEL_EXPERT_DOWN_BOOST
 
     def test_budget_plan_oq8_not_enabled(self):
         assert 8 not in _OQ_BPW_TARGETS
@@ -1181,8 +1191,9 @@ class TestLevelBudgetPlan:
         for k in plan.boost_map:
             assert "switch_mlp" not in k
 
-    def test_oq28_boosts_routed_down_proj_by_layer_sensitivity(self):
-        """oQ2.8 can boost routed projections, but only by whole layer modules."""
+    @pytest.mark.parametrize("oq_level", [2.7, 2.8])
+    def test_oq2x_boosts_routed_down_proj_by_layer_sensitivity(self, oq_level):
+        """oQ2.7/oQ2.8 boost routed projections by whole layer modules."""
         named_shapes = {}
         for i in range(2):
             named_shapes[f"model.layers.{i}.ffn.switch_mlp.gate_proj"] = (8, 64, 64)
@@ -1194,13 +1205,14 @@ class TestLevelBudgetPlan:
             "_oq_sensitivity_map": {"0": 1.0, "1": 0.1},
         }
         plan = _build_quant_plan(
-            named_shapes, config, 2.8, target_bpw=2.65, hard_cap_bpw=2.7
+            named_shapes, config, oq_level, target_bpw=2.65, hard_cap_bpw=2.7
         )
         assert plan.boost_map["model.layers.0.ffn.switch_mlp.down_proj"]["bits"] == 3
         assert "model.layers.1.ffn.switch_mlp.down_proj" not in plan.boost_map
 
-    def test_oq28_boosts_gate_up_pair_after_routed_down_proj(self):
-        """After routed w2/down_proj, oQ2.8 boosts gate+up as a layer pair."""
+    @pytest.mark.parametrize("oq_level", [2.7, 2.8])
+    def test_oq2x_boosts_gate_up_pair_after_routed_down_proj(self, oq_level):
+        """After routed w2/down_proj, oQ2.7/oQ2.8 boost gate+up as a pair."""
         named_shapes = {
             "model.layers.0.ffn.switch_mlp.gate_proj": (8, 64, 64),
             "model.layers.0.ffn.switch_mlp.up_proj": (8, 64, 64),
@@ -1212,7 +1224,7 @@ class TestLevelBudgetPlan:
             "_oq_sensitivity_map": {"0": 1.0},
         }
         plan = _build_quant_plan(
-            named_shapes, config, 2.8, target_bpw=3.4, hard_cap_bpw=3.6
+            named_shapes, config, oq_level, target_bpw=3.4, hard_cap_bpw=3.6
         )
         assert plan.boost_map["model.layers.0.ffn.switch_mlp.down_proj"]["bits"] == 3
         assert plan.boost_map["model.layers.0.ffn.switch_mlp.gate_proj"]["bits"] == 3
@@ -3854,9 +3866,7 @@ class TestMeasureSensitivityVlmMtp:
         # lm_load_compat from it. Expose the real shim and pin the capability
         # flag so forwarding is deterministic regardless of installed mlx-lm.
         monkeypatch.setattr(real_ml, "_LM_LOAD_ACCEPTS_TRC", True)
-        sys.modules["omlx.utils.model_loading"].lm_load_compat = (
-            real_ml.lm_load_compat
-        )
+        sys.modules["omlx.utils.model_loading"].lm_load_compat = real_ml.lm_load_compat
 
         _measure_sensitivity(
             "/fake/text",

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -1234,8 +1234,8 @@ class TestLevelBudgetPlan:
         assert plan.boost_map["model.layers.0.ffn.switch_mlp.up_proj"]["bits"] == 3
 
     @pytest.mark.parametrize("oq_level", [2.5, 2.7])
-    def test_oq2x_prioritizes_routed_down_before_dense_greedy(self, oq_level):
-        """Code-preserving 2-bit levels spend target budget on routed down first."""
+    def test_oq2x_prioritizes_dense_greedy_before_routed_fallback(self, oq_level):
+        """oQ2.5/oQ2.7 spend target budget on dense sensitivity first."""
         named_shapes = {
             "model.layers.0.ffn.switch_mlp.down_proj": (8, 64, 64),
             "model.layers.0.mlp.gate_proj": (8, 64, 64),
@@ -1248,8 +1248,8 @@ class TestLevelBudgetPlan:
         plan = _build_quant_plan(
             named_shapes, config, oq_level, target_bpw=3.0, hard_cap_bpw=3.01
         )
-        assert plan.boost_map["model.layers.0.ffn.switch_mlp.down_proj"]["bits"] == 3
-        assert "model.layers.0.mlp.gate_proj" not in plan.boost_map
+        assert plan.boost_map["model.layers.0.mlp.gate_proj"]["bits"] == 3
+        assert "model.layers.0.ffn.switch_mlp.down_proj" not in plan.boost_map
 
     def test_oq2_budget_plan_respects_cap(self):
         """oQ2 with budget plan should stay within hard cap."""

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -1315,9 +1315,9 @@ class TestLevelBudgetPlan:
         plan = _build_quant_plan(
             named_shapes, config, 2, target_bpw=2.8, hard_cap_bpw=3.0
         )
-        assert plan.effective_bpw >= 2.7, (
-            f"Expected bpw >= 2.7, got {plan.effective_bpw:.2f}"
-        )
+        assert (
+            plan.effective_bpw >= 2.7
+        ), f"Expected bpw >= 2.7, got {plan.effective_bpw:.2f}"
         assert plan.effective_bpw <= 3.0
         # Attention should be boosted via protection floor
         attn_boosts = [k for k in plan.boost_map if "q_proj" in k or "v_proj" in k]
@@ -3402,9 +3402,9 @@ class TestQuantizeOqStreamingFp8:
 
         idx = _LazyTensorIndex([str(src / "model.safetensors")])
         assert len(idx._fp8_pairs) == 0, "BF16 weight should not pair with .scale"
-        assert "model.layers.0.self_attn.q_proj.scale" in idx, (
-            "scale key must remain visible"
-        )
+        assert (
+            "model.layers.0.self_attn.q_proj.scale" in idx
+        ), "scale key must remain visible"
 
 
 # =============================================================================

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -1021,10 +1021,10 @@ class TestLevelBudgetPlan:
         assert _LEVEL_BITS[2.7] == 2
         assert _LEVEL_BITS[2.8] == 2
 
-    @pytest.mark.parametrize("oq_level,expected_bits", [(2.5, 3), (3.5, 4)])
-    def test_half_level_mandatory_expert_down_proj_boost(self, oq_level, expected_bits):
-        """Fractional levels protect routed expert down_proj above base bits
+    def test_oq35_mandatory_expert_down_proj_boost(self):
+        """oQ3.5 protects routed expert down_proj above base bits
         even with negligible sensitivity scores."""
+        oq_level = 3.5
         named_shapes = {
             "model.layers.0.mlp.switch_mlp.down_proj": (8, 256, 256),
             "model.layers.0.mlp.switch_mlp.gate_proj": (8, 256, 256),
@@ -1042,25 +1042,24 @@ class TestLevelBudgetPlan:
         )
         boost = plan.boost_map.get("model.layers.0.mlp.switch_mlp.down_proj")
         assert boost is not None
-        assert boost["bits"] == expected_bits
+        assert boost["bits"] == 4
 
-    @pytest.mark.parametrize("oq_level,expected_bits", [(2.5, 3), (3.5, 4)])
-    def test_predicate_floor_for_expert_down_proj(self, oq_level, expected_bits):
-        """The non-budget predicate floor mirrors the mandatory boost."""
+    def test_oq35_predicate_floor_for_expert_down_proj(self):
+        """The non-budget predicate floor mirrors the oQ3.5 mandatory boost."""
         config = {
             "num_hidden_layers": 32,
             "num_experts": 8,
             "hidden_size": 1024,
         }
         result = universal_quant_predicate(
-            "model.layers.5.mlp.switch_mlp.down_proj", None, config, oq_level
+            "model.layers.5.mlp.switch_mlp.down_proj", None, config, 3.5
         )
         assert isinstance(result, dict)
-        assert result["bits"] == expected_bits
+        assert result["bits"] == 4
 
-    @pytest.mark.parametrize("oq_level", [2.7, 2.8])
+    @pytest.mark.parametrize("oq_level", [2.5, 2.7, 2.8])
     def test_oq2x_predicate_keeps_routed_down_proj_at_base_without_plan(self, oq_level):
-        """oQ2.7/oQ2.8 use budget-planned routed boosts, not a blanket floor."""
+        """oQ2.5/oQ2.7/oQ2.8 use budget-planned routed boosts."""
         config = {
             "num_hidden_layers": 32,
             "num_experts": 8,
@@ -1082,10 +1081,11 @@ class TestLevelBudgetPlan:
         assert 2 in _OQ_BPW_TARGETS
         assert _bpw_targets_for_level(2) == (2.8, 3.0)
 
-    def test_oq27_uses_routed_layer_boosts(self):
-        assert 2.7 in OQ_LEVELS
-        assert 2.7 in _ROUTED_LAYER_BOOST_LEVELS
-        assert 2.7 not in _LEVEL_EXPERT_DOWN_BOOST
+    def test_oq2_fractional_levels_use_routed_layer_boosts(self):
+        for level in (2.5, 2.7, 2.8):
+            assert level in OQ_LEVELS
+            assert level in _ROUTED_LAYER_BOOST_LEVELS
+            assert level not in _LEVEL_EXPERT_DOWN_BOOST
 
     def test_budget_plan_oq8_not_enabled(self):
         assert 8 not in _OQ_BPW_TARGETS
@@ -1191,9 +1191,9 @@ class TestLevelBudgetPlan:
         for k in plan.boost_map:
             assert "switch_mlp" not in k
 
-    @pytest.mark.parametrize("oq_level", [2.7, 2.8])
+    @pytest.mark.parametrize("oq_level", [2.5, 2.7, 2.8])
     def test_oq2x_boosts_routed_down_proj_by_layer_sensitivity(self, oq_level):
-        """oQ2.7/oQ2.8 boost routed projections by whole layer modules."""
+        """oQ2.5/oQ2.7/oQ2.8 boost routed projections by whole layer modules."""
         named_shapes = {}
         for i in range(2):
             named_shapes[f"model.layers.{i}.ffn.switch_mlp.gate_proj"] = (8, 64, 64)
@@ -1210,9 +1210,9 @@ class TestLevelBudgetPlan:
         assert plan.boost_map["model.layers.0.ffn.switch_mlp.down_proj"]["bits"] == 3
         assert "model.layers.1.ffn.switch_mlp.down_proj" not in plan.boost_map
 
-    @pytest.mark.parametrize("oq_level", [2.7, 2.8])
+    @pytest.mark.parametrize("oq_level", [2.5, 2.7, 2.8])
     def test_oq2x_boosts_gate_up_pair_after_routed_down_proj(self, oq_level):
-        """After routed w2/down_proj, oQ2.7/oQ2.8 boost gate+up as a pair."""
+        """After routed w2/down_proj, oQ2.5/oQ2.7/oQ2.8 boost gate+up as a pair."""
         named_shapes = {
             "model.layers.0.ffn.switch_mlp.gate_proj": (8, 64, 64),
             "model.layers.0.ffn.switch_mlp.up_proj": (8, 64, 64),
@@ -4170,7 +4170,7 @@ class TestReplayChainGuards:
 
 
 # =============================================================================
-# End-to-end: oQ2.5 half-level
+# End-to-end: oQ2.5 routed-layer boost
 # =============================================================================
 
 
@@ -4178,7 +4178,7 @@ class TestReplayChainGuards:
 class TestQuantizeOqStreamingOq25:
     def test_oq25_end_to_end_synthetic_moe(self, tmp_path):
         """oQ2.5 output: 2-bit affine base with routed expert down_proj
-        protected at 3-bit via the mandatory half-level boost."""
+        selected at 3-bit through the routed-layer budget plan."""
         from safetensors.numpy import save_file as np_save
 
         src = tmp_path / "src"
@@ -4190,6 +4190,9 @@ class TestQuantizeOqStreamingOq25:
                     8, h, h
                 ).astype(np.float32),
                 "model.layers.0.mlp.switch_mlp.gate_proj.weight": np.random.randn(
+                    8, h, h
+                ).astype(np.float32),
+                "model.layers.0.mlp.switch_mlp.up_proj.weight": np.random.randn(
                     8, h, h
                 ).astype(np.float32),
                 "model.layers.0.self_attn.q_proj.weight": np.random.randn(h, h).astype(
@@ -4233,3 +4236,4 @@ class TestQuantizeOqStreamingOq25:
             tensors.update(mx.load(str(sf)))
         assert "model.layers.0.mlp.switch_mlp.down_proj.scales" in tensors
         assert "model.layers.0.mlp.switch_mlp.gate_proj.scales" in tensors
+        assert "model.layers.0.mlp.switch_mlp.up_proj.scales" in tensors

--- a/tests/test_oq_manager.py
+++ b/tests/test_oq_manager.py
@@ -5,7 +5,7 @@ import json
 
 import pytest
 
-from omlx.admin.oq_manager import OQManager
+from omlx.admin.oq_manager import OQManager, QuantStatus, QuantTask
 
 
 @pytest.fixture
@@ -179,6 +179,38 @@ class TestOQManagerDtypeSupport:
 
         assert manager._tasks == {}
         assert not (root / "DeepSeek-V4-Flash-oQ4-fp16").exists()
+
+
+class TestOQManagerProgress:
+    def test_byte_level_quant_progress_disables_time_estimator(self):
+        task = QuantTask(
+            task_id="task",
+            model_name="Model",
+            model_path="/tmp/Model",
+            oq_level=2.5,
+            output_name="Model-oQ2.5e",
+            output_path="/tmp/Model-oQ2.5e",
+            status=QuantStatus.QUANTIZING,
+            progress=39.0,
+            progress_meta={"processed_bytes": 31, "total_bytes": 100},
+        )
+
+        assert OQManager._has_explicit_quant_progress(task) is True
+
+    def test_non_byte_quant_progress_can_use_time_estimator(self):
+        task = QuantTask(
+            task_id="task",
+            model_name="Model",
+            model_path="/tmp/Model",
+            oq_level=2.5,
+            output_name="Model-oQ2.5e",
+            output_path="/tmp/Model-oQ2.5e",
+            status=QuantStatus.QUANTIZING,
+            progress=30.0,
+            progress_meta={},
+        )
+
+        assert OQManager._has_explicit_quant_progress(task) is False
 
 
 class TestOQManagerEnhanced:

--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -68,6 +68,17 @@ class CohereTokenizer:
         return "".join(self._token_map[token_id] for token_id in token_ids)
 
 
+class DeepSeekV4Tokenizer(CohereTokenizer):
+    has_tool_calling = True
+    tool_call_start = "<｜DSML｜tool_calls>"
+    tool_call_end = "</｜DSML｜tool_calls>"
+
+    def tool_parser(self, text: str, tools=None):
+        from omlx.patches.deepseek_v4.tool_parser_v4 import parse_tool_call
+
+        return parse_tool_call(text, tools)
+
+
 class _FakeMelodyOptions:
     def cmd4(self):
         return self
@@ -253,13 +264,16 @@ class TestCohere2MoeOutputParserSession:
                         name="edit",
                         arguments=literal_newline_args,
                     )
-                    return SimpleNamespace(content=None, reasoning=None, tool_calls=[tc])
+                    return SimpleNamespace(
+                        content=None, reasoning=None, tool_calls=[tc]
+                    )
                 return SimpleNamespace(content=None, reasoning=None, tool_calls=[])
 
             def flush_partials(self):
                 return SimpleNamespace(content=None, reasoning=None, tool_calls=[])
 
         import types, json as _json
+
         module = types.ModuleType("cohere_melody")
         module.PyFilter = _FakeMelodyFilterLiteralNewline
         module.PyFilterOptions = _FakeMelodyOptions
@@ -267,6 +281,7 @@ class TestCohere2MoeOutputParserSession:
 
         tokenizer = CohereTokenizer({"TC": "TC"})
         from omlx.adapter.output_parser import Cohere2MoeOutputParserSession
+
         session = Cohere2MoeOutputParserSession.__new__(Cohere2MoeOutputParserSession)
         session._tokenizer = tokenizer
         session._melody = _FakeMelodyFilterLiteralNewline(None)
@@ -477,6 +492,90 @@ class TestGemma4OutputParserSession:
 
 
 class TestOutputParserFactory:
+    def test_detects_deepseek_v4_by_config(self):
+        tokenizer = DeepSeekV4Tokenizer({1: "x"})
+        factory = detect_output_parser(
+            "DeepSeek-V4-Flash-oQ4e",
+            tokenizer,
+            {"model_type": "deepseek_v4"},
+        )
+
+        assert factory is not None
+        assert factory.kind == "deepseek_v4"
+
+    def test_deepseek_v4_stops_at_first_dsml_tool_block(self):
+        tokenizer = DeepSeekV4Tokenizer(
+            {
+                1: "Before ",
+                2: "<｜DSML｜tool",
+                3: '_calls>\n<｜DSML｜invoke name="Bash">\n',
+                4: '<｜DSML｜parameter name="command" string="true">ls</｜DSML｜parameter>\n'
+                "</｜DSML｜invoke>\n",
+                5: "</｜DSML｜tool_calls>",
+            }
+        )
+        factory = detect_output_parser(
+            "DeepSeek-V4-Flash-oQ4e",
+            tokenizer,
+            {"model_type": "deepseek_v4"},
+        )
+        session = factory.create_session(tokenizer)
+
+        stream = []
+        visible = []
+        stop_seen = False
+        for token_id in [1, 2, 3, 4, 5]:
+            result = session.process_token(token_id)
+            stream.append(result.stream_text)
+            visible.append(result.visible_text)
+            stop_seen = stop_seen or result.is_stop
+            assert result.record_token is True
+
+        final = session.finalize()
+        stream.append(final.stream_text)
+        visible.append(final.visible_text)
+
+        assert stop_seen is True
+        assert "".join(stream) == "Before "
+        assert "".join(visible) == "Before "
+        assert final.finish_reason == "tool_calls"
+        assert len(final.tool_calls) == 1
+        assert final.tool_calls[0]["name"] == "Bash"
+        assert json.loads(final.tool_calls[0]["arguments"]) == {"command": "ls"}
+
+    def test_deepseek_v4_drops_text_after_tool_end_in_same_token(self):
+        tokenizer = DeepSeekV4Tokenizer(
+            {
+                1: '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="Bash">\n',
+                2: '<｜DSML｜parameter name="command" string="true">ls</｜DSML｜parameter>\n'
+                "</｜DSML｜invoke>\n",
+                3: "</｜DSML｜tool_calls>\n"
+                '<｜DSML｜parameter name="command" string="true">pwd</｜DSML｜parameter>',
+            }
+        )
+        factory = detect_output_parser(
+            "DeepSeek-V4-Flash-oQ4e",
+            tokenizer,
+            {"model_type": "deepseek_v4"},
+        )
+        session = factory.create_session(tokenizer)
+
+        stream = []
+        stop_seen = False
+        for token_id in [1, 2, 3]:
+            result = session.process_token(token_id)
+            stream.append(result.stream_text)
+            stop_seen = stop_seen or result.is_stop
+
+        final = session.finalize()
+        stream.append(final.stream_text)
+
+        assert stop_seen is True
+        assert "".join(stream) == ""
+        assert final.finish_reason == "tool_calls"
+        assert len(final.tool_calls) == 1
+        assert json.loads(final.tool_calls[0]["arguments"]) == {"command": "ls"}
+
     def test_detects_minimax_m3_by_config(self):
         tokenizer = CohereTokenizer({1: "x"})
         factory = detect_output_parser(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -75,7 +75,7 @@ class TestSchedulerConfig:
         assert config.policy == SchedulingPolicy.FCFS
         assert config.completion_batch_size == 32
         assert config.embedding_batch_size == 32
-        assert config.prefill_step_size == 2048
+        assert config.prefill_step_size == 512
         assert config.paged_cache_block_size == 256
         assert config.max_cache_blocks is None
         assert config.initial_cache_blocks == 256

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -75,7 +75,7 @@ class TestSchedulerConfig:
         assert config.policy == SchedulingPolicy.FCFS
         assert config.completion_batch_size == 32
         assert config.embedding_batch_size == 32
-        assert config.prefill_step_size == 512
+        assert config.prefill_step_size == 2048
         assert config.paged_cache_block_size == 256
         assert config.max_cache_blocks is None
         assert config.initial_cache_blocks == 256

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3883,6 +3883,16 @@ class TestOutputParserSmoke:
         def decode(self, token_ids, skip_special_tokens: bool = True):
             return "".join(self._token_map.get(token_id, "") for token_id in token_ids)
 
+    class _DeepSeekV4Tokenizer(_GemmaTokenizer):
+        has_tool_calling = True
+        tool_call_start = "<｜DSML｜tool_calls>"
+        tool_call_end = "</｜DSML｜tool_calls>"
+
+        def tool_parser(self, text: str, tools=None):
+            from omlx.patches.deepseek_v4.tool_parser_v4 import parse_tool_call
+
+            return parse_tool_call(text, tools)
+
     def test_gemma4_session_selected_and_markers_hidden(self, mock_model):
         mock_model.config.model_type = "gemma4"
         tokenizer = self._GemmaTokenizer(
@@ -4012,6 +4022,62 @@ class TestOutputParserSmoke:
         assert finished_ids == {"parser-stop-req"}
         assert outputs[-1].finished is True
         assert outputs[-1].finish_reason == "stop"
+
+    def test_deepseek_v4_tool_block_end_stops_batch_row(self, mock_model):
+        mock_model.config.model_type = "deepseek_v4"
+        tokenizer = self._DeepSeekV4Tokenizer(
+            {
+                11: "Working\n",
+                12: '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="Bash">\n',
+                13: '<｜DSML｜parameter name="command" string="true">ls</｜DSML｜parameter>\n'
+                "</｜DSML｜invoke>\n"
+                "</｜DSML｜tool_calls>\n"
+                '<｜DSML｜parameter name="command" string="true">pwd</｜DSML｜parameter>',
+            }
+        )
+        scheduler = Scheduler(
+            model=mock_model,
+            tokenizer=tokenizer,
+            config=SchedulerConfig(model_name="DeepSeek-V4-Flash-oQ4e"),
+        )
+
+        assert scheduler._output_parser_kind == "deepseek_v4"
+
+        request = Request(
+            request_id="deepseek-v4-tool-req",
+            prompt="prompt",
+            sampling_params=SamplingParams(max_tokens=5),
+            prompt_token_ids=[1, 2, 3],
+            num_prompt_tokens=3,
+            status=RequestStatus.RUNNING,
+            batch_uid=99,
+        )
+        scheduler.running[request.request_id] = request
+        scheduler.requests[request.request_id] = request
+        scheduler.uid_to_request_id[99] = request.request_id
+        scheduler.request_id_to_uid[request.request_id] = 99
+
+        responses = [
+            type("Resp", (), {"uid": 99, "token": 11, "finish_reason": None})(),
+            type("Resp", (), {"uid": 99, "token": 12, "finish_reason": None})(),
+            type("Resp", (), {"uid": 99, "token": 13, "finish_reason": None})(),
+        ]
+
+        outputs, finished_ids = scheduler._process_batch_responses(responses)
+
+        assert finished_ids == {"deepseek-v4-tool-req"}
+        assert outputs[-1].finished is True
+        assert outputs[-1].finish_reason == "tool_calls"
+        assert outputs[-1].output_text == "Working\n"
+        assert outputs[-1].new_token_ids == []
+        assert outputs[-1].tool_calls
+        assert outputs[-1].tool_calls[0]["name"] == "Bash"
+        assert json.loads(outputs[-1].tool_calls[0]["arguments"]) == {"command": "ls"}
+
+        full_stream = "".join(output.new_text for output in outputs)
+        assert full_stream == "Working\n"
+        assert "pwd" not in full_stream
+        assert "<｜DSML｜parameter" not in full_stream
 
 
 class TestVLMPositionStateClearing:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2727,6 +2727,42 @@ class TestExtractCacheStatesRotatingNormalization:
         assert bool(mx.all(normalized_values == expected_values).item())
         assert normalized_meta == ("0", "128", "1280", "128")
 
+    def test_extract_cache_states_normalizes_nested_cachelist_rotating_snapshot(
+        self, mock_model, mock_tokenizer
+    ):
+        """CacheList sub-caches should receive the same rotating normalization."""
+        mx = pytest.importorskip("mlx.core")
+        cache_mod = pytest.importorskip("mlx_lm.models.cache")
+        CacheList = cache_mod.CacheList
+        RotatingKVCache = cache_mod.RotatingKVCache
+
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+
+        rotating = RotatingKVCache(max_size=128, keep=0)
+        rotating.keys = mx.arange(255).reshape(1, 1, 255, 1)
+        rotating.values = mx.arange(1000, 1255).reshape(1, 1, 255, 1)
+        rotating.offset = 1280
+        rotating._idx = 255
+        cache_list = CacheList(rotating)
+
+        expected_keys = rotating.keys[..., -128:, :]
+        expected_values = rotating.values[..., -128:, :]
+
+        extracted, _ = scheduler._extract_cache_states([cache_list])
+
+        assert len(extracted) == 1
+        assert extracted[0]["class_name"] == "CacheList"
+        sub_states = extracted[0]["state"]
+        sub_class_names, sub_meta_states = extracted[0]["meta_state"]
+        normalized_keys, normalized_values = sub_states[0]
+
+        assert sub_class_names == ["RotatingKVCache"]
+        assert tuple(sub_meta_states[0]) == ("0", "128", "1280", "128")
+        assert normalized_keys.shape == (1, 1, 128, 1)
+        assert normalized_values.shape == (1, 1, 128, 1)
+        assert bool(mx.all(normalized_keys == expected_keys).item())
+        assert bool(mx.all(normalized_values == expected_values).item())
+
 
 class TestSchedulerSSDLayerSignature:
     """Tests for pre-lookup SSD layer signature refresh."""

--- a/tests/test_scheduler_prompt_boundary_store.py
+++ b/tests/test_scheduler_prompt_boundary_store.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for parser-stop prompt-boundary cache storage."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from omlx.request import Request, SamplingParams
+from omlx.scheduler import Scheduler, SchedulerConfig
+
+
+def _scheduler() -> Scheduler:
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.block_aware_cache = object()
+    scheduler.config = SchedulerConfig(paged_cache_block_size=4)
+    return scheduler
+
+
+def _request(prompt_tokens):
+    return SimpleNamespace(
+        prompt_token_ids=prompt_tokens,
+        specprefill_indices=None,
+    )
+
+
+def test_prompt_boundary_store_fills_only_sliceable_snapshot_placeholders():
+    scheduler = _scheduler()
+    prompt_tokens = list(range(10))
+    boundary_tokens = prompt_tokens[:8]
+    boundary_cache = [
+        {"state": (), "class_name": "KVCache", "cache_type": "KVCache"},
+        {
+            "state": ("rotating-at-boundary",),
+            "class_name": "RotatingKVCache",
+            "cache_type": "RotatingKVCache",
+        },
+    ]
+    live_cache = [
+        {"state": ("kv-live",), "class_name": "KVCache", "cache_type": "KVCache"},
+        {
+            "state": ("rotating-live-tail",),
+            "class_name": "RotatingKVCache",
+            "cache_type": "RotatingKVCache",
+        },
+    ]
+
+    scheduler._get_boundary_store_override = MagicMock(
+        return_value=(boundary_tokens, boundary_cache, None, {})
+    )
+    scheduler._extract_live_request_cache_for_store = MagicMock(
+        return_value=(live_cache, "live-config")
+    )
+
+    result = scheduler._prepare_prompt_boundary_cache_store(
+        "req-parser-stop",
+        _request(prompt_tokens),
+        uid=7,
+    )
+
+    assert result is not None
+    token_sequence, cache_to_store, model_config, intermediate_snapshots = result
+    assert token_sequence == boundary_tokens
+    assert cache_to_store == [live_cache[0], boundary_cache[1]]
+    assert model_config == "live-config"
+    assert intermediate_snapshots == {}
+    scheduler._extract_live_request_cache_for_store.assert_called_once_with(
+        "req-parser-stop",
+        7,
+        boundary_tokens,
+    )
+
+
+def test_prompt_boundary_store_skips_missing_snapshot_for_snapshot_models():
+    scheduler = _scheduler()
+    scheduler._get_boundary_store_override = MagicMock(return_value=None)
+    scheduler._detect_boundary_snapshot_need = MagicMock(return_value=True)
+    scheduler._extract_live_request_cache_for_store = MagicMock()
+
+    result = scheduler._prepare_prompt_boundary_cache_store(
+        "req-parser-stop",
+        _request(list(range(10))),
+        uid=7,
+    )
+
+    assert result is None
+    scheduler._extract_live_request_cache_for_store.assert_not_called()
+
+
+def test_prompt_boundary_store_uses_live_cache_for_sliceable_models():
+    scheduler = _scheduler()
+    prompt_tokens = list(range(10))
+    boundary_tokens = prompt_tokens[:8]
+    live_cache = [
+        {"state": ("kv-live",), "class_name": "KVCache", "cache_type": "KVCache"},
+        {
+            "state": ("batch-kv-live",),
+            "class_name": "BatchKVCache",
+            "cache_type": "BatchKVCache",
+        },
+    ]
+    scheduler._get_boundary_store_override = MagicMock(return_value=None)
+    scheduler._detect_boundary_snapshot_need = MagicMock(return_value=False)
+    scheduler._extract_live_request_cache_for_store = MagicMock(
+        return_value=(live_cache, "live-config")
+    )
+
+    result = scheduler._prepare_prompt_boundary_cache_store(
+        "req-parser-stop",
+        _request(prompt_tokens),
+        uid=7,
+    )
+
+    assert result == (boundary_tokens, live_cache, "live-config", None)
+    scheduler._extract_live_request_cache_for_store.assert_called_once_with(
+        "req-parser-stop",
+        7,
+        boundary_tokens,
+    )
+
+
+def test_cleanup_finished_stores_prompt_boundary_without_extracted_cache(
+    mock_model,
+    mock_tokenizer,
+):
+    scheduler = Scheduler(
+        model=mock_model,
+        tokenizer=mock_tokenizer,
+        config=SchedulerConfig(paged_cache_block_size=4),
+    )
+    scheduler.block_aware_cache = MagicMock()
+    scheduler.paged_cache_manager = None
+
+    request = Request(
+        request_id="req-parser-stop",
+        prompt="prompt",
+        sampling_params=SamplingParams(),
+    )
+    request.prompt_token_ids = list(range(10))
+    request.num_prompt_tokens = 10
+    request.output_token_ids = [100, 101]
+    request._extracted_cache = None
+
+    boundary_tokens = list(range(8))
+    boundary_cache = [
+        {"state": ("kv-at-boundary",), "class_name": "KVCache", "cache_type": "KVCache"}
+    ]
+    scheduler.running[request.request_id] = request
+    scheduler.requests[request.request_id] = request
+    scheduler.request_id_to_uid[request.request_id] = 7
+    scheduler.uid_to_request_id[7] = request.request_id
+
+    with (
+        patch.object(
+            scheduler,
+            "_prepare_prompt_boundary_cache_store",
+            return_value=(boundary_tokens, boundary_cache, "boundary-config", None),
+        ) as prepare,
+        patch.object(scheduler, "_remove_uid_from_active_batch"),
+    ):
+        scheduler._cleanup_finished({request.request_id})
+
+    prepare.assert_called_once_with(request.request_id, request, 7)
+    scheduler.block_aware_cache.store_cache.assert_called_once()
+    args, kwargs = scheduler.block_aware_cache.store_cache.call_args
+    assert args[0] == request.request_id
+    assert args[1] == boundary_tokens
+    assert args[2] == boundary_cache
+    assert kwargs["model_cache_config"] == "boundary-config"


### PR DESCRIPTION
## Summary

- add bundled DeepSeek V4 Metal custom kernels under the existing `omlx.custom_kernels.glm_moe_dsa` extension
- add MXFP4 routed-MoE block-list GEMM kernels for DeepSeek V4 expert projections, including pair-concat up/gate projection and native top-k weighted-sum support
- add a fused DeepSeek V4 sparse attention kernel that combines local KV, pooled KV, selected pooled blocks, and attention sinks in one native path
- add native DeepSeek V4 indexer score + topk512 prefill path while keeping decode top-k on the baseline semantics
- keep the global `SchedulerConfig.prefill_step_size` default unchanged at 2048

## Performance Benchmark

Model: DeepSeek-V4-Flash-oQ8 (151.5 GB)  
Machine: Mac Studio, M3 Ultra, 512 GB unified memory  
Workload: single request, UUID prompt, 128 generated tokens, cached_tokens=0, explicit prefill_step_size=512

### Throughput

| Context | Baseline PP | Optimized PP | PP speedup | Baseline TG | Optimized TG | TG delta |
|---:|---:|---:|---:|---:|---:|---:|
| 1k | 422.8 tok/s | 486.1 tok/s | 1.15x (+15.0%) | 29.1 tok/s | 29.2 tok/s | +0.3% |
| 4k | 434.1 tok/s | 514.5 tok/s | 1.19x (+18.5%) | 27.6 tok/s | 28.1 tok/s | +1.9% |
| 16k | 422.0 tok/s | 514.4 tok/s | 1.22x (+21.9%) | 26.6 tok/s | 26.9 tok/s | +0.9% |
| 32k | 393.2 tok/s | 504.4 tok/s | 1.28x (+28.3%) | 25.8 tok/s | 26.1 tok/s | +1.5% |
| 64k | 313.3 tok/s | 455.8 tok/s | 1.45x (+45.5%) | 25.1 tok/s | 25.2 tok/s | +0.7% |

### Peak Memory

| Context | Baseline peak mem | Optimized peak mem | Peak mem delta |
|---:|---:|---:|---:|
| 1k | 144.81 GiB | 144.71 GiB | -0.10 GiB |
| 4k | 145.05 GiB | 144.71 GiB | -0.34 GiB |
| 16k | 145.60 GiB | 144.71 GiB | -0.89 GiB |
| 32k | 147.38 GiB | 144.72 GiB | -2.66 GiB |
| 64k | 151.25 GiB | 144.75 GiB | -6.50 GiB |

Additional checks:
- 128k optimized row: 404.7 tok/s PP, 24.0 tok/s TG
- 128k exact TG128 decode-stress repeats: 446.0 / 458.0 tok/s PP, 23.8 tok/s TG
- 64k 6-needle NIAH passed with 512-token decode budget
- Original FP4+FP8 mixed DeepSeek-V4-Flash loads through this path and measured 512.1 tok/s PP, 26.3 tok/s TG at 16k

## Accuracy Benchmark

Runs used the oMLX standard accuracy benchmark harness with greedy decoding (`temperature=0`, `top_p=1`), thinking disabled, and batch size 32.

| Type | Model | Size | Avg | MMLU 1000 | Winogrande 1267 | HumanEval 164 | MBPP 300 | MMLU-Pro 1000 | KMMLU 500 |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
| **Original precision** | DeepSeek V4 Flash (MLX engine) | 148.7 GiB | 78.09% | 821/1000 82.10% | 926/1267 73.09% | 148/164 90.24% | 249/300 83.00% | 677/1000 67.70% | 362/500 72.40% |
| **MLX oQe** | DeepSeek-V4-Flash-oQ2.5e | 103.1 GiB | 74.56% | 784/1000 78.40% | 867/1267 68.43% | 146/164 89.02% | 234/300 78.00% | 665/1000 66.50% | 335/500 67.00% |
| **GGUF** | Q4K | 153.3 GiB | 78.64% | 820/1000 82.00% | 946/1267 74.66% | 147/164 89.63% | 250/300 83.33% | 682/1000 68.20% | 370/500 74.00% |
| **GGUF** | Q4K+IQ2XXS | 90.9 GiB | 69.85% | 596/1000 59.60% | 1024/1267 80.82% | 146/164 89.02% | 221/300 73.67% | 624/1000 62.40% | 268/500 53.60% |

## Validation

- `git diff --cached --check`
- `python -m py_compile omlx/patches/deepseek_v4/deepseek_v4_model.py omlx/patches/deepseek_v4/switch_layers.py omlx/custom_kernels/glm_moe_dsa/fast.py`
- `python -m pytest tests/test_scheduler.py::TestSchedulerConfig::test_default_values`
- `python -m pytest tests/test_glm_moe_dsa_patch.py`
- DeepSeek-V4-Flash-oQ8 endpoint benchmark, contexts 1k/4k/8k/16k/32k/64k/128k, 128 generated tokens
- DeepSeek-V4-Flash original FP4+FP8 mixed checkpoint 16k endpoint smoke/benchmark
