### PR TITLE
fix: release embedding MLX resources on unload

### DIFF
--- a/docs/architecture-zh.md
+++ b/docs/architecture-zh.md
@@ -1,0 +1,118 @@
+# oMLX 架构与缓存命中率机制
+
+日期：2026-06-27
+
+## 项目结构
+
+oMLX 是一个本地模型服务，核心路径由 API 层、引擎池、调度器、模型适配层和缓存层组成。
+
+- `omlx/cli.py`：命令行入口，`serve` 子命令负责启动服务并接入全局配置。
+- `omlx/server.py`、`omlx/api/`：HTTP API、OpenAI/Anthropic 兼容接口、管理接口和状态查询。
+- `omlx/engine_pool.py`、`omlx/engine_core.py`、`omlx/engine/`：模型加载、请求分发、引擎生命周期、VLM/embedding/reranker 等引擎封装。
+- `omlx/scheduler.py`：请求排队、prefill/decode 调度、prefix cache 接入、内存保护和请求清理。
+- `omlx/models/`：模型适配层，屏蔽 LLM、VLM、embedding、reranker 的加载和推理差异。
+- `omlx/cache/`：KV/prefix cache、paged SSD cache、hot cache、缓存统计和缓存序列化逻辑。
+- `omlx/settings.py`、`omlx/config.py`、`omlx/model_settings.py`：全局配置、CLI 参数映射和单模型配置。
+- `omlx/admin/`：管理 UI 和管理 API 静态资源。
+- `tests/`：单元测试、集成测试和回归测试。
+
+## 请求路径
+
+典型文本生成请求路径：
+
+1. API 层解析请求，生成 `Request`。
+2. `EnginePool` 选择或加载对应模型引擎。
+3. `EngineCore` 将请求交给 `Scheduler`。
+4. `Scheduler._prepare_prefix_cache_for_request()` 查询 prefix cache。
+5. 命中时复用已缓存 KV block，只对剩余 token 做 prefill。
+6. 未命中或重建失败时，从完整 prompt 重新 prefill。
+7. decode 产生输出 token，完成后调度器清理请求并尝试保存可复用 cache block。
+
+VLM 请求在 token 序列之外还会带图像相关 extra keys。extra keys 会进入 block hash，因此相同文本但不同图片不会误命中。
+
+## 缓存分层
+
+当前项目的主要缓存机制分三层：
+
+- Prefix/block cache：`PagedCacheManager` 以固定 block size 对 prompt token 分块，并用链式 hash 匹配连续前缀。
+- Paged SSD cache：`PagedSSDCacheManager` 将可复用 KV block 序列化到 SSD，服务重启或模型重新加载后仍可复用。
+- Hot cache：SSD cache 的内存加速层，热 block 以 LRU 管理，避免重复从 SSD 读同一批 block。
+
+调度器查询缓存时先通过 `BlockAwarePrefixCache.fetch_cache()` 找共享前缀；找到 block 后再 `preload_blocks()` 和 `reconstruct_cache()` 重建 KVCache 对象。SSD 读取成功后会提升到 hot cache，后续请求可从内存直接命中。
+
+## 命中率口径
+
+项目里至少存在两类命中率口径，分析时不能混用：
+
+- block 级命中率：`PagedCacheManager.get_computed_blocks()` 中每匹配一个完整 block 记一次 hit，遇到第一个缺失 block 记一次 miss。`BaseCacheStats.hit_rate = hits / (hits + misses)`。
+- 请求/prefix 级命中率：`BlockAwarePrefixCache.fetch_cache()` 只要找到可复用前缀就记一次 `_hits`，完全找不到才记 `_misses`，同时累计 `_tokens_saved`、`_tokens_matched_total` 和 `_tokens_requested_total`。
+- SSD/hot cache I/O 统计：`PagedSSDCacheManager.load_block()` 记录 SSD/hot cache 的 `loads`、`hits`、`misses`、`hot_cache_hits`、`hot_cache_promotions` 等。
+
+因此，一个请求可以是 prefix 级 hit，但只命中部分 block；也可能 block hash 存在，但 KV 重建失败后被调度器按 miss 处理。评估用户体感时，`cached_tokens / prompt_tokens` 通常比单纯 hit-rate 更有意义。
+
+## 命中条件
+
+prefix cache 命中要求前缀在 block 边界上连续匹配：
+
+- 模型名参与 cache signature，不同模型不会共用。
+- block hash 是链式 hash，前一个 block 的 hash 会参与下一个 block 的 hash。
+- 只有完整 block 会进入主要匹配路径，尾部不足一个 block 的 token 不会贡献 block 命中。
+- VLM extra keys 会参与 hash；同文本不同图片、图片位置不同或 extra key range 不同都会隔离缓存。
+- cache format、block size、layer cache type、TurboQuant/RotatingKVCache 等签名不兼容时，SSD block 会被跳过或清理。
+- exact hit 还需要能把 KV 状态安全修剪到 `N-1` token；某些 stateful cache 类型无法修剪时会回退全量 prefill。
+
+## 影响命中率的因素
+
+最常见的低命中原因：
+
+- prompt 前缀不稳定：系统提示、工具列表、时间戳、随机上下文、用户个性化内容放在开头。
+- prompt 太短或变化发生在首个 block 内，无法形成完整 block 命中。
+- block size 与模型 cache 类型对齐后较大，导致需要更长稳定前缀才能命中。
+- 频繁切换模型、量化配置、TurboQuant KV、RotatingKVCache 或 VLM 输入，导致 cache signature 变化。
+- SSD cache 容量不足，旧 block 被 LRU 淘汰。
+- hot cache 太小或被内存压力收缩，SSD 命中仍存在，但热命中下降。
+- 内存压力达到 guard 后，调度器会跳过 hot-cache preload/promotion，减少内存占用但降低热命中。
+- exact hit 遇到不可安全 trim 的 cache 类型，会为了确定性回退全量 prefill。
+
+## 提高命中率的办法
+
+策略层面优先级：
+
+1. 稳定 prompt 前缀。把系统提示、工具定义、固定格式说明放在最前面；把时间、会话摘要、用户临时变量放在后面。
+2. 让常用长前缀跨过 block 边界。短 prompt 或变化发生在第一个 block 内时，prefix cache 很难产生收益。
+3. 避免无意义的模型配置切换。模型名、block size、cache 类型和量化/KV 策略变化都会降低复用。
+4. 给 SSD cache 足够容量。`paged_ssd_cache_max_size` 太小会导致 LRU 淘汰，长上下文场景建议使用独立高速 SSD 目录。
+5. 给 hot cache 合理内存预算。`hot_cache_max_size=0` 等于关闭内存热层；过大则可能触发内存保护收缩。
+6. 降低内存压力。减少同时加载模型数量、降低 hot cache 预算或提高可用内存，避免调度器绕过 hot cache preload。
+7. 对 VLM 请求保持图片顺序和预处理稳定。图片 hash/range 是 key 的一部分，任何变化都会隔离 cache。
+8. 用 token 级指标看效果。关注接口返回的 cached prompt tokens、管理面 cache stats、SSD hot hit 和 tokens saved，而不是只看请求数 hit-rate。
+
+可操作配置：
+
+- 启用 SSD cache：设置 `paged_ssd_cache_dir` 或使用 CLI 的 `--paged-ssd-cache-dir`。
+- 调整 SSD 容量：`paged_ssd_cache_max_size` / `--paged-ssd-cache-max-size`。
+- 启用 hot cache：`hot_cache_max_size` / `--hot-cache-max-size` 设置为非零。
+- 对重复大前缀服务，优先使用固定 `--base-path` 和固定 cache 目录，避免每次启动换空缓存。
+
+## 观测与排障
+
+建议按这个顺序看：
+
+1. API 响应中的 cached prompt tokens 是否增加。
+2. `/admin/api/stats` 或管理 UI 的 hot cache、SSD cache、模型内存和 active request 状态。
+3. `PagedSSDCacheManager.get_stats_dict()` 暴露的 hot cache entries、hot cache size、SSD tracked size、loads/hits/misses。
+4. DEBUG 日志中的 prefix divergence 信息，用于判断 prompt 在哪里开始偏离已存前缀。
+5. 是否出现内存压力日志，例如跳过 hot-cache preload 或 process memory enforcer shrink hot cache。
+
+如果请求显示 idle 但内存或缓存状态异常，应结合 `vmmap -summary`、模型 unload 日志和管理面 stats 判断是 cache、模型权重、MLX/Metal allocator 还是进程常驻内存。
+
+## 当前可改进点
+
+从机制上看，当前缓存设计已经具备稳定前缀复用、SSD 持久化和热层加速。更值得补强的是观测和策略：
+
+- 在管理面同时展示请求级 hit rate、block 级 hit rate、token saved rate，避免单一命中率误导。
+- 将 prefix divergence 的结果做成管理 API/诊断接口，帮助用户知道第几个 token 或哪个 extra key 导致 miss。
+- 对 exact hit fallback 计数，区分“找到了缓存但因不可 trim 回退”的情况。
+- 对 hot cache bypass under pressure 计数，解释为什么 SSD 命中存在但热命中下降。
+- 为常见 chat template/工具调用场景提供 prompt 稳定性建议或模板检查。
+

