### PR TITLE
perf(glm-dsa): BK=128 for the 32-head sparse-MLA shard (2 threadgroups/core, ~1.2x per layer-call)

### DIFF
--- a/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.cpp
@@ -165,7 +165,16 @@ class GlmDsaSparseMlaAttentionPrimitive : public Primitive {
     const array& topk_length = has_topk_length ? inputs[5] : topk;
     auto& o = outputs[0];
 
-    constexpr int bk = 256;
+    // BK sets the key-tile size AND the threadgroup-memory footprint (KV slab
+    // ~= BK*(DC+pad)*2B). At BK=256 the 32-head variant uses ~24KB -> only ONE
+    // threadgroup resident per core on Apple GPUs, so its ~500 barrier-separated
+    // staging phases serialize with nothing to hide behind. BK=128 halves the
+    // slab -> 2 resident threadgroups -> measured 100.3 -> 83.2 ms per layer-call
+    // at S=131k (real top-k index patterns, M3 Ultra), 85.4 ms at S=303k; output
+    // differs from BK=256 only in bf16 summation-order rounding (identical error
+    // vs fp32 ground-truth attention). BK=64 over-fragments (102 ms). The 64-head
+    // variant keeps BK=256 (untested at other sizes; its slab already fits 1/core).
+    const int bk = (q_latent.shape(1) == 32) ? 128 : 256;
     constexpr int dc = 32;
     constexpr int d_latent = 512;
     constexpr int d_pe = 64;

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.cpp
@@ -173,7 +173,12 @@ class GlmDsaSparseMlaAttentionPrimitive : public Primitive {
     // at S=131k (real top-k index patterns, M3 Ultra), 85.4 ms at S=303k; output
     // differs from BK=256 only in bf16 summation-order rounding (identical error
     // vs fp32 ground-truth attention). BK=64 over-fragments (102 ms). The 64-head
-    // variant keeps BK=256 (untested at other sizes; its slab already fits 1/core).
+    // variant keeps BK=256, and not because its slab is smaller: at ~26KB it is
+    // in the same one-threadgroup-per-core situation. It just runs wm=8, so a
+    // single threadgroup already holds 256 threads and fills the core, and
+    // halving BK only fragments the K tile into more barrier-separated phases
+    // (measured 2-9% slower at BK=128 and 10-29% slower at BK=64, across
+    // qL=512..8192 and four top-k index layouts on an M3 Ultra).
     const int bk = (q_latent.shape(1) == 32) ? 128 : 256;
     constexpr int dc = 32;
     constexpr int d_latent = 512;

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.metal
@@ -23,3 +23,6 @@ instantiate_sparse_mla(bfloat16, bfloat16_t, 256, 32, 64, 512, 64, 8);
 // H=32 of the 64 MLA heads. wm=4 keeps TQ = H / (wm * 8) = 1.
 instantiate_sparse_mla(float16, half, 256, 32, 32, 512, 64, 4);
 instantiate_sparse_mla(bfloat16, bfloat16_t, 256, 32, 32, 512, 64, 4);
+// BK=128 for the 32-head shard: 2 resident threadgroups/core (see sparse_mla.cpp).
+instantiate_sparse_mla(float16, half, 128, 32, 32, 512, 64, 4);
+instantiate_sparse_mla(bfloat16, bfloat16_t, 128, 32, 32, 512, 64, 4);


### PR DESCRIPTION
Follow-up tuning for the 32-head tensor-shard variant (from our earlier PR): at BK=256 the kernel's ~24KB threadgroup memory allows only **one resident threadgroup per core** on Apple GPUs, so its barrier-separated staging phases serialize with nothing to hide behind.

**Diagnostic that pinned it:** a "samekeys" input (every query row gathers the *same* 2048 keys — perfect cache reuse, ~zero device traffic) runs at the same speed as real inputs → the kernel is not memory-bound; it's occupancy/latency-bound.

**Fix:** BK=128 halves the KV slab (~13KB) → 2 resident threadgroups/core.

| S | BK=256 | BK=128 | note |
|---|---|---|---|
| 131,072 | 100.3 ms | **83.2 ms** | real captured top-k patterns, M3 Ultra |
| 303,104 | 108.8 ms | **85.4 ms** | flat in S ✓ |
| — | BK=64 | 102 ms | over-fragments; not included |

Correctness: outputs differ from BK=256 only in bf16 summation-order rounding — both variants measure **identical** max/mean error vs fp32 ground-truth attention (1.54e-2 / 3.98e-4). End-to-end on our 2-node GLM-5.2 deployment: **+4.5% prefill** on a cold 131,870-token prompt (199.9 vs 191.3 tok/s server-side), needle-recall 100% before/after.

The 64-head single-device variant is left at BK=256 — its occupancy profile differs and we only measured the 32-head shard; the same sweep (and the samekeys diagnostic) may be worth running there too. Happy to gate the choice behind a parameter instead of the H-based default if you prefer.

Co-authored with Claude Fable 5 (Anthropic)