### PR TITLE
fix(status): surface residual native memory with no models loaded

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
@@ -65,7 +65,7 @@ struct StatusScreen: View {
             SectionHeader(String(localized: "status.section.active_now",
                                   defaultValue: "Active Now",
                                   comment: "Section header for the currently active models list"))
-            ActiveNowList(models: vm.stats?.activeModels.models ?? [])
+            ActiveNowList(activeModels: vm.stats?.activeModels)
 
             SectionHeader(String(localized: "status.section.system",
                                   defaultValue: "System",
@@ -536,20 +536,47 @@ private struct ThermalTrailing: View {
 // MARK: - Active Now
 
 private struct ActiveNowList: View {
-    let models: [StatsDTO.ActiveModelDTO]
+    let activeModels: StatsDTO.ActiveModelsDTO?
     @Environment(\.omlxTheme) private var theme
+
+    private var models: [StatsDTO.ActiveModelDTO] {
+        activeModels?.models ?? []
+    }
+
+    private var residualMemory: Int64 {
+        activeModels?.untrackedNativeMemory ?? 0
+    }
+
+    private var residualMemoryText: String {
+        activeModels?.untrackedNativeMemoryFormatted ?? formatBytes(residualMemory)
+    }
 
     var body: some View {
         ListGroup {
             if models.isEmpty {
                 FreeRow(isLast: true) {
-                    Text(String(localized: "status.active_now.empty",
-                                defaultValue: "Server idle — no models loaded",
-                                comment: "Empty-state text shown when the Active Now list has no entries"))
-                        .font(.omlxText(12))
-                        .foregroundStyle(theme.textTertiary)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, 12)
+                    VStack(spacing: 4) {
+                        if residualMemory > 0 {
+                            Text(String(localized: "status.active_now.residual",
+                                        defaultValue: "No models loaded, but \(residualMemoryText) native memory is still resident",
+                                        comment: "Empty-state text when no model is loaded but native memory remains resident"))
+                                .font(.omlxText(12, weight: .medium))
+                                .foregroundStyle(theme.amberDot)
+                            Text(String(localized: "status.active_now.residual_hint",
+                                        defaultValue: "Restart oMLX if cache reclaim does not clear it.",
+                                        comment: "Hint shown under residual native memory warning"))
+                                .font(.omlxText(11))
+                                .foregroundStyle(theme.textTertiary)
+                        } else {
+                            Text(String(localized: "status.active_now.empty",
+                                        defaultValue: "Server idle — no models loaded",
+                                        comment: "Empty-state text shown when the Active Now list has no entries"))
+                                .font(.omlxText(12))
+                                .foregroundStyle(theme.textTertiary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 12)
                 }
             } else {
                 ForEach(Array(models.enumerated()), id: \.element.id) { index, model in

--- a/apps/omlx-mac/Sources/Net/DTO/StatsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/StatsDTO.swift
@@ -35,6 +35,8 @@ struct StatsDTO: Codable, Equatable, Sendable {
         let models: [ActiveModelDTO]
         let modelMemoryUsed: Int64?
         let modelMemoryMax: Int64?
+        let untrackedNativeMemory: Int64?
+        let untrackedNativeMemoryFormatted: String?
         let totalActiveRequests: Int?
         let totalWaitingRequests: Int?
     }

--- a/apps/omlx-mac/Tests/oMLXTests/SystemMetricsTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/SystemMetricsTests.swift
@@ -125,6 +125,8 @@ final class SystemMetricsTests: XCTestCase {
                 models: [],
                 modelMemoryUsed: nil,
                 modelMemoryMax: nil,
+                untrackedNativeMemory: nil,
+                untrackedNativeMemoryFormatted: nil,
                 totalActiveRequests: active,
                 totalWaitingRequests: 0
             ),

--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -71,6 +71,8 @@
   "status.speed.token_generation": "Token Generation",
   "status.active_models.section_label": "Active Models",
   "status.active_models.no_models": "No models loaded",
+  "status.active_models.residual_memory": "No models loaded, but {memory} native memory is still resident",
+  "status.active_models.residual_memory_hint": "Restart oMLX if this does not clear after cache reclaim.",
   "status.active_models.active": "Active",
   "status.active_models.waiting": "Waiting",
   "status.active_models.req": "req",

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -71,6 +71,8 @@
   "status.speed.token_generation": "Generación de Tokens",
   "status.active_models.section_label": "Modelos Activos",
   "status.active_models.no_models": "No hay modelos cargados",
+  "status.active_models.residual_memory": "No models loaded, but {memory} native memory is still resident",
+  "status.active_models.residual_memory_hint": "Restart oMLX if this does not clear after cache reclaim.",
   "status.active_models.active": "Activo",
   "status.active_models.waiting": "Esperando",
   "status.active_models.req": "req",

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -71,6 +71,8 @@
   "status.speed.token_generation": "Génération de tokens",
   "status.active_models.section_label": "Modèles actifs",
   "status.active_models.no_models": "Aucun modèle chargé",
+  "status.active_models.residual_memory": "No models loaded, but {memory} native memory is still resident",
+  "status.active_models.residual_memory_hint": "Restart oMLX if this does not clear after cache reclaim.",
   "status.active_models.active": "Actif",
   "status.active_models.waiting": "En attente",
   "status.active_models.req": "req",

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -71,6 +71,8 @@
   "status.speed.token_generation": "トークン生成",
   "status.active_models.section_label": "アクティブモデル",
   "status.active_models.no_models": "ロード済みモデルなし",
+  "status.active_models.residual_memory": "No models loaded, but {memory} native memory is still resident",
+  "status.active_models.residual_memory_hint": "Restart oMLX if this does not clear after cache reclaim.",
   "status.active_models.active": "アクティブ",
   "status.active_models.waiting": "待機",
   "status.active_models.req": "リクエスト",

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -71,6 +71,8 @@
   "status.speed.token_generation": "토큰 생성",
   "status.active_models.section_label": "활성 모델",
   "status.active_models.no_models": "로드된 모델 없음",
+  "status.active_models.residual_memory": "로드된 모델은 없지만 네이티브 메모리 {memory}가 아직 남아 있음",
+  "status.active_models.residual_memory_hint": "캐시 회수 후에도 사라지지 않으면 oMLX를 재시작하세요.",
   "status.active_models.active": "활성",
   "status.active_models.waiting": "대기",
   "status.active_models.req": "요청",

--- a/omlx/admin/i18n/pt-BR.json
+++ b/omlx/admin/i18n/pt-BR.json
@@ -71,6 +71,8 @@
   "status.speed.token_generation": "Geração de Tokens",
   "status.active_models.section_label": "Modelos Ativos",
   "status.active_models.no_models": "Nenhum modelo carregado",
+  "status.active_models.residual_memory": "No models loaded, but {memory} native memory is still resident",
+  "status.active_models.residual_memory_hint": "Restart oMLX if this does not clear after cache reclaim.",
   "status.active_models.active": "Ativo",
   "status.active_models.waiting": "Aguardando",
   "status.active_models.req": "req",

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -71,6 +71,8 @@
   "status.speed.token_generation": "Генерация токенов",
   "status.active_models.section_label": "Активные модели",
   "status.active_models.no_models": "Ни одна модель не загружена",
+  "status.active_models.residual_memory": "No models loaded, but {memory} native memory is still resident",
+  "status.active_models.residual_memory_hint": "Restart oMLX if this does not clear after cache reclaim.",
   "status.active_models.active": "Активно",
   "status.active_models.waiting": "В ожидании",
   "status.active_models.req": "запрос",

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -71,6 +71,8 @@
   "status.speed.token_generation": "Token 生成速度",
   "status.active_models.section_label": "活躍模型",
   "status.active_models.no_models": "未載入模型",
+  "status.active_models.residual_memory": "No models loaded, but {memory} native memory is still resident",
+  "status.active_models.residual_memory_hint": "Restart oMLX if this does not clear after cache reclaim.",
   "status.active_models.active": "活躍",
   "status.active_models.waiting": "等待",
   "status.active_models.req": "請求",

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -71,6 +71,8 @@
   "status.speed.token_generation": "Token 生成",
   "status.active_models.section_label": "活跃模型",
   "status.active_models.no_models": "未加载模型",
+  "status.active_models.residual_memory": "No models loaded, but {memory} native memory is still resident",
+  "status.active_models.residual_memory_hint": "Restart oMLX if this does not clear after cache reclaim.",
   "status.active_models.active": "活跃",
   "status.active_models.waiting": "等待",
   "status.active_models.req": "请求",

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -4670,12 +4670,21 @@ def _build_active_models_data() -> dict:
         memory_used = enforcer_status.get("current_bytes", 0)
         memory_max = enforcer_status.get("ceiling_bytes", 0)
     else:
-        memory_used = status.get("current_model_memory", 0)
+        memory_used = status.get(
+            "effective_model_memory",
+            status.get("current_model_memory", 0),
+        )
         memory_max = status.get("final_ceiling", 0)
+    untracked_native_memory = status.get("untracked_native_memory", 0)
+    observed_native_memory = status.get("observed_native_memory", 0)
     return {
         "models": models,
         "model_memory_used": memory_used,
         "model_memory_max": memory_max,
+        "model_memory_accounted": status.get("current_model_memory", 0),
+        "observed_native_memory": observed_native_memory,
+        "untracked_native_memory": untracked_native_memory,
+        "untracked_native_memory_formatted": format_size(untracked_native_memory),
         "memory_pressure": {
             "enabled": bool(enforcer_status and enforcer_status.get("enabled")),
             "current_bytes": (

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -147,7 +147,17 @@
                             <!-- Empty state -->
                             <div x-show="!stats.active_models.models || stats.active_models.models.length === 0"
                                  class="px-6 py-8 text-center text-sm text-neutral-400">
-                                {{ t('status.active_models.no_models') }}
+                                <div x-show="!(stats.active_models.untracked_native_memory > 0)">
+                                    {{ t('status.active_models.no_models') }}
+                                </div>
+                                <div x-show="stats.active_models.untracked_native_memory > 0" x-cloak
+                                     class="space-y-1">
+                                    <div class="font-medium text-amber-700"
+                                         x-text="window.t('status.active_models.residual_memory').replace('{memory}', formatSizeBytes(stats.active_models.untracked_native_memory || 0))"></div>
+                                    <div class="text-xs text-neutral-500">
+                                        {{ t('status.active_models.residual_memory_hint') }}
+                                    </div>
+                                </div>
                             </div>
                             <!-- Model rows -->
                             <template x-for="m in (stats.active_models.models || [])" :key="m.id">

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -50,6 +50,8 @@ from .utils.proc_memory import get_phys_footprint
 
 logger = logging.getLogger(__name__)
 
+_NATIVE_MEMORY_RESIDUAL_FLOOR = 512 * 1024**2
+
 
 @dataclass
 class EngineEntry:
@@ -151,6 +153,34 @@ class EnginePool:
     def current_model_memory(self) -> int:
         """Current memory used by loaded models in bytes."""
         return self._current_model_memory
+
+    def _observed_native_memory(self) -> int:
+        """Return the live native memory ledger used for admission decisions."""
+        try:
+            return max(mx.get_active_memory(), get_phys_footprint())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Native memory observation unavailable: %s", exc)
+            return 0
+
+    def _untracked_native_memory(self, observed: int | None = None) -> int:
+        """Native memory still resident but no longer charged to live engines."""
+        observed = self._observed_native_memory() if observed is None else observed
+        loading_reserved = int(getattr(self, "_loading_reserved_bytes", 0) or 0)
+        accounted = self._current_model_memory + loading_reserved
+        residual = max(0, observed - accounted)
+        if residual < _NATIVE_MEMORY_RESIDUAL_FLOOR:
+            return 0
+        return residual
+
+    @property
+    def observed_native_memory(self) -> int:
+        """Live MLX/phys-footprint memory seen by the running process."""
+        return self._observed_native_memory()
+
+    @property
+    def untracked_native_memory(self) -> int:
+        """Residual native memory not attached to a loaded or loading engine."""
+        return self._untracked_native_memory()
 
     def configure_hot_cache_budget(self) -> None:
         """Ensure loaded schedulers share one process-wide hot cache budget."""
@@ -1713,9 +1743,23 @@ class EnginePool:
         Returns:
             Dictionary with pool status information
         """
+        observed_native_memory = self._observed_native_memory()
+        untracked_native_memory = self._untracked_native_memory(
+            observed_native_memory
+        )
+        loading_reserved_memory = int(
+            getattr(self, "_loading_reserved_bytes", 0) or 0
+        )
         return {
             "final_ceiling": self._current_ceiling(),
             "current_model_memory": self._current_model_memory,
+            "loading_reserved_memory": loading_reserved_memory,
+            "observed_native_memory": observed_native_memory,
+            "untracked_native_memory": untracked_native_memory,
+            "effective_model_memory": (
+                self._current_model_memory + loading_reserved_memory
+                + untracked_native_memory
+            ),
             "model_count": len(self._entries),
             "loaded_count": sum(
                 1 for e in self._entries.values() if e.engine is not None

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2131,6 +2131,7 @@ async def health():
 
     pool_status = None
     if _server_state.engine_pool is not None:
+        pool = _server_state.engine_pool
         enforcer = _server_state.process_memory_enforcer
         ceiling = 0
         if enforcer is not None:
@@ -2138,11 +2139,22 @@ async def health():
                 ceiling = enforcer.get_final_ceiling()
             except Exception as exc:  # noqa: BLE001
                 logger.warning("Health memory ceiling unavailable: %s", exc)
+        untracked_native_memory = int(
+            getattr(pool, "untracked_native_memory", 0) or 0
+        )
+        observed_native_memory = int(
+            getattr(pool, "observed_native_memory", 0) or 0
+        )
         pool_status = {
-            "model_count": _server_state.engine_pool.model_count,
-            "loaded_count": _server_state.engine_pool.loaded_model_count,
+            "model_count": pool.model_count,
+            "loaded_count": pool.loaded_model_count,
             "final_ceiling": ceiling,
-            "current_model_memory": _server_state.engine_pool.current_model_memory,
+            "current_model_memory": pool.current_model_memory,
+            "observed_native_memory": observed_native_memory,
+            "untracked_native_memory": untracked_native_memory,
+            "effective_model_memory": (
+                pool.current_model_memory + untracked_native_memory
+            ),
         }
 
     return {
@@ -2168,6 +2180,9 @@ async def server_status(_: bool = Depends(verify_api_key)):
     models_loaded = 0
     models_loading = 0
     loaded_models = []
+    model_memory_accounted = 0
+    untracked_native_memory = 0
+    observed_native_memory = 0
     model_memory_used = 0
     model_memory_max = None
 
@@ -2175,7 +2190,14 @@ async def server_status(_: bool = Depends(verify_api_key)):
         models_discovered = pool.model_count
         models_loaded = pool.loaded_model_count
         loaded_models = pool.get_loaded_model_ids()
-        model_memory_used = pool.current_model_memory
+        model_memory_accounted = pool.current_model_memory
+        untracked_native_memory = int(
+            getattr(pool, "untracked_native_memory", 0) or 0
+        )
+        observed_native_memory = int(
+            getattr(pool, "observed_native_memory", 0) or 0
+        )
+        model_memory_used = model_memory_accounted + untracked_native_memory
         enforcer = _server_state.process_memory_enforcer
         if enforcer is not None:
             try:
@@ -2224,9 +2246,17 @@ async def server_status(_: bool = Depends(verify_api_key)):
         "avg_prefill_tps": snapshot["avg_prefill_tps"],
         "avg_generation_tps": snapshot["avg_generation_tps"],
         "model_memory_used": model_memory_used,
+        "model_memory_accounted": model_memory_accounted,
+        "observed_native_memory": observed_native_memory,
+        "untracked_native_memory": untracked_native_memory,
         "model_memory_max": model_memory_max,
         "model_memory_used_formatted": (
             format_size(model_memory_used) if model_memory_used else "0B"
+        ),
+        "untracked_native_memory_formatted": (
+            format_size(untracked_native_memory)
+            if untracked_native_memory
+            else "0B"
         ),
         "model_memory_max_formatted": (
             format_size(model_memory_max) if model_memory_max else "unlimited"

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -309,7 +309,7 @@ class TestEnginePoolErrors:
         assert pool.get_entry("model-a") is None
 
 
-class TestEnginePoolStatus:
+class TestEnginePoolStatusReporting:
     """Tests for EnginePool status reporting."""
 
     def test_get_status(self, small_mock_model_dir):
@@ -333,6 +333,72 @@ class TestEnginePoolStatus:
         model_a_status = next(m for m in status["models"] if m["id"] == "model-a")
         assert model_a_status["pinned"] is True
         assert model_a_status["loaded"] is False
+
+    def test_get_status_reports_untracked_native_memory(
+        self, small_mock_model_dir, monkeypatch
+    ):
+        """No loaded engine should not hide residual MLX/Metal memory."""
+        gb = 1024**3
+        observed_native_memory = 7 * gb
+        pool = _make_pool(ceiling=64 * gb)
+        pool.discover_models(str(small_mock_model_dir))
+
+        monkeypatch.setattr(
+            "omlx.engine_pool.mx.get_active_memory",
+            lambda: observed_native_memory,
+        )
+        monkeypatch.setattr("omlx.engine_pool.get_phys_footprint", lambda: 0)
+
+        status = pool.get_status()
+
+        assert status["loaded_count"] == 0
+        assert status["current_model_memory"] == 0
+        assert status["observed_native_memory"] == observed_native_memory
+        assert status["untracked_native_memory"] == observed_native_memory
+        assert status["effective_model_memory"] == observed_native_memory
+
+    def test_get_status_subtracts_accounted_memory_from_native_residual(
+        self, small_mock_model_dir, monkeypatch
+    ):
+        """Residual memory is the observed native ledger minus accounted memory."""
+        gb = 1024**3
+        accounted_memory = 3 * gb
+        observed_native_memory = 8 * gb
+        pool = _make_pool(ceiling=64 * gb)
+        pool.discover_models(str(small_mock_model_dir))
+        pool._current_model_memory = accounted_memory
+
+        monkeypatch.setattr(
+            "omlx.engine_pool.mx.get_active_memory",
+            lambda: observed_native_memory,
+        )
+        monkeypatch.setattr("omlx.engine_pool.get_phys_footprint", lambda: 0)
+
+        status = pool.get_status()
+
+        assert status["current_model_memory"] == accounted_memory
+        assert status["observed_native_memory"] == observed_native_memory
+        assert status["untracked_native_memory"] == (
+            observed_native_memory - accounted_memory
+        )
+        assert status["effective_model_memory"] == observed_native_memory
+
+    def test_get_status_ignores_small_native_memory_noise(
+        self, small_mock_model_dir, monkeypatch
+    ):
+        """Tiny native samples are not reported as meaningful residual memory."""
+        noise = 128 * 1024**2
+        pool = _make_pool(ceiling=64 * 1024**3)
+        pool.discover_models(str(small_mock_model_dir))
+
+        monkeypatch.setattr("omlx.engine_pool.mx.get_active_memory", lambda: noise)
+        monkeypatch.setattr("omlx.engine_pool.get_phys_footprint", lambda: 0)
+
+        status = pool.get_status()
+
+        assert status["observed_native_memory"] == noise
+        assert status["untracked_native_memory"] == 0
+        assert status["effective_model_memory"] == 0
 
     def test_get_model_ids(self, small_mock_model_dir):
         """Test get_model_ids returns all model IDs."""

--- a/tests/test_status_endpoint.py
+++ b/tests/test_status_endpoint.py
@@ -76,6 +76,38 @@ class TestStatusEndpoint:
         assert "GB" in data["model_memory_used_formatted"]
         assert "GB" in data["model_memory_max_formatted"]
 
+    def test_reports_untracked_native_memory_with_no_loaded_models(
+        self, client
+    ):
+        """Residual native memory is reported even with no loaded models."""
+        gb = 1024**3
+        residual_memory = 6 * gb
+        pool = MagicMock(spec=[
+            "model_count", "loaded_model_count", "get_loaded_model_ids",
+            "current_model_memory", "observed_native_memory",
+            "untracked_native_memory", "_entries",
+        ])
+        pool.model_count = 5
+        pool.loaded_model_count = 0
+        pool.get_loaded_model_ids.return_value = []
+        pool.current_model_memory = 0
+        pool.observed_native_memory = residual_memory
+        pool.untracked_native_memory = residual_memory
+        pool._entries = {}
+
+        self._state.engine_pool = pool
+
+        resp = client.get("/api/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["models_loaded"] == 0
+        assert data["loaded_models"] == []
+        assert data["model_memory_used"] == residual_memory
+        assert data["model_memory_accounted"] == 0
+        assert data["observed_native_memory"] == residual_memory
+        assert data["untracked_native_memory"] == residual_memory
+        assert "GB" in data["untracked_native_memory_formatted"]
+
     def test_status_ignores_memory_ceiling_error(self, client):
         """Memory telemetry failures should not break status polling."""
         pool = MagicMock(spec=[
@@ -122,6 +154,32 @@ class TestStatusEndpoint:
         data = resp.json()
         assert data["status"] == "healthy"
         assert data["engine_pool"]["final_ceiling"] == 0
+
+    def test_health_reports_untracked_native_memory(self, client):
+        """Health telemetry includes residual native memory separately."""
+        gb = 1024**3
+        residual_memory = 9 * gb
+        pool = MagicMock(spec=[
+            "model_count", "loaded_model_count", "current_model_memory",
+            "observed_native_memory", "untracked_native_memory",
+        ])
+        pool.model_count = 5
+        pool.loaded_model_count = 0
+        pool.current_model_memory = 0
+        pool.observed_native_memory = residual_memory
+        pool.untracked_native_memory = residual_memory
+
+        self._state.engine_pool = pool
+
+        resp = client.get("/health")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "healthy"
+        assert data["engine_pool"]["loaded_count"] == 0
+        assert data["engine_pool"]["observed_native_memory"] == residual_memory
+        assert data["engine_pool"]["untracked_native_memory"] == residual_memory
+        assert data["engine_pool"]["effective_model_memory"] == residual_memory
 
     def test_aggregates_active_waiting_requests(self, client):
         """Active/waiting request counts are summed across loaded engines."""


### PR DESCRIPTION
After a Bench > Performance run finishes, the throughput benchmark cleanup unloads the benchmark model. On affected runs the server can then show no loaded models while native MLX/Metal/process memory is still resident. That makes `/api/status` and the Active Models empty state misleading: users see `model_memory_used: 0B` / "No models loaded", but the admission guard still sees the native footprint via `max(mx.get_active_memory(), get_phys_footprint())`, and the next model load can be rejected.

This PR does not try to fix every underlying retention source. It makes the status surfaces honest when residual native memory is still present after unload.

## Reproduction

1. Open the macOS app or admin UI and go to Bench > Performance.
2. Pick a model and run a throughput benchmark.
3. Wait for the benchmark cleanup phase to unload the model.
4. On affected runs, the UI reports no loaded models and `/api/status` reports model memory as 0, while native process memory remains resident and still counts against the next load.

The benchmark path is the normal throughput bench route: `POST /admin/api/bench/start` creates a run, `run_benchmark()` unloads any existing models, loads the target model, runs warmup/single/batch tests, then calls `_unload_engine()` for the benchmark model during cleanup.

## Changes

1. Add observed native memory telemetry to `EnginePool` using the same native-memory ledger the load guard relies on.
2. Report residual native memory separately as `untracked_native_memory` when it is no longer charged to loaded models.
3. Expose the new fields on `/health` and `/api/status`, and include residual native memory in `model_memory_used` so status polling is not misleading.
4. Update the admin dashboard and macOS Active Now empty state to show a residual-memory warning instead of only "No models loaded".

## Safety

This is observational only. It does not change model loading, unloading, cache reclaim, or memory admission behavior. A small floor suppresses normal process noise so the warning is reserved for meaningful residual native memory.

## Test plan

1. `git diff --check`
2. `.venv/bin/python -m compileall -q omlx tests/test_engine_pool.py tests/test_status_endpoint.py`
3. `.venv/bin/python -m pytest -q tests/test_engine_pool.py::TestEnginePoolStatusReporting tests/test_status_endpoint.py`
4. `.venv/bin/python -m pytest -q -p no:cacheprovider` -> `6093 passed, 39 skipped, 67 deselected`
5. `swiftc -typecheck apps/omlx-mac/Sources/Net/DTO/StatsDTO.swift`

## Related

Refs #1322, especially the request to surface the process-memory breakdown when `/api/status` shows `model_memory_used: 0B` but the memory guard still sees resident memory. Same visible symptom as #1060 and the closed #1459, but this PR is scoped to reporting/UX rather than root-cause retention cleanup.
