### PR TITLE
fix(attention): keep decode-shaped multi-row SDPA off the prefill kernel routes

### DIFF
--- a/omlx/patches/qwen35_fa256_attention.py
+++ b/omlx/patches/qwen35_fa256_attention.py
@@ -3,7 +3,8 @@
 
 This patch is intentionally narrow:
   - Qwen3.5/3.6 dense VLM attention layout: q heads=24, kv heads=4, D=256
-  - causal prefill/chunked-prefill only (q_len > 1)
+  - causal prefill/chunked-prefill only (q_len >= 16; decode and MTP verify
+    stay on the stock path)
   - no array masks and no sinks
 
 The native op uses MLX's steel attention template through the oMLX custom
@@ -23,6 +24,13 @@ import mlx.core as mx
 logger = logging.getLogger(__name__)
 
 _PATCHED = False
+
+# Decode-shaped multi-row calls (MTP verify: q_len = 1 + draft depth <= 9)
+# must not take the steel prefill kernel: it scans the full KV per call, so
+# at tiny q_len it is 3-16x slower than the stock fused/unfused path and
+# collapses long-context MTP throughput (issue #2127). Genuine prefill
+# chunks are always far above this floor.
+_MIN_ROUTE_Q_LEN = 16
 
 
 def _native_kernel():
@@ -62,7 +70,7 @@ def _should_route(queries, keys, cache, mask, sinks, min_kv_len: int) -> bool:
         head_dim == 256
         and q_heads == 24
         and kv_heads == 4
-        and q_len > 1
+        and q_len >= _MIN_ROUTE_Q_LEN
         and kv_len >= min_kv_len
         and q_len <= kv_len
     )

--- a/omlx/patches/sdpa256_attention.py
+++ b/omlx/patches/sdpa256_attention.py
@@ -31,6 +31,13 @@ HEAD_DIM = 256
 # fallback's O(L^2) score matrix becomes a memory problem. Below this, the
 # fused-GEMM fallback is faster and fits comfortably. Tunable.
 _SDPA256_MIN_KV_LEN = 8192
+# Decode-shaped multi-row calls (MTP verify: q_len = 1 + draft depth <= 9)
+# must not take this route: the per-KV-tile eval sync only amortizes over
+# prefill-sized q tiles, and at tiny q_len it costs O(kv_len/tile) sequential
+# dispatches per call — 8-22x slower than stock SDPA, collapsing long-context
+# MTP throughput (issue #2127). Below this floor the stock path's score
+# matrix is at most n_q * 15 * kv_len, which is never a memory problem.
+_SDPA256_MIN_Q_LEN = 16
 # Tile sizes for the online-softmax kernel (tuned on M2 Max).
 _Q_TILE = 512
 _KV_TILE = 1024
@@ -122,7 +129,7 @@ def _should_route(queries, keys, cache, mask, sinks) -> bool:
             return False
         if queries.shape[-1] != HEAD_DIM:
             return False
-        if queries.shape[-2] <= 1:  # decode -> fused vector kernel handles 256
+        if queries.shape[-2] < _SDPA256_MIN_Q_LEN:  # decode / MTP verify
             return False
         if not (mask is None or (isinstance(mask, str) and mask == "causal")):
             return False

--- a/tests/test_qwen35_fa256_attention.py
+++ b/tests/test_qwen35_fa256_attention.py
@@ -68,6 +68,13 @@ def test_route_gate_is_qwen_fa256_only():
     assert not patch._should_route(q[:, :12], k, None, "causal", None, 2048)
     assert not patch._should_route(q, k[:, :2], None, "causal", None, 2048)
     assert not patch._should_route(q[:, :, :1], k, None, "causal", None, 2048)
+    # decode-shaped multi-row (MTP verify, qL = 1 + depth <= 9) -> stock path;
+    # the steel prefill kernel is 3-16x slower at tiny q_len (issue #2127)
+    for q_len in (2, 4, 9, 15):
+        qv, kv, _ = _qkv(q_len, 16384)
+        assert not patch._should_route(qv, kv, None, "causal", None, 2048)
+    qv, kv, _ = _qkv(16, 16384)
+    assert patch._should_route(qv, kv, None, "causal", None, 2048)
     assert not patch._should_route(q, k, None, mx.zeros((128, 2048)), None, 2048)
     assert not patch._should_route(q, k, None, "causal", mx.zeros((4,)), 2048)
 

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -88,6 +88,13 @@ def test_should_route_gate():
     # decode (qL==1) -> fused vector kernel handles 256
     qd, kd, _ = _qkv(1, 16384)
     assert sdpa256._should_route(qd, kd, None, "causal", None) is False
