### PR TITLE
fix: persist serve configuration safely

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -38,37 +38,34 @@ def _has_cli_overrides(args) -> bool:
     All argparse defaults are None, so `is not None` means the user
     explicitly passed the flag on the command line.
     """
-    if hasattr(args, "model_dir") and args.model_dir is not None:
+    persisted_fields = (
+        "model_dir",
+        "port",
+        "host",
+        "log_level",
+        "sse_keepalive_mode",
+        "max_concurrent_requests",
+        "embedding_batch_size",
+        "memory_guard",
+        "memory_guard_gb",
+        "paged_ssd_cache_dir",
+        "paged_ssd_cache_max_size",
+        "hot_cache_max_size",
+        "initial_cache_blocks",
+        "mcp_config",
+        "hf_endpoint",
+        "hf_cache_enabled",
+        "ms_endpoint",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+        "ca_bundle",
+    )
+    if any(getattr(args, field, None) is not None for field in persisted_fields):
         return True
-    if hasattr(args, "port") and args.port is not None:
-        return True
-    if hasattr(args, "host") and args.host is not None:
-        return True
-    if hasattr(args, "log_level") and args.log_level is not None:
-        return True
-    if hasattr(args, "embedding_batch_size") and args.embedding_batch_size is not None:
-        return True
-    if hasattr(args, "memory_guard") and args.memory_guard is not None:
-        return True
-    if hasattr(args, "memory_guard_gb") and args.memory_guard_gb is not None:
-        return True
-    if hasattr(args, "mcp_config") and args.mcp_config is not None:
-        return True
-    if hasattr(args, "hf_endpoint") and args.hf_endpoint is not None:
-        return True
-    if hasattr(args, "hf_cache_enabled") and args.hf_cache_enabled is not None:
-        return True
-    if hasattr(args, "ms_endpoint") and args.ms_endpoint is not None:
-        return True
-    if hasattr(args, "http_proxy") and args.http_proxy is not None:
-        return True
-    if hasattr(args, "https_proxy") and args.https_proxy is not None:
-        return True
-    if hasattr(args, "no_proxy") and args.no_proxy is not None:
-        return True
-    if hasattr(args, "ca_bundle") and args.ca_bundle is not None:
-        return True
-    return False
+
+    # --no-cache is the only persistable boolean flag with a False default.
+    return bool(getattr(args, "no_cache", False))
 
 
 def serve_command(args):
@@ -177,7 +174,7 @@ def serve_command(args):
     # Save CLI args to settings.json if non-default values provided
     if _has_cli_overrides(args):
         try:
-            settings.save()
+            settings.save_cli_overrides(args)
             print("Saved CLI arguments to settings.json")
         except Exception as e:
             print(f"Warning: Failed to save settings: {e}")

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -1025,7 +1025,7 @@ class GlobalSettings:
                 markitdown_pdf_processing_engine.strip() or "markitdown"
             )
 
-    def _apply_cli_overrides(self, args: Any) -> None:
+    def _apply_cli_overrides(self, args: Any, *, include_api_key: bool = True) -> None:
         """
         Apply CLI argument overrides.
 
@@ -1069,18 +1069,35 @@ class GlobalSettings:
         # Cache settings
         if hasattr(args, "cache_enabled") and args.cache_enabled is not None:
             self.cache.enabled = args.cache_enabled
-        if hasattr(args, "ssd_cache_dir") and args.ssd_cache_dir is not None:
-            self.cache.ssd_cache_dir = args.ssd_cache_dir
-        if hasattr(args, "ssd_cache_max_size") and args.ssd_cache_max_size is not None:
-            self.cache.ssd_cache_max_size = args.ssd_cache_max_size
+
+        # ``paged_ssd_cache_*`` are the public CLI names. Keep the older
+        # internal names as fallbacks for callers that still build a namespace
+        # directly.
+        paged_cache_dir = getattr(args, "paged_ssd_cache_dir", None)
+        if paged_cache_dir is not None:
+            self.cache.ssd_cache_dir = paged_cache_dir
+            self.cache.enabled = True
+        elif (cache_dir := getattr(args, "ssd_cache_dir", None)) is not None:
+            self.cache.ssd_cache_dir = cache_dir
+
+        cache_max_size = getattr(args, "paged_ssd_cache_max_size", None)
+        if cache_max_size is None:
+            cache_max_size = getattr(args, "ssd_cache_max_size", None)
+        if cache_max_size is not None:
+            self.cache.ssd_cache_max_size = cache_max_size
+
+        if hasattr(args, "hot_cache_max_size") and args.hot_cache_max_size is not None:
+            self.cache.hot_cache_max_size = args.hot_cache_max_size
         if (
             hasattr(args, "initial_cache_blocks")
             and args.initial_cache_blocks is not None
         ):
             self.cache.initial_cache_blocks = args.initial_cache_blocks
