### PR TITLE
fix(turboquant): track the written physical end in batched KV caches

### DIFF
--- a/omlx/turboquant_kv.py
+++ b/omlx/turboquant_kv.py
@@ -246,6 +246,16 @@ class BatchTurboQuantKVCache(TurboQuantKVCache):
         else:
             self.offset = -left_padding[0]
         self._right_padding = None
+        # Written physical column count (B>1 only; B=1 uses the parent's int
+        # offset). Rows are end-aligned, but this must NOT be derived from
+        # offset.max(): once filter() removes the last zero-left-padding row,
+        # every logical offset is short of the written end, and an
+        # offset-derived position writes INSIDE the survivors' live KV. It
+        # also must not be derived from _state_length(self.keys): that is the
+        # step-allocated capacity, not the written end. (Deliberately not
+        # named `_idx` — mlx-vlm's rollback_speculative_cache changes
+        # behavior on that attribute.)
+        self._phys_end = 0
 
     # ---- update_and_fetch override for B>1 only ----------------------------
 
@@ -255,13 +265,14 @@ class BatchTurboQuantKVCache(TurboQuantKVCache):
             return super().update_and_fetch(keys, values)
         # B>1: track per-request offset separately from state offset
         T_new = keys.shape[2]
-        # Use int offset for state management
-        int_offset = self.offset.max().item()
+        # Append at the written physical end (see __init__._phys_end note).
+        int_offset = self._phys_end
         self.offset += T_new
         saved_offset = self.offset
         self.offset = int_offset
         result = super().update_and_fetch(keys, values)
         self.offset = saved_offset
+        self._phys_end = int_offset + T_new
         return result
 
     # ---- state override for B>1 (offset is mx.array) -----------------------
@@ -270,15 +281,22 @@ class BatchTurboQuantKVCache(TurboQuantKVCache):
     def state(self):
         if isinstance(self.offset, int):
             return super().state
-        # B>1: use keys length directly (offset is mx.array, can't compare with int)
+        # B>1: slice to the written end — _state_length(self.keys) is the
+        # step-allocated capacity and would expose unwritten columns to
+        # attention after the buffer grows.
         if self.keys is None:
             return None, None
-        length = _state_length(self.keys)
+        length = self._phys_end
         return _slice_state(self.keys, length), _slice_state(self.values, length)
 
     @state.setter
     def state(self, value):
         TurboQuantKVCache.state.fset(self, value)
+        # Restored states (SSD cache, extract/merge round-trips) are packed
+        # at their exact written width — sync the physical end for the B>1
+        # bookkeeping paths.
+        if self.keys is not None and not isinstance(self.offset, int):
+            self._phys_end = _state_length(self.keys)
 
     # ---- make_mask override (batch-aware) ----------------------------------
 
@@ -291,14 +309,22 @@ class BatchTurboQuantKVCache(TurboQuantKVCache):
         offset = self.offset
         if isinstance(offset, int):
             return create_attention_mask(N, offset, return_array, window_size)
-        if isinstance(offset, mx.array) and offset.size == 1:
+        if (
+            isinstance(offset, mx.array)
+            and offset.size == 1
+            and int(self.left_padding.max().item()) == 0
+        ):
             return create_attention_mask(N, offset.item(), return_array, window_size)
-        # B>1: delegate to mlx-lm's create_causal_mask with the physical column
-        # count + per-request left_padding, exactly like BatchKVCache. The old
-        # hand-rolled term compared each request's sequence length (offset)
-        # against the column index, which masked out valid left-padded tokens —
-        # so left-padded requests attended to ~nothing and decoded garbage.
-        phys = offset.max().item()
+        # B>1 (or a left-padded survivor after filter()): delegate to mlx-lm's
+        # create_causal_mask with the physical column count + per-request
+        # left_padding, exactly like BatchKVCache. The old hand-rolled term
+        # compared each request's sequence length (offset) against the column
+        # index, which masked out valid left-padded tokens — so left-padded
+        # requests attended to ~nothing and decoded garbage. The column count
+        # is the WRITTEN end, not offset.max(): after the zero-left-padding
+        # row departs, offset.max() undercounts and blinds the survivors to
+        # their own tail context.
+        phys = self._phys_end
         return create_causal_mask(
             N, offset=phys, window_size=window_size, left_padding=self.left_padding
         )
@@ -309,6 +335,12 @@ class BatchTurboQuantKVCache(TurboQuantKVCache):
 
     def _ensure_array_offset(self):
         if isinstance(self.offset, int):
+            # B=1 tracks written columns in the parent's int offset (plus any
+            # left padding); sync the physical end before switching to
+            # per-request array offsets, where the parent no longer maintains
+            # it.
+            lp0 = int(self.left_padding[0].item()) if self.left_padding is not None else 0
+            self._phys_end = max(self._phys_end, self.offset + lp0)
             self.offset = mx.array([self.offset])
 
     def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
