### PR TITLE
feat(macOS): show live inference activity in the menu bar

### DIFF
--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -4878,6 +4878,24 @@
         }
       }
     },
+    "menubar.item.show_live_activity_in_menu_bar" : {
+      "comment" : "Menubar item that toggles current request activity text beside the oMLX icon",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Live Activity in Menu Bar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать активность в строке меню"
+          }
+        }
+      }
+    },
     "menubar.item.start_server" : {
       "comment" : "Menubar item that starts the server",
       "extractionState" : "manual",
@@ -5054,6 +5072,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Загрузка статистики…"
+          }
+        }
+      }
+    },
+    "menubar.stats.live_activity" : {
+      "comment" : "Section header inside the Serving Stats submenu for the current active request",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Activity"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Текущая активность"
           }
         }
       }

--- a/apps/omlx-mac/Sources/Menubar/MenubarController.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarController.swift
@@ -46,6 +46,7 @@ final class MenubarController: NSObject {
     private let activityLabel = NSTextField(labelWithString: "")
     private let statusIconView = NSImageView()
     private var statusContentConstraints: [NSLayoutConstraint] = []
+    private var activityLabelConstraints: [NSLayoutConstraint] = []
     private let menu = NSMenu()
 
     private var statsPoller: MenubarStatsPoller?
@@ -379,6 +380,9 @@ final class MenubarController: NSObject {
         )
         activityLabel.isHidden = statusItemPresentation.activityTitle.isEmpty
         statusItem.length = statusItemPresentation.itemLength
+        setActivityLabelLayoutReserved(
+            statusItemPresentation.reservesActivityLabelSpace
+        )
         let statusItemToolTip = MenubarController.menuBarButtonToolTip(
             serverState: state,
             liveActivity: liveActivity,
@@ -644,6 +648,7 @@ final class MenubarController: NSObject {
 
         let iconCenterTrailingOffset = NSStatusBar.system.thickness / 2
         NSLayoutConstraint.deactivate(statusContentConstraints)
+        NSLayoutConstraint.deactivate(activityLabelConstraints)
         statusContentConstraints = [
             statusContentView.leadingAnchor.constraint(equalTo: statusButton.leadingAnchor),
             statusContentView.trailingAnchor.constraint(equalTo: statusButton.trailingAnchor),
@@ -655,7 +660,9 @@ final class MenubarController: NSObject {
             statusIconView.centerXAnchor.constraint(
                 equalTo: statusContentView.trailingAnchor,
                 constant: -iconCenterTrailingOffset
-            ),
+            )
+        ]
+        activityLabelConstraints = [
             activityLabel.leadingAnchor.constraint(
                 greaterThanOrEqualTo: statusContentView.leadingAnchor,
                 constant: Self.activityLeadingPadding
@@ -667,6 +674,14 @@ final class MenubarController: NSObject {
             activityLabel.centerYAnchor.constraint(equalTo: statusContentView.centerYAnchor)
         ]
         NSLayoutConstraint.activate(statusContentConstraints)
+    }
+
+    private func setActivityLabelLayoutReserved(_ reservesActivityLabelSpace: Bool) {
+        if reservesActivityLabelSpace {
+            NSLayoutConstraint.activate(activityLabelConstraints)
+        } else {
+            NSLayoutConstraint.deactivate(activityLabelConstraints)
+        }
     }
 
     // MARK: - Notification handlers
@@ -967,6 +982,7 @@ extension MenubarController {
         let itemLength: CGFloat
         let iconCenterTrailingOffset: CGFloat
         let activityTitle: String
+        let reservesActivityLabelSpace: Bool
         let accessibilityValue: String?
     }
 
@@ -997,6 +1013,7 @@ extension MenubarController {
             itemLength: itemLength,
             iconCenterTrailingOffset: iconCenterTrailingOffset,
             activityTitle: activityTitle,
+            reservesActivityLabelSpace: !activityTitle.isEmpty,
             accessibilityValue: activityTitle.isEmpty ? nil : activityTitle
         )
     }

--- a/apps/omlx-mac/Sources/Menubar/MenubarController.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarController.swift
@@ -23,6 +23,13 @@
 import AppKit
 
 @MainActor
+private final class MenubarStatusContentView: NSView {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+}
+
+@MainActor
 final class MenubarController: NSObject {
 
     // MARK: - Inputs / state
@@ -35,6 +42,10 @@ final class MenubarController: NSObject {
     private let requestQuit: () -> Void
 
     private var statusItem: NSStatusItem
+    private let statusContentView = MenubarStatusContentView()
+    private let activityLabel = NSTextField(labelWithString: "")
+    private let statusIconView = NSImageView()
+    private var statusContentConstraints: [NSLayoutConstraint] = []
     private let menu = NSMenu()
 
     private var statsPoller: MenubarStatsPoller?
@@ -54,6 +65,7 @@ final class MenubarController: NSObject {
     private var restartItem: NSMenuItem!
     private var statsParentItem: NSMenuItem!
     private var statsSubmenu: NSMenu!
+    private var showLiveActivityInMenuBarItem: NSMenuItem!
     private var adminPanelItem: NSMenuItem!
     private var webAdminItem: NSMenuItem!
     private var chatItem: NSMenuItem!
@@ -61,6 +73,17 @@ final class MenubarController: NSObject {
 
     private let iconOutline: NSImage?
     private let iconFilled: NSImage?
+
+    private static let showLiveActivityInMenuBarDefaultsKey = "showLiveActivityInMenuBar"
+
+    private var isLiveActivityEnabled: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: Self.showLiveActivityInMenuBarDefaultsKey)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: Self.showLiveActivityInMenuBarDefaultsKey)
+        }
+    }
 
     // MARK: - Init
 
@@ -79,7 +102,9 @@ final class MenubarController: NSObject {
         self.openAppView = openAppView
         self.requestQuit = requestQuit
 
-        self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        // The item grows left as activity text appears. Its custom content
+        // keeps the bird pinned inside the rightmost square segment.
+        self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
 
         // Cap icons at 18×18 pt (the standard macOS menubar icon size).
         // Our SVGs are 497×497 natural; without this, the status item
@@ -99,18 +124,19 @@ final class MenubarController: NSObject {
 
         super.init()
 
-        statusItem.button?.image = outline
+        statusIconView.image = outline
         // SF Symbol fallback for asset-catalog miss in Debug builds.
-        if statusItem.button?.image == nil {
+        if statusIconView.image == nil {
             let fallback = NSImage(
                 systemSymbolName: "cube.transparent",
                 accessibilityDescription: "oMLX"
             )
             fallback?.isTemplate = true
-            statusItem.button?.image = fallback
+            statusIconView.image = fallback
         }
         statusItem.behavior = []
         statusItem.menu = menu
+        configureStatusItemContent()
         // This menu is state-driven by refreshMenuState(). If AppKit's
         // automatic target/action enabling stays on, stopped-server items
         // such as Web Dashboard and Chat can be re-enabled while opening.
@@ -209,6 +235,17 @@ final class MenubarController: NSObject {
         statsParentItem.submenu = statsSubmenu
         menu.addItem(statsParentItem)
         rebuildStatsSubmenu()
+
+        showLiveActivityInMenuBarItem = item(
+            String(
+                localized: "menubar.item.show_live_activity_in_menu_bar",
+                defaultValue: "Show Live Activity in Menu Bar",
+                comment: "Menubar item that toggles current request activity text beside the oMLX icon"
+            ),
+            action: #selector(toggleLiveActivityInMenuBar),
+            symbol: nil
+        )
+        menu.addItem(showLiveActivityInMenuBarItem)
 
         menu.addItem(.separator())
 
@@ -322,11 +359,34 @@ final class MenubarController: NSObject {
         chatItem.isEnabled = availability.chat
 
         refreshUpdateMenuItem()
+        showLiveActivityInMenuBarItem.state = isLiveActivityEnabled ? .on : .off
 
         // Icon swap — outline when not actively serving, filled otherwise
         let serving = state.isRunningLike
-        statusItem.button?.image = serving ? iconFilled : iconOutline
-        statusItem.button?.image?.isTemplate = true
+        statusIconView.image = serving ? iconFilled : iconOutline
+        statusIconView.image?.isTemplate = true
+        let liveActivity = statsPoller?.liveStats?.liveActivity
+        let activityTitle = MenubarController.menuBarButtonTitle(
+            serverState: state,
+            liveActivity: liveActivity,
+            isLiveActivityEnabled: isLiveActivityEnabled
+        )
+        activityLabel.stringValue = activityTitle
+        let statusItemPresentation = MenubarController.menuBarStatusItemPresentation(
+            activityTitle: activityTitle,
+            activityTextWidth: activityLabel.intrinsicContentSize.width,
+            statusBarThickness: NSStatusBar.system.thickness
+        )
+        activityLabel.isHidden = statusItemPresentation.activityTitle.isEmpty
+        statusItem.length = statusItemPresentation.itemLength
+        let statusItemToolTip = MenubarController.menuBarButtonToolTip(
+            serverState: state,
+            liveActivity: liveActivity,
+            isLiveActivityEnabled: isLiveActivityEnabled
+        )
+        statusItem.button?.toolTip = statusItemToolTip
+        statusItem.button?.setAccessibilityValue(statusItemPresentation.accessibilityValue)
+        statusItem.button?.setAccessibilityHelp(statusItemToolTip)
     }
 
     private func refreshUpdateMenuItem() {
@@ -422,6 +482,7 @@ final class MenubarController: NSObject {
             return
         }
         let session = statsPoller?.sessionStats
+        let liveActivity = statsPoller?.liveStats?.liveActivity
         let alltime = statsPoller?.alltimeStats
         if session == nil && alltime == nil {
             statsSubmenu.addItem(disabled(statsPoller == nil
@@ -432,6 +493,17 @@ final class MenubarController: NSObject {
                                                    defaultValue: "Loading stats…",
                                                    comment: "Disabled placeholder shown while stats are loading")))
             return
+        }
+
+        if let liveActivity {
+            statsSubmenu.addItem(disabled(String(
+                localized: "menubar.stats.live_activity",
+                defaultValue: "Live Activity",
+                comment: "Section header inside the Serving Stats submenu for the current active request"
+            )))
+            statsSubmenu.addItem(disabled(liveActivity.menuBarTitle))
+            statsSubmenu.addItem(disabled(liveActivity.detail))
+            statsSubmenu.addItem(.separator())
         }
 
         statsSubmenu.addItem(disabled(String(localized: "menubar.stats.session_section",
@@ -513,6 +585,7 @@ final class MenubarController: NSObject {
             name: MenubarStatsPoller.didUpdateNotification,
             object: p
         )
+        p.setLiveActivityPollingEnabled(isLiveActivityEnabled)
         p.start()
         self.statsPoller = p
         self.statsPollerBaseURL = baseURL
@@ -531,7 +604,7 @@ final class MenubarController: NSObject {
 
     private func startVisibilityWatcher() {
         let watcher = MenubarVisibilityWatcher(initial: statusItem) { [weak self] in
-            self?.recreateStatusItem() ?? NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+            self?.recreateStatusItem() ?? NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         }
         watcher.scheduleInitialCheck(after: 3.0)
         self.visibilityWatcher = watcher
@@ -539,12 +612,61 @@ final class MenubarController: NSObject {
 
     private func recreateStatusItem() -> NSStatusItem {
         NSStatusBar.system.removeStatusItem(statusItem)
-        let new = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        new.button?.image = iconOutline
-        new.button?.image?.isTemplate = true
-        new.menu = menu
-        statusItem = new
-        return new
+        let newStatusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        newStatusItem.behavior = []
+        newStatusItem.menu = menu
+        statusItem = newStatusItem
+        configureStatusItemContent()
+        refreshMenuState()
+        return newStatusItem
+    }
+
+    private func configureStatusItemContent() {
+        guard let statusButton = statusItem.button else { return }
+
+        statusButton.title = ""
+        statusButton.image = nil
+        statusButton.setAccessibilityLabel("oMLX")
+        statusContentView.removeFromSuperview()
+        statusContentView.translatesAutoresizingMaskIntoConstraints = false
+        statusButton.addSubview(statusContentView)
+
+        activityLabel.translatesAutoresizingMaskIntoConstraints = false
+        activityLabel.font = statusButton.font
+        activityLabel.textColor = .labelColor
+        activityLabel.alignment = .right
+        activityLabel.lineBreakMode = .byClipping
+        statusIconView.translatesAutoresizingMaskIntoConstraints = false
+        statusIconView.imageScaling = .scaleProportionallyDown
+        statusIconView.contentTintColor = .labelColor
+        statusContentView.addSubview(activityLabel)
+        statusContentView.addSubview(statusIconView)
+
+        let iconCenterTrailingOffset = NSStatusBar.system.thickness / 2
+        NSLayoutConstraint.deactivate(statusContentConstraints)
+        statusContentConstraints = [
+            statusContentView.leadingAnchor.constraint(equalTo: statusButton.leadingAnchor),
+            statusContentView.trailingAnchor.constraint(equalTo: statusButton.trailingAnchor),
+            statusContentView.topAnchor.constraint(equalTo: statusButton.topAnchor),
+            statusContentView.bottomAnchor.constraint(equalTo: statusButton.bottomAnchor),
+            statusIconView.widthAnchor.constraint(equalToConstant: Self.statusIconSize),
+            statusIconView.heightAnchor.constraint(equalToConstant: Self.statusIconSize),
+            statusIconView.centerYAnchor.constraint(equalTo: statusContentView.centerYAnchor),
+            statusIconView.centerXAnchor.constraint(
+                equalTo: statusContentView.trailingAnchor,
+                constant: -iconCenterTrailingOffset
+            ),
+            activityLabel.leadingAnchor.constraint(
+                greaterThanOrEqualTo: statusContentView.leadingAnchor,
+                constant: Self.activityLeadingPadding
+            ),
+            activityLabel.trailingAnchor.constraint(
+                equalTo: statusIconView.leadingAnchor,
+                constant: -Self.activityToIconSpacing
+            ),
+            activityLabel.centerYAnchor.constraint(equalTo: statusContentView.centerYAnchor)
+        ]
+        NSLayoutConstraint.activate(statusContentConstraints)
     }
 
     // MARK: - Notification handlers
@@ -577,6 +699,7 @@ final class MenubarController: NSObject {
         // Stats only need to redraw if the submenu is open or about to open;
         // menuWillOpen (NSMenuDelegate) handles the latter, so for now we
         // rebuild eagerly — the next render will pick up fresh values.
+        refreshMenuState()
         rebuildStatsSubmenu()
     }
 
@@ -585,6 +708,13 @@ final class MenubarController: NSObject {
     }
 
     // MARK: - Actions
+
+    @objc private func toggleLiveActivityInMenuBar() {
+        isLiveActivityEnabled.toggle()
+        statsPoller?.setLiveActivityPollingEnabled(isLiveActivityEnabled)
+        refreshMenuState()
+        rebuildStatsSubmenu()
+    }
 
     @objc private func startServer() {
         guard let server else { return }
@@ -818,6 +948,72 @@ extension MenubarController {
     /// Companion to `displayPort(server:fallback:)` — same rationale.
     static func displayHost(server: ServerProcess?, fallback: String) -> String {
         server?.host ?? fallback
+    }
+
+    /// Keeps live activity text out of a stopped or transitioning status item.
+    /// Internal so the policy is unit-tested without constructing NSStatusItem.
+    static func menuBarButtonTitle(
+        serverState: ServerProcess.State,
+        liveActivity: MenubarStatsPoller.Stats.LiveActivity?,
+        isLiveActivityEnabled: Bool
+    ) -> String {
+        guard isLiveActivityEnabled, serverState.isRunningLike else {
+            return ""
+        }
+        return liveActivity?.menuBarTitle ?? ""
+    }
+
+    struct MenuBarStatusItemPresentation: Equatable {
+        let itemLength: CGFloat
+        let iconCenterTrailingOffset: CGFloat
+        let activityTitle: String
+        let accessibilityValue: String?
+    }
+
+    private static let statusIconSize: CGFloat = 18
+    private static let activityLeadingPadding: CGFloat = 6
+    private static let activityToIconSpacing: CGFloat = 6
+
+    static func menuBarStatusItemPresentation(
+        activityTitle: String,
+        activityTextWidth: CGFloat,
+        statusBarThickness: CGFloat
+    ) -> MenuBarStatusItemPresentation {
+        let iconCenterTrailingOffset = statusBarThickness / 2
+        let itemLength: CGFloat
+        if activityTitle.isEmpty {
+            itemLength = NSStatusItem.squareLength
+        } else {
+            itemLength = ceil(
+                activityLeadingPadding
+                    + activityTextWidth
+                    + activityToIconSpacing
+                    + statusIconSize / 2
+                    + iconCenterTrailingOffset
+            )
+        }
+
+        return MenuBarStatusItemPresentation(
+            itemLength: itemLength,
+            iconCenterTrailingOffset: iconCenterTrailingOffset,
+            activityTitle: activityTitle,
+            accessibilityValue: activityTitle.isEmpty ? nil : activityTitle
+        )
+    }
+
+    static func menuBarButtonToolTip(
+        serverState: ServerProcess.State,
+        liveActivity: MenubarStatsPoller.Stats.LiveActivity?,
+        isLiveActivityEnabled: Bool
+    ) -> String {
+        guard !menuBarButtonTitle(
+            serverState: serverState,
+            liveActivity: liveActivity,
+            isLiveActivityEnabled: isLiveActivityEnabled
+        ).isEmpty else {
+            return "oMLX"
+        }
+        return liveActivity?.detail ?? "oMLX"
     }
 
     /// Builds the browser URL for the web admin dashboard. Uses the

--- a/apps/omlx-mac/Sources/Menubar/MenubarStatsPoller.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarStatsPoller.swift
@@ -1,7 +1,8 @@
-// Menubar poller: use lightweight /api/status for live display and liveness,
-// with occasional /admin/api/stats?scope=alltime fetches for the All-Time
-// submenu. Emits NotificationCenter posts so the menubar refreshes without
-// polling state itself.
+// Menubar poller: use lightweight /api/status for liveness, authenticated
+// /admin/api/activity reads for current request activity, and occasional
+// all-time stats reads for the Serving Stats submenu. Emits
+// NotificationCenter posts so the menubar refreshes without polling state
+// itself.
 //
 // PR 7's OMLXClient will absorb this auth machinery; for now the poller owns
 // its own URLSession + cookie jar to keep the menubar self-contained.
@@ -21,6 +22,11 @@ final class MenubarStatsPoller {
         var avgPrefillTps: Double?
         var avgGenerationTps: Double?
         var totalRequests: Int?
+        var activeModels: ActiveModels?
+
+        var liveActivity: LiveActivity? {
+            LiveActivity(activeModels: activeModels)
+        }
 
         enum CodingKeys: String, CodingKey {
             case totalPromptTokens = "total_prompt_tokens"
@@ -29,31 +35,224 @@ final class MenubarStatsPoller {
             case avgPrefillTps    = "avg_prefill_tps"
             case avgGenerationTps = "avg_generation_tps"
             case totalRequests    = "total_requests"
+            case activeModels     = "active_models"
+        }
+
+        struct ActiveModels: Codable, Sendable, Equatable {
+            let models: [ActiveModel]
+            let totalWaitingRequests: Int?
+
+            enum CodingKeys: String, CodingKey {
+                case models
+                case totalWaitingRequests = "total_waiting_requests"
+            }
+        }
+
+        struct ActiveModel: Codable, Sendable, Equatable {
+            let id: String
+            let prefilling: [PrefillProgress]?
+            let generating: [GenerationProgress]?
+            let activities: [NonStreamingActivity]?
+        }
+
+        struct PrefillProgress: Codable, Sendable, Equatable {
+            let processed: Int?
+            let total: Int?
+            let speed: Double?
+            let eta: Double?
+        }
+
+        struct GenerationProgress: Codable, Sendable, Equatable {
+            let generatedTokens: Int?
+            let tokensPerSecond: Double?
+            let elapsedSeconds: Double?
+
+            enum CodingKeys: String, CodingKey {
+                case generatedTokens = "generated_tokens"
+                case tokensPerSecond = "tokens_per_second"
+                case elapsedSeconds = "elapsed_seconds"
+            }
+        }
+
+        struct NonStreamingActivity: Codable, Sendable, Equatable {
+            let kind: String?
+            let detail: String?
+            let elapsedSeconds: Double?
+
+            enum CodingKeys: String, CodingKey {
+                case kind
+                case detail
+                case elapsedSeconds = "elapsed_seconds"
+            }
+        }
+
+        struct LiveActivity: Equatable, Sendable {
+            let menuBarTitle: String
+            let detail: String
+
+            private init(menuBarTitle: String, detail: String) {
+                self.menuBarTitle = menuBarTitle
+                self.detail = detail
+            }
+
+            init?(activeModels: ActiveModels?) {
+                guard let activeModels else {
+                    return nil
+                }
+
+                for activeModel in activeModels.models {
+                    if let prefill = activeModel.prefilling?.first {
+                        self = Self.prefill(modelID: activeModel.id, progress: prefill)
+                        return
+                    }
+                }
+
+                for activeModel in activeModels.models {
+                    if let generation = activeModel.generating?.first {
+                        self = Self.generation(modelID: activeModel.id, progress: generation)
+                        return
+                    }
+                }
+
+                for activeModel in activeModels.models {
+                    if let activity = activeModel.activities?.first {
+                        self = Self.nonStreaming(modelID: activeModel.id, activity: activity)
+                        return
+                    }
+                }
+
+                if let waitingRequestCount = activeModels.totalWaitingRequests,
+                   waitingRequestCount > 0 {
+                    self = Self.waiting(requestCount: waitingRequestCount)
+                    return
+                }
+
+                return nil
+            }
+
+            private static func prefill(
+                modelID: String,
+                progress: PrefillProgress
+            ) -> LiveActivity {
+                let processedTokens = max(0, progress.processed ?? 0)
+                let totalTokens = max(0, progress.total ?? 0)
+                let percentage = totalTokens > 0
+                    ? Int((Double(processedTokens) / Double(totalTokens) * 100).rounded())
+                    : 0
+
+                var detailParts = [modelID]
+                if let tokensPerSecond = progress.speed, tokensPerSecond > 0 {
+                    detailParts.append("\(Int(tokensPerSecond.rounded())) tok/s")
+                }
+                if let etaSeconds = progress.eta, etaSeconds >= 0 {
+                    detailParts.append("\(formatDuration(etaSeconds)) left")
+                }
+
+                return LiveActivity(
+                    menuBarTitle: "PP \(percentage)% · \(formatTokenCount(processedTokens))/\(formatTokenCount(totalTokens))",
+                    detail: detailParts.joined(separator: " · ")
+                )
+            }
+
+            private static func generation(
+                modelID: String,
+                progress: GenerationProgress
+            ) -> LiveActivity {
+                let tokensPerSecond = max(0, progress.tokensPerSecond ?? 0)
+                let generatedTokens = max(0, progress.generatedTokens ?? 0)
+
+                var detailParts = [modelID, "\(generatedTokens) tok"]
+                if let elapsedSeconds = progress.elapsedSeconds {
+                    detailParts.append(formatDuration(elapsedSeconds))
+                }
+
+                return LiveActivity(
+                    menuBarTitle: "GEN \(String(format: "%.1f", tokensPerSecond)) tok/s",
+                    detail: detailParts.joined(separator: " · ")
+                )
+            }
+
+            private static func waiting(requestCount: Int) -> LiveActivity {
+                LiveActivity(
+                    menuBarTitle: "WAIT \(requestCount)",
+                    detail: "\(requestCount) queued request\(requestCount == 1 ? "" : "s")"
+                )
+            }
+
+            private static func nonStreaming(
+                modelID: String,
+                activity: NonStreamingActivity
+            ) -> LiveActivity {
+                let elapsed = activity.elapsedSeconds.map(formatDuration)
+                let activityDetail = activity.detail ?? activity.kind ?? "Active request"
+                var detailParts = [modelID, activityDetail]
+                if let elapsed {
+                    detailParts.append(elapsed)
+                }
+
+                return LiveActivity(
+                    menuBarTitle: elapsed.map { "RUN \($0)" } ?? "RUN",
+                    detail: detailParts.joined(separator: " · ")
+                )
+            }
+
+            private static func formatTokenCount(_ tokenCount: Int) -> String {
+                if tokenCount >= 1_000_000 {
+                    let millions = Double(tokenCount) / 1_000_000
+                    return String(format: millions >= 10 ? "%.0fM" : "%.1fM", millions)
+                }
+                if tokenCount >= 1_000 {
+                    return "\(Int((Double(tokenCount) / 1_000).rounded()))k"
+                }
+                return "\(tokenCount)"
+            }
+
+            private static func formatDuration(_ seconds: Double) -> String {
+                let roundedSeconds = max(0, Int(seconds.rounded()))
+                if roundedSeconds >= 60 {
+                    let minutes = roundedSeconds / 60
+                    let remainingSeconds = roundedSeconds % 60
+                    return remainingSeconds == 0
+                        ? "\(minutes)m"
+                        : "\(minutes)m \(remainingSeconds)s"
+                }
+                return "\(roundedSeconds)s"
+            }
         }
     }
 
     private let baseURL: URL
     private let apiKey: String?
-    private let interval: TimeInterval
+    private let idleInterval: TimeInterval
+    private let liveActivityInterval: TimeInterval
     private let session: URLSession
     private var task: Task<Void, Never>?
-    /// Number of ticks between all-time fetches. Live status is cheap and
+    /// Number of ticks between all-time fetches. Current request activity
     /// needs steady refresh; all-time stats only show in the "All-Time"
     /// submenu, so polling them at the same rate burns server CPU for no UX
-    /// benefit. At interval=2s this fetches every 30s.
-    private let alltimeEveryNTicks = 15
+    /// benefit. At the one-second live interval this fetches every 30 seconds.
+    private let alltimeRefreshInterval: TimeInterval = 30
     private var tickCount = 0
+    private var isLiveActivityPollingEnabled = false
 
     private(set) var sessionStats: Stats?
+    private(set) var liveStats: Stats?
     private(set) var alltimeStats: Stats?
     private(set) var lastStatusSuccessAt: Date?
 
-    init(baseURL: URL, apiKey: String?, interval: TimeInterval = 2.0) {
+    init(
+        baseURL: URL,
+        apiKey: String?,
+        interval: TimeInterval = 2.0,
+        liveActivityInterval: TimeInterval = 1.0,
+        sessionConfiguration: URLSessionConfiguration? = nil
+    ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
-        self.interval = interval
+        self.idleInterval = interval
+        self.liveActivityInterval = liveActivityInterval
 
-        let cfg = URLSessionConfiguration.default
+        let cfg = sessionConfiguration ?? URLSessionConfiguration.default
         // `HTTPCookieStorage()` returns a detached instance that never
         // actually persists cookies, so the post-login session cookie was
         // dropped and every subsequent /api/stats request 401-ed. Since
@@ -74,8 +273,8 @@ final class MenubarStatsPoller {
         task = Task { @MainActor [weak self] in
             while !Task.isCancelled {
                 guard let self else { return }
-                await self.tick()
-                try? await Task.sleep(for: .seconds(self.interval))
+                await self.refreshOnce()
+                try? await Task.sleep(for: .seconds(self.currentPollingInterval))
             }
         }
     }
@@ -85,6 +284,21 @@ final class MenubarStatsPoller {
         task = nil
     }
 
+    func setLiveActivityPollingEnabled(_ isEnabled: Bool) {
+        guard isLiveActivityPollingEnabled != isEnabled else {
+            return
+        }
+
+        isLiveActivityPollingEnabled = isEnabled
+        if !isEnabled {
+            clearLiveStats()
+        }
+    }
+
+    var currentPollingInterval: TimeInterval {
+        isLiveActivityPollingEnabled ? liveActivityInterval : idleInterval
+    }
+
     deinit {
         // Detached cancel — actor-isolated stop() can't run from deinit.
         task?.cancel()
@@ -92,23 +306,51 @@ final class MenubarStatsPoller {
 
     // MARK: - Polling
 
-    private func tick() async {
+    func refreshOnce() async {
+        let alltimeEveryNTicks = max(
+            1,
+            Int((alltimeRefreshInterval / currentPollingInterval).rounded())
+        )
         let fetchAlltime = (tickCount % alltimeEveryNTicks == 0)
         tickCount &+= 1
         do {
             let s = try await fetchPublicStatus()
             self.sessionStats = s
             self.lastStatusSuccessAt = Date()
-            NotificationCenter.default.post(
-                name: Self.didUpdateNotification, object: self
-            )
+            if isLiveActivityPollingEnabled {
+                do {
+                    let live = try await fetchAdminActivity()
+                    if isLiveActivityPollingEnabled {
+                        self.liveStats = live
+                    }
+                } catch {
+                    if isLiveActivityPollingEnabled {
+                        clearLiveStats(shouldPostUpdate: false)
+                    }
+                }
+            }
             if fetchAlltime, hasAPIKey,
                let alltime = try? await fetchAdminStats(scope: "alltime") {
                 self.alltimeStats = alltime
             }
+            NotificationCenter.default.post(
+                name: Self.didUpdateNotification, object: self
+            )
         } catch {
             // Suppress: server may be transitioning, paused, or 401-pending.
             // Next tick retries; we log only the once-per-tick failure mode.
+            clearLiveStats()
+        }
+    }
+
+    private func clearLiveStats(shouldPostUpdate: Bool = true) {
+        guard liveStats != nil else {
+            return
+        }
+
+        liveStats = nil
+        if shouldPostUpdate {
+            NotificationCenter.default.post(name: Self.didUpdateNotification, object: self)
         }
     }
 
@@ -138,6 +380,22 @@ final class MenubarStatsPoller {
             let (data2, response2) = try await session.data(for: req)
             try validateOK(response2)
             return try JSONDecoder().decode(Stats.self, from: data2)
+        }
+        try validateOK(response)
+        return try JSONDecoder().decode(Stats.self, from: data)
+    }
+
+    private func fetchAdminActivity() async throws -> Stats {
+        let url = try makeURL(path: "/admin/api/activity")
+        var req = URLRequest(url: url)
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        let (data, response) = try await session.data(for: req)
+
+        if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+            try await login()
+            let (authenticatedData, authenticatedResponse) = try await session.data(for: req)
+            try validateOK(authenticatedResponse)
+            return try JSONDecoder().decode(Stats.self, from: authenticatedData)
         }
         try validateOK(response)
         return try JSONDecoder().decode(Stats.self, from: data)

--- a/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
@@ -318,6 +318,8 @@ final class MenubarControllerPortTests: XCTestCase {
         XCTAssertEqual(activePresentation.itemLength, 133)
         XCTAssertEqual(idlePresentation.iconCenterTrailingOffset, 12)
         XCTAssertEqual(activePresentation.iconCenterTrailingOffset, 12)
+        XCTAssertFalse(idlePresentation.reservesActivityLabelSpace)
+        XCTAssertTrue(activePresentation.reservesActivityLabelSpace)
         XCTAssertEqual(activePresentation.activityTitle, "PP 55% · 6k/11k")
         XCTAssertNil(idlePresentation.accessibilityValue)
         XCTAssertEqual(activePresentation.accessibilityValue, "PP 55% · 6k/11k")

--- a/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
@@ -19,12 +19,179 @@
 // failed). These tests exercise the helper directly — instantiating the
 // full controller in a unit test would require a live `NSStatusBar`.
 
+import AppKit
 import Foundation
 import XCTest
 @testable import oMLX
 
+private final class MenubarStatsRequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var activityRequestCount = 0
+    private var activityResponseStatusCode = 200
+    private var publicStatusResponseStatusCode = 200
+    private var updateNotificationCount = 0
+
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        activityRequestCount = 0
+        activityResponseStatusCode = 200
+        publicStatusResponseStatusCode = 200
+        updateNotificationCount = 0
+    }
+
+    func recordActivityRequest() {
+        lock.lock()
+        defer { lock.unlock() }
+        activityRequestCount += 1
+    }
+
+    func recordedActivityRequestCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return activityRequestCount
+    }
+
+    func setActivityResponseStatusCode(_ statusCode: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        activityResponseStatusCode = statusCode
+    }
+
+    func currentActivityResponseStatusCode() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return activityResponseStatusCode
+    }
+
+    func setPublicStatusResponseStatusCode(_ statusCode: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        publicStatusResponseStatusCode = statusCode
+    }
+
+    func currentPublicStatusResponseStatusCode() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return publicStatusResponseStatusCode
+    }
+
+    func recordUpdateNotification() {
+        lock.lock()
+        defer { lock.unlock() }
+        updateNotificationCount += 1
+    }
+
+    func recordedUpdateNotificationCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return updateNotificationCount
+    }
+}
+
+private final class MenubarStatsURLProtocol: URLProtocol, @unchecked Sendable {
+    private static let requestRecorder = MenubarStatsRequestRecorder()
+
+    static func resetRequestRecorder() {
+        requestRecorder.reset()
+    }
+
+    static func recordedActivityRequestCount() -> Int {
+        requestRecorder.recordedActivityRequestCount()
+    }
+
+    static func setActivityResponseStatusCode(_ statusCode: Int) {
+        requestRecorder.setActivityResponseStatusCode(statusCode)
+    }
+
+    static func setPublicStatusResponseStatusCode(_ statusCode: Int) {
+        requestRecorder.setPublicStatusResponseStatusCode(statusCode)
+    }
+
+    static func recordUpdateNotification() {
+        requestRecorder.recordUpdateNotification()
+    }
+
+    static func recordedUpdateNotificationCount() -> Int {
+        requestRecorder.recordedUpdateNotificationCount()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let scope = components?.queryItems?.first(where: { $0.name == "scope" })?.value
+        let statusCode: Int
+        if url.path == "/api/status" {
+            statusCode = Self.requestRecorder.currentPublicStatusResponseStatusCode()
+        } else if url.path == "/admin/api/activity" {
+            Self.requestRecorder.recordActivityRequest()
+            statusCode = Self.requestRecorder.currentActivityResponseStatusCode()
+        } else {
+            statusCode = 200
+        }
+        let payload: String
+        switch (url.path, scope) {
+        case ("/api/status", _):
+            payload = #"{"total_prompt_tokens":99}"#
+        case ("/admin/api/activity", _):
+            payload = #"""
+            {
+              "active_models": {
+                "models": [
+                  {
+                    "id": "Laguna XS.2",
+                    "generating": [
+                      {
+                        "request_id": "generation-1",
+                        "generated_tokens": 128,
+                        "tokens_per_second": 42.1,
+                        "elapsed_seconds": 3.0
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+            """#
+        case ("/admin/api/stats", "alltime"):
+            payload = #"{"total_requests":3}"#
+        default:
+            payload = "{}"
+        }
+
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(payload.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
 @MainActor
 final class MenubarControllerPortTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        MenubarStatsURLProtocol.resetRequestRecorder()
+    }
 
     /// Test-only PythonRuntime. ServerProcess holds it but doesn't
     /// dereference until `start()` — these tests never start, they just
@@ -42,6 +209,373 @@ final class MenubarControllerPortTests: XCTestCase {
     func testSpawnEnvironmentAdvertisesMenubarSupervisor() {
         let env = makeRuntime().makeEnvironment()
         XCTAssertEqual(env["OMLX_SUPERVISED"], "menubar")
+    }
+
+    func testLiveActivityPrioritizesPrefillOverGeneration() throws {
+        let data = try XCTUnwrap(
+            """
+            {
+              "active_models": {
+                "models": [
+                  {
+                    "id": "Laguna XS.2",
+                    "prefilling": [
+                      {
+                        "request_id": "prefill-1",
+                        "processed": 12000,
+                        "total": 32000,
+                        "speed": 321.4,
+                        "eta": 46.9
+                      }
+                    ],
+                    "generating": [
+                      {
+                        "request_id": "generation-1",
+                        "generated_tokens": 128,
+                        "tokens_per_second": 42.1,
+                        "elapsed_seconds": 3.0
+                      }
+                    ]
+                  }
+                ],
+                "total_waiting_requests": 2
+              }
+            }
+            """.data(using: .utf8)
+        )
+
+        let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
+        let activity = try XCTUnwrap(stats.liveActivity)
+
+        XCTAssertEqual(activity.menuBarTitle, "PP 38% · 12k/32k")
+        XCTAssertEqual(activity.detail, "Laguna XS.2 · 321 tok/s · 47s left")
+    }
+
+    func testMenuBarButtonTitleRequiresTheLiveActivityPreference() throws {
+        let data = try XCTUnwrap(
+            """
+            {
+              "active_models": {
+                "models": [
+                  {
+                    "id": "Laguna XS.2",
+                    "generating": [
+                      {
+                        "request_id": "generation-1",
+                        "generated_tokens": 128,
+                        "tokens_per_second": 42.1,
+                        "elapsed_seconds": 3.0
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+            """.data(using: .utf8)
+        )
+        let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
+        let activity = try XCTUnwrap(stats.liveActivity)
+
+        XCTAssertEqual(
+            MenubarController.menuBarButtonTitle(
+                serverState: .running(pid: 123),
+                liveActivity: activity,
+                isLiveActivityEnabled: false
+            ),
+            ""
+        )
+        XCTAssertEqual(
+            MenubarController.menuBarButtonTitle(
+                serverState: .stopped,
+                liveActivity: activity,
+                isLiveActivityEnabled: true
+            ),
+            ""
+        )
+        XCTAssertEqual(
+            MenubarController.menuBarButtonTitle(
+                serverState: .running(pid: 123),
+                liveActivity: activity,
+                isLiveActivityEnabled: true
+            ),
+            "GEN 42.1 tok/s"
+        )
+    }
+
+    func testLiveActivityUsesOneStatusItemWithBirdPinnedToItsRightEdge() {
+        let idlePresentation = MenubarController.menuBarStatusItemPresentation(
+            activityTitle: "",
+            activityTextWidth: 0,
+            statusBarThickness: 24
+        )
+        let activePresentation = MenubarController.menuBarStatusItemPresentation(
+            activityTitle: "PP 55% · 6k/11k",
+            activityTextWidth: 100,
+            statusBarThickness: 24
+        )
+
+        XCTAssertEqual(idlePresentation.itemLength, NSStatusItem.squareLength)
+        XCTAssertEqual(activePresentation.itemLength, 133)
+        XCTAssertEqual(idlePresentation.iconCenterTrailingOffset, 12)
+        XCTAssertEqual(activePresentation.iconCenterTrailingOffset, 12)
+        XCTAssertEqual(activePresentation.activityTitle, "PP 55% · 6k/11k")
+        XCTAssertNil(idlePresentation.accessibilityValue)
+        XCTAssertEqual(activePresentation.accessibilityValue, "PP 55% · 6k/11k")
+    }
+
+    func testMenuBarToolTipRequiresVisibleLiveActivity() throws {
+        let data = try XCTUnwrap(
+            """
+            {
+              "active_models": {
+                "models": [
+                  {
+                    "id": "Laguna XS.2",
+                    "generating": [
+                      {
+                        "generated_tokens": 128,
+                        "tokens_per_second": 42.1,
+                        "elapsed_seconds": 3.0
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+            """.data(using: .utf8)
+        )
+        let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
+        let activity = try XCTUnwrap(stats.liveActivity)
+
+        XCTAssertEqual(
+            MenubarController.menuBarButtonToolTip(
+                serverState: .running(pid: 123),
+                liveActivity: activity,
+                isLiveActivityEnabled: true
+            ),
+            "Laguna XS.2 · 128 tok · 3s"
+        )
+        XCTAssertEqual(
+            MenubarController.menuBarButtonToolTip(
+                serverState: .running(pid: 123),
+                liveActivity: activity,
+                isLiveActivityEnabled: false
+            ),
+            "oMLX"
+        )
+        XCTAssertEqual(
+            MenubarController.menuBarButtonToolTip(
+                serverState: .stopped,
+                liveActivity: activity,
+                isLiveActivityEnabled: true
+            ),
+            "oMLX"
+        )
+    }
+
+    func testLiveActivityShowsGenerationWhenNoPrefillIsActive() throws {
+        let data = try XCTUnwrap(
+            """
+            {
+              "active_models": {
+                "models": [
+                  {
+                    "id": "Laguna XS.2",
+                    "generating": [
+                      {
+                        "request_id": "generation-1",
+                        "generated_tokens": 128,
+                        "tokens_per_second": 42.1,
+                        "elapsed_seconds": 3.0
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+            """.data(using: .utf8)
+        )
+
+        let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
+        let activity = try XCTUnwrap(stats.liveActivity)
+
+        XCTAssertEqual(activity.menuBarTitle, "GEN 42.1 tok/s")
+        XCTAssertEqual(activity.detail, "Laguna XS.2 · 128 tok · 3s")
+    }
+
+    func testLiveActivityShowsQueuedRequestsWhenNoRequestIsRunning() throws {
+        let data = try XCTUnwrap(
+            """
+            {
+              "active_models": {
+                "models": [],
+                "total_waiting_requests": 2
+              }
+            }
+            """.data(using: .utf8)
+        )
+
+        let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
+        let activity = try XCTUnwrap(stats.liveActivity)
+
+        XCTAssertEqual(activity.menuBarTitle, "WAIT 2")
+        XCTAssertEqual(activity.detail, "2 queued requests")
+    }
+
+    func testLiveActivityShowsNonStreamingEngineWork() throws {
+        let data = try XCTUnwrap(
+            """
+            {
+              "active_models": {
+                "models": [
+                  {
+                    "id": "embed-model",
+                    "activities": [
+                      {
+                        "kind": "embedding",
+                        "detail": "Embedding",
+                        "elapsed_seconds": 12.0
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+            """.data(using: .utf8)
+        )
+
+        let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
+        let activity = try XCTUnwrap(stats.liveActivity)
+
+        XCTAssertEqual(activity.menuBarTitle, "RUN 12s")
+        XCTAssertEqual(activity.detail, "embed-model · Embedding · 12s")
+    }
+
+    func testRefreshOnceLoadsLiveActivityFromActivityEndpoint() async {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [MenubarStatsURLProtocol.self]
+        let poller = MenubarStatsPoller(
+            baseURL: URL(string: "http://omlx.test")!,
+            apiKey: "test-key",
+            sessionConfiguration: sessionConfiguration
+        )
+        poller.setLiveActivityPollingEnabled(true)
+
+        await poller.refreshOnce()
+
+        XCTAssertEqual(poller.sessionStats?.totalPromptTokens, 99)
+        XCTAssertEqual(poller.liveStats?.liveActivity?.menuBarTitle, "GEN 42.1 tok/s")
+        XCTAssertEqual(poller.alltimeStats?.totalRequests, 3)
+        XCTAssertEqual(MenubarStatsURLProtocol.recordedActivityRequestCount(), 1)
+    }
+
+    func testPollingOnlyAcceleratesAfterLiveActivityOptIn() {
+        let poller = MenubarStatsPoller(
+            baseURL: URL(string: "http://omlx.test")!,
+            apiKey: "test-key"
+        )
+
+        XCTAssertEqual(poller.currentPollingInterval, 2.0)
+
+        poller.setLiveActivityPollingEnabled(true)
+        XCTAssertEqual(poller.currentPollingInterval, 1.0)
+
+        poller.setLiveActivityPollingEnabled(false)
+        XCTAssertEqual(poller.currentPollingInterval, 2.0)
+    }
+
+    func testRefreshOnceLoadsActivityWithoutAPIKeyWhenServerAllowsIt() async {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [MenubarStatsURLProtocol.self]
+        let poller = MenubarStatsPoller(
+            baseURL: URL(string: "http://omlx.test")!,
+            apiKey: nil,
+            sessionConfiguration: sessionConfiguration
+        )
+        poller.setLiveActivityPollingEnabled(true)
+
+        await poller.refreshOnce()
+
+        XCTAssertEqual(poller.liveStats?.liveActivity?.menuBarTitle, "GEN 42.1 tok/s")
+        XCTAssertEqual(MenubarStatsURLProtocol.recordedActivityRequestCount(), 1)
+    }
+
+    func testRefreshOncePostsOneConsolidatedUpdateNotification() async {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [MenubarStatsURLProtocol.self]
+        let poller = MenubarStatsPoller(
+            baseURL: URL(string: "http://omlx.test")!,
+            apiKey: "test-key",
+            sessionConfiguration: sessionConfiguration
+        )
+        poller.setLiveActivityPollingEnabled(true)
+        let observer = NotificationCenter.default.addObserver(
+            forName: MenubarStatsPoller.didUpdateNotification,
+            object: poller,
+            queue: nil
+        ) { _ in
+            MenubarStatsURLProtocol.recordUpdateNotification()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        await poller.refreshOnce()
+
+        XCTAssertEqual(MenubarStatsURLProtocol.recordedUpdateNotificationCount(), 1)
+    }
+
+    func testRefreshOnceSkipsLiveAdminStatsWhenActivityDisplayIsDisabled() async {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [MenubarStatsURLProtocol.self]
+        let poller = MenubarStatsPoller(
+            baseURL: URL(string: "http://omlx.test")!,
+            apiKey: "test-key",
+            sessionConfiguration: sessionConfiguration
+        )
+
+        poller.setLiveActivityPollingEnabled(false)
+        await poller.refreshOnce()
+
+        XCTAssertEqual(poller.sessionStats?.totalPromptTokens, 99)
+        XCTAssertNil(poller.liveStats)
+        XCTAssertEqual(MenubarStatsURLProtocol.recordedActivityRequestCount(), 0)
+    }
+
+    func testRefreshOnceClearsLiveActivityAfterActivityFailure() async {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [MenubarStatsURLProtocol.self]
+        let poller = MenubarStatsPoller(
+            baseURL: URL(string: "http://omlx.test")!,
+            apiKey: "test-key",
+            sessionConfiguration: sessionConfiguration
+        )
+        poller.setLiveActivityPollingEnabled(true)
+
+        await poller.refreshOnce()
+        XCTAssertNotNil(poller.liveStats?.liveActivity)
+
+        MenubarStatsURLProtocol.setActivityResponseStatusCode(500)
+        await poller.refreshOnce()
+
+        XCTAssertNil(poller.liveStats)
+    }
+
+    func testRefreshOnceClearsLiveActivityAfterPublicStatusFailure() async {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [MenubarStatsURLProtocol.self]
+        let poller = MenubarStatsPoller(
+            baseURL: URL(string: "http://omlx.test")!,
+            apiKey: "test-key",
+            sessionConfiguration: sessionConfiguration
+        )
+        poller.setLiveActivityPollingEnabled(true)
+
+        await poller.refreshOnce()
+        XCTAssertNotNil(poller.liveStats?.liveActivity)
+
+        MenubarStatsURLProtocol.setPublicStatusResponseStatusCode(500)
+        await poller.refreshOnce()
+
+        XCTAssertNil(poller.liveStats)
     }
 
     // MARK: - displayPort

--- a/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
@@ -53,6 +53,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
             estimatedSizeFormatted: nil,
             pinned: nil,
             isDefault: nil,
+            isFavorite: nil,
             engineType: nil,
             modelType: nil,
             configModelType: configModelType,

--- a/apps/omlx-mac/Tests/oMLXTests/ModelsScreenSortingTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelsScreenSortingTests.swift
@@ -51,6 +51,7 @@ final class ModelsScreenSortingTests: XCTestCase {
             estimatedSizeFormatted: nil,
             pinned: nil,
             isDefault: nil,
+            isFavorite: nil,
             engineType: nil,
             modelType: nil,
             configModelType: nil,

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -4465,6 +4465,12 @@ async def get_server_stats(
     }
 
 
+@router.get("/api/activity")
+async def get_server_activity(is_admin: bool = Depends(require_admin)):
+    """Return lightweight current model and request activity for live displays."""
+    return {"active_models": _build_active_models_data()}
+
+
 def _build_active_models_data() -> dict:
     """Build active models status for the dashboard Active Models card."""
     from ..model_discovery import format_size

--- a/tests/test_admin_api_key.py
+++ b/tests/test_admin_api_key.py
@@ -697,6 +697,22 @@ class TestStatsSecurity:
         # api_key is included for admin-only CLI snippet generation in the dashboard
         assert result["api_key"] == "super-secret-key"
 
+    def test_activity_response_does_not_build_runtime_cache_observability(self):
+        active_models = {"models": [{"id": "model-a"}]}
+
+        with (
+            patch.object(
+                admin_routes,
+                "_build_active_models_data",
+                return_value=active_models,
+            ),
+            patch.object(admin_routes, "_build_runtime_cache_observability") as build_runtime_cache,
+        ):
+            result = asyncio.run(admin_routes.get_server_activity(is_admin=True))
+
+        assert result == {"active_models": active_models}
+        build_runtime_cache.assert_not_called()
+
     def test_active_models_data_ignores_enforcer_status_error(self):
         """Admin stats should not fail when memory telemetry is unavailable."""
         pool = MagicMock()


### PR DESCRIPTION
## Summary

- add an opt-in menu-bar live activity display for prompt prefill, generation speed/token count, queued requests, and non-streaming work
- keep the bird icon stationary inside one unified status item while activity text expands to its left
- add a lightweight authenticated `/admin/api/activity` endpoint instead of polling the full runtime-cache stats payload
- preserve the existing 2-second idle status cadence and use 1-second activity polling only after explicit opt-in
- expose the live state through the status item accessibility value and consolidate UI updates to one notification per poll cycle

## Testing

- `xcodebuild test -project oMLX.xcodeproj -scheme oMLX -destination platform=macOS` — 200 passed, 1 skipped
- `uv run pytest tests/test_admin_api_key.py tests/test_active_models_visibility.py -q` — 81 passed
- localization catalog JSON validation and `git diff --check` passed
- Ruff and mypy were also run; both retain existing repository-wide baselines unrelated to the changed lines

## Issues

Closes #250.
Addresses #1985.
Related to #45, #163, and #1103.

The adaptive polling and lightweight activity endpoint are designed to avoid regressing the idle polling concerns tracked in #2069.