### PR TITLE
feat: GLM-5.2 native MTP speculative decoding (external head)

### DIFF
--- a/omlx/patches/mlx_lm_mtp/__init__.py
+++ b/omlx/patches/mlx_lm_mtp/__init__.py
@@ -78,7 +78,13 @@ def apply_mlx_lm_mtp_patch() -> bool:
         True if the patch is now active. False if a sub-step refused
         to apply (mlx-lm not importable, missing prerequisite patch).
     """
-    from . import batch_generator, cache_rollback, deepseek_v4_model, qwen35_model
+    from . import (
+        batch_generator,
+        cache_rollback,
+        deepseek_v4_model,
+        glm_moe_dsa_model,
+        qwen35_model,
+    )
 
     if not cache_rollback.apply():
         return False
@@ -88,6 +94,8 @@ def apply_mlx_lm_mtp_patch() -> bool:
         logger.debug("Qwen3.5/3.6 MTP patch did not apply (likely import error)")
     if not deepseek_v4_model.apply():
         logger.debug("DeepSeek-V4 MTP patch did not apply (likely missing base patch)")
+    if not glm_moe_dsa_model.apply():
+        logger.debug("GLM-5.2 MTP patch did not apply (likely non-GLM model)")
     if not batch_generator.apply():
         logger.warning(
             "BatchGenerator MTP dispatch patch failed; MTP path will be inactive"

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -1541,6 +1541,18 @@ def _run_verify_cycle(gen_batch: Any, state: _MtpState) -> None:
         _clear_rollback(gen_batch.prompt_cache)
         state.stats.cache_ops_ms += (time.perf_counter() - t0) * 1000
 
+        # Aligned-cache heads (e.g. GLM-5.2 external MTP): also insert the
+        # accepted draft's (hidden, token) pair so the head cache tracks
+        # every confirmed position and RoPE/indexer offsets stay exact.
+        # Logits of this fill forward are never evaluated (lazy), so the
+        # lm_head matmul is skipped — only the KV/indexer update runs.
+        if getattr(gen_batch.model, "_omlx_mtp_aligned_cache", False):
+            gen_batch.model.mtp_forward(
+                hidden_at_confirmed,
+                _ensure_uint32(state.draft_tok).reshape(1, 1),
+                state.mtp_cache,
+            )
+
         # --- MTP head forward for next draft (timed inside _step_mtp) ---
         new_draft, new_draft_lp = _step_mtp(
             gen_batch,

--- a/omlx/patches/mlx_lm_mtp/glm_moe_dsa_model.py
+++ b/omlx/patches/mlx_lm_mtp/glm_moe_dsa_model.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GLM-5.2 (glm_moe_dsa) native MTP head for the mlx_lm_mtp draft/verify cycle.
+
+GLM-5.2's MTP layer is DeepSeek-V3-style: at position ``i`` it fuses the
+backbone's pre-norm hidden state (``hnorm``) with the embedding of token
+``i+1`` (``enorm``) through a concat + ``eh_proj``, then runs one full
+``GlmMoeDsaDecoderLayer`` (full DSA indexer + MoE) and shares the backbone's
+``lm_head``. Zhipu explicitly designed it as the draft model for speculative
+decoding.
+
+Unlike Qwen3.5 / DeepSeek-V4-Flash, common quantized GLM-5.2 checkpoints
+(e.g. mxfp4) strip the MTP tensors, so the head ships as a *separate*
+checkpoint (``model_type: glm_moe_dsa_mtp``, ~11 GB Q4). This patch therefore
+does NOT hook ``Model.__init__``/``sanitize`` — the head is attached
+post-load from a sibling ``<model_dir>/mtp/`` directory (see
+``maybe_attach_glm_mtp``), which keeps the strict main-checkpoint load
+untouched and the model byte-identical to stock when MTP is off.
+
+The BatchGenerator MTP dispatch is model-agnostic: it only needs
+``model(inputs, cache, return_hidden=True)`` -> ``(logits, hidden)``,
+``model.mtp_forward(hidden, next_ids, mtp_cache)``, ``model.make_mtp_cache()``
+and the ``_omlx_mtp_decode_enabled`` instance marker — all provided here.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Stash set at pre-load time (maybe_apply_pre_load_patches) and consumed at
+# post-load time (apply_post_load_transforms). Same single-MLX-executor
+# serialization argument as ``mlx_lm_mtp._MTP_ACTIVE``.
+_GLM_MTP_PATH: Optional[str] = None
+
+
+def set_glm_mtp_path(path: Optional[str]) -> None:
+    global _GLM_MTP_PATH
+    _GLM_MTP_PATH = path
+
+
+def find_glm_mtp_checkpoint(model_path: str) -> Optional[str]:
+    """Return the MTP head checkpoint dir for a GLM model, or None.
+
+    Convention: a ``mtp/`` subdirectory (or symlink) inside the model
+    directory holding ``config.json`` (``model_type: glm_moe_dsa_mtp``) +
+    ``*.safetensors``.
+    """
+    cand = Path(model_path) / "mtp"
+    if (cand / "config.json").exists():
+        return str(cand)
+    return None
+
+
+def apply() -> bool:
+    """Patch the (oMLX-vendored) ``mlx_lm.models.glm_moe_dsa`` module.
+
+    Must run after ``apply_glm_moe_dsa_patch`` registered the module and
+    before ``mlx_lm.load()``. Idempotent via class markers.
+    """
+    glm = sys.modules.get("mlx_lm.models.glm_moe_dsa")
+    if glm is None or not hasattr(glm, "Model"):
+        logger.debug(
+            "glm_moe_dsa module not registered; skipping GLM MTP patch "
+            "(expected for non-GLM models)"
+        )
+        return False
+
+    _register_mtp_module(glm)
+    _patch_backbone_call(glm)
+    _patch_model(glm)
+
+    if not getattr(glm.Model, "_omlx_glm_mtp_patched", False):
+        glm.Model._omlx_glm_mtp_patched = True
+        logger.info("GLM-5.2 MTP model patch applied (external head)")
+    return True
+
+
+def _cache_classes(glm: Any):
+    CacheList = getattr(glm, "CacheList", None)
+    KVCache = getattr(glm, "KVCache", None)
+    if CacheList is None or KVCache is None:
+        from mlx_lm.models.cache import CacheList, KVCache  # type: ignore
+    return CacheList, KVCache
+
+
+# ---------------------------------------------------------------------------
+# GlmMoeDsaMTP — the head module (external checkpoint).
+# ---------------------------------------------------------------------------
+
+
+def _register_mtp_module(glm: Any) -> None:
+    if hasattr(glm, "GlmMoeDsaMTP"):
+        return
+
+    import mlx.nn as nn
+
+    class GlmMoeDsaMTP(nn.Module):
+        """GLM-5.2 MTP head: enorm/hnorm -> concat -> eh_proj -> one
+        ``GlmMoeDsaDecoderLayer`` (full indexer) -> norm. Shares the
+        backbone's ``embed_tokens`` and ``lm_head`` at call time."""
+
+        def __init__(self, config: Any, layer_idx: int):
+            super().__init__()
+            dim = config.hidden_size
+            self.enorm = nn.RMSNorm(dim, eps=config.rms_norm_eps)
+            self.hnorm = nn.RMSNorm(dim, eps=config.rms_norm_eps)
+            self.eh_proj = nn.Linear(dim * 2, dim, bias=False)
+            self.layers = [glm.GlmMoeDsaDecoderLayer(config, layer_idx)]
+            self.norm = nn.RMSNorm(dim, eps=config.rms_norm_eps)
+
+    glm.GlmMoeDsaMTP = GlmMoeDsaMTP
+
+
+# ---------------------------------------------------------------------------
+# Backbone — optional pre-norm hidden return.
+# ---------------------------------------------------------------------------
+
+
+def _patch_backbone_call(glm: Any) -> None:
+    cls = glm.GlmMoeDsaModel
+    existing = cls.__dict__.get("__call__")
+    if getattr(existing, "_omlx_glm_mtp_marker", False):
+        return
+
+    import mlx.core as mx
+
+    create_attention_mask = glm.create_attention_mask
+    original_call = cls.__call__
+
+    def __call__(
+        self,
+        x,
+        cache=None,
+        return_hidden: bool = False,
+        n_confirmed: int = 0,
+    ):
+        # ``n_confirmed`` is accepted for the patched-backbone interface and
+        # unused: GLM keeps all decode state in KV caches, rejection rolls
+        # back via cache_rollback (same rationale as DeepSeek-V4).
+        if not return_hidden:
+            return original_call(self, x, cache)
+
+        # Mirror of the vendored body, returning the pre-norm hidden too.
+        h = self.embed_tokens(x)
+
+        pipeline_rank = self.pipeline_rank
+        pipeline_size = self.pipeline_size
+
+        if cache is None:
+            cache = [None] * self.num_layers
+        mask = create_attention_mask(
+            h, cache[0][0] if cache[0] else None, return_array=True
+        )
+
+        if pipeline_rank < pipeline_size - 1:
+            h = mx.distributed.recv_like(h, (pipeline_rank + 1))
+
+        prev_topk_indices = None
+        for i in range(self.num_layers):
+            h, prev_topk_indices = self.layers[self.start_idx + i](
+                h, mask, cache[i], prev_topk_indices
+            )
+
+        if pipeline_rank != 0:
+            h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
+            if cache[-1] is not None:
+                cache[-1][0].keys = mx.depends(cache[-1][0].keys, h)
+
+        if pipeline_size > 1:
+            h = mx.distributed.all_gather(h)[: h.shape[0]]
+
+        return self.norm(h), h
+
+    __call__._omlx_glm_mtp_marker = True
+    cls.__call__ = __call__
+
+
+# ---------------------------------------------------------------------------
+# Model — return_hidden passthrough + mtp_forward / make_mtp_cache / attach.
+# ---------------------------------------------------------------------------
+
+
+def _patch_model(glm: Any) -> None:
+    cls = glm.Model
+    existing = cls.__dict__.get("__call__")
+    if getattr(existing, "_omlx_glm_mtp_marker", False):
+        return
+
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    create_attention_mask = glm.create_attention_mask
+    CacheList, KVCache = _cache_classes(glm)
+    original_call = cls.__call__
+
+    def __call__(
+        self,
+        inputs,
+        cache=None,
+        return_hidden: bool = False,
+        n_confirmed: int = 0,
+        **kwargs,
+    ):
+        if not return_hidden:
+            return original_call(self, inputs, cache, **kwargs)
+        normed, h = self.model(inputs, cache, return_hidden=True)
+        return self.lm_head(normed), h
+
+    def make_mtp_cache(self):
+        # The MTP layer runs a full indexer -> CacheList(attn KV, indexer KV).
+        if getattr(self, "mtp", None) is None:
+            return None
+        return [CacheList(KVCache(), KVCache())]
+
+    def mtp_forward(self, hidden, next_ids, mtp_cache):
+        e = self.model.embed_tokens(next_ids)
+        fused = self.mtp.eh_proj(
+            mx.concatenate([self.mtp.enorm(e), self.mtp.hnorm(hidden)], axis=-1)
+        )
+        c = mtp_cache[0]
+        mask = create_attention_mask(fused, c[0] if c[0] else None, return_array=True)
+        x, prev = fused, None
+        for layer in self.mtp.layers:
+            x, prev = layer(x, mask, c, prev)
+        return self.lm_head(self.mtp.norm(x))
+
+    def attach_glm_mtp(self, mtp_path: str):
+        """Build + load the MTP head from its separate checkpoint and mark
+        the instance MTP-decode-enabled for the BatchGenerator dispatch."""
+        import glob
+        import json
+
+        cfgf = json.load(open(Path(mtp_path) / "config.json"))
+        tcfg = cfgf.get("text_config", cfgf)
+        qcfg = cfgf.get("quantization_config") or tcfg.get("quantization") or {}
+        margs = glm.ModelArgs.from_dict(tcfg)
+        layer_idx = next(
+            i
+            for i in range(margs.num_hidden_layers)
+            if i >= margs.first_k_dense_replace and margs.indexer_types[i] == "full"
+        )
+        head = glm.GlmMoeDsaMTP(margs, layer_idx)
+        weights = {}
+        for f in glob.glob(str(Path(mtp_path) / "*.safetensors")):
+            weights.update(mx.load(f))
+        # The vendored GLM MoE fuses gate_proj+up_proj into gate_up_proj
+        # (see deepseek_v32.sanitize); the external head checkpoint stores
+        # them split — replicate the fusion here (concat on the expert
+        # output axis, forward splits in half on axis=-1).
+        fuse_prefixes = sorted(
+            {
+                k.rsplit(".gate_proj.", 1)[0]
+                for k in weights
+                if ".switch_mlp.gate_proj." in k
+            }
+        )
+        for prefix in fuse_prefixes:
+            for k in ("weight", "scales", "biases"):
+                g = f"{prefix}.gate_proj.{k}"
+                u = f"{prefix}.up_proj.{k}"
+                if g in weights and u in weights:
+                    weights[f"{prefix}.gate_up_proj.{k}"] = mx.concatenate(
+                        [weights.pop(g), weights.pop(u)], axis=1
+                    )
+        nn.quantize(
+            head,
+            group_size=qcfg.get("group_size", 64),
+            bits=qcfg.get("bits", 4),
+            class_predicate=lambda p, m: (p + ".scales") in weights,
+        )
+        head.load_weights(list(weights.items()), strict=True)
+        mx.eval(head.parameters())
+        self.mtp = head
+        self._omlx_mtp_decode_enabled = True
+        self._omlx_mtp_aligned_cache = True
+        logger.info(
+            "GLM MTP head attached from %s (layer_idx=%d, %d tensors)",
+            mtp_path,
+            layer_idx,
+            len(weights),
+        )
+        return self
+
+    __call__._omlx_glm_mtp_marker = True
+    cls.__call__ = __call__
+    cls.make_mtp_cache = make_mtp_cache
+    cls.mtp_forward = mtp_forward
+    cls.attach_glm_mtp = attach_glm_mtp
+
+
+# ---------------------------------------------------------------------------
+# Post-load attach entry point (called from apply_post_load_transforms).
+# ---------------------------------------------------------------------------
+
+
+def maybe_attach_glm_mtp(model: Any, model_settings: Any = None) -> Any:
+    """Attach the external GLM MTP head when armed at pre-load time.
+
+    No-op unless ``set_glm_mtp_path`` stashed a checkpoint path for this
+    load (which already encodes the model_type + settings gate).
+    """
+    global _GLM_MTP_PATH
+    path = _GLM_MTP_PATH
+    _GLM_MTP_PATH = None
+    if not path:
+        return model
+    if not hasattr(model, "attach_glm_mtp"):
+        logger.warning(
+            "GLM MTP path stashed but model has no attach_glm_mtp "
+            "(patch not applied?) — skipping"
+        )
+        return model
+    try:
+        model.attach_glm_mtp(path)
+    except Exception:
+        logger.exception("GLM MTP head attach failed — continuing without MTP")
+    return model

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -195,8 +195,10 @@ def maybe_apply_pre_load_patches(
     # models with mtp_enabled=False) are not polluted by a prior model
     # load that left the flag True.
     from ..patches.mlx_lm_mtp import set_mtp_active
+    from ..patches.mlx_lm_mtp.glm_moe_dsa_model import set_glm_mtp_path
 
     set_mtp_active(False)
+    set_glm_mtp_path(None)
 
     _patch_mlx_lm_load_config()
 
@@ -239,6 +241,40 @@ def maybe_apply_pre_load_patches(
 
         if apply_glm_moe_dsa_patch():
             logger.info("GLM MoE DSA pre-load patch applied for %s", model_name)
+
+        # GLM-5.2 MTP: the head ships as a separate checkpoint (common
+        # quantized checkpoints strip the mtp.* tensors), so the in-config
+        # detection (_is_mtp_compatible) does not apply. Gate on
+        # model_settings.mtp_enabled + a <model_dir>/mtp checkpoint and
+        # arm the post-load attach (apply_post_load_transforms).
+        from ..patches.mlx_lm_mtp.glm_moe_dsa_model import (
+            find_glm_mtp_checkpoint,
+        )
+
+        glm_mtp_enabled = bool(
+            model_settings is not None
+            and getattr(model_settings, "mtp_enabled", False)
+        )
+        glm_mtp_path = (
+            find_glm_mtp_checkpoint(str(model_name)) if glm_mtp_enabled else None
+        )
+        if glm_mtp_path:
+            from ..patches.mlx_lm_mtp import apply_mlx_lm_mtp_patch
+
+            if apply_mlx_lm_mtp_patch():
+                from ..patches.mlx_lm_mtp.glm_moe_dsa_model import (
+                    set_glm_mtp_path as _arm_glm_mtp,
+                )
+
+                _arm_glm_mtp(glm_mtp_path)
+                logger.info(
+                    "GLM MTP armed for %s (head: %s)", model_name, glm_mtp_path
+                )
+        elif glm_mtp_enabled:
+            logger.warning(
+                "mtp_enabled is set for %s but no <model_dir>/mtp checkpoint "
+                "was found — MTP inactive", model_name,
+            )
 
     minimax_m3_types = {"minimax_m3", "minimax_m3_vl"}
     if for_vlm and (
@@ -577,6 +613,10 @@ def apply_post_load_transforms(model: Any, model_settings: Any = None) -> Any:
     Returns:
         The (possibly patched) model.
     """
+    from ..patches.mlx_lm_mtp.glm_moe_dsa_model import maybe_attach_glm_mtp
+
+    model = maybe_attach_glm_mtp(model, model_settings)
+
     if model_settings is None:
         return model
 

--- a/tests/test_glm_mtp_patch.py
+++ b/tests/test_glm_mtp_patch.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for omlx.patches.mlx_lm_mtp.glm_moe_dsa_model (GLM-5.2 external MTP head).
+
+Mirrors the structural style of test_mlx_lm_mtp_patch.py / test_glm_moe_dsa_patch.py:
+registration, method presence, idempotency, and the external-checkpoint arming
+path — no full-size model instantiation.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def _apply_glm_base():
+    try:
+        from omlx.patches.glm_moe_dsa import apply_glm_moe_dsa_patch
+    except ImportError:
+        pytest.skip("omlx.patches.glm_moe_dsa not importable")
+    apply_glm_moe_dsa_patch()
+    import sys
+
+    glm = sys.modules.get("mlx_lm.models.glm_moe_dsa")
+    if glm is None or not hasattr(glm, "Model"):
+        pytest.skip("glm_moe_dsa module not registered (mlx_lm absent?)")
+    return glm
+
+
+class TestApply:
+    def test_apply_requires_registered_glm_module(self, monkeypatch):
+        import sys
+
+        from omlx.patches.mlx_lm_mtp import glm_moe_dsa_model
+
+        monkeypatch.delitem(sys.modules, "mlx_lm.models.glm_moe_dsa", raising=False)
+        assert glm_moe_dsa_model.apply() is False
+
+    def test_apply_registers_head_and_hooks(self):
+        glm = _apply_glm_base()
+        from omlx.patches.mlx_lm_mtp import glm_moe_dsa_model
+
+        assert glm_moe_dsa_model.apply() is True
+        assert hasattr(glm, "GlmMoeDsaMTP")
+        for attr in ("mtp_forward", "make_mtp_cache", "attach_glm_mtp"):
+            assert hasattr(glm.Model, attr), attr
+        # Backbone + outer __call__ carry the idempotency marker.
+        assert getattr(glm.GlmMoeDsaModel.__call__, "_omlx_glm_mtp_marker", False)
+        assert getattr(glm.Model.__dict__["__call__"], "_omlx_glm_mtp_marker", False)
+
+    def test_apply_idempotent(self):
+        glm = _apply_glm_base()
+        from omlx.patches.mlx_lm_mtp import glm_moe_dsa_model
+
+        assert glm_moe_dsa_model.apply() is True
+        call_before = glm.Model.__dict__["__call__"]
+        assert glm_moe_dsa_model.apply() is True
+        assert glm.Model.__dict__["__call__"] is call_before
+
+    def test_orchestrator_includes_glm_submodule(self):
+        _apply_glm_base()
+        from omlx.patches.mlx_lm_mtp import apply_mlx_lm_mtp_patch
+
+        assert apply_mlx_lm_mtp_patch() is True
+
+
+class TestExternalCheckpointArming:
+    def test_find_glm_mtp_checkpoint(self, tmp_path):
+        from omlx.patches.mlx_lm_mtp.glm_moe_dsa_model import find_glm_mtp_checkpoint
+
+        assert find_glm_mtp_checkpoint(str(tmp_path)) is None
+        mtp = tmp_path / "mtp"
+        mtp.mkdir()
+        assert find_glm_mtp_checkpoint(str(tmp_path)) is None  # config.json requis
+        (mtp / "config.json").write_text(json.dumps({"model_type": "glm_moe_dsa_mtp"}))
+        assert find_glm_mtp_checkpoint(str(tmp_path)) == str(mtp)
+
+    def test_stash_set_and_consumed_once(self):
+        from omlx.patches.mlx_lm_mtp import glm_moe_dsa_model as g
+
+        g.set_glm_mtp_path("/nonexistent/mtp")
+
+        class _NoAttach:
+            pass
+
+        model = _NoAttach()
+        # Modèle sans attach_glm_mtp → warning + modèle inchangé, stash consommé.
+        assert g.maybe_attach_glm_mtp(model) is model
+        # Second appel : stash vidé → no-op strict.
+        assert g.maybe_attach_glm_mtp(model) is model
+
+    def test_attach_failure_is_fail_open(self):
+        glm = _apply_glm_base()
+        from omlx.patches.mlx_lm_mtp import glm_moe_dsa_model as g
+
+        assert g.apply() is True
+
+        class _FakeModel:
+            attach_glm_mtp = glm.Model.attach_glm_mtp
+
+        g.set_glm_mtp_path("/nonexistent/mtp")
+        model = _FakeModel()
+        # Chemin inexistant → l'attach lève en interne, maybe_attach n'explose
+        # pas et rend le modèle inchangé (serving sans MTP).
+        assert g.maybe_attach_glm_mtp(model) is model
+        assert getattr(model, "_omlx_mtp_decode_enabled", False) is False
+
+    def test_pre_load_arms_glm_mtp(self, tmp_path, monkeypatch):
+        _apply_glm_base()
+        from omlx.model_settings import ModelSettings
+        from omlx.patches.mlx_lm_mtp import glm_moe_dsa_model as g
+        from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+        model_dir = tmp_path / "GLM-5.2-test"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "glm_moe_dsa"}))
+        mtp = model_dir / "mtp"
+        mtp.mkdir()
+        (mtp / "config.json").write_text(json.dumps({"model_type": "glm_moe_dsa_mtp"}))
+
+        settings = ModelSettings(mtp_enabled=True)
+        maybe_apply_pre_load_patches(str(model_dir), model_settings=settings)
+        assert g._GLM_MTP_PATH == str(mtp)
+
+        # mtp_enabled=False → stash non armé (reset par le pré-load suivant).
+        settings_off = ModelSettings(mtp_enabled=False)
+        maybe_apply_pre_load_patches(str(model_dir), model_settings=settings_off)
+        assert g._GLM_MTP_PATH is None


### PR DESCRIPTION
## Summary

Extends the native MTP speculative decoding (`patches/mlx_lm_mtp/`, currently Qwen 3.5/3.6 + DeepSeek-V4-Flash) to **GLM-5.2** (`glm_moe_dsa`). GLM-5.2's MTP layer was explicitly designed by Zhipu as the speculative draft model ([GLM-5.2 blog](https://huggingface.co/blog/zai-org/glm-52-blog)), and oMLX already has the best GLM-5.2 story on Apple Silicon — this completes it.

## What's different about GLM-5.2

1. **External head checkpoint.** Common quantized GLM-5.2 builds (e.g. mxfp4) strip the `mtp.*` tensors; the head circulates as a separate ~11 GB checkpoint (`model_type: glm_moe_dsa_mtp`, e.g. `GLM-5.2-MTP-MLX-Q4`). So instead of the in-checkpoint `__init__`/`sanitize` hooks used by Qwen/DeepSeek, the head is **attached post-load** from a `<model_dir>/mtp/` directory (dir or symlink), gated on `model_settings.mtp_enabled`. The strict main-checkpoint load is untouched and with MTP off the model is byte-identical to stock. `gate_up_proj` fusion of the vendored MoE is replicated for the head weights (concat on the expert output axis).

2. **Aligned head cache (gap-fill).** On the accept path the generic cycle inserts only one `(hidden, token)` pair per two confirmed tokens, so the head's KV/RoPE/DSA-indexer positions drift one position per accepted draft — with GLM's positional-sensitive head the accept rate collapses. This PR inserts the accepted draft's pair as well, **gated on a `_omlx_mtp_aligned_cache` model marker** so Qwen/DeepSeek behavior is unchanged. The fill forward's logits are never evaluated, so the lm_head matmul is lazily skipped. With the gap-fill, accept goes from collapse to **80–92 % (greedy)**.

## Measurements (M3 Ultra 512 GB, GLM-5.2-mxfp4 + GLM-5.2-MTP-MLX-Q4, greedy, 3 fixed prompts)

| | decode tok/s | accept |
|---|---|---|
| oMLX HEAD, no MTP | 18.6–19.7 | — |
| this PR, MTP on | 15.7–16.4 | 79.8 / 87.6 / 91.7 % |

Being upfront: **on this bandwidth-bound setup the net decode is parity-to-slightly-below.** Per-request timing shows why: the L=2 verify forward costs ~2.2× an L=1 forward (112 ms vs 51 ms) because with 8-of-256 routing two adjacent tokens share almost no routed experts, and routed expert weights dominate the memory traffic. The MTP plumbing is correct and measured (the accept rates above are the proof); it becomes a net win wherever small-L expert gather amortizes better — see the companion issue with the full numbers. Until then, `mtp_enabled: false` (the default) keeps everything stock.

## Test plan

- `mtp_enabled: false` (default): no behavioral change (verified byte-identical outputs at temp 0 on 3 prompts).
- `mtp_enabled: true` + `<model_dir>/mtp` present: head attaches post-load (log line), MTP path activates for singleton batches, per-request stats logged (`MTP[uid] ... accept=...`).
- `mtp_enabled: true` without the head dir: warning, MTP inactive, serving unaffected.
- Attach failure (weight mismatch): logged, serving continues without MTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
