### PR TITLE
feat(mtp): enable native MTP with TurboQuant KV cache

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2421,7 +2421,7 @@ async def update_model_settings(
                         "mlx-lm sanitize() path strips them."
                     ),
                 )
-            # Mutual exclusion with DFlash / TurboQuant — ModelSettings.__post_init__
+            # Mutual exclusion with DFlash — ModelSettings.__post_init__
             # also enforces this, but we surface a clearer error here.
             dflash_after = (
                 bool(request.dflash_enabled)
@@ -2432,16 +2432,6 @@ async def update_model_settings(
                 raise HTTPException(
                     status_code=400,
                     detail="MTP and DFlash cannot both be enabled; choose one speculative-decoding path.",
-                )
-            tq_after = (
-                bool(request.turboquant_kv_enabled)
-                if "turboquant_kv_enabled" in sent
-                else current_settings.turboquant_kv_enabled
-            )
-            if tq_after:
-                raise HTTPException(
-                    status_code=400,
-                    detail="MTP and TurboQuant KV cannot both be enabled; TurboQuant patches the attention path MTP relies on.",
                 )
         current_settings.mtp_enabled = new_mtp_enabled
 

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -1374,7 +1374,7 @@ class EnginePool:
             # Native MTP forces LM-only dispatch even for VLM models. Vision
             # encoder weights are ignored because the patched mtp_forward only
             # exists on the language model path. mtp_enabled was already
-            # validated as mutually exclusive with dflash / turboquant in
+            # validated as mutually exclusive with dflash in
             # metal-knowledge: with the mlx-vlm runtime MTP patch (see
             # omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py) VLM models
             # can run MTP natively while keeping vision intact. The old

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -89,7 +89,7 @@ class ModelSettings:
             for multi-row decode batches whose cache positions are aligned. Unaligned
             continuous batches fall back to standard decoding automatically. Compatible
             model_types: qwen3_5*, qwen3_6*, deepseek_v4*. Mutually exclusive with
-            dflash_enabled and turboquant_kv_enabled.
+            dflash_enabled.
         vlm_mtp_enabled: Enable VLM MTP speculative decoding via an external assistant
             drafter (mlx-vlm 191d7c8+). Target = Gemma4 VLM body, drafter must be a
             "gemma4_assistant" model.
@@ -189,7 +189,7 @@ class ModelSettings:
     # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch). When enabled, BatchGenerator
     # uses MTP draft+verify for singleton decode and aligned multi-row decode batches.
     # Compatible model_types: qwen3_5*, qwen3_6*, deepseek_v4*. Mutually exclusive
-    # with dflash and turboquant.
+    # with dflash.
     mtp_enabled: bool = False
     # Maximum chained MTP draft tokens per verify cycle (speculative depth).
     # None = default (3). Effective for Qwen3.5/3.6 native MTP only;
@@ -227,19 +227,15 @@ class ModelSettings:
     active_profile_name: Optional[str] = None  # Name of the currently-applied profile
 
     def __post_init__(self) -> None:
-        # Native MTP is mutually exclusive with DFlash (also speculative) and
-        # TurboQuant KV (patches the same attention path). Reject combos at
-        # construction time so the conflict surfaces in the admin UI / API
-        # rather than at model load.
+        # Native MTP is mutually exclusive with DFlash (also speculative).
+        # Reject the combo at construction time so the conflict surfaces in
+        # the admin UI / API rather than at model load. TurboQuant KV is
+        # compatible: its attention patch routes MTP's decode-shaped
+        # multi-row verify through the quantized decode kernels.
         if self.mtp_enabled and self.dflash_enabled:
             raise ValueError(
                 "mtp_enabled and dflash_enabled cannot both be True; choose one "
                 "speculative-decoding path per model"
-            )
-        if self.mtp_enabled and self.turboquant_kv_enabled:
-            raise ValueError(
-                "mtp_enabled and turboquant_kv_enabled cannot both be True; "
-                "TurboQuant patches the attention path that MTP relies on"
             )
         # vlm_mtp wraps mlx-vlm's MTP loop and bypasses mlx-lm BatchGenerator
         # at decode time, so it cannot coexist with any other speculative path

--- a/omlx/patches/turboquant_attention.py
+++ b/omlx/patches/turboquant_attention.py
@@ -3,6 +3,10 @@
 
 When TurboQuantKVCache is detected, routes attention to:
   - Decode (L=1): cache.decode_attention() — Metal kernel, no dequant
+  - Decode-shaped multi-row (1 < L <= 15, causal; MTP verify): the L rows
+    are folded into the GQA repeat dimension so the codecs' decode kernels
+    apply, with the causal tail mask injected between key scoring and the
+    value weighted sum — one lazy pass over the KV, no dequantize
   - Prefill (L>1): cache.prefill_attention() fast path, fallback to
     dequantize + mx.fast.scaled_dot_product_attention
 """
@@ -18,6 +22,155 @@ _PATCHED = False
 _LONG_PREFILL_QUANTIZED_THRESHOLD = 8192
 _LONG_PREFILL_QUERY_BLOCK_SIZE = 256
 _LONG_PREFILL_KEY_CHUNK_SIZE = 16384
+# MTP verify is a decode-shaped multi-row call (q_len = 1 + draft depth <= 9).
+# Above this floor a multi-row call is genuine (chunked) prefill.
+_DECODE_MULTIROW_MAX_Q_LEN = 15
+# The repeat kernels unroll per-repeat register arrays, so folding is only a
+# win while n_repeats * q_len stays under the register-pressure knee
+# (measured: 24 fine, 30+ loses to single-chunk quantized_attention).
+_MAX_FOLDED_REPEATS = 24
+# Softmax-denominator floor, matching turboquant's quantized_attention.
+_STATS_EPS = 1e-6
+
+
+def _decode_multirow_quantized_attention(real_cache, queries, keys, values, scale):
+    """Wider verify rows: one-shot quantized_attention over the whole KV.
+
+    A single query block and a single key chunk turn quantized_attention's
+    chunked online softmax into one pass — its einsum path amortizes the
+    key unpack across rows, staying flat in q_len where the folded decode
+    kernels hit register spill.
+    """
+    if not hasattr(real_cache, "quantized_attention"):
+        return None
+    old_query_block_size = getattr(real_cache, "prefill_query_block_size", None)
+    old_key_chunk_size = getattr(real_cache, "prefill_key_chunk_size", None)
+    try:
+        real_cache.prefill_query_block_size = queries.shape[-2]
+        real_cache.prefill_key_chunk_size = real_cache.decode_key_chunk_size
+        return real_cache.quantized_attention(
+            queries,
+            keys_state=keys,
+            values_state=values,
+            scale=scale,
+            mask="causal",
+        )
+    finally:
+        if old_query_block_size is not None:
+            real_cache.prefill_query_block_size = old_query_block_size
+        if old_key_chunk_size is not None:
+            real_cache.prefill_key_chunk_size = old_key_chunk_size
+
+
+def _decode_multirow_attention(real_cache, queries, keys, values, scale):
+    """Causal multi-row attention over TurboQuant states in one lazy pass.
+
+    MTP verify would otherwise fall into the prefill fallbacks, which
+    re-dequantize or chunk-scan the whole cache with per-chunk eval syncs
+    on every verify cycle (issue #2127 class). Folding the L rows into the
+    repeat dimension keeps the L==1 decode kernels applicable (repeat
+    count is a kernel template parameter); the causal tail mask is applied
+    on the raw scores before the value weighted sum. Returns None when the
+    states don't fit; the caller falls back to the generic paths.
+    """
+    from mlx_vlm.turboquant import TurboQuantSplitState
+
+    from ..turboquant_kv import _state_length
+
+    keys_state = real_cache._unwrap(keys)
+    values_state = real_cache._unwrap(values)
+    B, n_q_heads, L, D = queries.shape
+    n_kv_heads = (
+        keys_state.low.norms.shape[1]
+        if isinstance(keys_state, TurboQuantSplitState)
+        else keys_state.norms.shape[1]
+    )
+    n_repeats = n_q_heads // n_kv_heads
+    total = _state_length(keys_state)
+    if total < L:
+        return None
+    if n_repeats * L > _MAX_FOLDED_REPEATS:
+        return _decode_multirow_quantized_attention(
+            real_cache, queries, keys, values, scale
+        )
+
+    folded = (queries * scale).reshape(B, n_kv_heads, n_repeats * L, 1, D)
+    prepared = real_cache.key_codec.prepare_queries(folded)
+    scores = real_cache.key_codec.score_prepared(prepared, keys_state)
+
+    # (B, H, R*L, 1, T): fold index r*L + i is the row at global position
+    # total - L + i; mask the keys after it.
+    scores = scores.reshape(B, n_kv_heads, n_repeats, L, total)
+    q_pos = mx.arange(total - L, total)
+    causal = mx.arange(total)[None, :] <= q_pos[:, None]
+    scores = mx.where(causal, scores, mx.finfo(scores.dtype).min)
+    scores = scores.reshape(B, n_kv_heads, n_repeats * L, 1, total)
+
+    out, denom, _ = real_cache.value_codec.weighted_sum_stats_from_scores(
+        scores, values_state
+    )
+    out = out / mx.maximum(denom[..., None], _STATS_EPS)
+    out = out.reshape(B, n_q_heads, L, real_cache.value_codec.dim)
+    return out.astype(queries.dtype)
+
+
+def _patch_update_eval_policy() -> None:
+    """Skip the per-layer eval for decode-shaped multi-row cache appends.
+
+    Upstream ``update_and_fetch`` forces ``mx.eval`` whenever more than one
+    token is appended — a graph-bounding measure sized for prefill chunks.
+    MTP verify appends 2..9 rows per layer, so that policy serializes every
+    layer of every verify cycle (~15 forced syncs/cycle). Raise the eval
+    floor to prefill-sized appends; verify rows stay lazy and materialize
+    at the cycle's sampling sync like the rest of the forward.
+    """
+    from mlx_vlm import turboquant as _tq
+
+    cls = _tq.TurboQuantKVCache
+    if getattr(cls, "_omlx_multirow_eval_patched", False):
+        return
+
+    def update_and_fetch(self, keys, values):
+        # Mirror of upstream TurboQuantKVCache.update_and_fetch; the only
+        # change is the eval gate (n_new > 1 -> prefill-sized appends).
+        self._ensure_codecs(keys, values)
+
+        new_keys, new_values = self._try_fused_kv_quantize(keys, values)
+        if new_keys is None:
+            new_keys = self.key_codec.quantize(keys)
+            new_values = self.value_codec.quantize(values)
+
+        new_end = self.offset + keys.shape[2]
+        if self.keys is None:
+            self.keys = _tq._allocate_state_like(new_keys, new_end)
+            self.values = _tq._allocate_state_like(new_values, new_end)
+        else:
+            self.keys = _tq._reserve_state_capacity(
+                self.keys, self.offset, new_end, self.cache_step
+            )
+            self.values = _tq._reserve_state_capacity(
+                self.values, self.offset, new_end, self.cache_step
+            )
+
+        _tq._write_state(self.keys, new_keys, self.offset)
+        _tq._write_state(self.values, new_values, self.offset)
+
+        n_heads = keys.shape[1]
+        n_new = keys.shape[2]
+
+        self.offset = new_end
+        self._cached_state = None
+        self._cached_state_offset = -1
+        if n_new > _DECODE_MULTIROW_MAX_Q_LEN or (self.offset % 50 == 0):
+            mx.eval(self.keys, self.values)
+        ks, vs = self.state
+        return (
+            _tq._QuantizedStateProxy(ks, self.offset, n_heads),
+            _tq._QuantizedStateProxy(vs, self.offset, n_heads),
+        )
+
+    cls.update_and_fetch = update_and_fetch
+    cls._omlx_multirow_eval_patched = True
 
 
 def apply_turboquant_attention_patch() -> bool:
@@ -30,6 +183,11 @@ def apply_turboquant_attention_patch() -> bool:
         from mlx_lm.models import base as mlx_base
     except ImportError:
         return False
+
+    try:
+        _patch_update_eval_policy()
+    except Exception:
+        logger.debug("TurboQuant update eval-policy patch skipped", exc_info=True)
 
     original_sdpa = mlx_base.scaled_dot_product_attention
 
@@ -83,6 +241,24 @@ def apply_turboquant_attention_patch() -> bool:
                     scale=scale,
                     mask=mask,
                 )
+            if (
+                queries.shape[-2] <= _DECODE_MULTIROW_MAX_Q_LEN
+                and isinstance(mask, str)
+                and mask == "causal"
+            ):
+                # Decode-shaped multi-row (MTP verify) — see helper docstring.
+                try:
+                    result = _decode_multirow_attention(
+                        real_cache, queries, keys, values, scale
+                    )
+                    if result is not None:
+                        return result
+                except Exception:
+                    logger.debug(
+                        "TurboQuant multi-row decode attention failed; "
+                        "falling back to prefill paths",
+                        exc_info=True,
+                    )
             # Prefill: try quantized fast path, fallback to dequantize+SDPA
             result = real_cache.prefill_attention(
                 queries,

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -1299,9 +1299,12 @@ class TestModelSettingsMtp:
         with pytest.raises(ValueError, match="speculative-decoding"):
             ModelSettings(mtp_enabled=True, dflash_enabled=True)
 
-    def test_mutual_exclusion_with_turboquant(self):
-        with pytest.raises(ValueError, match="TurboQuant"):
-            ModelSettings(mtp_enabled=True, turboquant_kv_enabled=True)
+    def test_mtp_with_turboquant_allowed(self):
+        # TurboQuant's attention patch routes MTP's decode-shaped multi-row
+        # verify through the quantized decode kernels, so the combo is valid.
+        s = ModelSettings(mtp_enabled=True, turboquant_kv_enabled=True)
+        assert s.mtp_enabled is True
+        assert s.turboquant_kv_enabled is True
 
     def test_mtp_with_specprefill_allowed(self):
         # SpecPrefill targets a different code path (sparse prefill scoring),

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -506,6 +506,108 @@ def test_attention_patch_falls_back_when_quantized_prefill_fails(monkeypatch):
     assert calls == {"quantized": 1, "dequantize": 1}
 
 
+@pytest.mark.parametrize("q_len", [2, 4, 9])
+def test_decode_multirow_matches_dequantize_reference(q_len):
+    """MTP-verify-shaped attention (fold path at small q_len, single-chunk
+    quantized_attention above the folded-repeat knee) must match the
+    dequantize+SDPA reference with an explicit causal tail mask."""
+    from omlx.patches.turboquant_attention import _decode_multirow_attention
+
+    mx.random.seed(0)
+    B, n_q, n_kv, D, T = 1, 24, 4, 256, 512
+    fp_cache = KVCache()
+    fp_cache.update_and_fetch(
+        mx.random.normal((B, n_kv, T, D)).astype(mx.float16),
+        mx.random.normal((B, n_kv, T, D)).astype(mx.float16),
+    )
+    tq = TurboQuantKVCache.from_cache(fp_cache, bits=4.0)
+    ks, vs = tq.state
+    queries = mx.random.normal((B, n_q, q_len, D)).astype(mx.float16)
+    scale = D**-0.5
+
+    out = _decode_multirow_attention(tq, queries, ks, vs, scale)
+    assert out is not None
+    assert out.shape == (B, n_q, q_len, D)
+
+    dk, dv = tq.dequantize()
+    causal = mx.arange(T)[None, :] <= mx.arange(T - q_len, T)[:, None]
+    ref = mx.fast.scaled_dot_product_attention(
+        queries.astype(mx.float32), dk, dv, scale=scale, mask=causal
+    )
+    assert mx.abs(out.astype(mx.float32) - ref).max().item() < 5e-3
+    # The causal tail mask must actually bind (an unmasked reference differs).
+    ref_nomask = mx.fast.scaled_dot_product_attention(
+        queries.astype(mx.float32), dk, dv, scale=scale, mask=None
+    )
+    assert mx.abs(ref_nomask - ref).max().item() > 1e-3
+
+
+def test_attention_patch_routes_decode_multirow_causal(monkeypatch):
+    """A decode-shaped multi-row causal call (MTP verify) must take the
+    multirow decode route — never prefill_attention / dequantize (issue
+    #2127 class: those re-scan the whole cache per verify cycle)."""
+    from mlx_lm.models import base as mlx_base
+
+    from omlx.patches import turboquant_attention as tq_attention
+
+    tq_attention.apply_turboquant_attention_patch()
+
+    fp_cache = KVCache()
+    fp_cache.update_and_fetch(
+        mx.random.normal((1, 4, 64, 256)).astype(mx.float16),
+        mx.random.normal((1, 4, 64, 256)).astype(mx.float16),
+    )
+    tq = TurboQuantKVCache.from_cache(fp_cache, bits=4.0)
+    ks, vs = tq.state
+
+    def fail_prefill(self, *args, **kwargs):
+        raise AssertionError("verify must not take prefill_attention")
+
+    def fail_dequantize(self, *args, **kwargs):
+        raise AssertionError("verify must not dequantize the cache")
+
+    monkeypatch.setattr(TurboQuantKVCache, "prefill_attention", fail_prefill)
+    monkeypatch.setattr(TurboQuantKVCache, "dequantize", fail_dequantize)
+
+    queries = mx.random.normal((1, 24, 4, 256)).astype(mx.float16)
+    out = mlx_base.scaled_dot_product_attention(
+        queries, ks, vs, tq, scale=256**-0.5, mask="causal"
+    )
+    mx.eval(out)
+    assert out.shape == queries.shape
+
+
+def test_attention_patch_multirow_ignores_non_causal_masks():
+    """Array masks and mask=None keep the existing prefill routing (the
+    multirow route encodes causal-tail semantics only)."""
+    from omlx.patches import turboquant_attention as tq_attention
+
+    tq_attention.apply_turboquant_attention_patch()
+
+    from mlx_lm.models import base as mlx_base
+
+    fp_cache = KVCache()
+    fp_cache.update_and_fetch(
+        mx.random.normal((1, 2, 8, 32)),
+        mx.random.normal((1, 2, 8, 32)),
+    )
+    tq = TurboQuantKVCache.from_cache(fp_cache, bits=4.0)
+    ks, vs = tq.state
+    queries = mx.random.normal((1, 4, 2, 32))
+    # mask=None multi-row: full (non-causal) attention via the prefill chain.
+    out = mlx_base.scaled_dot_product_attention(
+        queries, ks, vs, tq, scale=32**-0.5, mask=None
+    )
+    mx.eval(out)
+    assert out.shape == queries.shape
+    dk, dv = tq.dequantize()
+    ref = mx.fast.scaled_dot_product_attention(
+        queries, dk.astype(queries.dtype), dv.astype(queries.dtype),
+        scale=32**-0.5, mask=None,
+    )
+    assert mx.abs(out - ref).max().item() < 5e-2
+
+
 # ---------------------------------------------------------------------------
 # Codec rebuild tests (SSD cache reconstruction, issue #577)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
MTP + TurboQuant KV has been rejected at the settings layer since the
original MTP toggle — a defensive exclusion, not a measured one. This PR
makes the combo work and removes the guard.

Best merged after #2130 (with TurboQuant enabled, `skip_last` leaves the
last KVCache layer unquantized, and that layer's verify relies on the
q_len gates fixed there).

## What was actually broken

MTP verify (q_len = 1 + depth <= 9, mask="causal") fell into TurboQuant's
prefill chain: `prefill_attention` bails on string masks (and on the
default MSE key codec), so every verify cycle either fully dequantized
the cache per layer (kv <= 8K) or ran the chunked online-softmax with a
per-chunk eval (kv > 8K). On top of that, `update_and_fetch` forces
`mx.eval` per layer whenever more than one token is appended — a prefill
graph-bounding measure that costs ~15 forced syncs per verify cycle.

Rollback was never the problem: TurboQuant `trim()` is offset-based and
the next append overwrites in place, and `mtp_partial_rollback` is
duck-typed on `is_trimmable`/`trim`.

## Changes

- `turboquant_attention.py`: new `_decode_multirow_attention` for causal
  decode-shaped multi-row calls. The L rows are folded into the GQA
  repeat dimension so the codecs' L==1 decode kernels apply (repeat
  count is a kernel template parameter); the causal tail mask is
  injected between key scoring and the value weighted sum. One lazy pass
  over the KV, no dequantize. Folding is used while
  n_repeats * q_len <= 24 (measured register-pressure knee of the
  unrolled repeat kernels); wider calls delegate to a single-block,
  single-chunk `quantized_attention`, whose einsum path amortizes the
  key unpack across rows and stays flat in q_len.
- `update_and_fetch` eval policy: mirrored with the eval gate raised
  from `n_new > 1` to prefill-sized appends (> 15). Verify rows stay
  lazy and materialize at the cycle's sampling sync.
- Guard removal: `ModelSettings.__post_init__` raise, admin API check,
  stale comments. The vlm_mtp exclusions are unrelated and kept.

## Benchmarks

Qwen3.6-27B-oQ4e-mtp, TurboQuant 4-bit KV, greedy, 256 tokens, M3 Ultra
(real serving path via BatchedEngine):

| context | TQ AR | TQ+MTP unfixed | TQ+MTP this PR |
|---------|-------|----------------|-----------------|
| 2K      | 33.5  | 37.3 (+11%)    | **41.9 (+25%)** |
| 16K     | 30.8  | 19.9 (-35%)    | **30.7 (parity)** |

At 16K the combo is parity, not a win: quantized multi-row attention
costs ~0.7 ms/layer/row, which eats the speculation margin at long
context; the adaptive depth controller settles at d1/d2 and holds the
line. The gain lives at short-to-mid context. TTFT unchanged (prefill
appends still eval).

## Correctness

- Fold path vs dequantize+SDPA reference: max diff <= 3.4e-4 across
  T=64..32K, L=2..9, with the causal mask verified to bind (locked in as
  a parametrized parity test).
- 16K greedy output is byte-identical to TQ AR across all variants. At
  2K the fused single-pass decode kernel (AR) and the score+stats
  kernels (verify) differ at the usual ULP argmax-flip level — the same
  divergence class as any kernel change.

## Tests

3 new tests in `test_turboquant.py` (reference parity, verify-route
assertion that prefill_attention/dequantize are never hit, non-causal
masks keep the prefill chain); the settings mutual-exclusion test is now
an allowed-combo test. Full suite: 6,210 passed.
