### PR TITLE
perf: exit prefill-patch gates on a single shape check at decode

### DIFF
--- a/omlx/patches/qwen35_fa256_attention.py
+++ b/omlx/patches/qwen35_fa256_attention.py
@@ -48,13 +48,20 @@ def _has_quantized_cache(cache) -> bool:
 
 
 def _should_route(queries, keys, cache, mask, sinks, min_kv_len: int) -> bool:
+    # Query-shape gates first: this runs on every SDPA call of every decode
+    # step, so the common (decode / MTP verify) case must exit on the q_len
+    # check before touching Metal state or cache attributes (issue #2132).
+    # ``keys`` may be a TurboQuant state proxy without ``ndim``/``dtype``, so
+    # it must not be inspected before the quantized-cache check declines.
+    if queries.ndim != 4 or queries.shape[-2] < _MIN_ROUTE_Q_LEN:
+        return False
     if not mx.metal.is_available() or _has_quantized_cache(cache):
         return False
     if sinks is not None:
         return False
     if mask is not None and not (isinstance(mask, str) and mask == "causal"):
         return False
-    if queries.ndim != 4 or keys.ndim != 4:
+    if keys.ndim != 4:
         return False
     if queries.dtype not in (mx.float16, mx.bfloat16):
         return False
@@ -70,7 +77,6 @@ def _should_route(queries, keys, cache, mask, sinks, min_kv_len: int) -> bool:
         head_dim == 256
         and q_heads == 24
         and kv_heads == 4
-        and q_len >= _MIN_ROUTE_Q_LEN
         and kv_len >= min_kv_len
         and q_len <= kv_len
     )

--- a/omlx/patches/qwen35_moe_weighted_sum.py
+++ b/omlx/patches/qwen35_moe_weighted_sum.py
@@ -40,16 +40,18 @@ def _target_verify_arg(args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
 
 
 def _should_route(self: Any, x: mx.array, target_verify: bool, min_tokens: int) -> bool:
+    # Shape gates first: this runs on every MoE block call of every decode
+    # step, so the common (decode) case must exit on the seq-len check
+    # before touching env vars or Metal state (issue #2132).
+    if x.ndim != 3 or x.shape[-2] < min_tokens:
+        return False
     if target_verify:
+        return False
+    if x.dtype not in (mx.float16, mx.bfloat16):
         return False
     if os.environ.get("OMLX_QWEN35_MOE_WEIGHTED_SUM", "1") == "0":
         return False
     if not mx.metal.is_available():
-        return False
-    if x.ndim != 3 or x.shape[-2] < min_tokens or x.dtype not in (
-        mx.float16,
-        mx.bfloat16,
-    ):
         return False
     if getattr(self, "sharding_group", None) is not None:
         return False
@@ -126,6 +128,9 @@ def _fast_moe(self: Any, x: mx.array, target_verify: bool) -> mx.array:
 
 def _make_patched_call(orig_call: Callable[..., mx.array], min_tokens: int):
     def patched(self, x: mx.array, *args, **kwargs):
+        # Decode fast path: one shape check before any argument parsing.
+        if x.ndim != 3 or x.shape[-2] < min_tokens:
+            return orig_call(self, x, *args, **kwargs)
         target_verify = _target_verify_arg(args, kwargs)
         if not _should_route(self, x, target_verify, min_tokens):
             return orig_call(self, x, *args, **kwargs)

--- a/omlx/patches/qwen35_q4_mlp.py
+++ b/omlx/patches/qwen35_q4_mlp.py
@@ -160,12 +160,16 @@ def _make_patched_mlp(
     q8_min_tokens: int,
 ):
     def patched(self, x, *args, **kwargs):
+        # Decode / short-sequence fast path first: this wrapper runs on every
+        # MLP call of every layer of every decode step, so the common case
+        # must exit on a single shape check (issue #2132 — per-call gate
+        # overhead across the qwen35 prefill patches costs ~2% TG).
+        if x.ndim < 3 or x.shape[-2] < min_tokens:
+            return orig_call(self, x, *args, **kwargs)
         target_verify = bool(kwargs.get("target_verify", False))
         if args and isinstance(args[0], bool):
             target_verify = target_verify or bool(args[0])
         if target_verify or os.environ.get("OMLX_QWEN35_Q4_MLP", "1") == "0":
-            return orig_call(self, x, *args, **kwargs)
-        if x.ndim < 3:
             return orig_call(self, x, *args, **kwargs)
         gate_proj = getattr(self, "gate_proj", None)
         up_proj = getattr(self, "up_proj", None)
@@ -292,11 +296,13 @@ def apply_qwen35_q4_prefill_linear_patch() -> bool:
     )
 
     def should_route(linear: Any, x: mx.array, target_verify: bool) -> bool:
+        # Shape gates first, env kill-switch last: the runtime toggle only
+        # matters on the (rare) routed side, while decode pays this per call.
         return (
             not target_verify
-            and os.environ.get("OMLX_QWEN35_Q4_LINEAR", "1") != "0"
             and x.ndim == 3
             and _can_route_affine_linear(linear, x, min_tokens, q8_min_tokens)
+            and os.environ.get("OMLX_QWEN35_Q4_LINEAR", "1") != "0"
         )
 
     def patched_linear(linear, x: mx.array, target_verify: bool):
