### PR TITLE
fix(oq): decode U8 e8m0 block scales in MXFP8 dequant

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -1367,7 +1367,17 @@ _FP8_WEIGHT_DTYPES = frozenset(("F8_E4M3", "F8_E5M2", "I8"))
 
 def _block_dequant_fp8(weight_raw, scale_raw, w_dtype, s_dtype):
     """Block-scaled dequant of a single FP8/I8 weight+scale pair to BF16."""
-    if s_dtype == "F8_E8M0":
+    # MXFP8 checkpoints (e.g. MiniMax-M3) save the e8m0 shared exponents
+    # with safetensors dtype U8: fp8 weight, one scale byte per 32 columns.
+    # Those bytes are exponents, not linear scales. Float-typed scales
+    # (DeepSeek block-128 weight_scale_inv) stay linear.
+    e8m0 = s_dtype == "F8_E8M0" or (
+        s_dtype in ("U8", "UINT8")
+        and w_dtype in ("F8_E4M3", "F8_E5M2")
+        and scale_raw.ndim == 2
+        and weight_raw.shape[-1] == scale_raw.shape[-1] * 32
+    )
+    if e8m0:
         scale = mx.power(mx.array(2.0), scale_raw.astype(mx.float32) - 127.0)
     else:
         scale = scale_raw

--- a/tests/test_oq_fp8_dequant.py
+++ b/tests/test_oq_fp8_dequant.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for _block_dequant_fp8 scale decoding.
+
+MXFP8 checkpoints (e.g. MiniMax-M3) store their e8m0 block scales with
+safetensors dtype U8. Those bytes are shared exponents and must decode as
+2^(s - 127), the same as the F8_E8M0 branch. Treating them as linear
+scales blows the weights up by orders of magnitude.
+
+DeepSeek-style FP8 checkpoints also use weight_scale_inv keys but store
+the scales as real floats (block 128). Those must keep multiplying
+linearly, so the discriminator is the scale dtype, not the key name.
+"""
+
+import glob
+import os
+
+import mlx.core as mx
+import pytest
+
+from omlx.oq import _block_dequant_fp8, _LazyTensorIndex
+
+M3_DIR = "/Volumes/Scratch/models/MiniMax-M3-MXFP8"
+
+
+def test_u8_scale_decodes_as_e8m0_exponent():
+    mx.random.seed(0)
+    w = mx.random.normal((64, 128)).astype(mx.bfloat16)
+    qw, scales = mx.quantize(w, group_size=32, bits=8, mode="mxfp8")
+    ref = mx.dequantize(qw, scales, group_size=32, bits=8, mode="mxfp8")
+    assert scales.dtype == mx.uint8
+
+    # On-disk view of the same data: raw e4m3 bytes, one per element.
+    raw_fp8 = qw.view(mx.uint8)
+    assert raw_fp8.shape == (64, 128)
+
+    # Sanity check the target first: the explicit from_fp8 * 2^(s-127)
+    # formula must reproduce mx.dequantize exactly, otherwise ref is not
+    # a valid oracle for the function under test.
+    explicit = (
+        mx.from_fp8(raw_fp8, dtype=mx.bfloat16).reshape(64, 4, 32).astype(mx.float32)
+        * mx.power(mx.array(2.0), scales.astype(mx.float32) - 127.0)[:, :, None]
+    ).reshape(64, 128)
+    assert mx.array_equal(explicit.astype(mx.bfloat16), ref).item()
+
+    got = _block_dequant_fp8(raw_fp8, scales, "F8_E4M3", "U8")
+    assert got.shape == ref.shape
+    assert mx.allclose(
+        got.astype(mx.float32), ref.astype(mx.float32), atol=1e-2, rtol=1e-2
+    ).item(), (
+        f"mean|got|={mx.abs(got).mean().item():.4g} vs "
+        f"mean|ref|={mx.abs(ref).mean().item():.4g}"
+    )
+
+
+def test_f32_scale_stays_linear():
+    # DeepSeek-style pair: e4m3 weight with a float block scale
+    # (block 128). The scale is a linear multiplier and must be applied
+    # as-is, untouched by the U8 exponent decoding.
+    mx.random.seed(1)
+    w = mx.random.normal((256, 128)).astype(mx.bfloat16)
+    qw, _ = mx.quantize(w, group_size=32, bits=8, mode="mxfp8")
+    raw_fp8 = qw.view(mx.uint8)
+    scale = mx.array([[0.5], [2.0]], dtype=mx.float32)
+
+    got = _block_dequant_fp8(raw_fp8, scale, "F8_E4M3", "F32")
+
+    wf = mx.from_fp8(raw_fp8, dtype=mx.bfloat16).astype(mx.float32)
+    expected = mx.concatenate([wf[:128] * 0.5, wf[128:] * 2.0], axis=0)
+    assert mx.allclose(got.astype(mx.float32), expected, atol=1e-2, rtol=1e-2).item()
+
+
+@pytest.mark.skipif(not os.path.isdir(M3_DIR), reason="M3 not present")
+def test_minimax_m3_k_proj_magnitude():
+    # Grounded check on a real MXFP8 checkpoint. Pre-fix this layer
+    # dequantized to mean|w| ~13410; the correct value is ~0.03.
+    shards = sorted(glob.glob(os.path.join(M3_DIR, "model-*.safetensors")))
+    idx = _LazyTensorIndex(shards)
+    key = "language_model.model.layers.3.self_attn.k_proj.weight"
+    weight = idx._dequant_one(key)
+    mean_abs = mx.abs(weight).mean().item()
+    max_abs = mx.abs(weight).max().item()
+    assert mean_abs < 1.0, f"mean|w|={mean_abs}"
+    assert max_abs < 2.0, f"max|w|={max_abs}"


### PR DESCRIPTION
## Problem

`_block_dequant_fp8` only applies the e8m0 exponent decode (`2^(s-127)`) when the
scale tensor has safetensors dtype `F8_E8M0`. MXFP8 checkpoints such as MiniMax-M3
store their OCP microscaling shared exponents as dtype **U8** instead — one scale
byte per 32-column block, alongside an `F8_E4M3` weight. Those bytes are e8m0
exponents, but the U8 dtype misses the check, so they were multiplied in as raw
linear scale values.

The result is silently catastrophic: dequantized weights come out roughly five
orders of magnitude too large. On `layers.3.self_attn.k_proj` of MiniMax-M3 the
mean absolute weight is 13410 instead of 0.0297 (~450,000x off). Because
`quantize_oq_streaming` reads its source through the same dequant path, **every
quantization built from an MXFP8 checkpoint with U8 scales is corrupted**, not just
direct loads.

Reproduced by hand against two independent references (an explicit `2^(s-127)`
decode and `mx.dequantize(mode="mxfp8")`), which agree bit-for-bit; the current
code disagrees by ~450,000x.

## Fix

Treat a scale as e8m0 when it is `F8_E8M0`, or when it is `U8`/`UINT8` paired with
an fp8 weight in the block layout (2-D scale, weight columns == scale columns * 32).
The discriminator is the scale **dtype and layout**, not the key name: DeepSeek's
`weight_scale_inv` scales are stored as float in a block-128 layout and are genuinely
linear, so they must keep flowing through the linear branch. The added condition
does not touch them.

## Tests

`tests/test_oq_fp8_dequant.py`:
- model-free fp8 block dequant checked bit-exact against `mx.dequantize(mode="mxfp8")`
- a float-scale regression case that asserts linear scales stay linear (DeepSeek path)
- a magnitude sanity check on a real MiniMax-M3 tensor

All three pass on top of current `main` (0.5.0rc1).
