### PR TITLE
fix(reranker): fail fast on missing chat template, avoid duplicate think prefill

### DIFF
--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -330,6 +330,14 @@ class MLXRerankerModel:
            combined "<Instruct>/<Query>/<Document>" block — the exact content
            that _rerank_causal_lm reconstructs at scoring time.
         """
+        # Fail fast with a clear error when the tokenizer has no chat template
+        # at all — rendering would only produce an opaque downstream failure.
+        if hasattr(tokenizer, "chat_template") and tokenizer.chat_template is None:
+            raise ValueError(
+                f"Tokenizer for {self.model_name} has no chat template; "
+                f"cannot derive the CausalLM reranker prompt prefix/suffix."
+            )
+
         _SENTINEL = "<<__CONTENT_SENTINEL__>>"
         messages = [
             {"role": "system", "content": self._CAUSAL_LM_SYSTEM_PROMPT},
@@ -350,9 +358,13 @@ class MLXRerankerModel:
 
         parts = standard_rendered.split(_SENTINEL)
         if len(parts) == 2:
+            suffix = parts[1]
             # Append <think> block for models that use the
-            # thinking-then-answering format
-            return parts[0], parts[1] + "<think>\n\n</think>\n\n"
+            # thinking-then-answering format, unless the template already
+            # emitted a think prefill of its own.
+            if "<think>" not in suffix:
+                suffix += "<think>\n\n</think>\n\n"
+            return parts[0], suffix
 
         native_affixes, native_rendered, native_error = (
             self._extract_reranker_native_affixes(tokenizer)

--- a/tests/test_reranker_causal_lm.py
+++ b/tests/test_reranker_causal_lm.py
@@ -320,6 +320,34 @@ class TestCausalLMPromptAffixes:
             ["system", "query", "document"],
         ]
 
+    def test_standard_template_think_prefill_not_duplicated(self):
+        """A standard template that already emits a think prefill must not
+        get a second <think> block appended."""
+        model = MLXRerankerModel("unused")
+
+        class _ThinkingTokenizer(self._StandardTokenizer):
+            def apply_chat_template(self, messages, **kwargs):
+                return super().apply_chat_template(messages, **kwargs) + (
+                    "<think>\n\n</think>\n\n"
+                )
+
+        prefix, suffix = model._extract_causal_lm_affixes(_ThinkingTokenizer())
+
+        assert prefix == self._EXPECTED_PREFIX
+        assert suffix == self._EXPECTED_SUFFIX
+        assert suffix.count("<think>") == 1
+
+    def test_missing_chat_template_raises_clear_error(self):
+        """A tokenizer with chat_template=None fails fast with a clear error
+        instead of an opaque rendering failure."""
+        model = MLXRerankerModel("unused")
+
+        class _NoTemplateTokenizer:
+            chat_template = None
+
+        with pytest.raises(ValueError, match="no chat template"):
+            model._extract_causal_lm_affixes(_NoTemplateTokenizer())
+
     def test_native_template_rendering_error_falls_through(self):
         """A template that raises on both shapes surfaces both errors."""
         model = MLXRerankerModel("unused")


### PR DESCRIPTION
Follow-up to #2147 (merged): these two edge-case fixes were pushed to the PR branch shortly after the merge, so they missed the train.

Both were first handled by the alternative approach in #1964 and are absorbed here so the merged implementation covers them too:

- **Fail fast on missing chat template.** A tokenizer with `chat_template=None` now raises a clear `ValueError` up front instead of surfacing an opaque rendering failure from `apply_chat_template`.
- **No duplicate `<think>` prefill.** The standard-template path only appends the `<think>\n\n</think>\n\n` block when the rendered suffix doesn't already contain one, so templates that emit their own think prefill are no longer double-prefixed.

## Verification

- Two new tests in `TestCausalLMPromptAffixes` (`test_standard_template_think_prefill_not_duplicated`, `test_missing_chat_template_raises_clear_error`); `pytest tests/test_reranker_causal_lm.py`: 30 passed.
- Re-verified against the real tokenizers of `mlx-community/Qwen3-Reranker-0.6B-mxfp8` and `-4bit`: prefix/suffix extraction unchanged, token sequences still identical across both template paths.

generated by Claude Code