### PR TITLE
fix: drop engine constructor aliases during unload

### DIFF
--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -258,6 +258,11 @@ class EngineCore:
         self._start_time: Optional[float] = None
         self._steps_executed = 0
 
+        # Drop transient aliases after ownership moves to the engine/scheduler
+        # graph, so close()/deep_reset() can make that graph unreachable.
+        model = None
+        tokenizer = None
+
         logger.debug(f"Engine {self._engine_id} initialized")
 
     async def start(self) -> None:
@@ -1185,6 +1190,9 @@ class AsyncEngineCore:
         config: Optional[EngineConfig] = None,
     ):
         self.engine = EngineCore(model, tokenizer, config)
+        # Drop wrapper-local aliases after EngineCore takes ownership.
+        model = None
+        tokenizer = None
 
     @property
     def _mlx_executor(self):

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1875,6 +1875,11 @@ class Scheduler:
         # since _get_xtc_special_tokens() delegates to _get_stop_tokens().
         self._xtc_special_tokens: list[int] = self._get_xtc_special_tokens()
 
+        # Drop transient aliases after ownership moves to scheduler fields;
+        # close()/deep_reset() clear those fields during teardown.
+        model = None
+        tokenizer = None
+
     @contextmanager
     def _phase_timer(self, phase: str):
         """Lightweight wall-time accumulator for cache-on overhead diagnostics.


### PR DESCRIPTION
## Summary
- drop transient model/tokenizer constructor aliases in EngineCore, AsyncEngineCore, and Scheduler after ownership moves to instance fields
- keep the change scoped to the batched engine construction path that affects LLM unload teardown
- no local docs/scripts or unrelated engine cleanup are included

## Why
A Qwen3-4B-Instruct-2507-MLX-4bit single-model load/unload cycle on current upstream/main (#2056 included) still leaves the first unloaded process at about 2.15GB of IOAccelerator (graphics) residency even though /api/status reports models_loaded=0 and model_memory_used=0.

I rechecked the older local integration fix after the review feedback on #2053. The broad local-reference cleanup did remove this first-unload residency, so I isolated the smallest code path that reproduces the improvement.

## Isolation results
All runs used a restarted 127.0.0.1:11335 server, MallocSpaceEfficient=1, clean initial /api/status, and vmmap -summary sampling.

- upstream/main 2edd26e (#2056): Qwen3-4B after-unload IOAccelerator stayed at 2150.4MB from cycle 1 through cycle 5
- local/integration broad cleanup: Qwen3-4B after-unload IOAccelerator returned to 1.7MB from cycle 1
- scheduler-only alias cleanup: still retained 2150.4MB after unload
- engine-core-only alias cleanup: still retained 2150.4MB after unload
- this combined EngineCore + Scheduler alias cleanup: returned to 1.7MB after unload for cycles 1-3

Control model:
- Ornith-1.0-35B-5bit-mlx on upstream/main returned to 2.0MB IOAccelerator after unload across 3 cycles, so the Qwen result is not a generic vmmap/probe artifact.

## Testing
- git diff --check
- .venv/bin/python -m py_compile omlx/engine_core.py omlx/scheduler.py
- live Qwen3-4B-Instruct-2507-MLX-4bit 3-cycle load/unload vmmap validation on this branch
