### PR TITLE
fix(mtp): unblock MTP under continuous batching — singleton recovery + opt-in row-wise batch path (#2150)

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -71,6 +71,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 from collections import deque
 from dataclasses import dataclass, field
 from types import SimpleNamespace
@@ -135,6 +136,7 @@ def apply() -> bool:
             realign_rows = getattr(self, "_omlx_realign_rows", None)
             if callable(realign_rows):
                 realign_rows()
+            _maybe_clear_multirow_marker(self)
 
             if _is_mtp_batch_eligible(self):
                 try:
@@ -159,6 +161,7 @@ def apply() -> bool:
                     _drop_mtp_state(self, "step-fallback")
             else:
                 _drop_mtp_state(self, "non-singleton-or-ineligible")
+            _log_multirow_mtp_inactive_once(self)
             _mark_standard_multirow_decode(self)
             return original_next(self, *args, **kwargs)
 
@@ -317,10 +320,41 @@ def _mtp_common_eligible(gen_batch: Any) -> bool:
     return True
 
 
+_ROWWISE_BATCH_MTP_ENV = "OMLX_MTP_ROWWISE_BATCH"
+
+
+def _rowwise_batch_mtp_enabled() -> bool:
+    """Opt-in for row-wise MTP on multi-row batches (default off).
+
+    The row-wise path runs one backbone forward per row per cycle, so its
+    aggregate throughput is roughly single-stream MTP throughput regardless
+    of batch size, while standard batched decode amortizes one forward over
+    all rows. Measured on Qwen3.6-27B-oQ4e-mtp / M3 Ultra (pp1024/tg128):
+    row-wise 53.3 / 52.5 tok/s aggregate at batch 2 / 4 versus 65.2 / 86.5
+    for standard batched decode — despite 83-93% draft acceptance. It only
+    pays off when tokens-per-cycle exceeds the row count, so it stays off
+    unless explicitly requested.
+    """
+    return os.environ.get(_ROWWISE_BATCH_MTP_ENV, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
 def _allows_new_mtp_activation(gen_batch: Any, state_attr: str) -> bool:
     if getattr(gen_batch, state_attr, None) is not None:
         return True
-    if getattr(gen_batch, "_omlx_mtp_saw_standard_multirow_decode", False):
+    # The multirow-decode marker guards the singleton-init invariant only
+    # (see _mark_standard_multirow_decode). Row-wise batch activation seeds
+    # every row from a freshly extracted per-row cache, so a prior standard
+    # multi-row decode is exactly the state it expects — blocking it here
+    # would permanently lock batches out of MTP, because a batch's first
+    # decode step is always standard.
+    if state_attr == "_omlx_mtp_state" and getattr(
+        gen_batch, "_omlx_mtp_saw_standard_multirow_decode", False
+    ):
         return False
     return bool(getattr(gen_batch, "_omlx_mtp_activation_safe", True))
 
@@ -332,6 +366,10 @@ def _mark_standard_multirow_decode(gen_batch: Any) -> None:
     no longer satisfies the narrow invariant that singleton MTP initialization
     relies on. Existing row-wise MTP state may continue, but starting a fresh
     singleton MTP state after late-join/late-finish reshaping is unsafe.
+
+    The marker is not permanent: once the batch shrinks back to one row with a
+    verifiably compact cache, ``_maybe_clear_multirow_marker`` lifts it so the
+    surviving request regains MTP for the rest of its generation.
     """
     try:
         if len(getattr(gen_batch, "uids", []) or []) > 1:
@@ -340,21 +378,65 @@ def _mark_standard_multirow_decode(gen_batch: Any) -> None:
         pass
 
 
-def _batch_rows_aligned_for_mtp(gen_batch: Any) -> bool:
-    """True when all batch rows share the same target-cache decode position."""
-    prompt_cache = getattr(gen_batch, "prompt_cache", None) or []
-    for cache in prompt_cache:
-        offset = getattr(cache, "offset", None)
-        if offset is None:
+def _log_multirow_mtp_inactive_once(gen_batch: Any) -> None:
+    """Say once, at INFO, why an MTP-capable batch is decoding without MTP.
+
+    #2150 showed the silent fallback is easy to misread: the benchmark's
+    batched phases report plain continuous-batching numbers while every log
+    line about MTP inactivity hides at DEBUG. One line per batch keeps the
+    signal visible without per-step spam.
+    """
+    if getattr(gen_batch, "_omlx_mtp_inactive_logged", False):
+        return
+    uids = getattr(gen_batch, "uids", None)
+    if uids is None or len(uids) <= 1:
+        return
+    if not _mtp_common_eligible(gen_batch):
+        return
+    gen_batch._omlx_mtp_inactive_logged = True
+    if not _rowwise_batch_mtp_enabled():
+        logger.info(
+            "MTP inactive for %d-row batch: standard batched decode is faster "
+            "at this batch size (set %s=1 to force row-wise MTP)",
+            len(uids),
+            _ROWWISE_BATCH_MTP_ENV,
+        )
+    else:
+        logger.info(
+            "MTP inactive for %d-row batch: %s",
+            len(uids),
+            _ineligibility_reason(gen_batch) or "activation deferred",
+        )
+
+
+def _maybe_clear_multirow_marker(gen_batch: Any) -> None:
+    """Re-enable singleton MTP once a shrunken batch is verifiably safe again.
+
+    The multirow marker exists because a row surviving batch reshaping may sit
+    in a cache whose layout singleton MTP's raw backbone calls don't expect
+    (left padding). ``BatchKVCache.filter()`` shifts out the minimum shared
+    left padding, so a batch filtered down to one row is compact again in the
+    common case — verify that per layer instead of assuming, and only then
+    lift the marker. Without this, a request that ever shared a decode step
+    with another request is locked out of MTP for the rest of its generation
+    even once it is running alone (#2150).
+    """
+    if not getattr(gen_batch, "_omlx_mtp_saw_standard_multirow_decode", False):
+        return
+    uids = getattr(gen_batch, "uids", None)
+    if uids is None or len(uids) != 1:
+        return
+    for cache in getattr(gen_batch, "prompt_cache", None) or []:
+        left_padding = getattr(cache, "left_padding", None)
+        if left_padding is None:
             continue
         try:
-            if hasattr(offset, "tolist"):
-                values = [int(v) for v in offset.tolist()]
-                return len(set(values)) <= 1
-            return True
+            if max(int(v) for v in left_padding.tolist()) > 0:
+                return
         except Exception:
-            return False
-    return True
+            return
+    gen_batch._omlx_mtp_saw_standard_multirow_decode = False
+    logger.info("MTP singleton recovery: multirow marker cleared (compact cache)")
 
 
 def _is_mtp_eligible(gen_batch: Any) -> bool:
@@ -390,8 +472,14 @@ def _is_mtp_batch_eligible(gen_batch: Any) -> bool:
         return False
     if getattr(
         gen_batch, "_omlx_mtp_batch_state", None
-    ) is None and not _batch_rows_aligned_for_mtp(gen_batch):
+    ) is None and not _rowwise_batch_mtp_enabled():
         return False
+    # No cache-position alignment requirement: activation seeds each row from
+    # its own extract_cache(idx) view and steady-state row cycles diverge the
+    # per-row offsets immediately anyway (accept counts differ per row), so
+    # the merge path already handles ragged rows. Under continuous batching
+    # rows join at different times, so requiring aligned offsets at
+    # activation kept this path from ever engaging (#2150).
     return True
 
 
@@ -419,8 +507,15 @@ def _ineligibility_reason(gen_batch: Any) -> str:
     if uids is None:
         return "GenerationBatch has no uids"
     if len(uids) != 1:
-        if not _batch_rows_aligned_for_mtp(gen_batch):
-            return "row-wise MTP requires aligned target-cache positions"
+        if not _allows_new_mtp_activation(gen_batch, "_omlx_mtp_batch_state"):
+            return "pending prompt work may still merge into this batch"
+        if getattr(
+            gen_batch, "_omlx_mtp_batch_state", None
+        ) is None and not _rowwise_batch_mtp_enabled():
+            return (
+                f"row-wise batch MTP is opt-in ({_ROWWISE_BATCH_MTP_ENV}=1); "
+                "standard batched decode is faster at batch >= 2"
+            )
         return ""
     if not _allows_new_mtp_activation(gen_batch, "_omlx_mtp_state"):
         return "pending prompt work may still merge into this singleton batch"

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -989,9 +989,11 @@ class TestBatchGeneratorDispatch:
 
         assert batch_generator._generation_batch_has_active_mtp(_EmptyBatch()) is False
 
-    def test_rowwise_batch_eligibility_requires_safe_activation(self):
+    def test_rowwise_batch_eligibility_requires_safe_activation(self, monkeypatch):
         from omlx.patches.mlx_lm_mtp import is_mtp_active, set_mtp_active
         from omlx.patches.mlx_lm_mtp import batch_generator
+
+        monkeypatch.setenv(batch_generator._ROWWISE_BATCH_MTP_ENV, "1")
 
         class _MtpModel:
             def __init__(self):
@@ -1023,9 +1025,51 @@ class TestBatchGeneratorDispatch:
         finally:
             set_mtp_active(prior_active)
 
-    def test_rowwise_batch_new_activation_requires_aligned_offsets(self):
+    def test_rowwise_batch_new_activation_is_opt_in(self, monkeypatch):
+        # Default (env unset): no NEW row-wise activation — standard batched
+        # decode measured faster at batch >= 2. Existing batch state still
+        # continues so a mid-flight batch is not torn down by a config flip.
         from omlx.patches.mlx_lm_mtp import is_mtp_active, set_mtp_active
         from omlx.patches.mlx_lm_mtp import batch_generator
+
+        monkeypatch.delenv(batch_generator._ROWWISE_BATCH_MTP_ENV, raising=False)
+
+        class _MtpModel:
+            def __init__(self):
+                self.mtp = object()
+                self._omlx_mtp_decode_enabled = True
+
+            def mtp_forward(self, *_):
+                pass
+
+        prior_active = is_mtp_active()
+        try:
+            set_mtp_active(True)
+            batch = SimpleNamespace(
+                model=_MtpModel(),
+                uids=[1, 2],
+                logits_processors=[],
+                _omlx_mtp_activation_safe=True,
+                prompt_cache=[],
+            )
+            assert batch_generator._is_mtp_batch_eligible(batch) is False
+
+            batch._omlx_mtp_batch_state = batch_generator._MtpBatchState(
+                states={1: batch_generator._MtpState(uid=1)}
+            )
+            assert batch_generator._is_mtp_batch_eligible(batch) is True
+        finally:
+            set_mtp_active(prior_active)
+
+    def test_rowwise_batch_new_activation_allows_ragged_offsets(self, monkeypatch):
+        # Continuous batching admits rows at different times, so per-row
+        # cache offsets rarely align. Activation must not require alignment:
+        # each row is seeded from its own extract_cache view and steady-state
+        # row cycles diverge the offsets anyway (#2150).
+        from omlx.patches.mlx_lm_mtp import is_mtp_active, set_mtp_active
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        monkeypatch.setenv(batch_generator._ROWWISE_BATCH_MTP_ENV, "1")
 
         class _Offset:
             def __init__(self, values):
@@ -1052,12 +1096,92 @@ class TestBatchGeneratorDispatch:
                 _omlx_mtp_activation_safe=True,
                 prompt_cache=[SimpleNamespace(offset=_Offset([8, 5]))],
             )
-            assert batch_generator._is_mtp_batch_eligible(batch) is False
-
-            batch.prompt_cache = [SimpleNamespace(offset=_Offset([8, 8]))]
             assert batch_generator._is_mtp_batch_eligible(batch) is True
         finally:
             set_mtp_active(prior_active)
+
+    def test_rowwise_batch_activation_allowed_after_standard_multirow_decode(
+        self, monkeypatch
+    ):
+        # The multirow-decode marker protects singleton re-initialization
+        # only. A batch's first decode step is always standard (MTP has not
+        # activated yet), so blocking batch activation on the marker would
+        # permanently lock every batch out of row-wise MTP (#2150).
+        from omlx.patches.mlx_lm_mtp import is_mtp_active, set_mtp_active
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        monkeypatch.setenv(batch_generator._ROWWISE_BATCH_MTP_ENV, "1")
+
+        class _MtpModel:
+            def __init__(self):
+                self.mtp = object()
+                self._omlx_mtp_decode_enabled = True
+
+            def mtp_forward(self, *_):
+                pass
+
+        prior_active = is_mtp_active()
+        try:
+            set_mtp_active(True)
+            batch = SimpleNamespace(
+                model=_MtpModel(),
+                uids=[1, 2],
+                logits_processors=[],
+                _omlx_mtp_activation_safe=True,
+                _omlx_mtp_saw_standard_multirow_decode=True,
+                prompt_cache=[],
+            )
+            assert batch_generator._is_mtp_batch_eligible(batch) is True
+
+            singleton = SimpleNamespace(
+                model=_MtpModel(),
+                uids=[1],
+                logits_processors=[],
+                _omlx_mtp_activation_safe=True,
+                _omlx_mtp_saw_standard_multirow_decode=True,
+            )
+            assert batch_generator._is_mtp_eligible(singleton) is False
+        finally:
+            set_mtp_active(prior_active)
+
+    def test_singleton_recovery_clears_marker_when_cache_compact(self):
+        # A batch that shrinks back to one row with no residual left padding
+        # satisfies the singleton-init invariant again, so the multirow
+        # marker must lift and the surviving request regains MTP (#2150).
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        class _Padding:
+            def __init__(self, values):
+                self._values = values
+
+            def tolist(self):
+                return list(self._values)
+
+        batch = SimpleNamespace(
+            uids=[1],
+            _omlx_mtp_saw_standard_multirow_decode=True,
+            prompt_cache=[SimpleNamespace(left_padding=_Padding([0]))],
+        )
+        batch_generator._maybe_clear_multirow_marker(batch)
+        assert batch._omlx_mtp_saw_standard_multirow_decode is False
+
+        # Residual padding: the invariant does not hold — keep the marker.
+        padded = SimpleNamespace(
+            uids=[1],
+            _omlx_mtp_saw_standard_multirow_decode=True,
+            prompt_cache=[SimpleNamespace(left_padding=_Padding([3]))],
+        )
+        batch_generator._maybe_clear_multirow_marker(padded)
+        assert padded._omlx_mtp_saw_standard_multirow_decode is True
+
+        # Still multi-row: never clears.
+        multirow = SimpleNamespace(
+            uids=[1, 2],
+            _omlx_mtp_saw_standard_multirow_decode=True,
+            prompt_cache=[SimpleNamespace(left_padding=_Padding([0, 0]))],
+        )
+        batch_generator._maybe_clear_multirow_marker(multirow)
+        assert multirow._omlx_mtp_saw_standard_multirow_decode is True
 
     def test_mtp_state_valid_requires_single_matching_uid(self):
         from omlx.patches.mlx_lm_mtp.batch_generator import (


### PR DESCRIPTION
Addresses the second half of #2150 — "MTP is fully inactive during continuous batching" — and fixes a related regression the same gates cause: a request that ever shares a decode step with another request loses MTP for the rest of its generation, even once it is running alone again.

## Root cause: two gates make the row-wise batch path unreachable

**1. The alignment gate can never pass under continuous batching.** `_batch_rows_aligned_for_mtp` requires all rows to share one cache offset at activation. Rows join a batch at different times (even the built-in throughput benchmark's simultaneous 2x/4x phases prefill sequentially), so this never holds — instrumenting the benchmark showed **254/254 batched decode steps** blocked with `row-wise MTP requires aligned target-cache positions`. The requirement is also unnecessary: activation seeds each row from its own `extract_cache(idx)` view, and steady-state row cycles diverge the per-row offsets immediately anyway (accept counts differ per row), so the merge path already handles ragged rows.

**2. A chicken-and-egg deadlock on the multirow marker.** `_allows_new_mtp_activation` consults `_omlx_mtp_saw_standard_multirow_decode` for the **batch** state attr too — but a batch's first decode step is always standard (MTP hasn't activated yet), which sets the marker and locks batch activation out permanently. The marker's own docstring scopes it to *singleton* re-initialization after reshaping ("Existing row-wise MTP state may continue, but starting a fresh **singleton** MTP state ... is unsafe").

The same marker causes the hidden real-world regression: when a batch shrinks back to one row, fresh singleton activation stays blocked forever, so any overlap permanently downgrades the surviving request to standard decode.

## What this PR does

**Singleton MTP recovery after batch shrink (default on).** When a batch is back to one row and every layer cache is *verifiably* compact (`BatchKVCache.filter()` shifts out the minimum shared left padding, so filtering down to one row compacts fully — checked per layer rather than assumed), the marker is lifted and the surviving request regains MTP. Measured on M3 Ultra / Qwen3.6-27B-oQ4-mtp (3-layer MTP head, depth 3): the survivor re-activates and finishes at **77–83% draft acceptance (~63 tok/s) instead of 35.7 tok/s standard decode**.

**Row-wise batch MTP fixed, but opt-in (`OMLX_MTP_ROWWISE_BATCH=1`).** With the two gates fixed, the path activates and works correctly — `MTP row-wise batch path activated for 3 sequences`, 83–93% per-row acceptance, coherent outputs. But it should not be the default: the row-wise design runs **one backbone forward per row per cycle**, so its aggregate throughput is roughly single-stream MTP throughput regardless of batch size, while standard batched decode amortizes one forward over all rows. Built-in throughput benchmark, same model/hardware, pp1024/tg128:

| | single | batch 2 (agg) | batch 4 (agg) |
|---|---|---|---|
| standard decode (MTP off) | 35.7 tok/s | **65.2 tok/s** | **86.5 tok/s** |
| row-wise MTP forced on | **63.2 tok/s** | 53.3 tok/s | 52.5 tok/s |

So at batch ≥ 2 standard batching wins despite high acceptance; row-wise only pays off when tokens-per-cycle exceeds the row count (deep chains / very high acceptance). Hence: off by default, one env flag to experiment, and existing batch state always continues (a config flip never tears down a mid-flight batch).

**Diagnosability.** One INFO line per multi-row batch explaining why MTP is inactive (`MTP inactive for 2-row batch: standard batched decode is faster at this batch size (set OMLX_MTP_ROWWISE_BATCH=1 to force row-wise MTP)`), and `_ineligibility_reason` now covers the batch-activation gates. This directly addresses the issue's observation that the batched benchmark numbers silently exclude MTP — the fallback was previously DEBUG-only and easy to misread.

## Validation

- `tests/test_mlx_lm_mtp_patch.py`: 100 passed (updated the alignment-gate test to the new contract; added opt-in-default-off, activation-after-multirow, and recovery tests). The existing `test_singleton_activation_blocked_after_standard_multirow_decode` still passes unchanged — singleton blocking semantics are preserved until the cache is verifiably compact.
- Live server (M3 Ultra, 0.5.0-lineage): default config — 3 simultaneous requests decode as a standard batch with the INFO line, then `MTP singleton recovery: multirow marker cleared (compact cache)` fires when the short requests finish and the long one completes 522/600 tokens under MTP at 77.2% acceptance, output coherent. With `OMLX_MTP_ROWWISE_BATCH=1` — row-wise activates for 3 sequences, 92%+ acceptance, coherent outputs, no fallback errors.

One observed behavior worth noting for anyone reproducing: staggered arrivals usually don't form a batch at all while a singleton MTP stream is active (`patched_bg_next` forces `completion_batch_size = 0`), so they queue and run serially; multi-row batches mostly form from (near-)simultaneous arrivals. That interaction is untouched here but affects which of these paths a given workload hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
