### PR TITLE
fix(reranker): support reranker-native chat template for CausalLM rerankers

### DIFF
--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -300,25 +300,7 @@ class MLXRerankerModel:
             )
 
         # Pre-compute prefix and suffix tokens for the prompt template.
-        # Use apply_chat_template() for portability across tokenizer formats,
-        # then split on a sentinel to extract prefix/suffix boundaries.
-        _SENTINEL = "<<__CONTENT_SENTINEL__>>"
-        messages = [
-            {"role": "system", "content": self._CAUSAL_LM_SYSTEM_PROMPT},
-            {"role": "user", "content": _SENTINEL},
-        ]
-        template_str = tokenizer.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=True
-        )
-        parts = template_str.split(_SENTINEL)
-        if len(parts) != 2:
-            raise ValueError(
-                f"Chat template produced unexpected format; "
-                f"could not split on sentinel. Template: {template_str!r}"
-            )
-        prefix = parts[0]
-        # Append <think> block for models that use thinking-then-answering format
-        suffix = parts[1] + "<think>\n\n</think>\n\n"
+        prefix, suffix = self._extract_causal_lm_affixes(tokenizer)
 
         self._prefix_tokens = tokenizer.encode(prefix, add_special_tokens=False)
         self._suffix_tokens = tokenizer.encode(suffix, add_special_tokens=False)
@@ -331,6 +313,114 @@ class MLXRerankerModel:
         )
 
         return model, tokenizer