@@ -363,9 +395,12 @@ class BatchTurboQuantKVCache(TurboQuantKVCache):
         self._ensure_array_offset()
         other._ensure_array_offset()
         max_off = max(self.offset.max().item(), other.offset.max().item())
-        # Use the underlying int offset (total tokens) for state operations
-        s_idx = _state_length(self.keys) if self.keys is not None else 0
-        o_idx = _state_length(other.keys) if other.keys is not None else 0
+        # Align on the WRITTEN ends: _state_length is step-allocated capacity,
+        # and padding a joining row by capacity difference would bury its
+        # content behind unwritten columns. _pad_and_trim also slices each
+        # side down to its written end, normalizing any over-allocation.
+        s_idx = self._phys_end if self.keys is not None else 0
+        o_idx = other._phys_end if other.keys is not None else 0
         max_idx = max(s_idx, o_idx)
         ref_keys = self.keys if self.keys is not None else other.keys
         ref_values = self.values if self.values is not None else other.values
@@ -400,8 +435,7 @@ class BatchTurboQuantKVCache(TurboQuantKVCache):
 
         self.offset = mx.concatenate([s_off, o_off])
         self.left_padding = mx.concatenate([s_lp, o_lp])
-        # Parent's offset is used for state length — set to max
-        # (state property uses self.offset for slicing)
+        self._phys_end = max_idx
         self._cached_state = None
         self._cached_state_offset = -1
 
@@ -506,4 +540,5 @@ class BatchTurboQuantKVCache(TurboQuantKVCache):
             mx.eval(batch.keys, batch.values)
 
         batch.offset += max_length
+        batch._phys_end = max_length
         return batch

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -1041,3 +1041,86 @@ def test_batch_masked_decode_is_accurate():
     assert (
         rel < 0.05
     ), f"B>1 masked decode inaccurate (err {rel:.1%}) — RHT fix missing from pinned mlx-vlm?"
+
+
+def _make_ragged_batch(bits=8.0, t_long=48, t_short=32, nkv=2, d=32, seed=5):
+    mx.random.seed(seed)
+    rows = []
+    for t in (t_long, t_short):
+        c = TurboQuantKVCache(bits=bits)
+        k = mx.random.normal((1, nkv, t, d)).astype(mx.float16)
+        v = mx.random.normal((1, nkv, t, d)).astype(mx.float16)
+        c.update_and_fetch(k, v)
+        mx.eval(c.keys, c.values)
+        rows.append((c, k, v))
+    batch = BatchTurboQuantKVCache.merge([c for c, _, _ in rows])
+    return batch, rows
+
+
+def test_batch_tq_append_position_survives_min_lp_row_departure():
+    """Continuous batching: when the zero-left-padding row departs (filter),
+    the physical append position must stay at the buffer's written end.
+    Deriving it from offset.max() makes every later decode write land
+    min(left_padding) columns early — overwriting the surviving rows' live
+    KV in place and silently losing the appended tokens (issue class: batched
+    TurboQuant intelligence collapse)."""
+    batch, rows = _make_ragged_batch()
+    _, k2, v2 = rows[1]
+
+    batch.filter(mx.array([1]))  # the lp=0 row departs; survivor lp=16
+
+    ref_k = [k2[0]]
+    for _ in range(3):
+        nk = mx.random.normal((1, 2, 1, 32)).astype(mx.float16)
+        nv = mx.random.normal((1, 2, 1, 32)).astype(mx.float16)
+        batch.update_and_fetch(nk, nv)
+        ref_k.append(nk[0])
+    mx.eval(batch.keys, batch.values)
+
+    ref_k = mx.concatenate(ref_k, axis=1)  # (nkv, 35, d) logical truth
+    dk, _ = batch.dequantize()
+    lp = int(batch.left_padding[0].item())
+    stored = dk.shape[2] - lp
+    assert stored >= ref_k.shape[1], (
+        f"appended tokens lost: {stored} stored of {ref_k.shape[1]} logical"
+    )
+    got = dk[0, :, lp : lp + ref_k.shape[1], :].astype(mx.float32)
+    err = mx.abs(got - ref_k.astype(mx.float32)).max().item()
+    assert err < 0.2, f"surviving row KV stomped in place (max err {err:.3f})"
+
+
+def test_batch_tq_make_mask_width_after_min_lp_row_departure():
+    """make_mask must span the written physical columns, not offset.max():
+    after the lp=0 row departs the two diverge and a shrunken mask blinds
+    the survivors to their own tail context."""
+    batch, _ = _make_ragged_batch()
+    batch.filter(mx.array([1]))
+    m = batch.make_mask(1, return_array=True)
+    assert m.shape[-1] == 48 + 1, (
+        f"mask spans {m.shape[-1]} columns, expected 49 (48 written + 1 new)"
+    )
+
+
+def test_batch_tq_append_growth_keeps_content_and_geometry():
+    """Appending past the merged buffer's exact capacity must step-grow the
+    state without shifting content or leaking unwritten capacity columns
+    into .state / attention geometry."""
+    batch, rows = _make_ragged_batch()
+    _, k1, _ = rows[0]
+
+    nk = mx.random.normal((2, 2, 1, 32)).astype(mx.float16)
+    nv = mx.random.normal((2, 2, 1, 32)).astype(mx.float16)
+    batch.update_and_fetch(nk, nv)  # write at 48 -> triggers reserve growth
+    mx.eval(batch.keys, batch.values)
+
+    ks, _ = batch.state
+    from omlx.turboquant_kv import _state_length as _sl
+    assert _sl(getattr(ks, "_state", ks)) == 49, (
+        f".state exposes {_sl(getattr(ks, '_state', ks))} columns, expected 49"
+    )
+    dk, _ = batch.dequantize()
+    got = dk[0, :, :48, :].astype(mx.float32)
+    err = mx.abs(got - k1[0].astype(mx.float32)).max().item()
+    assert err < 0.2, f"row0 content shifted/corrupted after growth ({err:.3f})"
+    err_new = mx.abs(dk[0, :, 48, :].astype(mx.float32) - nk[0, :, 0, :].astype(mx.float32)).max().item()
+    assert err_new < 0.2, f"appended token not at written end ({err_new:.3f})"


