### PR TITLE
Fix Homebrew formula installation on macOS 27 beta

### DIFF
--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -16,6 +16,11 @@ class Omlx < Formula
   depends_on :macos
   depends_on "python@3.11"
 
+  # macOS 27 beta's `strip` corrupts dynamic offsets in Mach-O libraries
+  # (llvm/llvm-project#203678). Skip Homebrew's post-install clean pass over
+  # the venv so it never runs `strip` on the compiled dylibs.
+  skip_clean "libexec" if MacOS.version >= "27"
+
   # mlx-audio pins mlx-lm==0.31.1 which conflicts with omlx's git-pinned
   # mlx-lm. Fetch source separately so we can patch the pin before install.
   resource "mlx-audio" do
@@ -51,6 +56,19 @@ class Omlx < Formula
     # C/C++ extension builds use LDFLAGS.
     ENV.append "LDFLAGS", "-Wl,-headerpad_max_install_names"
     ENV.append "RUSTFLAGS", "-C link-arg=-Wl,-headerpad_max_install_names"
+
+    no_binary = "cohere_melody,pydantic-core,rpds-py,tiktoken"
+    if MacOS.version >= "27"
+      # macOS 27's dyld requires the LC_SYMTAB string pool to start on an
+      # 8-byte boundary; prebuilt Rust wheels aligned to 4 bytes fail dlopen
+      # with "mis-aligned LINKEDIT string pool". Build them from source, and
+      # keep Cargo/maturin's release stripping off so the beta's broken
+      # `strip` (llvm/llvm-project#203678) never touches the fresh dylibs.
+      no_binary += ",tokenizers"
+      ENV["CARGO_PROFILE_RELEASE_STRIP"] = "false"
+      ENV["MATURIN_STRIP"] = "false"
+    end
+
     if build.with?("custom-kernel")
       kernel_sources = [
         buildpath/"omlx/custom_kernels/glm_moe_dsa/csrc",
@@ -61,21 +79,29 @@ class Omlx < Formula
       end
 
       ENV["OMLX_WITH_CUSTOM_KERNEL"] = "1"
+      # Pin CMake to the venv's Python; its default discovery can pick a
+      # newer unlinked system Python instead. setup.py forwards CMAKE_ARGS
+      # to the kernel builds.
+      ENV.append "CMAKE_ARGS", "-DPython_EXECUTABLE=#{libexec}/bin/python"
     end
 
     # Install omlx (with optional grammar extra for structured output)
     install_spec = build.with?("grammar") ? "#{buildpath}[grammar]" : buildpath.to_s
     system libexec/"bin/pip", "install",
-           "--no-binary", "cohere_melody,pydantic-core,rpds-py,tiktoken",
+           "--no-binary", no_binary,
            install_spec
 
     if build.with?("custom-kernel")
-      system libexec/"bin/python", "-c", <<~PYTHON
-        from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
-        from omlx.custom_kernels.minimax_m3 import fast as minimax_fast
-        assert glm_fast.is_native_available(), glm_fast.import_error()
-        assert minimax_fast.is_native_available(), minimax_fast.import_error()
-      PYTHON
+      # Run from libexec so buildpath's raw omlx/ source tree doesn't shadow
+      # the compiled package in the venv's site-packages.
+      Dir.chdir(libexec) do
+        system libexec/"bin/python", "-c", <<~PYTHON
+          from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+          from omlx.custom_kernels.minimax_m3 import fast as minimax_fast
+          assert glm_fast.is_native_available(), glm_fast.import_error()
+          assert minimax_fast.is_native_available(), minimax_fast.import_error()
+        PYTHON
+      end
     end
 
     # Install mlx-audio with patched mlx-lm pin to avoid version conflict

--- a/tests/test_homebrew_formula.py
+++ b/tests/test_homebrew_formula.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression tests for the Homebrew formula's macOS 27 beta workarounds.
+
+macOS 27 betas broke `brew install omlx` in several ways (issue #2110):
+
+- dyld now requires the LC_SYMTAB string pool in Mach-O libraries to be
+  8-byte aligned, so prebuilt Rust wheels (e.g. tokenizers) fail dlopen.
+- The beta `strip` binary corrupts dynamic offsets in Mach-O libraries
+  (llvm/llvm-project#203678), so Cargo/maturin release stripping and
+  Homebrew's post-install clean pass must be kept away from the dylibs.
+- CMake's default Python discovery can pick a newer unlinked system
+  Python instead of the formula's venv when building custom kernels.
+- The custom-kernel verification ran from the build directory, where the
+  raw omlx/ source tree shadows the installed package.
+
+The formula is Ruby, so these are text-level assertions that the guards
+stay present in Formula/omlx.rb.
+"""
+
+from pathlib import Path
+
+import pytest
+
+FORMULA_PATH = Path(__file__).resolve().parents[1] / "Formula" / "omlx.rb"
+
+MACOS_27_GUARD = 'MacOS.version >= "27"'
+
+
+@pytest.fixture(scope="module")
+def formula() -> str:
+    return FORMULA_PATH.read_text()
+
+
+class TestMacOS27Workarounds:
+    def test_tokenizers_built_from_source_on_macos_27(self, formula):
+        """Rust wheels with 4-byte-aligned LINKEDIT must be rebuilt natively."""
+        assert MACOS_27_GUARD in formula
+        assert 'no_binary += ",tokenizers"' in formula
+
+    def test_base_no_binary_list_unconditional(self, formula):
+        """Older macOS keeps the existing source-build list unchanged."""
+        assert 'no_binary = "cohere_melody,pydantic-core,rpds-py,tiktoken"' in formula
+        assert '"--no-binary", no_binary' in formula
+
+    def test_release_stripping_disabled_on_macos_27(self, formula):
+        """The beta strip binary corrupts dylibs; Cargo/maturin must not strip."""
+        assert 'ENV["CARGO_PROFILE_RELEASE_STRIP"] = "false"' in formula
+        assert 'ENV["MATURIN_STRIP"] = "false"' in formula
+
+    def test_homebrew_clean_pass_skipped_on_macos_27(self, formula):
+        """Homebrew's clean pass also runs strip over the venv's dylibs."""
+        assert f'skip_clean "libexec" if {MACOS_27_GUARD}' in formula
+
+
+class TestCustomKernelBuild:
+    def test_cmake_pinned_to_venv_python(self, formula):
+        """CMake must not discover a stray system Python for kernel builds."""
+        assert '-DPython_EXECUTABLE=#{libexec}/bin/python' in formula
+
+    def test_kernel_verification_not_shadowed_by_buildpath(self, formula):
+        """Import check must run outside buildpath's raw omlx/ source tree."""
+        assert "Dir.chdir(libexec)" in formula


### PR DESCRIPTION
This addresses multiple compilation and runtime failures on macOS 27 beta (#2110):

- **dyld alignment**: macOS 27's dynamic linker requires the LC_SYMTAB string pool to be 8-byte aligned. Prebuilt Rust wheels (e.g. `tokenizers`) aligned to 4 bytes fail `dlopen`, so they are now built from source on macOS 27+.
- **Broken `strip`**: The beta's `strip` corrupts dynamic offsets in Mach-O libraries (llvm/llvm-project#203678). Cargo/maturin release stripping is disabled and Homebrew's post-install clean pass is skipped (`skip_clean "libexec"`) on macOS 27+.
- **CMake Python discovery**: CMake's default Python discovery can pick a stray system Python instead of the formula's venv. `CMAKE_ARGS` now pins `Python_EXECUTABLE` to the venv's Python for custom kernel builds.
- **Directory shadowing**: The custom-kernel verification step ran from the build directory, where the raw `omlx/` source tree shadowed the installed package. It now runs from `libexec`.

Regression tests are added in `tests/test_homebrew_formula.py` to assert these guards remain in the formula.

Closes #2110