### PR TITLE
fix(cache): key paged SSD blocks by TurboQuant bit depth

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -204,6 +204,13 @@ def _canonicalize_layer_cache_types(
     wrapper_to_canonical = {
         "SizedArraysCache": "ArraysCache",
         "PrefillReadyRotatingKVCache": "RotatingKVCache",
+        # Batch and single-request TurboQuant caches persist the same packed
+        # per-request state (the save path records whichever class name it
+        # extracted; the restore path rebuilds a TurboQuantKVCache from
+        # either). Collapsing them keeps the predicted layout from
+        # refresh_ssd_layer_signature — which always says
+        # "TurboQuantKVCache" — from sweeping valid batch-form blocks.
+        "BatchTurboQuantKVCache": "TurboQuantKVCache",
     }
     return [
         wrapper_to_canonical.get(cache_type, cache_type)
@@ -217,6 +224,7 @@ def _cache_compat_signature(
     num_layers: int = 0,
     block_size: int = 0,
     layer_cache_types: list[str] | None = None,
+    turboquant_kv_bits: float | None = None,
 ) -> str:
     """Return a stable compatibility signature for a persisted cache block."""
     payload = {
@@ -225,7 +233,63 @@ def _cache_compat_signature(
         "block_size": int(block_size or 0),
         "layer_cache_types": list(layer_cache_types or []),
     }
+    # TurboQuant packed state width depends on the bit depth
+    # (packed_width = ceil(head_dim * bits / 32)), so blocks written at
+    # different bit depths are shape-incompatible (#2045). Only stamped
+    # when TurboQuant is active so non-TurboQuant signatures stay
+    # byte-identical to the previous format.
+    if turboquant_kv_bits is not None:
+        payload["turboquant_kv_bits"] = float(turboquant_kv_bits)
     return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _signature_turboquant_bits(cache_signature: str) -> float | None:
+    """Extract ``turboquant_kv_bits`` from a stored signature, or None."""
+    if not cache_signature:
+        return None
+    try:
+        payload = json.loads(cache_signature)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        # Corrupted/foreign signature that parses as a JSON scalar or list.
+        # Report "no recorded depth" instead of raising: an AttributeError
+        # here would abort the whole stale-signature sweep.
+        return None
+    bits = payload.get("turboquant_kv_bits")
+    if bits is None:
+        return None
+    try:
+        return float(bits)
+    except (TypeError, ValueError):
+        return None
+
+
+def _block_turboquant_bits(
+    layer_cache_types: list[str] | None,
+    layer_meta_states: list[tuple] | None,
+) -> float | None:
+    """Read the bit depth a block's own TurboQuant layers were packed at.
+
+    TurboQuant meta_state is ``(offset, bits, seed, ...)`` — the same tuple
+    the restore path reads back at reconstruction. Deriving the signature
+    stamp from the block itself keeps it truthful even when the manager's
+    expectation is stale or not yet learned.
+    """
+    if not layer_cache_types or not layer_meta_states:
+        return None
+    for i, cache_type in enumerate(layer_cache_types):
+        if cache_type not in ("TurboQuantKVCache", "BatchTurboQuantKVCache"):
+            continue
+        if i >= len(layer_meta_states):
+            continue
+        meta_state = layer_meta_states[i]
+        if isinstance(meta_state, (list, tuple)) and len(meta_state) >= 3:
+            try:
+                return float(meta_state[1])
+            except (TypeError, ValueError):
+                return None
+    return None
 
 
 def _clamp_rotating_meta_states(
@@ -1010,9 +1074,15 @@ class PagedSSDCacheManager(CacheManager):
         self._expected_num_layers = expected_num_layers
         self._expected_block_size = expected_block_size
         self._expected_layer_cache_types = expected_layer_cache_types
+        # TurboQuant bit depth requests will quantize at; learned together
+        # with the layer signature via ``set_expected_layer_signature``
+        # (the depth is only known once the engine has applied the model's
+        # TurboQuant settings, after this manager is constructed).
+        self._expected_turboquant_kv_bits: float | None = None
         # Set once we have swept stale-signature blocks for the current
-        # ``_expected_layer_cache_types``. Re-assigning the signature (e.g.,
-        # via ``adopt_layer_signature_if_unset``) resets this so the new
+        # ``_expected_layer_cache_types`` / ``_expected_turboquant_kv_bits``.
+        # Re-assigning the signature (e.g., via
+        # ``adopt_layer_signature_if_unset``) resets this so the new
         # signature triggers its own one-shot sweep.
         self._signature_sweep_completed = False
         self._lock = threading.RLock()
@@ -1448,7 +1518,7 @@ class PagedSSDCacheManager(CacheManager):
     def _is_compatible_cache_signature(self, metadata: PagedSSDBlockMetadata) -> bool:
         """Return True when a saved cache_signature matches enabled checks."""
         if not metadata.cache_signature:
-            return True
+            return self._signature_bits_match("")
 
         try:
             payload = json.loads(metadata.cache_signature)
@@ -1491,7 +1561,27 @@ class PagedSSDCacheManager(CacheManager):
             ) != _canonicalize_layer_cache_types(self._expected_layer_cache_types):
                 return False
 
+        if not self._signature_bits_match(metadata.cache_signature):
+            return False
+
         return True
+
+    def _signature_bits_match(self, cache_signature: str) -> bool:
+        """True when a block's recorded TurboQuant depth satisfies expectations.
+
+        With no expected depth every block passes. With one, the block must
+        PROVE a matching depth: the packed state width is
+        ``ceil(head_dim * bits / 32)``, so a block written at another depth —
+        or one with no recorded depth (pre-depth-stamping saves) — has an
+        incompatible or unverifiable width, and restoring it poisons batch
+        concatenation (#2045).
+        """
+        if self._expected_turboquant_kv_bits is None:
+            return True
+        return (
+            _signature_turboquant_bits(cache_signature)
+            == self._expected_turboquant_kv_bits
+        )
 
     def _expected_cache_signature(self) -> str:
         if (
@@ -1506,6 +1596,7 @@ class PagedSSDCacheManager(CacheManager):
             num_layers=self._expected_num_layers,
             block_size=self._expected_block_size,
             layer_cache_types=self._expected_layer_cache_types,
+            turboquant_kv_bits=self._expected_turboquant_kv_bits,
         )
 
     def _read_file_metadata(self, file_path: Path) -> PagedSSDBlockMetadata | None:
@@ -1939,11 +2030,21 @@ class PagedSSDCacheManager(CacheManager):
                     _store_nstate_elements(f"layer_{i}", list(layer_data))
 
             block_size = self._expected_block_size or token_count
+            # Stamp the depth the block's own TurboQuant layers were packed
+            # at (observation), falling back to the manager's expectation
+            # only when the block carries no meta_state. A signature must
+            # never vouch for a width the payload does not have.
+            block_bits = _block_turboquant_bits(layer_cache_types, layer_meta_states)
             cache_signature = _cache_compat_signature(
                 model_name=model_name,
                 num_layers=len(cache_data),
                 block_size=block_size,
                 layer_cache_types=layer_cache_types,
+                turboquant_kv_bits=(
+                    block_bits
+                    if block_bits is not None
+                    else self._expected_turboquant_kv_bits
+                ),
             )
 
             # Prepare metadata
@@ -2880,12 +2981,22 @@ class PagedSSDCacheManager(CacheManager):
         )
         return True
 
-    def set_expected_layer_signature(self, layer_cache_types: list[str] | None) -> bool:
+    def set_expected_layer_signature(
+        self,
+        layer_cache_types: list[str] | None,
+        *,
+        turboquant_kv_bits: float | None = None,
+    ) -> bool:
         """Set the live layer-cache signature, replacing stale expectations.
 
         Unlike ``adopt_layer_signature_if_unset``, this is used by callers that
         learn the final cache layout after manager construction (for example
         TurboQuant settings applied by the engine after the scheduler starts).
+
+        ``turboquant_kv_bits`` is the live TurboQuant bit depth (None when
+        TurboQuant is inactive). A bit-depth change alone also triggers the
+        sweep: blocks written at another depth have a different packed state
+        width and would crash batch concatenation if mixed (#2045).
 
         Returns True when the canonical signature changed and a stale-signature
         sweep should run. Returns False for empty input or a canonical no-op.
@@ -2895,28 +3006,35 @@ class PagedSSDCacheManager(CacheManager):
 
         new_signature = list(layer_cache_types)
         new_canonical = _canonicalize_layer_cache_types(new_signature)
+        new_bits = (
+            float(turboquant_kv_bits) if turboquant_kv_bits is not None else None
+        )
 
         with self._lock:
             old_signature = self._expected_layer_cache_types
             old_canonical = _canonicalize_layer_cache_types(old_signature)
-            if old_canonical == new_canonical:
+            bits_changed = new_bits != self._expected_turboquant_kv_bits
+            if old_canonical == new_canonical and not bits_changed:
                 if old_signature != new_signature:
                     self._expected_layer_cache_types = new_signature
                 return False
 
             self._expected_layer_cache_types = new_signature
+            self._expected_turboquant_kv_bits = new_bits
             self._signature_sweep_completed = False
 
         logger.info(
             "PagedSSDCacheManager updated layer cache signature "
-            "(%d layers, %d unique types)",
+            "(%d layers, %d unique types, turboquant_kv_bits=%s)",
             len(new_signature),
             len(set(new_canonical or ())),
+            new_bits,
         )
         return True
 
     def invalidate_stale_layer_signature(self) -> int:
-        """Drop in-memory index entries whose layer_cache_types disagree
+        """Drop in-memory index entries whose layer_cache_types — or, when a
+        TurboQuant depth is expected, whose recorded bit depth — disagree
         with the current expected signature.
 
         Scoped to the current ``_expected_model_name``: blocks belonging to
@@ -2940,6 +3058,7 @@ class PagedSSDCacheManager(CacheManager):
             return 0
 
         expected = _canonicalize_layer_cache_types(self._expected_layer_cache_types)
+        expects_bits = self._expected_turboquant_kv_bits is not None
 
         with self._index._lock:
             stale: list[bytes] = []
@@ -2948,10 +3067,19 @@ class PagedSSDCacheManager(CacheManager):
                     continue
                 got = _canonicalize_layer_cache_types(meta.layer_cache_types)
                 if got is None:
-                    # Pre-signature blocks lack the metadata to judge.
-                    # Skip rather than guess. Newer saves will replace them.
+                    # Pre-signature blocks lack the metadata to judge the
+                    # layout. Without a depth expectation, skip rather than
+                    # guess — newer saves will replace them. With one, the
+                    # block can no more prove its packed width than its
+                    # layout, so it is unsafe to keep (see
+                    # _signature_bits_match).
+                    if expects_bits:
+                        stale.append(h)
                     continue
                 if got != expected:
+                    stale.append(h)
+                    continue
+                if not self._signature_bits_match(meta.cache_signature):
                     stale.append(h)
 
         for h in stale:

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -9838,17 +9838,27 @@ class Scheduler:
         except Exception as e:
             logger.debug(f"Failed to extract model info: {e}")
 
-    def _infer_live_layer_cache_types(self) -> list[str] | None:
-        """Infer the layer-cache signature that future SSD saves will use."""
+    def _infer_live_layer_cache_types(
+        self,
+    ) -> tuple[list[str], float | None] | None:
+        """Infer the layer-cache signature that future SSD saves will use.
+
+        Returns ``(layer_cache_types, turboquant_kv_bits)`` — the predicted
+        per-layer type names plus the depth requests will quantize at (None
+        when TurboQuant is inactive or ineligible) — or None when no
+        signature can be inferred.
+        """
         if not HAS_CACHE_TYPE_HANDLERS or ModelCacheConfig is None:
             return None
 
-        make_cache = getattr(self.model, "make_cache", None)
-        if not callable(make_cache):
-            return None
-
+        # Build the cache list the same way the request path does
+        # (make_prompt_cache defers to model.make_cache when the model
+        # defines one, and falls back to plain per-layer KVCache otherwise).
+        # Requiring model.make_cache here made the refresh a silent no-op
+        # for every plain dense model, so the manager never learned the
+        # TurboQuant layout or bit depth (#2045).
         try:
-            cache_list = make_cache()
+            cache_list = make_prompt_cache(self.model)
         except Exception as e:
             logger.debug("Failed to build cache list for SSD signature: %s", e)
             return None
@@ -9871,14 +9881,18 @@ class Scheduler:
             return None
 
         if self._turboquant_kv_bits is None:
-            return layer_cache_types
+            return layer_cache_types, None
 
         try:
-            if not self._turboquant_eligible(cache_list):
-                return layer_cache_types
+            eligible = self._turboquant_eligible(cache_list)
         except Exception as e:
+            # Fail safe: committing an un-rewritten (plain-KV) layout here
+            # would make the stale-signature sweep evict every valid
+            # TurboQuant block, so refuse to infer rather than guess.
             logger.debug("Failed to evaluate TurboQuant SSD signature: %s", e)
-            return layer_cache_types
+            return None
+        if not eligible:
+            return layer_cache_types, None
 
         kv_indices = [
             i for i, c in enumerate(cache_list) if _is_turboquant_kv_family_cache(c)
@@ -9889,7 +9903,12 @@ class Scheduler:
             if idx != last_kv_idx and idx < len(layer_cache_types):
                 layer_cache_types[idx] = "TurboQuantKVCache"
 
-        return layer_cache_types
+        # The depth is keyed off the same eligibility gate the request path
+        # uses, not the rewritten names: models whose convertible caches sit
+        # inside CacheList layers report bare "CacheList" names at every
+        # depth, so the bits field is the only signature discriminator for
+        # them (#2045).
+        return layer_cache_types, float(self._turboquant_kv_bits)
 
     def refresh_ssd_layer_signature(self) -> list[str] | None:
         """Set the SSD manager's live layer signature before prefix lookup."""
@@ -9897,14 +9916,24 @@ class Scheduler:
         if manager is None:
             return None
 
-        layer_cache_types = self._infer_live_layer_cache_types()
-        if not layer_cache_types:
+        inferred = self._infer_live_layer_cache_types()
+        if inferred is None:
+            if self._turboquant_kv_bits is not None:
+                logger.warning(
+                    "Could not infer the SSD cache layer signature; "
+                    "TurboQuant bit-depth compatibility checks stay disabled "
+                    "for this session (stale-depth blocks are not swept)."
+                )
             return None
+        layer_cache_types, turboquant_kv_bits = inferred
 
         try:
             set_signature = getattr(manager, "set_expected_layer_signature", None)
             if callable(set_signature):
-                set_signature(layer_cache_types)
+                set_signature(
+                    layer_cache_types,
+                    turboquant_kv_bits=turboquant_kv_bits,
+                )
             else:
                 manager.adopt_layer_signature_if_unset(layer_cache_types)
             manager.invalidate_stale_layer_signature()

--- a/omlx/turboquant_kv.py
+++ b/omlx/turboquant_kv.py
@@ -439,6 +439,21 @@ class BatchTurboQuantKVCache(TurboQuantKVCache):
                 )
         bits = caches[0].bits
         seed = caches[0].seed
+        configs = {(c.bits, c.seed) for c in caches}
+        if len(configs) > 1:
+            # Packed state width is ceil(head_dim * bits / 32) and codecs are
+            # rebuilt from (head_dim, bits, seed), so members quantized under
+            # different configs cannot share a batch. Without this guard the
+            # mismatch surfaces as a raw mx.concatenate shape error (or, for
+            # equal widths, silent garbage decode) deep in
+            # _concat_state_batch (#2045).
+            raise ValueError(
+                "Cannot batch TurboQuant caches with mixed quantization "
+                f"configs (bits, seed): {sorted(configs)}. A request restored "
+                "from cache blocks written at another turboquant_kv_bits "
+                "depth cannot share a batch with fresh requests; clear the "
+                "paged SSD cache for this model if this persists."
+            )
         lengths = [c.offset for c in caches]
         max_length = max(lengths)
         padding = [max_length - l for l in lengths]

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -24,7 +24,9 @@ from omlx.cache.paged_ssd_cache import (
     PagedSSDCacheIndex,
     PagedSSDCacheManager,
     SharedHotCacheBudget,
+    _block_turboquant_bits,
     _cache_compat_signature,
+    _signature_turboquant_bits,
     _extract_tensor_bytes,
     _restore_tensor_from_bytes,
     _write_safetensors_no_mx,
@@ -3683,3 +3685,322 @@ class TestLayerSignatureSweep:
         # Same call signature — already set, returns False, flag stays.
         assert mgr.adopt_layer_signature_if_unset(["ArraysCache", "KVCache"]) is False
         assert mgr._signature_sweep_completed is True
+
+
+class TestTurboquantBitsSignature:
+    """#2045: the cache signature must key the TurboQuant bit depth.
+
+    TurboQuant packed state width is ceil(head_dim * bits / 32), so blocks
+    written at different bit depths are shape-incompatible. Without the
+    bits field in the signature, 4-bit and 6-bit blocks for the same model
+    coexist and crash ``_concat_state_batch`` when their requests are
+    batched together.
+    """
+
+    TURBO = ["ArraysCache", "TurboQuantKVCache", "TurboQuantKVCache", "KVCache"]
+
+    def _make_meta(
+        self,
+        *,
+        block_hash: bytes,
+        layer_cache_types: list[str] | None,
+        turboquant_kv_bits: float | None = None,
+        cache_signature: str | None = None,
+        model_name: str = "test-model",
+        num_layers: int = 4,
+        block_size: int = 2048,
+    ) -> PagedSSDBlockMetadata:
+        now = time.time()
+        if cache_signature is None:
+            cache_signature = _cache_compat_signature(
+                model_name=model_name,
+                num_layers=num_layers,
+                block_size=block_size,
+                layer_cache_types=layer_cache_types,
+                turboquant_kv_bits=turboquant_kv_bits,
+            )
+        return PagedSSDBlockMetadata(
+            block_hash=block_hash,
+            file_path=Path("/tmp/never-touched.safetensors"),
+            file_size=1024,
+            token_count=block_size,
+            created_at=now,
+            last_access=now,
+            num_layers=num_layers,
+            model_name=model_name,
+            block_size=block_size,
+            layer_cache_types=layer_cache_types,
+            cache_signature=cache_signature,
+        )
+
+    def _make_manager(
+        self,
+        tmp_path: Path,
+        *,
+        layer_cache_types: list[str] | None = None,
+        turboquant_kv_bits: float | None = None,
+    ) -> PagedSSDCacheManager:
+        # Expectations are set through set_expected_layer_signature — the
+        # same call the scheduler's refresh makes — so these tests exercise
+        # the path production actually runs.
+        manager = PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_cache",
+            max_size_bytes=1 << 30,
+            expected_model_name="test-model",
+            expected_num_layers=4,
+            expected_block_size=2048,
+        )
+        if layer_cache_types is not None:
+            manager.set_expected_layer_signature(
+                layer_cache_types, turboquant_kv_bits=turboquant_kv_bits
+            )
+        return manager
+
+    def test_signature_unchanged_when_bits_none(self):
+        # Non-TurboQuant signatures must stay byte-identical to the previous
+        # format so existing caches of non-TurboQuant models keep validating.
+        old_format = json.dumps(
+            {
+                "model_name": "m",
+                "num_layers": 4,
+                "block_size": 2048,
+                "layer_cache_types": ["KVCache"],
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        assert (
+            _cache_compat_signature(
+                model_name="m",
+                num_layers=4,
+                block_size=2048,
+                layer_cache_types=["KVCache"],
+            )
+            == old_format
+        )
+
+    def test_signature_includes_bits_when_set(self):
+        sig = _cache_compat_signature(
+            model_name="m",
+            num_layers=4,
+            block_size=2048,
+            layer_cache_types=self.TURBO,
+            turboquant_kv_bits=6,
+        )
+        assert json.loads(sig)["turboquant_kv_bits"] == 6.0
+
+    def test_signature_bits_helper_tolerates_non_dict_json(self):
+        # A corrupted signature that parses as a JSON scalar/list must read
+        # as "no recorded depth", not raise — an AttributeError here would
+        # abort the stale-signature sweep and leave mixed-width blocks live.
+        assert _signature_turboquant_bits("123") is None
+        assert _signature_turboquant_bits("[1, 2]") is None
+        assert _signature_turboquant_bits("null") is None
+        assert _signature_turboquant_bits("{not json") is None
+        assert _signature_turboquant_bits("") is None
+
+    def test_block_bits_read_from_meta_state(self):
+        # TurboQuant meta_state is (offset, bits, seed, ...) — the same tuple
+        # the restore path reads.
+        assert (
+            _block_turboquant_bits(self.TURBO, [(), (256, 4.0, 0), (256, 4.0, 0), ()])
+            == 4.0
+        )
+        # Batch-form class name counts too.
+        assert (
+            _block_turboquant_bits(
+                ["BatchTurboQuantKVCache"], [(256, 6.0, 0)]
+            )
+            == 6.0
+        )
+        # Non-TurboQuant layouts and absent meta yield None.
+        assert _block_turboquant_bits(["KVCache"], [(256,)]) is None
+        assert _block_turboquant_bits(self.TURBO, None) is None
+        assert _block_turboquant_bits(self.TURBO, [(), (), (), ()]) is None
+
+    def test_compat_rejects_other_or_unproven_bit_depth(self, tmp_path: Path):
+        mgr = self._make_manager(
+            tmp_path, layer_cache_types=self.TURBO, turboquant_kv_bits=6
+        )
+
+        matching = self._make_meta(
+            block_hash=b"01" * 10, layer_cache_types=self.TURBO, turboquant_kv_bits=6
+        )
+        other_depth = self._make_meta(
+            block_hash=b"02" * 10, layer_cache_types=self.TURBO, turboquant_kv_bits=4
+        )
+        # 0.4.x-era block: TurboQuant layout but no bits field recorded.
+        legacy = self._make_meta(block_hash=b"03" * 10, layer_cache_types=self.TURBO)
+        no_signature = self._make_meta(
+            block_hash=b"04" * 10, layer_cache_types=self.TURBO, cache_signature=""
+        )
+
+        assert mgr._is_compatible_block(matching) is True
+        assert mgr._is_compatible_block(other_depth) is False
+        assert mgr._is_compatible_block(legacy) is False
+        assert mgr._is_compatible_block(no_signature) is False
+
+    def test_compat_unchanged_when_bits_not_expected(self, tmp_path: Path):
+        # TurboQuant disabled: legacy and signature-less blocks keep loading
+        # exactly as before (zero behavioral change).
+        mgr = self._make_manager(tmp_path, layer_cache_types=self.TURBO)
+
+        legacy = self._make_meta(block_hash=b"05" * 10, layer_cache_types=self.TURBO)
+        no_signature = self._make_meta(
+            block_hash=b"06" * 10, layer_cache_types=self.TURBO, cache_signature=""
+        )
+
+        assert mgr._is_compatible_block(legacy) is True
+        assert mgr._is_compatible_block(no_signature) is True
+
+    def test_sweep_drops_other_bit_depth(self, tmp_path: Path):
+        mgr = self._make_manager(
+            tmp_path, layer_cache_types=self.TURBO, turboquant_kv_bits=6
+        )
+        mgr._index.add(
+            self._make_meta(
+                block_hash=b"11" * 10,
+                layer_cache_types=self.TURBO,
+                turboquant_kv_bits=4,
+            )
+        )
+        mgr._index.add(
+            self._make_meta(
+                block_hash=b"12" * 10,
+                layer_cache_types=self.TURBO,
+                turboquant_kv_bits=6,
+            )
+        )
+        mgr._index.add(
+            self._make_meta(block_hash=b"13" * 10, layer_cache_types=self.TURBO)
+        )
+        # Same-model block with no layout metadata at all: with a depth
+        # expected it can no more prove its width than its layout.
+        mgr._index.add(
+            self._make_meta(
+                block_hash=b"14" * 10, layer_cache_types=None, cache_signature=""
+            )
+        )
+
+        dropped = mgr.invalidate_stale_layer_signature()
+
+        assert dropped == 3
+        assert mgr._index.get(b"11" * 10) is None  # 4-bit under 6-bit expectation
+        assert mgr._index.get(b"12" * 10) is not None  # matching depth survives
+        assert mgr._index.get(b"13" * 10) is None  # unproven depth
+        assert mgr._index.get(b"14" * 10) is None  # no metadata, depth expected
+
+    def test_sweep_keeps_legacy_blocks_when_bits_not_expected(self, tmp_path: Path):
+        mgr = self._make_manager(tmp_path, layer_cache_types=self.TURBO)
+        mgr._index.add(
+            self._make_meta(block_hash=b"15" * 10, layer_cache_types=self.TURBO)
+        )
+        # No layout metadata, no depth expectation: skip rather than guess
+        # (pre-existing behavior preserved).
+        mgr._index.add(
+            self._make_meta(
+                block_hash=b"16" * 10, layer_cache_types=None, cache_signature=""
+            )
+        )
+
+        assert mgr.invalidate_stale_layer_signature() == 0
+        assert mgr._index.get(b"15" * 10) is not None
+        assert mgr._index.get(b"16" * 10) is not None
+
+    def test_batch_and_single_turboquant_names_compare_equal(self, tmp_path: Path):
+        # The save path records whichever class name it extracted; the
+        # predicted layout always says "TurboQuantKVCache". Batch-form
+        # blocks persist the same packed per-request state and must not be
+        # swept (that would cold-start the cache every restart).
+        batch_form = [
+            "ArraysCache",
+            "BatchTurboQuantKVCache",
+            "BatchTurboQuantKVCache",
+            "KVCache",
+        ]
+        mgr = self._make_manager(
+            tmp_path, layer_cache_types=self.TURBO, turboquant_kv_bits=6
+        )
+        mgr._index.add(
+            self._make_meta(
+                block_hash=b"21" * 10,
+                layer_cache_types=batch_form,
+                turboquant_kv_bits=6,
+            )
+        )
+
+        assert mgr.invalidate_stale_layer_signature() == 0
+        assert mgr._index.get(b"21" * 10) is not None
+        assert (
+            mgr._is_compatible_block(
+                self._make_meta(
+                    block_hash=b"22" * 10,
+                    layer_cache_types=batch_form,
+                    turboquant_kv_bits=6,
+                )
+            )
+            is True
+        )
+
+    def test_bits_change_alone_triggers_sweep(self, tmp_path: Path):
+        mgr = self._make_manager(
+            tmp_path, layer_cache_types=self.TURBO, turboquant_kv_bits=4
+        )
+        mgr._signature_sweep_completed = True
+
+        changed = mgr.set_expected_layer_signature(self.TURBO, turboquant_kv_bits=6)
+
+        assert changed is True
+        assert mgr._expected_turboquant_kv_bits == 6.0
+        assert mgr._signature_sweep_completed is False
+
+    def test_same_bits_and_types_is_noop(self, tmp_path: Path):
+        mgr = self._make_manager(
+            tmp_path, layer_cache_types=self.TURBO, turboquant_kv_bits=6
+        )
+        mgr._signature_sweep_completed = True
+
+        changed = mgr.set_expected_layer_signature(self.TURBO, turboquant_kv_bits=6)
+
+        assert changed is False
+        assert mgr._signature_sweep_completed is True
+
+    @pytest.mark.skipif(not _has_mlx(), reason="requires MLX")
+    def test_save_path_stamps_block_bits_in_signature(self, tmp_path: Path):
+        # Drive the REAL save path: the persisted signature must record the
+        # depth from the block's own TurboQuant meta_state (observation),
+        # not just the manager's expectation.
+        import mlx.core as mx
+
+        mgr = self._make_manager(
+            tmp_path,
+            layer_cache_types=["TurboQuantKVCache", "KVCache"],
+            turboquant_kv_bits=6,
+        )
+        try:
+            keys = mx.zeros((1, 2, 8, 4), dtype=mx.float16)
+            values = mx.zeros((1, 2, 8, 4), dtype=mx.float16)
+            saved = mgr.save_block(
+                block_hash=b"77" * 16,
+                cache_data=[(keys, values), (keys, values)],
+                token_count=8,
+                model_name="test-model",
+                layer_cache_types=["TurboQuantKVCache", "KVCache"],
+                layer_meta_states=[(8, 6.0, 0), (8,)],
+            )
+            assert saved is True
+            # Wait for the background writer to flush the file to disk.
+            file_path = mgr._get_file_path(b"77" * 16)
+            for _ in range(50):
+                if file_path.exists():
+                    break
+                time.sleep(0.1)
+            assert file_path.exists(), "background writer never produced the file"
+
+            files = list((tmp_path / "ssd_cache").rglob("*.safetensors"))
+            assert len(files) == 1
+            _, metadata = mx.load(str(files[0]), return_metadata=True)
+            payload = json.loads(metadata["cache_signature"])
+            assert payload["turboquant_kv_bits"] == 6.0
+        finally:
+            mgr.close()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2736,7 +2736,10 @@ class TestSchedulerSSDLayerSignature:
     ):
         from mlx_lm.models.cache import KVCache
 
-        from omlx.cache.paged_ssd_cache import PagedSSDBlockMetadata
+        from omlx.cache.paged_ssd_cache import (
+            PagedSSDBlockMetadata,
+            _cache_compat_signature,
+        )
 
         class TwoLayerModel:
             config = SimpleNamespace(
@@ -2786,6 +2789,16 @@ class TestSchedulerSSDLayerSignature:
                 model_name="test-model",
                 block_size=4,
                 layer_cache_types=["TurboQuantKVCache", "KVCache"],
+                # TurboQuant blocks must prove their bit depth to survive a
+                # sweep under an active depth expectation (#2045); this is
+                # the signature the save path stamps since the fix.
+                cache_signature=_cache_compat_signature(
+                    model_name="test-model",
+                    num_layers=2,
+                    block_size=4,
+                    layer_cache_types=["TurboQuantKVCache", "KVCache"],
+                    turboquant_kv_bits=4.0,
+                ),
             )
             manager._index.add(stale)
             manager._index.add(fresh)
@@ -2799,6 +2812,86 @@ class TestSchedulerSSDLayerSignature:
             assert manager._expected_layer_cache_types == layer_cache_types
             assert manager._index.get(stale.block_hash) is None
             assert manager._index.get(fresh.block_hash) is not None
+        finally:
+            scheduler.shutdown()
+
+    def test_refresh_infers_layout_without_model_make_cache(
+        self, mock_tokenizer, tmp_path
+    ):
+        # Plain dense models (most mlx-lm architectures) define no
+        # make_cache; the request path builds their caches through
+        # make_prompt_cache's per-layer KVCache fallback. The refresh must
+        # infer through the same fallback — requiring model.make_cache made
+        # it a silent no-op for these models, so the manager never learned
+        # the TurboQuant bit depth and mixed-width blocks kept loading
+        # after a turboquant_kv_bits change (#2045).
+        from omlx.cache.paged_ssd_cache import (
+            PagedSSDBlockMetadata,
+            _cache_compat_signature,
+        )
+
+        turbo_types = ["TurboQuantKVCache", "KVCache"]
+
+        class PlainDenseModel:
+            config = SimpleNamespace(
+                num_hidden_layers=2,
+                num_key_value_heads=2,
+                num_attention_heads=2,
+                head_dim=32,
+            )
+            layers = [object(), object()]
+
+        scheduler = Scheduler(
+            model=PlainDenseModel(),
+            tokenizer=mock_tokenizer,
+            config=SchedulerConfig(
+                paged_ssd_cache_dir=str(tmp_path),
+                paged_cache_block_size=4,
+                model_name="test-model",
+            ),
+        )
+        try:
+            manager = scheduler.paged_ssd_cache_manager
+            assert manager is not None
+
+            def _block(block_hash: bytes, bits: float | None) -> PagedSSDBlockMetadata:
+                return PagedSSDBlockMetadata(
+                    block_hash=block_hash,
+                    file_path=tmp_path / "never-touched.safetensors",
+                    file_size=1024,
+                    token_count=4,
+                    created_at=0.0,
+                    last_access=0.0,
+                    num_layers=2,
+                    model_name="test-model",
+                    block_size=4,
+                    layer_cache_types=turbo_types,
+                    cache_signature=_cache_compat_signature(
+                        model_name="test-model",
+                        num_layers=2,
+                        block_size=4,
+                        layer_cache_types=turbo_types,
+                        turboquant_kv_bits=bits,
+                    ),
+                )
+
+            old_depth = _block(b"old".ljust(32, b"\0"), 4.0)
+            unproven = _block(b"unproven".ljust(32, b"\0"), None)
+            current = _block(b"current".ljust(32, b"\0"), 6.0)
+            manager._index.add(old_depth)
+            manager._index.add(unproven)
+            manager._index.add(current)
+
+            scheduler._turboquant_kv_bits = 6.0
+            scheduler._turboquant_skip_last = True
+
+            layer_cache_types = scheduler.refresh_ssd_layer_signature()
+
+            assert layer_cache_types == turbo_types
+            assert manager._expected_turboquant_kv_bits == 6.0
+            assert manager._index.get(old_depth.block_hash) is None
+            assert manager._index.get(unproven.block_hash) is None
+            assert manager._index.get(current.block_hash) is not None
         finally:
             scheduler.shutdown()
 

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -146,6 +146,29 @@ def test_batch_tq_merge_extract():
     assert e2.offset == 4
 
 
+def test_batch_tq_merge_rejects_mixed_bit_depths():
+    """#2045 last-line guard: members packed at different depths (or seeds)
+    have incompatible packed widths/codecs and must fail loud at merge, not
+    as a raw mx.concatenate shape error deep in _concat_state_batch."""
+    c4 = TurboQuantKVCache(bits=4.0)
+    c4.update_and_fetch(
+        mx.random.normal((1, 2, 4, 32)), mx.random.normal((1, 2, 4, 32))
+    )
+    c6 = TurboQuantKVCache(bits=6.0)
+    c6.update_and_fetch(
+        mx.random.normal((1, 2, 4, 32)), mx.random.normal((1, 2, 4, 32))
+    )
+    mx.eval(c4.keys, c4.values, c6.keys, c6.values)
+
+    with pytest.raises(ValueError, match="mixed quantization"):
+        BatchTurboQuantKVCache.merge([c4, c6])
+
+    with pytest.raises(ValueError, match="mixed quantization"):
+        BatchTurboQuantKVCache.merge(
+            [c4, TurboQuantKVCache(bits=4.0, seed=1)]
+        )
+
+
 def test_batch_tq_merge_preserves_empty_rows():
     """Regression: mixed empty/non-empty rows must keep the batch dimension."""
     full = TurboQuantKVCache(bits=4.0)


### PR DESCRIPTION
Fixes #2045.

## Summary

- The paged SSD cache signature now records `turboquant_kv_bits`, stamped from each block's own TurboQuant meta_state, so blocks written at different depths can no longer coexist as "compatible" and crash batch concatenation.
- The compatibility check and the one-shot stale-signature sweep enforce the recorded depth whenever a depth is expected; a depth change alone triggers the sweep (no restart needed).
- `BatchTurboQuantKVCache.merge` now rejects mixed `(bits, seed)` members with a clear error — the reporter's remedy (c), as a last-line guard for any path the signature cannot cover.

## Why

TurboQuant packed state width is `ceil(head_dim * bits / 32)`. The signature recorded `layer_cache_types` (knows a layer is TurboQuant) but not *which* depth, so after changing `turboquant_kv_bits` the old-width blocks kept validating. Reproduced on a 0.5B model (head_dim 64, widths 8 vs 12) following the issue's steps: a request whose prefix restored from old 4-bit blocks was silently pinned to 4-bit (the new setting was not honored — post-flip tail blocks saved at the old width), and the moment it was batched with a fresh-prefix request quantized at 6-bit:

```
RuntimeError: [concatenate] All the input array dimensions must match exactly except
for the concatenation axis. However, the provided shapes are (1,2,2607,12), (1,2,2607,8),
and the concatenation axis is 0.
```

— structurally identical to the issue's `(1,2,21061,48)` vs `(1,2,21061,32)` (head_dim 256). Both co-batched requests 500, and the poison is persistent: the blocks live on disk, so every future co-batch repeats the failure until the cache directory is deleted by hand.

A second bug fell out of the repro: the signature refresh (`_infer_live_layer_cache_types`) required `model.make_cache`, which plain dense models don't define — so on the live serving path the refresh was a silent no-op and the manager never learned the layout at all. It now builds its probe cache via `make_prompt_cache`, exactly like the request path.

## Changes

- `_cache_compat_signature` gains `turboquant_kv_bits`; `save_block` stamps it from the block's own meta_state (`(offset, bits, seed)` — the same tuple the restore path reads), falling back to the manager's expectation. A signature never vouches for a width the payload does not have.
- `_signature_bits_match` (one predicate, used by both the compat check and the sweep): with a depth expected, a block must prove a matching depth; unproven blocks (pre-fix saves, metadata-less same-model blocks, corrupted signatures) are treated as stale.
- `set_expected_layer_signature` takes keyword-only `turboquant_kv_bits`; a bits change alone marks the sweep pending.
- `Scheduler._infer_live_layer_cache_types` returns `(layer_cache_types, bits)`; the depth is keyed off the same `_turboquant_eligible` gate the request path uses (models whose convertible caches sit inside `CacheList` report identical type names at every depth — the bits field is their only discriminator). An eligibility-probe failure refuses to infer rather than committing a wrong layout the sweep would act on, and a `logger.warning` fires when TurboQuant is active but no signature could be inferred.
- `_canonicalize_layer_cache_types` collapses `BatchTurboQuantKVCache` → `TurboQuantKVCache` (same packed per-request state on disk; the save path records whichever form it extracted, and sweeping batch-form blocks against the always-singular predicted layout would cold-start the cache every restart).
- `BatchTurboQuantKVCache.merge` raises `ValueError` naming the mixed configs and the remedy, instead of a raw `mx.concatenate` shape error (or, at equal widths, silent garbage decode — seeds determine codec contents).

## Why this is safe

- **Non-TurboQuant models: zero change.** The bits field is only stamped when TurboQuant is active, so their signatures stay byte-identical to the current format and existing caches keep validating (test-pinned).
- **One-time cost, stated plainly:** existing TurboQuant users' blocks predate depth stamping and are swept once after upgrade even if their settings never changed — their width is unverifiable, and keeping them is exactly the reported crash. The sweep drops index entries only; files are reclaimed by the existing LRU.
- **Named residual:** on models where cache-layout inference fails entirely, the first-save `adopt_layer_signature_if_unset` fallback still can't learn bits (pre-fix behavior). That path now warns at startup, and the merge guard converts any resulting mixed-width batch into a clear, actionable error instead of the raw concat failure. Threading bits through the save/adopt plumbing is a possible follow-up if such a model surfaces.
- Seed is part of the merge guard but not the signature: it's hardcoded 0 everywhere today; if it ever becomes configurable it belongs in the signature too (noted for then).

## Tests

`python -m pytest tests/test_paged_ssd_cache.py tests/test_scheduler.py tests/test_turboquant.py -q` → **350 passed** (13 new: signature format pinning old/new, non-dict-JSON tolerance, block-bits extraction from meta_state, compat + sweep depth rules including legacy/unproven blocks, batch/single name canonicalization, bits-change-triggers-sweep, a real-save-path test asserting the persisted file's signature records the depth, scheduler refresh on a make_cache-less dense model, and the merge mixed-config guard). Adjacent suites (`test_turboquant_ssd`, `test_prefix_cache`, `test_prefix_cache_v4_block_storage`, `test_cache_type_handlers`, `test_turboquant_batch_memory`): **195 passed**.

Also verified the new tests fail with the fix reverted (3 behavioral failures plus a collection error on the new helpers).

End-to-end on a live server (Qwen2.5-0.5B, TQ enabled, sandboxed `--base-path`): reproduced the crash on current `main` with the exact issue log shape; on this branch the startup sweep invalidates the mixed-width blocks once (`Invalidated 17 SSD index entries…`), the previously-crashing concurrent request pair completes, new blocks persist with `"turboquant_kv_bits": 6.0` in their signatures, and a subsequent restart keeps them (`kept 17`, sweep idempotent) with full prefix-cache hits.