### PR DESCRIPTION
Fixes #2172

## Problem

Serving any model with TurboQuant KV enabled degrades output quality severely under
concurrent load, independent of bit depth. Measured on Qwen3.6-35B-A3B oQ4 (GSM8K /
HumanEval, n=30, greedy deterministic profile, thinking off):

| Config | GSM8K | HumanEval |
|---|---|---|
| TQ-KV off, batch 4 | 96.7 | 90.0 |
| TQ-KV 8-bit, batch 1 | 96.7 | 90.0 |
| TQ-KV 8-bit, batch 4 | **53.3** | **70.0** |
| TQ-KV 8-bit, batch 4, MTP off | **53.3** | **70.0** |

This matches the #2172 report (their GSM8K also lands at ~50–53, 8-bit as bad as
4-bit). MTP is not required — the reporter's isolation happened to toggle KV together
with MTP, but the collapse reproduces identically with MTP off, and it is invisible at
batch 1 (which is why it resists single-request reproduction).

## Root cause

`BatchTurboQuantKVCache` has no record of its written physical end. The B>1
`update_and_fetch` derived the append position from `offset.max()`, and `make_mask`
derived its column count the same way. That equals the written end only while some row
has zero left padding. The moment `filter()` removes the last zero-padding row — a
routine continuous-batching event whenever the longest-prompt request finishes first —
every logical offset falls short of the written end, and each subsequent decode append
lands `min(left_padding)` columns early: it **overwrites the surviving rows' live KV in
place**, the appended tokens are silently lost (the buffer never grows), and the mask
shrinks below the survivors' own context. Every surviving request in the batch is
corrupted from that point on; the damage compounds with each departure.

Deriving the position from `_state_length()` instead would also be wrong: that is the
step-allocated capacity, not the written end, so after any buffer growth it would leak
unwritten columns into `.state` and attention geometry (and `extend()` already had this
capacity-vs-written confusion when aligning a joining batch).

Unit repro (now a regression test): merge rows of 48/32 tokens → filter out the
zero-padding row → append 3 tokens → buffer stuck at 48, 3 tokens lost, the survivor's
logical positions 16–18 overwritten (content error 4.76 vs 0.01 quantization noise).
The identical sequence through dense `BatchKVCache` appends correctly.

## Fix

Track an explicit written-column count (`_phys_end`): maintained by
`update_and_fetch`/`merge`/`extend`, synced at the B=1→B>1 transition
(`_ensure_array_offset`) and by the state setter for restored states, and used for the
append position, the `.state` slice, `make_mask` geometry (including the
single-survivor-with-left-padding case, which previously built an unpadded mask from
the logical offset), and `extend` alignment. Deliberately not named `_idx`:
`rollback_speculative_cache` in mlx-vlm changes behavior on that attribute, and this
change keeps that path untouched.

Behavior is bit-identical while the zero-left-padding invariant holds (`_phys_end ==
offset.max()` in that regime), so unbatched and pre-departure serving are unaffected.

## Validation

- 3 new regression tests (RED-proven on the unfixed code): append position after the
  min-left-padding row departs (content vs dense mirror), `make_mask` width after
  departure, and append-past-capacity growth keeping content and geometry.
- `tests/test_turboquant.py`: 43/43. All test files importing the module (scheduler,
  paged SSD cache, MTP patches, VLM MTP, benchmark, integration): 740 passed.
- Model-level re-run of the two degraded cells on this branch: **both recover to
  96.7 / 90.0** — identical to the TQ-off control.
