### PR TITLE
fix(model_discovery): discover DFlash draft checkpoints from HF cache

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -1095,6 +1095,31 @@ def _safetensors_has_mlx_metadata(path: Path) -> bool:
 
 _MLX_NAME_RE = re.compile(r"(^|[-_/])mlx($|[-_/])", re.IGNORECASE)
 
+# Speculative-decoding helper checkpoints (e.g. z-lab/Qwen3.6-27B-DFlash) are
+# MLX-loadable drafts even though their safetensors are saved in PyTorch ("pt")
+# format and the repo name carries no "mlx" token, so the HF-cache MLX
+# heuristic must recognise them explicitly or they vanish from the draft-model
+# picker (#1643). Detection delegates to is_helper_model_config so the drafter
+# markers stay in sync with helper flagging and engine_pool's drafter
+# resolution.
+def _is_helper_checkpoint(model_path: Path) -> bool:
+    """True if ``model_path`` is a speculative-decoding helper checkpoint.
+
+    Must never raise on an unreadable entry: unlike the config reads inside
+    _register_model, this runs outside discover_models' per-model guard, so
+    an escaped exception would abort the whole scan. UnicodeDecodeError from
+    a non-UTF-8 config.json is a ValueError, not a JSONDecodeError.
+    """
+    config_path = model_path / "config.json"
+    if not config_path.exists():
+        return False
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return False
+    return is_helper_model_config(config)
+
 
 def _is_hf_cache_mlx_compatible(model_dir: Path, source_repo_id: str) -> bool:
     """Heuristic for HF cache entries that can be loaded without conversion."""
@@ -1110,6 +1135,13 @@ def _is_hf_cache_mlx_compatible(model_dir: Path, source_repo_id: str) -> bool:
     if repo_lower.startswith("mlx-community/") or _MLX_NAME_RE.search(source_repo_id):
         logger.info(
             f"Treating HF cache model as MLX-compatible by repo name: {source_repo_id}"
+        )
+        return True
+
+    if _is_helper_checkpoint(model_dir):
+        logger.info(
+            f"Treating HF cache model as MLX-compatible speculative-decoding "
+            f"helper: {source_repo_id}"
         )
         return True
 

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -10,6 +10,7 @@ import pytest
 from omlx.model_discovery import (
     DiscoveredModel,
     _is_adapter_dir,
+    _is_helper_checkpoint,
     _is_unsupported_model,
     _read_model_context_length,
     _register_model,
@@ -1520,6 +1521,78 @@ class TestHfCacheDiscovery:
         assert len(models) == 1
         assert "acme--PlainModel" in models
         assert models["acme--PlainModel"].source_repo_id == "acme/PlainModel"
+
+    def test_hf_cache_dflash_draft_is_discovered(self, tmp_path):
+        """HF cache DFlash draft checkpoints are discovered despite pt-format
+        safetensors and a repo name with no 'mlx' token (#1643)."""
+        np = pytest.importorskip("numpy")
+        safetensors_numpy = pytest.importorskip("safetensors.numpy")
+
+        entry, snapshot = self._make_hf_cache_entry(
+            tmp_path, "z-lab", "Qwen3.6-27B-DFlash"
+        )
+        (snapshot / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "qwen3",
+                    "architectures": ["DFlashDraftModel"],
+                    "dflash_config": {},
+                }
+            )
+        )
+        # pt-format safetensors (NOT mlx) so only the DFlash architecture — not
+        # safetensors metadata or the repo name — can qualify this entry.
+        safetensors_numpy.save_file(
+            {"weight": np.zeros((1,), dtype=np.float32)},
+            snapshot / "model.safetensors",
+            metadata={"format": "pt"},
+        )
+
+        models = discover_models(tmp_path)
+        assert "z-lab--Qwen3.6-27B-DFlash" in models
+        # The shared DiscoveredModel construction path must flag the draft as
+        # a helper so it lands in the draft picker, not the chat-model list.
+        assert models["z-lab--Qwen3.6-27B-DFlash"].is_helper is True
+
+    def test_is_helper_checkpoint_on_disk_edge_cases(self, tmp_path):
+        """The on-disk wrapper qualifies a drafter config and never raises on
+        unreadable entries (it runs outside discover_models' per-model guard).
+
+        Marker-family coverage lives in TestIsHelperModelConfig; this pins
+        only the wrapper's own file-handling behavior.
+        """
+        draft = tmp_path / "draft"
+        draft.mkdir()
+        (draft / "config.json").write_text(
+            json.dumps({"model_type": "qwen3", "architectures": ["DFlashDraftModel"]})
+        )
+        assert _is_helper_checkpoint(draft) is True
+
+        # plain (non-draft) model config stays excluded
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        (plain / "config.json").write_text(
+            json.dumps({"model_type": "llama", "architectures": ["LlamaForCausalLM"]})
+        )
+        assert _is_helper_checkpoint(plain) is False
+
+        # no config.json at all
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert _is_helper_checkpoint(empty) is False
+
+        # malformed JSON must not raise
+        bad_json = tmp_path / "bad-json"
+        bad_json.mkdir()
+        (bad_json / "config.json").write_text("{not json")
+        assert _is_helper_checkpoint(bad_json) is False
+
+        # non-UTF-8 bytes must not raise: UnicodeDecodeError is a ValueError,
+        # not a JSONDecodeError, and an escape here aborts the whole scan
+        bad_bytes = tmp_path / "bad-bytes"
+        bad_bytes.mkdir()
+        (bad_bytes / "config.json").write_bytes(b'\xff\xfe{"a": 1}')
+        assert _is_helper_checkpoint(bad_bytes) is False
 
     def test_mixed_flat_and_hf_cache(self, tmp_path):
         """Mix of flat models and HF cache entries."""


