### PR TITLE
Ship oqe_calibration_data.json in the wheel

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -4758,6 +4758,22 @@ def _load_calibration_data(
     Returns:
         MLX array of shape (num_samples, seq_length) or None on failure.
     """
+    if dataset == _OQE_CALIB_DATASET:
+        # oQe (enhanced=True) requests this built-in corpus by name. If the data
+        # file is not present in the installed package, the generic handler below
+        # would swallow the error and silently calibrate the imatrix on a smaller,
+        # different corpus, producing a subtly worse enhanced model with no signal
+        # to the caller. Fail loudly instead: a missing built-in data file is a
+        # broken installation the user cannot fix by retrying. See package-data in
+        # pyproject.toml, which must ship oqe_calibration_data.json.
+        oqe_path = Path(__file__).parent / "oqe_calibration_data.json"
+        if not oqe_path.exists():
+            raise FileNotFoundError(
+                f"oQe calibration corpus not found at {oqe_path}. This file ships "
+                "with omlx but is missing from the current installation, so "
+                "enhanced quantization cannot calibrate correctly. Reinstall omlx "
+                "from a distribution that includes oqe_calibration_data.json."
+            )
     if dataset in ("code_multilingual", "code", "multilingual", _OQE_CALIB_DATASET):
         try:
             return _load_builtin_calibration(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,7 @@ where = ["."]
 include = ["omlx*"]
 
 [tool.setuptools.package-data]
-"omlx" = ["oq_calibration_data.json"]
+"omlx" = ["oq_calibration_data.json", "oqe_calibration_data.json"]
 "omlx.admin" = ["templates/**/*.html", "static/**/*", "i18n/*.json"]
 "omlx.eval" = ["data/*.jsonl"]
 "omlx.custom_kernels.glm_moe_dsa" = ["*.metallib", "*.dylib", "*.so"]

--- a/tests/test_oqe_calibration_packaging.py
+++ b/tests/test_oqe_calibration_packaging.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for shipping the oQe imatrix calibration corpus.
+
+`enhanced=True` (oQe) quantization calibrates its importance matrix on the
+built-in ``oqe_calibration_data.json`` corpus. That file lives in the ``omlx``
+package but was missing from ``[tool.setuptools.package-data]``, so every wheel
+build dropped it and oQe silently fell back to a different, smaller corpus.
+These tests fail if the corpus stops being declared or stops being importable.
+"""
+
+import json
+import tomllib
+from importlib.resources import files
+from pathlib import Path
+
+import pytest
+
+# Keys the oQe calibration path reads out of the corpus (omlx.oq).
+_EXPECTED_KEYS = {
+    "tool_calling",
+    "chat",
+    "mixed",
+    "reasoning",
+    "code",
+    "en",
+    "ko",
+    "zh",
+    "ja",
+    "bartowski",
+}
+
+
+def _pyproject_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+@pytest.mark.skipif(
+    not _pyproject_path().is_file(),
+    reason="pyproject.toml not available (installed without source tree)",
+)
+def test_oqe_corpus_declared_in_package_data():
+    data = tomllib.loads(_pyproject_path().read_text(encoding="utf-8"))
+    package_data = data["tool"]["setuptools"]["package-data"]["omlx"]
+    assert "oqe_calibration_data.json" in package_data, (
+        "oqe_calibration_data.json must be in [tool.setuptools.package-data] "
+        "so it ships in the wheel; otherwise oQe silently mis-calibrates."
+    )
+
+
+def test_oqe_corpus_shipped_and_loadable():
+    resource = files("omlx").joinpath("oqe_calibration_data.json")
+    assert resource.is_file(), (
+        "oqe_calibration_data.json is not present in the installed omlx "
+        "package; enhanced quantization cannot calibrate correctly."
+    )
+    corpus = json.loads(resource.read_text(encoding="utf-8"))
+    assert isinstance(corpus, dict)
+    present = _EXPECTED_KEYS & set(corpus)
+    assert present, f"oQe corpus contains none of the expected keys: {_EXPECTED_KEYS}"
+
+
+def test_oq_corpus_still_shipped():
+    resource = files("omlx").joinpath("oq_calibration_data.json")
+    assert resource.is_file()
+
+
+def test_missing_oqe_corpus_raises_instead_of_silent_fallback(monkeypatch):
+    """When the oQe corpus is absent, calibration must fail loudly rather than
+    silently fall back to a different corpus and mis-calibrate the imatrix."""
+    import omlx.oq as oq
+
+    real_exists = Path.exists
+
+    def fake_exists(self):
+        if self.name == "oqe_calibration_data.json":
+            return False
+        return real_exists(self)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    with pytest.raises(FileNotFoundError, match="oQe calibration corpus"):
+        oq._load_calibration_data(tokenizer=None, dataset=oq._OQE_CALIB_DATASET)


### PR DESCRIPTION
## Problem

The oQe quantization path (`enhanced=True`) calibrates its importance matrix on a
built-in corpus, `omlx/oqe_calibration_data.json`. That file is tracked in the
repo but is not listed in `[tool.setuptools.package-data]`, which only declares
`oq_calibration_data.json`:

```toml
[tool.setuptools.package-data]
"omlx" = ["oq_calibration_data.json"]
```

Because setuptools has no `include_package_data` and no MANIFEST here, a wheel
built from a clean checkout drops `oqe_calibration_data.json`. At runtime the oQe
path then falls through the generic handler in `_load_calibration_data`:

```python
if dataset in ("code_multilingual", "code", "multilingual", _OQE_CALIB_DATASET):
    try:
        return _load_builtin_calibration(tokenizer, dataset, num_samples, seq_length)
    except Exception as e:
        logger.warning(f"Built-in calibration failed: {e}, falling back to mlx-lm default")
```

so an `enhanced=True` run catches the `FileNotFoundError`, logs the warning above,
tries to load the dataset name from HuggingFace (which also fails), and finally
falls back to the built-in `code_multilingual` corpus (`oq_calibration_data.json`).
The net effect is that oQe calibrates its imatrix on a different, smaller corpus
and produces a subtly worse model, with only a warning line to signal it.

## Evidence

Built a wheel from a clean `git archive` of `main` (no stale `egg-info`, no
`build/`, kernels off) before and after the fix:

```
# main as-is
$ unzip -l dist/omlx-*.whl | grep calibration_data.json
  1293049  omlx/oq_calibration_data.json          # oqe_ is absent

# with oqe_calibration_data.json added to package-data
$ unzip -l dist/omlx-*.whl | grep calibration_data.json
  1293049  omlx/oq_calibration_data.json
  4536202  omlx/oqe_calibration_data.json
```

(A build from a working tree that already has an `omlx.egg-info/SOURCES.txt`
listing the file will include it regardless, which can hide the bug during local
testing. The clean-checkout build is the one that matches `pip install git+...`.)

## Changes

1. Add `oqe_calibration_data.json` to `package-data` so it ships in the wheel.
2. When the oQe corpus is requested and the file is not present, raise a clear
   `FileNotFoundError` instead of falling through to a different corpus. A missing
   built-in data file is a broken install the user cannot fix by retrying, so
   failing loudly is safer than a silently degraded enhanced model. If you would
   rather keep the fallback, this can be softened to a single explicit warning.
3. Add regression tests: the package-data declaration, the corpus being importable
   from the installed package, and the new guard.

## Not included (on purpose)

The `custom_kernels/*/csrc/*.metal` sources are also not in `package-data`, but I
left them out of this change. They are build inputs compiled by `setup.py` only
when `OMLX_WITH_CUSTOM_KERNEL` is set; a normal install ships the compiled `_ext`
(or falls back to `mx.fast`) and never reads the `.metal` source at runtime, so
adding them would only grow the wheel. Happy to ship them separately for sdist
source completeness if you want that.

## Repro

```bash
git archive --format=tar main | tar -x -C /tmp/omlx-clean
cd /tmp/omlx-clean
OMLX_WITH_CUSTOM_KERNEL= uv build --wheel --out-dir dist
unzip -l dist/omlx-*.whl | grep oqe_calibration_data.json   # empty on main
```
