### PR TITLE
fix: text highlight in chat in dark mode

### DIFF
--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -62,6 +62,11 @@
         --timeline-accent: #60a5fa;
     }
 
+    [data-theme="dark"] ::selection {
+        background-color: #3f3f46;
+        color: var(--text-primary);
+    }
+
     body {
         background-color: var(--bg-primary) !important;
         color: var(--text-primary) !important;


### PR DESCRIPTION
Quick fix to the highlight text style in the chat interface in dark mode so that the highlighted text is visible:

Before:
<img width="1586" height="304" alt="image" src="https://github.com/user-attachments/assets/d62d629e-0053-4a65-9a9d-1dd9e5c715f9" />

After:
<img width="1590" height="204" alt="image" src="https://github.com/user-attachments/assets/53ed5828-4d70-433c-a998-815f494c53e0" />