### PR DESCRIPTION
Fixes #1643

## What happens

`_is_hf_cache_mlx_compatible` (new in 0.4) admits an HF-cache entry only when its safetensors declare `format=mlx` or the repo name carries an `mlx` token. DFlash draft checkpoints (e.g. `z-lab/Qwen3.6-27B-DFlash`) are MLX-loadable but ship pt-format safetensors under a repo name with no `mlx` token, so 0.4 silently drops them from HF-cache discovery — and they vanish from the DFlash draft-model picker.

That matches the report exactly: "I see the z-lab DFLASH models as downloaded but I cannot select them anymore", "Used to work in 0.3 branch" (0.3 had no such gate), and the commenter's workaround "redownload the DFLASH model … then it appears" (a fresh download can land outside the HF-cache layout, bypassing the gate).

## The fix

Recognise speculative-decoding helper checkpoints in the gate by delegating to the existing `is_helper_model_config`, so the drafter markers (`DFlashDraftModel` architecture, `dflash_config` block, `*_mtp` / `*_assistant` model_type) live in one place, in sync with `is_helper` flagging and engine_pool's drafter resolution — per the "keep these in sync" note above `HELPER_CONFIG_MODEL_TYPE_SUFFIXES`. Admitted drafts flow through the shared `DiscoveredModel` construction path, which flags them `is_helper=True`, so they surface in the draft picker (and can be hidden from the chat-model list via `hide_helper_models` — the reporter's "should only surface draft models" wish).

The new wrapper never raises on an unreadable entry: it runs outside `discover_models`' per-model guard, so an escaped exception would abort the whole scan. `UnicodeDecodeError` from a non-UTF-8 config.json is a `ValueError`, not a `JSONDecodeError`, hence the explicit exception tuple.

## Why this is safe

- A plain non-MLX PyTorch model still fails the gate — `is_helper_model_config` requires an explicit drafter marker.
- For helper checkpoints this is parity, not a new surface: the flat `model_dir` path has no MLX-compat gate, so the same checkpoint placed there is already discovered today. The change only stops the HF-cache layout from behaving differently.
- Trade-off, named: delegation is broader than a DFlash-only check — a pt-format `*_mtp` / `*_assistant` checkpoint in the HF cache becomes discoverable too (flagged `is_helper`, same treatment it already gets in `model_dir`). If you'd rather admit only DFlash drafts from the HF cache, the predicate can trivially narrow to the architecture/config-block markers — happy to adjust.

## Verification

- Verified against three real DFlash draft checkpoints on disk (z-lab Qwen3-Coder-Next and Qwen3.5-122B-A10B drafts, plus a Qwen3.6-27B FP16 draft): all carry `DFlashDraftModel` + `dflash_config` and pass the predicate; a config-less partial download correctly fails it.
- `tests/test_model_discovery.py`: 155 passed. Two new tests: `test_hf_cache_dflash_draft_is_discovered` (drives the real `discover_models` path on a pt-format cache entry and asserts the `is_helper` flag) and `test_is_helper_checkpoint_on_disk_edge_cases` (missing / malformed / non-UTF-8 config.json never raise). Marker-family coverage stays in the existing `TestIsHelperModelConfig`.
- Revert-proof: with the fix reverted, `test_hf_cache_dflash_draft_is_discovered` fails with the exact field symptom — the draft is absent from discovery.

Siblings checked: the flat `model_dir` path needs no change (no gate there). The `model*.safetensors` precondition still runs before the helper check, so a draft with unconventionally-named weights would still be skipped — named as out of scope (real DFlash drafts ship `model.safetensors`).
