### PR TITLE
feat: warn at startup when installed git-pinned deps drift from pyproject

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -136,6 +136,14 @@ def serve_command(args):
         logging.getLogger("httpcore").setLevel(logging.INFO)
         logging.getLogger("httpx").setLevel(logging.INFO)
 
+    # Warn when an installed git-pinned dependency drifted from pyproject.
+    # pip skips `pkg @ git+...@SHA` pins whose version number already
+    # matches, so a source install upgraded with `pip install -e .` can run
+    # new omlx code against stale dependency commits.
+    from .utils.pin_drift import log_git_pin_drift
+
+    log_git_pin_drift()
+
     # Ensure required directories exist
     settings.ensure_directories()
 

--- a/omlx/utils/pin_drift.py
+++ b/omlx/utils/pin_drift.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Detect installed git-pinned dependencies that drifted from omlx's pins.
+
+pip treats a ``pkg @ git+...@SHA`` requirement as satisfied whenever the
+installed version number matches, even when the installed commit differs.
+``pip install -e .`` after a ``git pull`` therefore keeps whatever commit
+was already present for any pin that moved without a version bump, and the
+resulting skew produces failures that look like omlx bugs (stale model
+implementations shadowing vendored compat modules, fixes that "landed" but
+never arrived). Detect confirmed drift at startup and log exactly how to
+fix it.
+
+Kept as a leaf module so the comparison logic stays unit-testable without
+the CLI surface.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Full 40-hex commit at the end of the URL (fragment stripped first). Pins
+# by branch or tag have no stable commit to compare against, so they are
+# not checked.
+_PINNED_COMMIT_RE = re.compile(r"@([0-9a-f]{40})$")
+
+
+@dataclass(frozen=True)
+class PinDrift:
+    """One git-pinned dependency whose installed commit differs from the pin."""
+
+    name: str
+    # Original requirement string, reusable verbatim as a pip argument.
+    requirement: str
+    pinned_commit: str
+    installed_commit: str
+
+
+def find_git_pin_drift(
+    requirements: Iterable[str],
+    read_direct_url: Callable[[str], str | None],
+) -> list[PinDrift]:
+    """Compare git-pinned requirements against installed direct_url.json data.
+
+    ``read_direct_url`` maps a distribution name to the text of its
+    ``direct_url.json``, or None when the package or the file is missing.
+
+    Environment markers are deliberately not evaluated: a marker only
+    decides whether pip installs the package (e.g. the audio extra). If the
+    package is present it came from some pin and is worth checking; if it
+    is absent the None lookup skips it.
+
+    Only a confirmed vcs commit mismatch is reported. Anything unverifiable
+    is skipped so index installs (no direct_url.json) and Homebrew resource
+    builds (archive_info, not vcs_info) never produce false positives.
+    """
+    from packaging.requirements import InvalidRequirement, Requirement
+
+    drift: list[PinDrift] = []
+    for raw in requirements:
+        try:
+            req = Requirement(raw)
+        except InvalidRequirement:
+            continue
+        url = req.url or ""
+        if not url.startswith("git+"):
+            continue
+        pinned_match = _PINNED_COMMIT_RE.search(url.split("#", 1)[0])
+        if pinned_match is None:
+            continue
+        pinned = pinned_match.group(1)
+
+        text = read_direct_url(req.name)
+        if text is None:
+            continue
+        try:
+            direct_url = json.loads(text)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(direct_url, dict):
+            continue
+        vcs_info = direct_url.get("vcs_info")
+        if not isinstance(vcs_info, dict):
+            continue
+        installed = str(vcs_info.get("commit_id") or "")
+        if installed and installed.lower() != pinned.lower():
+            drift.append(
+                PinDrift(
+                    name=req.name,
+                    requirement=raw,
+                    pinned_commit=pinned,
+                    installed_commit=installed,
+                )
+            )
+    return drift
+
+
+def _read_installed_direct_url(name: str) -> str | None:
+    from importlib import metadata
+
+    try:
+        dist = metadata.distribution(name)
+    except metadata.PackageNotFoundError:
+        return None
+    # read_text returns None when the file does not exist (index installs).
+    return dist.read_text("direct_url.json")
+
+
+def log_git_pin_drift(dist_name: str = "omlx") -> list[PinDrift]:
+    """Log one warning per drifted git pin.
+
+    Never raises: this is a startup diagnostic and must not take the
+    server down, whatever the metadata on this machine looks like.
+    """
+    try:
+        from importlib import metadata
+
+        requirements = metadata.requires(dist_name) or []
+        drift = find_git_pin_drift(requirements, _read_installed_direct_url)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("git pin drift check failed: %s", exc)
+        return []
+    for item in drift:
+        logger.warning(
+            "%s is installed at commit %.12s but omlx pins %.12s. pip skips "
+            "moved git pins when the version number is unchanged, so "
+            "'pip install -e .' does not correct this. Fix with: "
+            'pip install --force-reinstall --no-deps "%s"',
+            item.name,
+            item.installed_commit,
+            item.pinned_commit,
+            item.requirement,
+        )
+    return drift

