### PR TITLE
feat: add malloc pressure relief on hot cache clear and model unload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# 仓库规范指南
+
+## 项目结构与模块组织
+
+`omlx/` 包含 Python 包与服务端实现。关键区域包括：
+- `omlx/engine*` — 推理引擎与生命周期管理
+- `omlx/models/` — 模型封装
+- `omlx/admin/` — 管理面板与 API 路由
+- `omlx/cache/` — 缓存实现
+- `omlx/eval/` — 内置评测数据
+
+`tests/` 存放单元测试与集成测试。`apps/`、`Formula/` 和 `packaging/`
+包含 macOS 应用、Homebrew 公式及发布打包资源。`scripts/` 仅存放仓库
+官方提供的工具脚本；本地维护文件应保持在版本跟踪之外。
+
+## 构建、测试与开发命令
+
+- `uv sync --dev`：安装运行时与开发依赖。
+- `.venv/bin/omlx serve --host 127.0.0.1 --port 8000`：启动本地服务。
+- `.venv/bin/python -m pytest`：运行全部测试。
+- `.venv/bin/python -m pytest tests/test_engine_core.py -q`：运行指定测试文件。
+- `uv run ruff check .`：执行代码检查。
+- `uv run ruff format .` 或 `uv run black .`：格式化 Python 代码。
+
+部分依赖为 git 锁定版本且依赖 MLX；优先使用项目虚拟环境，而非系统 Python。
+
+## 编码风格与命名约定
+
+- Python 代码使用 4 空格缩进，行宽不超过 88 字符。
+- 类名使用 `PascalCase`，函数和变量使用 `snake_case`，测试函数以 `test_` 开头。
+- 新增抽象前先参考已有的引擎/模型模式。
+- 注释保持简洁，仅对非显而易见的生命周期、线程、缓存或 MLX 行为进行说明。
+
+## 测试规范
+
+- 使用 `pytest` + `pytest-asyncio`，测试文件位于 `tests/`。
+- 对涉及生命周期、缓存、解析、API 行为变更的代码，添加针对性的回归测试。
+- 开发阶段使用精准命令，在影响范围交叉时再运行更广的测试。
+- 部分 MLX 测试需要 Apple Silicon/Metal；在 PR 说明中标注跳过或本地受阻的验证项。
+
+## 提交与 Pull Request 规范
+
+- commit 信息使用简洁的祈使句，必要时加约定前缀，如 `fix: release embedding MLX resources on unload` 或 `docs: update memory retest report`。
+- 提交个人仓库时，commit message 必须使用中文；向 GitHub 上游提交 PR 时根据源仓库语言提交。
+- 上游 PR 应聚焦、仅包含代码变更，除非明确要求文档更新。
+- PR 描述应包含：摘要、测试命令、相关验证证据、关联 issue 或后续 PR。
+
+## 分支职责与同步规则
+
+- `mirror` 只作为源仓库镜像分支，跟踪 `upstream/main`。维护时仅允许
+  `git switch mirror && git merge --ff-only upstream/main`；不要在该分支提交
+  本地修改，也不要让它跟踪 fork 或本地远程。
+- `main` 是本机集成分支，跟踪 `github-fork/main`。本地修复、已验证的集成
+  提交和需要推送到个人 fork 的工作应汇入 `main`。
+- `local/integration` 仅作为历史过渡分支使用；若它与 `main` 指向同一提交，
+  不应继续在其上开发新工作。
+- 临时 `fix/*` 分支在上游或 `main` 已通过祖先关系或 patch-id 等价合入后
+  应清理。删除前先用 `git cherry -v main <branch>` 或等价 diff 核验；若
+  只是 patch-id 等价而非祖先关系，才考虑 `git branch -D`。
+- 同步顺序建议：先更新 `mirror`，再把 `mirror` 合入 `main`，最后从 `main`
+  切出新的修复分支或推送到 `github-fork/main`。
+
+## 安全与配置提示
+
+- 不提交 API 密钥、本地模型路径、生成的报告或机器特定的启动脚本。
+- 使用 `.git/info/exclude` 排除仅本地使用的目录，如 `/local-omlx/`。
+
+## local-omlx/ — 本地维护仓库
+
+`omlx/local-omlx/` 是一个独立的 Git 仓库，用于跟踪本地产生的
+修改与维护记录。关键约束：
+
+1. **仅本地使用** — 不推送到任何远程仓库，不涉及上游 PR。
+2. **独立 git 状态** — 该目录有自己的 `.git`，与项目主仓库的 `git status`
+   互不影响；`local-omlx/` 的内容也不会出现在主仓库的 diff 中。
+3. **用途** — 保存临时排查脚本、本地测试报告、诊断文档、未提交的
+   工作区变更等。适合需要版本追溯但不愿污染主仓库历史的场景。
+4. **agent 行为** — 当 agent 在该目录中执行 git 操作（add/commit/log/diff）
+   时，应使用 `cd local-omlx && git …` 明确限定作用域；
+   不得将其误认为主仓库的分支或暂存区。
+
+示例命令：
+```bash
+cd local-omlx
+git add -A && git commit -m "本地修改摘要"
+git log --oneline          # 查看变更记录
+```

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -4828,7 +4828,7 @@ async def clear_hot_cache(is_admin: bool = Depends(require_admin)):
 
     from ..engine_core import get_mlx_executor
     from ..scheduler import _sync_and_clear_cache
