### PR TITLE
feat(oq): layer-streaming imatrix calibration for models larger than RAM

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -1367,7 +1367,17 @@ _FP8_WEIGHT_DTYPES = frozenset(("F8_E4M3", "F8_E5M2", "I8"))
 
 def _block_dequant_fp8(weight_raw, scale_raw, w_dtype, s_dtype):
     """Block-scaled dequant of a single FP8/I8 weight+scale pair to BF16."""
-    if s_dtype == "F8_E8M0":
+    # MXFP8 checkpoints (e.g. MiniMax-M3) save the e8m0 shared exponents
+    # with safetensors dtype U8: fp8 weight, one scale byte per 32 columns.
+    # Those bytes are exponents, not linear scales. Float-typed scales
+    # (DeepSeek block-128 weight_scale_inv) stay linear.
+    e8m0 = s_dtype == "F8_E8M0" or (
+        s_dtype in ("U8", "UINT8")
+        and w_dtype in ("F8_E4M3", "F8_E5M2")
+        and scale_raw.ndim == 2
+        and weight_raw.shape[-1] == scale_raw.shape[-1] * 32
+    )
+    if e8m0:
         scale = mx.power(mx.array(2.0), scale_raw.astype(mx.float32) - 127.0)
     else:
         scale = scale_raw

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -16,9 +16,10 @@ import re
 import shutil
 import tempfile
 import time as _time
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Optional, Union
+from typing import Any
 
 import numpy as np
 
@@ -149,7 +150,7 @@ class OQImatrixData:
 
 def universal_quant_predicate(
     path: str, module, config: dict, oq_level: int = 4
-) -> Union[bool, dict]:
+) -> bool | dict:
     """Per-tensor quantization decision based on GGUF/unsloth/llama.cpp rules.
 
     Protection levels vary by oQ level:
@@ -964,8 +965,7 @@ def _build_quant_plan(
             f"{name}×{count}" for name, count in sorted(route_dist.items())
         )
         logger.info(
-            f"  plan detail: {bits_summary} | routes: {route_summary} | "
-            f"top: {top_str}"
+            f"  plan detail: {bits_summary} | routes: {route_summary} | top: {top_str}"
         )
 
     return QuantPlan(
@@ -2142,7 +2142,7 @@ def _sensitivity_lm_config_override(config: dict) -> dict | None:
 def make_predicate(config: dict, oq_level: int = 4) -> Callable:
     """Create a quant_predicate closure for mlx-lm's quantize_model."""
 
-    def predicate(path: str, module) -> Union[bool, dict]:
+    def predicate(path: str, module) -> bool | dict:
         return universal_quant_predicate(path, module, config, oq_level)
 
     return predicate
