### PR TITLE
fix(server): drop malformed parser tool calls

### DIFF
--- a/omlx/api/parser_tool_calls.py
+++ b/omlx/api/parser_tool_calls.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Helpers for converting parser-emitted tool calls to OpenAI models."""
+
+import logging
+import uuid
+
+from pydantic import ValidationError
+
+from .openai_models import FunctionCall, ToolCall
+
+logger = logging.getLogger(__name__)
+
+
+def convert_parser_tool_calls(tool_calls: list[dict] | None) -> list[ToolCall]:
+    """Convert parser-emitted tool-call dicts into validated OpenAI ToolCalls.
+
+    Parser output comes from model text and can contain malformed JSON
+    arguments. Treat those as recoverable parser failures rather than letting
+    Pydantic validation abort the response stream.
+    """
+    converted: list[ToolCall] = []
+    for tool_call in tool_calls or []:
+        if not isinstance(tool_call, dict):
+            continue
+        name = tool_call.get("name", "")
+        arguments = tool_call.get("arguments", "{}") or "{}"
+        try:
+            converted.append(
+                ToolCall(
+                    id=tool_call.get("id")
+                    or tool_call.get("call_id")
+                    or f"call_{uuid.uuid4().hex[:8]}",
+                    type="function",
+                    function=FunctionCall(
+                        name=name,
+                        arguments=arguments,
+                    ),
+                )
+            )
+        except (TypeError, ValueError, ValidationError) as e:
+            snippet = str(arguments)
+            if len(snippet) > 120:
+                snippet = snippet[:117] + "..."
+            logger.warning(
+                "Dropping malformed parser tool call %r: %s. arguments=%r",
+                name,
+                e,
+                snippet,
+            )
+            continue
+    return converted

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -121,12 +121,13 @@ from .api.openai_models import (
     CompletionChoice,
     CompletionRequest,
     CompletionResponse,
-    FunctionCall,
     ModelInfo,
     ModelsResponse,
     PromptTokensDetails,
-    ToolCall,
     Usage,
+)
+from .api.parser_tool_calls import (
+    convert_parser_tool_calls as _convert_parser_tool_calls,
 )
 from .api.rerank_models import (
     RerankRequest,
@@ -197,26 +198,6 @@ logger = logging.getLogger(__name__)
 
 # Security bearer for API key authentication
 security = HTTPBearer(auto_error=False)
-
-
-def _convert_parser_tool_calls(tool_calls: list[dict] | None) -> list[ToolCall]:
-    converted: list[ToolCall] = []
-    for tool_call in tool_calls or []:
-        if not isinstance(tool_call, dict):
-            continue
-        converted.append(
-            ToolCall(
-                id=tool_call.get("id")
-                or tool_call.get("call_id")
-                or f"call_{uuid.uuid4().hex[:8]}",
-                type="function",
-                function=FunctionCall(
-                    name=tool_call.get("name", ""),
-                    arguments=tool_call.get("arguments", "{}") or "{}",
-                ),
-            )
-        )
-    return converted
 
 
 # =============================================================================
@@ -5844,7 +5825,7 @@ async def create_response(
 
             # Parse tool calls
             if output.tool_calls:
-                tool_calls = output.tool_calls
+                tool_calls = _convert_parser_tool_calls(output.tool_calls)
                 cleaned_text = regular_content
                 cleaned_thinking = sanitize_tool_call_markup(
                     thinking_content, engine.tokenizer
@@ -6319,7 +6300,7 @@ async def stream_responses_api(
     tool_calls = None
     cleaned_text = accumulated_text
     if last_output and last_output.tool_calls:
-        tool_calls = last_output.tool_calls
+        tool_calls = _convert_parser_tool_calls(last_output.tool_calls)
         cleaned_text = ""
     elif has_tools and accumulated_text:
         thinking_content, regular_content = extract_thinking(accumulated_text)

--- a/tests/test_parser_tool_calls.py
+++ b/tests/test_parser_tool_calls.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for parser-emitted tool call conversion."""
+
+import logging
+
+from omlx.api.parser_tool_calls import convert_parser_tool_calls
+
+
+class TestParserToolCallConversion:
+    def test_drops_malformed_parser_tool_call_arguments(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="omlx.api.parser_tool_calls"):
+            converted = convert_parser_tool_calls(
+                [
+                    {
+                        "id": "call_bad",
+                        "name": "read",
+                        "arguments": '{"path": "/tmp/file"',
+                    }
+                ]
+            )
+
+        assert converted == []
+        assert "Dropping malformed parser tool call 'read'" in caplog.text
+
+    def test_keeps_valid_parser_tool_calls_when_one_is_malformed(self):
+        converted = convert_parser_tool_calls(
+            [
+                {
+                    "id": "call_valid",
+                    "name": "read",
+                    "arguments": '{"path": "/tmp/file"}',
+                },
+                {
+                    "id": "call_bad",
+                    "name": "write",
+                    "arguments": '{"path":',
+                },
+            ]
+        )
+
+        assert len(converted) == 1
+        assert converted[0].id == "call_valid"
+        assert converted[0].function.name == "read"
+        assert converted[0].function.arguments == '{"path": "/tmp/file"}'


### PR DESCRIPTION
Fixes #2012.

## Summary

Malformed tool-call arguments emitted by protocol parsers could propagate into `FunctionCall(...)` validation and abort non-streaming or SSE response handling. This moves parser tool-call conversion into a small shared helper and treats invalid parser-emitted arguments as recoverable parser failures: the malformed call is dropped with a warning while valid calls continue through unchanged.

## What changed

- Added `convert_parser_tool_calls()` for validated parser-emitted tool-call conversion.
- Routed all parser-provided tool-call paths in `server.py` through the helper, including OpenAI chat, Anthropic messages, and Responses API streaming/non-streaming paths.
- Added regression coverage for dropping malformed arguments while preserving valid tool calls in the same parser result.

## Validation

- `docker run --rm -v "$PWD":/repo -w /repo python:3.12-slim sh -lc 'python -m pip install -q pytest pydantic regex jsonschema fastapi && python -m pytest tests/test_parser_tool_calls.py -q'`
- `docker run --rm -v "$PWD":/repo -w /repo python:3.12-slim sh -lc 'python -m pip install -q black && python -m compileall -q omlx/server.py omlx/api/parser_tool_calls.py tests/test_parser_tool_calls.py && python -m black --check omlx/server.py omlx/api/parser_tool_calls.py tests/test_parser_tool_calls.py'`
