### PR TITLE
fix: pass prefill_duration in non-streaming request handlers (#2226)

### DIFF
--- a/omlx/engine/base.py
+++ b/omlx/engine/base.py
@@ -92,6 +92,7 @@ class GenerationOutput:
     diffusion_work_tps: float = 0.0
     generated_at: Optional[float] = None
     generated_until: Optional[float] = None
+    first_token_at: Optional[float] = None
 
 
 class BaseEngine(ABC):

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -668,6 +668,7 @@ class BatchedEngine(BaseEngine):
             finish_reason=output.finish_reason,
             tool_calls=output.tool_calls,
             cached_tokens=output.cached_tokens,
+            first_token_at=output.first_token_at,
         )
 
     async def stream_generate(

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -2803,6 +2803,7 @@ class VLMBatchedEngine(BaseEngine):
             finish_reason=output.finish_reason,
             tool_calls=output.tool_calls,
             cached_tokens=output.cached_tokens,
+            first_token_at=output.first_token_at,
         )
 
     async def stream_generate(

--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -902,10 +902,13 @@ class EngineCore:
 
         # Drain all outputs and get the last one (using the captured reference)
         final_output = None
+        first_token_at = None
         while True:
             output = collector.get_nowait()
             if output is None:
                 break
+            if first_token_at is None and output.generated_at is not None:
+                first_token_at = output.generated_at
             final_output = output
 
         # Cleanup
@@ -917,6 +920,7 @@ class EngineCore:
         if final_output.error:
             _raise_request_output_error(final_output)
 
+        final_output.first_token_at = first_token_at
         return final_output
 
     def generate_batch_sync(

--- a/omlx/request.py
+++ b/omlx/request.py
@@ -284,6 +284,9 @@ class RequestOutput:
     # Internal producer-side timestamp for the latest generated token included
     # in this output. This lets aggregated chunks preserve the decode interval.
     generated_until: Optional[float] = None
+    # Timestamp of the very first generated token for this request (perf_counter).
+    # Set by non-streaming generate() to allow TTFT / prefill-duration estimation.
+    first_token_at: Optional[float] = None
 
     # Tool calls (for Harmony and other models with tool calling support)
     tool_calls: Optional[List[Dict[str, str]]] = None

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3078,11 +3078,19 @@ async def create_completion(
                 f"Completion: {total_completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s), prompt: {total_prompt_tokens}"
             )
 
+            first_token_at = getattr(output, "first_token_at", None)
+            prefill_duration = (
+                (first_token_at - start_time)
+                if first_token_at is not None
+                else 0.0
+            )
+            gen_duration = elapsed - prefill_duration if prefill_duration > 0 else elapsed
             get_server_metrics().record_request_complete(
                 prompt_tokens=total_prompt_tokens,
                 completion_tokens=total_completion_tokens,
                 cached_tokens=total_cached_tokens,
-                generation_duration=elapsed,
+                prefill_duration=prefill_duration,
+                generation_duration=gen_duration,
                 model_id=resolve_model_id(request.model) or request.model,
             )
 
@@ -3544,10 +3552,18 @@ async def create_chat_completion(
                 f"finish_reason={output.finish_reason}, max_tokens={max_tokens}, "
                 f"request_max_tokens={request.max_tokens}"
             )
+            first_token_at = getattr(output, "first_token_at", None)
+            ttft = (
+                (first_token_at - start_time)
+                if first_token_at is not None
+                else 0.0
+            )
+            gen_duration = elapsed - ttft if ttft > 0 else elapsed
             metric_prefill_duration, metric_gen_duration = _resolve_metric_durations(
                 output,
                 is_diffusion=is_diffusion,
-                generation_duration=elapsed,
+                prefill_duration=ttft,
+                generation_duration=gen_duration,
             )
 
             get_server_metrics().record_request_complete(
@@ -5367,11 +5383,19 @@ async def create_anthropic_message(
                 f"({tokens_per_sec:.1f} tok/s)"
             )
 
+            first_token_at = getattr(output, "first_token_at", None)
+            prefill_duration = (
+                (first_token_at - start_time)
+                if first_token_at is not None
+                else 0.0
+            )
+            gen_duration = elapsed - prefill_duration if prefill_duration > 0 else elapsed
             get_server_metrics().record_request_complete(
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
                 cached_tokens=output.cached_tokens,
-                generation_duration=elapsed,
+                prefill_duration=prefill_duration,
+                generation_duration=gen_duration,
                 model_id=resolved_model,
             )
 
@@ -5854,11 +5878,19 @@ async def create_response(
                 f"({tokens_per_sec:.1f} tok/s)"
             )
 
+            first_token_at = getattr(output, "first_token_at", None)
+            prefill_duration = (
+                (first_token_at - start_time)
+                if first_token_at is not None
+                else 0.0
+            )
+            gen_duration = elapsed - prefill_duration if prefill_duration > 0 else elapsed
             get_server_metrics().record_request_complete(
                 prompt_tokens=output.prompt_tokens,
                 completion_tokens=output.completion_tokens,
                 cached_tokens=output.cached_tokens,
-                generation_duration=elapsed,
+                prefill_duration=prefill_duration,
+                generation_duration=gen_duration,
                 model_id=resolved_model,
             )
 


### PR DESCRIPTION
## Root Cause

Non-streaming handlers (completions, chat completions, Anthropic messages,

Responses API) never passed prefill_duration to record_request_complete(),

causing avg_prefill_tps to always report 0.0 in the dashboard and menu bar.


How i tested it:

**First:**
$ curl -s -H "Authorization: Bearer hello" -H "Content-Type: application/json" http://localhost:8000/v1/chat/completions -d '{
  "model": "Ornith-1.0-9B-4bit",
  "stream": false,
  "max_tokens": 20,
  "messages": [{"role": "user", "content": "What is 2+2?"}]
}' | python3 -m json.tool 2>/dev/null | grep -E 'prompt_tokens|completion_tokens'


**output trimmed but yeah something like this:**
        "prompt_tokens": 17,
        "completion_tokens": 20,
  
        
        **Then to check the status:**
curl -s -H "Authorization: Bearer hello" http://localhost:8000/api/status | python3 -m json.tool 2>/dev/null | grep -E 'avg_prefill|avg_generation|total_requests|total_prompt'

**output:**
    "total_requests": 1,
    "total_prompt_tokens": 17,
    "avg_prefill_tps": 0.0,
    "avg_generation_tps": 14.8,


Screenshot of UI:
<img width="1317" height="652" alt="Screenshot 2026-07-14 at 11 05 06 PM" src="https://github.com/user-attachments/assets/de4e0bbb-b618-4779-8069-fe7d22c520d2" />


You can see the prompt processing is 0


## Fix

1. Capture the first token's `generated_at` timestamp during the non-streaming `generate()` drain loop in `EngineCore`
2. Propagate it as `first_token_at` through `RequestOutput` → `GenerationOutput`
3. Each non-streaming handler computes TTFT from this timestamp and splits elapsed time into prefill vs generation durations — matching how the streaming handlers already work