### PR TITLE
fix: reduce empty-process native memory retention

### DIFF
--- a/apps/omlx-mac/Sources/Server/PythonRuntime.swift
+++ b/apps/omlx-mac/Sources/Server/PythonRuntime.swift
@@ -104,6 +104,10 @@ struct PythonRuntime {
     func makeEnvironment() -> [String: String] {
         var env = ProcessInfo.processInfo.environment
         env["OMLX_SUPERVISED"] = "menubar"
+        // macOS malloc otherwise keeps large empty arenas resident after
+        // repeated model load/unload cycles. This must be set before Python
+        // starts; setting it inside omlx.cli is too late for malloc init.
+        env["MallocSpaceEfficient"] = env["MallocSpaceEfficient"] ?? "1"
 
         var path = env["PATH"] ?? ""
         for prefix in homebrewPaths.reversed() where !path.contains(prefix) {

--- a/omlx/engine/base.py
+++ b/omlx/engine/base.py
@@ -26,6 +26,19 @@ _preflight_logger = logging.getLogger("omlx.engine.preflight")
 _PREFLIGHT_UNREACHABLE_WARNED: set[tuple[str, str]] = set()
 
 
+def _clear_teardown_references(
+    engine: object,
+    *,
+    none_attrs: tuple[str, ...],
+    false_attrs: tuple[str, ...] = (),
+) -> None:
+    """Clear wrapper-side references in a consistent stop() teardown pass."""
+    for attr in none_attrs:
+        setattr(engine, attr, None)
+    for attr in false_attrs:
+        setattr(engine, attr, False)
+
+
 def _warn_scheduler_unreachable_once(
     engine: object, method: str, detail: str = ""
 ) -> None:

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -14,7 +14,12 @@ from typing import Any
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_special_tokens, detect_and_strip_partial
 from ..utils.tokenizer import get_tokenizer_config
-from .base import BaseEngine, GenerationOutput, _warn_scheduler_unreachable_once
+from .base import (
+    BaseEngine,
+    GenerationOutput,
+    _clear_teardown_references,
+    _warn_scheduler_unreachable_once,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -426,9 +431,16 @@ class BatchedEngine(BaseEngine):
                     self._engine.engine.close()
                 except Exception as e:
                     logger.warning(f"Error closing engine: {e}")
-        self._engine = None
-        self._model = None
-        self._tokenizer = None
+        _clear_teardown_references(
+            self,
+            none_attrs=(
+                "_engine",
+                "_model",
+                "_tokenizer",
+                "_grammar_compiler",
+            ),
+            false_attrs=("_grammar_compiler_init_attempted",),
+        )
         self._loaded = False
         logger.info("BatchedEngine stopped")
 

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -51,7 +51,12 @@ from ..utils.image import (
     compute_per_image_hashes,
     extract_images_from_messages,
 )
-from .base import BaseEngine, GenerationOutput, _warn_scheduler_unreachable_once
+from .base import (
+    BaseEngine,
+    GenerationOutput,
+    _clear_teardown_references,
+    _warn_scheduler_unreachable_once,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1635,13 +1640,20 @@ class VLMBatchedEngine(BaseEngine):
         # final worker-thread MLX reclaim. Otherwise the VLM wrapper can keep
         # model weights or cached feature arrays alive until after the reclaim
         # pass has already run.
-        self._engine = None
-        self._vlm_model = None
-        self._processor = None
-        self._adapter = None
-        self._tokenizer = None
-        self._vlm_mtp_drafter = None
-        self._diffusion_family = None
+        _clear_teardown_references(
+            self,
+            none_attrs=(
+                "_engine",
+                "_vlm_model",
+                "_processor",
+                "_adapter",
+                "_tokenizer",
+                "_grammar_compiler",
+                "_vlm_mtp_drafter",
+                "_diffusion_family",
+            ),
+            false_attrs=("_grammar_compiler_init_attempted",),
+        )
 
         if engine:
             if hasattr(engine, "engine") and engine.engine is not None:

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -294,6 +294,32 @@ class TestBatchedEngineInitialization:
 
         assert engine.model_type is None
 
+    @pytest.mark.asyncio
+    async def test_stop_clears_wrapper_teardown_references(self):
+        """stop() releases wrapper-side native helper references."""
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        inner_engine = MagicMock()
+        engine._engine = MagicMock()
+        engine._engine.stop = AsyncMock()
+        engine._engine.engine = inner_engine
+        engine._model = object()
+        engine._tokenizer = object()
+        engine._grammar_compiler = object()
+        engine._grammar_compiler_init_attempted = True
+        engine._loaded = True
+
+        await engine.stop()
+
+        assert engine._engine is None
+        assert engine._model is None
+        assert engine._tokenizer is None
+        assert engine._grammar_compiler is None
+        assert engine._grammar_compiler_init_attempted is False
+        assert engine._loaded is False
+        inner_engine.close.assert_called_once()
+
 
 class TestBatchedEngineStreamingCleanup:
     """Tests for streaming generator cleanup paths."""

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -1909,6 +1909,8 @@ class TestStopSafety:
         vision_cache.close.side_effect = lambda: events.append("vision_cache")
         engine._vision_cache = vision_cache
         engine._engine.stop = AsyncMock(side_effect=lambda: events.append("stop"))
+        engine._grammar_compiler = object()
+        engine._grammar_compiler_init_attempted = True
 
         mock_inner_engine = MagicMock()
 
@@ -1919,6 +1921,8 @@ class TestStopSafety:
             assert engine._processor is None
             assert engine._adapter is None
             assert engine._tokenizer is None
+            assert engine._grammar_compiler is None
+            assert engine._grammar_compiler_init_attempted is False
             assert engine._vision_cache is None
 
         mock_inner_engine.close.side_effect = close_side_effect


### PR DESCRIPTION
## Summary
- set MallocSpaceEfficient=1 for the macOS app server process before Python starts
- add a small shared teardown helper for wrapper-side reference clearing
- use the helper in batched/VLM stop paths to clear model/tokenizer/native grammar compiler references consistently
- keep this follow-up PR scoped to code and tests only; no docs included

## Testing
- git diff --check
- .venv/bin/python -m pytest tests/test_batched_engine.py::TestBatchedEngineInitialization tests/test_vlm_engine.py::TestStopSafety tests/test_grammar.py::TestListGrammarParsers
- .venv/bin/python -m pytest tests/test_batched_engine.py::TestBatchedEngineInitialization tests/test_vlm_engine.py tests/test_grammar.py::TestListGrammarParsers

## Notes
- This is a follow-up to the model unload memory work and intentionally excludes documentation changes.
- The helper is deliberately limited to wrapper-side references; EngineCore still performs stream-local MLX reclaim on its own executor.