### PR TITLE
fix(dflash): stop double-charging hot-cache bytes in the primary prefill guard

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -93,12 +93,21 @@ class _DFlashPrefillGuard:
         # Written by ProcessMemoryEnforcer._propagate_memory_limit each tick.
         self._prefill_memory_guard: bool = False
         self._memory_hard_limit_bytes: int = 0
+        self._memory_hot_cache_used_bytes: int = 0
 
     def record_mlx_active_memory(self, active_bytes: int) -> None:
         self._last_mlx_active_memory_bytes = max(0, int(active_bytes))
 
     def _current_usage_bytes(self) -> int:
-        return max(self._last_mlx_active_memory_bytes, get_phys_footprint())
+        # The enforcer already subtracts a hot-cache reservation from the
+        # ``_memory_hard_limit_bytes`` it propagates here, so serialized
+        # hot-cache CPU bytes must not ALSO be counted in usage via
+        # phys_footprint — that charges them twice and over-rejects by the
+        # hot-cache size. Mirrors ``Scheduler._current_usage_bytes``.
+        phys = max(
+            0, get_phys_footprint() - max(0, int(self._memory_hot_cache_used_bytes))
+        )
+        return max(self._last_mlx_active_memory_bytes, phys)
 
     def preflight_or_raise(
         self,

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -1009,6 +1009,14 @@ class ProcessMemoryEnforcer:
         hot_cache_reserved = (
             self._hot_cache_reserved_bytes() if ceiling > 0 or abort_limit > 0 else 0
         )
+        # Clamp to the reservation: the usage-side exclusion must never exceed
+        # what the ceiling actually gave up, or a transient hot-cache overshoot
+        # past max_bytes would net-weaken the guard exactly under pressure.
+        hot_cache_used = (
+            min(self._hot_cache_used_bytes(), hot_cache_reserved)
+            if hot_cache_reserved > 0
+            else 0
+        )
         scheduler_ceiling = self._scheduler_limit_bytes(
             ceiling, reserved=hot_cache_reserved
         )
@@ -1077,6 +1085,12 @@ class ProcessMemoryEnforcer:
             scheduler._memory_dynamic_ceiling_bytes = breakdown["dynamic"]
             scheduler._memory_metal_cap_bytes = breakdown["metal_cap"]
             scheduler._memory_hot_cache_reserved_bytes = hot_cache_reserved
+            # Usage-side counterpart of the reservation above: targets whose
+            # usage read is raw phys_footprint (the DFlash primary guard)
+            # subtract this so serialized hot-cache CPU bytes are not charged
+            # both here and in the reserved ceiling. The Scheduler reads its
+            # own live counter instead and ignores this attr.
+            scheduler._memory_hot_cache_used_bytes = hot_cache_used
             # Tier name disambiguates dynamic = computed reclaimable
             # (safe/balanced/aggressive) from dynamic = user-pinned
             # custom_ceiling_bytes (custom). The advice ladder needs

--- a/tests/test_dflash_prefill_memory_guard.py
+++ b/tests/test_dflash_prefill_memory_guard.py
@@ -227,6 +227,85 @@ def test_guard_uses_cached_active_when_larger_than_physical():
     assert exc.value.request_id == "r-cached"
 
 
+def test_guard_excludes_hot_cache_bytes_from_physical_usage():
+    """Serialized hot-cache CPU bytes must not be charged twice.
+
+    The enforcer already subtracts a hot-cache reservation from the ceiling it
+    propagates (``_memory_hot_cache_reserved_bytes`` side); counting the same
+    bytes again inside phys_footprint over-rejects by the hot-cache size —
+    the same double-count the scheduler guard fixed for issue 1796. The limit
+    here is chosen so the prefill fits exactly iff the exclusion is applied.
+    """
+    guard = _make_guard()
+    guard._prefill_memory_guard = True
+    phys = 3 * 1024**3
+    hot_used = 1 * 1024**3
+    guard._memory_hot_cache_used_bytes = hot_used
+    peak = guard.memory_monitor.estimate_prefill_peak_bytes(65536, 2048)
+    # Fits with the exclusion (phys - hot_used + peak), not without.
+    guard._memory_hard_limit_bytes = int(phys - hot_used + peak)
+
+    with (
+        patch("omlx.engine.dflash.get_phys_footprint", return_value=phys),
+        patch(
+            "omlx.memory_monitor.mx.get_active_memory",
+            side_effect=AssertionError("preflight must not read MLX directly"),
+        ),
+    ):
+        guard.preflight_or_raise(num_prompt_tokens=65536, request_id="r-hot")
+
+    # Still rejects when genuinely over even after the exclusion.
+    guard._memory_hard_limit_bytes = int(phys - hot_used + peak - 1)
+    with (
+        patch("omlx.engine.dflash.get_phys_footprint", return_value=phys),
+        patch(
+            "omlx.memory_monitor.mx.get_active_memory",
+            side_effect=AssertionError("preflight must not read MLX directly"),
+        ),
+        pytest.raises(PrefillMemoryExceededError) as exc,
+    ):
+        guard.preflight_or_raise(num_prompt_tokens=65536, request_id="r-hot2")
+    assert exc.value.estimated_bytes >= int(phys - hot_used + peak)
+
+
+def test_guard_hot_cache_exclusion_clamps_and_keeps_active_floor():
+    """A hot-cache figure larger than phys clamps the phys term to 0 instead
+    of going negative, and the recorded MLX active sample still floors the
+    usage — the exclusion must never eat into *GPU* pressure accounting."""
+    guard = _make_guard()
+    guard._prefill_memory_guard = True
+    active = 1 * 1024**3
+    phys = 2 * 1024**3
+    guard.record_mlx_active_memory(active)
+    guard._memory_hot_cache_used_bytes = 4 * 1024**3  # > phys → clamp to 0
+    peak = guard.memory_monitor.estimate_prefill_peak_bytes(65536, 2048)
+
+    # Usage must be the active floor (1 GiB), not raw phys (2 GiB): a limit
+    # of active + peak fits with the clamp applied, not without.
+    guard._memory_hard_limit_bytes = int(active + peak)
+    with (
+        patch("omlx.engine.dflash.get_phys_footprint", return_value=phys),
+        patch(
+            "omlx.memory_monitor.mx.get_active_memory",
+            side_effect=AssertionError("preflight must not read MLX directly"),
+        ),
+    ):
+        guard.preflight_or_raise(num_prompt_tokens=65536, request_id="r-clamp")
+
+    # The active floor itself is never reduced by the exclusion.
+    guard._memory_hard_limit_bytes = int(active + peak - 1)
+    with (
+        patch("omlx.engine.dflash.get_phys_footprint", return_value=phys),
+        patch(
+            "omlx.memory_monitor.mx.get_active_memory",
+            side_effect=AssertionError("preflight must not read MLX directly"),
+        ),
+        pytest.raises(PrefillMemoryExceededError) as exc,
+    ):
+        guard.preflight_or_raise(num_prompt_tokens=65536, request_id="r-clamp2")
+    assert exc.value.estimated_bytes >= int(active + peak)
+
+
 def test_guard_rejects_cached_tokens():
     """The narrowed signature is deliberate: a DFlash prefix-cache hit
     reconstructs KV into active memory, so accepting a hit count here would

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -730,6 +730,53 @@ class TestDisabledWhenCeilingZero:
         assert scheduler._memory_metal_cap_bytes == metal_b
         assert scheduler._memory_hot_cache_reserved_bytes == hot_reserved_b
 
+    async def test_propagates_hot_cache_used_for_usage_side_exclusion(
+        self, mock_engine_pool
+    ):
+        """Targets whose usage read is raw phys_footprint (the DFlash primary
+        guard) need the used-bytes counterpart of the reservation, or the
+        hot cache is charged twice: once in the reserved ceiling, once in
+        phys. The enforcer propagates the exact used figure each tick."""
+        metal_b = 16 * 1024**3
+        hot_used_b = 3 * 1024**3
+        enforcer = _make_enforcer(mock_engine_pool, ceiling=metal_b)
+        enforcer._hot_cache_reserved_bytes = lambda: hot_used_b + 512 * 1024**2
+        enforcer._hot_cache_used_bytes = lambda: hot_used_b
+        scheduler = MagicMock(spec=[])
+        scheduler._memory_hot_cache_used_bytes = 0
+        scheduler.batch_generator = None
+        engine = MagicMock(spec=[])
+        engine.scheduler = scheduler
+        entry = _make_entry("model-a", engine=engine)
+        mock_engine_pool._entries = {"model-a": entry}
+
+        enforcer._propagate_memory_limit()
+
+        assert scheduler._memory_hot_cache_used_bytes == hot_used_b
+
+    async def test_propagated_hot_cache_used_clamped_to_reservation(
+        self, mock_engine_pool
+    ):
+        """A transient overshoot (live hot-cache bytes past max_bytes) must not
+        exclude more usage than the reservation removed from the ceiling —
+        that would net-weaken the guard exactly under pressure."""
+        metal_b = 16 * 1024**3
+        reserved_b = 3 * 1024**3  # capped at max_bytes
+        enforcer = _make_enforcer(mock_engine_pool, ceiling=metal_b)
+        enforcer._hot_cache_reserved_bytes = lambda: reserved_b
+        enforcer._hot_cache_used_bytes = lambda: 5 * 1024**3  # overshoot
+        scheduler = MagicMock(spec=[])
+        scheduler._memory_hot_cache_used_bytes = 0
+        scheduler.batch_generator = None
+        engine = MagicMock(spec=[])
+        engine.scheduler = scheduler
+        entry = _make_entry("model-a", engine=engine)
+        mock_engine_pool._entries = {"model-a": entry}
+
+        enforcer._propagate_memory_limit()
+
+        assert scheduler._memory_hot_cache_used_bytes == reserved_b
+
 
 class TestPrefillMemoryGuardToggle:
     """Tests for prefill_memory_guard setter and Metal limit management."""


### PR DESCRIPTION
Addresses the last remaining sibling path of #1796 (see also #1833).

## Summary

- The DFlash primary-path prefill guard no longer charges serialized hot-cache CPU bytes twice. The enforcer now propagates the hot-cache used-bytes figure alongside the reservation it already sends, and `_DFlashPrefillGuard` subtracts it from `phys_footprint` — mirroring what `Scheduler._current_usage_bytes` already does.

## Why

Since #1833's fix (44588854), the enforcer subtracts a hot-cache reservation from the ceiling it propagates to every watermark target, and since #1796's fix (e52aeb93) the scheduler compensates on the usage side by excluding hot-cache CPU bytes from its `phys_footprint` read — together the hot cache is charged exactly once on scheduler-driven paths.

The DFlash primary guard receives the same reserved ceiling (it's a `_resolve_scheduler` target), but still measured usage as raw `max(active, phys_footprint)`. Hot-cache bytes were therefore charged twice on that path — once in the reduced limit, once in usage — so as the hot cache fills, the guard over-rejects by up to the hot-cache size. That's the same false-rejection mechanism both issues describe:

> Memory guard counts serialized hot-cache CPU bytes as GPU pressure — prefill safety cap shrinks 1:1 as the hot cache fills (#1796)

> long-context requests aborted once the hot cache fills (#1833)

fixed for the scheduler and enforcer paths, surviving only on DFlash primary. Nobody has reported it there yet (it needs DFlash primary + a populated hot cache from a co-resident scheduler-driven model + a prefill near the ceiling), so this is a proactive parity fix rather than a response to a field report.

## Changes

- `omlx/process_memory_enforcer.py` — `_propagate_memory_limit` computes the hot-cache used-bytes figure and writes it to every target as `_memory_hot_cache_used_bytes`, next to the existing `_memory_hot_cache_reserved_bytes`. The value is clamped to the reservation, so a transient overshoot past `max_bytes` can never exclude more usage than the ceiling actually gave up (the exclusion is never net-optimistic).
- `omlx/engine/dflash.py` — `_DFlashPrefillGuard._current_usage_bytes` subtracts that figure from `phys_footprint` (clamped at zero) before taking the max with the recorded MLX-active sample. The active floor is never reduced — GPU pressure accounting is untouched.

Sibling sweep: the Scheduler keeps reading its own live counter and simply ignores the new attr (no double application); the enforcer's own process-level pressure accounting deliberately stays on full `phys_footprint` (unchanged, per 44588854's design); DFlash fallback mode resolves the fallback engine's real scheduler, which already has the exclusion; diffusion engines are skipped by the propagation loop as before.

## Why this is safe

- With no enforcer running (standalone guards, tests), the new attr stays 0 and the guard computes exactly what it does today.
- The propagated value is clamped to the reservation, so usage-side exclusion ≤ limit-side reservation always holds — the guard can only get *stricter* than a perfectly-symmetric accounting, never looser.
- The preflight path gains no MLX/Metal or cache-manager calls — the guard reads one plain int attribute written by the enforcer tick, same pattern as the existing watermark attrs.

## Tests

Four new tests, in the existing per-module files:

- `test_guard_excludes_hot_cache_bytes_from_physical_usage` — the double-count repro: a prefill that fits exactly iff the exclusion is applied, plus the inverse (still rejects when genuinely over).
- `test_guard_hot_cache_exclusion_clamps_and_keeps_active_floor` — an oversized hot-cache figure clamps to zero instead of going negative, and the MLX-active floor still rejects on its own.
- `test_propagates_hot_cache_used_for_usage_side_exclusion` — the enforcer writes the used figure to resolved targets each tick.
- `test_propagated_hot_cache_used_clamped_to_reservation` — an overshoot past `max_bytes` propagates the clamped reservation, not the raw figure.

```
$ pytest tests/test_dflash_prefill_memory_guard.py tests/test_process_memory_enforcer.py tests/test_scheduler_prefill_memory_guard.py -q
187 passed
```

Also verified all four new tests fail when the fix is reverted (guard counts raw phys; enforcer never writes the attr).
