### PR TITLE
32-head sparse-MLA variant for tensor-sharded (multi-device) runs

### DIFF
--- a/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.cpp
@@ -109,8 +109,9 @@ class GlmDsaSparseMlaAttentionPrimitive : public Primitive {
         !last_dim_contiguous(topk_indices)) {
       return true;
     }
-    if (q_latent.shape(1) != 64 || kv_latent.shape(1) != 1 ||
-        k_pe.shape(1) != 1 || topk_indices.shape(1) != 1) {
+    if ((q_latent.shape(1) != 64 && q_latent.shape(1) != 32) ||
+        kv_latent.shape(1) != 1 || k_pe.shape(1) != 1 ||
+        topk_indices.shape(1) != 1) {
       return true;
     }
     if (q_latent.shape(3) != 512 || kv_latent.shape(3) != 512 ||
@@ -166,13 +167,13 @@ class GlmDsaSparseMlaAttentionPrimitive : public Primitive {
 
     constexpr int bk = 256;
     constexpr int dc = 32;
-    constexpr int h = 64;
     constexpr int d_latent = 512;
     constexpr int d_pe = 64;
-    constexpr int wm = 8;
 
     const int B = q_latent.shape(0);
     const int H = q_latent.shape(1);
+    const int h = H;                  // head count selects the kernel instantiation
+    const int wm = (H == 64) ? 8 : 4; // TQ = H / (wm * 8) must be >= 1: 64->8, 32->4
     const int qL = q_latent.shape(2);
     const int kL = kv_latent.shape(2);
     int64_t topk_length_strides[2] = {0, 0};

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.metal
@@ -19,3 +19,7 @@
 
 instantiate_sparse_mla(float16, half, 256, 32, 64, 512, 64, 8);
 instantiate_sparse_mla(bfloat16, bfloat16_t, 256, 32, 64, 512, 64, 8);
+// 32-head variant for tensor-sharded (multi-device) runs: each shard holds
+// H=32 of the 64 MLA heads. wm=4 keeps TQ = H / (wm * 8) = 1.
+instantiate_sparse_mla(float16, half, 256, 32, 32, 512, 64, 4);
+instantiate_sparse_mla(bfloat16, bfloat16_t, 256, 32, 32, 512, 64, 4);

--- a/omlx/patches/glm_moe_dsa/glm_moe_dsa_model.py
+++ b/omlx/patches/glm_moe_dsa/glm_moe_dsa_model.py
@@ -264,7 +264,7 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
         )
         native_sparse_mla_shape = (
             topk_indices is not None
-            and self.num_heads == 64
+            and self.num_heads in (32, 64)  # 32 = tensor-sharded half of the 64 MLA heads
             and q_pe.shape[-1] == 64
             and kv_latent.shape[-1] == 512
             and k_pe.shape[-1] == 64


### PR DESCRIPTION
## What

Adds a 32-head instantiation of the GLM-5.2 sparse-MLA prefill kernel, for setups that shard the 64 MLA heads across devices (tensor parallelism). Three small changes:

- `sparse_mla.cpp`: accept `H ∈ {32, 64}`; `h`/`wm` become runtime values (`wm=4` for H=32 so the threadgroup tile `TQ = H/(wm*8)` stays ≥ 1 — with the shipped `wm=8`, H=32 gives TQ=0 and trips the static assert).
- `sparse_mla.metal`: 32-head fp16/bf16 instantiations.
- `glm_moe_dsa_model.py`: relax the 64-head gate to `(32, 64)`.

Single-device 64-head behavior is unchanged (same instantiation, same `wm`).

## Why

We run GLM-5.2 tensor-parallel across two Mac Studios (512 GB each, Thunderbolt) via exo, with your kernels vendored (thanks — they're excellent). Each node holds 32 of the 64 heads, so the kernel's 64-head guard sent every shard to the fallback path. This PR is the change we've been running in production.

## Validation

- Output parity with the pure-MLX sparse reference to bf16 noise (~3e-3 rel) at both 64 and 32 heads.
- Live 2-node cluster: 100% structured needle-in-haystack recall at 120k/200k/300k/350k-token contexts (temp-0, decoys, 5 depth positions), coherent output, byte-consistent across shards.
- Prefill 1.59× at 41k vs the non-kernel sparse path; ~3.5× vs dense at 84k.

One note from long-context testing that may interest you: your fused `dsa_indexer_scores` path is immune to an MLX reduction bug we root-caused (`mx.sum` over a non-last axis of large strided tensors returns all-zeros, ml-explore/mlx#3784) — the pure-MLX indexer path materializes exactly the trigger shape at ≥128k contexts. We also upstreamed a workaround + a pure-MLX sparse prefill to mlx-lm (ml-explore/mlx-lm#1454), crediting this PR for the concept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)