### PR TITLE
fix(audio): reject unsupported TTS response_format with 400

### DIFF
--- a/omlx/api/audio_routes.py
+++ b/omlx/api/audio_routes.py
@@ -619,13 +619,18 @@ async def create_speech(request: AudioSpeechRequest):
 
     if not request.input or not request.input.strip():
         raise HTTPException(status_code=400, detail="'input' field must not be empty")
+    # Only WAV is produced (no transcoding); reject unsupported response_format
+    # with a clear 400 instead of silently returning WAV. (#753, #1013)
+    if request.response_format not in (None, "wav"):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"response_format '{request.response_format}' is not supported; "
+                "only 'wav' is currently available"
+            ),
+        )
     streaming_interval = DEFAULT_NATIVE_TTS_STREAMING_INTERVAL_SECONDS
     if request.stream:
-        if request.response_format not in (None, "wav"):
-            raise HTTPException(
-                status_code=400,
-                detail="Streaming TTS currently only supports response_format='wav'",
-            )
         streaming_interval = _resolve_tts_streaming_interval(request)
 
     audio_bytes = _decode_ref_audio_base64(request)

--- a/tests/test_audio_tts.py
+++ b/tests/test_audio_tts.py
@@ -197,6 +197,21 @@ class TestTTSEndpointBasic:
         )
         assert response.status_code == 200
 
+    def test_post_speech_rejects_unsupported_format(self, server_tts_client):
+        """Unsupported response_format gets 400, not silently-WAV bytes."""
+        client, _ = server_tts_client
+        response = client.post(
+            "/v1/audio/speech",
+            json={"model": "qwen3-tts", "input": "Hello", "response_format": "mp3"},
+        )
+        assert response.status_code == 400
+        detail = response.json().get("detail") or response.json().get("error", {}).get(
+            "message", ""
+        )
+        # The error must name both the rejected format and the supported one.
+        assert "mp3" in detail
+        assert "wav" in detail.lower()
+
     def test_response_is_audio_bytes(self, server_tts_client):
         """Response body is non-empty bytes."""
         client, _ = server_tts_client
@@ -453,7 +468,7 @@ class TestTTSStreaming:
             assert call.kwargs.get("max_tokens") == 512
 
     def test_streaming_rejects_non_wav_response_format(self, server_tts_client):
-        """stream=true only supports response_format=wav in phase 1."""
+        """The response_format guard covers the streaming path too."""
         client, _ = server_tts_client
         response = client.post(
             "/v1/audio/speech",


### PR DESCRIPTION
Fixes #1013. Fixes #753.

## Summary

- `/v1/audio/speech` now rejects any `response_format` other than `"wav"` (or unset) with a 400 that names the unsupported format, on both the streaming and non-streaming paths.

## Why

The endpoint only produces WAV audio — there is no transcoding — but it silently returned WAV bytes for *any* requested `response_format`. Clients that asked for `mp3`/`opus` got mislabeled audio, exactly as both reports show:

> `"response_format": "opus"` … expected: Ogg data, Opus audio; got: RIFF (little-endian) data, WAVE audio (#753)

> accepts a request with `"response_format": "mp3"` … but the server returns `content-type: audio/wav` and WAV audio data (#1013)

A format guard already existed, but only inside the `stream=True` branch — non-streaming requests (both issues' repros) bypassed it entirely.

## Changes

- `omlx/api/audio_routes.py`: moved the guard to the top of `create_speech` so it covers both the streaming and non-streaming paths; any `response_format` other than `None` or `"wav"` gets a clear 400 naming the format. Removed the now-redundant streaming-only guard, and updated the pre-existing streaming test's docstring to match the unified contract.
- Transcoding to mp3/opus is out of scope here — this makes the contract honest (400 instead of mislabeled bytes) until/unless transcoding is added.

Design note: an alternative is constraining the field as `Literal["wav"]` on `AudioSpeechRequest` (Pydantic 422). I kept the route-level guard because it matches this endpoint's existing ingress checks (the empty-`input` 400 immediately above) and preserves the status code the old streaming guard already used, so no client-visible contract changes shape.

Overlap heads-up: two open April PRs propose actual transcoding for #753 — #818 (wav/pcm via stdlib, mp3/opus/flac/aac via an ffmpeg subprocess, inside a two-fix bundle) and #823 (ffmpeg-backed transcode on a worker thread). This PR takes only the contract-honesty step — an honest 400 instead of mislabeled bytes, zero new dependencies — and is forward-compatible with transcoding landing later (the guard's accepted set simply widens). Happy to close this in favor of either if transcoding is the direction you want.

## Why this is safe

- `AudioSpeechRequest.response_format` defaults to `"wav"`, so requests that omit the field are unaffected — zero behavioral change for existing well-formed usage.
- Streaming requests already got a 400 for non-wav formats; they keep getting one (now with the shared message).

## Tests

- `tests/test_audio_tts.py::TestTTSEndpointBasic::test_post_speech_rejects_unsupported_format` — non-streaming request with `response_format="mp3"` gets 400 naming both the rejected and the supported format; the existing streaming-path test still covers `stream=True`.

```
$ pytest tests/test_audio_tts.py -q
62 passed, 1 deselected
```

Also verified the new test fails when the fix is reverted (endpoint returns 200 with WAV bytes for `response_format="mp3"`).