@@ -3924,7 +3924,7 @@ def quantize_oq_streaming(
     output_path: str,
     oq_level: int,
     group_size: int = 64,
-    progress_callback: Optional[Callable[[str, float], None]] = None,
+    progress_callback: Callable[[str, float], None] | None = None,
     text_only: bool = False,
     target_bpw: float | None = None,
     hard_cap_bpw: float | None = None,
@@ -4094,8 +4094,7 @@ def quantize_oq_streaming(
         if _ram_safe_proxy_dir is not None and _ram_safe_proxy_dir.exists():
             shutil.rmtree(_ram_safe_proxy_dir, ignore_errors=True)
             logger.info(
-                f"oQ{oq_level:g}: cleaned up calibration proxy at "
-                f"{_ram_safe_proxy_dir}"
+                f"oQ{oq_level:g}: cleaned up calibration proxy at {_ram_safe_proxy_dir}"
             )
         _ram_safe_proxy_dir = None
 
@@ -4140,9 +4139,7 @@ def quantize_oq_streaming(
                 progress_callback=cb,
                 progress_start=13.0,
                 progress_end=18.0,
-                load_path_factory=(
-                    _imatrix_load_path if _model_exceeds_ram else None
-                ),
+                load_path_factory=(_imatrix_load_path if _model_exceeds_ram else None),
             )
         except BaseException:
             _cleanup_ram_safe_proxy()
@@ -5642,6 +5639,154 @@ def _collect_imatrix_from_model(
     return collector.entries, metadata
 
 
+# --- Streamed per-layer weight sourcing (layer-streaming imatrix collector) ---
+# MiniMax-M3 focused for now: the layer prefix, the args location, and the
+# lazy-load path in _streamed_text_args assume the minimax_m3_vl layout.
+# When a second architecture needs streaming, a model-type dispatch table
+# replaces the hardcoded prefix and the args lookup.
+
+_STREAM_TEXT_LAYER_PREFIX = "language_model.model.layers."
+_STREAM_EMBED_KEY = "language_model.model.embed_tokens.weight"
+
+
+def _streamed_text_args(model_path, *, trust_remote_code: bool = False):
+    """TextConfig plus the concrete decoder layer class for streamed sourcing.
+
+    Lazy-loads the VLM once through the same path _collect_imatrix uses (so
+    the M3 compat patches apply), reads language_model.model.args and the
+    layer class off the live model, then drops it. Lazy load never
+    materializes weights, so this costs seconds, not RAM.
+    """
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    maybe_apply_pre_load_patches(str(model_path), for_vlm=True)
+
+    from mlx_vlm.utils import load_model as vlm_load_model
+
+    orig_load_weights = nn.Module.load_weights
+
+    def _lenient_load_weights(self, file_or_weights, *args, **kwargs):
+        kwargs.pop("strict", None)
+        return orig_load_weights(self, file_or_weights, *args, strict=False, **kwargs)
+
+    nn.Module.load_weights = _lenient_load_weights
+    try:
+        model = vlm_load_model(
+            Path(model_path), lazy=True, trust_remote_code=trust_remote_code
+        )
+    finally:
+        nn.Module.load_weights = orig_load_weights
+
+    lm = model.language_model.model
+    args = lm.args
+    layer_cls = type(lm.layers[0])
+    del lm, model
+    mx.clear_cache()
+    return args, layer_cls
+
+
+def _streamed_source_plan(model_path, config: dict) -> "_DiscoveredPlan":
+    """Private lazy index plus discovered sanitize plan for one pass.
+
+    _DiscoveredPlan.pop is destructive, so every streaming pass builds its
+    own instance instead of sharing the quantize loop's. The rebuild is
+    header-only and costs seconds.
+    """
+    weight_files = sorted(Path(model_path).glob("*.safetensors"))
+    if not weight_files:
+        raise FileNotFoundError(f"no safetensors shards under {model_path}")
+    lazy_index = _LazyTensorIndex(weight_files)
+    sanitize_fn = _build_model_sanitizer(config)
+    if sanitize_fn is None:
+        raise RuntimeError(f"no sanitizer for model_type={config.get('model_type')!r}")
+    plan = _discover_sanitize_plan(sanitize_fn, lazy_index)
+    if plan is None:
+        raise RuntimeError("sanitize plan discovery failed for streamed sourcing")
+    return _DiscoveredPlan(plan, lazy_index)
+
+
+def _streamed_layer_items(dp: "_DiscoveredPlan", layer_idx: int) -> list:
+    """Pop every tensor of one text layer, keyed relative to the bare block."""
+    prefix = f"{_STREAM_TEXT_LAYER_PREFIX}{layer_idx}."
+    keys = sorted(k for k in dp if k.startswith(prefix))
+    if not keys:
+        raise KeyError(f"no checkpoint tensors for text layer {layer_idx}")
+    return [(k[len(prefix) :], dp.pop(k)) for k in keys]
+
+
+def _load_streamed_block_weights(block, items, layer_idx: int) -> str:
+    """Fill a bare decoder block from popped checkpoint tensors.
+
+    strict=True is the primary path. If mlx rejects the pairing (raw-array
+    attributes like e_score_correction_bias could plausibly trip it), fall
+    back to a lenient load guarded by an exact key-set and shape check so
+    nothing goes missing silently. Returns "strict" or "lenient".
+    """
+    try:
+        block.load_weights(items, strict=True)
+        return "strict"
+    except ValueError as exc:
+        expected = dict(tree_flatten(block.parameters()))
+        got = dict(items)
+        missing = sorted(set(expected) - set(got))
+        extra = sorted(set(got) - set(expected))
+        if missing or extra:
+            raise ValueError(
+                f"streamed layer {layer_idx}: checkpoint keys do not cover "
+                f"the block (missing={missing}, extra={extra})"
+            ) from exc
+        bad_shapes = sorted(
+            k for k, v in got.items() if tuple(v.shape) != tuple(expected[k].shape)
+        )
+        if bad_shapes:
+            raise
+        logger.info(
+            "streamed layer %d: strict load rejected a matching key set (%s); "
+            "using lenient load with key-set and shape guards",
+            layer_idx,
+            exc,
+        )
+        block.load_weights(items, strict=False)
+        return "lenient"
+
+
+def _iter_streamed_layer_blocks(
+    source, config: dict, *, trust_remote_code: bool = False
+):
+    """Yield (layer_idx, block, is_moe) with each text layer fully resident.
+
+    Each layer gets its own bare decoder block (attention wiring is
+    layer-index dependent, so one instance cannot be reused across the
+    dense/MoE boundary), filled straight from the checkpoint through a
+    private sanitize plan and evaluated before the yield. The caller owns
+    the block; the generator drops its own reference before popping the
+    next layer so at most one layer's weights are ever resident here.
+    """
+    args, layer_cls = _streamed_text_args(source, trust_remote_code=trust_remote_code)
+    dp = _streamed_source_plan(source, config)
+    for layer_idx in range(args.num_hidden_layers):
+        items = _streamed_layer_items(dp, layer_idx)
+        block = layer_cls(args, layer_idx)
+        mode = _load_streamed_block_weights(block, items, layer_idx)
+        del items
+        mx.eval(block.parameters())
+        is_moe = bool(block.is_moe_layer)
+        logger.debug(
+            "streamed layer %d sourced (%s load, moe=%s)", layer_idx, mode, is_moe
+        )
+        yield layer_idx, block, is_moe
+        del block  # delete-L before load-L+1: never two layers resident here
+        mx.clear_cache()
+
+
+def _streamed_embed_weight(source, config: dict):
+    """Source the token embedding table (bf16 on disk) for the stage-0 pass."""
+    dp = _streamed_source_plan(source, config)
+    weight = dp.pop(_STREAM_EMBED_KEY)
+    mx.eval(weight)
+    return weight
+
+
 def _collect_imatrix(
     model_path: str,
     config: dict,
@@ -5758,9 +5903,7 @@ def _oqe_cache_missing_mtp_entries(cache: OQImatrixData, config: dict) -> bool:
             return False
     except Exception:
         return False
-    return not any(
-        ".mtp." in key or key.startswith("mtp.") for key in cache.entries
-    )
+    return not any(".mtp." in key or key.startswith("mtp.") for key in cache.entries)
 
 
 def _load_or_collect_imatrix(
@@ -5809,8 +5952,7 @@ def _load_or_collect_imatrix(
                 )
                 return cache
             logger.info(
-                "oQe imatrix: cache missing required expert coverage, "
-                "recollecting %s",
+                "oQe imatrix: cache missing required expert coverage, recollecting %s",
                 path,
             )
         else:
@@ -6337,8 +6479,10 @@ def _measure_sensitivity_from_quantized_model(
     from omlx.utils.model_loading import (
         _checkpoint_has_mtp_weights,
         _has_mtp_heads,
-        lm_load_compat as lm_load,
         maybe_apply_pre_load_patches,
+    )
+    from omlx.utils.model_loading import (
+        lm_load_compat as lm_load,
     )
 
     # Reuse the centralised pre-load dispatch (DeepSeek V4 base patch,
@@ -6364,13 +6508,10 @@ def _measure_sensitivity_from_quantized_model(
                     apply_mlx_vlm_mtp_runtime_patch()
                     prev_active = is_mtp_active()
                     set_mtp_active(True)
-                    restore_mtp_active = lambda: set_mtp_active(
-                        prev_active
-                    )  # noqa: E731
+                    restore_mtp_active = lambda: set_mtp_active(prev_active)  # noqa: E731
                 except Exception as e:
                     logger.debug(
-                        "mlx-vlm MTP runtime patch skipped for proxy sensitivity: "
-                        f"{e}"
+                        f"mlx-vlm MTP runtime patch skipped for proxy sensitivity: {e}"
                     )
 
             from mlx_lm.tokenizer_utils import load as load_tokenizer

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -4022,10 +4022,15 @@ def quantize_oq_streaming(
         stream_calibration: Collect the oQe imatrix by streaming one decoder
             layer at a time from the source checkpoint instead of loading a
             whole model. Calibrates the real weights with a single layer
-            resident, so it needs no RAM-safe proxy. None (default)
-            auto-enables streaming when the source exceeds the RAM budget;
-            the OMLX_OQ_STREAM_CALIBRATION environment variable overrides
-            the auto rule. Only consulted when enhanced is True.
+            resident, so it needs no RAM-safe proxy. Sensitivity measurement
+            streams too: fused into the same sweep when the imatrix is
+            freshly collected (one weight load serves both passes), or as a
+            standalone streamed pass on an imatrix cache hit. An existing
+            oq_sensitivity_map.json or an explicit sensitivity_model_path
+            still wins over both. None (default) auto-enables streaming when
+            the source exceeds the RAM budget; the OMLX_OQ_STREAM_CALIBRATION
+            environment variable overrides the auto rule. Only consulted when
+            enhanced is True.
     """
     if oq_level not in OQ_LEVELS:
         raise ValueError(
@@ -4147,6 +4152,8 @@ def quantize_oq_streaming(
 
     imatrix_data: OQImatrixData | None = None
     imatrix_report: dict[str, Any] | None = None
+    stream_imatrix = False
+    streamed_sensitivity_map: dict | None = None
     if enhanced:
         if imatrix_num_samples < 1:
             raise ValueError("imatrix_num_samples must be >= 1")
@@ -4171,6 +4178,14 @@ def quantize_oq_streaming(
                 f"oQ{oq_level:g}: oQe imatrix will stream one layer at a "
                 "time from the source checkpoint (no calibration proxy)"
             )
+        # When the streamed sweep is going to visit every layer anyway and
+        # this build still needs a measured sensitivity map, fuse the qdq
+        # measurement into that sweep: one weight load serves both passes.
+        fuse_sensitivity = (
+            stream_imatrix
+            and not sensitivity_map_path.exists()
+            and not sensitivity_model_path
+        )
 
         def _imatrix_load_path() -> str:
             cb(
@@ -4199,10 +4214,22 @@ def quantize_oq_streaming(
                     else None
                 ),
                 stream_calibration=stream_imatrix,
+                measure_sensitivity=fuse_sensitivity,
+                sensitivity_oq_level=oq_level,
+                sensitivity_num_samples=_SENS_NUM_SAMPLES,
+                sensitivity_seq_length=_SENS_SEQ_LENGTH,
             )
         except BaseException:
             _cleanup_ram_safe_proxy()
             raise
+        if fuse_sensitivity and not imatrix_data.reused:
+            # Fresh fused collection; a cache hit skips the sweep and the
+            # sensitivity branches below fall back to a standalone streamed
+            # measurement instead (a cached map may predate this oq_level).
+            streamed_sensitivity_map = (
+                imatrix_data.metadata.get("collection", {}).get("sensitivity_map")
+                or None
+            )
         cb("imatrix", 18.0, "oQe imatrix calibration ready")
         imatrix_report = {
             "enabled": True,
@@ -4238,6 +4265,28 @@ def quantize_oq_streaming(
                 oq_level,
                 num_samples=128,
                 seq_length=256,
+                trust_remote_code=trust_remote_code,
+            )
+        elif streamed_sensitivity_map:
+            logger.info(
+                f"oQ{oq_level:g}: sensitivity measured in the fused streaming "
+                f"calibration sweep ({len(streamed_sensitivity_map)} layers)"
+            )
+            sensitivity_map = streamed_sensitivity_map
+        elif stream_imatrix:
+            # Streaming calibration is active but the fused sweep never ran
+            # (imatrix cache hit). Measure with a standalone streamed pass:
+            # still the real weights, still no proxy, no whole-model load.
+            logger.info(
+                f"oQ{oq_level:g}: measuring sensitivity by streaming layers "
+                "from the source checkpoint (no calibration proxy)"
+            )
+            sensitivity_map = _measure_sensitivity_streaming(
+                model_path,
+                config,
+                oq_level,
+                num_samples=_SENS_NUM_SAMPLES,
+                seq_length=_SENS_SEQ_LENGTH,
                 trust_remote_code=trust_remote_code,
             )
         elif (
@@ -5895,6 +5944,101 @@ class _StreamingNoModel:
     """
 
 
+def _streamed_sensitivity_state(
+    tokenizer,
+    embed_weight,
+    *,
+    calib_dataset: str,
+    num_samples: int,
+    seq_length: int,
+    calib_seed: int,
+) -> dict[str, Any] | None:
+    """Float boundary state for the streamed qdq sensitivity sweep.
+
+    The sensitivity measurement keeps its own calibration boundary (own
+    corpus, sample count, and sequence length), separate from the imatrix
+    boundary, embedded through the caller's already-resident embedding
+    table. Mask and position ids come from the same generic
+    _prepare_layer_inputs branch _measure_sensitivity_from_model takes.
+    Returns None when the calibration draw fails.
+    """
+    mx.random.seed(int(calib_seed))
+    calib_data = _load_calibration_data(
+        tokenizer,
+        dataset=calib_dataset,
+        num_samples=num_samples,
+        seq_length=seq_length,
+    )
+    if calib_data is None:
+        return None
+    inputs = embed_weight[calib_data]
+    inputs, masks, position_ids = _prepare_layer_inputs(
+        _StreamingNoModel(), [None], calib_data, inputs
+    )
+    mx.eval(inputs)
+    return {
+        "inputs": inputs,
+        "mask": masks[0],
+        "position_ids": position_ids,
+        "scores": {},
+    }
+
+
+def _streamed_sensitivity_layer(
+    state: dict[str, Any], layer_idx: int, block, config, oq_level
+) -> None:
+    """Measure one layer's qdq sensitivity while its block is resident.
+
+    Exactly _measure_sensitivity_from_model's per-layer walk: float
+    forward, temporary quantize-dequantize with the active predicate
+    configuration, quantized forward, relative MSE, weight restore, float
+    output propagated to the next layer. Runs on the pristine block after
+    the imatrix capture wrappers are off, so nothing leaks into the
+    imatrix statistic. A dead forward is fatal here where the resident
+    path skips the layer: with streamed sourcing it means a weight-load
+    bug, and a silently missing score would skew the bit allocation.
+    """
+    out_float, _ = _forward_layer_result(
+        block, state["inputs"], state["mask"], state["position_ids"]
+    )
+    if out_float is None:
+        raise RuntimeError(
+            f"streamed sensitivity: layer {layer_idx} float forward returned "
+            f"no output for {type(block).__name__}"
+        )
+    saved = _temporary_quantize_block(block, config, oq_level, _OQ_DEFAULT_GROUP_SIZE)
+    try:
+        out_quant, _ = _forward_layer_result(
+            block, state["inputs"], state["mask"], state["position_ids"]
+        )
+        if out_quant is None:
+            raise RuntimeError(
+                f"streamed sensitivity: layer {layer_idx} quantized forward "
+                f"returned no output for {type(block).__name__}"
+            )
+        raw_mse = ((out_float - out_quant) ** 2).mean()
+        out_magnitude = (out_float**2).mean()
+        mse_val = raw_mse / mx.maximum(out_magnitude, 1e-10)
+        mx.eval(mse_val)
+        state["scores"][layer_idx] = mse_val.item()
+    finally:
+        _restore_saved_weights(block, saved)
+    # Materialize the boundary before the caller releases the block: a lazy
+    # output would keep the whole layer's weights alive in its graph.
+    mx.eval(out_float)
+    state["inputs"] = out_float
+
+
+def _log_streamed_sensitivity(oq_level, scores: dict[int, float]) -> None:
+    if not scores:
+        return
+    ranked = sorted(scores.items(), key=lambda x: -x[1])
+    logger.info(
+        f"oQ{oq_level:g} streamed: layer sensitivity (descending): "
+        + ", ".join(f"L{i}={s:.4f}" for i, s in ranked)
+    )
+
+
 def _collect_imatrix_streaming(
     source,
     tokenizer,
@@ -5909,6 +6053,12 @@ def _collect_imatrix_streaming(
     trust_remote_code: bool = False,
     calib_data=None,
     calib_seed: int = _OQE_STREAM_CALIB_SEED,
+    measure_sensitivity: bool = False,
+    sensitivity_oq_level=None,
+    sensitivity_calib_dataset: str = "code_multilingual",
+    sensitivity_num_samples: int = 32,
+    sensitivity_seq_length: int = 256,
+    sensitivity_calib_seed: int = _OQE_STREAM_CALIB_SEED,
 ) -> tuple[dict[str, OQImatrixEntry], dict[str, Any]]:
     """Collect the oQe imatrix with one decoder layer resident at a time.
 
@@ -5927,7 +6077,21 @@ def _collect_imatrix_streaming(
 
     ``calib_data`` injects a pre-drawn token array (tests); otherwise the
     draw happens here, seeded with ``calib_seed``.
+
+    ``measure_sensitivity`` fuses the per-layer qdq sensitivity
+    measurement into the first round, so one weight load serves both
+    passes: each block is scored right after its imatrix forwards, once
+    the capture wrappers are off and the weights are pristine again. The
+    sensitivity boundary is completely separate from the imatrix boundary
+    (its own corpus, sample count, sequence length, and seed via the
+    ``sensitivity_*`` arguments), which keeps the imatrix accumulation
+    byte-identical to a sensitivity-free run. Scores land in
+    ``metadata["sensitivity_map"]`` as {layer_idx: relative_mse}, the
+    exact metric _measure_sensitivity_from_model produces; requires
+    ``sensitivity_oq_level`` for the qdq predicate.
     """
+    if measure_sensitivity and sensitivity_oq_level is None:
+        raise ValueError("measure_sensitivity requires sensitivity_oq_level")
     source = Path(source)
     adaptive_max_samples = max(
         int(num_samples),
@@ -5965,6 +6129,23 @@ def _collect_imatrix_streaming(
     embed_weight = _streamed_embed_weight(source, config)
     embedded = embed_weight[calib_data]
     mx.eval(embedded)
+    sens_state = None
+    if measure_sensitivity:
+        # Build the sensitivity boundary while the embedding table is still
+        # resident, so the fused sweep costs no extra stage-0 read.
+        sens_state = _streamed_sensitivity_state(
+            tokenizer,
+            embed_weight,
+            calib_dataset=sensitivity_calib_dataset,
+            num_samples=sensitivity_num_samples,
+            seq_length=sensitivity_seq_length,
+            calib_seed=sensitivity_calib_seed,
+        )
+        if sens_state is None:
+            logger.warning(
+                "oQe imatrix streaming: sensitivity calibration draw failed, "
+                "the sweep will return an empty sensitivity map"
+            )
     del embed_weight
     mx.clear_cache()
 
@@ -6041,6 +6222,14 @@ def _collect_imatrix_streaming(
                     working[slot] = out
             finally:
                 collector.restore(block)
+            if sens_state is not None and round_index == 0:
+                # One weight load serves both passes: with the capture
+                # wrappers off the block is pristine again, so the qdq
+                # sensitivity forwards ride the same residency. Sensitivity
+                # is a single pass; escalation rounds skip it.
+                _streamed_sensitivity_layer(
+                    sens_state, layer_idx, block, config, sensitivity_oq_level
+                )
             # The generator owns the other reference and releases it when
             # resumed, before sourcing the next layer.
             del block
@@ -6103,6 +6292,10 @@ def _collect_imatrix_streaming(
                     "installed_modules": 0,
                     "processed_samples": 0,
                 }
+            if sens_state is not None:
+                # Only the scores are needed past round 0; drop the float
+                # boundary so escalation rounds do not carry it.
+                sens_state["inputs"] = None
 
         del working
         mx.clear_cache()
@@ -6166,6 +6359,10 @@ def _collect_imatrix_streaming(
         "rounds": rounds,
         "load_kind": "streaming",
     }
+    if measure_sensitivity:
+        scores = sens_state["scores"] if sens_state is not None else {}
+        _log_streamed_sensitivity(sensitivity_oq_level, scores)
+        metadata["sensitivity_map"] = scores
     return collector.entries, metadata
 
 
@@ -6304,7 +6501,18 @@ def _load_or_collect_imatrix(
     progress_end: float = 18.0,
     load_path_factory: Callable[[], str] | None = None,
     stream_calibration: bool = False,
+    measure_sensitivity: bool = False,
+    sensitivity_oq_level=None,
+    sensitivity_num_samples: int = 32,
+    sensitivity_seq_length: int = 256,
 ) -> OQImatrixData:
+    # ``measure_sensitivity`` asks the streaming collector to fuse the
+    # per-layer qdq sensitivity measurement into the collection sweep; the
+    # scores come back under metadata["collection"]["sensitivity_map"]. It
+    # only applies to a fresh streamed collection: a cache hit returns
+    # early (the cached map, if any, may have been measured at another
+    # oq_level, so callers must not consume it and should fall back to
+    # _measure_sensitivity_streaming instead).
     source = Path(model_path)
     path = Path(cache_path)
     expected = _source_imatrix_signature(
@@ -6378,6 +6586,10 @@ def _load_or_collect_imatrix(
             progress_callback=progress_callback,
             progress_start=progress_start,
             progress_end=progress_end,
+            measure_sensitivity=measure_sensitivity,
+            sensitivity_oq_level=sensitivity_oq_level,
+            sensitivity_num_samples=sensitivity_num_samples,
+            sensitivity_seq_length=sensitivity_seq_length,
         )
     else:
         # ``load_path_factory`` swaps in an alternate checkpoint for the
@@ -6618,6 +6830,66 @@ def _measure_sensitivity(
     mx.clear_cache()
 
     return sensitivity
+
+
+def _measure_sensitivity_streaming(
+    model_path,
+    config: dict,
+    oq_level,
+    *,
+    calib_dataset: str = "code_multilingual",
+    num_samples: int = 32,
+    seq_length: int = 256,
+    trust_remote_code: bool = False,
+    calib_seed: int = _OQE_STREAM_CALIB_SEED,
+) -> dict[int, float]:
+    """Measure per-layer qdq sensitivity with one decoder layer resident.
+
+    Standalone counterpart to the fused pass in _collect_imatrix_streaming,
+    for builds where the imatrix came out of the cache but the sensitivity
+    map still has to be measured. Sources each block straight from the
+    checkpoint, so it needs neither a whole-model load nor the RAM-safe
+    proxy, and it scores the real weights rather than a lossy 4-bit stand-in.
+
+    Returns {layer_idx: relative_mse}, the same metric and walk as
+    _measure_sensitivity_from_model.
+    """
+    source = Path(model_path)
+    from mlx_lm.tokenizer_utils import load as load_tokenizer
+
+    tokenizer = load_tokenizer(source)
+    embed_weight = _streamed_embed_weight(source, config)
+    state = _streamed_sensitivity_state(
+        tokenizer,
+        embed_weight,
+        calib_dataset=calib_dataset,
+        num_samples=num_samples,
+        seq_length=seq_length,
+        calib_seed=calib_seed,
+    )
+    del embed_weight
+    mx.clear_cache()
+    if state is None:
+        return {}
+
+    for layer_idx, block, _is_moe in _iter_streamed_layer_blocks(
+        source, config, trust_remote_code=trust_remote_code
+    ):
+        _streamed_sensitivity_layer(state, layer_idx, block, config, oq_level)
+        del block
+        mx.synchronize()
+        mx.clear_cache()
+        active = mx.get_active_memory()
+        if active > _OQE_STREAM_ACTIVE_LIMIT_BYTES:
+            raise RuntimeError(
+                f"streamed sensitivity: layer {layer_idx} left "
+                f"{active / 1e9:.1f} GB active, past the "
+                f"{_OQE_STREAM_ACTIVE_LIMIT_BYTES / 1e9:.0f} GB streaming "
+                "budget; aborting before the leak compounds across layers"
+            )
+
+    _log_streamed_sensitivity(oq_level, state["scores"])
+    return state["scores"]
 
 
 _REQUANT_VALID_BITS = {2, 3, 4, 5, 6, 8}

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -12,6 +12,7 @@ base bits and add targeted routed-expert protection plus a higher bpw budget.
 import hashlib
 import json
 import logging
+import os
 import re
 import shutil
 import tempfile
@@ -3520,6 +3521,22 @@ def _oqe_cache_matches(cache: OQImatrixData, expected: dict[str, Any]) -> bool:
     return all(cache.metadata.get(k) == v for k, v in expected.items())
 
 
+def _oqe_cache_load_kind(cache: OQImatrixData) -> str | None:
+    """How the cached imatrix was collected, or None for pre-field caches.
+
+    "streaming" marks a layer-streamed collection against the real source
+    weights; "resident" marks the whole-model walk (possibly against a
+    RAM-safe proxy). The source signature cannot tell these apart, so the
+    field is what keeps a proxy-collected cache from silently satisfying a
+    streaming request.
+    """
+    collection = cache.metadata.get("collection")
+    if isinstance(collection, dict) and collection.get("load_kind"):
+        return str(collection["load_kind"])
+    kind = cache.metadata.get("load_kind")
+    return str(kind) if kind else None
+
+
 def _oqe_cache_has_required_expert_coverage(
     cache: OQImatrixData,
 ) -> bool:
@@ -3919,6 +3936,26 @@ def _quantize_chunked(w, group_size, bits, mode, importance=None):
 # --- end chunked-quantize helpers ---
 
 
+def _resolve_stream_calibration(
+    stream_calibration: bool | None, *, model_exceeds_ram: bool
+) -> bool:
+    """Decide whether oQe calibration streams layers from the checkpoint.
+
+    Explicit argument first, then the OMLX_OQ_STREAM_CALIBRATION env var,
+    then the auto rule: stream when the source does not fit in RAM, where
+    the resident collector would otherwise calibrate on a lossy quantized
+    proxy of the model.
+    """
+    if stream_calibration is not None:
+        return bool(stream_calibration)
+    env = os.environ.get("OMLX_OQ_STREAM_CALIBRATION", "").strip().lower()
+    if env in ("1", "true", "yes", "on"):
+        return True
+    if env in ("0", "false", "no", "off"):
+        return False
+    return model_exceeds_ram
+
+
 def quantize_oq_streaming(
     model_path: str,
     output_path: str,
@@ -3939,6 +3976,7 @@ def quantize_oq_streaming(
     imatrix_strict: bool = False,
     imatrix_num_samples: int = 128,
     imatrix_seq_length: int = 512,
+    stream_calibration: bool | None = None,
 ) -> None:
     """Tensor-by-tensor quantization. Memory: ~3-4GB regardless of model size.
 
@@ -3981,6 +4019,13 @@ def quantize_oq_streaming(
             of falling back to standard oQ quantization for those tensors.
         imatrix_num_samples: Calibration sample count for imatrix collection.
         imatrix_seq_length: Calibration sequence length for imatrix collection.
+        stream_calibration: Collect the oQe imatrix by streaming one decoder
+            layer at a time from the source checkpoint instead of loading a
+            whole model. Calibrates the real weights with a single layer
+            resident, so it needs no RAM-safe proxy. None (default)
+            auto-enables streaming when the source exceeds the RAM budget;
+            the OMLX_OQ_STREAM_CALIBRATION environment variable overrides
+            the auto rule. Only consulted when enhanced is True.
     """
     if oq_level not in OQ_LEVELS:
         raise ValueError(
@@ -4118,6 +4163,15 @@ def quantize_oq_streaming(
             )
         cb("imatrix", 13.0, "Preparing oQe imatrix calibration")
 
+        stream_imatrix = _resolve_stream_calibration(
+            stream_calibration, model_exceeds_ram=_model_exceeds_ram
+        )
+        if stream_imatrix:
+            logger.info(
+                f"oQ{oq_level:g}: oQe imatrix will stream one layer at a "
+                "time from the source checkpoint (no calibration proxy)"
+            )
+
         def _imatrix_load_path() -> str:
             cb(
                 "imatrix",
@@ -4139,7 +4193,12 @@ def quantize_oq_streaming(
                 progress_callback=cb,
                 progress_start=13.0,
                 progress_end=18.0,
-                load_path_factory=(_imatrix_load_path if _model_exceeds_ram else None),
+                load_path_factory=(
+                    _imatrix_load_path
+                    if (_model_exceeds_ram and not stream_imatrix)
+                    else None
+                ),
+                stream_calibration=stream_imatrix,
             )
         except BaseException:
             _cleanup_ram_safe_proxy()
@@ -5243,7 +5302,16 @@ class OQImatrixCollector:
             return int(w.shape[-1] * 32 // int(bits))
         return int(w.shape[-1])
 
-    def install(self, model) -> int:
+    def install(self, model, name_prefix: str = "") -> int:
+        """Wrap capture modules; entry names get ``name_prefix`` prepended.
+
+        The streaming collector installs on bare decoder blocks whose
+        module paths are relative (``self_attn.q_proj``); the prefix
+        restores the full-model names the resident collector produces, so
+        ``_lookup_imatrix_importance`` resolves entries identically for
+        both collection paths. Restore keeps using the relative names,
+        which is what ``update_modules`` needs on the wrapped object.
+        """
         replacements = []
         for name, module in model.named_modules():
             if not name or not self._is_capture_module(module):
@@ -5255,7 +5323,9 @@ class OQImatrixCollector:
             if cls in _OQE_SWITCH_LINEAR_CLASSES:
                 self.switch_capture_modules += 1
             self._original_modules[name] = module
-            replacements.append((name, _ImatrixCaptureWrapper(module, name, self)))
+            replacements.append(
+                (name, _ImatrixCaptureWrapper(module, f"{name_prefix}{name}", self))
+            )
         if replacements:
             model.update_modules(tree_unflatten(replacements), strict=False)
         return len(replacements)
@@ -5787,6 +5857,318 @@ def _streamed_embed_weight(source, config: dict):
     return weight
 
 
+# Default seed for the streaming collector's calibration draw. The permutation
+# inside _load_calibration_data is otherwise unseeded, which would make two
+# streaming runs incomparable.
+_OQE_STREAM_CALIB_SEED = 0
+
+# Hard per-layer ceiling on MLX active memory. One resident MoE layer plus
+# the boundary activations sits near 30 GB; anything past this limit means
+# the release idiom broke (a retained lazy graph keeps dead layers alive),
+# and it is far better to abort at layer 2 than to jetsam at layer 40.
+_OQE_STREAM_ACTIVE_LIMIT_BYTES = 50 * 1024**3
+
+
+def _stream_round_micro_ranges(
+    start: int, stop: int, micro_batch_size: int
+) -> list[tuple[int, int]]:
+    """Micro-batch boundaries for one round.
+
+    Clipped at the round end exactly like the resident collector's inner
+    loop clips at step boundaries, so the fp32 summation grouping matches.
+    """
+    ranges = []
+    lo = start
+    while lo < stop:
+        hi = min(lo + micro_batch_size, stop)
+        ranges.append((lo, hi))
+        lo = hi
+    return ranges
+
+
+class _StreamingNoModel:
+    """Model stand-in for _prepare_layer_inputs: streaming holds no model.
+
+    Carries no model_type, make_cache, or args, which routes the mask and
+    position-id construction through the same generic branch the resident
+    collector takes for this model family.
+    """
+
+
+def _collect_imatrix_streaming(
+    source,
+    tokenizer,
+    config,
+    *,
+    calib_dataset: str = _OQE_CALIB_DATASET,
+    num_samples: int = 128,
+    seq_length: int = 512,
+    progress_callback=None,
+    progress_start: float = 13.0,
+    progress_end: float = 18.0,
+    trust_remote_code: bool = False,
+    calib_data=None,
+    calib_seed: int = _OQE_STREAM_CALIB_SEED,
+) -> tuple[dict[str, OQImatrixEntry], dict[str, Any]]:
+    """Collect the oQe imatrix with one decoder layer resident at a time.
+
+    Same (entries, metadata) contract as _collect_imatrix_from_model, but
+    round-outer / layer-outer: round r pushes the next ``num_samples``
+    samples through every layer via _iter_streamed_layer_blocks before the
+    coverage predicate is evaluated. The imatrix statistic is an additive
+    token sum, so given the same calibration draw and the same micro-batch
+    partitioning this walk is bit-identical to the resident sample-outer
+    walk whenever coverage is reached at a round boundary (the expected
+    case at default settings). On escalation every layer is re-streamed
+    for the new samples, a full checkpoint re-read, and the run can
+    overshoot the resident stop point by up to one round minus one
+    micro-batch: layer-outer cannot stop mid-round because every layer
+    must see the same sample multiset.
+
+    ``calib_data`` injects a pre-drawn token array (tests); otherwise the
+    draw happens here, seeded with ``calib_seed``.
+    """
+    source = Path(source)
+    adaptive_max_samples = max(
+        int(num_samples),
+        min(
+            int(num_samples) * _OQE_MAX_SAMPLE_MULTIPLIER,
+            _OQE_MAX_ADAPTIVE_SAMPLES,
+        ),
+    )
+    if calib_data is None:
+        mx.random.seed(int(calib_seed))
+        calib_data = _load_calibration_data(
+            tokenizer,
+            dataset=calib_dataset,
+            num_samples=adaptive_max_samples,
+            seq_length=seq_length,
+        )
+    if calib_data is None:
+        return {}, {"dataset": calib_dataset, "processed_samples": 0}
+
+    available_samples = int(calib_data.shape[0])
+    max_samples = min(available_samples, adaptive_max_samples)
+    step_samples = max(1, int(num_samples))
+    batch_plan = _oqe_calibration_batch_plan(
+        config,
+        requested_samples=step_samples,
+        seq_length=seq_length,
+    )
+    micro_batch_size = int(batch_plan["micro_batch_size"])
+
+    # Stage 0: source the embedding table once, embed the full adaptive-max
+    # draw, drop the table. Embedding everything up front (6.4 GB at the
+    # 1024x512 ceiling) means an escalation round re-streams layers only
+    # for its own sample slice instead of re-running stage 0.
+    calib_data = calib_data[:max_samples]
+    embed_weight = _streamed_embed_weight(source, config)
+    embedded = embed_weight[calib_data]
+    mx.eval(embedded)
+    del embed_weight
+    mx.clear_cache()
+
+    # One causal mask and one position-id row serve every layer and every
+    # micro-batch: both depend only on seq_length and the activation dtype.
+    _, layer_masks, position_ids = _prepare_layer_inputs(
+        _StreamingNoModel(), [None], calib_data[:1], embedded[:1]
+    )
+    mask = layer_masks[0]
+
+    text_config = config.get("text_config") or {}
+    total_layers = int(
+        text_config.get("num_hidden_layers") or config.get("num_hidden_layers") or 0
+    )
+
+    collector = OQImatrixCollector()
+    installed = 0
+    switch_capture_modules = 0
+    capture_module_classes: dict[str, int] = {}
+    micro_batches = 0
+    processed_samples = 0
+    round_index = 0
+    rounds: list[dict[str, Any]] = []
+    require_expert_counts = False
+    coverage = _imatrix_expert_coverage_stats(collector.entries)
+    coverage_sufficient = False
+    collection_sufficient = False
+
+    logger.info(
+        "oQe imatrix streaming: adaptive max=%d, step=%d, micro-batch=%d "
+        "(available=%s, capture budget=%s)",
+        max_samples,
+        step_samples,
+        micro_batch_size,
+        _format_size(int(batch_plan["live_available_bytes"])),
+        _format_size(int(batch_plan["capture_budget_bytes"])),
+    )
+
+    while processed_samples < max_samples:
+        round_start = processed_samples
+        round_stop = min(round_start + step_samples, max_samples)
+        ranges = _stream_round_micro_ranges(round_start, round_stop, micro_batch_size)
+        working = [embedded[lo:hi] for lo, hi in ranges]
+
+        # No MTP-head pass here: the checkpoints this path serves declare
+        # MTP modules without shipping their weights (MiniMax-M3), so the
+        # resident collector's head pass is a no-op for them too. A source
+        # with real mtp.* tensors needs the _collect_mtp_head_imatrix
+        # equivalent added after the last layer.
+        for layer_idx, block, _is_moe in _iter_streamed_layer_blocks(
+            source, config, trust_remote_code=trust_remote_code
+        ):
+            prefix = f"{_STREAM_TEXT_LAYER_PREFIX}{layer_idx}."
+            layer_installed = collector.install(block, name_prefix=prefix)
+            if round_index == 0:
+                installed += layer_installed
+            try:
+                for slot in range(len(working)):
+                    out, _ = _forward_layer_result(
+                        block, working[slot], mask, position_ids
+                    )
+                    if out is None:
+                        # The resident collector skips a dead layer forward;
+                        # here it would mean a sourcing bug feeding silently
+                        # corrupt statistics downstream, so abort instead.
+                        raise RuntimeError(
+                            f"streamed layer {layer_idx} forward returned no "
+                            f"output for {type(block).__name__}: every "
+                            "signature in the (inputs, mask, None, "
+                            "position_ids) family failed; refusing to "
+                            "continue with a partial imatrix"
+                        )
+                    mx.eval(out)
+                    working[slot] = out
+            finally:
+                collector.restore(block)
+            # The generator owns the other reference and releases it when
+            # resumed, before sourcing the next layer.
+            del block
+            mx.synchronize()
+            mx.clear_cache()
+            active = mx.get_active_memory()
+            logger.info(
+                "oQe imatrix streaming: round %d layer %d/%d done "
+                "(active %.1f GB, peak %.1f GB, cache %.1f GB)",
+                round_index + 1,
+                layer_idx + 1,
+                total_layers,
+                active / 1e9,
+                mx.get_peak_memory() / 1e9,
+                mx.get_cache_memory() / 1e9,
+            )
+            if active > _OQE_STREAM_ACTIVE_LIMIT_BYTES:
+                raise RuntimeError(
+                    f"streamed layer {layer_idx}: active memory "
+                    f"{active / 1e9:.1f} GB exceeds the "
+                    f"{_OQE_STREAM_ACTIVE_LIMIT_BYTES / 1e9:.0f} GB "
+                    "streaming budget after release; aborting before the "
+                    "leak compounds across layers"
+                )
+            layer_frac = (layer_idx + 1) / total_layers if total_layers else 1.0
+            round_span = round_stop - round_start
+            frac = (round_start + round_span * layer_frac) / max(max_samples, 1)
+            pct = progress_start + min(max(frac, 0.0), 1.0) * (
+                progress_end - progress_start
+            )
+            _emit_progress(
+                progress_callback,
+                "imatrix",
+                pct,
+                f"oQe imatrix streaming round {round_index + 1}: "
+                f"layer {layer_idx + 1}/{total_layers or '?'}",
+                {
+                    "round": round_index + 1,
+                    "layer": layer_idx,
+                    "processed_samples": processed_samples,
+                    "round_samples": round_span,
+                    "max_samples": max_samples,
+                    "micro_batch_size": micro_batch_size,
+                    "active_memory_bytes": int(active),
+                },
+            )
+
+        if round_index == 0:
+            # Counter snapshot after the first full sweep. Later rounds
+            # re-install on freshly sourced blocks, which would double the
+            # collector's per-class tallies.
+            capture_module_classes = dict(collector.capture_module_classes)
+            switch_capture_modules = int(collector.switch_capture_modules)
+            require_expert_counts = _imatrix_requires_expert_counts(
+                config, switch_capture_modules
+            )
+            if installed == 0:
+                return {}, {
+                    "dataset": calib_dataset,
+                    "installed_modules": 0,
+                    "processed_samples": 0,
+                }
+
+        del working
+        mx.clear_cache()
+
+        processed_samples = round_stop
+        micro_batches += len(ranges)
+        round_index += 1
+        coverage = _imatrix_expert_coverage_stats(collector.entries)
+        coverage_sufficient = _imatrix_expert_coverage_sufficient(
+            coverage, require_expert_counts=require_expert_counts
+        )
+        collection_sufficient = (
+            processed_samples >= int(num_samples) and coverage_sufficient
+        )
+        rounds.append(
+            {
+                "processed_samples": processed_samples,
+                "coverage_sufficient": coverage_sufficient,
+                "collection_sufficient": collection_sufficient,
+                "coverage": coverage,
+            }
+        )
+        logger.info(
+            "oQe imatrix streaming: round %d done, %d/%d samples, "
+            "zero experts=%d, p05=%.1f, sufficient=%s",
+            round_index,
+            processed_samples,
+            max_samples,
+            int(coverage.get("zero_count_experts", 0)),
+            float(coverage.get("p05_count", 0.0)),
+            collection_sufficient,
+        )
+        if collection_sufficient:
+            break
+
+    if require_expert_counts and not coverage.get("has_expert_counts", False):
+        logger.warning(
+            "oQe imatrix streaming: model config expects routed experts, "
+            "but no expert activation counts were captured"
+        )
+
+    metadata = {
+        "dataset": calib_dataset,
+        "requested_samples": int(num_samples),
+        "seq_length": int(seq_length),
+        "adaptive": True,
+        "adaptive_step_samples": step_samples,
+        "adaptive_max_samples": max_samples,
+        "available_samples": available_samples,
+        "micro_batch_size": micro_batch_size,
+        "micro_batches": micro_batches,
+        "batch_plan": batch_plan,
+        "processed_samples": processed_samples,
+        "installed_modules": installed,
+        "capture_module_classes": dict(sorted(capture_module_classes.items())),
+        "switch_capture_modules": switch_capture_modules,
+        "requires_expert_counts": require_expert_counts,
+        "coverage_sufficient": coverage_sufficient,
+        "collection_sufficient": collection_sufficient,
+        "coverage": coverage,
+        "rounds": rounds,
+        "load_kind": "streaming",
+    }
+    return collector.entries, metadata
+
+
 def _collect_imatrix(
     model_path: str,
     config: dict,
@@ -5921,6 +6303,7 @@ def _load_or_collect_imatrix(
     progress_start: float = 13.0,
     progress_end: float = 18.0,
     load_path_factory: Callable[[], str] | None = None,
+    stream_calibration: bool = False,
 ) -> OQImatrixData:
     source = Path(model_path)
     path = Path(cache_path)
@@ -5934,7 +6317,19 @@ def _load_or_collect_imatrix(
     if reuse_cache and path.exists():
         cache = _load_oqe_imatrix(path)
         if _oqe_cache_matches(cache, expected):
-            if _oqe_cache_missing_mtp_entries(cache, config):
+            cache_load_kind = _oqe_cache_load_kind(cache)
+            if stream_calibration and cache_load_kind != "streaming":
+                # The source signature cannot distinguish a cache collected
+                # on a lossy proxy from one streamed off the real weights,
+                # so a streaming request rejects anything not explicitly
+                # marked as stream-collected (legacy caches included).
+                logger.info(
+                    "oQe imatrix: streaming calibration requested but cache "
+                    "%s was collected as %s, recollecting",
+                    path,
+                    cache_load_kind or "an unknown load kind",
+                )
+            elif _oqe_cache_missing_mtp_entries(cache, config):
                 logger.info(
                     "oQe imatrix: cache predates MTP-head collection "
                     "(no mtp.* entries), recollecting %s",
@@ -5959,35 +6354,57 @@ def _load_or_collect_imatrix(
             logger.info("oQe imatrix: cache metadata mismatch, recollecting %s", path)
 
     logger.info(
-        "oQe imatrix: collecting %d samples x %d tokens from %s",
+        "oQe imatrix: collecting %d samples x %d tokens from %s%s",
         num_samples,
         seq_length,
         calib_dataset,
+        " (layer streaming)" if stream_calibration else "",
     )
-    # ``load_path_factory`` swaps in an alternate checkpoint for the
-    # calibration forwards (a RAM-safe quantized proxy of the source when
-    # the source exceeds system RAM). Resolved only on a cache miss so a
-    # reusable cache never pays the proxy build. The cache signature stays
-    # keyed to the source checkpoint either way.
-    load_path = model_path
-    if load_path_factory is not None:
-        load_path = load_path_factory()
-    entries, collection_metadata = _collect_imatrix(
-        load_path,
-        config,
-        calib_dataset=calib_dataset,
-        num_samples=num_samples,
-        seq_length=seq_length,
-        trust_remote_code=trust_remote_code,
-        progress_callback=progress_callback,
-        progress_start=progress_start,
-        progress_end=progress_end,
-    )
+    if stream_calibration:
+        # The streaming collector reads the source checkpoint directly with
+        # one decoder layer resident at a time, so the RAM-safe proxy
+        # indirection below does not apply: it calibrates the real weights.
+        from mlx_lm.tokenizer_utils import load as load_tokenizer
+
+        tokenizer = load_tokenizer(Path(model_path))
+        entries, collection_metadata = _collect_imatrix_streaming(
+            model_path,
+            tokenizer,
+            config,
+            calib_dataset=calib_dataset,
+            num_samples=num_samples,
+            seq_length=seq_length,
+            trust_remote_code=trust_remote_code,
+            progress_callback=progress_callback,
+            progress_start=progress_start,
+            progress_end=progress_end,
+        )
+    else:
+        # ``load_path_factory`` swaps in an alternate checkpoint for the
+        # calibration forwards (a RAM-safe quantized proxy of the source when
+        # the source exceeds system RAM). Resolved only on a cache miss so a
+        # reusable cache never pays the proxy build. The cache signature stays
+        # keyed to the source checkpoint either way.
+        load_path = model_path
+        if load_path_factory is not None:
+            load_path = load_path_factory()
+        entries, collection_metadata = _collect_imatrix(
+            load_path,
+            config,
+            calib_dataset=calib_dataset,
+            num_samples=num_samples,
+            seq_length=seq_length,
+            trust_remote_code=trust_remote_code,
+            progress_callback=progress_callback,
+            progress_start=progress_start,
+            progress_end=progress_end,
+        )
     if not entries:
         raise RuntimeError("oQe imatrix collection produced no entries")
     metadata = {
         **expected,
         "entry_count": len(entries),
+        "load_kind": collection_metadata.get("load_kind", "resident"),
         "collection": collection_metadata,
         "expert_coverage": collection_metadata.get("coverage", {}),
         "requires_expert_counts": bool(

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -6195,6 +6195,7 @@ def _collect_imatrix_streaming(
         # resident collector's head pass is a no-op for them too. A source
         # with real mtp.* tensors needs the _collect_mtp_head_imatrix
         # equivalent added after the last layer.
+        first_streamed_layer = round_index == 0
         for layer_idx, block, _is_moe in _iter_streamed_layer_blocks(
             source, config, trust_remote_code=trust_remote_code
         ):
@@ -6202,6 +6203,21 @@ def _collect_imatrix_streaming(
             layer_installed = collector.install(block, name_prefix=prefix)
             if round_index == 0:
                 installed += layer_installed
+            if first_streamed_layer:
+                # Fail on the first layer, not after a full sweep: if the
+                # capture predicate matches nothing on a real decoder block
+                # the source layout is wrong and every layer would install
+                # zero, so the imatrix would come back empty after streaming
+                # the whole model for nothing.
+                first_streamed_layer = False
+                if layer_installed == 0:
+                    collector.restore(block)
+                    raise RuntimeError(
+                        f"streamed layer {layer_idx}: collector installed 0 "
+                        f"capture modules on {type(block).__name__}; the source "
+                        "layout does not match the capture predicate. Refusing "
+                        f"to sweep all {total_layers} layers for an empty imatrix"
+                    )
             try:
                 for slot in range(len(working)):
                     out, _ = _forward_layer_result(

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -3937,7 +3937,10 @@ def _quantize_chunked(w, group_size, bits, mode, importance=None):
 
 
 def _resolve_stream_calibration(
-    stream_calibration: bool | None, *, model_exceeds_ram: bool
+    stream_calibration: bool | None,
+    *,
+    model_exceeds_ram: bool,
+    model_type: str | None,
 ) -> bool:
     """Decide whether oQe calibration streams layers from the checkpoint.
 
@@ -3945,15 +3948,38 @@ def _resolve_stream_calibration(
     then the auto rule: stream when the source does not fit in RAM, where
     the resident collector would otherwise calibrate on a lossy quantized
     proxy of the model.
+
+    Streaming only works for the layouts the sourcer understands
+    (_STREAM_CALIBRATION_SUPPORTED_MODEL_TYPES). For every other model_type
+    the auto rule and a truthy env var stay on the proxy path, and an
+    explicit stream_calibration=True fails fast here with a clear message
+    rather than an AttributeError deep in the sourcer.
     """
+    supported = _stream_calibration_supported(model_type)
     if stream_calibration is not None:
+        if stream_calibration and not supported:
+            raise ValueError(
+                f"stream_calibration=True was requested for "
+                f"model_type={model_type!r}, but the streaming imatrix sourcer "
+                f"only supports {sorted(_STREAM_CALIBRATION_SUPPORTED_MODEL_TYPES)}. "
+                "Leave stream_calibration unset to calibrate through the RAM-safe "
+                "proxy, or extend the streamed sourcer for this layout."
+            )
         return bool(stream_calibration)
     env = os.environ.get("OMLX_OQ_STREAM_CALIBRATION", "").strip().lower()
     if env in ("1", "true", "yes", "on"):
-        return True
+        if not supported:
+            logger.warning(
+                "OMLX_OQ_STREAM_CALIBRATION asked for streaming calibration, but "
+                "model_type=%r has no streamed sourcer (supported: %s); using the "
+                "RAM-safe proxy instead.",
+                model_type,
+                sorted(_STREAM_CALIBRATION_SUPPORTED_MODEL_TYPES),
+            )
+        return supported
     if env in ("0", "false", "no", "off"):
         return False
-    return model_exceeds_ram
+    return model_exceeds_ram and supported
 
 
 def quantize_oq_streaming(
@@ -4029,8 +4055,12 @@ def quantize_oq_streaming(
             oq_sensitivity_map.json or an explicit sensitivity_model_path
             still wins over both. None (default) auto-enables streaming when
             the source exceeds the RAM budget; the OMLX_OQ_STREAM_CALIBRATION
-            environment variable overrides the auto rule. Only consulted when
-            enhanced is True.
+            environment variable overrides the auto rule. The streamed sourcer
+            only supports the MiniMax-M3 (minimax_m3_vl) layout, so both the
+            auto rule and a truthy env var stay on the RAM-safe proxy for every
+            other model_type, and an explicit stream_calibration=True on an
+            unsupported layout raises a ValueError up front instead of failing
+            deep in the sourcer. Only consulted when enhanced is True.
     """
     if oq_level not in OQ_LEVELS:
         raise ValueError(
@@ -4171,7 +4201,9 @@ def quantize_oq_streaming(
         cb("imatrix", 13.0, "Preparing oQe imatrix calibration")
 
         stream_imatrix = _resolve_stream_calibration(
-            stream_calibration, model_exceeds_ram=_model_exceeds_ram
+            stream_calibration,
+            model_exceeds_ram=_model_exceeds_ram,
+            model_type=str(config.get("model_type", "")),
         )
         if stream_imatrix:
             logger.info(
@@ -5762,10 +5794,23 @@ def _collect_imatrix_from_model(
 # MiniMax-M3 focused for now: the layer prefix, the args location, and the
 # lazy-load path in _streamed_text_args assume the minimax_m3_vl layout.
 # When a second architecture needs streaming, a model-type dispatch table
-# replaces the hardcoded prefix and the args lookup.
+# replaces the hardcoded prefix and the args lookup, and its model_type joins
+# _STREAM_CALIBRATION_SUPPORTED_MODEL_TYPES below so the calibration decision
+# starts routing it through the streamed path.
 
 _STREAM_TEXT_LAYER_PREFIX = "language_model.model.layers."
 _STREAM_EMBED_KEY = "language_model.model.embed_tokens.weight"
+
+# Only these checkpoint model_types have a streamed sourcer. Every other layout
+# keeps the RAM-safe proxy calibration path: the auto rule never streams them,
+# and an explicit stream_calibration request for one fails fast (see
+# _resolve_stream_calibration). Keep this in lockstep with the sourcer above.
+_STREAM_CALIBRATION_SUPPORTED_MODEL_TYPES = frozenset({"minimax_m3_vl"})
+
+
+def _stream_calibration_supported(model_type: str | None) -> bool:
+    """True when the streamed sourcer handles this checkpoint's layout."""
+    return str(model_type or "").lower() in _STREAM_CALIBRATION_SUPPORTED_MODEL_TYPES
 
 
 def _streamed_text_args(model_path, *, trust_remote_code: bool = False):

--- a/tests/test_oq_fp8_dequant.py
+++ b/tests/test_oq_fp8_dequant.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for _block_dequant_fp8 scale decoding.
+
+MXFP8 checkpoints (e.g. MiniMax-M3) store their e8m0 block scales with
+safetensors dtype U8. Those bytes are shared exponents and must decode as
+2^(s - 127), the same as the F8_E8M0 branch. Treating them as linear
+scales blows the weights up by orders of magnitude.
+
+DeepSeek-style FP8 checkpoints also use weight_scale_inv keys but store
+the scales as real floats (block 128). Those must keep multiplying
+linearly, so the discriminator is the scale dtype, not the key name.
+"""
+
+import glob
+import os
+
+import mlx.core as mx
+import pytest
+
+from omlx.oq import _block_dequant_fp8, _LazyTensorIndex
+
+M3_DIR = "/Volumes/Scratch/models/MiniMax-M3-MXFP8"
+
+
+def test_u8_scale_decodes_as_e8m0_exponent():
+    mx.random.seed(0)
+    w = mx.random.normal((64, 128)).astype(mx.bfloat16)
+    qw, scales = mx.quantize(w, group_size=32, bits=8, mode="mxfp8")
+    ref = mx.dequantize(qw, scales, group_size=32, bits=8, mode="mxfp8")
+    assert scales.dtype == mx.uint8
+
+    # On-disk view of the same data: raw e4m3 bytes, one per element.
+    raw_fp8 = qw.view(mx.uint8)
+    assert raw_fp8.shape == (64, 128)
+
+    # Sanity check the target first: the explicit from_fp8 * 2^(s-127)
+    # formula must reproduce mx.dequantize exactly, otherwise ref is not
+    # a valid oracle for the function under test.
+    explicit = (
+        mx.from_fp8(raw_fp8, dtype=mx.bfloat16).reshape(64, 4, 32).astype(mx.float32)
+        * mx.power(mx.array(2.0), scales.astype(mx.float32) - 127.0)[:, :, None]
+    ).reshape(64, 128)
+    assert mx.array_equal(explicit.astype(mx.bfloat16), ref).item()
+
+    got = _block_dequant_fp8(raw_fp8, scales, "F8_E4M3", "U8")
+    assert got.shape == ref.shape
+    assert mx.allclose(
+        got.astype(mx.float32), ref.astype(mx.float32), atol=1e-2, rtol=1e-2
+    ).item(), (
+        f"mean|got|={mx.abs(got).mean().item():.4g} vs "
+        f"mean|ref|={mx.abs(ref).mean().item():.4g}"
+    )
+
+
+def test_f32_scale_stays_linear():
+    # DeepSeek-style pair: e4m3 weight with a float block scale
+    # (block 128). The scale is a linear multiplier and must be applied
+    # as-is, untouched by the U8 exponent decoding.
+    mx.random.seed(1)
+    w = mx.random.normal((256, 128)).astype(mx.bfloat16)
+    qw, _ = mx.quantize(w, group_size=32, bits=8, mode="mxfp8")
+    raw_fp8 = qw.view(mx.uint8)
+    scale = mx.array([[0.5], [2.0]], dtype=mx.float32)
+
+    got = _block_dequant_fp8(raw_fp8, scale, "F8_E4M3", "F32")
+
+    wf = mx.from_fp8(raw_fp8, dtype=mx.bfloat16).astype(mx.float32)
+    expected = mx.concatenate([wf[:128] * 0.5, wf[128:] * 2.0], axis=0)
+    assert mx.allclose(got.astype(mx.float32), expected, atol=1e-2, rtol=1e-2).item()
+
+
+@pytest.mark.skipif(not os.path.isdir(M3_DIR), reason="M3 not present")
+def test_minimax_m3_k_proj_magnitude():
+    # Grounded check on a real MXFP8 checkpoint. Pre-fix this layer
+    # dequantized to mean|w| ~13410; the correct value is ~0.03.
+    shards = sorted(glob.glob(os.path.join(M3_DIR, "model-*.safetensors")))
+    idx = _LazyTensorIndex(shards)
+    key = "language_model.model.layers.3.self_attn.k_proj.weight"
+    weight = idx._dequant_one(key)
+    mean_abs = mx.abs(weight).mean().item()
+    max_abs = mx.abs(weight).max().item()
+    assert mean_abs < 1.0, f"mean|w|={mean_abs}"
+    assert max_abs < 2.0, f"max|w|={max_abs}"

--- a/tests/test_oq_stream_collect.py
+++ b/tests/test_oq_stream_collect.py
@@ -1,0 +1,488 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Layer-streaming imatrix collector: parity with the resident collector.
+
+The streaming collector walks rounds on the outside and layers on the
+inside, holding one decoder layer resident at a time. The imatrix statistic
+is a pure additive token sum, so that traversal must reproduce the
+whole-model sample-outer collector bit for bit when both sides see the same
+calibration draw and the same micro-batch partitioning.
+
+These tests pin that contract on a truncated bf16 MiniMax-M3: the original
+layers 0..3 (three dense layers plus the first MoE layer, which also carries
+the sparse-attention index projections), dequantized from the real MXFP8
+checkpoint and written as a standalone model that both collectors load
+identically. The fixture is cached on disk and reused across runs; the
+module skips when neither the cached fixture nor the source checkpoint is
+present.
+"""
+
+import json
+import shutil
+from contextlib import contextmanager
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+import pytest
+
+import omlx.oq as oq
+from omlx.oq import (
+    _OQE_CALIB_DATASET,
+    OQImatrixData,
+    _collect_imatrix_from_model,
+    _collect_imatrix_streaming,
+    _imatrix_metadata_path,
+    _LazyTensorIndex,
+    _load_or_collect_imatrix,
+    _lookup_imatrix_importance,
+    _resolve_stream_calibration,
+    _streamed_source_plan,
+)
+
+M3_DIR = Path("/Volumes/Scratch/models/MiniMax-M3-MXFP8")
+FIXTURE_DIR = Path("/Volumes/Scratch/omlx-050/fixtures/minimax-m3-trunc4-bf16")
+FIXTURE_DONE = FIXTURE_DIR / "fixture_meta.json"
+
+KEEP_LAYERS = 4
+LAYER_PREFIX = "language_model.model.layers."
+CALIB_SEED = 20260709
+NUM_SAMPLES = 32
+SEQ_LENGTH = 512
+MICRO_BATCH = 8
+
+pytestmark = pytest.mark.skipif(
+    not M3_DIR.is_dir() and not FIXTURE_DONE.exists(),
+    reason="neither MiniMax-M3-MXFP8 nor the cached truncated fixture is present",
+)
+
+
+# --- fixture model build ----------------------------------------------------
+
+_KEPT_SINGLETONS = (
+    "language_model.model.embed_tokens.weight",
+    "language_model.model.norm.weight",
+    "language_model.lm_head.weight",
+)
+_TOKENIZER_FILES = (
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    "vocab.json",
+    "merges.txt",
+    "generation_config.json",
+    "chat_template.jinja",
+)
+_SHARD_BUDGET = 4 * 1024**3
+
+
+def _keep_key(key: str) -> bool:
+    if key in _KEPT_SINGLETONS:
+        return True
+    if not key.startswith(LAYER_PREFIX):
+        return False
+    layer = key[len(LAYER_PREFIX) :].split(".", 1)[0]
+    return layer.isdigit() and int(layer) < KEEP_LAYERS
+
+
+def _truncated_config() -> dict:
+    """Source config cut down to KEEP_LAYERS, bf16, schedule preserved."""
+    config = json.loads((M3_DIR / "config.json").read_text())
+    config.pop("quantization_config", None)
+    text = config["text_config"]
+    text["num_hidden_layers"] = KEEP_LAYERS
+    if isinstance(text.get("moe_layer_freq"), list):
+        text["moe_layer_freq"] = text["moe_layer_freq"][:KEEP_LAYERS]
+    sparse = text.get("sparse_attention_config")
+    if isinstance(sparse, dict):
+        for key in ("sparse_disable_index_value", "sparse_attention_freq"):
+            if isinstance(sparse.get(key), list):
+                sparse[key] = sparse[key][:KEEP_LAYERS]
+    return config
+
+
+def _build_fixture() -> None:
+    """Dequantize layers 0..3 plus embed/norm/lm_head into a bf16 checkpoint.
+
+    Goes through _LazyTensorIndex so the fp8 pairs take the exact dequant
+    path the streaming sourcer uses (weight_scale_inv U8 e8m0 decode). The
+    output keeps the original per-expert key layout, so both mlx-vlm load
+    and the streamed sanitize plan assemble the MoE stacks themselves.
+    """
+    idx = _LazyTensorIndex(sorted(M3_DIR.glob("*.safetensors")))
+    logical = idx.logical_metadata()
+    kept = sorted(k for k in logical if _keep_key(k))
+    assert kept, "no fixture keys found in the source checkpoint"
+
+    dtype_bytes = _LazyTensorIndex._DTYPE_BYTES
+    sizes = {}
+    for key in kept:
+        shape, dtype = logical[key]
+        n = 1
+        for dim in shape:
+            n *= dim
+        sizes[key] = n * dtype_bytes[dtype]
+
+    shards: list[list[str]] = []
+    current: list[str] = []
+    current_bytes = 0
+    for key in kept:
+        if current and current_bytes + sizes[key] > _SHARD_BUDGET:
+            shards.append(current)
+            current, current_bytes = [], 0
+        current.append(key)
+        current_bytes += sizes[key]
+    if current:
+        shards.append(current)
+
+    FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+    weight_map = {}
+    for i, keys in enumerate(shards, start=1):
+        name = f"model-{i:05d}-of-{len(shards):05d}.safetensors"
+        tensors = {}
+        for key in keys:
+            tensor = idx[key]
+            mx.eval(tensor)
+            tensors[key] = tensor
+            weight_map[key] = name
+        mx.save_safetensors(str(FIXTURE_DIR / name), tensors)
+        del tensors
+        mx.clear_cache()
+
+    (FIXTURE_DIR / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {"total_size": sum(sizes.values())},
+                "weight_map": weight_map,
+            },
+            indent=2,
+        )
+    )
+    (FIXTURE_DIR / "config.json").write_text(json.dumps(_truncated_config(), indent=2))
+    for name in _TOKENIZER_FILES:
+        src = M3_DIR / name
+        if src.exists():
+            shutil.copy2(src, FIXTURE_DIR / name)
+    FIXTURE_DONE.write_text(
+        json.dumps({"source": str(M3_DIR), "keep_layers": KEEP_LAYERS})
+    )
+
+
+@pytest.fixture(scope="session")
+def fixture_dir():
+    if not FIXTURE_DONE.exists():
+        if not M3_DIR.is_dir():
+            pytest.skip("fixture not built and the source checkpoint is absent")
+        if FIXTURE_DIR.exists():
+            shutil.rmtree(FIXTURE_DIR)
+        _build_fixture()
+    return FIXTURE_DIR
+
+
+@pytest.fixture(scope="module")
+def fixture_config(fixture_dir):
+    return json.loads((fixture_dir / "config.json").read_text())
+
+
+@pytest.fixture(scope="module")
+def tokenizer(fixture_dir):
+    from mlx_lm.tokenizer_utils import load as load_tokenizer
+
+    return load_tokenizer(fixture_dir)
+
+
+# --- collection helpers -----------------------------------------------------
+
+
+@contextmanager
+def _pinned_micro_batch(size: int):
+    """Pin the calibration micro-batch so both collectors partition alike.
+
+    _oqe_calibration_batch_plan reads live free memory, so an unpinned run
+    could legally pick different micro-batch sizes for the two collectors
+    and break fp32 summation-grouping parity.
+    """
+    original = oq._oqe_calibration_batch_plan
+
+    def pinned(config, *, requested_samples, seq_length):
+        plan = original(
+            config, requested_samples=requested_samples, seq_length=seq_length
+        )
+        plan["micro_batch_size"] = int(size)
+        return plan
+
+    oq._oqe_calibration_batch_plan = pinned
+    try:
+        yield
+    finally:
+        oq._oqe_calibration_batch_plan = original
+
+
+def _load_resident_model(model_dir: Path):
+    """Load the fixture the way _collect_imatrix loads a VLM source."""
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    maybe_apply_pre_load_patches(str(model_dir), for_vlm=True)
+
+    from mlx_vlm.utils import load_model as vlm_load_model
+
+    orig_load_weights = nn.Module.load_weights
+
+    def lenient_load_weights(self, file_or_weights, *args, **kwargs):
+        kwargs.pop("strict", None)
+        return orig_load_weights(self, file_or_weights, *args, strict=False, **kwargs)
+
+    nn.Module.load_weights = lenient_load_weights
+    try:
+        return vlm_load_model(Path(model_dir), lazy=True)
+    finally:
+        nn.Module.load_weights = orig_load_weights
+
+
+@pytest.fixture(scope="module")
+def resident_result(fixture_dir, fixture_config, tokenizer):
+    """Entries and metadata from the existing whole-model collector."""
+    model = _load_resident_model(fixture_dir)
+    try:
+        with _pinned_micro_batch(MICRO_BATCH):
+            # The subsample permutation inside _load_calibration_data is
+            # unseeded; seeding right before the collect pins the draw to
+            # the same one the streaming run makes with calib_seed.
+            mx.random.seed(CALIB_SEED)
+            entries, metadata = _collect_imatrix_from_model(
+                model,
+                tokenizer,
+                fixture_config,
+                calib_dataset=_OQE_CALIB_DATASET,
+                num_samples=NUM_SAMPLES,
+                seq_length=SEQ_LENGTH,
+            )
+    finally:
+        del model
+        mx.synchronize()
+        mx.clear_cache()
+    return entries, metadata
+
+
+@pytest.fixture(scope="module")
+def streaming_result(fixture_dir, fixture_config, tokenizer):
+    """Entries and metadata from the layer-streaming collector."""
+    with _pinned_micro_batch(MICRO_BATCH):
+        entries, metadata = _collect_imatrix_streaming(
+            fixture_dir,
+            tokenizer,
+            fixture_config,
+            calib_dataset=_OQE_CALIB_DATASET,
+            num_samples=NUM_SAMPLES,
+            seq_length=SEQ_LENGTH,
+            calib_seed=CALIB_SEED,
+        )
+    mx.synchronize()
+    mx.clear_cache()
+    return entries, metadata
+
+
+# --- tests -------------------------------------------------------------------
+
+
+def test_stream_calibration_flag_resolution(monkeypatch):
+    """Explicit argument beats the env var, env var beats the RAM auto-rule."""
+    monkeypatch.delenv("OMLX_OQ_STREAM_CALIBRATION", raising=False)
+    assert _resolve_stream_calibration(True, model_exceeds_ram=False) is True
+    assert _resolve_stream_calibration(False, model_exceeds_ram=True) is False
+    assert _resolve_stream_calibration(None, model_exceeds_ram=True) is True
+    assert _resolve_stream_calibration(None, model_exceeds_ram=False) is False
+
+    monkeypatch.setenv("OMLX_OQ_STREAM_CALIBRATION", "1")
+    assert _resolve_stream_calibration(None, model_exceeds_ram=False) is True
+    monkeypatch.setenv("OMLX_OQ_STREAM_CALIBRATION", "off")
+    assert _resolve_stream_calibration(None, model_exceeds_ram=True) is False
+    monkeypatch.setenv("OMLX_OQ_STREAM_CALIBRATION", "0")
+    assert _resolve_stream_calibration(True, model_exceeds_ram=False) is True
+
+
+def test_streaming_matches_resident_imatrix(resident_result, streaming_result):
+    """THE GATE: layer-outer must equal sample-outer bit for bit."""
+    res_entries, res_meta = resident_result
+    st_entries, st_meta = streaming_result
+
+    # Parity precondition: coverage must be reached inside round one on
+    # both sides. Past round one the resident collector may stop mid-round
+    # (per micro-batch) while the streaming collector only stops at round
+    # boundaries, so the sample multisets legitimately diverge. If this
+    # fires, raise NUM_SAMPLES rather than loosening the comparison.
+    assert res_meta["coverage_sufficient"], res_meta["coverage"]
+    assert len(res_meta["rounds"]) == 1, res_meta["rounds"]
+    assert len(st_meta["rounds"]) == 1, st_meta["rounds"]
+    assert res_meta["processed_samples"] == st_meta["processed_samples"] == NUM_SAMPLES
+    assert res_meta["micro_batch_size"] == st_meta["micro_batch_size"] == MICRO_BATCH
+
+    assert st_meta["load_kind"] == "streaming"
+    assert set(st_meta) == set(res_meta) | {"load_kind"}
+
+    assert st_entries, "streaming collector produced no entries"
+    assert set(st_entries) == set(res_entries)
+
+    moe_entries = 0
+    diffs = []
+    for name in sorted(res_entries):
+        res, st = res_entries[name], st_entries[name]
+        assert res.in_sum2.dtype == np.float32 == st.in_sum2.dtype, name
+        assert res.counts.dtype == np.int64 == st.counts.dtype, name
+        assert res.in_sum2.shape == st.in_sum2.shape, name
+        # Counts are integers (per-expert routing tallies for the MoE
+        # entries). No tolerance is acceptable here.
+        assert np.array_equal(res.counts, st.counts), f"{name}: routing counts diverge"
+        if res.counts.size > 1:
+            moe_entries += 1
+        if not np.array_equal(res.in_sum2, st.in_sum2):
+            rel = np.abs(st.in_sum2 - res.in_sum2) / np.maximum(
+                np.abs(res.in_sum2), 1e-30
+            )
+            diffs.append((float(rel.max()), name))
+    assert moe_entries == 2, (
+        "expected exactly gate_up_proj and down_proj per-expert entries, "
+        f"got {moe_entries}"
+    )
+
+    if diffs:
+        diffs.sort(reverse=True)
+        worst_rel, worst_name = diffs[0]
+        print(
+            f"\nimatrix parity: bitwise equality failed on {len(diffs)} of "
+            f"{len(res_entries)} entries; max rel diff {worst_rel:.3e} at "
+            f"{worst_name}. Suspects: eval-order or mask-branch divergence "
+            "between the resident and streamed forwards."
+        )
+        for _, name in diffs:
+            res, st = res_entries[name], st_entries[name]
+            assert np.allclose(st.in_sum2, res.in_sum2, rtol=1e-5, atol=0.0), (
+                f"{name}: in_sum2 rel diff exceeds 1e-5"
+            )
+
+
+def test_streaming_entry_keys_prefixed(fixture_dir, fixture_config, streaming_result):
+    """Streamed entries carry full model paths and feed importance lookup."""
+    entries, _ = streaming_result
+
+    assert all(name.startswith(LAYER_PREFIX) for name in entries)
+    layers_seen = {name[len(LAYER_PREFIX) :].split(".", 1)[0] for name in entries}
+    assert layers_seen == {str(i) for i in range(KEEP_LAYERS)}
+
+    dp = _streamed_source_plan(fixture_dir, fixture_config)
+    quantizable = []
+    for key in dp:
+        if not key.startswith(LAYER_PREFIX) or not key.endswith(".weight"):
+            continue
+        shape = dp.plan_shape(key)
+        if len(shape) >= 2:
+            quantizable.append((key, shape))
+    assert quantizable
+
+    # Exact correspondence: every quantizable layer tensor has an entry,
+    # and there are no orphan entries.
+    assert {key[: -len(".weight")] for key, _ in quantizable} == set(entries)
+
+    data = OQImatrixData(entries=entries, metadata={}, path="")
+    report = {"applied": [], "missing": [], "mismatched": [], "zero_count_experts": 0}
+    for key, shape in quantizable:
+        importance = _lookup_imatrix_importance(
+            data, key, tuple(shape), strict=False, report=report
+        )
+        assert importance is not None, f"no importance resolved for {key}"
+    assert report["missing"] == []
+    assert report["mismatched"] == []
+
+
+def test_streaming_out_none_is_fatal(fixture_dir, fixture_config, monkeypatch):
+    """A layer forward returning None must abort the collection loudly."""
+    monkeypatch.setattr(oq, "_forward_layer_result", lambda *a, **k: (None, None))
+    calib = mx.zeros((2, 8), dtype=mx.int32)
+    with pytest.raises(RuntimeError, match="forward"):
+        _collect_imatrix_streaming(
+            fixture_dir,
+            None,
+            fixture_config,
+            calib_dataset=_OQE_CALIB_DATASET,
+            num_samples=2,
+            seq_length=8,
+            calib_data=calib,
+        )
+
+
+def test_cache_load_kind_busts_legacy(
+    fixture_dir, fixture_config, tmp_path, monkeypatch
+):
+    """Streaming runs reject caches that were not stream-collected."""
+    cache_path = tmp_path / "m3-trunc4.npz"
+    common = dict(
+        cache_path=str(cache_path),
+        reuse_cache=True,
+        num_samples=2,
+        seq_length=64,
+        strict=False,
+        trust_remote_code=False,
+    )
+
+    first = _load_or_collect_imatrix(
+        str(fixture_dir), fixture_config, **common, stream_calibration=True
+    )
+    assert first.reused is False
+    assert first.metadata["load_kind"] == "streaming"
+    assert first.metadata["collection"]["load_kind"] == "streaming"
+
+    # A streaming-collected npz round-trips.
+    second = _load_or_collect_imatrix(
+        str(fixture_dir), fixture_config, **common, stream_calibration=True
+    )
+    assert second.reused is True
+    assert set(second.entries) == set(first.entries)
+
+    # Recollections from here on are stubbed; these cases only assert the
+    # cache-validation decision.
+    calls = []
+
+    def fake_stream(source, tokenizer, config, **kwargs):
+        calls.append(kwargs)
+        return dict(first.entries), dict(first.metadata["collection"])
+
+    monkeypatch.setattr(oq, "_collect_imatrix_streaming", fake_stream)
+
+    meta_path = _imatrix_metadata_path(cache_path)
+    saved = json.loads(meta_path.read_text())
+
+    # Legacy cache: no load_kind anywhere. Must be recollected.
+    legacy = json.loads(json.dumps(saved))
+    legacy.pop("load_kind", None)
+    legacy.get("collection", {}).pop("load_kind", None)
+    meta_path.write_text(json.dumps(legacy))
+    third = _load_or_collect_imatrix(
+        str(fixture_dir), fixture_config, **common, stream_calibration=True
+    )
+    assert len(calls) == 1, "legacy cache without load_kind must be recollected"
+    assert third.reused is False
+    assert third.metadata["load_kind"] == "streaming"
+
+    # Mismatching load_kind (a resident-collected cache). Must be recollected.
+    mismatched = json.loads(json.dumps(saved))
+    mismatched["load_kind"] = "resident"
+    mismatched["collection"]["load_kind"] = "resident"
+    meta_path.write_text(json.dumps(mismatched))
+    fourth = _load_or_collect_imatrix(
+        str(fixture_dir), fixture_config, **common, stream_calibration=True
+    )
+    assert len(calls) == 2, "resident-collected cache must be recollected"
+    assert fourth.reused is False
+
+    # The non-streaming path keeps accepting a legacy cache unchanged.
+    meta_path.write_text(json.dumps(legacy))
+
+    def no_resident_collect(*args, **kwargs):
+        raise AssertionError("resident collection must not run on a cache hit")
+
+    monkeypatch.setattr(oq, "_collect_imatrix", no_resident_collect)
+    fifth = _load_or_collect_imatrix(
+        str(fixture_dir), fixture_config, **common, stream_calibration=False
+    )
+    assert fifth.reused is True

--- a/tests/test_oq_stream_collect.py
+++ b/tests/test_oq_stream_collect.py
@@ -486,3 +486,26 @@ def test_cache_load_kind_busts_legacy(
         str(fixture_dir), fixture_config, **common, stream_calibration=False
     )
     assert fifth.reused is True
+
+
+def test_streaming_aborts_on_first_layer_zero_install(
+    fixture_dir, fixture_config, tokenizer, monkeypatch
+):
+    """A source whose layout defeats the capture predicate must abort on the
+    first layer, not after streaming every layer for an empty imatrix."""
+    monkeypatch.setattr(oq.OQImatrixCollector, "install", lambda self, *a, **k: 0)
+    with (
+        _pinned_micro_batch(MICRO_BATCH),
+        pytest.raises(RuntimeError, match="installed 0 capture modules"),
+    ):
+        _collect_imatrix_streaming(
+            fixture_dir,
+            tokenizer,
+            fixture_config,
+            calib_dataset=_OQE_CALIB_DATASET,
+            num_samples=NUM_SAMPLES,
+            seq_length=SEQ_LENGTH,
+            calib_seed=CALIB_SEED,
+        )
+    mx.synchronize()
+    mx.clear_cache()

--- a/tests/test_oq_stream_collect.py
+++ b/tests/test_oq_stream_collect.py
@@ -287,19 +287,45 @@ def streaming_result(fixture_dir, fixture_config, tokenizer):
 
 
 def test_stream_calibration_flag_resolution(monkeypatch):
-    """Explicit argument beats the env var, env var beats the RAM auto-rule."""
+    """Explicit argument beats the env var, env var beats the RAM auto-rule.
+
+    Runs on a supported model_type so the precedence, not the layout gate, is
+    what these assertions exercise. The gate itself lives in
+    test_oq_stream_resolve.py.
+    """
     monkeypatch.delenv("OMLX_OQ_STREAM_CALIBRATION", raising=False)
-    assert _resolve_stream_calibration(True, model_exceeds_ram=False) is True
-    assert _resolve_stream_calibration(False, model_exceeds_ram=True) is False
-    assert _resolve_stream_calibration(None, model_exceeds_ram=True) is True
-    assert _resolve_stream_calibration(None, model_exceeds_ram=False) is False
+    mt = "minimax_m3_vl"
+    assert (
+        _resolve_stream_calibration(True, model_exceeds_ram=False, model_type=mt)
+        is True
+    )
+    assert (
+        _resolve_stream_calibration(False, model_exceeds_ram=True, model_type=mt)
+        is False
+    )
+    assert (
+        _resolve_stream_calibration(None, model_exceeds_ram=True, model_type=mt) is True
+    )
+    assert (
+        _resolve_stream_calibration(None, model_exceeds_ram=False, model_type=mt)
+        is False
+    )
 
     monkeypatch.setenv("OMLX_OQ_STREAM_CALIBRATION", "1")
-    assert _resolve_stream_calibration(None, model_exceeds_ram=False) is True
+    assert (
+        _resolve_stream_calibration(None, model_exceeds_ram=False, model_type=mt)
+        is True
+    )
     monkeypatch.setenv("OMLX_OQ_STREAM_CALIBRATION", "off")
-    assert _resolve_stream_calibration(None, model_exceeds_ram=True) is False
+    assert (
+        _resolve_stream_calibration(None, model_exceeds_ram=True, model_type=mt)
+        is False
+    )
     monkeypatch.setenv("OMLX_OQ_STREAM_CALIBRATION", "0")
-    assert _resolve_stream_calibration(True, model_exceeds_ram=False) is True
+    assert (
+        _resolve_stream_calibration(True, model_exceeds_ram=False, model_type=mt)
+        is True
+    )
 
 
 def test_streaming_matches_resident_imatrix(resident_result, streaming_result):

--- a/tests/test_oq_stream_resolve.py
+++ b/tests/test_oq_stream_resolve.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model-type gating for the streaming imatrix calibration decision.
+
+_resolve_stream_calibration decides whether oQe calibration streams layers
+from the checkpoint instead of building a RAM-safe proxy. The streamed
+sourcer only understands the MiniMax-M3 (minimax_m3_vl) layout, so the
+decision has to stay inside that supported set:
+
+- the auto rule (source exceeds RAM) must not turn streaming on for a layout
+  the sourcer cannot handle, otherwise an oQe build of a big non-MiniMax model
+  that completes today through the proxy would start crashing by default
+- an explicit request for streaming on an unsupported layout is a
+  misconfiguration and must fail early with a clear message, not a late
+  AttributeError deep in the sourcer
+
+These are pure decision-logic tests: no checkpoint, no model load, no GPU, so
+they run in CI where the MiniMax-M3 weights are absent.
+"""
+
+import logging
+
+import pytest
+
+from omlx.oq import (
+    _STREAM_CALIBRATION_SUPPORTED_MODEL_TYPES,
+    _resolve_stream_calibration,
+)
+
+SUPPORTED = "minimax_m3_vl"
+UNSUPPORTED = "qwen3_5_moe"
+
+
+@pytest.fixture(autouse=True)
+def _clear_stream_env(monkeypatch):
+    """Keep OMLX_OQ_STREAM_CALIBRATION out of the decision unless a test sets it."""
+    monkeypatch.delenv("OMLX_OQ_STREAM_CALIBRATION", raising=False)
+
+
+# --- the auto rule (stream_calibration=None, no env) --------------------------
+
+
+def test_auto_streams_supported_model_that_exceeds_ram():
+    assert (
+        _resolve_stream_calibration(None, model_exceeds_ram=True, model_type=SUPPORTED)
+        is True
+    )
+
+
+def test_auto_keeps_proxy_for_supported_model_within_ram():
+    assert (
+        _resolve_stream_calibration(None, model_exceeds_ram=False, model_type=SUPPORTED)
+        is False
+    )
+
+
+def test_auto_does_not_stream_unsupported_model_over_ram():
+    """The merge blocker: a big non-MiniMax model must keep the proxy path."""
+    assert (
+        _resolve_stream_calibration(
+            None, model_exceeds_ram=True, model_type=UNSUPPORTED
+        )
+        is False
+    )
+
+
+def test_auto_treats_missing_model_type_as_unsupported():
+    assert (
+        _resolve_stream_calibration(None, model_exceeds_ram=True, model_type="")
+        is False
+    )
+
+
+# --- explicit argument --------------------------------------------------------
+
+
+def test_explicit_true_streams_supported_even_within_ram():
+    assert (
+        _resolve_stream_calibration(True, model_exceeds_ram=False, model_type=SUPPORTED)
+        is True
+    )
+
+
+def test_explicit_false_never_streams_even_over_ram():
+    assert (
+        _resolve_stream_calibration(False, model_exceeds_ram=True, model_type=SUPPORTED)
+        is False
+    )
+
+
+def test_explicit_true_on_unsupported_raises_early():
+    with pytest.raises(ValueError) as exc:
+        _resolve_stream_calibration(
+            True, model_exceeds_ram=True, model_type=UNSUPPORTED
+        )
+    msg = str(exc.value)
+    assert UNSUPPORTED in msg, "error must name the unsupported model_type"
+    assert SUPPORTED in msg, "error must name the supported set"
+    assert "stream_calibration" in msg
+
+
+def test_explicit_true_on_empty_model_type_raises():
+    with pytest.raises(ValueError):
+        _resolve_stream_calibration(True, model_exceeds_ram=False, model_type="")
+
+
+# --- environment override -----------------------------------------------------
+
+
+def test_env_true_streams_supported(monkeypatch):
+    monkeypatch.setenv("OMLX_OQ_STREAM_CALIBRATION", "1")
+    assert (
+        _resolve_stream_calibration(None, model_exceeds_ram=False, model_type=SUPPORTED)
+        is True
+    )
+
+
+def test_env_true_on_unsupported_falls_back_to_proxy(monkeypatch, caplog):
+    """A session-wide env var is a soft preference: unsupported layouts keep
+    the proxy rather than raising, so only the explicit argument is a hard
+    per-build assertion. The rejected preference is warned, not silent."""
+    monkeypatch.setenv("OMLX_OQ_STREAM_CALIBRATION", "true")
+    with caplog.at_level(logging.WARNING):
+        result = _resolve_stream_calibration(
+            None, model_exceeds_ram=True, model_type=UNSUPPORTED
+        )
+    assert result is False
+    assert UNSUPPORTED in caplog.text
+    assert "OMLX_OQ_STREAM_CALIBRATION" in caplog.text
+
+
+def test_env_false_overrides_auto_for_supported(monkeypatch):
+    monkeypatch.setenv("OMLX_OQ_STREAM_CALIBRATION", "0")
+    assert (
+        _resolve_stream_calibration(None, model_exceeds_ram=True, model_type=SUPPORTED)
+        is False
+    )
+
+
+# --- the supported set --------------------------------------------------------
+
+
+def test_supported_set_is_minimax_only():
+    """Pin the supported layout: widening it is a conscious, reviewed change."""
+    assert frozenset({"minimax_m3_vl"}) == _STREAM_CALIBRATION_SUPPORTED_MODEL_TYPES
+
+
+def test_model_type_match_is_case_insensitive():
+    assert (
+        _resolve_stream_calibration(
+            None, model_exceeds_ram=True, model_type="MiniMax_M3_VL"
+        )
+        is True
+    )
+
+
+def test_model_type_is_a_required_argument():
+    """Every caller must state the layout; omitting it is a programming error,
+    not a silent fall-through to the unsupported branch."""
+    with pytest.raises(TypeError):
+        _resolve_stream_calibration(None, model_exceeds_ram=True)

--- a/tests/test_oq_stream_sensitivity.py
+++ b/tests/test_oq_stream_sensitivity.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streamed per-layer sensitivity: parity with the resident measurement.
+
+The layer-streaming calibration sweep also measures quantization sensitivity
+on the block it already holds resident: forward in float, temporarily
+quantize-dequantize the block with the active predicate configuration,
+forward again, score the relative MSE, restore the weights, and propagate the
+float output to the next layer. That is exactly the walk
+_measure_sensitivity_from_model does on a whole loaded model, so on a model
+both sides can hold the per-layer scores must match, and the extra qdq
+forwards must not move the imatrix statistic by a single bit.
+
+The sensitivity boundary is deliberately separate from the imatrix boundary
+(its own calibration corpus, sample count, and sequence length), which is
+what these tests pin alongside the scores themselves.
+
+Reuses the truncated bf16 MiniMax-M3 fixture from test_oq_stream_collect
+(original layers 0..3: three dense layers plus the first MoE layer). The
+module skips when neither the cached fixture nor the source checkpoint is
+present. The imported fixtures shadow their own names as test parameters,
+hence the F811 suppressions.
+"""
+
+import mlx.core as mx
+import numpy as np
+import omlx.oq as oq
+import pytest
+from omlx.oq import (
+    _OQE_CALIB_DATASET,
+    _collect_imatrix_streaming,
+    _measure_sensitivity_from_model,
+    quantize_oq_streaming,
+)
+from test_oq_stream_collect import (  # noqa: F401  (imported fixtures)
+    CALIB_SEED,
+    FIXTURE_DONE,
+    KEEP_LAYERS,
+    M3_DIR,
+    MICRO_BATCH,
+    NUM_SAMPLES,
+    SEQ_LENGTH,
+    _load_resident_model,
+    _pinned_micro_batch,
+    fixture_config,
+    fixture_dir,
+    resident_result,
+    tokenizer,
+)
+
+pytestmark = pytest.mark.skipif(
+    not M3_DIR.is_dir() and not FIXTURE_DONE.exists(),
+    reason="neither MiniMax-M3-MXFP8 nor the cached truncated fixture is present",
+)
+
+OQ_LEVEL = 3
+SENS_DATASET = "code_multilingual"
+SENS_SAMPLES = 32
+SENS_SEQ = 256
+
+
+@pytest.fixture(scope="module")
+def resident_sensitivity(fixture_dir, fixture_config, tokenizer):  # noqa: F811
+    """Per-layer scores from the whole-model measurement, seeded draw."""
+    model = _load_resident_model(fixture_dir)
+    try:
+        # The subsample permutation inside _load_calibration_data is
+        # unseeded; seeding right before the measurement pins the draw to
+        # the one the streamed sweep makes with sensitivity_calib_seed.
+        mx.random.seed(CALIB_SEED)
+        scores = _measure_sensitivity_from_model(
+            model,
+            tokenizer,
+            fixture_config,
+            OQ_LEVEL,
+            calib_dataset=SENS_DATASET,
+            num_samples=SENS_SAMPLES,
+            seq_length=SENS_SEQ,
+        )
+    finally:
+        del model
+        mx.synchronize()
+        mx.clear_cache()
+    return scores
+
+
+@pytest.fixture(scope="module")
+def fused_result(fixture_dir, fixture_config, tokenizer):  # noqa: F811
+    """Entries and metadata from one fused imatrix + sensitivity sweep."""
+    with _pinned_micro_batch(MICRO_BATCH):
+        entries, metadata = _collect_imatrix_streaming(
+            fixture_dir,
+            tokenizer,
+            fixture_config,
+            calib_dataset=_OQE_CALIB_DATASET,
+            num_samples=NUM_SAMPLES,
+            seq_length=SEQ_LENGTH,
+            calib_seed=CALIB_SEED,
+            measure_sensitivity=True,
+            sensitivity_oq_level=OQ_LEVEL,
+            sensitivity_calib_dataset=SENS_DATASET,
+            sensitivity_num_samples=SENS_SAMPLES,
+            sensitivity_seq_length=SENS_SEQ,
+            sensitivity_calib_seed=CALIB_SEED,
+        )
+    mx.synchronize()
+    mx.clear_cache()
+    return entries, metadata
+
+
+def test_streamed_sensitivity_matches_resident(fused_result, resident_sensitivity):
+    """THE GATE: fused-sweep sensitivity must equal the resident scores."""
+    _, metadata = fused_result
+    streamed = metadata["sensitivity_map"]
+
+    expected_layers = set(range(KEEP_LAYERS))
+    assert set(resident_sensitivity) == expected_layers, (
+        f"resident measurement is missing layers: {resident_sensitivity}"
+    )
+    assert set(streamed) == expected_layers, (
+        f"streamed measurement is missing layers: {streamed}"
+    )
+    # A degenerate all-zero map would satisfy equality while carrying no
+    # ranking signal; qdq at oQ3 must produce a real error on every layer.
+    assert all(v > 0.0 for v in streamed.values()), streamed
+
+    diffs = {i: abs(streamed[i] - resident_sensitivity[i]) for i in expected_layers}
+    max_diff = max(diffs.values())
+    exact = all(streamed[i] == resident_sensitivity[i] for i in expected_layers)
+    print(
+        f"\nsensitivity parity: {'bitwise' if exact else 'approximate'}, "
+        f"max abs diff {max_diff:.3e} "
+        f"(resident={resident_sensitivity}, streamed={streamed})"
+    )
+    if not exact:
+        for i in sorted(expected_layers):
+            assert diffs[i] < 1e-6, (
+                f"layer {i}: streamed {streamed[i]!r} vs resident "
+                f"{resident_sensitivity[i]!r}, abs diff {diffs[i]:.3e}"
+            )
+
+
+def test_imatrix_gate_still_bitwise(resident_result, fused_result):  # noqa: F811
+    """The fused qdq forwards must not perturb the imatrix statistic.
+
+    Same comparison as test_streaming_matches_resident_imatrix, now with
+    the sensitivity pass riding the sweep: every entry must still equal
+    the resident collector bit for bit, and the metadata contract must
+    only grow by the sensitivity map.
+    """
+    res_entries, res_meta = resident_result
+    fused_entries, fused_meta = fused_result
+
+    assert fused_meta["load_kind"] == "streaming"
+    assert set(fused_meta) == set(res_meta) | {"load_kind", "sensitivity_map"}
+    assert fused_meta["processed_samples"] == res_meta["processed_samples"]
+
+    assert set(fused_entries) == set(res_entries)
+    for name in sorted(res_entries):
+        res, fused = res_entries[name], fused_entries[name]
+        assert np.array_equal(res.counts, fused.counts), (
+            f"{name}: routing counts diverge with fused sensitivity"
+        )
+        assert np.array_equal(res.in_sum2, fused.in_sum2), (
+            f"{name}: in_sum2 diverges with fused sensitivity"
+        )
+
+
+def test_streaming_build_uses_no_proxy_for_sensitivity(
+    fixture_dir,  # noqa: F811
+    tmp_path,
+    monkeypatch,
+):
+    """stream_calibration=True must never touch the proxy or a whole model.
+
+    Both wiring branches are exercised: a fresh collection measures
+    sensitivity inside the fused sweep, and a second run that hits the
+    imatrix cache falls back to the standalone streamed sweep. Every
+    proxy-building and whole-model-loading entry point is patched to blow
+    up, so a regression on either branch cannot pass silently. The build
+    is aborted right after the sensitivity map lands in the config; the
+    quantization loop itself is out of scope here.
+    """
+    for entry_point in (
+        "_build_proxy_for_sensitivity",
+        "_build_streaming_proxy_for_sensitivity",
+        "_measure_sensitivity_from_quantized_model",
+        "_measure_sensitivity",
+        "_collect_imatrix",
+    ):
+
+        def _forbidden(*args, _name=entry_point, **kwargs):
+            raise AssertionError(f"{_name} must not run when calibration streams")
+
+        monkeypatch.setattr(oq, entry_point, _forbidden)
+
+    standalone_calls = []
+    orig_standalone = oq._measure_sensitivity_streaming
+
+    def spy_standalone(*args, **kwargs):
+        standalone_calls.append(kwargs)
+        return orig_standalone(*args, **kwargs)
+
+    monkeypatch.setattr(oq, "_measure_sensitivity_streaming", spy_standalone)
+
+    captured = {}
+    orig_non_quantizable = oq._build_non_quantizable_set
+
+    def spy_non_quantizable(config):
+        captured["config"] = config
+        return orig_non_quantizable(config)
+
+    monkeypatch.setattr(oq, "_build_non_quantizable_set", spy_non_quantizable)
+
+    class _StopBuildError(Exception):
+        pass
+
+    def stop(*args, **kwargs):
+        raise _StopBuildError
+
+    monkeypatch.setattr(oq, "_collect_named_weight_shapes_from_weights", stop)
+
+    cache_path = tmp_path / "imatrix.npz"
+
+    def run(out_name: str) -> dict:
+        captured.clear()
+        with pytest.raises(_StopBuildError):
+            quantize_oq_streaming(
+                str(fixture_dir),
+                str(tmp_path / out_name),
+                OQ_LEVEL,
+                enhanced=True,
+                stream_calibration=True,
+                imatrix_cache_path=str(cache_path),
+                imatrix_num_samples=NUM_SAMPLES,
+                imatrix_seq_length=SEQ_LENGTH,
+            )
+        sensitivity_map = captured["config"].get("_oq_sensitivity_map")
+        assert sensitivity_map, "no sensitivity map reached the config"
+        assert set(sensitivity_map) == {str(i) for i in range(KEEP_LAYERS)}
+        assert all(v > 0.0 for v in sensitivity_map.values())
+        return sensitivity_map
+
+    # Fresh collection: sensitivity comes out of the fused sweep.
+    run("out-fused")
+    assert standalone_calls == [], (
+        "a fresh streamed collection must fuse sensitivity, not run a second sweep"
+    )
+    assert cache_path.exists(), "imatrix cache was not written by the first run"
+
+    # Cache hit: the fused sweep never runs, the standalone streamed
+    # measurement covers sensitivity instead.
+    run("out-cached")
+    assert len(standalone_calls) == 1, (
+        "an imatrix cache hit must measure sensitivity with the standalone "
+        "streamed sweep"
+    )

--- a/tests/test_oq_stream_sourcer.py
+++ b/tests/test_oq_stream_sourcer.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-layer weight sourcing for the layer-streaming imatrix collector.
+
+The streaming collector never holds the whole model: each MiniMaxDecoderLayer
+is built bare, filled straight from the checkpoint through a private sanitize
+plan, forwarded, and released. These tests pin the sourcing primitive:
+
+- tensors land in the right block slots, bit-equal to an independent pop
+- the strict loader accepts the exact popped key set (dense and MoE)
+- a bare block forwards cachelessly with the collector's mask/position_ids
+- one MoE layer stays inside the streaming memory budget and leaks nothing
+
+Every test reads the real MiniMax-M3-MXFP8 checkpoint; the module skips when
+it is not mounted. test_peak_rss_one_layer is defined first on purpose, so
+its memory accounting runs before the module-scoped block fixture exists.
+"""
+
+import json
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+import pytest
+from mlx.utils import tree_flatten
+
+from omlx.oq import (
+    _forward_layer_result,
+    _iter_streamed_layer_blocks,
+    _LazyTensorIndex,
+    _prepare_layer_inputs,
+    _streamed_embed_weight,
+    _streamed_layer_items,
+    _streamed_source_plan,
+    _streamed_text_args,
+)
+
+M3_DIR = Path("/Volumes/Scratch/models/MiniMax-M3-MXFP8")
+LAYER_PREFIX = "language_model.model.layers."
+
+pytestmark = pytest.mark.skipif(
+    not M3_DIR.is_dir(), reason="MiniMax-M3-MXFP8 checkpoint not present"
+)
+
+
+def _bits(a):
+    """Numpy view of an mx array's raw bits, for exact equality checks."""
+    uint_for_size = {1: mx.uint8, 2: mx.uint16, 4: mx.uint32, 8: mx.uint64}
+    return np.array(a.view(uint_for_size[a.dtype.size]))
+
+
+@pytest.fixture(scope="module")
+def m3_config():
+    return json.loads((M3_DIR / "config.json").read_text())
+
+
+@pytest.fixture(scope="module")
+def text_args():
+    return _streamed_text_args(M3_DIR)
+
+
+@pytest.fixture(scope="module")
+def sourced_blocks(m3_config):
+    """Layer 0 (dense) and layer 3 (first MoE + sparse index) via the generator."""
+    blocks = {}
+    for layer_idx, block, is_moe in _iter_streamed_layer_blocks(M3_DIR, m3_config):
+        if layer_idx in (0, 3):
+            blocks[layer_idx] = (block, is_moe)
+        del block
+        mx.clear_cache()
+        if layer_idx >= 3:
+            break
+    yield blocks
+    blocks.clear()
+    mx.synchronize()
+    mx.clear_cache()
+
+
+def test_peak_rss_one_layer(m3_config):
+    """Sourcing plus forwarding one MoE layer must fit the streaming budget.
+
+    Runs first in the module so no other fixture holds weights: the peak is
+    the honest cost of one streamed layer. The active-memory delta at the
+    end is the leak tripwire for the collector's release idiom.
+    """
+    mx.synchronize()
+    mx.clear_cache()
+    mx.reset_peak_memory()
+    baseline = mx.get_active_memory()
+
+    block3 = None
+    for layer_idx, block, is_moe in _iter_streamed_layer_blocks(M3_DIR, m3_config):
+        if layer_idx == 3:
+            assert is_moe
+            block3 = block
+        del block
+        mx.clear_cache()
+        if layer_idx >= 3:
+            break
+    assert block3 is not None
+
+    hidden = m3_config["text_config"]["hidden_size"]
+    seq = 512
+    mask = nn.MultiHeadAttention.create_additive_causal_mask(seq).astype(mx.bfloat16)
+    position_ids = mx.arange(seq)[None, :]
+    mx.random.seed(11)
+    for _ in range(4):
+        x = (0.1 * mx.random.normal((1, seq, hidden))).astype(mx.bfloat16)
+        out, _ = _forward_layer_result(block3, x, mask, position_ids)
+        assert out is not None, "no forward signature matched for the MoE block"
+        mx.eval(out)
+        del out, x
+
+    del block3
+    mx.synchronize()
+    mx.clear_cache()
+
+    peak = mx.get_peak_memory()
+    active_after = mx.get_active_memory()
+    print(
+        f"\nstreamed layer 3: peak {peak / 1e9:.2f} GB, "
+        f"baseline {baseline / 1e9:.2f} GB, after release {active_after / 1e9:.2f} GB"
+    )
+    assert peak < 30e9, f"peak {peak / 1e9:.2f} GB blows the 30 GB streaming budget"
+    assert active_after - baseline < 1e9, (
+        f"active memory did not return to baseline: "
+        f"{baseline / 1e9:.2f} GB -> {active_after / 1e9:.2f} GB"
+    )
+
+
+def test_sourced_layer_weights_match_ground_truth(m3_config, sourced_blocks):
+    """load_weights must route every tensor to the right slot, bit for bit.
+
+    Ground truth is an independent _DiscoveredPlan pop of the same keys:
+    same dequant path, separate instance, so a routing bug in the block
+    fill cannot cancel out.
+    """
+    truth = _streamed_source_plan(M3_DIR, m3_config)
+    for layer_idx in (0, 3):
+        block, _ = sourced_blocks[layer_idx]
+        params = dict(tree_flatten(block.parameters()))
+        prefix = f"{LAYER_PREFIX}{layer_idx}."
+        keys = sorted(k for k in truth if k.startswith(prefix))
+        assert keys, f"no plan keys for layer {layer_idx}"
+        for key in keys:
+            rel = key[len(prefix) :]
+            assert rel in params, f"{rel} not a parameter of the bare block"
+            expected = truth.pop(key)
+            got = params[rel]
+            assert got.dtype == expected.dtype, key
+            assert got.shape == expected.shape, key
+            assert np.array_equal(_bits(got), _bits(expected)), f"{key} differs"
+            del expected
+            mx.clear_cache()
+
+
+def test_strict_load_accepts_layer_keyset(text_args, m3_config):
+    """The popped key set loads under strict=True for dense and MoE layers.
+
+    Settles the open question about e_score_correction_bias and the
+    index_q/k_proj sparse tensors: the checkpoint keys must equal the
+    block's parameter tree exactly, with no lenient fallback needed.
+    """
+    args, layer_cls = text_args
+    dp = _streamed_source_plan(M3_DIR, m3_config)
+    for layer_idx in (0, 3):
+        items = _streamed_layer_items(dp, layer_idx)
+        block = layer_cls(args, layer_idx)
+        block.load_weights(items, strict=True)
+        loaded = {k for k, _ in items}
+        expected = {k for k, _ in tree_flatten(block.parameters())}
+        assert loaded == expected, (
+            f"layer {layer_idx}: missing={sorted(expected - loaded)} "
+            f"extra={sorted(loaded - expected)}"
+        )
+        del block, items
+        mx.clear_cache()
+
+
+def test_bare_block_forwards(text_args, sourced_blocks):
+    """A cacheless prefill through a bare block must produce clean output."""
+    args, _ = text_args
+    mx.random.seed(7)
+    x = (0.1 * mx.random.normal((1, 8, args.hidden_size))).astype(mx.bfloat16)
+    calib = mx.zeros((1, 8), dtype=mx.int32)
+
+    class _NoModel:
+        """Stand-in for the model arg: streaming has no whole model."""
+
+    for layer_idx in (0, 3):
+        block, is_moe = sourced_blocks[layer_idx]
+        assert is_moe == (layer_idx == 3)
+        inputs, masks, position_ids = _prepare_layer_inputs(
+            _NoModel(), [block], calib, x
+        )
+        out, _ = _forward_layer_result(block, inputs, masks[0], position_ids)
+        assert out is not None, f"layer {layer_idx}: no forward signature matched"
+        mx.eval(out)
+        assert out.shape == x.shape
+        assert not bool(mx.isnan(out).any()), f"layer {layer_idx}: NaN in output"
+        assert not bool(mx.isinf(out).any()), f"layer {layer_idx}: Inf in output"
+
+
+def test_embed_weight_matches_checkpoint(m3_config):
+    """Stage-0 embedding sourcing: bf16, right shape, bit-equal to disk."""
+    weight = _streamed_embed_weight(M3_DIR, m3_config)
+    text_cfg = m3_config["text_config"]
+    assert weight.dtype == mx.bfloat16
+    assert weight.shape == (text_cfg["vocab_size"], text_cfg["hidden_size"])
+
+    idx = _LazyTensorIndex(sorted(M3_DIR.glob("*.safetensors")))
+    raw = idx["language_model.model.embed_tokens.weight"]
+    mx.eval(raw)
+    assert np.array_equal(_bits(weight), _bits(raw))


### PR DESCRIPTION
## Problem

oQe activation-importance (imatrix) calibration runs a forward pass over the model
while it is fully resident. For a source that is larger than RAM the collector falls
back to a uniform quantized proxy, and the proxy also has to fit in memory. On a 256 GB
machine that ceiling is reached well before the largest MoE checkpoints: MiniMax-M3
(about 428B total) needs a 4-bit proxy of roughly 225 GB, which jetsam-kills the process
before the calibration forward finishes. There is no way to imatrix-calibrate a model of
that size on the box, so it has to be quantized without imatrix, which is exactly where
the low-bit routed experts need the importance weighting most.

## Approach

This adds a layer-streaming calibration path that inverts the loop. Instead of holding
the whole model (or a proxy) resident and iterating samples over it, it iterates layers
over the samples:

1. Source one decoder layer's weights directly from the checkpoint (lazy, one layer).
2. Run every calibration micro-batch through that layer, capturing the imatrix statistics
   and, on the first round, the fused qdq sensitivity for the same residency.
3. Release the layer, feed the cached activations to the next layer, repeat.

At most one layer's weights are resident at a time. The imatrix accumulation is an
additive per-token sum, so layer-outer collection is bit-for-bit identical to the existing
sample-outer collection; tests assert that equivalence on fixtures. Adaptive expert
coverage still works: escalation adds whole rounds so every layer sees the same sample
multiset. A hard per-layer active-memory ceiling aborts if a layer fails to release,
rather than letting a leak compound across the sweep.

## Rebased onto current main (v0.6.3)

The branch is now a rebase of the original series onto current `main`. The MXFP8 U8
e8m0 dequant fix that used to open this series is gone from the diff — main already
carries it, with a superset test. Three call sites were reworked against code that moved
since the original base: the imatrix cache-hit branch calls the three-argument
`_oqe_cache_missing_mtp_entries` and keeps `_oqe_cache_has_required_expert_coverage`
in the chain, and the auto-stream rule keys off the calibration budget's
`requires_proxy` rather than the old exceeds-RAM boolean, so streaming engages exactly
where the proxy build would otherwise kick in.

## Rebased onto current main (2026-09-07)

Re-based again onto current `main` (`aa8db73`, post-0.6.4). One conflict, in the
write-path sanitizer call: main's `_build_model_sanitizer` grew `model_path` and
`preserve_mtp`, this branch prepends the qwen4_exp package exposure and the
refuse-on-missing-sanitizer guard. Resolved as both — the package is exposed first,
then main's signature is called, then the guard runs. Nothing else in the series moved.

The proxy policy that landed meanwhile (#3269 and its follow-up) and this path
coexist by construction rather than by luck: `load_path_factory` is passed only when
`_model_requires_proxy and not stream_imatrix`, so for a checkpoint the streamed
sourcer supports the real calibration runs and the proxy is never built; for every
other oversized checkpoint main's proxy still handles it. The automatic rule keys off
the same `requires_proxy` budget flag, so the two policies read one decision.

## Second supported architecture: qwen4_exp

The sourcer now handles Qwen4-Exp checkpoints (Qwen3.8-Flash-Next: 48 MoE layers,
36 GDN + 12 QSA, a 20M-row N-gram PLE table at layer 2, live MTP weights). The pieces
that were qwen4_exp-shaped rather than generic:

- The forward state is built by hand instead of through `_prepare_layer_inputs`, whose
  qwen4_exp branch gates on object identity with a live `model.layers` list that a
  one-block-at-a-time generator never has. The state carries the hc-tiled boundary and a
  per-layer mask schedule from `config.text_config.layer_types` (None for
  linear_attention, causal for full_attention) — one shared mask would calibrate every
  QSA layer non-causally.
- The PLE runtime is pinned to mmap on the module instance the layer class actually
  reads (the pre-load patches can re-install the vendored module), and the 128 N-gram
  shard tensors the sanitize plan still carries are filtered before the pop — an
  mmap-mode block self-sources them, and popping them first materialized the whole
  ~100 GB table once per sweep just to discard it.
- Streamed blocks run in eval mode. Freshly constructed modules default to training
  mode, and the Qwen3.5-family GDN picks its fused kernel with
  `use_kernel=not self.training`; the training-mode scan diverges by one bf16 ulp per
  forward, which is enough to flip borderline MoE routing choices and break bitwise
  parity with the resident collector.
- A build that drops the MTP head (`preserve_mtp=False`) no longer invalidates its
  imatrix cache on every reuse: `require_mtp_entries` is threaded from `preserve_mtp`,
  since a cache without mtp.* entries is complete for a build that never quantizes
  them. Without this, any source that ships real MTP weights recollects the full
  imatrix on every quantization run.
- `quantize_oq_streaming` grows `preserve_ngram_table`: the N-gram shard tensors are
  written unquantized in the checkpoint dtype with no per-layer quantization entry, so
  the table can be quantized separately from the core (its measured sensitivity is far
  below the core's). The synthetic `weight_scale` the mmap-mode embedding registers is
  stripped from the output; it is not checkpoint data and strict loaders reject
  artifacts that carry it.

## Result

- MiniMax-M3 (MXFP8, no truncation): calibrates with a peak around 58 GB instead of
  the 225 GB proxy that OOM'd, as before.
- Qwen3.8-Flash-Next (335 GB bf16, larger than RAM): a full fused
  imatrix+sensitivity collection (128x512, adaptive escalation to 1,024 samples,
  8 rounds) runs in 50 minutes with ~21 GB active, and the streamed collector
  reproduces the resident block-walk on a truncated real-weights fixture fully
  bitwise: exact expert routing counts and bit-identical `in_sum2` on every entry,
  fused qdq sensitivity within 1e-6 of `_measure_sensitivity_from_model`.

## Interface

Opt-in and additive; the resident path is unchanged. `stream_calibration=True`, the
`OMLX_OQ_STREAM_CALIBRATION` env var, or automatic when the calibration budget says the
source needs a proxy. The imatrix cache records how it was collected (`load_kind`), so
a proxy-collected cache cannot silently satisfy a streaming request and vice versa.

## Widening the supported set

The set is deliberately small: a model_type joins
`_STREAM_CALIBRATION_SUPPORTED_MODEL_TYPES` only once its layer dispatch is written
and its bitwise parity gate passes, because a checkpoint whose forward state the
sourcer builds wrongly produces a plausible imatrix that is quietly wrong. A
production report on glm5_next (GLM-5.3-Flash, 45 layers, 306 GB source, M1 Ultra
128 GB) is in the thread below: 45/45 layers in ~23 minutes, 671 entries covering 682
tensors, parity gate green, and the dispatch it needed is the hyper-connection
coefficients riding along per layer plus the MTP head as a 46th block with its own
embedding pass. That dispatch is welcome as a follow-up on top of this once the
sourcer lands.

Two notes from that report worth recording here: the `.npz` cache is written once at
the end of a collection, so a failure in the last layer costs the whole sweep; and a
model with an MTP head needs the embedding table re-read for the head's pass, so the
release has to happen after the layer loop rather than before the head. Both are
incremental improvements on the same file and are better as separate changes than as
additions to this diff.

## Tests

- `test_oq_stream_resolve.py`: the decision precedence and the pinned supported set.
- `test_oq_stream_sourcer.py` / `test_oq_stream_collect.py` /
  `test_oq_stream_sensitivity.py`: the MiniMax fixture suite, unchanged (skips when
  the checkpoint is absent).
- `test_oq_stream_qwen4_exp.py`: the qwen4_exp mask schedule, per-slot state, the
  pre-pop shard filter (plan values are poisoned to prove skipped keys are never
  materialized), the table-preserve predicate, and both settings of
  `require_mtp_entries`.
- `test_oq_stream_qwen4_exp_parity.py`: the bitwise streamed-vs-resident gate on a
  truncated real-weights Flash-Next fixture (GDN + PLE + QSA layers), including the
  fused-sensitivity comparison.

