### PR TITLE
Require commentary channel for Harmony tool calls

### DIFF
--- a/omlx/adapter/harmony.py
+++ b/omlx/adapter/harmony.py
@@ -60,6 +60,15 @@ def _has_no_real_recipient(recipient: str | None) -> bool:
     return recipient is None or recipient == "<|start|>assistant"
 
 
+def _is_commentary_tool_call_message(msg: Any) -> bool:
+    recipient = getattr(msg, "recipient", None)
+    return (
+        getattr(msg, "channel", None) == "commentary"
+        and isinstance(recipient, str)
+        and recipient.startswith("functions.")
+    )
+
+
 @lru_cache(maxsize=1)
 def load_harmony_gpt_oss_encoding() -> HarmonyEncoding:
     """Load the Harmony gpt-oss encoding with a small retry window."""
@@ -333,7 +342,7 @@ class HarmonyStreamingParser:
                 return tool_calls
 
             for msg in messages:
-                if not msg.recipient or not msg.recipient.startswith("functions."):
+                if not _is_commentary_tool_call_message(msg):
                     continue
 
                 name = msg.recipient[10:]  # Remove "functions." prefix
@@ -470,7 +479,7 @@ def parse_tool_calls_from_tokens(
                     if isinstance(text, str):
                         analysis_text += text
 
-            elif msg.recipient and msg.recipient.startswith("functions."):
+            elif _is_commentary_tool_call_message(msg):
                 # Extract tool calls from commentary channel
                 name = msg.recipient[10:]  # Remove "functions." prefix
                 arguments = ""

--- a/tests/test_harmony.py
+++ b/tests/test_harmony.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for Harmony streaming parser (omlx.adapter.harmony)."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -101,6 +102,33 @@ class TestToolCallParsing:
         _, stream_token, visible_token, _ = last
         assert stream_token is None
         assert visible_token is None
+
+    def test_get_tool_calls_requires_commentary_channel(self):
+        """Only commentary messages with function recipients become tool calls."""
+        parser = object.__new__(HarmonyStreamingParser)
+        parser._parser = SimpleNamespace(
+            messages=[
+                SimpleNamespace(
+                    channel="analysis",
+                    recipient="functions.Read",
+                    content=[SimpleNamespace(text="analysis-noise")],
+                ),
+                SimpleNamespace(
+                    channel="commentary",
+                    recipient="functions.Read",
+                    content=[SimpleNamespace(text='{"path":"ok.py"}')],
+                ),
+                SimpleNamespace(
+                    channel="final",
+                    recipient="functions.Read",
+                    content=[SimpleNamespace(text="final-noise")],
+                ),
+            ]
+        )
+
+        assert parser.get_tool_calls() == [
+            {"name": "Read", "arguments": '{"path":"ok.py"}'}
+        ]
 
 
 # ── Multi-message sequences ──────────────────────────────────────────
@@ -359,3 +387,49 @@ class TestParseToolCallsFromTokens:
         assert output_text == ""
         assert "thinking" in analysis_text
         assert tool_calls == []
+
+    def test_requires_commentary_channel_for_function_recipient(self, monkeypatch):
+        """Mixed messages keep only commentary function recipients as tool calls."""
+        messages = [
+            SimpleNamespace(
+                channel="analysis",
+                recipient="functions.Read",
+                content=[SimpleNamespace(text="analysis-noise")],
+            ),
+            SimpleNamespace(
+                channel="commentary",
+                recipient="functions.Read",
+                content=[SimpleNamespace(text='{"path":"ok.py"}')],
+            ),
+            SimpleNamespace(
+                channel="final",
+                recipient="functions.Read",
+                content=[SimpleNamespace(text="final-noise")],
+            ),
+            SimpleNamespace(
+                channel="other",
+                recipient="functions.Read",
+                content=[SimpleNamespace(text="other-noise")],
+            ),
+        ]
+
+        class FakeEncoding:
+            def encode(self, text, allowed_special="all"):
+                return [1, 2] if text == "<|start|>assistant" else [3]
+
+            def decode(self, token_ids):
+                return "decoded"
+
+            def parse_messages_from_completion_tokens(self, token_ids, role, strict):
+                return messages
+
+        monkeypatch.setattr(
+            "omlx.adapter.harmony.load_harmony_gpt_oss_encoding",
+            lambda: FakeEncoding(),
+        )
+
+        output_text, analysis_text, tool_calls = parse_tool_calls_from_tokens([99])
+
+        assert analysis_text == "analysis-noise"
+        assert output_text == "final-noise"
+        assert tool_calls == [{"name": "Read", "arguments": '{"path":"ok.py"}'}]


### PR DESCRIPTION
HI men
Fixes #2032

This makes Harmony tool-call extraction a bit stricter: `functions.*` messages are now treated as tool calls only when they are in the `commentary` channel.

Previously, a `functions.*` recipient in `analysis` or `final` could be picked up as a tool call too, which does not match the Harmony format and can create false tool calls.

Changed both paths mentioned in the issue:
- `HarmonyStreamingParser.get_tool_calls()`
- `parse_tool_calls_from_tokens()`

Also added regression tests for mixed `analysis` / `commentary` / `final` messages to make sure only the `commentary` one becomes a tool call.

Tested with:

```bash
python -m pytest tests/test_harmony.py -q

I am waiting you opinion