-    from ..utils.proc_memory import get_phys_footprint
+    from ..utils.proc_memory import get_phys_footprint, relieve_malloc_pressure
 
     footprint_before = get_phys_footprint()
     total_cleared = 0
@@ -4887,12 +4887,14 @@ async def clear_hot_cache(is_admin: bool = Depends(require_admin)):
                 await loop.run_in_executor(get_mlx_executor(), _sync_and_clear_cache)
     else:
         await loop.run_in_executor(get_mlx_executor(), _sync_and_clear_cache)
+    malloc_bytes_relieved = relieve_malloc_pressure()
     bytes_reclaimed = max(0, footprint_before - get_phys_footprint())
 
     return {
         "status": "ok",
         "total_cleared": total_cleared,
         "bytes_reclaimed": bytes_reclaimed,
+        "malloc_bytes_relieved": malloc_bytes_relieved,
     }
 
 

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -46,7 +46,7 @@ from .exceptions import (
 )
 from .model_discovery import discover_models, format_size
 from .scheduler import SchedulerConfig
-from .utils.proc_memory import get_phys_footprint
+from .utils.proc_memory import get_phys_footprint, relieve_malloc_pressure
 
 logger = logging.getLogger(__name__)
 
@@ -1240,6 +1240,14 @@ class EnginePool:
                     f"Emergency reclaim succeeded: "
                     f"active_memory={format_size(active_after)}"
                 )
+
+        relieved = relieve_malloc_pressure()
+        if relieved:
+            logger.info(
+                "Malloc pressure relief after unloading %s: relieved=%s",
+                model_id,
+                format_size(relieved),
+            )
 
         self._wake_process_memory_enforcer()
 

--- a/omlx/utils/proc_memory.py
+++ b/omlx/utils/proc_memory.py
@@ -74,6 +74,9 @@ _RUSAGE_INFO_V4 = 4
 
 _libproc: ctypes.CDLL | None = None
 _proc_pid_rusage = None
+_libsystem: ctypes.CDLL | None = None
+_malloc_default_zone = None
+_malloc_zone_pressure_relief = None
 
 if sys.platform == "darwin":
     try:
@@ -89,6 +92,20 @@ if sys.platform == "darwin":
         logger.warning(f"libproc unavailable, phys_footprint will return 0: {e}")
         _libproc = None
         _proc_pid_rusage = None
+
+    try:
+        _libsystem = ctypes.CDLL("/usr/lib/libSystem.dylib", use_errno=True)
+        _malloc_default_zone = _libsystem.malloc_default_zone
+        _malloc_default_zone.argtypes = []
+        _malloc_default_zone.restype = ctypes.c_void_p
+        _malloc_zone_pressure_relief = _libsystem.malloc_zone_pressure_relief
+        _malloc_zone_pressure_relief.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+        _malloc_zone_pressure_relief.restype = ctypes.c_size_t
+    except (AttributeError, OSError) as e:
+        logger.debug("malloc pressure relief unavailable: %s", e)
+        _libsystem = None
+        _malloc_default_zone = None
+        _malloc_zone_pressure_relief = None
 
 
 def get_phys_footprint(pid: int | None = None) -> int:
@@ -116,3 +133,31 @@ def get_phys_footprint(pid: int | None = None) -> int:
     if rc != 0:
         return 0
     return info.ri_phys_footprint
