### PR TITLE
build: move the mlx pin to 0.32.0 and nanobind to 2.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,13 @@ requires = [
     "setuptools>=61.0",
     "wheel",
     "cmake>=3.27",
-    # Pin nanobind to match the ABI version MLX 0.31.2 was built with
-    # (MLX pins nanobind v2.12.0 / ABI v19 via FetchContent in its CMakeLists.txt).
-    # A newer nanobind (e.g. 2.13.0 / ABI v20) isolates the `mlx` NB_DOMAIN, so
-    # custom kernel extensions (omlx.custom_kernels.*) reject every mlx.core.array
-    # at the type caster with `incompatible function arguments`.
-    "nanobind==2.12.0",
-    "mlx==0.31.2",
+    # Pin nanobind to match the ABI version MLX 0.32.0 was built with
+    # (MLX pins nanobind v2.13.0 via FetchContent in its CMakeLists.txt).
+    # A mismatched nanobind isolates the `mlx` NB_DOMAIN, so custom kernel
+    # extensions (omlx.custom_kernels.*) reject every mlx.core.array at the
+    # type caster with `incompatible function arguments`.
+    "nanobind==2.13.0",
+    "mlx==0.32.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -39,9 +39,11 @@ classifiers = [
 ]
 
 dependencies = [
-    # Vanilla MLX v0.31.2; optional custom kernels live under
-    # omlx.custom_kernels.* when built for release.
-    "mlx==0.31.2",
+    # Vanilla MLX v0.32.0; optional custom kernels live under
+    # omlx.custom_kernels.* when built for release. The bundled kernel
+    # binaries are ABI-coupled to this exact mlx version — bumping the pin
+    # requires rebuilding them (OMLX_WITH_CUSTOM_KERNEL=1 setup.py build_ext).
+    "mlx==0.32.0",
     # mlx-lm from commit (ab1806e, v0.31.3) - transformers 5.13+
     # NewlineTokenizer registration compatibility, DeepSeek/GLM DSA indexer
     # RoPE fix, trust_remote_code load gate, transformers 5.7.0
@@ -221,7 +223,7 @@ include = ["omlx*"]
 # mlx and mlx-lm are git-pinned; override transitive pins
 # (e.g. mlx-audio -> mlx-lm==0.31.1) so the resolver accepts them.
 override-dependencies = [
-    "mlx==0.31.2",
+    "mlx==0.32.0",
     "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@ab1806e8f5d6aa035973af194a1b9198ab4754dc",
 ]
 


### PR DESCRIPTION
Lifts the `mlx==0.31.2` pin to `mlx==0.32.0`. Related to #2132: v0.4.4 declared `mlx>=0.31.2`, so fresh v0.4.4 installs made after Jul 7 pull mlx 0.32.0 while 0.5.0.dev2 stayed on 0.31.2, which is part of the TG gap reported there (I measure ~+2% TG coming back with 0.32.0). The bundled kernel extensions are ABI-coupled to the exact mlx wheel, so the runtime pin, the `[build-system]` nanobind/mlx requires, and the `[tool.uv]` override move together in one step.

## Verification

I rebuilt all three extensions against mlx 0.32.0 + nanobind 2.13.0 (`OMLX_WITH_CUSTOM_KERNEL=1 python setup.py build_ext --inplace`): all native symbols load (qwen35_prefill 6, glm_moe_dsa 13, minimax_m3), numeric parity holds vs the mx reference on fa256 attention (max diff 2e-3, fp16) and q4 affine qmm (1e-3), and the 54 unit tests across the kernel/patch suites pass.

16k prefill re-run of the throughput claims from #1984 / #2048 / #2100 on the rebuilt kernels (single request, UUID prompt, tg=128, greedy, M3 Ultra):

| Model @16k | Claimed (PR) | Measured (this PR) | Notes |
|---|---|---|---|
| Qwen3.6-27B-oQ4e | pp 429.5 / tg 31.5 (#2100, same quant) | **pp 433.2 / tg 33.6** | holds |
| GLM-5.2-oQ4e | pp 178.9 / tg 14.7 (#1984, measured on oQ4) | **pp 182.1 / tg 14.8** | holds; kernel-off baseline was 128 pp |
| DeepSeek-V4-Flash-oQ2.5e | pp 514.4 / tg 26.9 (#2048, measured on oQ8, `prefill_step_size=512`) | pp 493 / tg 27.6 (step 512) | same-model control on mlx 0.31.2 kernels measured pp 498.5 / tg 27.7, so no 0.32 regression; the gap vs the claim is the oQ2.5e-vs-oQ8 quant difference |