+
+    def _extract_causal_lm_affixes(self, tokenizer: Any) -> Tuple[str, str]:
+        """Extract the static prompt prefix/suffix around the rerank content.
+
+        Handles two chat template shapes:
+
+        1. Standard chat template (system/user roles): render with a sentinel
+           as the user content and split around it.
+        2. Reranker-native template (Qwen/Qwen3-Reranker ships one as
+           chat_template.jinja since its 2026-04 sentence-transformers
+           update, and MLX conversions made after that inherit it): the
+           template only understands system/query/document roles and silently
+           drops user messages, so the sentinel never appears in the output.
+           Render with per-slot sentinels instead and split around the
+           combined "<Instruct>/<Query>/<Document>" block — the exact content
+           that _rerank_causal_lm reconstructs at scoring time.
+        """
+        _SENTINEL = "<<__CONTENT_SENTINEL__>>"
+        messages = [
+            {"role": "system", "content": self._CAUSAL_LM_SYSTEM_PROMPT},
+            {"role": "user", "content": _SENTINEL},
+        ]
+        standard_rendered = ""
+        standard_error: Exception | None = None
+        try:
+            standard_rendered = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+        except Exception as e:
+            standard_error = e
+            logger.warning(
+                f"system/user chat template rendering failed for "
+                f"{self.model_name}: {e}"
+            )
+
+        parts = standard_rendered.split(_SENTINEL)
+        if len(parts) == 2:
+            # Append <think> block for models that use the
+            # thinking-then-answering format
+            return parts[0], parts[1] + "<think>\n\n</think>\n\n"
+
+        native_affixes, native_rendered, native_error = (
+            self._extract_reranker_native_affixes(tokenizer)
+        )
+        if native_affixes is not None:
+            logger.info(
+                "Using reranker-native chat template (query/document roles) "
+                f"for {self.model_name}"
+            )
+            return native_affixes
+
+        raise ValueError(
+            f"Could not extract CausalLM reranker prompt affixes for "
+            f"{self.model_name}. "
+            f"Standard system/user attempt: {standard_rendered!r} "
+            f"(error: {standard_error!r}). "
+            f"Reranker-native query/document attempt: {native_rendered!r} "
+            f"(error: {native_error!r})."
+        ) from (standard_error or native_error)
+
+    def _extract_reranker_native_affixes(
+        self, tokenizer: Any
+    ) -> "Tuple[Tuple[str, str] | None, str, Exception | None]":
+        """Extract affixes from a reranker-native chat template, if present.
+
+        Returns (affixes, rendered, error). Affixes is None when the template
+        raises or does not render the expected "<Instruct>/<Query>/<Document>"
+        content block; the rendered string and the exception (if any) are
+        returned for diagnostics.
+        """
+        instruct_sentinel = "<<__INSTRUCT_SENTINEL__>>"
+        query_sentinel = "<<__QUERY_SENTINEL__>>"
+        document_sentinel = "<<__DOCUMENT_SENTINEL__>>"
+        # The native template maps the system role to the <Instruct> slot; its
+        # judge system prompt is hardcoded inside the template itself.
+        messages = [
+            {"role": "system", "content": instruct_sentinel},
+            {"role": "query", "content": query_sentinel},
+            {"role": "document", "content": document_sentinel},
+        ]
+        try:
+            rendered = tokenizer.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+        except Exception as e:
+            logger.warning(
+                f"reranker-native chat template rendering failed for "
+                f"{self.model_name}: {e}"
+            )
+            return None, "", e
+
+        # Intentionally strict, byte-exact match against the content block the
+        # upstream Qwen/Qwen3-Reranker template renders. _rerank_causal_lm
+        # reconstructs this exact block at scoring time, so tolerating
+        # formatting drift here would silently produce prompts that differ
+        # from what the template intends; failing detection loudly is safer.
+        content_block = (
+            f"<Instruct>: {instruct_sentinel}\n"
+            f"<Query>: {query_sentinel}\n"
+            f"<Document>: {document_sentinel}"
+        )
+        parts = rendered.split(content_block)
+        if len(parts) != 2:
+            return None, rendered, None
+
+        # The native template already emits the trailing <think> block, so the
+        # suffix is used as-is.
+        return (parts[0], parts[1]), rendered, None
 
     def _load_jina_reranker(self) -> Tuple[Any, Any]:
         """

--- a/tests/test_reranker_causal_lm.py
+++ b/tests/test_reranker_causal_lm.py
@@ -211,6 +211,144 @@ class TestCausalLMReranker:
             assert args[2] == 512
 
 
+class TestCausalLMPromptAffixes:
+    """Tests for prefix/suffix extraction across chat template shapes."""
+
+    # The reranker-native template Qwen/Qwen3-Reranker-0.6B ships as
+    # chat_template.jinja since its 2026-04 sentence-transformers update.
+    # It only understands system/query/document roles and drops user messages.
+    _NATIVE_TEMPLATE = (
+        '{%- set instruction = messages | selectattr("role", "eq", "system") '
+        '| map(attribute="content") | first | default("Given a web search '
+        'query, retrieve relevant passages that answer the query") -%}\n'
+        '{%- set query_text = messages | selectattr("role", "eq", "query") '
+        '| map(attribute="content") | first -%}\n'
+        '{%- set document_text = messages | selectattr("role", "eq", '
+        '"document") | map(attribute="content") | first -%}\n'
+        "<|im_start|>system\n"
+        "Judge whether the Document meets the requirements based on the Query "
+        "and the Instruct provided. Note that the answer can only be "
+        '"yes" or "no".<|im_end|>\n'
+        "<|im_start|>user\n"
+        "<Instruct>: {{ instruction }}\n"
+        "<Query>: {{ query_text }}\n"
+        "<Document>: {{ document_text }}<|im_end|>\n"
+        "<|im_start|>assistant\n"
+        # The upstream file ends with "</think>\n\n\n"; jinja strips exactly
+        # one trailing newline, so the rendered suffix ends with "</think>\n\n"
+        # — byte-identical to the standard-template path.
+        "<think>\n\n</think>\n\n\n"
+    )
+
+    _EXPECTED_PREFIX = (
+        "<|im_start|>system\n"
+        "Judge whether the Document meets the requirements based on the Query "
+        "and the Instruct provided. Note that the answer can only be "
+        '"yes" or "no".<|im_end|>\n'
+        "<|im_start|>user\n"
+    )
+    _EXPECTED_SUFFIX = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+
+    class _StandardTokenizer:
+        """Mimics a standard system/user chat template (e.g., Qwen3 ChatML)."""
+
+        def apply_chat_template(
+            self, messages, tokenize=False, add_generation_prompt=True
+        ):
+            rendered = ""
+            for message in messages:
+                rendered += (
+                    f"<|im_start|>{message['role']}\n"
+                    f"{message['content']}<|im_end|>\n"
+                )
+            if add_generation_prompt:
+                rendered += "<|im_start|>assistant\n"
+            return rendered
+
+    class _NativeTokenizer:
+        """Mock tokenizer that renders a hard-coded reranker-native Jinja
+        template (mirroring the upstream Qwen3-Reranker chat_template.jinja)."""
+
+        def __init__(self, template):
+            self._template = template
+
+        def apply_chat_template(
+            self, messages, tokenize=False, add_generation_prompt=True
+        ):
+            jinja2 = pytest.importorskip("jinja2")
+            return (
+                jinja2.Environment()
+                .from_string(self._template)
+                .render(
+                    messages=messages,
+                    add_generation_prompt=add_generation_prompt,
+                )
+            )
+
+    def test_standard_template_extracts_affixes(self):
+        """Sentinel split on a system/user template yields prefix and suffix."""
+        model = MLXRerankerModel("unused")
+        prefix, suffix = model._extract_causal_lm_affixes(self._StandardTokenizer())
+
+        assert prefix == self._EXPECTED_PREFIX
+        assert suffix == self._EXPECTED_SUFFIX
+
+    def test_native_template_extracts_affixes(self):
+        """The reranker-native template (query/document roles) is detected
+        after the standard system/user attempt falls through, and yields the
+        same affixes as the standard template path."""
+        model = MLXRerankerModel("unused")
+        tokenizer = self._NativeTokenizer(self._NATIVE_TEMPLATE)
+
+        role_calls = []
+        original_apply = tokenizer.apply_chat_template
+
+        def recording_apply(messages, **kwargs):
+            role_calls.append([m["role"] for m in messages])
+            return original_apply(messages, **kwargs)
+
+        tokenizer.apply_chat_template = recording_apply
+        prefix, suffix = model._extract_causal_lm_affixes(tokenizer)
+
+        assert prefix == self._EXPECTED_PREFIX
+        assert suffix == self._EXPECTED_SUFFIX
+        # The standard system/user attempt must run first and fall through
+        # (the native template drops the user message, so the sentinel never
+        # appears), then the native query/document attempt succeeds.
+        assert role_calls == [
+            ["system", "user"],
+            ["system", "query", "document"],
+        ]
+
+    def test_native_template_rendering_error_falls_through(self):
+        """A template that raises on both shapes surfaces both errors."""
+        model = MLXRerankerModel("unused")
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.side_effect = RuntimeError("bad template")
+
+        with pytest.raises(
+            ValueError, match="Could not extract CausalLM reranker"
+        ) as excinfo:
+            model._extract_causal_lm_affixes(tokenizer)
+
+        # Both attempts' errors are in the message, and the original exception
+        # is chained for debugging.
+        assert "bad template" in str(excinfo.value)
+        assert isinstance(excinfo.value.__cause__, RuntimeError)
+
+    def test_incompatible_template_raises_value_error(self):
+        """A template matching neither shape raises instead of mis-splitting,
+        and the error includes both rendered attempts."""
+        model = MLXRerankerModel("unused")
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "static output, no slots"
+
+        with pytest.raises(ValueError, match="query/document attempt") as excinfo:
+            model._extract_causal_lm_affixes(tokenizer)
+
+        assert "static output, no slots" in str(excinfo.value)
+
+
 class TestJinaReranker:
     """Focused tests for Jina listwise reranker internals."""
 


### PR DESCRIPTION
Fixes #2146

## Problem

`mlx-community/Qwen3-Reranker-0.6B-4bit` (and any Qwen3-Reranker conversion created after upstream's 2026-04 sentence-transformers update) fails to load with a 500. The inherited reranker-native `chat_template.jinja` only understands `system`/`query`/`document` roles and drops `user` messages, so the sentinel-based prefix/suffix extraction in `_load_causal_lm` never finds its sentinel and raises. See #2146 for the full analysis.

## Changes

- Extract the affix logic into `_extract_causal_lm_affixes`, which tries the standard system/user sentinel split first (unchanged behavior), then falls back to the reranker-native shape: render with per-slot sentinels for `system`/`query`/`document` and split around the combined `<Instruct>/<Query>/<Document>` block — the exact content `_rerank_causal_lm` reconstructs at scoring time. The native template already emits the trailing `<think>` block, so the suffix is used as-is.
- The byte-exact match against the native content block is intentionally strict: tolerating formatting drift would silently produce prompts that differ from what the template intends.
- When both template shapes fail, the error now includes both rendered attempts and both exceptions, chains the original exception (`raise ... from`), and rendering failures are logged at `warning` instead of `debug`.

## Verification

- New tests in `TestCausalLMPromptAffixes` cover: the standard template path, the native template path (rendering the upstream Qwen3-Reranker jinja byte-for-byte, including its trailing-newline behavior), the call-order fallthrough (standard attempt first, then native), rendering errors surfacing both attempts with exception chaining, and templates matching neither shape.
- Verified end-to-end against the real tokenizers of both `mlx-community/Qwen3-Reranker-0.6B-mxfp8` (standard path) and `mlx-community/Qwen3-Reranker-0.6B-4bit` (native fallback): both extract prefix/suffix successfully and produce **identical token sequences** (prefix 39 tokens, suffix 9 tokens), so scoring behavior is unchanged across the two paths.
- `pytest tests/test_reranker_causal_lm.py`: 28 passed. New code is black/ruff clean; remaining warnings in the touched files are pre-existing.

generated by Claude Code