--- a/tests/test_pin_drift.py
+++ b/tests/test_pin_drift.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the git pin drift startup diagnostic."""
+
+import json
+
+from omlx.utils.pin_drift import PinDrift, find_git_pin_drift, log_git_pin_drift
+
+PINNED = "78b96eb5462141447b9a6b4943ef553891da56dd"
+STALE = "086ab9d5d575fec64d8d8ad907ce000007c25c1a"
+VLM_REQ = f"mlx-vlm@ git+https://github.com/Blaizzy/mlx-vlm@{PINNED}"
+
+
+def _vcs_json(commit):
+    return json.dumps(
+        {
+            "url": "https://github.com/Blaizzy/mlx-vlm",
+            "vcs_info": {"commit_id": commit, "vcs": "git"},
+        }
+    )
+
+
+class TestFindGitPinDrift:
+    def test_matching_commit_reports_nothing(self):
+        drift = find_git_pin_drift([VLM_REQ], lambda name: _vcs_json(PINNED))
+        assert drift == []
+
+    def test_moved_pin_reports_drift(self):
+        drift = find_git_pin_drift([VLM_REQ], lambda name: _vcs_json(STALE))
+        assert drift == [
+            PinDrift(
+                name="mlx-vlm",
+                requirement=VLM_REQ,
+                pinned_commit=PINNED,
+                installed_commit=STALE,
+            )
+        ]
+
+    def test_commit_comparison_is_case_insensitive(self):
+        drift = find_git_pin_drift([VLM_REQ], lambda name: _vcs_json(PINNED.upper()))
+        assert drift == []
+
+    def test_missing_package_is_skipped(self):
+        """Extras that were never installed (e.g. the audio extra) look up
+        as None and must not warn."""
+        drift = find_git_pin_drift([VLM_REQ], lambda name: None)
+        assert drift == []
+
+    def test_index_install_without_direct_url_is_skipped(self):
+        # _read_installed_direct_url returns None for index installs; the
+        # lambda models that. Nothing to compare, nothing to report.
+        drift = find_git_pin_drift([VLM_REQ], lambda name: None)
+        assert drift == []
+
+    def test_archive_install_is_skipped(self):
+        """Homebrew builds deps from tarball resources; direct_url.json has
+        archive_info, not vcs_info. There is no commit to compare, so no
+        warning even when the tarball is something else entirely."""
+        archive = json.dumps(
+            {
+                "url": "file:///tmp/mlx-vlm-0.6.3.tar.gz",
+                "archive_info": {"hash": "sha256=abc"},
+            }
+        )
+        drift = find_git_pin_drift([VLM_REQ], lambda name: archive)
+        assert drift == []
+
+    def test_non_git_requirements_are_ignored(self):
+        reqs = ["numpy>=1.24.0,<2.4", "regex", 'mcp>=1.2; extra == "mcp"']
+        drift = find_git_pin_drift(reqs, lambda name: _vcs_json(STALE))
+        assert drift == []
+
+    def test_branch_pin_without_commit_is_ignored(self):
+        req = "mlx-vlm@ git+https://github.com/Blaizzy/mlx-vlm@main"
+        drift = find_git_pin_drift([req], lambda name: _vcs_json(STALE))
+        assert drift == []
+
+    def test_url_fragment_does_not_hide_the_commit(self):
+        req = (
+            f"mlx-vlm@ git+https://github.com/Blaizzy/mlx-vlm@{PINNED}"
+            "#egg=mlx-vlm"
+        )
+        drift = find_git_pin_drift([req], lambda name: _vcs_json(STALE))
+        assert len(drift) == 1
+
+    def test_extra_marker_pin_is_still_checked_when_installed(self):
+        """Markers are not evaluated: an installed audio-extra pin with a
+        drifted commit must warn."""
+        req = (
+            "mlx-audio[tts,stt,sts]@ git+https://github.com/Blaizzy/mlx-audio"
+            f"@{PINNED} ; extra == \"audio\""
+        )
+        drift = find_git_pin_drift([req], lambda name: _vcs_json(STALE))
+        assert len(drift) == 1
+        assert drift[0].name == "mlx-audio"
+        # The requirement string is echoed verbatim so the warning's pip
+        # command reinstalls the same extras.
+        assert drift[0].requirement == req
+
+    def test_malformed_direct_url_is_tolerated(self):
+        for bad in ["not json", "[]", json.dumps({"vcs_info": "nope"})]:
+            assert find_git_pin_drift([VLM_REQ], lambda name: bad) == []
+
+    def test_malformed_requirement_is_tolerated(self):
+        drift = find_git_pin_drift(
+            ["===not-a-requirement===", VLM_REQ],
+            lambda name: _vcs_json(STALE),
+        )
+        assert len(drift) == 1
+
+    def test_missing_commit_id_is_skipped(self):
+        text = json.dumps({"vcs_info": {"vcs": "git"}})
+        assert find_git_pin_drift([VLM_REQ], lambda name: text) == []
+
+
+class TestLogGitPinDrift:
+    def test_runs_against_real_metadata(self):
+        # Whatever this machine's venv looks like, the check must complete
+        # and return a list.
+        assert isinstance(log_git_pin_drift(), list)
+
+    def test_unknown_distribution_never_raises(self):
+        assert log_git_pin_drift("definitely-not-a-real-dist") == []
+
+    def test_drift_logs_actionable_warning(self, monkeypatch, caplog):
+        import importlib.metadata as im
+
+        from omlx.utils import pin_drift
+
+        monkeypatch.setattr(
+            pin_drift, "_read_installed_direct_url", lambda name: _vcs_json(STALE)
+        )
+        monkeypatch.setattr(im, "requires", lambda dist: [VLM_REQ])
+
+        with caplog.at_level("WARNING", logger="omlx.utils.pin_drift"):
+            drift = log_git_pin_drift()
+
+        assert len(drift) == 1
+        message = caplog.text
+        assert STALE[:12] in message
+        assert PINNED[:12] in message
+        assert f'pip install --force-reinstall --no-deps "{VLM_REQ}"' in message


### PR DESCRIPTION
## Summary

Follow-up to the note in #2175. pip treats a `pkg @ git+...@SHA` requirement as satisfied whenever the installed version number matches, even when the installed commit differs. So `pip install -e .` after a `git pull` silently keeps stale dependency commits for any pin that moved without a version bump. The failures this produces do not look like an install problem: while working on #2153 my venv held mlx-vlm `086ab9d` against the `78b96eb` pin, both self-reporting 0.6.3, and the only symptom was the stale commit's in-tree `minimax_m3_vl` shadowing the vendored compat modules. Anyone who upgrades a source install across a pin move can end up in this state and will report it as an omlx bug.

`omlx serve` now runs a drift check once at startup, right after logging is configured. For every git-pinned requirement that names a full 40-hex commit, it compares the pin against the installed package's `direct_url.json` vcs commit and logs one warning per confirmed mismatch, including the exact command that fixes it:

```
mlx-lm is installed at commit bdb77dae5389 but omlx pins ab1806e8f5d6. pip skips moved git pins when the version number is unchanged, so 'pip install -e .' does not correct this. Fix with: pip install --force-reinstall --no-deps "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@ab1806e8f5d6aa035973af194a1b9198ab4754dc"
```

That warning line is real: the first time the check ran on my machine it caught a second drift I did not know about (mlx-lm at `bdb77da` against the `ab1806e8` pin, both 0.31.3), on the same venv where I had just fixed the mlx-vlm drift by hand.

Design notes:

- Only a confirmed vcs commit mismatch warns. Index installs record no `direct_url.json` and Homebrew resource builds record `archive_info` rather than `vcs_info`; both are unverifiable and stay silent, so brew and PyPI-style installs never see a false positive.
- Environment markers are not evaluated. A marker only decides whether pip installs a package. If an extras pin (mlx-audio behind the audio extra) is installed it gets checked; if absent, the missing distribution skips it.
- Pins by branch or tag have no stable commit to compare and are ignored.
- The check never raises. Any metadata surprise degrades to a debug log; startup is unaffected.

## Test plan

- [x] `tests/test_pin_drift.py`: 16 new tests in `TestFindGitPinDrift` / `TestLogGitPinDrift` (match, drift, case-insensitive compare, index and archive installs, missing packages, branch pins, URL fragments, extras requirements, malformed requirement and JSON inputs, never-raises).
- [x] Full suite: 6439 passed, 43 skipped.
- [x] Live: a pin-clean venv starts with no warning. A faked `commit_id` in dflash-mlx's `direct_url.json` produces the warning with the correct reinstall command. The real mlx-lm drift above was caught on the first live run and the suggested command fixed it.

Refs #2175