### PR TITLE
feat: Tencent Hy3 (hy_v3) support — mlx-lm PR #1211 pre-load patch + ':opensource' think tags

### DIFF
--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -20,6 +20,8 @@ _OPEN_LEN = len(_OPEN_TAG)   # 7
 _CLOSE_LEN = len(_CLOSE_TAG)  # 8
 _MINIMAX_OPEN_TAG = "<mm:think>"
 _MINIMAX_CLOSE_TAG = "</mm:think>"
+_HY3_OPEN_TAG = "<think:opensource>"
+_HY3_CLOSE_TAG = "</think:opensource>"
 
 # Regex for non-streaming extraction (complete text)
 _THINKING_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
@@ -169,8 +171,11 @@ def extract_thinking(text: str) -> Tuple[str, str]:
     if not text:
         return ("", "")
 
-    text = text.replace(_MINIMAX_OPEN_TAG, _OPEN_TAG).replace(
-        _MINIMAX_CLOSE_TAG, _CLOSE_TAG
+    text = (
+        text.replace(_MINIMAX_OPEN_TAG, _OPEN_TAG)
+        .replace(_MINIMAX_CLOSE_TAG, _CLOSE_TAG)
+        .replace(_HY3_OPEN_TAG, _OPEN_TAG)
+        .replace(_HY3_CLOSE_TAG, _CLOSE_TAG)
     )
 
     thinking_parts = []
@@ -273,11 +278,22 @@ class ThinkingParser:
                     i += _OPEN_LEN
                     continue
 
+                if remaining.startswith(_HY3_OPEN_TAG):
+                    self._in_thinking = True
+                    i += len(_HY3_OPEN_TAG)
+                    continue
+
                 # Try to match </think>
                 if remaining.startswith(_CLOSE_TAG):
                     self._in_thinking = False
                     self._close_seen = True
                     i += _CLOSE_LEN
+                    continue
+
+                if remaining.startswith(_HY3_CLOSE_TAG):
+                    self._in_thinking = False
+                    self._close_seen = True
+                    i += len(_HY3_CLOSE_TAG)
                     continue
 
                 # Check if it could be a partial tag (not enough chars yet)
@@ -360,15 +376,14 @@ class ThinkingParser:
         yet a complete match.
         """
         length = len(text)
-        if length >= _CLOSE_LEN:
+        if length >= len(_HY3_CLOSE_TAG):
             # Long enough to determine - not a partial tag
             return False
 
-        # Check against both tags
-        if _OPEN_TAG[:length] == text:
-            return True
-        if _CLOSE_TAG[:length] == text:
-            return True
+        # Check against all recognised tags
+        for tag in (_OPEN_TAG, _CLOSE_TAG, _HY3_OPEN_TAG, _HY3_CLOSE_TAG):
+            if length < len(tag) and tag[:length] == text:
+                return True
 
         return False
 

--- a/omlx/patches/hy_v3/__init__.py
+++ b/omlx/patches/hy_v3/__init__.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tencent Hy3 (HunYuan V3, ``model_type: hy_v3``) support for mlx-lm.
+
+Brings ml-explore/mlx-lm#1211 into oMLX without modifying the pinned mlx-lm
+package. The upstream PR adds:
+
+* ``mlx_lm.models.hy_v3`` — the 80-layer MoE decoder (192 routed experts +
+  1 shared, sigmoid router with expert bias, qk-norm, MTP weights skipped
+  in ``sanitize()``).
+* ``mlx_lm.tool_parsers.hy_v3`` / ``hy_v3_opensource`` — the Hy3 tool-call
+  format. The released checkpoints rename every special token with an
+  ``":opensource"`` suffix at the same token ids (``<tool_calls>`` →
+  ``<tool_calls:opensource>``), so the release needs the ``_opensource``
+  sentinels while Hy3-preview uses the plain ones.
+* Tool-parser inference and think-token detection in ``tokenizer_utils``:
+  Hy3 templates contain ``<arg_key`` (like GLM 4.7) but also ``<tool_sep``,
+  so the hy_v3 check must run before the ``<arg_key>`` → ``glm47`` branch,
+  and ``<think:opensource>``/``</think:opensource>`` must be recognised as
+  a thinking pair.
+
+All hooks are upstream-first: once mlx-lm merges #1211 they become no-ops.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+PR_HEAD_SHA = "b7635e9cff3a953a89505aee1e029073810f777f"
+PR_URL = "https://github.com/ml-explore/mlx-lm/pull/1211"
+
+_APPLIED = False
+
+_VENDORED_MODULES = (
+    # (qualname, vendored filename) — hy_v3 tool parser must be registered
+    # before hy_v3_opensource, which does ``from .hy_v3 import parse_tool_call``.
+    ("mlx_lm.models.hy_v3", "hy_v3_model.py", "mlx_lm.models"),
+    ("mlx_lm.tool_parsers.hy_v3", "hy_v3_tool_parser.py", "mlx_lm.tool_parsers"),
+    (
+        "mlx_lm.tool_parsers.hy_v3_opensource",
+        "hy_v3_opensource_tool_parser.py",
+        "mlx_lm.tool_parsers",
+    ),
+)
+
+
+def _register_module(qualname: str, filename: str, package: str) -> None:
+    if qualname in sys.modules:
+        return
+
+    file_path = Path(__file__).parent / filename
+    spec = importlib.util.spec_from_file_location(qualname, str(file_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not create spec for {qualname} from {file_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = package
+    sys.modules[qualname] = module
+    spec.loader.exec_module(module)
+
+    parent = importlib.import_module(package)
+    setattr(parent, qualname.rsplit(".", 1)[1], module)
+    logger.info("Registered %s from %s", qualname, filename)
+
+
+def _patch_infer_tool_parser() -> None:
+    """Run the hy_v3 template check ahead of mlx-lm's inference.
+
+    Hy3 chat templates contain ``<arg_key`` (which mlx-lm maps to ``glm47``)
+    *and* ``<tool_sep``; upstream #1211 disambiguates by checking the pair
+    first. Mirror that here by wrapping ``_infer_tool_parser``.
+    """
+    import mlx_lm.tokenizer_utils as tu
+
+    original = tu._infer_tool_parser
+    if getattr(original, "_omlx_hy_v3", False):
+        return
+
+    def _infer_tool_parser_with_hy_v3(chat_template):
+        if isinstance(chat_template, str) and (
+            "<tool_sep" in chat_template and "<arg_key" in chat_template
+        ):
+            return (
+                "hy_v3_opensource" if ":opensource" in chat_template else "hy_v3"
+            )
+        return original(chat_template)
+
+    _infer_tool_parser_with_hy_v3._omlx_hy_v3 = True
+    tu._infer_tool_parser = _infer_tool_parser_with_hy_v3
+
+
+def _patch_infer_thinking() -> None:
+    """Recognise the release tokenizer's ``<think:opensource>`` pair."""
+    import mlx_lm.tokenizer_utils as tu
+
+    infer = getattr(tu, "_infer_thinking", None)
+    if infer is None or getattr(infer, "_omlx_hy_v3", False):
+        return
+
+    def _infer_thinking_with_hy_v3(tokenizer):
+        result = infer(tokenizer)
+        if result and result[0] is not None:
+            return result
+        vocab = tokenizer.get_vocab()
+        start, end = "<think:opensource>", "</think:opensource>"
+        if start in vocab and end in vocab:
+            return (start, end, (vocab[start],), (vocab[end],))
+        return result
+
+    _infer_thinking_with_hy_v3._omlx_hy_v3 = True
+    tu._infer_thinking = _infer_thinking_with_hy_v3
+
+
+def apply_hy_v3_patch() -> bool:
+    """Register Hy3 support when the pinned mlx-lm does not provide it."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        import mlx_lm  # noqa: F401
+    except ImportError:
+        logger.debug("mlx_lm not importable - hy_v3 patch skipped")
+        return False
+
+    try:
+        importlib.import_module("mlx_lm.models.hy_v3")
+        upstream = True
+    except ImportError:
+        upstream = False
+
+    if not upstream:
+        for qualname, filename, package in _VENDORED_MODULES:
+            _register_module(qualname, filename, package)
+        _patch_infer_tool_parser()
+        _patch_infer_thinking()
+        _APPLIED = True
+        logger.info("Hy3 mlx-lm patch applied (PR 1211 head %s)", PR_HEAD_SHA[:8])
+        return True
+
+    _APPLIED = True
+    logger.debug("mlx_lm.models.hy_v3 already available upstream")
+    return False
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+__all__ = ["apply_hy_v3_patch", "is_applied", "PR_HEAD_SHA", "PR_URL"]

--- a/omlx/patches/hy_v3/hy_v3_model.py
+++ b/omlx/patches/hy_v3/hy_v3_model.py
@@ -1,0 +1,388 @@
+# Copyright © 2026 Apple Inc.
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
+
+from .activations import swiglu
+from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .pipeline import PipelineMixin
+from .rope_utils import initialize_rope
+from .switch_layers import SwitchGLU
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    num_experts: int
+    num_experts_per_tok: int
+    num_shared_experts: int
+    expert_hidden_dim: int
+    first_k_dense_replace: int
+    rms_norm_eps: float
+    rope_parameters: Dict[str, Any]
+    router_scaling_factor: float = 1.0
+    qk_norm: bool = True
+    route_norm: bool = True
+    moe_router_use_sigmoid: bool = True
+    moe_router_enable_expert_bias: bool = True
+    tie_word_embeddings: bool = False
+    num_nextn_predict_layers: int = 0
+    max_position_embeddings: int = 262144
+    enable_moe_fp32_combine: bool = False
+    enable_lm_head_fp32: bool = False
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+
+        dim = args.hidden_size
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)
+        self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.v_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=False)
+        self.o_proj = nn.Linear(self.n_heads * self.head_dim, dim, bias=False)
+
+        self.use_qk_norm = args.qk_norm
+        if self.use_qk_norm:
+            self.q_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+            self.k_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+
+        self.rope = initialize_rope(
+            dims=self.head_dim,
+            base=args.rope_parameters["rope_theta"],
+            traditional=False,
+            scaling_config=args.rope_parameters,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+
+        queries = self.q_proj(x).reshape(B, L, self.n_heads, self.head_dim)
+        keys = self.k_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
+        values = self.v_proj(x).reshape(B, L, self.n_kv_heads, self.head_dim)
+
+        if self.use_qk_norm:
+            queries = self.q_norm(queries)
+            keys = self.k_norm(keys)
+
+        queries = queries.transpose(0, 2, 1, 3)
+        keys = keys.transpose(0, 2, 1, 3)
+        values = values.transpose(0, 2, 1, 3)
+
+        offset = cache.offset if cache is not None else 0
+        queries = self.rope(queries, offset=offset)
+        keys = self.rope(keys, offset=offset)
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(output)
+
+
+class MLP(nn.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def __call__(self, x):
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+@mx.compile
+def expert_select(
+    gates,
+    expert_bias,
+    top_k,
+    routed_scaling_factor,
+    norm_topk_prob,
+):
+    scores = mx.sigmoid(gates.astype(mx.float32))
+    orig_scores = scores
+    scores = scores + expert_bias
+
+    inds = mx.argpartition(scores, kth=-top_k, axis=-1)[..., -top_k:]
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+    if top_k > 1 and norm_topk_prob:
+        scores = scores / (scores.sum(axis=-1, keepdims=True) + 1e-20)
+    scores = scores * routed_scaling_factor
+
+    return inds, scores
+
+
+class MoEGate(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.norm_topk_prob = args.route_norm
+        self.routed_scaling_factor = args.router_scaling_factor
+        self.gate = nn.Linear(args.hidden_size, args.num_experts, bias=False)
+        self.expert_bias = mx.zeros((args.num_experts,))
+
+    def __call__(self, x):
+        return expert_select(
+            self.gate(x),
+            self.expert_bias,
+            self.top_k,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+        )
+
+
+class MoE(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.num_experts_per_tok = args.num_experts_per_tok
+        self.switch_mlp = SwitchGLU(
+            args.hidden_size,
+            args.expert_hidden_dim,
+            args.num_experts,
+        )
+        self.router = MoEGate(args)
+        if args.num_shared_experts > 0:
+            self.shared_mlp = MLP(
+                args.hidden_size,
+                args.expert_hidden_dim * args.num_shared_experts,
+            )
+        else:
+            self.shared_mlp = None
+
+        self.fp32_combine = args.enable_moe_fp32_combine
+        self.sharding_group = None
+
+    def __call__(self, x):
+        if self.sharding_group is not None:
+            x = sum_gradients(self.sharding_group)(x)
+
+        inds, scores = self.router(x)
+        if not self.fp32_combine:
+            scores = scores.astype(x.dtype)
+        y = self.switch_mlp(x, inds)
+        y = (y * scores[..., None]).sum(axis=-2)
+        if self.shared_mlp is not None:
+            y = y + self.shared_mlp(x)
+
+        if self.sharding_group is not None:
+            y = mx.distributed.all_sum(y, group=self.sharding_group)
+
+        return y.astype(x.dtype)
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.self_attn = Attention(args)
+        if layer_idx < args.first_k_dense_replace:
+            self.mlp = MLP(args.hidden_size, args.intermediate_size)
+        else:
+            self.mlp = MoE(args)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class HYV3Model(PipelineMixin, nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.vocab_size = args.vocab_size
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [DecoderLayer(args, idx) for idx in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        x: mx.array,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        h = self.embed_tokens(x)
+
+        pipeline_rank = self.pipeline_rank
+        pipeline_size = self.pipeline_size
+
+        if cache is None:
+            cache = [None] * len(self.pipeline_layers)
+        mask = create_attention_mask(h, cache[0])
+
+        if pipeline_rank < pipeline_size - 1:
+            h = mx.distributed.recv_like(h, (pipeline_rank + 1))
+
+        for layer, c in zip(self.pipeline_layers, cache):
+            h = layer(h, mask, cache=c)
+
+        if pipeline_rank != 0:
+            h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
+            if cache[-1] is not None:
+                cache[-1].keys = mx.depends(cache[-1].keys, h)
+
+        if pipeline_size > 1:
+            h = mx.distributed.all_gather(h)[: h.shape[0]]
+
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = HYV3Model(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+    ):
+        out = self.model(inputs, cache)
+        if self.args.enable_lm_head_fp32:
+            out = out.astype(mx.float32)
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(out)
+        return self.lm_head(out)
+
+    def sanitize(self, weights):
+        n_layers = self.args.num_hidden_layers
+        n_mtp = self.args.num_nextn_predict_layers
+
+        if n_mtp > 0:
+            mtp_prefixes = tuple(f"model.layers.{n_layers + i}." for i in range(n_mtp))
+            weights = {
+                k: v for k, v in weights.items() if not k.startswith(mtp_prefixes)
+            }
+
+        for l in range(n_layers):
+            prefix = f"model.layers.{l}"
+
+            bias_key = f"{prefix}.mlp.expert_bias"
+            if bias_key in weights:
+                weights[f"{prefix}.mlp.router.expert_bias"] = weights.pop(bias_key)
+
+            for m in ("gate_proj", "down_proj", "up_proj"):
+                for k in ("weight", "scales", "biases"):
+                    if f"{prefix}.mlp.experts.0.{m}.{k}" in weights:
+                        to_join = [
+                            weights.pop(f"{prefix}.mlp.experts.{e}.{m}.{k}")
+                            for e in range(self.args.num_experts)
+                        ]
+                        weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(to_join)
+
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+
+        return weights
+
+    def shard(self, group: Optional[mx.distributed.Group] = None):
+        group = group or mx.distributed.init()
+        N = group.size()
+        for layer in self.model.layers:
+            layer.self_attn.q_proj = shard_linear(
+                layer.self_attn.q_proj, "all-to-sharded", group=group
+            )
+            layer.self_attn.k_proj = shard_linear(
+                layer.self_attn.k_proj, "all-to-sharded", group=group
+            )
+            layer.self_attn.v_proj = shard_linear(
+                layer.self_attn.v_proj, "all-to-sharded", group=group
+            )
+            layer.self_attn.o_proj = shard_linear(
+                layer.self_attn.o_proj, "sharded-to-all", group=group
+            )
+            layer.self_attn.n_heads //= N
+            layer.self_attn.n_kv_heads = max(1, layer.self_attn.n_kv_heads // N)
+
+            if isinstance(layer.mlp, MLP):
+                layer.mlp.gate_proj = shard_linear(
+                    layer.mlp.gate_proj, "all-to-sharded", group=group
+                )
+                layer.mlp.down_proj = shard_linear(
+                    layer.mlp.down_proj, "sharded-to-all", group=group
+                )
+                layer.mlp.up_proj = shard_linear(
+                    layer.mlp.up_proj, "all-to-sharded", group=group
+                )
+            else:
+                layer.mlp.sharding_group = group
+                if layer.mlp.shared_mlp is not None:
+                    shard_inplace(
+                        layer.mlp.shared_mlp.gate_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                    shard_inplace(
+                        layer.mlp.shared_mlp.down_proj,
+                        "sharded-to-all",
+                        group=group,
+                    )
+                    shard_inplace(
+                        layer.mlp.shared_mlp.up_proj,
+                        "all-to-sharded",
+                        group=group,
+                    )
+                shard_inplace(
+                    layer.mlp.switch_mlp.gate_proj, "all-to-sharded", group=group
+                )
+                shard_inplace(
+                    layer.mlp.switch_mlp.down_proj, "sharded-to-all", group=group
+                )
+                shard_inplace(
+                    layer.mlp.switch_mlp.up_proj, "all-to-sharded", group=group
+                )
+
+    @property
+    def layers(self):
+        return self.model.pipeline_layers
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            if path.endswith("mlp.router.gate"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            return "expert_bias" not in k
+
+        return predicate

--- a/omlx/patches/hy_v3/hy_v3_model.py
+++ b/omlx/patches/hy_v3/hy_v3_model.py
@@ -146,8 +146,13 @@ class MoEGate(nn.Module):
         self.expert_bias = mx.zeros((args.num_experts,))
 
     def __call__(self, x):
+        # Router matmul in fp32, matching the transformers reference
+        # (HYV3TopKRouter computes F.linear on .float() operands): with 192
+        # experts under a sigmoid router + e-score correction bias, top-8
+        # selection margins are tight and bf16 matmul rounding can flip
+        # expert choices. See mlx-lm#1211 discussion.
         return expert_select(
-            self.gate(x),
+            self.gate(x.astype(mx.float32)),
             self.expert_bias,
             self.top_k,
             self.routed_scaling_factor,

--- a/omlx/patches/hy_v3/hy_v3_opensource_tool_parser.py
+++ b/omlx/patches/hy_v3/hy_v3_opensource_tool_parser.py
@@ -1,0 +1,15 @@
+# Copyright © 2026 Apple Inc.
+
+"""
+Tool parser for Tencent Hy3 (HYV3).
+
+The full Hy3 release renames the Hy3-preview chat tokens with an
+":opensource" suffix at the same token ids (``<tool_calls>`` becomes
+``<tool_calls:opensource>``). Parsing is shared with ``hy_v3``; only the
+start and end sentinels differ.
+"""
+
+from .hy_v3 import parse_tool_call
+
+tool_call_start = "<tool_calls:opensource>"
+tool_call_end = "</tool_calls:opensource>"

--- a/omlx/patches/hy_v3/hy_v3_tool_parser.py
+++ b/omlx/patches/hy_v3/hy_v3_tool_parser.py
@@ -1,0 +1,108 @@
+# Copyright © 2026 Apple Inc.
+
+"""
+Tool parser for Tencent Hy3-preview (HYV3).
+
+Reference:
+https://github.com/vllm-project/vllm/blob/main/vllm/tool_parsers/hy_v3_tool_parser.py
+
+Format:
+    <tool_calls>
+    <tool_call>function_name<tool_sep>
+    <arg_key>key1</arg_key>
+    <arg_value>value1</arg_value>
+    ...
+    </tool_call>
+    ...
+    </tool_calls>
+
+The full Hy3 release renames every token with a ":opensource" suffix
+(``<tool_call:opensource>`` etc.), which the regexes below also accept;
+see ``hy_v3_opensource`` for the suffixed start/end sentinels.
+"""
+
+import ast
+import json
+from typing import Any
+
+import regex as re
+
+tool_call_start = "<tool_calls>"
+tool_call_end = "</tool_calls>"
+
+_SUFFIX = r"(?::[\w-]+)?"
+
+_tool_call_regex = re.compile(
+    rf"<tool_call{_SUFFIX}>(.*?)<tool_sep{_SUFFIX}>(.*?)</tool_call{_SUFFIX}>",
+    re.DOTALL,
+)
+_arg_pair_regex = re.compile(
+    rf"<arg_key{_SUFFIX}>(.*?)</arg_key{_SUFFIX}>"
+    rf"(?:\\n|\s)*"
+    rf"<arg_value{_SUFFIX}>(.*?)</arg_value{_SUFFIX}>",
+    re.DOTALL,
+)
+_tool_sep_regex = re.compile(
+    rf"(?:\s*<tool_call{_SUFFIX}>)?(.*?)<tool_sep{_SUFFIX}>", re.DOTALL
+)
+_arg_key_regex = re.compile(rf"<arg_key{_SUFFIX}>")
+
+
+def _is_string_type(
+    tool_name: str,
+    arg_name: str,
+    tools: list[Any] | None,
+) -> bool:
+    if tools is None:
+        return False
+    for tool in tools:
+        func = tool.get("function", {})
+        if func.get("name") != tool_name:
+            continue
+        params = func.get("parameters") or {}
+        arg_type = params.get("properties", {}).get(arg_name, {}).get("type")
+        return arg_type == "string"
+    return False
+
+
+def _deserialize(value: str) -> Any:
+    try:
+        return json.loads(value)
+    except Exception:
+        pass
+    try:
+        return ast.literal_eval(value)
+    except Exception:
+        pass
+    return value
+
+
+def _parse_single_call(text: str, tools: list[Any] | None):
+    name_match = _tool_sep_regex.match(text)
+    if name_match:
+        func_name = name_match.group(1).strip()
+        body = text[name_match.end() :]
+    else:
+        func_name = _arg_key_regex.split(text, 1)[0].strip()
+        body = text
+
+    arg_dct: dict[str, Any] = {}
+    for key, value in _arg_pair_regex.findall(body):
+        arg_key = key.strip()
+        arg_val = value.strip()
+        if not _is_string_type(func_name, arg_key, tools):
+            arg_val = _deserialize(arg_val)
+        arg_dct[arg_key] = arg_val
+    return dict(name=func_name, arguments=arg_dct)
+
+
+def parse_tool_call(text: str, tools: list[Any] | None = None):
+    matches = _tool_call_regex.findall(text)
+    if matches:
+        calls = [
+            _parse_single_call(f"{name}<tool_sep>{body}", tools)
+            for name, body in matches
+        ]
+        return calls[0] if len(calls) == 1 else calls
+
+    return _parse_single_call(text.strip(), tools)

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -224,6 +224,12 @@ def maybe_apply_pre_load_patches(
         if apply_step3p7_patch():
             logger.info("Step 3.7 pre-load patch applied for %s", model_name)
 
+    if model_type == "hy_v3":
+        from ..patches.hy_v3 import apply_hy_v3_patch
+
+        if apply_hy_v3_patch():
+            logger.info("Hy3 pre-load patch applied for %s", model_name)
+
     text_config = config.get("text_config")
     text_model_type = (
         text_config.get("model_type") if isinstance(text_config, dict) else None


### PR DESCRIPTION
## What

Adds serving support for **Tencent Hy3 / HunYuan V3** (`model_type: hy_v3`, 295B-A21B MoE) ahead of upstream mlx-lm merging [ml-explore/mlx-lm#1211](https://github.com/ml-explore/mlx-lm/pull/1211).

Two parts:

### 1. `patches/hy_v3` — upstream-first pre-load patch (step3p7 pattern)

Vendors PR #1211 (head `b7635e9c`, credit **@kernelpool**) and registers it at pre-load dispatch:

- `mlx_lm.models.hy_v3` — 80-layer MoE: 192 routed experts + 1 shared, sigmoid router with expert bias + scaling, qk-norm; MTP (`num_nextn_predict_layers`) weights skipped in `sanitize()`.
- `mlx_lm.tool_parsers.hy_v3` / `hy_v3_opensource` — the **released** checkpoints rename every special token with an `:opensource` suffix at the same token ids (`<tool_calls>` → `<tool_calls:opensource>`), so the release needs the suffixed sentinels while Hy3-preview uses the plain ones.
- `tokenizer_utils` wrappers: the hy_v3 template check must run **before** the `<arg_key>` → `glm47` branch (Hy3 templates contain both `<arg_key` and `<tool_sep`), and `<think:opensource>`/`</think:opensource>` is recognised as a thinking pair.

Every hook is upstream-first: once the pinned mlx-lm ships `hy_v3` natively, the patch is a no-op.

### 2. `api/thinking.py` — `:opensource` think-tag separation

`extract_thinking()` and `ThinkingParser` only knew `<think>`/`</think>` (plus the MiniMax remap), so Hy3's chain-of-thought leaked into `content` and `reasoning_content` stayed empty. This adds the Hy3 tags to the batch normalisation chain, as first-class open/close alternatives in the streaming parser, and widens `_could_be_tag`'s partial-tag buffering window.

## Testing

Running in production on a Mac Studio M3 Ultra (512 GB) against two oQ4e/mxfp4 quants of the 598 GB BF16 release checkpoint:

- Model loads and serves via the batched engine (~25 tok/s single-stream, TPOT ~41 ms, 262K ctx).
- Tool calling returns structured `tool_calls` (verified single-shot and through a LiteLLM gateway); template inference correctly picks `hy_v3_opensource`.
- With `chat_template_kwargs: {"reasoning_effort": "high"}` (the template's thinking gate), CoT lands in `reasoning_content`, answers stay clean in `content` — streaming and batch paths both verified.
- Graded A/A- in 11/12 categories of an internal role-mapped benchmark suite after these fixes (up from wide-spread leakage-capped grades before).

Notes for reviewers: the Hy3 chat template pre-opens `<think:opensource>` in the generation prompt (handled by the existing `prompt_opens_thinking` machinery once the tokenizer attrs are inferred), and with `tools` present the template intentionally omits the reasoning-mode token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)