### PR TITLE
fix: fall back for Qwen3.5/3.6 ragged decode kernels exceeding threadgroup limit

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -376,6 +376,19 @@ class BatchedEngine(BaseEngine):
                     "Qwen MoE weighted-sum patch not applied", exc_info=True
                 )
 
+        if (
+            getattr(self._model_settings, "qwen35_ragged_decode_fallback_enabled", True)
+            is not False
+        ):
+            try:
+                from ..patches.qwen35_ragged_decode import (
+                    apply_qwen35_ragged_decode_patch,
+                )
+
+                apply_qwen35_ragged_decode_patch()
+            except Exception:
+                logger.debug("qwen3_5 ragged decode patch not applied", exc_info=True)
+
         # Create engine config (copy to avoid mutating the shared instance)
         scheduler_config = (
             copy.copy(self._scheduler_config)

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1581,6 +1581,19 @@ class VLMBatchedEngine(BaseEngine):
                 logger.debug(
                     "Qwen MoE weighted-sum patch not applied", exc_info=True
                 )
+
+        if (
+            getattr(self._model_settings, "qwen35_ragged_decode_fallback_enabled", True)
+            is not False
+        ):
+            try:
+                from ..patches.qwen35_ragged_decode import (
+                    apply_qwen35_ragged_decode_patch,
+                )
+
+                apply_qwen35_ragged_decode_patch()
+            except Exception:
+                logger.debug("qwen3_5 ragged decode patch not applied", exc_info=True)
         scheduler.refresh_ssd_layer_signature()
 
         # SpecPrefill: load draft model and pass to scheduler

--- a/omlx/patches/qwen35_ragged_decode.py
+++ b/omlx/patches/qwen35_ragged_decode.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_PATCHED = False
+_PROBE_CACHE: dict[tuple[Any, ...], bool] = {}
+_PATCH_MARKER = "_omlx_qwen35_ragged_decode_patch"
+_ORIGINAL_ATTR = "_omlx_qwen35_ragged_decode_original"
+
+
+def _threadgroup_limit_error(exc: Exception) -> bool:
+    msg = str(exc)
+    return "Thread group size" in msg or "threads per threadgroup" in msg
+
+
+def _signature(q35, queries, keys, values, pads) -> tuple[Any, ...] | None:
+    try:
+        if (
+            queries.ndim != 4
+            or keys.ndim != 4
+            or values.ndim != 4
+            or queries.shape[2] != 1
+            or queries.dtype not in (mx.bfloat16, mx.float16)
+            or keys.dtype != queries.dtype
+            or values.dtype != queries.dtype
+        ):
+            return None
+        batch, q_heads, _, d_size = queries.shape
+        pads_tuple = tuple(int(p) for p in pads)
+        if len(pads_tuple) != batch or any(p < 0 for p in pads_tuple):
+            return None
+        kv_heads = keys.shape[1]
+        k_size = keys.shape[2]
+        v_size = values.shape[-1]
+        if (
+            q_heads % kv_heads != 0
+            or d_size != v_size
+            or d_size not in (64, 96, 128, 256)
+            or any(p >= k_size for p in pads_tuple)
+        ):
+            return None
+        plans = [
+            q35._qwen3_5_sdpa_vector_plan(k_size - pad, q_heads, kv_heads)
+            for pad in pads_tuple
+        ]
+        if len(set(plans)) != 1:
+            return None
+        mode, blocks = plans[0]
+        return (
+            mode,
+            int(blocks),
+            str(queries.dtype),
+            int(d_size),
+            int(v_size),
+            int(q_heads),
+            int(kv_heads),
+        )
+    except Exception:
+        return None
+
+
+def _call_with_probe(original, key, queries, keys, values, pads, scale):
+    cached = _PROBE_CACHE.get(key)
+    if cached is False:
+        return None
+
+    try:
+        out = original(queries, keys, values, pads, scale)
+        if cached is True or out is None:
+            return out
+        mx.eval(out)
+        _PROBE_CACHE[key] = True
+        return out
+    except Exception as exc:
+        if _threadgroup_limit_error(exc):
+            logger.warning(
+                "qwen3_5 ragged decode kernel %s exceeds threadgroup limit; "
+                "using reference fallback",
+                key,
+            )
+            _PROBE_CACHE[key] = False
+            return None
+        raise
+
+
+def apply_qwen35_ragged_decode_patch() -> bool:
+    global _PATCHED
+    if _PATCHED:
+        return False
+
+    try:
+        from mlx_vlm.models.qwen3_5 import language as q35
+
+        current = q35._qwen3_5_ragged_decode_attention
+    except (ImportError, AttributeError):
+        return False
+
+    if getattr(current, _PATCH_MARKER, False):
+        _PATCHED = True
+        return False
+
+    original = current
+
+    def patched(queries, keys, values, pads, scale):
+        key = _signature(q35, queries, keys, values, pads)
+        if key is None:
+            return original(queries, keys, values, pads, scale)
+        return _call_with_probe(original, key, queries, keys, values, pads, scale)
+
+    setattr(patched, _PATCH_MARKER, True)
+    setattr(patched, _ORIGINAL_ATTR, original)
+    q35._qwen3_5_ragged_decode_attention = patched
+    _PATCHED = True
+    logger.info("qwen3_5 ragged decode threadgroup fallback patch applied")
+    return True

--- a/tests/test_qwen35_ragged_decode.py
+++ b/tests/test_qwen35_ragged_decode.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import patch
+
+import mlx.core as mx
+import pytest
+
+DTYPE = mx.float16
+D_SIZE = 256
+
+
+def _make_arrays(batch=2, q_heads=16, kv_heads=2, k_size=2048):
+    mx.random.seed(42)
+    q = mx.random.normal((batch, q_heads, 1, D_SIZE)).astype(DTYPE)
+    k = mx.random.normal((batch, kv_heads, k_size, D_SIZE)).astype(DTYPE)
+    v = mx.random.normal((batch, kv_heads, k_size, D_SIZE)).astype(DTYPE)
+    mx.eval(q, k, v)
+    return q, k, v
+
+
+def _make_q35_module():
+    mod = types.ModuleType("mlx_vlm.models.qwen3_5.language")
+
+    def _qwen3_5_sdpa_vector_plan(seq_len, q_heads, kv_heads):
+        if seq_len >= 1024:
+            return ("two_pass", 1024)
+        return ("one_pass", 0)
+
+    mod._qwen3_5_sdpa_vector_plan = _qwen3_5_sdpa_vector_plan
+    return mod
+
+
+def test_signature_valid_shape():
+    from omlx.patches.qwen35_ragged_decode import _signature
+
+    q35 = _make_q35_module()
+    q, k, v = _make_arrays()
+    sig = _signature(q35, q, k, v, [0, 128])
+    assert sig is not None
+    assert sig[0] == "two_pass"
+    assert sig[2] == str(DTYPE)
+    assert sig[3] == D_SIZE
+
+
+def test_signature_wrong_ndim():
+    from omlx.patches.qwen35_ragged_decode import _signature
+
+    q35 = _make_q35_module()
+    q = mx.zeros((2, 16, D_SIZE)).astype(DTYPE)
+    k = mx.zeros((2, 2, 2048, D_SIZE)).astype(DTYPE)
+    v = mx.zeros((2, 2, 2048, D_SIZE)).astype(DTYPE)
+    assert _signature(q35, q, k, v, [0, 0]) is None
+
+
+def test_signature_non_decode_seq():
+    from omlx.patches.qwen35_ragged_decode import _signature
+
+    q35 = _make_q35_module()
+    q = mx.zeros((2, 16, 4, D_SIZE)).astype(DTYPE)
+    k = mx.zeros((2, 2, 2048, D_SIZE)).astype(DTYPE)
+    v = mx.zeros((2, 2, 2048, D_SIZE)).astype(DTYPE)
+    assert _signature(q35, q, k, v, [0, 0]) is None
+
+
+def test_signature_diverging_plans():
+    from omlx.patches.qwen35_ragged_decode import _signature
+
+    q35 = _make_q35_module()
+    q, k, v = _make_arrays(batch=2, k_size=2048)
+    assert _signature(q35, q, k, v, [1023, 1025]) is None
+
+
+def test_fallback_on_threadgroup_error(monkeypatch):
+    from omlx.patches import qwen35_ragged_decode as mod
+
+    monkeypatch.setattr(mod, "_PROBE_CACHE", {})
+    call_count = {"n": 0}
+
+    def failing_original(q, k, v, pads, scale):
+        call_count["n"] += 1
+        raise ValueError(
+            "Thread group size (1024) is greater than "
+            "the maximum allowed threads per threadgroup (896)."
+        )
+
+    q, k, v = _make_arrays()
+    key = ("two_pass", 1024, str(DTYPE), D_SIZE, D_SIZE, 16, 2)
+
+    result = mod._call_with_probe(failing_original, key, q, k, v, [0, 128], 1.0)
+    assert result is None
+    assert mod._PROBE_CACHE[key] is False
+    assert call_count["n"] == 1
+
+    result2 = mod._call_with_probe(failing_original, key, q, k, v, [0, 128], 1.0)
+    assert result2 is None
+    assert call_count["n"] == 1
+
+
+def test_passthrough_when_supported(monkeypatch):
+    from omlx.patches import qwen35_ragged_decode as mod
+
+    monkeypatch.setattr(mod, "_PROBE_CACHE", {})
+    sentinel = mx.zeros((2, 16, 1, D_SIZE)).astype(DTYPE)
+    call_count = {"n": 0}
+
+    def good_original(q, k, v, pads, scale):
+        call_count["n"] += 1
+        return sentinel
+
+    q, k, v = _make_arrays()
+    key = ("two_pass", 1024, str(DTYPE), D_SIZE, D_SIZE, 16, 2)
+
+    result = mod._call_with_probe(good_original, key, q, k, v, [0, 128], 1.0)
+    assert result is sentinel
+    assert mod._PROBE_CACHE[key] is True
+    assert call_count["n"] == 1
+
+    result2 = mod._call_with_probe(good_original, key, q, k, v, [0, 128], 1.0)
+    assert result2 is sentinel
+    assert call_count["n"] == 2
+
+
+def test_non_threadgroup_error_propagates(monkeypatch):
+    from omlx.patches import qwen35_ragged_decode as mod
+
+    monkeypatch.setattr(mod, "_PROBE_CACHE", {})
+
+    def bad_original(q, k, v, pads, scale):
+        raise RuntimeError("something unrelated")
+
+    q, k, v = _make_arrays()
+    key = ("two_pass", 1024, str(DTYPE), D_SIZE, D_SIZE, 16, 2)
+
+    with pytest.raises(RuntimeError, match="unrelated"):
+        mod._call_with_probe(bad_original, key, q, k, v, [0, 0], 1.0)
+
+    assert key not in mod._PROBE_CACHE
+
+
+def test_patch_install_and_idempotent(monkeypatch):
+    q35 = pytest.importorskip("mlx_vlm.models.qwen3_5.language")
+    from omlx.patches import qwen35_ragged_decode as mod
+
+    monkeypatch.setattr(mod, "_PATCHED", False)
+    monkeypatch.setattr(mod, "_PROBE_CACHE", {})
+
+    def original_fn(queries, keys, values, pads, scale):
+        return mx.zeros((2, 16, 1, D_SIZE)).astype(DTYPE)
+
+    monkeypatch.setattr(q35, "_qwen3_5_ragged_decode_attention", original_fn)
+
+    result1 = mod.apply_qwen35_ragged_decode_patch()
+    assert result1 is True
+    assert mod._PATCHED is True
+    assert q35._qwen3_5_ragged_decode_attention is not original_fn
+    assert getattr(q35._qwen3_5_ragged_decode_attention, mod._PATCH_MARKER, False)
+
+    patched_fn = q35._qwen3_5_ragged_decode_attention
+    result2 = mod.apply_qwen35_ragged_decode_patch()
+    assert result2 is False
+    assert q35._qwen3_5_ragged_decode_attention is patched_fn
+
+
+def test_patch_returns_false_on_import_error(monkeypatch):
+    from omlx.patches import qwen35_ragged_decode as mod
+
+    monkeypatch.setattr(mod, "_PATCHED", False)
+    monkeypatch.delitem(sys.modules, "mlx_vlm.models.qwen3_5.language", raising=False)
+    monkeypatch.delitem(sys.modules, "mlx_vlm.models.qwen3_5", raising=False)
+    monkeypatch.delitem(sys.modules, "mlx_vlm.models", raising=False)
+    monkeypatch.delitem(sys.modules, "mlx_vlm", raising=False)
+
+    with patch.dict("sys.modules", {"mlx_vlm": None}):
+        result = mod.apply_qwen35_ragged_decode_patch()
+    assert result is False
+    assert mod._PATCHED is False


### PR DESCRIPTION
## Problem

During Throughput benchmark (and in production batched decode with unequal prompt lengths), Qwen3.5/3.6 models crash with:

```
ValueError: Thread group size (1024) is greater than the maximum allowed threads per threadgroup (896).
```

The error fires inside `mx.async_eval` during `generate.py:_step`, killing the whole batch mid-generation. Relates to #2049.

## Root cause

`mlx_vlm/models/qwen3_5/language.py` dispatches both `one_pass` and `two_pass_2` ragged left-padded decode SDPA kernels with hardcoded `threadgroup=(1024, 1, 1)`. On some GPUs (M1 Max confirmed, also M2 Ultra per #2049), the two-pass-2 pipeline compiles with `maxTotalThreadsPerThreadgroup=896` due to register pressure at `D_SIZE=256`.

`MTLDevice.maxThreadsPerThreadgroup` reports `1024` (hardware cap), but `MTLComputePipelineState.maxTotalThreadsPerThreadgroup` is per-kernel and authoritative — it can be lower depending on register/threadgroup memory usage of the compiled kernel.

## Fix

New patch `omlx/patches/qwen35_ragged_decode.py` monkey-patches `_qwen3_5_ragged_decode_attention`:

1. On first call for each unique kernel signature (mode, blocks, dtype, D_SIZE, V_SIZE, heads), probes the real launch with an eager `mx.eval`.
2. If the launch raises the threadgroup limit error, caches `False` for that signature and returns `None`.
3. Returning `None` routes the caller (`_target_verify_left_padded_attention`, line 1322) to the existing row-grouped reference fallback — no new math, same numerics.
4. Supported signatures cache `True` after the first probe; hot path is a single dict lookup thereafter.

Wire-up follows the same pattern as `sdpa256_attention` and `qwen35_fa256_attention`: installed in `BatchedEngine` and `VLMBatchedEngine` after the other Qwen prefill patches, gated by `model_settings.qwen35_ragged_decode_fallback_enabled` (default `True`).

## Tests

`tests/test_qwen35_ragged_decode.py` (9 tests, no model needed):
- Fallback on 896 threadgroup error → returns `None`, caches `False`, original called once only
- Passthrough when supported → returns output, caches `True`
- Cache hit on second call (probe runs once per signature)
- Non-threadgroup errors propagate unchanged
- Install idempotent (`apply_...()` returns `True` first time, `False` on repeat)
- Import error returns `False` without patching

```
pytest tests/test_qwen35_ragged_decode.py -q
9 passed in 8.52s
```