### PR TITLE
fix: correct kwarg mismatch in python -m omlx.server entry point (#2241)

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -6767,14 +6767,9 @@ Note: Use the omlx CLI for full feature support.
     if args.mcp_config:
         os.environ["OMLX_MCP_CONFIG"] = args.mcp_config
 
-    # Parse pinned models
-    pinned_models = args.pin.split(",") if args.pin else []
     # Initialize server
     init_server(
-        model_dir=args.model_dir,
-        pinned_models=pinned_models,
-        default_model=args.default_model,
-        max_tokens=args.max_tokens,
+        model_dirs=args.model_dir,
     )
 
     # Start server


### PR DESCRIPTION
## Summary
`python -m omlx.server --model-dir /path` crashes immediately with:
TypeError: init_server() got an unexpected keyword argument 'model_dir'

`main()` passed `model_dir=`, `pinned_models=`, `default_model=`, and `max_tokens=` to `init_server()`, but `init_server()` only accepts `model_dirs=` (plural), `scheduler_config=`, `api_key=`, and `global_settings=`.
## Fix
Corrected the `init_server()` call to pass `model_dirs=args.model_dir`.