+
+
+def relieve_malloc_pressure(goal: int = 0) -> int:
+    """Ask Darwin malloc to return free pages from the default zone.
+
+    Model teardown already drops Python references and clears MLX allocator
+    caches, but macOS malloc can keep empty pages resident in the process after
+    large native allocations churn. ``malloc_zone_pressure_relief`` is the
+    supported Darwin hook for nudging that allocator state back toward the OS.
+
+    Args:
+        goal: Optional byte goal passed to malloc_zone_pressure_relief. ``0``
+            lets malloc choose how much releasable memory to return.
+
+    Returns:
+        Bytes reported as relieved by malloc. Returns 0 on non-Darwin systems,
+        when the symbol is unavailable, or when the call fails.
+    """
+    if _malloc_default_zone is None or _malloc_zone_pressure_relief is None:
+        return 0
+    try:
+        zone = _malloc_default_zone()
+        if not zone:
+            return 0
+        return int(_malloc_zone_pressure_relief(zone, max(0, int(goal))))
+    except Exception as exc:
+        logger.debug("malloc pressure relief failed: %s", exc)
+        return 0

--- a/tests/test_admin_hot_cache_clear.py
+++ b/tests/test_admin_hot_cache_clear.py
@@ -58,6 +58,7 @@ class _reclaim_env:
         self.synchronize = MagicMock()
         self.footprint = MagicMock(side_effect=[footprint_before, footprint_after])
         self.get_mlx_executor = MagicMock(return_value=self._executor)
+        self.relieve_malloc_pressure = MagicMock(return_value=128)
 
     def __enter__(self):
         self._patches = [
@@ -65,6 +66,10 @@ class _reclaim_env:
             patch("mlx.core.synchronize", self.synchronize),
             patch("omlx.engine_core.get_mlx_executor", self.get_mlx_executor),
             patch("omlx.utils.proc_memory.get_phys_footprint", self.footprint),
+            patch(
+                "omlx.utils.proc_memory.relieve_malloc_pressure",
+                self.relieve_malloc_pressure,
+            ),
         ]
         for p in self._patches:
             p.start()
@@ -121,8 +126,14 @@ class TestHotCacheClear:
         ):
             result = _run_clear()
 
-        assert set(result.keys()) == {"status", "total_cleared", "bytes_reclaimed"}
+        assert set(result.keys()) == {
+            "status",
+            "total_cleared",
+            "bytes_reclaimed",
+            "malloc_bytes_relieved",
+        }
         assert result["status"] == "ok"
+        assert result["malloc_bytes_relieved"] == 128
 
 
 class TestClearReachesOrphans:

--- a/tests/test_proc_memory.py
+++ b/tests/test_proc_memory.py
@@ -7,7 +7,7 @@ import sys
 
 import pytest
 
-from omlx.utils.proc_memory import get_phys_footprint
+from omlx.utils.proc_memory import get_phys_footprint, relieve_malloc_pressure
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="Darwin-only API")
@@ -56,3 +56,43 @@ class TestGetPhysFootprintFallback:
         monkeypatch.setattr("omlx.utils.proc_memory._proc_pid_rusage", None)
         assert get_phys_footprint() == 0
         assert get_phys_footprint(pid=12345) == 0
+
+
+class TestRelieveMallocPressure:
+    def test_returns_zero_when_unavailable(self, monkeypatch):
+        monkeypatch.setattr("omlx.utils.proc_memory._malloc_default_zone", None)
+        monkeypatch.setattr("omlx.utils.proc_memory._malloc_zone_pressure_relief", None)
+
+        assert relieve_malloc_pressure() == 0
+
+    def test_calls_default_zone_pressure_relief(self, monkeypatch):
+        calls = []
+
+        def default_zone():
+            calls.append(("zone",))
+            return 123
+
+        def pressure_relief(zone, goal):
+            calls.append(("relief", zone, goal))
+            return 4096
+
+        monkeypatch.setattr(
+            "omlx.utils.proc_memory._malloc_default_zone", default_zone
+        )
+        monkeypatch.setattr(
+            "omlx.utils.proc_memory._malloc_zone_pressure_relief", pressure_relief
+        )
+
+        assert relieve_malloc_pressure(goal=2048) == 4096
+        assert calls == [("zone",), ("relief", 123, 2048)]
+
+    def test_negative_goal_is_clamped(self, monkeypatch):
+        monkeypatch.setattr(
+            "omlx.utils.proc_memory._malloc_default_zone", lambda: 123
+        )
+        monkeypatch.setattr(
+            "omlx.utils.proc_memory._malloc_zone_pressure_relief",
+            lambda zone, goal: goal,
+        )
+
+        assert relieve_malloc_pressure(goal=-1) == 0


### PR DESCRIPTION
- Add relieve_malloc_pressure() using Darwin malloc_zone_pressure_relief to nudge the default zone into returning free pages back to the OS.
- Call it in admin/clear-hot-cache endpoint and after engine pool unload.
- Update AGENTS.md: rename .local-maintenance → local-omlx throughout.