### PR TITLE
fix(cache): isolate SpecPrefill draft SSD cache

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1653,6 +1653,7 @@ class Scheduler:
 
         # SpecPrefill: draft model for attention-based sparse prefill
         self._specprefill_draft_model: Any | None = None
+        self._draft_paged_ssd_cache_manager: Any | None = None
         # Track active specprefill request for RoPE cleanup
         self._specprefill_active_request_id: str | None = None
 
@@ -6389,12 +6390,21 @@ class Scheduler:
     ) -> None:
         """Set the draft model for SpecPrefill scoring.
 
-        Creates a separate BlockAwarePrefixCache for the draft model
-        using the existing paged SSD cache infrastructure. The model_name
-        in compute_block_hash() naturally isolates draft blocks from target.
+        Creates separate block and SSD cache managers for the draft model so
+        target TurboQuant signatures cannot invalidate draft cache blocks.
         """
+        if not self._close_specprefill_draft_cache_manager():
+            raise RuntimeError(
+                "Could not close the previous SpecPrefill draft SSD cache manager"
+            )
         self._specprefill_draft_model = draft_model
         self._draft_prefix_cache: Any | None = None
+        if not draft_model_name:
+            logger.info(
+                "SpecPrefill: draft model set without a stable model name "
+                "(no SSD cache)"
+            )
+            return
 
         if (
             self.paged_cache_manager is not None
@@ -6404,16 +6414,48 @@ class Scheduler:
                 from .cache.paged_cache import PagedCacheManager
                 from .cache.prefix_cache import BlockAwarePrefixCache
 
-                name = draft_model_name or "specprefill-draft"
+                name = draft_model_name
+                draft_cache_list = make_prompt_cache(draft_model)
+                draft_layer_cache_types = None
+                if HAS_CACHE_TYPE_HANDLERS and ModelCacheConfig is not None:
+                    try:
+                        draft_model_cache_config = ModelCacheConfig.from_cache_list(
+                            draft_cache_list,
+                            model_name=name,
+                        )
+                        draft_layer_cache_types = draft_model_cache_config.get_type_names()
+                    except Exception as e:
+                        logger.debug(
+                            "Could not infer SpecPrefill draft cache layout: %s", e
+                        )
                 draft_paged = PagedCacheManager(
                     block_size=self.config.paged_cache_block_size,
                     max_blocks=self.paged_cache_manager.max_blocks,
                     model_name=name,
                 )
+                draft_ssd = PagedSSDCacheManager(
+                    cache_dir=Path(self.config.paged_ssd_cache_dir),
+                    max_size_bytes=self.config.paged_ssd_cache_max_size,
+                    hot_cache_max_bytes=self.config.hot_cache_max_size,
+                    hot_cache_only=self.config.hot_cache_only,
+                    hot_cache_budget=self.config.hot_cache_budget,
+                    expected_model_name=name,
+                    expected_num_layers=len(draft_cache_list),
+                    expected_block_size=self.config.paged_cache_block_size,
+                    expected_block_size_tokens=self.config.paged_cache_block_size,
+                    expected_kv_bytes_per_token=getattr(
+                        self.paged_ssd_cache_manager,
+                        "_expected_kv_bytes_per_token",
+                        200_000,
+                    ),
+                    expected_layer_cache_types=draft_layer_cache_types,
+                )
+                self._draft_paged_ssd_cache_manager = draft_ssd
+                draft_paged.set_paged_ssd_cache_manager(draft_ssd)
                 self._draft_prefix_cache = BlockAwarePrefixCache(
                     model=draft_model,
                     paged_cache_manager=draft_paged,
-                    paged_ssd_cache_manager=self.paged_ssd_cache_manager,
+                    paged_ssd_cache_manager=draft_ssd,
                 )
                 self._draft_prefix_cache.set_cold_restore_callback(
                     self._restore_block_from_cold
@@ -6422,10 +6464,31 @@ class Scheduler:
                     f"SpecPrefill: draft model set with SSD cache (model_name={name})"
                 )
             except Exception as e:
+                self._draft_prefix_cache = None
+                self._close_specprefill_draft_cache_manager()
                 logger.warning(f"SpecPrefill: draft SSD cache setup failed: {e}")
                 logger.info("SpecPrefill: draft model set (no SSD cache)")
         else:
             logger.info("SpecPrefill: draft model set (no SSD cache)")
+
+    def _close_specprefill_draft_cache_manager(self) -> bool:
+        manager = self._draft_paged_ssd_cache_manager
+        if manager is None:
+            return True
+        try:
+            manager.close()
+        except Exception as e:
+            logger.warning("SpecPrefill draft SSD cache shutdown error: %s", e)
+            return False
+        writer_thread = getattr(manager, "_writer_thread", None)
+        if writer_thread is not None and writer_thread.is_alive():
+            logger.warning(
+                "SpecPrefill draft SSD cache writer remains active after shutdown"
+            )
+            return False
+
+        self._draft_paged_ssd_cache_manager = None
+        return True
 
     def set_vlm_mtp_drafter(
         self,
@@ -10016,7 +10079,10 @@ class Scheduler:
                 self._boundary_snapshot_store.shutdown()
             except Exception as e:
                 logger.warning("Boundary snapshot store shutdown error: %s", e)
+        self._close_specprefill_draft_cache_manager()
         self.paged_cache_manager = None
+        self._draft_prefix_cache = None
+        self._specprefill_draft_model = None
         self.block_aware_cache = None
         self.memory_monitor = None
         self._boundary_snapshot_store = None
@@ -10084,6 +10150,9 @@ class Scheduler:
             except Exception as e:
                 logger.warning("Boundary snapshot store shutdown error: %s", e)
             self._boundary_snapshot_store = None
+        self._close_specprefill_draft_cache_manager()
+        self._draft_prefix_cache = None
+        self._specprefill_draft_model = None
         if self.paged_ssd_cache_manager is not None:
             self.paged_ssd_cache_manager.close()
             self.paged_ssd_cache_manager = None

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3110,6 +3110,166 @@ class TestSchedulerSSDLayerSignature:
             scheduler.shutdown()
 
 
+class TestSpecPrefillDraftCacheSignature:
+    """Regression coverage for SpecPrefill draft-cache isolation (#1925)."""
+
+    def test_draft_cache_reconstructs_with_target_turboquant_enabled(
+        self, mock_tokenizer, tmp_path
+    ):
+        from mlx_lm.models.cache import ArraysCache, KVCache
+
+        from omlx.cache.paged_ssd_cache import _canonicalize_layer_cache_types
+
+        class HybridModel:
+            def __init__(self, repeats: int):
+                self.repeats = repeats
+                self.config = SimpleNamespace(
+                    num_hidden_layers=repeats * 4,
+                    num_key_value_heads=2,
+                    num_attention_heads=2,
+                    head_dim=32,
+                )
+
+            def make_cache(self):
+                return [
+                    cache
+                    for _ in range(self.repeats)
+                    for cache in (
+                        ArraysCache(size=2),
+                        ArraysCache(size=2),
+                        ArraysCache(size=2),
+                        KVCache(),
+                    )
+                ]
+
+        scheduler = Scheduler(
+            model=HybridModel(repeats=2),
+            tokenizer=mock_tokenizer,
+            config=SchedulerConfig(
+                paged_ssd_cache_dir=str(tmp_path),
+                paged_cache_block_size=4,
+                model_name="target-model",
+            ),
+        )
+        try:
+            scheduler._turboquant_kv_bits = 4.0
+            scheduler._turboquant_skip_last = True
+            target_manager = scheduler.paged_ssd_cache_manager
+            target_types = [
+                "ArraysCache",
+                "ArraysCache",
+                "ArraysCache",
+                "TurboQuantKVCache",
+                "ArraysCache",
+                "ArraysCache",
+                "ArraysCache",
+                "KVCache",
+            ]
+            assert scheduler.refresh_ssd_layer_signature() == target_types
+            assert target_manager is not None
+
+            scheduler.set_specprefill_draft_model(
+                HybridModel(repeats=1), draft_model_name="draft-model"
+            )
+            draft_cache = scheduler._draft_prefix_cache
+            assert draft_cache is not None
+
+            draft_manager = draft_cache.paged_ssd_cache
+            assert draft_manager is not target_manager
+            assert target_manager._expected_model_name == "target-model"
+            assert target_manager._expected_layer_cache_types == target_types
+            assert draft_manager._expected_model_name == "draft-model"
+            assert draft_manager._expected_layer_cache_types == [
+                "ArraysCache", "ArraysCache", "ArraysCache", "KVCache"
+            ]
+            block_size = draft_cache.block_size
+            arrays_state = (
+                mx.ones((1, 3, 8)),
+                mx.ones((1, 2, 8, 8)),
+            )
+            kv_state = (
+                mx.ones((1, 2, 4, 32)),
+                mx.ones((1, 2, 4, 32)),
+            )
+            draft_types = [
+                "ArraysCache",
+                "ArraysCache",
+                "ArraysCache",
+                "KVCache",
+            ]
+            block_metadata = {
+                "model_name": "draft-model",
+                "num_layers": 4,
+                "block_size": block_size,
+                "layer_cache_types": draft_types,
+                "layer_meta_states": [(), (), (), ()],
+            }
+
+            with (
+                patch.object(
+                    draft_cache.paged_ssd_cache,
+                    "has_block",
+                    return_value=True,
+                ),
+                patch.object(
+                    draft_cache.paged_ssd_cache,
+                    "load_block_with_metadata",
+                    return_value=(
+                        [arrays_state, arrays_state, arrays_state, kv_state],
+                        block_metadata,
+                    ),
+                ),
+            ):
+                block_table, remaining_tokens = draft_cache.fetch_cache(
+                    "draft-request", list(range(block_size))
+                )
+                assert block_table is not None
+                assert remaining_tokens == []
+                reconstructed = draft_cache.reconstruct_cache(block_table)
+
+            assert reconstructed is not None
+            reconstructed_types = [type(layer).__name__ for layer in reconstructed]
+            assert _canonicalize_layer_cache_types(reconstructed_types) == draft_types
+            scheduler.deep_reset()
+            assert scheduler._specprefill_draft_model is None
+            assert scheduler._draft_prefix_cache is None
+            assert scheduler._draft_paged_ssd_cache_manager is None
+            assert draft_manager._writer_thread is None or not (
+                draft_manager._writer_thread.is_alive()
+            )
+        finally:
+            scheduler.shutdown()
+
+    def test_replacing_draft_preserves_manager_when_close_fails(
+        self, mock_model, mock_tokenizer
+    ):
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        previous_manager = MagicMock()
+        previous_manager.close.side_effect = RuntimeError("writer still active")
+        previous_model = object()
+        previous_manager._writer_thread = None
+        previous_prefix_cache = object()
+        scheduler._draft_paged_ssd_cache_manager = previous_manager
+        scheduler._specprefill_draft_model = previous_model
+        scheduler._draft_prefix_cache = previous_prefix_cache
+
+        try:
+            with pytest.raises(
+                RuntimeError,
+                match="Could not close the previous SpecPrefill draft SSD cache manager",
+            ):
+                scheduler.set_specprefill_draft_model(
+                    object(), draft_model_name="replacement-draft"
+                )
+
+            assert scheduler._draft_paged_ssd_cache_manager is previous_manager
+            assert scheduler._specprefill_draft_model is previous_model
+            assert scheduler._draft_prefix_cache is previous_prefix_cache
+        finally:
+            previous_manager.close.side_effect = None
+            scheduler.shutdown()
+
+
 class TestCacheCorruptionRecovery:
     """Tests for cache corruption detection and recovery."""
 


### PR DESCRIPTION
## Summary

- give the SpecPrefill draft model its own model-scoped `PagedSSDCacheManager`
- connect the draft `PagedCacheManager` to that SSD manager so persisted draft blocks are discoverable after restart
- preserve the target model's TurboQuant layer signature while validating draft blocks against the draft model's own layer count and cache types
- close and release the draft manager during replacement, reset, shutdown, and failed setup
- add model-free regression coverage for target/draft signature isolation, cold SSD discovery, reconstruction, and teardown

## Root cause

The log attached to #1925 contains a stronger signal than the original summary: the cached signature has **24 layers**, while the live expected signature has **40 layers**.

Those layouts match the configured models exactly:

- Qwen3.5-0.8B SpecPrefill draft: 24 layers
- Qwen3.6-35B-A3B target: 40 layers

The draft `BlockAwarePrefixCache` used a separate `PagedCacheManager`, but shared the target model's `PagedSSDCacheManager`. Once TurboQuant installed the target's 40-layer signature, draft reconstruction compared its 24-layer blocks against that target signature and emitted the reported mismatch. The draft paged manager was also not connected to SSD, so persisted draft hashes could not be discovered after process restart.

This change scopes the draft SSD index and signature to the draft model while retaining the existing shared cache directory and hot-cache budget.

## Verification

### Automated

- the regression test fails on `v0.4.4`
- it also fails on current main before this change
- it passes with this change
- 509 relevant tests pass:
  - `tests/test_scheduler.py`
  - `tests/test_specprefill.py`
  - `tests/test_vlm_specprefill.py`
  - `tests/test_prefix_cache.py`
  - `tests/test_paged_ssd_cache.py`
  - `tests/test_engine_preflight.py`
  - `tests/test_scheduler_prefill_memory_guard.py`

### Real-model validation

Tested on an M5 Pro with 48 GB unified memory using:

- target: `mlx-community/Qwen3.6-35B-A3B-4bit`
- draft: `mlx-community/Qwen3.5-0.8B-MLX-8bit`
- TurboQuant KV: 4-bit, skip-last enabled
- SpecPrefill: enabled, 20% keep
- paged SSD cache enabled

Observed:

- same-session second request: `draft cache hit 8192`
- first matching request after server restart: `draft cache hit 8192`
- no `Cache layer type mismatch` warning
- with SpecPrefill disabled as a control, TurboQuant target prefix caching restored `8192` target tokens on the second request

## Metric clarification

With SpecPrefill enabled, API `prompt_tokens_details.cached_tokens` remains `0` because it represents the target prefix cache, and sparse target KV states are intentionally not persisted. SpecPrefill draft reuse is reported separately in the server log as `draft cache hit N`. The repaired behavior here is successful draft-cache reuse without cross-model signature invalidation.

Addresses #1925.
