### PR TITLE
fix: load indexed MTP sidecar safetensors skipped by mlx-lm's glob

### DIFF
--- a/omlx/patches/deepseek_v4/utils_patch.py
+++ b/omlx/patches/deepseek_v4/utils_patch.py
@@ -145,7 +145,7 @@ def _build_patched_load_model() -> Callable:
                 "trust this model."
             )
 
-        weight_files = glob.glob(str(model_path / "model*.safetensors"))
+        weight_files = _utils.glob.glob(str(model_path / "model*.safetensors"))
 
         if not weight_files and strict:
             raise FileNotFoundError(f"No safetensors found in {model_path}")

--- a/omlx/patches/deepseek_v4/utils_patch.py
+++ b/omlx/patches/deepseek_v4/utils_patch.py
@@ -20,7 +20,6 @@ When mlx-lm merges PR 1192 upstream this patch should be removed.
 
 from __future__ import annotations
 
-import glob
 import importlib.util
 import json
 import logging

--- a/omlx/patches/mlx_lm_extra_tensors.py
+++ b/omlx/patches/mlx_lm_extra_tensors.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Patch mlx-lm's weight-shard glob to pick up indexed MTP sidecar files.
+
+``mlx_lm.utils.load_model`` discovers weight shards with
+``glob.glob(str(model_path / "model*.safetensors"))``. MTPLX-forge exports
+(e.g. ``wang-yang/Ornith-1.0-35B-MTPLX``) ship the MTP head's weights in a
+separate ``mtp.safetensors`` sidecar that ``model.safetensors.index.json``
+references but that filename doesn't match the glob. The sidecar is
+silently skipped, so the ``mtp.*`` keys it holds never reach
+``TextModel.sanitize`` — Native MTP then raises "the converted weights are
+missing the mtp.* tensors" even though the checkpoint has them (issue
+#2062).
+
+Fix: replace the ``glob`` name ``mlx_lm.utils`` resolves at call time with a
+thin proxy. Every pattern except the ``model*.safetensors`` shard-discovery
+call passes straight through to the real ``glob.glob``; that one call gets
+augmented with sidecar files referenced by ``mtp.*``-prefixed keys in the
+model's safetensors index.
+
+This is distinct from issue #1944 / PR #1962, which fix the Native MTP
+*compatibility check* (``_checkpoint_has_mtp_weights`` /
+``_model_has_mtp_weight_tensors``) for OptiQ checkpoints whose sidecar isn't
+referenced by the index at all. Neither of those touches actual weight
+loading, so they don't help here.
+"""
+
+from __future__ import annotations
+
+import glob as _glob_module
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_EXTRA_TENSOR_FILES: list[str] = []
+
+_MTP_INDEX_PREFIXES = (
+    "mtp.",
+    "language_model.mtp.",
+    "model.mtp.",
+    "model.language_model.mtp.",
+)
+
+
+def set_extra_tensor_files(files: list[str]) -> None:
+    """Set the process-wide sidecar file list for the next ``mlx_lm.load()``.
+
+    Same construction-time-flag pattern as ``mlx_lm_mtp.set_mtp_active``:
+    the caller resets this to ``[]`` before every load so a model without a
+    sidecar isn't polluted by a prior load's file list.
+    """
+    global _EXTRA_TENSOR_FILES
+    _EXTRA_TENSOR_FILES = list(files)
+
+
+def get_extra_tensor_files() -> list[str]:
+    return list(_EXTRA_TENSOR_FILES)
+
+
+def sidecar_files_for(model_path: str | Path) -> list[str]:
+    """Return absolute paths of safetensors sidecars holding mtp.* weights.
+
+    Reads ``model.safetensors.index.json``'s ``weight_map``, collects the
+    distinct filenames backing ``mtp.*``-prefixed keys, and drops any that
+    already match mlx-lm's own ``model*.safetensors`` glob (no need to add
+    those — mlx-lm finds them on its own).
+
+    Returns ``[]`` when there's no index, the index is unreadable, or every
+    mtp.* key already lives in a ``model*.safetensors`` shard.
+    """
+    p = Path(model_path)
+    index_path = p / "model.safetensors.index.json"
+    if not index_path.exists():
+        return []
+    try:
+        weight_map = json.loads(index_path.read_text()).get("weight_map") or {}
+    except Exception as e:
+        logger.debug("Failed to read %s for sidecar scan: %s", index_path, e)
+        return []
+
+    sidecar_names = {
+        fname
+        for key, fname in weight_map.items()
+        if isinstance(key, str)
+        and key.startswith(_MTP_INDEX_PREFIXES)
+        and isinstance(fname, str)
+    }
+    if not sidecar_names:
+        return []
+
+    already_covered = {
+        Path(f).name for f in _glob_module.glob(str(p / "model*.safetensors"))
+    }
+    return sorted(
+        str(p / fname) for fname in sidecar_names if fname not in already_covered
+    )
+
+
+class _GlobProxy:
+    """Delegates to the real ``glob`` module, augmenting one call site.
+
+    Only the ``model*.safetensors`` shard-discovery pattern is
+    special-cased; every other call (tokenizer/config discovery, checkpoint
+    saving, sharded-pipeline file selection, etc.) passes through
+    untouched.
+    """
+
+    _omlx_extra_tensors_proxy = True
+
+    def glob(self, pattern, *args, **kwargs):
+        matches = _glob_module.glob(pattern, *args, **kwargs)
+        if pattern.endswith("model*.safetensors") and _EXTRA_TENSOR_FILES:
+            existing = set(matches)
+            matches = matches + [f for f in _EXTRA_TENSOR_FILES if f not in existing]
+        return matches
+
+    def __getattr__(self, name):
+        return getattr(_glob_module, name)
+
+
+def apply() -> bool:
+    """Install the glob proxy on ``mlx_lm.utils``. Idempotent."""
+    try:
+        from mlx_lm import utils as mlx_lm_utils
+    except ImportError:
+        logger.debug("mlx_lm.utils not importable; skipping extra-tensors patch")
+        return False
+
+    if not getattr(mlx_lm_utils.glob, "_omlx_extra_tensors_proxy", False):
+        mlx_lm_utils.glob = _GlobProxy()
+        logger.info("mlx-lm MTP sidecar glob patch applied")
+    return True

--- a/omlx/patches/mlx_lm_extra_tensors.py
+++ b/omlx/patches/mlx_lm_extra_tensors.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Patch mlx-lm's weight-shard glob to pick up indexed MTP sidecar files.
+"""Patch mlx-lm's weight-shard glob to pick up MTP sidecar files.
 
 ``mlx_lm.utils.load_model`` discovers weight shards with
 ``glob.glob(str(model_path / "model*.safetensors"))``. MTPLX-forge exports