+    # decode-shaped multi-row (MTP verify, qL = 1 + depth <= 9) -> stock path;
+    # the per-tile eval sync collapses long-context MTP tok/s (issue #2127)
+    for q_len in (2, 4, 9, 15):
+        qv, kv, _ = _qkv(q_len, 16384)
+        assert sdpa256._should_route(qv, kv, None, "causal", None) is False
+    qv, kv, _ = _qkv(16, 16384)
+    assert sdpa256._should_route(qv, kv, None, "causal", None) is True
     # short kv -> keep the faster fallback
     qs, ks, _ = _qkv(2048, 4096)
     assert sdpa256._should_route(qs, ks, None, "causal", None) is False


### PR DESCRIPTION
Fixes #2127.

## Problem

Depth-k MTP throughput collapses at long context: -53% tg TPS at 8K and
-71% at 32K vs v0.4.4's depth-1 (#2127, Qwen3.5-9B). The cliff starts at
exactly 8K, and there is a milder version from 2K on 24/4-head models
(Qwen3.5-VL dense / Qwen3.6).

## Root cause

The MTP verify forward is a decode-shaped multi-row call: q_len = 1 +
draft depth (2..9 rows), mask="causal". Two prefill-only attention
patches route on `q_len > 1` and capture it:

- `sdpa256_attention.py` (head_dim=256, kv_len >= 8192 — the 8K cliff):
  verify lands in `_flash_sdpa256`, a tiled online-softmax that calls
  `mx.eval` per 1024-token KV tile. That sync amortizes over 512-row
  prefill Q tiles; at 2-9 rows it is O(kv/1024) sequential dispatches
  per layer per verify cycle. Measured 8-22x slower than stock SDPA at
  verify shapes, ~+94 ms per cycle at 32K on 8 full-attention layers —
  matching the reported TPOT deltas. v0.4.4 predates this patch (#2025),
  which is why depth-1 was stable there.
- `qwen35_fa256_attention.py` (24/4 heads, kv_len >= 2048): the steel
  prefill kernel is 3-16x slower than stock at the same shapes.

The <=4K numbers in the issue (-1..-4%) are below both thresholds and
are the ordinary depth-k trade, not this bug.

## Fix

Add a q_len floor (16) to both `_should_route` gates. Decode-shaped
multi-row calls fall through to stock SDPA: MLX's fused vector kernel
natively handles q_len <= 8 at head_dim 256, and even the 9-row unfused
path beats both patched routes at every measured kv_len. Genuine prefill
chunks are far above the floor and keep the tiled/steel routes; a
sub-16-row prefill tail chunk costs at most an n_q x 15 x kv_len score
matrix on the stock path (fine even at 262K context), so the memory
guard registration is unchanged.

## Benchmarks

Qwen3.6-27B-oQ4e-mtp, 15.8K-token prompt, greedy, 256 tokens, M3 Ultra
(real serving path via BatchedEngine):

| config              | before             | after            |
|---------------------|--------------------|------------------|
| MTP off             | 32.6 tok/s         | (path unchanged) |
| MTP on, fa256 steel | 16.2 tok/s (-50%)  | **46.1 (+41%)**  |
| MTP on, sdpa256     | 14.7 tok/s (-55%)  | **46.4 (+42%)**  |

Instrumented run: before the fix every verify call at kv~15K (1712 and
1744 of them) hit the prefill routes; after, zero. Per-cycle backbone
time 145 ms -> 47 ms. TTFT unchanged (36.5 s / 39.2 s) — prefill still
routes. Greedy output is byte-identical to the AR baseline on the
default path before and after.

## Tests

New gate assertions in `test_sdpa256_attention.py` /
`test_qwen35_fa256_attention.py` (q_len 2/4/9/15 rejected, 16 routed);
kernel-equivalence tests for prefill shapes unchanged. Full suite green.
