### PR TITLE
fix(server): include role in the chunk-mode chat keepalive delta

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1857,10 +1857,18 @@ def init_server(
 _KEEPALIVE_SENTINEL = object()
 
 _KEEPALIVE_COMMENT = ": keep-alive\n\n"
+# The delta carries "role":"assistant" because this frame is the FIRST event
+# of every stream and some accumulators type the whole stream from the first
+# chunk's role: LangChain.js builds a generic ChatMessageChunk when it is
+# absent, and merging the real chunks into it silently discards all
+# tool_call_chunks (#2074, hits n8n AI Agent workflows). Cloud APIs open every
+# stream with a role chunk, so clients rely on it; the OpenAI SDKs, openai-go,
+# and LangChain all tolerate the duplicate role in later chunks.
 _KEEPALIVE_CHAT_CHUNK = (
     'data: {"id":"chatcmpl-keepalive","object":"chat.completion.chunk",'
     '"created":0,"model":"keepalive",'
-    '"choices":[{"index":0,"delta":{"content":""},"finish_reason":null}]}\n\n'
+    '"choices":[{"index":0,"delta":{"role":"assistant","content":""},'
+    '"finish_reason":null}]}\n\n'
 )
 _KEEPALIVE_COMPLETION_CHUNK = (
     'data: {"id":"cmpl-keepalive","object":"text_completion","created":0,'
@@ -1909,11 +1917,16 @@ def _chat_keepalive_chunk(response_id: str) -> str:
     keepalive with the stream's own ``response_id`` makes it a true no-op for
     those clients while remaining a parseable data event for clients that can't
     handle SSE comment lines.
+
+    The delta must also carry ``"role":"assistant"`` — see the comment on
+    ``_KEEPALIVE_CHAT_CHUNK`` (accumulators that type the stream from the
+    first chunk's role drop tool_call_chunks without it, #2074).
     """
     return (
         'data: {"id":"' + response_id + '","object":"chat.completion.chunk",'
         '"created":0,"model":"keepalive",'
-        '"choices":[{"index":0,"delta":{"content":""},"finish_reason":null}]}\n\n'
+        '"choices":[{"index":0,"delta":{"role":"assistant","content":""},'
+        '"finish_reason":null}]}\n\n'
     )
 
 

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -111,6 +111,7 @@ class TestKeepaliveChunkFormats:
         body = items[0].removeprefix("data: ").strip()
         payload = json.loads(body)
         assert payload["object"] == "chat.completion.chunk"
+        assert payload["choices"][0]["delta"]["role"] == "assistant"
         assert payload["choices"][0]["delta"]["content"] == ""
         assert payload["choices"][0]["finish_reason"] is None
 
@@ -172,6 +173,7 @@ class TestChatKeepaliveSharesStreamId:
         payload = json.loads(frame.removeprefix("data: ").strip())
         assert payload["id"] == "chatcmpl-abc123"
         assert payload["object"] == "chat.completion.chunk"
+        assert payload["choices"][0]["delta"]["role"] == "assistant"
         assert payload["choices"][0]["delta"]["content"] == ""
         assert payload["choices"][0]["finish_reason"] is None
 
@@ -182,6 +184,33 @@ class TestChatKeepaliveSharesStreamId:
             _chat_keepalive_chunk("chatcmpl-real").removeprefix("data: ").strip()
         )
         assert payload["id"] != "chatcmpl-keepalive"
+
+
+class TestChatKeepaliveCarriesRole:
+    """Every chat keepalive delta must carry ``role: assistant``.
+
+    The chunk-form keepalive is the first SSE event of every stream, and some
+    accumulators type the whole stream from the first chunk's role.
+    LangChain.js builds a generic ChatMessageChunk when the role is absent and
+    then discards all tool_call_chunks when the real AI chunks merge into it,
+    so streamed tool calls are silently lost (#2074, n8n AI Agent workflows).
+    """
+
+    def _first_chunk_role(self, frame: str):
+        # Mirror the accumulator rule: the stream's type is decided by the
+        # first chunk's delta.role alone.
+        payload = json.loads(frame.removeprefix("data: ").strip())
+        return payload["choices"][0]["delta"].get("role")
+
+    def test_static_sentinel_frame_carries_assistant_role(self):
+        from omlx.server import _KEEPALIVE_CHAT_CHUNK
+
+        assert self._first_chunk_role(_KEEPALIVE_CHAT_CHUNK) == "assistant"
+
+    def test_id_sharing_frame_carries_assistant_role(self):
+        from omlx.server import _chat_keepalive_chunk
+
+        assert self._first_chunk_role(_chat_keepalive_chunk("chatcmpl-x")) == "assistant"
 
 
 class TestResolveKeepalive:


### PR DESCRIPTION
Fixes #2074.

## What happens

With the default `sse_keepalive_mode: "chunk"`, the keepalive frame is the first SSE event of every chat stream and its delta has no `role`. LangChain.js types a stream from its first chunk: no role means it builds a generic `ChatMessageChunk`, and when the real chunks merge into it every `tool_call_chunk` is discarded. Streamed tool calls are lost silently while text keeps streaming, so every n8n AI Agent workflow (n8n bundles LangChain.js) behaves as if the model refused to call its tools.

This is the same strict-accumulator class as #1478 (openai-go dropping chunks over the keepalive's mismatched id). Cloud APIs open every stream with a role chunk, and clients rely on that.

## The fix

Add `"role":"assistant"` to the keepalive delta in both chat frames: the static sentinel frame (`_KEEPALIVE_CHAT_CHUNK`) and the id-sharing frame from #1478 (`_chat_keepalive_chunk`). The reporter verified that the OpenAI SDKs, openai-go, and LangChain all tolerate the duplicate role in later chunks, and my live test below confirms it for LangChain. The completions keepalive has no role concept and the Anthropic ping is a typed event, so chat is the whole surface.

## Tests

Extended the two existing frame-format tests and added `TestChatKeepaliveCarriesRole` (2 tests) asserting the first-frame role invariant on both frames. Full suite: 6116 passed; one pre-existing failure in `test_mlx_vlm_minimax_m3_compat` that also fails on clean `d42528af` in my env (stale local mlx_vlm pin, unrelated).

## Live verification

Ran the reporter's literal LangChain.js repro (`@langchain/openai` 1.4.4) against a served Qwen3.5-9B-MLX-4bit, before and after the fix on the same machine:

```
unpatched:  ChatMessageChunk undefined                      <- tool call lost
patched:    AIMessageChunk [{"name":"get_weather","args":{"city":"Paris"},"id":"call_b8e00d17","type":"tool_call"}]
```

Wire transcript after the fix (first two frames):

```
data: {"id":"chatcmpl-3f62e3f5",...,"model":"keepalive","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
data: {"id":"chatcmpl-3f62e3f5",...,"model":"Qwen3.5-9B-MLX-4bit","choices":[{"index":0,"delta":{"role":"assistant"}}]}
```

The `sse_keepalive_mode: "comment"` workaround from the issue keeps working; comment mode is untouched.