### PR TITLE
Fix embedding MLX resource release on unload

### DIFF
--- a/omlx/engine/embedding.py
+++ b/omlx/engine/embedding.py
@@ -101,13 +101,12 @@ class EmbeddingEngine(BaseNonStreamingEngine):
             return
 
         logger.info(f"Stopping embedding engine: {self._model_name}")
+        model = self._model
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(get_mlx_executor(), model.close)
         self._model = None
 
         gc.collect()
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            get_mlx_executor(), lambda: (mx.synchronize(), mx.clear_cache())
-        )
         logger.info(f"Embedding engine stopped: {self._model_name}")
 
     async def embed(

--- a/omlx/models/embedding.py
+++ b/omlx/models/embedding.py
@@ -7,9 +7,11 @@ text embeddings using Apple's MLX framework, with native fallback
 for XLMRoBERTa, BERT, and Qwen2-decoder embedding models.
 """
 
+import gc
 import inspect
 import json
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -17,6 +19,7 @@ from typing import Any, Dict, List, Optional, Union
 import mlx.core as mx
 from mlx.utils import tree_flatten
 
+from ..utils.compile_cache import clear_thread_compile_cache
 from .mlx_embeddings_compat import (
     patch_qwen3_vl_processor_for_torch_free_image_loading,
 )
@@ -32,6 +35,7 @@ _CONTEXT_LENGTH_ATTRS = (
     "seq_length",
     "n_positions",
 )
+_FALSE_ENV_VALUES = {"0", "false", "no", "off"}
 
 
 @dataclass
@@ -476,6 +480,15 @@ class MLXEmbeddingModel:
           for some embedding/reranker models, causing eval() runtime errors.
         - We compile a narrower function that returns only the final embedding array.
         """
+        compile_env = os.getenv("OMLX_EMBEDDING_COMPILE", "1").strip().lower()
+        if compile_env in _FALSE_ENV_VALUES:
+            logger.info(
+                "mx.compile disabled for %s by OMLX_EMBEDDING_COMPILE",
+                self.model_name,
+            )
+            self._compiled_embed = None
+            return False
+
         base_model = self.model
 
         try:
@@ -497,6 +510,37 @@ class MLXEmbeddingModel:
             logger.info(f"mx.compile unavailable for {self.model_name}: {e}")
             self._compiled_embed = None
             return False
+
+    def close(self) -> None:
+        """Release model, processor, and compiled embedding resources."""
+        if not self._loaded and self.model is None and self.processor is None:
+            self._compiled_embed = None
+            self._is_compiled = False
+            return
+
+        logger.info(
+            "Releasing embedding model resources: %s "
+            "(compiled=%s, native=%s)",
+            self.model_name,
+            self._is_compiled,
+            self._using_native,
+        )
+
+        self._compiled_embed = None
+        self._is_compiled = False
+
+        self.model = None
+        self.processor = None
+        self._hidden_size = None
+        self._loaded = False
+        self._using_native = False
+        self._remap_input_ids_to_inputs = False
+
+        gc.collect()
+        mx.synchronize()
+        mx.clear_cache()
+        clear_thread_compile_cache()
+        gc.collect()
 
     def embed(
         self,

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -799,6 +799,55 @@ class TestEmbeddingCompileFallback:
         with pytest.raises(ValueError, match="does not support image inputs"):
             model.embed([{"image": "https://example.com/image.jpg"}])
 
+    def test_try_compile_respects_disable_env(self, monkeypatch):
+        """OMLX_EMBEDDING_COMPILE=0 should skip mx.compile for root-cause probes."""
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        monkeypatch.setenv("OMLX_EMBEDDING_COMPILE", "0")
+        model = MLXEmbeddingModel("test-model")
+        model.model = MagicMock()
+
+        with patch("omlx.models.embedding.mx") as mock_mx:
+            result = model._try_compile()
+
+        assert result is False
+        assert model._compiled_embed is None
+        mock_mx.compile.assert_not_called()
+
+    def test_close_releases_compiled_model_and_processor_resources(self):
+        """close() should drop wrapper references before clearing MLX caches."""
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel("test-model")
+        model.model = MagicMock()
+        model.processor = MagicMock()
+        model._loaded = True
+        model._hidden_size = 384
+        model._using_native = False
+        model._is_compiled = True
+        model._compiled_embed = MagicMock()
+        model._remap_input_ids_to_inputs = True
+
+        with patch("omlx.models.embedding.gc.collect") as collect, \
+             patch("omlx.models.embedding.mx") as mock_mx, \
+             patch(
+                 "omlx.models.embedding.clear_thread_compile_cache"
+             ) as clear_compile_cache:
+            model.close()
+
+        assert model.model is None
+        assert model.processor is None
+        assert model._compiled_embed is None
+        assert model._loaded is False
+        assert model._hidden_size is None
+        assert model._using_native is False
+        assert model._is_compiled is False
+        assert model._remap_input_ids_to_inputs is False
+        mock_mx.synchronize.assert_called_once()
+        mock_mx.clear_cache.assert_called_once()
+        clear_compile_cache.assert_called_once()
+        assert collect.call_count == 2
+
 
 class TestEmbeddingEngine:
     """Tests for EmbeddingEngine."""
@@ -822,6 +871,8 @@ class TestEmbeddingEngine:
             mock_model.load.assert_called_once()
 
             asyncio.run(engine.stop())
+            mock_model.close.assert_called_once()
+            assert engine._model is None
 
     def test_engine_embed(self):
         """Test embedding generation through engine."""


### PR DESCRIPTION
## Summary
- add an explicit `MLXEmbeddingModel.close()` teardown path that drops compiled embedding callables before model and processor references
- run embedding model teardown on the shared MLX executor so thread-local compile cache cleanup happens on the worker that loaded and ran the model
- add `OMLX_EMBEDDING_COMPILE=0` as a diagnostic escape hatch for embedding `mx.compile`

## Why
Repeated load/unload cycles for `Qwen3-Embedding-4B-4bit-DWQ` could leave about 2.15 GB of `IOAccelerator (graphics)` memory resident per unload even though `/api/status` reported no loaded models and zero model memory. The compiled embedding callable closes over the model object, and the previous stop path only dropped the wrapper reference from the engine.

Related to upstream MLX compile-cache/thread-local behavior: ml-explore/mlx#2086 and ml-explore/mlx#3280.

## Validation
- `.venv/bin/python -m pytest tests/test_embedding.py::TestEmbeddingCompileFallback::test_try_compile_respects_disable_env tests/test_embedding.py::TestEmbeddingCompileFallback::test_close_releases_compiled_model_and_processor_resources tests/test_embedding.py::TestEmbeddingEngine::test_engine_lifecycle tests/test_engine_keepalive.py::TestTryCompile::test_embedding_try_compile_success tests/test_engine_keepalive.py::TestTryCompile::test_embedding_try_compile_failure`

Local memory-cycle validation on 11335:
- `Qwen3-Embedding-4B-4bit-DWQ`, 5 rounds: after-unload `IOAccelerator (graphics)` drift was `+0.0 MB`, physical-footprint drift was `+21.1 MB`
- `Qwen3-Reranker-0.6B-4bit`, 5 rounds: after-unload graphics drift was `+0.0 MB`
- `Qwen3-4B-Instruct-2507-MLX-4bit`, 5 rounds: after-unload graphics drift versus round 1 was `+0.0 MB`
- `Ornith-1.0-35B-5bit-mlx`, 3 rounds: after-unload graphics drift was `+0.0 MB`