### PR TITLE
Lightning MTP: depth-k native speculative decoding for Qwen3.6-27B / 35B-A3B, DeepSeek-V4-Flash and GLM-5.2

### DIFF
--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -61,6 +61,7 @@ MODEL_SPECIFIC_PROFILE_FIELDS = (
     "dflash_draft_sink_size",
     "dflash_verify_mode",
     "mtp_enabled",
+    "mtp_num_draft_tokens",
     "vlm_mtp_enabled",
     "vlm_mtp_draft_model",
     "vlm_mtp_draft_block_size",

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -191,6 +191,12 @@ class ModelSettings:
     # Compatible model_types: qwen3_5*, qwen3_6*, deepseek_v4*. Mutually exclusive
     # with dflash and turboquant.
     mtp_enabled: bool = False
+    # Maximum chained MTP draft tokens per verify cycle (speculative depth).
+    # None = default (3). Effective for Qwen3.5/3.6 native MTP only;
+    # DeepSeek-V4 native MTP always runs depth 1. An adaptive controller
+    # picks 1..max per sequence from rolling acceptance/latency estimates;
+    # set to 1 for a fixed depth-1 cycle.
+    mtp_num_draft_tokens: Optional[int] = None
 
     # VLM MTP speculative decoding via external MTP drafter (mlx-vlm f96138e+).
     # Supported drafter types: gemma4_assistant (for Gemma 4 VLMs), qwen3_5_mtp

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -4379,19 +4379,7 @@ def quantize_oq_streaming(
                     ):
                         w_mx = w_mx.astype(target_dtype)
                     importance = None
-                    # MTP-head tensors quantize PLAIN (no imatrix weighting):
-                    # the weighted clipping search minimizes weighted MSE,
-                    # but draft quality is argmax agreement with the trunk —
-                    # measured on Qwen3.6-27B (same trunk, greedy, identical
-                    # prompts) the imatrix-weighted gs32 head accepts 60.7%
-                    # on prose vs 69.6% for plain min/max gs32. The head
-                    # still participates in imatrix *collection* so coverage
-                    # reporting stays clean.
-                    if (
-                        imatrix_data is not None
-                        and qmode == "affine"
-                        and not _is_mtp_tensor(tensor_name)
-                    ):
+                    if imatrix_data is not None and qmode == "affine":
                         importance = _lookup_imatrix_importance(
                             imatrix_data,
                             tensor_name,

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -2862,8 +2862,33 @@ def _get_predicate_bits(
         bits = result.get("bits", base_bits)
         gs = result.get("group_size", group_size)
         mode = result.get("mode", _mode_for_bits(bits))
+        if _is_mtp_tensor(tensor_name):
+            raised = _mtp_bits_override(bits)
+            if raised != bits:
+                # Floor lift re-derives mode and group size; unchanged bits
+                # keep the predicate's choice (e.g. mxfp8 head projections).
+                bits, mode = raised, _mode_for_bits(raised)
+                gs = _gs_for_mode(raised, group_size)
         return bits, gs, mode
-    return base_bits, _gs_for_mode(base_bits, group_size), _mode_for_bits(base_bits)
+    bits = base_bits
+    if _is_mtp_tensor(tensor_name):
+        bits = _mtp_bits_override(bits)
+    return bits, _gs_for_mode(bits, group_size), _mode_for_bits(bits)
+
+
+# Minimum bits for quantized MTP-head tensors. Sub-4-bit oQ levels drag the
+# head down with the trunk (DeepSeek-V4 oQ2.5e stored its head's routed
+# experts and attention at 2-bit gs64), but the head only shapes drafts —
+# every emitted token is trunk-verified — so its footprint (~2 GB on
+# DeepSeek-V4-Flash, ~15 MB on Qwen3.6) buys draft acceptance directly and
+# costs almost nothing relative to the model.
+_MTP_MIN_BITS = 4
+
+
+def _mtp_bits_override(bits: int) -> int:
+    if bits and bits < _MTP_MIN_BITS:
+        return _MTP_MIN_BITS
+    return bits
 
 
 def _mode_for_bits(bits: int) -> str:
@@ -4354,7 +4379,19 @@ def quantize_oq_streaming(
                     ):
                         w_mx = w_mx.astype(target_dtype)
                     importance = None
-                    if imatrix_data is not None and qmode == "affine":
+                    # MTP-head tensors quantize PLAIN (no imatrix weighting):
+                    # the weighted clipping search minimizes weighted MSE,
+                    # but draft quality is argmax agreement with the trunk —
+                    # measured on Qwen3.6-27B (same trunk, greedy, identical
+                    # prompts) the imatrix-weighted gs32 head accepts 60.7%
+                    # on prose vs 69.6% for plain min/max gs32. The head
+                    # still participates in imatrix *collection* so coverage
+                    # reporting stays clean.
+                    if (
+                        imatrix_data is not None
+                        and qmode == "affine"
+                        and not _is_mtp_tensor(tensor_name)
+                    ):
                         importance = _lookup_imatrix_importance(
                             imatrix_data,
                             tensor_name,
@@ -5095,11 +5132,22 @@ class OQImatrixCollector:
         cls = type(module).__name__
         if cls in _OQE_SWITCH_LINEAR_CLASSES:
             return hasattr(module, "weight") and getattr(module.weight, "ndim", 0) == 3
+        # QuantizedLinear capture lets imatrix collection run against
+        # already-quantized checkpoints (e.g. deriving a recalibrated MTP
+        # head from an oQ8 model when the bf16 source is gone).
         return (
-            cls == "Linear"
+            cls in ("Linear", "QuantizedLinear")
             and hasattr(module, "weight")
             and getattr(module.weight, "ndim", 0) == 2
         )
+
+    @staticmethod
+    def _module_in_dim(module) -> int:
+        w = module.weight
+        bits = getattr(module, "bits", None)
+        if bits and w.dtype == mx.uint32:
+            return int(w.shape[-1] * 32 // int(bits))
+        return int(w.shape[-1])
 
     def install(self, model) -> int:
         replacements = []
@@ -5138,7 +5186,7 @@ class OQImatrixCollector:
 
     def collect_dense(self, name: str, module, x) -> None:
         try:
-            in_dim = int(module.weight.shape[-1])
+            in_dim = self._module_in_dim(module)
             if getattr(x, "shape", ()) and int(x.shape[-1]) != in_dim:
                 return
             mx.eval(x)
@@ -5224,6 +5272,54 @@ class OQImatrixCollector:
             self._accumulate_switch(entry, idx_flat, x_source, n_experts, token_ids)
         except Exception as e:
             logger.debug("oQe imatrix switch capture skipped for %s: %s", name, e)
+
+
+def _collect_mtp_head_imatrix(model, batch, hidden) -> bool:
+    """Run the MTP head over a calibration micro-batch.
+
+    The trunk-layer walk never invokes the head, so without this pass every
+    ``mtp.*`` linear lands in the imatrix "missing" list and gets quantized
+    without calibration — measurably hurting draft acceptance. Mirrors the
+    decode-time contract: fuse the trunk's post-norm hidden at position t
+    with the embedding of token t+1 (the head's own input RMSNorms make the
+    residual pre/post-norm difference negligible for activation statistics).
+    """
+    inner = getattr(model, "language_model", None) or model
+    mtp = getattr(inner, "mtp", None)
+    if mtp is None:
+        return False
+    try:
+        if isinstance(mtp, (list, tuple)):
+            # DeepSeek-V4 style: MTPBlock stack consuming the raw (4D)
+            # trunk hidden; Model.mtp_forward wires mask/cache/embedding.
+            out = inner.mtp_forward(
+                hidden[:, :-1],
+                batch[:, 1:],
+                inner.make_mtp_cache(),
+            )
+            mx.eval(out)
+            return True
+        core = getattr(inner, "model", None) or inner
+        norm = getattr(core, "norm", None)
+        embed = getattr(core, "embed_tokens", None)
+        if norm is None or embed is None:
+            return False
+        # The head's attention reads cache.offset unconditionally on the
+        # mlx-vlm classes — give it a fresh cache per micro-batch.
+        make_cache = getattr(inner, "make_mtp_cache", None)
+        if callable(make_cache):
+            mtp_cache = make_cache()
+        else:
+            from mlx_lm.models.cache import KVCache
+
+            mtp_cache = [KVCache() for _ in mtp.layers]
+        h = norm(hidden[:, :-1, :])
+        out = mtp(h, batch[:, 1:], embed, mtp_cache)
+        mx.eval(out)
+        return True
+    except Exception as e:
+        logger.warning("oQe imatrix MTP head pass skipped: %s", e)
+        return False
 
 
 def _collect_imatrix_from_model(
@@ -5328,6 +5424,14 @@ def _collect_imatrix_from_model(
                         and position_ids.get("kind") == "glm_moe_dsa"
                     ):
                         position_ids["prev_topk_indices"] = aux or prev_aux
+                    mx.synchronize()
+                    mx.clear_cache()
+
+                # MTP-head pass: the layer walk above leaves ``inputs`` as
+                # the final-layer hidden states; feed them (post-norm) plus
+                # the shifted token ids through the head so its linears
+                # contribute imatrix entries too.
+                if _collect_mtp_head_imatrix(model, batch, inputs):
                     mx.synchronize()
                     mx.clear_cache()
 
@@ -5464,16 +5568,21 @@ def _collect_imatrix(
     maybe_apply_pre_load_patches(model_path, for_vlm=is_vlm)
 
     restore_mtp_active = None
-    if is_vlm and _has_mtp_heads(config) and has_mtp_weights:
+    if _has_mtp_heads(config) and has_mtp_weights:
+        # Attach the MTP head on the temporary calibration model so the
+        # head-forward pass in _collect_imatrix_from_model can exercise its
+        # linears (they'd otherwise land in the imatrix "missing" list).
         try:
             from omlx.patches.mlx_lm_mtp import is_mtp_active, set_mtp_active
-            from omlx.patches.mlx_vlm_mtp import (
-                apply_mlx_vlm_mtp_patch,
-                apply_mlx_vlm_mtp_runtime_patch,
-            )
 
-            apply_mlx_vlm_mtp_patch()
-            apply_mlx_vlm_mtp_runtime_patch()
+            if is_vlm:
+                from omlx.patches.mlx_vlm_mtp import (
+                    apply_mlx_vlm_mtp_patch,
+                    apply_mlx_vlm_mtp_runtime_patch,
+                )
+
+                apply_mlx_vlm_mtp_patch()
+                apply_mlx_vlm_mtp_runtime_patch()
             prev_active = is_mtp_active()
             set_mtp_active(True)
 
@@ -5482,7 +5591,7 @@ def _collect_imatrix(
 
             restore_mtp_active = _restore_mtp_active
         except Exception as e:
-            logger.debug("mlx-vlm MTP runtime patch skipped for oQe imatrix: %s", e)
+            logger.debug("MTP runtime patch skipped for oQe imatrix: %s", e)
 
     try:
         if is_vlm:
@@ -5541,6 +5650,22 @@ def _collect_imatrix(
         mx.clear_cache()
 
 
+def _oqe_cache_missing_mtp_entries(cache: OQImatrixData, config: dict) -> bool:
+    """True when the model declares MTP heads but the cache predates the
+    MTP-head collection pass (no ``mtp.*`` entries) — force a recollect so
+    the head gets calibrated quantization instead of landing in "missing"."""
+    try:
+        from omlx.utils.model_loading import _has_mtp_heads
+
+        if not _has_mtp_heads(config):
+            return False
+    except Exception:
+        return False
+    return not any(
+        ".mtp." in key or key.startswith("mtp.") for key in cache.entries
+    )
+
+
 def _load_or_collect_imatrix(
     model_path: str,
     config: dict,
@@ -5568,7 +5693,13 @@ def _load_or_collect_imatrix(
     if reuse_cache and path.exists():
         cache = _load_oqe_imatrix(path)
         if _oqe_cache_matches(cache, expected):
-            if _oqe_cache_has_required_expert_coverage(cache):
+            if _oqe_cache_missing_mtp_entries(cache, config):
+                logger.info(
+                    "oQe imatrix: cache predates MTP-head collection "
+                    "(no mtp.* entries), recollecting %s",
+                    path,
+                )
+            elif _oqe_cache_has_required_expert_coverage(cache):
                 cache.reused = True
                 logger.info("oQe imatrix: using cache %s", path)
                 _emit_progress(

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -4053,6 +4053,42 @@ def quantize_oq_streaming(
             "OOM-prone paths will be skipped"
         )
 
+    # RAM-safe calibration proxy, shared between oQe imatrix collection and
+    # auto-proxy sensitivity so an exceeds-RAM run builds it at most once.
+    # Built lazily (an imatrix cache hit never pays for it) and deleted as
+    # soon as the last calibration pass is done.
+    _ram_safe_proxy_dir: Path | None = None
+
+    def _ensure_ram_safe_proxy() -> Path:
+        nonlocal _ram_safe_proxy_dir
+        if _ram_safe_proxy_dir is None:
+            logger.warning(
+                f"oQ{oq_level:g}: model size ({_model_bytes / 1e9:.1f} GB) "
+                f"exceeds {int(_MAX_MODEL_RAM_FRACTION * 100)}% of system RAM "
+                f"({_system_ram / 1e9:.1f} GB). Building a uniform "
+                f"{_PROXY_QUANT_BITS}-bit proxy on disk for the calibration "
+                "passes."
+            )
+            _ram_safe_proxy_dir = _build_proxy_for_sensitivity(
+                model_path,
+                config=config,
+                dtype=dtype,
+                working_dir=str(output.parent),
+                trust_remote_code=trust_remote_code,
+                preserve_mtp=preserve_mtp,
+            )
+        return _ram_safe_proxy_dir
+
+    def _cleanup_ram_safe_proxy() -> None:
+        nonlocal _ram_safe_proxy_dir
+        if _ram_safe_proxy_dir is not None and _ram_safe_proxy_dir.exists():
+            shutil.rmtree(_ram_safe_proxy_dir, ignore_errors=True)
+            logger.info(
+                f"oQ{oq_level:g}: cleaned up calibration proxy at "
+                f"{_ram_safe_proxy_dir}"
+            )
+        _ram_safe_proxy_dir = None
+
     cb("loading", 12.0, "Preparing quantization inputs")
 
     imatrix_data: OQImatrixData | None = None
@@ -4072,19 +4108,35 @@ def quantize_oq_streaming(
                 )
             )
         cb("imatrix", 13.0, "Preparing oQe imatrix calibration")
-        imatrix_data = _load_or_collect_imatrix(
-            model_path,
-            config,
-            cache_path=imatrix_cache_path,
-            reuse_cache=imatrix_reuse_cache,
-            num_samples=int(imatrix_num_samples),
-            seq_length=int(imatrix_seq_length),
-            strict=imatrix_strict,
-            trust_remote_code=trust_remote_code,
-            progress_callback=cb,
-            progress_start=13.0,
-            progress_end=18.0,
-        )
+
+        def _imatrix_load_path() -> str:
+            cb(
+                "imatrix",
+                13.0,
+                "Building RAM-safe proxy for imatrix calibration",
+            )
+            return str(_ensure_ram_safe_proxy())
+
+        try:
+            imatrix_data = _load_or_collect_imatrix(
+                model_path,
+                config,
+                cache_path=imatrix_cache_path,
+                reuse_cache=imatrix_reuse_cache,
+                num_samples=int(imatrix_num_samples),
+                seq_length=int(imatrix_seq_length),
+                strict=imatrix_strict,
+                trust_remote_code=trust_remote_code,
+                progress_callback=cb,
+                progress_start=13.0,
+                progress_end=18.0,
+                load_path_factory=(
+                    _imatrix_load_path if _model_exceeds_ram else None
+                ),
+            )
+        except BaseException:
+            _cleanup_ram_safe_proxy()
+            raise
         cb("imatrix", 18.0, "oQe imatrix calibration ready")
         imatrix_report = {
             "enabled": True,
@@ -4153,15 +4205,8 @@ def quantize_oq_streaming(
                 f"{_PROXY_QUANT_BITS}-bit proxy on disk so sensitivity "
                 "measurement stays data-driven."
             )
-            _proxy_dir: Path | None = None
             try:
-                _proxy_dir = _build_proxy_for_sensitivity(
-                    model_path,
-                    config=config,
-                    dtype=dtype,
-                    working_dir=str(output.parent),
-                    trust_remote_code=trust_remote_code,
-                )
+                _proxy_dir = _ensure_ram_safe_proxy()
                 logger.info(
                     f"oQ{oq_level:g}: proxy ready at {_proxy_dir}, measuring sensitivity"
                 )
@@ -4181,9 +4226,7 @@ def quantize_oq_streaming(
                     "full-fp16 sensitivity measurement."
                 ) from e
             finally:
-                if _proxy_dir is not None and _proxy_dir.exists():
-                    shutil.rmtree(_proxy_dir, ignore_errors=True)
-                    logger.info(f"oQ{oq_level:g}: cleaned up proxy at {_proxy_dir}")
+                _cleanup_ram_safe_proxy()
         elif _model_exceeds_ram:
             raise RuntimeError(
                 f"oQ{oq_level:g}: model exceeds {int(_MAX_MODEL_RAM_FRACTION * 100)}% "
@@ -4210,12 +4253,18 @@ def quantize_oq_streaming(
     # error here so the rest of quantize_oq_streaming never runs without a
     # data-driven sensitivity map.
     if not sensitivity_map:
+        _cleanup_ram_safe_proxy()
         raise RuntimeError(
             f"oQ{oq_level:g}: sensitivity measurement produced no scores. "
             "Check the preceding log lines for the root cause (model load, "
             "calibration data, or layer discovery), and either fix it or "
             "pass an explicit sensitivity_model_path."
         )
+
+    # Calibration passes are done — drop the RAM-safe proxy (built when the
+    # source exceeds system RAM; a cached sensitivity map plus an imatrix
+    # cache hit means it was never built at all).
+    _cleanup_ram_safe_proxy()
 
     cb(
         "loading",
@@ -5702,6 +5751,7 @@ def _load_or_collect_imatrix(
     progress_callback=None,
     progress_start: float = 13.0,
     progress_end: float = 18.0,
+    load_path_factory: Callable[[], str] | None = None,
 ) -> OQImatrixData:
     source = Path(model_path)
     path = Path(cache_path)
@@ -5746,8 +5796,16 @@ def _load_or_collect_imatrix(
         seq_length,
         calib_dataset,
     )
+    # ``load_path_factory`` swaps in an alternate checkpoint for the
+    # calibration forwards (a RAM-safe quantized proxy of the source when
+    # the source exceeds system RAM). Resolved only on a cache miss so a
+    # reusable cache never pays the proxy build. The cache signature stays
+    # keyed to the source checkpoint either way.
+    load_path = model_path
+    if load_path_factory is not None:
+        load_path = load_path_factory()
     entries, collection_metadata = _collect_imatrix(
-        model_path,
+        load_path,
         config,
         calib_dataset=calib_dataset,
         num_samples=num_samples,
@@ -5993,12 +6051,14 @@ def _build_proxy_for_sensitivity(
     dtype: str,
     working_dir: str | None = None,
     trust_remote_code: bool = False,
+    preserve_mtp: bool = False,
 ) -> Path:
-    """Build a temporary uniform 4-bit proxy for sensitivity measurement.
+    """Build a temporary uniform 4-bit proxy for calibration passes.
 
     Used when the source model exceeds available RAM and full-fp16
-    sensitivity measurement is not feasible. The proxy keeps oQ data-driven;
-    without it, quantize_oq_streaming aborts the run with a RuntimeError.
+    sensitivity measurement / oQe imatrix collection is not feasible. The
+    proxy keeps oQ data-driven; without it, quantize_oq_streaming aborts
+    the run with a RuntimeError.
 
     ``working_dir`` controls where the proxy is written. Defaults to the
     system temp dir when None, but callers should pass the parent of the
@@ -6006,6 +6066,9 @@ def _build_proxy_for_sensitivity(
     already provisioned for the quantized output. This avoids the trap of
     Linux ``/tmp`` being tmpfs (RAM-backed), which would defeat the whole
     point of the OOM-driven proxy.
+
+    ``preserve_mtp`` keeps the MTP head in the proxy so the imatrix head
+    pass can exercise its linears; sensitivity-only proxies leave it off.
 
     The caller is responsible for deleting the returned directory.
     """
@@ -6017,6 +6080,7 @@ def _build_proxy_for_sensitivity(
         proxy_dir,
         dtype=dtype,
         trust_remote_code=trust_remote_code,
+        preserve_mtp=preserve_mtp,
     )
     return proxy_dir
 
@@ -6027,6 +6091,7 @@ def _build_streaming_proxy_for_sensitivity(
     *,
     dtype: str,
     trust_remote_code: bool = False,
+    preserve_mtp: bool = False,
 ) -> None:
     """Build a loadable 4-bit sensitivity proxy without loading the source.
 
@@ -6133,7 +6198,7 @@ def _build_streaming_proxy_for_sensitivity(
                 w_mx = w_mx[:]
             shape = w_mx.shape
 
-            if _is_mtp_tensor(tensor_name):
+            if _is_mtp_tensor(tensor_name) and not preserve_mtp:
                 del w_mx
                 continue
 
@@ -6214,7 +6279,8 @@ def _build_streaming_proxy_for_sensitivity(
         "_oq_non_quantizable",
     ):
         output_config.pop(temp_key, None)
-    _normalize_mtp_in_config(output_config)
+    if not preserve_mtp:
+        _normalize_mtp_in_config(output_config)
     quant_info = dict(quantization_config)
     for key, val in per_layer_config.items():
         quant_info[key] = val

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -818,8 +818,16 @@ def _build_quant_plan(
             continue
         layer_idx = _extract_layer_index(path)
         if layer_idx < 0:
-            continue
-        layer_score = float(layer_scores.get(str(layer_idx), 0.0))
+            # MTP-head tensors carry no ``layers.<n>`` index but should
+            # compete like any other non-expert tensor (the stated contract
+            # is backbone-equal treatment for the head's internal block);
+            # score 0 seeds them at the bottom tier and the under-target
+            # fallback lifts them with the rest.
+            if not _is_mtp_tensor(path):
+                continue
+            layer_score = 0.0
+        else:
+            layer_score = float(layer_scores.get(str(layer_idx), 0.0))
         # Current bits (floor or base)
         cur_bits = boost_map[path]["bits"] if path in boost_map else base_bits
         cur_gs = _gs_for_mode(cur_bits, _OQ_DEFAULT_GROUP_SIZE)
@@ -2488,6 +2496,28 @@ def _is_mtp_tensor(name: str) -> bool:
     return name.startswith("mtp.") or ".mtp." in name
 
 
+def _source_has_nextn_tensors(keys, config: dict) -> bool:
+    """True iff the checkpoint stores its MTP head as extra decoder layers.
+
+    DeepSeek-V3-style checkpoints (GLM-5.2 among them) keep the MTP layers
+    as ``model.layers.<num_hidden_layers + i>.*`` rather than ``mtp.*``;
+    the model patch's sanitize remaps them, so for preservation purposes
+    they count as MTP tensors even though ``_is_mtp_tensor`` (which sees
+    post-sanitize names) doesn't match them.
+    """
+    cfgs = (config, config.get("text_config") or {})
+    n_mtp = max(int(c.get("num_nextn_predict_layers", 0) or 0) for c in cfgs)
+    if n_mtp <= 0:
+        return False
+    n_main = 0
+    for c in cfgs:
+        n_main = max(n_main, int(c.get("num_hidden_layers", 0) or 0))
+    if n_main <= 0:
+        return False
+    prefixes = tuple(f"model.layers.{n_main + i}." for i in range(n_mtp))
+    return any(k.startswith(prefixes) for k in keys)
+
+
 def _normalize_mtp_in_config(config: dict) -> None:
     """Zero out MTP layer counts in the output config (in place).
 
@@ -2815,18 +2845,18 @@ def _is_mtp_protected_tensor(name: str) -> bool:
     Qwen3.5-27B accepted 0/157 cycles). PR 990 protects ``mtp.fc`` for
     Qwen3.5/3.6; PR 15's DeepSeek-V4 ``MTPBlock`` exposes the same
     semantics under different names (``e_proj`` + ``h_proj`` for the
-    embedding/hidden fusion; ``hc_head.*`` for the final projection).
-    All of these stay in full precision; the MTP block's internal
-    DeepseekV4Block (attn/ffn) gets the same quantization as the
-    backbone's other layers.
+    embedding/hidden fusion; ``hc_head.*`` for the final projection);
+    GLM-5.2's ``GlmMTPBlock`` calls it ``eh_proj``. All of these stay in
+    full precision; the MTP block's internal decoder block (attn/ffn)
+    gets the same quantization as the backbone's other layers.
     """
     if not (name.startswith("mtp.") or ".mtp." in name):
         return False
     # Qwen3.5/3.6 fusion projection
     if name.endswith("mtp.fc.weight") or ".mtp.fc.weight" in name:
         return True
-    # DeepSeek-V4 MTPBlock fusion projections
-    if name.endswith(".e_proj.weight") or name.endswith(".h_proj.weight"):
+    # DeepSeek-V4 / GLM-5.2 MTP block fusion projections
+    if name.endswith((".e_proj.weight", ".h_proj.weight", ".eh_proj.weight")):
         return True
     # DeepSeek-V4 HyperHead final projection (sanitized form has the dot;
     # the raw-HF form arrives as ``hc_head_<param>`` and we cover both).
@@ -3993,7 +4023,11 @@ def quantize_oq_streaming(
     cb("loading", 8.0, "Indexing source weights")
 
     all_weights = _LazyTensorIndex(weight_files)
-    if preserve_mtp and not any(_is_mtp_tensor(k) for k in all_weights.keys()):
+    if (
+        preserve_mtp
+        and not any(_is_mtp_tensor(k) for k in all_weights.keys())
+        and not _source_has_nextn_tensors(all_weights.keys(), config)
+    ):
         logger.warning(
             "Preserve MTP requested for %s, but no mtp.* tensors were found "
             "in the checkpoint; disabling MTP preservation",

--- a/omlx/patches/deepseek_v4/cache_extras.py
+++ b/omlx/patches/deepseek_v4/cache_extras.py
@@ -50,11 +50,11 @@ class PoolingCache(_BaseCache):
         # One-update undo log for MTP draft rejection: trim() needs the
         # pre-update state plus this update's raw inputs to undo the last
         # token when it completed a pool window. Only decode / MTP-verify
-        # sized updates (L <= 2) are ever trimmed; skipping the stash for
-        # prompt chunks avoids pinning large prefill projections. Buffer
-        # slices are taken before any mutation, so they reference the
-        # pre-update array node.
-        if L <= 2:
+        # sized updates (L <= 8 covers depth-k chain verify windows) are
+        # ever trimmed; skipping the stash for prompt chunks avoids pinning
+        # large prefill projections. Buffer slices are taken before any
+        # mutation, so they reference the pre-update array node.
+        if L <= 8:
             self._undo = (
                 self.buf_kv[:, : self.remainder] if self.remainder > 0 else None,
                 self.buf_gate[:, : self.remainder] if self.remainder > 0 else None,
@@ -282,7 +282,7 @@ class BatchPoolingCache(_BaseCache):
         # the stashed objects keep the pre-update contents. The pooled
         # tensor needs no snapshot: update_and_fetch only writes beyond the
         # old _pool_lengths, so restoring the length lists is enough.
-        if L <= 2:
+        if L <= 8:
             self._undo = (
                 self.buf_kv,
                 self.buf_gate,

--- a/omlx/patches/glm_moe_dsa/glm_moe_dsa_model.py
+++ b/omlx/patches/glm_moe_dsa/glm_moe_dsa_model.py
@@ -268,6 +268,52 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
         if self.indexer is not None and cache is not None and cache[0] is not None:
             cache[0].keys = mx.depends(cache[0].keys, (cache[1].keys, cache[1].values))
 
+        # Decode-shape multi-row forwards (MTP draft verify and head folds):
+        # generalize the L == 1 per-row topk gather instead of dispatching
+        # the native sparse-MLA kernel, whose prefill-shaped grid runs ~8x
+        # slower than this at tiny L (4.2 ms vs 0.5 ms per layer at K≈4.7k).
+        # Each row attends to its own gathered top-k in latent space, so the
+        # cost is independent of context length. Indices are causally valid
+        # per row by construction (same contract the L == 1 path relies on).
+        if (
+            topk_indices is not None
+            and 1 < L <= _ABSORBED_DECODE_MAX_L
+            and B == 1
+            and topk_indices.shape[2] == L
+            and topk_prefix_rows == 0
+        ):
+            idx = topk_indices[0, 0]  # (L, topk)
+            kv_rows = kv_latent[0, 0][idx]  # (L, topk, latent)
+            pe_rows = k_pe[0, 0][idx]  # (L, topk, rope)
+            q_lat = self.embed_q(q_nope)  # (1, H, L, latent)
+            qg = q_lat.transpose(0, 2, 1, 3)[0][:, :, None]  # (L, H, 1, latent)
+            qp = q_pe.transpose(0, 2, 1, 3)[0][:, :, None]  # (L, H, 1, rope)
+            pe_scores = (qp * self.scale) @ pe_rows[:, None].swapaxes(-1, -2)
+            # The native indexer emits causally valid indices, but the
+            # argpartition fallback can select future rows; mask gathered
+            # keys past each row's own absolute position.
+            row_pos = mx.arange(
+                kv_latent.shape[2] - L, kv_latent.shape[2], dtype=idx.dtype
+            )
+            valid = idx <= row_pos[:, None]  # (L, topk)
+            pe_scores = mx.where(
+                valid[:, None, None, :],
+                pe_scores,
+                mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
+            )
+            output = scaled_dot_product_attention(
+                qg,
+                kv_rows[:, None],
+                kv_rows[:, None],
+                cache=cache,
+                scale=self.scale,
+                mask=pe_scores,
+            )  # (L, H, 1, latent)
+            output = output[:, :, 0].transpose(1, 0, 2)[None]  # (1, H, L, latent)
+            output = self.unembed_out(output)
+            output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+            return self.o_proj(output), topk_state
+
         direct_sparse_mla_min_k = int(
             _native_sparse_mla_default_min_k()
         )
@@ -282,10 +328,7 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
         direct_sparse_mla_requested = (
             native_sparse_mla_shape
             and L > 1
-            and (
-                kv_latent.shape[2] >= direct_sparse_mla_min_k
-                or L <= _ABSORBED_DECODE_MAX_L
-            )
+            and kv_latent.shape[2] >= direct_sparse_mla_min_k
         )
         if direct_sparse_mla_requested:
             fast_topk_indices = glm_fast.has("dsa_topk_indices")

--- a/omlx/patches/glm_moe_dsa/glm_moe_dsa_model.py
+++ b/omlx/patches/glm_moe_dsa/glm_moe_dsa_model.py
@@ -30,6 +30,15 @@ def _native_sparse_mla_default_min_k() -> str:
     return "11264" if glm_fast.has("glm_dsa_sparse_mla_attention") else str(2**63 - 1)
 
 
+# Decode-sized multi-row forwards (MTP draft verify and head folds run
+# L = depth+1 <= 8 rows). The min_k threshold above marks where the sparse
+# kernel beats the *prefill* paths; below it, small L would otherwise fall
+# through to the fallback that materializes full-cache multi-head K/V
+# (embed_q/unembed_out over every cached position) — the absorbed latent
+# path and the sparse kernel are both far cheaper at these shapes.
+_ABSORBED_DECODE_MAX_L = 8
+
+
 def _parse_topk_state(topk_state):
     topk_indices = topk_state
     prefix_rows = 0
@@ -273,7 +282,10 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
         direct_sparse_mla_requested = (
             native_sparse_mla_shape
             and L > 1
-            and kv_latent.shape[2] >= direct_sparse_mla_min_k
+            and (
+                kv_latent.shape[2] >= direct_sparse_mla_min_k
+                or L <= _ABSORBED_DECODE_MAX_L
+            )
         )
         if direct_sparse_mla_requested:
             fast_topk_indices = glm_fast.has("dsa_topk_indices")
@@ -338,7 +350,8 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
                 mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
             )
 
-        if L == 1:
+        absorbed = L <= _ABSORBED_DECODE_MAX_L
+        if absorbed:
             q_nope = self.embed_q(q_nope)
             k = v = kv_latent
         else:
@@ -348,7 +361,7 @@ class GlmMoeDsaAttention(DeepseekV32Attention):
         output = scaled_dot_product_attention(
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
-        if L == 1:
+        if absorbed:
             output = self.unembed_out(output)
 
         output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)

--- a/omlx/patches/mlx_lm_mtp/__init__.py
+++ b/omlx/patches/mlx_lm_mtp/__init__.py
@@ -59,6 +59,24 @@ def is_mtp_active() -> bool:
     return _MTP_ACTIVE
 
 
+# Draft depth (number of chained MTP draft tokens per verify cycle) for the
+# next model load. Same construction-time-flag pattern as _MTP_ACTIVE: the
+# patched ``TextModel.__init__`` copies it onto the instance
+# (``_omlx_mtp_depth``) so decode never reads the global. Depth > 1 only
+# engages on models whose patch marks ``_omlx_mtp_chain`` (Qwen3.5/3.6);
+# DeepSeek-V4 stays on the depth-1 legacy cycle.
+_MTP_DEPTH = 1
+
+
+def set_mtp_depth(depth: int) -> None:
+    global _MTP_DEPTH
+    _MTP_DEPTH = max(1, min(8, int(depth)))
+
+
+def get_mtp_depth() -> int:
+    return _MTP_DEPTH
+
+
 def apply_mlx_lm_mtp_patch() -> bool:
     """Apply the model-side and BatchGenerator monkey-patches.
 
@@ -93,5 +111,14 @@ def apply_mlx_lm_mtp_patch() -> bool:
             "BatchGenerator MTP dispatch patch failed; MTP path will be inactive"
         )
         return False
+
+    # Verify-shape qmm kernels. Optional: inert unless armed around an MTP
+    # verify forward, and strictly shape-gated at call time.
+    try:
+        from ..qwen35_verify_qmm import apply_verify_qmm_patch
+
+        apply_verify_qmm_patch()
+    except Exception:
+        logger.debug("verify qmm patch not applied", exc_info=True)
 
     return True

--- a/omlx/patches/mlx_lm_mtp/__init__.py
+++ b/omlx/patches/mlx_lm_mtp/__init__.py
@@ -96,7 +96,13 @@ def apply_mlx_lm_mtp_patch() -> bool:
         True if the patch is now active. False if a sub-step refused
         to apply (mlx-lm not importable, missing prerequisite patch).
     """
-    from . import batch_generator, cache_rollback, deepseek_v4_model, qwen35_model
+    from . import (
+        batch_generator,
+        cache_rollback,
+        deepseek_v4_model,
+        glm_moe_dsa_model,
+        qwen35_model,
+    )
 
     if not cache_rollback.apply():
         return False
@@ -106,6 +112,8 @@ def apply_mlx_lm_mtp_patch() -> bool:
         logger.debug("Qwen3.5/3.6 MTP patch did not apply (likely import error)")
     if not deepseek_v4_model.apply():
         logger.debug("DeepSeek-V4 MTP patch did not apply (likely missing base patch)")
+    if not glm_moe_dsa_model.apply():
+        logger.debug("GLM-5.2 MTP patch did not apply (likely missing base patch)")
     if not batch_generator.apply():
         logger.warning(
             "BatchGenerator MTP dispatch patch failed; MTP path will be inactive"

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -1322,10 +1322,18 @@ class _DepthController:
     ADAPT_INTERVAL = 16
     PROBE_INTERVAL = 96
     PROBE_LEN = 6
-    MARGINAL_MS = 7.0  # prior cost of one extra verify token (measured 6-10ms)
+    # Prior cost of one extra verify token. 7 ms matches dense backbones
+    # (measured 6-10 ms); fine-grained MoE models override it per model —
+    # each extra verify row pulls a nearly disjoint routed-expert set, so
+    # the marginal row costs a large fraction of a full step and a dense
+    # prior makes the controller over-draft on low-acceptance content
+    # until the EMA catches up.
+    MARGINAL_MS = 7.0
     HYSTERESIS = 1.03
 
-    def __init__(self, max_depth: int):
+    def __init__(self, max_depth: int, marginal_ms: Optional[float] = None):
+        if marginal_ms:
+            self.MARGINAL_MS = float(marginal_ms)
         self.max_depth = max(1, int(max_depth))
         self.cur = self.max_depth  # start deep so deep stats populate early
         self.p = [0.6] * self.max_depth
@@ -1572,7 +1580,12 @@ def _post_init_mtp(gen_batch: Any) -> None:
         state.depth = depth
         state.head_clone = head_clone
         if depth > 1:
-            state.controller = _DepthController(depth)
+            state.controller = _DepthController(
+                depth,
+                marginal_ms=getattr(
+                    gen_batch.model, "_omlx_mtp_marginal_ms", None
+                ),
+            )
         state.mtp_cache = gen_batch.model.make_mtp_cache()
         state.next_main = _ensure_uint32(next_main_tok)
         state.queue.append((int(main_tok.tolist()[0]), main_lp, "init"))

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -80,6 +80,20 @@ from . import cache_rollback as _rollback_mod
 
 logger = logging.getLogger(__name__)
 
+
+def _set_verify_qmm_armed(flag: bool) -> None:
+    """Arm the verify-shape qmm routing for the duration of an MTP forward.
+
+    Import is deferred and failure-tolerant: the kernel module is optional
+    and its absence must not affect the MTP path.
+    """
+    try:
+        from ..qwen35_verify_qmm import set_verify_qmm_armed
+
+        set_verify_qmm_armed(flag)
+    except Exception:
+        pass
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -434,12 +448,17 @@ class _MtpStats:
     """
 
     cycles: int = 0  # number of verify cycles run
-    accepts: int = 0  # cycles where the draft was accepted
-    rejects: int = 0  # cycles where the draft was rejected
+    accepts: int = 0  # accepted draft tokens (depth-k: sum over positions)
+    rejects: int = 0  # cycles that ended in a rejection
     init_emits: int = 0  # tokens emitted from the post-init queue (always 2)
     draft_emits: int = 0  # tokens emitted as accepted drafts
     bonus_emits: int = 0  # tokens emitted as bonus (accepted + emit_bonus)
     verify_emits: int = 0  # tokens emitted as verify-position correction (reject path)
+    # Per-depth accept telemetry for chained drafting: drafted[j] counts
+    # cycles where a draft existed at depth j; accepted[j] counts how many
+    # of those were verified. Depth-1 legacy path fills index 0 only.
+    depth_drafted: List[int] = field(default_factory=list)
+    depth_accepted: List[int] = field(default_factory=list)
     # Component-level timings. Help diagnose where MTP overhead comes from
     # when accept rate is healthy but wall-clock throughput isn't.
     backbone_ms: float = 0.0  # cumulative time inside the 2-token verify forward
@@ -481,6 +500,39 @@ class _MtpState:
     # verify cycle can compare draft vs verify ids without a separate
     # GPU→CPU sync (`int(draft_tok.tolist()[0])` would force a stall).
     draft_id: int = -1
+
+    # --- depth-k chained drafting (Qwen3.5/3.6 only) ---
+    # chain=True routes decode through _run_verify_cycle_chain; False keeps
+    # the PR-990 depth-1 legacy cycle.
+    chain: bool = False
+    depth: int = 1
+    # head_clone=True runs speculative head steps on a per-cycle cache clone
+    # (models whose head cache can't be exactly trimmed once rotated).
+    head_clone: bool = False
+    # Pending draft tokens for the next verify forward: (depth,) uint32 array.
+    # Host-side ids are read in the verify cycle's single sync, not here.
+    drafts: Optional[Any] = None
+    # Per-draft raw logprob rows (vocab,) — emitted as the accepted drafts'
+    # logprobs (PR 990 contract) — and sampler-filtered rows for stochastic
+    # acceptance. Lazy arrays; only evaluated if a consumer touches them.
+    draft_lps: List[Any] = field(default_factory=list)
+    draft_accept_lps: List[Any] = field(default_factory=list)
+    # MTP-head cache offset at cycle start. Chain entries beyond this offset
+    # are speculative and trimmed at commit; committed history is re-appended
+    # from verify-forward hidden rows so the head sees a dense, committed-only
+    # timeline.
+    hist_offset: int = 0
+    # Sampler for draft tokens (lazily resolved). For stochastic target
+    # samplers this is a *sharper* distribution than the target (temp 0.6 /
+    # top_p 0.95 / top_k 20) — the Leviathan/Chen acceptance ratio uses the
+    # true draft distribution q, so any q keeps the output distribution
+    # exact, and truncating the 1-layer head's noisy tail is what keeps
+    # acceptance usable on high-entropy content (creative prose collapses to
+    # ~10-20% with matched-temp drafts).
+    draft_sampler: Optional[Any] = None
+    # Adaptive depth controller (None = fixed depth). Chooses how many
+    # drafts the next chain builds from rolling accept/latency estimates.
+    controller: Optional[Any] = None
 
     # Accept-rate / throughput counters. Surfaced via logger.info on finish.
     stats: _MtpStats = field(default_factory=_MtpStats)
@@ -1032,6 +1084,12 @@ def _restore_or_trim_caches(prompt_cache: List[Any]) -> bool:
     """
     for c in prompt_cache:
         if getattr(c, "rollback_state", None) is not None:
+            # A draft stash marks the chain-path *pre-forward* snapshot
+            # semantics (qwen35_model unsplit verify); restoring it here
+            # would drop the confirmed token too. Only mtp_partial_rollback
+            # knows how to replay it — refuse so the caller falls back.
+            if getattr(c, "_mtp_draft_stash", None) is not None:
+                return False
             continue
         if hasattr(c, "is_trimmable") and c.is_trimmable():
             continue
@@ -1110,9 +1168,11 @@ def _call_backbone(
     if n_confirmed:
         kwargs["n_confirmed"] = n_confirmed
     _rollback_mod.set_undo_armed(True)
+    _set_verify_qmm_armed(True)
     try:
         result = model(inputs, **kwargs)
     finally:
+        _set_verify_qmm_armed(False)
         _rollback_mod.set_undo_armed(False)
 
     # LanguageModelOutput (mlx-vlm dataclass)
@@ -1134,6 +1194,8 @@ def _clear_rollback(prompt_cache: List[Any]) -> None:
     for c in prompt_cache:
         if hasattr(c, "rollback_state") and c.rollback_state is not None:
             c.rollback_state = None
+        if getattr(c, "_mtp_draft_stash", None) is not None:
+            c._mtp_draft_stash = None
         if getattr(c, "_mtp_undo", None) is not None:
             c._mtp_undo = None
         for sub in getattr(c, "caches", ()):
@@ -1148,6 +1210,299 @@ def _ensure_uint32(arr):
     if arr.dtype == mx.uint32:
         return arr
     return arr.astype(mx.uint32)
+
+
+# ---------------------------------------------------------------------------
+# Depth-k chained drafting helpers (Qwen3.5/3.6): a linear draft chain through
+# the MTP head, one batched verify forward covering all drafts plus a free
+# bonus row, offset-trim KV rollback with GDN prefix replay, and a
+# committed-only MTP-head history rebuilt from verify hidden rows each cycle.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_mtp_chain_depth(model: Any) -> Tuple[bool, int, bool]:
+    """Read the chain capability markers stamped on the model at load.
+
+    Returns ``(chain, depth, head_clone)``. ``head_clone`` marks models
+    whose MTP-head cache cannot be exactly trimmed (e.g. DeepSeek-V4's
+    RotatingKVCache head once rotated): the chain then runs its speculative
+    draft steps on a per-cycle clone and keeps the persistent head cache
+    committed-only, instead of trimming speculative entries afterwards.
+    """
+    candidates = [model]
+    for attr in ("language_model", "_language_model"):
+        inner = getattr(model, attr, None)
+        if inner is not None and inner is not model:
+            candidates.append(inner)
+    for candidate in candidates:
+        if getattr(candidate, "_omlx_mtp_chain", False):
+            depth = int(getattr(candidate, "_omlx_mtp_depth", 1) or 1)
+            head_clone = bool(getattr(candidate, "_omlx_mtp_head_clone", False))
+            return True, max(1, min(8, depth)), head_clone
+    return False, 1, False
+
+
+def _clone_mtp_head_cache(mtp_cache: List[Any]) -> List[Any]:
+    """Detached per-cycle copy of the MTP-head cache for speculative steps.
+
+    ``copy.copy`` keeps scalars; mx.array attributes are detached with
+    ``v + 0`` so the clone's in-place ring writes never mutate arrays the
+    persistent cache still references; list attributes are shallow-copied.
+    Container caches (``CacheList``-style, exposing ``.caches``) recurse.
+    """
+    import copy
+
+    import mlx.core as mx
+
+    def clone_one(c):
+        if c is None:
+            return None
+        subs = getattr(c, "caches", None)
+        if subs is not None:
+            return type(c)(*[clone_one(sub) for sub in subs])
+        new = copy.copy(c)
+        for attr, val in vars(c).items():
+            if isinstance(val, mx.array):
+                setattr(new, attr, val + 0)
+            elif isinstance(val, list):
+                setattr(new, attr, list(val))
+        return new
+
+    return [clone_one(c) for c in mtp_cache]
+
+
+def _trunk_norm_module(model: Any):
+    """Final RMSNorm of the backbone (for post_norm head inputs).
+
+    Walks both wrapper conventions: mlx-lm's outer ``Model.language_model``
+    and oMLX's ``VLMModelAdapter._language_model`` (mlx-vlm path).
+    """
+    inner = model
+    for attr in ("language_model", "_language_model"):
+        candidate = getattr(model, attr, None)
+        if candidate is not None:
+            inner = candidate
+            break
+    return inner.model.norm
+
+
+# The MTP head is fed the trunk's *post-norm* hidden and chains on its own
+# post-norm output. Measured on Qwen3.6-27B this accepts a few points higher
+# than PR 990's pre-norm at every depth. Draft-side only, so output identity
+# is unaffected regardless.
+_HEAD_HIDDEN_POST_NORM = True
+
+
+def _mtp_head_trim_to(mtp_cache: List[Any], offset: int) -> None:
+    """Trim speculative chain entries so the head cache ends at ``offset``."""
+    for c in mtp_cache:
+        current = int(getattr(c, "offset", 0))
+        extra = current - offset
+        if extra > 0:
+            c.trim(extra)
+
+
+class _DepthController:
+    """Adaptive draft-depth selection.
+
+    Pure host-side bookkeeping — no extra GPU syncs. Tracks EMA conditional
+    acceptance per depth position and EMA cycle wall-time per depth used,
+    then picks the depth with the best expected tokens/sec:
+
+        score(d) = (1 + p1 + p1*p2 + ... ) / t_est(d)
+
+    Re-evaluated every ADAPT_INTERVAL cycles with 3% switch hysteresis.
+    Deep positions go stale once the controller settles shallow, so every
+    PROBE_INTERVAL cycles it runs a short probe burst at max depth to
+    refresh their estimates. Content-adaptive by construction: prose/chat
+    settles at depth 1, code/predictable text climbs to 2-3.
+    """
+
+    ALPHA = 0.08  # EMA weight (~12-cycle memory)
+    ADAPT_INTERVAL = 16
+    PROBE_INTERVAL = 96
+    PROBE_LEN = 6
+    MARGINAL_MS = 7.0  # prior cost of one extra verify token (measured 6-10ms)
+    HYSTERESIS = 1.03
+
+    def __init__(self, max_depth: int):
+        self.max_depth = max(1, int(max_depth))
+        self.cur = self.max_depth  # start deep so deep stats populate early
+        self.p = [0.6] * self.max_depth
+        self.t: Dict[int, float] = {}
+        self.cycles = 0
+        self.probe_left = 0
+
+    def observe(self, used: int, accepted: int, cycle_ms: float) -> None:
+        a = self.ALPHA
+        self.cycles += 1
+        for j in range(used):
+            hit = 1.0 if j < accepted else 0.0
+            self.p[j] = (1.0 - a) * self.p[j] + a * hit
+            if j >= accepted:
+                break
+        prev = self.t.get(used)
+        self.t[used] = cycle_ms if prev is None else (1.0 - a) * prev + a * cycle_ms
+        if self.probe_left > 0:
+            self.probe_left -= 1
+            if self.probe_left == 0:
+                self.cur = self._best()
+            return
+        if self.cycles % self.ADAPT_INTERVAL == 0:
+            self.cur = self._best()
+        if (
+            self.max_depth > 1
+            and self.cur < self.max_depth
+            and self.cycles % self.PROBE_INTERVAL == 0
+        ):
+            self.cur = self.max_depth
+            self.probe_left = self.PROBE_LEN
+
+    def _t_est(self, d: int) -> float:
+        if d in self.t:
+            return self.t[d]
+        if not self.t:
+            return 30.0 + self.MARGINAL_MS * d
+        ref = min(self.t, key=lambda x: abs(x - d))
+        return self.t[ref] + self.MARGINAL_MS * (d - ref)
+
+    def _score(self, d: int) -> float:
+        expected = 1.0
+        run = 1.0
+        for j in range(d):
+            run *= self.p[j]
+            expected += run
+        return expected / max(1e-6, self._t_est(d))
+
+    def _best(self) -> int:
+        cur_score = self._score(self.cur)
+        best_d, best_score = self.cur, cur_score
+        for d in range(1, self.max_depth + 1):
+            s = self._score(d)
+            if s > best_score:
+                best_d, best_score = d, s
+        if best_d != self.cur and best_score < cur_score * self.HYSTERESIS:
+            return self.cur
+        return best_d
+
+
+# Draft sampler for stochastic (temp > 0) decoding. A sharper distribution
+# than the target: the 1-layer head's noisy tail otherwise gets sampled and
+# rejected, collapsing acceptance on high-entropy content. Exactness holds
+# because the Leviathan/Chen ratio uses this sampler's own distribution as q.
+_DRAFT_SAMPLER_TEMP = 0.6
+_DRAFT_SAMPLER_TOP_P = 0.95
+_DRAFT_SAMPLER_TOP_K = 20
+
+
+def _resolve_draft_sampler(gen_batch: Any, state: _MtpState):
+    """Sampler used to draw MTP draft tokens.
+
+    Greedy target → greedy drafts (preserves the greedy-identity contract).
+    Stochastic target → the sharper draft sampler above. The acceptance ratio
+    and residual sampling use this sampler's filtered distribution as q, so
+    the emitted token distribution still equals the target sampler's exactly.
+    """
+    if state.draft_sampler is not None:
+        return state.draft_sampler
+    if _is_greedy(gen_batch):
+        state.draft_sampler = _resolve_sampler(gen_batch)
+        return state.draft_sampler
+
+    from omlx.utils.sampling import make_sampler
+
+    state.draft_sampler = make_sampler(
+        temp=_DRAFT_SAMPLER_TEMP,
+        top_p=_DRAFT_SAMPLER_TOP_P,
+        top_k=_DRAFT_SAMPLER_TOP_K,
+    )
+    return state.draft_sampler
+
+
+def _chain_next_drafts(
+    gen_batch: Any,
+    state: _MtpState,
+    hidden_rows: Any,
+    committed: Any,
+    prev_buf: Optional[Any],
+) -> None:
+    """Rebuild committed MTP-head history and draft the next chain.
+
+    ``hidden_rows`` is the trunk hidden at the positions of the n tokens
+    *preceding* each committed token — (1, n, H) pre-norm for Qwen (the
+    final trunk norm is applied here), or the model's native 4D raw hidden
+    for DeepSeek-V4 (passed through untouched); ``committed`` is the (n,)
+    uint32 committed tokens. One batched head forward appends n committed
+    history entries and yields the next cycle's first draft logits for free
+    (its last entry pairs the newest committed token with the hidden of its
+    predecessor — exactly the fused state that predicts the next-next token).
+    The remaining drafts chain on the head's own output hidden; with
+    ``state.head_clone`` those speculative steps run on a per-cycle clone so
+    the persistent head cache stays committed-only.
+
+    Populates ``state.drafts`` / ``draft_lps`` / ``draft_accept_lps`` and
+    advances ``state.hist_offset`` by n. All arrays are dispatched with
+    ``mx.async_eval`` and stay lazy on the host; the next verify cycle's
+    single sync resolves them.
+    """
+    import mlx.core as mx
+
+    model = gen_batch.model
+    sampler = _resolve_draft_sampler(gen_batch, state)
+    procs = _proc_list(gen_batch)
+
+    if _HEAD_HIDDEN_POST_NORM and hidden_rows.ndim == 3:
+        hidden_rows = _trunk_norm_module(model)(hidden_rows)
+
+    n = committed.shape[0]
+    logits, head_hidden = model.mtp_forward(
+        hidden_rows,
+        committed.reshape(1, n),
+        state.mtp_cache,
+        return_hidden=True,
+        logits_keep=1,
+    )
+    state.hist_offset += int(n)
+
+    draft_toks: List[Any] = []
+    draft_lps: List[Any] = []
+    draft_accept_lps: List[Any] = []
+
+    chain_prefix = committed[-1:]
+    h = head_hidden[:, -1:]
+    depth = state.controller.cur if state.controller is not None else state.depth
+    chain_cache = state.mtp_cache
+    if state.head_clone and depth > 1:
+        chain_cache = _clone_mtp_head_cache(state.mtp_cache)
+    for j in range(depth):
+        logits_2d = logits[:, -1, :]
+        if procs is not None and prev_buf is not None:
+            prev = mx.concatenate(
+                [prev_buf.astype(mx.int32), chain_prefix.astype(mx.int32)]
+                + [t.reshape(1).astype(mx.int32) for t in draft_toks]
+            )
+            logits_2d = _apply_processors(procs, prev, logits_2d)
+        lp_2d = _logprobs(logits_2d)
+        tok = _ensure_uint32(sampler(lp_2d))
+        draft_toks.append(tok)
+        draft_lps.append(lp_2d.squeeze(0))
+        draft_accept_lps.append(_accept_lp_for(sampler, lp_2d).squeeze(0))
+        if j + 1 == depth:
+            break
+        logits, head_hidden = model.mtp_forward(
+            h,
+            tok.reshape(1, 1),
+            chain_cache,
+            return_hidden=True,
+        )
+        h = head_hidden[:, -1:]
+
+    state.drafts = mx.concatenate(draft_toks)
+    state.draft_lps = draft_lps
+    state.draft_accept_lps = draft_accept_lps
+    # Fire-and-forget dispatch: the GPU evaluates the chain while the host
+    # finishes emit bookkeeping; the next cycle's sync finds it materialized.
+    mx.async_eval(state.drafts)
 
 
 # ---------------------------------------------------------------------------
@@ -1204,6 +1559,35 @@ def _post_init_mtp(gen_batch: Any) -> None:
     next_main_logits = _apply_processors(procs, prev_buf, next_main_logits)
     next_main_lp = _logprobs(next_main_logits)
     next_main_tok = sampler(next_main_lp)  # (1,)
+
+    chain, depth, head_clone = _resolve_mtp_chain_depth(gen_batch.model)
+
+    if chain:
+        # Depth-k seed: the history fold pairs hidden(main_tok) with
+        # next_main_tok — the first committed history entry — and its logits
+        # are the first draft's distribution; the rest of the chain follows.
+        mx.eval(main_tok, next_main_tok)
+        state = _MtpState(uid=gen_batch.uids[0])
+        state.chain = True
+        state.depth = depth
+        state.head_clone = head_clone
+        if depth > 1:
+            state.controller = _DepthController(depth)
+        state.mtp_cache = gen_batch.model.make_mtp_cache()
+        state.next_main = _ensure_uint32(next_main_tok)
+        state.queue.append((int(main_tok.tolist()[0]), main_lp, "init"))
+        state.queue.append(
+            (int(next_main_tok.tolist()[0]), next_main_lp.squeeze(0), "init")
+        )
+        _chain_next_drafts(
+            gen_batch,
+            state,
+            hidden[:, -1:],
+            state.next_main,
+            prev_buf,
+        )
+        gen_batch._omlx_mtp_state = state
+        return
 
     # MTP head sees (hidden_at_main, next_main_tok) and proposes the draft
     # that the *next* verify cycle will check against forward([next_main, draft]).
@@ -1392,21 +1776,34 @@ def _log_mtp_stats(uid: Any, stats: "_MtpStats", finish_reason: str) -> None:
     total_emits = (
         stats.init_emits + stats.draft_emits + stats.bonus_emits + stats.verify_emits
     )
-    if stats.cycles > 0:
-        rate_str = f"{stats.accepts / stats.cycles * 100:.1f}%"
+    total_drafted = sum(stats.depth_drafted) or stats.cycles
+    if total_drafted > 0:
+        rate_str = f"{stats.accepts / total_drafted * 100:.1f}%"
     else:
         rate_str = "n/a"
+    if stats.depth_drafted:
+        depth_str = " depth[" + ",".join(
+            f"d{i + 1}={a}/{d}"
+            for i, (a, d) in enumerate(
+                zip(stats.depth_accepted, stats.depth_drafted)
+            )
+        ) + "]"
+    else:
+        depth_str = ""
+    tpc = total_emits / stats.cycles if stats.cycles else 0.0
     logger.info(
-        "MTP[%s] finish=%s tokens=%d cycles=%d accept=%d/%d (%s) "
+        "MTP[%s] finish=%s tokens=%d cycles=%d tok/cycle=%.2f accept=%d/%d (%s)%s "
         "emits[init=%d,draft=%d,bonus=%d,verify=%d] "
         "timing[backbone=%.1fms mtp=%.1fms sample=%.1fms cache=%.1fms]",
         uid,
         finish_reason,
         total_emits,
         stats.cycles,
+        tpc,
         stats.accepts,
-        stats.cycles,
+        total_drafted,
         rate_str,
+        depth_str,
         stats.init_emits,
         stats.draft_emits,
         stats.bonus_emits,
@@ -1435,6 +1832,233 @@ def _bump_emit_stat(state: _MtpState, source: str) -> None:
 
 
 def _run_verify_cycle(gen_batch: Any, state: _MtpState) -> None:
+    """Dispatch to the depth-k chain cycle or the PR-990 depth-1 legacy cycle."""
+    if state.chain:
+        return _run_verify_cycle_chain(gen_batch, state)
+    return _run_verify_cycle_legacy(gen_batch, state)
+
+
+def _run_verify_cycle_chain(gen_batch: Any, state: _MtpState) -> None:
+    """One depth-k verify cycle.
+
+    Verify ``[next_main, d1..dk]`` in a single backbone forward with
+    ``n_confirmed=1``. Greedy acceptance is computed in-graph, so the whole
+    cycle costs exactly ONE host sync (a ~2k-int ``tolist``); the next draft
+    chain is dispatched with ``mx.async_eval`` and resolves inside the next
+    cycle's sync. Emits ``m + 1`` tokens per cycle (m = accepted drafts, plus
+    bonus on full accept or the verify-position correction on reject).
+    """
+    import time
+
+    import mlx.core as mx
+
+    if state.next_main is None or state.drafts is None:
+        raise _MtpStepFallback("chain cycle entered without next_main / drafts")
+
+    sampler = _resolve_sampler(gen_batch)
+    procs = _proc_list(gen_batch)
+    is_greedy = _is_greedy(gen_batch)
+    # Adaptive depth: the chain may have drafted fewer than state.depth
+    # tokens this cycle — the verify window follows the actual drafts.
+    k = int(state.drafts.shape[0])
+    cycle_t0 = time.perf_counter()
+
+    inputs = mx.concatenate([state.next_main, state.drafts])  # (k+1,)
+
+    # Token buffer per input position (mirrors PR 990 _step_backbone). Row j's
+    # processor prefix is everything before that input position.
+    prev_rows: List[Optional[Any]] = [None] * (k + 1)
+    if procs is not None:
+        buf = gen_batch._token_context[0]
+        prev_rows[0] = buf.update_and_fetch(state.next_main)
+        for j in range(k):
+            prev_rows[j + 1] = buf.update_and_fetch(state.drafts[j : j + 1])
+
+    # --- backbone verify forward + single host sync ---
+    t0 = time.perf_counter()
+    logits, hidden, gdn_states = _call_backbone(
+        gen_batch.model,
+        inputs[None, :],
+        gen_batch.prompt_cache,
+        n_confirmed=1,
+    )
+    rows = logits[0]  # (k+1, vocab)
+    if procs is not None:
+        rows = mx.stack(
+            [
+                _apply_processors(procs, prev_rows[j], rows[j : j + 1]).squeeze(0)
+                for j in range(k + 1)
+            ]
+        )
+    combined_lp = rows - mx.logsumexp(rows, axis=-1, keepdims=True)  # (k+1, V)
+
+    if is_greedy:
+        targets = mx.argmax(rows, axis=-1).astype(mx.int32)  # (k+1,)
+        matches = (targets[:k] == state.drafts.astype(mx.int32)).astype(mx.int32)
+        m_arr = mx.cumprod(matches).sum().reshape(1)
+        host = mx.concatenate(
+            [m_arr, targets, state.drafts.astype(mx.int32)]
+        ).tolist()
+        m = int(host[0])
+        target_ids = host[1 : k + 2]
+        draft_ids = host[k + 2 :]
+        state.stats.backbone_ms += (time.perf_counter() - t0) * 1000
+        t0 = time.perf_counter()
+        emit_last_id = target_ids[m] if m < k else target_ids[k]
+        emit_last_lp = combined_lp[m if m < k else k]
+    else:
+        # Stochastic: batched Leviathan/Chen acceptance computed in-graph —
+        # per-position ratios of the filtered target rows (p) against the
+        # draft sampler's filtered rows (q), cumulative accept, residual
+        # samples for every position, and the bonus draw, all resolved in
+        # ONE host sync (mirrors the greedy path's sync structure).
+        accept_rows = _accept_lp_for(sampler, combined_lp)  # (k+1, V)
+        q_rows = mx.stack(state.draft_accept_lps)  # (k, V)
+        idx = state.drafts.astype(mx.int32)[:, None]
+        p_at = mx.take_along_axis(accept_rows[:k], idx, axis=-1).squeeze(-1)
+        q_at = mx.take_along_axis(q_rows, idx, axis=-1).squeeze(-1)
+        ratio = p_at - q_at  # (k,) log acceptance ratios
+        u = mx.random.uniform(shape=(k,))
+        acc = mx.logical_or(ratio >= 0, mx.log(u) < ratio)
+        m_arr = mx.cumprod(acc.astype(mx.int32)).sum().reshape(1)
+        # Residual distributions max(p - q, 0) per draft position. Only the
+        # reject position's sample is used; computing all k keeps the cycle
+        # single-sync and costs a few elementwise vocab ops on GPU.
+        p_all = mx.exp(accept_rows[:k])
+        res = mx.maximum(p_all - mx.exp(q_rows), 0.0)
+        z = res.sum(axis=-1, keepdims=True)
+        res_dist = mx.where(z > 0, res, p_all)
+        res_samples = mx.random.categorical(mx.log(res_dist))  # (k,)
+        bonus_tok = sampler(combined_lp[k : k + 1]).reshape(1)
+        host = mx.concatenate(
+            [
+                m_arr.astype(mx.int32),
+                state.drafts.astype(mx.int32),
+                res_samples.astype(mx.int32),
+                bonus_tok.astype(mx.int32),
+            ]
+        ).tolist()
+        m = int(host[0])
+        draft_ids = host[1 : k + 1]
+        res_ids = host[k + 1 : 2 * k + 1]
+        bonus_id = host[2 * k + 1]
+        state.stats.backbone_ms += (time.perf_counter() - t0) * 1000
+        t0 = time.perf_counter()
+        if m < k:
+            emit_last_id = res_ids[m]
+            emit_last_lp = combined_lp[m]
+        else:
+            emit_last_id = bonus_id
+            emit_last_lp = combined_lp[k]
+
+    # Clamp the accepted count to what every cache layer can roll back
+    # (optional model hook — DeepSeek-V4 PoolingCache replay windows are
+    # bounded). Emitting fewer verified drafts is always correct; position
+    # ``m`` was itself accepted when the clamp lowers it, so its draft
+    # token is a fair emit for the correction slot.
+    if m < k:
+        clamp = getattr(gen_batch.model, "mtp_clamp_accept", None)
+        if callable(clamp):
+            clamped = int(clamp(gen_batch.prompt_cache, m, k))
+            if clamped < m:
+                m = clamped
+                emit_last_id = draft_ids[m]
+                emit_last_lp = combined_lp[m]
+
+    # --- stats ---
+    state.stats.cycles += 1
+    if len(state.stats.depth_drafted) < state.depth:
+        pad = state.depth - len(state.stats.depth_drafted)
+        state.stats.depth_drafted.extend([0] * pad)
+        state.stats.depth_accepted.extend([0] * pad)
+    for j in range(k):
+        state.stats.depth_drafted[j] += 1
+        if j < m:
+            state.stats.depth_accepted[j] += 1
+        else:
+            break
+    state.stats.accepts += m
+    if m < k:
+        state.stats.rejects += 1
+    state.stats.sample_ms += (time.perf_counter() - t0) * 1000
+
+    # --- commit: queue emits + cache rollback ---
+    t0 = time.perf_counter()
+    for j in range(m):
+        state.queue.append((int(draft_ids[j]), state.draft_lps[j], "draft"))
+    if m == k:
+        state.queue.append((int(emit_last_id), emit_last_lp, "bonus"))
+        _clear_rollback(gen_batch.prompt_cache)
+    else:
+        state.queue.append((int(emit_last_id), emit_last_lp, "verify"))
+        if not _chain_rollback(
+            gen_batch.model, gen_batch.prompt_cache, m, k, gdn_states
+        ):
+            if procs is not None:
+                _trim_token_buffer(gen_batch, k - m)
+            raise _MtpStepFallback("cache layer rejects chain rollback")
+        if procs is not None:
+            _trim_token_buffer(gen_batch, k - m)
+    state.stats.cache_ops_ms += (time.perf_counter() - t0) * 1000
+
+    # --- MTP-head history + next draft chain (async-dispatched) ---
+    t0 = time.perf_counter()
+    if not state.head_clone:
+        _mtp_head_trim_to(state.mtp_cache, state.hist_offset)
+    committed = mx.array(
+        [int(d) for d in draft_ids[:m]] + [int(emit_last_id)], dtype=mx.uint32
+    )
+    next_main = committed[-1:]
+    hidden_rows = hidden[:, : m + 1]
+    prev_buf = None
+    if procs is not None:
+        prev_buf = gen_batch._token_context[0].tokens
+    _chain_next_drafts(gen_batch, state, hidden_rows, committed, prev_buf)
+    state.next_main = next_main
+    state.stats.mtp_head_ms += (time.perf_counter() - t0) * 1000
+    if state.controller is not None:
+        state.controller.observe(
+            k, m, (time.perf_counter() - cycle_t0) * 1000
+        )
+
+
+def _chain_rollback(
+    model: Any,
+    prompt_cache: List[Any],
+    accepted: int,
+    num_drafts: int,
+    gdn_states: Optional[list] = None,
+) -> bool:
+    """Roll the backbone cache back to ``accepted`` drafts after a chain verify.
+
+    mlx-vlm path (``gdn_states`` populated): delegate to the stock
+    ``rollback_speculative_cache``, which natively supports partial accepts —
+    it keeps ``accepted + 1`` positions of the ``num_drafts + 1``-token
+    verify window and replays the accepted prefix through the captured GDN
+    states. mlx-lm path: ``mtp_partial_rollback`` (qwen35_model patch).
+    """
+    if gdn_states is not None and hasattr(model, "rollback_speculative_cache"):
+        try:
+            model.rollback_speculative_cache(
+                prompt_cache, gdn_states, accepted, num_drafts + 1
+            )
+            return True
+        except Exception as exc:
+            logger.debug("rollback_speculative_cache failed: %s", exc)
+            return False
+    rollback = getattr(model, "mtp_partial_rollback", None)
+    if callable(rollback):
+        try:
+            return bool(rollback(prompt_cache, accepted, num_drafts))
+        except Exception as exc:
+            logger.debug("mtp_partial_rollback failed: %s", exc)
+            return False
+    if accepted == 0 and num_drafts == 1:
+        return _restore_or_trim_caches(prompt_cache)
+    return False
+
+
+def _run_verify_cycle_legacy(gen_batch: Any, state: _MtpState) -> None:
     """Run one verify cycle. Populates ``state.queue`` with 1 (reject) or 2
     (accept) tokens for upcoming emit calls. Updates ``state.next_main`` and
     ``state.draft_tok`` / ``state.draft_lp`` for the cycle after that.

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -1951,6 +1951,23 @@ def _run_verify_cycle_chain(gen_batch: Any, state: _MtpState) -> None:
             emit_last_id = bonus_id
             emit_last_lp = combined_lp[k]
 
+    # Boundary-aligned commit: when the scheduler needs block-boundary
+    # cache snapshots (hybrid models), land the committed run exactly on
+    # the next block boundary whenever it falls inside the accepted
+    # drafts. The emit-time snapshot capture can then observe the boundary
+    # state (cache offset == emitted count), which the emit queue's
+    # run-ahead otherwise makes rare. Emitting fewer verified drafts is
+    # distribution-exact; the cost is at most depth-1 verified tokens once
+    # per block.
+    align = int(getattr(gen_batch.model, "_omlx_mtp_commit_align", 0) or 0)
+    if align > 0 and m > 0:
+        emitted = len(gen_batch.tokens[0])
+        aligned = ((emitted // align) + 1) * align - emitted
+        if 0 < aligned < m:
+            m = aligned
+            emit_last_id = draft_ids[m]
+            emit_last_lp = combined_lp[m]
+
     # Clamp the accepted count to what every cache layer can roll back
     # (optional model hook — DeepSeek-V4 PoolingCache replay windows are
     # bounded). Emitting fewer verified drafts is always correct; position

--- a/omlx/patches/mlx_lm_mtp/cache_rollback.py
+++ b/omlx/patches/mlx_lm_mtp/cache_rollback.py
@@ -65,8 +65,9 @@ def _wrap_rotating(cls, fields) -> None:
     def update_and_fetch(self, keys, values):
         # Only armed verify-sized updates are undoable: S == 1 uses the
         # in-place ring write (setitem invalidates reference snapshots) and
-        # prompt chunks have no rollback consumer.
-        if keys.shape[2] == 2 and _is_undo_armed():
+        # prompt chunks have no rollback consumer. The upper bound covers
+        # depth-k chain verify windows (k + 1 tokens).
+        if 2 <= keys.shape[2] <= 8 and _is_undo_armed():
             snap = {}
             for f in fields:
                 v = getattr(self, f)

--- a/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
+++ b/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
@@ -273,6 +273,16 @@ def _patch_model(dsv4: Any) -> None:
         if mtp_decode_enabled:
             n_main = config.num_hidden_layers
             self.mtp = [dsv4.MTPBlock(config, n_main + i) for i in range(n_mtp)]
+            # Depth-k chained drafting is available: mtp_forward supports
+            # return_hidden below, backbone rollback goes through
+            # mtp_partial_rollback, and the head cache is a RotatingKVCache
+            # (not exactly trimmable once rotated) so the chain runs its
+            # speculative head steps on a per-cycle clone.
+            from . import get_mtp_depth
+
+            self._omlx_mtp_chain = True
+            self._omlx_mtp_depth = get_mtp_depth()
+            self._omlx_mtp_head_clone = True
 
     def __call__(
         self,
@@ -331,7 +341,14 @@ def _patch_model(dsv4: Any) -> None:
                 )
         return caches
 
-    def mtp_forward(self, h, input_ids, cache=None):
+    def mtp_forward(
+        self,
+        h,
+        input_ids,
+        cache=None,
+        return_hidden: bool = False,
+        logits_keep: int = 0,
+    ):
         """Run the chained MTP blocks + final hc_head/norm/lm_head on a 4D hidden.
 
         Mirrors PR 15: each MTP block fuses ``h`` with the embedded
@@ -339,6 +356,13 @@ def _patch_model(dsv4: Any) -> None:
         passes the result through a ``DeepseekV4Block``. The last block's
         ``hc_head`` collapses the Hyper-head dimension before ``norm`` and
         the shared ``lm_head`` produce logits.
+
+        ``return_hidden`` additionally returns the last block's raw 4D
+        output — the chain feeds it back as the next draft step's ``h``
+        (the same contract the block sees when consuming trunk hidden).
+        ``logits_keep`` limits the hc_head/norm/lm_head tail to the last N
+        positions (0 = all); the chain's history+draft fold only needs the
+        final position and the vocab is large enough that it matters.
         """
         if cache is None:
             cache = [None] * len(self.mtp)
@@ -364,9 +388,74 @@ def _patch_model(dsv4: Any) -> None:
 
         materialize_cache_arrays(cache)
 
-        out = last_block.hc_head(h)
+        logits_source = h
+        if logits_keep and logits_source.shape[1] > logits_keep:
+            logits_source = logits_source[:, -logits_keep:]
+        out = last_block.hc_head(logits_source)
         out = last_block.norm(out)
-        return self.lm_head(out)
+        logits = self.lm_head(out)
+        if return_hidden:
+            return logits, h
+        return logits
+
+    def _cache_can_trim(c, n: int) -> bool:
+        """Non-mutating check that ``c.trim(n)`` will succeed.
+
+        Needed because a failed ``trim`` on one layer after earlier layers
+        already trimmed leaves per-layer lengths desynchronised (the hazard
+        ``_restore_or_trim_caches`` documents). PoolingCaches expose the
+        exact undo feasibility; rotating caches accept the trim while the
+        armed undo (or an unrotated buffer) covers it.
+        """
+        if isinstance(c, CacheList):
+            return all(_cache_can_trim(sub, n) for sub in c.caches)
+        remainder = getattr(c, "remainder", None)
+        if remainder is not None:  # PoolingCache / BatchPoolingCache
+            rem_min = remainder if isinstance(remainder, int) else min(remainder)
+            if n <= rem_min:
+                return True
+            can_undo = getattr(c, "_can_undo", None)
+            return bool(can_undo and can_undo(n))
+        is_trimmable = getattr(c, "is_trimmable", None)
+        if callable(is_trimmable) and is_trimmable():
+            return True
+        # Rotated RotatingKVCache: the cache_rollback undo stash covers the
+        # last armed multi-token write.
+        undo = getattr(c, "_mtp_undo", None)
+        if undo is not None:
+            return undo[1].shape[2] >= n
+        return False
+
+    def mtp_clamp_accept(self, cache, accepted: int, num_drafts: int) -> int:
+        """Largest ``m' <= accepted`` whose rollback every layer supports.
+
+        Emitting fewer verified drafts than the acceptance test allowed is
+        always correct (the skipped ones are re-derived next cycle); it
+        just wastes a little verified work. This keeps the chain alive when
+        a PoolingCache can't replay a longer confirmed prefix (its pooled
+        windows can't be reconstructed inside ``trim``).
+        """
+        for m in range(accepted, -1, -1):
+            n = num_drafts - m
+            if n <= 0 or all(_cache_can_trim(c, n) for c in cache):
+                return m
+        return 0
+
+    def mtp_partial_rollback(self, cache, accepted: int, num_drafts: int) -> bool:
+        """Trim the verify window back to ``accepted`` drafts on every layer."""
+        n = num_drafts - accepted
+        if n <= 0:
+            return True
+        if not all(_cache_can_trim(c, n) for c in cache):
+            return False
+        for c in cache:
+            if c.trim(n) != n:
+                logger.warning(
+                    "DeepSeek-V4 MTP rollback trim shortfall on %s",
+                    type(c).__name__,
+                )
+                return False
+        return True
 
     def sanitize(self, weights: Dict[str, Any]) -> Dict[str, Any]:
         """Combined oMLX-base + PR 15 sanitize.
@@ -548,4 +637,6 @@ def _patch_model(dsv4: Any) -> None:
     cls.__call__ = __call__
     cls.mtp_forward = mtp_forward
     cls.make_mtp_cache = make_mtp_cache
+    cls.mtp_clamp_accept = mtp_clamp_accept
+    cls.mtp_partial_rollback = mtp_partial_rollback
     cls.sanitize = sanitize

--- a/omlx/patches/mlx_lm_mtp/glm_moe_dsa_model.py
+++ b/omlx/patches/mlx_lm_mtp/glm_moe_dsa_model.py
@@ -1,0 +1,459 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GLM-5.2 (glm_moe_dsa) native MTP head for the depth-k chain cycle.
+
+GLM-5.2's checkpoint carries one extra decoder layer (index
+``num_hidden_layers``) that implements DeepSeek-V3-style multi-token
+prediction: the trunk's post-norm hidden and the embedding of the next
+token are each RMSNorm'd (``hnorm`` / ``enorm``), concatenated, projected
+back to ``hidden_size`` (``eh_proj``), and run through one full
+``GlmMoeDsaDecoderLayer`` (own DSA indexer + 256-expert MoE); logits come
+from ``shared_head.norm`` + the shared ``lm_head``. The layer is trained
+as the speculative draft model, so it slots straight into the chain cycle.
+
+oMLX registers the GLM base model via ``omlx/patches/glm_moe_dsa/``
+(landing it in ``sys.modules['mlx_lm.models.glm_moe_dsa']``); this patch
+sits on top and adds the MTP module + ``mtp_forward`` / ``make_mtp_cache``
+plus the sanitize handling that keeps and remaps the extra layer's
+weights (``model.layers.<n>.*`` -> ``mtp.<i>.*``). Apply order matches
+deepseek_v4_model: the caller runs ``apply()`` after the base patch has
+registered the module.
+
+Convention notes (draft-quality critical):
+
+- The trunk hidden the head consumes is the *post-final-norm* hidden —
+  the same tensor the trunk's own lm_head reads. ``batch_generator``
+  applies the trunk norm on 3D hidden rows (``_HEAD_HIDDEN_POST_NORM``),
+  so the patched backbone ``__call__`` returns the raw pre-norm hidden.
+- Chained depth>1 steps feed the head block's raw residual output back
+  as the next ``h``; ``hnorm`` re-normalises it inside ``mtp_forward``.
+- The head runs its own DSA indexer (the checkpoint ships indexer
+  weights for the MTP layer, and the freq/offset pattern marks it
+  "full"). ``index_share_for_mtp_iteration`` reuse of trunk indices is a
+  possible future draft-cost optimisation, not a correctness knob.
+
+Rollback: every cache in play (latent KV + indexer KV, head and trunk)
+is a plain trimmable ``KVCache``, so draft rejection uses stock ``trim``
+— no rotating-cache undo, no clamp, and the chain runs directly on the
+persistent head cache (``_omlx_mtp_head_clone = False``).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def _is_our_method(cls: Any, attr: str, marker: str) -> bool:
+    existing = cls.__dict__.get(attr)
+    return getattr(existing, marker, False)
+
+
+def apply() -> bool:
+    """Apply the GLM MTP model-side patches when the base patch is active."""
+    glm = sys.modules.get("mlx_lm.models.glm_moe_dsa")
+    if glm is None or not hasattr(glm, "Model"):
+        logger.debug(
+            "glm_moe_dsa module not registered; skipping MTP patch (this is "
+            "expected for non-GLM models)"
+        )
+        return False
+
+    _patch_model_args(glm)
+    _register_mtp_block(glm)
+    _patch_glm_model_call(glm)
+    _patch_model(glm)
+
+    if not hasattr(glm.Model, "_omlx_mtp_patched"):
+        glm.Model._omlx_mtp_patched = "patch"
+        logger.info("GLM-5.2 MTP model patch applied")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# ModelArgs — carry num_nextn_predict_layers and extend indexer_types to
+# cover MTP layers.
+# ---------------------------------------------------------------------------
+
+def _patch_model_args(glm: Any) -> None:
+    """Wrap ``ModelArgs.from_dict`` so MTP layers are constructible.
+
+    ``num_nextn_predict_layers`` isn't a declared field (BaseModelArgs
+    filters unknown keys), and ``indexer_types`` only spans the backbone,
+    so ``GlmMoeDsaAttention(config, n_main + i)`` would IndexError. The
+    wrapper stashes the count and appends indexer types for the MTP
+    layers using the same freq/offset formula as ``__post_init__``.
+    """
+    args_cls = glm.ModelArgs
+    if "_omlx_mtp_args_patched" in args_cls.__dict__:
+        return
+
+    original_from_dict = args_cls.from_dict.__func__
+
+    def patched_from_dict(cls, params):
+        args = original_from_dict(cls, params)
+        n_mtp = int(params.get("num_nextn_predict_layers", 0) or 0)
+        args.num_nextn_predict_layers = n_mtp
+        if n_mtp > 0 and isinstance(args.indexer_types, list):
+            n_main = int(args.num_hidden_layers)
+            freq = max(int(getattr(args, "index_topk_freq", 1) or 1), 1)
+            offset = int(getattr(args, "index_skip_topk_offset", 2) or 0)
+            # Copy before extending — the list is shared with the caller's
+            # config dict and must not grow in place.
+            types = list(args.indexer_types)
+            while len(types) < n_main + n_mtp:
+                i = len(types)
+                types.append(
+                    "full" if (max(i - offset + 1, 0) % freq) == 0 else "shared"
+                )
+            args.indexer_types = types
+        return args
+
+    args_cls.from_dict = classmethod(patched_from_dict)
+    args_cls._omlx_mtp_args_patched = True
+
+
+# ---------------------------------------------------------------------------
+# GlmMTPBlock — register on the module.
+# ---------------------------------------------------------------------------
+
+def _register_mtp_block(glm: Any) -> None:
+    if hasattr(glm, "GlmMTPBlock"):
+        return
+
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    GlmMoeDsaDecoderLayer = glm.GlmMoeDsaDecoderLayer
+
+    class GlmMTPBlock(nn.Module):
+        """One MTP layer: enorm/hnorm fusion + a full GLM decoder layer.
+
+        ``norm`` holds the checkpoint's ``shared_head.norm`` — applied to
+        the block output before the shared lm_head (mtp_forward does the
+        lm_head so ``logits_keep`` can shrink the vocab matmul).
+        """
+
+        def __init__(self, config, layer_idx: int):
+            super().__init__()
+            dim = config.hidden_size
+            self.enorm = nn.RMSNorm(dim, eps=config.rms_norm_eps)
+            self.hnorm = nn.RMSNorm(dim, eps=config.rms_norm_eps)
+            self.eh_proj = nn.Linear(2 * dim, dim, bias=False)
+            self.norm = nn.RMSNorm(dim, eps=config.rms_norm_eps)
+            self.block = GlmMoeDsaDecoderLayer(config, layer_idx)
+
+        def __call__(self, h, embed_tokens, input_ids, mask, cache):
+            e = self.enorm(embed_tokens(input_ids))
+            x = self.eh_proj(mx.concatenate([e, self.hnorm(h)], axis=-1))
+            x, _ = self.block(x, mask, cache, None)
+            return x
+
+    glm.GlmMTPBlock = GlmMTPBlock
+
+
+# ---------------------------------------------------------------------------
+# GlmMoeDsaModel — return_raw_hidden support.
+# ---------------------------------------------------------------------------
+
+def _patch_glm_model_call(glm: Any) -> None:
+    """Replace ``GlmMoeDsaModel.__call__`` to optionally return the raw hidden."""
+    cls = glm.GlmMoeDsaModel
+    if _is_our_method(cls, "__call__", "_omlx_mtp_call_marker"):
+        return
+
+    import mlx.core as mx
+    from mlx_lm.models.base import create_attention_mask
+
+    def __call__(self, x, cache=None, return_raw_hidden: bool = False):
+        h = self.embed_tokens(x)
+
+        pipeline_rank = self.pipeline_rank
+        pipeline_size = self.pipeline_size
+
+        if cache is None:
+            cache = [None] * self.num_layers
+        mask = create_attention_mask(
+            h, cache[0][0] if cache[0] else None, return_array=True
+        )
+
+        if pipeline_rank < pipeline_size - 1:
+            h = mx.distributed.recv_like(h, (pipeline_rank + 1))
+
+        prev_topk_indices = None
+        for i in range(self.num_layers):
+            h, prev_topk_indices = self.layers[self.start_idx + i](
+                h, mask, cache[i], prev_topk_indices
+            )
+
+        if pipeline_rank != 0:
+            h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
+            if cache[-1] is not None:
+                cache[-1][0].keys = mx.depends(cache[-1][0].keys, h)
+
+        if pipeline_size > 1:
+            h = mx.distributed.all_gather(h)[: h.shape[0]]
+
+        out = self.norm(h)
+        if return_raw_hidden:
+            return out, h
+        return out
+
+    __call__._omlx_mtp_call_marker = True
+    cls.__call__ = __call__
+
+
+# ---------------------------------------------------------------------------
+# Model — wrap __init__, replace __call__, add mtp_forward / make_mtp_cache,
+# wrap sanitize with the MTP weight remapping.
+# ---------------------------------------------------------------------------
+
+def _patch_model(glm: Any) -> None:
+    cls = glm.Model
+    init_wrapped = getattr(cls, "_omlx_mtp_init_wrapped", False)
+    call_owned = _is_our_method(cls, "__call__", "_omlx_mtp_call_marker")
+    if init_wrapped and call_owned:
+        return
+
+    import mlx.core as mx
+    from mlx_lm.models.base import create_attention_mask
+    from mlx_lm.models.cache import KVCache
+
+    from omlx.patches.glm_moe_dsa.deepseek_v32 import (
+        _use_load_fused_wk_weights_proj,
+    )
+
+    original_init = cls.__init__
+    original_sanitize = cls.sanitize
+
+    def __init__(self, config):
+        original_init(self, config)
+        n_mtp = int(getattr(config, "num_nextn_predict_layers", 0) or 0)
+        # Gated on the MTP active-flag so mtp_enabled=False produces a
+        # model indistinguishable from stock (same pattern as qwen35 /
+        # deepseek_v4).
+        from . import is_mtp_active
+
+        mtp_decode_enabled = bool(n_mtp > 0 and is_mtp_active())
+        self._omlx_mtp_decode_enabled = mtp_decode_enabled
+        if mtp_decode_enabled:
+            n_main = config.num_hidden_layers
+            self.mtp = [glm.GlmMTPBlock(config, n_main + i) for i in range(n_mtp)]
+            from . import get_mtp_depth
+
+            self._omlx_mtp_chain = True
+            self._omlx_mtp_depth = get_mtp_depth()
+            self._omlx_mtp_head_clone = False
+            # Marginal cost prior for the adaptive depth controller: with
+            # 8-of-256 routing each extra verify row pulls an almost
+            # disjoint expert set (~55% of step bytes), measured ~35 ms
+            # per row on GLM-5.2 vs the dense-backbone 7 ms default.
+            self._omlx_mtp_marginal_ms = 35.0
+
+    def __call__(
+        self,
+        inputs,
+        cache=None,
+        return_hidden: bool = False,
+        n_confirmed: int = 0,
+    ):
+        # ``n_confirmed`` only matters for models with module-level
+        # recurrent state (Qwen3.5's GatedDeltaNet). GLM keeps all decode
+        # state in trimmable KVCaches, so it is accepted and unused.
+        if return_hidden:
+            out, h_raw = self.model(inputs, cache, return_raw_hidden=True)
+            return self.lm_head(out), h_raw
+        out = self.model(inputs, cache)
+        return self.lm_head(out)
+
+    def make_mtp_cache(self):
+        """Two plain KVCaches per MTP block: latent KV + DSA indexer KV.
+
+        A flat list (not a CacheList) so the chain's ``_mtp_head_trim_to``
+        sees each cache's ``offset``/``trim`` directly; ``mtp_forward``
+        re-slices pairs per block.
+        """
+        if not hasattr(self, "mtp"):
+            return None
+        caches = []
+        for _ in self.mtp:
+            caches.append(KVCache())
+            caches.append(KVCache())
+        return caches
+
+    def mtp_forward(
+        self,
+        h,
+        input_ids,
+        cache=None,
+        return_hidden: bool = False,
+        logits_keep: int = 0,
+    ):
+        """Run the MTP block(s) + shared_head norm + shared lm_head.
+
+        ``h`` is the trunk's post-norm hidden for the history fold, or the
+        head's own raw output for chained draft steps — ``hnorm`` inside
+        the block normalises either. ``return_hidden`` also returns the
+        block's raw residual output (the next chain step's ``h``);
+        ``logits_keep`` limits the norm+lm_head tail to the last N
+        positions (0 = all).
+        """
+        if cache is None:
+            cache = [None] * (2 * len(self.mtp))
+
+        mask = create_attention_mask(h, cache[0], return_array=True)
+
+        last_block = None
+        for i, mtp_block in enumerate(self.mtp):
+            layer_cache = cache[2 * i : 2 * i + 2]
+            if layer_cache[0] is None:
+                layer_cache = None
+            h = mtp_block(
+                h, self.model.embed_tokens, input_ids, mask, layer_cache
+            )
+            last_block = mtp_block
+
+        logits_source = h
+        if logits_keep and logits_source.shape[1] > logits_keep:
+            logits_source = logits_source[:, -logits_keep:]
+        logits = self.lm_head(last_block.norm(logits_source))
+        if return_hidden:
+            return logits, h
+        return logits
+
+    def mtp_partial_rollback(self, cache, accepted: int, num_drafts: int) -> bool:
+        """Trim the verify window back to ``accepted`` drafts on every layer.
+
+        Every GLM cache is a CacheList of plain KVCaches (latent KV +
+        indexer KV), so a straight trim covers any partial accept.
+        """
+        n = num_drafts - accepted
+        if n <= 0:
+            return True
+        if not all(c.is_trimmable() for c in cache):
+            return False
+        for c in cache:
+            if c.trim(n) != n:
+                logger.warning(
+                    "GLM MTP rollback trim shortfall on %s", type(c).__name__
+                )
+                return False
+        return True
+
+    def sanitize(self, weights: Dict[str, Any]) -> Dict[str, Any]:
+        """Keep + remap the checkpoint's extra MTP layer.
+
+        Raw-HF/FP8 checkpoints store the MTP layer as
+        ``model.layers.<n_main + i>.*``. The stock sanitize strips layers
+        >= ``num_hidden_layers`` and runs its per-layer transforms
+        (FP8 dequant, expert stacking, fused gate_up, kv_b -> embed_q /
+        unembed_out split, indexer fusion) over backbone indices only —
+        so the layer count is temporarily bumped to cover the MTP layers,
+        letting every transform apply to them identically, and the
+        transformed keys are then renamed under ``mtp.<i>.*``.
+
+        Pre-remapped checkpoints (oQ output) pass through the stock
+        sanitize untouched apart from the load-time indexer fusion, which
+        is replicated for the mtp prefix because the stock loop only
+        walks ``model.layers.<l>``.
+        """
+        has_mtp = hasattr(self, "mtp")
+        n_mtp = len(self.mtp) if has_mtp else 0
+        n_main = int(self.args.num_hidden_layers)
+
+        has_mtp_weights = any(
+            k.startswith("mtp.") or k.startswith(f"model.layers.{n_main}.")
+            for k in weights
+        )
+        if has_mtp and not has_mtp_weights:
+            # Graceful fallback for checkpoints that stripped the head.
+            try:
+                del self.mtp
+            except AttributeError:
+                pass
+            self._omlx_mtp_decode_enabled = False
+            has_mtp = False
+            n_mtp = 0
+
+        if not has_mtp:
+            # Stock sanitize drops raw nextn layers; stray pre-remapped
+            # mtp.* keys (head-ful checkpoint loaded with MTP off) are
+            # dropped here so the strict load doesn't trip on them.
+            weights = {k: v for k, v in weights.items() if not k.startswith("mtp.")}
+            return original_sanitize(self, weights)
+
+        has_nextn_keys = any(
+            any(k.startswith(f"model.layers.{n_main + i}.") for i in range(n_mtp))
+            for k in weights
+        )
+
+        if has_nextn_keys:
+            self.args.num_hidden_layers = n_main + n_mtp
+            try:
+                weights = original_sanitize(self, weights)
+            finally:
+                self.args.num_hidden_layers = n_main
+
+            remapped: Dict[str, Any] = {}
+            special = {
+                "eh_proj.weight": "eh_proj.weight",
+                "enorm.weight": "enorm.weight",
+                "hnorm.weight": "hnorm.weight",
+                "shared_head.norm.weight": "norm.weight",
+            }
+            for k, v in weights.items():
+                nk = k
+                for i in range(n_mtp):
+                    prefix = f"model.layers.{n_main + i}."
+                    if not k.startswith(prefix):
+                        continue
+                    rest = k[len(prefix):]
+                    if rest.startswith(("shared_head.head.", "embed_tokens.")):
+                        # Duplicates of the shared lm_head / embeddings some
+                        # nextn checkpoints carry; the modules are shared.
+                        nk = None
+                    elif rest in special:
+                        nk = f"mtp.{i}.{special[rest]}"
+                    else:
+                        nk = f"mtp.{i}.block.{rest}"
+                    break
+                if nk is not None:
+                    remapped[nk] = v
+            return remapped
+
+        # Load-time indexer wk/weights_proj fusion for the mtp prefix
+        # (mirrors the stock backbone loop; gate depends on the
+        # checkpoint's quantization spec). Must run BEFORE the stock
+        # sanitize: when the backbone loop fuses anything it rebuilds the
+        # dict dropping every ``.self_attn.indexer.wk.`` /
+        # ``.weights_proj.`` key by substring — which would strip the MTP
+        # block's unfused keys too. The fused key name doesn't match
+        # those substrings, so it passes through untouched.
+        if _use_load_fused_wk_weights_proj(self.args):
+            for i in range(n_mtp):
+                prefix = f"mtp.{i}.block.self_attn.indexer"
+                if f"{prefix}.wk.weight" not in weights:
+                    continue
+                for suffix in ("weight", "scales", "biases"):
+                    wk_key = f"{prefix}.wk.{suffix}"
+                    wp_key = f"{prefix}.weights_proj.{suffix}"
+                    if wk_key in weights and wp_key in weights:
+                        weights[f"{prefix}.wk_weights_proj.{suffix}"] = (
+                            mx.concatenate(
+                                [weights.pop(wk_key), weights.pop(wp_key)],
+                                axis=0,
+                            )
+                        )
+        return original_sanitize(self, weights)
+
+    if not init_wrapped:
+        cls.__init__ = __init__
+        cls._omlx_mtp_init_wrapped = True
+    __call__._omlx_mtp_call_marker = True
+    cls.__call__ = __call__
+    cls.mtp_forward = mtp_forward
+    cls.make_mtp_cache = make_mtp_cache
+    cls.mtp_partial_rollback = mtp_partial_rollback
+    cls.sanitize = sanitize

--- a/omlx/patches/mlx_lm_mtp/norm_repair.py
+++ b/omlx/patches/mlx_lm_mtp/norm_repair.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Load-time repair for miscalibrated MTP-head RMSNorm weights.
+
+Qwen3-Next RMSNorm gammas are zero-centered in the raw checkpoint; the MLX
+convention stores them shifted by +1. Older oQ conversions decided the shift
+per-key from the tensor mean (``mean < 0.5 -> shift``), which misclassifies
+head norms whose raw mean already sits at or above 0.5 — observed:
+``q_norm``/``k_norm`` (raw ~0.75), ``post_attention_layernorm`` (raw ~0.87 on
+Qwen3.6-35B-A3B), and ``mtp.norm`` (raw ~1.3-1.9) — leaving them one below
+the correct value. Measured cost: tens of points of draft acceptance.
+
+Detection is reference-based, not absolute: for each vulnerable head norm,
+the mean of the *backbone's* counterpart tensors in the same payload is the
+anchor (backbone norms are always converted correctly — their raw means sit
+well below the old heuristic's cutoff). A correctly stored head norm sits at
+or slightly above its backbone anchor; a broken one sits ~1 below. Repair
+applies +1 when ``anchor_mean - head_mean > 0.4``. Idempotent: after the
+shift the value lands above the anchor, so a second pass is a no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Tuple, Union
+
+logger = logging.getLogger(__name__)
+
+# Head-norm suffix -> backbone counterpart suffix. Only norms whose raw mean
+# can plausibly exceed the old heuristic's 0.5 cutoff are listed; the rest
+# (input_layernorm, pre_fc_norm_*) have strongly negative raw means and were
+# always converted correctly.
+_REPAIR_GROUPS = {
+    ".self_attn.q_norm.weight": ".self_attn.q_norm.weight",
+    ".self_attn.k_norm.weight": ".self_attn.k_norm.weight",
+    ".post_attention_layernorm.weight": ".post_attention_layernorm.weight",
+    "mtp.norm.weight": "model.norm.weight",
+}
+
+# Minimum gap below the backbone anchor that marks a missing +1. Correct
+# head norms measure 0.19-0.56 ABOVE their anchor on Qwen3.6-27B/35B-A3B;
+# broken ones measure 0.44-0.74 below.
+_REPAIR_MARGIN = 0.4
+
+
+def _mean(v) -> float:
+    import mlx.core as mx
+
+    return float(v.astype(mx.float32).mean().item())
+
+
+def repair_legacy_head_norms(
+    weights: Union[dict, List[Tuple[str, Any]]],
+) -> Tuple[Union[dict, List[Tuple[str, Any]]], int]:
+    """Re-apply the missing +1 shift to raw-stored MTP-head norms.
+
+    Accepts and returns either a dict or a list of (key, tensor) pairs (the
+    two shapes ``nn.Module.load_weights`` payloads take). Returns the
+    (possibly-modified) payload and the number of tensors repaired.
+    """
+    is_list = not isinstance(weights, dict)
+    items = list(weights.items()) if isinstance(weights, dict) else list(weights)
+
+    head_indices: List[Tuple[int, str]] = []  # (item index, head suffix)
+    for i, (k, v) in enumerate(items):
+        if "mtp." not in k or getattr(v, "ndim", 0) != 1:
+            continue
+        for head_sfx in _REPAIR_GROUPS:
+            if k.endswith(head_sfx):
+                head_indices.append((i, head_sfx))
+                break
+    if not head_indices:
+        return weights, 0
+
+    # Backbone anchors: mean-of-means over counterpart tensors.
+    sums: Dict[str, float] = {}
+    counts: Dict[str, int] = {}
+    needed = {_REPAIR_GROUPS[sfx] for _, sfx in head_indices}
+    for k, v in items:
+        if "mtp." in k or getattr(v, "ndim", 0) != 1:
+            continue
+        for ref_sfx in needed:
+            if k.endswith(ref_sfx):
+                try:
+                    sums[ref_sfx] = sums.get(ref_sfx, 0.0) + _mean(v)
+                    counts[ref_sfx] = counts.get(ref_sfx, 0) + 1
+                except Exception:
+                    pass
+                break
+
+    fixed = 0
+    for i, head_sfx in head_indices:
+        ref_sfx = _REPAIR_GROUPS[head_sfx]
+        if not counts.get(ref_sfx):
+            continue
+        anchor = sums[ref_sfx] / counts[ref_sfx]
+        k, v = items[i]
+        try:
+            gap = anchor - _mean(v)
+        except Exception:
+            continue
+        if gap > _REPAIR_MARGIN:
+            items[i] = (k, v + 1.0)
+            fixed += 1
+    if fixed:
+        logger.info(
+            "Repaired %d MTP-head norms (+1 zero-centered gamma shift)",
+            fixed,
+        )
+    return (items if is_list else dict(items)), fixed

--- a/omlx/patches/mlx_lm_mtp/qwen35_model.py
+++ b/omlx/patches/mlx_lm_mtp/qwen35_model.py
@@ -318,27 +318,21 @@ def _patch_gated_delta_net(q35: Any) -> None:
             qkv = mx.where(mask[..., None], qkv, 0)
 
         if n_confirmed > 0 and n_confirmed < S:
-            mask_c = mask[:, :n_confirmed] if mask is not None else None
-            mask_d = mask[:, n_confirmed:] if mask is not None else None
-            out_c, conv_c, ssm_c = self._process_chunk(
-                qkv[:, :n_confirmed],
-                a[:, :n_confirmed],
-                b[:, :n_confirmed],
-                conv_state,
-                ssm_state,
-                mask_c,
+            # MTP verify forward. Unlike PR 990 (which processes the
+            # confirmed prefix and draft suffix as two chunks, snapshotting
+            # in between), run the whole window as ONE chunk — measured
+            # ~2.6ms/cycle cheaper across 48 linear layers on Qwen3.6-27B —
+            # and keep zero-copy *pre-forward* state refs plus the projected
+            # inputs. On a rejection, ``mtp_partial_rollback`` replays the
+            # kept prefix (confirmed + accepted drafts) through
+            # ``_process_chunk`` from those refs; on full accept the refs
+            # are dropped and the verify costs nothing extra.
+            out, conv_f, ssm_f = self._process_chunk(
+                qkv, a, b, conv_state, ssm_state, mask
             )
             if cache is not None:
-                cache.rollback_state = (conv_c, ssm_c)
-            out_d, conv_f, ssm_f = self._process_chunk(
-                qkv[:, n_confirmed:],
-                a[:, n_confirmed:],
-                b[:, n_confirmed:],
-                conv_c,
-                ssm_c,
-                mask_d,
-            )
-            out = mx.concatenate([out_c, out_d], axis=1)
+                cache.rollback_state = (conv_state, ssm_state)
+                cache._mtp_draft_stash = (qkv, a, b)
         else:
             lengths = cache.lengths if cache is not None else None
             out, conv_f, ssm_f = self._process_chunk(
@@ -474,6 +468,12 @@ def _patch_text_model(q35: Any) -> None:
         self._omlx_mtp_decode_enabled = mtp_decode_enabled
         if mtp_decode_enabled:
             self.mtp = q35.MTPModule(args)
+            # Depth-k chained drafting is available on this model: the qwen
+            # patch supports return_hidden mtp_forward + partial rollback.
+            from . import get_mtp_depth
+
+            self._omlx_mtp_chain = True
+            self._omlx_mtp_depth = get_mtp_depth()
 
     def __call__(
         self,
@@ -498,21 +498,93 @@ def _patch_text_model(q35: Any) -> None:
             return out, hidden
         return out
 
-    def mtp_forward(self, hidden_states, next_token_ids, mtp_cache):
+    def mtp_forward(
+        self,
+        hidden_states,
+        next_token_ids,
+        mtp_cache,
+        return_hidden: bool = False,
+        logits_keep: int = 0,
+    ):
+        """MTP-head forward.
+
+        ``return_hidden`` returns the head's post-norm hidden alongside the
+        logits so depth-k drafting can chain the head on its own output.
+        ``logits_keep`` limits the lm_head projection to the last N positions
+        (0 = all): the depth-k history+draft fold only needs logits at the
+        final position, and the vocab is large enough (~250k) that skipping
+        the other rows matters.
+        """
         mtp_out = self.mtp(
             hidden_states,
             next_token_ids,
             self.model.embed_tokens,
             mtp_cache,
         )
+        logits_source = mtp_out
+        if logits_keep and logits_source.shape[1] > logits_keep:
+            logits_source = logits_source[:, -logits_keep:, :]
         if self.args.tie_word_embeddings:
-            return self.model.embed_tokens.as_linear(mtp_out)
-        return self.lm_head(mtp_out)
+            logits = self.model.embed_tokens.as_linear(logits_source)
+        else:
+            logits = self.lm_head(logits_source)
+        if return_hidden:
+            return logits, mtp_out
+        return logits
 
     def make_mtp_cache(self):
         if hasattr(self, "mtp"):
             return [KVCache() for _ in self.mtp.layers]
         return []
+
+    def mtp_partial_rollback(self, cache, accepted: int, num_drafts: int) -> bool:
+        """Roll the backbone cache back to ``accepted`` drafts after a depth-k
+        verify forward over ``[confirmed, d1..dk]``.
+
+        Full-attention KV layers trim ``num_drafts - accepted`` positions.
+        GatedDeltaNet layers restore the zero-copy pre-forward state refs
+        (``rollback_state``) and replay the kept prefix — the confirmed
+        token plus the accepted drafts — through ``_process_chunk`` from the
+        stashed projected inputs. One small gated-delta kernel per linear
+        layer, paid only on rejections; the verify forward itself runs
+        unsplit. Returns False if any layer lacks the state needed (caller
+        falls back to the standard step).
+        """
+        layers = self.model.layers
+        if len(cache) != len(layers):
+            return False
+        trim_n = num_drafts - accepted
+        if trim_n <= 0:
+            return True
+        keep = 1 + accepted  # confirmed token + accepted drafts
+        for layer, c in zip(layers, cache):
+            if getattr(layer, "is_linear", False):
+                if getattr(c, "rollback_state", None) is None:
+                    return False
+                if getattr(c, "_mtp_draft_stash", None) is None:
+                    return False
+            else:
+                if not (hasattr(c, "is_trimmable") and c.is_trimmable()):
+                    return False
+        for layer, c in zip(layers, cache):
+            if getattr(layer, "is_linear", False):
+                conv_0, ssm_0 = c.rollback_state
+                qkv_s, a_s, b_s = c._mtp_draft_stash
+                _, conv_m, ssm_m = layer.linear_attn._process_chunk(
+                    qkv_s[:, :keep],
+                    a_s[:, :keep],
+                    b_s[:, :keep],
+                    conv_0,
+                    ssm_0,
+                    None,
+                )
+                c[0] = conv_m
+                c[1] = ssm_m
+                c.rollback_state = None
+                c._mtp_draft_stash = None
+            else:
+                c.trim(trim_n)
+        return True
 
     def sanitize(self, weights):
         # Full PR 990 replacement of TextModel.sanitize. We can't call the
@@ -602,10 +674,21 @@ def _patch_text_model(q35: Any) -> None:
                 # when the outer Model wraps language_model, so test the
                 # ``mtp.`` substring rather than anchoring with startswith.
                 if "mtp." in k:
-                    # Per-key decision: a head norm may still be raw-HF even
-                    # when a sibling head norm (e.g. mtp.norm) is already in
-                    # the +1 convention. Shift only the raw-HF ones.
-                    if _is_oq_tracked_tensor(v):
+                    if should_shift_norm_weights:
+                        # Raw-HF source: every Qwen3-Next RMSNorm gamma is
+                        # zero-centered, so head norms shift uniformly like
+                        # the backbone's. The mean heuristic below
+                        # misclassifies q_norm/k_norm (raw mean ~0.75) and
+                        # mtp.norm (raw ~1.27) as already-shifted, leaving
+                        # them -1 off — measured cost ~14pp of draft
+                        # acceptance on Qwen3.6-27B (prose 62.8% -> 76.3%).
+                        # ``v + 1.0`` also handles oQ _TrackedTensor (its
+                        # __add__ records an unconditional "add" transform).
+                        weights[k] = v + 1.0
+                    # Pre-converted checkpoints: per-key decision — a head
+                    # norm may still be raw-HF even when a sibling is
+                    # already +1 (JANG mixed bundles).
+                    elif _is_oq_tracked_tensor(v):
                         weights[k] = _mark_mtp_norm_conditional_add(v)
                     elif _mtp_norm_is_raw_hf(v, should_shift_norm_weights):
                         weights[k] = v + 1.0
@@ -636,6 +719,7 @@ def _patch_text_model(q35: Any) -> None:
     cls.__call__ = __call__
     cls.mtp_forward = mtp_forward
     cls.make_mtp_cache = make_mtp_cache
+    cls.mtp_partial_rollback = mtp_partial_rollback
     cls.sanitize = sanitize
     cls.quant_predicate = property(quant_predicate)
 
@@ -667,22 +751,52 @@ def _patch_outer_model(q35: Any) -> None:
             n_confirmed=n_confirmed,
         )
 
-    def mtp_forward(self, hidden_states, next_token_ids, mtp_cache):
+    def mtp_forward(
+        self,
+        hidden_states,
+        next_token_ids,
+        mtp_cache,
+        return_hidden: bool = False,
+        logits_keep: int = 0,
+    ):
         return self.language_model.mtp_forward(
-            hidden_states, next_token_ids, mtp_cache
+            hidden_states,
+            next_token_ids,
+            mtp_cache,
+            return_hidden=return_hidden,
+            logits_keep=logits_keep,
         )
 
     def make_mtp_cache(self):
         return self.language_model.make_mtp_cache()
 
+    def mtp_partial_rollback(self, cache, accepted: int, num_drafts: int) -> bool:
+        return self.language_model.mtp_partial_rollback(cache, accepted, num_drafts)
+
     __call__._omlx_mtp_call_marker = True
     cls.__call__ = __call__
     cls.mtp_forward = mtp_forward
     cls.make_mtp_cache = make_mtp_cache
+    cls.mtp_partial_rollback = mtp_partial_rollback
     # Informational marker for external code that just wants to know "is
     # this class touched by the MTP patch". Idempotency itself uses the
     # function-level _omlx_mtp_call_marker above.
     cls._omlx_mtp_patched = True
+
+    if not getattr(cls, "_omlx_mtp_norm_repair_patched", False):
+        original_load_weights = cls.load_weights
+
+        def load_weights(self, weights, strict=True):
+            from .norm_repair import repair_legacy_head_norms
+
+            try:
+                weights, _ = repair_legacy_head_norms(weights)
+            except Exception:
+                logger.warning("MTP head-norm repair failed", exc_info=True)
+            return original_load_weights(self, weights, strict=strict)
+
+        cls.load_weights = load_weights
+        cls._omlx_mtp_norm_repair_patched = True
 
 
 # ---------------------------------------------------------------------------

--- a/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_model.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_model.py
@@ -120,19 +120,17 @@ def apply() -> bool:
             "mtp.norm.weight",
         )
 
-        # MTP-head norms can ship in a different convention than the backbone,
-        # even MIXED within the head (JANG MXFP4 Qwen3.6 bundles keep
-        # ``mtp.norm`` in MLX's +1 convention while the per-layer head norms
-        # remain raw-HF, mean ~= 0). The backbone-only conv1d signal never
-        # shifts those head norms, so every head RMSNorm multiplies by ~0 and
-        # MTP draft acceptance collapses to ~0%. Decide PER-KEY for MTP norms
-        # from each weight's own magnitude (raw-HF center ~0, MLX-shifted ~1).
-        # Mirrors the fix in mlx_lm_mtp/qwen35_model.py. The magnitude is
-        # unreadable during oQ streaming plan discovery (the weight is a
-        # no-data ``_TrackedTensor`` and ``mx.mean(...).item()`` raises), so
-        # emit a conditional replay transform there. A fixed fallback is wrong
-        # for full-precision Qwen3.6 sources where MTP norm conventions are
-        # mixed.
+        # MTP-head norm conventions: raw-HF sources (unsanitized conv1d
+        # present) shift every head norm uniformly with the backbone — see
+        # the raw-HF branch below. Pre-converted checkpoints can ship MIXED
+        # head conventions (JANG MXFP4 Qwen3.6 bundles keep ``mtp.norm`` in
+        # MLX's +1 convention while the per-layer head norms remain raw-HF),
+        # so that branch decides PER-KEY from each weight's own magnitude
+        # (raw-HF center ~0, MLX-shifted ~1). Mirrors
+        # mlx_lm_mtp/qwen35_model.py. The magnitude is unreadable during oQ
+        # streaming plan discovery (the weight is a no-data ``_TrackedTensor``
+        # and ``mx.mean(...).item()`` raises), so emit a conditional replay
+        # transform there.
         def _is_oq_tracked_tensor(_w):
             return _w.__class__.__name__ == "_TrackedTensor" and hasattr(_w, "_clone")
 
@@ -171,9 +169,17 @@ def apply() -> bool:
                 # ``key`` is already remapped to ``language_model.mtp.*`` for
                 # MTP weights here, so test the ``mtp.`` substring.
                 if "mtp." in key:
-                    # Per-key: a head norm may still be raw-HF even when a
-                    # sibling head norm (e.g. mtp.norm) is already shifted.
-                    if _is_oq_tracked_tensor(value):
+                    if should_shift_norm_weights:
+                        # Raw-HF source: every Qwen3-Next RMSNorm gamma is
+                        # zero-centered — shift head norms uniformly like the
+                        # backbone's. Per-key mean heuristics misclassify
+                        # q_norm/k_norm (raw ~0.75), post_attention_layernorm
+                        # (raw ~0.87 on 35B-A3B), and mtp.norm (raw ~1.3-1.9),
+                        # costing tens of points of draft acceptance.
+                        value = value + 1.0
+                    # Pre-converted checkpoints: per-key decision (JANG
+                    # mixed-convention bundles).
+                    elif _is_oq_tracked_tensor(value):
                         value = _mark_mtp_norm_conditional_add(value)
                     elif _mtp_norm_is_raw_hf(value, should_shift_norm_weights):
                         value = value + 1.0

--- a/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py
@@ -227,6 +227,14 @@ def _patch_vlm_language_model(q35moe_lang: Any) -> None:
         )
         if n_mtp > 0 and attach_enabled:
             self.mtp = q35moe_lang.MTPModule(args)
+        if self._omlx_mtp_decode_enabled:
+            # Depth-k chained drafting works on this path: mtp_forward
+            # supports return_hidden below, and rollback uses mlx-vlm's
+            # stock rollback_speculative_cache (native partial accepts).
+            from ..mlx_lm_mtp import get_mtp_depth
+
+            self._omlx_mtp_chain = True
+            self._omlx_mtp_depth = get_mtp_depth()
 
     def __call__(self, inputs, inputs_embeds=None, mask=None, cache=None, **kwargs):
         """Backbone forward with optional MTP-cycle return shape.
@@ -277,16 +285,33 @@ def _patch_vlm_language_model(q35moe_lang: Any) -> None:
             shared_kv_states={} if return_shared_kv else None,
         )
 
-    def mtp_forward(self, hidden_states, next_token_ids, mtp_cache):
+    def mtp_forward(
+        self,
+        hidden_states,
+        next_token_ids,
+        mtp_cache,
+        return_hidden: bool = False,
+        logits_keep: int = 0,
+    ):
+        """MTP-head forward (see mlx_lm_mtp.qwen35_model for the depth-k
+        chain contract: return_hidden yields the head's post-norm hidden for
+        chaining; logits_keep limits the lm_head to the last N positions)."""
         mtp_out = self.mtp(
             hidden_states,
             next_token_ids,
             self.model.embed_tokens,
             mtp_cache,
         )
+        logits_source = mtp_out
+        if logits_keep and logits_source.shape[1] > logits_keep:
+            logits_source = logits_source[:, -logits_keep:, :]
         if self.args.tie_word_embeddings:
-            return self.model.embed_tokens.as_linear(mtp_out)
-        return self.lm_head(mtp_out)
+            logits = self.model.embed_tokens.as_linear(logits_source)
+        else:
+            logits = self.lm_head(logits_source)
+        if return_hidden:
+            return logits, mtp_out
+        return logits
 
     def make_mtp_cache(self):
         if hasattr(self, "mtp"):
@@ -333,7 +358,25 @@ def _patch_vlm_model_adapter() -> None:
     def mtp(self):
         return getattr(self._language_model, "mtp", None)
 
-    def mtp_forward(self, hidden_states, next_token_ids, mtp_cache):
+    def mtp_forward(
+        self,
+        hidden_states,
+        next_token_ids,
+        mtp_cache,
+        return_hidden: bool = False,
+        logits_keep: int = 0,
+    ):
+        # Forward the depth-k chain kwargs only when set: chain drafting is
+        # only enabled on language models whose runtime patch supports them
+        # (dense qwen3_5), so a stock/MoE mtp_forward never sees them.
+        if return_hidden or logits_keep:
+            return self._language_model.mtp_forward(
+                hidden_states,
+                next_token_ids,
+                mtp_cache,
+                return_hidden=return_hidden,
+                logits_keep=logits_keep,
+            )
         return self._language_model.mtp_forward(
             hidden_states, next_token_ids, mtp_cache
         )

--- a/omlx/patches/mlx_vlm_mtp/qwen35_vlm_model.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_vlm_model.py
@@ -129,9 +129,18 @@ def apply() -> bool:
                 # ``key`` is already remapped to ``language_model.mtp.*`` for
                 # MTP weights here, so test the ``mtp.`` substring.
                 if "mtp." in key:
-                    # Per-key: a head norm may still be raw-HF even when a
-                    # sibling head norm (e.g. mtp.norm) is already shifted.
-                    if _is_oq_tracked_tensor(value):
+                    if should_shift_norm_weights:
+                        # Raw-HF source: every Qwen3-Next RMSNorm gamma is
+                        # zero-centered — shift head norms uniformly like
+                        # the backbone's. The mean heuristic misclassifies
+                        # q_norm/k_norm (raw ~0.75) and mtp.norm (raw
+                        # ~1.27), costing ~14pp draft acceptance.
+                        # ``+ 1.0`` also records an unconditional "add"
+                        # transform on oQ _TrackedTensor.
+                        value = value + 1.0
+                    # Pre-converted checkpoints: per-key decision (JANG
+                    # mixed-convention bundles).
+                    elif _is_oq_tracked_tensor(value):
                         value = _mark_mtp_norm_conditional_add(value)
                     elif _mtp_norm_is_raw_hf(value, should_shift_norm_weights):
                         value = value + 1.0

--- a/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
@@ -65,10 +65,43 @@ def apply() -> bool:
     # VLMModelAdapter pass-throughs are installed by the MoE runtime patch
     # too; the function is idempotent so calling it twice is safe.
     _patch_vlm_model_adapter()
+    _patch_vlm_outer_model_load_weights()
 
     _APPLIED = True
     logger.info("mlx-vlm Qwen3.5 (dense) runtime MTP patch applied")
     return True
+
+
+def _patch_vlm_outer_model_load_weights() -> None:
+    """Repair miscalibrated MTP-head norms in ``Model.load_weights`` payloads.
+
+    Older oQ conversions stored the head's q_norm/k_norm/mtp.norm one below
+    the correct MLX value; ``repair_legacy_head_norms`` re-applies the +1 at
+    load time. Idempotent-safe on correctly-converted models.
+    """
+    try:
+        from mlx_vlm.models import qwen3_5 as q35_outer
+    except Exception as e:
+        logger.debug(f"mlx_vlm outer qwen3_5 not importable: {e}")
+        return
+
+    cls = q35_outer.Model
+    if getattr(cls, "_omlx_mtp_norm_repair_patched", False):
+        return
+
+    original_load_weights = cls.load_weights
+
+    def load_weights(self, weights, strict=True):
+        from ..mlx_lm_mtp.norm_repair import repair_legacy_head_norms
+
+        try:
+            weights, _ = repair_legacy_head_norms(weights)
+        except Exception:
+            logger.warning("MTP head-norm repair failed", exc_info=True)
+        return original_load_weights(self, weights, strict=strict)
+
+    cls.load_weights = load_weights
+    cls._omlx_mtp_norm_repair_patched = True
 
 
 # ---------------------------------------------------------------------------
@@ -211,6 +244,14 @@ def _patch_vlm_language_model(q35_lang: Any) -> None:
         )
         if n_mtp > 0 and attach_enabled:
             self.mtp = q35_lang.MTPModule(args)
+        if self._omlx_mtp_decode_enabled:
+            # Depth-k chained drafting works on this path: mtp_forward
+            # supports return_hidden below, and rollback uses mlx-vlm's
+            # stock rollback_speculative_cache (native partial accepts).
+            from ..mlx_lm_mtp import get_mtp_depth
+
+            self._omlx_mtp_chain = True
+            self._omlx_mtp_depth = get_mtp_depth()
 
     def __call__(self, inputs, inputs_embeds=None, mask=None, cache=None, **kwargs):
         """Backbone forward with optional MTP-cycle return shape.
@@ -252,16 +293,33 @@ def _patch_vlm_language_model(q35_lang: Any) -> None:
             shared_kv_states={} if return_shared_kv else None,
         )
 
-    def mtp_forward(self, hidden_states, next_token_ids, mtp_cache):
+    def mtp_forward(
+        self,
+        hidden_states,
+        next_token_ids,
+        mtp_cache,
+        return_hidden: bool = False,
+        logits_keep: int = 0,
+    ):
+        """MTP-head forward (see mlx_lm_mtp.qwen35_model for the depth-k
+        chain contract: return_hidden yields the head's post-norm hidden for
+        chaining; logits_keep limits the lm_head to the last N positions)."""
         mtp_out = self.mtp(
             hidden_states,
             next_token_ids,
             self.model.embed_tokens,
             mtp_cache,
         )
+        logits_source = mtp_out
+        if logits_keep and logits_source.shape[1] > logits_keep:
+            logits_source = logits_source[:, -logits_keep:, :]
         if self.args.tie_word_embeddings:
-            return self.model.embed_tokens.as_linear(mtp_out)
-        return self.lm_head(mtp_out)
+            logits = self.model.embed_tokens.as_linear(logits_source)
+        else:
+            logits = self.lm_head(logits_source)
+        if return_hidden:
+            return logits, mtp_out
+        return logits
 
     def make_mtp_cache(self):
         if hasattr(self, "mtp"):
@@ -298,7 +356,24 @@ def _patch_vlm_model_adapter() -> None:
     def mtp(self):
         return getattr(self._language_model, "mtp", None)
 
-    def mtp_forward(self, hidden_states, next_token_ids, mtp_cache):
+    def mtp_forward(
+        self,
+        hidden_states,
+        next_token_ids,
+        mtp_cache,
+        return_hidden: bool = False,
+        logits_keep: int = 0,
+    ):
+        # Forward the depth-k chain kwargs only when set so language models
+        # whose mtp_forward predates them (MoE runtime) keep working.
+        if return_hidden or logits_keep:
+            return self._language_model.mtp_forward(
+                hidden_states,
+                next_token_ids,
+                mtp_cache,
+                return_hidden=return_hidden,
+                logits_keep=logits_keep,
+            )
         return self._language_model.mtp_forward(
             hidden_states, next_token_ids, mtp_cache
         )

--- a/omlx/patches/qwen35_q4_mlp.py
+++ b/omlx/patches/qwen35_q4_mlp.py
@@ -455,13 +455,21 @@ def apply_qwen35_q4_lm_prefill_linear_patch() -> bool:
         except Exception:
             gated_delta_update = getattr(module, "gated_delta_update", None)
 
-        def patched_gdn(self, inputs, mask=None, cache=None):
+        def patched_gdn(self, inputs, mask=None, cache=None, n_confirmed: int = 0):
+            # n_confirmed is the Native-MTP draft/verify split (patches/mlx_lm_mtp).
+            # Verify forwards are always far below min_tokens, so this wrapper
+            # never routes them; forward the kwarg to the underlying (MTP-patched)
+            # __call__ only when set, so stock GatedDeltaNet stays compatible.
             if (
                 gated_delta_update is None
                 or inputs.ndim != 3
                 or inputs.shape[-2] < min_tokens
                 or self.sharding_group is not None
             ):
+                if n_confirmed:
+                    return orig_gdn(
+                        self, inputs, mask=mask, cache=cache, n_confirmed=n_confirmed
+                    )
                 return orig_gdn(self, inputs, mask=mask, cache=cache)
 
             input_linears = (
@@ -471,6 +479,10 @@ def apply_qwen35_q4_lm_prefill_linear_patch() -> bool:
                 self.in_proj_a,
             )
             if not any(should_route(linear, inputs) for linear in input_linears):
+                if n_confirmed:
+                    return orig_gdn(
+                        self, inputs, mask=mask, cache=cache, n_confirmed=n_confirmed
+                    )
                 return orig_gdn(self, inputs, mask=mask, cache=cache)
 
             B, S, _ = inputs.shape

--- a/omlx/patches/qwen35_verify_qmm.py
+++ b/omlx/patches/qwen35_verify_qmm.py
@@ -1,0 +1,501 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Adapted from MTPLX (mtplx/verify_kernels.py)
+#   Copyright 2026 Youssof Altoukhi
+#   Licensed under the Apache License, Version 2.0
+#   https://github.com/youssofal/mtplx
+#   "Powered by MTPLX by Youssof Altoukhi"
+#
+# The split-K and multi-simdgroup (msg) kernel morphologies and their Metal
+# source generation below are ported from MTPLX. The oMLX integration —
+# thread-local armed routing through ``nn.QuantizedLinear``, the hybrid
+# dispatch, and the M=3..6 / N-floor gating — is original to oMLX.
+"""Verify-shape quantized-matmul kernels for native MTP.
+
+Speculative verify multiplies a skinny row batch (M = 1 + draft depth)
+against the model's quantized weights. Stock MLX qmm is tuned for M=1
+(decode) and large-M (prefill); at M=3..6 it pays a steep per-row penalty —
+measured on Qwen3.6-27B/M3 Ultra the lm_head scales linearly (1.2ms at M=1 →
+4.3ms at M=4) and the summed MLP/GDN projections add ~15ms per verify call.
+
+Two kernel morphologies:
+
+- split-K: grid y = N/4 column tiles, K reduction split across 2..4
+  simdgroups with a threadgroup reduction. Wins in-context (mixed scheduling
+  with attention/GDN kernels) — deep occupancy queues + latency hiding.
+- msg (multi-simdgroup): one threadgroup carries NSG barrier-free
+  simdgroups, each owning a BN=4 column tile with the full-K reduction
+  lane-strided over pack-interleaved weight words. Wins on huge-N (lm_head)
+  where the split-K tiny-tile grid thrashes the scheduler.
+
+Dispatch: split-K everywhere, msg for N >= 100k. Routing is armed only around
+the MTP verify forward via a thread-local flag (set by
+``omlx.patches.mlx_lm_mtp.batch_generator._call_backbone``) so nothing else
+in the process sees the patched ``nn.QuantizedLinear``.
+
+Numerics: fp32 accumulation in lane-strided K order differs from stock qmm
+at bf16 tail-ULP level. Greedy outputs can therefore occasionally diverge
+from the unrouted path (the token is still trunk-verified — the divergence
+class is the same as any kernel change).
+
+Supported: 4-bit and 8-bit affine, group_size in {32, 64, 128}, bf16/fp16
+activations, M in 3..6, K % 64 == 0, N % 4 == 0. Everything else falls
+back to stock.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+_KERNEL_CACHE: dict = {}
+_ROUTE_ARMED = threading.local()
+
+_MSG_NSG = 8  # simdgroups per threadgroup for the msg (lm_head) kernel
+
+# Only route projections with N >= this. The vk kernels beat stock qmm on GPU
+# time at every eligible shape, but each ``mx.fast.metal_kernel`` invocation
+# pays more Python/dispatch overhead than the built-in fast path. With ~330
+# projections per verify forward, routing the small GDN/attention shapes
+# (~1.0x GPU win) costs more on the CPU than it saves; the large-N shapes are
+# few calls with real wins (lm_head 2.6-3.3x at M=3-4).
+_MIN_ROUTE_N = 16384
+
+
+def set_verify_qmm_armed(flag: bool) -> None:
+    """Arm/disarm verify-qmm routing (MTP verify forwards only)."""
+    _ROUTE_ARMED.value = bool(flag)
+
+
+def _is_armed() -> bool:
+    return getattr(_ROUTE_ARMED, "value", False)
+
+
+# ---------------------------------------------------------------------------
+# msg kernel — lm_head geometry.
+# ---------------------------------------------------------------------------
+
+
+def _fma_block(m: int, bits: int) -> str:
+    per = 8 if bits == 4 else 4
+    mask = "0xFu" if bits == 4 else "0xFFu"
+    shift = 4 if bits == 4 else 8
+    lines = [f"for (int ki = 0; ki < {per}; ++ki) {{"]
+    for j in range(4):
+        lines.append(
+            f"    float w{j} = float((p{j} >> (ki * {shift})) & {mask}) * s{j} + b{j};"
+        )
+    for j in range(4):
+        for r in range(m):
+            lines.append(
+                f"    acc[{j} * {m} + {r}] += "
+                f"float(v{r}[ki{'' if bits == 4 else ' + koff'}]) * w{j};"
+            )
+    lines.append("}")
+    return "\n            ".join(lines)
+
+
+def _build_msg_kernel(m: int, bits: int, group_size: int, dtype, nsg: int):
+    import mlx.core as mx
+
+    key = ("msg", m, bits, group_size, dtype, nsg)
+    if key in _KERNEL_CACHE:
+        return _KERNEL_CACHE[key]
+
+    xloads = "\n            ".join(
+        f"Vec8 v{r} = xv[({r} * K + k_base) / 8];" for r in range(m)
+    )
+    if bits == 4:
+        pack_setup = """
+            int k_base = pack * 8;
+            int gi = k_base / GS;
+            uint32_t p0 = w_q[(n0 + 0) * K_by_p + pack];
+            uint32_t p1 = w_q[(n0 + 1) * K_by_p + pack];
+            uint32_t p2 = w_q[(n0 + 2) * K_by_p + pack];
+            uint32_t p3 = w_q[(n0 + 3) * K_by_p + pack];
+        """
+        body = f"""
+        for (int pack = int(lane); pack < K_by_p; pack += 32) {{
+            {pack_setup}
+            {xloads}
+            float s0 = float(scales[(n0 + 0) * K_by_gs + gi]);
+            float s1 = float(scales[(n0 + 1) * K_by_gs + gi]);
+            float s2 = float(scales[(n0 + 2) * K_by_gs + gi]);
+            float s3 = float(scales[(n0 + 3) * K_by_gs + gi]);
+            float b0 = float(biases[(n0 + 0) * K_by_gs + gi]);
+            float b1 = float(biases[(n0 + 1) * K_by_gs + gi]);
+            float b2 = float(biases[(n0 + 2) * K_by_gs + gi]);
+            float b3 = float(biases[(n0 + 3) * K_by_gs + gi]);
+            _Pragma("unroll")
+            {_fma_block(m, 4)}
+        }}
+        """
+    else:
+        body = f"""
+        for (int pair = int(lane); pair < K_by_p; pair += 32) {{
+            int k_base = pair * 8;
+            int gi = k_base / GS;
+            {xloads}
+            _Pragma("unroll")
+            for (int wsel = 0; wsel < 2; ++wsel) {{
+                int koff = wsel * 4;
+                uint32_t p0 = w_q[(n0 + 0) * (K / 4) + pair * 2 + wsel];
+                uint32_t p1 = w_q[(n0 + 1) * (K / 4) + pair * 2 + wsel];
+                uint32_t p2 = w_q[(n0 + 2) * (K / 4) + pair * 2 + wsel];
+                uint32_t p3 = w_q[(n0 + 3) * (K / 4) + pair * 2 + wsel];
+                float s0 = float(scales[(n0 + 0) * K_by_gs + gi]);
+                float s1 = float(scales[(n0 + 1) * K_by_gs + gi]);
+                float s2 = float(scales[(n0 + 2) * K_by_gs + gi]);
+                float s3 = float(scales[(n0 + 3) * K_by_gs + gi]);
+                float b0 = float(biases[(n0 + 0) * K_by_gs + gi]);
+                float b1 = float(biases[(n0 + 1) * K_by_gs + gi]);
+                float b2 = float(biases[(n0 + 2) * K_by_gs + gi]);
+                float b3 = float(biases[(n0 + 3) * K_by_gs + gi]);
+                _Pragma("unroll")
+                {_fma_block(m, 8)}
+            }}
+        }}
+        """
+
+    n_acc = 4 * m
+    source = f"""
+        using namespace metal;
+        constexpr int GS = {group_size};
+        constexpr int NSG = {nsg};
+        constexpr int MROWS = {m};
+
+        uint sg = simdgroup_index_in_threadgroup;
+        uint lane = thread_index_in_simdgroup;
+        uint tg_n = threadgroup_position_in_grid.y;
+
+        int K = int(K_size);
+        int N = int(N_size);
+        int K_by_p = {"K / 8" if bits == 4 else "K / 8"};
+        int K_by_gs = K / GS;
+        int n0 = (int(tg_n) * NSG + int(sg)) * 4;
+        if (n0 + 3 >= N) {{ return; }}
+
+        float acc[{n_acc}];
+        _Pragma("unroll")
+        for (int i = 0; i < {n_acc}; ++i) {{
+            acc[i] = 0.0f;
+        }}
+
+        using Vec8 = vec<T, 8>;
+        const device Vec8 *xv = (const device Vec8*)x;
+
+        {body}
+
+        _Pragma("unroll")
+        for (int i = 0; i < {n_acc}; ++i) {{
+            acc[i] = simd_sum(acc[i]);
+        }}
+
+        if (lane < {n_acc}) {{
+            int j = int(lane) / MROWS;
+            int row = int(lane) - j * MROWS;
+            y[row * N + n0 + j] = T(acc[int(lane)]);
+        }}
+    """
+
+    dtype_tag = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    kernel = mx.fast.metal_kernel(
+        name=f"omlx_vk_m{m}_q{bits}_nsg{nsg}_gs{group_size}_{dtype_tag}",
+        input_names=["x", "w_q", "scales", "biases", "K_size", "N_size"],
+        output_names=["y"],
+        source=source,
+    )
+    _KERNEL_CACHE[key] = kernel
+    return kernel
+
+
+# ---------------------------------------------------------------------------
+# split-K kernel — default.
+# ---------------------------------------------------------------------------
+
+
+def _pack_block(m: int, bits: int, sfx: str) -> str:
+    p = f"pack{sfx}"
+    lines = [f"int k_base{sfx} = {p} * 8;", f"int gi{sfx} = k_base{sfx} / GS;"]
+    for r in range(m):
+        lines.append(f"Vec8 v{sfx}_{r} = xv[({r} * K + k_base{sfx}) / 8];")
+    if bits == 4:
+        for j in range(4):
+            lines.append(f"uint32_t p{sfx}_{j} = w_q[(n0 + {j}) * K_by_p + {p}];")
+        for j in range(4):
+            lines.append(
+                f"float s{sfx}_{j} = float(scales[(n0 + {j}) * K_by_gs + gi{sfx}]);"
+                f" float b{sfx}_{j} = float(biases[(n0 + {j}) * K_by_gs + gi{sfx}]);"
+            )
+        for j in range(4):
+            block = [
+                "{",
+                f"    uint32_t packed = p{sfx}_{j};",
+                f"    float s = s{sfx}_{j};",
+                f"    float b = b{sfx}_{j};",
+                "    for (int ki = 0; ki < 8; ++ki) {",
+                "        float wv = float((packed >> (ki * 4)) & 0xFu) * s + b;",
+            ]
+            for r in range(m):
+                block.append(
+                    f"        acc[{j} * {m} + {r}] += float(v{sfx}_{r}[ki]) * wv;"
+                )
+            block.extend(["    }", "}"])
+            lines.extend(block)
+    else:
+        for j in range(4):
+            lines.append(
+                f"uint32_t pa{sfx}_{j} = w_q[(n0 + {j}) * K_by_w + {p} * 2];"
+                f" uint32_t pb{sfx}_{j} = w_q[(n0 + {j}) * K_by_w + {p} * 2 + 1];"
+            )
+        for j in range(4):
+            lines.append(
+                f"float s{sfx}_{j} = float(scales[(n0 + {j}) * K_by_gs + gi{sfx}]);"
+                f" float b{sfx}_{j} = float(biases[(n0 + {j}) * K_by_gs + gi{sfx}]);"
+            )
+        for j in range(4):
+            block = [
+                "{",
+                f"    uint32_t pa = pa{sfx}_{j};",
+                f"    uint32_t pb = pb{sfx}_{j};",
+                f"    float s = s{sfx}_{j};",
+                f"    float b = b{sfx}_{j};",
+                "    for (int ki = 0; ki < 4; ++ki) {",
+                "        float wa = float((pa >> (ki * 8)) & 0xFFu) * s + b;",
+                "        float wb = float((pb >> (ki * 8)) & 0xFFu) * s + b;",
+            ]
+            for r in range(m):
+                block.append(
+                    f"        acc[{j} * {m} + {r}] += float(v{sfx}_{r}[ki]) * wa;"
+                )
+                block.append(
+                    f"        acc[{j} * {m} + {r}] += float(v{sfx}_{r}[ki + 4]) * wb;"
+                )
+            block.extend(["    }", "}"])
+            lines.extend(block)
+    return "\n            ".join(lines)
+
+
+def _build_ksplit_kernel(m: int, bits: int, group_size: int, dtype, *, k_parts: int):
+    import mlx.core as mx
+
+    key = ("ksplit", m, bits, group_size, dtype, k_parts)
+    if key in _KERNEL_CACHE:
+        return _KERNEL_CACHE[key]
+
+    n_acc = 4 * m
+    loop = f"""
+        for (int packA = p_start + int(lane); packA < p_end; packA += 32) {{
+            {_pack_block(m, bits, "A")}
+        }}
+    """
+
+    source = f"""
+        using namespace metal;
+        constexpr int GS = {group_size};
+        constexpr int K_PARTS = {k_parts};
+
+        uint part = simdgroup_index_in_threadgroup;
+        uint lane = thread_index_in_simdgroup;
+        uint tg_n = threadgroup_position_in_grid.y;
+
+        int K = int(K_size);
+        int K_by_p = K / 8;
+        int K_by_w = K / 4;
+        int K_by_gs = K / GS;
+        int per_part = K_by_p / K_PARTS;
+        int N = int(N_size);
+        int n0 = int(tg_n) * 4;
+        int p_start = int(part) * per_part;
+        int p_end = (int(part) == K_PARTS - 1) ? K_by_p : p_start + per_part;
+
+        float acc[{n_acc}];
+        _Pragma("unroll")
+        for (int i = 0; i < {n_acc}; ++i) {{
+            acc[i] = 0.0f;
+        }}
+
+        using Vec8 = vec<T, 8>;
+        const device Vec8 *xv = (const device Vec8*)x;
+
+        {loop}
+
+        _Pragma("unroll")
+        for (int i = 0; i < {n_acc}; ++i) {{
+            acc[i] = simd_sum(acc[i]);
+        }}
+
+        threadgroup float partials[K_PARTS * {n_acc}];
+        if (lane == 0) {{
+            _Pragma("unroll")
+            for (int i = 0; i < {n_acc}; ++i) {{
+                partials[int(part) * {n_acc} + i] = acc[i];
+            }}
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (part == 0 && lane < {n_acc}) {{
+            float total = 0.0f;
+            _Pragma("unroll")
+            for (int p = 0; p < K_PARTS; ++p) {{
+                total += partials[p * {n_acc} + int(lane)];
+            }}
+            int j = int(lane) / {m};
+            int row = int(lane) - j * {m};
+            y[row * N + n0 + j] = T(total);
+        }}
+    """
+
+    dtype_tag = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    kernel = mx.fast.metal_kernel(
+        name=f"omlx_vk_ks_m{m}_q{bits}_kp{k_parts}_gs{group_size}_{dtype_tag}",
+        input_names=["x", "w_q", "scales", "biases", "K_size", "N_size"],
+        output_names=["y"],
+        source=source,
+    )
+    _KERNEL_CACHE[key] = kernel
+    return kernel
+
+
+# ---------------------------------------------------------------------------
+# Dispatch.
+# ---------------------------------------------------------------------------
+
+
+def _pad_rows(mx, x2, m: int):
+    M = int(x2.shape[0])
+    if M < m:
+        pad = mx.zeros((m - M, x2.shape[1]), dtype=x2.dtype)
+        return mx.contiguous(mx.concatenate([x2, pad], axis=0)), M
+    return mx.contiguous(x2), M
+
+
+def vk_qmm(x2, w_q, scales, biases, *, bits: int, group_size: int):
+    """Verify-shape qmm: (M, K) x (N, K)^T -> (M, N), M in 2..6.
+
+    Rows are padded up to the kernel's M template. split-K for regular
+    shapes, msg tile for huge N (lm_head).
+    """
+    import mlx.core as mx
+
+    M = int(x2.shape[0])
+    K = int(x2.shape[1])
+    N = int(w_q.shape[0])
+    m = 4 if M <= 4 else 6
+
+    if N >= 100000 and N % (4 * _MSG_NSG) == 0:
+        xm, M0 = _pad_rows(mx, x2, m)
+        kernel = _build_msg_kernel(m, bits, group_size, x2.dtype, _MSG_NSG)
+        cols = 4 * _MSG_NSG
+        (y,) = kernel(
+            inputs=[xm, w_q, scales, biases, K, N],
+            template=[("T", x2.dtype)],
+            grid=(32 * _MSG_NSG, (N + cols - 1) // cols, 1),
+            threadgroup=(32 * _MSG_NSG, 1, 1),
+            output_shapes=[(m, N)],
+            output_dtypes=[x2.dtype],
+        )
+        return y[:M0, :] if M0 < m else y
+
+    # Small M gets a dedicated template (fewer wasted accumulators).
+    m = max(2, min(6, M))
+    xm, M0 = _pad_rows(mx, x2, m)
+    k_parts = 2 if N >= 4096 else 4
+    kernel = _build_ksplit_kernel(m, bits, group_size, x2.dtype, k_parts=k_parts)
+    (y,) = kernel(
+        inputs=[xm, w_q, scales, biases, K, N],
+        template=[("T", x2.dtype)],
+        grid=(32 * k_parts, N // 4, 1),
+        threadgroup=(32 * k_parts, 1, 1),
+        output_shapes=[(m, N)],
+        output_dtypes=[x2.dtype],
+    )
+    return y[:M0, :] if M0 < m else y
+
+
+def vk_eligible(M: int, K: int, N: int, bits: int, group_size: int, dtype) -> bool:
+    import mlx.core as mx
+
+    # M >= 3: at M=2 (depth-1 verify) the dispatch overhead eats the GPU win
+    # AND skipping it keeps depth-1 greedy output bit-identical to the
+    # unrouted path. Depth >= 2 verifies at M >= 3 where the kernels pay.
+    return (
+        int(bits) in (4, 8)
+        and int(group_size) in (32, 64, 128)
+        and dtype in (mx.bfloat16, mx.float16)
+        and 3 <= int(M) <= 6
+        and int(K) % 64 == 0
+        and int(N) % 4 == 0
+        and int(N) >= _MIN_ROUTE_N
+    )
+
+
+# ---------------------------------------------------------------------------
+# QuantizedLinear routing patch.
+# ---------------------------------------------------------------------------
+
+_QL_PATCHED = False
+
+
+def apply_verify_qmm_patch() -> bool:
+    """Route verify-shaped ``nn.QuantizedLinear`` calls to the vk kernels.
+
+    Strictly gated: only while the MTP verify flag is armed
+    (``set_verify_qmm_armed``), only batch-1 rank-3 inputs with 3..6 rows,
+    only 4/8-bit affine layouts the kernels support. Everything else takes
+    the stock path.
+    """
+    global _QL_PATCHED
+    if _QL_PATCHED:
+        return True
+
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    cls = nn.QuantizedLinear
+    if getattr(cls, "_omlx_verify_qmm_patched", False):
+        _QL_PATCHED = True
+        return True
+
+    orig_call = cls.__call__
+
+    def patched_call(self, x):
+        if (
+            _is_armed()
+            and x.ndim == 3
+            and x.shape[0] == 1
+            and 2 <= x.shape[1] <= 6
+            and getattr(self, "mode", "affine") == "affine"
+            and vk_eligible(
+                x.shape[1],
+                x.shape[-1],
+                self.scales.shape[0],
+                self.bits,
+                self.group_size,
+                x.dtype,
+            )
+        ):
+            try:
+                y = vk_qmm(
+                    x[0],
+                    self.weight,
+                    self.scales,
+                    self.biases,
+                    bits=self.bits,
+                    group_size=self.group_size,
+                )
+                if hasattr(self, "bias"):
+                    y = y + self.bias
+                return y[None]
+            except Exception:
+                logger.debug("verify qmm route failed; stock fallback", exc_info=True)
+                return orig_call(self, x)
+        return orig_call(self, x)
+
+    cls.__call__ = patched_call
+    cls._omlx_verify_qmm_patched = True
+    _QL_PATCHED = True
+    logger.info("MTP verify qmm patch applied (M=2..6 affine 4/8-bit)")
+    return True

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1106,6 +1106,44 @@ def _is_turboquant_kv_family_cache(cache_obj: Any) -> bool:
     return isinstance(cache_obj, _MLXKVCache) or _is_turboquant_kv_cache(cache_obj)
 
 
+class _BoundaryStoreUnavailable(Exception):
+    """No boundary-aligned snapshot exists for non-sliceable cache state.
+
+    Raised inside the final-response store path when the model needs
+    boundary snapshots but none were captured (e.g. every capture was
+    skipped by the speculative-decode skew guard). Storing the live
+    state instead would label off-boundary recurrent/rotating state
+    with a block-boundary token count and corrupt later prefix hits;
+    the handler skips the store and releases the block references.
+    """
+
+
+def _first_leaf_cache_offset(cache_obj: Any) -> int | None:
+    """First integer ``offset`` found walking into composite caches.
+
+    CacheList-style wrappers (DeepSeek-V4 / GLM per-layer caches) expose
+    no ``offset`` themselves — the token position lives on their leading
+    sub-cache (RotatingKVCache / KVCache, whose ``offset`` counts
+    forwarded tokens). Walk depth-first so that leading leaf decides;
+    later sub-caches may count something else entirely (PoolingCache's
+    ``offset`` is the pooled-window count).
+    """
+    subs = getattr(cache_obj, "caches", None)
+    if isinstance(subs, (list, tuple)):
+        for sub in subs:
+            offset = _first_leaf_cache_offset(sub)
+            if offset is not None:
+                return offset
+        return None
+    offset = getattr(cache_obj, "offset", None)
+    if offset is None:
+        return None
+    try:
+        return int(offset)
+    except Exception:
+        return None
+
+
 def _prompt_cache_needs_snapshots(prompt_cache: list[Any]) -> bool:
     """Return True if any layer cache is non-sliceable (needs snapshots).
 
@@ -4954,10 +4992,16 @@ class Scheduler:
             self._boundary_snapshot_required = False
             return False
 
-        self._boundary_snapshot_required = any(
-            self._cache_tree_has_stateful_non_sliceable(layer_cache)
-            for layer_cache in cache_list
-        )
+        try:
+            self._boundary_snapshot_required = any(
+                self._cache_tree_has_stateful_non_sliceable(layer_cache)
+                for layer_cache in cache_list
+            )
+        except TypeError:
+            # make_cache() returned something non-iterable (stub models in
+            # tests); treat as not snapshot-needing.
+            self._boundary_snapshot_required = False
+            return False
 
         if self._boundary_snapshot_required:
             logger.info(
@@ -5017,13 +5061,13 @@ class Scheduler:
                         return None
                     cache_list, _tokens = result[uid]
                     if expected_tokens is not None:
+                        # Walk into CacheList wrappers: DeepSeek-V4/GLM layer
+                        # caches carry their token offset on a sub-cache, and
+                        # checking only the wrapper would silently pass a
+                        # skewed capture through.
                         for c in cache_list:
-                            offset = getattr(c, "offset", None)
+                            offset = _first_leaf_cache_offset(c)
                             if offset is None:
-                                continue
-                            try:
-                                offset = int(offset)
-                            except Exception:
                                 continue
                             if offset != expected_tokens:
                                 logger.debug(
@@ -8946,6 +8990,17 @@ class Scheduler:
                                                 cacheable_sequence,
                                             )
                                         )
+                                        if (
+                                            boundary_override is None
+                                            and self._detect_boundary_snapshot_need()
+                                        ):
+                                            # Non-sliceable cache state is only
+                                            # storable from boundary-aligned
+                                            # snapshots; the live state sits at
+                                            # the current decode offset (which
+                                            # speculative decode can leave off
+                                            # the emitted count entirely).
+                                            raise _BoundaryStoreUnavailable()
                                         if boundary_override is not None:
                                             (
                                                 token_sequence_to_store,
@@ -9098,6 +9153,25 @@ class Scheduler:
                                 f"{len(request.prompt_token_ids)} prompt + "
                                 f"{len(request.output_token_ids)} output)"
                             )
+                        except _BoundaryStoreUnavailable:
+                            logger.debug(
+                                "Skipping cache store for %s: no boundary-aligned "
+                                "snapshot for non-sliceable cache state (all "
+                                "captures skipped, e.g. by the speculative-decode "
+                                "skew guard); storing live state would corrupt "
+                                "later prefix hits",
+                                request_id,
+                            )
+                            block_table = None
+                            if self.paged_cache_manager:
+                                block_table = self.paged_cache_manager.get_block_table(
+                                    request_id
+                                )
+                            if block_table and self.paged_cache_manager:
+                                self.paged_cache_manager.release_for_eviction(
+                                    block_table.block_ids
+                                )
+                            self.block_aware_cache.clear_request_entry(request_id)
                         except Exception as e:
                             logger.debug(
                                 f"Failed to submit async store for {request_id}: {e}"

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -4964,6 +4964,17 @@ class Scheduler:
                 "Enabled boundary cache snapshots for stateful non-sliceable "
                 "cache layers"
             )
+            # Ask the speculative (MTP) decode path to land its commits on
+            # block boundaries: its emit queue otherwise leaves the cache a
+            # few tokens ahead of the emitted count when a boundary token
+            # surfaces, which forces the consistency guard in
+            # _extract_boundary_snapshot to skip most captures.
+            block = int(self.config.paged_cache_block_size or 0)
+            if block > 0:
+                try:
+                    self.model._omlx_mtp_commit_align = block
+                except Exception:
+                    pass
         else:
             logger.debug(
                 "Boundary cache snapshots disabled (no stateful non-sliceable "
@@ -4972,11 +4983,24 @@ class Scheduler:
 
         return self._boundary_snapshot_required
 
-    def _extract_boundary_snapshot(self, uid: int) -> list[Any] | None:
+    def _extract_boundary_snapshot(
+        self, uid: int, expected_tokens: int | None = None
+    ) -> list[Any] | None:
         """Extract a per-request prompt cache snapshot via extract_cache().
 
         Uses BatchGenerator.extract_cache() which returns
         Dict[uid, (cache_list, tokens_list)].
+
+        ``expected_tokens`` guards positional consistency: a snapshot labeled
+        "state at N tokens" must be extracted while the cache holds exactly N
+        forwarded tokens. The standard decode step always satisfies this at
+        emit time, but speculative (MTP) decode advances the cache in bursts
+        and emits from a queue, so the cache can be a few tokens ahead of —
+        or one behind — the emitted count when the boundary token surfaces.
+        A skewed snapshot would pair block-aligned KV with recurrent (SSM)
+        state from a different position and corrupt later prefix-cache hits
+        on hybrid models; skipping the capture merely costs a reuse
+        opportunity.
         """
         if self.batch_generator is None:
             return None
@@ -4992,6 +5016,26 @@ class Scheduler:
                     if uid not in result:
                         return None
                     cache_list, _tokens = result[uid]
+                    if expected_tokens is not None:
+                        for c in cache_list:
+                            offset = getattr(c, "offset", None)
+                            if offset is None:
+                                continue
+                            try:
+                                offset = int(offset)
+                            except Exception:
+                                continue
+                            if offset != expected_tokens:
+                                logger.debug(
+                                    "Skipping boundary snapshot for uid=%s: "
+                                    "cache offset %d != boundary %d "
+                                    "(speculative decode skew)",
+                                    uid,
+                                    offset,
+                                    expected_tokens,
+                                )
+                                return None
+                            break
                     # Only extract non-sliceable layers to avoid costly
                     # deep-copy accumulation (same rationale as prefill path).
                     return [
@@ -5024,7 +5068,9 @@ class Scheduler:
         if not self._detect_boundary_snapshot_need():
             return
 
-        snapshot_cache = self._extract_boundary_snapshot(uid)
+        snapshot_cache = self._extract_boundary_snapshot(
+            uid, expected_tokens=total_tokens
+        )
         if not snapshot_cache:
             return
 

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -286,10 +286,20 @@ def maybe_apply_pre_load_patches(
         from ..patches.mlx_lm_mtp import (
             apply_mlx_lm_mtp_patch,
             set_mtp_active,
+            set_mtp_depth,
         )
 
         if apply_mlx_lm_mtp_patch():
             set_mtp_active(mtp_enabled)
+            # mtp_num_draft_tokens is the MAX draft depth; an adaptive
+            # controller picks 1..max per sequence from rolling accept/latency
+            # estimates, so prose/chat settles at 1 and predictable text
+            # climbs. Set it to 1 for a fixed depth-1 cycle. Note: depth >= 2
+            # verify forwards route through the verify-shape qmm kernels
+            # (M >= 3), whose numerics can diverge from the unrouted path at
+            # bf16 tail-ULP level.
+            depth = getattr(model_settings, "mtp_num_draft_tokens", None)
+            set_mtp_depth(int(depth) if depth else 3)
             if mtp_enabled:
                 logger.info(
                     "Native MTP patch applied for %s (model_type=%s, active)",

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -472,8 +472,33 @@ _MTP_WEIGHT_PREFIXES = (
 )
 
 
+def _nextn_weight_prefixes(model_path: str | Path) -> tuple[str, ...]:
+    """Weight-key prefixes for MTP layers stored as extra decoder layers.
+
+    DeepSeek-V3-style checkpoints (GLM-5.2 among them) keep their MTP head
+    as ``model.layers.<num_hidden_layers + i>.*`` rather than ``mtp.*``;
+    the model patch's sanitize remaps them at load/convert time, so for
+    detection purposes those layers count as MTP weights.
+    """
+    try:
+        config = json.loads((Path(model_path) / "config.json").read_text())
+    except Exception:
+        return ()
+    cfgs = (config, config.get("text_config") or {})
+    n_mtp = max(int(c.get("num_nextn_predict_layers", 0) or 0) for c in cfgs)
+    if n_mtp <= 0:
+        return ()
+    n_main = max(int(c.get("num_hidden_layers", 0) or 0) for c in cfgs)
+    if n_main <= 0:
+        return ()
+    return tuple(f"model.layers.{n_main + i}." for i in range(n_mtp))
+
+
 def _checkpoint_has_mtp_weights(model_path: str | Path) -> bool:
-    """True iff the checkpoint at *model_path* ships any ``mtp.*`` weight tensor.
+    """True iff the checkpoint at *model_path* ships any MTP weight tensor.
+
+    Matches both the ``mtp.*`` naming and the nextn layout (extra decoder
+    layers past ``num_hidden_layers``, see ``_nextn_weight_prefixes``).
 
     Some Qwen3.6 MoE VLM exports declare ``mtp_num_hidden_layers > 0`` in
     ``config.json`` but strip the MTP weights during conversion (e.g.
@@ -491,12 +516,14 @@ def _checkpoint_has_mtp_weights(model_path: str | Path) -> bool:
     if not p.is_dir():
         return False
 
+    prefixes = _MTP_WEIGHT_PREFIXES + _nextn_weight_prefixes(p)
+
     index_path = p / "model.safetensors.index.json"
     if index_path.exists():
         try:
             data = json.loads(index_path.read_text())
             weight_map = data.get("weight_map") or {}
-            return any(k.startswith(_MTP_WEIGHT_PREFIXES) for k in weight_map)
+            return any(k.startswith(prefixes) for k in weight_map)
         except Exception as e:
             logger.debug("Failed to read %s for mtp weight scan: %s", index_path, e)
 
@@ -513,7 +540,7 @@ def _checkpoint_has_mtp_weights(model_path: str | Path) -> bool:
         try:
             with safetensors.safe_open(str(shard), framework="numpy") as f:
                 for k in f.keys():
-                    if k.startswith(_MTP_WEIGHT_PREFIXES):
+                    if k.startswith(prefixes):
                         return True
         except Exception as e:
             logger.debug("Failed to read %s header for mtp weight scan: %s", shard, e)

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -523,9 +523,9 @@ def _checkpoint_has_mtp_weights(model_path: str | Path) -> bool:
 def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
     """Decide whether the native MTP patch can be applied to this model.
 
-    Phase 1 supports Qwen3.5/3.6 (mlx-lm PR 990) and DeepSeek-V4-Flash
-    (Blaizzy/mlx-lm fork PR 15). The model also has to declare MTP heads
-    in the config; otherwise the patch is a no-op.
+    Supports Qwen3.5/3.6 (mlx-lm PR 990), DeepSeek-V4-Flash (Blaizzy/mlx-lm
+    fork PR 15) and GLM-5.2 (glm_moe_dsa). The model also has to declare
+    MTP heads in the config; otherwise the patch is a no-op.
     """
     if not _has_mtp_heads(config):
         return False
@@ -535,6 +535,7 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
         model_type.startswith("qwen3_5")
         or model_type.startswith("qwen3_6")
         or model_type.startswith("deepseek_v4")
+        or model_type == "glm_moe_dsa"
     )
 
 

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -1201,14 +1201,35 @@ class TestPoolingCacheTrimRollback:
         )
 
     def test_untrimmable_when_no_undo_after_prompt(self, applied_patch):
-        """Prompt-sized updates (L > 2) don't stash an undo log; a trim at
+        """Prompt-sized updates (L > 8) don't stash an undo log; a trim at
         a pool boundary right after one must report not-trimmable instead
-        of corrupting state."""
+        of corrupting state. (Updates up to L == 8 keep an undo so depth-k
+        MTP verify windows can roll back.)"""
+        from mlx_lm.models.cache import PoolingCache
+
+        cache = PoolingCache(4)
+        self._push(
+            cache,
+            self._tok([float(v) for v in range(1, 13)]),  # L = 12 > 8
+            0,
+        )
+        assert cache.remainder == 0
+        assert cache.pooled is not None
+        assert not cache.is_trimmable()
+        assert cache.trim(1) == 0
+
+    def test_verify_sized_update_keeps_undo(self, applied_patch):
+        """MTP verify windows (2 < L <= 8) stash an undo log: a trim right
+        after one rolls back across the pool boundary instead of failing."""
         from mlx_lm.models.cache import PoolingCache
 
         cache = PoolingCache(4)
         self._push(cache, self._tok([1.0, 2.0, 3.0, 4.0]), 0)
         assert cache.remainder == 0
         assert cache.pooled is not None
-        assert not cache.is_trimmable()
-        assert cache.trim(1) == 0
+        assert cache.is_trimmable()
+        assert cache.trim(1) == 1
+        # The completed window is undone: its 3 surviving tokens are back
+        # in the remainder buffer and no pooled row remains visible.
+        assert cache.remainder == 3
+        assert cache.size() == 0

--- a/tests/test_glm_mtp_patch.py
+++ b/tests/test_glm_mtp_patch.py
@@ -360,3 +360,42 @@ class TestSmallLRouting:
             absorbed = run(L, 8)
             diff = float(mx.abs(legacy - absorbed).max())
             assert diff < 2e-5, f"L={L}: {diff}"
+
+    def test_topk_gather_matches_masked_reference(self, glm, mtp_active):
+        """With the DSA indexer active (K > index_topk), the decode-shape
+        per-row gather path must equal the legacy masked full-K path."""
+        import omlx.patches.glm_moe_dsa.glm_moe_dsa_model as gm
+        from mlx_lm.models.base import create_attention_mask
+        from mlx_lm.models.cache import KVCache
+
+        mx.random.seed(5)
+        args = glm.ModelArgs.from_dict(TINY_CFG)
+        attn = glm.GlmMoeDsaAttention(args, 0)
+        mx.eval(attn.parameters())
+
+        def run(L, max_l):
+            mx.random.seed(17)
+            cache = [KVCache(), KVCache()]
+            # Prefill past index_topk (16) so the indexer emits topk state.
+            x_pre = mx.random.normal((1, 24, TINY_CFG["hidden_size"]))
+            mask = create_attention_mask(x_pre, cache[0], return_array=True)
+            out, _ = attn(x_pre, mask, cache, None)
+            mx.eval(out)
+            x = mx.random.normal((1, L, TINY_CFG["hidden_size"]))
+            mask = create_attention_mask(x, cache[0], return_array=True)
+            saved = gm._ABSORBED_DECODE_MAX_L
+            gm._ABSORBED_DECODE_MAX_L = max_l
+            try:
+                out, state = attn(x, mask, cache, None)
+                mx.eval(out)
+            finally:
+                gm._ABSORBED_DECODE_MAX_L = saved
+            return out, state
+
+        for L in (2, 3, 4):
+            legacy, legacy_state = run(L, 1)  # masked materialize fallback
+            gathered, state = run(L, 8)  # per-row topk gather
+            idx, prefix = gm._parse_topk_state(state)
+            assert idx is not None and idx.shape[2] == L and prefix == 0
+            diff = float(mx.abs(legacy - gathered).max())
+            assert diff < 2e-5, f"L={L}: {diff}"

--- a/tests/test_glm_mtp_patch.py
+++ b/tests/test_glm_mtp_patch.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the GLM-5.2 (glm_moe_dsa) native MTP patch."""
+
+import sys
+
+import mlx.core as mx
+import mlx.utils as mu
+import pytest
+
+from omlx.patches.glm_moe_dsa import apply_glm_moe_dsa_patch
+from omlx.patches.mlx_lm_mtp import apply_mlx_lm_mtp_patch, set_mtp_active
+
+
+@pytest.fixture(scope="module")
+def glm():
+    apply_glm_moe_dsa_patch()
+    apply_mlx_lm_mtp_patch()
+    return sys.modules["mlx_lm.models.glm_moe_dsa"]
+
+
+@pytest.fixture()
+def mtp_active():
+    set_mtp_active(True)
+    yield
+    set_mtp_active(False)
+
+
+TINY_CFG = dict(
+    model_type="glm_moe_dsa",
+    vocab_size=128,
+    hidden_size=64,
+    index_head_dim=32,
+    index_n_heads=4,
+    index_topk=16,
+    intermediate_size=96,
+    moe_intermediate_size=32,
+    num_hidden_layers=2,
+    num_attention_heads=4,
+    num_key_value_heads=4,
+    n_shared_experts=1,
+    n_routed_experts=4,
+    routed_scaling_factor=1.0,
+    kv_lora_rank=32,
+    q_lora_rank=48,
+    qk_rope_head_dim=16,
+    v_head_dim=32,
+    qk_nope_head_dim=24,
+    topk_method="noaux_tc",
+    scoring_func="sigmoid",
+    norm_topk_prob=True,
+    n_group=1,
+    topk_group=1,
+    num_experts_per_tok=2,
+    moe_layer_freq=1,
+    first_k_dense_replace=1,
+    max_position_embeddings=512,
+    rms_norm_eps=1e-5,
+    rope_parameters={"rope_theta": 10000.0, "rope_type": "default"},
+    attention_bias=False,
+    index_topk_freq=4,
+    index_skip_topk_offset=3,
+    indexer_types=["full", "shared"],
+    num_nextn_predict_layers=1,
+)
+
+
+def _raw_hf_weights(glm, model):
+    """Rebuild a raw-HF-layout weights dict from a built model's params.
+
+    Inverts the sanitize transforms for the MTP layer (switch stacking,
+    gate_up fusion, embed_q/unembed_out) so sanitize can be exercised on
+    checkpoint-shaped input.
+    """
+    cfg = TINY_CFG
+    flat = dict(mu.tree_flatten(model.parameters()))
+    weights = {}
+    for k, v in flat.items():
+        if k.startswith("mtp.0."):
+            rest = k[len("mtp.0."):]
+            if rest.startswith("block."):
+                rk = "model.layers.2." + rest[len("block."):]
+            elif rest == "norm.weight":
+                rk = "model.layers.2.shared_head.norm.weight"
+            else:
+                rk = "model.layers.2." + rest
+            weights[rk] = v
+        else:
+            weights[k] = v
+
+    raw = {}
+    for k, v in weights.items():
+        if ".mlp.switch_mlp.gate_up_proj.weight" in k:
+            base = k.split(".mlp.switch_mlp.")[0]
+            gate, up = mx.split(v, 2, axis=1)
+            for e in range(v.shape[0]):
+                raw[f"{base}.mlp.experts.{e}.gate_proj.weight"] = gate[e]
+                raw[f"{base}.mlp.experts.{e}.up_proj.weight"] = up[e]
+        elif ".mlp.switch_mlp.down_proj.weight" in k:
+            base = k.split(".mlp.switch_mlp.")[0]
+            for e in range(v.shape[0]):
+                raw[f"{base}.mlp.experts.{e}.down_proj.weight"] = v[e]
+        elif ".self_attn.embed_q.weight" in k:
+            continue  # regenerated from the fabricated kv_b_proj below
+        elif ".self_attn.unembed_out.weight" in k:
+            base = k.split(".self_attn.")[0]
+            nh = cfg["num_attention_heads"]
+            hd = cfg["qk_nope_head_dim"] + cfg["v_head_dim"]
+            raw[f"{base}.self_attn.kv_b_proj.weight"] = mx.random.normal(
+                (nh * hd, cfg["kv_lora_rank"])
+            )
+        else:
+            raw[k] = v
+    return raw
+
+
+class TestModelArgs:
+    def test_nextn_count_and_indexer_extension(self, glm):
+        args = glm.ModelArgs.from_dict(TINY_CFG)
+        assert args.num_nextn_predict_layers == 1
+        # freq=4/offset=3: layer 2 -> max(0,0)%4==0 -> "full"
+        assert args.indexer_types == ["full", "shared", "full"]
+
+    def test_no_nextn_is_untouched(self, glm):
+        cfg = dict(TINY_CFG, num_nextn_predict_layers=0)
+        args = glm.ModelArgs.from_dict(cfg)
+        assert args.num_nextn_predict_layers == 0
+        assert args.indexer_types == ["full", "shared"]
+
+
+class TestModelInit:
+    def test_mtp_attached_when_active(self, glm, mtp_active):
+        args = glm.ModelArgs.from_dict(TINY_CFG)
+        model = glm.Model(args)
+        assert hasattr(model, "mtp") and len(model.mtp) == 1
+        assert model._omlx_mtp_decode_enabled
+        assert model._omlx_mtp_chain
+        assert model._omlx_mtp_head_clone is False
+
+    def test_mtp_skipped_when_inactive(self, glm):
+        set_mtp_active(False)
+        args = glm.ModelArgs.from_dict(TINY_CFG)
+        model = glm.Model(args)
+        assert not hasattr(model, "mtp")
+        assert model._omlx_mtp_decode_enabled is False
+
+
+class TestSanitize:
+    def test_raw_hf_remap_and_strict_load(self, glm, mtp_active):
+        mx.random.seed(0)
+        args = glm.ModelArgs.from_dict(TINY_CFG)
+        model = glm.Model(args)
+        raw = _raw_hf_weights(glm, model)
+
+        out = model.sanitize(raw)
+        assert not any(".layers.2." in k for k in out)
+        for expected in (
+            "mtp.0.eh_proj.weight",
+            "mtp.0.enorm.weight",
+            "mtp.0.hnorm.weight",
+            "mtp.0.norm.weight",
+            "mtp.0.block.mlp.switch_mlp.gate_up_proj.weight",
+            "mtp.0.block.self_attn.embed_q.weight",
+            "mtp.0.block.self_attn.indexer.wk.weight",
+        ):
+            assert expected in out, expected
+        model.load_weights(list(out.items()), strict=True)
+
+    def test_layer_count_restored_after_sanitize(self, glm, mtp_active):
+        args = glm.ModelArgs.from_dict(TINY_CFG)
+        model = glm.Model(args)
+        raw = _raw_hf_weights(glm, model)
+        model.sanitize(raw)
+        assert model.args.num_hidden_layers == TINY_CFG["num_hidden_layers"]
+
+    def test_presanitized_passthrough(self, glm, mtp_active):
+        """oQ-style checkpoints (already mtp.*) survive a second sanitize."""
+        mx.random.seed(0)
+        args = glm.ModelArgs.from_dict(TINY_CFG)
+        model = glm.Model(args)
+        once = model.sanitize(_raw_hf_weights(glm, model))
+        twice = model.sanitize(dict(once))
+        assert sorted(twice) == sorted(once)
+        model.load_weights(list(twice.items()), strict=True)
+
+    def test_mtp_off_drops_all_mtp_keys(self, glm, mtp_active):
+        mx.random.seed(0)
+        args = glm.ModelArgs.from_dict(TINY_CFG)
+        model = glm.Model(args)
+        sanitized = model.sanitize(_raw_hf_weights(glm, model))
+
+        set_mtp_active(False)
+        model_off = glm.Model(args)
+        out = model_off.sanitize(dict(sanitized))
+        assert not any(k.startswith("mtp.") for k in out)
+        model_off.load_weights(list(out.items()), strict=True)
+
+    def test_missing_head_weights_degrades_gracefully(self, glm, mtp_active):
+        mx.random.seed(0)
+        args = glm.ModelArgs.from_dict(TINY_CFG)
+        model = glm.Model(args)
+        sanitized = model.sanitize(_raw_hf_weights(glm, model))
+        stripped = {k: v for k, v in sanitized.items() if not k.startswith("mtp.")}
+
+        model2 = glm.Model(args)
+        out = model2.sanitize(stripped)
+        assert not hasattr(model2, "mtp")
+        assert model2._omlx_mtp_decode_enabled is False
+        model2.load_weights(list(out.items()), strict=True)
+
+
+class TestIndexerFusion:
+    def test_mtp_indexer_fused_alongside_backbone(self, glm, mtp_active):
+        """MTP indexer fusion must happen before the stock sanitize: its
+        backbone fusion pass drops every unfused ``.indexer.wk`` /
+        ``.weights_proj`` key by substring, MTP keys included."""
+        cfg = dict(TINY_CFG)
+        q8 = {"bits": 8, "group_size": 64, "mode": "affine"}
+        cfg["quantization"] = {
+            "group_size": 64,
+            "bits": 4,
+            "mode": "affine",
+            "model.layers.0.self_attn.indexer.wk": dict(q8),
+            "model.layers.0.self_attn.indexer.weights_proj": dict(q8),
+        }
+        args = glm.ModelArgs.from_dict(cfg)
+        model = glm.Model(args)
+        assert model.mtp[0].block.self_attn.indexer.wk_weights_proj is not None
+
+        h = TINY_CFG["hidden_size"]
+        hd = TINY_CFG["index_head_dim"]
+        nh = TINY_CFG["index_n_heads"]
+        weights = {}
+        for prefix in (
+            "model.layers.0.self_attn.indexer",
+            "mtp.0.block.self_attn.indexer",
+        ):
+            for suffix in ("weight", "scales", "biases"):
+                weights[f"{prefix}.wk.{suffix}"] = mx.zeros((hd, 4))
+                weights[f"{prefix}.weights_proj.{suffix}"] = mx.zeros((nh, 4))
+
+        out = model.sanitize(weights)
+        for prefix in (
+            "model.layers.0.self_attn.indexer",
+            "mtp.0.block.self_attn.indexer",
+        ):
+            assert f"{prefix}.wk_weights_proj.weight" in out, prefix
+            assert f"{prefix}.wk.weight" not in out
+            assert f"{prefix}.weights_proj.weight" not in out
+        assert out["mtp.0.block.self_attn.indexer.wk_weights_proj.weight"].shape == (
+            hd + nh,
+            4,
+        )
+
+
+class TestForward:
+    @pytest.fixture()
+    def loaded(self, glm, mtp_active):
+        mx.random.seed(0)
+        args = glm.ModelArgs.from_dict(TINY_CFG)
+        model = glm.Model(args)
+        out = model.sanitize(_raw_hf_weights(glm, model))
+        model.load_weights(list(out.items()), strict=True)
+        mx.eval(model.parameters())
+        return model
+
+    def test_return_hidden_and_mtp_cycle(self, loaded):
+        model = loaded
+        cache = model.make_cache()
+        toks = mx.array([[1, 2, 3, 4]])
+        logits, hidden = model(toks, cache=cache, return_hidden=True)
+        mx.eval(logits, hidden)
+        assert logits.shape == (1, 4, TINY_CFG["vocab_size"])
+        assert hidden.shape == (1, 4, TINY_CFG["hidden_size"])
+
+        # hidden is pre-norm: normed hidden feeds the head (post-norm contract)
+        post = model.model.norm(hidden)
+        mtp_cache = model.make_mtp_cache()
+        assert isinstance(mtp_cache, list) and len(mtp_cache) == 2
+
+        lg, hh = model.mtp_forward(
+            post, toks, mtp_cache, return_hidden=True, logits_keep=1
+        )
+        mx.eval(lg, hh)
+        assert lg.shape == (1, 1, TINY_CFG["vocab_size"])
+        assert hh.shape == (1, 4, TINY_CFG["hidden_size"])
+        assert mtp_cache[0].offset == 4 and mtp_cache[1].offset == 4
+
+        # chained draft step + rollback trim
+        lg2, _ = model.mtp_forward(
+            hh[:, -1:], mx.array([[7]]), mtp_cache, return_hidden=True
+        )
+        mx.eval(lg2)
+        assert mtp_cache[0].offset == 5
+
+        from omlx.patches.mlx_lm_mtp.batch_generator import _mtp_head_trim_to
+
+        _mtp_head_trim_to(mtp_cache, 4)
+        assert mtp_cache[0].offset == 4 and mtp_cache[1].offset == 4
+
+    def test_partial_rollback_trims_verify_window(self, loaded):
+        model = loaded
+        cache = model.make_cache()
+        logits, _ = model(mx.array([[1, 2, 3]]), cache=cache, return_hidden=True)
+        mx.eval(logits, *(c[0].keys for c in cache))
+        base = cache[0][0].offset
+
+        # verify window: num_drafts + 1 rows, accept 1 of 3 drafts
+        logits, _ = model(
+            mx.array([[4, 5, 6, 7]]), cache=cache, return_hidden=True
+        )
+        mx.eval(logits, *(c[0].keys for c in cache))
+        assert cache[0][0].offset == base + 4
+
+        assert model.mtp_partial_rollback(cache, 1, 3)
+        for c in cache:
+            for sub in c.caches:  # latent KV (+ indexer KV on full layers)
+                assert sub.offset == base + 2  # next_main + 1 accepted draft
+
+    def test_n_confirmed_accepted(self, loaded):
+        cache = loaded.make_cache()
+        logits, _ = loaded(
+            mx.array([[1, 2]]), cache=cache, return_hidden=True, n_confirmed=1
+        )
+        mx.eval(logits)
+        assert logits.shape == (1, 2, TINY_CFG["vocab_size"])
+
+
+class TestSmallLRouting:
+    def test_absorbed_matches_materialized(self, glm, mtp_active):
+        """The widened L<=8 absorbed path equals the legacy materialize path."""
+        import omlx.patches.glm_moe_dsa.glm_moe_dsa_model as gm
+        from mlx_lm.models.base import create_attention_mask
+        from mlx_lm.models.cache import KVCache
+
+        mx.random.seed(3)
+        args = glm.ModelArgs.from_dict(TINY_CFG)
+        attn = glm.GlmMoeDsaAttention(args, 0)
+        mx.eval(attn.parameters())
+
+        def run(L, max_l):
+            mx.random.seed(11)
+            cache = [KVCache(), KVCache()]
+            x_pre = mx.random.normal((1, 12, TINY_CFG["hidden_size"]))
+            mask = create_attention_mask(x_pre, cache[0], return_array=True)
+            out, _ = attn(x_pre, mask, cache, None)
+            mx.eval(out)
+            x = mx.random.normal((1, L, TINY_CFG["hidden_size"]))
+            mask = create_attention_mask(x, cache[0], return_array=True)
+            saved = gm._ABSORBED_DECODE_MAX_L
+            gm._ABSORBED_DECODE_MAX_L = max_l
+            try:
+                out, _ = attn(x, mask, cache, None)
+                mx.eval(out)
+            finally:
+                gm._ABSORBED_DECODE_MAX_L = saved
+            return out
+
+        for L in (2, 3, 4, 8):
+            legacy = run(L, 1)
+            absorbed = run(L, 8)
+            diff = float(mx.abs(legacy - absorbed).max())
+            assert diff < 2e-5, f"L={L}: {diff}"

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -309,11 +309,13 @@ class TestQwen35MtpNormShift:
 
     def test_oq_discovery_keeps_mtp_norm_shift_on_raw_hf_source(self):
         """oQ streaming-plan discovery runs sanitize on no-data _TrackedTensor
-        placeholders where the per-key magnitude can't be read. The helper
-        must record a conditional replay transform for MTP norms so the
-        materialization path can still decide from the real tensor value.
-        Otherwise full-precision Qwen3.6 sources with mixed MTP norm
-        conventions can be double-shifted or left unshifted."""
+        placeholders. On a raw-HF source (unsanitized conv1d present) every
+        Qwen3-Next RMSNorm gamma is zero-centered, so MTP-head norms record
+        the same unconditional +1 "add" transform as the backbone norms.
+        (The old conditional add_if_mean_lt_0_5 misclassified q_norm/k_norm
+        [raw mean ~0.75] and mtp.norm [raw ~1.27], costing ~14pp of draft
+        acceptance on Qwen3.6-27B.) Pre-converted sources — no unsanitized
+        conv1d — keep the per-key conditional for mixed-convention bundles."""
         import mlx.core as mx
 
         from omlx.oq import _discover_sanitize_plan
@@ -336,14 +338,10 @@ class TestQwen35MtpNormShift:
         }
         plan = _discover_sanitize_plan(m.sanitize, _FakeIdx(meta))
 
-        # Backbone still has a fixed +1 add from the raw-HF conv1d signal.
-        # MTP norms need per-key value checks at materialization time.
+        # Raw-HF source: backbone AND head norms all take the fixed +1 add.
         assert plan["model.layers.0.input_layernorm.weight"]["transform"] == "add"
-        assert (
-            plan["mtp.layers.0.input_layernorm.weight"]["transform"]
-            == "add_if_mean_lt_0_5"
-        )
-        assert plan["mtp.norm.weight"]["transform"] == "add_if_mean_lt_0_5"
+        assert plan["mtp.layers.0.input_layernorm.weight"]["transform"] == "add"
+        assert plan["mtp.norm.weight"]["transform"] == "add"
 
 
 class TestQwen35MoeSanitize:

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -484,6 +484,36 @@ class TestCheckpointHasMtpWeights:
         )
         assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is False
 
+    def test_returns_true_for_nextn_layout(self, tmp_path):
+        # DeepSeek-V3-style checkpoints (GLM-5.2) keep the MTP head as an
+        # extra decoder layer past num_hidden_layers, not under mtp.*.
+        import json as _json
+
+        (tmp_path / "config.json").write_text(
+            _json.dumps({"num_hidden_layers": 78, "num_nextn_predict_layers": 1})
+        )
+        self._write_index(
+            tmp_path,
+            {
+                "model.layers.0.self_attn.q_a_proj.weight": "model.safetensors",
+                "model.layers.78.eh_proj.weight": "model.safetensors",
+            },
+        )
+        assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is True
+
+    def test_returns_false_for_nextn_config_without_weights(self, tmp_path):
+        # Config declares nextn layers but the checkpoint stripped them.
+        import json as _json
+
+        (tmp_path / "config.json").write_text(
+            _json.dumps({"num_hidden_layers": 78, "num_nextn_predict_layers": 1})
+        )
+        self._write_index(
+            tmp_path,
+            {"model.layers.0.self_attn.q_a_proj.weight": "model.safetensors"},
+        )
+        assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is False
+
     def test_returns_false_for_empty_dir(self, tmp_path):
         # No index, no shards — caller treats as "no MTP weights".
         assert model_loading._checkpoint_has_mtp_weights(str(tmp_path)) is False

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -2314,8 +2314,17 @@ class TestBuildProxyForSensitivity:
 
         calls = []
 
-        def _fake_build(model_path, output_path, *, dtype, trust_remote_code=False):
-            calls.append((model_path, output_path, dtype, trust_remote_code))
+        def _fake_build(
+            model_path,
+            output_path,
+            *,
+            dtype,
+            trust_remote_code=False,
+            preserve_mtp=False,
+        ):
+            calls.append(
+                (model_path, output_path, dtype, trust_remote_code, preserve_mtp)
+            )
             output_path.mkdir()
 
         monkeypatch.setattr(_oq, "_build_streaming_proxy_for_sensitivity", _fake_build)
@@ -2325,7 +2334,9 @@ class TestBuildProxyForSensitivity:
             trust_remote_code=True,
         )
 
-        assert calls == [(str(tmp_path / "src_model"), proxy_dir, "bfloat16", True)]
+        assert calls == [
+            (str(tmp_path / "src_model"), proxy_dir, "bfloat16", True, False)
+        ]
         assert proxy_dir.exists()
 
     def test_returns_path_under_system_temp(self, tmp_path):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1962,6 +1962,114 @@ class TestSchedulerBoundarySnapshots:
 
         assert "req-skew" not in scheduler._boundary_cache_snapshots
 
+    @staticmethod
+    def _cache_list_layer(leaf_offset: int):
+        """CacheList-style wrapper: no own offset, sub-caches carry it."""
+
+        class _Leaf:
+            offset = leaf_offset
+
+        class _PoolingLeaf:
+            # Offset counts pooled windows, not tokens — must not be used
+            # by the guard (it walks depth-first, leading leaf wins).
+            offset = leaf_offset // 4
+
+        class _CacheListLike:
+            caches = [_Leaf(), _PoolingLeaf()]
+
+        return _CacheListLike()
+
+    def test_boundary_snapshot_skew_guard_sees_cachelist_sub_offsets(
+        self, mock_model, mock_tokenizer
+    ):
+        """DeepSeek/GLM-style CacheList layers expose no offset themselves;
+        the guard must walk into sub-caches or a skewed capture passes."""
+        config = SchedulerConfig(paged_cache_block_size=4)
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler._boundary_snapshot_required = True
+
+        layer = self._cache_list_layer(leaf_offset=6)  # ran ahead of boundary 4
+        scheduler.batch_generator = MagicMock()
+        scheduler.batch_generator.extract_cache.return_value = {
+            123: ([layer], [10, 11, 12, 13])
+        }
+
+        request = Request(
+            request_id="req-cl-skew",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+        )
+        request.prompt_token_ids = [10, 11]
+        request.num_prompt_tokens = 2
+        request.output_token_ids = [12, 13]  # Total = 4 (boundary)
+
+        scheduler._maybe_capture_boundary_snapshot(request, 123)
+
+        assert "req-cl-skew" not in scheduler._boundary_cache_snapshots
+
+    def test_boundary_snapshot_captured_through_cachelist(
+        self, mock_model, mock_tokenizer
+    ):
+        """Aligned CacheList sub-offsets pass the guard and capture proceeds."""
+        config = SchedulerConfig(paged_cache_block_size=4)
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler._boundary_snapshot_required = True
+
+        layer = self._cache_list_layer(leaf_offset=4)
+        scheduler.batch_generator = MagicMock()
+        scheduler.batch_generator.extract_cache.return_value = {
+            123: ([layer], [10, 11, 12, 13])
+        }
+
+        request = Request(
+            request_id="req-cl-ok",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+        )
+        request.prompt_token_ids = [10, 11]
+        request.num_prompt_tokens = 2
+        request.output_token_ids = [12, 13]
+
+        scheduler._maybe_capture_boundary_snapshot(request, 123)
+
+        assert 4 in scheduler._boundary_cache_snapshots["req-cl-ok"]
+
+    def test_cleanup_finished_skips_store_without_boundary_snapshot(
+        self, mock_model, mock_tokenizer
+    ):
+        """Snapshot-needing models must not store live non-sliceable state
+        when no boundary-aligned snapshot exists (e.g. every capture was
+        skipped by the speculative-decode skew guard)."""
+        config = SchedulerConfig(paged_cache_block_size=4)
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler.paged_cache_manager = None
+        scheduler._boundary_snapshot_required = True
+
+        request = Request(
+            request_id="req-no-snap",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+        )
+        request.prompt_token_ids = [1, 2, 3, 4]
+        request.num_prompt_tokens = 4
+        request.output_token_ids = [5, 6, 7, 8]  # Total = 8 (2 full blocks)
+        request._extracted_cache = [{"state": "live-cache"}]
+        request._model_cache_config = "live-config"
+
+        scheduler.running["req-no-snap"] = request
+        scheduler.requests["req-no-snap"] = request
+        # No boundary snapshots recorded for this request.
+
+        scheduler._cleanup_finished({"req-no-snap"})
+
+        scheduler.block_aware_cache.store_cache.assert_not_called()
+        scheduler.block_aware_cache.clear_request_entry.assert_called_with(
+            "req-no-snap"
+        )
+
     def test_cleanup_finished_skips_output_tokens_for_reasoning_model(
         self, mock_model, mock_tokenizer
     ):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1902,6 +1902,9 @@ class TestSchedulerBoundarySnapshots:
         # which returns {uid: (cache_list, tokens_list)}.
         mock_layer_cache = MagicMock()
         type(mock_layer_cache).__name__ = "BatchArraysCache"
+        # Positional-consistency guard: the cache must hold exactly the
+        # boundary token count at capture time (standard decode invariant).
+        mock_layer_cache.offset = 4
 
         scheduler.batch_generator = MagicMock()
         scheduler.batch_generator.extract_cache.return_value = {
@@ -1923,6 +1926,41 @@ class TestSchedulerBoundarySnapshots:
         snapshot = scheduler._boundary_cache_snapshots["req-boundary"][4]
         # Non-sliceable cache layer is kept as-is in the snapshot
         assert snapshot == [mock_layer_cache]
+
+    def test_boundary_snapshot_skipped_on_speculative_skew(
+        self, mock_model, mock_tokenizer
+    ):
+        """Speculative (MTP) decode advances the cache in bursts and emits
+        from a queue, so the cache can be a few tokens ahead of the emitted
+        count when the boundary token surfaces. A snapshot captured then
+        would pair the boundary label with recurrent state from a different
+        position — the capture must be skipped instead."""
+        config = SchedulerConfig(paged_cache_block_size=4)
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler._boundary_snapshot_required = True
+
+        mock_layer_cache = MagicMock()
+        type(mock_layer_cache).__name__ = "BatchArraysCache"
+        mock_layer_cache.offset = 6  # cache ran ahead of the emitted count
+
+        scheduler.batch_generator = MagicMock()
+        scheduler.batch_generator.extract_cache.return_value = {
+            123: ([mock_layer_cache], [10, 11, 12, 13])
+        }
+
+        request = Request(
+            request_id="req-skew",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+        )
+        request.prompt_token_ids = [10, 11]
+        request.num_prompt_tokens = 2
+        request.output_token_ids = [12, 13]  # Total = 4 (boundary)
+
+        scheduler._maybe_capture_boundary_snapshot(request, 123)
+
+        assert "req-skew" not in scheduler._boundary_cache_snapshots
 
     def test_cleanup_finished_skips_output_tokens_for_reasoning_model(
         self, mock_model, mock_tokenizer


### PR DESCRIPTION
## Summary

Rebuilds native MTP decoding from the fixed depth-1 cycle into a **depth-k chained draft/verify pipeline with adaptive depth**, and fixes the correctness bugs that were destroying draft acceptance in production. The pipeline design draws on [MTPLX](https://github.com/youssofal/mtplx) by Youssof Altoukhi (Apache-2.0), and the verify-shape Metal kernels are adapted from it with attribution.

| Model | No MTP | Existing MTP | **This PR** | vs baseline | vs existing MTP |
|---|---|---|---|---|---|
| Qwen3.6-27B (oQ4e) | 35.0 tok/s | 42.8 tok/s | **55.1 tok/s @ 69–78%** | **1.57×** | **1.29×** |
| Qwen3.6-35B-A3B (oQ4, MoE) | 89.6 tok/s | 85.2 tok/s @ 46–48% | **140.4 tok/s @ 74–83%** | **1.57×** | **1.65×** |
| DeepSeek-V4-Flash (oQ2.5e) | 29.5 tok/s | 34.3 tok/s @ 74–80% | **35.1 tok/s @ 61–68%** | 1.19× | 1.02× |
| GLM-5.2 (oQ4, MoE) | 15.6 tok/s | — | **17.9 tok/s @ 57–74%** | **1.15×** | — |

Test setup: Mac Studio M3 Ultra 512 GB · macOS 15.5 · MLX 0.31.2 · mlx-lm 0.31.3, greedy 400-token generations over code / prose / Korean-creative prompts.

## What changed

### Decode loop
- **Depth-k chained drafting**: one backbone forward verifies `[next_main, d1..dk]` and yields a bonus token on full accept. Max depth via `ModelSettings.mtp_num_draft_tokens` (default 3).
- **Adaptive depth controller**: EMAs of per-depth conditional acceptance and cycle latency pick the best depth per sequence automatically.
- **One host sync per cycle**: greedy and stochastic acceptance are computed in-graph; the next draft chain is pre-dispatched with `mx.async_eval`.
- **Sharp draft sampler**: drafts sample at temp 0.6 / top_p 0.95 / top_k 20. The acceptance ratio uses the draft distribution as *q*, so the output distribution is unchanged — acceptance just goes up (temp-1.0 Korean creative: 24.9% → 54.4%).

### Model coverage
- **Qwen3.6-27B** (mlx-lm / mlx-vlm): unsplit GDN verify + partial rollback that replays only the accepted prefix.
- **Qwen3.6-35B-A3B** (MoE VLM): chain wired through the MoE runtime.
- **DeepSeek-V4-Flash**: chain over the 4D hyper-head hidden; per-cycle clone for the rotating head cache; rollback clamps the accepted count to what PoolingCache layers can undo.
- **GLM-5.2** (`glm_moe_dsa`): the checkpoint's nextn layer as the draft head; L ≤ 8 forwards routed to the absorbed-latent / sparse-MLA paths instead of the full-cache K/V materialization fallback (L=2 verify was ~2.2× an L=1 step); per-model marginal-cost prior so the depth controller doesn't over-draft on fine-grained MoE.

### Verify-shape Metal kernels (`patches/qwen35_verify_qmm.py`)
Split-K / multi-simdgroup kernels that remove stock qmm's per-row penalty at verify shapes (M = 1 + depth). Routed only during MTP verify forwards and only for N ≥ 16384 projections (lm_head 2.6–3.3×; ~+7% end-to-end on the 27B).

**Attribution**: the kernel morphologies and Metal source generation are adapted from **[MTPLX](https://github.com/youssofal/mtplx)** (`mtplx/verify_kernels.py`, Copyright 2026 Youssof Altoukhi, Apache-2.0) — stated in the file header. The oMLX integration (thread-local routing, dispatch, gating) is new code.

## Benchmarks

### Qwen3.6-27B-oQ4e-mtp (VLM engine)

| Config | code | creative-ko | prose | overall | accept |
|---|---|---|---|---|---|
| No MTP | 34.9 | 35.3 | 34.8 | 35.0 | — |
| **This PR** | **57.4** | **51.5** | **56.4** | **55.1** | 69–78% |

temp 0.7 Korean creative, 600 tokens: **46.6 tok/s @ 66.0%** (existing MTP degraded to 11–25% acceptance on long generations at temp ≥ 0.7).

### Qwen3.6-35B-A3B-oQ4-mtp (MoE, VLM engine)

| Config | greedy code | greedy creative-ko | t0.7 creative-ko (800 tok) |
|---|---|---|---|
| No MTP | 88.7 | 90.6 | — |
| Existing MTP | 85.2 @ 48.5% | 85.2 @ 46.3% | 61.3 @ 30.0% |
| **This PR** | **142.9 @ 83.3%** | **138.0 @ 74.1%** | **104.9 @ 67.8%** |

### DeepSeek-V4-Flash-oQ2.5e-mtp (LM engine)

| Config | code | creative-ko | t0.7 creative | accept |
|---|---|---|---|---|
| No MTP | 29.3 | 29.6 | — | — |
| **This PR** | **36.3** | **33.9** | **32.3** | 61–68% |

### GLM-5.2-oQ4-mtp (LM engine)

| Config | code | creative-ko | prose | t0.7 creative-ko | accept |
|---|---|---|---|---|---|
| No MTP | 15.5 | 15.7 | 15.6 | — | — |
| **This PR** | **18.2** | **18.0** | **18.0** | **17.1** | 57–74% |

## Output fidelity

- Stochastic sampling: exact — `min(1, p/q)` acceptance with residual correction; the draft sampler only changes *q*, never the output law.
- Greedy: `mtp_num_draft_tokens=1` reproduces the standard step token-for-token (hash-verified). The default depth-3 config can diverge at bf16 tail-ULP level; every token remains trunk-verified.
- 148 tests pass (`test_mlx_lm_mtp_patch.py`, `test_vlm_mtp.py`, `test_vlm_mtp_proxy.py`, `test_glm_mtp_patch.py`).

## Prior art

- ml-explore/mlx-lm PR 990 (Qwen3.5/3.6 native MTP), Blaizzy/mlx-lm PR 15 (DeepSeek-V4)
- Leviathan, Kalman & Matias, *Fast Inference from Transformers via Speculative Decoding* (ICML 2023)
- [MTPLX](https://github.com/youssofal/mtplx) by Youssof Altoukhi (Apache-2.0) — verify-kernel port and technique inspiration, attributed in the kernel file header

