### PR TITLE
Fix boundary snapshot writer retaining raw tensor bytes after unload

### DIFF
--- a/omlx/cache/boundary_snapshot_store.py
+++ b/omlx/cache/boundary_snapshot_store.py
@@ -509,6 +509,7 @@ class BoundarySnapshotSSDStore:
     def _writer_loop(self) -> None:
         """Background thread that writes safetensors files."""
         while not self._shutdown.is_set():
+            item = None
             try:
                 item = self._write_queue.get(timeout=1.0)
             except queue.Empty:
@@ -522,8 +523,15 @@ class BoundarySnapshotSSDStore:
             # rmtree the snapshot directory while we're mid-write and
             # we'd recreate ``req-X/`` underneath it, leaving an
             # orphaned file after the cleanup returns.
-            with self._writer_busy:
-                self._process_write_item(item)
+            try:
+                with self._writer_busy:
+                    self._process_write_item(item)
+            finally:
+                # ``item`` contains ``tensors_raw``. If the thread waits for
+                # the next queue entry without clearing this local, the frame
+                # can pin a whole boundary snapshot after pending_writes was
+                # cleaned up.
+                item = None
 
     def _process_write_item(self, item) -> None:
         """Process one (pw_key, tensors_raw, metadata, file_path) queue item.

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -1683,6 +1683,7 @@ class PagedSSDCacheManager(CacheManager):
         standard file I/O operations.
         """
         while True:
+            item = None
             try:
                 item = self._write_queue.get(timeout=1.0)
             except queue.Empty:
@@ -1695,12 +1696,18 @@ class PagedSSDCacheManager(CacheManager):
                 break
 
             block_hash, tensors_raw, metadata, file_path = item
-            self._write_block_file(
-                block_hash, tensors_raw, metadata, file_path, source="background"
-            )
-            self._clear_pending_write(
-                block_hash, remove_hot_cache=not self._hot_cache_enabled
-            )
+            try:
+                self._write_block_file(
+                    block_hash, tensors_raw, metadata, file_path, source="background"
+                )
+                self._clear_pending_write(
+                    block_hash, remove_hot_cache=not self._hot_cache_enabled
+                )
+            finally:
+                # Avoid pinning the last raw tensor-byte batch while the
+                # writer thread blocks waiting for more work.
+                item = None
+                block_hash = tensors_raw = metadata = file_path = None
 
     def save_block(
         self,

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -9877,6 +9877,11 @@ class Scheduler:
         self.tokenizer = None
 
         # Release all cache-related references for GC
+        if self._boundary_snapshot_store is not None:
+            try:
+                self._boundary_snapshot_store.shutdown()
+            except Exception as e:
+                logger.warning("Boundary snapshot store shutdown error: %s", e)
         self.paged_cache_manager = None
         self.block_aware_cache = None
         self.memory_monitor = None
@@ -9935,6 +9940,16 @@ class Scheduler:
             self._inflight_store_info.clear()
             self._cache_freshness_waits.clear()
             self._prefix_cache_prepared.clear()
+        if self._boundary_snapshot_store is not None:
+            try:
+                self._boundary_snapshot_store.cleanup_all()
+            except Exception as e:
+                logger.warning("Boundary snapshot store cleanup error: %s", e)
+            try:
+                self._boundary_snapshot_store.shutdown()
+            except Exception as e:
+                logger.warning("Boundary snapshot store shutdown error: %s", e)
+            self._boundary_snapshot_store = None
         if self.paged_ssd_cache_manager is not None:
             self.paged_ssd_cache_manager.close()
             self.paged_ssd_cache_manager = None

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1459,6 +1459,38 @@ class TestSchedulerReset:
         ], f"Expected drain to bracket executor.shutdown, got: {call_order}"
         fake_executor.shutdown.assert_called_once_with(wait=False)
 
