### PR TITLE
fix(oq): scope VisionConfig model_type normalization to Qwen types

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -2658,6 +2658,12 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
             vision_config = model_config.vision_config
             if isinstance(vision_config, dict):
                 vision_config = model_module.VisionConfig.from_dict(vision_config)
+            if hasattr(vision_config, "model_type") and isinstance(
+                vision_config.model_type, str
+            ) and vision_config.model_type.startswith("qwen") and vision_config.model_type.endswith("_vision"):
+                vision_config.model_type = vision_config.model_type.removesuffix(
+                    "_vision"
+                )
             text_config = model_config.text_config
             if isinstance(text_config, dict):
                 text_config = model_module.TextConfig.from_dict(text_config)

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -20,6 +20,48 @@ _CKPT_TEXT_PREFIX = "model.language_model."
 _RUNTIME_TEXT_PREFIX = "language_model.model."
 
 _MLX_LM_LOAD_CONFIG_PATCHED = False
+_VLM_VISION_CONFIG_MT_PATCHED = False
+
+
+def _needs_vision_suffix_strip(model_type: str) -> bool:
+    """Return True for Qwen vision model types that need ``_vision`` stripped."""
+    return model_type.startswith("qwen") and model_type.endswith("_vision")
+
+
+def _patch_vlm_vision_config_model_type() -> None:
+    """Strip ``_vision`` suffix from Qwen ``VisionConfig.model_type``.
+
+    HuggingFace transformers auto-generates ``vision_config.model_type`` by
+    appending ``_vision`` to the base model type (e.g. ``qwen3_5_moe_vision``).
+    mlx-vlm's Qwen ``VisionModel.__init__`` has a hardcoded allowlist that only
+    accepts the base name.  Other families (gemma3n, minicpmv4_6) *require* the
+    ``_vision`` suffix, so we only strip for Qwen types.
+    """
+    global _VLM_VISION_CONFIG_MT_PATCHED
+    if _VLM_VISION_CONFIG_MT_PATCHED:
+        return
+
+    try:
+        from mlx_vlm.models.base import BaseModelConfig
+    except ImportError:
+        return
+
+    if getattr(BaseModelConfig, "_omlx_vision_mt_patched", False):
+        _VLM_VISION_CONFIG_MT_PATCHED = True
+        return
+
+    original = BaseModelConfig.from_dict.__func__
+
+    def patched(cls, params):
+        if params and isinstance(params, dict):
+            mt = params.get("model_type", "")
+            if isinstance(mt, str) and _needs_vision_suffix_strip(mt):
+                params = {**params, "model_type": mt.removesuffix("_vision")}
+        return original(cls, params)
+
+    BaseModelConfig.from_dict = classmethod(patched)
+    BaseModelConfig._omlx_vision_mt_patched = True
+    _VLM_VISION_CONFIG_MT_PATCHED = True
 
 # mlx_lm.load dropped trust_remote_code in some releases. Check once at
 # import time so call sites can pass it safely across versions.
@@ -199,6 +241,7 @@ def maybe_apply_pre_load_patches(
     set_mtp_active(False)
 
     _patch_mlx_lm_load_config()
+    _patch_vlm_vision_config_model_type()
 
     config_path = Path(model_name) / "config.json"
     if not config_path.exists():


### PR DESCRIPTION
## Problem

HuggingFace transformers appends `_vision` to vision sub-config `model_type` (e.g. `qwen3_5_moe_vision`), but mlx-vlm's Qwen `VisionModel.__init__` only accepts the base name. The previous fix stripped `_vision` unconditionally, which broke other families (gemma3n, minicpmv4_6) that require the suffix.

## Fix

Scope the `_vision` suffix normalization to Qwen model types only (`omlx/oq.py` and `omlx/utils/model_loading.py`).

## Test plan

- [x] Qwen3.6 VLM loads correctly (`vision_config.model_type` normalized from `qwen3_5_moe_vision` → `qwen3_5_moe`)
- [x] oQ sensitivity measurement succeeds on Qwen VLMs
- [x] Non-Qwen VLMs (gemma3n, minicpmv4_6) are unaffected — their `_vision` suffix is preserved