### PR TITLE
fix: remove stale "auto" from Hot Cache Size sublabel

### DIFF
--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -3871,7 +3871,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "RAM ceiling for hot cache. \"0\" disables, \"8GB\" or \"auto\" accepted."
+            "value" : "RAM ceiling for hot cache. \"0\" disables, \"8GB\" accepted."
           }
         }
       }


### PR DESCRIPTION
The Hot Cache Size field description in the macOS app claimed "auto" is accepted, but the code normalizes it to "0" (disabled). This misleads users into entering "auto" which silently becomes disabled.

Updated both the localization string and Swift defaultValue to accurately reflect accepted values: "0" or a size like "8GB".