--- a/docs/compile-install-guide.md
+++ b/docs/compile-install-guide.md
@@ -1,0 +1,512 @@
+# oMLX compile and install guide
+
+Date: 2026-06-27
+
+This guide covers building and installing oMLX from this source tree on Apple
+Silicon macOS. It focuses on developer installs, optional native kernel builds,
+and the local Swift macOS app build.
+
+## Current Environment Check
+
+Checked on this machine:
+
+| Item | Result | Notes |
+| --- | --- | --- |
+| Repository | `/Users/zhouwei/code/zw/omlx` | Source tree used for the local editable install. |
+| macOS | `26.5.1 (25F80)` | Meets the project requirement of macOS 15.0+. |
+| CPU/platform | Apple Silicon arm64 | Required by MLX. |
+| Default `python3` | `3.14.3` | Avoid using this for the project until dependencies officially support it. |
+| Project `.venv` Python | `3.12.9` | Recommended local interpreter for source development. |
+| `uv` | `0.9.7` | Installed through Homebrew. |
+| Homebrew | `6.0.2` | Available. |
+| Xcode selection | `/Library/Developer/CommandLineTools` | Command Line Tools are active, not full Xcode. |
+| `xcodebuild` | Not available with current selection | Full Swift app builds need full Xcode selected. |
+| `clang` | Apple clang `21.0.0` | Available from Command Line Tools. |
+| `cmake` | `4.2.1` | Available. |
+| `metal` compiler | Not found | Required for optional Metal custom kernels. Install/select full Xcode. |
+| Existing oMLX CLI | `.venv/bin/omlx --version` -> `0.4.4` | Current editable environment works. |
+| MLX runtime | `mlx 0.31.2`, default device `Device(gpu, 0)` | Metal device is visible outside the sandbox. |
+| `uv.lock` | Not tracked in this checkout | `pyproject.toml` is the dependency source of truth for source installs here. |
+
+The current environment is good enough for normal source installation and
+server development. It is not sufficient for a full Swift app build or optional
+custom Metal kernel build until full Xcode is installed and selected.
+
+## Requirements
+
+Minimum project requirements:
+
+- Apple Silicon Mac.
+- macOS 15.0 or newer.
+- Python 3.11 to 3.13 for practical development. Python 3.12 is recommended.
+- `uv` or `pip`.
+- Command Line Tools for normal Python/source work.
+- Full Xcode for Swift app builds, asset compilation, signing, and optional
+  Metal custom kernels.
+
+Recommended tools:
+
+```bash
+brew install uv cmake
+xcode-select --install
+```
+
+For full app or Metal kernel builds, install Xcode from Apple and select it:
+
+```bash
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+xcodebuild -version
+xcrun --find metal
+```
+
+Both commands should succeed before attempting the app bundle or custom kernel
+paths.
+
+## Dependency Sources and Mirrors
+
+`pyproject.toml` pins several packages directly from GitHub:
+
+- `mlx-lm`
+- `mlx-embeddings`
+- `mlx-vlm`
+- `dflash-mlx`
+- optional `mlx-audio`
+
+A domestic PyPI mirror speeds up wheel downloads, but it does not replace
+`git+https://github.com/...` dependencies.
+
+Recommended PyPI mirror command:
+
+```bash
+UV_DEFAULT_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple uv sync
+```
+
+The install validated in this checkout used Aliyun:
+
+```bash
+UV_DEFAULT_INDEX=https://mirrors.aliyun.com/pypi/simple uv pip install --python .venv/bin/python -e .
+```
+
+If GitHub access is slow, install only the packages needed for a targeted task,
+or configure GitHub access separately. The PyPI mirror alone cannot mirror the
+Git dependencies declared in `pyproject.toml`.
+
+## Local Dependency Override Used Here
+
+For this local machine, `pyproject.toml` was changed to avoid repeated GitHub
+dependency fetches during source installs. The GitHub-pinned dependencies now
+point at local source directories:
+
+| Package | Local source |
+| --- | --- |
+| `mlx-lm` | `/Users/zhouwei/code/zw/mlx-lm` |
+| `mlx-embeddings` | `/Users/zhouwei/code/zw/mlx-embeddings-32981fa4e8064ed664b52071789dd18271fe4206` |
+| `mlx-vlm` | `/Users/zhouwei/code/zw/mlx-vlm-e3906673d54df42cf573b837a76e65d58a2b865c` |
+| `dflash-mlx` | `/Users/zhouwei/code/zw/dflash-mlx-9ca002898b48e14c9727dec17299f497e8467870` |
+| `mlx-audio` | `/Users/zhouwei/code/zw/mlx-audio-51753266e0a4f766fd5e6fbc46652224efc23981` |
+
+The `mlx-lm` local checkout was moved to the original pinned commit:
+
+```bash
+git -C /Users/zhouwei/code/zw/mlx-lm \
+  -c http.version=HTTP/1.1 \
+  fetch --depth=1 origin 2c008fd0252b2c569227d12568356ab88ab0560a
+git -C /Users/zhouwei/code/zw/mlx-lm \
+  checkout --detach 2c008fd0252b2c569227d12568356ab88ab0560a
+```
+
+Because the local `mlx-vlm` source was prepared from a codeload tarball rather
+than a git clone, its directory name carries the commit hash. Keep that path
+stable as long as `pyproject.toml` points to it.
+
+### `mlx-vlm` Download Card
+
+The main install blocker was `mlx-vlm`. Smaller repositories could be cloned or
+downloaded, but `mlx-vlm` repeatedly failed over the configured HTTP proxy:
+
+- `git fetch` / `git clone` could sit without progress or fail with early EOF.
+- codeload over HTTP/2 failed around `10MB` with:
+  `HTTP/2 stream 1 was not closed cleanly: CANCEL`.
+- A partially extracted in-repo `mlx-vlm.../` directory was only about `4.9MB`
+  and had no `pyproject.toml`; it was not usable as a Python dependency.
+
+The reliable path was to force HTTP/1.1 for codeload:
+
+```bash
+curl --http1.1 -L --fail \
+  --retry 8 --retry-all-errors \
+  --connect-timeout 30 \
+  --speed-limit 1000 --speed-time 120 \
+  -o /tmp/mlx-vlm-e3906673d54df42cf573b837a76e65d58a2b865c.tar.gz \
+  https://codeload.github.com/Blaizzy/mlx-vlm/tar.gz/e3906673d54df42cf573b837a76e65d58a2b865c
+
+gzip -t /tmp/mlx-vlm-e3906673d54df42cf573b837a76e65d58a2b865c.tar.gz
+mkdir -p /tmp/mlx-vlm-extract
+tar -xzf /tmp/mlx-vlm-e3906673d54df42cf573b837a76e65d58a2b865c.tar.gz \
+  -C /tmp/mlx-vlm-extract
+
+rsync -a \
+  /tmp/mlx-vlm-extract/mlx-vlm-e3906673d54df42cf573b837a76e65d58a2b865c/ \
+  /Users/zhouwei/code/zw/mlx-vlm-e3906673d54df42cf573b837a76e65d58a2b865c/
+```
+
+After syncing, verify the local dependency has package metadata:
+
+```bash
+test -f /Users/zhouwei/code/zw/mlx-vlm-e3906673d54df42cf573b837a76e65d58a2b865c/pyproject.toml
+test -d /Users/zhouwei/code/zw/mlx-vlm-e3906673d54df42cf573b837a76e65d58a2b865c/mlx_vlm
+```
+
+Clean temporary artifacts after the verified copy:
+
+```bash
+rm -rf \
+  /tmp/mlx-vlm-e3906673d54df42cf573b837a76e65d58a2b865c.tar.gz \
+  /tmp/mlx-vlm-extract
+```
+
+## Source Development Install
+
+Use a supported Python version explicitly. Do not rely on this machine's default
+`python3` if it is Python 3.14.
+
+```bash
+cd /Users/zhouwei/code/zw/omlx
+
+# Example with Homebrew Python 3.12 if available.
+uv venv --python 3.12 .venv
+source .venv/bin/activate
+
+UV_DEFAULT_INDEX=https://mirrors.aliyun.com/pypi/simple \
+  uv pip install --python .venv/bin/python -e .
+```
+
+With MCP support:
+
+```bash
+UV_DEFAULT_INDEX=https://mirrors.aliyun.com/pypi/simple \
+  uv pip install --python .venv/bin/python -e ".[mcp]"
+```
+
+With development tools:
+
+```bash
+UV_DEFAULT_INDEX=https://mirrors.aliyun.com/pypi/simple \
+  uv pip install --python .venv/bin/python -e ".[dev]"
+```
+
+If you prefer resolver-managed sync:
+
+```bash
+UV_DEFAULT_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple uv sync --dev
+```
+
+Use `uv sync --dev` only when GitHub dependency downloads are acceptable in the
+current network.
+
+## Verify Source Install
+
+Check the CLI:
+
+```bash
+.venv/bin/omlx --version
+.venv/bin/omlx --help
+```
+
+Check MLX and Metal visibility:
+
+```bash
+.venv/bin/python -c 'import importlib.metadata as m; import mlx.core as mx; print("mlx", m.version("mlx")); print(mx.default_device())'
+```
+
+Expected device on a working Apple Silicon setup:
+
+```text
+Device(gpu, 0)
+```
+
+Check dependency consistency:
+
+```bash
+uv pip check --python .venv/bin/python
+```
+
+Expected result:
+
+```text
+All installed packages are compatible
+```
+
+Confirm important local dependency origins:
+
+```bash
+.venv/bin/python -c 'import importlib.metadata as m, pathlib; names=["mlx-vlm","mlx-lm","mlx-embeddings","dflash-mlx"]; [(print("==", n, m.distribution(n).version), print((pathlib.Path(m.distribution(n)._path)/"direct_url.json").read_text())) for n in names]'
+```
+
+Each `direct_url.json` should point to a local `file:///Users/zhouwei/code/zw/...`
+path.
+
+Run a foreground server:
+
+```bash
+.venv/bin/omlx serve \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --model-dir ~/.omlx/models \
+  --hf-endpoint https://hf-mirror.com \
+  --log-level info
+```
+
+Health check:
+
+```bash
+curl -sS http://127.0.0.1:8000/api/status
+```
+
+If you pass `--api-key`, include:
+
+```bash
+curl -sS \
+  -H 'Authorization: Bearer <your-api-key>' \
+  http://127.0.0.1:8000/api/status
+```
+
+## Test Commands
+
+Targeted tests are usually faster and more reliable than a full test run during
+installation work.
+
+```bash
+.venv/bin/python -m pytest tests/test_cli.py \
+  tests/test_vlm_model_adapter.py::TestVLMModelAdapter::test_release_resources_drops_model_references
+.venv/bin/python -m pytest tests/test_cli.py
+.venv/bin/python -m pytest tests/test_per_engine_threads.py tests/test_engine_core.py
+```
+
+The validated source install passed:
+
+```text
+54 passed in 2.07s
+```
+
+Run MLX/Metal tests outside restricted sandboxes. A restricted environment can
+fail with errors such as:
+
+```text
+RuntimeError: [metal::load_device] No Metal device available
+```
+
+Run diff hygiene before committing:
+
+```bash
+git diff --check
+```
+
+## Optional Native Custom Kernel Build
+
+The optional GLM custom kernels live under:
+
+```text
+omlx/custom_kernels/glm_moe_dsa
+```
+
+Build path:
+
+```bash
+cd /Users/zhouwei/code/zw/omlx
+source .venv/bin/activate
+
+OMLX_WITH_CUSTOM_KERNEL=1 \
+OMLX_CUSTOM_KERNEL_DEPLOYMENT_TARGET=15.0 \
+python setup.py build_ext --inplace --force --with-custom-kernel
+```
+
+Prerequisites:
+
+- Full Xcode selected.
+- `xcrun --find metal` succeeds.
+- `cmake` is available.
+- `mlx==0.31.2` is installed in the active environment.
+
+Current machine status: this path is blocked until full Xcode is selected,
+because `xcrun --find metal` currently fails.
+
+## Swift macOS App Build
+
+The Python/PyObjC app pipeline has been retired. The Swift app under
+`apps/omlx-mac` is the current local app bundle path.
+
+Build Python venvstacks layers only:
+
+```bash
+cd /Users/zhouwei/code/zw/omlx
+python packaging/build.py --venvstacks-only
+```
+
+Print the layer fingerprint:
+
+```bash
+python packaging/build.py --print-fingerprint
+```
+
+Build the full local app bundle:
+
+```bash
+apps/omlx-mac/Scripts/build.sh release
+```
+
+Reuse an existing `packaging/_export` layer tree:
+
+```bash
+apps/omlx-mac/Scripts/build.sh release --no-rebuild-donor
+```
+
+Build only the Swift app shell while reusing existing Python layers:
+
+```bash
+apps/omlx-mac/Scripts/build.sh swift
+```
+
+Build with optional custom kernels:
+
+```bash
+apps/omlx-mac/Scripts/build.sh release --with-custom-kernel
+```
+
+Output:
+
+```text
+apps/omlx-mac/build/Stage/oMLX.app
+```
+
+Install or run:
+
+```bash
+open apps/omlx-mac/build/Stage/oMLX.app
+```
+
+or copy the app to `/Applications`.
+
+Current machine status: full app build is blocked until full Xcode is selected,
+because `xcodebuild` currently reports that the active developer directory is
+only Command Line Tools.
+
+## Common Failure Modes
+
+### `uv sync` is too slow
+
+Use a domestic PyPI mirror:
+
+```bash
+UV_DEFAULT_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple uv sync --dev
+```
+
+or:
+
+```bash
+UV_DEFAULT_INDEX=https://mirrors.aliyun.com/pypi/simple uv sync --dev
+```
+
+If it still stalls, the likely bottleneck is one of the GitHub dependencies.
+For local debugging, install only the required packages into `.venv` with
+`uv pip install`.
+
+### `mlx-vlm` download fails around 10MB
+
+If codeload fails with `HTTP/2 stream 1 was not closed cleanly: CANCEL`, force
+HTTP/1.1:
+
+```bash
+curl --http1.1 -L --fail --retry 8 --retry-all-errors \
+  -o /tmp/mlx-vlm.tar.gz \
+  https://codeload.github.com/Blaizzy/mlx-vlm/tar.gz/e3906673d54df42cf573b837a76e65d58a2b865c
+```
+
+Always run `gzip -t` before trusting the tarball. A truncated extraction may
+look like a source tree but miss `pyproject.toml`, which makes the `file://`
+dependency invalid.
+
+### `uv pip install --reinstall mlx-lm` upgrades transitive packages
+
+Installing a single local dependency directly can temporarily pull versions
+outside oMLX's root constraints. In one run, direct reinstall of `mlx-lm`
+upgraded `numpy` to `2.5.0`; reinstalling the root project restored the project
+constraint:
+
+```bash
+UV_DEFAULT_INDEX=https://mirrors.aliyun.com/pypi/simple \
+  uv pip install --python .venv/bin/python -e .
+
+uv pip check --python .venv/bin/python
+```
+
+### Default Python is too new
+
+This machine's default `python3` is `3.14.3`. The project metadata says
+`requires-python >=3.11`, but several ML/packaging dependencies may lag behind
+new Python releases. Use Python 3.12 or 3.13 explicitly.
+
+### `xcodebuild` fails with Command Line Tools
+
+Symptom:
+
+```text
+xcode-select: error: tool 'xcodebuild' requires Xcode
+```
+
+Fix:
+
+```bash
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+```
+
+### `xcrun --find metal` fails
+
+This blocks optional Metal custom kernels. Install/select full Xcode, then
+rerun:
+
+```bash
+xcrun --find metal
+```
+
+### MLX cannot see a Metal device
+
+Verify outside restricted sandboxes:
+
+```bash
+.venv/bin/python -c 'import mlx.core as mx; print(mx.default_device())'
+```
+
+Expected:
+
+```text
+Device(gpu, 0)
+```
+
+## Recommended Local Workflow
+
+For normal development on this machine:
+
+```bash
+cd /Users/zhouwei/code/zw/omlx
+source .venv/bin/activate
+
+.venv/bin/omlx --version
+.venv/bin/python -m pytest tests/test_cli.py
+git diff --check
+```
+
+For server validation:
+
+```bash
+.venv/bin/omlx serve \
+  --host 127.0.0.1 \
+  --port 11445 \
+  --model-dir ~/.omlx/models \
+  --hf-endpoint https://hf-mirror.com \
+  --base-path /tmp/omlx-dev \
+  --log-level info
+```
+
+Use a non-default port such as `11445` when the app-managed server or other
+local services may already own the standard port.

