### PR TITLE
refactor: extract SpecPrefill workflow from scheduler

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6835,174 +6835,36 @@ class Scheduler:
         if remaining is None:
             return
 
-        n_remaining = len(remaining)
         from .patches.specprefill import DEFAULT_KEEP_RATE, DEFAULT_THRESHOLD
+        from .specprefill.policy import plan_specprefill_scoring
 
-        threshold = (
-            getattr(request, "_specprefill_threshold", None) or DEFAULT_THRESHOLD
+        # Apply deterministic admission before the draft workflow.
+        plan = plan_specprefill_scoring(
+            remaining_tokens=remaining,
+            system_prompt_end=request.specprefill_system_end,
+            cached_tokens=request.cached_tokens,
+            requested_threshold=getattr(request, "_specprefill_threshold", None),
+            requested_keep_pct=getattr(request, "_specprefill_keep_pct", None),
+            default_threshold=DEFAULT_THRESHOLD,
+            default_keep_pct=DEFAULT_KEEP_RATE,
         )
-        keep_pct = getattr(request, "_specprefill_keep_pct", None) or DEFAULT_KEEP_RATE
-
-        # Threshold check on TOTAL remaining (not after system exclusion)
-        if n_remaining <= threshold:
+        if plan is None:
             return
 
-        # System prompt protection: exclude system tokens from scoring.
-        # If paged cache already covered the system prompt, remaining
-        # won't include it (effective_system = 0).
-        system_end = request.specprefill_system_end
-        effective_system = max(0, system_end - request.cached_tokens)
-        tokens_to_score = (
-            remaining[effective_system:] if effective_system > 0 else remaining
+        from .specprefill.draft import run_specprefill_draft_scoring
+
+        run_specprefill_draft_scoring(
+            request=request,
+            plan=plan,
+            draft_model=self._specprefill_draft_model,
+            draft_prefix_cache=self._draft_prefix_cache,
+            model_id=os.path.basename(self.config.model_name.rstrip("/")),
+            prefill_step_size=self.config.prefill_step_size,
+            stream=self._stream,
+            extract_cache_states=self._extract_cache_states,
+            sync_and_clear_cache=lambda: _sync_and_clear_cache(self._stream),
+            log=logger,
         )
-        n_to_score = len(tokens_to_score)
-
-        # If conversation portion is below threshold after system exclusion,
-        # skip SpecPrefill (system will be full-prefilled by normal path)
-        if n_to_score <= threshold:
-            return
-
-        tracker = get_prefill_tracker()
-        model_id = os.path.basename(self.config.model_name.rstrip("/"))
-
-        try:
-            from .patches.specprefill import score_tokens, select_chunks
-
-            # Draft prefix cache lookup
-            draft_cache = None
-            draft_cached_tokens = 0
-            if self._draft_prefix_cache is not None:
-                try:
-                    block_table, draft_remaining = self._draft_prefix_cache.fetch_cache(
-                        request.request_id, tokens_to_score
-                    )
-                    if block_table and block_table.num_tokens > 0:
-                        self._draft_prefix_cache.preload_blocks(block_table)
-                        reconstructed = self._draft_prefix_cache.reconstruct_cache(
-                            block_table
-                        )
-                        if reconstructed:
-                            draft_cache = reconstructed
-                            draft_cached_tokens = block_table.num_tokens
-                except Exception as e:
-                    logger.debug(f"SpecPrefill: draft cache fetch failed: {e}")
-
-            spec_extra = {
-                "prompt_tokens": request.num_prompt_tokens,
-                "system_tokens": request.specprefill_system_end,
-                "conversation_tokens": request.num_prompt_tokens
-                - request.specprefill_system_end,
-                "cached_tokens": request.cached_tokens,
-            }
-
-            def _score_progress(processed: int, total: int, phase: str) -> None:
-                tracker.update(
-                    request.request_id,
-                    min(processed, total - 1),
-                    total,
-                    model_id,
-                    phase=f"specprefill_{phase}",
-                    detail="scoring draft tokens",
-                    extra=spec_extra,
-                )
-
-            # Register tracker entry and stream draft scoring progress so the
-            # dashboard shows movement during long SpecPrefill scoring pauses.
-            tracker.update(
-                request.request_id,
-                0,
-                n_to_score,
-                model_id,
-                phase="specprefill_scoring",
-                detail="scoring draft tokens",
-                extra=spec_extra,
-            )
-
-            t0 = time.monotonic()
-            # Draft scoring bypasses BatchGenerator, so keep its lazy model
-            # work and evals on this engine's worker-local stream.
-            with mx.stream(self._stream):
-                importance, used_cache = score_tokens(
-                    self._specprefill_draft_model,
-                    tokens_to_score,
-                    prefill_step_size=self.config.prefill_step_size,
-                    existing_cache=draft_cache,
-                    progress_callback=_score_progress,
-                )
-            selected = select_chunks(importance, keep_pct=keep_pct)
-            t_score = time.monotonic() - t0
-
-            n_selected = selected.shape[0]
-            request.specprefill_indices = selected
-            request.specprefill_total_tokens = n_to_score
-            request.specprefill_position_offset = (
-                request.cached_tokens + effective_system
-            )
-            request._specprefill_system_tokens = effective_system
-
-            extras = []
-            if draft_cached_tokens > 0:
-                extras.append(f"draft cache hit {draft_cached_tokens}")
-            total_prompt = request.num_prompt_tokens
-            system_total = request.specprefill_system_end
-            cached = request.cached_tokens
-            extras.append(
-                f"prompt {total_prompt} = "
-                f"system {system_total} + conv {total_prompt - system_total}, "
-                f"cached {cached}"
-            )
-
-            tracker.update(
-                request.request_id,
-                n_to_score - 1,
-                n_to_score,
-                model_id,
-                phase="specprefill_selected",
-                detail="selected sparse tokens",
-                extra={
-                    **spec_extra,
-                    "scored_tokens": n_to_score,
-                    "selected_tokens": n_selected,
-                    "keep_percent": round(n_selected / n_to_score * 100),
-                },
-            )
-
-            logger.info(
-                f"SpecPrefill: scored {n_to_score} tokens in {t_score:.1f}s, "
-                f"selected {n_selected}/{n_to_score} "
-                f"(keep={n_selected/n_to_score*100:.0f}%, {', '.join(extras)})"
-            )
-
-            # Save draft cache for next turn
-            if self._draft_prefix_cache is not None and used_cache is not None:
-                try:
-                    extracted, mcc = self._extract_cache_states(used_cache)
-                    if extracted:
-                        self._draft_prefix_cache.store_cache(
-                            request.request_id,
-                            tokens_to_score,
-                            extracted,
-                            model_cache_config=mcc,
-                        )
-                except Exception as e:
-                    logger.debug(f"SpecPrefill: draft cache store failed: {e}")
-
-            # Free draft cache from memory.  Use _sync_and_clear_cache() so
-            # the engine stream is drained before Metal buffers are
-            # returned to the pool — a bare mx.clear_cache() here can race
-            # with in-flight async evals and trigger a kernel panic (#557).
-            del used_cache
-            _sync_and_clear_cache(self._stream)
-
-            # Mark scoring complete (auto-removes tracker entry).
-            tracker.update(request.request_id, n_to_score, n_to_score, model_id)
-
-        except Exception as e:
-            logger.error(
-                f"SpecPrefill scoring failed, falling back to normal path: {e}"
-            )
-            request.specprefill_indices = None
-            tracker.remove(request.request_id)
 
     def _cleanup_specprefill(self, request_id: str) -> None:
         """Clean up SpecPrefill RoPE patches when a request finishes."""
@@ -8198,31 +8060,34 @@ class Scheduler:
                 model_id = os.path.basename(self.config.model_name.rstrip("/"))
                 total_pp = 0
                 try:
-                    from .patches.specprefill import (
-                        _find_attention_layers,
-                        _get_attn_module,
-                        _OffsetAdjustedRoPE,
-                        cleanup_rope,
-                        sparse_prefill,
-                    )
-
-                    t0 = time.monotonic()
-
-                    sp_cache = make_prompt_cache(self.model)
-                    all_tokens = tokens_to_process
                     sys_count = getattr(request, "_specprefill_system_tokens", 0)
+                    all_tokens = tokens_to_process
 
-                    # Register tracker entry so the dashboard shows the PP
-                    # indicator throughout sys + sparse prefill. Denominator
-                    # mirrors the last-token removal applied below so the bar
-                    # ends cleanly at 100%.
-                    sel_list_pre = request.specprefill_indices.tolist()
-                    m_pre = len(all_tokens) - sys_count
-                    n_eff = len(sel_list_pre) - (
-                        1 if (m_pre - 1) in sel_list_pre else 0
+                    from .specprefill.planning import plan_specprefill_target
+
+                    target_plan = plan_specprefill_target(
+                        all_tokens=all_tokens,
+                        system_token_count=sys_count,
+                        selected_indices=request.specprefill_indices.tolist(),
+                        position_offset=request.specprefill_position_offset,
                     )
-                    total_pp = sys_count + n_eff
+                    m_pre = target_plan.conversation_token_count
+                    n_eff = target_plan.sparse_selected_token_count
+                    total_pp = target_plan.total_tracker_prefill_count
                     tracker.update(request.request_id, 0, total_pp, model_id)
+
+                    spec_sparse_extra = {
+                        "prompt_tokens": request.num_prompt_tokens,
+                        "system_tokens": request.specprefill_system_end,
+                        "conversation_tokens": request.num_prompt_tokens
+                        - request.specprefill_system_end,
+                        "cached_tokens": request.cached_tokens,
+                        "scored_tokens": m_pre,
+                        "selected_tokens": n_eff,
+                        "keep_percent": (
+                            round(n_eff / m_pre * 100) if m_pre > 0 else 0
+                        ),
+                    }
 
                     def _check_specprefill_abort(processed: int) -> None:
                         if request.request_id in self._pending_abort_ids:
@@ -8234,102 +8099,18 @@ class Scheduler:
                             self.waiting.appendleft(request)
                             raise _PrefillAbortedError([], processed)
 
-                    # Phase 1: system prompt full prefill (if not cached)
-                    if sys_count > 0:
-                        sys_arr = mx.array(all_tokens[:sys_count])
-                        step = self.config.prefill_step_size
-                        sys_processed = 0
-                        spec_sparse_extra = {
-                            "prompt_tokens": request.num_prompt_tokens,
-                            "system_tokens": request.specprefill_system_end,
-                            "conversation_tokens": request.num_prompt_tokens
-                            - request.specprefill_system_end,
-                            "cached_tokens": request.cached_tokens,
-                            "scored_tokens": m_pre,
-                            "selected_tokens": n_eff,
-                            "keep_percent": (
-                                round(n_eff / m_pre * 100) if m_pre > 0 else 0
-                            ),
-                        }
-                        while sys_arr.size > step:
-                            _check_specprefill_abort(sys_processed)
-                            tracker.update(
-                                request.request_id,
-                                sys_processed,
-                                total_pp,
-                                model_id,
-                                phase="specprefill_system",
-                                detail="system prompt prefill",
-                                extra=spec_sparse_extra,
-                            )
-                            with mx.stream(self._stream):
-                                self.model(sys_arr[:step][None], cache=sp_cache)
-                                mx.eval([c.state for c in sp_cache])
-                            sys_processed += step
-                            _check_specprefill_abort(sys_processed)
-                            tracker.update(
-                                request.request_id,
-                                min(sys_processed, total_pp - 1),
-                                total_pp,
-                                model_id,
-                                phase="specprefill_system",
-                                detail="system prompt prefill",
-                                extra=spec_sparse_extra,
-                            )
-                            sys_arr = sys_arr[step:]
-                            # Use _sync_and_clear_cache() instead of bare
-                            # mx.clear_cache() to flush the engine stream
-                            # before releasing Metal buffers.  A bare call here
-                            # can race with in-flight command buffers submitted
-                            # by the preceding mx.eval(), triggering the same
-                            # 'completeMemory() prepare count underflow' kernel
-                            # panic that #435 fixed elsewhere (#557).
-                            _sync_and_clear_cache(self._stream)
-                        if sys_arr.size > 0:
-                            _check_specprefill_abort(sys_processed)
-                            final_sys = int(sys_arr.size)
-                            tracker.update(
-                                request.request_id,
-                                sys_processed,
-                                total_pp,
-                                model_id,
-                                phase="specprefill_system",
-                                detail="system prompt prefill",
-                                extra=spec_sparse_extra,
-                            )
-                            with mx.stream(self._stream):
-                                self.model(sys_arr[None], cache=sp_cache)
-                                mx.eval([c.state for c in sp_cache])
-                            sys_processed += final_sys
-                            _check_specprefill_abort(sys_processed)
-                            tracker.update(
-                                request.request_id,
-                                min(sys_processed, total_pp - 1),
-                                total_pp,
-                                model_id,
-                                phase="specprefill_system",
-                                detail="system prompt prefill",
-                                extra=spec_sparse_extra,
-                            )
-                        logger.info(
-                            f"SpecPrefill: system prompt {sys_count} tokens full prefill"
+                    def _report_system_progress(processed: int, total: int) -> None:
+                        tracker.update(
+                            request.request_id,
+                            min(processed, total_pp - 1),
+                            total_pp,
+                            model_id,
+                            phase="specprefill_system",
+                            detail="system prompt prefill",
+                            extra=spec_sparse_extra,
                         )
 
-                    # Phase 2: conversation sparse prefill
-                    conv_tokens = all_tokens[sys_count:]
-                    selected = request.specprefill_indices
-                    conv_len = len(conv_tokens)
-                    pos_offset = request.specprefill_position_offset
-                    last_idx = conv_len - 1
-
-                    # Remove last token from selected set — BatchGenerator
-                    # will process it separately for generation kickoff.
-                    selected_list = selected.tolist()
-                    if last_idx in selected_list:
-                        selected_list.remove(last_idx)
-                        selected = mx.array(sorted(selected_list))
-
-                    def _sparse_progress(processed: int, total: int) -> None:
+                    def _report_sparse_progress(processed: int, total: int) -> None:
                         _check_specprefill_abort(sys_count + processed)
                         tracker.update(
                             request.request_id,
@@ -8339,12 +8120,10 @@ class Scheduler:
                             phase="specprefill_sparse",
                             detail="sparse target prefill",
                             extra={
-                                "scored_tokens": conv_len,
-                                "selected_tokens": int(selected.shape[0]),
+                                "scored_tokens": m_pre,
+                                "selected_tokens": n_eff,
                                 "keep_percent": (
-                                    round(int(selected.shape[0]) / conv_len * 100)
-                                    if conv_len > 0
-                                    else 0
+                                    round(n_eff / m_pre * 100) if m_pre > 0 else 0
                                 ),
                                 "prompt_tokens": request.num_prompt_tokens,
                                 "system_tokens": request.specprefill_system_end,
@@ -8354,66 +8133,47 @@ class Scheduler:
                             },
                         )
 
-                    # Sparse target prefill also runs its own model/eval loop.
-                    with mx.stream(self._stream):
-                        sparse_prefill(
-                            self.model,
-                            conv_tokens,
-                            selected,
-                            sp_cache,
-                            step_size=self.config.prefill_step_size,
-                            position_offset=pos_offset,
-                            progress_callback=_sparse_progress,
-                        )
-                    # sparse_prefill installs _OffsetAdjustedRoPE with
-                    # adjustment = conv_len - selected_len'. Subtract 1 to account for the
-                    # extra token BatchGenerator will process.
-                    for _, layer in _find_attention_layers(self.model):
-                        attn = _get_attn_module(layer)
-                        if (
-                            attn
-                            and hasattr(attn, "rope")
-                            and isinstance(attn.rope, _OffsetAdjustedRoPE)
-                        ):
-                            attn.rope._adjustment -= 1
+                    from .specprefill.target import run_specprefill_target_prefill
 
-                    selected_len = int(selected.shape[0])
-                    t_prefill = time.monotonic() - t0
-                    total_prompt = request.num_prompt_tokens
-                    cached = request.cached_tokens
-                    logger.info(
-                        f"SpecPrefill: sparse prefill {selected_len}/{conv_len} conv tokens in {t_prefill:.1f}s "
-                        f"(total {total_prompt}, cached {cached}, "
-                        f"system {sys_count} full, conv {conv_len} sparse)"
+                    target_result = run_specprefill_target_prefill(
+                        target_model=self.model,
+                        request=request,
+                        plan=target_plan,
+                        all_tokens=all_tokens,
+                        selected_indices=request.specprefill_indices,
+                        prefill_step_size=self.config.prefill_step_size,
+                        stream=self._stream,
+                        check_abort=_check_specprefill_abort,
+                        report_system_progress=_report_system_progress,
+                        report_sparse_progress=_report_sparse_progress,
+                        sync_and_clear_cache=lambda: _sync_and_clear_cache(self._stream),
+                        log=logger,
                     )
 
-                    # Set up request as if we had a prefix cache hit
-                    cache_to_use = sp_cache
-                    # Last token for generation kickoff
-                    tokens_to_process = all_tokens[-1:]
+                    cache_to_use = target_result.prompt_cache
+                    tokens_to_process = target_result.tokens_to_process
                     self._specprefill_active_request_id = request.request_id
 
                     # Mark spec-prefill complete (auto-removes tracker entry).
                     tracker.update(request.request_id, total_pp, total_pp, model_id)
 
                 except _PrefillAbortedError:
+                    from .patches.specprefill import cleanup_rope
+
                     cleanup_rope(self.model)
                     request.specprefill_indices = None
                     tracker.remove(request.request_id)
-                    sp_cache = None
-                    sys_arr = None
-                    conv_tokens = None
-                    selected = None
                     _sync_and_clear_cache(self._stream)
                     self._cleanup_prefill_abort_request(request)
                     continue
                 except Exception as e:
+                    from .patches.specprefill import cleanup_rope
+
                     logger.error(f"SpecPrefill sparse prefill failed: {e}")
                     cleanup_rope(self.model)
                     request.specprefill_indices = None
                     tracker.remove(request.request_id)
                     # Fall through to normal prefill
-
             # External prefill: process tokens[0:N-1] outside BatchGenerator.
             # Only the last token goes to insert() for the first decode step.
             # SpecPrefill already handled its own prefill above, so skip for those.

--- a/omlx/specprefill/__init__.py
+++ b/omlx/specprefill/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Internal SpecPrefill planning and execution workflows."""

--- a/omlx/specprefill/draft.py
+++ b/omlx/specprefill/draft.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Draft-model scoring workflow for SpecPrefill."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Sequence
+from typing import Any, Protocol
+
+import mlx.core as mx
+
+from ..prefill_progress import get_prefill_tracker
+from ..request import Request
+from .policy import SpecPrefillScoringPlan
+
+
+class DraftPrefixCache(Protocol):
+    """Draft-cache operations used by the scoring workflow."""
+
+    def fetch_cache(
+        self, request_id: str, tokens: Sequence[int]
+    ) -> tuple[Any, list[int]]: ...
+
+    def preload_blocks(self, block_table: Any) -> int: ...
+
+    def reconstruct_cache(self, block_table: Any) -> Any: ...
+
+    def store_cache(
+        self,
+        request_id: str,
+        tokens: Sequence[int],
+        cache_data: list[Any],
+        model_cache_config: Any = ...,
+    ) -> Any: ...
+
+
+ExtractCacheStates = Callable[[list[Any]], tuple[list[dict[str, Any]], Any | None]]
+SyncAndClearCache = Callable[[], None]
+
+
+def run_specprefill_draft_scoring(
+    *,
+    request: Request,
+    plan: SpecPrefillScoringPlan,
+    draft_model: Any,
+    draft_prefix_cache: DraftPrefixCache | None,
+    model_id: str,
+    prefill_step_size: int,
+    stream: Any,
+    extract_cache_states: ExtractCacheStates,
+    sync_and_clear_cache: SyncAndClearCache,
+    log: logging.Logger,
+) -> None:
+    """Score draft tokens, persist reusable cache state, and update ``request``."""
+    tokens_to_score = plan.tokens_to_score
+    n_to_score = plan.n_to_score
+    tracker = get_prefill_tracker()
+
+    try:
+        # Resolve patch helpers at call time so engine-specific patches apply.
+        from ..patches.specprefill import score_tokens, select_chunks
+
+        draft_cache = None
+        draft_cached_tokens = 0
+        if draft_prefix_cache is not None:
+            try:
+                block_table, _draft_remaining = draft_prefix_cache.fetch_cache(
+                    request.request_id, tokens_to_score
+                )
+                if block_table and block_table.num_tokens > 0:
+                    draft_prefix_cache.preload_blocks(block_table)
+                    reconstructed_cache = draft_prefix_cache.reconstruct_cache(
+                        block_table
+                    )
+                    if reconstructed_cache:
+                        draft_cache = reconstructed_cache
+                        draft_cached_tokens = block_table.num_tokens
+            except Exception as error:
+                log.debug(f"SpecPrefill: draft cache fetch failed: {error}")
+
+        tracker_extra = {
+            "prompt_tokens": request.num_prompt_tokens,
+            "system_tokens": request.specprefill_system_end,
+            "conversation_tokens": request.num_prompt_tokens
+            - request.specprefill_system_end,
+            "cached_tokens": request.cached_tokens,
+        }
+
+        def report_score_progress(
+            processed: int, total: int, phase: str
+        ) -> None:
+            tracker.update(
+                request.request_id,
+                min(processed, total - 1),
+                total,
+                model_id,
+                phase=f"specprefill_{phase}",
+                detail="scoring draft tokens",
+                extra=tracker_extra,
+            )
+
+        tracker.update(
+            request.request_id,
+            0,
+            n_to_score,
+            model_id,
+            phase="specprefill_scoring",
+            detail="scoring draft tokens",
+            extra=tracker_extra,
+        )
+        scoring_started_at = time.monotonic()
+        with mx.stream(stream):
+            importance, used_cache = score_tokens(
+                draft_model,
+                tokens_to_score,
+                prefill_step_size=prefill_step_size,
+                existing_cache=draft_cache,
+                progress_callback=report_score_progress,
+            )
+        selected_indices = select_chunks(importance, keep_pct=plan.keep_pct)
+        scoring_seconds = time.monotonic() - scoring_started_at
+
+        selected_token_count = selected_indices.shape[0]
+        request.specprefill_indices = selected_indices
+        request.specprefill_total_tokens = n_to_score
+        request.specprefill_position_offset = (
+            request.cached_tokens + plan.effective_system
+        )
+        # Scheduler-owned dynamic field.
+        request._specprefill_system_tokens = plan.effective_system  # type: ignore[attr-defined]
+
+        log_extra = []
+        if draft_cached_tokens > 0:
+            log_extra.append(f"draft cache hit {draft_cached_tokens}")
+        log_extra.append(
+            f"prompt {request.num_prompt_tokens} = system "
+            f"{request.specprefill_system_end} + conv "
+            f"{request.num_prompt_tokens - request.specprefill_system_end}, "
+            f"cached {request.cached_tokens}"
+        )
+        tracker.update(
+            request.request_id,
+            n_to_score - 1,
+            n_to_score,
+            model_id,
+            phase="specprefill_selected",
+            detail="selected sparse tokens",
+            extra={
+                **tracker_extra,
+                "scored_tokens": n_to_score,
+                "selected_tokens": selected_token_count,
+                "keep_percent": round(selected_token_count / n_to_score * 100),
+            },
+        )
+        log.info(
+            f"SpecPrefill: scored {n_to_score} tokens in {scoring_seconds:.1f}s, "
+            f"selected {selected_token_count}/{n_to_score} "
+            f"(keep={selected_token_count / n_to_score * 100:.0f}%, "
+            f"{', '.join(log_extra)})"
+        )
+
+        if draft_prefix_cache is not None and used_cache is not None:
+            try:
+                extracted_cache, model_cache_config = extract_cache_states(used_cache)
+                if extracted_cache:
+                    draft_prefix_cache.store_cache(
+                        request.request_id,
+                        tokens_to_score,
+                        extracted_cache,
+                        model_cache_config=model_cache_config,
+                    )
+            except Exception as error:
+                log.debug(f"SpecPrefill: draft cache store failed: {error}")
+
+        # Drain the stream before releasing Metal buffers to avoid #557.
+        del used_cache
+        sync_and_clear_cache()
+        tracker.update(request.request_id, n_to_score, n_to_score, model_id)
+    except Exception as error:
+        log.error(f"SpecPrefill scoring failed, falling back to normal path: {error}")
+        request.specprefill_indices = None
+        tracker.remove(request.request_id)

--- a/omlx/specprefill/planning.py
+++ b/omlx/specprefill/planning.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Target-phase planning for SpecPrefill sparse prefill."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SpecPrefillTargetPlan:
+    """Target-prefill inputs derived from selected conversation indices."""
+
+    system_token_count: int
+    conversation_tokens: Sequence[int]
+    conversation_token_count: int
+    generation_kickoff_index: int
+    remove_kickoff_index: bool
+    sparse_selected_token_count: int
+    total_tracker_prefill_count: int
+    position_offset: int
+
+
+def plan_specprefill_target(
+    *,
+    all_tokens: Sequence[int],
+    system_token_count: int,
+    selected_indices: Sequence[int],
+    position_offset: int,
+) -> SpecPrefillTargetPlan:
+    """Derive target-prefill inputs without touching MLX state."""
+    conversation_tokens = all_tokens[system_token_count:]
+    conversation_token_count = len(conversation_tokens)
+    generation_kickoff_index = conversation_token_count - 1
+
+    # BatchGenerator processes the generation-kickoff token separately.
+    remove_kickoff_index = generation_kickoff_index in selected_indices
+    sparse_selected_token_count = len(selected_indices) - int(remove_kickoff_index)
+
+    return SpecPrefillTargetPlan(
+        system_token_count=system_token_count,
+        conversation_tokens=conversation_tokens,
+        conversation_token_count=conversation_token_count,
+        generation_kickoff_index=generation_kickoff_index,
+        remove_kickoff_index=remove_kickoff_index,
+        sparse_selected_token_count=sparse_selected_token_count,
+        total_tracker_prefill_count=(
+            system_token_count + sparse_selected_token_count
+        ),
+        position_offset=position_offset,
+    )

--- a/omlx/specprefill/policy.py
+++ b/omlx/specprefill/policy.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Admission policy for SpecPrefill draft scoring."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SpecPrefillScoringPlan:
+    """Scoring inputs accepted for one request."""
+
+    tokens_to_score: Sequence[int]
+    effective_system: int
+    keep_pct: float
+    n_to_score: int
+
+
+def plan_specprefill_scoring(
+    *,
+    remaining_tokens: Sequence[int],
+    system_prompt_end: int,
+    cached_tokens: int,
+    requested_threshold: int | None,
+    requested_keep_pct: float | None,
+    default_threshold: int,
+    default_keep_pct: float,
+) -> SpecPrefillScoringPlan | None:
+    """Return scoring inputs when both admission checks accept the request."""
+    threshold = requested_threshold or default_threshold
+    keep_pct = requested_keep_pct or default_keep_pct
+
+    # First admission applies to all remaining prompt tokens.
+    if len(remaining_tokens) <= threshold:
+        return None
+
+    # Exclude only uncached system-prefix tokens before the second admission.
+    effective_system = max(0, system_prompt_end - cached_tokens)
+    tokens_to_score = (
+        remaining_tokens[effective_system:]
+        if effective_system > 0
+        else remaining_tokens
+    )
+    n_to_score = len(tokens_to_score)
+    if n_to_score <= threshold:
+        return None
+
+    return SpecPrefillScoringPlan(
+        tokens_to_score=tokens_to_score,
+        effective_system=effective_system,
+        keep_pct=keep_pct,
+        n_to_score=n_to_score,
+    )

--- a/omlx/specprefill/target.py
+++ b/omlx/specprefill/target.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Target-model prefill workflow for SpecPrefill."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+from mlx_lm.models.cache import make_prompt_cache
+
+from ..request import Request
+from .planning import SpecPrefillTargetPlan
+
+
+@dataclass(frozen=True)
+class SpecPrefillTargetPrefillResult:
+    """Target cache and generation-kickoff token returned on success."""
+
+    prompt_cache: list[Any]
+    tokens_to_process: Sequence[int]
+
+
+CheckAbort = Callable[[int], None]
+ReportProgress = Callable[[int, int], None]
+SyncAndClearCache = Callable[[], None]
+
+
+def run_specprefill_target_prefill(
+    *,
+    target_model: Any,
+    request: Request,
+    plan: SpecPrefillTargetPlan,
+    all_tokens: Sequence[int],
+    selected_indices: mx.array,
+    prefill_step_size: int,
+    stream: Any,
+    check_abort: CheckAbort,
+    report_system_progress: ReportProgress,
+    report_sparse_progress: ReportProgress,
+    sync_and_clear_cache: SyncAndClearCache,
+    log: logging.Logger,
+) -> SpecPrefillTargetPrefillResult:
+    """Prefill system and selected conversation tokens for one request."""
+    prompt_cache = None
+    sys_arr = None
+    conversation_tokens = None
+    selected = None
+    selected_indices_list = None
+
+    try:
+        from ..patches.specprefill import (
+            _find_attention_layers,
+            _get_attn_module,
+            _OffsetAdjustedRoPE,
+            sparse_prefill,
+        )
+
+        system_token_count = plan.system_token_count
+        conversation_tokens = plan.conversation_tokens
+        conversation_token_count = plan.conversation_token_count
+        generation_kickoff_index = plan.generation_kickoff_index
+        prefill_started_at = time.monotonic()
+        prompt_cache = make_prompt_cache(target_model)
+
+        if system_token_count > 0:
+            sys_arr = mx.array(all_tokens[:system_token_count])
+            system_processed = 0
+            while sys_arr.size > prefill_step_size:
+                check_abort(system_processed)
+                report_system_progress(system_processed, system_token_count)
+                with mx.stream(stream):
+                    target_model(sys_arr[:prefill_step_size][None], cache=prompt_cache)
+                    mx.eval([cache_layer.state for cache_layer in prompt_cache])
+                system_processed += prefill_step_size
+                check_abort(system_processed)
+                report_system_progress(system_processed, system_token_count)
+                sys_arr = sys_arr[prefill_step_size:]
+                # Drain before clear to avoid the stream/cache race in #557.
+                sync_and_clear_cache()
+            if sys_arr.size > 0:
+                check_abort(system_processed)
+                final_system_token_count = int(sys_arr.size)
+                report_system_progress(system_processed, system_token_count)
+                with mx.stream(stream):
+                    target_model(sys_arr[None], cache=prompt_cache)
+                    mx.eval([cache_layer.state for cache_layer in prompt_cache])
+                system_processed += final_system_token_count
+                check_abort(system_processed)
+                report_system_progress(system_processed, system_token_count)
+            log.info(
+                f"SpecPrefill: system prompt {system_token_count} tokens full prefill"
+            )
+
+        selected = selected_indices
+        # BatchGenerator processes the generation-kickoff token separately.
+        if plan.remove_kickoff_index:
+            selected_indices_list = selected.tolist()
+            selected_indices_list.remove(generation_kickoff_index)
+            selected = mx.array(sorted(selected_indices_list))
+
+        with mx.stream(stream):
+            sparse_prefill(
+                target_model,
+                conversation_tokens,
+                selected,
+                prompt_cache,
+                step_size=prefill_step_size,
+                position_offset=plan.position_offset,
+                progress_callback=report_sparse_progress,
+            )
+
+        # sparse_prefill computes adjustment for selected conversation tokens.
+        # Decrement to reserve BatchGenerator's separately processed kickoff position.
+        for _, layer in _find_attention_layers(target_model):
+            attention_module = _get_attn_module(layer)
+            if (
+                attention_module
+                and hasattr(attention_module, "rope")
+                and isinstance(attention_module.rope, _OffsetAdjustedRoPE)
+            ):
+                attention_module.rope._adjustment -= 1
+
+        selected_token_count = int(selected.shape[0])
+        prefill_seconds = time.monotonic() - prefill_started_at
+        log.info(
+            f"SpecPrefill: sparse prefill {selected_token_count}/"
+            f"{conversation_token_count} conv tokens in {prefill_seconds:.1f}s "
+            f"(total {request.num_prompt_tokens}, cached {request.cached_tokens}, "
+            f"system {system_token_count} full, conv {conversation_token_count} sparse)"
+        )
+        return SpecPrefillTargetPrefillResult(
+            prompt_cache=prompt_cache,
+            tokens_to_process=all_tokens[-1:],
+        )
+    except Exception:
+        prompt_cache = None
+        sys_arr = None
+        conversation_tokens = None
+        selected_indices = None
+        selected_indices_list = None
+        selected = None
+        raise

--- a/tests/test_specprefill_draft.py
+++ b/tests/test_specprefill_draft.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the SpecPrefill draft-scoring workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import mlx.core as mx
+
+import omlx.specprefill.draft as draft_workflow
+from omlx.request import Request, SamplingParams
+from omlx.specprefill.policy import plan_specprefill_scoring
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.debug_messages: list[str] = []
+        self.info_messages: list[str] = []
+        self.error_messages: list[str] = []
+
+    def debug(self, message: str, *args: Any, **kwargs: Any) -> None:
+        self.debug_messages.append(message)
+
+    def info(self, message: str, *args: Any, **kwargs: Any) -> None:
+        self.info_messages.append(message)
+
+    def error(self, message: str, *args: Any, **kwargs: Any) -> None:
+        self.error_messages.append(message)
+
+
+class _Tracker:
+    def __init__(self) -> None:
+        self.updates: list[dict[str, Any]] = []
+        self.removed: list[str] = []
+
+    def update(
+        self,
+        request_id: str,
+        processed: int,
+        total: int,
+        model_id: str,
+        phase: str = "prefill",
+        detail: str | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        self.updates.append(
+            {
+                "request_id": request_id,
+                "processed": processed,
+                "total": total,
+                "model_id": model_id,
+                "phase": phase,
+                "detail": detail,
+                "extra": extra,
+            }
+        )
+
+    def remove(self, request_id: str) -> None:
+        self.removed.append(request_id)
+
+
+class _DraftCache:
+    def __init__(
+        self,
+        block_table: Any = None,
+        reconstructed_cache: Any = None,
+        fetch_error: Exception | None = None,
+    ) -> None:
+        self.block_table = block_table
+        self.reconstructed_cache = reconstructed_cache
+        self.fetch_error = fetch_error
+        self.fetches: list[tuple[str, list[int]]] = []
+        self.preloads: list[Any] = []
+        self.reconstructions: list[Any] = []
+        self.stores: list[tuple[str, list[int], list[Any], Any]] = []
+
+    def fetch_cache(self, request_id: str, tokens: list[int]) -> tuple[Any, list[int]]:
+        self.fetches.append((request_id, list(tokens)))
+        if self.fetch_error is not None:
+            raise self.fetch_error
+        return self.block_table, []
+
+    def preload_blocks(self, block_table: Any) -> int:
+        self.preloads.append(block_table)
+        return block_table.num_tokens
+
+    def reconstruct_cache(self, block_table: Any) -> Any:
+        self.reconstructions.append(block_table)
+        return self.reconstructed_cache
+
+    def store_cache(
+        self,
+        request_id: str,
+        tokens: list[int],
+        cache_data: list[Any],
+        model_cache_config: Any = None,
+    ) -> None:
+        self.stores.append(
+            (request_id, list(tokens), cache_data, model_cache_config)
+        )
+
+
+def _request_and_plan() -> tuple[Request, Any]:
+    request = Request(
+        request_id="request-1",
+        prompt=list(range(20)),
+        sampling_params=SamplingParams(),
+    )
+    request.prompt_token_ids = list(range(20))
+    request.num_prompt_tokens = 20
+    request.remaining_tokens = request.prompt_token_ids
+    request.specprefill_system_end = 4
+    request.cached_tokens = 0
+    plan = plan_specprefill_scoring(
+        remaining_tokens=request.remaining_tokens,
+        system_prompt_end=request.specprefill_system_end,
+        cached_tokens=request.cached_tokens,
+        requested_threshold=None,
+        requested_keep_pct=None,
+        default_threshold=8,
+        default_keep_pct=0.2,
+    )
+    assert plan is not None
+    return request, plan
+
+
+def _run(
+    request: Request,
+    plan: Any,
+    *,
+    draft_cache: _DraftCache | None = None,
+    score_tokens: Callable[..., Any] | None = None,
+    extract_cache_states: Callable[[list[Any]], tuple[list[dict[str, Any]], Any]] | None = None,
+) -> tuple[_Tracker, _Logger, dict[str, Any]]:
+    tracker = _Tracker()
+    logger = _Logger()
+    selected_indices = mx.arange(3)
+    stream = object()
+    trace: dict[str, Any] = {"streams": [], "syncs": [], "score_calls": []}
+
+    def default_score_tokens(
+        model: Any, tokens: list[int], **kwargs: Any
+    ) -> tuple[Any, list[str]]:
+        trace["score_calls"].append(kwargs)
+        return mx.zeros(plan.n_to_score), ["draft-cache"]
+
+    def select_chunks(importance: Any, keep_pct: float) -> Any:
+        return selected_indices
+
+    def use_stream(selected_stream: Any):
+        trace["streams"].append(selected_stream)
+        return nullcontext()
+
+    with (
+        patch.object(draft_workflow, "get_prefill_tracker", return_value=tracker),
+        patch(
+            "omlx.patches.specprefill.score_tokens",
+            side_effect=score_tokens or default_score_tokens,
+        ),
+        patch("omlx.patches.specprefill.select_chunks", side_effect=select_chunks),
+        patch.object(draft_workflow.mx, "stream", side_effect=use_stream),
+    ):
+        draft_workflow.run_specprefill_draft_scoring(
+            request=request,
+            plan=plan,
+            draft_model=object(),
+            draft_prefix_cache=draft_cache,
+            model_id="model-id",
+            prefill_step_size=4,
+            stream=stream,
+            extract_cache_states=extract_cache_states or (lambda cache: ([], None)),
+            sync_and_clear_cache=lambda: trace["syncs"].append(stream),
+            log=logger,
+        )
+    trace["selected_indices"] = selected_indices
+    trace["stream"] = stream
+    return tracker, logger, trace
+
+
+def test_success_updates_request_tracker_logger_and_stream():
+    request, plan = _request_and_plan()
+
+    tracker, logger, trace = _run(request, plan)
+
+    assert request.specprefill_indices is trace["selected_indices"]
+    assert request.specprefill_total_tokens == plan.n_to_score
+    assert request.specprefill_position_offset == plan.effective_system
+    assert request._specprefill_system_tokens == plan.effective_system
+    assert [update["phase"] for update in tracker.updates] == [
+        "specprefill_scoring",
+        "specprefill_selected",
+        "prefill",
+    ]
+    assert tracker.updates[-1]["processed"] == plan.n_to_score
+    assert tracker.removed == []
+    assert trace["streams"] == [trace["stream"]]
+    assert trace["syncs"] == [trace["stream"]]
+    assert logger.info_messages[0].startswith("SpecPrefill: scored")
+
+
+def test_reconstructed_cache_is_scored_and_stored():
+    request, plan = _request_and_plan()
+    block_table = SimpleNamespace(num_tokens=3)
+    reconstructed_cache = ["reconstructed"]
+    draft_cache = _DraftCache(block_table, reconstructed_cache)
+    model_cache_config = object()
+
+    def extract_cache_states(cache: list[Any]) -> tuple[list[dict[str, Any]], Any]:
+        assert cache == ["draft-cache"]
+        return [{"state": "value"}], model_cache_config
+
+    _, _, trace = _run(
+        request,
+        plan,
+        draft_cache=draft_cache,
+        extract_cache_states=extract_cache_states,
+    )
+
+    assert trace["score_calls"][0]["existing_cache"] is reconstructed_cache
+    assert draft_cache.fetches == [(request.request_id, list(plan.tokens_to_score))]
+    assert draft_cache.preloads == [block_table]
+    assert draft_cache.reconstructions == [block_table]
+    assert draft_cache.stores == [
+        (
+            request.request_id,
+            list(plan.tokens_to_score),
+            [{"state": "value"}],
+            model_cache_config,
+        )
+    ]
+
+
+def test_cache_fetch_error_falls_back_to_uncached_scoring():
+    request, plan = _request_and_plan()
+    draft_cache = _DraftCache(fetch_error=RuntimeError("disk gone"))
+
+    _, logger, trace = _run(request, plan, draft_cache=draft_cache)
+
+    assert trace["score_calls"][0]["existing_cache"] is None
+    assert any("draft cache fetch failed: disk gone" in message for message in logger.debug_messages)
+
+
+def test_scoring_error_clears_request_and_tracker():
+    request, plan = _request_and_plan()
+
+    def fail_scoring(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("boom")
+
+    tracker, logger, _ = _run(request, plan, score_tokens=fail_scoring)
+
+    assert request.specprefill_indices is None
+    assert tracker.removed == [request.request_id]
+    assert logger.error_messages == [
+        "SpecPrefill scoring failed, falling back to normal path: boom"
+    ]

--- a/tests/test_specprefill_planning.py
+++ b/tests/test_specprefill_planning.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SpecPrefill target planning."""
+
+from __future__ import annotations
+
+import pytest
+
+from omlx.specprefill.planning import plan_specprefill_target
+
+
+def _all_tokens(system_token_count: int, conversation_token_count: int) -> list[int]:
+    return list(range(system_token_count)) + list(
+        range(1_000, 1_000 + conversation_token_count)
+    )
+
+
+@pytest.mark.parametrize(
+    ("selected_indices", "expected_remove", "expected_sparse_count"),
+    [([0, 2, 7], True, 2), ([0, 2], False, 2), ([7, 1, 7, 4], True, 3)],
+)
+def test_kickoff_selection_changes_tracker_count_once(
+    selected_indices: list[int], expected_remove: bool, expected_sparse_count: int
+):
+    plan = plan_specprefill_target(
+        all_tokens=_all_tokens(system_token_count=3, conversation_token_count=8),
+        system_token_count=3,
+        selected_indices=selected_indices,
+        position_offset=3,
+    )
+
+    assert plan.remove_kickoff_index is expected_remove
+    assert plan.sparse_selected_token_count == expected_sparse_count
+    assert plan.total_tracker_prefill_count == 3 + expected_sparse_count
+
+
+@pytest.mark.parametrize("system_token_count", [0, 3])
+def test_target_plan_preserves_phase_inputs_and_position_offset(
+    system_token_count: int,
+):
+    all_tokens = _all_tokens(system_token_count, conversation_token_count=8)
+    plan = plan_specprefill_target(
+        all_tokens=all_tokens,
+        system_token_count=system_token_count,
+        selected_indices=[0, 4],
+        position_offset=17,
+    )
+
+    assert plan.system_token_count == system_token_count
+    assert list(plan.conversation_tokens) == all_tokens[system_token_count:]
+    assert plan.conversation_token_count == 8
+    assert plan.generation_kickoff_index == 7
+    assert plan.position_offset == 17

--- a/tests/test_specprefill_policy.py
+++ b/tests/test_specprefill_policy.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SpecPrefill scoring admission."""
+
+from __future__ import annotations
+
+import pytest
+
+from omlx.specprefill.policy import plan_specprefill_scoring
+
+DEFAULT_THRESHOLD = 8
+DEFAULT_KEEP_PCT = 0.20
+
+
+def _conversation_tokens(count: int) -> list[int]:
+    return list(range(1_000, 1_000 + count))
+
+
+def _plan(
+    remaining_tokens: list[int],
+    *,
+    system_prompt_end: int = 0,
+    cached_tokens: int = 0,
+    requested_threshold: int | None = None,
+    requested_keep_pct: float | None = None,
+):
+    return plan_specprefill_scoring(
+        remaining_tokens=remaining_tokens,
+        system_prompt_end=system_prompt_end,
+        cached_tokens=cached_tokens,
+        requested_threshold=requested_threshold,
+        requested_keep_pct=requested_keep_pct,
+        default_threshold=DEFAULT_THRESHOLD,
+        default_keep_pct=DEFAULT_KEEP_PCT,
+    )
+
+
+@pytest.mark.parametrize(
+    ("system_token_count", "conversation_token_count"),
+    [(0, 8), (0, 7), (3, 8), (3, 7)],
+)
+def test_two_stage_admission_rejects_threshold_boundaries(
+    system_token_count: int, conversation_token_count: int
+):
+    remaining_tokens = list(range(system_token_count)) + _conversation_tokens(
+        conversation_token_count
+    )
+
+    assert (
+        _plan(remaining_tokens, system_prompt_end=system_token_count) is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("system_prompt_end", "cached_tokens", "expected_effective_system"),
+    [(5, 0, 5), (5, 3, 2), (5, 5, 0), (5, 8, 0)],
+)
+def test_system_prefix_exclusion_preserves_the_scoring_slice(
+    system_prompt_end: int,
+    cached_tokens: int,
+    expected_effective_system: int,
+):
+    remaining_tokens = list(range(system_prompt_end)) + _conversation_tokens(10)
+
+    plan = _plan(
+        remaining_tokens,
+        system_prompt_end=system_prompt_end,
+        cached_tokens=cached_tokens,
+    )
+
+    assert plan is not None
+    assert plan.effective_system == expected_effective_system
+    assert list(plan.tokens_to_score) == remaining_tokens[expected_effective_system:]
+    assert plan.n_to_score == len(remaining_tokens) - expected_effective_system
+
+
+@pytest.mark.parametrize(
+    ("requested_threshold", "token_count", "should_admit"),
+    [(None, 8, False), (0, 8, False), (4, 5, True), (12, 10, False)],
+)
+def test_default_and_override_thresholds_control_admission(
+    requested_threshold: int | None, token_count: int, should_admit: bool
+):
+    plan = _plan(
+        _conversation_tokens(token_count),
+        requested_threshold=requested_threshold,
+    )
+
+    assert (plan is not None) is should_admit
+
+
+@pytest.mark.parametrize(
+    ("requested_keep_pct", "expected_keep_pct"),
+    [(None, DEFAULT_KEEP_PCT), (0, DEFAULT_KEEP_PCT), (0.35, 0.35)],
+)
+def test_keep_percentage_uses_default_or_override(
+    requested_keep_pct: float | None, expected_keep_pct: float
+):
+    plan = _plan(_conversation_tokens(10), requested_keep_pct=requested_keep_pct)
+
+    assert plan is not None
+    assert plan.keep_pct == expected_keep_pct

--- a/tests/test_specprefill_target.py
+++ b/tests/test_specprefill_target.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the SpecPrefill target-prefill workflow."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import mlx.core as mx
+import pytest
+
+import omlx.specprefill.target as target_workflow
+from omlx.specprefill.planning import plan_specprefill_target
+
+
+class _Logger:
+    def __init__(self) -> None:
+        self.info_messages: list[str] = []
+
+    def info(self, message: str, *args: Any, **kwargs: Any) -> None:
+        self.info_messages.append(message)
+
+
+class _AbortError(Exception):
+    pass
+
+
+class _Model:
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, Any]] = []
+
+    def __call__(self, tokens: Any, *, cache: Any) -> Any:
+        self.calls.append((tokens, cache))
+        return tokens
+
+
+class _CacheLayer:
+    def __init__(self) -> None:
+        self.state = object()
+
+
+def _all_tokens(system_token_count: int, conversation_token_count: int) -> list[int]:
+    return list(range(system_token_count)) + list(
+        range(1_000, 1_000 + conversation_token_count)
+    )
+
+
+def _run(
+    *,
+    system_token_count: int,
+    conversation_token_count: int,
+    selected_indices: list[int],
+    abort_error: _AbortError | None = None,
+    abort_at: int | None = None,
+    sparse_abort_error: _AbortError | None = None,
+) -> tuple[Any, _Logger, dict[str, Any]]:
+    all_tokens = _all_tokens(system_token_count, conversation_token_count)
+    plan = plan_specprefill_target(
+        all_tokens=all_tokens,
+        system_token_count=system_token_count,
+        selected_indices=selected_indices,
+        position_offset=system_token_count,
+    )
+    model = _Model()
+    prompt_cache = [_CacheLayer()]
+    selected_array = mx.array(selected_indices)
+    rope_type = type("Rope", (), {"_adjustment": 10})
+    rope = rope_type()
+    attention_module = SimpleNamespace(rope=rope)
+    attention_layer = SimpleNamespace(self_attn=attention_module)
+    model.layers = [attention_layer]
+    logger = _Logger()
+    stream = object()
+    trace: dict[str, Any] = {
+        "abort_points": [],
+        "evaluations": [],
+        "sparse_calls": [],
+        "sparse_progress": [],
+        "streams": [],
+        "syncs": [],
+        "system_progress": [],
+    }
+
+    def check_abort(processed: int) -> None:
+        trace["abort_points"].append(processed)
+        if abort_error is not None and processed == abort_at:
+            raise abort_error
+
+    def report_system_progress(processed: int, total: int) -> None:
+        trace["system_progress"].append((processed, total))
+
+    def report_sparse_progress(processed: int, total: int) -> None:
+        trace["sparse_progress"].append((processed, total))
+        if sparse_abort_error is not None:
+            raise sparse_abort_error
+
+    def sparse_prefill(
+        target_model: Any,
+        tokens: Any,
+        selected: Any,
+        cache: Any,
+        **kwargs: Any,
+    ) -> None:
+        trace["sparse_calls"].append(
+            {
+                "cache": cache,
+                "model": target_model,
+                "position_offset": kwargs["position_offset"],
+                "selected": selected,
+                "step_size": kwargs["step_size"],
+                "tokens": list(tokens),
+            }
+        )
+        kwargs["progress_callback"](0, len(tokens))
+
+    def use_stream(selected_stream: Any):
+        assert selected_stream is stream
+        trace["streams"].append(selected_stream)
+        return nullcontext()
+
+    with (
+        patch.object(target_workflow, "make_prompt_cache", return_value=prompt_cache),
+        patch.object(target_workflow.mx, "eval", side_effect=trace["evaluations"].append),
+        patch.object(target_workflow.mx, "stream", side_effect=use_stream),
+        patch(
+            "omlx.patches.specprefill._find_attention_layers",
+            return_value=[(0, attention_layer)],
+        ),
+        patch(
+            "omlx.patches.specprefill._get_attn_module",
+            return_value=attention_module,
+        ),
+        patch("omlx.patches.specprefill._OffsetAdjustedRoPE", rope_type),
+        patch("omlx.patches.specprefill.sparse_prefill", side_effect=sparse_prefill),
+    ):
+        result = target_workflow.run_specprefill_target_prefill(
+            target_model=model,
+            request=SimpleNamespace(
+                cached_tokens=0,
+                num_prompt_tokens=len(all_tokens),
+            ),
+            plan=plan,
+            all_tokens=all_tokens,
+            selected_indices=selected_array,
+            prefill_step_size=4,
+            stream=stream,
+            check_abort=check_abort,
+            report_system_progress=report_system_progress,
+            report_sparse_progress=report_sparse_progress,
+            sync_and_clear_cache=lambda: trace["syncs"].append(stream),
+            log=logger,
+        )
+    trace.update(
+        {
+            "all_tokens": all_tokens,
+            "model": model,
+            "prompt_cache": prompt_cache,
+            "rope": rope,
+            "selected_indices": selected_array,
+            "stream": stream,
+        }
+    )
+    return result, logger, trace
+
+
+def test_system_prefill_chunks_reports_checks_abort_and_uses_stream():
+    _, _, trace = _run(
+        system_token_count=13,
+        conversation_token_count=8,
+        selected_indices=[0, 2, 6],
+    )
+
+    assert [int(tokens.shape[1]) for tokens, _ in trace["model"].calls] == [4, 4, 4, 1]
+    assert all(cache is trace["prompt_cache"] for _, cache in trace["model"].calls)
+    assert trace["system_progress"] == [
+        (0, 13),
+        (4, 13),
+        (4, 13),
+        (8, 13),
+        (8, 13),
+        (12, 13),
+        (12, 13),
+        (13, 13),
+    ]
+    assert trace["abort_points"] == [0, 4, 4, 8, 8, 12, 12, 13]
+    assert len(trace["evaluations"]) == 4
+    assert trace["streams"] == [trace["stream"]] * 5
+    assert trace["syncs"] == [trace["stream"]] * 3
+
+
+@pytest.mark.parametrize(
+    ("selected_indices", "expected_selected", "keeps_original"),
+    [([0, 5, 10], [0, 5, 10], True), ([10, 11, 0], [0, 10], False), ([11, 1, 11, 5], [1, 5, 11], False)],
+)
+def test_sparse_prefill_preserves_sparse_inputs(
+    selected_indices: list[int], expected_selected: list[int], keeps_original: bool
+):
+    _, _, trace = _run(
+        system_token_count=5,
+        conversation_token_count=12,
+        selected_indices=selected_indices,
+    )
+
+    sparse_call = trace["sparse_calls"][0]
+    assert sparse_call["model"] is trace["model"]
+    assert sparse_call["cache"] is trace["prompt_cache"]
+    assert sparse_call["tokens"] == trace["all_tokens"][5:]
+    assert sparse_call["step_size"] == 4
+    assert sparse_call["position_offset"] == 5
+    assert sparse_call["selected"].tolist() == expected_selected
+    assert (sparse_call["selected"] is trace["selected_indices"]) is keeps_original
+
+
+def test_runtime_patch_helpers_adjust_rope_log_and_handoff_result():
+    with patch.object(target_workflow.time, "monotonic", side_effect=[10.0, 11.2]):
+        result, logger, trace = _run(
+            system_token_count=5,
+            conversation_token_count=10,
+            selected_indices=[0, 5, 9],
+        )
+
+    assert result.prompt_cache is trace["prompt_cache"]
+    assert result.tokens_to_process == trace["all_tokens"][-1:]
+    assert trace["rope"]._adjustment == 9
+    assert logger.info_messages == [
+        "SpecPrefill: system prompt 5 tokens full prefill",
+        "SpecPrefill: sparse prefill 2/10 conv tokens in 1.2s "
+        "(total 15, cached 0, system 5 full, conv 10 sparse)",
+    ]
+
+
+def test_scheduler_abort_error_propagates_unchanged():
+    abort_error = _AbortError("abort")
+
+    with pytest.raises(_AbortError) as exception_info:
+        _run(
+            system_token_count=13,
+            conversation_token_count=8,
+            selected_indices=[0, 2, 6],
+            abort_error=abort_error,
+            abort_at=4,
+        )
+
+    assert exception_info.value is abort_error
+
+
+def test_abort_releases_target_locals_before_propagating():
+    abort_error = _AbortError("abort during sparse prefill")
+
+    with pytest.raises(_AbortError) as exception_info:
+        _run(
+            system_token_count=5,
+            conversation_token_count=8,
+            selected_indices=[0, 2, 7],
+            sparse_abort_error=abort_error,
+        )
+
+    assert exception_info.value is abort_error
+    target_traceback = exception_info.tb
+    while (
+        target_traceback is not None
+        and target_traceback.tb_frame.f_code
+        is not target_workflow.run_specprefill_target_prefill.__code__
+    ):
+        target_traceback = target_traceback.tb_next
+    assert target_traceback is not None
+    target_locals = target_traceback.tb_frame.f_locals
+    assert target_locals["prompt_cache"] is None
+    assert target_locals["sys_arr"] is None
+    assert target_locals["conversation_tokens"] is None
+    assert target_locals["selected_indices"] is None
+    assert target_locals["selected_indices_list"] is None
+    assert target_locals["selected"] is None


### PR DESCRIPTION
## Summary

- extract SpecPrefill scoring admission and target-phase planning into pure modules under `omlx/specprefill/`
- extract draft scoring and target prefill execution behind explicit Scheduler-owned dependencies
- keep batching, request lifecycle, progress ownership, abort handling, cleanup, and cache submission in `Scheduler`
- add focused characterization tests for cache reuse, stream ownership, token selection, RoPE adjustment, logging, and abort cleanup

This is a behavior-preserving refactor intended to make follow-up work such as #2177 smaller and easier to review.

Closes #2185.

## Verification

- `uv run ruff check omlx/specprefill tests/test_specprefill_policy.py tests/test_specprefill_planning.py tests/test_specprefill_draft.py tests/test_specprefill_target.py`
- `uv run pytest tests/test_specprefill_policy.py tests/test_specprefill_planning.py tests/test_specprefill_draft.py tests/test_specprefill_target.py tests/test_specprefill.py tests/test_per_engine_threads.py tests/test_scheduler.py tests/test_vlm_specprefill.py -v --tb=short -x` (`253 passed`)
- default full suite: `6472 passed, 43 skipped, 67 deselected`; two unrelated GLM-MTP numerical-tolerance tests fail reproducibly in isolation
- `git diff --check`