### PR TITLE
fix: cap supported Python below 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 description = "LLM inference server, optimized for your Mac"
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 authors = [
     {name = "omlx contributors"}
 ]


### PR DESCRIPTION
## Summary
- Cap supported Python versions to >=3.11,<3.14
- Prevent uv from selecting CPython 3.14 for dev setup

## Why
Running uv sync --dev on a machine where uv selected CPython 3.14 failed with:

    Distribution onnxruntime==1.20.1 can't be installed because it doesn't have a source distribution or wheel for the current platform
    hint: You're using CPython 3.14 (cp314), but onnxruntime only has wheels for cp311, cp312, cp313, cp313t

The project currently depends on packages that don't publish cp314 wheels yet, so Python 3.14 should be excluded until the dependency set supports it.

## Test
- Parsed pyproject.toml with Python tomllib and verified requires-python is >=3.11,<3.14