--- a/docs/hermes-omlx-local-optimization-tracker.md
+++ b/docs/hermes-omlx-local-optimization-tracker.md
@@ -1,0 +1,543 @@
+# Hermes + oMLX 本地优化跟踪
+
+日期：2026-06-27
+
+## 范围
+
+本文档用于长期跟踪本机 Hermes + oMLX 组合使用时的性能、缓存、内存和稳定性优化。
+
+当前从日志中观察到的部署形态：
+
+- Hermes 默认 provider：`omlx`。
+- oMLX base URL：`http://localhost:11335/v1`。
+- 主模型：`Qwen3.6-35B-A3B-nvfp4`。
+- Hermes 使用的 oMLX 辅助模型：
+  - `Qwen3.5-4B-4bit`：用于压缩、标题生成、网页抽取和 skills hub 等辅助任务。
+  - `Qwen3-Embedding-0.6B-8bit`：用于 embedding。
+  - `bge-reranker-v2-m3`：用于 rerank。
+- oMLX 源码启动命令：
+  `scripts/start-omlx-app-config.sh --host 127.0.0.1 --port 11335`
+- oMLX 当前关键设置：
+  - `memory_guard_custom_ceiling_gb=76`
+  - `max_concurrent_requests=2`
+  - `ssd_cache_dir=/Users/zhouwei/.omlx/cache`
+  - `ssd_cache_max_size=55GB`
+  - `hot_cache_max_size=10GB`
+  - `max_context_window=128000`
+  - `max_tokens=16384`
+
+## 当前日志快照
+
+从 Hermes 本地日志解析出的 API 调用统计：
+
+- 解析到的 Hermes API 调用总数：`6241`。
+- 主本地模型调用：
+  - `Qwen3.6-35B-A3B-nvfp4`：`5651` 次。
+- 平均缓存比例：`92.6%`。
+- 缓存比例范围：`2%` 到 `100%`。
+- 缓存比例分桶：
+  - `0-50%`：`191` 次。
+  - `50-80%`：`305` 次。
+  - `80-90%`：`380` 次。
+  - `90-100%`：`5365` 次。
+- 延迟：
+  - 平均 `10.78s`；
+  - p50 `5.5s`；
+  - p95 `33.2s`；
+  - 最大 `489.7s`。
+- 输入 token：
+  - 平均 `62533`；
+  - p95 `149047`；
+  - 最大 `237258`。
+- 输出 token：
+  - 平均 `235`；
+  - p95 `824`；
+  - 最大 `13699`。
+
+oMLX `/api/status` 快照：
+
+- `models_loaded=4`
+- 已加载模型：
+  - `Qwen3-Embedding-0.6B-8bit`
+  - `Qwen3.5-4B-4bit`
+  - `Qwen3.6-35B-A3B-nvfp4`
+  - `bge-reranker-v2-m3`
+- `model_memory_used=25.76GB`
+- `model_memory_max=76.00GB`
+- `total_prompt_tokens=7889207`
+- `total_completion_tokens=41149`
+- `total_cached_tokens=7098368`
+- `cache_efficiency=90.0`
+- `avg_prefill_tps=924.0`
+- `avg_generation_tps=60.7`
+- `active_requests=0`
+- `waiting_requests=0`
+
+oMLX server 日志样本：
+
+- 解析到的 chat completion：`325` 次。
+- 解析到的 embedding 请求：`300` 次。
+- 解析到的 rerank 请求：`35` 次。
+- 模型加载：`118` 次。
+- 模型卸载：`110` 次。
+- TTL 触发卸载：`16` 次。
+- warning/error：`80` 条。
+- Chat prompt 平均/最大：
+  - 平均 `47458` tokens；
+  - 最大 `140251` tokens。
+- Chat 延迟平均/最大：
+  - 平均 `7.57s`；
+  - 最大 `184.30s`。
+- 平均生成吞吐：`74.4 tok/s`。
+- Embedding 延迟平均/最大：
+  - 平均 `0.142s`；
+  - 最大 `1.831s`。
+- Rerank 延迟平均/最大：
+  - 平均 `0.279s`；
+  - 最大 `0.679s`。
+
+## 主要发现
+
+### 1. 缓存机制有效，但超长上下文仍是主要延迟来源
+
+Hermes 的缓存比例整体较高。最近本地回合多次达到 `91%-100%` 缓存命中，oMLX 也报告 `cache_efficiency=90.0`。
+
+慢路径不是普通的缓存失效，而是输入上下文过大：
+
+- 最近 oMLX 最大 prompt：`140251` tokens；
+- 历史 Hermes 最大输入：`237258` tokens；
+- 历史最慢 API 调用：`489.7s`，输入 `179373` tokens，缓存只有 `11%`；
+- 也存在缓存比例很高但总上下文过大导致仍然很慢的调用。
+
+判断：
+
+- 高缓存率能显著降低 prefill 成本，但不能让 `100k+` 上下文变得便宜。
+- 当上下文很大时，即使只有较小的未缓存尾部，也可能带来明显 prefill 成本。
+- 即使 oMLX prefix cache 有效，Hermes 侧的上下文压缩和工具输出治理仍然关键。
+
+### 2. 主模型和辅助模型共用同一个 SSD cache 目录
+
+当前 cache 目录：
+
+```text
+/Users/zhouwei/.omlx/cache
+```
+
+当前目录大小：
+
+```text
+55G /Users/zhouwei/.omlx/cache
+```
+
+该目录已经基本达到配置的 `55GB` 上限。
+
+日志显示，不同模型或不同 cache signature 共用目录时，会产生大量 incompatible cache：
+
+```text
+SSD cache scan complete: scanned=551, indexed=71, errors=0,
+total_size=7.84 GB, skipped_incompatible=479 blocks (47.44 GB)
+```
+
+在这次扫描中，对当前加载模型真正兼容可用的只有 `7.84GB`，但另有 `47.44GB` 被识别为 incompatible。也就是说，目录看起来有 `55GB`，但对当前模型的有效容量远小于这个数。
+
+判断：
+
+- 单个共享 SSD cache 目录使用方便，但不适合 Hermes 这种混合模型工作负载。
+- `Qwen3.6-35B-A3B-nvfp4` 和 `Qwen3.5-4B-4bit` 的 cache signature 不兼容。
+- 辅助模型 cache 会挤占或驱逐主模型 cache，降低主模型长期复用收益。
+
+### 3. 辅助模型反复加载和卸载
+
+日志显示模型生命周期抖动较明显：
+
+- 模型加载：`118` 次。
+- 模型卸载：`110` 次。
+- TTL 触发卸载：`16` 次。
+
+近期示例：
+
+```text
+TTL expired for model 'Qwen3.5-4B-4bit' (idle 301s > ttl 300s)
+Unloaded model: Qwen3.5-4B-4bit
+```
+
+在一次大 prefill 中，oMLX 为主模型腾出 headroom，主动驱逐了空闲辅助模型：
+
+```text
+Request ... needs prefill headroom before throttling
+Evicting idle model 'bge-reranker-v2-m3' for prefill headroom on
+'Qwen3.6-35B-A3B-nvfp4'
+Evicting idle model 'Qwen3-Embedding-0.6B-8bit' for prefill headroom on
+'Qwen3.6-35B-A3B-nvfp4'
+```
+
+随后 Hermes 又需要 embedding/rerank，于是这些模型重新加载。
+
+判断：
+
+- 当前单个 oMLX 进程同时混用了：
+  - 一个长上下文大主模型；
+  - 一个 4B 辅助模型；
+  - embedding 模型；
+  - reranker 模型。
+- 这个方案能工作，但 prefill headroom 和 TTL 策略会导致模型 churn。
+- churn 会增加延迟，也可能加剧 allocator/cache 行为的不稳定。
+
+### 4. Embedding compile fallback 反复出现
+
+重复 warning：
+
+```text
+compiled embedding path failed for Qwen3-Embedding-0.6B-8bit:
+[eval] Attempting to eval an array during function transformations like compile
+or vmap is not allowed.; disabling compile and falling back to eager generate()
+```
+
+判断：
+
+- oMLX 能正确恢复：禁用 compile 并回退 eager mode。
+- 但每次重新加载后仍会重复出现 warning。
+- 这大概率不是主要延迟瓶颈，但会污染日志；如果该模型路径已知无法稳定 compile，最好在加载前就跳过 compile。
+
+### 5. Hermes 存在与生成性能无关但影响可维护性的配置/平台噪音
+
+Lark/Feishu 重复失败：
+
+```text
+Could not find a suitable TLS CA certificate bundle, invalid path:
+/Users/zhouwei/code/hermes-agent/venv/lib/python3.11/site-packages/certifi/cacert.pem
+```
+
+Hermes 配置 warning：
+
+```text
+providers.llama: unknown config keys ignored: model_type
+providers.lms: unknown config keys ignored: model_type
+providers.omlx: unknown config keys ignored: model_type
+config.yaml has empty section(s): `context_file_max_chars`,
+`max_concurrent_sessions`
+display.personality is set but agent.personalities is empty/null
+```
+
+Browser CDP warning：
+
+```text
+Failed to resolve CDP endpoint http://localhost:9222
+```
+
+判断：
+
+- 这些不是 oMLX 推理瓶颈。
+- 但它们持续污染日志，也可能影响 gateway、cron、平台消息收发可靠性。
+- `certifi` 问题需要优先修复，因为它会破坏 Feishu/Lark 重连和 cron job。
+
+## 推荐优化计划
+
+### P0：在单实例内实现逻辑 cache 域和策略治理
+
+最新结论：不优先拆成两个 oMLX 实例。
+
+拆分实例可以绕开主模型和辅助模型互相挤占的问题，但会增加 Hermes 路由、启动脚本、配置同步、监控和故障定位复杂度。更重要的是，如果只能靠多实例隔离 cache，说明 oMLX 单实例的多模型 cache 策略还不够成熟。更优雅的方向是在一个 oMLX 进程内，把 SSD cache 从“一个全局 LRU 池”升级为“按模型、签名、角色和热度治理的共享 cache”。
+
+当前代码已经具备可利用的基础：
+
+- hot cache 淘汰时会写回 SSD。
+- hot cache 已经有 LRU 和共享预算机制。
+- SSD cache metadata 已包含 `model_name`、`cache_signature`、`last_access`、`token_count`。
+- SSD 层已有 compatible/incompatible index，并按 `last_access` 做 LRU。
+- 已有 stale layer signature 的保守清理逻辑。
+
+缺口不是缺少 cache 层，而是策略粒度偏粗：
+
+- hot cache 被驱逐后，当前策略更接近“写回 SSD”，缺少准入判断。
+- SSD 淘汰主要看全局 `last_access`，没有充分区分主模型、辅助模型、当前活跃 signature、命中价值和重算成本。
+- incompatible block 会被统计和参与淘汰，但缺少比例上限和后台主动清扫策略。
+- 模型卸载和 cache 降权之间缺少明确关系。
+
+建议的单实例机制：
+
+1. 逻辑 cache 域
+
+   在同一个 `ssd_cache_dir` 内按以下维度划分逻辑域，不拆进程、不拆服务：
+
+   - `model_name`
+   - `cache_signature`
+   - `model_role`，例如 `primary_chat`、`assistant_chat`、`embedding`、`rerank`
+   - compatible / incompatible
+
+2. SSD cache 准入策略
+
+   不要所有 hot cache eviction 都无条件落盘。优先持久化：
+
+   - hot cache 命中率高的 block；
+   - 被 hot cache 驱逐、但近期有复用证据的 block；
+   - token 数较大、重算成本高的 block；
+   - 属于主 chat 模型稳定 prefix 的 block；
+   - 当前活跃 `cache_signature` 下的 block。
+
+   降低或跳过持久化：
+
+   - 一次性长尾 prompt；
+   - 低命中辅助模型 block；
+   - rerank/embedding 的短生命周期 block；
+   - 已经属于 inactive signature 的 block。
+
+3. 按域预算
+
+   保持单实例，但给不同逻辑域设置软预算：
+
+   - 主 chat 模型：保底大部分 SSD cache，例如 `70%-80%`。
+   - 辅助 chat 模型：小比例预算，例如 `10%-20%`。
+   - embedding/rerank：默认很小，必要时只进入 hot cache，不长期 SSD 持久化。
+   - incompatible/stale：设置硬比例上限，例如不超过总 SSD cache 的 `5%-10%`。
+
+   这些预算应是软约束：空闲空间可以共享，但发生压力时按域回收。
+
+4. 淘汰评分
+
+   从单纯全局 LRU 升级为评分制。候选字段：
+
+   - `last_access`
+   - `hit_count`
+   - `hot_cache_eviction_count`
+   - `model_role`
+   - `token_count`
+   - `cache_signature` 是否当前活跃
+   - 是否 compatible
+   - 是否超过域预算或 TTL
+
+   淘汰优先级建议：
+
+   ```text
+   stale/incompatible
+   > 超过预算的低命中辅助模型 block
+   > 冷的辅助模型 block
+   > 冷的主模型 block
+   > 高命中主模型 block
+   ```
+
+5. 后台 cache janitor
+
+   增加轻量后台清扫器，避免在请求路径里一次性清理大量文件：
+
+   - 定期释放长期未访问 block；
+   - 控制 incompatible/stale block 占比；
+   - 空闲时清理 inactive signature；
+   - 分批 unlink，避免推理线程被文件删除阻塞；
+   - 输出每个逻辑域的 cache 使用量和清理原因。
+
+   互斥要求：
+
+   - 当所有模型都已经卸载，并进入 cache 自愈/内存清理治理作业后，后续模型加载和业务请求必须等待治理完成。
+   - 治理作业应有明确的 maintenance gate，不能与 `get_engine()`、模型加载、TTL 卸载、手动卸载或 runtime settings reload 并发修改 engine/cache 状态。
+   - 治理期间可以拒绝或排队新请求；更适合本地 Hermes 场景的策略是排队等待，而不是直接返回错误。
+   - 治理必须是 bounded：限制单轮 unlink 文件数和最长耗时，避免最后一个模型卸载后长时间阻塞下一次加载。
+   - 互斥治理不应调用 `clear_hot_cache()` 或 `SharedHotCacheBudget.clear_all_owners()`，因为目标是保留 hot cache，只治理 SSD cache 和释放模型运行态内存。
+
+6. 模型卸载时只降权，不立即清 cache
+
+   模型卸载应该释放内存，但不等于删除有价值的 SSD cache：
+
+   - 主模型卸载：保留高命中、高 token 成本 block；
+   - 辅助 chat 模型卸载：降低优先级，只保留近期命中过的少量 block；
+   - embedding/rerank 卸载：优先短 TTL 或不长期持久化。
+
+预期收益：
+
+- 保持单 oMLX 实例，降低配置和维护复杂度。
+- 避免辅助模型 cache 长期挤占主模型 cache。
+- 提高 `55GB` SSD cache 的有效可用比例。
+- 降低 incompatible block 占用。
+- 为后续多模型长期运行提供稳定机制，而不是依赖部署拓扑规避。
+
+执行顺序：
+
+- [x] 增加 per-role/per-signature cache 统计输出：`get_stats_dict()` 新增 `cache_domain_usage`。
+- [x] 为 SSD metadata 增加 `hit_count`、`last_hit_at`、`model_role`、`hot_cache_evictions` 策略字段，并保持旧 metadata 兼容读取。
+- [x] 在 hot cache eviction 写回 SSD 前增加准入判断：默认保持既有写回契约，只对明确的低复用 embedding/rerank block 降低持久化优先级。
+- [x] 在 SSD 淘汰逻辑中加入域预算和评分制：优先清理 incompatible/inactive signature，再清理超过预算的 embedding/rerank 和辅助 chat 域，保护高命中主 chat block。
+- [x] 增加显式 cache domain janitor：`run_cache_domain_janitor()`，当前为手动/后续调度调用，不额外启动后台线程。
+- [x] 增加测试覆盖：主模型高命中 block 不应被低命中辅助模型优先挤出；incompatible/stale 占比超过阈值时应优先清理；低复用 embedding hot eviction 可跳过 SSD 持久化。
+- [x] 增加 maintenance gate：全模型卸载后的治理作业执行期间，`get_engine()` 和后续模型加载请求必须等待治理完成。
+- [x] 将治理接入最后一个模型卸载后的空闲窗口：当没有 loaded/loading/in-use/pending unload 模型时，执行 SSD cache janitor 和额外 MLX 内存清理。
+- [x] 治理使用临时 SSD cache manager，`hot_cache_max_bytes=0`、`hot_cache_budget=None`，不调用共享 hot cache 清理。
+
+实现记录：
+
+- 分支：`feature/single-instance-cache-domains`。
+- 核心代码：`omlx/cache/paged_ssd_cache.py`、`omlx/engine_pool.py`。
+- 测试代码：`tests/test_paged_ssd_cache.py`、`tests/test_engine_pool.py`。
+- 策略边界：
+  - 不拆分 oMLX 实例；
+  - 不拆分 `ssd_cache_dir`；
+  - 不改变默认 hot cache write-back 契约；
+  - 只对明确低价值的 embedding/rerank 短生命周期 block 做 SSD 准入降级；
+  - SSD 淘汰使用小窗口候选评分，不在请求路径做全量扫描。
+  - 全模型卸载后的治理会阻塞后续模型加载，直到治理完成。
+  - 治理只扫描/清理 SSD cache 和执行 MLX allocator 清理，不释放共享 hot cache。
+- 已验证：
+  - `git diff --check` 通过；
+  - `.venv/bin/python -m compileall -q omlx/cache/paged_ssd_cache.py tests/test_paged_ssd_cache.py` 通过；
+  - `.venv/bin/python -m pytest tests/test_hot_cache.py tests/test_paged_ssd_cache.py` 通过，`185 passed`。
+  - `.venv/bin/python -m compileall -q omlx/cache/paged_ssd_cache.py omlx/engine_pool.py tests/test_paged_ssd_cache.py tests/test_engine_pool.py` 通过；
+  - `.venv/bin/python -m pytest tests/test_hot_cache.py tests/test_paged_ssd_cache.py tests/test_engine_pool.py` 通过，`284 passed`。
+  - `11445` 真机验证通过：
+    - 使用 `scripts/start-omlx-app-config.sh --host 127.0.0.1 --port 11445` 启动源码服务。
+    - 手动加载 `Qwen3-Embedding-0.6B-8bit`、`Qwen3-Reranker-0.6B-4bit`、`Qwen2.5-0.5B-Instruct-MLX-4bit` 后，状态显示 `models_loaded=3`、模型内存约 `1.22GB`。
+    - 小 LLM 长前缀连续请求验证 prefix cache：第一次 `cached_tokens=0`，第二次 `cached_tokens=2560`，`cache_efficiency=46.3`。
+    - 卸载 embedding 和 reranker 时仍有 LLM 存活，未触发全模型卸载治理；状态分别降至 `models_loaded=2`、`models_loaded=1`。
+    - 卸载最后一个 LLM 后触发治理：日志显示 `Cache domain janitor freed 3.25 GB across 32 files`，随后 `All-models-unloaded maintenance complete: ssd_freed=3.25GB, hot_cache_preserved=True`；API 状态为 `models_loaded=0`、`model_memory_used_formatted=0B`。
+    - 治理后立即执行真实 `/v1/rerank` 请求，`Qwen3-Reranker-0.6B-4bit` 可正常加载并返回排序结果，说明 maintenance gate 已释放，业务可继续进入。
+    - 再次卸载最后一个 reranker 后二次触发治理：日志显示 `Cache domain janitor freed 3.17 GB across 32 files`，随后 `All-models-unloaded maintenance complete: ssd_freed=3.17GB, hot_cache_preserved=True`；API 状态再次回到 `models_loaded=0`、模型内存 `0B`。
+    - 注意：`/admin/api/models/{model}/load` 支持 Bearer API key 或 admin session，但 `/admin/api/models/{model}/unload` 当前只接受 admin session cookie；真机验证通过 `/admin/auto-login` 用主 API key 换取临时 session cookie 后执行卸载。
+- 未完成/后续：
+  - `uv run ruff ...` 当前仍受依赖解析问题阻塞：解析 Python 3.14 split 时找不到 `num2words>=0.5.14`；本地 `.venv` 中没有 `ruff` 可执行文件。
+  - 当前 janitor 已接入“全模型卸载后”的空闲窗口，但尚未暴露管理 API 或状态 API。
+
+### P1：清理或扩容当前 SSD cache
+
+当前状态：
+
+- `ssd_cache_max_size=55GB`。
+- cache 目录已经是 `55G`。
+- 最近扫描中，对某个模型只有 `7.84GB` compatible，另有 `47.44GB` incompatible。
+
+方案：
+
+1. 短期：停服后清理当前 SSD cache。
+2. 中期：如果磁盘允许，把 SSD cache 预算提高到 `100GB-150GB`。
+3. 更优方案：扩容与“单实例内逻辑 cache 域、准入策略、域预算和后台清扫”一起做。
+
+跟踪项：
+
+- [ ] 记录基线：`du -sh ~/.omlx/cache`。
+- [ ] 记录每个模型启动时的 SSD scan 统计。
+- [ ] 切换 cache 策略时清理 stale/incompatible cache，并记录清理原因。
+- [ ] 预热后重新检查 `indexed` 与 `skipped_incompatible`。
+
+### P1：减少不必要的模型 churn
+
+当前问题：
+
+- 部分模型 TTL 实际约为 `300s`。
+- 辅助模型会在 Hermes 活跃工作流中卸载又重载。
+- 长 prefill 会为了 headroom 驱逐 embedding/reranker。
+
+可能策略：
+
+- 提高常用辅助模型 TTL。
+- 在单实例内降低 embedding/rerank 的 SSD 持久化优先级，优先让它们使用 hot cache 或短 TTL cache。
+- Hermes 工作期间避免在同一个 oMLX 进程里加载探索性大模型。
+- 如果内存紧张，优先调整模型 TTL、cache 准入和域预算，而不是拆分进程。
+
+跟踪项：
+
+- [ ] 每天统计 load/unload 次数。
+- [ ] 跟踪 embedding 和 rerank 的 p95 延迟变化。
+- [ ] 跟踪 prefill headroom 是否仍会驱逐辅助模型。
+- [ ] 跟踪辅助模型被卸载后，其 SSD cache 是否按策略降权或清扫。
+
+### P1：降低 Hermes 上下文压力
+
+当前模式：
+
+- 平均输入：`62533` tokens。
+- p95 输入：`149047` tokens。
+- 历史最大输入：`237258` tokens。
+
+Hermes 侧可做的工作：
+
+- 对本地模型会话使用更激进的压缩策略。
+- 降低保留的工具输出体积。
+- 避免把长日志或大文件反复注入主对话上下文。
+- 优先传递文件引用和聚焦摘录，而不是全文塞进主上下文。
+- 评估 `compression.protect_last_n=30` 是否过高；如果质量允许，可以降低。
+
+跟踪项：
+
+- [ ] 跟踪每轮 Hermes 输入 token 的 p50/p95。
+- [ ] 按缓存率分桶跟踪延迟。
+- [ ] 调整压缩策略后跟踪质量退化。
+
+### P2：禁用已知不稳定的 embedding compile 路径
+
+当前问题：
+
+- `Qwen3-Embedding-0.6B-8bit` 反复尝试 compile，失败后回退 eager。
+
+可能修复：
+
+- 如果 oMLX 已支持相关配置，为该模型显式跳过 embedding compile。
+- 如果没有配置，可以考虑一个窄补丁：记住该模型/config 的 compile 失败，重载时直接 eager。
+
+跟踪项：
+
+- [ ] 检查是否已有 embedding compile 控制项。
+- [ ] 若无控制项，记录为小型后续 issue 或补丁。
+- [ ] 修改后验证 embedding 延迟和 warning 数量。
+
+### P2：清理 Hermes 配置和平台噪音
+
+事项：
+
+- 修复 Hermes venv 中的 `certifi` 路径。
+- 如果当前 Hermes 不再接受 `model_type`，从 provider 配置中移除该字段。
+- 将空 YAML section 改成 `{}` 或删除：
+  - `context_file_max_chars`
+  - `max_concurrent_sessions`
+- 如果不使用 browser tools，禁用 CDP；如果使用，则启动 `localhost:9222` Chrome debug endpoint。
+
+跟踪项：
+
+- [ ] 修复 certifi 路径，并验证 Lark/Feishu 可重连。
+- [ ] 确认不再重复出现 `unknown config keys ignored`。
+- [ ] 确认不使用 browser tools 时不再重复出现 CDP warning。
+
+## 长期跟踪指标
+
+每轮调优至少采集一次：
+
+```bash
+curl -s -H "Authorization: Bearer <OMLX_API_KEY>" \
+  http://127.0.0.1:11335/api/status
+
+du -sh ~/.omlx/cache ~/.omlx/cache/vision_features 2>/dev/null
+
+rg "SSD cache scan complete|PagedSSDCacheManager initialized" \
+  ~/.omlx/logs/server.log
+
+rg "API call #[0-9]+:.*cache=" ~/.hermes/logs/agent.log
+
+rg "Loading model:|Unloaded model:|TTL expired|prefill headroom" \
+  ~/.omlx/logs/server.log
+```
+
+建议长期跟踪字段：
+
+- Hermes：
+  - 每轮 API 调用次数；
+  - 输入 token p50/p95/max；
+  - 输出 token p50/p95/max；
+  - 缓存比例 p50/p95/min；
+  - 延迟 p50/p95/max。
+- oMLX：
+  - 已加载模型；
+  - 模型内存占用；
+  - total cached tokens；
+  - cache efficiency；
+  - SSD compatible vs incompatible block；
+  - hot cache size 和 hot cache hit；
+  - load/unload 次数；
+  - prefill headroom eviction 次数。
+
+## 当前判断
+
+当前组合已经明显受益于 oMLX prefix cache。最大收益不太可能来自拆分 oMLX 实例，而更可能来自在单实例内完善 cache 准入、逻辑域预算、淘汰评分和后台清扫机制，同时控制 Hermes 上下文增长、降低辅助模型 churn。
+
+优先级：
+
+1. 在单 oMLX 实例内实现逻辑 cache 域、准入策略、域预算和后台 janitor。
+2. 策略上线后清理或扩大 SSD cache。
+3. 降低 Hermes 上下文大小和重复大工具输出。
+4. 减少辅助模型加载/卸载 churn。
+5. 清理 Hermes 配置和日志噪音。