+    def test_shutdown_closes_boundary_snapshot_store(
+        self, mock_model, mock_tokenizer
+    ):
+        """shutdown() must stop the boundary snapshot writer thread.
+
+        cleanup_all() only clears the store contents. If shutdown() is skipped,
+        the writer thread can keep its last raw tensor-byte queue item alive.
+        """
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        store = MagicMock()
+        scheduler._boundary_snapshot_store = store
+
+        scheduler.shutdown()
+
+        store.cleanup_all.assert_called_once_with()
+        store.shutdown.assert_called_once_with()
+        assert scheduler._boundary_snapshot_store is None
+
+    def test_deep_reset_closes_boundary_snapshot_store(
+        self, mock_model, mock_tokenizer
+    ):
+        """deep_reset() destroys the scheduler and must stop snapshot writers."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        store = MagicMock()
+        scheduler._boundary_snapshot_store = store
+
+        scheduler.deep_reset()
+
+        store.cleanup_all.assert_called_once_with()
+        store.shutdown.assert_called_once_with()
+        assert scheduler._boundary_snapshot_store is None
+
     def test_shutdown_fatal_exits_when_store_cache_worker_times_out(
         self, mock_model, mock_tokenizer
     ):


### PR DESCRIPTION
## Summary

This PR fixes a long-running memory retention path in the SSD boundary snapshot and paged SSD cache writer threads.

The issue can show up after long-context workloads that create boundary snapshots or store-cache writes. The model can be fully unloaded and the API-visible model memory can return to zero, while the Python process still retains gigabytes of host malloc memory. In a local long-run incident, the service had `models_loaded=0`, `model_memory_used=0B`, and MLX active memory settled back to `1.02KB`, but `vmmap` still showed `Physical footprint=3.4G` with `MALLOC_LARGE=3.1G` and `heap` showed roughly `3.47GB` of non-object allocations. Clearing the hot cache reclaimed nothing, which ruled out the visible hot cache as the retention owner.

The root cause is that the background writer thread can keep the last queue item alive in its idle frame. For boundary snapshots, that queue item contains `tensors_raw`, the raw bytes copied from KV/cache tensors before writing safetensors files. The scheduler also dropped its `BoundarySnapshotSSDStore` reference during teardown without stopping the store, so the daemon writer thread could continue to hold the store and its last queue item even after cleanup.

## Changes

- Clear the local `item` reference in `BoundarySnapshotSSDStore._writer_loop()` after every processed queue item, so the idle writer frame cannot pin the previous snapshot raw bytes.
- Clear the equivalent raw tensor payload locals in `PagedSSDCacheManager._writer_loop()` after each background write.
- Make `Scheduler.shutdown()` clean up and stop the boundary snapshot store before dropping the reference.
- Make `Scheduler.deep_reset()` stop the boundary snapshot store before releasing scheduler cache references.
- Add regression tests covering both scheduler teardown paths.

## Why this matters

This retention path is easy to miss because the normal model accounting looks healthy:

- `/api/status` can report `models_loaded=0` and `model_memory_used=0B`.
- Engine unload logs can report active memory settling back to `1.02KB`.
- `IOAccelerator` can stay low, so this is not the old Metal-backed model memory leak shape.
- Hot-cache clearing can reclaim zero bytes because the retained owner is the writer thread frame, not a visible cache table.

Without stopping the boundary snapshot store and clearing the writer frame locals, a production service can appear idle but still retain large raw snapshot byte buffers after long-context workloads. The fix is intentionally narrow: it does not change cache formats, cache lookup behavior, or request scheduling; it only ensures teardown and idle writer frames release large temporary payloads.

## Local validation

Before the fix, a long-running local service reproduced the problem after boundary snapshot and store-cache activity:

- `models_loaded=0`, `active_requests=0`, `waiting_requests=0`, `model_memory_used=0B`
- `vmmap -summary`: `Physical footprint=3.4G`, `MALLOC_LARGE=3.1G`, `IOAccelerator (graphics)=4064K`
- `heap -s`: `non-object=3.47GB`, with large blocks around 2MB and 3MB
- `/admin/api/hot-cache/clear`: `bytes_reclaimed=0`

After applying the fix and restarting from the patched source, the same long-running service stayed stable after several hours and hundreds of requests:

- Runtime: about 7h14m
- Requests: 482
- Prompt tokens: 18,346,560
- Cached tokens: 17,214,464
- `models_loaded=0`, `active_requests=0`, `waiting_requests=0`, `model_memory_used=0B`
- Admin memory pressure: ok, about 0.3GB current bytes
- `vmmap -summary`: `Physical footprint=281.9M`, `MALLOC_LARGE=3760K`, `IOAccelerator (graphics)=4992K`
- Latest unload sequence ended with `active_memory: 1.02KB (settled)`

This indicates the previous multi-GB raw-byte retention did not recur under the same class of long-context boundary snapshot workload.

## Tests

Passed:

```bash
git diff --check upstream/main...HEAD
.venv/bin/python -m py_compile \
  omlx/cache/boundary_snapshot_store.py \
  omlx/cache/paged_ssd_cache.py \
  omlx/scheduler.py \
  tests/test_scheduler.py
.venv/bin/python -m pytest \
  tests/test_scheduler.py::TestSchedulerReset::test_shutdown_closes_boundary_snapshot_store \
  tests/test_scheduler.py::TestSchedulerReset::test_deep_reset_closes_boundary_snapshot_store -q
.venv/bin/python -m pytest \
  tests/test_boundary_snapshot_store.py::TestBoundarySnapshotSSDStore::test_cleanup_all \
  tests/test_scheduler.py::TestSchedulerReset::test_shutdown_drains_after_bounded_wait -q
```

The targeted pytest commands passed with 2 tests each.

Attempted but blocked by the current dependency resolver setup, not by this patch:

```bash
uv run ruff check omlx/cache/boundary_snapshot_store.py omlx/cache/paged_ssd_cache.py omlx/scheduler.py tests/test_scheduler.py
```

`uv` failed dependency resolution for the Python 3.14 split because `omlx[bundle]` depends on `num2words>=0.5.14` and the resolver could not find a satisfiable package for that split. The local venv also does not currently include `ruff`.

This PR fixes the memory retention path that was reported in https://github.com/jundot/omlx/issues/1568. The boundary snapshot writer thread keeps the last queue item alive (containing tensors_raw, raw bytes from KV/cache tensors) after model unload, causing multi-GB MALLOC_LARGE retention even when models_loaded=0 and MLX memory is zero.

The fix ensures teardown in Scheduler.shutdown() / deep_reset() properly stops the boundary snapshot store and clears writer frame locals, releasing large temporary payloads.