### PR TITLE
feat(status): report native custom kernel availability in /api/status

### DIFF
--- a/omlx/custom_kernels/__init__.py
+++ b/omlx/custom_kernels/__init__.py
@@ -1,3 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
 """Optional native custom kernels bundled with oMLX."""
 
+from __future__ import annotations
+
+import importlib
+
+NATIVE_KERNEL_PACKAGES = ("glm_moe_dsa", "minimax_m3", "qwen35_prefill")
+
+
+def native_kernel_status() -> dict[str, dict[str, object]]:
+    """Report availability of every optional native kernel extension.
+
+    Source installs only compile the native extensions when built with
+    ``OMLX_WITH_CUSTOM_KERNEL=1`` (which additionally needs the Metal
+    toolchain). Without them the affected model families silently fall back
+    to much slower generic paths, so availability is surfaced through
+    ``GET /api/status`` for diagnosability instead of only a log line.
+
+    Never raises: a package that fails to import is reported as unavailable
+    with the stringified error.
+    """
+    status: dict[str, dict[str, object]] = {}
+    for name in NATIVE_KERNEL_PACKAGES:
+        try:
+            fast = importlib.import_module(f"{__name__}.{name}.fast")
+            available = bool(fast.is_native_available())
+            error = fast.import_error()
+        except Exception as exc:  # noqa: BLE001 - status must never break
+            available = False
+            error = exc
+        status[name] = {
+            "available": available,
+            "import_error": str(error) if error is not None else None,
+        }
+    return status

--- a/omlx/patches/glm_moe_dsa/__init__.py
+++ b/omlx/patches/glm_moe_dsa/__init__.py
@@ -80,12 +80,17 @@ def apply_glm_moe_dsa_patch() -> bool:
     _APPLIED = True
     missing = _missing_fast_symbols()
     if missing:
+        native_error = glm_fast.native_import_error()
         logger.warning(
             "GLM MoE DSA optimized patch applied, but fast kernel symbols are "
-            "missing from %s and mx.fast: %s. Build the native extension for "
-            "the accelerated path.",
+            "missing from %s and mx.fast: %s. Prefill for glm_moe_dsa models "
+            "will run a much slower non-fused fallback with higher memory use "
+            "(see issue #2137). Build the native extension for the accelerated "
+            "path (pip install with OMLX_WITH_CUSTOM_KERNEL=1; requires the "
+            "Metal toolchain) or use an official release build.%s",
             NATIVE_KERNELS_PACKAGE,
             ", ".join(missing),
+            f" Native import error: {native_error}" if native_error else "",
         )
     elif glm_fast.native_available():
         logger.info(

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2150,6 +2150,7 @@ async def health():
 @app.get("/api/status")
 async def server_status(_: bool = Depends(verify_api_key)):
     """Lightweight status endpoint for external tool polling (statuslines, scripts)."""
+    from .custom_kernels import native_kernel_status
     from .model_discovery import format_size
     from .server_metrics import get_server_metrics
 
@@ -2225,6 +2226,7 @@ async def server_status(_: bool = Depends(verify_api_key)):
         "model_memory_max_formatted": (
             format_size(model_memory_max) if model_memory_max else "unlimited"
         ),
+        "custom_kernels": native_kernel_status(),
     }
 
 

--- a/tests/test_status_endpoint.py
+++ b/tests/test_status_endpoint.py
@@ -204,3 +204,59 @@ class TestStatusEndpoint:
         data = resp.json()
         assert data["model_memory_max"] is None
         assert data["model_memory_max_formatted"] == "unlimited"
+
+
+class TestStatusCustomKernels:
+    """/api/status reports native custom kernel availability.
+
+    Diagnosability for silently-degraded source installs: without the
+    native extensions the affected model families fall back to much slower
+    generic paths (issue #2137), and this block makes that detectable by
+    external polling instead of only a log line.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_server_state(self):
+        state = ServerState()
+        with patch("omlx.server._server_state", state):
+            yield
+
+    def test_custom_kernels_block_lists_every_package(self, client):
+        from omlx.custom_kernels import NATIVE_KERNEL_PACKAGES
+
+        resp = client.get("/api/status")
+        assert resp.status_code == 200
+        kernels = resp.json()["custom_kernels"]
+        assert set(kernels) == set(NATIVE_KERNEL_PACKAGES)
+        for report in kernels.values():
+            assert set(report) == {"available", "import_error"}
+            assert isinstance(report["available"], bool)
+            assert report["import_error"] is None or isinstance(
+                report["import_error"], str
+            )
+
+    def test_available_packages_report_no_import_error(self, client):
+        resp = client.get("/api/status")
+        for name, report in resp.json()["custom_kernels"].items():
+            if report["available"]:
+                assert report["import_error"] is None, name
+            else:
+                assert report["import_error"], name
+
+    def test_native_kernel_status_never_raises_on_broken_package(self):
+        from omlx import custom_kernels
+
+        real_import = custom_kernels.importlib.import_module
+
+        def broken_import(name, *args, **kwargs):
+            if name.endswith(".fast"):
+                raise RuntimeError("simulated native import explosion")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(
+            custom_kernels.importlib, "import_module", side_effect=broken_import
+        ):
+            status = custom_kernels.native_kernel_status()
+        for name, report in status.items():
+            assert report["available"] is False, name
+            assert "simulated native import explosion" in report["import_error"]


### PR DESCRIPTION
## Problem

Source installs only compile the optional native kernel extensions when built with `OMLX_WITH_CUSTOM_KERNEL=1`, and the build additionally requires the Metal toolchain (plain Command Line Tools fail with `xcrun: unable to find utility \"metal\"`). When the extensions are absent, every fast path guarded by `has_symbol(...)` silently returns to generic MLX fallbacks. For `glm_moe_dsa` that fallback materializes dense per-head indexer scores: we measured **~29 tok/s vs ~845 tok/s prefill** (29x) on the same box/model/prompt (M3 Ultra 512GB, GLM-5.2 DQ4plus-q8, 9.6k-token prompt), plus the memory growth described in #2137. Full analysis: https://github.com/jundot/omlx/issues/2137#issuecomment-4942102843

The only current signal is a patch-time `logger.warning` that is easy to miss, so users report the degraded mode as a performance regression.

## Change

- `GET /api/status` gains a `custom_kernels` block reporting, per native kernel package (`glm_moe_dsa`, `minimax_m3`, `qwen35_prefill`): `{available: bool, import_error: str|null}`. Implemented as `omlx.custom_kernels.native_kernel_status()`; never raises, so the status endpoint cannot break even on a wedged native module. Example on a source install without the kernels:

  ```json
  "custom_kernels": {
    "glm_moe_dsa": {"available": false, "import_error": "ImportError(\"cannot import name '_ext' ...\")"},
    ...
  }
  ```

- The existing GLM MoE DSA fallback warning now states the performance consequence, includes the underlying native import error, and names the build remediation.

## Testing

`tests/test_status_endpoint.py` extended with a `TestStatusCustomKernels` class: block shape/coverage, available-vs-import_error consistency, and a never-raises test with a simulated native import explosion. 11/11 pass run twice on an M3 Ultra: once with the native extensions absent and once with them present.

## Possible follow-up

Happy to also contribute a CI job that publishes wheels with prebuilt kernels so pip users get the accelerated path by default, if that is a direction you want.