--- a/docs/omlx-11335-model-cycle-memory-leak-report-zh.md
+++ b/docs/omlx-11335-model-cycle-memory-leak-report-zh.md
@@ -206,3 +206,53 @@
 - 完成 10 轮完整循环。
 - after-unload 的 `Physical footprint` 和 `IOAccelerator (graphics)` 不应线性增长。
 - 建议阈值：第 10 轮 after-unload 相比第 1 轮 after-unload 增长小于 500MB；如果 macOS/MLX 有合理缓存保留，则至少应在前 2-3 轮后收敛，而不能持续每轮增加约 2GB。
+
+## 修复后复测
+
+复测时间：2026-07-01 09:24-09:33 Asia/Shanghai。
+
+修复内容：
+
+- `MLXEmbeddingModel.close()` 显式释放 embedding wrapper 资源：
+  - 先清空 `_compiled_embed`，再清空 `model` / `processor`。
+  - 重置 `_loaded`、`_is_compiled`、`_using_native`、`_hidden_size`、输入 key remap 状态。
+  - 在调用线程执行 `gc.collect()`、`mx.synchronize()`、`mx.clear_cache()`、`clear_thread_compile_cache()`。
+- `EmbeddingEngine.stop()` 改为在全局 MLX executor 中调用 `MLXEmbeddingModel.close()`，确保释放发生在 embedding load/embed 使用的同一 MLX worker 线程。
+- 增加 `OMLX_EMBEDDING_COMPILE=0` 排障开关，可在不改代码的情况下禁用 embedding `mx.compile`。
+
+已执行单模型复测。每个模型测试前均重启 11335 服务，并确认 `/health` 空载。
+
+| 模型 | 轮次 | after-unload Physical Footprint 漂移 | after-unload IOAccelerator Graphics 漂移 | 结论 |
+| --- | ---: | ---: | ---: | --- |
+| Qwen3-Embedding-4B-4bit-DWQ | 5 | +21.1MB | +0.0MB | 修复主因泄露 |
+| Qwen3-Reranker-0.6B-4bit | 5 | +19.3MB | +0.0MB | 对照通过 |
+| Qwen3-4B-Instruct-2507-MLX-4bit | 5 | +0.0MB | +0.0MB | 对照通过；仍保留历史已知首轮 runtime/cache 驻留 |
+| Ornith-1.0-35B-5bit-mlx | 3 | +22.2MB | +0.0MB | 对照通过 |
+
+主因模型修复前后对比：
+
+| 指标 | 修复前 5 轮 after-unload | 修复后 5 轮 after-unload |
+| --- | ---: | ---: |
+| RSS 漂移 | +8651.0MB | +21.6MB |
+| Physical Footprint 漂移 | +8601.6MB | +21.1MB |
+| IOAccelerator Graphics 漂移 | +8601.6MB | +0.0MB |
+
+修复后 `Qwen3-Embedding-4B-4bit-DWQ` 的逐轮 after-unload 样本：
+
+| Cycle | after-unload RSS MB | after-unload Physical Footprint MB | after-unload IOAccelerator Graphics MB | API model_memory_used MB |
+| ---: | ---: | ---: | ---: | ---: |
+| baseline | 134.4 | 94.2 | 1.2 | 0.0 |
+| 1 | 176.6 | 111.3 | 1.9 | 0.0 |
+| 2 | 181.7 | 116.4 | 1.9 | 0.0 |
+| 3 | 186.9 | 121.4 | 1.9 | 0.0 |
+| 4 | 193.0 | 127.4 | 1.9 | 0.0 |
+| 5 | 198.2 | 132.4 | 1.9 | 0.0 |
+
+复测输出文件：
+
+- `/tmp/omlx-memory-cycle-probe/embedding-qwen3-4b-dwq.jsonl`
+- `/tmp/omlx-memory-cycle-probe/reranker-qwen3-06b.jsonl`
+- `/tmp/omlx-memory-cycle-probe/instruct-qwen3-4b.jsonl`
+- `/tmp/omlx-memory-cycle-probe/ornith-35b-5bit.jsonl`
+
+四模型组合回归在本次会话中按用户指示取消，未作为本次验收证据。当前 11335 已重新启动并恢复空载，最终健康检查显示 `loaded_count=0`、`current_model_memory=0`。

