### PR TITLE
fix(ci): pin transformers below 5.13 to unbreak mlx-lm import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,13 @@ dependencies = [
     # mlx-embeddings from latest commit (32981fa)
     "mlx-embeddings @ git+https://github.com/Blaizzy/mlx-embeddings@32981fa4e8064ed664b52071789dd18271fe4206",
     # mlx-vlm custom processors bypass HF AutoProcessor, so torch is not required
-    "transformers>=5.7.0",
+    # <5.13: transformers 5.13.0 (released 2026-07-03) tightened
+    # _LazyAutoMapping.register to require config classes, breaking mlx-lm
+    # 0.31.3's AutoTokenizer.register("NewlineTokenizer", ...) at import time
+    # (AttributeError: 'str' object has no attribute '__module__'). Every
+    # `import mlx_lm` fails on a fresh resolve. Lift once the mlx-lm pin
+    # advances past a fix.
+    "transformers>=5.7.0,<5.13",
     # transformers 5.x's tokenization_mistral_common module imports
     # ReasoningEffort from mistral_common (added in 1.10). The audio extras
     # transitively pull mistral-common via mlx-audio[stt], which historically


### PR DESCRIPTION
## What

Caps `transformers` at `<5.13` in `pyproject.toml`.

## Why — CI is red for every PR since today

transformers **5.13.0** (released 2026-07-03) tightened `_LazyAutoMapping.register()` — it now accesses `key.__module__` on the config-class key. mlx-lm 0.31.3 (the commit pinned in this repo) still registers its `NewlineTokenizer` with a **string** key:

```python
# mlx_lm/tokenizer_utils.py:503
AutoTokenizer.register("NewlineTokenizer", fast_tokenizer_class=NewlineTokenizer)
```

so on any freshly resolved environment, `import mlx_lm` — and therefore `import omlx.server`, and therefore **all test collection** — dies with:

```
transformers/models/auto/auto_factory.py:680: in register
    if key.__module__.startswith("transformers."):
E   AttributeError: 'str' object has no attribute '__module__'
```

`pyproject.toml` only required `transformers>=5.7.0`, so CI picks up 5.13.0 the moment it resolves. main's last green run (Jul 2) predates the release; every run since — CI #761, #762, #763 across PRs — fails identically with 54 collection errors. Environments resolved before Jul 3 (including dev machines) are unaffected, which is why this only shows up in CI.

## Lift condition

Remove the cap once the mlx-lm pin advances past a release that registers the tokenizer with a config class (or transformers restores string-key tolerance).