### PR TITLE
ci: build and publish wheels with native custom kernels precompiled

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -51,8 +51,13 @@ jobs:
 
       - name: Smoke-test wheel (native kernels must import and report available)
         run: |
+          echo "--- native artifacts in the wheel:"
+          unzip -l dist/*.whl | grep -E "_ext|dylib|metallib" || { echo "no native artifacts in wheel"; exit 1; }
           python -m venv /tmp/wheel-smoke
           /tmp/wheel-smoke/bin/pip install --quiet dist/*.whl
+          # run from outside the checkout so `import omlx` resolves to the
+          # installed wheel, not the source tree in cwd
+          cd /tmp
           /tmp/wheel-smoke/bin/python - <<'PY'
           import importlib
           failed = []

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,86 @@
+name: Build wheels
+
+# Builds pip wheels WITH the native custom kernels precompiled, so pip users
+# get the accelerated GLM-5.2 / MiniMax M3 / Qwen3.5 paths without needing
+# the Metal toolchain locally (source installs without it silently fall back
+# to much slower generic kernels; see #2137 / #2208).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-wheels:
+    # macos-15: the native kernels target MACOSX_DEPLOYMENT_TARGET=15.0, so
+    # the post-build import smoke test needs a Sequoia host.
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Build wheel with native custom kernels
+        env:
+          OMLX_WITH_CUSTOM_KERNEL: "1"
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel
+
+      - name: Smoke-test wheel (native kernels must import and report available)
+        run: |
+          python -m venv /tmp/wheel-smoke
+          /tmp/wheel-smoke/bin/pip install --quiet dist/*.whl
+          /tmp/wheel-smoke/bin/python - <<'PY'
+          import importlib
+          failed = []
+          for pkg in ("glm_moe_dsa", "minimax_m3", "qwen35_prefill"):
+              fast = importlib.import_module(f"omlx.custom_kernels.{pkg}.fast")
+              ok = bool(fast.is_native_available())
+              print(f"{pkg}: native_available={ok} import_error={fast.import_error()}")
+              if not ok:
+                  failed.append(pkg)
+          raise SystemExit(f"native kernels missing from wheel: {failed}" if failed else 0)
+          PY
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wheels-py${{ matrix.python-version }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  attach-to-release:
+    if: github.event_name == 'release'
+    needs: build-wheels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Attach wheels to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" dist/*.whl \
+            --repo "${{ github.repository }}" --clobber

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -39,9 +39,15 @@ jobs:
       - name: Build wheel with native custom kernels
         env:
           OMLX_WITH_CUSTOM_KERNEL: "1"
+        # --no-isolation with preinstalled build deps: CMake's Python discovery
+        # does not reliably resolve pip's isolated build env on the hosted
+        # runners (it found the system framework Python without nanobind), so
+        # we build against the job's Python and pin it for CMake explicitly.
         run: |
-          python -m pip install --upgrade pip build
-          python -m build --wheel
+          python -m pip install --upgrade pip
+          python -m pip install build setuptools wheel "cmake>=3.27" "nanobind==2.13.0" "mlx==0.32.0"
+          export CMAKE_ARGS="-DPython_EXECUTABLE=$(python -c 'import sys; print(sys.executable)')"
+          python -m build --wheel --no-isolation
 
       - name: Smoke-test wheel (native kernels must import and report available)
         run: |


### PR DESCRIPTION
Follow-up to #2137 / #2191 / #2208, and the wheel-CI offer from #2191: most pip/source users never build the native custom kernels (needs `OMLX_WITH_CUSTOM_KERNEL=1` plus the Metal toolchain that Command Line Tools lack), so they silently run the generic fallback, for GLM-5.2 that is ~30x slower prefill. This workflow gives pip users the same precompiled kernels the DMG ships:

- builds cp311/cp312/cp313 arm64 wheels on `macos-15` (the kernels target `MACOSX_DEPLOYMENT_TARGET=15.0`, so the import smoke needs a Sequoia host) with `OMLX_WITH_CUSTOM_KERNEL=1`
- `--no-isolation` with preinstalled pinned build deps (`nanobind==2.13.0`, `mlx==0.32.0`, `cmake>=3.27`) and an explicit `-DPython_EXECUTABLE` pin, CMake's Python discovery does not reliably resolve pip's isolated build env on hosted runners
- gates every wheel on two checks: the native artifacts (`_ext`, `.dylib`, `.metallib`) are present in the wheel, and a fresh-venv install (run from outside the checkout) reports `is_native_available() == True` for all three kernel packages
- uploads artifacts on `workflow_dispatch`; attaches wheels to the release on publish (same trigger shape as `update-formula.yml`)

**Validated green on my fork's Actions across all three Python versions:** https://github.com/StartupBros/omlx/actions/runs/29173718204

Action pins follow the repo convention (full SHAs). Happy to adjust triggers/naming, e.g. if you would rather gate this behind a tag pattern or fold it into the release pipeline that builds the DMG.