--- a/docs/omlx-11335-model-cycle-memory-leak-report-zh.md
+++ b/docs/omlx-11335-model-cycle-memory-leak-report-zh.md
@@ -1,0 +1,208 @@
+# oMLX 11335 多模型加载/卸载内存泄露测试报告
+
+测试时间：2026-07-01 08:31-08:39 Asia/Shanghai
+
+测试对象：当前分支 `local/integration`，服务通过 `scripts/start-omlx-app-config.sh --host 127.0.0.1 --port 11335` 在 tmux 会话 `omlx-11335` 中启动。
+
+## 结论
+
+存在可稳定复现的 unload 后进程驻留内存递增问题。API 层面每轮卸载后均显示 `models_loaded=0`、`model_memory_used=0`，但 macOS `vmmap -summary` 显示 `IOAccelerator (graphics)` 以约 2.1GB/轮的速度线性增长。
+
+这不是普通 Python heap 泄露：`MALLOC_LARGE` 在卸载后回到约 52.6MB，`VM_ALLOCATE` 仅从 161.1MB 增至 270.4MB。主要增量全部落在 Metal/IOAccelerator 驱动驻留区。
+
+## 测试模型
+
+正式测试使用 oMLX 当前可见模型 ID：
+
+| 用户指定模型 | 本次实际 oMLX 模型 ID |
+| --- | --- |
+| Qwen3-4B-Instruct-2507-MLX-4bit | Qwen3-4B-Instruct-2507-MLX-4bit |
+| Qwen3-Embedding-4B-4bit-DWQ | Qwen3-Embedding-4B-4bit-DWQ |
+| Qwen3-Reranker-0.6B-4bit | Qwen3-Reranker-0.6B-4bit |
+| leonsarmiento/Ornith-1.0-35B-5bit-mlx | Ornith-1.0-35B-5bit-mlx |
+
+## 测试方法
+
+1. 停止 tmux 中原服务。
+2. 使用同一启动命令重启 11335，得到新 PID `25297`。
+3. 重启后服务自动加载默认模型 `Ornith-1.0-35B-5bit-mlx`，正式测试脚本先卸载所有已加载模型并等待 `models_loaded=0`。
+4. 记录空载基线。
+5. 循环加载 4 个目标模型，记录“全部加载后”内存。
+6. 反向卸载 4 个目标模型，等待 `models_loaded=0` 后记录“全部卸载后”内存。
+
+原始样本：
+
+- `/tmp/omlx-memory-test-11335/samples.jsonl`
+- `/tmp/omlx-memory-test-11335/samples.csv`（脚本被人工中断，CSV 未必生成；JSONL 为权威记录）
+
+后续复测请使用仓库内脚本与方案：
+
+- `scripts/omlx_memory_cycle_probe.py`
+- `docs/omlx-memory-cycle-retest-plan-zh.md`
+
+## 样本数据
+
+脚本被人工停止前完成了 8 轮完整加载/卸载，并进入第 9 轮加载。以下表格只使用 8 轮完整卸载样本。
+
+| 阶段 | Cycle | RSS MB | Physical Footprint MB | IOAccelerator Graphics MB | API model_memory_used MB |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| clean baseline | 0 | 490.1 | 265.7 | 2.0 | 0.0 |
+| after unload | 1 | 2742.9 | 2457.6 | 2150.4 | 0.0 |
+| after unload | 2 | 4931.8 | 4608.0 | 4300.8 | 0.0 |
+| after unload | 3 | 7108.5 | 6860.8 | 6451.2 | 0.0 |
+| after unload | 4 | 9291.0 | 9011.2 | 8601.6 | 0.0 |
+| after unload | 5 | 11467.8 | 11161.6 | 10752.0 | 0.0 |
+| after unload | 6 | 13644.3 | 13414.4 | 13004.8 | 0.0 |
+| after unload | 7 | 15818.9 | 15564.8 | 15155.2 | 0.0 |
+| after unload | 8 | 17992.6 | 17715.2 | 17305.6 | 0.0 |
+
+完整加载峰值也随轮次同步抬升：
+
+| Cycle | 全部加载后 RSS MB | 全部加载后 Physical Footprint MB | 全部加载后 IOAccelerator Graphics MB |
+| ---: | ---: | ---: | ---: |
+| 1 | 29757.0 | 29491.2 | 28672.0 |
+| 2 | 31928.7 | 31641.6 | 30822.4 |
+| 3 | 34095.3 | 33792.0 | 33075.2 |
+| 4 | 36261.9 | 36044.8 | 35225.6 |
+| 5 | 38431.7 | 38195.2 | 37376.0 |
+| 6 | 40598.2 | 40345.6 | 39526.4 |
+| 7 | 42765.7 | 42496.0 | 41676.8 |
+| 8 | 44932.5 | 44646.4 | 43827.2 |
+
+## 定量判断
+
+以 8 轮完整卸载样本计算：
+
+- RSS：490.1MB -> 17992.6MB，净增 17502.5MB。
+- Physical footprint：265.7MB -> 17715.2MB，净增 17449.5MB。
+- IOAccelerator (graphics)：2.0MB -> 17305.6MB，净增 17303.6MB。
+- 从第 1 轮卸载后到第 8 轮卸载后，Physical footprint 增长 15257.6MB，约 2179.7MB/轮。
+- 每轮 API 均确认 `model_memory_used=0`，说明 oMLX 的模型内存账本已经归零，但进程物理驻留没有归零。
+
+人工停止脚本后，当前服务仍空载：
+
+- `/api/status`: `models_loaded=0`, `model_memory_used=0`
+- `vmmap -summary 25297`: `Physical footprint=19.4G`, `IOAccelerator (graphics)=19.0G`
+
+这与第 9 轮被中断前的加载/卸载残留一致。
+
+## 原因分析
+
+### 已排除
+
+1. 不是“模型没有卸载”。每个完整 after-unload 样本 API 都显示 `models_loaded=0`。
+2. 不是 oMLX 模型内存计数没有扣减。每个完整 after-unload 样本 API 都显示 `model_memory_used=0`。
+3. 不是普通 Python malloc 主导。卸载后 `MALLOC_LARGE` 稳定回到约 52.6MB，`MALLOC_SMALL (empty)` 在 116-148MB 区间波动。
+
+### 高概率原因
+
+卸载路径已经执行了常规清理，但仍无法释放一部分 Metal 驱动层驻留内存：
+
+- `EnginePool._unload_engine()` 在停止 engine 后清空引用、执行 `gc.collect()`，并通过 MLX executor 调用 `mx.synchronize()` + `mx.clear_cache()`。
+- `EngineCore.close()` 会在 engine 线程上执行 `scheduler.shutdown`、`scheduler.deep_reset`，随后清空 model/tokenizer/scheduler 引用，并在线程本地 stream 上执行 `_final_engine_thread_reclaim()`。
+- `_final_engine_thread_reclaim()` 内部再次执行 `gc.collect()`、`_sync_and_clear_cache(stream)`、`gc.collect()`。
+
+因此，本次现象不是缺少最基本的 `clear_cache` 调用，而是“多 engine/多后端模型重复创建销毁后，仍有与 MLX/Metal stream、compiled graph、model wrapper 或 driver allocation 相关的 GPU allocation 没有回到系统”。
+
+尤其值得注意的是：每轮残留约 2.1GB，远低于四个模型全部加载的 30GB 账面模型内存，但增长非常线性，说明更像是某个固定模型或固定 backend 的卸载残留，而不是随机碎片。需要进一步拆分到单模型测试定位。
+
+## 解决方案
+
+## 追加定位：单模型隔离测试
+
+追加测试时间：2026-07-01 08:50-09:01 Asia/Shanghai。
+
+为缩小范围，每个模型测试前都重启 11335 服务，并在重启后确认空载。测试结果如下：
+
+| 模型 | 轮次 | after-unload Physical Footprint 漂移 | after-unload IOAccelerator Graphics 漂移 | 判断 |
+| --- | ---: | ---: | ---: | --- |
+| Qwen3-Embedding-4B-4bit-DWQ | 5 | +8601.6MB | +8601.6MB | 线性泄露，主因 |
+| Qwen3-Reranker-0.6B-4bit | 5 | +8.3MB | +0.0MB | 可排除 |
+| Qwen3-4B-Instruct-2507-MLX-4bit | 5 | +0.0MB（相对第 1 轮卸载后） | +0.0MB（相对第 1 轮卸载后） | 首轮保留约 2.15GB，但后续收敛，不是线性泄露源 |
+| Ornith-1.0-35B-5bit-mlx | 3 | +19.3MB | +0.0MB | 可排除 |
+
+单模型原始样本：
+
+- `/tmp/omlx-single-model-tests/Qwen3-Embedding-4B-4bit-DWQ.jsonl`
+- `/tmp/omlx-single-model-tests/Qwen3-Reranker-0.6B-4bit.jsonl`
+- `/tmp/omlx-single-model-tests/Qwen3-4B-Instruct-2507-MLX-4bit.jsonl`
+- `/tmp/omlx-single-model-tests/Ornith-1.0-35B-5bit-mlx.jsonl`
+
+### 关键证据
+
+`Qwen3-Embedding-4B-4bit-DWQ` 单独循环即可复现与多模型测试一致的每轮约 2.15GB 残留：
+
+| Cycle | after-unload RSS MB | after-unload Physical Footprint MB | after-unload IOAccelerator Graphics MB | API model_memory_used MB |
+| ---: | ---: | ---: | ---: | ---: |
+| baseline | 483.1 | 265.3 | 2.0 | 0.0 |
+| 1 | 2649.4 | 2457.6 | 2150.4 | 0.0 |
+| 2 | 4811.0 | 4608.0 | 4300.8 | 0.0 |
+| 3 | 6974.0 | 6758.4 | 6451.2 | 0.0 |
+| 4 | 9137.6 | 8908.8 | 8601.6 | 0.0 |
+| 5 | 11300.4 | 11059.2 | 10752.0 | 0.0 |
+
+对应服务日志显示 embedding unload 的内部 MLX active memory 未释放：
+
+- 第 4 轮：`Settle barrier timed out for 'Qwen3-Embedding-4B-4bit-DWQ': freed=0.00B`
+- 第 4 轮：`Emergency reclaim failed ... active_memory=8.44GB exceeds safe threshold (5.00GB)`
+- 第 5 轮：`Settle barrier timed out ... freed=0.00B`
+- 第 5 轮：`Emergency reclaim failed ... active_memory=10.54GB exceeds safe threshold (5.00GB)`
+
+对照组：
+
+- `Qwen3-Reranker-0.6B-4bit` 每轮卸载后 `IOAccelerator (graphics)` 回到 2.0MB，日志中 active memory 回到约 1KB。
+- `Ornith-1.0-35B-5bit-mlx` 每轮卸载后 `IOAccelerator (graphics)` 回到 2.0MB，日志中 `freed=23.50GB` 且 active memory 回到约 1KB。
+- `Qwen3-4B-Instruct-2507-MLX-4bit` 首轮卸载后保留约 2.15GB，后续加载/卸载不再增长；这是一次性 runtime/cache 驻留，不是本次多模型线性增长的主因。
+
+### 缩小后的根因判断
+
+问题集中在 `Qwen3-Embedding-4B-4bit-DWQ` 的 embedding backend，尤其是 `mlx-embeddings` fallback + `mx.compile` 路径。
+
+代码证据：
+
+- `EmbeddingEngine.start()` 在全局 MLX executor 中调用 `MLXEmbeddingModel.load()`。
+- `MLXEmbeddingModel.load()` 对该模型走 `mlx-embeddings` fallback，并调用 `_try_compile()`。
+- `_try_compile()` 创建 `_compiled_embed = mx.compile(_compiled_embed)`，其中闭包捕获 `base_model = self.model`。
+- `EmbeddingEngine.stop()` 只执行 `self._model = None`、`gc.collect()`、全局 executor 上的 `mx.synchronize()` + `mx.clear_cache()`。
+
+这条链路没有显式释放 `MLXEmbeddingModel.model`、`processor`、`_compiled_embed`，也没有像 `EngineCore.close()` 那样在 engine-owned executor/thread/stream 上执行完整 reclaim。结合 `freed=0.00B` 和每轮新增一个模型体量级别的 `IOAccelerator (graphics)`，高概率是 compiled callable、compile cache 或 `mlx-embeddings` 模型对象仍持有旧模型权重/Metal buffer。
+
+### 更新后的修复优先级
+
+1. 先修 `EmbeddingEngine.stop()` / `MLXEmbeddingModel` teardown，而不是先动 VLM、Reranker 或通用 EngineCore。
+2. 为 `MLXEmbeddingModel` 增加显式 `close()` 或 `release_resources()`：
+   - 先将 `_compiled_embed = None`
+   - 再将 `model = None`
+   - 再将 `processor = None`
+   - 重置 `_loaded/_is_compiled`
+   - 在线程内执行 `gc.collect()`、`mx.synchronize()`、`mx.clear_cache()`
+3. 如果 MLX 提供 compile cache 清理 API，应在 embedding stop 中清理当前线程 compile cache；否则优先增加开关，允许对 embedding 禁用 `mx.compile`，验证泄露是否消失。
+4. 增加回归测试脚本或手工验收：单独对 `Qwen3-Embedding-4B-4bit-DWQ` 做 5-10 轮 load/unload，after-unload `IOAccelerator (graphics)` 不应继续每轮 +2.15GB。
+
+### 立即规避
+
+1. 当需要长时间稳定运行 11335 时，避免频繁加载/卸载这组模型；对常用模型保持常驻，减少 churn。
+2. 如果业务上必须频繁切换模型，应在卸载后监控 `vmmap -summary <pid>` 的 `IOAccelerator (graphics)`，不要只看 `/api/status`。
+3. 当空载 `IOAccelerator (graphics)` 超过阈值（例如 8-12GB）时，执行服务级重启；当前证据显示进程重启可以恢复到数百 MB 级空载基线。
+
+### 修复路线
+
+1. 增加单模型循环测试，分别测试四个模型，每个模型至少 5 轮：
+   - 只测 `Qwen3-4B-Instruct-2507-MLX-4bit`
+   - 只测 `Qwen3-Embedding-4B-4bit-DWQ`
+   - 只测 `Qwen3-Reranker-0.6B-4bit`
+   - 只测 `Ornith-1.0-35B-5bit-mlx`
+   目标是确认每轮约 2.1GB 的残留来自哪个 engine/backend。
+2. 在卸载日志中补充 `mx.get_active_memory()`、`mx.get_peak_memory()`、`vmmap IOAccelerator` 快照，避免只依赖 oMLX 内部账本。
+3. 审查模型 wrapper 的 backend-specific 释放接口，优先检查 VLM/Batched/Embedding/Reranker 的 `stop()` 是否真正释放 tokenizer、processor、compiled callable、model module、stream-local caches。
+4. 对每个 engine executor shutdown 后增加可选强制等待与线程退出验证。当前 `EngineCore.close()` 在 compile-cache 可清理时调用 `shutdown(wait=False)`，这有利于避免卡死，但无法证明线程和 thread-local MLX/Metal 资源已经退出。
+5. 如果单模型定位到 MLX/Metal 运行时层而非 oMLX 引用残留，应增加“内存阈值触发 supervised restart”的运维保护，并把 MLX 版本、macOS 版本、复现脚本和 `vmmap` 证据提交给上游。
+
+### 验证标准
+
+修复后重新执行同一测试：
+
+- 重启后先卸载自动加载模型，确认 `models_loaded=0`。
+- 完成 10 轮完整循环。
+- after-unload 的 `Physical footprint` 和 `IOAccelerator (graphics)` 不应线性增长。
+- 建议阈值：第 10 轮 after-unload 相比第 1 轮 after-unload 增长小于 500MB；如果 macOS/MLX 有合理缓存保留，则至少应在前 2-3 轮后收敛，而不能持续每轮增加约 2GB。

--- a/docs/omlx-memory-cycle-retest-plan-zh.md
+++ b/docs/omlx-memory-cycle-retest-plan-zh.md
@@ -1,0 +1,192 @@
+# oMLX 模型加载/卸载内存驻留复测方案
+
+本文档用于复测 11335 服务在模型反复加载/卸载后的内存驻留问题，重点验证 `Qwen3-Embedding-4B-4bit-DWQ` 的 embedding backend 是否仍然每轮泄露约 2.15GB `IOAccelerator (graphics)`。
+
+## 前置条件
+
+- 当前分支已安装可运行的本地 editable 环境。
+- oMLX 使用 `scripts/start-omlx-app-config.sh --host 127.0.0.1 --port 11335` 启动。
+- 测试前必须重启服务，避免旧的 Metal/MLX 驻留污染基线。
+- 测试脚本需要 admin API key：
+
+```bash
+export OMLX_API_KEY='<admin-api-key>'
+```
+
+如果服务不是 `http://127.0.0.1:11335`，同时设置：
+
+```bash
+export OMLX_BASE_URL='http://127.0.0.1:11335'
+```
+
+## 标准重启步骤
+
+在 tmux 会话 `omlx-11335` 中重启服务：
+
+```bash
+tmux send-keys -t omlx-11335 C-c
+sleep 5
+tmux send-keys -t omlx-11335 'scripts/start-omlx-app-config.sh --host 127.0.0.1 --port 11335' Enter
+```
+
+确认新进程监听：
+
+```bash
+lsof -nP -iTCP:11335 -sTCP:LISTEN
+curl -sS -H "Authorization: Bearer $OMLX_API_KEY" \
+  http://127.0.0.1:11335/api/status
+```
+
+注意：服务可能会自动加载默认模型。复测脚本默认会在正式采样前卸载所有已加载模型，并等待 `models_loaded=0`。
+
+## 脚本
+
+统一脚本：
+
+```bash
+.venv/bin/python scripts/omlx_memory_cycle_probe.py --help
+```
+
+脚本输出：
+
+- JSONL：逐阶段原始样本
+- CSV：同样本的表格版本
+- summary JSON：漂移摘要
+
+默认输出目录：
+
+```text
+/tmp/omlx-memory-cycle-probe
+```
+
+每条样本包含：
+
+- `/api/status` 中的 `models_loaded`、`loaded_models`、`model_memory_used`
+- `ps` RSS
+- `vmmap -summary` 中的 `Physical footprint`
+- `vmmap -summary` 中的 `IOAccelerator (graphics)`
+- `MALLOC_LARGE`、`MALLOC_SMALL (empty)`、`VM_ALLOCATE`
+
+## 复测 A：Embedding 单模型定位
+
+目的：验证已定位的主因是否仍然存在。
+
+重启服务后执行：
+
+```bash
+.venv/bin/python scripts/omlx_memory_cycle_probe.py \
+  --model Qwen3-Embedding-4B-4bit-DWQ \
+  --rounds 5 \
+  --label embedding-qwen3-4b-dwq
+```
+
+已知异常签名：
+
+- 每轮 after-unload 都是 `models_loaded=0`、`model_memory_used_mb=0.0`
+- `IOAccelerator (graphics)` 每轮约 +2150MB
+- 5 轮后 after-unload `IOAccelerator (graphics)` 约 10752MB
+- 服务日志出现 `Settle barrier timed out ... freed=0.00B`
+- 服务日志出现 `Emergency reclaim failed ... active_memory=...`
+
+修复后验收标准：
+
+- after-unload 的 `IOAccelerator (graphics)` 不再每轮线性增长。
+- 建议 5 轮后相对第 1 轮 after-unload 漂移小于 500MB。
+- 如果 MLX/Metal 保留一次性缓存，必须在前 1-2 轮后收敛。
+
+## 复测 B：对照模型
+
+目的：确认修复没有破坏其它 backend 的卸载行为。
+
+每个模型测试前都重启服务。
+
+Reranker：
+
+```bash
+.venv/bin/python scripts/omlx_memory_cycle_probe.py \
+  --model Qwen3-Reranker-0.6B-4bit \
+  --rounds 5 \
+  --label reranker-qwen3-06b
+```
+
+Instruct：
+
+```bash
+.venv/bin/python scripts/omlx_memory_cycle_probe.py \
+  --model Qwen3-4B-Instruct-2507-MLX-4bit \
+  --rounds 5 \
+  --label instruct-qwen3-4b
+```
+
+Ornith：
+
+```bash
+.venv/bin/python scripts/omlx_memory_cycle_probe.py \
+  --model Ornith-1.0-35B-5bit-mlx \
+  --rounds 3 \
+  --label ornith-35b-5bit
+```
+
+已知基线：
+
+- `Qwen3-Reranker-0.6B-4bit`：5 轮 after-unload `IOAccelerator (graphics)` 漂移 0MB。
+- `Ornith-1.0-35B-5bit-mlx`：3 轮 after-unload `IOAccelerator (graphics)` 漂移 0MB。
+- `Qwen3-4B-Instruct-2507-MLX-4bit`：首轮可能保留约 2.15GB，但后续不继续累加。
+
+## 复测 C：四模型组合回归
+
+目的：验证真实组合场景是否修复。
+
+重启服务后执行：
+
+```bash
+.venv/bin/python scripts/omlx_memory_cycle_probe.py \
+  --default-suite \
+  --rounds 10 \
+  --label four-model-suite-11335
+```
+
+四模型组合包含：
+
+- `Qwen3-4B-Instruct-2507-MLX-4bit`
+- `Qwen3-Embedding-4B-4bit-DWQ`
+- `Qwen3-Reranker-0.6B-4bit`
+- `Ornith-1.0-35B-5bit-mlx`
+
+修复前异常签名：
+
+- 8 轮完整卸载后，`IOAccelerator (graphics)` 从 2.0MB 增至 17305.6MB。
+- 增长约 2.1GB/轮。
+- `/api/status` 每轮 after-unload 仍显示 `models_loaded=0`、`model_memory_used=0`。
+
+修复后验收标准：
+
+- 10 轮 after-unload 不应线性增长。
+- 建议第 10 轮 after-unload 相比第 1 轮 after-unload 的 `IOAccelerator (graphics)` 漂移小于 500MB。
+- 如果存在一次性 runtime/cache 驻留，应在前 1-2 轮后收敛。
+
+## 结果归档
+
+建议将每次复测输出目录复制或移动到 repo 外的时间戳目录，例如：
+
+```bash
+mkdir -p /tmp/omlx-memory-retention-runs/$(date +%Y%m%d-%H%M%S)
+cp -p /tmp/omlx-memory-cycle-probe/* /tmp/omlx-memory-retention-runs/$(date +%Y%m%d-%H%M%S)/
+```
+
+若要把关键结论写入仓库文档，更新：
+
+```text
+docs/omlx-11335-model-cycle-memory-leak-report-zh.md
+```
+
+至少记录：
+
+- commit/branch
+- macOS 版本
+- MLX / mlx-lm / mlx-embeddings 版本
+- 服务启动命令
+- 测试模型
+- 轮次数
+- summary JSON 中的 drift 数值
+- 服务日志中的 unload settle 结果