+        if getattr(args, "no_cache", False):
+            self.cache.enabled = False
 
         # Auth settings
-        if hasattr(args, "api_key") and args.api_key is not None:
+        if include_api_key and hasattr(args, "api_key") and args.api_key is not None:
             self.auth.api_key = args.api_key
 
         # MCP settings
@@ -1172,12 +1189,27 @@ class GlobalSettings:
         }
 
         try:
-            with open(settings_file, "w", encoding="utf-8") as f:
+            if os.name == "posix" and settings_file.exists():
+                settings_file.chmod(0o600)
+            with os.fdopen(
+                os.open(settings_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600),
+                "w",
+                encoding="utf-8",
+            ) as f:
                 json.dump(data, f, indent=2)
             logger.info(f"Saved settings to {settings_file}")
         except OSError as e:
             logger.error(f"Failed to save settings to {settings_file}: {e}")
             raise
+
+    def save_cli_overrides(self, args: Any) -> None:
+        """Persist explicit non-secret CLI configuration without freezing env state."""
+        persisted = type(self)(base_path=self.base_path)
+        settings_file = self.base_path / "settings.json"
+        if settings_file.exists():
+            persisted._load_from_file(settings_file)
+        persisted._apply_cli_overrides(args, include_api_key=False)
+        persisted.save()
 
     def ensure_directories(self) -> None:
         """Create necessary directories if they don't exist."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -728,6 +728,7 @@ class TestServeCommandFunctions:
         settings.ensure_directories = lambda: log_dir.mkdir(parents=True, exist_ok=True)
         settings.validate = lambda: []
         settings.save = MagicMock()
+        settings.save_cli_overrides = MagicMock()
         settings.to_scheduler_config = lambda: SimpleNamespace(
             paged_ssd_cache_dir=None,
             paged_ssd_cache_max_size=0,
@@ -862,6 +863,8 @@ class TestServeCommandFunctions:
 
             assert exc.value.code != 0
             assert events == ["bind"]
+            settings.save_cli_overrides.assert_called_once_with(args)
+            settings.save.assert_not_called()
             assert "omlx.server" not in sys.modules
         finally:
             listener.close()
@@ -944,9 +947,25 @@ class TestHasCliOverrides:
             "port": None,
             "host": None,
             "log_level": None,
+            "sse_keepalive_mode": None,
+            "max_concurrent_requests": None,
             "embedding_batch_size": None,
             "memory_guard": None,
             "memory_guard_gb": None,
+            "paged_ssd_cache_dir": None,
+            "paged_ssd_cache_max_size": None,
+            "hot_cache_max_size": None,
+            "no_cache": False,
+            "initial_cache_blocks": None,
+            "mcp_config": None,
+            "hf_endpoint": None,
+            "hf_cache_enabled": None,
+            "ms_endpoint": None,
+            "http_proxy": None,
+            "https_proxy": None,
+            "no_proxy": None,
+            "ca_bundle": None,
+            "api_key": None,
         }
         defaults.update(kwargs)
         return argparse.Namespace(**defaults)
@@ -1000,6 +1019,29 @@ class TestHasCliOverrides:
 
         assert _has_cli_overrides(self._make_args(hf_cache_enabled=False)) is True
         assert _has_cli_overrides(self._make_args(hf_cache_enabled=True)) is True
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("sse_keepalive_mode", "off"),
+            ("max_concurrent_requests", 2),
+            ("paged_ssd_cache_dir", "/tmp/cache"),
+            ("paged_ssd_cache_max_size", "2GB"),
+            ("hot_cache_max_size", "1GB"),
+            ("no_cache", True),
+            ("initial_cache_blocks", 64),
+        ],
+    )
+    def test_all_persisted_serve_flags_count_as_overrides(self, field, value):
+        from omlx.cli import _has_cli_overrides
+
+        assert _has_cli_overrides(self._make_args(**{field: value})) is True
+
+    def test_api_key_alone_is_not_persisted(self):
+        """A command-line secret must not be written to settings.json."""
+        from omlx.cli import _has_cli_overrides
+
+        assert _has_cli_overrides(self._make_args(api_key="test-key")) is False
 
     def test_multiple_overrides(self):
         from omlx.cli import _has_cli_overrides

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -919,6 +919,20 @@ class TestGlobalSettings:
             assert data["server"]["port"] == 9001
             assert data["auth"]["api_key"] == "saved-key"
 
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permissions only")
+    def test_save_restricts_settings_file_permissions(self):
+        """Credential-bearing settings are readable only by their owner."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings = GlobalSettings(base_path=Path(tmpdir))
+            settings.save()
+
+            settings_file = Path(tmpdir) / "settings.json"
+            assert settings_file.stat().st_mode & 0o777 == 0o600
+
+            settings_file.chmod(0o644)
+            settings.save()
+            assert settings_file.stat().st_mode & 0o777 == 0o600
+
     def test_save_and_load_cors_origins(self):
         """Test saving and loading cors_origins through settings file."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1426,6 +1440,61 @@ class TestGlobalSettings:
             assert settings.cache.enabled is False
             assert settings.cache.ssd_cache_dir == "/cli/cache"
             assert settings.cache.ssd_cache_max_size == "500GB"
+
+    def test_cli_override_paged_ssd_cache(self):
+        """Public serve cache flags persist to the matching settings fields."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            args = Namespace(
+                paged_ssd_cache_dir="/cli/cache",
+                paged_ssd_cache_max_size="500GB",
+                hot_cache_max_size="8GB",
+                no_cache=False,
+            )
+            settings = GlobalSettings(base_path=Path(tmpdir))
+            settings.cache.enabled = False
+            settings._apply_cli_overrides(args)
+            assert settings.cache.enabled is True
+            assert settings.cache.ssd_cache_dir == "/cli/cache"
+            assert settings.cache.ssd_cache_max_size == "500GB"
+            assert settings.cache.hot_cache_max_size == "8GB"
+
+    def test_cli_override_no_cache(self):
+        """--no-cache persists an explicit cache disablement."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings = GlobalSettings.load(
+                base_path=tmpdir,
+                cli_args=Namespace(
+                    paged_ssd_cache_dir="/cli/cache",
+                    no_cache=True,
+                ),
+            )
+            assert settings.cache.enabled is False
+            assert settings.cache.ssd_cache_dir == "/cli/cache"
+
+    def test_save_cli_overrides_preserves_runtime_secrets_and_env(self):
+        """Saving a CLI setting must not serialize transient overrides."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_path = Path(tmpdir)
+            stored = GlobalSettings(base_path=base_path)
+            stored.auth.api_key = "stored-key"
+            stored.cache.enabled = True
+            stored.save()
+
+            args = Namespace(port=8765, api_key="cli-key")
+            with patch.dict(
+                os.environ,
+                {"OMLX_API_KEY": "env-key", "OMLX_CACHE_ENABLED": "false"},
+                clear=False,
+            ):
+                runtime = GlobalSettings.load(base_path=base_path, cli_args=args)
+                assert runtime.auth.api_key == "cli-key"
+                assert runtime.cache.enabled is False
+                runtime.save_cli_overrides(args)
+
+            persisted = GlobalSettings.load(base_path=base_path)
+            assert persisted.server.port == 8765
+            assert persisted.auth.api_key == "stored-key"
+            assert persisted.cache.enabled is True
 
     def test_cli_override_initial_cache_blocks(self):
         """Test CLI override for initial_cache_blocks."""


### PR DESCRIPTION
## Summary

- Persist all non-secret `omlx serve` configuration flags, including SSE, scheduler, and cache settings.
- Keep CLI and environment API-key overrides transient when another CLI setting is saved.
- Restrict credential-bearing settings files to their owner on POSIX systems.

## Root cause

The CLI persistence check and settings mapper had diverged from the public `serve` flags. Saving the merged runtime settings also captured environment overrides and command-line credentials.

## Checks

- `PYTHONUTF8=1 python -m pytest tests/test_cli.py -q -k "not test_serve_exits_on_port_conflict_before_importing_server"` — 60 passed
- Targeted CLI/settings persistence and security tests — 24 passed, 1 POSIX-only test skipped on Windows
- `python -m compileall -q omlx tests`