@@ -14,8 +14,8 @@ missing the mtp.* tensors" even though the checkpoint has them (issue
 Fix: replace the ``glob`` name ``mlx_lm.utils`` resolves at call time with a
 thin proxy. Every pattern except the ``model*.safetensors`` shard-discovery
 call passes straight through to the real ``glob.glob``; that one call gets
-augmented with sidecar files referenced by ``mtp.*``-prefixed keys in the
-model's safetensors index.
+augmented with sidecar files declared by that model's config or referenced by
+``mtp.*``-prefixed keys in its safetensors index.
 
 This is distinct from issue #1944 / PR #1962, which fix the Native MTP
 *compatibility check* (``_checkpoint_has_mtp_weights`` /
@@ -29,11 +29,10 @@ from __future__ import annotations
 import glob as _glob_module
 import json
 import logging
+import os
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
-
-_EXTRA_TENSOR_FILES: list[str] = []
 
 _MTP_INDEX_PREFIXES = (
     "mtp.",
@@ -43,58 +42,61 @@ _MTP_INDEX_PREFIXES = (
 )
 
 
-def set_extra_tensor_files(files: list[str]) -> None:
-    """Set the process-wide sidecar file list for the next ``mlx_lm.load()``.
-
-    Same construction-time-flag pattern as ``mlx_lm_mtp.set_mtp_active``:
-    the caller resets this to ``[]`` before every load so a model without a
-    sidecar isn't polluted by a prior load's file list.
-    """
-    global _EXTRA_TENSOR_FILES
-    _EXTRA_TENSOR_FILES = list(files)
-
-
-def get_extra_tensor_files() -> list[str]:
-    return list(_EXTRA_TENSOR_FILES)
-
-
 def sidecar_files_for(model_path: str | Path) -> list[str]:
     """Return absolute paths of safetensors sidecars holding mtp.* weights.
 
-    Reads ``model.safetensors.index.json``'s ``weight_map``, collects the
-    distinct filenames backing ``mtp.*``-prefixed keys, and drops any that
-    already match mlx-lm's own ``model*.safetensors`` glob (no need to add
-    those — mlx-lm finds them on its own).
+    Merges ``config.json``'s ``mlx_lm_extra_tensors.mtp_file`` with filenames
+    backing ``mtp.*``-prefixed keys in ``model.safetensors.index.json``. Drops
+    exact files already matched by mlx-lm's own ``model*.safetensors`` glob.
 
-    Returns ``[]`` when there's no index, the index is unreadable, or every
-    mtp.* key already lives in a ``model*.safetensors`` shard.
+    Returns ``[]`` when neither source declares an MTP sidecar or every
+    declared file is already covered by mlx-lm's shard glob.
     """
     p = Path(model_path)
-    index_path = p / "model.safetensors.index.json"
-    if not index_path.exists():
-        return []
-    try:
-        weight_map = json.loads(index_path.read_text()).get("weight_map") or {}
-    except Exception as e:
-        logger.debug("Failed to read %s for sidecar scan: %s", index_path, e)
-        return []
+    sidecar_names: set[str] = set()
 
-    sidecar_names = {
-        fname
-        for key, fname in weight_map.items()
-        if isinstance(key, str)
-        and key.startswith(_MTP_INDEX_PREFIXES)
-        and isinstance(fname, str)
-    }
+    config_path = p / "config.json"
+    if config_path.exists():
+        try:
+            config = json.loads(config_path.read_text())
+            extra_tensors = config.get("mlx_lm_extra_tensors")
+            if isinstance(extra_tensors, dict):
+                mtp_file = extra_tensors.get("mtp_file")
+                if isinstance(mtp_file, str) and mtp_file:
+                    sidecar_names.add(mtp_file)
+        except Exception as e:
+            logger.debug("Failed to read %s for sidecar scan: %s", config_path, e)
+
+    index_path = p / "model.safetensors.index.json"
+    if index_path.exists():
+        try:
+            weight_map = json.loads(index_path.read_text()).get("weight_map") or {}
+            sidecar_names.update(
+                fname
+                for key, fname in weight_map.items()
+                if isinstance(key, str)
+                and key.startswith(_MTP_INDEX_PREFIXES)
+                and isinstance(fname, str)
+            )
+        except Exception as e:
+            logger.debug("Failed to read %s for sidecar scan: %s", index_path, e)
+
     if not sidecar_names:
         return []
 
+    model_root = Path(os.path.abspath(p))
     already_covered = {
-        Path(f).name for f in _glob_module.glob(str(p / "model*.safetensors"))
+        Path(os.path.abspath(f))
+        for f in _glob_module.glob(str(model_root / "model*.safetensors"))
     }
-    return sorted(
-        str(p / fname) for fname in sidecar_names if fname not in already_covered
-    )
+    sidecars = {
+        path
+        for fname in sidecar_names
+        if (path := Path(os.path.abspath(model_root / fname))).is_relative_to(
+            model_root
+        )
+    }
+    return sorted(str(path) for path in sidecars if path not in already_covered)
 
 
 class _GlobProxy:
@@ -110,9 +112,14 @@ class _GlobProxy:
 
     def glob(self, pattern, *args, **kwargs):
         matches = _glob_module.glob(pattern, *args, **kwargs)
-        if pattern.endswith("model*.safetensors") and _EXTRA_TENSOR_FILES:
+        try:
+            pattern_path = Path(pattern)
+        except TypeError:
+            return matches
+        if pattern_path.name == "model*.safetensors":
+            sidecars = sidecar_files_for(pattern_path.parent)
             existing = set(matches)
-            matches = matches + [f for f in _EXTRA_TENSOR_FILES if f not in existing]
+            matches = matches + [f for f in sidecars if f not in existing]
         return matches
 
     def __getattr__(self, name):

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -375,11 +375,11 @@ def maybe_apply_pre_load_patches(
       mlx-lm exposes it as a bare DeepSeek-V3.2 subclass and cannot load
       checkpoints whose shared DSA layers carry no indexer weights.
     - MTP sidecar glob patch (issue #2062) when the config declares MTP
-      heads and the checkpoint's safetensors index references mtp.*
-      weights in a file mlx-lm's ``model*.safetensors`` glob wouldn't find
-      on its own (e.g. ``mtp.safetensors``). Always applied regardless of
-      ``mtp_enabled`` for the same sanitize-correctness reason as the
-      Native MTP patch below.
+      heads and either config.json or the checkpoint's safetensors index
+      references MTP weights in a file mlx-lm's ``model*.safetensors`` glob
+      wouldn't find on its own (e.g. ``mtp.safetensors``). Always applied
+      regardless of ``mtp_enabled`` for the same sanitize-correctness reason
+      as the Native MTP patch below.
     - Native MTP patch (PR 990 + PR 15) when the config declares MTP heads
       on a supported model_type. Always applied for sanitize correctness;
       head attachment is gated by ``model_settings.mtp_enabled``.
@@ -404,13 +404,9 @@ def maybe_apply_pre_load_patches(
     # Reset the process-wide MTP flag so non-MTP-compatible models (or
     # models with mtp_enabled=False) are not polluted by a prior model
     # load that left the flag True.
-    from ..patches.mlx_lm_extra_tensors import set_extra_tensor_files
     from ..patches.mlx_lm_mtp import set_mtp_active
 
     set_mtp_active(False)
-    # Same reset rationale as above: a model without an MTP sidecar must
-    # not inherit the previous model's sidecar file list.
-    set_extra_tensor_files([])
 
     _patch_mlx_lm_load_config()
 
@@ -604,10 +600,10 @@ def maybe_apply_pre_load_patches(
 
     # Some Native MTP checkpoints (MTPLX-forge exports, issue #2062) ship
     # the mtp.* weights in a sidecar safetensors file that
-    # model.safetensors.index.json references but whose filename doesn't
-    # match mlx-lm's model*.safetensors glob, so mlx-lm silently skips it.
-    # Detect + register those sidecars before mlx_lm.load() runs so the
-    # patched sanitize actually sees the mtp.* keys instead of raising
+    # config.json or model.safetensors.index.json references but whose
+    # filename doesn't match mlx-lm's model*.safetensors glob, so mlx-lm
+    # silently skips it. Detect those sidecars before mlx_lm.load() runs so
+    # the patched sanitize actually sees the mtp.* keys instead of raising
     # "converted weights are missing the mtp.* tensors" on a checkpoint
     # that has them. Gated on _has_mtp_heads (not mtp_enabled) because
     # sanitize correctness — like the MTP patch application below — must
@@ -619,15 +615,13 @@ def maybe_apply_pre_load_patches(
         )
 
         sidecars = sidecar_files_for(model_name)
-        if sidecars:
-            set_extra_tensor_files(sidecars)
-            if apply_extra_tensors_patch():
-                logger.info(
-                    "MTP sidecar glob patch applied for %s (%d file(s): %s)",
-                    model_name,
-                    len(sidecars),
-                    ", ".join(Path(f).name for f in sidecars),
-                )
+        if sidecars and apply_extra_tensors_patch():
+            logger.info(
+                "MTP sidecar glob patch applied for %s (%d file(s): %s)",
+                model_name,
+                len(sidecars),
+                ", ".join(Path(f).name for f in sidecars),
+            )
 
     # Apply the MTP patch whenever the model has MTP heads on a compatible
     # model_type — even when mtp_enabled is False. The patch is required

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -374,6 +374,12 @@ def maybe_apply_pre_load_patches(
       declares ``model_type == "glm_moe_dsa"``. Required because pinned
       mlx-lm exposes it as a bare DeepSeek-V3.2 subclass and cannot load
       checkpoints whose shared DSA layers carry no indexer weights.
+    - MTP sidecar glob patch (issue #2062) when the config declares MTP
+      heads and the checkpoint's safetensors index references mtp.*
+      weights in a file mlx-lm's ``model*.safetensors`` glob wouldn't find
+      on its own (e.g. ``mtp.safetensors``). Always applied regardless of
+      ``mtp_enabled`` for the same sanitize-correctness reason as the
+      Native MTP patch below.
     - Native MTP patch (PR 990 + PR 15) when the config declares MTP heads
       on a supported model_type. Always applied for sanitize correctness;
       head attachment is gated by ``model_settings.mtp_enabled``.
@@ -398,9 +404,13 @@ def maybe_apply_pre_load_patches(
     # Reset the process-wide MTP flag so non-MTP-compatible models (or
     # models with mtp_enabled=False) are not polluted by a prior model
     # load that left the flag True.
+    from ..patches.mlx_lm_extra_tensors import set_extra_tensor_files
     from ..patches.mlx_lm_mtp import set_mtp_active
 
     set_mtp_active(False)
+    # Same reset rationale as above: a model without an MTP sidecar must
+    # not inherit the previous model's sidecar file list.
+    set_extra_tensor_files([])
 
     _patch_mlx_lm_load_config()
 
@@ -591,6 +601,33 @@ def maybe_apply_pre_load_patches(
                 "Muse Glimmer mlx-vlm compatibility patch applied for %s",
                 model_name,
             )
+
+    # Some Native MTP checkpoints (MTPLX-forge exports, issue #2062) ship
+    # the mtp.* weights in a sidecar safetensors file that
+    # model.safetensors.index.json references but whose filename doesn't
+    # match mlx-lm's model*.safetensors glob, so mlx-lm silently skips it.
+    # Detect + register those sidecars before mlx_lm.load() runs so the
+    # patched sanitize actually sees the mtp.* keys instead of raising
+    # "converted weights are missing the mtp.* tensors" on a checkpoint
+    # that has them. Gated on _has_mtp_heads (not mtp_enabled) because
+    # sanitize correctness — like the MTP patch application below — must
+    # hold regardless of whether the head is attached.
+    if _has_mtp_heads(config):
+        from ..patches.mlx_lm_extra_tensors import (
+            apply as apply_extra_tensors_patch,
+            sidecar_files_for,
+        )
+
+        sidecars = sidecar_files_for(model_name)
+        if sidecars:
+            set_extra_tensor_files(sidecars)
+            if apply_extra_tensors_patch():
+                logger.info(
+                    "MTP sidecar glob patch applied for %s (%d file(s): %s)",
+                    model_name,
+                    len(sidecars),
+                    ", ".join(Path(f).name for f in sidecars),
+                )
 
     # Apply the MTP patch whenever the model has MTP heads on a compatible
     # model_type — even when mtp_enabled is False. The patch is required

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -611,6 +611,8 @@ def maybe_apply_pre_load_patches(
     if _has_mtp_heads(config):
         from ..patches.mlx_lm_extra_tensors import (
             apply as apply_extra_tensors_patch,
+        )
+        from ..patches.mlx_lm_extra_tensors import (
             sidecar_files_for,
         )
 

--- a/tests/test_mlx_lm_extra_tensors.py
+++ b/tests/test_mlx_lm_extra_tensors.py
@@ -349,7 +349,8 @@ class TestMaybeApplyPreLoadPatchesDispatch:
     def test_target_sidecar_does_not_leak_into_specprefill_draft(
         self, tmp_path, monkeypatch
     ):
-        """Second mlx-lm load stays scoped without a second pre-load dispatch."""
+        """DeepSeek-patched second load stays scoped without redispatch."""
+        from omlx.patches.deepseek_v4.utils_patch import apply_utils_patch
         from omlx.utils.model_loading import maybe_apply_pre_load_patches
 
         try:
@@ -394,6 +395,10 @@ class TestMaybeApplyPreLoadPatchesDispatch:
 
         original_glob = mlx_lm_utils.glob
         try:
+            # DeepSeek V4 permanently replaces mlx-lm's loader. Its replacement
+            # must still resolve the live mlx_lm.utils.glob proxy.
+            apply_utils_patch()
+            mlx_lm_utils.glob = extra_tensors._GlobProxy()
             maybe_apply_pre_load_patches(str(target))
             mlx_lm_utils.load_model(
                 target,

--- a/tests/test_mlx_lm_extra_tensors.py
+++ b/tests/test_mlx_lm_extra_tensors.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the MTP sidecar glob patch (issue #2062).
 
-Covers ``sidecar_files_for`` (index scan), the process-wide file-list
-flag, ``_GlobProxy`` (augmented glob), ``apply()`` (idempotent install),
-and the ``maybe_apply_pre_load_patches`` dispatch wiring.
+Covers ``sidecar_files_for`` (config + index scan), model-scoped
+``_GlobProxy`` augmentation, ``apply()`` (idempotent install), and the
+``maybe_apply_pre_load_patches`` dispatch wiring.
 """
 
 from __future__ import annotations
@@ -15,17 +15,14 @@ import pytest
 from omlx.patches import mlx_lm_extra_tensors as extra_tensors
 
 
-@pytest.fixture(autouse=True)
-def _reset_extra_tensor_files():
-    extra_tensors.set_extra_tensor_files([])
-    yield
-    extra_tensors.set_extra_tensor_files([])
-
-
 def _write_index(tmp_path, weight_map: dict) -> None:
     (tmp_path / "model.safetensors.index.json").write_text(
         json.dumps({"metadata": {}, "weight_map": weight_map})
     )
+
+
+def _write_config(tmp_path, config: dict) -> None:
+    (tmp_path / "config.json").write_text(json.dumps(config))
 
 
 class TestSidecarFilesFor:
@@ -34,6 +31,10 @@ class TestSidecarFilesFor:
 
     def test_returns_empty_on_malformed_index(self, tmp_path):
         (tmp_path / "model.safetensors.index.json").write_text("{not valid")
+        assert extra_tensors.sidecar_files_for(tmp_path) == []
+
+    def test_returns_empty_on_malformed_config(self, tmp_path):
+        (tmp_path / "config.json").write_text("{not valid")
         assert extra_tensors.sidecar_files_for(tmp_path) == []
 
     def test_returns_empty_when_no_mtp_keys(self, tmp_path):
@@ -69,6 +70,58 @@ class TestSidecarFilesFor:
                 str(tmp_path / "mtp.safetensors")
             ]
 
+    def test_finds_nested_sidecar_declared_by_config(self, tmp_path):
+        _write_config(
+            tmp_path,
+            {
+                "mlx_lm_extra_tensors": {
+                    "mtp_file": "mtp/weights.safetensors",
+                    "mtp_tensor_count": 15,
+                }
+            },
+        )
+        assert extra_tensors.sidecar_files_for(tmp_path) == [
+            str(tmp_path / "mtp" / "weights.safetensors")
+        ]
+
+    def test_merges_and_deduplicates_config_and_index_sidecars(self, tmp_path):
+        _write_config(
+            tmp_path,
+            {"mlx_lm_extra_tensors": {"mtp_file": "mtp/weights.safetensors"}},
+        )
+        _write_index(
+            tmp_path,
+            {
+                "mtp.fc.weight": "mtp/weights.safetensors",
+                "mtp.norm.weight": "mtp-extra.safetensors",
+            },
+        )
+        assert extra_tensors.sidecar_files_for(tmp_path) == [
+            str(tmp_path / "mtp-extra.safetensors"),
+            str(tmp_path / "mtp" / "weights.safetensors"),
+        ]
+
+    @pytest.mark.parametrize(
+        "extra_config",
+        [
+            None,
+            "mtp.safetensors",
+            {"mtp_file": None},
+            {"mtp_file": 123},
+            {"mtp_file": ""},
+        ],
+    )
+    def test_ignores_invalid_config_declaration(self, tmp_path, extra_config):
+        _write_config(tmp_path, {"mlx_lm_extra_tensors": extra_config})
+        assert extra_tensors.sidecar_files_for(tmp_path) == []
+
+    def test_ignores_sidecar_path_outside_model_directory(self, tmp_path):
+        _write_config(
+            tmp_path,
+            {"mlx_lm_extra_tensors": {"mtp_file": "../outside.safetensors"}},
+        )
+        assert extra_tensors.sidecar_files_for(tmp_path) == []
+
     def test_ignores_mtp_keys_already_in_a_model_shard(self, tmp_path):
         # mlx-lm's own glob already covers this file; don't duplicate it.
         (tmp_path / "model-00001-of-00001.safetensors").write_bytes(b"")
@@ -97,21 +150,6 @@ class TestSidecarFilesFor:
         assert extra_tensors.sidecar_files_for(tmp_path) == []
 
 
-class TestExtraTensorFilesFlag:
-    def test_default_is_empty(self):
-        assert extra_tensors.get_extra_tensor_files() == []
-
-    def test_set_and_get_roundtrip(self):
-        extra_tensors.set_extra_tensor_files(["/a/mtp.safetensors"])
-        assert extra_tensors.get_extra_tensor_files() == ["/a/mtp.safetensors"]
-
-    def test_get_returns_a_copy(self):
-        extra_tensors.set_extra_tensor_files(["/a/mtp.safetensors"])
-        files = extra_tensors.get_extra_tensor_files()
-        files.append("/b/other.safetensors")
-        assert extra_tensors.get_extra_tensor_files() == ["/a/mtp.safetensors"]
-
-
 class TestGlobProxy:
     def test_passthrough_for_unrelated_pattern(self, tmp_path):
         (tmp_path / "config.json").write_text("{}")
@@ -122,7 +160,7 @@ class TestGlobProxy:
         (tmp_path / "model-00001-of-00001.safetensors").write_bytes(b"")
         sidecar = str(tmp_path / "mtp.safetensors")
         (tmp_path / "mtp.safetensors").write_bytes(b"")
-        extra_tensors.set_extra_tensor_files([sidecar])
+        _write_index(tmp_path, {"mtp.fc.weight": "mtp.safetensors"})
 
         proxy = extra_tensors._GlobProxy()
         matches = proxy.glob(str(tmp_path / "model*.safetensors"))
@@ -131,7 +169,7 @@ class TestGlobProxy:
             sidecar,
         }
 
-    def test_no_augmentation_when_flag_empty(self, tmp_path):
+    def test_no_augmentation_when_model_has_no_sidecars(self, tmp_path):
         (tmp_path / "model-00001-of-00001.safetensors").write_bytes(b"")
         proxy = extra_tensors._GlobProxy()
         matches = proxy.glob(str(tmp_path / "model*.safetensors"))
@@ -140,11 +178,32 @@ class TestGlobProxy:
     def test_does_not_duplicate_a_match_already_found(self, tmp_path):
         shard = tmp_path / "model-00001-of-00001.safetensors"
         shard.write_bytes(b"")
-        extra_tensors.set_extra_tensor_files([str(shard)])
+        _write_index(tmp_path, {"mtp.fc.weight": shard.name})
 
         proxy = extra_tensors._GlobProxy()
         matches = proxy.glob(str(tmp_path / "model*.safetensors"))
         assert matches == [str(shard)]
+
+    def test_resolves_sidecars_from_each_pattern_model_directory(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+        target_shard = target / "model.safetensors"
+        target_shard.write_bytes(b"")
+        target_sidecar = target / "mtp.safetensors"
+        target_sidecar.write_bytes(b"")
+        _write_index(target, {"mtp.fc.weight": target_sidecar.name})
+
+        draft = tmp_path / "draft"
+        draft.mkdir()
+        draft_shard = draft / "model.safetensors"
+        draft_shard.write_bytes(b"")
+
+        proxy = extra_tensors._GlobProxy()
+        assert set(proxy.glob(str(target / "model*.safetensors"))) == {
+            str(target_shard),
+            str(target_sidecar),
+        }
+        assert proxy.glob(str(draft / "model*.safetensors")) == [str(draft_shard)]
 
     def test_getattr_delegates_to_real_glob_module(self):
         proxy = extra_tensors._GlobProxy()
@@ -213,7 +272,7 @@ class TestApply:
         original_glob = mlx_lm_utils.glob
         try:
             extra_tensors.apply()
-            extra_tensors.set_extra_tensor_files([str(sidecar)])
+            _write_index(tmp_path, {"mtp.fc.weight": sidecar.name})
             matches = mlx_lm_utils.glob.glob(str(tmp_path / "model*.safetensors"))
             assert str(sidecar) in matches
         finally:
@@ -223,7 +282,13 @@ class TestApply:
 class TestMaybeApplyPreLoadPatchesDispatch:
     """Integration: the loader-level dispatch in model_loading.py."""
 
-    def _write_mtp_model(self, tmp_path, *, sidecar: bool):
+    def _write_mtp_model(
+        self,
+        tmp_path,
+        *,
+        indexed_sidecar: bool = False,
+        config_sidecar: str | None = None,
+    ):
         config = {
             "model_type": "qwen3_5_moe",
             "architectures": ["Qwen3_5MoeForConditionalGeneration"],
@@ -233,42 +298,121 @@ class TestMaybeApplyPreLoadPatchesDispatch:
                 "num_hidden_layers": 2,
             },
         }
-        (tmp_path / "config.json").write_text(json.dumps(config))
+        if config_sidecar is not None:
+            config["mlx_lm_extra_tensors"] = {"mtp_file": config_sidecar}
+        _write_config(tmp_path, config)
         weight_map = {"model.embed_tokens.weight": "model-00001-of-00001.safetensors"}
         (tmp_path / "model-00001-of-00001.safetensors").write_bytes(b"")
-        if sidecar:
+        if indexed_sidecar:
             weight_map["mtp.fc.weight"] = "mtp.safetensors"
             (tmp_path / "mtp.safetensors").write_bytes(b"")
+        if config_sidecar is not None:
+            sidecar_path = tmp_path / config_sidecar
+            sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+            sidecar_path.write_bytes(b"")
         _write_index(tmp_path, weight_map)
 
-    def test_registers_sidecar_for_mtp_model(self, tmp_path):
+    def test_installs_proxy_for_indexed_sidecar(self, tmp_path):
         from omlx.utils.model_loading import maybe_apply_pre_load_patches
 
-        self._write_mtp_model(tmp_path, sidecar=True)
-        maybe_apply_pre_load_patches(str(tmp_path))
-        assert extra_tensors.get_extra_tensor_files() == [
-            str(tmp_path / "mtp.safetensors")
-        ]
+        try:
+            from mlx_lm import utils as mlx_lm_utils
+        except ImportError:
+            pytest.skip("mlx-lm not importable")
 
-    def test_no_sidecar_registered_when_index_has_no_extra_files(self, tmp_path):
+        self._write_mtp_model(tmp_path, indexed_sidecar=True)
+        original_glob = mlx_lm_utils.glob
+        try:
+            maybe_apply_pre_load_patches(str(tmp_path))
+            matches = mlx_lm_utils.glob.glob(str(tmp_path / "model*.safetensors"))
+            assert str(tmp_path / "mtp.safetensors") in matches
+        finally:
+            mlx_lm_utils.glob = original_glob
+
+    def test_installs_proxy_for_config_declared_nested_sidecar(self, tmp_path):
         from omlx.utils.model_loading import maybe_apply_pre_load_patches
 
-        self._write_mtp_model(tmp_path, sidecar=False)
-        maybe_apply_pre_load_patches(str(tmp_path))
-        assert extra_tensors.get_extra_tensor_files() == []
+        try:
+            from mlx_lm import utils as mlx_lm_utils
+        except ImportError:
+            pytest.skip("mlx-lm not importable")
 
-    def test_flag_resets_between_loads(self, tmp_path):
-        """A model without MTP heads must not inherit a prior sidecar list."""
+        self._write_mtp_model(tmp_path, config_sidecar="mtp/weights.safetensors")
+        original_glob = mlx_lm_utils.glob
+        try:
+            maybe_apply_pre_load_patches(str(tmp_path))
+            matches = mlx_lm_utils.glob.glob(str(tmp_path / "model*.safetensors"))
+            assert str(tmp_path / "mtp" / "weights.safetensors") in matches
+        finally:
+            mlx_lm_utils.glob = original_glob
+
+    def test_target_sidecar_does_not_leak_into_specprefill_draft(
+        self, tmp_path, monkeypatch
+    ):
+        """Second mlx-lm load stays scoped without a second pre-load dispatch."""
         from omlx.utils.model_loading import maybe_apply_pre_load_patches
 
-        mtp_dir = tmp_path / "mtp_model"
-        mtp_dir.mkdir()
-        self._write_mtp_model(mtp_dir, sidecar=True)
-        maybe_apply_pre_load_patches(str(mtp_dir))
-        assert extra_tensors.get_extra_tensor_files() != []
+        try:
+            from mlx_lm import utils as mlx_lm_utils
+        except ImportError:
+            pytest.skip("mlx-lm not importable")
 
-        plain_dir = tmp_path / "plain_model"
-        plain_dir.mkdir()
-        (plain_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
-        maybe_apply_pre_load_patches(str(plain_dir))
-        assert extra_tensors.get_extra_tensor_files() == []
+        target = tmp_path / "target"
+        target.mkdir()
+        self._write_mtp_model(target, indexed_sidecar=True)
+
+        draft = tmp_path / "draft"
+        draft.mkdir()
+        draft_shard = draft / "model.safetensors"
+        draft_shard.write_bytes(b"")
+        _write_config(draft, {"model_type": "llama"})
+
+        class FakeModelArgs:
+            @classmethod
+            def from_dict(cls, config):
+                return cls()
+
+        class FakeModel:
+            def __init__(self, args):
+                self.loaded_weights = []
+
+            def eval(self):
+                pass
+
+            def load_weights(self, weights, strict=True):
+                self.loaded_weights = list(weights)
+
+        loaded_files = []
+        monkeypatch.setattr(
+            mlx_lm_utils.mx,
+            "load",
+            lambda path: loaded_files.append(str(path)) or {},
+        )
+
+        def get_model_classes(config):
+            return FakeModel, FakeModelArgs
+
+        original_glob = mlx_lm_utils.glob
+        try:
+            maybe_apply_pre_load_patches(str(target))
+            mlx_lm_utils.load_model(
+                target,
+                lazy=True,
+                get_model_classes=get_model_classes,
+            )
+            target_files = set(loaded_files)
+
+            loaded_files.clear()
+            mlx_lm_utils.load_model(
+                draft,
+                lazy=True,
+                get_model_classes=get_model_classes,
+            )
+
+            assert target_files == {
+                str(target / "model-00001-of-00001.safetensors"),
+                str(target / "mtp.safetensors"),
+            }
+            assert loaded_files == [str(draft_shard)]
+        finally:
+            mlx_lm_utils.glob = original_glob

--- a/tests/test_mlx_lm_extra_tensors.py
+++ b/tests/test_mlx_lm_extra_tensors.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the MTP sidecar glob patch (issue #2062).
+
+Covers ``sidecar_files_for`` (index scan), the process-wide file-list
+flag, ``_GlobProxy`` (augmented glob), ``apply()`` (idempotent install),
+and the ``maybe_apply_pre_load_patches`` dispatch wiring.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from omlx.patches import mlx_lm_extra_tensors as extra_tensors
+
+
+@pytest.fixture(autouse=True)
+def _reset_extra_tensor_files():
+    extra_tensors.set_extra_tensor_files([])
+    yield
+    extra_tensors.set_extra_tensor_files([])
+
+
+def _write_index(tmp_path, weight_map: dict) -> None:
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": weight_map})
+    )
+
+
+class TestSidecarFilesFor:
+    def test_returns_empty_when_no_index(self, tmp_path):
+        assert extra_tensors.sidecar_files_for(tmp_path) == []
+
+    def test_returns_empty_on_malformed_index(self, tmp_path):
+        (tmp_path / "model.safetensors.index.json").write_text("{not valid")
+        assert extra_tensors.sidecar_files_for(tmp_path) == []
+
+    def test_returns_empty_when_no_mtp_keys(self, tmp_path):
+        _write_index(
+            tmp_path,
+            {"model.embed_tokens.weight": "model-00001-of-00001.safetensors"},
+        )
+        assert extra_tensors.sidecar_files_for(tmp_path) == []
+
+    def test_finds_sidecar_referenced_by_bare_mtp_prefix(self, tmp_path):
+        # Ornith-1.0-35B-MTPLX layout: index lists mtp.* keys pointing at a
+        # sidecar file that doesn't match model*.safetensors.
+        _write_index(
+            tmp_path,
+            {
+                "model.embed_tokens.weight": "model-00001-of-00001.safetensors",
+                "mtp.fc.weight": "mtp.safetensors",
+                "mtp.layers.0.self_attn.q_proj.weight": "mtp.safetensors",
+            },
+        )
+        assert extra_tensors.sidecar_files_for(tmp_path) == [
+            str(tmp_path / "mtp.safetensors")
+        ]
+
+    def test_finds_sidecar_for_prefixed_mtp_key_variants(self, tmp_path):
+        for prefix in (
+            "language_model.mtp.",
+            "model.mtp.",
+            "model.language_model.mtp.",
+        ):
+            _write_index(tmp_path, {f"{prefix}fc.weight": "mtp.safetensors"})
+            assert extra_tensors.sidecar_files_for(tmp_path) == [
+                str(tmp_path / "mtp.safetensors")
+            ]
+
+    def test_ignores_mtp_keys_already_in_a_model_shard(self, tmp_path):
+        # mlx-lm's own glob already covers this file; don't duplicate it.
+        (tmp_path / "model-00001-of-00001.safetensors").write_bytes(b"")
+        _write_index(
+            tmp_path,
+            {"mtp.fc.weight": "model-00001-of-00001.safetensors"},
+        )
+        assert extra_tensors.sidecar_files_for(tmp_path) == []
+
+    def test_dedups_and_sorts_multiple_sidecar_files(self, tmp_path):
+        _write_index(
+            tmp_path,
+            {
+                "mtp.fc.weight": "mtp-b.safetensors",
+                "mtp.norm.weight": "mtp-b.safetensors",
+                "mtp.layers.0.mlp.gate_proj.weight": "mtp-a.safetensors",
+            },
+        )
+        assert extra_tensors.sidecar_files_for(tmp_path) == [
+            str(tmp_path / "mtp-a.safetensors"),
+            str(tmp_path / "mtp-b.safetensors"),
+        ]
+
+    def test_ignores_non_string_weight_map_entries(self, tmp_path):
+        _write_index(tmp_path, {"mtp.fc.weight": 123})
+        assert extra_tensors.sidecar_files_for(tmp_path) == []
+
+
+class TestExtraTensorFilesFlag:
+    def test_default_is_empty(self):
+        assert extra_tensors.get_extra_tensor_files() == []
+
+    def test_set_and_get_roundtrip(self):
+        extra_tensors.set_extra_tensor_files(["/a/mtp.safetensors"])
+        assert extra_tensors.get_extra_tensor_files() == ["/a/mtp.safetensors"]
+
+    def test_get_returns_a_copy(self):
+        extra_tensors.set_extra_tensor_files(["/a/mtp.safetensors"])
+        files = extra_tensors.get_extra_tensor_files()
+        files.append("/b/other.safetensors")
+        assert extra_tensors.get_extra_tensor_files() == ["/a/mtp.safetensors"]
+
+
+class TestGlobProxy:
+    def test_passthrough_for_unrelated_pattern(self, tmp_path):
+        (tmp_path / "config.json").write_text("{}")
+        proxy = extra_tensors._GlobProxy()
+        assert proxy.glob(str(tmp_path / "*.json")) == [str(tmp_path / "config.json")]
+
+    def test_augments_model_safetensors_pattern(self, tmp_path):
+        (tmp_path / "model-00001-of-00001.safetensors").write_bytes(b"")
+        sidecar = str(tmp_path / "mtp.safetensors")
+        (tmp_path / "mtp.safetensors").write_bytes(b"")
+        extra_tensors.set_extra_tensor_files([sidecar])
+
+        proxy = extra_tensors._GlobProxy()
+        matches = proxy.glob(str(tmp_path / "model*.safetensors"))
+        assert set(matches) == {
+            str(tmp_path / "model-00001-of-00001.safetensors"),
+            sidecar,
+        }
+
+    def test_no_augmentation_when_flag_empty(self, tmp_path):
+        (tmp_path / "model-00001-of-00001.safetensors").write_bytes(b"")
+        proxy = extra_tensors._GlobProxy()
+        matches = proxy.glob(str(tmp_path / "model*.safetensors"))
+        assert matches == [str(tmp_path / "model-00001-of-00001.safetensors")]
+
+    def test_does_not_duplicate_a_match_already_found(self, tmp_path):
+        shard = tmp_path / "model-00001-of-00001.safetensors"
+        shard.write_bytes(b"")
+        extra_tensors.set_extra_tensor_files([str(shard)])
+
+        proxy = extra_tensors._GlobProxy()
+        matches = proxy.glob(str(tmp_path / "model*.safetensors"))
+        assert matches == [str(shard)]
+
+    def test_getattr_delegates_to_real_glob_module(self):
+        proxy = extra_tensors._GlobProxy()
+        assert proxy.escape("a*b") == extra_tensors._glob_module.escape("a*b")
+
+    def test_marker_attribute_present(self):
+        proxy = extra_tensors._GlobProxy()
+        assert proxy._omlx_extra_tensors_proxy is True
+
+
+class TestApply:
+    def test_apply_installs_proxy_on_mlx_lm_utils(self):
+        try:
+            from mlx_lm import utils as mlx_lm_utils
+        except ImportError:
+            pytest.skip("mlx-lm not importable")
+
+        original_glob = mlx_lm_utils.glob
+        try:
+            assert extra_tensors.apply() is True
+            assert (
+                getattr(mlx_lm_utils.glob, "_omlx_extra_tensors_proxy", False) is True
+            )
+        finally:
+            mlx_lm_utils.glob = original_glob
+
+    def test_apply_idempotent(self):
+        try:
+            from mlx_lm import utils as mlx_lm_utils
+        except ImportError:
+            pytest.skip("mlx-lm not importable")
+
+        original_glob = mlx_lm_utils.glob
+        try:
+            assert extra_tensors.apply() is True
+            installed = mlx_lm_utils.glob
+            assert extra_tensors.apply() is True
+            # Second call is a no-op — same proxy instance stays installed.
+            assert mlx_lm_utils.glob is installed
+        finally:
+            mlx_lm_utils.glob = original_glob
+
+    def test_apply_returns_false_when_mlx_lm_not_importable(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "mlx_lm" or name.startswith("mlx_lm."):
+                raise ImportError("simulated missing mlx-lm")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        assert extra_tensors.apply() is False
+
+    def test_installed_proxy_actually_augments_load_model_glob(self, tmp_path):
+        try:
+            from mlx_lm import utils as mlx_lm_utils
+        except ImportError:
+            pytest.skip("mlx-lm not importable")
+
+        (tmp_path / "model-00001-of-00001.safetensors").write_bytes(b"")
+        sidecar = tmp_path / "mtp.safetensors"
+        sidecar.write_bytes(b"")
+
+        original_glob = mlx_lm_utils.glob
+        try:
+            extra_tensors.apply()
+            extra_tensors.set_extra_tensor_files([str(sidecar)])
+            matches = mlx_lm_utils.glob.glob(str(tmp_path / "model*.safetensors"))
+            assert str(sidecar) in matches
+        finally:
+            mlx_lm_utils.glob = original_glob
+
+
+class TestMaybeApplyPreLoadPatchesDispatch:
+    """Integration: the loader-level dispatch in model_loading.py."""
+
+    def _write_mtp_model(self, tmp_path, *, sidecar: bool):
+        config = {
+            "model_type": "qwen3_5_moe",
+            "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+            "text_config": {
+                "model_type": "qwen3_5_moe_text",
+                "mtp_num_hidden_layers": 1,
+                "num_hidden_layers": 2,
+            },
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        weight_map = {"model.embed_tokens.weight": "model-00001-of-00001.safetensors"}
+        (tmp_path / "model-00001-of-00001.safetensors").write_bytes(b"")
+        if sidecar:
+            weight_map["mtp.fc.weight"] = "mtp.safetensors"
+            (tmp_path / "mtp.safetensors").write_bytes(b"")
+        _write_index(tmp_path, weight_map)
+
+    def test_registers_sidecar_for_mtp_model(self, tmp_path):
+        from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+        self._write_mtp_model(tmp_path, sidecar=True)
+        maybe_apply_pre_load_patches(str(tmp_path))
+        assert extra_tensors.get_extra_tensor_files() == [
+            str(tmp_path / "mtp.safetensors")
+        ]
+
+    def test_no_sidecar_registered_when_index_has_no_extra_files(self, tmp_path):
+        from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+        self._write_mtp_model(tmp_path, sidecar=False)
+        maybe_apply_pre_load_patches(str(tmp_path))
+        assert extra_tensors.get_extra_tensor_files() == []
+
+    def test_flag_resets_between_loads(self, tmp_path):
+        """A model without MTP heads must not inherit a prior sidecar list."""
+        from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+        mtp_dir = tmp_path / "mtp_model"
+        mtp_dir.mkdir()
+        self._write_mtp_model(mtp_dir, sidecar=True)
+        maybe_apply_pre_load_patches(str(mtp_dir))
+        assert extra_tensors.get_extra_tensor_files() != []
+
+        plain_dir = tmp_path / "plain_model"
+        plain_dir.mkdir()
+        (plain_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        maybe_apply_pre_load_patches(str(plain_dir))
+        assert extra_tensors.get_extra_tensor_files() == []


### PR DESCRIPTION
## Problem

`mlx_lm.utils.load_model` discovers weight shards with `glob.glob(model*.safetensors)`. MTPLX-forge exports (e.g. `wang-yang/Ornith-1.0-35B-MTPLX`) ship the MTP head's weights in a separate `mtp.safetensors` sidecar. `model.safetensors.index.json` correctly references it (785 `mtp.*` keys → `mtp.safetensors`), but the filename doesn't match the loader's glob pattern, so the file is silently skipped. The patched `TextModel.sanitize` then sees an attached MTP head with zero `mtp.*` keys in the weight dict and raises:

> Lightning MTP is enabled for this model but the converted weights are missing the mtp.* tensors.

...even though the checkpoint has them.

Fixes #2062.

## Fix

`omlx/patches/mlx_lm_extra_tensors.py`:
- `sidecar_files_for(model_path)` scans `model.safetensors.index.json`'s `weight_map` for `mtp.*`-prefixed keys (matching the same prefix family used elsewhere for MTP detection: bare `mtp.`, `language_model.mtp.`, `model.mtp.`, `model.language_model.mtp.`) and resolves their backing file(s), excluding anything mlx-lm's own `model*.safetensors` glob would already find.
- A `_GlobProxy` installed as `mlx_lm.utils.glob` passes every glob call through to the real `glob` module unchanged, except the `model*.safetensors` shard-discovery pattern, which gets the sidecar files appended.
- Process-wide file list (`set_extra_tensor_files` / `get_extra_tensor_files`) follows the same construction-time-flag pattern already used by `mlx_lm_mtp.set_mtp_active` — reset to `[]` at the top of `maybe_apply_pre_load_patches` so a model without a sidecar doesn't inherit a prior load's file list.

Wired into `maybe_apply_pre_load_patches` (`omlx/utils/model_loading.py`), gated on `_has_mtp_heads(config)` rather than `mtp_enabled`, matching the existing rationale for the Native MTP patch dispatch right below it: sanitize correctness must hold regardless of whether the head is attached.

## Not in scope

#1944 / PR #1962 fix a different bug: the Native MTP *compatibility check* (`_checkpoint_has_mtp_weights` / `_model_has_mtp_weight_tensors`) false-negatives for OptiQ checkpoints whose sidecar isn't referenced by the index at all (uses a separate `mtp_file` config key instead). Neither of those PRs touches actual weight loading, so they wouldn't have fixed this issue even if merged.

## Testing

New `tests/test_mlx_lm_extra_tensors.py` (24 tests): index scanning (bare/prefixed mtp keys, already-covered shards, malformed/missing index, dedup+sort), the process-wide flag, `_GlobProxy` passthrough/augmentation/dedup, `apply()` idempotency and import-failure handling, and integration coverage of the `maybe_apply_pre_load_patches` dispatch (including the reset-between-loads case).

```
uv run --python 3.11 pytest tests/test_mlx_lm_extra_tensors.py tests/test_mlx_lm_mtp_patch.py tests/test_model_loading.py -q
# 153 passed
uv run --python 3.11 ruff check omlx/patches/mlx_lm_extra_tensors.py omlx/utils/model_loading.py tests/test_mlx_lm_extra_tensors.py --isolated
# All checks passed!
```