--- a/docs/omlx-memory-retention-investigation-zh.md
+++ b/docs/omlx-memory-retention-investigation-zh.md
@@ -1,0 +1,462 @@
+# oMLX 卸载内存保留问题调查
+
+日期：2026-06-26
+
+## 问题
+
+观察到的 oMLX 后端状态与 UI 和管理缓存表面不一致：
+
+- UI 显示无活跃任务，热缓存为空。
+- 仅加载了一个模型：`Qwen3.6-35B-A3B-nvfp4`。
+- `/api/status` 报告无活跃或等待中的请求。
+- 进程仍然持有非常大的驻留内存 footprint：`64.8G`。
+- `vmmap -summary` 将大部分内存归因于 Metal/IOAccelerator：
+  `IOAccelerator (graphics): 61.9G`。
+
+清空热缓存没有回收任何内存：
+
+- `/admin/api/hot-cache/clear`：`total_cleared=0`，`bytes_reclaimed=0`。
+
+卸载已加载的模型释放了模型权重内存，但并非所有 Metal 内存都被回收：
+
+- `POST /v1/models/Qwen3.6-35B-A3B-nvfp4/unload`
+- 日志结果：`freed=19.01GB`，`active_memory: 42.89GB (settled)`。
+- 卸载后，`/api/status` 显示 `models_loaded=0` 和 `model_memory_used=0B`。
+- `vmmap` 仍显示 footprint 约 `45.6G`，其中 `IOAccelerator 42.9G`。
+
+重启服务器释放了内存：
+
+- 新进程 footprint：约 `109.5M`。
+- `IOAccelerator`：约 `48K`。
+
+这证明了保留的内存既不是热缓存、也不是模型权重，更不是以已加载模型形式可见的内容。而是引擎卸载后进程生命周期的 Metal/MLX 内存保留。
+
+相关上游 issue 评论：
+
+- https://github.com/jundot/omlx/issues/1691#issuecomment-4809293896
+
+该评论记录了 oMLX `0.4.4` 上同类内存保留问题，但有一个重要澄清：泄漏并不要求预填充失败或 mid-stream fallback。在该复现中，一次成功的长上下文补全同样留下了大量 Metal 分配：
+
+- 请求正常完成，日志中有 `prompt: 40338` 和 `finish_reason=stop`。
+- oMLX 报告 `active_requests=0`、`waiting_requests=0`，且仅有一个已加载模型，模型内存账面约 `19.95GB`。
+- 进程级 `vmmap -summary` 仍显示 `64.8G` 物理 footprint，以及 `61.9G` 的 `IOAccelerator (graphics)`。
+- 先卸载 embedding 模型，再卸载主模型后，`models_loaded=0` 且 `model_memory_used_formatted=0B`，但 `vmmap` 仍显示 `45.6G` 物理 footprint 和 `42.9G` 的 `IOAccelerator (graphics)`。
+- `POST /admin/api/hot-cache/clear` 回收了 `0` 字节。
+- `lsof` 未显示模型权重文件仍被打开。
+- 重启 Python/oMLX 进程后，footprint 降至约 `109.5M`，`IOAccelerator` 降至 `48K`。
+
+这将本地调查与上游 issue `#1691` 连接起来：保留内存并不限于某一条错误路径。共同特征是进程生命周期内的 MLX/Metal 分配，不再以已加载模型、热缓存条目或活跃请求形式可见。
+
+## 日志中的证据
+
+该事件发生在一个长上下文生成之后，伴随重复的分块预填充内存压力：
+
+- 大量日志行显示 `Chunked prefill above max_bytes... 68.xGB > 67.9GB`。
+- 在 `2026-06-26 17:10:29`，oMLX 存储了一个边界缓存快照：
+  `storing 28672/40512 tokens`。
+- 同一补全报告：
+  `Chat completion: 174 tokens in 183.43s, prompt: 40338`。
+
+之后，在模型卸载后：
+
+- 调度器关闭/深度重置完成。
+- oMLX 日志显示 `freed=19.01GB`。
+- MLX 活跃内存仍为 `42.89GB`。
+
+这表明大型临时/前缀缓存/预填充 Metal 分配在引擎生命周期内存活，即使在请求和模型状态通过管理 API 不可见之后。相关的 `#1691` 复现强化了这一解释：它在一次成功请求之后、卸载所有真实模型之后、且 hot-cache 回收返回 `0` 字节之后，仍观察到同样的 `IOAccelerator` footprint 保留。
+
+## 分析
+
+根本原因很可能是 `EngineCore.close()` 中的拆除顺序和 executor/流所有权 bug。
+
+补丁前的相关行为：
+
+- 每个引擎拥有自己的 MLX executor 和线程局部 MLX stream。
+- 调度器关闭和深度重置通过该引擎 executor 运行。
+- 之后，`EngineCore.close()` 清除 MLX 编译缓存并关闭 executor。
+- 只有在处理完 executor 之后，才清除输出收集器并将 `self.model`、`self.tokenizer` 和 `self.scheduler` 设为 `None`。
+- 在丢弃这些引用后，没有对引擎工作线程执行最终的 `mx.synchronize(stream)` 加 `mx.clear_cache()` 操作。
+- 其他管理/全局清空路径使用全局 MLX executor，而非可能持有保留缓冲区的引擎 executor/stream。
+
+还存在一个微妙的引用保留问题：
+
+- `for fn in (self.scheduler.shutdown, self.scheduler.deep_reset)` 循环后，局部变量 `fn` 仍绑定到最后一个调度器方法。
+- 该绑定的方法可以在 `close()` 返回前保持调度器对象存活。
+- 在丢弃此引用之前执行最终的 GC/回收，无法看到真正可回收的对象图。
+
+为什么这匹配运行时证据：
+
+- 模型卸载释放了约 `19GB`，与模型权重被丢弃一致。
+- 剩余的 `42.9GB` 是 Metal/IOAccelerator 内存，与大型预填充/缓存/临时 MLX 缓冲区一致。
+- 重启释放了所有内容，证明它是进程本地的保留 MLX/Metal 状态，而非外部文件或热缓存条目。
+- 上游 `#1691` 评论显示，不发生 in-flight 请求失败时也会出现同样模式，因此修复应针对正常的引擎拆除和工作线程回收路径，而不是只清理 failed-prefill 路径。
+
+实时验证还暴露了第二个 VLM 特定的引用保留路径：
+
+- `EngineCore.model` 对于 VLM 引擎是一个 `VLMModelAdapter`。
+- 该 adapter 同时保留了 `_vlm_model` 和 `_language_model` 的强引用。
+- `VLMBatchedEngine` 还在包装器侧保留了 VLM 模型、processor、adapter、tokenizer 和 drafter 的引用，直到 `EngineCore.close()` 之后。
+- 第一次补丁运行，在 `EngineCore.close()` 中添加了最终工作线程回收，卸载后仍保留了约 `19.0GB` 的
+  `IOAccelerator (graphics)`。
+- 仅在 `EngineCore.close()` 之前丢弃包装器引用本身不够，因为 `EngineCore.model` 内的 adapter 仍然持有原始模型对象。
+
+因此最终修复需要两者兼顾：
+
+- 在引擎自有引用丢弃之后，在工作线程上执行最终回收；以及
+- 在执行最终回收之前，显式释放 VLM adapter/包装器引用。
+
+次要观察：
+
+- `VLMBatchedEngine.has_active_requests()` 仅检查输出收集器。
+- 即使存在调度器侧的异步清理或延迟删除，它也可能报告无活跃请求。
+- 这可能导致 UI 在调度器/MLX 内存生命周期完全稳定之前更早显示空闲。这可能不是卸载后残留内存的主要原因，但会向用户隐藏清理活动。
+
+## 当前补丁
+
+更改的文件：
+
+- `omlx/engine_core.py`
+- `omlx/engine/vlm.py`
+- `omlx/models/vlm.py`
+- `tests/test_per_engine_threads.py`
+- `tests/test_engine_core.py`
+- `tests/test_vlm_model_adapter.py`
+
+补丁意图：
+
+1. 添加 `_final_engine_thread_reclaim(stream)`。
+2. 在该辅助函数中：
+   - 执行 `gc.collect()`；
+   - 调用调度器的 `_sync_and_clear_cache(stream)`；
+   - 再次执行 `gc.collect()`。
+3. 在 `EngineCore.close()` 中：
+   - 在引擎 executor 上执行调度器关闭和深度重置；
+   - 清除残留的绑定方法局部变量 `fn`；
+   - 关闭并分离 SSD 缓存管理器；
+   - 清除输出收集器和请求侧的流状态；
+   - 如果存在，调用模型特定的 `release_resources()`；
+   - 将 `self.model`、`self.tokenizer` 和 `self.scheduler` 设为 `None`；
+   - 将 `_final_engine_thread_reclaim(self._mlx_stream)` 提交到同一引擎 executor；
+   - 然后根据现有编译缓存策略，清除 MLX 编译缓存并关闭或不朽化 executor。
+4. 在 `VLMBatchedEngine.stop()` 中：
+   - 在关闭内部引擎之前丢弃包装器侧引用。
+5. 在 `VLMModelAdapter.release_resources()` 中：
+   - 在最终工作线程回收之前，丢弃待处理的 VLM 数组和原始 `_vlm_model` / `_language_model` 引用。
+
+重要的设计选择是：最终回收在引擎自有引用被丢弃之后执行，并且在拥有 MLX 分配的是同一工作线程/流上执行。
+
+测试更改：
+
+- `test_close_clears_compile_cache_then_shuts_down` 现在断言：
+  - 模型特定的 `release_resources()` 在最终回收之前运行；
+  - 最终回收在编译缓存清除之前调用；
+  - 到最终回收执行时，`engine.model`、`engine.tokenizer` 和 `engine.scheduler` 已为 `None`。
+- `test_close_fatal_exits_when_compile_cache_clear_times_out` 现在考虑编译缓存清除之前的额外 executor 提交。
+- `test_release_resources_drops_model_references` 断言 VLM adapter 丢弃原始模型和待处理数组引用。
+
+## 验证更新
+
+初始直接测试命令：
+
+```bash
+uv run pytest tests/test_per_engine_threads.py tests/test_engine_core.py
+```
+
+在准备依赖时失败：
+
+```text
+Failed to download mlx-metal==0.31.2
+Failed to extract archive: mlx_metal-0.31.2-py3-none-macosx_26_0_arm64.whl
+I/O operation failed during extraction
+Failed to download distribution due to network timeout.
+Try increasing UV_HTTP_TIMEOUT (current value: 30s).
+```
+
+然后将测试移至 tmux：
+
+```bash
+tmux new -A -d -s omlx
+tmux send-keys -t omlx 'cd /Users/zhouwei/code/zw/omlx && UV_HTTP_TIMEOUT=300 uv run pytest tests/test_per_engine_threads.py tests/test_engine_core.py 2>&1 | tee /tmp/omlx-pytest.log' C-m
+```
+
+该命令运行了数分钟，无 stdout 输出，且 `/tmp/omlx-pytest.log` 仍为空，因此被中断并拆分为环境设置加测试执行。
+
+当前 tmux 命令：
+
+```bash
+cd /Users/zhouwei/code/zw/omlx && UV_HTTP_TIMEOUT=300 uv sync 2>&1 | tee /tmp/omlx-uv-sync.log
+```
+
+截至最新检查：
+
+- `uv sync` 仍在运行。
+- `/tmp/omlx-uv-sync.log` 仍为 `0` 字节。
+- `lsof -p <uv-pid>` 显示 `uv` 处于活跃状态，未死锁：
+  - 已打开 HTTPS 连接；
+  - 正在 `~/.cache/uv` 下写入临时文件；
+  - 观察到的文件包括 `mlx/lib/mlx.metallib` 和 `cmake`。
+
+因此原始阻塞点是依赖下载/提取速度或网络行为，而非已知的代码/测试失败。
+
+由于 GitHub 依赖的完整 `uv sync` 太慢，验证路径缩小为目标测试：
+
+1. 停止缓慢的 `uv sync` / `git fetch` 进程。
+2. 使用现有的 `.venv`。
+3. 仅从清华 PyPI 镜像安装这些测试所需的最小包：
+
+```bash
+uv pip install --python .venv/bin/python \
+  --index-url https://pypi.tuna.tsinghua.edu.cn/simple \
+  pytest pytest-asyncio mlx==0.31.2 fastapi uvicorn numpy pyyaml \
+  requests psutil setproctitle transformers tokenizers huggingface-hub \
+  jinja2 itsdangerous pillow rich sentencepiece tiktoken protobuf tqdm \
+  jsonschema python-multipart tabulate socksio
+
+uv pip install --python .venv/bin/python \
+  --index-url https://pypi.tuna.tsinghua.edu.cn/simple \
+  mlx-lm mlx-vlm
+```
+
+注意：
+
+- 国内 PyPI 镜像解决了 wheel/包下载瓶颈。
+- 它不替换 `pyproject.toml` 中 `git+https://github.com/...` 的依赖；这些仍需 GitHub 或显式 Git 镜像。
+- 在沙箱内运行 MLX 导入失败：
+  `RuntimeError: [metal::load_device] No Metal device available`。
+- 在沙箱外运行相同的测试命令允许 MLX 访问 Metal。
+
+目标验证通过：
+
+```bash
+.venv/bin/python -m pytest tests/test_per_engine_threads.py tests/test_engine_core.py
+```
+
+结果：
+
+```text
+78 passed in 4.31s
+```
+
+VLM adapter/包装器引用释放补丁后，更窄的目标套件也通过：
+
+```bash
+.venv/bin/python -m pytest \
+  tests/test_vlm_model_adapter.py::TestVLMModelAdapter::test_release_resources_drops_model_references \
+  tests/test_vlm_engine.py::TestStopSafety \
+  tests/test_per_engine_threads.py::TestPerEngineExecutor::test_close_clears_compile_cache_then_shuts_down \
+  tests/test_engine_core.py::TestEngineCoreClose
+```
+
+结果：
+
+```text
+9 passed in 1.33s
+```
+
+`git diff --check` 也通过。
+
+## 端口 11445 上的实时验证
+
+验证服务器：
+
+```bash
+.venv/bin/python -m omlx.cli serve \
+  --host 127.0.0.1 \
+  --port 11445 \
+  --base-path /tmp/omlx-patched-validation2 \
+  --model-dir /Users/zhouwei/.omlx/models \
+  --api-key validation-key \
+  --hf-endpoint https://hf-mirror.com \
+  --paged-ssd-cache-dir /tmp/omlx-patched-validation2/cache \
+  --paged-ssd-cache-max-size 20GB \
+  --hot-cache-max-size 10GB \
+  --memory-guard-gb 76 \
+  --log-level info
+```
+
+请求前的基线：
+
+- `/api/status`：`models_loaded=0`，`model_memory_used=0B`。
+- `vmmap`：物理 footprint `102.3M`。
+- `vmmap`：`IOAccelerator (graphics)` 驻留 `48K`。
+
+长上下文请求：
+
+- 模型：`Qwen3.6-35B-A3B-nvfp4`。
+- 提示 tokens：`51419`。
+- 缓存提示 tokens：`0`。
+- 补全 tokens：`32`。
+- 请求状态：`200`。
+- 客户端 elapsed wall time：`37.99s`。
+
+卸载前：
+
+- `/api/status`：`models_loaded=1`。
+- `/api/status`：`model_memory_used_formatted=19.95GB`。
+- `vmmap`：物理 footprint `23.6G`。
+- `vmmap`：`IOAccelerator (graphics)` 驻留 `20.5G`。
+
+卸载后：
+
+- `POST /v1/models/Qwen3.6-35B-A3B-nvfp4/unload` 返回：
+  `{"status":"ok","model_id":"Qwen3.6-35B-A3B-nvfp4"}`。
+- `/api/status`：`models_loaded=0`，`model_memory_used=0B`。
+- `vmmap`：物理 footprint `569.7M`。
+- `vmmap`：`IOAccelerator (graphics)` 驻留 `2832K`。
+- 服务器日志：
+  `Unloaded model: Qwen3.6-35B-A3B-nvfp4, freed=20.41GB (expected>=17.95GB), active_memory: 1.02KB (settled)`。
+
+这验证了补丁在复现泄漏的相同长预填充场景中释放了之前保留的 Metal 内存。剩余的进程 footprint 是正常的运行时/库分配器残留，而非之前的保留 GPU 分配。
+
+## 后续：范围收窄和重复 bge reranker 循环
+
+日期：2026-06-27
+
+VLM 卸载修复验证后，单独测试了第二个内存保留症状：
+
+- 反复加载和卸载 `bge-reranker-v2-m3` 可能导致每个循环进程物理 footprint 增加数十 MB 到约一百 MB。
+- 在这些运行中，卸载后 `/v1/models/status` 返回 `current_model_memory=0`。
+- `vmmap` 显示卸载后 `IOAccelerator (graphics)` 回到约 `1-2MB`。
+- 增长归因于 macOS malloc 类别，尤其是 `MALLOC_LARGE (empty)`。
+
+这与原始 VLM/长预填充泄漏机制不同：
+
+- 原始 bug 在 VLM 引擎卸载后保留 MLX/Metal 内存。
+- bge reranker 循环在模型已释放后保留分配器拥有的空堆页。
+
+测试了多个更窄的假设：
+
+- 禁用 reranker `mx.compile` **未**阻止循环 footprint 增长。
+- 运行时调用 macOS `malloc_zone_pressure_relief()` 不是可靠修复，已从最终代码路径中移除。
+- 以 `MallocSpaceEfficient=1` 启动进程确实在重复 bge 加载/卸载测试中阻止了增长。
+
+使用 `MallocSpaceEfficient=1` 的验证：
+
+- 隔离 `11445` 服务，6 次 bge 循环：
+  - 卸载后：`101.2M`，`102.6M`，`103.0M`，`103.4M`，`103.9M`，`104.3M`。
+- 通过本地源启动脚本重启的现有 `11335` 服务，3 次 bge 循环：
+  - 卸载后：`102.8M`，`103.2M`，`103.6M`。
+
+最终范围决策：
+
+- 上游 PR 仅包含 VLM/EngineCore 拆除修复（对应 issue 级 MLX/Metal 保留问题）。
+- 本地源启动脚本在重复模型加载/卸载循环中保持 `MallocSpaceEfficient=1` 作为 macOS 部署策略。
+- 运行时 malloc 压力释放 helper 被移除，因为它增加了 ctypes 复杂度却未解决重复 bge footprint 增长。
+- Reranker `mx.compile` 默认保持启用。可使用 `OMLX_RERANKER_COMPILE=0` 进行排障禁用，但禁用不属于内存修复的一部分。
+
+干净的 upstream PR：
+
+- PR: https://github.com/jundot/omlx/pull/2010
+- Issue: https://github.com/jundot/omlx/issues/2004
+- 相关 issue 复现：
+  https://github.com/jundot/omlx/issues/1691#issuecomment-4809293896
+- 范围：
+  - `EngineCore.close()` 在最终工作线程 MLX 回收之前丢弃 model/tokenizer/scheduler 引用。
+  - `VLMBatchedEngine.stop()` 在关闭内部引擎之前丢弃包装器侧 VLM 引用。
+  - `VLMModelAdapter.release_resources()` 在最终回收之前丢弃 VLM 拥有的数组和原始模型引用。
+- 明确排除在 PR 之外：
+  - 本地安装文档和 `pyproject.toml` `file://` 依赖路径；
+  - `.codebase-memory` 工件；
+  - 本地源启动脚本；
+  - macOS `MallocSpaceEfficient=1` 部署设置；
+  - 运行时 malloc 压力释放 helper。
+
+## 建议的后续步骤
+
+1. 如果后续仍需要完整依赖同步，优先使用国内 PyPI 镜像获取 wheel 包，但单独处理 GitHub 依赖：
+
+```bash
+UV_DEFAULT_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple uv sync
+```
+
+2. 对于此补丁，目标测试已通过：
+
+```bash
+.venv/bin/python -m pytest tests/test_per_engine_threads.py tests/test_engine_core.py
+```
+
+3. 运行基本 diff 卫生检查：
+
+```bash
+git diff --check
+```
+
+补丁后已通过。
+
+4. 端口 `11445` 上的实时内存验证已通过；补丁后卸载路径将 `IOAccelerator (graphics)` 从 `20.5G` 降至 `2832K`。
+
+5. 考虑后续 UI/管理修复：
+
+- 使活跃请求报告包含调度器清理状态，如待处理异步删除、进行中的 store futures 或延迟清空状态。
+- 这不替代内存修复，但会使"空闲"状态在清理期间更真实。
+
+## 历史阻塞命令
+
+以下命令属于阻塞的完整同步路径，在此保留以供审计。
+
+检查 tmux `uv sync` 命令是否完成：
+
+```bash
+tmux capture-pane -pt omlx -S -220
+ls -l /tmp/omlx-uv-sync.log
+```
+
+如果 `uv sync` 仍在运行且输出为空，检查活跃进程：
+
+```bash
+ps aux | rg '[u]v sync|[u]v run pytest'
+lsof -p <uv-pid>
+```
+
+`uv sync` 完成后，单独运行目标测试：
+
+```bash
+UV_HTTP_TIMEOUT=300 uv run pytest tests/test_per_engine_threads.py tests/test_engine_core.py
+```
+
+或在现有 tmux 会话中：
+
+```bash
+tmux send-keys -t omlx 'cd /Users/zhouwei/code/zw/omlx && UV_HTTP_TIMEOUT=300 uv run pytest tests/test_per_engine_threads.py tests/test_engine_core.py 2>&1 | tee /tmp/omlx-pytest.log' C-m
+```
+
+## 2026-06-27 后续：单实例 cache 域和最终卸载治理验证
+
+本节记录后续本地分支验证，范围不同于上游 PR `#2010`。目标是验证两个本地任务：
+
+- 单 oMLX 实例内的 cache domain 策略和 prefix cache 复用；
+- 所有模型卸载后的 cache 自愈治理、MLX 清理和 maintenance gate。
+
+验证服务：
+
+```bash
+scripts/start-omlx-app-config.sh --host 127.0.0.1 --port 11445
+```
+
+验证结果：
+
+- 源码服务在 `127.0.0.1:11445` 启动，base path 为 `~/.omlx`，SSD cache 为 `~/.omlx/cache`，hot cache 为 `10GB`。
+- 依次加载：
+  - `Qwen3-Embedding-0.6B-8bit`
+  - `Qwen3-Reranker-0.6B-4bit`
+  - `Qwen2.5-0.5B-Instruct-MLX-4bit`
+- 三个模型同时加载后，状态显示 `models_loaded=3`，模型内存约 `1.22GB`。
+- 对小 LLM 使用稳定长前缀连续请求：
+  - 第一次：`prompt_tokens=2725`，`cached_tokens=0`；
+  - 第二次：`prompt_tokens=2725`，`cached_tokens=2560`，`cache_efficiency=46.3`。
+- 卸载 embedding 和 reranker 时仍有 LLM 存活，只执行单模型卸载，不触发全模型治理。
+- 卸载最后一个 LLM 后触发最终治理：
+  - `Cache domain janitor freed 3.25 GB across 32 files`
+  - `All-models-unloaded maintenance complete: ssd_freed=3.25GB, hot_cache_preserved=True`
+  - API 状态回到 `models_loaded=0`、`model_memory_used_formatted=0B`、无 active/waiting request。
+- 治理后立即执行真实 `/v1/rerank` 请求，`Qwen3-Reranker-0.6B-4bit` 正常加载并返回相关性排序结果，说明 maintenance gate 完成后业务可以继续进入。
+- 再次卸载最后一个 reranker 后，治理可重复触发：
+  - `Cache domain janitor freed 3.17 GB across 32 files`
+  - `All-models-unloaded maintenance complete: ssd_freed=3.17GB, hot_cache_preserved=True`
+  - API 状态再次回到 `models_loaded=0`、模型内存 `0B`。
+
+额外发现：
+
+- `/admin/api/models/{model}/load` 支持 Bearer API key 或 admin session。
+- `/admin/api/models/{model}/unload` 当前只接受 admin session cookie。真机验证通过 `/admin/auto-login` 使用主 API key 换取临时 admin cookie 后执行卸载。
+- 本次验证没有改变上游 PR `#2010` 的范围；cache domain 和 final unload governance 属于本地分支后续增强。

