### PR TITLE
fix(server): defer non-streaming JSON keepalive to the first interval

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2082,13 +2082,14 @@ async def _with_json_keepalive(
     For non-streaming requests, the HTTP response body is buffered until
     generation finishes, causing client read timeouts on long prefills.
     This wrapper uses StreamingResponse to send space characters as
-    keepalive. JSON parsers ignore leading whitespace, so the final
-    response parses normally.
+    keepalive, deferred until a full interval of actual waiting: fast
+    responses start directly with the JSON payload (strict clients reject
+    bodies that do not start with the JSON value), while long prefills
+    still hold the connection open. JSON parsers ignore the leading
+    whitespace on the slow path, so the final response parses normally.
     """
     task = asyncio.ensure_future(coro)
     keepalive_elapsed = 0.0
-
-    yield " "
 
     try:
         while not task.done():

--- a/tests/test_markitdown_integration.py
+++ b/tests/test_markitdown_integration.py
@@ -285,7 +285,7 @@ def test_markitdown_stream_response_starts_before_conversion(monkeypatch):
     asyncio.run(exercise())
 
 
-def test_markitdown_non_stream_response_starts_before_conversion(monkeypatch):
+def test_markitdown_non_stream_body_is_clean_json(monkeypatch):
     state = ServerState()
     state.engine_pool = _EmptyPool()
     state.global_settings = _settings_with_markitdown_model()
@@ -318,10 +318,13 @@ def test_markitdown_non_stream_response_starts_before_conversion(monkeypatch):
 
         iterator = response.body_iterator.__aiter__()
         first = await iterator.__anext__()
-        assert first == " "
-        chunk = await iterator.__anext__()
-        assert "Converted markdown" in chunk
+        # Fast path after #2066: no keepalive whitespace is prepended, so
+        # the body is a single chunk that starts with the JSON payload.
+        assert first.startswith("{")
+        assert "Converted markdown" in first
         assert started is True
+        with pytest.raises(StopAsyncIteration):
+            await iterator.__anext__()
         await iterator.aclose()
 
     asyncio.run(exercise())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for omlx.server module - sampling parameter resolution and exception handlers."""
 
+import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,6 +24,7 @@ from omlx.server import (
     _reject_diffusion_structured_outputs,
     _reset_boundary_snapshots_for_server,
     _resolve_metric_durations,
+    _with_json_keepalive,
     app,
     get_engine,
     get_max_context_window,
@@ -1003,3 +1006,52 @@ class TestHealthPreloadReadiness:
             assert body["status"] == "healthy"
         finally:
             server_mod._server_state.pinned_preload_complete = old
+
+
+class TestJsonKeepaliveDeferral:
+    """Tests for the deferred non-streaming JSON keepalive contract."""
+
+    class _ConnectedRequest:
+        async def is_disconnected(self):
+            return False
+
+    @pytest.mark.asyncio
+    async def test_fast_response_starts_with_json_payload(self):
+        payload = '{"object": "list", "data": []}'
+
+        async def _fast():
+            return payload
+
+        chunks = [
+            chunk
+            async for chunk in _with_json_keepalive(
+                self._ConnectedRequest(), _fast()
+            )
+        ]
+
+        assert chunks == [payload]
+
+    @pytest.mark.asyncio
+    async def test_slow_response_still_receives_keepalive(self):
+        payload = '{"object": "list", "data": []}'
+        release = asyncio.Event()
+
+        async def _slow():
+            await release.wait()
+            return payload
+
+        gen = _with_json_keepalive(
+            self._ConnectedRequest(),
+            _slow(),
+            interval=0.02,
+            disconnect_poll=0.01,
+        )
+        # The coroutine cannot finish until released, so the first chunk
+        # must be a keepalive space emitted after the interval elapses.
+        first = await gen.__anext__()
+        assert first == " "
+        release.set()
+        rest = [chunk async for chunk in gen]
+
+        assert rest[-1] == payload
+        assert json.loads(first + "".join(rest)) == json.loads(payload)


### PR DESCRIPTION
Fixes #2066.

## Summary

`_with_json_keepalive` yielded an unconditional space as the first chunk of every non-streaming JSON response. The wait loop below it already emits a space after each full `interval` of waiting, so the eager first space is the only thing standing between fast responses and a body that starts with `{`. This PR removes it: keepalive is now deferred until a full interval of actual waiting, exactly as the issue suggests.

## Why

Reproduced on current `main` (Qwen2.5-0.5B-Instruct-4bit, non-streaming `/v1/chat/completions`):

```
$ curl -s ... | xxd | head -1
00000000: 207b 2269 6422 3a22 6368 6174 636d 706c   {"id":"chatcmpl
```

The body begins with `0x20` — valid JSON per spec, but strict OpenAI-compatible clients reject it (the reporter's openclaw embedding adapter fails with "malformed JSON response"). On this branch the same request starts cleanly:

```
00000000: 7b22 6964 223a 2263 6861 7463 6d70 6c2d  {"id":"chatcmpl-
```

The keepalive was added (610796df8) so clients with ~15s read timeouts survive long prefills. That guarantee is preserved: no call site overrides `interval=10.0`, so a slow response's first byte now arrives after at most ~10s of waiting — still inside the 15s window the feature was built for, and identical to the steady-state gap between the old code's periodic spaces. Any client that survived the old code's 10s inter-chunk gaps survives the new first-byte wait. Fast responses (embeddings finish in ~9ms per the issue) never needed the space at all.

## Changes

- `omlx/server.py`: drop the unconditional `yield " "`; docstring updated to state the deferred contract. A side benefit: the old first suspension point sat outside the `try/finally`, so a generator close at exactly that yield skipped task cancellation and orphaned the generation task — the first suspension point is now inside the `try`.
- `tests/test_server.py`: `TestJsonKeepaliveDeferral` — a fast coroutine must produce exactly `[payload]` (no whitespace anywhere), and an event-gated slow coroutine must still receive a keepalive space before its payload (deterministic: the coroutine cannot complete until the test releases it, so the first chunk can only be the interval keepalive). Both run with a connected-request stub so the disconnect-poll branch executes as production runs it.
- `tests/test_markitdown_integration.py`: `test_markitdown_non_stream_response_starts_before_conversion` pinned the old contract (first chunk `" "` before conversion begins). Re-pinned to the new one as `test_markitdown_non_stream_body_is_clean_json`: conversion still deferred into the body iterator, single chunk starting with the JSON payload.

## Sibling paths

- All six non-streaming call sites (`/v1/completions`, `/v1/chat/completions`, `/v1/embeddings`, `/v1/messages`, responses API, markitdown) funnel through this one wrapper with default intervals — covered by construction; verified `/v1/chat/completions` and `/v1/completions` live.
- `_with_sse_keepalive` also sends an immediate initial frame, but as a spec-valid SSE comment/no-op event that event-stream parsers handle in-band — intentionally out of scope (plain JSON has no in-band equivalent, which is exactly why the space hack breaks strict parsers).
- Responses that take longer than one interval still carry leading whitespace before the JSON — that is the keepalive feature itself and remains the documented contract for the slow path (strict clients with long prefills would need a transport-level mechanism; not this PR).

## Why this is safe

- The wait loop is unchanged; `asyncio.wait` returns the moment the task completes, so fast responses gain no added latency (verified live).
- Headers and status are unaffected: Starlette sends `http.response.start` before iterating the body in both versions, so error behavior and status commitment are identical, and the `PrefillMemoryExceededError` body still flows through the same path.
- Time-to-first-body-byte on slow requests moves from ~0s to at most one interval (10s). Stated plainly: a client whose timeout is keyed to the first body byte specifically and is shorter than 10s would regress — but such a client already failed the old code's 10s gaps between subsequent keepalives, so no surviving consumer profile is affected.
- The `result is not None` tail is unreachable today (all six builders return `model_dump_json()` strings or raise); a None result would now produce an empty body instead of a single space — both equally unparseable, noted for completeness.

## Tests

Full suite with the CI filter (`pytest -m "not slow and not integration"`) → **6096 passed, 23 skipped**. The new fast-path test fails on `main` (`[' ', payload] != [payload]`) and passes on this branch; the slow-path test passes on both, pinning that the keepalive feature survives.

End-to-end: sandboxed server on `main` reproduces the issue's leading `0x20`; restarted on this branch, the same requests return bodies starting with `{` that a strict `json.loads` with a `body[:1] == b'{'` precheck accepts.
