### PR TITLE
feat: optionally accelerate ModelScope downloads with aria2

### DIFF
--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -15,7 +15,6 @@ class Omlx < Formula
   depends_on arch: :arm64
   depends_on :macos
   depends_on "python@3.11"
-  depends_on "aria2"
 
   # macOS 27 beta's `strip` corrupts dynamic offsets in Mach-O libraries
   # (llvm/llvm-project#203678). Skip Homebrew's post-install clean pass over

--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -15,6 +15,7 @@ class Omlx < Formula
   depends_on arch: :arm64
   depends_on :macos
   depends_on "python@3.11"
+  depends_on "aria2"
 
   # macOS 27 beta's `strip` corrupts dynamic offsets in Mach-O libraries
   # (llvm/llvm-project#203678). Skip Homebrew's post-install clean pass over

--- a/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
@@ -39,6 +39,19 @@ struct DownloadsScreen: View {
                 msAvailable: vm.msAvailable
             )
 
+            Aria2SettingsSection(
+                installed: vm.aria2Installed,
+                version: vm.aria2Version,
+                installing: vm.aria2Installing,
+                saving: vm.aria2Saving,
+                proxyDisabled: vm.aria2ProxyDisabled,
+                proxy: $vm.aria2Proxy,
+                connectionsPerFile: $vm.aria2ConnectionsPerFile,
+                concurrentFiles: $vm.aria2ConcurrentFiles,
+                onInstall: { vm.installAria2(client: services.client) },
+                onSave: { vm.saveAria2Settings(client: services.client) }
+            )
+
             if vm.source == .hf {
                 AddFromHFSection(
                     repoText: $vm.repoText,
@@ -128,6 +141,84 @@ struct DownloadsScreen: View {
                     vm.startDownload(repo: repo, client: services.client)
                 }
             )
+        }
+    }
+}
+
+private struct Aria2SettingsSection: View {
+    let installed: Bool
+    let version: String?
+    let installing: Bool
+    let saving: Bool
+    let proxyDisabled: Bool
+    @Binding var proxy: String
+    @Binding var connectionsPerFile: Int
+    @Binding var concurrentFiles: Int
+    let onInstall: () -> Void
+    let onSave: () -> Void
+
+    var body: some View {
+        SectionHeader("aria2")
+        ListGroup {
+            FreeRow {
+                HStack(spacing: 10) {
+                    Image(systemName: installed ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                        .foregroundStyle(installed ? .green : .orange)
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(installed ? (version ?? "aria2 ready") : "aria2 is required for model downloads")
+                            .font(.omlxText(12, weight: .medium))
+                        if !installed {
+                            Text("One-click installation uses Homebrew. Install Homebrew first if it is unavailable.")
+                                .font(.omlxText(10.5))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    Spacer()
+                    if !installed {
+                        Button(installing ? "Installing…" : "Install aria2", action: onInstall)
+                            .buttonStyle(.omlx(.primary))
+                            .disabled(installing)
+                    }
+                }
+            }
+            FreeRow {
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("aria2 HTTP proxy")
+                        .font(.omlxText(11, weight: .medium))
+                    TextField("http://127.0.0.1:7897", text: $proxy)
+                        .textFieldStyle(.roundedBorder)
+                        .disabled(proxyDisabled)
+                    Text(proxyDisabled
+                         ? "Mirror downloads force a direct connection, so the aria2 proxy is unavailable."
+                         : "Optional HTTP proxy used only by aria2; empty inherits the current oMLX environment.")
+                        .font(.omlxText(10.5))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            FreeRow {
+                Stepper(value: $connectionsPerFile, in: 1...16) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Connections per file: \(connectionsPerFile)")
+                        Text("Splits one large file into parallel ranges; higher values may speed up a single large file.")
+                            .font(.omlxText(10.5)).foregroundStyle(.secondary)
+                    }
+                }
+            }
+            FreeRow(isLast: true) {
+                HStack {
+                    Stepper(value: $concurrentFiles, in: 1...16) {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text("Concurrent files: \(concurrentFiles)")
+                            Text("Controls how many files download at once; higher values increase connections and disk pressure.")
+                                .font(.omlxText(10.5)).foregroundStyle(.secondary)
+                        }
+                    }
+                    Spacer()
+                    Button(saving ? "Saving…" : "Save", action: onSave)
+                        .buttonStyle(.omlx(.primary))
+                        .disabled(saving)
+                }
+            }
         }
     }
 }

--- a/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
@@ -39,18 +39,20 @@ struct DownloadsScreen: View {
                 msAvailable: vm.msAvailable
             )
 