--- a/omlx/engine/embedding.py
+++ b/omlx/engine/embedding.py
@@ -101,13 +101,12 @@ class EmbeddingEngine(BaseNonStreamingEngine):
             return
 
         logger.info(f"Stopping embedding engine: {self._model_name}")
+        model = self._model
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(get_mlx_executor(), model.close)
         self._model = None
 
         gc.collect()
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            get_mlx_executor(), lambda: (mx.synchronize(), mx.clear_cache())
-        )
         logger.info(f"Embedding engine stopped: {self._model_name}")
 
     async def embed(

--- a/omlx/models/embedding.py
+++ b/omlx/models/embedding.py
@@ -7,9 +7,11 @@ text embeddings using Apple's MLX framework, with native fallback
 for XLMRoBERTa, BERT, and Qwen2-decoder embedding models.
 """
 
+import gc
 import inspect
 import json
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -17,6 +19,7 @@ from typing import Any, Dict, List, Optional, Union
 import mlx.core as mx
 from mlx.utils import tree_flatten
 
+from ..utils.compile_cache import clear_thread_compile_cache
 from .mlx_embeddings_compat import (
     patch_qwen3_vl_processor_for_torch_free_image_loading,
 )
@@ -32,6 +35,7 @@ _CONTEXT_LENGTH_ATTRS = (
     "seq_length",
     "n_positions",
 )
+_FALSE_ENV_VALUES = {"0", "false", "no", "off"}
 
 
 @dataclass
@@ -476,6 +480,15 @@ class MLXEmbeddingModel:
           for some embedding/reranker models, causing eval() runtime errors.
         - We compile a narrower function that returns only the final embedding array.
         """
+        compile_env = os.getenv("OMLX_EMBEDDING_COMPILE", "1").strip().lower()
+        if compile_env in _FALSE_ENV_VALUES:
+            logger.info(
+                "mx.compile disabled for %s by OMLX_EMBEDDING_COMPILE",
+                self.model_name,
+            )
+            self._compiled_embed = None
+            return False
+
         base_model = self.model
 
         try:
@@ -497,6 +510,37 @@ class MLXEmbeddingModel:
             logger.info(f"mx.compile unavailable for {self.model_name}: {e}")
             self._compiled_embed = None
             return False
+
+    def close(self) -> None:
+        """Release model, processor, and compiled embedding resources."""
+        if not self._loaded and self.model is None and self.processor is None:
+            self._compiled_embed = None
+            self._is_compiled = False
+            return
+
+        logger.info(
+            "Releasing embedding model resources: %s "
+            "(compiled=%s, native=%s)",
+            self.model_name,
+            self._is_compiled,
+            self._using_native,
+        )
+
+        self._compiled_embed = None
+        self._is_compiled = False
+
+        self.model = None
+        self.processor = None
+        self._hidden_size = None
+        self._loaded = False
+        self._using_native = False
+        self._remap_input_ids_to_inputs = False
+
+        gc.collect()
+        mx.synchronize()
+        mx.clear_cache()
+        clear_thread_compile_cache()
+        gc.collect()
 
     def embed(
         self,

--- a/scripts/omlx_memory_cycle_probe.py
+++ b/scripts/omlx_memory_cycle_probe.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Probe oMLX model load/unload memory retention.
+
+The script assumes the target oMLX service is already running. For clean
+before/after comparisons, restart the service before invoking this probe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+
+
+DEFAULT_MODELS = [
+    "Qwen3-4B-Instruct-2507-MLX-4bit",
+    "Qwen3-Embedding-4B-4bit-DWQ",
+    "Qwen3-Reranker-0.6B-4bit",
+    "Ornith-1.0-35B-5bit-mlx",
+]
+
+
+def run(cmd: list[str], timeout: int = 120) -> str:
+    return subprocess.check_output(
+        cmd,
+        text=True,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+    )
+
+
+def listener_port(base_url: str) -> int:
+    parsed = urlparse(base_url)
+    if parsed.port is not None:
+        return parsed.port
+    if parsed.scheme == "https":
+        return 443
+    return 80
+
+
+def find_pid(port: int) -> int:
+    output = run(["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN"])
+    for line in output.splitlines()[1:]:
+        parts = line.split()
+        if len(parts) >= 2:
+            return int(parts[1])
+    raise RuntimeError(f"No listener found on port {port}")
+
+
+def parse_size_to_mb(text: str) -> float:
+    match = re.match(r"\s*([0-9.]+)([KMGTP]?)", text)
+    if not match:
+        return 0.0
+    value = float(match.group(1))
+    unit = match.group(2)
+    return value * {
+        "": 1 / 1024 / 1024,
+        "K": 1 / 1024,
+        "M": 1,
+        "G": 1024,
+        "T": 1024 * 1024,
+    }[unit]
+
+
+def ps_rss_mb(pid: int) -> float:
+    return int(run(["ps", "-p", str(pid), "-o", "rss="]).strip()) / 1024
+
+
+def vmmap_metrics(pid: int) -> dict[str, float | None]:
+    output = run(["vmmap", "-summary", str(pid)], timeout=180)
+    metrics: dict[str, float | None] = {
+        "physical_footprint_mb": None,
+        "physical_footprint_peak_mb": None,
+        "ioaccelerator_graphics_mb": None,
+        "ioaccelerator_mb": None,
+        "malloc_large_mb": None,
+        "malloc_small_empty_mb": None,
+        "vm_allocate_mb": None,
+    }
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Physical footprint:"):
+            metrics["physical_footprint_mb"] = parse_size_to_mb(
+                stripped.split(":", 1)[1]
+            )
+        elif stripped.startswith("Physical footprint (peak):"):
+            metrics["physical_footprint_peak_mb"] = parse_size_to_mb(
+                stripped.split(":", 1)[1]
+            )
+        elif stripped.startswith("IOAccelerator (graphics)"):
+            metrics["ioaccelerator_graphics_mb"] = parse_size_to_mb(
+                stripped.split()[2]
+            )
+        elif stripped.startswith("IOAccelerator "):
+            metrics["ioaccelerator_mb"] = parse_size_to_mb(stripped.split()[1])
+        elif stripped.startswith("MALLOC_LARGE"):
+            metrics["malloc_large_mb"] = parse_size_to_mb(stripped.split()[1])
+        elif stripped.startswith("MALLOC_SMALL (empty)"):
+            metrics["malloc_small_empty_mb"] = parse_size_to_mb(stripped.split()[2])
+        elif stripped.startswith("VM_ALLOCATE"):
+            metrics["vm_allocate_mb"] = parse_size_to_mb(stripped.split()[1])
+    return metrics
+
+
+def status(session: requests.Session, base_url: str) -> dict[str, Any]:
+    resp = session.get(f"{base_url}/api/status", timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def admin_login(session: requests.Session, base_url: str, api_key: str) -> None:
+    resp = session.post(
+        f"{base_url}/admin/api/login",
+        json={"api_key": api_key, "remember": False},
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+
+def model_action(
+    session: requests.Session,
+    base_url: str,
+    model: str,
+    action: str,
+    timeout: int,
+) -> dict[str, Any]:
+    resp = session.post(f"{base_url}/admin/api/models/{model}/{action}", timeout=timeout)
+    if resp.status_code == 400 and action == "unload" and "not loaded" in resp.text:
+        return {"status": "already_unloaded", "model_id": model}
+    resp.raise_for_status()
+    return resp.json()
+
+
+def wait_loaded(
+    session: requests.Session,
+    base_url: str,
+    expected: set[str],
+    timeout: int,
+) -> dict[str, Any]:
+    deadline = time.time() + timeout
+    last: dict[str, Any] = {}
+    while time.time() < deadline:
+        last = status(session, base_url)
+        loaded = set(last.get("loaded_models") or [])
+        if expected.issubset(loaded) and not last.get("models_loading"):
+            return last
+        time.sleep(2)
+    raise TimeoutError(f"Timed out waiting for loaded={sorted(expected)}; last={last}")
+
+
+def wait_unloaded(
+    session: requests.Session,
+    base_url: str,
+    timeout: int,
+) -> dict[str, Any]:
+    deadline = time.time() + timeout
+    last: dict[str, Any] = {}
+    while time.time() < deadline:
+        last = status(session, base_url)
+        if not last.get("loaded_models") and not last.get("models_loading"):
+            return last
+        time.sleep(2)
+    raise TimeoutError(f"Timed out waiting for all models unloaded; last={last}")
+
+
+def safe_name(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("_") or "models"
+
+
+def sample(
+    session: requests.Session,
+    base_url: str,
+    pid: int,
+    cycle: int,
+    phase: str,
+    models: list[str],
+    jsonl_path: Path,
+) -> dict[str, Any]:
+    current = status(session, base_url)
+    row: dict[str, Any] = {
+        "timestamp": datetime.now().isoformat(timespec="seconds"),
+        "cycle": cycle,
+        "phase": phase,
+        "pid": pid,
+        "tested_models": ",".join(models),
+        "rss_mb": round(ps_rss_mb(pid), 1),
+        "models_loaded": current.get("models_loaded"),
+        "loaded_models": ",".join(current.get("loaded_models") or []),
+        "model_memory_used_mb": round(
+            (current.get("model_memory_used") or 0) / 1024 / 1024,
+            1,
+        ),
+        "active_requests": current.get("active_requests"),
+        "waiting_requests": current.get("waiting_requests"),
+    }
+    for key, value in vmmap_metrics(pid).items():
+        row[key] = None if value is None else round(value, 1)
+    with jsonl_path.open("a") as f:
+        f.write(json.dumps(row, ensure_ascii=False) + "\n")
+    print(json.dumps(row, ensure_ascii=False), flush=True)
+    return row
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        return
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def build_summary(
+    *,
+    pid: int,
+    rounds: int,
+    models: list[str],
+    rows: list[dict[str, Any]],
+    jsonl_path: Path,
+    csv_path: Path,
+) -> dict[str, Any]:
+    after_rows = [r for r in rows if r["phase"] == "after_unload"]
+    if not after_rows:
+        raise RuntimeError("No after_unload samples were collected")
+
+    baseline = rows[0]
+    first = after_rows[0]
+    last = after_rows[-1]
+
+    return {
+        "pid": pid,
+        "rounds": rounds,
+        "models": models,
+        "baseline": baseline,
+        "first_after_unload": first,
+        "last_after_unload": last,
+        "rss_drift_after_unload_mb": round(last["rss_mb"] - first["rss_mb"], 1),
+        "physical_footprint_drift_after_unload_mb": round(
+            last["physical_footprint_mb"] - first["physical_footprint_mb"],
+            1,
+        ),
+        "ioaccelerator_graphics_drift_after_unload_mb": round(
+            last["ioaccelerator_graphics_mb"] - first["ioaccelerator_graphics_mb"],
+            1,
+        ),
+        "rss_drift_vs_clean_baseline_mb": round(
+            last["rss_mb"] - baseline["rss_mb"],
+            1,
+        ),
+        "physical_footprint_drift_vs_clean_baseline_mb": round(
+            last["physical_footprint_mb"] - baseline["physical_footprint_mb"],
+            1,
+        ),
+        "samples_jsonl": str(jsonl_path),
+        "samples_csv": str(csv_path),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Cycle oMLX model load/unload and record process memory."
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("OMLX_BASE_URL", "http://127.0.0.1:11335"),
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("OMLX_API_KEY"),
+        help="Admin API key. Defaults to OMLX_API_KEY.",
+    )
+    parser.add_argument(
+        "--model",
+        action="append",
+        dest="models",
+        help="Model ID to include. Repeat to test multiple models.",
+    )
+    parser.add_argument(
+        "--default-suite",
+        action="store_true",
+        help="Use the four-model suite from the 11335 leak investigation.",
+    )
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--settle-seconds", type=int, default=8)
+    parser.add_argument("--load-timeout", type=int, default=900)
+    parser.add_argument("--unload-timeout", type=int, default=900)
+    parser.add_argument(
+        "--out-dir",
+        default="/tmp/omlx-memory-cycle-probe",
+        help="Directory for JSONL/CSV/summary output.",
+    )
+    parser.add_argument(
+        "--label",
+        default=None,
+        help="Output filename label. Defaults to model-derived label.",
+    )
+    parser.add_argument(
+        "--skip-preclean",
+        action="store_true",
+        help="Do not unload models already loaded before cycle 1.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.api_key:
+        print("error: --api-key or OMLX_API_KEY is required", file=sys.stderr)
+        return 2
+    if args.default_suite:
+        models = list(DEFAULT_MODELS)
+    else:
+        models = list(args.models or [])
+    if not models:
+        print("error: provide --model at least once or use --default-suite", file=sys.stderr)
+        return 2
+    if args.rounds < 1:
+        print("error: --rounds must be >= 1", file=sys.stderr)
+        return 2
+
+    base_url = args.base_url.rstrip("/")
+    pid = find_pid(listener_port(base_url))
+    session = requests.Session()
+    session.headers.update({"Authorization": f"Bearer {args.api_key}"})
+    admin_login(session, base_url, args.api_key)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    label = args.label or safe_name("__".join(models))
+    jsonl_path = out_dir / f"{label}.jsonl"
+    csv_path = out_dir / f"{label}.csv"
+    summary_path = out_dir / f"{label}.summary.json"
+    jsonl_path.write_text("")
+
+    print(f"pid={pid}", flush=True)
+    print(f"base_url={base_url}", flush=True)
+    print(f"models={models}", flush=True)
+
+    if not args.skip_preclean:
+        current = status(session, base_url)
+        for loaded in list(current.get("loaded_models") or []):
+            print(f"preclean unload {loaded}", flush=True)
+            model_action(session, base_url, loaded, "unload", args.unload_timeout)
+        wait_unloaded(session, base_url, args.unload_timeout)
+        time.sleep(args.settle_seconds)
+
+    rows: list[dict[str, Any]] = [
+        sample(session, base_url, pid, 0, "initial_clean_baseline", models, jsonl_path)
+    ]
+
+    for cycle in range(1, args.rounds + 1):
+        rows.append(sample(session, base_url, pid, cycle, "before_load", models, jsonl_path))
+
+        for model in models:
+            print(f"cycle={cycle} load {model}", flush=True)
+            model_action(session, base_url, model, "load", args.load_timeout)
+        wait_loaded(session, base_url, set(models), args.load_timeout)
+        time.sleep(args.settle_seconds)
+        rows.append(sample(session, base_url, pid, cycle, "all_loaded", models, jsonl_path))
+
+        for model in reversed(models):
+            print(f"cycle={cycle} unload {model}", flush=True)
+            model_action(session, base_url, model, "unload", args.unload_timeout)
+        wait_unloaded(session, base_url, args.unload_timeout)
+        time.sleep(args.settle_seconds)
+        rows.append(sample(session, base_url, pid, cycle, "after_unload", models, jsonl_path))
+
+    write_csv(csv_path, rows)
+    summary = build_summary(
+        pid=pid,
+        rounds=args.rounds,
+        models=models,
+        rows=rows,
+        jsonl_path=jsonl_path,
+        csv_path=csv_path,
+    )
+    summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2))
+    print("SUMMARY " + json.dumps(summary, ensure_ascii=False), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/start-omlx-app-config.sh
+++ b/scripts/start-omlx-app-config.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OMLX_BIN="$REPO_ROOT/.venv/bin/omlx"
+BASE_PATH="${OMLX_BASE_PATH:-$HOME/.omlx}"
+
+if [ ! -x "$OMLX_BIN" ]; then
+    echo "error: missing executable $OMLX_BIN" >&2
+    echo "Run the source install first: uv pip install --python .venv/bin/python -e ." >&2
+    exit 1
+fi
+
+if [ ! -f "$BASE_PATH/settings.json" ]; then
+    echo "error: missing app settings at $BASE_PATH/settings.json" >&2
+    echo "Launch the app once or set OMLX_BASE_PATH to an existing oMLX data directory." >&2
+    exit 1
+fi
+
+cd "$REPO_ROOT"
+
+# macOS malloc's default large-allocation behavior can keep hundreds of MB of
+# empty pages resident after repeated MLX model load/unload cycles, especially
+# for bge-reranker-v2-m3. Space-efficient mode keeps those pages from
+# accumulating while preserving normal model memory reclamation.
+export MallocSpaceEfficient="${MallocSpaceEfficient:-1}"
+
+exec "$OMLX_BIN" serve --base-path "$BASE_PATH" "$@"

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -799,6 +799,55 @@ class TestEmbeddingCompileFallback:
         with pytest.raises(ValueError, match="does not support image inputs"):
             model.embed([{"image": "https://example.com/image.jpg"}])
 
+    def test_try_compile_respects_disable_env(self, monkeypatch):
+        """OMLX_EMBEDDING_COMPILE=0 should skip mx.compile for root-cause probes."""
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        monkeypatch.setenv("OMLX_EMBEDDING_COMPILE", "0")
+        model = MLXEmbeddingModel("test-model")
+        model.model = MagicMock()
+
+        with patch("omlx.models.embedding.mx") as mock_mx:
+            result = model._try_compile()
+
+        assert result is False
+        assert model._compiled_embed is None
+        mock_mx.compile.assert_not_called()
+
+    def test_close_releases_compiled_model_and_processor_resources(self):
+        """close() should drop wrapper references before clearing MLX caches."""
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel("test-model")
+        model.model = MagicMock()
+        model.processor = MagicMock()
+        model._loaded = True
+        model._hidden_size = 384
+        model._using_native = False
+        model._is_compiled = True
+        model._compiled_embed = MagicMock()
+        model._remap_input_ids_to_inputs = True
+
+        with patch("omlx.models.embedding.gc.collect") as collect, \
+             patch("omlx.models.embedding.mx") as mock_mx, \
+             patch(
+                 "omlx.models.embedding.clear_thread_compile_cache"
+             ) as clear_compile_cache:
+            model.close()
+
+        assert model.model is None
+        assert model.processor is None
+        assert model._compiled_embed is None
+        assert model._loaded is False
+        assert model._hidden_size is None
+        assert model._using_native is False
+        assert model._is_compiled is False
+        assert model._remap_input_ids_to_inputs is False
+        mock_mx.synchronize.assert_called_once()
+        mock_mx.clear_cache.assert_called_once()
+        clear_compile_cache.assert_called_once()
+        assert collect.call_count == 2
+
 
 class TestEmbeddingEngine:
     """Tests for EmbeddingEngine."""
@@ -822,6 +871,8 @@ class TestEmbeddingEngine:
             mock_model.load.assert_called_once()
 
             asyncio.run(engine.stop())
+            mock_model.close.assert_called_once()
+            assert engine._model is None
 
     def test_engine_embed(self):
         """Test embedding generation through engine."""


### PR DESCRIPTION
## Summary

Fixes memory leak where Metal/IOAccelerator GPU resources were not properly released after unloading embedding models.

Closes #514
Addresses memory growth patterns reported in #582

## Changes

### Core Fix
- **omlx/models/embedding.py**: Added MLXEmbeddingModel.close() to explicitly release embedding wrapper resources (model, processor, compiled embed) before clearing MLX caches
- **omlx/engine/embedding.py**: Modified EmbeddingEngine.stop() to call MLXEmbeddingModel.close() via the MLX executor thread
- Added OMLX_EMBEDDING_COMPILE=0 environment variable to disable mx.compile for debugging

### Test Coverage
- Added unit tests for close() resource release behavior
- Added test for OMLX_EMBEDDING_COMPILE environment variable

## Verification

Tested with 4 models over multiple load/unload cycles:
- **Qwen3-Embedding-4B-4bit-DWQ**: ~8.6GB leak reduced to +21.6MB (5 cycles)
- **Qwen3-Reranker-0.6B-4bit**: +19.3MB (control)
- **Qwen3-4B-Instruct-2507-MLX-4bit**: +0.0MB (control)
- **Ornith-1.0-35B-5bit-mlx**: +22.2MB (control)

Post-fix, IOAccelerator Graphics growth stabilized at ~0 MB/cycle (was ~2.1GB/cycle).
