### PR TITLE
fix(glm-dsa): deterministic radix top-k output pass (tie membership/order raced)

### DIFF
--- a/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/steel_dsa_indexer_score.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/steel_dsa_indexer_score.h
@@ -16,6 +16,10 @@ METAL_FUNC uint dsa_ordered_key_16(T x) {
   return (bits & 0x8000) ? uint((~bits) & 0xffff) : uint(bits | 0x8000);
 }
 
+METAL_FUNC uint dsa_ordered_key_16_bits(ushort bits) {
+  return (bits & 0x8000) ? uint((~bits) & 0xffff) : uint(bits | 0x8000);
+}
+
 template <typename T, typename O, int TOPK, int THREADS>
 [[kernel, max_total_threads_per_threadgroup(THREADS)]] void dsa_topk_indices_16bit(
     const device T* scores [[buffer(0)]],
@@ -134,19 +138,63 @@ template <typename T, typename O, int TOPK, int THREADS>
       threadgroup_barrier(mem_flags::mem_threadgroup);
     }
   } else {
-    for (int i = int(tid); i < scan_limit; i += THREADS) {
+    // Deterministic output pass (replaces the atomic-race append, which made both
+    // tie MEMBERSHIP and output ORDER GPU-scheduling-dependent — measured: the
+    // selected set changed on ~80% of realistic rows across re-runs, so replicated
+    // TP ranks could pick different tie-band keys). Raking scan: each thread owns
+    // one contiguous segment of the row (count pass -> one threadgroup-wide
+    // exclusive scan of per-thread totals, ~3 barriers total -> emit pass).
+    // Strictly-greater entries fill [0, n_greater) and threshold ties fill
+    // [n_greater, TOPK) lowest-index-first — membership and order are functions of
+    // the scores alone. Costs one extra read of the score row vs the racy append.
+    constexpr uint kSimdgroups = THREADS / 32;
+    threadgroup uint tg_partials_g[kSimdgroups];
+    threadgroup uint tg_partials_t[kSimdgroups];
+    const uint simd_id = tid / 32;
+    const uint lane_id = tid % 32;
+    const int seg = (scan_limit + THREADS - 1) / THREADS;
+    const int s0 = int(tid) * seg;
+    const int s1 = metal::min(s0 + seg, scan_limit);
+
+    uint local_g = 0;
+    uint local_t = 0;
+    for (int i = s0; i < s1; ++i) {
       const uint key = dsa_ordered_key_16(row_scores[i]);
-      if (key > threshold_key) {
-        const uint pos =
-            atomic_fetch_add_explicit(&counters[0], 1, memory_order_relaxed);
-        if (pos < uint(TOPK)) {
-          row_out[pos] = O(i);
-        }
-      } else if (key == threshold_key) {
-        const uint pos =
-            atomic_fetch_add_explicit(&counters[1], 1, memory_order_relaxed);
-        if (pos < uint(TOPK)) {
-          row_out[pos] = O(i);
+      local_g += key > threshold_key ? 1u : 0u;
+      local_t += key == threshold_key ? 1u : 0u;
+    }
+
+    // Exclusive scan of the 1024 per-thread (greater, tie) totals.
+    uint pre_g = metal::simd_prefix_exclusive_sum(local_g);
+    uint pre_t = metal::simd_prefix_exclusive_sum(local_t);
+    if (lane_id == 31) {
+      tg_partials_g[simd_id] = pre_g + local_g;
+      tg_partials_t[simd_id] = pre_t + local_t;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (simd_id == 0) {
+      const uint pg = lane_id < kSimdgroups ? tg_partials_g[lane_id] : 0u;
+      const uint pt = lane_id < kSimdgroups ? tg_partials_t[lane_id] : 0u;
+      const uint sg = metal::simd_prefix_exclusive_sum(pg);
+      const uint st = metal::simd_prefix_exclusive_sum(pt);
+      if (lane_id < kSimdgroups) {
+        tg_partials_g[lane_id] = sg;
+        tg_partials_t[lane_id] = st;
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    uint pos_g = tg_partials_g[simd_id] + pre_g;
+    uint pos_t = uint(state[3]) + tg_partials_t[simd_id] + pre_t;
+    if (local_g > 0 || (local_t > 0 && pos_t < uint(TOPK))) {
+      for (int j = s0; j < s1; ++j) {
+        const uint key = dsa_ordered_key_16(row_scores[j]);
+        if (key > threshold_key) {
+          row_out[pos_g++] = O(j);
+        } else if (key == threshold_key) {
+          if (pos_t < uint(TOPK)) {
+            row_out[pos_t++] = O(j);
+          }
         }
       }
     }


### PR DESCRIPTION
## The bug

`dsa_topk_indices`' non-bucketed output pass assigns slots via bare `atomic_fetch_add`: entries **equal to the threshold key race for the remaining slots**, and output order is scheduling-random. On real GLM-5.2 activations at S=131072 the rank-2048 threshold carries **47–180 exact bf16 ties per query row** (decode steps: mean 122, max 1096), so the selected *set* changed on ~80% of rows across 20 identical re-runs on an M3 Ultra. Consequences we measured in a live deployment (2× M3 Ultra, tensor-parallel):

- temp-0 generations are not byte-reproducible (identical cold 131k prompts → differently-worded answers every run);
- TP replicas that compute the indexer redundantly can silently attend to *different* keys (tie-band divergence).

## The fix

Replace the racy append with a raking prefix-scan (one threadgroup-wide exclusive scan of per-thread counts): strictly-greater keys fill `[0, n_greater)` in index order, threshold ties fill the remainder **lowest-index-first** — the output is a pure function of the scores. The `bucketed` variant is untouched.

## Cost / validation

- One extra read of the score row: 4.69 → 5.56 ms standalone at [4096×131072] (bf16, M3 Ultra) ≈ 0.1% of a 131k prefill chunk.
- Selection fidelity vs fp32 ground truth unchanged (0.9957 mean top-2048 overlap at 131k).
- 20× same-process and cross-process byte-identical outputs (previously ~80% of rows differed).
- End-to-end: two fully-cold identical 131k-token temp-0 runs now produce byte-identical generations; NIAH recall 100% before/after.

This is running in production on our 2-node GLM-5.2 deployment (the same sources, vendored). Happy to adjust style or add a regression test if you'd like one in-tree.

Co-authored with Claude Fable 5 (Anthropic)