@@ -306,10 +312,10 @@ def apply_qwen35_q4_prefill_linear_patch() -> bool:
 
     def patched_linears(linears, x: mx.array, target_verify: bool):
         if (
-            target_verify
-            or os.environ.get("OMLX_QWEN35_Q4_LINEAR", "1") == "0"
-            or x.ndim != 3
+            x.ndim != 3
             or x.shape[-2] < min_tokens
+            or target_verify
+            or os.environ.get("OMLX_QWEN35_Q4_LINEAR", "1") == "0"
         ):
             return orig_linears(linears, x, target_verify)
 
@@ -365,10 +371,11 @@ def apply_qwen35_q4_lm_prefill_linear_patch() -> bool:
     )
 
     def should_route(linear: Any, x: mx.array) -> bool:
+        # Shape gates first, env kill-switch last (decode pays this per call).
         return (
-            os.environ.get("OMLX_QWEN35_Q4_LM_LINEAR", "1") != "0"
-            and x.ndim == 3
+            x.ndim == 3
             and _can_route_affine_linear(linear, x, min_tokens, q8_min_tokens)
+            and os.environ.get("OMLX_QWEN35_Q4_LM_LINEAR", "1") != "0"
         )
 
     def qmm_or_linear(linear: Any, x: mx.array) -> mx.array:

--- a/omlx/patches/sdpa256_attention.py
+++ b/omlx/patches/sdpa256_attention.py
@@ -119,7 +119,16 @@ def _flash_sdpa256(queries, keys, values, scale, mask):
 def _should_route(queries, keys, cache, mask, sinks) -> bool:
     # Never raise: any unexpected input must fall through to the original SDPA,
     # never break a request. Worst case we decline to engage.
+    # Shape gates first: this wrapper is installed unconditionally and runs
+    # on every SDPA call of every decode step, so the common (decode / MTP
+    # verify) case must exit on the q_len check alone (issue #2132).
     try:
+        if queries.shape[-2] < _SDPA256_MIN_Q_LEN:  # decode / MTP verify
+            return False
+        if queries.shape[-1] != HEAD_DIM:
+            return False
+        if keys.shape[-2] < _SDPA256_MIN_KV_LEN:
+            return False
         if sinks is not None:
             return False
         # Quantized KV cache (TurboQuant etc.): keys/values are packed state,
@@ -127,13 +136,7 @@ def _should_route(queries, keys, cache, mask, sinks) -> bool:
         # hasattr(cache, "bits"); let the quant-aware path handle it.
         if cache is not None and hasattr(cache, "bits"):
             return False
-        if queries.shape[-1] != HEAD_DIM:
-            return False
-        if queries.shape[-2] < _SDPA256_MIN_Q_LEN:  # decode / MTP verify
-            return False
         if not (mask is None or (isinstance(mask, str) and mask == "causal")):
-            return False
-        if keys.shape[-2] < _SDPA256_MIN_KV_LEN:
             return False
         n_q = queries.shape[-3]
         n_kv = keys.shape[-3]


### PR DESCRIPTION
Addresses the omlx-side portion of #2132 (does not close it — the remaining delta there is the mlx version skew discussed in the issue).

## Problem

The Qwen3.5/3.6 prefill acceleration patches (`qwen35_q4_mlp`, `qwen35_moe_weighted_sum`, `qwen35_fa256_attention`, `sdpa256_attention`) wrap hot per-layer call sites. Their routing gates evaluated env vars, `mx.metal.is_available()`, kwargs parsing, and module attribute lookups *before* the sequence-length check — so every decode call of every layer of every token paid the full gate cost just to conclude "not prefill". On Qwen3.6-35B-A3B (stock MLX 4-bit, M3 Ultra, pp1024/tg128 dashboard protocol) that adds up to ~2% TG. Kill-switch isolation: q4_mlp +1.2, fa256 +0.7, moe_weighted_sum +0.5 tok/s.

## Fix

Reorder every gate shape-first so the decode case exits on a single shape comparison. Env kill-switches keep their runtime-toggle semantics on the routed (prefill) side. One latent hazard fixed along the way: in `fa256._should_route` the reorder must not inspect `keys` before the quantized-cache check declines — TurboQuant passes a `_QuantizedStateProxy` that exposes `.shape` but not `ndim`/`dtype` (the gate has no try/except). `gdn_chunked` was already lean and is untouched.

This is a pure reorder of boolean gates: no routing outcome changes for any input, and no kernel selection changes anywhere.

## Results

| | TG tok/s |
|---|---|
| main before | 110.5–111.1 |
| all four patches disabled (ceiling) | 112.7 |
| **this PR** | **112.5 (median of 4)** |

PP unchanged (~1785 tok/s — prefill routing intact). Greedy output is byte-identical to main before the change in both regimes: decode-only (851-token prompt, sha `5708bed4`) and with all prefill routes engaged (3,924-token prompt: moe_ws/q4_mlp/fa256 active, sha `434a2a79`).

## Tests

All 30 unit tests across the five patch suites pass, including the kernel-parity tests.