-            Aria2SettingsSection(
-                installed: vm.aria2Installed,
-                version: vm.aria2Version,
-                installing: vm.aria2Installing,
-                saving: vm.aria2Saving,
-                proxyDisabled: vm.aria2ProxyDisabled,
-                proxy: $vm.aria2Proxy,
-                connectionsPerFile: $vm.aria2ConnectionsPerFile,
-                concurrentFiles: $vm.aria2ConcurrentFiles,
-                onInstall: { vm.installAria2(client: services.client) },
-                onSave: { vm.saveAria2Settings(client: services.client) }
-            )
+            if vm.source == .ms {
+                Aria2SettingsSection(
+                    installed: vm.aria2Installed,
+                    version: vm.aria2Version,
+                    installing: vm.aria2Installing,
+                    saving: vm.aria2Saving,
+                    proxyDisabled: vm.aria2ProxyDisabled,
+                    proxy: $vm.aria2Proxy,
+                    connectionsPerFile: $vm.aria2ConnectionsPerFile,
+                    concurrentFiles: $vm.aria2ConcurrentFiles,
+                    onInstall: { vm.installAria2(client: services.client) },
+                    onSave: { vm.saveAria2Settings(client: services.client) }
+                )
+            }
 
             if vm.source == .hf {
                 AddFromHFSection(
@@ -165,7 +167,7 @@ private struct Aria2SettingsSection: View {
                     Image(systemName: installed ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
                         .foregroundStyle(installed ? .green : .orange)
                     VStack(alignment: .leading, spacing: 3) {
-                        Text(installed ? (version ?? "aria2 ready") : "aria2 is required for model downloads")
+                        Text(installed ? (version ?? "aria2 ready") : "Optional ModelScope acceleration")
                             .font(.omlxText(12, weight: .medium))
                         if !installed {
                             Text("One-click installation uses Homebrew. Install Homebrew first if it is unavailable.")

--- a/apps/omlx-mac/Sources/AppView/ViewModels/DownloadsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/DownloadsScreenVM.swift
@@ -67,7 +67,7 @@ final class DownloadsScreenVM {
     var aria2ConcurrentFiles = 4
 
     var aria2ProxyDisabled: Bool {
-        source == .hf ? mirrorIsCustom : msMirrorIsCustom
+        msMirrorIsCustom
     }
 
     private(set) var msSearchResults: [MSModelInfo] = []

--- a/apps/omlx-mac/Sources/AppView/ViewModels/DownloadsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/DownloadsScreenVM.swift
@@ -56,6 +56,20 @@ final class DownloadsScreenVM {
     var msMirrorDraft: String = ""
     private(set) var msMirrorBusy: Bool = false
 
+    // MARK: - aria2
+
+    private(set) var aria2Installed = false
+    private(set) var aria2Version: String?
+    private(set) var aria2Installing = false
+    private(set) var aria2Saving = false
+    var aria2Proxy = ""
+    var aria2ConnectionsPerFile = 8
+    var aria2ConcurrentFiles = 4
+
+    var aria2ProxyDisabled: Bool {
+        source == .hf ? mirrorIsCustom : msMirrorIsCustom
+    }
+
     private(set) var msSearchResults: [MSModelInfo] = []
     private(set) var msSearchLoading: Bool = false
     var msSearchDismissed: Bool = false
@@ -145,6 +159,7 @@ final class DownloadsScreenVM {
             }
         }
         await refreshMirrors(client: client)
+        await refreshAria2(client: client)
         await refreshMsAvailability(client: client)
         await loadActiveRecommendedIfNeeded(client: client)
     }
@@ -183,8 +198,55 @@ final class DownloadsScreenVM {
             let settings = try await client.getGlobalSettings()
             self.mirrorEndpoint = settings.huggingface?.endpoint ?? ""
             self.msMirrorEndpoint = settings.modelscope?.endpoint ?? ""
+            self.aria2Proxy = settings.aria2?.proxy ?? ""
+            self.aria2ConnectionsPerFile = settings.aria2?.connectionsPerFile ?? 8
+            self.aria2ConcurrentFiles = settings.aria2?.concurrentFiles ?? 4
         } catch {
             // Non-fatal — leave mirrors as defaults.
+        }
+    }
+
+    private func refreshAria2(client: OMLXClient) async {
+        do {
+            let status = try await client.getAria2Status()
+            aria2Installed = status.installed
+            aria2Version = status.version
+        } catch {
+            aria2Installed = false
+        }
+    }
+
+    func installAria2(client: OMLXClient) {
+        Task { [weak self] in
+            guard let self else { return }
+            aria2Installing = true
+            defer { aria2Installing = false }
+            do {
+                let status = try await client.installAria2()
+                aria2Installed = status.installed
+                aria2Version = status.version
+                lastError = status.error
+            } catch {
+                lastError = error.omlxDescription
+            }
+        }
+    }
+
+    func saveAria2Settings(client: OMLXClient) {
+        Task { [weak self] in
+            guard let self else { return }
+            aria2Saving = true
+            defer { aria2Saving = false }
+            do {
+                _ = try await client.updateGlobalSettings(GlobalSettingsPatch(
+                    aria2Proxy: aria2Proxy.trimmingCharacters(in: .whitespaces),
+                    aria2ConnectionsPerFile: aria2ConnectionsPerFile,
+                    aria2ConcurrentFiles: aria2ConcurrentFiles
+                ))
+                lastError = nil
+            } catch {
+                lastError = error.omlxDescription
+            }
         }
     }
 

--- a/apps/omlx-mac/Sources/Net/DTO/GlobalSettingsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/GlobalSettingsDTO.swift
@@ -27,6 +27,7 @@ struct GlobalSettingsDTO: Codable, Equatable, Sendable {
     let sampling: SamplingDTO?
     let huggingface: HuggingFaceDTO?
     let modelscope: ModelScopeDTO?
+    let aria2: Aria2DTO?
     let network: NetworkDTO?
     let claudeCode: ClaudeCodeSettings?
     let integrations: IntegrationsSettings?
@@ -143,6 +144,12 @@ struct GlobalSettingsDTO: Codable, Equatable, Sendable {
         let endpoint: String
     }
 
+    struct Aria2DTO: Codable, Equatable, Sendable {
+        let proxy: String
+        let connectionsPerFile: Int
+        let concurrentFiles: Int
+    }
+
     /// Mirrors `omlx.settings.NetworkSettings`. All four fields are simple
     /// strings; empty string = unset. Patched via `network_*` flat keys.
     struct NetworkDTO: Codable, Equatable, Sendable {
@@ -227,6 +234,10 @@ struct GlobalSettingsPatch: Encodable, Equatable, Sendable {
     /// ModelScope mirror endpoint. Empty string = use modelscope.cn.
     /// Patched via `ms_endpoint` (encoder converts to snake_case).
     var msEndpoint: String? = nil
+
+    var aria2Proxy: String? = nil
+    var aria2ConnectionsPerFile: Int? = nil
+    var aria2ConcurrentFiles: Int? = nil
 
     /// Process-wide outbound HTTP proxy. Empty string = unset. The server
     /// applies via env vars (HTTP_PROXY / HTTPS_PROXY / NO_PROXY /

--- a/apps/omlx-mac/Sources/Net/DTO/HFTaskDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/HFTaskDTO.swift
@@ -41,6 +41,13 @@ struct StartHFDownloadResponse: Decodable, Sendable {
     let task: HFTaskDTO?
 }
 
+struct Aria2StatusDTO: Decodable, Sendable {
+    let installed: Bool
+    let path: String?
+    let version: String?
+    let error: String?
+}
+
 // GET /admin/api/hf/recommended returns two parallel lists (mirrors
 // hf_downloader.py:237-240). The dashboard JS paginates them separately;
 // the Swift screen merges them into a single deduped list ordered

--- a/apps/omlx-mac/Sources/Net/Endpoints.swift
+++ b/apps/omlx-mac/Sources/Net/Endpoints.swift
@@ -44,6 +44,8 @@ enum AdminAPI {
     static let presetsRefresh  = "\(prefix)/presets/refresh"
 
     static let hfTasks         = "\(prefix)/hf/tasks"
+    static let aria2Status     = "\(prefix)/aria2/status"
+    static let aria2Install    = "\(prefix)/aria2/install"
     static let hfDownload      = "\(prefix)/hf/download"
     static func hfCancel(_ taskId: String) -> String { "\(prefix)/hf/cancel/\(taskId)" }
     static func hfRetry(_ taskId: String) -> String  { "\(prefix)/hf/retry/\(taskId)" }

--- a/apps/omlx-mac/Sources/Net/OMLXClient.swift
+++ b/apps/omlx-mac/Sources/Net/OMLXClient.swift
@@ -198,6 +198,14 @@ final class OMLXClient: ObservableObject {
         try await get(AdminAPI.hfTasks)
     }
 
+    func getAria2Status() async throws -> Aria2StatusDTO {
+        try await get(AdminAPI.aria2Status)
+    }
+
+    func installAria2() async throws -> Aria2StatusDTO {
+        try await postEmpty(AdminAPI.aria2Install)
+    }
+
     func startHFDownload(repoId: String, hfToken: String = "") async throws -> StartHFDownloadResponse {
         try await post(AdminAPI.hfDownload, body: StartHFDownloadRequest(
             repoId: repoId, hfToken: hfToken

--- a/apps/omlx-mac/Tests/oMLXTests/DTOFixtureTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/DTOFixtureTests.swift
@@ -109,6 +109,9 @@ final class DTOFixtureTests: XCTestCase {
         XCTAssertNotNil(settings.integrations,  "integrations block missing")
         XCTAssertEqual(settings.scheduler?.embeddingBatchSize, 32)
         XCTAssertEqual(settings.huggingface?.hfCacheEnabled, true)
+        XCTAssertEqual(settings.aria2?.connectionsPerFile, 8)
+        XCTAssertEqual(settings.aria2?.concurrentFiles, 4)
+        XCTAssertEqual(settings.aria2?.proxy, "http://127.0.0.1:7897")
     }
 
     // MARK: - Models list

--- a/apps/omlx-mac/Tests/oMLXTests/Fixtures/global-settings.json
+++ b/apps/omlx-mac/Tests/oMLXTests/Fixtures/global-settings.json
@@ -52,6 +52,11 @@
     "modelscope": {
         "endpoint": ""
     },
+    "aria2": {
+        "proxy": "http://127.0.0.1:7897",
+        "connections_per_file": 8,
+        "concurrent_files": 4
+    },
     "network": {
         "http_proxy": "",
         "https_proxy": "",

--- a/omlx/admin/aria2_downloader.py
+++ b/omlx/admin/aria2_downloader.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Shared aria2 process support for Hugging Face and ModelScope downloads."""
+"""Optional aria2 process support for ModelScope downloads."""
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import shutil
 import tempfile
@@ -23,7 +24,7 @@ _PROXY_KEYS = {
 
 
 class Aria2UnavailableError(RuntimeError):
-    """Raised when a model download is requested without aria2 installed."""
+    """Raised when an aria2 runner is requested without aria2 installed."""
 
 
 class Aria2DownloadError(RuntimeError):
@@ -62,20 +63,23 @@ def find_brew() -> str | None:
     return _find_executable("brew", _BREW_PATHS)
 
 
-def configured_aria2_runner() -> Aria2Runner:
-    """Build a runner from global settings, with defaults before init."""
+def configured_aria2_runner() -> Aria2Runner | None:
+    """Build a configured runner, or return None when aria2 is unavailable."""
 
     try:
         from ..settings import get_settings
 
         settings = get_settings().aria2
     except (RuntimeError, AttributeError):
-        return Aria2Runner()
-    return Aria2Runner(
-        proxy=settings.proxy,
-        connections_per_file=settings.connections_per_file,
-        concurrent_files=settings.concurrent_files,
-    )
+        settings = None
+    try:
+        return Aria2Runner(
+            proxy=settings.proxy if settings else "",
+            connections_per_file=settings.connections_per_file if settings else 8,
+            concurrent_files=settings.concurrent_files if settings else 4,
+        )
+    except Aria2UnavailableError:
+        return None
 
 
 async def get_aria2_status() -> dict[str, object]:
@@ -117,10 +121,7 @@ class Aria2Runner:
     ):
         self.executable = executable or find_aria2c()
         if not self.executable:
-            raise Aria2UnavailableError(
-                "aria2 is required for model downloads. Install it from the "
-                "Downloads screen or run: brew install aria2"
-            )
+            raise Aria2UnavailableError("aria2 is not installed")
         self.proxy = proxy.strip()
         self.connections_per_file = max(1, min(16, int(connections_per_file)))
         self.concurrent_files = max(1, min(16, int(concurrent_files)))
@@ -218,9 +219,10 @@ class Aria2Runner:
         *,
         bypass_proxies: bool,
     ) -> None:
-        """Run one aria2 process and always remove its protected manifest."""
+        """Download into hidden staging and publish files only after success."""
 
-        manifest = self.write_manifest(files, target_dir)
+        staging_dir = target_dir / "._____temp"
+        manifest = self.write_manifest(files, staging_dir)
         command = self.build_command(manifest, bypass_proxies=bypass_proxies)
         environment = self.build_environment(os.environ, bypass_proxies=bypass_proxies)
         process: asyncio.subprocess.Process | None = None
@@ -256,6 +258,15 @@ class Aria2Runner:
             raise Aria2DownloadError(
                 message.strip() or f"aria2 exited with status {process.returncode}."
             )
+
+        for item in files:
+            relative = PurePosixPath(item.relative_path)
+            staged = staging_dir.joinpath(*relative.parts)
+            destination = target_dir.joinpath(*relative.parts)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(staged, destination)
+        with contextlib.suppress(OSError):
+            staging_dir.rmdir()
 
 
 class Aria2Installer:

--- a/omlx/admin/aria2_downloader.py
+++ b/omlx/admin/aria2_downloader.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared aria2 process support for Hugging Face and ModelScope downloads."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+_ARIA2_PATHS = ("/opt/homebrew/bin/aria2c", "/usr/local/bin/aria2c")
+_BREW_PATHS = ("/opt/homebrew/bin/brew", "/usr/local/bin/brew")
+_PROXY_KEYS = {
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "ftp_proxy",
+    "no_proxy",
+}
+
+
+class Aria2UnavailableError(RuntimeError):
+    """Raised when a model download is requested without aria2 installed."""
+
+
+class Aria2DownloadError(RuntimeError):
+    """Raised when aria2 exits unsuccessfully."""
+
+
+@dataclass(frozen=True)
+class Aria2File:
+    """One repository file ready for transfer by aria2."""
+
+    url: str
+    relative_path: str
+    size: int = 0
+    headers: tuple[str, ...] = ()
+
+
+def _find_executable(name: str, candidates: Sequence[str]) -> str | None:
+    resolved = shutil.which(name)
+    if resolved:
+        return resolved
+    for candidate in candidates:
+        if os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def find_aria2c() -> str | None:
+    """Return the aria2c executable path, including common Homebrew paths."""
+
+    return _find_executable("aria2c", _ARIA2_PATHS)
+
+
+def find_brew() -> str | None:
+    """Return the Homebrew executable path on Apple Silicon or Intel Macs."""
+
+    return _find_executable("brew", _BREW_PATHS)
+
+
+def configured_aria2_runner() -> Aria2Runner:
+    """Build a runner from global settings, with defaults before init."""
+
+    try:
+        from ..settings import get_settings
+
+        settings = get_settings().aria2
+    except (RuntimeError, AttributeError):
+        return Aria2Runner()
+    return Aria2Runner(
+        proxy=settings.proxy,
+        connections_per_file=settings.connections_per_file,
+        concurrent_files=settings.concurrent_files,
+    )
+
+
+async def get_aria2_status() -> dict[str, object]:
+    """Return executable availability and the first version line."""
+
+    executable = find_aria2c()
+    if not executable:
+        return {"installed": False, "path": None, "version": None}
+    process = await asyncio.create_subprocess_exec(
+        executable,
+        "--version",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    try:
+        output, _ = await asyncio.wait_for(process.communicate(), timeout=5)
+    except TimeoutError:
+        process.kill()
+        await process.wait()
+        return {"installed": True, "path": executable, "version": None}
+    first_line = output.decode("utf-8", errors="replace").splitlines()
+    return {
+        "installed": True,
+        "path": executable,
+        "version": first_line[0] if first_line else None,
+    }
+
+
+class Aria2Runner:
+    """Build safe aria2 manifests and commands for short-lived downloads."""
+
+    def __init__(
+        self,
+        executable: str | None = None,
+        *,
+        proxy: str = "",
+        connections_per_file: int = 8,
+        concurrent_files: int = 4,
+    ):
+        self.executable = executable or find_aria2c()
+        if not self.executable:
+            raise Aria2UnavailableError(
+                "aria2 is required for model downloads. Install it from the "
+                "Downloads screen or run: brew install aria2"
+            )
+        self.proxy = proxy.strip()
+        self.connections_per_file = max(1, min(16, int(connections_per_file)))
+        self.concurrent_files = max(1, min(16, int(concurrent_files)))
+
+    @staticmethod
+    def build_environment(
+        environ: Mapping[str, str], *, bypass_proxies: bool
+    ) -> dict[str, str]:
+        """Copy an environment, optionally removing every proxy spelling."""
+
+        if not bypass_proxies:
+            return dict(environ)
+        return {
+            key: value
+            for key, value in environ.items()
+            if key.lower() not in _PROXY_KEYS
+        }
+
+    def build_command(self, manifest: Path, *, bypass_proxies: bool) -> list[str]:
+        """Return an argv vector; secrets live in the protected manifest."""
+
+        args = [
+            self.executable,
+            f"--input-file={manifest}",
+            "--continue=true",
+            "--allow-overwrite=true",
+            "--auto-file-renaming=false",
+            "--file-allocation=none",
+            f"--max-connection-per-server={self.connections_per_file}",
+            f"--split={self.connections_per_file}",
+            f"--max-concurrent-downloads={self.concurrent_files}",
+            "--min-split-size=1M",
+            "--max-tries=5",
+            "--retry-wait=2",
+            "--connect-timeout=30",
+            "--timeout=60",
+            "--summary-interval=1",
+            "--download-result=hide",
+            "--console-log-level=warn",
+        ]
+        if bypass_proxies:
+            args.extend(
+                [
+                    "--all-proxy=",
+                    "--http-proxy=",
+                    "--https-proxy=",
+                    "--ftp-proxy=",
+                    "--no-proxy=*",
+                ]
+            )
+        elif self.proxy:
+            args.append(f"--all-proxy={self.proxy}")
+        return args
+
+    def write_manifest(self, files: Sequence[Aria2File], target_dir: Path) -> Path:
+        """Write a mode-0600 aria2 input file for repository payload files."""
+
+        target_dir.mkdir(parents=True, exist_ok=True)
+        lines: list[str] = []
+        for item in files:
+            relative = PurePosixPath(item.relative_path)
+            if relative.is_absolute() or ".." in relative.parts or not relative.name:
+                raise ValueError(
+                    f"Model file must use a safe relative path: {item.relative_path!r}"
+                )
+            destination_dir = target_dir.joinpath(*relative.parts[:-1])
+            destination_dir.mkdir(parents=True, exist_ok=True)
+            lines.append(item.url)
+            lines.append(f"  dir={destination_dir}")
+            lines.append(f"  out={relative.name}")
+            for header in item.headers:
+                if "\n" in header or "\r" in header:
+                    raise ValueError("aria2 headers must not contain newlines")
+                lines.append(f"  header={header}")
+
+        fd, raw_path = tempfile.mkstemp(
+            prefix=".omlx-aria2-", suffix=".txt", dir=target_dir
+        )
+        manifest = Path(raw_path)
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write("\n".join(lines))
+                handle.write("\n")
+        except Exception:
+            os.close(fd)
+            manifest.unlink(missing_ok=True)
+            raise
+        return manifest
+
+    async def download(
+        self,
+        files: Sequence[Aria2File],
+        target_dir: Path,
+        *,
+        bypass_proxies: bool,
+    ) -> None:
+        """Run one aria2 process and always remove its protected manifest."""
+
+        manifest = self.write_manifest(files, target_dir)
+        command = self.build_command(manifest, bypass_proxies=bypass_proxies)
+        environment = self.build_environment(os.environ, bypass_proxies=bypass_proxies)
+        process: asyncio.subprocess.Process | None = None
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                env=environment,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            output, _ = await process.communicate()
+        except asyncio.CancelledError:
+            if process and process.returncode is None:
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=3)
+                except TimeoutError:
+                    process.kill()
+                    await process.wait()
+            raise
+        finally:
+            manifest.unlink(missing_ok=True)
+
+        if process.returncode:
+            message = output.decode("utf-8", errors="replace")[-8000:]
+            for item in files:
+                for header in item.headers:
+                    message = message.replace(header, "[REDACTED]")
+                    if ":" in header:
+                        secret = header.split(":", 1)[1].strip()
+                        if secret:
+                            message = message.replace(secret, "[REDACTED]")
+            raise Aria2DownloadError(
+                message.strip() or f"aria2 exited with status {process.returncode}."
+            )
+
+
+class Aria2Installer:
+    """Install the fixed aria2 Homebrew package without shell interpolation."""
+
+    _lock = asyncio.Lock()
+
+    async def _run(self, *args: str, env: Mapping[str, str]) -> tuple[int, str]:
+        process = await asyncio.create_subprocess_exec(
+            *args,
+            env=dict(env),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        output, _ = await process.communicate()
+        text = output.decode("utf-8", errors="replace")[-8000:]
+        return process.returncode or 0, text
+
+    async def install(self) -> dict[str, object]:
+        """Install aria2 with Homebrew and return a bounded status payload."""
+
+        brew = find_brew()
+        if not brew:
+            return {
+                "installed": False,
+                "error": "Homebrew is required to install aria2 automatically.",
+            }
+
+        async with self._lock:
+            code, output = await self._run(
+                brew, "install", "aria2", env=os.environ.copy()
+            )
+        if code == 0:
+            return {"installed": True, "path": find_aria2c(), "output": output}
+        return {
+            "installed": False,
+            "error": output.strip() or f"Homebrew exited with status {code}.",
+        }

--- a/omlx/admin/ms_downloader.py
+++ b/omlx/admin/ms_downloader.py
@@ -1,20 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 """ModelScope model downloader for oMLX admin panel.
 
-Downloads models from ModelScope Hub using the modelscope SDK's snapshot_download
-with directory-size-based progress polling.
+Builds manifests with the ModelScope SDK and transfers every payload file
+through aria2 with directory-size-based progress polling.
 """
 
 import asyncio
 import logging
 import os
-import shutil
 import time
 import uuid
 from pathlib import Path
 from typing import Callable, Optional
+from urllib.parse import urlencode
 
 import requests
+
+from .aria2_downloader import Aria2File, Aria2Runner, configured_aria2_runner
 
 from .hf_downloader import (
     DownloadStatus,
@@ -28,12 +30,10 @@ logger = logging.getLogger(__name__)
 # Check if modelscope SDK is available
 MS_SDK_AVAILABLE = False
 try:
-    from modelscope import snapshot_download as ms_snapshot_download
     from modelscope.hub.api import HubApi as MSHubApi
 
     MS_SDK_AVAILABLE = True
 except ImportError:
-    ms_snapshot_download = None  # type: ignore[assignment]
     MSHubApi = None  # type: ignore[assignment, misc]
 
 # Timeout for ModelScope API calls (seconds).
@@ -87,6 +87,35 @@ def _extract_model_size_from_files(file_list: list) -> int:
         if isinstance(size, (int, float)):
             total += int(size)
     return total
+
+
+def _to_aria2_files(
+    model_id: str,
+    file_list: list[dict],
+    *,
+    endpoint: str,
+    token: str,
+) -> list[Aria2File]:
+    """Convert ModelScope file metadata to aria2 payload entries."""
+
+    headers = (f"Authorization: Bearer {token}",) if token else ()
+    files: list[Aria2File] = []
+    for entry in file_list:
+        if str(entry.get("Type", "")).lower() in {"tree", "directory", "dir"}:
+            continue
+        filename = entry.get("Name") or entry.get("Path") or ""
+        if not filename:
+            continue
+        query = urlencode({"Revision": "master", "FilePath": filename})
+        files.append(
+            Aria2File(
+                url=f"{endpoint.rstrip('/')}/api/v1/models/{model_id}/repo?{query}",
+                relative_path=filename,
+                size=int(entry.get("Size") or entry.get("size") or 0),
+                headers=headers,
+            )
+        )
+    return files
 
 
 # ---------------------------------------------------------------------------
@@ -378,8 +407,8 @@ async def _fetch_ms_models_rest(
 class MSDownloader:
     """Manages ModelScope model downloads with progress tracking.
 
-    Uses modelscope.snapshot_download() for actual downloads and polls
-    the target directory size to estimate progress.
+    Uses ModelScope for manifests, aria2 for payload transfers, and target-
+    directory polling for progress.
 
     Args:
         model_dir: Directory where downloaded models are stored.
@@ -719,6 +748,8 @@ class MSDownloader:
                 "Expected format: 'owner/model' (e.g., 'qwen/Qwen2.5-7B-Instruct-MLX')"
             )
 
+        aria2 = configured_aria2_runner()
+
         # Check for duplicate active downloads
         for task in self._tasks.values():
             if task.repo_id == model_id and task.status in (
@@ -735,7 +766,7 @@ class MSDownloader:
 
         # Start download in background
         self._active_tasks[task_id] = asyncio.create_task(
-            self._run_download(task_id, ms_token)
+            self._run_download(task_id, ms_token, aria2)
         )
 
         logger.info(f"MS Download queued: {model_id} (task_id={task_id})")
@@ -830,7 +861,7 @@ class MSDownloader:
         del self._tasks[task_id]
         self._cancelled.discard(task_id)
 
-        # Start fresh download (snapshot_download resumes from existing files)
+        # Start fresh task; aria2 resumes from existing files and .aria2 state.
         new_task = await self.start_download(model_id, ms_token)
         new_task.retry_count = old_retry_count + 1
         return new_task
@@ -861,12 +892,17 @@ class MSDownloader:
 
         logger.info("MS Downloader shut down")
 
-    async def _run_download(self, task_id: str, ms_token: str) -> None:
+    async def _run_download(
+        self,
+        task_id: str,
+        ms_token: str,
+        aria2: Aria2Runner | None = None,
+    ) -> None:
         """Execute a download task.
 
         Waits for the download semaphore (only one download runs at a time),
-        then fetches file info for total size and runs snapshot_download in a
-        thread while polling the target directory for progress updates.
+        then fetches a file manifest and runs aria2 while polling the target
+        directory for progress updates.
         """
         task = self._tasks[task_id]
 
@@ -884,70 +920,36 @@ class MSDownloader:
                 # when sharing a model directory.
                 target_dir = self._model_dir / task.repo_id
 
-                # Get total file size for progress estimation
-                try:
-                    api = _get_ms_api()
-                    if api:
-                        file_list = await asyncio.wait_for(
-                            asyncio.to_thread(api.get_model_files, task.repo_id),
-                            timeout=_MS_API_TIMEOUT,
-                        )
-                        if file_list:
-                            task.total_size = _extract_model_size_from_files(
-                                file_list
-                            )
-                except Exception as e:
-                    logger.warning(
-                        f"Could not fetch file info for {task.repo_id}: {e}. "
-                        "Progress estimation will be unavailable."
-                    )
+                api = _get_ms_api()
+                if api is None:
+                    raise RuntimeError("ModelScope SDK not available")
+                file_list = await asyncio.wait_for(
+                    asyncio.to_thread(api.get_model_files, task.repo_id),
+                    timeout=_MS_API_TIMEOUT,
+                )
+                endpoint = _get_ms_endpoint()
+                files = _to_aria2_files(
+                    task.repo_id,
+                    file_list or [],
+                    endpoint=endpoint,
+                    token=ms_token,
+                )
+                task.total_size = sum(item.size for item in files)
 
                 # Start progress polling
                 self._progress_tasks[task_id] = asyncio.create_task(
                     self._poll_progress(task_id, target_dir)
                 )
 
-                # Build download kwargs
-                dl_kwargs = {
-                    "model_id": task.repo_id,
-                    "local_dir": str(target_dir),
-                }
-                if ms_token:
-                    dl_kwargs["token"] = ms_token
-
-                # Run snapshot_download in a thread (blocking call)
-                # Note: Thread cannot be interrupted, cancellation is checked after completion
-                await asyncio.to_thread(
-                    ms_snapshot_download,
-                    **dl_kwargs,
+                await (aria2 or Aria2Runner()).download(
+                    files,
+                    target_dir,
+                    bypass_proxies=endpoint != _DEFAULT_MS_ENDPOINT,
                 )
 
-                # Check if cancelled while downloading - clean up downloaded files
+                # Check if cancelled while downloading. aria2 keeps its
+                # partial files so a retry can resume instead of starting over.
                 if task_id in self._cancelled:
-                    logger.info(
-                        f"MS Download was cancelled during execution: {task.repo_id}. "
-                        "Cleaning up downloaded files..."
-                    )
-                    if target_dir.exists():
-                        try:
-                            shutil.rmtree(target_dir)
-                            logger.info(f"Cleaned up cancelled download: {target_dir}")
-                        except Exception as cleanup_err:
-                            logger.warning(f"Failed to clean up {target_dir}: {cleanup_err}")
-                    # Drop empty org folder left behind by the cancelled download.
-                    parent = target_dir.parent
-                    if (
-                        parent != self._model_dir
-                        and parent.exists()
-                        and not any(parent.iterdir())
-                    ):
-                        try:
-                            parent.rmdir()
-                        except OSError as cleanup_err:
-                            logger.debug(
-                                f"Could not remove empty org folder {parent}: "
-                                f"{cleanup_err}"
-                            )
                     return
 
                 # Success
@@ -1029,7 +1031,7 @@ class MSDownloader:
                 task.downloaded_size = current_size
 
                 if task.total_size > 0:
-                    # Cap at 99% until snapshot_download confirms completion
+                    # Cap at 99% until aria2 confirms completion.
                     task.progress = min(
                         (current_size / task.total_size) * 100, 99.0
                     )
@@ -1057,7 +1059,7 @@ class MSDownloader:
                         f"MS Download stalled for {task.repo_id} "
                         f"(task_id={task_id})"
                     )
-                    # Cancel the snapshot_download thread
+                    # Cancelling the task terminates its aria2 child process.
                     active_task = self._active_tasks.get(task_id)
                     if active_task and not active_task.done():
                         active_task.cancel()

--- a/omlx/admin/ms_downloader.py
+++ b/omlx/admin/ms_downloader.py
@@ -1,23 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 """ModelScope model downloader for oMLX admin panel.
 
-Builds manifests with the ModelScope SDK and transfers every payload file
-through aria2 with directory-size-based progress polling.
+Uses aria2 when available and falls back to the ModelScope SDK.
 """
 
 import asyncio
 import logging
 import os
+import shutil
 import time
 import uuid
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Optional
 from urllib.parse import urlencode
 
 import requests
 
 from .aria2_downloader import Aria2File, Aria2Runner, configured_aria2_runner
-
 from .hf_downloader import (
     DownloadStatus,
     DownloadTask,
@@ -30,10 +30,12 @@ logger = logging.getLogger(__name__)
 # Check if modelscope SDK is available
 MS_SDK_AVAILABLE = False
 try:
+    from modelscope import snapshot_download as ms_snapshot_download
     from modelscope.hub.api import HubApi as MSHubApi
 
     MS_SDK_AVAILABLE = True
 except ImportError:
+    ms_snapshot_download = None  # type: ignore[assignment]
     MSHubApi = None  # type: ignore[assignment, misc]
 
 # Timeout for ModelScope API calls (seconds).
@@ -106,7 +108,8 @@ def _to_aria2_files(
         filename = entry.get("Name") or entry.get("Path") or ""
         if not filename:
             continue
-        query = urlencode({"Revision": "master", "FilePath": filename})
+        revision = entry.get("Revision") or entry.get("revision") or "master"
+        query = urlencode({"Revision": revision, "FilePath": filename})
         files.append(
             Aria2File(
                 url=f"{endpoint.rstrip('/')}/api/v1/models/{model_id}/repo?{query}",
@@ -116,6 +119,29 @@ def _to_aria2_files(
             )
         )
     return files
+
+
+def _fetch_ms_file_manifest(
+    model_id: str,
+    *,
+    endpoint: str,
+    token: str,
+) -> list[dict]:
+    """Fetch file metadata including immutable per-file revisions."""
+
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    response = requests.get(
+        f"{endpoint.rstrip('/')}/api/v1/models/{model_id}/repo/files",
+        params={"Revision": "master", "Recursive": "True"},
+        headers=headers,
+        timeout=_MS_API_TIMEOUT,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    data = payload.get("Data", payload) if isinstance(payload, dict) else payload
+    if isinstance(data, dict):
+        return data.get("Files") or data.get("files") or []
+    return data if isinstance(data, list) else []
 
 
 # ---------------------------------------------------------------------------
@@ -350,7 +376,7 @@ def _parse_ms_model_entry(entry: dict) -> dict:
         model_id = name
     else:
         model_id = path
-    
+
     downloads = entry.get("Downloads") or 0
     likes = entry.get("Likes") or entry.get("Stars") or 0
     # StorageSize is the total size in bytes
@@ -407,8 +433,8 @@ async def _fetch_ms_models_rest(
 class MSDownloader:
     """Manages ModelScope model downloads with progress tracking.
 
-    Uses ModelScope for manifests, aria2 for payload transfers, and target-
-    directory polling for progress.
+    Uses aria2 for payload transfers when installed, otherwise ModelScope's
+    native downloader, with target-directory polling for progress.
 
     Args:
         model_dir: Directory where downloaded models are stored.
@@ -861,7 +887,7 @@ class MSDownloader:
         del self._tasks[task_id]
         self._cancelled.discard(task_id)
 
-        # Start fresh task; aria2 resumes from existing files and .aria2 state.
+        # Start a fresh task; either backend handles its own resume behavior.
         new_task = await self.start_download(model_id, ms_token)
         new_task.retry_count = old_retry_count + 1
         return new_task
@@ -901,8 +927,8 @@ class MSDownloader:
         """Execute a download task.
 
         Waits for the download semaphore (only one download runs at a time),
-        then fetches a file manifest and runs aria2 while polling the target
-        directory for progress updates.
+        then uses aria2 when available or the ModelScope SDK otherwise while
+        polling the target directory for progress updates.
         """
         task = self._tasks[task_id]
 
@@ -920,36 +946,72 @@ class MSDownloader:
                 # when sharing a model directory.
                 target_dir = self._model_dir / task.repo_id
 
-                api = _get_ms_api()
-                if api is None:
-                    raise RuntimeError("ModelScope SDK not available")
-                file_list = await asyncio.wait_for(
-                    asyncio.to_thread(api.get_model_files, task.repo_id),
-                    timeout=_MS_API_TIMEOUT,
-                )
                 endpoint = _get_ms_endpoint()
-                files = _to_aria2_files(
-                    task.repo_id,
-                    file_list or [],
-                    endpoint=endpoint,
-                    token=ms_token,
-                )
-                task.total_size = sum(item.size for item in files)
+                files: list[Aria2File] = []
+                if aria2:
+                    file_list = await asyncio.wait_for(
+                        asyncio.to_thread(
+                            _fetch_ms_file_manifest,
+                            task.repo_id,
+                            endpoint=endpoint,
+                            token=ms_token,
+                        ),
+                        timeout=_MS_API_TIMEOUT,
+                    )
+                    files = _to_aria2_files(
+                        task.repo_id,
+                        file_list,
+                        endpoint=endpoint,
+                        token=ms_token,
+                    )
+                    task.total_size = sum(item.size for item in files)
+                else:
+                    try:
+                        api = _get_ms_api()
+                        if api:
+                            file_list = await asyncio.wait_for(
+                                asyncio.to_thread(
+                                    api.get_model_files,
+                                    task.repo_id,
+                                ),
+                                timeout=_MS_API_TIMEOUT,
+                            )
+                            task.total_size = _extract_model_size_from_files(
+                                file_list or []
+                            )
+                    except Exception as e:
+                        logger.warning(
+                            f"Could not fetch file info for {task.repo_id}: {e}. "
+                            "Progress estimation will be unavailable."
+                        )
 
                 # Start progress polling
                 self._progress_tasks[task_id] = asyncio.create_task(
                     self._poll_progress(task_id, target_dir)
                 )
 
-                await (aria2 or Aria2Runner()).download(
-                    files,
-                    target_dir,
-                    bypass_proxies=endpoint != _DEFAULT_MS_ENDPOINT,
-                )
+                if aria2:
+                    await aria2.download(
+                        files,
+                        target_dir,
+                        bypass_proxies=endpoint != _DEFAULT_MS_ENDPOINT,
+                    )
+                else:
+                    if ms_snapshot_download is None:
+                        raise RuntimeError("ModelScope SDK not available")
+                    dl_kwargs = {
+                        "model_id": task.repo_id,
+                        "local_dir": str(target_dir),
+                    }
+                    if ms_token:
+                        dl_kwargs["token"] = ms_token
+                    await asyncio.to_thread(ms_snapshot_download, **dl_kwargs)
 
-                # Check if cancelled while downloading. aria2 keeps its
-                # partial files so a retry can resume instead of starting over.
+                # Aria2 partials remain hidden for resume. Preserve the SDK's
+                # existing cleanup behavior when its blocking call finishes.
                 if task_id in self._cancelled:
+                    if not aria2 and target_dir.exists():
+                        shutil.rmtree(target_dir)
                     return
 
                 # Success
@@ -1031,7 +1093,7 @@ class MSDownloader:
                 task.downloaded_size = current_size
 
                 if task.total_size > 0:
-                    # Cap at 99% until aria2 confirms completion.
+                    # Cap at 99% until the active backend confirms completion.
                     task.progress = min(
                         (current_size / task.total_size) * 100, 99.0
                     )
@@ -1059,7 +1121,8 @@ class MSDownloader:
                         f"MS Download stalled for {task.repo_id} "
                         f"(task_id={task_id})"
                     )
-                    # Cancelling the task terminates its aria2 child process.
+                    # Cancelling terminates aria2 immediately; the SDK thread
+                    # retains its existing cooperative cancellation behavior.
                     active_task = self._active_tasks.get(task_id)
                     if active_task and not active_task.done():
                         active_task.cancel()
@@ -1088,7 +1151,7 @@ class MSDownloader:
 
     @staticmethod
     def _get_dir_size(path: Path) -> int:
-        """Calculate total size of all files in a directory."""
+        """Calculate bytes physically present, not sparse logical lengths."""
         if not path.exists():
             return 0
         total = 0
@@ -1096,7 +1159,13 @@ class MSDownloader:
             for f in path.rglob("*"):
                 if f.is_file():
                     try:
-                        total += f.stat().st_size
+                        stat = f.stat()
+                        blocks = getattr(stat, "st_blocks", None)
+                        total += (
+                            stat.st_size
+                            if blocks is None
+                            else min(stat.st_size, blocks * 512)
+                        )
                     except OSError:
                         pass
         except OSError:

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -38,6 +38,7 @@ from ..model_profiles import EXCLUDED_FROM_PROFILES
 from ..model_settings import merge_chat_template_kwargs
 from ..settings import BURST_DECODE_MODES, SubKeyEntry, burst_decode_env
 from ..utils.release_check import normalize_update_channel, select_latest_release
+from .aria2_downloader import Aria2Installer, get_aria2_status
 from .auth import (
     REMEMBER_ME_MAX_AGE,
     SESSION_MAX_AGE,
@@ -47,11 +48,6 @@ from .auth import (
     validate_api_key,
     verify_api_key,
     verify_session,
-)
-from .aria2_downloader import (
-    Aria2Installer,
-    Aria2UnavailableError,
-    get_aria2_status,
 )
 
 logger = logging.getLogger(__name__)
@@ -267,7 +263,7 @@ class GlobalSettingsRequest(BaseModel):
     # ModelScope settings
     ms_endpoint: str | None = None
 
-    # aria2 transfer settings shared by Hugging Face and ModelScope
+    # Optional aria2 transfer settings for ModelScope
     aria2_proxy: str | None = None
     aria2_connections_per_file: int | None = Field(default=None, ge=1, le=16)
     aria2_concurrent_files: int | None = Field(default=None, ge=1, le=16)
@@ -5244,7 +5240,7 @@ async def probe_cache(
 
 @router.get("/api/aria2/status")
 async def aria2_status(is_admin: bool = Depends(require_admin)):
-    """Return whether the required aria2 executable is available."""
+    """Return whether the optional aria2 executable is available."""
 
     return await get_aria2_status()
 
@@ -5270,8 +5266,6 @@ async def start_hf_download(
         return {"success": True, "task": task.to_dict()}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    except Aria2UnavailableError as e:
-        raise HTTPException(status_code=503, detail=str(e))
 
 
 @router.get("/api/hf/tasks")

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -23,12 +23,13 @@ from dataclasses import asdict, is_dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal, Optional
+from urllib.parse import urlparse
 
 import requests
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from ..api.markitdown import MARKITDOWN_MODEL_ID, markitdown_model_visible
 from ..api.openai_models import _coerce_tool_call_arguments
@@ -47,8 +48,14 @@ from .auth import (
     verify_api_key,
     verify_session,
 )
+from .aria2_downloader import (
+    Aria2Installer,
+    Aria2UnavailableError,
+    get_aria2_status,
+)
 
 logger = logging.getLogger(__name__)
+_aria2_installer = Aria2Installer()
 
 PRESET_REMOTE_URL = "https://omlx.ai/assets/omlx_preset.json"
 
@@ -260,6 +267,11 @@ class GlobalSettingsRequest(BaseModel):
     # ModelScope settings
     ms_endpoint: str | None = None
 
+    # aria2 transfer settings shared by Hugging Face and ModelScope
+    aria2_proxy: str | None = None
+    aria2_connections_per_file: int | None = Field(default=None, ge=1, le=16)
+    aria2_concurrent_files: int | None = Field(default=None, ge=1, le=16)
+
     # Network settings
     network_http_proxy: str | None = None
     network_https_proxy: str | None = None
@@ -308,6 +320,19 @@ class GlobalSettingsRequest(BaseModel):
     # Auth settings
     api_key: str | None = None
     skip_api_key_verification: bool | None = None
+
+    @field_validator("aria2_proxy")
+    @classmethod
+    def validate_aria2_proxy(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            return ""
+        parsed = urlparse(cleaned)
+        if parsed.scheme != "http" or not parsed.hostname:
+            raise ValueError("aria2_proxy must be an HTTP proxy URL")
+        return cleaned
 
 
 class HFDownloadRequest(BaseModel):
@@ -3246,6 +3271,11 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
         "modelscope": {
             "endpoint": global_settings.modelscope.endpoint,
         },
+        "aria2": {
+            "proxy": global_settings.aria2.proxy,
+            "connections_per_file": global_settings.aria2.connections_per_file,
+            "concurrent_files": global_settings.aria2.concurrent_files,
+        },
         "network": {
             "http_proxy": global_settings.network.http_proxy,
             "https_proxy": global_settings.network.https_proxy,
@@ -3642,6 +3672,21 @@ async def update_global_settings(
         logger.info(
             f"ModelScope endpoint updated to: " f"{request.ms_endpoint or '(default)'}"
         )
+
+    aria2_changed = False
+    if request.aria2_proxy is not None:
+        global_settings.aria2.proxy = request.aria2_proxy
+        aria2_changed = True
+    if request.aria2_connections_per_file is not None:
+        global_settings.aria2.connections_per_file = (
+            request.aria2_connections_per_file
+        )
+        aria2_changed = True
+    if request.aria2_concurrent_files is not None:
+        global_settings.aria2.concurrent_files = request.aria2_concurrent_files
+        aria2_changed = True
+    if aria2_changed:
+        runtime_applied.append("aria2")
 
     # Apply network settings (Live - immediately applied via env vars)
     network_changed = False
@@ -5197,6 +5242,20 @@ async def probe_cache(
 # =============================================================================
 
 
+@router.get("/api/aria2/status")
+async def aria2_status(is_admin: bool = Depends(require_admin)):
+    """Return whether the required aria2 executable is available."""
+
+    return await get_aria2_status()
+
+
+@router.post("/api/aria2/install")
+async def install_aria2(is_admin: bool = Depends(require_admin)):
+    """Install the fixed aria2 package through Homebrew."""
+
+    return await _aria2_installer.install()
+
+
 @router.post("/api/hf/download")
 async def start_hf_download(
     request: HFDownloadRequest,
@@ -5211,6 +5270,8 @@ async def start_hf_download(
         return {"success": True, "task": task.to_dict()}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except Aria2UnavailableError as e:
+        raise HTTPException(status_code=503, detail=str(e))
 
 
 @router.get("/api/hf/tasks")

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -370,9 +370,7 @@
             aria2Saving: false,
             aria2Error: '',
             get aria2MirrorActive() {
-                const endpoint = this.downloaderSource === 'hf'
-                    ? this.globalSettings.huggingface.endpoint
-                    : this.globalSettings.modelscope.endpoint;
+                const endpoint = this.globalSettings.modelscope.endpoint;
                 return Boolean((endpoint || '').trim());
             },
             msAvailable: false,

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -99,6 +99,8 @@
                 sampling: { max_context_window: 32768, max_context_window_policy: null, max_tokens: 32768, temperature: 1.0, top_p: 0.95, top_k: 0, repetition_penalty: 1.0 },
                 mcp: { config_path: '' },
                 huggingface: { endpoint: '', hf_cache_enabled: true, hf_cache_path: '' },
+                modelscope: { endpoint: '' },
+                aria2: { proxy: '', connections_per_file: 8, concurrent_files: 4 },
                 network: { http_proxy: '', https_proxy: '', no_proxy: '', ca_bundle: '' },
                 auth: { api_key_set: false, api_key: '', skip_api_key_verification: false, sub_keys: [] },
                 claude_code: { context_scaling_enabled: false, target_context_size: 200000, mode: 'cloud', opus_model: null, sonnet_model: null, haiku_model: null },
@@ -363,6 +365,16 @@
 
             // ModelScope Downloader state
             downloaderSource: 'hf',
+            aria2Status: { installed: false, path: null, version: null },
+            aria2Installing: false,
+            aria2Saving: false,
+            aria2Error: '',
+            get aria2MirrorActive() {
+                const endpoint = this.downloaderSource === 'hf'
+                    ? this.globalSettings.huggingface.endpoint
+                    : this.globalSettings.modelscope.endpoint;
+                return Boolean((endpoint || '').trim());
+            },
             msAvailable: false,
             msInitialized: false,
             msRepoId: '',
@@ -557,6 +569,7 @@
 
                 await Promise.all([
                     this.loadGlobalSettings(),
+                    this.loadAria2Status(),
                     this.loadModels(),
                     this.loadServerInfo(),
                     this.loadProfileFields(),
@@ -779,6 +792,8 @@
                             sampling: { ...this.globalSettings.sampling, ...data.sampling },
                             mcp: { ...this.globalSettings.mcp, ...data.mcp },
                             huggingface: { ...this.globalSettings.huggingface, ...data.huggingface },
+                            modelscope: { ...this.globalSettings.modelscope, ...data.modelscope },
+                            aria2: { ...this.globalSettings.aria2, ...data.aria2 },
                             network: { ...this.globalSettings.network, ...data.network },
                             auth: { ...this.globalSettings.auth, ...data.auth },
                             claude_code: { ...this.globalSettings.claude_code, ...data.claude_code },
@@ -897,6 +912,9 @@
                             sampling_repetition_penalty: this.globalSettings.sampling.repetition_penalty,
                             mcp_config: this.globalSettings.mcp.config_path,
                             hf_cache_enabled: this.globalSettings.huggingface.hf_cache_enabled,
+                            aria2_proxy: this.globalSettings.aria2.proxy,
+                            aria2_connections_per_file: Number(this.globalSettings.aria2.connections_per_file),
+                            aria2_concurrent_files: Number(this.globalSettings.aria2.concurrent_files),
                             network_http_proxy: this.globalSettings.network.http_proxy,
                             network_https_proxy: this.globalSettings.network.https_proxy,
                             network_no_proxy: this.globalSettings.network.no_proxy,
@@ -4349,6 +4367,61 @@
                     // Use explicit theme
                     this.activeTheme = this.theme;
                     document.documentElement.setAttribute('data-theme', this.activeTheme);
+                }
+            },
+
+            // =================================================================
+            // aria2 dependency and transfer settings
+            // =================================================================
+
+            async loadAria2Status() {
+                try {
+                    const response = await fetch('/admin/api/aria2/status');
+                    if (response.ok) this.aria2Status = await response.json();
+                } catch (err) {
+                    this.aria2Error = String(err);
+                }
+            },
+
+            async installAria2() {
+                this.aria2Installing = true;
+                this.aria2Error = '';
+                try {
+                    const response = await fetch('/admin/api/aria2/install', { method: 'POST' });
+                    const data = await response.json();
+                    if (!response.ok || !data.installed) {
+                        this.aria2Error = data.error || 'aria2 installation failed. Homebrew is required.';
+                        return;
+                    }
+                    await this.loadAria2Status();
+                } catch (err) {
+                    this.aria2Error = String(err);
+                } finally {
+                    this.aria2Installing = false;
+                }
+            },
+
+            async saveAria2Settings() {
+                this.aria2Saving = true;
+                this.aria2Error = '';
+                try {
+                    const response = await fetch('/admin/api/global-settings', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            aria2_proxy: this.globalSettings.aria2.proxy,
+                            aria2_connections_per_file: Number(this.globalSettings.aria2.connections_per_file),
+                            aria2_concurrent_files: Number(this.globalSettings.aria2.concurrent_files),
+                        }),
+                    });
+                    if (!response.ok) {
+                        const data = await response.json();
+                        this.aria2Error = data.detail || 'Failed to save aria2 settings.';
+                    }
+                } catch (err) {
+                    this.aria2Error = String(err);
+                } finally {
+                    this.aria2Saving = false;
                 }
             },
 

--- a/omlx/admin/templates/dashboard/_models.html
+++ b/omlx/admin/templates/dashboard/_models.html
@@ -234,12 +234,12 @@
                             </button>
                         </div>
 
-                        <!-- aria2 dependency and transfer settings -->
-                        <div class="bg-white rounded-2xl border border-neutral-200 overflow-hidden mb-6">
+                        <!-- Optional ModelScope aria2 acceleration -->
+                        <div x-show="downloaderSource === 'ms'" x-cloak class="bg-white rounded-2xl border border-neutral-200 overflow-hidden mb-6">
                             <div class="flex items-center justify-between px-4 sm:px-6 py-4 bg-neutral-100 border-b border-neutral-200">
                                 <div>
                                     <div class="text-xs font-bold uppercase tracking-wider text-neutral-600">aria2</div>
-                                    <div class="text-xs text-neutral-500 mt-1" x-text="aria2Status.installed ? (aria2Status.version || 'Ready') : 'Required for model downloads'"></div>
+                                    <div class="text-xs text-neutral-500 mt-1" x-text="aria2Status.installed ? (aria2Status.version || 'Ready') : 'Optional ModelScope acceleration'"></div>
                                 </div>
                                 <button x-show="!aria2Status.installed" @click="installAria2()" :disabled="aria2Installing"
                                         class="px-4 py-2 bg-neutral-900 text-white text-xs font-semibold rounded-full disabled:opacity-50">

--- a/omlx/admin/templates/dashboard/_models.html
+++ b/omlx/admin/templates/dashboard/_models.html
@@ -234,6 +234,54 @@
                             </button>
                         </div>
 
+                        <!-- aria2 dependency and transfer settings -->
+                        <div class="bg-white rounded-2xl border border-neutral-200 overflow-hidden mb-6">
+                            <div class="flex items-center justify-between px-4 sm:px-6 py-4 bg-neutral-100 border-b border-neutral-200">
+                                <div>
+                                    <div class="text-xs font-bold uppercase tracking-wider text-neutral-600">aria2</div>
+                                    <div class="text-xs text-neutral-500 mt-1" x-text="aria2Status.installed ? (aria2Status.version || 'Ready') : 'Required for model downloads'"></div>
+                                </div>
+                                <button x-show="!aria2Status.installed" @click="installAria2()" :disabled="aria2Installing"
+                                        class="px-4 py-2 bg-neutral-900 text-white text-xs font-semibold rounded-full disabled:opacity-50">
+                                    <span x-text="aria2Installing ? 'Installing…' : 'Install aria2'"></span>
+                                </button>
+                            </div>
+                            <div class="px-6 py-5 space-y-4">
+                                <p x-show="!aria2Status.installed" class="text-xs text-amber-700">
+                                    One-click installation uses Homebrew. Install Homebrew first if it is unavailable.
+                                </p>
+                                <div>
+                                    <label class="block text-xs font-medium text-neutral-600 mb-1.5">aria2 HTTP proxy</label>
+                                    <input type="text" x-model="globalSettings.aria2.proxy"
+                                           :disabled="aria2MirrorActive"
+                                           placeholder="http://127.0.0.1:7897"
+                                           class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm font-mono disabled:bg-neutral-100 disabled:text-neutral-400">
+                                    <p class="text-xs text-neutral-500 mt-1.5"
+                                       x-text="aria2MirrorActive ? 'Mirror downloads force a direct connection, so the aria2 proxy is unavailable.' : 'Optional HTTP proxy used only by aria2; empty inherits the current oMLX environment.'"></p>
+                                </div>
+                                <div class="grid sm:grid-cols-2 gap-4">
+                                    <label class="block">
+                                        <span class="text-xs font-medium text-neutral-600">Connections per file</span>
+                                        <input type="number" min="1" max="16" x-model.number="globalSettings.aria2.connections_per_file"
+                                               class="mt-1.5 w-full px-4 py-2 border border-neutral-200 rounded-xl">
+                                        <span class="block text-xs text-neutral-500 mt-1">Splits one large file into parallel ranges; higher values may speed up a single large file.</span>
+                                    </label>
+                                    <label class="block">
+                                        <span class="text-xs font-medium text-neutral-600">Concurrent files</span>
+                                        <input type="number" min="1" max="16" x-model.number="globalSettings.aria2.concurrent_files"
+                                               class="mt-1.5 w-full px-4 py-2 border border-neutral-200 rounded-xl">
+                                        <span class="block text-xs text-neutral-500 mt-1">Controls how many files download at once; higher values increase connections and disk pressure.</span>
+                                    </label>
+                                </div>
+                                <div class="flex items-center justify-between">
+                                    <p x-show="aria2Error" x-text="aria2Error" class="text-xs text-red-600"></p>
+                                    <button @click="saveAria2Settings()" :disabled="aria2Saving"
+                                            class="ml-auto px-4 py-2 bg-neutral-900 text-white text-xs font-semibold rounded-full disabled:opacity-50"
+                                            x-text="aria2Saving ? 'Saving…' : 'Save aria2 settings'"></button>
+                                </div>
+                            </div>
+                        </div>
+
                         <!-- ===== HuggingFace Source ===== -->
                         <div x-show="downloaderSource === 'hf'">
 

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -553,7 +553,7 @@ class ModelScopeSettings:
 
 @dataclass
 class Aria2Settings:
-    """Shared aria2 transfer settings for every model source."""
+    """Optional aria2 transfer settings for ModelScope downloads."""
 
     proxy: str = ""
     connections_per_file: int = 8

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -552,6 +552,37 @@ class ModelScopeSettings:
 
 
 @dataclass
+class Aria2Settings:
+    """Shared aria2 transfer settings for every model source."""
+
+    proxy: str = ""
+    connections_per_file: int = 8
+    concurrent_files: int = 4
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "proxy": self.proxy,
+            "connections_per_file": self.connections_per_file,
+            "concurrent_files": self.concurrent_files,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Aria2Settings:
+        def bounded(value: Any, default: int) -> int:
+            try:
+                parsed = int(value)
+            except (TypeError, ValueError):
+                parsed = default
+            return max(1, min(16, parsed))
+
+        return cls(
+            proxy=str(data.get("proxy", "") or "").strip(),
+            connections_per_file=bounded(data.get("connections_per_file"), 8),
+            concurrent_files=bounded(data.get("concurrent_files"), 4),
+        )
+
+
+@dataclass
 class NetworkSettings:
     """Network proxy and TLS trust settings."""
 
@@ -797,6 +828,7 @@ class GlobalSettings:
     mcp: MCPSettings = field(default_factory=MCPSettings)
     huggingface: HuggingFaceSettings = field(default_factory=HuggingFaceSettings)
     modelscope: ModelScopeSettings = field(default_factory=ModelScopeSettings)
+    aria2: Aria2Settings = field(default_factory=Aria2Settings)
     network: NetworkSettings = field(default_factory=NetworkSettings)
     sampling: SamplingSettings = field(default_factory=SamplingSettings)
     logging: LoggingSettings = field(default_factory=LoggingSettings)
@@ -887,6 +919,8 @@ class GlobalSettings:
                 self.huggingface = HuggingFaceSettings.from_dict(data["huggingface"])
             if "modelscope" in data:
                 self.modelscope = ModelScopeSettings.from_dict(data["modelscope"])
+            if "aria2" in data:
+                self.aria2 = Aria2Settings.from_dict(data["aria2"])
             if "network" in data:
                 self.network = NetworkSettings.from_dict(data["network"])
             if "sampling" in data:
@@ -1162,6 +1196,7 @@ class GlobalSettings:
             "mcp": self.mcp.to_dict(),
             "huggingface": self.huggingface.to_dict(),
             "modelscope": self.modelscope.to_dict(),
+            "aria2": self.aria2.to_dict(),
             "network": self.network.to_dict(),
             "sampling": self.sampling.to_dict(),
             "logging": self.logging.to_dict(),
@@ -1446,6 +1481,7 @@ class GlobalSettings:
             "mcp": self.mcp.to_dict(),
             "huggingface": self.huggingface.to_dict(),
             "modelscope": self.modelscope.to_dict(),
+            "aria2": self.aria2.to_dict(),
             "network": self.network.to_dict(),
             "sampling": self.sampling.to_dict(),
             "logging": self.logging.to_dict(),

--- a/tests/test_admin_api_key.py
+++ b/tests/test_admin_api_key.py
@@ -1118,6 +1118,26 @@ class TestGlobalSettingsValidation:
                 integrations_openclaw_tools_profile="invalid-profile"
             )
 
+    def test_aria2_connection_limits(self):
+        with pytest.raises(ValidationError):
+            admin_routes.GlobalSettingsRequest(aria2_connections_per_file=0)
+        with pytest.raises(ValidationError):
+            admin_routes.GlobalSettingsRequest(aria2_concurrent_files=17)
+        req = admin_routes.GlobalSettingsRequest(
+            aria2_connections_per_file=16,
+            aria2_concurrent_files=1,
+        )
+        assert req.aria2_connections_per_file == 16
+        assert req.aria2_concurrent_files == 1
+
+    def test_aria2_proxy_accepts_http_and_rejects_socks(self):
+        req = admin_routes.GlobalSettingsRequest(
+            aria2_proxy="http://127.0.0.1:7897"
+        )
+        assert req.aria2_proxy == "http://127.0.0.1:7897"
+        with pytest.raises(ValidationError):
+            admin_routes.GlobalSettingsRequest(aria2_proxy="socks5://127.0.0.1:7897")
+
     def test_integrations_openclaw_tools_profile_accepts_valid_values(self):
         req = admin_routes.GlobalSettingsRequest(
             integrations_openclaw_tools_profile="coding"

--- a/tests/test_admin_server_aliases.py
+++ b/tests/test_admin_server_aliases.py
@@ -470,6 +470,30 @@ class TestUpdateGlobalSettingsMidSystemCache:
         gs.save.assert_called_once()
 
 
+class TestUpdateGlobalSettingsAria2:
+    def test_saves_transfer_settings_for_next_download(self):
+        gs = _make_global_settings()
+        gs.aria2 = SimpleNamespace(
+            proxy="", connections_per_file=8, concurrent_files=4
+        )
+        request = GlobalSettingsRequest(
+            aria2_proxy="http://127.0.0.1:7897",
+            aria2_connections_per_file=12,
+            aria2_concurrent_files=3,
+        )
+
+        with _patched_global_settings(gs):
+            result = asyncio.run(
+                admin_routes.update_global_settings(request=request, is_admin=True)
+            )
+
+        assert gs.aria2.proxy == "http://127.0.0.1:7897"
+        assert gs.aria2.connections_per_file == 12
+        assert gs.aria2.concurrent_files == 3
+        assert "aria2" in result["runtime_applied"]
+        gs.save.assert_called_once()
+
+
 class TestUpdateGlobalSettingsSampling:
     """update_global_settings: saving and hot-applying sampling defaults."""
 

--- a/tests/test_aria2_downloader.py
+++ b/tests/test_aria2_downloader.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from omlx.admin.aria2_downloader import (
+    Aria2DownloadError,
+    Aria2File,
+    Aria2Installer,
+    Aria2Runner,
+    Aria2UnavailableError,
+    configured_aria2_runner,
+    find_aria2c,
+    get_aria2_status,
+)
+
+
+def test_find_aria2c_uses_path() -> None:
+    with patch("omlx.admin.aria2_downloader.shutil.which", return_value="/bin/aria2c"):
+        assert find_aria2c() == "/bin/aria2c"
+
+
+def test_mirror_environment_removes_every_proxy_spelling() -> None:
+    environ = {
+        "HTTP_PROXY": "http://app-proxy",
+        "http_proxy": "http://lower-proxy",
+        "HTTPS_PROXY": "http://secure-proxy",
+        "https_proxy": "http://lower-secure-proxy",
+        "ALL_PROXY": "socks5://all-proxy",
+        "all_proxy": "socks5://lower-all-proxy",
+        "FTP_PROXY": "http://ftp-proxy",
+        "ftp_proxy": "http://lower-ftp-proxy",
+        "NO_PROXY": "localhost",
+        "no_proxy": "localhost",
+        "PATH": "/usr/bin",
+    }
+
+    result = Aria2Runner.build_environment(environ, bypass_proxies=True)
+
+    assert result == {"PATH": "/usr/bin"}
+
+
+def test_default_environment_preserves_proxy_configuration() -> None:
+    environ = {"HTTPS_PROXY": "http://proxy", "PATH": "/usr/bin"}
+
+    assert Aria2Runner.build_environment(environ, bypass_proxies=False) == environ
+
+
+def test_command_explicitly_disables_aria2_proxies_for_mirror(tmp_path: Path) -> None:
+    runner = Aria2Runner(
+        executable="/opt/homebrew/bin/aria2c",
+        proxy="http://127.0.0.1:7897",
+        connections_per_file=12,
+        concurrent_files=3,
+    )
+
+    args = runner.build_command(tmp_path / "manifest.txt", bypass_proxies=True)
+
+    assert "--all-proxy=" in args
+    assert "--http-proxy=" in args
+    assert "--https-proxy=" in args
+    assert "--ftp-proxy=" in args
+    assert "--no-proxy=*" in args
+    assert "--all-proxy=http://127.0.0.1:7897" not in args
+    assert "--split=12" in args
+    assert "--max-connection-per-server=12" in args
+    assert "--max-concurrent-downloads=3" in args
+
+
+def test_command_uses_explicit_aria2_proxy_without_mirror(tmp_path: Path) -> None:
+    runner = Aria2Runner(
+        executable="/opt/homebrew/bin/aria2c",
+        proxy="http://127.0.0.1:7897",
+    )
+
+    args = runner.build_command(tmp_path / "manifest.txt", bypass_proxies=False)
+
+    assert "--all-proxy=http://127.0.0.1:7897" in args
+
+
+def test_manifest_keeps_token_out_of_command_line_and_rejects_path_escape(
+    tmp_path: Path,
+) -> None:
+    runner = Aria2Runner(executable="/opt/homebrew/bin/aria2c")
+    token = "hf_secret_token"
+    files = [
+        Aria2File(
+            url="https://huggingface.co/owner/model/resolve/main/model.safetensors",
+            relative_path="weights/model.safetensors",
+            size=123,
+            headers=(f"Authorization: Bearer {token}",),
+        )
+    ]
+
+    manifest = runner.write_manifest(files, tmp_path)
+    command = runner.build_command(manifest, bypass_proxies=False)
+
+    assert token not in " ".join(command)
+    assert token in manifest.read_text()
+    assert oct(manifest.stat().st_mode & 0o777) == "0o600"
+
+    with pytest.raises(ValueError, match="relative path"):
+        runner.write_manifest(
+            [Aria2File(url="https://example.test/file", relative_path="../escape")],
+            tmp_path,
+        )
+
+
+def test_runner_requires_aria2() -> None:
+    with (
+        patch("omlx.admin.aria2_downloader.find_aria2c", return_value=None),
+        pytest.raises(Aria2UnavailableError, match="aria2"),
+    ):
+        Aria2Runner()
+
+
+def test_configured_runner_reads_global_transfer_settings() -> None:
+    settings = MagicMock()
+    settings.aria2.proxy = "http://127.0.0.1:7897"
+    settings.aria2.connections_per_file = 6
+    settings.aria2.concurrent_files = 2
+
+    with (
+        patch("omlx.settings.get_settings", return_value=settings),
+        patch("omlx.admin.aria2_downloader.find_aria2c", return_value="/bin/aria2c"),
+    ):
+        runner = configured_aria2_runner()
+
+    assert runner.proxy == "http://127.0.0.1:7897"
+    assert runner.connections_per_file == 6
+    assert runner.concurrent_files == 2
+
+
+@pytest.mark.asyncio
+async def test_download_removes_protected_manifest_after_success(
+    tmp_path: Path,
+) -> None:
+    runner = Aria2Runner(executable="/usr/bin/true")
+    files = [Aria2File(url="https://example.test/model", relative_path="model.bin")]
+
+    await runner.download(files, tmp_path, bypass_proxies=True)
+
+    assert list(tmp_path.glob(".omlx-aria2-*.txt")) == []
+
+
+@pytest.mark.asyncio
+async def test_download_redacts_authentication_from_aria2_error(tmp_path: Path) -> None:
+    executable = tmp_path / "failing-aria2"
+    executable.write_text(
+        "#!/bin/sh\n" "manifest=${1#--input-file=}\n" 'cat "$manifest"\n' "exit 7\n"
+    )
+    executable.chmod(0o755)
+    token = "hf_do_not_leak"
+    runner = Aria2Runner(executable=str(executable))
+    files = [
+        Aria2File(
+            url="https://example.test/model",
+            relative_path="model.bin",
+            headers=(f"Authorization: Bearer {token}",),
+        )
+    ]
+
+    with pytest.raises(Aria2DownloadError) as exc_info:
+        await runner.download(files, tmp_path, bypass_proxies=False)
+
+    assert token not in str(exc_info.value)
+    assert "[REDACTED]" in str(exc_info.value)
+    assert list(tmp_path.glob(".omlx-aria2-*.txt")) == []
+
+
+@pytest.mark.asyncio
+async def test_installer_runs_homebrew_without_a_shell() -> None:
+    installer = Aria2Installer()
+
+    with (
+        patch(
+            "omlx.admin.aria2_downloader.find_brew",
+            return_value="/opt/homebrew/bin/brew",
+        ),
+        patch.object(installer, "_run", return_value=(0, "installed")) as run,
+    ):
+        result = await installer.install()
+
+    assert result["installed"] is True
+    run.assert_awaited_once_with(
+        "/opt/homebrew/bin/brew", "install", "aria2", env=os.environ.copy()
+    )
+
+
+@pytest.mark.asyncio
+async def test_installer_reports_missing_homebrew() -> None:
+    installer = Aria2Installer()
+
+    with patch("omlx.admin.aria2_downloader.find_brew", return_value=None):
+        result = await installer.install()
+
+    assert result == {
+        "installed": False,
+        "error": "Homebrew is required to install aria2 automatically.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_status_reports_missing_aria2() -> None:
+    with patch("omlx.admin.aria2_downloader.find_aria2c", return_value=None):
+        assert await get_aria2_status() == {
+            "installed": False,
+            "path": None,
+            "version": None,
+        }

--- a/tests/test_aria2_downloader.py
+++ b/tests/test_aria2_downloader.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import asyncio
 import os
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -135,16 +137,77 @@ def test_configured_runner_reads_global_transfer_settings() -> None:
     assert runner.concurrent_files == 2
 
 
+def test_configured_runner_is_optional_when_aria2_is_missing() -> None:
+    with patch("omlx.admin.aria2_downloader.find_aria2c", return_value=None):
+        assert configured_aria2_runner() is None
+
+
 @pytest.mark.asyncio
 async def test_download_removes_protected_manifest_after_success(
     tmp_path: Path,
 ) -> None:
-    runner = Aria2Runner(executable="/usr/bin/true")
+    executable = tmp_path / "fake-aria2"
+    executable.write_text(
+        f"#!{sys.executable}\n"
+        "from pathlib import Path\n"
+        "import sys\n"
+        "manifest = Path(sys.argv[1].split('=', 1)[1])\n"
+        "directory = None\n"
+        "for line in manifest.read_text().splitlines():\n"
+        "    if line.startswith('  dir='):\n"
+        "        directory = Path(line[6:])\n"
+        "    elif line.startswith('  out='):\n"
+        "        directory.mkdir(parents=True, exist_ok=True)\n"
+        "        (directory / line[6:]).write_bytes(b'payload')\n"
+    )
+    executable.chmod(0o755)
+    runner = Aria2Runner(executable=str(executable))
     files = [Aria2File(url="https://example.test/model", relative_path="model.bin")]
 
     await runner.download(files, tmp_path, bypass_proxies=True)
 
+    assert (tmp_path / "model.bin").read_bytes() == b"payload"
     assert list(tmp_path.glob(".omlx-aria2-*.txt")) == []
+
+
+@pytest.mark.asyncio
+async def test_cancelled_download_keeps_partial_file_hidden(tmp_path: Path) -> None:
+    executable = tmp_path / "slow-aria2"
+    executable.write_text(
+        f"#!{sys.executable}\n"
+        "from pathlib import Path\n"
+        "import sys, time\n"
+        "manifest = Path(sys.argv[1].split('=', 1)[1])\n"
+        "directory = None\n"
+        "for line in manifest.read_text().splitlines():\n"
+        "    if line.startswith('  dir='):\n"
+        "        directory = Path(line[6:])\n"
+        "    elif line.startswith('  out='):\n"
+        "        directory.mkdir(parents=True, exist_ok=True)\n"
+        "        (directory / line[6:]).write_bytes(b'partial')\n"
+        "time.sleep(30)\n"
+    )
+    executable.chmod(0o755)
+    runner = Aria2Runner(executable=str(executable))
+    files = [Aria2File(url="https://example.test/model", relative_path="model.bin")]
+
+    task = asyncio.create_task(
+        runner.download(files, tmp_path, bypass_proxies=False)
+    )
+    hidden = tmp_path / "._____temp" / "model.bin"
+    final = tmp_path / "model.bin"
+    try:
+        for _ in range(200):
+            if hidden.exists() or final.exists():
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert hidden.read_bytes() == b"partial"
+    assert not final.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_aria2_routes.py
+++ b/tests/test_aria2_routes.py
@@ -2,10 +2,8 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from fastapi import HTTPException
 
 import omlx.admin.routes as admin_routes
-from omlx.admin.aria2_downloader import Aria2UnavailableError
 
 
 @pytest.mark.asyncio
@@ -33,19 +31,3 @@ async def test_aria2_install_route_uses_fixed_installer() -> None:
         assert await admin_routes.install_aria2(is_admin=True) == result
 
     install.assert_awaited_once_with()
-
-
-@pytest.mark.asyncio
-async def test_hf_download_reports_missing_aria2_as_service_unavailable() -> None:
-    downloader = AsyncMock()
-    downloader.start_download.side_effect = Aria2UnavailableError("aria2 missing")
-    request = admin_routes.HFDownloadRequest(repo_id="owner/model")
-
-    with (
-        patch.object(admin_routes, "_hf_downloader", downloader),
-        pytest.raises(HTTPException) as exc_info,
-    ):
-        await admin_routes.start_hf_download(request=request, is_admin=True)
-
-    assert exc_info.value.status_code == 503
-    assert "aria2 missing" in exc_info.value.detail

--- a/tests/test_aria2_routes.py
+++ b/tests/test_aria2_routes.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+import omlx.admin.routes as admin_routes
+from omlx.admin.aria2_downloader import Aria2UnavailableError
+
+
+@pytest.mark.asyncio
+async def test_aria2_status_route_returns_dependency_state() -> None:
+    expected = {
+        "installed": True,
+        "path": "/opt/homebrew/bin/aria2c",
+        "version": "aria2 version 1.37.0",
+    }
+    with patch(
+        "omlx.admin.routes.get_aria2_status",
+        new=AsyncMock(return_value=expected),
+    ):
+        assert await admin_routes.aria2_status(is_admin=True) == expected
+
+
+@pytest.mark.asyncio
+async def test_aria2_install_route_uses_fixed_installer() -> None:
+    result = {"installed": True, "path": "/opt/homebrew/bin/aria2c"}
+    with patch.object(
+        admin_routes._aria2_installer,
+        "install",
+        new=AsyncMock(return_value=result),
+    ) as install:
+        assert await admin_routes.install_aria2(is_admin=True) == result
+
+    install.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_hf_download_reports_missing_aria2_as_service_unavailable() -> None:
+    downloader = AsyncMock()
+    downloader.start_download.side_effect = Aria2UnavailableError("aria2 missing")
+    request = admin_routes.HFDownloadRequest(repo_id="owner/model")
+
+    with (
+        patch.object(admin_routes, "_hf_downloader", downloader),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await admin_routes.start_hf_download(request=request, is_admin=True)
+
+    assert exc_info.value.status_code == 503
+    assert "aria2 missing" in exc_info.value.detail

--- a/tests/test_aria2_web_ui.py
+++ b/tests/test_aria2_web_ui.py
@@ -19,6 +19,9 @@ def test_dashboard_saves_both_concurrency_controls() -> None:
 
 
 def test_download_page_explains_controls_and_disables_proxy_for_mirror() -> None:
+    assert 'x-show="downloaderSource === \'ms\'"' in TEMPLATE
+    assert "Optional ModelScope acceleration" in TEMPLATE
+    assert "Required for model downloads" not in TEMPLATE
     assert "Splits one large file into parallel ranges" in TEMPLATE
     assert "Controls how many files download at once" in TEMPLATE
     assert ':disabled="aria2MirrorActive"' in TEMPLATE

--- a/tests/test_aria2_web_ui.py
+++ b/tests/test_aria2_web_ui.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+JS = (ROOT / "omlx/admin/static/js/dashboard.js").read_text()
+TEMPLATE = (ROOT / "omlx/admin/templates/dashboard/_models.html").read_text()
+
+
+def test_dashboard_loads_status_and_can_install_binary() -> None:
+    assert "'/admin/api/aria2/status'" in JS
+    assert "'/admin/api/aria2/install'" in JS
+    assert "async installAria2()" in JS
+
+
+def test_dashboard_saves_both_concurrency_controls() -> None:
+    assert "aria2_connections_per_file" in JS
+    assert "aria2_concurrent_files" in JS
+    assert "aria2_proxy" in JS
+
+
+def test_download_page_explains_controls_and_disables_proxy_for_mirror() -> None:
+    assert "Splits one large file into parallel ranges" in TEMPLATE
+    assert "Controls how many files download at once" in TEMPLATE
+    assert ':disabled="aria2MirrorActive"' in TEMPLATE
+    assert "One-click installation uses Homebrew" in TEMPLATE

--- a/tests/test_homebrew_formula.py
+++ b/tests/test_homebrew_formula.py
@@ -48,8 +48,8 @@ def formula_update_workflow() -> str:
 
 
 class TestFormulaReleaseUpdate:
-    def test_aria2_is_a_runtime_dependency(self, formula):
-        assert 'depends_on "aria2"' in formula
+    def test_aria2_is_not_a_runtime_dependency(self, formula):
+        assert 'depends_on "aria2"' not in formula
 
     def test_source_sha_update_is_scoped_to_top_level(self, formula_update_workflow):
         """Release bumps must not replace checksums inside resource blocks."""

--- a/tests/test_homebrew_formula.py
+++ b/tests/test_homebrew_formula.py
@@ -48,6 +48,9 @@ def formula_update_workflow() -> str:
 
 
 class TestFormulaReleaseUpdate:
+    def test_aria2_is_a_runtime_dependency(self, formula):
+        assert 'depends_on "aria2"' in formula
+
     def test_source_sha_update_is_scoped_to_top_level(self, formula_update_workflow):
         """Release bumps must not replace checksums inside resource blocks."""
         sha_update = next(

--- a/tests/test_ms_downloader.py
+++ b/tests/test_ms_downloader.py
@@ -2,17 +2,18 @@
 """Tests for the ModelScope model downloader."""
 
 import asyncio
-import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import omlx.admin.ms_downloader as ms_downloader_module
 from omlx.admin.aria2_downloader import Aria2File
 from omlx.admin.hf_downloader import DownloadStatus, DownloadTask
 from omlx.admin.ms_downloader import (
-    MSDownloader,
     _ENRICH_CACHE,
+    MSDownloader,
     _enrich_cache_get,
     _enrich_cache_put,
     _enrich_ms_entry,
@@ -28,6 +29,15 @@ from omlx.admin.ms_downloader import (
 
 async def _slow_aria2(*args, **kwargs) -> None:
     await asyncio.sleep(10)
+
+
+@pytest.fixture(autouse=True)
+def _use_native_downloader_unless_test_selects_aria2():
+    with patch(
+        "omlx.admin.ms_downloader.configured_aria2_runner",
+        return_value=None,
+    ):
+        yield
 
 
 # =============================================================================
@@ -84,7 +94,11 @@ def test_to_aria2_files_uses_mirror_and_token() -> None:
         "owner/model",
         [
             {"Path": "config.json", "Size": 10},
-            {"Path": "weights/model.safetensors", "Size": 100},
+            {
+                "Path": "weights/model.safetensors",
+                "Size": 100,
+                "Revision": "abc123",
+            },
             {"Path": "weights", "Type": "tree"},
         ],
         endpoint="https://ms-mirror.example",
@@ -97,7 +111,7 @@ def test_to_aria2_files_uses_mirror_and_token() -> None:
     ]
     assert files[1].url == (
         "https://ms-mirror.example/api/v1/models/owner/model/repo"
-        "?Revision=master&FilePath=weights%2Fmodel.safetensors"
+        "?Revision=abc123&FilePath=weights%2Fmodel.safetensors"
     )
     assert files[1].headers == ("Authorization: Bearer secret",)
     assert sum(item.size for item in files) == 110
@@ -112,6 +126,18 @@ async def test_ms_download_delegates_payload_to_aria2_and_bypasses_proxy_for_mir
     api.get_model_files.return_value = [
         {"Path": "model.safetensors", "Size": 100}
     ]
+    manifest_response = MagicMock()
+    manifest_response.json.return_value = {
+        "Data": {
+            "Files": [
+                {
+                    "Path": "model.safetensors",
+                    "Size": 100,
+                    "Revision": "abc123",
+                }
+            ]
+        }
+    }
     runner = MagicMock()
     runner.download = AsyncMock()
 
@@ -120,6 +146,9 @@ async def test_ms_download_delegates_payload_to_aria2_and_bypasses_proxy_for_mir
     ), patch(
         "omlx.admin.ms_downloader._get_ms_endpoint",
         return_value="https://ms-mirror.example",
+    ), patch(
+        "omlx.admin.ms_downloader.requests.get",
+        return_value=manifest_response,
     ), patch(
         "omlx.admin.ms_downloader.configured_aria2_runner", return_value=runner
     ):
@@ -133,7 +162,7 @@ async def test_ms_download_delegates_payload_to_aria2_and_bypasses_proxy_for_mir
         Aria2File(
             url=(
                 "https://ms-mirror.example/api/v1/models/owner/model/repo"
-                "?Revision=master&FilePath=model.safetensors"
+                "?Revision=abc123&FilePath=model.safetensors"
             ),
             relative_path="model.safetensors",
             size=100,
@@ -143,6 +172,38 @@ async def test_ms_download_delegates_payload_to_aria2_and_bypasses_proxy_for_mir
     assert target == tmp_path / "owner/model"
     assert runner.download.await_args.kwargs == {"bypass_proxies": True}
     assert task.status == DownloadStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_ms_download_falls_back_to_sdk_when_aria2_is_missing(
+    tmp_path: Path,
+) -> None:
+    downloader = MSDownloader(model_dir=str(tmp_path))
+    api = MagicMock()
+    api.get_model_files.return_value = [
+        {"Path": "model.safetensors", "Size": 100}
+    ]
+    snapshot_download = MagicMock()
+
+    with patch("omlx.admin.ms_downloader.MS_SDK_AVAILABLE", True), patch(
+        "omlx.admin.ms_downloader._get_ms_api", return_value=api
+    ), patch(
+        "omlx.admin.aria2_downloader.find_aria2c", return_value=None
+    ), patch.object(
+        ms_downloader_module,
+        "ms_snapshot_download",
+        snapshot_download,
+        create=True,
+    ):
+        task = await downloader.start_download("owner/model", "secret")
+        await downloader._active_tasks[task.task_id]
+
+    assert task.status == DownloadStatus.COMPLETED
+    snapshot_download.assert_called_once_with(
+        model_id="owner/model",
+        local_dir=str(tmp_path / "owner/model"),
+        token="secret",
+    )
 
     def test_with_non_numeric_size(self):
         files = [{"Size": "not_a_number"}, {"Size": 100}]
@@ -290,23 +351,24 @@ class TestMSDownloader:
         """aria2 must receive a target directory under the org subfolder."""
         model_dir.mkdir(parents=True, exist_ok=True)
         downloader = MSDownloader(model_dir=str(model_dir))
+        runner = MagicMock()
+        runner.download = AsyncMock()
 
         with patch(
             "omlx.admin.ms_downloader.MS_SDK_AVAILABLE", True
         ), patch(
-            "omlx.admin.ms_downloader._get_ms_api"
-        ) as mock_get_api, patch(
-            "omlx.admin.ms_downloader.Aria2Runner.download"
-        ) as mock_download:
-            mock_api = MagicMock()
-            mock_api.get_model_files.return_value = []
-            mock_get_api.return_value = mock_api
+            "omlx.admin.ms_downloader.configured_aria2_runner",
+            return_value=runner,
+        ), patch(
+            "omlx.admin.ms_downloader._fetch_ms_file_manifest",
+            return_value=[],
+        ):
 
             await downloader.start_download("qwen/Qwen2.5-7B-Instruct-MLX")
             await asyncio.sleep(0.5)
 
-            assert mock_download.await_count == 1
-            assert mock_download.await_args.args[1] == (
+            assert runner.download.await_count == 1
+            assert runner.download.await_args.args[1] == (
                 model_dir / "qwen" / "Qwen2.5-7B-Instruct-MLX"
             )
 
@@ -476,6 +538,27 @@ class TestMSDownloader:
         (tmp_path / "a.bin").write_bytes(b"x" * 100)
         (tmp_path / "b.bin").write_bytes(b"y" * 200)
         assert MSDownloader._get_dir_size(tmp_path) == 300
+
+    def test_get_dir_size_counts_allocated_bytes_for_sparse_files(self):
+        class SparseFile:
+            @staticmethod
+            def is_file():
+                return True
+
+            @staticmethod
+            def stat():
+                return SimpleNamespace(st_size=8 * 1024 * 1024, st_blocks=8)
+
+        class Directory:
+            @staticmethod
+            def exists():
+                return True
+
+            @staticmethod
+            def rglob(_pattern):
+                return [SparseFile()]
+
+        assert MSDownloader._get_dir_size(Directory()) == 4096
 
     def test_get_dir_size_nonexistent(self, tmp_path):
         assert MSDownloader._get_dir_size(tmp_path / "nonexistent") == 0

--- a/tests/test_ms_downloader.py
+++ b/tests/test_ms_downloader.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from omlx.admin.aria2_downloader import Aria2File
 from omlx.admin.hf_downloader import DownloadStatus, DownloadTask
 from omlx.admin.ms_downloader import (
     MSDownloader,
@@ -21,7 +22,12 @@ from omlx.admin.ms_downloader import (
     _fetch_model_detail_size,
     _get_ms_endpoint,
     _parse_ms_model_entry,
+    _to_aria2_files,
 )
+
+
+async def _slow_aria2(*args, **kwargs) -> None:
+    await asyncio.sleep(10)
 
 
 # =============================================================================
@@ -71,6 +77,72 @@ class TestExtractModelSizeFromFiles:
     def test_with_missing_size(self):
         files = [{"name": "file.bin"}, {"Size": 100}]
         assert _extract_model_size_from_files(files) == 100
+
+
+def test_to_aria2_files_uses_mirror_and_token() -> None:
+    files = _to_aria2_files(
+        "owner/model",
+        [
+            {"Path": "config.json", "Size": 10},
+            {"Path": "weights/model.safetensors", "Size": 100},
+            {"Path": "weights", "Type": "tree"},
+        ],
+        endpoint="https://ms-mirror.example",
+        token="secret",
+    )
+
+    assert [item.relative_path for item in files] == [
+        "config.json",
+        "weights/model.safetensors",
+    ]
+    assert files[1].url == (
+        "https://ms-mirror.example/api/v1/models/owner/model/repo"
+        "?Revision=master&FilePath=weights%2Fmodel.safetensors"
+    )
+    assert files[1].headers == ("Authorization: Bearer secret",)
+    assert sum(item.size for item in files) == 110
+
+
+@pytest.mark.asyncio
+async def test_ms_download_delegates_payload_to_aria2_and_bypasses_proxy_for_mirror(
+    tmp_path: Path,
+) -> None:
+    downloader = MSDownloader(model_dir=str(tmp_path))
+    api = MagicMock()
+    api.get_model_files.return_value = [
+        {"Path": "model.safetensors", "Size": 100}
+    ]
+    runner = MagicMock()
+    runner.download = AsyncMock()
+
+    with patch("omlx.admin.ms_downloader.MS_SDK_AVAILABLE", True), patch(
+        "omlx.admin.ms_downloader._get_ms_api", return_value=api
+    ), patch(
+        "omlx.admin.ms_downloader._get_ms_endpoint",
+        return_value="https://ms-mirror.example",
+    ), patch(
+        "omlx.admin.ms_downloader.configured_aria2_runner", return_value=runner
+    ):
+        task = await downloader.start_download("owner/model", "secret")
+        active = downloader._active_tasks[task.task_id]
+        await active
+
+    runner.download.assert_awaited_once()
+    files, target = runner.download.await_args.args
+    assert files == [
+        Aria2File(
+            url=(
+                "https://ms-mirror.example/api/v1/models/owner/model/repo"
+                "?Revision=master&FilePath=model.safetensors"
+            ),
+            relative_path="model.safetensors",
+            size=100,
+            headers=("Authorization: Bearer secret",),
+        )
+    ]
+    assert target == tmp_path / "owner/model"
+    assert runner.download.await_args.kwargs == {"bypass_proxies": True}
+    assert task.status == DownloadStatus.COMPLETED
 
     def test_with_non_numeric_size(self):
         files = [{"Size": "not_a_number"}, {"Size": 100}]
@@ -139,7 +211,7 @@ class TestMSDownloader:
         ), patch(
             "omlx.admin.ms_downloader._get_ms_api"
         ) as mock_get_api, patch(
-            "omlx.admin.ms_downloader.ms_snapshot_download"
+            "omlx.admin.ms_downloader.Aria2Runner.download"
         ):
             mock_api = MagicMock()
             mock_api.get_model_files.return_value = []
@@ -175,7 +247,7 @@ class TestMSDownloader:
         ), patch(
             "omlx.admin.ms_downloader._get_ms_api"
         ) as mock_get_api, patch(
-            "omlx.admin.ms_downloader.ms_snapshot_download"
+            "omlx.admin.ms_downloader.Aria2Runner.download"
         ):
             mock_api = MagicMock()
             mock_api.get_model_files.return_value = []
@@ -199,8 +271,8 @@ class TestMSDownloader:
         ), patch(
             "omlx.admin.ms_downloader._get_ms_api"
         ) as mock_get_api, patch(
-            "omlx.admin.ms_downloader.ms_snapshot_download",
-            side_effect=lambda **kwargs: asyncio.sleep(10),
+            "omlx.admin.ms_downloader.Aria2Runner.download",
+            side_effect=_slow_aria2,
         ):
             mock_api = MagicMock()
             mock_api.get_model_files.return_value = []
@@ -215,7 +287,7 @@ class TestMSDownloader:
 
     @pytest.mark.asyncio
     async def test_download_uses_owner_model_layout(self, model_dir):
-        """ms_snapshot_download must receive local_dir under the org subfolder."""
+        """aria2 must receive a target directory under the org subfolder."""
         model_dir.mkdir(parents=True, exist_ok=True)
         downloader = MSDownloader(model_dir=str(model_dir))
 
@@ -224,7 +296,7 @@ class TestMSDownloader:
         ), patch(
             "omlx.admin.ms_downloader._get_ms_api"
         ) as mock_get_api, patch(
-            "omlx.admin.ms_downloader.ms_snapshot_download"
+            "omlx.admin.ms_downloader.Aria2Runner.download"
         ) as mock_download:
             mock_api = MagicMock()
             mock_api.get_model_files.return_value = []
@@ -233,9 +305,8 @@ class TestMSDownloader:
             await downloader.start_download("qwen/Qwen2.5-7B-Instruct-MLX")
             await asyncio.sleep(0.5)
 
-            assert mock_download.called
-            call_kwargs = mock_download.call_args[1]
-            assert call_kwargs["local_dir"] == str(
+            assert mock_download.await_count == 1
+            assert mock_download.await_args.args[1] == (
                 model_dir / "qwen" / "Qwen2.5-7B-Instruct-MLX"
             )
 
@@ -250,8 +321,8 @@ class TestMSDownloader:
         ), patch(
             "omlx.admin.ms_downloader._get_ms_api"
         ) as mock_get_api, patch(
-            "omlx.admin.ms_downloader.ms_snapshot_download",
-            side_effect=lambda **kwargs: time.sleep(10),
+            "omlx.admin.ms_downloader.Aria2Runner.download",
+            side_effect=_slow_aria2,
         ):
             mock_api = MagicMock()
             mock_api.get_model_files.return_value = []
@@ -326,7 +397,7 @@ class TestMSDownloader:
         ), patch(
             "omlx.admin.ms_downloader._get_ms_api"
         ) as mock_get_api, patch(
-            "omlx.admin.ms_downloader.ms_snapshot_download"
+            "omlx.admin.ms_downloader.Aria2Runner.download"
         ):
             mock_api = MagicMock()
             mock_api.get_model_files.return_value = []

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import pytest
 
 from omlx.settings import (
+    Aria2Settings,
     BURST_DECODE_MODES,
     DEFAULT_BURST_DECODE_MODE,
     AuthSettings,
@@ -35,6 +36,35 @@ from omlx.settings import (
     reset_settings,
     resolve_default_base_path,
 )
+
+
+class TestAria2Settings:
+    def test_defaults(self):
+        settings = Aria2Settings()
+        assert settings.proxy == ""
+        assert settings.connections_per_file == 8
+        assert settings.concurrent_files == 4
+
+    def test_round_trip(self):
+        settings = Aria2Settings.from_dict(
+            {
+                "proxy": "http://127.0.0.1:7897",
+                "connections_per_file": 12,
+                "concurrent_files": 3,
+            }
+        )
+        assert settings.to_dict() == {
+            "proxy": "http://127.0.0.1:7897",
+            "connections_per_file": 12,
+            "concurrent_files": 3,
+        }
+
+    def test_file_values_are_clamped_to_safe_range(self):
+        settings = Aria2Settings.from_dict(
+            {"connections_per_file": 0, "concurrent_files": 99}
+        )
+        assert settings.connections_per_file == 1
+        assert settings.concurrent_files == 16
 
 
 class TestServerSettings:


### PR DESCRIPTION
Closes #2188.

## Overview

This PR now keeps Hugging Face on the native Xet-enabled downloader added in `732a976f` and limits aria2 to an optional ModelScope acceleration path.

ModelScope downloads use aria2 when `aria2c` is available and fall back to the existing ModelScope SDK otherwise. DMG installs therefore keep working without Homebrew or any new runtime dependency.

## What changed

### Optional ModelScope acceleration

- Added a short-lived `Aria2Runner` for ModelScope payload transfers.
- Missing aria2 selects the existing `modelscope.snapshot_download` path instead of returning an error.
- The web dashboard and native macOS app present aria2 as optional and only on the ModelScope download surface.
- One-click Homebrew installation remains available, but aria2 is not a Formula dependency.

### Correctness and cancellation

- Fetches the ModelScope file manifest with each file's immutable `Revision` and pins every payload URL to that revision.
- Downloads into a hidden `._____temp` staging directory and publishes files with `os.replace()` only after aria2 exits successfully.
- Cancelled and resumable partial files never appear under final model filenames, so model discovery cannot mistake them for a complete checkpoint.
- Progress uses allocated blocks (`st_blocks * 512`, capped by logical size) so sparse aria2 files do not jump to near-100% immediately.

### Process and network behavior

- Keeps authorization headers in a mode-0600 manifest rather than process arguments.
- Uses argv-based subprocess execution without a shell.
- Terminates the aria2 child on cancellation and redacts authorization values from surfaced errors.
- Supports bounded connections per file and concurrent-file controls.
- A configured ModelScope mirror strips application-layer proxy variables for the aria2 child; it does not attempt to bypass TUN/VPN routing.

### Hugging Face

- No Hugging Face downloader code is changed by this PR.
- Main's Xet path, chunk deduplication, and `abort_xet_session()` cancellation behavior remain intact.

## Review fixes

- Downloader tests explicitly select/mock the backend and no longer depend on the machine's real `PATH`.
- ModelScope payload URLs are revision-pinned.
- Partial files stay hidden until completion.
- Sparse-file progress reports allocated bytes.
- `docs/superpowers/specs` was removed from both the PR diff and commit history.
- The Homebrew aria2 hard dependency was removed.

## Validation

- `uv run --frozen pytest -q tests/ -m "not slow and not integration"`
  - `6862 passed, 52 skipped, 67 deselected`
- Focused downloader/UI/formula regression suite
  - `112 passed`
- `xcodebuild ... build`
  - passed
- `xcodebuild ... test`
  - passed
- Ruff checks for the new aria2 module and regression files
  - passed
- `git diff --check`
  - passed

## Reviewer guide

1. `omlx/admin/aria2_downloader.py` — staging, subprocess, proxy, cancellation, and redaction.
2. `omlx/admin/ms_downloader.py` — optional backend selection, pinned manifest, fallback, and progress.
3. `omlx/settings.py` and `omlx/admin/routes.py` — settings and install/status endpoints.
4. Web/native UI changes and regression tests.
