### PR TITLE
fix(cache): normalize tool_call arguments in cache probe

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -4917,6 +4917,37 @@ async def clear_hot_cache(is_admin: bool = Depends(require_admin)):
     }
 
 
+def _normalize_probe_tool_calls(messages: list[dict]) -> list[dict]:
+    """Parse echoed tool_call arguments (JSON string -> object) for templating.
+
+    Native tool-calling chat templates (GLM, Qwen3.x, MiniMax) iterate
+    ``tool_call.function.arguments.items()``, but the OpenAI wire form sends
+    ``arguments`` as a JSON string. Rendering the string form raises
+    ``'str object' has no attribute 'items'`` and the probe 400s, so any
+    conversation that used tools reports an error (hollow cache dot) instead
+    of a real hit/miss. The chat path parses these before rendering; mirror
+    that here so (a) tool conversations tokenize and (b) the probe's block
+    hashes line up with what a real prefill produced. Returns shallow copies
+    so the caller's message dicts are left untouched.
+    """
+    from ..api.utils import _try_parse_json
+
+    normalized: list[dict] = []
+    for msg in messages:
+        tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else None
+        if not tool_calls:
+            normalized.append(msg)
+            continue
+        new_calls = []
+        for tc in tool_calls:
+            fn = tc.get("function") if isinstance(tc, dict) else None
+            if isinstance(fn, dict) and "arguments" in fn:
+                tc = {**tc, "function": {**fn, "arguments": _try_parse_json(fn["arguments"])}}
+            new_calls.append(tc)
+        normalized.append({**msg, "tool_calls": new_calls})
+    return normalized
+
+
 @router.post("/api/cache/probe")
 async def probe_cache(
     request: CacheProbeRequest,
@@ -4984,7 +5015,7 @@ async def probe_cache(
     # Render + tokenize the prompt using the same path as generation so the
     # hashes line up with what the scheduler would produce at prefill.
     try:
-        messages = request.messages
+        messages = _normalize_probe_tool_calls(request.messages)
         if hasattr(engine, "_preprocess_messages"):
             messages = engine._preprocess_messages(messages)
         try:


### PR DESCRIPTION
## Problem

`POST /admin/api/cache/probe` re-applies the chat template to the raw request messages to compute block hashes. Native tool-calling chat templates (GLM-4.x/5.x, Qwen3.x, MiniMax) iterate `tool_call.function.arguments.items()`, but the OpenAI wire form sends `arguments` as a **JSON string**. So any conversation that contains tool calls fails template rendering with:

```
Failed to tokenize messages: 'str object' has no attribute 'items'
```

The endpoint returns HTTP 400, so cache-status clients (e.g. the Canopy chat UI's per-conversation cache dots) can never show real cache state for any tool/RAG conversation — they render a permanent "unknown/error" state regardless of whether the prefix is actually cached.

The chat-completions path already normalizes these (`omlx/api/utils.py`, `_try_parse_json` — *"chat_template applies `|tojson`"*); the probe path simply skipped that step.

## Fix

Add `_normalize_probe_tool_calls()` and run `request.messages` through it before templating. It parses each `tool_call.function.arguments` (JSON string → object) via the existing `_try_parse_json` helper, on shallow copies so caller dicts are untouched. This both:

1. Stops the 400 on tool conversations, and
2. Keeps the probe's block hashes aligned with what a real prefill produces (the chat path parses the same way).

## Repro / verification

Before, probing a message list with an assistant `tool_calls` + `role:"tool"` result returned `400 Failed to tokenize messages: 'str object' has no attribute 'items'`.

After, the same probe tokenizes and returns real block counts. Verified end-to-end against a Canopy install: 32/33 conversations went from `status:"error"` to `status:"ok"`, and SSD-cached tool conversations now report their `blocks_ssd_disk` (and render as cache hits) instead of erroring.