### PR TITLE
fix(admin): give the accuracy bench queue chain an ownership token

### DIFF
--- a/omlx/admin/accuracy_benchmark.py
+++ b/omlx/admin/accuracy_benchmark.py
@@ -37,6 +37,15 @@ _queue_running: bool = False
 _current_run_id: Optional[str] = None
 _current_model: Optional[str] = None
 _engine_pool_ref: Any = None
+# Chain-ownership token. A "chain" is one start_next_from_queue call plus
+# the _continue_queue tail it spawns. Each chain captures the token current
+# at its start; cancel_queue and start_next_from_queue bump it. A chain
+# whose token is stale (e.g. it was soft-cancelled and only noticed at its
+# next checkpoint, after the user already started a new chain) must not pop
+# the queue or mutate _queue_running/_current_run_id — otherwise it starts
+# a run concurrently with the live chain, whose Phase 1 "unload all models"
+# rips the engine out from under the active run.
+_chain_id: int = 0
 
 VALID_BENCHMARKS = [
     "mmlu", "mmlu_pro", "kmmlu", "cmmlu", "jmmlu",
@@ -221,6 +230,7 @@ def start_next_from_queue(engine_pool: Any) -> Optional[str]:
     This is synchronous so the caller gets the bench_id immediately.
     """
     global _queue_running, _current_run_id, _current_model, _engine_pool_ref
+    global _chain_id
 
     _engine_pool_ref = engine_pool
 
@@ -233,6 +243,10 @@ def start_next_from_queue(engine_pool: Any) -> Optional[str]:
     request = _queue.pop(0)
     _queue_running = True
     _current_model = request.model_id
+    # This chain takes ownership of the queue; any earlier chain still
+    # draining a soft-cancelled run bails at its next _continue_queue call.
+    _chain_id += 1
+    my_chain = _chain_id
 
     cleanup_old_runs()
     run = create_run(request)
@@ -249,15 +263,24 @@ def start_next_from_queue(engine_pool: Any) -> Optional[str]:
         except Exception as e:
             logger.error(f"Queue: error running {request.model_id}: {e}")
         # Auto-continue with next in queue
-        await _continue_queue(engine_pool)
+        await _continue_queue(engine_pool, my_chain)
 
     run.task = asyncio.create_task(_run_and_continue())
     return run.bench_id
 
 
-async def _continue_queue(engine_pool: Any) -> None:
-    """Continue processing the queue after a run completes."""
+async def _continue_queue(engine_pool: Any, chain_id: int) -> None:
+    """Continue processing the queue after a run completes.
+
+    `chain_id` is the ownership token captured when this chain started.
+    A stale chain (orphaned by cancel_queue, with a new chain started by
+    the user since) returns without popping the queue or touching the
+    gate, so it cannot start a run concurrently with the live chain.
+    """
     global _queue_running, _current_run_id, _current_model
+
+    if chain_id != _chain_id:
+        return
 
     if not _queue:
         _queue_running = False
@@ -271,6 +294,10 @@ async def _continue_queue(engine_pool: Any) -> None:
     cleanup_old_runs()
     run = create_run(request)
     _current_run_id = run.bench_id
+    # Queue-continued runs execute inside this chain's own task; record it
+    # so cancel_queue can hard-cancel them instead of waiting for the next
+    # on_progress checkpoint (up to a full generation batch away).
+    run.task = asyncio.current_task()
 
     logger.info(
         f"Queue: continuing with {request.model_id} "
@@ -282,14 +309,18 @@ async def _continue_queue(engine_pool: Any) -> None:
     except Exception as e:
         logger.error(f"Queue: error running {request.model_id}: {e}")
 
-    await _continue_queue(engine_pool)
+    await _continue_queue(engine_pool, chain_id)
 
 
 async def cancel_queue() -> None:
     """Cancel the current run and clear the queue."""
-    global _queue_running, _current_run_id, _current_model
+    global _queue_running, _current_run_id, _current_model, _chain_id
 
     _queue.clear()
+    # Orphan the live chain before releasing the gate: if the cancelled run
+    # only notices at its next checkpoint, its trailing _continue_queue must
+    # not race whatever chain the user starts after this cancel.
+    _chain_id += 1
 
     if _current_run_id:
         run = get_run(_current_run_id)

--- a/tests/test_accuracy_benchmark.py
+++ b/tests/test_accuracy_benchmark.py
@@ -2,16 +2,20 @@
 """Unit tests for accuracy benchmark orchestration."""
 
 import asyncio
+import contextlib
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import omlx.admin.accuracy_benchmark as accuracy_benchmark
 from omlx.admin.accuracy_benchmark import (
     VALID_BENCHMARKS,
     AccuracyBenchmarkRequest,
     AccuracyBenchmarkRun,
     _accumulated_results,
     add_to_queue,
+    cancel_queue,
     cleanup_old_runs,
     create_run,
     get_accumulated_results,
@@ -19,6 +23,7 @@ from omlx.admin.accuracy_benchmark import (
     get_run,
     reset_accumulated_results,
     run_accuracy_benchmark,
+    start_next_from_queue,
 )
 from omlx.model_settings import ModelSettings
 
@@ -491,3 +496,235 @@ class TestExternalAccuracyRun:
         error_events = [e for e in run.events if e["type"] == "error"]
         assert error_events
         mock_client.aclose.assert_awaited()
+
+
+class _StubResult:
+    """Minimal stand-in for an eval BenchmarkResult."""
+
+    def __init__(self):
+        self.benchmark_name = "mmlu"
+        self.accuracy = 1.0
+        self.total_questions = 1
+        self.correct_count = 1
+        self.time_seconds = 0.0
+        self.question_results = []
+        self.category_scores = None
+        self.thinking_used = False
+
+
+class _StubEnginePool:
+    """Engine pool stub that tracks which model engines are loaded."""
+
+    def __init__(self):
+        self._suppress_ttl = False
+        self._settings_manager = None
+        self.loaded: list[str] = []
+
+    def get_loaded_model_ids(self):
+        return list(self.loaded)
+
+    async def _unload_engine(self, model_id):
+        if model_id in self.loaded:
+            self.loaded.remove(model_id)
+
+    async def get_engine(self, model_id, force_lm=False):
+        self.loaded.append(model_id)
+        return SimpleNamespace(model_id=model_id)
+
+
+class TestQueueChainOwnership:
+    """Regression tests for the cancel→re-add queue race (issue 1655).
+
+    Runs started by _continue_queue used to have task=None, so cancel_queue
+    could only soft-cancel them; the orphaned chain's trailing
+    _continue_queue then popped the NEW queue and ran its item concurrently
+    with the chain the user started after the cancel, whose Phase 1
+    "unload all models" killed the active run (accuracy collapsed to 0.0%).
+    """
+
+    def setup_method(self):
+        self._reset_module_state()
+
+    def teardown_method(self):
+        # Leave no queue/gate state behind for other test files.
+        self._reset_module_state()
+
+    @staticmethod
+    def _reset_module_state():
+        accuracy_benchmark._queue.clear()
+        accuracy_benchmark._accuracy_runs.clear()
+        accuracy_benchmark._queue_running = False
+        accuracy_benchmark._current_run_id = None
+        accuracy_benchmark._current_model = None
+        reset_accumulated_results()
+
+    @staticmethod
+    def _request(model_id: str) -> AccuracyBenchmarkRequest:
+        return AccuracyBenchmarkRequest(model_id=model_id, benchmarks={"mmlu": 1})
+
+    @staticmethod
+    async def _wait_for(predicate, timeout=5.0):
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while not predicate():
+            assert loop.time() < deadline, "timed out waiting for condition"
+            await asyncio.sleep(0.01)
+
+    @pytest.mark.asyncio
+    async def test_continue_queue_run_is_hard_cancellable(self):
+        """A queue-continued run records its chain task, so cancel_queue
+        cancels it immediately instead of leaving it to run until its next
+        on_progress checkpoint (up to a full generation batch away)."""
+        b_entered = asyncio.Event()
+        b_finished_normally = False
+
+        class StubEval:
+            async def load_dataset(self, sample_size=0):
+                return [{"id": "1"}]
+
+            async def run(self, engine, items, on_progress, batch_size=1,
+                          sampling_kwargs=None, enable_thinking=False):
+                nonlocal b_finished_normally
+                if engine.model_id == "model-b":
+                    b_entered.set()
+                    # Blocks until hard-cancelled; never returns on its own.
+                    await asyncio.Event().wait()
+                    b_finished_normally = True
+                return _StubResult()
+
+        pool = _StubEnginePool()
+        with patch.dict("omlx.eval.BENCHMARKS", {"mmlu": StubEval}, clear=True):
+            add_to_queue(self._request("model-a"))
+            add_to_queue(self._request("model-b"))
+            start_next_from_queue(pool)
+
+            # model-a completes instantly; model-b is started by
+            # _continue_queue, the path that used to leave task=None.
+            await asyncio.wait_for(b_entered.wait(), timeout=5)
+            run_b = get_run(get_queue_status()["current_bench_id"])
+            assert run_b.request.model_id == "model-b"
+            assert run_b.task is not None
+
+            await cancel_queue()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(run_b.task, timeout=5)
+
+        assert run_b.status == "cancelled"
+        assert not b_finished_normally
+        # The cancelled run still emits its terminal event so attached SSE
+        # streams close.
+        assert any(e["type"] == "error" for e in run_b.events)
+        assert run_b.terminal is True
+
+    @pytest.mark.asyncio
+    async def test_stale_chain_leaves_queue_and_gate_alone(self):
+        """_continue_queue holding a stale ownership token returns without
+        popping the queue or mutating the running gate."""
+        pool = _StubEnginePool()
+        add_to_queue(self._request("model-d"))
+        accuracy_benchmark._queue_running = True
+        accuracy_benchmark._current_run_id = "live-run"
+        accuracy_benchmark._current_model = "model-c"
+
+        await accuracy_benchmark._continue_queue(
+            pool, accuracy_benchmark._chain_id - 1
+        )
+
+        status = get_queue_status()
+        assert [q["model_id"] for q in status["queue"]] == ["model-d"]
+        assert status["running"] is True
+        assert accuracy_benchmark._current_run_id == "live-run"
+        assert accuracy_benchmark._current_model == "model-c"
+        assert pool.loaded == []  # stale chain never started a run
+
+    @pytest.mark.asyncio
+    async def test_cancel_then_requeue_does_not_corrupt_new_chain(self):
+        """The reported sequence: cancel during a queue-continued run, then
+        immediately queue new models. The orphaned chain must not pop the
+        new queue, flip the gate, or run anything concurrently with the
+        chain started after the cancel."""
+        b_entered = asyncio.Event()
+        b_release = asyncio.Event()
+        c_entered = asyncio.Event()
+        c_release = asyncio.Event()
+        # (event, model_id) log of evaluator.run entries/exits. The cancelled
+        # model-b run may legitimately overlap model-c while its last batch
+        # drains; the regression is model-d entering while model-c runs.
+        run_log: list[tuple[str, str]] = []
+
+        class StubEval:
+            async def load_dataset(self, sample_size=0):
+                return [{"id": "1"}]
+
+            async def run(self, engine, items, on_progress, batch_size=1,
+                          sampling_kwargs=None, enable_thinking=False):
+                run_log.append(("enter", engine.model_id))
+                try:
+                    if engine.model_id == "model-b":
+                        b_entered.set()
+                        # Simulate an in-flight generation batch: it keeps
+                        # running past the cancel and only notices it at the
+                        # next on_progress checkpoint.
+                        with contextlib.suppress(
+                            asyncio.TimeoutError, asyncio.CancelledError
+                        ):
+                            await asyncio.wait_for(asyncio.Event().wait(), 0.05)
+                        await b_release.wait()
+                        # Checkpoint: raises CancelledError, run is cancelled.
+                        await on_progress(1, 1)
+                    elif engine.model_id == "model-c":
+                        c_entered.set()
+                        await c_release.wait()
+                finally:
+                    run_log.append(("exit", engine.model_id))
+                return _StubResult()
+
+        pool = _StubEnginePool()
+        with patch.dict("omlx.eval.BENCHMARKS", {"mmlu": StubEval}, clear=True):
+            add_to_queue(self._request("model-a"))
+            add_to_queue(self._request("model-b"))
+            start_next_from_queue(pool)
+
+            await asyncio.wait_for(b_entered.wait(), timeout=5)
+            run_b = get_run(get_queue_status()["current_bench_id"])
+
+            # User cancels, then immediately queues two new models.
+            await cancel_queue()
+            add_to_queue(self._request("model-c"))
+            start_next_from_queue(pool)
+            add_to_queue(self._request("model-d"))
+            start_next_from_queue(pool)  # no-op: gate is held by model-c
+
+            await asyncio.wait_for(c_entered.wait(), timeout=5)
+            status = get_queue_status()
+            assert status["current_model"] == "model-c"
+            assert [q["model_id"] for q in status["queue"]] == ["model-d"]
+            c_bench_id = status["current_bench_id"]
+
+            # Let the soft-cancel window close: model-b's batch finishes and
+            # the orphaned chain reaches its trailing _continue_queue.
+            b_release.set()
+            await self._wait_for(lambda: run_b.terminal)
+            await asyncio.sleep(0.05)
+
+            # The stale chain must not have popped model-d, flipped the
+            # gate, or started anything next to the live chain.
+            status = get_queue_status()
+            assert [q["model_id"] for q in status["queue"]] == ["model-d"]
+            assert status["running"] is True
+            assert status["current_bench_id"] == c_bench_id
+            assert ("enter", "model-d") not in run_log
+
+            # The live chain finishes model-c, then runs model-d normally.
+            c_release.set()
+            await self._wait_for(
+                lambda: not get_queue_status()["running"]
+                and not get_queue_status()["queue"]
+            )
+
+        # model-d ran strictly after model-c finished — never concurrently.
+        assert run_log.index(("enter", "model-d")) > run_log.index(
+            ("exit", "model-c")
+        )
+        completed = [r["model_id"] for r in get_accumulated_results()]
+        assert completed == ["model-a", "model-c", "model-d"]


### PR DESCRIPTION
Fixes #1655.

## Summary

- Benchmark-queue runs started by `_continue_queue` are now hard-cancellable, and a soft-cancelled chain can no longer pop the queue or reset the running gate after a new chain has started.
- Fixes the reported symptom: the running model's test is stopped, its result card collapses to ~0.0%, and the queued model starts immediately.

## Why

A "chain" is one `start_next_from_queue` call plus the `_continue_queue` tail it spawns. Runs started by `_continue_queue` never had `run.task` set, so `cancel_queue` could only soft-cancel them: the run kept executing until its next `on_progress` checkpoint (up to a full generation batch away), while the `_queue_running` gate was reset immediately.

Any model queued in that window started a new chain — and when the soft-cancelled run finally returned, the old chain's trailing `_continue_queue` unconditionally popped the new queue and ran its item concurrently with the live chain. The second run's Phase 1 "unload all models" then ripped the engine out from under the active run: the running model is stopped, its result collapses to ~0.0%, and the queued model immediately starts — exactly the behavior in the report:

> The running model is stopped, its results are reset to 0.0%, and the queued model immediately starts.

Scope note: a plain add-while-running correctly appends to `_queue` on current `main`. The corruption window opens with the first `cancel_queue`; from then on, every add-while-running can corrupt the active test, because each finishing chain resets the gate while the other still runs.

## Changes

All in `omlx/admin/accuracy_benchmark.py`:

- A module-level `_chain_id` ownership token. `start_next_from_queue` bumps and captures it; `_continue_queue` bails out first thing when its token is stale — without popping the queue or touching `_queue_running`/`_current_run_id`; `cancel_queue` bumps the token to orphan the live chain *before* releasing the gate.
- Queue-continued runs record their chain task (`asyncio.current_task()`) so `cancel_queue` hard-cancels them instead of waiting for the checkpoint.
- Normal (non-cancel) queue flow is unchanged, and cancelled runs still emit their terminal SSE error event so attached streams close.

Design note — why a token rather than having the trailing `_continue_queue` check its run's `status == "cancelled"`: that check would work today, but only because the sole cancel path is whole-queue and there happens to be no yield between a run's terminal-status write and its continuation. The token keys on chain identity instead of run outcome, so it stays correct if either of those assumptions ever changes (e.g. a future per-run cancel).

Sibling paths: external-endpoint benchmark runs share the same queue chain, so they get the same ownership protection; the `sampling_profile` path is orthogonal (per-run request field, untouched).

## Why this is safe

- The orphaned run may still overlap the new chain briefly while its last batch drains — that's intended cancel semantics, not the bug: the orphaned run's status is already `"cancelled"` and its results discarded, and the new chain's Phase 1 unload just accelerates its teardown (`engine.stop()` aborts in-flight generation; a redundant unload is a guarded no-op). Awaiting the cancelled task inside `cancel_queue` would block the HTTP cancel route for up to a generation batch with no correctness gain.
- Hard-cancel can now land during a continued run's final unload phase and label an effectively-finished run `cancelled` — that's the pre-existing semantics first-of-chain runs (whose `run.task` was always set) already have; accumulated results are never rolled back either way. This change just makes continued runs consistent.

## Tests

Three regression tests in `tests/test_accuracy_benchmark.py::TestQueueChainOwnership`:

- `test_continue_queue_run_is_hard_cancellable` — a queue-continued run records its chain task and `cancel_queue` cancels it promptly instead of waiting for the checkpoint.
- `test_stale_chain_leaves_queue_and_gate_alone` — an orphaned chain's trailing `_continue_queue` neither pops the queue nor resets the gate.
- `test_cancel_then_requeue_does_not_corrupt_new_chain` — the full reported scenario: cancel, re-add while the soft-cancelled run drains, and the new chain runs its models sequentially with no concurrent second run.

```
$ pytest tests/test_accuracy_benchmark.py -q
33 passed
```

Also verified all three new tests fail when the fix is reverted (the stale chain pops the new queue and runs concurrently).
