### PR TITLE
fix: accept gemma4_unified in the DFlash compatibility gate (#2153)

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -57,6 +57,12 @@ def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
     Reading top-level only keeps the gate aligned with what dflash will
     actually load.
 
+    ``gemma4_unified`` (current mlx-community/lmstudio Gemma 4 exports,
+    #2153) is accepted too: mlx-lm's MODEL_REMAPPING loads those
+    checkpoints through the same ``gemma4`` module — the vision/audio
+    towers are dropped in sanitize and the text stack DFlash drives is
+    identical, which live-testing against z-lab's 12B drafter confirmed.
+
     Returns:
         (is_compatible, reason). ``reason`` is empty when compatible.
     """
@@ -72,7 +78,7 @@ def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
     model_type = str(cfg.get("model_type") or "").lower()
 
     is_qwen = "qwen" in model_type
-    is_gemma4 = model_type in ("gemma4", "gemma4_text")
+    is_gemma4 = model_type in ("gemma4", "gemma4_text", "gemma4_unified")
     is_laguna = model_type == "laguna"
     if not (is_qwen or is_gemma4 or is_laguna):
         return False, (

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -806,6 +806,27 @@ class TestDFlashCompatibility:
         assert compatible is True
         assert reason == ""
 
+    def test_gemma4_unified_top_level_is_compatible(self, tmp_path):
+        """Current mlx-community Gemma 4 exports declare gemma4_unified at the
+        top level with text_config.model_type=gemma4_unified_text (#2153).
+        mlx-lm remaps gemma4_unified onto the gemma4 module, so DFlash drives
+        the same text stack and the gate must accept it."""
+        try:
+            from omlx.engine.dflash import is_dflash_compatible
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+        (tmp_path / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "gemma4_unified",
+                    "text_config": {"model_type": "gemma4_unified_text"},
+                }
+            )
+        )
+        compatible, reason = is_dflash_compatible(tmp_path)
+        assert compatible is True
+        assert reason == ""
+
     def test_gemma4_assistant_is_incompatible(self, tmp_path):
         """MTP -assistant variants declare gemma4_assistant at the top level
         even though their text_config.model_type is gemma4_text. The toggle


### PR DESCRIPTION
## Summary

All current mlx-community and lmstudio Gemma 4 MLX exports declare `model_type: gemma4_unified`, and DFlash refuses to start on every one of them (#2153). I reproduced this on v0.5.0 (`2130f14a`) with the reporter's model and traced it. There are three separate blockers:

1. `Gemma4TargetOps.supports_model` in dflash-mlx only accepts `gemma4` and `gemma4_text`. This is the failure in the reported log: the target model loads fine, `resolve_target_ops` raises, and engine_pool falls back to the vlm engine.
2. The z-lab Gemma 4 drafters are transformers 5.x exports that nest rope settings under `rope_parameters` with no top-level `rope_theta`, which `DFlashDraftModelArgs` requires. The draft bundle fails to load even with the gate opened.
3. omlx's own `is_dflash_compatible` also rejects `gemma4_unified`. This gate only feeds the dashboard compatibility display; it never blocks the runtime.

This PR fixes number 3 and adds a test. Numbers 1 and 2 are fixed in bstnxbt/dflash-mlx#49. Once that lands, a pin bump here makes the whole path work; I can fold the bump into this PR or send it separately, whichever is easier to review.

The change is safe because mlx-lm already loads `gemma4_unified` checkpoints through its gemma4 module (`MODEL_REMAPPING`), dropping the vision and audio towers in sanitize. The text stack DFlash drives is identical to the old `gemma4` exports; only the model_type string differs. The docstring keeps the `gemma4_assistant` reasoning intact.

### Live verification (M4 Pro 64GB, `mlx-community/gemma-4-12B-it-4bit` + `z-lab/gemma4-12B-it-DFlash`)

Before, unmodified v0.5.0:

```
DFlash start failed for gemma-4-12B-it-4bit: Unsupported target architecture for DFlash target ops: model_type=gemma4_unified, model_class=Model, supported target backends: qwen_gdn, gemma4. Falling back to vlm engine.
```

After, with the dflash-mlx fixes applied:

```
DFlash generation complete: 400 tokens, 40.1 tok/s, acceptance=65.2%, cycles=139
```

No AR fallback, coherent output. Wall clock went from 31.5 to 36.6 tok/s on a 400 token code prompt at temp 0. The uplift is smaller than the published dense 27B numbers because a 12B 4-bit target is already cheap per token; acceptance matches the old-format exports.

## Test plan

- [x] `pytest tests/test_dflash_engine.py -q`: 64 passed, includes the new `test_gemma4_unified_top_level_is_compatible` (mirrors the real unified config shape, including the nested `gemma4_unified_text`).
- [x] Full suite `pytest -q`: 6424 passed, 43 skipped.
- [x] Live repro and fix verification as above.

## Related

While setting this up I hit a footgun that can bite anyone upgrading a source install: `pip install -e .` does not update a git-pinned dependency when the pin moves to a new commit but the version number stays the same. My venv held mlx-vlm `086ab9d` while pyproject pins `78b96eb`, both reporting 0.6.3, and the only symptom was a confusing MiniMax test failure (the stale commit's in-tree `minimax_m3_vl` shadows the vendored compat modules). Source installs that upgraded across recent pin moves can be running new omlx code against old dependency commits without knowing. I will open a follow-up PR that warns at startup when an installed git pin drifts from pyproject.

Refs #2153