### PR TITLE
feat(scheduler): inert-by-default interactive isolation controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,31 @@ Handles concurrent requests through mlx-lm's BatchGenerator. Max concurrent requ
 
 Context scaling support for running smaller context models with Claude Code. Scales reported token counts so that auto-compact triggers at the right timing, and SSE keep-alive prevents read timeouts during long prefill.
 
+### Interactive Prefill Preemption
+
+Priority-based interactive chat isolation. When enabled, background (daemon) requests are parked at chunk boundaries to let interactive (chat) requests proceed immediately. Bounded by TTL, session count, and byte limit.
+
+**Flags (all default off):**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `OMLX_PRIORITY_SCHEDULING` | `0` | Enable priority-based admission (0=interactive, 10=background) |
+| `OMLX_PREFILL_PREEMPTION` | `0` | Park background prefill when interactive requests wait |
+| `OMLX_INTERACTIVE_CACHE_TTL_SECS` | `600` | TTL for interactive trailing KV cache entries |
+| `OMLX_INTERACTIVE_CACHE_MAX_SESSIONS` | `64` | Max entries in interactive cache |
+| `OMLX_INTERACTIVE_CACHE_MAX_BYTES_GB` | `2` | Max bytes for interactive cache |
+
+**Rollback order:**
+
+```bash
+# Disable in this order, reload after each
+OMLX_INTERACTIVE_CACHE_TTL_SECS=0
+OMLX_INTERACTIVE_DECODE_FLOOR=0
+OMLX_PREFILL_PREEMPTION=0
+```
+
+After rollback, existing priority admission, reserved slots, 512-token prefill, and adaptive cache remain active.
+
 ### Multi-Model Serving
 
 Load LLMs, VLMs, embedding models, and rerankers within the same server. Models are managed through a combination of automatic and manual controls:

--- a/bench_kernels/bench_gated_delta.py
+++ b/bench_kernels/bench_gated_delta.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python
+"""Component-level GPU microbenchmark for LLM decode on Apple Silicon (M2 Ultra).
+
+Targets the GatedDeltaNet linear-attention block used by 30 of the 40 decoder
+layers in Ornith-1.0-35B-4bit (Qwen3.5-MoE hybrid: linear_attention every
+layer except every 4th, which is full_attention). Splits one layer's linear-
+attention forward into three pieces so we can see how much of it is the
+custom Metal delta-rule scan kernel vs. everything else (projections, causal
+depthwise conv, RMS-norms, sigmoid/softplus gating prep):
+
+  - linear_block_full     : GatedDeltaNet.__call__ end-to-end (real module,
+                             real ArraysCache-shaped recurrent state)
+  - gated_delta_kernel_only: the bare mx.fast.metal_kernel scan
+                             (mlx_lm.models.gated_delta.gated_delta_kernel)
+                             called directly at the exact q/k/v/g/beta/state
+                             shapes GatedDeltaNet feeds it for T=1 decode
+  - linear_glue           : the same block with the scan stubbed to an
+                             identity (out = v), isolating in_proj_qkv/z/b/a,
+                             the causal conv1d+silu, the two q/k RMS-norms,
+                             sigmoid(beta)/compute_g gating prep, the gated
+                             RMSNormGated, and out_proj
+
+Run with the omlx venv interpreter:
+  /Volumes/Untitled/GitHub/omlx/.venv/bin/python bench_kernels/bench_gated_delta.py
+
+Methodology (must match the task spec exactly):
+  - Real mlx-lm module classes: mlx_lm.models.qwen3_5.GatedDeltaNet /
+    TextModelArgs, mlx_lm.models.cache.ArraysCache, and the raw scan kernel +
+    gating helper from mlx_lm.models.gated_delta, instantiated from the real
+    model's config.json (nested under text_config). Weights randomly
+    initialized, bf16 for all non-quantized params -- except A_log, which the
+    real TextModel.cast_predicate deliberately keeps in float32 (it feeds
+    mx.exp(A_log) inside compute_g; sanitize()/quantize() never touch it
+    either), so we replicate that one exception exactly.
+  - Decode shapes: hidden state [B, 1, 2048] for B in {1, 2, 4, 8}.
+  - Recurrent state is REAL ArraysCache shape, pre-populated with random
+    values (not a cold/zero cache) before warmup: cache[0] = conv state
+    (B, conv_kernel_size-1, conv_dim), cache[1] = delta state
+    (B, linear_num_value_heads, linear_value_head_dim, linear_key_head_dim)
+    in float32, matching gated_delta_update's own mx.zeros(..., float32).
+  - Warmup 20 iters with mx.eval.
+  - Mode A (amortized): K=50 forward calls chained WITHOUT intermediate eval;
+    each call's output (or a perturbed tensor, when output isn't fed back
+    into the next call's slot) feeds the next iteration so MLX can't collapse
+    identical subgraphs; ONE mx.eval on the final outputs; report wall/K ms.
+  - Mode B (synced): K=50 calls, mx.eval after every call; report wall/K ms.
+    (B - A) approximates per-call sync/dispatch overhead.
+  - time.perf_counter for all wall-clock measurement.
+
+Sanity bound: the real engine decodes at ~11.3ms/token (B=1) end to end,
+covering ALL 40 layers (30 linear-attention + 10 full-attention), MoE MLP
+(256 experts, top-8) on every layer, embedding/lm_head/norms/sampler. This
+harness only measures the linear-attention sub-block, so 30 * ms_amortized
+(the extrapolated per-step contribution of just this component family) must
+leave comfortable headroom under 11.3ms for everything else -- if it doesn't,
+something is wrong (e.g. accidentally timing something MoE-shaped) and the
+run is re-measured, not reported.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_map_with_path
+
+from mlx_lm.models.qwen3_5 import GatedDeltaNet, TextModelArgs
+from mlx_lm.models.cache import ArraysCache
+from mlx_lm.models.gated_delta import compute_g, gated_delta_kernel
+
+CONFIG_PATH = "/Volumes/Untitled/Models/Athena/mlx/Ornith-1.0-35B-4bit/config.json"
+BATCH_SIZES = (1, 2, 4, 8)
+WARMUP = 20
+K_MODEL = 50
+
+N_LINEAR_LAYERS = 30
+N_TOTAL_LAYERS = 40
+REAL_TOTAL_MS = {1: 11.3, 2: 15.6, 4: 20.7, 8: 32.0}
+
+
+# ---------------------------------------------------------------------------
+# Config loading -- real TextModelArgs (only the fields GatedDeltaNet reads),
+# real config.json (fields nested under text_config)
+# ---------------------------------------------------------------------------
+
+
+def load_text_args():
+    with open(CONFIG_PATH) as f:
+        cfg = json.load(f)
+    tc = cfg["text_config"]
+    args = TextModelArgs.from_dict(tc)
+    return args, tc
+
+
+def build_model(args: TextModelArgs) -> GatedDeltaNet:
+    mx.random.seed(0)
+    model = GatedDeltaNet(args)
+
+    # bf16 everywhere except A_log, exactly mirroring TextModel.cast_predicate
+    # (real loader: mlx_lm.utils casts every param through this predicate).
+    def cast(path, p):
+        if path.endswith("A_log"):
+            return p.astype(mx.float32)
+        return p.astype(mx.bfloat16)
+
+    model.update(tree_map_with_path(cast, model.parameters()))
+    model.eval()  # training=False -> gated_delta_update takes use_kernel=True
+    mx.eval(model.parameters())
+    return model
+
+
+def make_cache(model: GatedDeltaNet, batch: int) -> ArraysCache:
+    """Real ArraysCache(size=2), pre-populated with realistic (non-zero,
+    non-cold) recurrent state at the exact shapes GatedDeltaNet reads/writes:
+      cache[0] = conv state   (B, conv_kernel_size-1, conv_dim)          bf16
+      cache[1] = delta state  (B, num_v_heads, head_v_dim, head_k_dim)  f32
+    """
+    cache = ArraysCache(size=2)
+    cache[0] = mx.random.normal(
+        (batch, model.conv_kernel_size - 1, model.conv_dim)
+    ).astype(mx.bfloat16)
+    cache[1] = mx.random.normal(
+        (batch, model.num_v_heads, model.head_v_dim, model.head_k_dim)
+    ).astype(mx.float32)
+    mx.eval(cache[0], cache[1])
+    return cache
+
+
+# ---------------------------------------------------------------------------
+# The "glue" cost: projections + causal conv + q/k RMS-norm + gating prep
+# (sigmoid(beta)/compute_g) + gated RMSNormGated + out_proj -- everything in
+# GatedDeltaNet.__call__ EXCEPT the scan/kernel (component #2, benched
+# separately).
+#
+# IMPORTANT (discovered empirically while building this harness, not assumed):
+# stubbing the scan to an identity INSIDE one single chained forward (out = v
+# + 0.0*(beta+g), then norm+out_proj, all in one Python function, chained 50x
+# without intermediate eval) produces a measurement artifact, not a real
+# number: Mode A (amortized) comes out ~5-9x HIGHER than Mode B (synced) for
+# that construction -- e.g. one early version of this harness measured
+# linear_glue amortized=1.09ms / synced=0.83ms at B=1, i.e. amortized > synced,
+# which is impossible for real GPU work (chaining without sync can only
+# remove per-call sync overhead, never add cost). Bisecting op-by-op pinned
+# the cause: `compute_g` is `@partial(mx.compile, shapeless=True)`-wrapped,
+# and when its output is combined with OTHER ops (a broadcast add feeding a
+# further matmul) inside a 50-deep chain that never syncs, MLX pays a large
+# repeated CPU-side dispatch/graph-splice cost for the compiled sub-graph
+# that Mode B's per-call mx.eval() happens to hide (GPU-busy time overlaps
+# the CPU-side cost) but Mode A's single-eval-at-the-end does not. Isolated
+# in a clean loop of its own (no other ops sharing the call), compute_g is
+# fast and well-behaved (amortized 0.036ms, synced 0.23ms for B=1) -- so the
+# fix is exactly the alternative the task spec offers: "time the
+# projection+conv ops separately" instead of one chained stubbed-scan block.
+# We measure each op-group in its own clean Mode A/B loop (input varied by a
+# tiny per-iteration constant, per spec) and SUM the resulting ms_amortized
+# and ms_synced across groups to report a single 'linear_glue' number. This
+# also means linear_glue's ms_amortized is a lower bound (no chaining
+# interaction across groups can inflate it) while linear_block_full's own
+# Mode A (measured on the real, unmodified module -- which is fine because
+# there compute_g's output flows straight into gated_delta_kernel, a single
+# fused mx.fast.metal_kernel call, not through further generic ops) remains
+# a directly faithful, unmodified measurement of the real forward path.
+# ---------------------------------------------------------------------------
+
+
+def bench_op_group(make_input, forward, k=K_MODEL, warmup=WARMUP):
+    """Generic Mode A / Mode B pair for a single, self-contained op group
+    (no cross-group op mixing -- see the note above on why that matters)."""
+    for i in range(warmup):
+        mx.eval(forward(make_input(i)))
+
+    outs = []
+    t0 = time.perf_counter()
+    for i in range(k):
+        outs.append(forward(make_input(i)))
+    mx.eval(outs)
+    t1 = time.perf_counter()
+    ms_a = (t1 - t0) * 1000.0 / k
+
+    t0 = time.perf_counter()
+    for i in range(k):
+        mx.eval(forward(make_input(i)))
+    t1 = time.perf_counter()
+    ms_b = (t1 - t0) * 1000.0 / k
+
+    return ms_a, ms_b
+
+
+def derive_scan_inputs(m: GatedDeltaNet, inputs: mx.array, cache: ArraysCache):
+    """Run the real pre-scan glue path once to get q/k/v/g/beta/state at the
+    exact shapes+dtypes GatedDeltaNet actually feeds gated_delta_kernel for a
+    T=1 decode step (no guessing dtypes by hand)."""
+    B, S, _ = inputs.shape
+
+    qkv = m.in_proj_qkv(inputs)
+    b = m.in_proj_b(inputs)
+    a = m.in_proj_a(inputs)
+
+    conv_state = cache[0]
+    conv_input = mx.concatenate([conv_state, qkv], axis=1)
+    n_keep = m.conv_kernel_size - 1
+    cache[0] = mx.contiguous(conv_input[:, -n_keep:, :])
+    conv_out = nn.silu(m.conv1d(conv_input))
+
+    q, k, v = [
+        t.reshape(B, S, h, d)
+        for t, h, d in zip(
+            mx.split(conv_out, [m.key_dim, 2 * m.key_dim], -1),
+            [m.num_k_heads, m.num_k_heads, m.num_v_heads],
+            [m.head_k_dim, m.head_k_dim, m.head_v_dim],
+        )
+    ]
+    inv_scale = k.shape[-1] ** -0.5
+    q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
+    k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+
+    beta = mx.sigmoid(b)
+    g = compute_g(m.A_log, a, m.dt_bias)
+    state = cache[1]
+    mx.eval(q, k, v, g, beta, state)
+    return q, k, v, g, beta, state
+
+
+# ---------------------------------------------------------------------------
+# Timing primitives (shared Mode A / Mode B pattern)
+# ---------------------------------------------------------------------------
+
+
+def bench_linear_block_full(model: GatedDeltaNet, batch: int):
+    cache = make_cache(model, batch)
+    x0 = mx.random.normal((batch, 1, model.hidden_size)).astype(mx.bfloat16)
+
+    def forward(x):
+        return model(x, mask=None, cache=cache)
+
+    # Warmup
+    x = x0
+    for _ in range(WARMUP):
+        x = forward(x)
+        mx.eval(x)
+
+    # Mode A: chained (output fed back as next input -- shape-compatible),
+    # no intermediate eval, one eval at the end.
+    x = x0
+    outs = []
+    t0 = time.perf_counter()
+    for _ in range(K_MODEL):
+        x = forward(x)
+        outs.append(x)
+    mx.eval(outs)
+    t1 = time.perf_counter()
+    ms_a = (t1 - t0) * 1000.0 / K_MODEL
+
+    # Mode B: synced every call.
+    x = x0
+    t0 = time.perf_counter()
+    for _ in range(K_MODEL):
+        x = forward(x)
+        mx.eval(x)
+    t1 = time.perf_counter()
+    ms_b = (t1 - t0) * 1000.0 / K_MODEL
+
+    return ms_a, ms_b
+
+
+def bench_gated_delta_kernel_only(model: GatedDeltaNet, batch: int):
+    cache = make_cache(model, batch)
+    x0 = mx.random.normal((batch, 1, model.hidden_size)).astype(mx.bfloat16)
+    q, k, v0, g, beta, state0 = derive_scan_inputs(model, x0, cache)
+
+    def forward(v, state):
+        return gated_delta_kernel(q, k, v, g, beta, state, None)
+
+    # Warmup
+    v, state = v0, state0
+    for i in range(WARMUP):
+        v = v + 1e-6
+        y, state = forward(v, state)
+        mx.eval(y, state)
+
+    # Mode A: chain recurrent state across calls (realistic), perturb v each
+    # iteration so MLX can't collapse identical subgraphs, one eval at end.
+    v, state = v0, state0
+    outs = []
+    t0 = time.perf_counter()
+    for i in range(K_MODEL):
+        v = v + 1e-6
+        y, state = forward(v, state)
+        outs.append(y)
+        outs.append(state)
+    mx.eval(outs)
+    t1 = time.perf_counter()
+    ms_a = (t1 - t0) * 1000.0 / K_MODEL
+
+    # Mode B: synced every call.
+    v, state = v0, state0
+    t0 = time.perf_counter()
+    for i in range(K_MODEL):
+        v = v + 1e-6
+        y, state = forward(v, state)
+        mx.eval(y, state)
+    t1 = time.perf_counter()
+    ms_b = (t1 - t0) * 1000.0 / K_MODEL
+
+    return ms_a, ms_b
+
+
+def bench_linear_glue(model: GatedDeltaNet, batch: int):
+    cache = make_cache(model, batch)
+    x0 = mx.random.normal((batch, 1, model.hidden_size)).astype(mx.bfloat16)
+
+    def forward(x):
+        return glue_forward(model, x, cache)
+
+    # Warmup
+    x = x0
+    for _ in range(WARMUP):
+        x = forward(x)
+        mx.eval(x)
+
+    # Mode A: chained (output fed back -- shape-compatible), one eval at end.
+    x = x0
+    outs = []
+    t0 = time.perf_counter()
+    for _ in range(K_MODEL):
+        x = forward(x)
+        outs.append(x)
+    mx.eval(outs)
+    t1 = time.perf_counter()
+    ms_a = (t1 - t0) * 1000.0 / K_MODEL
+
+    # Mode B: synced every call.
+    x = x0
+    t0 = time.perf_counter()
+    for _ in range(K_MODEL):
+        x = forward(x)
+        mx.eval(x)
+    t1 = time.perf_counter()
+    ms_b = (t1 - t0) * 1000.0 / K_MODEL
+
+    return ms_a, ms_b
+
+
+def bench_linear_glue(model: GatedDeltaNet, batch: int):
+    """Sum of separately-benched op groups covering every op in
+    GatedDeltaNet.__call__ except the scan/kernel -- see the module note
+    above `bench_op_group` for why groups are measured independently rather
+    than chained together in one stubbed-scan forward."""
+    m = model
+    x0 = mx.random.normal((batch, 1, m.hidden_size)).astype(mx.bfloat16)
+    conv_state0 = mx.random.normal(
+        (batch, m.conv_kernel_size - 1, m.conv_dim)
+    ).astype(mx.bfloat16)
+    mx.eval(x0, conv_state0)
+
+    # (a) in_proj_qkv + in_proj_z + causal conv1d + silu + split/reshape.
+    def proj_conv_fwd(x):
+        B, S, _ = x.shape
+        qkv = m.in_proj_qkv(x)
+        z = m.in_proj_z(x).reshape(B, S, m.num_v_heads, m.head_v_dim)
+        conv_input = mx.concatenate([conv_state0, qkv], axis=1)
+        conv_out = nn.silu(m.conv1d(conv_input))
+        q, k, v = [
+            t.reshape(B, S, h, d)
+            for t, h, d in zip(
+                mx.split(conv_out, [m.key_dim, 2 * m.key_dim], -1),
+                [m.num_k_heads, m.num_k_heads, m.num_v_heads],
+                [m.head_k_dim, m.head_k_dim, m.head_v_dim],
+            )
+        ]
+        return q, k, v, z
+
+    q0, k0, v0, z0 = proj_conv_fwd(x0)
+    mx.eval(q0, k0, v0, z0)
+
+    ms_a1, ms_b1 = bench_op_group(
+        lambda i: x0 + i * 1e-6, proj_conv_fwd
+    )
+
+    # (b) q/k RMS-norm.
+    inv_scale = k0.shape[-1] ** -0.5
+
+    def rmsnorm_fwd(qk):
+        q, k = qk
+        qq = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
+        kk = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+        return qq, kk
+
+    ms_a2, ms_b2 = bench_op_group(
+        lambda i: (q0 + i * 1e-6, k0 + i * 1e-6), rmsnorm_fwd
+    )
+
+    # (c) gating prep: in_proj_b, in_proj_a, sigmoid(beta), compute_g.
+    def gating_fwd(x):
+        b = m.in_proj_b(x)
+        a = m.in_proj_a(x)
+        beta = mx.sigmoid(b)
+        g = compute_g(m.A_log, a, m.dt_bias)
+        return beta, g
+
+    ms_a3, ms_b3 = bench_op_group(lambda i: x0 + i * 1e-6, gating_fwd)
+
+    # (d) gated RMSNormGated(v, z) + out_proj.
+    def post_fwd(vz):
+        v, z = vz
+        B, S = v.shape[:2]
+        out = m.norm(v, z)
+        return m.out_proj(out.reshape(B, S, -1))
+
+    ms_a4, ms_b4 = bench_op_group(
+        lambda i: (v0 + i * 1e-6, z0 + i * 1e-6), post_fwd
+    )
+
+    return ms_a1 + ms_a2 + ms_a3 + ms_a4, ms_b1 + ms_b2 + ms_b3 + ms_b4
+
+
+def main():
+    args, tc = load_text_args()
+    model = build_model(args)
+
+    print(
+        f"hidden_size={model.hidden_size} num_k_heads={model.num_k_heads} "
+        f"num_v_heads={model.num_v_heads} head_k_dim={model.head_k_dim} "
+        f"head_v_dim={model.head_v_dim} key_dim={model.key_dim} "
+        f"value_dim={model.value_dim} conv_dim={model.conv_dim} "
+        f"conv_kernel_size={model.conv_kernel_size} "
+        f"layer_types linear_attention count="
+        f"{sum(1 for t in tc['layer_types'] if t == 'linear_attention')} / "
+        f"{len(tc['layer_types'])}"
+    )
+
+    results = []
+    for batch in BATCH_SIZES:
+        ms_a, ms_b = bench_linear_block_full(model, batch)
+        results.append(("linear_block_full", batch, ms_a, ms_b))
+        print(
+            f"linear_block_full      B={batch:2d}  amortized={ms_a:8.4f} ms  synced={ms_b:8.4f} ms"
+        )
+
+        ms_a, ms_b = bench_gated_delta_kernel_only(model, batch)
+        results.append(("gated_delta_kernel_only", batch, ms_a, ms_b))
+        print(
+            f"gated_delta_kernel_only B={batch:2d}  amortized={ms_a:8.4f} ms  synced={ms_b:8.4f} ms"
+        )
+
+        ms_a, ms_b = bench_linear_glue(model, batch)
+        results.append(("linear_glue", batch, ms_a, ms_b))
+        print(
+            f"linear_glue             B={batch:2d}  amortized={ms_a:8.4f} ms  synced={ms_b:8.4f} ms"
+        )
+
+    print("\n--- sanity check: 30x linear_block_full vs real total decode ms ---")
+    for batch in BATCH_SIZES:
+        row = next(r for r in results if r[0] == "linear_block_full" and r[1] == batch)
+        extrap = row[2] * N_LINEAR_LAYERS
+        total = REAL_TOTAL_MS[batch]
+        pct = 100.0 * extrap / total
+        print(
+            f"B={batch:2d}  30*linear_block_full(amortized)={extrap:7.3f} ms  "
+            f"real_total={total:6.2f} ms  share={pct:5.1f}%"
+        )
+
+    print("\n--- JSON ---")
+    print(
+        json.dumps(
+            {
+                "config": {
+                    "hidden_size": model.hidden_size,
+                    "linear_num_key_heads": model.num_k_heads,
+                    "linear_num_value_heads": model.num_v_heads,
+                    "linear_key_head_dim": model.head_k_dim,
+                    "linear_value_head_dim": model.head_v_dim,
+                    "linear_conv_kernel_dim": model.conv_kernel_size,
+                    "n_linear_layers": N_LINEAR_LAYERS,
+                    "n_total_layers": N_TOTAL_LAYERS,
+                },
+                "results": [
+                    {"component": c, "batch": b, "ms_amortized": a, "ms_synced": s}
+                    for c, b, a, s in results
+                ],
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_kernels/bench_head_norm_sampler.py
+++ b/bench_kernels/bench_head_norm_sampler.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python
+"""Component-level GPU microbenchmark for LLM decode on Apple Silicon (M2 Ultra).
+
+Targets everything OUTSIDE the 40 transformer decoder layers of
+Ornith-1.0-35B-4bit (Qwen3.5-MoE hybrid, linear+full attention, 256 experts):
+  - lm_head (4-bit quantized output projection, hidden -> vocab logits)
+  - embedding_lookup (token id -> hidden, 4-bit quantized embedding table)
+  - final_norm (the model's trailing RMSNorm)
+  - layer_norm (ONE representative per-layer RMSNorm; model has 2 x 40 = 80 of these)
+  - sampler (omlx's eager temp/top_p/top_k sampler, from omlx.utils.sampling)
+  - dispatch_overhead (per-GPU-dispatch floor + per-call sync cost calibration)
+
+Run with the omlx venv interpreter:
+  /Volumes/Untitled/GitHub/omlx/.venv/bin/python bench_kernels/bench_head_norm_sampler.py
+
+Methodology (must match the task spec exactly):
+  - Real mlx-lm module classes/args: nn.Embedding, nn.Linear, nn.RMSNorm are the
+    literal classes mlx_lm.models.qwen3_5.{Qwen3_5TextModel,TextModel,DecoderLayer}
+    instantiate for embed_tokens / lm_head / {input,post_attention}_layernorm. We
+    build ONLY those submodules (not the full 40-layer / 256-expert stack — that
+    would need ~70GB transient bf16 memory to construct on a 64GB machine and its
+    timing is explicitly out of scope for this component list) using shapes/eps
+    parsed from the REAL TextModelArgs.from_dict() on the model's actual config.json
+    (nested under text_config). Quantization (4-bit affine group_size=64) is applied
+    to lm_head/embedding exactly as mlx_lm's TextModel.quant_predicate would: MoE
+    router/shared_expert_gate paths get 8-bit, everything else (including lm_head
+    and embed_tokens, per this model's config.json) gets the default 4-bit/64.
+  - bf16 for all non-quantized params (norms).
+  - Decode shapes: hidden state [B, 1, 2048] for B in {1, 2, 4, 8}.
+  - Warmup 20 iters with mx.eval.
+  - Mode A (amortized): K=50 forward calls chained WITHOUT intermediate eval,
+    input varied each iteration so MLX can't collapse identical subgraphs, ONE
+    mx.eval on the final outputs at the end; report wall/K ms.
+  - Mode B (synced): K=50 calls, mx.eval after every call; report wall/K ms.
+    (B - A) approximates per-call sync/dispatch overhead.
+  - time.perf_counter for all wall-clock measurement.
+"""
+
+import json
+import time
+from dataclasses import dataclass
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.qwen3_5 import TextModelArgs
+from omlx.utils.sampling import make_sampler
+
+CONFIG_PATH = "/Volumes/Untitled/Models/Athena/mlx/Ornith-1.0-35B-4bit/config.json"
+BATCH_SIZES = (1, 2, 4, 8)
+WARMUP = 20
+K_MODEL = 50
+K_DISPATCH = 200
+DISPATCH_SHAPE = (64, 64)
+
+# ---------------------------------------------------------------------------
+# Config loading — real TextModelArgs, real config.json (text_config nesting)
+# ---------------------------------------------------------------------------
+
+
+def load_text_args() -> TextModelArgs:
+    with open(CONFIG_PATH) as f:
+        cfg = json.load(f)
+    text_cfg = cfg["text_config"]
+    # TextModelArgs.from_dict (via BaseModelArgs) only consumes fields that are
+    # declared dataclass fields; extras are dropped, so passing the raw nested
+    # dict is exactly what mlx_lm's own model loader does.
+    args = TextModelArgs.from_dict(text_cfg)
+    return args, cfg
+
+
+def quant_settings(cfg: dict) -> dict:
+    q = cfg["quantization"]
+    return {"group_size": q["group_size"], "bits": q["bits"], "mode": q["mode"]}
+
+
+# ---------------------------------------------------------------------------
+# Timing primitives
+# ---------------------------------------------------------------------------
+
+
+def time_mode_a(make_input, forward, k=K_MODEL):
+    """Chained, no intermediate eval — one mx.eval at the end. Returns ms/call."""
+    x = make_input(0)
+    outputs = []
+    t0 = time.perf_counter()
+    for i in range(k):
+        x = make_input(i)
+        y = forward(x)
+        outputs.append(y)
+    mx.eval(outputs)
+    t1 = time.perf_counter()
+    return (t1 - t0) * 1000.0 / k
+
+
+def time_mode_b(make_input, forward, k=K_MODEL):
+    """Synced — mx.eval after every call. Returns ms/call."""
+    t0 = time.perf_counter()
+    for i in range(k):
+        x = make_input(i)
+        y = forward(x)
+        mx.eval(y)
+    t1 = time.perf_counter()
+    return (t1 - t0) * 1000.0 / k
+
+
+def warmup(make_input, forward, n=WARMUP):
+    for i in range(n):
+        mx.eval(forward(make_input(i)))
+
+
+def bench_component(make_input, forward, k=K_MODEL):
+    warmup(make_input, forward)
+    ms_a = time_mode_a(make_input, forward, k)
+    ms_b = time_mode_b(make_input, forward, k)
+    return ms_a, ms_b
+
+
+# ---------------------------------------------------------------------------
+# Build components from the real mlx-lm classes/args
+# ---------------------------------------------------------------------------
+
+
+def build_components(args: TextModelArgs, qcfg: dict):
+    hidden = args.hidden_size
+    vocab = args.vocab_size
+    eps = args.rms_norm_eps
+
+    mx.random.seed(0)
+
+    # embed_tokens: identical construction to Qwen3_5TextModel.__init__
+    embed = nn.Embedding(vocab, hidden)
+    embed.set_dtype(mx.bfloat16)
+    embed_q = nn.QuantizedEmbedding.from_embedding(
+        embed, group_size=qcfg["group_size"], bits=qcfg["bits"], mode=qcfg["mode"]
+    )
+
+    # lm_head: identical construction to TextModel.__init__ (tie_word_embeddings=False)
+    lm_head = nn.Linear(hidden, vocab, bias=False)
+    lm_head.set_dtype(mx.bfloat16)
+    lm_head_q = nn.QuantizedLinear.from_linear(
+        lm_head, group_size=qcfg["group_size"], bits=qcfg["bits"], mode=qcfg["mode"]
+    )
+
+    # final_norm: identical construction to Qwen3_5TextModel.norm
+    final_norm = nn.RMSNorm(hidden, eps=eps)
+    final_norm.set_dtype(mx.bfloat16)
+
+    # layer_norm: identical construction to DecoderLayer.input_layernorm /
+    # .post_attention_layernorm (both are plain nn.RMSNorm(hidden, eps); there
+    # are 2 per layer x 40 layers = 80 in the real model, all the same shape/cost)
+    layer_norm = nn.RMSNorm(hidden, eps=eps)
+    layer_norm.set_dtype(mx.bfloat16)
+
+    mx.eval(embed_q.parameters(), lm_head_q.parameters(), final_norm.parameters(), layer_norm.parameters())
+
+    return embed_q, lm_head_q, final_norm, layer_norm
+
+
+# ---------------------------------------------------------------------------
+# Per-component benchmarks
+# ---------------------------------------------------------------------------
+
+
+def bench_lm_head(lm_head_q, hidden, batch):
+    x0 = mx.random.normal((batch, 1, hidden)).astype(mx.bfloat16)
+
+    def make_input(i):
+        return x0 + (i * 1e-4)
+
+    def forward(x):
+        return lm_head_q(x)
+
+    return bench_component(make_input, forward)
+
+
+def bench_embedding(embed_q, vocab, batch):
+    def make_input(i):
+        # vary ids each iter (mod vocab) so MLX can't collapse identical subgraphs
+        return mx.remainder(mx.full((batch, 1), i, dtype=mx.uint32), vocab)
+
+    def forward(ids):
+        return embed_q(ids)
+
+    return bench_component(make_input, forward)
+
+
+def bench_norm(norm_mod, hidden, batch):
+    """RMSNorm output shape == input shape, so per spec we feed the output back
+    in as the next call's input (norm(norm(norm(...x...)))) for Mode A chaining
+    — this both satisfies the "feed output back if shape-compatible" rule and
+    naturally varies the data each iteration (no manual epsilon needed)."""
+    x0 = mx.random.normal((batch, 1, hidden)).astype(mx.bfloat16)
+
+    warmup(lambda i: x0, norm_mod)
+
+    # Mode A: chain norm(norm(norm(...x...))) for K calls, one eval at the end
+    x = x0
+    outs = []
+    t0 = time.perf_counter()
+    for i in range(K_MODEL):
+        x = norm_mod(x)
+        outs.append(x)
+    mx.eval(outs)
+    t1 = time.perf_counter()
+    ms_a = (t1 - t0) * 1000.0 / K_MODEL
+
+    # Mode B: synced each call
+    x = x0
+    t0 = time.perf_counter()
+    for i in range(K_MODEL):
+        x = norm_mod(x)
+        mx.eval(x)
+    t1 = time.perf_counter()
+    ms_b = (t1 - t0) * 1000.0 / K_MODEL
+
+    return ms_a, ms_b
+
+
+def bench_sampler(sampler, vocab, batch):
+    logits0 = mx.random.normal((batch, vocab)).astype(mx.bfloat16)
+
+    def make_input(i):
+        return logits0 + (i * 1e-6)
+
+    def forward(logits):
+        return sampler(logits)
+
+    return bench_component(make_input, forward)
+
+
+def bench_dispatch_overhead():
+    x0 = mx.random.normal(DISPATCH_SHAPE).astype(mx.float32)
+
+    def forward(x):
+        return x * 1.0001
+
+    warmup(lambda i: x0, forward, n=WARMUP)
+
+    # Mode A: chained, one eval at end
+    x = x0
+    t0 = time.perf_counter()
+    for i in range(K_DISPATCH):
+        x = x * 1.0001
+    mx.eval(x)
+    t1 = time.perf_counter()
+    ms_a = (t1 - t0) * 1000.0 / K_DISPATCH
+
+    # Mode B: synced every call
+    x = x0
+    t0 = time.perf_counter()
+    for i in range(K_DISPATCH):
+        x = x * 1.0001
+        mx.eval(x)
+    t1 = time.perf_counter()
+    ms_b = (t1 - t0) * 1000.0 / K_DISPATCH
+
+    return ms_a, ms_b
+
+
+# ---------------------------------------------------------------------------
+# Rough estimate of dispatches/decode-step from reading qwen3_5.py / qwen3_next.py
+# ---------------------------------------------------------------------------
+
+DISPATCH_ESTIMATE_NOTES = """
+Rough op-count estimate per DecoderLayer.__call__ (qwen3_5.py), by reading code
+(NOT measured — MLX doesn't expose a per-call dispatch counter used here):
+  - input_layernorm (RMSNorm, fused mx.fast.rms_norm)              ~1 dispatch
+  - linear_attn (GatedDeltaNet, 30/40 layers) OR self_attn (10/40):
+      GatedDeltaNet: 4 in_proj matmuls + concat/conv1d/silu + split/reshape
+                     + 2 rms_norm (q,k) + gated_delta_update (custom, treated
+                     as ~3 fused kernels) + RMSNormGated (~2) + out_proj  ~20
+      Attention (full, every 4th layer): q/k/v proj (3) + rope (2) +
+                     sdpa (1 fused) + o_proj (1)                          ~10-12
+  - post_attention_layernorm (RMSNorm)                                    ~1
+  - SparseMoeBlock (num_experts=256, top-8): router matmul+softmax+topk
+    (~5) + gathered switch_mlp expert matmuls (gate/up/down, grouped)
+    (~8) + shared_expert (3 matmuls + gate, ~4) + combine (~3)          ~20-25
+  Per-layer total: ~40-55 dispatches x 40 layers  =>  ~1,700-2,200 dispatches
+  Plus embedding(1) + final_norm(1) + lm_head(1) + sampler(~5-8 for
+  top_p/top_k/categorical) => decode step total order-of-magnitude ~1,800-2,300
+  GPU dispatches. Labeled ESTIMATE ONLY, not a measured count.
+"""
+
+
+def main():
+    args, cfg = load_text_args()
+    qcfg = quant_settings(cfg)
+    hidden = args.hidden_size
+    vocab = args.vocab_size
+    n_layers = args.num_hidden_layers
+
+    print(f"hidden_size={hidden} vocab_size={vocab} num_hidden_layers={n_layers} "
+          f"rms_norm_eps={args.rms_norm_eps} quant={qcfg}")
+
+    embed_q, lm_head_q, final_norm, layer_norm = build_components(args, qcfg)
+
+    gen_cfg = cfg.get("generation_config", {})
+    sampler = make_sampler(
+        temp=gen_cfg.get("temperature", 1.0),
+        top_p=gen_cfg.get("top_p", 0.95),
+        top_k=gen_cfg.get("top_k", 20),
+    )
+    print(f"sampler: temp={sampler.temp} top_p={sampler.top_p} top_k={sampler.top_k}")
+
+    results = []
+
+    for batch in BATCH_SIZES:
+        ms_a, ms_b = bench_lm_head(lm_head_q, hidden, batch)
+        results.append(("lm_head", batch, ms_a, ms_b))
+        print(f"lm_head        B={batch:2d}  amortized={ms_a:8.4f} ms  synced={ms_b:8.4f} ms")
+
+        ms_a, ms_b = bench_embedding(embed_q, vocab, batch)
+        results.append(("embedding_lookup", batch, ms_a, ms_b))
+        print(f"embedding_lookup B={batch:2d}  amortized={ms_a:8.4f} ms  synced={ms_b:8.4f} ms")
+
+        ms_a, ms_b = bench_norm(final_norm, hidden, batch)
+        results.append(("final_norm", batch, ms_a, ms_b))
+        print(f"final_norm     B={batch:2d}  amortized={ms_a:8.4f} ms  synced={ms_b:8.4f} ms")
+
+        ms_a, ms_b = bench_norm(layer_norm, hidden, batch)
+        results.append(("layer_norm", batch, ms_a, ms_b))
+        print(f"layer_norm     B={batch:2d}  amortized={ms_a:8.4f} ms  synced={ms_b:8.4f} ms")
+
+        ms_a, ms_b = bench_sampler(sampler, vocab, batch)
+        results.append(("sampler", batch, ms_a, ms_b))
+        print(f"sampler        B={batch:2d}  amortized={ms_a:8.4f} ms  synced={ms_b:8.4f} ms")
+
+    ms_a, ms_b = bench_dispatch_overhead()
+    results.append(("dispatch_overhead", 1, ms_a, ms_b))
+    print(f"dispatch_overhead (K={K_DISPATCH}, shape={DISPATCH_SHAPE})  "
+          f"amortized={ms_a:8.5f} ms  synced={ms_b:8.5f} ms  "
+          f"(sync_delta~{ms_b - ms_a:.5f} ms)")
+
+    print(DISPATCH_ESTIMATE_NOTES)
+
+    print("\n--- JSON ---")
+    print(json.dumps(
+        {
+            "config": {
+                "hidden_size": hidden,
+                "vocab_size": vocab,
+                "num_hidden_layers": n_layers,
+                "rms_norm_eps": args.rms_norm_eps,
+                "quantization": qcfg,
+            },
+            "results": [
+                {"component": c, "batch": b, "ms_amortized": a, "ms_synced": s}
+                for c, b, a, s in results
+            ],
+        },
+        indent=2,
+    ))
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_kernels/bench_sampler_fused_topk_topp.py
+++ b/bench_kernels/bench_sampler_fused_topk_topp.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+"""Microbenchmark: old (full-vocab argsort) vs. fused top-k+top-p sampler
+fast path, at the real 248,320-token production vocab.
+
+Compares the actual end-to-end swap inside make_sampler for the
+top_p+top_k-only case (temp > 0, both filters active, no min_p/xtc):
+  - old   : apply_top_p(logprobs, top_p) -> apply_top_k(..., top_k) ->
+            categorical_sampling(..., temp)  (make_sampler's composition
+            before this change; still reachable via the unfused
+            apply_top_p/apply_top_k/categorical_sampling helpers)
+  - fused : omlx.utils.sampling._fused_top_k_top_p_sample — argpartition
+            down to the top_k candidates, sort/cumsum/mask only those, then
+            sample directly and map back through the gathered indices —
+            never sorts or scatters at full-vocab scale, and never
+            materializes a vocab-sized filtered array at all.
+
+Run with the omlx venv interpreter:
+  /Volumes/Untitled/GitHub/omlx/.venv/bin/python bench_kernels/bench_sampler_fused_topk_topp.py
+
+Methodology (matches bench_kernels/bench_head_norm_sampler.py exactly):
+  - Decode shapes: logits [B, 248320] for B in {1, 8} (production vocab size,
+    from Ornith-1.0-35B-4bit's text_config.vocab_size).
+  - Production sampler config: temperature=1.0, top_p=0.95, top_k=20.
+  - Warmup 20 iters with mx.eval.
+  - Mode A (amortized): K=50 calls chained WITHOUT intermediate eval, input
+    varied each iteration so MLX can't collapse identical subgraphs, ONE
+    mx.eval on the final outputs at the end; report wall/K ms.
+  - time.perf_counter for all wall-clock measurement.
+"""
+
+import time
+
+import mlx.core as mx
+
+from omlx.utils.sampling import (
+    _fused_top_k_top_p_sample,
+    apply_top_k,
+    apply_top_p,
+    categorical_sampling,
+)
+
+VOCAB = 248320
+BATCH_SIZES = (1, 8)
+WARMUP = 20
+K = 50
+TOP_P = 0.95
+TOP_K = 20
+TEMP = 1.0
+
+
+def old_top_k_top_p_sample(
+    logprobs: mx.array, top_k: int, top_p: float, temp: float
+) -> mx.array:
+    """The pre-fusion pipeline: full-vocab top_p -> full-vocab top_k ->
+    categorical_sampling, exactly as make_sampler composed them before."""
+    out = apply_top_p(logprobs, top_p)
+    out = apply_top_k(out, top_k)
+    return categorical_sampling(out, temp)
+
+
+def time_mode_a(make_input, forward, k=K):
+    """Chained, no intermediate eval -- one mx.eval at the end. Returns ms/call."""
+    outputs = []
+    t0 = time.perf_counter()
+    for i in range(k):
+        x = make_input(i)
+        y = forward(x)
+        outputs.append(y)
+    mx.eval(outputs)
+    t1 = time.perf_counter()
+    return (t1 - t0) * 1000.0 / k
+
+
+def warmup(make_input, forward, n=WARMUP):
+    for i in range(n):
+        mx.eval(forward(make_input(i)))
+
+
+def bench(make_input, forward):
+    warmup(make_input, forward)
+    return time_mode_a(make_input, forward)
+
+
+def make_logits(batch):
+    base = mx.random.normal((batch, VOCAB)).astype(mx.bfloat16) * 3.0
+
+    def make_input(i):
+        # Vary data each iteration so MLX can't collapse identical subgraphs.
+        return base + (i * 1e-6)
+
+    return make_input
+
+
+def main():
+    mx.random.seed(0)
+    print(f"vocab={VOCAB} top_p={TOP_P} top_k={TOP_K} temp={TEMP} K={K} warmup={WARMUP}")
+
+    results = []
+    for batch in BATCH_SIZES:
+        make_input = make_logits(batch)
+
+        ms_old = bench(
+            make_input, lambda x: old_top_k_top_p_sample(x, TOP_K, TOP_P, TEMP)
+        )
+        ms_new = bench(
+            make_input, lambda x: _fused_top_k_top_p_sample(x, TOP_K, TOP_P, TEMP)
+        )
+        speedup = ms_old / ms_new if ms_new else float("inf")
+
+        results.append((batch, ms_old, ms_new, speedup))
+        print(
+            f"B={batch:2d}  old={ms_old:8.4f} ms  fused={ms_new:8.4f} ms  "
+            f"speedup={speedup:5.2f}x"
+        )
+
+    print()
+    for batch, ms_old, ms_new, speedup in results:
+        status = "PASS" if speedup >= 3.0 else "FAIL"
+        print(f"[{status}] B={batch}: speedup={speedup:.2f}x (gate: >=3x)")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench_kernels/moe_attn_component_bench.py
+++ b/bench_kernels/moe_attn_component_bench.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python
+"""
+Component-level GPU microbenchmark for Ornith-1.0-35B-4bit (Qwen3.5-MoE hybrid) decode.
+
+Benchmarks two decode-critical sub-modules built from the REAL mlx-lm model
+classes (mlx_lm.models.qwen3_5 / qwen3_next), instantiated from the real
+ModelArgs read out of the deployed model's config.json, with randomly
+initialized weights (bf16 for non-quantized params, real 4-bit affine
+quantization for the MoE expert weights matching the checkpoint's own
+quantization_config):
+
+  1. moe_block  - Qwen3NextSparseMoeBlock (SwitchGLU, 256 experts, top-8,
+                  moe_intermediate_size 512, + dense shared-expert) run
+                  QUANTIZED (4-bit experts / shared-expert, 8-bit
+                  router-gate + shared-expert-gate, matching the
+                  checkpoint's quant_predicate exactly).
+  2. moe_router - just the gate Linear + softmax + top-k select/renorm
+                  slice of (1), reported separately as a diagnostic
+                  (NOTE: this cost is *already included inside* moe_block's
+                  number -- see methodology_notes, do not double count).
+  3. full_attn_block - Qwen3NextAttention (GQA, 16 Q heads / 2 KV heads,
+                  head_dim 256) run bf16 (not quantized -- see
+                  methodology_notes) with a real KVCache prefilled to 2048
+                  tokens via one real "causal" prefill forward, then timed
+                  over T=1 decode steps (cache grows 2048 -> 2048+K across
+                  the timed loop, exactly like real decode).
+
+Run with the omlx venv interpreter:
+  /Volumes/Untitled/GitHub/omlx/.venv/bin/python \
+      /Volumes/Untitled/GitHub/omlx/bench_kernels/moe_attn_component_bench.py
+
+Writes nothing to disk; prints a JSON report to stdout.
+"""
+
+import json
+import time
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.base import create_attention_mask
+from mlx_lm.models.cache import KVCache
+from mlx_lm.models.qwen3_5 import TextModelArgs
+from mlx_lm.models.qwen3_next import Qwen3NextAttention, Qwen3NextSparseMoeBlock
+
+CONFIG_PATH = (
+    "/Volumes/Untitled/Models/Athena/mlx/Ornith-1.0-35B-4bit/config.json"
+)
+
+HIDDEN = 2048
+CTX_LEN = 2048  # realistic decode context to preload the KV cache to
+BATCHES = [1, 2, 4, 8]
+K = 50  # timed forward calls per mode
+WARMUP = 20
+
+# real-engine reference totals (ms/token) given in the task, for the sanity
+# check against physically-absurd component shares.
+REAL_ENGINE_MS = {1: 11.3, 2: 15.6, 4: 20.7, 8: 32.0}
+
+
+# --------------------------------------------------------------------------
+# Model construction
+# --------------------------------------------------------------------------
+
+
+def load_args():
+    cfg = json.load(open(CONFIG_PATH))
+    text_cfg = cfg["text_config"]
+    args = TextModelArgs.from_dict(text_cfg)
+    quant_cfg = cfg.get("quantization_config", cfg.get("quantization", {}))
+    return args, cfg, quant_cfg
+
+
+def moe_quant_predicate(path, module):
+    """Mirrors mlx_lm.models.qwen3_5.TextModel.quant_predicate exactly:
+    the router gate and the shared-expert gate are 8-bit, everything else
+    quantizable gets the default (4-bit / group_size 64 / affine)."""
+    if not hasattr(module, "to_quantized"):
+        return False
+    leaf = path.split(".")[-1]
+    if leaf in ("gate", "shared_expert_gate"):
+        return {"group_size": 64, "bits": 8, "mode": "affine"}
+    return True
+
+
+def build_moe_block(args, group_size, bits):
+    block = Qwen3NextSparseMoeBlock(args)
+    block.set_dtype(mx.bfloat16)
+    nn.quantize(
+        block,
+        group_size=group_size,
+        bits=bits,
+        mode="affine",
+        class_predicate=moe_quant_predicate,
+    )
+    mx.eval(block.parameters())
+    return block
+
+
+class RouterOnly(nn.Module):
+    """The gate/top-k slice of Qwen3NextSparseMoeBlock.__call__, isolated."""
+
+    def __init__(self, args):
+        super().__init__()
+        self.gate = nn.Linear(args.hidden_size, args.num_experts, bias=False)
+        self.top_k = args.num_experts_per_tok
+        self.norm_topk_prob = args.norm_topk_prob
+
+    def __call__(self, x):
+        gates = self.gate(x)
+        gates = mx.softmax(gates, axis=-1, precise=True)
+        k = self.top_k
+        inds = mx.argpartition(gates, kth=-k, axis=-1)[..., -k:]
+        scores = mx.take_along_axis(gates, inds, axis=-1)
+        if self.norm_topk_prob:
+            scores = scores / scores.sum(axis=-1, keepdims=True)
+        return scores
+
+
+def build_router(args, group_size, bits):
+    router = RouterOnly(args)
+    router.set_dtype(mx.bfloat16)
+    # the real checkpoint quantizes mlp.gate to 8-bit (see quant_predicate);
+    # match that here for fidelity even though not explicitly required.
+    nn.quantize(
+        router,
+        group_size=group_size,
+        bits=8,
+        mode="affine",
+    )
+    mx.eval(router.parameters())
+    return router
+
+
+def build_full_attn(args):
+    attn = Qwen3NextAttention(args)
+    attn.set_dtype(mx.bfloat16)
+    mx.eval(attn.parameters())
+    return attn
+
+
+# --------------------------------------------------------------------------
+# Timing harness
+# --------------------------------------------------------------------------
+
+
+def time_stateless(forward_fn, B, K=K, warmup=WARMUP):
+    tiny = mx.array(1e-4, dtype=mx.bfloat16)
+
+    def fresh_x():
+        x = mx.random.normal((B, 1, HIDDEN)).astype(mx.bfloat16)
+        mx.eval(x)
+        return x
+
+    # warmup (Mode B style: eval every iter)
+    x = fresh_x()
+    for _ in range(warmup):
+        x = x + tiny
+        out = forward_fn(x)
+        mx.eval(out)
+
+    # Mode A: chained, single eval at the end
+    x = fresh_x()
+    outs = []
+    t0 = time.perf_counter()
+    for _ in range(K):
+        x = x + tiny
+        out = forward_fn(x)
+        outs.append(out)
+    mx.eval(outs)
+    t1 = time.perf_counter()
+    ms_amortized = (t1 - t0) * 1000.0 / K
+
+    # Mode B: synced every call
+    x = fresh_x()
+    t0 = time.perf_counter()
+    for _ in range(K):
+        x = x + tiny
+        out = forward_fn(x)
+        mx.eval(out)
+    t1 = time.perf_counter()
+    ms_synced = (t1 - t0) * 1000.0 / K
+
+    return ms_amortized, ms_synced
+
+
+def prefill_cache(attn, B, ctx_len=CTX_LEN):
+    cache = KVCache()
+    xp = mx.random.normal((B, ctx_len, HIDDEN)).astype(mx.bfloat16)
+    mx.eval(xp)
+    mask = create_attention_mask(xp, cache)
+    out = attn(xp, mask=mask, cache=cache)
+    mx.eval(out, cache.keys, cache.values)
+    return cache
+
+
+def time_full_attn(attn, B, K=K, warmup=WARMUP):
+    tiny = mx.array(1e-4, dtype=mx.bfloat16)
+
+    # warmup (fresh cache, own prefill, evaluated every decode step)
+    cache = prefill_cache(attn, B)
+    x = mx.random.normal((B, 1, HIDDEN)).astype(mx.bfloat16)
+    mx.eval(x)
+    for _ in range(warmup):
+        x = x + tiny
+        out = attn(x, mask=None, cache=cache)
+        mx.eval(out)
+
+    # Mode A: chained decode steps (cache genuinely grows 2048 -> 2048+K,
+    # exactly as real decode does), single eval at the end
+    cache = prefill_cache(attn, B)
+    x = mx.random.normal((B, 1, HIDDEN)).astype(mx.bfloat16)
+    mx.eval(x)
+    outs = []
+    t0 = time.perf_counter()
+    for _ in range(K):
+        x = x + tiny
+        out = attn(x, mask=None, cache=cache)
+        outs.append(out)
+    mx.eval(outs)
+    t1 = time.perf_counter()
+    ms_amortized = (t1 - t0) * 1000.0 / K
+
+    # Mode B: synced every decode step
+    cache = prefill_cache(attn, B)
+    x = mx.random.normal((B, 1, HIDDEN)).astype(mx.bfloat16)
+    mx.eval(x)
+    t0 = time.perf_counter()
+    for _ in range(K):
+        x = x + tiny
+        out = attn(x, mask=None, cache=cache)
+        mx.eval(out)
+    t1 = time.perf_counter()
+    ms_synced = (t1 - t0) * 1000.0 / K
+
+    return ms_amortized, ms_synced
+
+
+# --------------------------------------------------------------------------
+# Main
+# --------------------------------------------------------------------------
+
+
+def main():
+    mx.random.seed(0)
+    args, cfg, quant_cfg = load_args()
+    group_size = quant_cfg.get("group_size", 64)
+    bits = quant_cfg.get("bits", 4)
+
+    full_attn_count = sum(
+        1
+        for i in range(args.num_hidden_layers)
+        if (i + 1) % args.full_attention_interval == 0
+    )
+    # Verified from code: mlx_lm.models.qwen3_5.DecoderLayer.__init__ does
+    #   if args.num_experts > 0: self.mlp = SparseMoeBlock(args)
+    #   else: self.mlp = MLP(...)
+    # with NO decoder_sparse_step / mlp_only_layers gating in this arch's
+    # DecoderLayer (that gating exists only in the plain qwen3_next.py
+    # DecoderLayer, unused by qwen3_5). Since num_experts=256 > 0 for every
+    # layer, ALL 40 layers get the sparse MoE FFN -- none are dense-only.
+    moe_ffn_count = args.num_hidden_layers
+    linear_attn_count = args.num_hidden_layers - full_attn_count
+
+    layer_counts = {
+        "moe_ffn": moe_ffn_count,
+        "full_attention": full_attn_count,
+        "linear_attention": linear_attn_count,
+        "moe_router": moe_ffn_count,  # 1 router per MoE layer; NOT additive, see notes
+        "total_layers": args.num_hidden_layers,
+    }
+
+    print(f"# layer_counts = {layer_counts}", flush=True)
+    print(
+        f"# quant: group_size={group_size} bits={bits} "
+        f"(router-gate/shared_expert_gate overridden to 8-bit per checkpoint)",
+        flush=True,
+    )
+
+    print("# building moe_block (quantized)...", flush=True)
+    moe_block = build_moe_block(args, group_size, bits)
+    print("# building moe_router (8-bit, diagnostic)...", flush=True)
+    router = build_router(args, group_size, bits)
+    print("# building full_attn_block (bf16, unquantized)...", flush=True)
+    attn = build_full_attn(args)
+
+    timings = []
+    for B in BATCHES:
+        print(f"# batch {B}: moe_block", flush=True)
+        a, s = time_stateless(moe_block, B)
+        timings.append({"component": "moe_block", "batch": B, "ms_amortized": a, "ms_synced": s})
+        print(f"#   moe_block   B={B}  amortized={a:.4f}ms  synced={s:.4f}ms", flush=True)
+
+        print(f"# batch {B}: moe_router", flush=True)
+        a, s = time_stateless(router, B)
+        timings.append({"component": "moe_router", "batch": B, "ms_amortized": a, "ms_synced": s})
+        print(f"#   moe_router  B={B}  amortized={a:.4f}ms  synced={s:.4f}ms", flush=True)
+
+        print(f"# batch {B}: full_attn_block", flush=True)
+        a, s = time_full_attn(attn, B)
+        timings.append({"component": "full_attn_block", "batch": B, "ms_amortized": a, "ms_synced": s})
+        print(f"#   full_attn   B={B}  amortized={a:.4f}ms  synced={s:.4f}ms", flush=True)
+
+    # extrapolate to a full decode step at batch 1 (Mode A / amortized numbers,
+    # since Mode A approximates the marginal per-block cost inside one big
+    # chained per-token graph -- which is exactly how the real engine's
+    # 40-layer forward + single eval per token amortizes dispatch overhead).
+    b1 = {t["component"]: t for t in timings if t["batch"] == 1}
+    extrapolated = {
+        "moe_ffn": b1["moe_block"]["ms_amortized"] * moe_ffn_count,
+        "full_attention": b1["full_attn_block"]["ms_amortized"] * full_attn_count,
+    }
+    extrapolated["moe_ffn_plus_full_attention_total"] = (
+        extrapolated["moe_ffn"] + extrapolated["full_attention"]
+    )
+    extrapolated["real_engine_b1_ms"] = REAL_ENGINE_MS[1]
+    extrapolated["share_of_real_engine_b1"] = (
+        extrapolated["moe_ffn_plus_full_attention_total"] / REAL_ENGINE_MS[1]
+    )
+
+    print("\n# ---- extrapolation @ batch=1 ----", flush=True)
+    print(json.dumps(extrapolated, indent=2), flush=True)
+
+    report = {
+        "layer_counts": layer_counts,
+        "timings": timings,
+        "extrapolated_ms_per_step": extrapolated,
+    }
+    print("\n# ---- FULL JSON REPORT ----")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -3372,6 +3372,10 @@ async def update_global_settings(
         # and its burst fields are read fresh each decode burst
         # (EngineCore._step_burst), so this takes effect on the next token.
         max_steps, single_s = BURST_DECODE_MODES[mode]
+        # Seed the mode string directly (read by EngineConfig for the
+        # aggressive-mode concurrent-budget behavior; kept separate from
+        # burst_decode_env()'s numeric-only OMLX_DECODE_BURST_* mapping).
+        os.environ["OMLX_DECODE_BURST_MODE"] = mode
         from ..server import _server_state
 
         pool = _server_state.engine_pool
@@ -3389,6 +3393,8 @@ async def update_global_settings(
                 if cfg is not None and hasattr(cfg, "decode_burst_budget_single_s"):
                     cfg.decode_burst_max_steps = max_steps
                     cfg.decode_burst_budget_single_s = single_s
+                    if hasattr(cfg, "decode_burst_mode"):
+                        cfg.decode_burst_mode = mode
         runtime_applied.append("burst_decode_mode")
         logger.info(f"Burst Decode mode set to '{mode}'")
     if request.auto_start_on_launch is not None:

--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -308,6 +308,14 @@ class ChatCompletionRequest(BaseModel):
     specprefill_threshold: Optional[int] = None
     # Seed for reproducible generation (best-effort)
     seed: Optional[int] = None
+    # Admission-scheduling priority — lower value is served first (see
+    # Request.priority docstring). Only consulted when the scheduler's
+    # policy is PRIORITY (opt-in via OMLX_PRIORITY_SCHEDULING=1); ignored
+    # under the default FCFS policy, so omitting this field changes nothing.
+    # None (default) is treated as the lowest priority tier (background) once
+    # the policy is enabled — an explicit interactive caller must set a lower
+    # value (e.g. 0) to be served ahead of unmarked background traffic.
+    priority: Optional[int] = None
 
     @field_validator("stop", mode="before")
     @classmethod

--- a/omlx/cache/interactive_session_cache.py
+++ b/omlx/cache/interactive_session_cache.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Protected Multi-Turn Interactive Cache for oMLX.
+
+Stores trailing KV state from priority-zero completions for exact-prefix
+transfer on the next turn. Bounded by TTL, session count, and byte limit.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class InteractiveCacheEntry:
+    """A single cached trailing KV state from a priority-zero completion."""
+
+    token_ids: tuple[int, ...]
+    cache_data: list[Any]
+    model_cache_config: Any | None
+    size_bytes: int
+    expires_at: float
+    last_access: float
+
+
+class InteractiveSessionCache:
+    """Bounded LRU cache for interactive multi-turn trailing KV state.
+
+    Only priority-zero completions store entries. Entries are keyed by
+    exact token prefix. On hit, the entry is *transferred* (removed before
+    return) so the caller owns the cache data exclusively.
+
+    Bounds:
+        ttl_secs: entries expire after this duration
+        max_sessions: maximum number of entries
+        max_bytes: maximum total size in bytes
+    """
+
+    def __init__(
+        self,
+        ttl_secs: float = 600.0,
+        max_sessions: int = 64,
+        max_bytes: int = 2 * 1024 * 1024 * 1024,  # 2 GB
+        clock: Any = time.monotonic,
+    ):
+        self._entries: OrderedDict[tuple[int, ...], InteractiveCacheEntry] = OrderedDict()
+        self._ttl = ttl_secs
+        self._max_sessions = max_sessions
+        self._max_bytes = max_bytes
+        self._clock = clock
+        self._hits = 0
+        self._misses = 0
+        self._evictions = 0
+        self._total_bytes = 0
+
+    def put(
+        self,
+        token_ids: list[int],
+        cache_data: list[Any],
+        model_cache_config: Any | None = None,
+    ) -> bool:
+        """Store a trailing KV state from a priority-zero completion.
+
+        Returns True if stored, False if rejected (empty/oversized).
+        """
+        if not token_ids or not cache_data:
+            return False
+
+        key = tuple(token_ids)
+
+        # Estimate size — use len(cache_data) as proxy if no size_bytes available
+        size_bytes = self._estimate_size(cache_data)
+        if size_bytes > self._max_bytes:
+            logger.warning(
+                f"Interactive cache: entry too large ({size_bytes} bytes), rejecting"
+            )
+            return False
+
+        now = self._clock()
+        entry = InteractiveCacheEntry(
+            token_ids=key,
+            cache_data=cache_data,
+            model_cache_config=model_cache_config,
+            size_bytes=size_bytes,
+            expires_at=now + self._ttl,
+            last_access=now,
+        )
+
+        # Replace if same key
+        if key in self._entries:
+            old = self._entries.pop(key)
+            self._total_bytes -= old.size_bytes
+
+        self._entries[key] = entry
+        self._total_bytes += size_bytes
+
+        # Evict LRU until within bounds
+        self._evict_lru()
+
+        return True
+
+    def take_longest_prefix(
+        self, token_ids: list[int]
+    ) -> tuple[list[Any], Any | None, int] | None:
+        """Find and take the longest exact-prefix entry.
+
+        Returns (cache_data, model_cache_config, prefix_len) or None on miss.
+        The entry is removed before return (transfer semantics).
+        """
+        self._evict_expired()
+
+        key = tuple(token_ids)
+        best_entry: InteractiveCacheEntry | None = None
+        best_len = 0
+
+        # Check all entries for prefix match
+        for entry_key, entry in self._entries.items():
+            elen = len(entry_key)
+            if elen <= best_len:
+                continue
+            if elen > len(key):
+                continue
+            if key[:elen] == entry_key:
+                best_entry = entry
+                best_len = elen
+
+        if best_entry is None:
+            self._misses += 1
+            return None
+
+        # Transfer: remove before returning, deep-copy for exclusive ownership
+        self._entries.pop(best_entry.token_ids)
+        self._total_bytes -= best_entry.size_bytes
+        self._hits += 1
+
+        return copy.deepcopy(best_entry.cache_data), best_entry.model_cache_config, best_len
+
+    def evict_expired(self) -> int:
+        """Remove expired entries. Returns count removed."""
+        return self._evict_expired()
+
+    def _evict_expired(self) -> int:
+        now = self._clock()
+        expired = [k for k, v in self._entries.items() if v.expires_at <= now]
+        for k in expired:
+            entry = self._entries.pop(k)
+            self._total_bytes -= entry.size_bytes
+            self._evictions += 1
+        return len(expired)
+
+    def shrink_to(self, target_bytes: int, force: bool = False) -> int:
+        """Evict LRU entries until byte usage reaches target.
+
+        When force=False, retains unexpired protected entries when possible.
+        Returns bytes released.
+        """
+        released = 0
+        while self._total_bytes > target_bytes and self._entries:
+            # Find LRU entry
+            oldest_key = next(iter(self._entries))
+            entry = self._entries[oldest_key]
+
+            # Don't evict unexpired entries in non-force mode
+            if not force and entry.expires_at > self._clock():
+                break
+
+            self._entries.pop(oldest_key)
+            self._total_bytes -= entry.size_bytes
+            released += entry.size_bytes
+            self._evictions += 1
+
+        return released
+
+    def clear(self) -> int:
+        """Remove all entries. Returns bytes released."""
+        released = self._total_bytes
+        count = len(self._entries)
+        self._entries.clear()
+        self._total_bytes = 0
+        self._evictions += count
+        return released
+
+    def get_stats(self) -> dict[str, int | float]:
+        """Return cache statistics."""
+        return {
+            "hits": self._hits,
+            "misses": self._misses,
+            "evictions": self._evictions,
+            "bytes": self._total_bytes,
+            "sessions": len(self._entries),
+        }
+
+    @property
+    def total_bytes(self) -> int:
+        return self._total_bytes
+
+    @property
+    def session_count(self) -> int:
+        return len(self._entries)
+
+    def _evict_lru(self) -> None:
+        """Evict LRU entries until within bounds."""
+        while len(self._entries) > self._max_sessions:
+            oldest_key = next(iter(self._entries))
+            entry = self._entries.pop(oldest_key)
+            self._total_bytes -= entry.size_bytes
+            self._evictions += 1
+
+        while self._total_bytes > self._max_bytes and self._entries:
+            oldest_key = next(iter(self._entries))
+            entry = self._entries.pop(oldest_key)
+            self._total_bytes -= entry.size_bytes
+            self._evictions += 1
+
+    def _estimate_size(self, cache_data: list[Any]) -> int:
+        """Estimate byte size of cache data."""
+        # Each entry is roughly 128 bytes per layer * num_layers
+        # Use a conservative estimate based on list length
+        return len(cache_data) * 128

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -324,9 +324,21 @@ def serve_command(args):
         # with mx.synchronize()). See issue #300.
         import mlx.core as mx
 
+        # The MLX buffer-cache pool retains freed Metal buffers for reuse (avoids the M4
+        # allocator::free()-while-in-use race, issue #300). Left at `total_mem` the pool grows to
+        # fill ALL GPU memory over hours; the prefill memory guard then counts that (reclaimable)
+        # cache as "used" and rejects every prompt (predicted-peak > ceiling) — chat dies with the
+        # pins resident. Bound the pool via OMLX_CACHE_LIMIT_GB so live model weights + a bounded
+        # reuse pool + prefill headroom coexist under the Metal wired cap. Unset → old behavior.
         total_mem = mx.device_info().get("memory_size", 0)
-        if total_mem > 0:
-            mx.set_cache_limit(total_mem)
+        cache_limit = total_mem
+        if _limit_gb := os.getenv("OMLX_CACHE_LIMIT_GB"):
+            try:
+                cache_limit = int(float(_limit_gb) * 1024**3)
+            except ValueError:
+                print(f"[omlx] invalid OMLX_CACHE_LIMIT_GB={_limit_gb!r}; using total_mem")
+        if cache_limit > 0:
+            mx.set_cache_limit(cache_limit)
 
         # Initialize server
         # Note: pinned_models and default_model are managed via admin page (model_settings.json)

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -165,6 +165,11 @@ def serve_command(args):
     # engine construction (no restart needed when the mode changes later).
     for _key, _value in burst_decode_env(settings.server.burst_decode_mode).items():
         os.environ[_key] = _value
+    # Also seed the mode string itself. EngineConfig reads this directly
+    # (separate from burst_decode_env()'s numeric-only mapping) so
+    # "aggressive" can raise the concurrent decode budget to match the
+    # single-request one.
+    os.environ["OMLX_DECODE_BURST_MODE"] = settings.server.burst_decode_mode
 
     # Validate before persisting CLI overrides, so invalid flags never poison
     # settings.json.

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -681,9 +681,23 @@ class BatchedEngine(BaseEngine):
         )
 
         finished_normally = False
+        # Cache the cleaned text keyed on the raw cumulative value so repeated
+        # chunks with an unchanged output_text (the common case: the scheduler
+        # only populates it once, on the final chunk - see RequestOutput.output_text)
+        # skip re-running the special-token regex. Without this, cleaning was
+        # re-applied to the full cumulative text on every streamed token,
+        # which is O(N) per token / O(N^2) total for an N-token response if
+        # output_text is ever populated incrementally (e.g. by a future engine
+        # or a test double). clean_special_tokens is pure, so caching on an
+        # unchanged input is byte-identical to recomputing it.
+        last_raw_output_text: str | None = None
+        last_cleaned_text = ""
         try:
             async for output in engine.stream_outputs(request_id):
-                text = clean_special_tokens(output.output_text)
+                if output.output_text != last_raw_output_text:
+                    last_cleaned_text = clean_special_tokens(output.output_text)
+                    last_raw_output_text = output.output_text
+                text = last_cleaned_text
 
                 # Set finished_normally BEFORE yield, because the consumer
                 # may stop iterating after receiving the final output,

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -802,6 +802,7 @@ class BatchedEngine(BaseEngine):
         messages: list[dict[str, Any]],
         tools: list[dict] | None = None,
         request_id: str | None = None,
+        rendered_prompt: str | None = None,
         **kwargs,
     ) -> None:
         """Early prefill memory check for chat completions.
@@ -817,19 +818,27 @@ class BatchedEngine(BaseEngine):
         Cheap enough to run as a precondition: tokenization of even a
         100k-token chat takes tens of milliseconds compared to the many
         seconds the prefill it gates would consume.
+
+        Args:
+            rendered_prompt: Optional prompt already rendered by the caller
+                with identical messages/tools/chat_template_kwargs/is_partial
+                (e.g. from ``stream_chat``'s render). When given, skips
+                re-rendering the chat template and just encodes it.
         """
         if not self._loaded:
             await self.start()
-        messages = self._preprocess_messages(messages)
-        template_tools = convert_tools_for_template(tools) if tools else None
-        ct_kwargs = kwargs.get("chat_template_kwargs")
-        partial = kwargs.get("is_partial")
-        prompt = self._apply_chat_template(
-            messages,
-            template_tools,
-            chat_template_kwargs=ct_kwargs,
-            is_partial=partial,
-        )
+        prompt = rendered_prompt
+        if prompt is None:
+            messages = self._preprocess_messages(messages)
+            template_tools = convert_tools_for_template(tools) if tools else None
+            ct_kwargs = kwargs.get("chat_template_kwargs")
+            partial = kwargs.get("is_partial")
+            prompt = self._apply_chat_template(
+                messages,
+                template_tools,
+                chat_template_kwargs=ct_kwargs,
+                is_partial=partial,
+            )
         # Tokenizer errors (UnicodeDecodeError, HF Rust "Already borrowed",
         # malformed input) are normally surfaced by the real chat path's
         # add_request → tokenize call as a 500 — there's no path-specific
@@ -897,6 +906,7 @@ class BatchedEngine(BaseEngine):
         repetition_penalty: float = 1.0,
         presence_penalty: float = 0.0,
         tools: list[dict] | None = None,
+        rendered_prompt: str | None = None,
         **kwargs,
     ) -> AsyncIterator[GenerationOutput]:
         """
@@ -912,6 +922,12 @@ class BatchedEngine(BaseEngine):
             repetition_penalty: Repetition penalty (1.0 = disabled)
             presence_penalty: Presence penalty (0.0 = disabled)
             tools: Optional tool definitions
+            rendered_prompt: Optional prompt already rendered by the caller
+                with identical messages/tools/chat_template_kwargs/is_partial
+                (e.g. from ``preflight_chat``'s render). When given, skips
+                re-rendering the chat template. Messages are still
+                preprocessed/tools still converted below since SpecPrefill
+                (further down) needs them independently of the render.
             **kwargs: Additional model-specific parameters
 
         Yields:
@@ -929,12 +945,14 @@ class BatchedEngine(BaseEngine):
         # Apply chat template
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
         partial = kwargs.pop("is_partial", None)
-        prompt = self._apply_chat_template(
-            messages,
-            template_tools,
-            chat_template_kwargs=ct_kwargs,
-            is_partial=partial,
-        )
+        prompt = rendered_prompt
+        if prompt is None:
+            prompt = self._apply_chat_template(
+                messages,
+                template_tools,
+                chat_template_kwargs=ct_kwargs,
+                is_partial=partial,
+            )
 
         # SpecPrefill: compute system prompt token count for protection.
         # Can't template system-only messages (most templates require user),

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -322,6 +322,18 @@ class BatchedEngine(BaseEngine):
             except Exception:
                 logger.debug("sdpa256 attention patch not applied", exc_info=True)
 
+        # qwen3_5 ragged-decode SDPA kernel hardcodes a 1024-thread threadgroup
+        # that exceeds the per-kernel limit on some GPUs (M2 Ultra=896), hard-
+        # crashing mid-length prompts. Neutralize -> portable vector SDPA.
+        try:
+            from ..patches.qwen3_5_ragged_sdpa_threadgroup import (
+                apply_qwen3_5_ragged_sdpa_threadgroup_fix,
+            )
+
+            apply_qwen3_5_ragged_sdpa_threadgroup_fix()
+        except Exception:
+            logger.debug("qwen3_5 ragged SDPA fix not applied", exc_info=True)
+
         # Create engine config (copy to avoid mutating the shared instance)
         scheduler_config = (
             copy.copy(self._scheduler_config)

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -602,6 +602,7 @@ class BatchedEngine(BaseEngine):
         output = await self._engine.generate(
             prompt=prompt,
             sampling_params=sampling_params,
+            priority=kwargs.get("priority", 0),
         )
 
         text = clean_special_tokens(output.output_text)
@@ -689,6 +690,7 @@ class BatchedEngine(BaseEngine):
         request_id = await engine.add_request(
             prompt=prompt,
             sampling_params=sampling_params,
+            priority=kwargs.get("priority", 0),
             **specprefill_kwargs,
         )
 

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1514,6 +1514,18 @@ class VLMBatchedEngine(BaseEngine):
                 apply_sdpa256_attention_patch()
             except Exception:
                 logger.debug("sdpa256 attention patch not applied", exc_info=True)
+
+        # qwen3_5 ragged-decode SDPA kernel hardcodes a 1024-thread threadgroup
+        # that exceeds the per-kernel limit on some GPUs (M2 Ultra=896), hard-
+        # crashing mid-length prompts. Neutralize -> portable vector SDPA.
+        try:
+            from ..patches.qwen3_5_ragged_sdpa_threadgroup import (
+                apply_qwen3_5_ragged_sdpa_threadgroup_fix,
+            )
+
+            apply_qwen3_5_ragged_sdpa_threadgroup_fix()
+        except Exception:
+            logger.debug("qwen3_5 ragged SDPA fix not applied", exc_info=True)
         scheduler.refresh_ssd_layer_signature()
 
         # SpecPrefill: load draft model and pass to scheduler

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -2720,6 +2720,10 @@ class VLMBatchedEngine(BaseEngine):
         output = await self._engine.generate(
             prompt=prompt,
             sampling_params=sampling_params,
+            # Admission-scheduling priority: this non-streaming fast path bypasses
+            # stream_generate and was the hop that silently dropped every caller's
+            # priority for the primary chat model (see engine/batched.py pattern).
+            priority=kwargs.get("priority", 0),
             vlm_inputs_embeds=vlm_inputs_embeds,
             vlm_extra_kwargs=vlm_extra_kwargs,
             vlm_image_hash=vlm_image_hash,
@@ -2841,6 +2845,11 @@ class VLMBatchedEngine(BaseEngine):
         request_id = await engine.add_request(
             prompt=prompt,
             sampling_params=sampling_params,
+            # Admission-scheduling priority (same forwarding as engine/batched.py).
+            # Without this the VLM engine — which serves the PRIMARY chat model —
+            # silently dropped every caller's priority to the default, making
+            # OMLX_PRIORITY_SCHEDULING and slot reservation inert for it.
+            priority=kwargs.get("priority", 0),
             vlm_inputs_embeds=vlm_inputs_embeds,
             vlm_extra_kwargs=vlm_extra_kwargs,
             vlm_image_hash=vlm_image_hash,

--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -556,6 +556,7 @@ class EngineCore:
         specprefill_keep_pct: Optional[float] = None,
         specprefill_threshold: Optional[int] = None,
         specprefill_system_end: Optional[int] = None,
+        priority: int = 0,
     ) -> str:
         """
         Add a request for processing.
@@ -572,6 +573,10 @@ class EngineCore:
             specprefill: Per-request SpecPrefill override (True/False/None)
             specprefill_keep_pct: Per-request keep rate override
             specprefill_threshold: Per-request threshold override (min tokens)
+            priority: Scheduling priority, lower = served first. Only
+                consulted when the scheduler's policy is PRIORITY (opt-in via
+                OMLX_PRIORITY_SCHEDULING=1); ignored under the default FCFS
+                policy. Default 0 (equal priority = arrival order preserved).
 
         Returns:
             The request ID
@@ -586,6 +591,7 @@ class EngineCore:
             request_id=request_id,
             prompt=prompt,
             sampling_params=sampling_params,
+            priority=priority,
             images=images,
             videos=videos,
             vlm_inputs_embeds=vlm_inputs_embeds,

--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -173,6 +173,24 @@ class EngineConfig:
             os.environ.get("OMLX_DECODE_BURST_BUDGET_S", "0.03")
         )
     )
+    # Burst Decode UI mode (see settings.BURST_DECODE_MODES: off/light/balanced/
+    # aggressive). Only "aggressive" changes behavior here: it lets concurrent
+    # requests share the same (larger) single-request budget below instead of
+    # the tighter decode_burst_budget_s, since an operator who opted into the
+    # fastest mode wants that under concurrency too (the ~0.03s concurrent
+    # default measured ~8% throughput loss vs. the single-request budget - see
+    # _step_burst). Seeded directly as OMLX_DECODE_BURST_MODE by cli.py /
+    # admin routes (kept separate from burst_decode_env()'s numeric-only
+    # mapping so that mapping's env-var set is unchanged).
+    decode_burst_mode: str = field(
+        default_factory=lambda: os.environ.get("OMLX_DECODE_BURST_MODE", "balanced")
+    )
+    # Whether OMLX_DECODE_BURST_BUDGET_S was explicitly set by the operator
+    # (vs. left at its coded default). An explicit value always wins over the
+    # aggressive-mode behavior above.
+    decode_burst_budget_s_explicit: bool = field(
+        default_factory=lambda: "OMLX_DECODE_BURST_BUDGET_S" in os.environ
+    )
 
 
 class EngineCore:
@@ -333,13 +351,22 @@ class EngineCore:
             return outputs
         # Adaptive budget: single active request -> aggressive (nothing else to
         # stay responsive to); concurrent -> tight to keep admission/abort low.
+        # Exception: "aggressive" mode's whole point is favoring throughput, so
+        # unless the operator explicitly pinned decode_burst_budget_s, give
+        # concurrent requests the same budget as solo ones instead of the
+        # tighter default (measured ~8% throughput loss from the extra
+        # per-burst GIL hand-offs under concurrency).
         running = getattr(self.scheduler, "running", None)
         single = running is None or len(running) <= 1
-        budget = (
-            self.config.decode_burst_budget_single_s
-            if single
-            else self.config.decode_burst_budget_s
-        )
+        if single:
+            budget = self.config.decode_burst_budget_single_s
+        elif (
+            self.config.decode_burst_mode == "aggressive"
+            and not self.config.decode_burst_budget_s_explicit
+        ):
+            budget = self.config.decode_burst_budget_single_s
+        else:
+            budget = self.config.decode_burst_budget_s
         if budget <= 0:
             return outputs
         deadline = time.monotonic() + budget

--- a/omlx/patches/qwen3_5_fused_decode/__init__.py
+++ b/omlx/patches/qwen3_5_fused_decode/__init__.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused decode-step patch for mlx-lm's Qwen3.5/3.6 ``GatedDeltaNet``.
+
+Wraps ``mlx_lm.models.qwen3_5.GatedDeltaNet.__call__`` (shared by the
+``qwen3_5`` and ``qwen3_5_moe`` model types — ``qwen3_5_moe.Model``
+subclasses ``qwen3_5.Model``) with a fast path that runs a single fused
+Metal kernel (see ``kernel.py``) covering the conv1d/SiLU/split/q-k-RMSNorm/
+gating "glue" AND the delta-rule scan of a T==1 decode step in one dispatch
+(see ``kernel.py``'s module docstring for why a two-kernel split — fused
+glue kernel + the existing unmodified scan kernel — was tried first and
+measured to fall short of the perf gate, and why merging into one dispatch
+was the fix).
+
+Composes with the Native-MTP patch (``omlx.patches.mlx_lm_mtp``), which also
+replaces ``GatedDeltaNet.__call__`` (for sanitize correctness, independent of
+whether MTP decoding is active) and may run before or after this one across
+repeated model loads in the same process. This patch always captures
+whatever ``__call__`` is *currently* installed as its fallback and always
+re-applies itself as long as it isn't already the topmost layer — so it
+self-heals regardless of application order, mirroring the MTP patch's own
+idempotency pattern. The fast path only ever engages for the plain T==1,
+no-mask, warm-cache, non-distributed, non-training case; everything else
+(prefill, n_confirmed draft/verify splits, first token of a sequence,
+padded/heterogeneous batches, sharded layers, non-Metal/CPU) falls straight
+through to that captured fallback, so composing with MTP or DFlash's
+lifecycle wrapping never loses correctness -- it just skips the fast path.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_PATCH_MARKER = "_omlx_qwen3_5_fused_decode_patch"
+
+
+def apply_qwen3_5_fused_decode_patch() -> bool:
+    """Patch ``mlx_lm.models.qwen3_5.GatedDeltaNet.__call__``. Idempotent.
+
+    Returns True when (re-)applied, False when the current ``__call__`` is
+    already this patch's own installed function.
+    """
+    try:
+        from mlx_lm.models import qwen3_5 as q35
+    except ImportError:
+        logger.debug("qwen3_5_fused_decode: mlx_lm.models.qwen3_5 not importable")
+        return False
+
+    from .kernel import fused_gdn_decode_step, is_available
+
+    cls = q35.GatedDeltaNet
+    current_call = cls.__dict__.get("__call__")
+    if getattr(current_call, _PATCH_MARKER, False):
+        return False
+
+    fallback_call = current_call
+
+    def _fused_forward(self, inputs, cache):
+        B, S, _ = inputs.shape
+        qkv = self.in_proj_qkv(inputs)
+        z = self.in_proj_z(inputs).reshape(B, S, self.num_v_heads, self.head_v_dim)
+        b = self.in_proj_b(inputs)
+        a = self.in_proj_a(inputs)
+
+        y, conv_state_out, delta_state_out = fused_gdn_decode_step(
+            qkv,
+            cache[0],
+            self.conv1d.weight,
+            b,
+            a,
+            self.dt_bias,
+            self.A_log,
+            cache[1],
+            num_k_heads=self.num_k_heads,
+            num_v_heads=self.num_v_heads,
+            head_k_dim=self.head_k_dim,
+            head_v_dim=self.head_v_dim,
+        )
+        cache[0] = conv_state_out
+        cache[1] = delta_state_out
+        cache.advance(S)
+
+        out = self.norm(y, z)
+        return self.out_proj(out.reshape(B, S, -1))
+
+    def patched_call(self, inputs, mask=None, cache=None):
+        B, S, _ = inputs.shape
+        if (
+            S == 1
+            and mask is None
+            and cache is not None
+            and cache[0] is not None
+            and cache[1] is not None
+            and getattr(cache, "lengths", None) is None
+            and self.sharding_group is None
+            and not self.training
+            and is_available()
+        ):
+            return _fused_forward(self, inputs, cache)
+        return fallback_call(self, inputs, mask, cache)
+
+    setattr(patched_call, _PATCH_MARKER, True)
+    cls.__call__ = patched_call
+    logger.info(
+        "qwen3_5_fused_decode: patched mlx_lm.models.qwen3_5.GatedDeltaNet.__call__"
+    )
+    return True
+
+
+__all__ = ["apply_qwen3_5_fused_decode_patch"]

--- a/omlx/patches/qwen3_5_fused_decode/kernel.py
+++ b/omlx/patches/qwen3_5_fused_decode/kernel.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused Metal kernel for a GatedDeltaNet T==1 decode step.
+
+Profiling on M2 Ultra (Ornith-1.0-35B-4bit, B=1 decode) found the 30
+linear-attention (GatedDeltaNet) layers cost ~6.28ms/step, of which only
+~1.9ms is the recurrent delta-rule scan (``mlx_lm.models.gated_delta.
+gated_delta_kernel``, itself a hand-written ``mx.fast.metal_kernel``). The
+remaining ~3.75ms is ~15 tiny dispatches per layer: the causal depthwise
+conv1d + SiLU, the q/k/v split, the q/k RMS-normalization, and the beta/g
+gating prep (``sigmoid`` + ``compute_g``'s exp/softplus/exp chain).
+
+First attempt (kept for the record, see git history / task report): fusing
+just that "glue" into its own single ``mx.fast.metal_kernel`` and keeping
+the existing scan kernel as a second, unmodified dispatch. Measured
+honestly, this did NOT hit the perf gate -- MLX's own native ops (conv1d,
+``mx.fast.rms_norm``, the ``mx.compile``d ``compute_g``) already batch
+cheaply inside one lazy Mode-A graph, so a hand-written custom kernel
+covering the same ops was a wash (sometimes slightly slower) once its own
+per-call Python/argument-marshaling overhead is counted. The dominant real
+cost at B=1 turned out to be the *fixed per-custom-kernel-dispatch overhead*
+itself (empirically ~20-50us/call on this hardware), not the glue's op
+count -- so two custom kernels (glue + scan) cost about the same as zero
+custom kernels for the glue (native ops) plus one for the scan.
+
+This module instead fuses conv+silu+split+q/k-RMSNorm+beta/g-gating
+*directly into the scan kernel's own dispatch*, eliminating the second
+custom-kernel call entirely (down to ONE dispatch total for everything
+except the ``nn.Linear`` matmuls and the final output ``RMSNormGated``).
+It reuses the scan kernel's exact grid/threadgroup layout and inner-loop
+math verbatim; the new work is computed per-thread as registers (never
+materialized as intermediate q/k/v/beta/g tensors), which also removes the
+HBM round-trip the two-kernel design paid for those six tensors.
+
+Grid layout (unchanged from ``mlx_lm.models.gated_delta.gated_delta_kernel``):
+``grid=(32, Dv, B*Hv)``, ``threadgroup=(32, 4, 1)`` -- one thread per
+``(dk-lane, dv, b*Hv+hv)``. Per thread:
+
+  - q/k: ``head_k_dim`` is covered by the 32 dk-lanes (``n_per_t =
+    head_k_dim // 32`` values per lane, exactly mirroring the scan's own
+    ``s_idx`` indexing). Each lane computes conv1d+SiLU for its own
+    ``n_per_t`` channels of its head, then a single ``simd_sum`` across the
+    32 lanes (one simdgroup, no cross-simdgroup reduction or
+    threadgroup_barrier needed) gives the full RMS-norm denominator for
+    that head. This work is redundant across the ``Dv`` different
+    threadgroups in the grid's y-dimension that all share the same
+    ``(b, hv)`` (q/k don't depend on ``dv``) and across the ``Hv/Hk``
+    v-heads that share a k/q head -- cheap ALU work traded for zero
+    synchronization, which is the right trade on a GPU that is
+    launch/bandwidth-bound at this tensor size, not compute-bound.
+  - v: a single conv1d+SiLU value for this thread's own ``(b, hv, dv)`` --
+    no reduction needed (v has no norm).
+  - beta/g: recomputed redundantly per thread from the tiny per-head
+    scalars -- five cheap float ops, far below the cost of any
+    synchronization that would be needed to share it instead.
+  - conv cache update: exactly one designated thread per output channel
+    writes ``cache[0]``'s shifted window (guarded so the ``Hk*2 + Hv``
+    channel groups are each written by exactly one thread, not the
+    redundant copies above).
+  - scan: the existing kernel's inner-loop body verbatim (decay, delta,
+    output, state write-back), just fed q/k/v/beta/g from registers
+    instead of global-memory reads.
+
+The output RMSNormGated (+ z-gate) stays OUTSIDE this kernel and runs as
+the native ``mx.fast.rms_norm`` op: it needs a reduction over the full 128
+``head_v_dim`` values per ``(b, hv)``, which live in ``Dv/4 = 32`` different
+threadgroups in this grid (each only owns a 4-wide slice of ``dv``) --
+folding that reduction in would need either a threadgroup of 32*128=4096
+threads (over the ~1024 Metal per-threadgroup limit) or a second pass, so
+it remains the native op (itself already a fused/optimized primitive, not
+naive multi-op) rather than a third custom dispatch.
+
+Specialized to conv_kernel_size == 4 (3 history steps + 1 new activation,
+unrolled) -- the only value this model family ships.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+_SOURCE = """
+    auto n = thread_position_in_grid.z;        // b * Hv + hv_idx
+    auto b_idx = n / Hv;
+    auto hv_idx = n % Hv;
+    constexpr int hv_per_hk = Hv / Hk;
+    auto hk_idx = hv_idx / hv_per_hk;
+    constexpr int n_per_t = Dk / 32;
+
+    auto dk_lane = thread_position_in_threadgroup.x;   // 0 .. 31
+    auto dv_idx  = thread_position_in_grid.y;          // 0 .. Dv-1
+
+    constexpr uint KeyDim   = (uint)Hk * (uint)Dk;
+    constexpr uint ValueDim = (uint)Hv * (uint)Dv;
+    constexpr uint ConvDim  = 2u * KeyDim + ValueDim;
+
+    // Exactly one (dv_idx, hv_idx-representative) thread group writes each
+    // q/k conv-cache channel, even though every thread recomputes q/k.
+    bool is_conv_writer = (dv_idx == 0) && (hv_idx % (uint)hv_per_hk == 0);
+
+    // ---- q/k: conv1d + SiLU for this lane's n_per_t channels, then a
+    // single simd_sum (one simdgroup = all 32 dk-lanes) for the RMS-norm
+    // denominator over the full head_k_dim. ----
+    float q_local[n_per_t];
+    float k_local[n_per_t];
+    float q_sumsq = 0.0f;
+    float k_sumsq = 0.0f;
+
+    for (int i = 0; i < n_per_t; ++i) {
+        uint local_dk = (uint)n_per_t * dk_lane + (uint)i;
+        uint qchan = hk_idx * (uint)Dk + local_dk;
+        uint kchan = KeyDim + hk_idx * (uint)Dk + local_dk;
+
+        auto qw  = conv1d_weight + qchan * 4u;
+        auto qcs = conv_state_in + b_idx * 3u * ConvDim + qchan;
+        float qacc = float(qw[0]) * float(qcs[0 * ConvDim])
+                   + float(qw[1]) * float(qcs[1 * ConvDim])
+                   + float(qw[2]) * float(qcs[2 * ConvDim]);
+        float q_new = float(qkv[b_idx * ConvDim + qchan]);
+        qacc += float(qw[3]) * q_new;
+        float q_conv = qacc * (1.0f / (1.0f + metal::fast::exp(-qacc)));
+        q_local[i] = q_conv;
+        q_sumsq += q_conv * q_conv;
+
+        auto kw  = conv1d_weight + kchan * 4u;
+        auto kcs = conv_state_in + b_idx * 3u * ConvDim + kchan;
+        float kacc = float(kw[0]) * float(kcs[0 * ConvDim])
+                   + float(kw[1]) * float(kcs[1 * ConvDim])
+                   + float(kw[2]) * float(kcs[2 * ConvDim]);
+        float k_new = float(qkv[b_idx * ConvDim + kchan]);
+        kacc += float(kw[3]) * k_new;
+        float k_conv = kacc * (1.0f / (1.0f + metal::fast::exp(-kacc)));
+        k_local[i] = k_conv;
+        k_sumsq += k_conv * k_conv;
+
+        if (is_conv_writer) {
+            conv_state_out[(b_idx * 3u + 0u) * ConvDim + qchan] = qcs[1 * ConvDim];
+            conv_state_out[(b_idx * 3u + 1u) * ConvDim + qchan] = qcs[2 * ConvDim];
+            conv_state_out[(b_idx * 3u + 2u) * ConvDim + qchan] = static_cast<InT>(q_new);
+            conv_state_out[(b_idx * 3u + 0u) * ConvDim + kchan] = kcs[1 * ConvDim];
+            conv_state_out[(b_idx * 3u + 1u) * ConvDim + kchan] = kcs[2 * ConvDim];
+            conv_state_out[(b_idx * 3u + 2u) * ConvDim + kchan] = static_cast<InT>(k_new);
+        }
+    }
+    q_sumsq = simd_sum(q_sumsq);
+    k_sumsq = simd_sum(k_sumsq);
+    float q_rms_inv = metal::rsqrt(q_sumsq / float(Dk) + 1e-6f);
+    float k_rms_inv = metal::rsqrt(k_sumsq / float(Dk) + 1e-6f);
+    float inv_scale = metal::rsqrt(float(Dk));
+    float q_scale = q_rms_inv * (1.0f / float(Dk));   // inv_scale^2 = 1/Dk
+    float k_scale = k_rms_inv * inv_scale;
+
+    // ---- v: single conv1d + SiLU value for this thread's (b, hv, dv) ----
+    uint vchan = 2u * KeyDim + hv_idx * (uint)Dv + dv_idx;
+    auto vw  = conv1d_weight + vchan * 4u;
+    auto vcs = conv_state_in + b_idx * 3u * ConvDim + vchan;
+    float vacc = float(vw[0]) * float(vcs[0 * ConvDim])
+               + float(vw[1]) * float(vcs[1 * ConvDim])
+               + float(vw[2]) * float(vcs[2 * ConvDim]);
+    float v_new = float(qkv[b_idx * ConvDim + vchan]);
+    vacc += float(vw[3]) * v_new;
+    float v_val = vacc * (1.0f / (1.0f + metal::fast::exp(-vacc)));
+    if (dk_lane == 0) {
+        conv_state_out[(b_idx * 3u + 0u) * ConvDim + vchan] = vcs[1 * ConvDim];
+        conv_state_out[(b_idx * 3u + 1u) * ConvDim + vchan] = vcs[2 * ConvDim];
+        conv_state_out[(b_idx * 3u + 2u) * ConvDim + vchan] = static_cast<InT>(v_new);
+    }
+
+    // ---- gating: beta = sigmoid(b), g = exp(-exp(A_log) * softplus(a+dt_bias)) ----
+    float b_val = float(b_lin[b_idx * (uint)Hv + hv_idx]);
+    float beta_val = 1.0f / (1.0f + metal::fast::exp(-b_val));
+    float xg = float(a_lin[b_idx * (uint)Hv + hv_idx]) + float(dt_bias[hv_idx]);
+    float sp = metal::max(xg, 0.0f)
+             + metal::log(1.0f + metal::fast::exp(-metal::fabs(xg)));
+    float alog = float(A_log[hv_idx]);
+    float g_val = metal::fast::exp(-metal::fast::exp(alog) * sp);
+
+    // ---- scan: mlx_lm.models.gated_delta.gated_delta_kernel's inner-loop
+    // body verbatim (T==1: the per-timestep loop collapses to one pass),
+    // fed from the registers above instead of global-memory reads. ----
+    auto i_state = delta_state_in  + (n * (uint)Dv + dv_idx) * (uint)Dk;
+    auto o_state = delta_state_out + (n * (uint)Dv + dv_idx) * (uint)Dk;
+
+    float state[n_per_t];
+    for (int i = 0; i < n_per_t; ++i) {
+        uint s_idx = (uint)n_per_t * dk_lane + (uint)i;
+        state[i] = static_cast<float>(i_state[s_idx]);
+    }
+
+    float kv_mem = 0.0f;
+    for (int i = 0; i < n_per_t; ++i) {
+        state[i] = state[i] * g_val;
+        kv_mem += state[i] * (k_local[i] * k_scale);
+    }
+    kv_mem = simd_sum(kv_mem);
+
+    float delta = (v_val - kv_mem) * beta_val;
+
+    float out = 0.0f;
+    for (int i = 0; i < n_per_t; ++i) {
+        state[i] = state[i] + (k_local[i] * k_scale) * delta;
+        out += state[i] * (q_local[i] * q_scale);
+    }
+    out = simd_sum(out);
+    if (thread_index_in_simdgroup == 0) {
+        y[n * (uint)Dv + dv_idx] = static_cast<InT>(out);
+    }
+    for (int i = 0; i < n_per_t; ++i) {
+        uint s_idx = (uint)n_per_t * dk_lane + (uint)i;
+        o_state[s_idx] = static_cast<StT>(state[i]);
+    }
+"""
+
+_kernel = None
+_kernel_build_attempted = False
+
+
+def _get_kernel():
+    global _kernel, _kernel_build_attempted
+    if _kernel_build_attempted:
+        return _kernel
+    _kernel_build_attempted = True
+    if not mx.metal.is_available():
+        return None
+    _kernel = mx.fast.metal_kernel(
+        name="qwen3_5_gdn_decode_step",
+        input_names=[
+            "qkv",
+            "conv_state_in",
+            "conv1d_weight",
+            "b_lin",
+            "a_lin",
+            "dt_bias",
+            "A_log",
+            "delta_state_in",
+        ],
+        output_names=["y", "conv_state_out", "delta_state_out"],
+        source=_SOURCE,
+        ensure_row_contiguous=True,
+    )
+    return _kernel
+
+
+def is_available() -> bool:
+    return (
+        mx.default_device() == mx.gpu
+        and mx.metal.is_available()
+        and _get_kernel() is not None
+    )
+
+
+def fused_gdn_decode_step(
+    qkv: mx.array,
+    conv_state_in: mx.array,
+    conv1d_weight: mx.array,
+    b_lin: mx.array,
+    a_lin: mx.array,
+    dt_bias: mx.array,
+    A_log: mx.array,
+    delta_state_in: mx.array,
+    *,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_k_dim: int,
+    head_v_dim: int,
+):
+    """Fused conv1d+SiLU+split+q/k-RMSNorm+gating+delta-scan for T==1 decode.
+
+    Args (all T==1, pre-flattened over the trivial sequence axis internally):
+      qkv:            (B, 1, conv_dim)  -- in_proj_qkv(inputs)
+      conv_state_in:  (B, 3, conv_dim)  -- cache[0] (conv_kernel_size-1 == 3)
+      conv1d_weight:  (conv_dim, 4, 1)  -- GatedDeltaNet.conv1d.weight
+      b_lin, a_lin:   (B, 1, num_v_heads) -- in_proj_b/a(inputs)
+      dt_bias:        (num_v_heads,)
+      A_log:          (num_v_heads,) float32
+      delta_state_in: (B, num_v_heads, head_v_dim, head_k_dim) -- cache[1]
+
+    Returns (y, conv_state_out, delta_state_out):
+      y:              (B, 1, num_v_heads, head_v_dim)  dtype == qkv.dtype
+                       (ready for ``GatedDeltaNet.norm(y, z)`` then out_proj)
+      conv_state_out: (B, 3, conv_dim)                 dtype == qkv.dtype
+      delta_state_out:(B, num_v_heads, head_v_dim, head_k_dim) dtype == delta_state_in.dtype
+
+    Specialized to conv_kernel_size == 4 and num_v_heads % num_k_heads == 0.
+    """
+    kernel = _get_kernel()
+    assert kernel is not None, "fused_gdn_decode_step requires Metal"
+    assert conv1d_weight.shape[1] == 4, "kernel is specialized to conv_kernel_size=4"
+    assert conv_state_in.shape[1] == 3, "kernel is specialized to conv_kernel_size=4"
+    assert head_k_dim % 32 == 0, "kernel assumes a 32-wide simdgroup divides head_k_dim"
+    assert num_v_heads % num_k_heads == 0
+
+    B = qkv.shape[0]
+    Hk, Hv = num_k_heads, num_v_heads
+    Dk, Dv = head_k_dim, head_v_dim
+    key_dim = Hk * Dk
+    value_dim = Hv * Dv
+    conv_dim = 2 * key_dim + value_dim
+    assert conv1d_weight.shape[0] == conv_dim
+
+    y, conv_state_out, delta_state_out = kernel(
+        inputs=[
+            qkv,
+            conv_state_in,
+            conv1d_weight,
+            b_lin,
+            a_lin,
+            dt_bias,
+            A_log,
+            delta_state_in,
+        ],
+        template=[
+            ("InT", qkv.dtype),
+            ("StT", delta_state_in.dtype),
+            ("Hk", Hk),
+            ("Hv", Hv),
+            ("Dk", Dk),
+            ("Dv", Dv),
+        ],
+        grid=(32, Dv, B * Hv),
+        threadgroup=(32, 4, 1),
+        output_shapes=[
+            (B, 1, Hv, Dv),
+            (B, 3, conv_dim),
+            (B, Hv, Dv, Dk),
+        ],
+        output_dtypes=[qkv.dtype, qkv.dtype, delta_state_in.dtype],
+    )
+    return y, conv_state_out, delta_state_out
+
+
+__all__ = ["fused_gdn_decode_step", "is_available"]

--- a/omlx/patches/qwen3_5_ragged_sdpa_threadgroup.py
+++ b/omlx/patches/qwen3_5_ragged_sdpa_threadgroup.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Guard the qwen3_5 ragged-decode SDPA fast kernel against GPUs whose per-kernel
+threadgroup limit is below its hardcoded 1024-thread launch.
+
+``mlx_vlm.models.qwen3_5.language._qwen3_5_ragged_decode_attention`` dispatches a
+custom Metal kernel (``_qwen3_5_ragged_sdpa_*``) with ``threadgroup=(1024, 1, 1)``
+— 32 simdgroups x 32 lanes (``constexpr int BN = 32; BD = 32``). That 1024 is
+STRUCTURAL: the kernel's final cross-simdgroup reduction maps the 32 per-simdgroup
+partials onto the 32 lanes of a single simdgroup, so the launch cannot be clamped
+below 32*32 without corrupting attention outputs.
+
+On GPUs where that compiled kernel's pipeline ``maxTotalThreadsPerThreadgroup`` is
+< 1024 (e.g. an M2 Ultra reports 896 for it, driven by register pressure), EVERY
+dispatch hard-crashes:
+
+    RuntimeError: Thread group size (1024) is greater than the maximum allowed
+    threads per threadgroup (896).
+
+That 500s any request whose head_dim=256 full-attention layers reach this path —
+i.e. essentially all mid-length chat prompts (~1k-8k prompt tokens). It surfaces
+async via ``engine_core._raise_request_output_error`` (the model builds the graph
+lazily; the kernel error is captured on the RequestOutput at ``mx.async_eval``
+time), so the traceback points at the sampling/eval step, not the kernel.
+
+Fix: neutralize the fast kernel so full-attention falls back to MLX's portable
+vector SDPA. head_dim 256 IS supported by MLX's fused vector kernel
+(``_SDPA_VECTOR_SUPPORTED_HEAD_DIMS`` includes 256) and it respects the per-kernel
+threadgroup limit, so the fallback is correct and crash-free. The only cost is the
+ragged-batch decode micro-optimization on affected GPUs.
+
+Default: disabled (the ragged kernel is neutralized) — it is fragile by
+construction (a hardcoded >warp*32 threadgroup that many Apple GPUs cap below
+1024). Set ``OMLX_QWEN35_RAGGED_SDPA_KEEP=1`` to keep the fast kernel on GPUs
+where it is known to run (its pipeline supports 1024 threads).
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_PATCHED = False
+
+
+def apply_qwen3_5_ragged_sdpa_threadgroup_fix() -> bool:
+    """Neutralize the qwen3_5 ragged-decode fast SDPA kernel unless explicitly
+    kept, so full-attention falls back to the threadgroup-safe portable SDPA.
+
+    Idempotent; returns True if the neutralizing patch was installed."""
+    global _PATCHED
+    if _PATCHED:
+        return False
+    if os.environ.get("OMLX_QWEN35_RAGGED_SDPA_KEEP") == "1":
+        logger.info(
+            "qwen3_5 ragged SDPA kernel kept (OMLX_QWEN35_RAGGED_SDPA_KEEP=1)"
+        )
+        return False
+
+    try:
+        from mlx_vlm.models.qwen3_5 import language as q35
+    except ImportError:
+        return False
+
+    if not hasattr(q35, "_qwen3_5_ragged_decode_attention"):
+        return False
+
+    def _ragged_decode_disabled(queries, keys, values, pads, scale):
+        # Return None -> caller falls back to portable per-pad-group
+        # scaled_dot_product_attention (MLX vector kernel, head_dim=256 safe).
+        return None
+
+    q35._qwen3_5_ragged_decode_attention = _ragged_decode_disabled
+    _PATCHED = True
+    logger.info(
+        "qwen3_5 ragged SDPA fast kernel disabled (threadgroup 1024 > per-kernel "
+        "limit on this GPU); using portable vector SDPA fallback"
+    )
+    return True

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import os
 import subprocess
 import time
 from contextlib import suppress
@@ -250,6 +251,104 @@ def _apply_metal_wired_limit(desired_bytes: int) -> tuple[int, int | None]:
         return 0, None
 
 
+
+class AdaptiveCacheController:
+    """
+    Pressure-coupled MLX buffer-cache pool (OMLX_ADAPTIVE_CACHE=1).
+
+    When HOST memory used% crosses `trigger_pct`, shrink the MLX buffer-reuse
+    pool to `shrink_bytes` (mx.set_cache_limit) and clear it immediately
+    (mx.clear_cache) — reclaiming the pool costs milliseconds, whereas the
+    enforcer's next rung (whole-model eviction) costs a 30-60s reload and
+    chat 502s. When used% falls below trigger - hysteresis, restore the
+    startup limit so throughput recovers.
+
+    Origin: invented by athena-sim's evolutionary search (2026-07-10 evolve
+    run: "AdaptiveCache shrink 2.6G @79% used" survived selection), then
+    hand-ported here. Staged rollout, same env-toggle pattern as
+    OMLX_PRIORITY_SCHEDULING / OMLX_CACHE_LIMIT_GB: default OFF = byte-
+    identical behaviour.
+    """
+
+    def __init__(
+        self,
+        enabled: bool,
+        shrink_bytes: int,
+        trigger_pct: float,
+        hysteresis_pct: float = 4.0,
+        set_cache_limit=None,
+        clear_cache=None,
+        base_limit_bytes: int | None = None,
+    ) -> None:
+        self.enabled = enabled
+        self._shrink_bytes = max(0, shrink_bytes)
+        self._trigger_pct = trigger_pct
+        self._restore_pct = trigger_pct - hysteresis_pct
+        self._set_cache_limit = set_cache_limit or mx.set_cache_limit
+        self._clear_cache = clear_cache or mx.clear_cache
+        self._base_limit_bytes = base_limit_bytes
+        self.shrunk = False
+
+    @classmethod
+    def from_env(cls) -> "AdaptiveCacheController":
+        enabled = os.environ.get("OMLX_ADAPTIVE_CACHE") == "1"
+
+        def _f(name: str, default: float) -> float:
+            try:
+                return float(os.environ.get(name, "") or default)
+            except ValueError:
+                return default
+
+        return cls(
+            enabled=enabled,
+            shrink_bytes=int(_f("OMLX_ADAPTIVE_CACHE_SHRINK_GB", 2.6) * 1024**3),
+            trigger_pct=_f("OMLX_ADAPTIVE_CACHE_TRIGGER_PCT", 79.0),
+        )
+
+    def _base_limit(self) -> int:
+        """Startup pool limit to restore to — same derivation as cli.py."""
+        if self._base_limit_bytes is not None:
+            return self._base_limit_bytes
+        limit = 0
+        if limit_gb := os.environ.get("OMLX_CACHE_LIMIT_GB"):
+            try:
+                limit = int(float(limit_gb) * 1024**3)
+            except ValueError:
+                limit = 0
+        if limit <= 0:
+            limit = int(mx.device_info().get("memory_size", 0)) or 1024**3
+        self._base_limit_bytes = limit
+        return limit
+
+    def maybe_adjust(self, host_used_pct: float) -> None:
+        """One hysteresis step; called from the enforcer poll loop."""
+        if not self.enabled:
+            return
+        if not self.shrunk and host_used_pct >= self._trigger_pct:
+            self._set_cache_limit(self._shrink_bytes)
+            self._clear_cache()
+            self.shrunk = True
+            logger.info(
+                "AdaptiveCache SHRINK: host used %.1f%% >= %.1f%% -> cache pool "
+                "limited to %.1f GiB and cleared (restore below %.1f%%)",
+                host_used_pct,
+                self._trigger_pct,
+                self._shrink_bytes / 1024**3,
+                self._restore_pct,
+            )
+        elif self.shrunk and host_used_pct <= self._restore_pct:
+            base = self._base_limit()
+            self._set_cache_limit(base)
+            self.shrunk = False
+            logger.info(
+                "AdaptiveCache RESTORE: host used %.1f%% <= %.1f%% -> cache pool "
+                "limit back to %.1f GiB",
+                host_used_pct,
+                self._restore_pct,
+                base / 1024**3,
+            )
+
+
 class ProcessMemoryEnforcer:
     """
     Background task that enforces process-level memory limits.
@@ -301,6 +400,7 @@ class ProcessMemoryEnforcer:
             prefill_min_chunk_tokens: Floor for adaptive shrink.
         """
         self._engine_pool = engine_pool
+        self._adaptive_cache = AdaptiveCacheController.from_env()
         self._memory_guard_tier = self._normalize_tier(memory_guard_tier)
         self._memory_guard_custom_ceiling_bytes = max(
             0, int(memory_guard_custom_ceiling_gb * 1024**3)
@@ -1211,6 +1311,15 @@ class ProcessMemoryEnforcer:
         # Always propagate so the scheduler sees the latest ceiling /
         # admission_paused, even when usage stays below the soft mark.
         self._propagate_memory_limit()
+
+        # AdaptiveCache: reclaim the MLX buffer-reuse pool under HOST pressure
+        # BEFORE the eviction ladder gets a chance to unload whole models.
+        if self._adaptive_cache.enabled:
+            try:
+                vm = psutil_compat.virtual_memory()
+                self._adaptive_cache.maybe_adjust(float(getattr(vm, "percent", 0.0)))
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("AdaptiveCache host-memory read failed: %s", exc)
 
         ceiling = self._get_hard_limit_bytes()
         if ceiling <= 0:

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6009,11 +6009,56 @@ class Scheduler:
 
         # Add to tracking
         self.requests[request.request_id] = request
-        self.waiting.append(request)
+        self._admit_to_waiting(request)
 
         logger.debug(
             f"Added request {request.request_id} with {request.num_prompt_tokens} prompt tokens"
         )
+
+    def _admit_to_waiting(self, request: Request) -> None:
+        """
+        Insert a newly-admitted request into the waiting queue.
+
+        FCFS policy (the default): append to the back — byte-identical to
+        the historical behavior this replaces.
+
+        PRIORITY policy (opt-in via OMLX_PRIORITY_SCHEDULING=1, see
+        settings.to_scheduler_config): stable-insert by ``request.priority``
+        (lower value = higher priority, see the field's docstring on
+        ``Request``). Scans from the back and inserts immediately after the
+        last waiting request whose priority is <= this one's, so requests of
+        EQUAL priority keep arrival order — when every caller leaves
+        ``priority`` at its default of 0 (nothing sets it yet, pending the
+        Rust-side wiring), this is exactly FCFS. O(n) in queue depth, but the
+        waiting queue is capped at ``max(max_num_seqs * 4, 32)`` admissions
+        (see the SchedulerQueueFullError check above) — a small, bounded
+        scan on the rare new-admission path, not a hot per-token loop.
+
+        Only the genuinely-new-admission path (this function) is
+        priority-ordered. The many ``self.waiting.appendleft(...)`` call
+        sites elsewhere in this file reschedule ALREADY-ADMITTED work
+        resuming after a transient failure (cache eviction, corruption
+        retry, generation overflow) — that work has sunk cost, so it holds
+        its front-of-queue slot against a new arrival of EQUAL OR LOWER
+        actual priority (same-or-higher priority VALUE), exactly as before
+        this change. It does NOT hold that slot against a new arrival of
+        STRICTLY HIGHER actual priority (e.g. a live interactive turn behind
+        a resumed background request) — that new arrival correctly cuts
+        ahead, because the entire point of priority scheduling is that
+        interactive traffic never waits behind background work, resumed or
+        not. This scan needs no special-casing for that: it only compares
+        against whatever is already in the queue, so a resumed item is
+        displaced exactly when — and only when — a strictly more urgent
+        request is actually waiting behind it.
+        """
+        if self.config.policy is not SchedulingPolicy.PRIORITY:
+            self.waiting.append(request)
+            return
+        for i in range(len(self.waiting) - 1, -1, -1):
+            if self.waiting[i].priority <= request.priority:
+                self.waiting.insert(i + 1, request)
+                return
+        self.waiting.insert(0, request)
 
     def set_specprefill_draft_model(
         self, draft_model: Any, draft_model_name: str | None = None

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -440,6 +440,27 @@ class _PrefillState:
 
 
 @dataclass
+class _SuspendedDecodeState:
+    """State for a background decode request suspended by the decode floor.
+
+    When interactive_decode_floor > 0, excess background decode rows are
+    removed from the BatchGenerator via ``remove(uids, return_prompt_caches=True)``
+    and stashed here.  The KV cache is preserved so the request can be
+    re-inserted (via ``batch_generator.insert``) once interactive work drains.
+    """
+
+    request: Any  # Request object
+    prompt_cache: list  # KV cache extracted by BatchGenerator.remove
+    all_tokens: list  # Generated token IDs so far
+    sampler: Any  # Sampler callable
+    logits_processors: list  # Per-row logits processors
+    state_machine: Any  # SequenceStateMachine
+    remaining_max_tokens: int  # Original max_tokens minus tokens already generated
+    suspended_at: float  # time.monotonic() when suspended
+    batch_uid: int  # Original UID from BatchGenerator (for rope_delta etc.)
+
+
+@dataclass
 class _InflightStoreInfo:
     tokens: list[int]
     extra_keys: tuple[Any, ...] | None = None
@@ -1573,6 +1594,11 @@ class Scheduler:
         self._prefill_rr_cursor: int = 0
         self._prefill_preemptions: int = 0
         self._prefill_resumes: int = 0
+        # Decode floor: suspend excess background decode rows when interactive
+        # requests are active, preserving KV cache for later re-insertion.
+        self._suspended_decodes: dict[str, _SuspendedDecodeState] = {}
+        self._decode_suspensions: int = 0
+        self._decode_resumes: int = 0
         self.requests: dict[str, Request] = {}  # All requests by ID
         self.finished_req_ids: set[str] = set()  # Recently finished
         self._generation_overflow_recovery_ids: set[str] = set()
@@ -4294,6 +4320,200 @@ class Scheduler:
             logger.debug("Resumed %d suspended background prefill(s)", resumed)
         return resumed
 
+    # -- Decode floor helpers ---------------------------------------------------
+
+    def _active_interactive_decode_count(self) -> int:
+        """Count running requests with priority <= 0 (interactive)."""
+        return sum(1 for r in self.running.values() if r.priority <= 0)
+
+    def _active_background_decode_count(self) -> int:
+        """Count running requests with priority > 0 (background)."""
+        return sum(1 for r in self.running.values() if r.priority > 0)
+
+    def _target_background_decode_rows(self) -> int:
+        """Calculate how many background decode rows to keep resident.
+
+        At floor 0.5, one interactive row permits one background row.
+        At floor 1.0, no background rows are allowed.
+        At floor 0.0, all background rows are kept (no floor).
+        """
+        floor = self.config.interactive_decode_floor
+        interactive = self._active_interactive_decode_count()
+        if floor <= 0.0 or interactive == 0:
+            return self._active_background_decode_count()
+        # floor ∈ (0, 1]: background_rows = interactive * (1 - floor) / floor
+        import math
+
+        return max(0, math.floor(interactive * (1.0 - floor) / floor))
+
+    def _suspend_decode_request(self, request_id: str) -> bool:
+        """Suspend a background decode request, preserving its KV cache.
+
+        Uses BatchGenerator.remove(uids, return_prompt_caches=True) to
+        extract the KV cache and remove the row from the generation batch.
+        The request stays in self.running but is marked as suspended so
+        _process_batch_responses skips it.
+
+        Returns True if the request was suspended.
+        """
+        if self.batch_generator is None:
+            return False
+        if request_id not in self.request_id_to_uid:
+            return False
+
+        uid = self.request_id_to_uid[request_id]
+        if uid < 0:
+            return False  # vlm_mtp, not in BatchGenerator
+
+        request = self.running.get(request_id)
+        if request is None or request.priority <= 0:
+            return False  # never suspend interactive
+
+        # Extract cache + remove from batch in one call.
+        _safe_sync_stream(self._stream)
+        caches = self.batch_generator.remove([uid], return_prompt_caches=True)
+        cache_entry = caches.get(uid)
+        if cache_entry is None:
+            logger.warning(
+                "decode_floor: remove returned no cache for uid=%d (%s)", uid, request_id
+            )
+            return False
+
+        prompt_cache, all_tokens = cache_entry
+        remaining = request.sampling_params.max_tokens - len(request.output_token_ids)
+
+        self._suspended_decodes[request_id] = _SuspendedDecodeState(
+            request=request,
+            prompt_cache=prompt_cache,
+            all_tokens=all_tokens,
+            sampler=getattr(request, "_sampler", None),
+            logits_processors=getattr(request, "_logits_processors", []),
+            state_machine=getattr(request, "_state_machine", None),
+            remaining_max_tokens=remaining,
+            suspended_at=time.monotonic(),
+            batch_uid=uid,
+        )
+        self._decode_suspensions += 1
+
+        # Unregister uid mappings but keep request in self.running
+        # (status stays RUNNING so _process_batch_responses can detect stale)
+        if hasattr(self.model, "unregister_rope_delta"):
+            self.model.unregister_rope_delta(uid)
+        _unregister_uid_row(self.model, uid)
+        del self.uid_to_request_id[uid]
+        del self.request_id_to_uid[request_id]
+        request.batch_uid = None  # type: ignore[assignment]
+
+        logger.debug(
+            "Suspended background decode %s (uid=%d, cache=%d tokens)",
+            request_id,
+            uid,
+            len(all_tokens) if all_tokens else 0,
+        )
+        return True
+
+    def _resume_suspended_decodes(self) -> int:
+        """Resume all suspended background decode requests.
+
+        Re-inserts each into the BatchGenerator via insert() with the
+        preserved KV cache. The request goes through a re-prefill with
+        cached KV, which is faster than a full prefill.
+
+        Returns the number of requests resumed.
+        """
+        if not self._suspended_decodes or self.batch_generator is None:
+            return 0
+
+        to_resume = list(self._suspended_decodes.items())
+        self._suspended_decodes.clear()
+        resumed = 0
+
+        for request_id, state in to_resume:
+            request = state.request
+            # Request may have been aborted while suspended
+            if request_id not in self.running:
+                continue
+
+            try:
+                _safe_sync_stream(self._stream)
+                uids = self.batch_generator.insert(
+                    [state.all_tokens],
+                    max_tokens=[state.remaining_max_tokens],
+                    caches=[state.prompt_cache] if state.prompt_cache else None,
+                    all_tokens=[state.all_tokens],
+                    samplers=[state.sampler] if state.sampler else None,
+                    logits_processors=[state.logits_processors] if state.logits_processors else None,
+                    state_machines=[state.state_machine] if state.state_machine else None,
+                )
+                if uids:
+                    uid = uids[0]
+                    _register_uid_rows(self.model, [uid], [state.sampler], [state.logits_processors])
+                    self.request_id_to_uid[request_id] = uid
+                    self.uid_to_request_id[uid] = request_id
+                    request.batch_uid = uid
+                    if hasattr(self.model, "register_rope_delta"):
+                        self.model.register_rope_delta(uid, request.rope_deltas)
+                    resumed += 1
+                    logger.debug(
+                        "Resumed background decode %s (uid=%d)", request_id, uid
+                    )
+            except Exception as e:
+                logger.error(
+                    "Failed to resume decode %s: %s — finishing with error",
+                    request_id,
+                    e,
+                )
+                request.finish_reason = "error"
+                request.set_finished(RequestStatus.FINISHED_ABORTED)
+
+        self._decode_resumes += resumed
+        return resumed
+
+    def _apply_decode_floor(self) -> None:
+        """Apply decode floor: suspend excess background rows if interactive active.
+
+        Called after _process_batch_responses in step(). Only acts when
+        interactive_decode_floor > 0 and priority scheduling is enabled.
+        """
+        floor = self.config.interactive_decode_floor
+        if floor <= 0.0:
+            return
+        if not self.running:
+            return
+
+        interactive = self._active_interactive_decode_count()
+        if interactive == 0:
+            # No interactive work — resume all suspended decodes
+            if self._suspended_decodes:
+                self._resume_suspended_decodes()
+            return
+
+        target = self._target_background_decode_rows()
+        current_bg = self._active_background_decode_count()
+        excess = current_bg - target
+
+        if excess <= 0:
+            # Within budget — resume any previously suspended that fit
+            if self._suspended_decodes:
+                self._resume_suspended_decodes()
+            return
+
+        # Suspend excess background rows (oldest first = lowest batch_uid)
+        bg_requests = sorted(
+            [
+                (rid, r)
+                for rid, r in self.running.items()
+                if r.priority > 0 and rid not in self._suspended_decodes
+            ],
+            key=lambda x: x[1].batch_uid or 0,
+        )
+        for request_id, _ in bg_requests[:excess]:
+            self._suspend_decode_request(request_id)
+
+    def _cleanup_suspended_decode(self, request_id: str) -> None:
+        """Remove a request from suspended decodes (e.g. on abort or finish)."""
+        self._suspended_decodes.pop(request_id, None)
+
     # -------------------------------------------------------------------------
 
     def _advance_chunked_prefills(
@@ -6994,6 +7214,9 @@ class Scheduler:
             (r, s) for r, s in self._suspended_prefills if r.request_id != request_id
         )
 
+        # Remove from suspended decodes (decode floor)
+        self._cleanup_suspended_decode(request_id)
+
         # Remove from running (BatchGenerator)
         if request.request_id in self.request_id_to_uid:
             uid = self.request_id_to_uid[request.request_id]
@@ -9524,6 +9747,12 @@ class Scheduler:
 
                     self._cleanup_finished(finished_ids)
 
+                    # Decode floor: suspend excess background decode rows
+                    # when interactive requests are active. Must run AFTER
+                    # _cleanup_finished so finished requests are removed
+                    # from suspended_decodes before we suspend new ones.
+                    self._apply_decode_floor()
+
                     # Periodic Metal allocator cleanup during long decodes.
                     # mx.random.categorical inside the sampler allocates a
                     # tiny scalar via gumbel → uniform on every call.
@@ -9724,6 +9953,9 @@ class Scheduler:
         self.prefilling.clear()
         self._prefill_states.clear()
         self._suspended_prefills.clear()
+        self._suspended_decodes.clear()
+        self._decode_suspensions = 0
+        self._decode_resumes = 0
         self._prefill_rr_cursor = 0
         self._prefill_preemptions = 0
         self._prefill_resumes = 0

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -8381,11 +8381,16 @@ class Scheduler:
                 if request.num_output_tokens > completion_tokens_before
                 else None
             )
+            # output_token_ids (the cumulative decode so far) is only filled in
+            # below on the finish path. Streaming (non-finished) consumers use
+            # new_text/new_token_ids for the delta; nothing reads the
+            # cumulative list on a non-finished RequestOutput, so building it
+            # here on every decode step was an O(output-length) copy wasted on
+            # every token of every stream.
             output = RequestOutput(
                 request_id=request_id,
                 new_token_ids=[response.token] if not is_stop else [],
                 new_text=new_text,
-                output_token_ids=list(request.output_token_ids),
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
                 generated_at=output_generated_at,
@@ -8405,6 +8410,7 @@ class Scheduler:
 
                 output.finished = True
                 output.finish_reason = response.finish_reason
+                output.output_token_ids = list(request.output_token_ids)
                 finished_ids.add(request_id)
 
                 if parser_session is not None:

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1314,6 +1314,23 @@ class SchedulerConfig:
     # reduces TTFT for concurrent requests but adds per-step overhead.
     chunked_prefill: bool = False
 
+    # Interactive-isolation controls (staged rollout, all inert by default).
+    # These only take effect under SchedulingPolicy.PRIORITY; under FCFS they
+    # stay disabled regardless of the env toggle so shipping this code is a
+    # no-op until explicitly enabled on the live scheduler.
+    # Park an in-flight background prefill at a chunk boundary when an
+    # interactive request is waiting, then resume it once interactive work drains.
+    prefill_preemption: bool = False
+    # Minimum fraction of decode throughput reserved for interactive requests
+    # while background work is active (0.0 = no floor, 1.0 = interactive-only).
+    interactive_decode_floor: float = 0.0
+    # Interactive response cache TTL in seconds (0.0 = disabled).
+    interactive_cache_ttl_secs: float = 0.0
+    # Max concurrent interactive sessions tracked by the response cache.
+    interactive_cache_max_sessions: int = 8
+    # Max bytes held by the interactive response cache (0 = use default 8GiB).
+    interactive_cache_max_bytes: int = 8 * 1024**3
+
     # Paged cache settings (internal defaults)
     paged_cache_block_size: int = 256  # Tokens per block
     max_cache_blocks: int | None = (

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1563,6 +1563,16 @@ class Scheduler:
         # Populated when chunked_prefill=True and prompt exceeds prefill_step_size.
         self.prefilling: deque[Request] = deque()
         self._prefill_states: dict[str, _PrefillState] = {}
+        # Interactive preemption (OMLX_PREFILL_PREEMPTION, inert unless PRIORITY
+        # scheduling is on). Background chunked prefills parked here when an
+        # interactive request is waiting, so its admission + prefill are never
+        # queued behind a multi-chunk background prefill. The _PrefillState is
+        # retained (cache + token cursor untouched) — we only move the Request
+        # out of self.prefilling so _advance_chunked_prefills stops advancing it.
+        self._suspended_prefills: deque[tuple[Request, _PrefillState]] = deque()
+        self._prefill_rr_cursor: int = 0
+        self._prefill_preemptions: int = 0
+        self._prefill_resumes: int = 0
         self.requests: dict[str, Request] = {}  # All requests by ID
         self.finished_req_ids: set[str] = set()  # Recently finished
         self._generation_overflow_recovery_ids: set[str] = set()
@@ -4222,6 +4232,69 @@ class Scheduler:
                 request.num_prompt_tokens,
                 cache_info,
             )
+
+    # -- Interactive preemption helpers ----------------------------------------
+
+    def _has_waiting_interactive(self) -> bool:
+        """Return True if any priority-0 (interactive) request is waiting."""
+        return any(request.priority <= 0 for request in self.waiting)
+
+    def _has_active_interactive(self) -> bool:
+        """Return True if any priority-0 (interactive) request is running."""
+        return any(request.priority <= 0 for request in self.running.values())
+
+    def _park_background_prefills_for_interactive(self) -> int:
+        """Park background chunked prefills when interactive is waiting.
+
+        Moves priority>0 requests out of self.prefilling (and their
+        _PrefillState out of self._prefill_states) into
+        self._suspended_prefills so _advance_chunked_prefills skips them.
+
+        Returns the number of requests parked.
+        """
+        if not self.config.prefill_preemption or not self._has_waiting_interactive():
+            return 0
+
+        kept: list[Request] = []
+        parked = 0
+        for request in self.prefilling:
+            if request.priority > 0:
+                state = self._prefill_states.pop(request.request_id, None)
+                if state is not None:
+                    self._suspended_prefills.append((request, state))
+                    parked += 1
+            else:
+                kept.append(request)
+        self.prefilling = deque(kept)
+        if parked:
+            self._prefill_preemptions += parked
+            logger.debug(
+                "Parked %d background prefill(s) for interactive admission",
+                parked,
+            )
+        return parked
+
+    def _resume_suspended_prefills(self) -> int:
+        """Resume parked background prefills when no interactive is waiting.
+
+        Moves all suspended requests back into self.prefilling and
+        self._prefill_states. Returns the number resumed.
+        """
+        if not self._suspended_prefills:
+            return 0
+
+        resumed = 0
+        while self._suspended_prefills:
+            request, state = self._suspended_prefills.popleft()
+            self.prefilling.append(request)
+            self._prefill_states[request.request_id] = state
+            resumed += 1
+        self._prefill_resumes += resumed
+        if resumed:
+            logger.debug("Resumed %d suspended background prefill(s)", resumed)
+        return resumed
+
+    # -------------------------------------------------------------------------
 
     def _advance_chunked_prefills(
         self,
@@ -6916,6 +6989,11 @@ class Scheduler:
                 r for r in self.prefilling if r.request_id != request_id
             )
 
+        # Remove from suspended prefills (parked by interactive preemption)
+        self._suspended_prefills = deque(
+            (r, s) for r, s in self._suspended_prefills if r.request_id != request_id
+        )
+
         # Remove from running (BatchGenerator)
         if request.request_id in self.request_id_to_uid:
             uid = self.request_id_to_uid[request.request_id]
@@ -9367,6 +9445,15 @@ class Scheduler:
             # Advance in-flight chunked prefills (one chunk per request).
             # Must run before _schedule_waiting() so that completing prefills
             # are inserted into BatchGenerator before the decode step.
+
+            # Interactive preemption: park background prefills when an
+            # interactive request is waiting, resume when it's not.
+            if self.config.prefill_preemption:
+                if self._has_waiting_interactive():
+                    self._park_background_prefills_for_interactive()
+                else:
+                    self._resume_suspended_prefills()
+
             chunked_scheduled: list[Request] = []
             chunked_rejected: list[RequestOutput] = []
             if self.prefilling:
@@ -9636,6 +9723,10 @@ class Scheduler:
         self.waiting.clear()
         self.prefilling.clear()
         self._prefill_states.clear()
+        self._suspended_prefills.clear()
+        self._prefill_rr_cursor = 0
+        self._prefill_preemptions = 0
+        self._prefill_resumes = 0
         self.running.clear()
         self.requests.clear()
         self.finished_req_ids.clear()

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1296,6 +1296,14 @@ class SchedulerConfig:
     max_num_batched_tokens: int = 8192
     # Scheduling policy
     policy: SchedulingPolicy = SchedulingPolicy.FCFS
+    # Interactive slot reservation (staged rollout via OMLX_INTERACTIVE_RESERVED_SLOTS).
+    # When > 0 and policy is PRIORITY, background requests (priority > 0) may occupy at
+    # most max_num_seqs - reserved running slots, so an interactive request (priority 0)
+    # never waits out a full background generation just to be admitted — the measured
+    # 60-220s interactive tail under daemon load is exactly that wait. Background can
+    # never be starved entirely (its share is floored at 1 slot). 0 = disabled (today's
+    # admission behaviour, byte-for-byte).
+    reserved_interactive_slots: int = 0
     # BatchGenerator settings (passed directly to mlx-lm)
     completion_batch_size: int = 32
     # Per-forward embedding input chunk size
@@ -7108,6 +7116,30 @@ class Scheduler:
         """Return requests already occupying scheduler capacity."""
         return len(self.running) + len(self.prefilling)
 
+    def _background_slots_exhausted(self, request: "Request") -> bool:
+        """
+        Interactive slot reservation (OMLX_INTERACTIVE_RESERVED_SLOTS).
+
+        True when `request` is a background request (priority > 0) and background
+        work already occupies its allowed share of admission slots
+        (max_num_seqs - reserved, floored at 1 so background is never starved).
+        Interactive requests (priority <= 0) are never reservation-blocked. Inert
+        unless the PRIORITY policy is enabled and reserved > 0.
+        """
+        reserved = self.config.reserved_interactive_slots
+        if reserved <= 0 or self.config.policy is not SchedulingPolicy.PRIORITY:
+            return False
+        if getattr(request, "priority", 0) <= 0:
+            return False
+        cap = self._effective_max_num_seqs()
+        background_cap = max(1, cap - reserved)
+        admitted_background = sum(
+            1
+            for r in list(self.running.values()) + list(self.prefilling)
+            if getattr(r, "priority", 0) > 0
+        )
+        return admitted_background >= background_cap
+
     def _preflight_memory_check(
         self, request: "Request"
     ) -> "_PreflightRejection | None":
@@ -7626,6 +7658,21 @@ class Scheduler:
                     break
 
             request = self.waiting[0]
+            # Interactive slot reservation: if the queue head is a background request
+            # and background already holds its allowed share of slots, stop admitting.
+            # The waiting queue is priority-ordered (_admit_to_waiting), so no
+            # interactive request can be behind a background head — breaking here never
+            # delays interactive work, and the reserved slot stays free for the next
+            # priority-0 arrival instead of being consumed by a multi-minute background
+            # generation.
+            if self._background_slots_exhausted(request):
+                logger.debug(
+                    "Admission deferred: background slots exhausted "
+                    "(reserved_interactive_slots=%d, admitted=%d)",
+                    self.config.reserved_interactive_slots,
+                    self._num_admitted_requests(),
+                )
+                break
             self._clear_memory_admission_blocker(request.request_id)
             self._clear_store_cache_admission_blocker(request.request_id)
             if self._should_defer_for_cache_freshness(request):

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -7116,7 +7116,9 @@ class Scheduler:
         """Return requests already occupying scheduler capacity."""
         return len(self.running) + len(self.prefilling)
 
-    def _background_slots_exhausted(self, request: "Request") -> bool:
+    def _background_slots_exhausted(
+        self, request: "Request", pending_scheduled: "list[Request] | tuple" = ()
+    ) -> bool:
         """
         Interactive slot reservation (OMLX_INTERACTIVE_RESERVED_SLOTS).
 
@@ -7125,6 +7127,11 @@ class Scheduler:
         (max_num_seqs - reserved, floored at 1 so background is never starved).
         Interactive requests (priority <= 0) are never reservation-blocked. Inert
         unless the PRIORITY policy is enabled and reserved > 0.
+
+        `pending_scheduled` must include requests admitted EARLIER IN THE SAME
+        _schedule_waiting pass — they are not yet in running/prefilling, and two
+        simultaneous background arrivals would otherwise both be admitted in one
+        pass, silently bypassing the reservation.
         """
         reserved = self.config.reserved_interactive_slots
         if reserved <= 0 or self.config.policy is not SchedulingPolicy.PRIORITY:
@@ -7135,7 +7142,11 @@ class Scheduler:
         background_cap = max(1, cap - reserved)
         admitted_background = sum(
             1
-            for r in list(self.running.values()) + list(self.prefilling)
+            for r in (
+                list(self.running.values())
+                + list(self.prefilling)
+                + list(pending_scheduled)
+            )
             if getattr(r, "priority", 0) > 0
         )
         return admitted_background >= background_cap
@@ -7665,12 +7676,13 @@ class Scheduler:
             # delays interactive work, and the reserved slot stays free for the next
             # priority-0 arrival instead of being consumed by a multi-minute background
             # generation.
-            if self._background_slots_exhausted(request):
-                logger.debug(
+            if self._background_slots_exhausted(request, scheduled):
+                logger.info(
                     "Admission deferred: background slots exhausted "
-                    "(reserved_interactive_slots=%d, admitted=%d)",
+                    "(reserved_interactive_slots=%d, admitted=%d, in_pass=%d)",
                     self.config.reserved_interactive_slots,
                     self._num_admitted_requests(),
+                    len(scheduled),
                 )
                 break
             self._clear_memory_admission_blocker(request.request_id)

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1854,6 +1854,14 @@ def init_server(
     logger.info("HF Uploader initialized")
 
 
+# Admission-priority default for requests that don't set ChatCompletionRequest.priority
+# (every caller today, until the Rust tool-server is wired). Deliberately a LOW-priority
+# (numerically high) value, not 0 — an unmarked/background request must never accidentally
+# outrank a caller that explicitly asked for priority=0 (interactive). Only consulted when
+# SchedulingPolicy.PRIORITY is enabled (OMLX_PRIORITY_SCHEDULING=1); irrelevant under the
+# default FCFS policy.
+_DEFAULT_BACKGROUND_PRIORITY = 10
+
 _KEEPALIVE_SENTINEL = object()
 
 _KEEPALIVE_COMMENT = ": keep-alive\n\n"
@@ -3338,6 +3346,18 @@ async def create_chat_completion(
         # Add seed for reproducible generation (best-effort)
         if request.seed is not None:
             chat_kwargs["seed"] = request.seed
+
+        # Admission-scheduling priority (see _DEFAULT_BACKGROUND_PRIORITY docstring
+        # above and Scheduler._admit_to_waiting). Threads through engine.chat /
+        # engine.stream_chat -> engine/batched.py's generate/stream_generate ->
+        # AsyncEngineCore -> EngineCore.add_request -> Request.priority. A caller
+        # that omits this field (everyone, until the Rust side sends it) gets the
+        # background default, never priority 0.
+        chat_kwargs["priority"] = (
+            request.priority
+            if request.priority is not None
+            else _DEFAULT_BACKGROUND_PRIORITY
+        )
 
         # Add thinking budget if applicable
         thinking_budget = _resolve_thinking_budget(request, request.model)

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -173,7 +173,7 @@ from .api.utils import (
     prepare_system_messages_for_template,
     uses_native_reasoning_content,
 )
-from .engine import BaseEngine, VLMBatchedEngine
+from .engine import BaseEngine, BatchedEngine, VLMBatchedEngine
 from .engine.embedding import EmbeddingEngine
 from .engine.reranker import RerankerEngine
 from .engine_pool import EnginePool
@@ -3403,6 +3403,35 @@ async def create_chat_completion(
         if request.stop:
             chat_kwargs["stop"] = request.stop
 
+        # Render the chat template once and reuse it for the prefill preflight
+        # check, thinking-mode detection, and the actual generation call below
+        # — previously each re-rendered (and preflight/count also re-encoded)
+        # the same prompt independently. Only wired up for BatchedEngine,
+        # whose preflight_chat/stream_chat render with identical inputs at
+        # this point; VLM's preflight intentionally renders a cheaper
+        # text-only approximation of the real (multimodal) prompt and DFlash
+        # may transparently fall back to a different engine, so their
+        # independent rendering is left untouched. `count_chat_tokens` above
+        # is also left independent: `merged_ct_kwargs` can still gain
+        # enable_thinking/preserve_thinking between that call and this point.
+        if isinstance(engine, BatchedEngine):
+            try:
+                _shared_prompt_messages = engine._preprocess_messages(messages)
+                _shared_prompt_tools = (
+                    convert_tools_for_template(tools_for_template)
+                    if tools_for_template
+                    else None
+                )
+                chat_kwargs["rendered_prompt"] = engine._apply_chat_template(
+                    _shared_prompt_messages,
+                    _shared_prompt_tools,
+                    chat_template_kwargs=merged_ct_kwargs or None,
+                    is_partial=is_partial,
+                )
+            except Exception:
+                # Fall back to each call site rendering independently, as before.
+                chat_kwargs.pop("rendered_prompt", None)
+
         # Pre-flight prefill memory guard. Must run BEFORE either branch wraps
         # the response in a StreamingResponse — starlette emits
         # http.response.start (status 200) before iterating the body generator,
@@ -4252,9 +4281,21 @@ async def stream_chat_completion(
     try:
         tokenizer = getattr(engine, "tokenizer", None)
         if tokenizer is not None:
-            prompt, prompt_token_ids = _render_chat_prompt_for_thinking_detection(
-                engine, messages, kwargs
-            )
+            # Reuse the prompt the caller already rendered for the preflight
+            # check when available, instead of rendering it a third time.
+            # Not safe for gpt_oss: `_preprocess_messages` strips <think>
+            # tags from prior assistant turns before rendering, but this
+            # helper's fallback render below does not, so a cached prompt
+            # would silently skip that step for Harmony models.
+            cached_prompt = kwargs.get("rendered_prompt")
+            if cached_prompt is not None and getattr(
+                engine, "model_type", None
+            ) != "gpt_oss":
+                prompt, prompt_token_ids = cached_prompt, None
+            else:
+                prompt, prompt_token_ids = _render_chat_prompt_for_thinking_detection(
+                    engine, messages, kwargs
+                )
             start_in_thinking, _ = prompt_opens_thinking(
                 tokenizer, prompt, prompt_token_ids=prompt_token_ids
             )

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -1458,6 +1458,56 @@ class GlobalSettings:
         except ValueError:
             reserved_interactive_slots = 0
 
+        # Interactive-isolation controls. All inert unless PRIORITY scheduling
+        # is on (OMLX_PRIORITY_SCHEDULING=1): under FCFS the policy cannot
+        # classify interactive work, so preemption stays off regardless of its
+        # own toggle. This keeps the staged rollout safe — the live FCFS
+        # scheduler is byte-identical until both knobs are enabled.
+        priority_enabled = scheduling_policy == SchedulingPolicy.PRIORITY
+
+        # Prefill preemption: only meaningful under PRIORITY.
+        prefill_preemption = (
+            os.environ.get("OMLX_PREFILL_PREEMPTION") == "1" and priority_enabled
+        )
+
+        # Interactive decode floor: probability-like ratio in [0, 1].
+        interactive_decode_floor = 0.0
+        floor_raw = os.environ.get("OMLX_INTERACTIVE_DECODE_FLOOR")
+        if floor_raw is not None:
+            try:
+                floor_val = float(floor_raw)
+            except ValueError:
+                floor_val = -1.0
+            if not (0.0 <= floor_val <= 1.0):
+                raise ValueError(
+                    "OMLX_INTERACTIVE_DECODE_FLOOR must be between 0 and 1"
+                )
+            interactive_decode_floor = floor_val
+
+        # Interactive response cache controls.
+        interactive_cache_ttl_secs = 0.0
+        if (ttl_raw := os.environ.get("OMLX_INTERACTIVE_CACHE_TTL_SECS")) is not None:
+            try:
+                interactive_cache_ttl_secs = float(ttl_raw)
+            except ValueError:
+                interactive_cache_ttl_secs = 0.0
+
+        try:
+            interactive_cache_max_sessions = int(
+                os.environ.get("OMLX_INTERACTIVE_CACHE_MAX_SESSIONS", "8") or "8"
+            )
+        except ValueError:
+            interactive_cache_max_sessions = 8
+
+        interactive_cache_max_bytes = 8 * 1024**3
+        if (
+            bytes_gb_raw := os.environ.get("OMLX_INTERACTIVE_CACHE_MAX_BYTES_GB")
+        ) is not None:
+            try:
+                interactive_cache_max_bytes = int(float(bytes_gb_raw) * 1024**3)
+            except ValueError:
+                interactive_cache_max_bytes = 8 * 1024**3
+
         return SchedulerConfig(
             policy=scheduling_policy,
             reserved_interactive_slots=max(0, reserved_interactive_slots),
@@ -1466,6 +1516,11 @@ class GlobalSettings:
             embedding_batch_size=self.scheduler.embedding_batch_size,
             chunked_prefill=self.scheduler.chunked_prefill,
             prefill_step_size=self.scheduler.prefill_step_size,
+            prefill_preemption=prefill_preemption,
+            interactive_decode_floor=interactive_decode_floor,
+            interactive_cache_ttl_secs=interactive_cache_ttl_secs,
+            interactive_cache_max_sessions=max(1, interactive_cache_max_sessions),
+            interactive_cache_max_bytes=interactive_cache_max_bytes,
             initial_cache_blocks=self.cache.initial_cache_blocks,
             paged_ssd_cache_dir=str(ssd_dir) if ssd_dir else None,
             hot_cache_only=self.cache.hot_cache_only,

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -1421,7 +1421,7 @@ class GlobalSettings:
         Returns:
             SchedulerConfig instance with values from settings.
         """
-        from .scheduler import SchedulerConfig
+        from .scheduler import SchedulerConfig, SchedulingPolicy
 
         # Always resolve ssd_dir so the scheduler can initialize PagedSSDCacheManager.
         # When hot_cache_only=True, PagedSSDCacheManager skips directory init and
@@ -1430,7 +1430,23 @@ class GlobalSettings:
             self.cache.get_ssd_cache_dir(self.base_path) if self.cache.enabled else None
         )
 
+        # Opt-in admission-priority scheduling (OMLX_PRIORITY_SCHEDULING=1):
+        # activates Scheduler._admit_to_waiting's priority-ordered insert
+        # instead of plain FCFS append. Read directly from the environment
+        # (not the settings-file schema) — an operational toggle, same
+        # pattern as OMLX_CACHE_LIMIT_GB elsewhere in this codebase. Default
+        # OFF: SchedulingPolicy.FCFS, byte-identical to pre-existing
+        # behavior, so shipping this code is a no-op until explicitly
+        # enabled — the staged rollout for a change to the live scheduler
+        # every chat request depends on.
+        scheduling_policy = (
+            SchedulingPolicy.PRIORITY
+            if os.environ.get("OMLX_PRIORITY_SCHEDULING") == "1"
+            else SchedulingPolicy.FCFS
+        )
+
         return SchedulerConfig(
+            policy=scheduling_policy,
             max_num_seqs=self.scheduler.max_concurrent_requests,
             completion_batch_size=self.scheduler.max_concurrent_requests,
             embedding_batch_size=self.scheduler.embedding_batch_size,

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -1445,8 +1445,22 @@ class GlobalSettings:
             else SchedulingPolicy.FCFS
         )
 
+        # Interactive slot reservation (OMLX_INTERACTIVE_RESERVED_SLOTS=1): with the
+        # PRIORITY policy on, background requests may hold at most
+        # max_concurrent_requests - N running slots, so an interactive turn is admitted
+        # into the reserved slot immediately instead of waiting out a multi-minute
+        # background generation (the measured 60-220s tail). Same env-toggle staged-
+        # rollout pattern as OMLX_PRIORITY_SCHEDULING; default 0 = admission unchanged.
+        try:
+            reserved_interactive_slots = int(
+                os.environ.get("OMLX_INTERACTIVE_RESERVED_SLOTS", "0") or "0"
+            )
+        except ValueError:
+            reserved_interactive_slots = 0
+
         return SchedulerConfig(
             policy=scheduling_policy,
+            reserved_interactive_slots=max(0, reserved_interactive_slots),
             max_num_seqs=self.scheduler.max_concurrent_requests,
             completion_batch_size=self.scheduler.max_concurrent_requests,
             embedding_batch_size=self.scheduler.embedding_batch_size,

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -263,6 +263,10 @@ class SchedulerSettings:
     # When True, long prefills are interleaved with decode steps.
     # Reduces TTFT for concurrent requests at the cost of per-step overhead.
     chunked_prefill: bool = False
+    # Token chunk size for chunked prefill (only used when chunked_prefill=True).
+    # Smaller values smooth interleaved decode-stream stalls during a large
+    # prefill at the cost of more per-step scheduling overhead.
+    prefill_step_size: int = 2048
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
@@ -284,6 +288,7 @@ class SchedulerSettings:
             max_concurrent_requests=value,
             embedding_batch_size=embedding_batch_size,
             chunked_prefill=bool(data.get("chunked_prefill", False)),
+            prefill_step_size=data.get("prefill_step_size", 2048),
         )
 
 
@@ -944,6 +949,13 @@ class GlobalSettings:
                 logger.warning(
                     f"Invalid OMLX_EMBEDDING_BATCH_SIZE value: {embedding_batch_size}"
                 )
+        if prefill_step_size := os.getenv("OMLX_PREFILL_STEP_SIZE"):
+            try:
+                self.scheduler.prefill_step_size = int(prefill_step_size)
+            except ValueError:
+                logger.warning(
+                    f"Invalid OMLX_PREFILL_STEP_SIZE value: {prefill_step_size}"
+                )
 
         # Cache settings
         if cache_enabled := os.getenv("OMLX_CACHE_ENABLED"):
@@ -1284,6 +1296,11 @@ class GlobalSettings:
                 f"Invalid embedding_batch_size: "
                 f"{self.scheduler.embedding_batch_size} (must be > 0)"
             )
+        if self.scheduler.prefill_step_size < 64:
+            errors.append(
+                f"Invalid prefill_step_size: "
+                f"{self.scheduler.prefill_step_size} (must be >= 64)"
+            )
 
         # Cache validation
         if self.cache.ssd_cache_max_size.lower() != "auto":
@@ -1418,6 +1435,7 @@ class GlobalSettings:
             completion_batch_size=self.scheduler.max_concurrent_requests,
             embedding_batch_size=self.scheduler.embedding_batch_size,
             chunked_prefill=self.scheduler.chunked_prefill,
+            prefill_step_size=self.scheduler.prefill_step_size,
             initial_cache_blocks=self.cache.initial_cache_blocks,
             paged_ssd_cache_dir=str(ssd_dir) if ssd_dir else None,
             hot_cache_only=self.cache.hot_cache_only,

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -439,6 +439,35 @@ def maybe_apply_pre_load_patches(
                     model_name,
                 )
 
+    # Fused GatedDeltaNet decode-step kernel for Qwen3.5/3.6 linear-attention
+    # layers (qwen3_5_moe.Model subclasses qwen3_5.Model, so both model types
+    # share the same mlx_lm.models.qwen3_5.GatedDeltaNet class). Must run
+    # last in this function: it captures whatever __call__ is currently
+    # installed (stock mlx-lm, or the Native-MTP patch's n_confirmed-aware
+    # version applied above) as its fallback, so applying it any earlier
+    # would let a subsequent MTP patch pass clobber it. Gated purely on
+    # model_type — the patch itself only ever engages its fast path for a
+    # T==1, no-mask, warm-cache, non-distributed, non-training decode step
+    # and falls through to the captured fallback for everything else
+    # (prefill, MTP draft/verify splits, first token, padded batches,
+    # sharded layers, non-Metal), so it is safe to apply unconditionally
+    # whenever this model family is loaded.
+    if (model_type and model_type.startswith("qwen3_5")) or (
+        text_model_type and text_model_type.startswith("qwen3_5")
+    ):
+        try:
+            from ..patches.qwen3_5_fused_decode import (
+                apply_qwen3_5_fused_decode_patch,
+            )
+        except Exception as e:
+            logger.debug("qwen3_5 fused decode patch import failed: %s", e)
+        else:
+            if apply_qwen3_5_fused_decode_patch():
+                logger.info(
+                    "qwen3_5 fused GatedDeltaNet decode-step patch applied for %s",
+                    model_name,
+                )
+
 
 def _has_mtp_heads(config: dict) -> bool:
     """True iff the model config declares any MTP head layers."""

--- a/omlx/utils/sampling.py
+++ b/omlx/utils/sampling.py
@@ -94,6 +94,73 @@ def apply_top_k(logprobs: mx.array, top_k: int) -> mx.array:
     return masked_logprobs
 
 
+def _top_k_top_p_candidates(
+    logprobs: mx.array, top_k: int, top_p: float
+) -> tuple[mx.array, mx.array]:
+    """Shared step for the fused top-k+top-p fast path: gather the top_k
+    logprobs via ``argpartition`` (no full-vocab sort), then run the same
+    ascending-sort/cumsum recipe ``apply_top_p`` uses — restricted to just
+    those top_k candidates instead of the whole vocabulary.
+
+    Top-p and top-k are both *prefix* filters over the same probability
+    ranking (highest logprob first), so composing them (in either order)
+    keeps exactly the top ``min(top_k, nucleus_size)`` tokens. Any token
+    ranked above a top-k candidate is, by construction, also inside the
+    top-k candidate set, so the "probability mass above this token" needed
+    for the top-p threshold is exactly computable from the top_k subset
+    alone. It just isn't relative to a subset sum of 1 the way the
+    full-vocab version is, since the top_k candidates don't carry the
+    whole probability mass — hence the ``subset_total`` shift below instead
+    of the ``1`` used in ``apply_top_p``.
+
+    Everything downstream (scatter for ``_fused_top_k_top_p``, sampling for
+    ``_fused_top_k_top_p_sample``) only needs a consistent (index, value)
+    pairing, not any particular order, so this stays in ascending-sorted
+    order throughout rather than remapping back to argpartition's order —
+    one fewer top_k-sized permutation to build.
+
+    Returns ``(sorted_idx, filtered_sorted_vals)``, both in ascending
+    logprob order: the top_k candidate indices into the vocab, and their
+    logprobs with non-surviving entries set to -inf.
+    """
+    # Must negate (matching apply_top_k's own argpartition call) rather than
+    # use kth=-top_k on the un-negated array: the two are only equivalent
+    # when there are no exact ties. At this vocab size in bf16, ties at the
+    # top_k boundary are common, and argpartition's tie-breaking differs
+    # between the two forms — using the un-negated form would occasionally
+    # select a different (equally-probable, but different-id) token than
+    # apply_top_k does, breaking exact parity with the composition this
+    # fast path replaces.
+    idx = mx.argpartition(-logprobs, kth=top_k - 1, axis=-1)[..., :top_k]
+    vals = mx.take_along_axis(logprobs, idx, axis=-1)
+
+    order = mx.argsort(vals, axis=-1)
+    sorted_idx = mx.take_along_axis(idx, order, axis=-1)
+    sorted_vals = mx.take_along_axis(vals, order, axis=-1)
+    cumulative_probs = mx.cumsum(mx.exp(sorted_vals), axis=-1)
+    subset_total = cumulative_probs[..., -1:]
+
+    filtered_sorted_vals = mx.where(
+        cumulative_probs > subset_total - top_p, sorted_vals, -float("inf")
+    )
+    return sorted_idx, filtered_sorted_vals
+
+
+def _fused_top_k_top_p(logprobs: mx.array, top_k: int, top_p: float) -> mx.array:
+    """Fused top-k + top-p filtering that avoids a full-vocab argsort.
+
+    Equivalent to ``apply_top_p(logprobs, top_p)`` followed by
+    ``apply_top_k(..., top_k)`` — the order ``make_sampler`` composes them
+    in when both are the only active filters — but computed from just the
+    top_k candidates (see ``_top_k_top_p_candidates``) instead of sorting
+    the whole vocabulary. Scatters the filtered candidates back into a
+    vocab-sized -inf array, matching apply_top_p/apply_top_k's contract.
+    """
+    sorted_idx, filtered_sorted_vals = _top_k_top_p_candidates(logprobs, top_k, top_p)
+    out = mx.full(logprobs.shape, -float("inf"), dtype=logprobs.dtype)
+    return mx.put_along_axis(out, sorted_idx, filtered_sorted_vals, axis=-1)
+
+
 def apply_xtc(
     logits: mx.array,
     xtc_probability: float,
@@ -129,6 +196,25 @@ def categorical_sampling(logits: mx.array, temp: float) -> mx.array:
     return mx.random.categorical(logits * (1 / temp))
 
 
+def _fused_top_k_top_p_sample(
+    logprobs: mx.array, top_k: int, top_p: float, temp: float
+) -> mx.array:
+    """Sample directly from the fused top-k+top-p candidates instead of
+    materializing a vocab-sized filtered array first.
+
+    ``_fused_top_k_top_p`` still has to scatter its ``top_k`` survivors
+    into a vocab-sized -inf array purely so a subsequent
+    ``categorical_sampling`` call can index into the vocab axis. Sampling
+    from the ``top_k``-sized candidates directly and mapping the result
+    back to a vocab id via the gathered indices skips that vocab-sized
+    scatter entirely — this is what ``make_sampler`` actually calls on its
+    fast path.
+    """
+    sorted_idx, filtered_sorted_vals = _top_k_top_p_candidates(logprobs, top_k, top_p)
+    local_idx = categorical_sampling(filtered_sorted_vals, temp)
+    return mx.take_along_axis(sorted_idx, local_idx[..., None], axis=-1).squeeze(-1)
+
+
 def make_sampler(
     temp: float = 0.0,
     top_p: float = 0.0,
@@ -147,26 +233,37 @@ def make_sampler(
     if temp == 0:
         sampler = lambda x: mx.argmax(x, axis=-1)
     else:
-        sampling_methods = []
-        if top_p > 0 and top_p < 1.0:
-            sampling_methods.append(lambda x: apply_top_p(x, top_p))
-        if min_p != 0.0:
-            sampling_methods.append(
-                lambda x: apply_min_p(x, min_p, min_tokens_to_keep)
-            )
-        if xtc_probability > 0.0:
-            sampling_methods.append(
-                lambda x: apply_xtc(
-                    x, xtc_probability, xtc_threshold, xtc_special_tokens
-                )
-            )
-        if top_k > 0:
-            sampling_methods.append(lambda x: apply_top_k(x, top_k))
+        top_p_active = top_p > 0 and top_p < 1.0
+        top_k_active = top_k > 0
+        if top_p_active and top_k_active and min_p == 0.0 and xtc_probability == 0.0:
+            # Fast path: top-p and top-k are the only active filters, so
+            # they can be fused into a single top_k-sized computation
+            # instead of a full-vocab argsort, sampling directly from the
+            # top_k candidates (see _fused_top_k_top_p_sample).
+            def sampler(logprobs: mx.array) -> mx.array:
+                return _fused_top_k_top_p_sample(logprobs, top_k, top_p, temp)
 
-        def sampler(logprobs: mx.array) -> mx.array:
-            for method in sampling_methods:
-                logprobs = method(logprobs)
-            return categorical_sampling(logprobs, temp)
+        else:
+            sampling_methods = []
+            if top_p_active:
+                sampling_methods.append(lambda x: apply_top_p(x, top_p))
+            if min_p != 0.0:
+                sampling_methods.append(
+                    lambda x: apply_min_p(x, min_p, min_tokens_to_keep)
+                )
+            if xtc_probability > 0.0:
+                sampling_methods.append(
+                    lambda x: apply_xtc(
+                        x, xtc_probability, xtc_threshold, xtc_special_tokens
+                    )
+                )
+            if top_k_active:
+                sampling_methods.append(lambda x: apply_top_k(x, top_k))
+
+            def sampler(logprobs: mx.array) -> mx.array:
+                for method in sampling_methods:
+                    logprobs = method(logprobs)
+                return categorical_sampling(logprobs, temp)
 
     # Expose sampling params on the returned callable so downstream code
     # (e.g. MTP acceptance check) can rebuild the filtered distribution

--- a/omlx/utils/tokenizer.py
+++ b/omlx/utils/tokenizer.py
@@ -299,6 +299,42 @@ class _CompatNaiveStreamingDetokenizer:
         return segment
 
 
+def _ensure_cached_vocab(tokenizer: Any) -> None:
+    """Memoize ``tokenizer.get_vocab()`` on the tokenizer instance itself.
+
+    ``BPEStreamingDetokenizer``/``SPMStreamingDetokenizer`` (mlx-lm) read
+    ``tokenizer.vocab`` in their constructors, and HuggingFace's ``.vocab``
+    property calls ``get_vocab()`` fresh on every access — which rebuilds the
+    *entire* vocab dict (hundreds of thousands of entries for some models)
+    from the underlying Rust tokenizer. Since ``create_streaming_detokenizer``
+    builds a brand-new detokenizer per request, that rebuild used to happen
+    on every single request even though the vocab never changes for a given
+    tokenizer instance.
+
+    Cache the result as an attribute on the tokenizer object itself (not a
+    module-level dict keyed by ``id()``): this scopes the cache exactly to
+    that tokenizer instance, so multiple tokenizers (multi-model server)
+    never share or clobber each other's cache, and the cache is freed
+    automatically when the tokenizer is garbage collected.
+    """
+    raw = unwrap_tokenizer(tokenizer)
+    if getattr(raw, "_omlx_vocab_cache", None) is not None:
+        return
+    get_vocab = getattr(raw, "get_vocab", None)
+    if get_vocab is None or not callable(get_vocab):
+        return
+    try:
+        vocab = get_vocab()
+    except Exception as exc:
+        logger.debug("Failed to precompute vocab for caching: %s", exc)
+        return
+    try:
+        raw._omlx_vocab_cache = vocab
+        raw.get_vocab = lambda: raw._omlx_vocab_cache
+    except (AttributeError, TypeError) as exc:
+        logger.debug("Tokenizer does not support vocab caching: %s", exc)
+
+
 def create_streaming_detokenizer(
     tokenizer: Any,
     model_path: str | Path | None = None,
@@ -309,6 +345,8 @@ def create_streaming_detokenizer(
     raw VLM/DFlash tokenizers may not.  In that case, mirror mlx-lm's
     tokenizer.json decoder detection before falling back to the naive decoder.
     """
+    _ensure_cached_vocab(tokenizer)
+
     has_existing_attr = True
     try:
         detokenizer = tokenizer.detokenizer

--- a/scripts/bench_interactive_preemption.py
+++ b/scripts/bench_interactive_preemption.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Benchmark: interactive preemption under daemon load.
+
+Measures TTFT for priority-0 (interactive) requests while priority-10
+(background) requests are running concurrently.
+
+Usage:
+    python scripts/bench_interactive_preemption.py \
+        --base-url http://127.0.0.1:18200 \
+        --model qwen3.6-35b-a3b-4bit \
+        --background 8 \
+        --background-prompt-tokens 16384 \
+        --interactive-runs 20 \
+        --turns 4
+
+Requires a running oMLX server with the model loaded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any
+
+import requests
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RequestMetrics:
+    request_id: str
+    is_interactive: bool
+    time_to_first_token: float | None = None
+    prompt_eval_duration: float | None = None
+    generation_duration: float | None = None
+    prompt_tokens_per_second: float | None = None
+    generation_tokens_per_second: float | None = None
+    cached_tokens: int | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    error: str | None = None
+
+
+@dataclass
+class BenchResult:
+    run_label: str
+    background_count: int
+    interactive_count: int
+    interactive_ttfts: list[float] = field(default_factory=list)
+    background_ttfts: list[float] = field(default_factory=list)
+    interactive_p50: float | None = None
+    interactive_p95: float | None = None
+    interactive_p99: float | None = None
+    background_p50: float | None = None
+    all_metrics: list[dict] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _percentile(values: list[float], p: float) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    k = (len(s) - 1) * p
+    f = int(k)
+    c = f + 1
+    if c >= len(s):
+        return s[-1]
+    return s[f] + (k - f) * (s[c] - s[f])
+
+
+def _prompt_tokens(n: int) -> list[int]:
+    """Generate n tokens (repeating a small vocabulary)."""
+    vocab = list(range(1000, 1100))
+    return [vocab[i % len(vocab)] for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# API calls
+# ---------------------------------------------------------------------------
+
+def check_health(base_url: str) -> dict:
+    r = requests.get(f"{base_url}/health", timeout=10)
+    r.raise_for_status()
+    return r.json()
+
+
+def get_model_id(base_url: str, model: str) -> str:
+    """Resolve model name via /v1/models."""
+    r = requests.get(f"{base_url}/v1/models", timeout=10)
+    r.raise_for_status()
+    models = r.json().get("data", [])
+    for m in models:
+        mid = m.get("id", "")
+        if model.lower() in mid.lower():
+            return mid
+    return model
+
+
+def fire_request(
+    base_url: str,
+    model: str,
+    prompt_tokens: list[int],
+    priority: int,
+    max_tokens: int = 64,
+    stream: bool = True,
+) -> RequestMetrics:
+    """Send a single request and parse metrics from the final SSE chunk."""
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": [{"role": "user", "content": "Hello"}],
+        "max_tokens": max_tokens,
+        "stream": stream,
+        "stream_options": {"include_usage": True},
+    }
+    # Non-streaming fallback
+    if not stream:
+        payload["stream"] = False
+
+    t_start = time.monotonic()
+
+    try:
+        if stream:
+            return _fire_stream(base_url, payload, priority, t_start)
+        else:
+            return _fire_non_stream(base_url, payload, priority, t_start)
+    except Exception as e:
+        return RequestMetrics(
+            request_id="error",
+            is_interactive=(priority == 0),
+            error=str(e),
+        )
+
+
+def _fire_stream(
+    base_url: str, payload: dict, priority: int, t_start: float
+) -> RequestMetrics:
+    """Fire a streaming request, parse TTFT and usage from SSE."""
+    headers = {"X-Request-Priority": str(priority)}
+    r = requests.post(
+        f"{base_url}/v1/chat/completions",
+        json=payload,
+        headers=headers,
+        stream=True,
+        timeout=120,
+    )
+    r.raise_for_status()
+
+    ttft = None
+    usage = None
+    for line in r.iter_lines(decode_unicode=True):
+        if not line or not line.startswith("data: "):
+            continue
+        data_str = line[6:]
+        if data_str.strip() == "[DONE]":
+            break
+        try:
+            chunk = json.loads(data_str)
+        except json.JSONDecodeError:
+            continue
+
+        # TTFT: first chunk with content
+        if ttft is None:
+            choices = chunk.get("choices", [])
+            if choices and choices[0].get("delta", {}).get("content"):
+                ttft = time.monotonic() - t_start
+
+        # Usage in final chunk
+        if "usage" in chunk:
+            usage = chunk["usage"]
+
+    elapsed = time.monotonic() - t_start
+
+    if usage:
+        return RequestMetrics(
+            request_id="",
+            is_interactive=(priority == 0),
+            time_to_first_token=usage.get("time_to_first_token") or ttft,
+            prompt_eval_duration=usage.get("prompt_eval_duration"),
+            generation_duration=usage.get("generation_duration"),
+            prompt_tokens_per_second=usage.get("prompt_tokens_per_second"),
+            generation_tokens_per_second=usage.get("generation_tokens_per_second"),
+            cached_tokens=(usage.get("prompt_tokens_details") or {}).get("cached_tokens"),
+            prompt_tokens=usage.get("prompt_tokens"),
+            completion_tokens=usage.get("completion_tokens"),
+        )
+    else:
+        return RequestMetrics(
+            request_id="",
+            is_interactive=(priority == 0),
+            time_to_first_token=ttft or elapsed,
+        )
+
+
+def _fire_non_stream(
+    base_url: str, payload: dict, priority: int, t_start: float
+) -> RequestMetrics:
+    """Fire a non-streaming request, parse TTFT from timing."""
+    r = requests.post(
+        f"{base_url}/v1/chat/completions",
+        json=payload,
+        timeout=120,
+    )
+    r.raise_for_status()
+    resp = r.json()
+    elapsed = time.monotonic() - t_start
+    usage = resp.get("usage", {})
+    return RequestMetrics(
+        request_id="",
+        is_interactive=(priority == 0),
+        time_to_first_token=usage.get("time_to_first_token") or elapsed,
+        prompt_eval_duration=usage.get("prompt_eval_duration"),
+        generation_duration=usage.get("generation_duration"),
+        prompt_tokens_per_second=usage.get("prompt_tokens_per_second"),
+        generation_tokens_per_second=usage.get("generation_tokens_per_second"),
+        cached_tokens=(usage.get("prompt_tokens_details") or {}).get("cached_tokens"),
+        prompt_tokens=usage.get("prompt_tokens"),
+        completion_tokens=usage.get("completion_tokens"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Benchmark runner
+# ---------------------------------------------------------------------------
+
+def run_bench(
+    base_url: str,
+    model: str,
+    bg_count: int,
+    bg_prompt_tokens: int,
+    interactive_runs: int,
+    turns: int,
+    max_tokens: int,
+    label: str,
+) -> BenchResult:
+    """Run one benchmark pass: bg_count background + interactive_runs interactive."""
+    print(f"\n{'='*60}")
+    print(f"Benchmark: {label}")
+    print(f"  background: {bg_count} x {bg_prompt_tokens} prompt tokens")
+    print(f"  interactive: {interactive_runs} runs x {turns} turns")
+    print(f"{'='*60}")
+
+    model_id = get_model_id(base_url, model)
+    print(f"  resolved model: {model_id}")
+
+    # Build prompts
+    bg_prompt = _prompt_tokens(bg_prompt_tokens)
+
+    result = BenchResult(run_label=label, background_count=bg_count, interactive_count=interactive_runs)
+
+    # Phase 1: fire background requests
+    print(f"\n  Firing {bg_count} background requests (priority=10)...")
+    bg_futures = {}
+    with ThreadPoolExecutor(max_workers=bg_count) as pool:
+        for i in range(bg_count):
+            fut = pool.submit(
+                fire_request, base_url, model_id, bg_prompt, priority=10, max_tokens=max_tokens
+            )
+            bg_futures[fut] = i
+        # Don't wait yet — let them start, then fire interactive
+
+    # Brief pause so background requests start prefilling
+    time.sleep(0.5)
+
+    # Phase 2: fire interactive requests
+    print(f"  Firing {interactive_runs} interactive requests (priority=0)...")
+    interactive_metrics: list[RequestMetrics] = []
+    turn_prompt = _prompt_tokens(256)
+
+    for run_i in range(interactive_runs):
+        for turn in range(turns):
+            m = fire_request(base_url, model_id, turn_prompt, priority=0, max_tokens=64)
+            m.request_id = f"interactive-{run_i}-turn{turn}"
+            interactive_metrics.append(m)
+            if m.time_to_first_token is not None:
+                print(f"    run {run_i} turn {turn}: TTFT={m.time_to_first_token:.3f}s")
+            elif m.error:
+                print(f"    run {run_i} turn {turn}: ERROR={m.error}")
+
+    # Collect background results
+    print(f"\n  Waiting for {bg_count} background requests to finish...")
+    bg_metrics: list[RequestMetrics] = []
+    for fut in as_completed(bg_futures):
+        m = fut.result()
+        m.request_id = f"background-{bg_futures[fut]}"
+        bg_metrics.append(m)
+
+    # Aggregate
+    result.interactive_ttfts = [
+        m.time_to_first_token for m in interactive_metrics
+        if m.time_to_first_token is not None and m.error is None
+    ]
+    result.background_ttfts = [
+        m.time_to_first_token for m in bg_metrics
+        if m.time_to_first_token is not None and m.error is None
+    ]
+    result.interactive_p50 = _percentile(result.interactive_ttfts, 0.50)
+    result.interactive_p95 = _percentile(result.interactive_ttfts, 0.95)
+    result.interactive_p99 = _percentile(result.interactive_ttfts, 0.99)
+    result.background_p50 = _percentile(result.background_ttfts, 0.50)
+    result.all_metrics = [asdict(m) for m in interactive_metrics + bg_metrics]
+
+    print(f"\n  Results ({label}):")
+    print(f"    interactive TTFT p50={result.interactive_p50:.3f}s  p95={result.interactive_p95:.3f}s  p99={result.interactive_p99:.3f}s  n={len(result.interactive_ttfts)}")
+    print(f"    background  TTFT p50={result.background_p50:.3f}s  n={len(result.background_ttfts)}")
+
+    errors = [m for m in interactive_metrics if m.error]
+    if errors:
+        print(f"    errors: {len(errors)}")
+        for e in errors[:5]:
+            print(f"      {e.request_id}: {e.error}")
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Assertions
+# ---------------------------------------------------------------------------
+
+def run_assertions(
+    result: BenchResult,
+    assert_ttft_p95: float | None,
+    assert_throughput_retention: float | None,
+    baseline: BenchResult | None,
+) -> list[str]:
+    """Return list of failure messages. Empty = all pass."""
+    failures: list[str] = []
+
+    if assert_ttft_p95 is not None:
+        if result.interactive_p95 is None:
+            failures.append(f"p95 TTFT: no data (all requests failed?)")
+        elif result.interactive_p95 > assert_ttft_p95:
+            failures.append(
+                f"p95 TTFT {result.interactive_p95:.3f}s > {assert_ttft_p95}s target"
+            )
+        else:
+            print(f"  PASS: p95 TTFT {result.interactive_p95:.3f}s <= {assert_ttft_p95}s")
+
+    if baseline and assert_throughput_retention is not None:
+        if baseline.background_p50 and result.background_p50:
+            retention = result.background_p50 / baseline.background_p50
+            if retention < assert_throughput_retention:
+                failures.append(
+                    f"background throughput retention {retention:.2f} < {assert_throughput_retention}"
+                )
+            else:
+                print(f"  PASS: background throughput retention {retention:.2f} >= {assert_throughput_retention}")
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Benchmark interactive preemption")
+    parser.add_argument("--base-url", default="http://127.0.0.1:18200")
+    parser.add_argument("--model", default="qwen3.6-35b-a3b-4bit")
+    parser.add_argument("--background", type=int, default=8)
+    parser.add_argument("--background-prompt-tokens", type=int, default=16384)
+    parser.add_argument("--interactive-runs", type=int, default=20)
+    parser.add_argument("--turns", type=int, default=4)
+    parser.add_argument("--max-tokens", type=int, default=64)
+    parser.add_argument("--baseline", type=str, default=None, help="Path to baseline JSON")
+    parser.add_argument("--assert-interactive-ttft-p95", type=float, default=None)
+    parser.add_argument("--assert-quiet-throughput-retention", type=float, default=None)
+    parser.add_argument("--json-out", type=str, default=None)
+    args = parser.parse_args()
+
+    # Health check
+    try:
+        health = check_health(args.base_url)
+        print(f"Server healthy: {health.get('status', 'unknown')}")
+    except Exception as e:
+        print(f"ERROR: Cannot reach server at {args.base_url}: {e}", file=sys.stderr)
+        return 1
+
+    # Load baseline if provided
+    baseline = None
+    if args.baseline:
+        bp = Path(args.baseline)
+        if bp.exists():
+            data = json.loads(bp.read_text())
+            baseline = BenchResult(**{k: v for k, v in data.items() if k in BenchResult.__dataclass_fields__})
+            print(f"Loaded baseline from {args.baseline}")
+
+    # Run
+    result = run_bench(
+        base_url=args.base_url,
+        model=args.model,
+        bg_count=args.background,
+        bg_prompt_tokens=args.background_prompt_tokens,
+        interactive_runs=args.interactive_runs,
+        turns=args.turns,
+        max_tokens=args.max_tokens,
+        label="candidate",
+    )
+
+    # Assert
+    failures = run_assertions(
+        result,
+        assert_ttft_p95=args.assert_interactive_ttft_p95,
+        assert_throughput_retention=args.assert_quiet_throughput_retention,
+        baseline=baseline,
+    )
+
+    # Save
+    if args.json_out:
+        out_path = Path(args.json_out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(asdict(result), indent=2))
+        print(f"\nSaved to {args.json_out}")
+
+    if failures:
+        print(f"\nFAILED: {len(failures)} assertion(s):", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print(f"\nAll assertions passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -807,3 +807,76 @@ class TestApplyChatTemplatePartialMode:
         # continue_final_message=True (not add_generation_prompt=True).
         assert count_kwargs["continue_final_message"] is True
         assert count_kwargs["add_generation_prompt"] is False
+
+
+class TestStreamChatRenderedPromptShortCircuit:
+    """``stream_chat`` must skip re-rendering the chat template when the
+    caller (server.py's chat-completions handler) already rendered it —
+    the redundant-render elimination on the hot chat-completions path."""
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_uses_rendered_prompt_when_given(self):
+        from omlx.engine.base import GenerationOutput
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        engine._loaded = True
+        engine._model = MagicMock(spec=[])  # not gpt_oss
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template = MagicMock(
+            side_effect=AssertionError(
+                "should not re-render when rendered_prompt is given"
+            )
+        )
+        engine._tokenizer = mock_tokenizer
+
+        captured_prompts = []
+
+        async def fake_stream_generate(prompt, **kwargs):
+            captured_prompts.append(prompt)
+            yield GenerationOutput(text="hi", new_text="hi")
+
+        engine.stream_generate = fake_stream_generate
+
+        outputs = [
+            output
+            async for output in engine.stream_chat(
+                [{"role": "user", "content": "hi"}],
+                rendered_prompt="already rendered prompt",
+            )
+        ]
+
+        assert captured_prompts == ["already rendered prompt"]
+        assert [o.new_text for o in outputs] == ["hi"]
+        mock_tokenizer.apply_chat_template.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_renders_when_rendered_prompt_omitted(self):
+        """Default (no rendered_prompt) behavior is unchanged."""
+        from omlx.engine.base import GenerationOutput
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        engine._loaded = True
+        engine._model = MagicMock(spec=[])  # not gpt_oss
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template = MagicMock(return_value="rendered here")
+        engine._tokenizer = mock_tokenizer
+
+        captured_prompts = []
+
+        async def fake_stream_generate(prompt, **kwargs):
+            captured_prompts.append(prompt)
+            yield GenerationOutput(text="hi", new_text="hi")
+
+        engine.stream_generate = fake_stream_generate
+
+        [
+            output
+            async for output in engine.stream_chat([{"role": "user", "content": "hi"}])
+        ]
+
+        assert captured_prompts == ["rendered here"]
+        mock_tokenizer.apply_chat_template.assert_called_once()

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -1621,6 +1621,63 @@ class TestStepBurst:
         finally:
             engine.close()
 
+    def test_aggressive_mode_uses_single_budget_when_concurrent(
+        self, mock_model, mock_tokenizer
+    ):
+        """'aggressive' mode shares the single-request budget under concurrency.
+
+        Unless the operator explicitly pinned decode_burst_budget_s, aggressive
+        mode should not throttle concurrent requests tighter than solo ones.
+        """
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            config = EngineConfig(
+                decode_burst_max_steps=4,
+                decode_burst_budget_single_s=10.0,  # large -> burst to cap
+                decode_burst_budget_s=0.0,  # would disable if used
+                decode_burst_mode="aggressive",
+            )
+            engine = EngineCore(
+                model=mock_model, tokenizer=mock_tokenizer, config=config
+            )
+        try:
+            engine.scheduler.step = MagicMock(
+                return_value=SchedulerOutput(has_work=True)
+            )
+            engine.scheduler.has_requests = MagicMock(return_value=True)
+            engine.scheduler.running = {"a": object(), "b": object()}  # concurrent
+            outs = engine._step_burst()
+            assert len(outs) == 4
+        finally:
+            engine.close()
+
+    def test_aggressive_mode_respects_explicit_concurrent_budget(
+        self, mock_model, mock_tokenizer
+    ):
+        """An explicitly-set decode_burst_budget_s still wins in aggressive mode."""
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            config = EngineConfig(
+                decode_burst_max_steps=4,
+                decode_burst_budget_single_s=10.0,  # would burst if used
+                decode_burst_budget_s=0.0,  # explicit -> must still disable
+                decode_burst_mode="aggressive",
+                decode_burst_budget_s_explicit=True,
+            )
+            engine = EngineCore(
+                model=mock_model, tokenizer=mock_tokenizer, config=config
+            )
+        try:
+            engine.scheduler.step = MagicMock(
+                return_value=SchedulerOutput(has_work=True)
+            )
+            engine.scheduler.has_requests = MagicMock(return_value=True)
+            engine.scheduler.running = {"a": object(), "b": object()}  # concurrent
+            outs = engine._step_burst()
+            assert len(outs) == 1
+        finally:
+            engine.close()
+
 
 class TestOrphanedCollectorReaping:
     """Reaping of output collectors orphaned by a client disconnect (#1154).

--- a/tests/test_engine_preflight.py
+++ b/tests/test_engine_preflight.py
@@ -206,6 +206,33 @@ async def test_batched_engine_preflight_chat_raises_for_oversize_prompt(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_batched_engine_preflight_chat_uses_rendered_prompt_when_given(
+    monkeypatch,
+):
+    """When the caller (server.py's chat-completions handler) already
+    rendered the chat template, ``preflight_chat`` must encode that prompt
+    directly instead of re-rendering it — the redundant-render elimination
+    on the hot chat-completions path."""
+    from omlx.engine.batched import BatchedEngine
+
+    scheduler = _make_scheduler()
+    scheduler.preflight_or_raise = lambda **k: None  # type: ignore[assignment]
+
+    engine = _build_engine_with_stub_scheduler(BatchedEngine, scheduler)
+    engine._apply_chat_template = MagicMock(
+        side_effect=AssertionError("should not re-render when rendered_prompt is given")
+    )
+
+    await engine.preflight_chat(
+        messages=[{"role": "user", "content": "x"}],
+        rendered_prompt="already rendered prompt",
+    )
+
+    engine._apply_chat_template.assert_not_called()
+    engine._tokenizer.encode.assert_called_once_with("already rendered prompt")
+
+
+@pytest.mark.asyncio
 async def test_vlm_engine_preflight_chat_raises_for_oversize_prompt(monkeypatch):
     from omlx.engine.vlm import VLMBatchedEngine
 

--- a/tests/test_interactive_session_cache.py
+++ b/tests/test_interactive_session_cache.py
@@ -1,0 +1,247 @@
+"""Tests for InteractiveSessionCache."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class FakeClock:
+    """Deterministic clock for testing."""
+
+    def __init__(self, start: float = 0.0):
+        self._now = start
+
+    def __call__(self) -> float:
+        return self._now
+
+    def advance(self, secs: float) -> None:
+        self._now += secs
+
+
+@pytest.fixture
+def clock():
+    return FakeClock()
+
+
+@pytest.fixture
+def cache(clock):
+    from omlx.cache.interactive_session_cache import InteractiveSessionCache
+
+    return InteractiveSessionCache(
+        ttl_secs=60.0,
+        max_sessions=4,
+        max_bytes=10_000,
+        clock=clock,
+    )
+
+
+# ---- put / take basic ----
+
+
+def test_priority_zero_completion_creates_protected_tip(cache, clock):
+    """Complete priority-zero turn → one protected entry with full token sequence."""
+    tokens = [100, 200, 300, 400]
+    cache_data = [b"layer0", b"layer1"]
+
+    assert cache.put(tokens, cache_data) is True
+    assert cache.session_count == 1
+
+    result = cache.take_longest_prefix(tokens)
+    assert result is not None
+    data, config, prefix_len = result
+    assert data == cache_data
+    assert prefix_len == 4
+    assert cache.session_count == 0  # transferred
+
+
+def test_background_completion_does_not_create_protected_tip(cache):
+    """Background completions don't call put → cache stays empty."""
+    # The cache itself doesn't filter by priority — caller decides.
+    # This test verifies that if we simply don't call put, cache is empty.
+    assert cache.session_count == 0
+    result = cache.take_longest_prefix([100, 200])
+    assert result is None
+
+
+def test_put_rejects_empty_tokens(cache):
+    assert cache.put([], [b"data"]) is False
+
+
+def test_put_rejects_empty_cache_data(cache):
+    assert cache.put([1, 2, 3], []) is False
+
+
+def test_put_rejects_oversized_entry(cache):
+    """Entry exceeding max_bytes is rejected."""
+    big_data = [b"x" * 1000 for _ in range(100)]
+    assert cache.put([1, 2, 3], big_data) is False
+    assert cache.session_count == 0
+
+
+# ---- prefix matching ----
+
+
+def test_partial_tip_matches_exact_extended_prefix(cache):
+    """Store non-block-aligned tokens, request same prefix + suffix → match."""
+    stored = [100, 200, 300]
+    cache.put(stored, [b"kv1"])
+
+    # Request with longer prefix — should match first 3 tokens
+    result = cache.take_longest_prefix([100, 200, 300, 400, 500])
+    assert result is not None
+    _, _, prefix_len = result
+    assert prefix_len == 3
+
+
+def test_longest_protected_prefix_wins(cache):
+    """Store nested prefixes → longest exact prefix transfers."""
+    short = [100, 200]
+    long = [100, 200, 300, 400]
+
+    cache.put(short, [b"short"])
+    cache.put(long, [b"long"])
+
+    result = cache.take_longest_prefix([100, 200, 300, 400, 500])
+    assert result is not None
+    data, _, prefix_len = result
+    assert data == [b"long"]
+    assert prefix_len == 4
+
+
+def test_hit_transfers_entry_instead_of_sharing_mutable_cache(cache):
+    """take removes entry before caller can mutate returned cache."""
+    tokens = [100, 200]
+    original_data = [b"kv"]
+    cache.put(tokens, original_data)
+
+    result = cache.take_longest_prefix(tokens)
+    assert result is not None
+    data, _, _ = result
+
+    # Mutate the returned data
+    data.append(b"mutated")
+
+    # Cache should be empty (transferred)
+    assert cache.session_count == 0
+
+    # Re-put original — should not contain mutation
+    cache.put(tokens, original_data)
+    result2 = cache.take_longest_prefix(tokens)
+    assert result2 is not None
+    assert b"mutated" not in result2[0]
+
+
+# ---- TTL ----
+
+
+def test_expired_entry_misses(cache, clock):
+    """Advance clock beyond TTL → miss + eviction."""
+    cache.put([100, 200], [b"kv"])
+
+    clock.advance(61.0)  # TTL is 60s
+
+    result = cache.take_longest_prefix([100, 200])
+    assert result is None
+    stats = cache.get_stats()
+    assert stats["evictions"] >= 1
+
+
+# ---- session limit ----
+
+
+def test_session_limit_evicts_lru(cache):
+    """Exceed session bound → LRU entry disappears."""
+    for i in range(6):  # max_sessions=4
+        cache.put([i * 100, i * 100 + 1], [f"kv{i}"])
+
+    assert cache.session_count == 4
+
+    # Oldest entries (0, 1) should be evicted
+    assert cache.take_longest_prefix([0, 1]) is None
+    assert cache.take_longest_prefix([100, 101]) is None
+
+
+# ---- byte limit ----
+
+
+def test_byte_limit_evicts_lru(cache):
+    """Exceed byte bound → bytes return at or below ceiling."""
+    # Each entry is ~128 bytes per cache_data element
+    # max_bytes=10000, so fill with large entries
+    for i in range(20):
+        data = [b"x" * 512 for _ in range(10)]  # ~6400 bytes each
+        cache.put([i], data)
+
+    assert cache.total_bytes <= 10_000
+
+
+# ---- pressure ----
+
+
+def test_hard_pressure_can_evict_protected_entry(cache, clock):
+    """force=True shrink_to(0) removes all entries."""
+    cache.put([100, 200], [b"kv"])
+    cache.put([300, 400], [b"kv2"])
+
+    released = cache.shrink_to(0, force=True)
+    assert released > 0
+    assert cache.session_count == 0
+
+
+def test_normal_pressure_preserves_unexpired_interactive_entry(cache, clock):
+    """force=False shrink retains unexpired entries when possible."""
+    cache.put([100, 200], [b"kv"])
+
+    # Shrink to a large target — should not evict unexpired entry
+    released = cache.shrink_to(1_000_000, force=False)
+    assert released == 0
+    assert cache.session_count == 1
+
+
+# ---- full-block prefix cache behavior unchanged ----
+
+
+def test_full_block_prefix_cache_behavior_is_unchanged(cache):
+    """Interactive cache doesn't interfere with normal prefix lookup."""
+    # Store an entry
+    cache.put([100, 200, 300], [b"kv"])
+
+    # Normal prefix lookup (different tokens) should miss
+    result = cache.take_longest_prefix([500, 600, 700])
+    assert result is None
+
+    # Original entry should still be there
+    assert cache.session_count == 1
+
+
+# ---- multi-turn cached tokens ----
+
+
+def test_multi_turn_cached_tokens_include_trailing_partial_tokens(cache):
+    """Store one full block plus partial tail → reported count includes both."""
+    # Simulate: full block = 256 tokens, partial = 42 tokens
+    full_block = list(range(256))
+    partial_tail = list(range(256, 298))
+    all_tokens = full_block + partial_tail
+
+    cache.put(all_tokens, [b"kv_full_and_partial"])
+
+    result = cache.take_longest_prefix(all_tokens)
+    assert result is not None
+    _, _, prefix_len = result
+    assert prefix_len == 298  # full block + partial
+
+
+# ---- stats ----
+
+
+def test_get_stats(cache):
+    cache.put([100], [b"a"])
+    cache.take_longest_prefix([100])  # hit
+    cache.take_longest_prefix([999])  # miss
+
+    stats = cache.get_stats()
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+    assert stats["sessions"] == 0  # transferred
+    assert isinstance(stats["bytes"], int)

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -418,6 +418,16 @@ class TestChatCompletionRequest:
         assert req.max_tokens is None
         assert req.stream is False
         assert req.tools is None
+        assert req.priority is None
+
+    def test_priority_field_accepts_explicit_value(self):
+        """priority round-trips; omitting it (the common case today) leaves None."""
+        req = ChatCompletionRequest(
+            model="gpt-4",
+            messages=[Message(role="user", content="Hello")],
+            priority=0,
+        )
+        assert req.priority == 0
 
     def test_request_with_all_fields(self):
         """Test creating request with all fields."""

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -2428,3 +2428,72 @@ class TestDFlashGuardPropagation:
         engine.scheduler = scheduler
         entry = _make_entry("model-a", engine=engine)
         assert enforcer._resolve_scheduler(entry) is scheduler
+
+
+class TestAdaptiveCacheController:
+    """OMLX_ADAPTIVE_CACHE: pressure-coupled MLX buffer-cache pool."""
+
+    def _controller(self, enabled=True, trigger=79.0, shrink_gb=2.6, base_gb=6.0):
+        from omlx.process_memory_enforcer import AdaptiveCacheController
+
+        calls = {"set": [], "clear": 0}
+
+        def fake_set(b):
+            calls["set"].append(b)
+
+        def fake_clear():
+            calls["clear"] += 1
+
+        c = AdaptiveCacheController(
+            enabled=enabled,
+            shrink_bytes=int(shrink_gb * 1024**3),
+            trigger_pct=trigger,
+            set_cache_limit=fake_set,
+            clear_cache=fake_clear,
+            base_limit_bytes=int(base_gb * 1024**3),
+        )
+        return c, calls
+
+    def test_disabled_never_touches_cache(self):
+        c, calls = self._controller(enabled=False)
+        for pct in (50.0, 85.0, 99.0, 60.0):
+            c.maybe_adjust(pct)
+        assert calls["set"] == [] and calls["clear"] == 0
+
+    def test_below_trigger_no_action(self):
+        c, calls = self._controller()
+        c.maybe_adjust(70.0)
+        assert calls["set"] == [] and not c.shrunk
+
+    def test_shrinks_once_at_trigger_and_holds(self):
+        c, calls = self._controller()
+        c.maybe_adjust(80.0)
+        c.maybe_adjust(90.0)  # stays shrunk, no repeat calls
+        assert calls["set"] == [int(2.6 * 1024**3)]
+        assert calls["clear"] == 1
+        assert c.shrunk
+
+    def test_hysteresis_restore(self):
+        c, calls = self._controller()
+        c.maybe_adjust(80.0)  # shrink
+        c.maybe_adjust(77.0)  # inside hysteresis band (restore at <= 75) -> hold
+        assert c.shrunk
+        c.maybe_adjust(74.0)  # restore
+        assert not c.shrunk
+        assert calls["set"][-1] == int(6.0 * 1024**3)
+        # full cycle can repeat
+        c.maybe_adjust(80.0)
+        assert c.shrunk and calls["clear"] == 2
+
+    def test_from_env_parsing(self, monkeypatch):
+        from omlx.process_memory_enforcer import AdaptiveCacheController
+
+        monkeypatch.setenv("OMLX_ADAPTIVE_CACHE", "1")
+        monkeypatch.setenv("OMLX_ADAPTIVE_CACHE_SHRINK_GB", "3.0")
+        monkeypatch.setenv("OMLX_ADAPTIVE_CACHE_TRIGGER_PCT", "82")
+        c = AdaptiveCacheController.from_env()
+        assert c.enabled
+        assert c._shrink_bytes == int(3.0 * 1024**3)
+        assert c._trigger_pct == 82.0
+        monkeypatch.delenv("OMLX_ADAPTIVE_CACHE")
+        assert not AdaptiveCacheController.from_env().enabled

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -17,6 +17,7 @@ import numpy as np
 import pytest
 
 from omlx.utils.sampling import (
+    _fused_top_k_top_p,
     apply_min_p,
     apply_top_k,
     apply_top_p,
@@ -173,3 +174,66 @@ def test_make_sampler_runs_with_various_top_p(top_p):
     mx.eval(out)
     token = out.item()
     assert 0 <= token < 1000
+
+
+def test_make_sampler_fused_top_p_top_k_runs_and_is_valid():
+    """make_sampler's fused top_p+top_k fast path should sample a valid token
+    for the production sampler config (temp=1.0, top_p=0.95, top_k=20)."""
+    mx.random.seed(0)
+    logits = mx.random.normal(shape=(1, 5000))
+    mx.eval(logits)
+
+    sampler = make_sampler(temp=1.0, top_p=0.95, top_k=20)
+    out = sampler(logits)
+    mx.eval(out)
+    token = out.item()
+    assert 0 <= token < 5000
+
+
+def _old_top_k_top_p_pipeline(
+    logprobs: mx.array, top_k: int, top_p: float
+) -> mx.array:
+    """Reproduces make_sampler's pre-fusion composition order (top_p first,
+    then top_k) using the unfused per-method helpers, as the fast-path
+    reference."""
+    out = apply_top_p(logprobs, top_p)
+    out = apply_top_k(out, top_k)
+    return out
+
+
+@pytest.mark.parametrize("top_p,top_k", [(0.95, 20), (0.9, 100)])
+@pytest.mark.parametrize("batch", [1, 4])
+def test_fused_top_k_top_p_matches_old_pipeline(batch, top_p, top_k):
+    """_fused_top_k_top_p (argpartition over just the top_k candidates) must
+    reproduce apply_top_p -> apply_top_k (full-vocab argsort) exactly: same
+    surviving token set, same renormalized probabilities within bf16
+    tolerance, at the real 248,320-token production vocab."""
+    vocab = 248320
+    n_iters = 200
+    mx.random.seed(0)
+
+    for i in range(n_iters):
+        raw = mx.random.normal(shape=(batch, vocab)).astype(mx.bfloat16) * 3.0
+        logprobs = raw - mx.logsumexp(
+            raw.astype(mx.float32), axis=-1, keepdims=True
+        ).astype(mx.bfloat16)
+
+        old = _old_top_k_top_p_pipeline(logprobs, top_k, top_p)
+        new = _fused_top_k_top_p(logprobs, top_k, top_p)
+        mx.eval(old, new)
+
+        old_np = np.asarray(old.astype(mx.float32))
+        new_np = np.asarray(new.astype(mx.float32))
+        old_finite = np.isfinite(old_np)
+        new_finite = np.isfinite(new_np)
+        assert np.array_equal(old_finite, new_finite), (
+            f"iter {i}: surviving token sets differ "
+            f"(old={old_finite.sum(-1)}, new={new_finite.sum(-1)})"
+        )
+
+        # Renormalized probabilities over the surviving tokens must match.
+        old_probs = np.asarray(mx.softmax(old, axis=-1).astype(mx.float32))
+        new_probs = np.asarray(mx.softmax(new, axis=-1).astype(mx.float32))
+        assert np.allclose(
+            old_probs, new_probs, atol=1e-3
+        ), f"iter {i}: renormalized probabilities differ by more than 1e-3"

--- a/tests/test_scheduler_admission.py
+++ b/tests/test_scheduler_admission.py
@@ -167,3 +167,11 @@ class TestInteractiveSlotReservation:
         s = self._scheduler()
         s.prefilling.append(self._req("bg1", 10))
         assert s._background_slots_exhausted(self._req("bg2", 10))
+
+    def test_same_pass_scheduled_counts_toward_share(self):
+        # Two simultaneous background arrivals in ONE _schedule_waiting pass:
+        # the first is admitted (in `scheduled`, not yet running); the second
+        # must still be blocked. Regression: live probe showed both admitted.
+        s = self._scheduler()
+        first_bg = self._req("bg1", 10)
+        assert s._background_slots_exhausted(self._req("bg2", 10), [first_bg])

--- a/tests/test_scheduler_admission.py
+++ b/tests/test_scheduler_admission.py
@@ -100,3 +100,70 @@ class TestAdmissionPausedField:
         s._prefill_memory_guard = False
         s._admission_paused = False
         assert s._admission_paused is False
+
+
+class TestInteractiveSlotReservation:
+    """OMLX_INTERACTIVE_RESERVED_SLOTS -> Scheduler._background_slots_exhausted."""
+
+    def _scheduler(self, *, max_num_seqs=2, reserved=1, policy=None):
+        from omlx.scheduler import SchedulerConfig, SchedulingPolicy
+
+        s = Scheduler.__new__(Scheduler)
+        s.config = SchedulerConfig(
+            max_num_seqs=max_num_seqs,
+            policy=policy if policy is not None else SchedulingPolicy.PRIORITY,
+            reserved_interactive_slots=reserved,
+        )
+        s.running = {}
+        s.prefilling = []
+        s.waiting = deque()
+        s._serialize_llama4_requests = False
+        s._generation_overflow_recovery_ids = set()
+        return s
+
+    def _req(self, rid: str, priority: int):
+        r = _make_request(rid)
+        r.priority = priority
+        return r
+
+    def test_disabled_by_default_is_inert(self):
+        s = self._scheduler(reserved=0)
+        s.running["bg1"] = self._req("bg1", 10)
+        s.running["bg2"] = self._req("bg2", 10)
+        assert not s._background_slots_exhausted(self._req("bg3", 10))
+
+    def test_blocks_background_when_share_full(self):
+        # max=2, reserved=1 -> background share = 1 slot.
+        s = self._scheduler()
+        s.running["bg1"] = self._req("bg1", 10)
+        assert s._background_slots_exhausted(self._req("bg2", 10))
+
+    def test_admits_background_when_share_free(self):
+        s = self._scheduler()
+        s.running["chat"] = self._req("chat", 0)  # interactive occupies, bg share free
+        assert not s._background_slots_exhausted(self._req("bg1", 10))
+
+    def test_interactive_never_reservation_blocked(self):
+        s = self._scheduler()
+        s.running["bg1"] = self._req("bg1", 10)
+        s.prefilling.append(self._req("bg2", 10))
+        assert not s._background_slots_exhausted(self._req("chat", 0))
+
+    def test_background_never_fully_starved(self):
+        # max=1, reserved=1 -> background share floors at 1, not 0.
+        s = self._scheduler(max_num_seqs=1, reserved=1)
+        assert not s._background_slots_exhausted(self._req("bg1", 10))
+        s.running["bg1"] = self._req("bg1", 10)
+        assert s._background_slots_exhausted(self._req("bg2", 10))
+
+    def test_inert_under_fcfs_policy(self):
+        from omlx.scheduler import SchedulingPolicy
+
+        s = self._scheduler(policy=SchedulingPolicy.FCFS)
+        s.running["bg1"] = self._req("bg1", 10)
+        assert not s._background_slots_exhausted(self._req("bg2", 10))
+
+    def test_prefilling_counts_toward_background_share(self):
+        s = self._scheduler()
+        s.prefilling.append(self._req("bg1", 10))
+        assert s._background_slots_exhausted(self._req("bg2", 10))

--- a/tests/test_scheduler_decode_floor.py
+++ b/tests/test_scheduler_decode_floor.py
@@ -1,0 +1,387 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for decode floor: suspend excess background decode rows when interactive active.
+
+Strategy: mock model/tokenizer/BatchGenerator, manipulate scheduler queues directly,
+verify suspend/resume logic without GPU.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from omlx.request import Request, SamplingParams
+from omlx.scheduler import (
+    Scheduler,
+    SchedulerConfig,
+    _SuspendedDecodeState,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_scheduler(
+    decode_floor: float = 0.5,
+    max_num_seqs: int = 8,
+) -> Scheduler:
+    model = MagicMock()
+    model.layers = []
+    tokenizer = MagicMock()
+    tokenizer.eos_token_id = 2
+    config = SchedulerConfig(
+        max_num_seqs=max_num_seqs,
+        prefill_step_size=4,
+        chunked_prefill=True,
+        paged_cache_block_size=0,
+        prefill_preemption=True,
+        interactive_decode_floor=decode_floor,
+    )
+    scheduler = Scheduler(model=model, tokenizer=tokenizer, config=config)
+    mock_bg = MagicMock()
+    mock_bg.insert.return_value = [42]
+    mock_bg.remove.return_value = {}
+    mock_bg.next_generated.return_value = iter([])
+    scheduler.batch_generator = mock_bg
+    scheduler._current_sampler_params = ()
+    return scheduler
+
+
+def _make_request(
+    request_id: str = "req-1",
+    n_tokens: int = 10,
+    priority: int = 0,
+    max_tokens: int = 32,
+) -> Request:
+    req = Request(
+        request_id=request_id,
+        prompt=list(range(n_tokens)),
+        sampling_params=SamplingParams(max_tokens=max_tokens),
+        priority=priority,
+    )
+    req.prompt_token_ids = list(range(n_tokens))
+    req.num_prompt_tokens = n_tokens
+    req.remaining_tokens = list(range(n_tokens))
+    return req
+
+
+def _enqueue_running(
+    scheduler: Scheduler,
+    request: Request,
+    uid: int = 10,
+) -> None:
+    """Put a request directly into running state (simulating post-prefill)."""
+    scheduler.running[request.request_id] = request
+    scheduler.requests[request.request_id] = request
+    scheduler.uid_to_request_id[uid] = request.request_id
+    scheduler.request_id_to_uid[request.request_id] = uid
+    request.batch_uid = uid
+
+
+# ---------------------------------------------------------------------------
+# Tests: floor calculation
+# ---------------------------------------------------------------------------
+
+class TestTargetBackgroundDecodeRows:
+    def test_floor_zero_keeps_all(self):
+        s = _make_scheduler(decode_floor=0.0)
+        r1 = _make_request("bg1", priority=10)
+        r2 = _make_request("bg2", priority=10)
+        _enqueue_running(s, r1, uid=1)
+        _enqueue_running(s, r2, uid=2)
+        # floor=0 means no limit
+        assert s._target_background_decode_rows() == 2
+
+    def test_floor_one_removes_all_with_interactive(self):
+        s = _make_scheduler(decode_floor=1.0)
+        interactive = _make_request("chat1", priority=0)
+        bg1 = _make_request("bg1", priority=10)
+        _enqueue_running(s, interactive, uid=1)
+        _enqueue_running(s, bg1, uid=2)
+        # floor=1.0, 1 interactive → floor((1*0)/1) = 0
+        assert s._target_background_decode_rows() == 0
+
+    def test_floor_one_keeps_all_when_no_interactive(self):
+        s = _make_scheduler(decode_floor=1.0)
+        r1 = _make_request("bg1", priority=10)
+        _enqueue_running(s, r1, uid=1)
+        # floor=1.0, 0 interactive → return current count (1)
+        assert s._target_background_decode_rows() == 1
+
+    def test_floor_half_one_per_interactive(self):
+        s = _make_scheduler(decode_floor=0.5)
+        interactive = _make_request("chat1", priority=0)
+        bg1 = _make_request("bg1", priority=10)
+        bg2 = _make_request("bg2", priority=10)
+        _enqueue_running(s, interactive, uid=1)
+        _enqueue_running(s, bg1, uid=2)
+        _enqueue_running(s, bg2, uid=3)
+        # 1 interactive, floor=0.5 → floor((1*(1-0.5))/0.5) = floor(1) = 1
+        assert s._target_background_decode_rows() == 1
+
+    def test_floor_quarter_two_per_interactive(self):
+        s = _make_scheduler(decode_floor=0.25)
+        interactive = _make_request("chat1", priority=0)
+        bg1 = _make_request("bg1", priority=10)
+        bg2 = _make_request("bg2", priority=10)
+        bg3 = _make_request("bg3", priority=10)
+        _enqueue_running(s, interactive, uid=1)
+        _enqueue_running(s, bg1, uid=2)
+        _enqueue_running(s, bg2, uid=3)
+        _enqueue_running(s, bg3, uid=4)
+        # 1 interactive, floor=0.25 → floor((1*0.75)/0.25) = floor(3) = 3
+        assert s._target_background_decode_rows() == 3
+
+    def test_no_interactive_returns_current(self):
+        s = _make_scheduler(decode_floor=0.5)
+        bg1 = _make_request("bg1", priority=10)
+        bg2 = _make_request("bg2", priority=10)
+        _enqueue_running(s, bg1, uid=1)
+        _enqueue_running(s, bg2, uid=2)
+        # No interactive → return current count
+        assert s._target_background_decode_rows() == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: suspend/resume
+# ---------------------------------------------------------------------------
+
+class TestSuspendDecodeRequest:
+    def test_suspend_extracts_cache_and_removes_from_batch(self):
+        s = _make_scheduler(decode_floor=0.5)
+        req = _make_request("bg1", priority=10)
+        _enqueue_running(s, req, uid=5)
+
+        fake_cache = [MagicMock(), MagicMock()]
+        fake_tokens = [1, 2, 3]
+        s.batch_generator.remove.return_value = {5: (fake_cache, fake_tokens)}
+
+        result = s._suspend_decode_request("bg1")
+        assert result is True
+        assert "bg1" in s._suspended_decodes
+        assert s._decode_suspensions == 1
+        s.batch_generator.remove.assert_called_once_with([5], return_prompt_caches=True)
+        # uid mappings cleaned up
+        assert 5 not in s.uid_to_request_id
+        assert "bg1" not in s.request_id_to_uid
+        # batch_uid cleared
+        assert req.batch_uid is None
+        # request stays in running
+        assert "bg1" in s.running
+
+    def test_suspend_preserves_state(self):
+        s = _make_scheduler(decode_floor=0.5)
+        req = _make_request("bg1", priority=10, max_tokens=100)
+        req.output_token_ids = [10, 11, 12]
+        _enqueue_running(s, req, uid=5)
+
+        fake_cache = [MagicMock()]
+        fake_tokens = [1, 2, 3, 10, 11, 12]
+        s.batch_generator.remove.return_value = {5: (fake_cache, fake_tokens)}
+
+        s._suspend_decode_request("bg1")
+        state = s._suspended_decodes["bg1"]
+        assert state.request is req
+        assert state.prompt_cache == fake_cache
+        assert state.remaining_max_tokens == 100 - 3  # max_tokens - len(output)
+
+    def test_suspend_skips_interactive(self):
+        s = _make_scheduler(decode_floor=0.5)
+        req = _make_request("chat1", priority=0)
+        _enqueue_running(s, req, uid=5)
+
+        result = s._suspend_decode_request("chat1")
+        assert result is False
+        assert "chat1" not in s._suspended_decodes
+
+    def test_suspend_skips_already_suspended(self):
+        s = _make_scheduler(decode_floor=0.5)
+        req = _make_request("bg1", priority=10)
+        _enqueue_running(s, req, uid=5)
+
+        fake_cache = [MagicMock()]
+        s.batch_generator.remove.return_value = {5: (fake_cache, [1])}
+        s._suspend_decode_request("bg1")
+        s.batch_generator.remove.reset_mock()
+
+        # Second call should return False (not in request_id_to_uid)
+        result = s._suspend_decode_request("bg1")
+        assert result is False
+        s.batch_generator.remove.assert_not_called()
+
+    def test_suspend_skips_vlm_mtp(self):
+        s = _make_scheduler(decode_floor=0.5)
+        req = _make_request("mtp1", priority=10)
+        _enqueue_running(s, req, uid=-1)  # negative uid = vlm_mtp
+
+        result = s._suspend_decode_request("mtp1")
+        assert result is False
+
+
+class TestResumeSuspendedDecodes:
+    def test_resume_reinserts_into_batch(self):
+        s = _make_scheduler(decode_floor=0.5)
+        req = _make_request("bg1", priority=10)
+        _enqueue_running(s, req, uid=5)
+
+        fake_cache = [MagicMock()]
+        fake_tokens = [1, 2, 3]
+        s.batch_generator.remove.return_value = {5: (fake_cache, fake_tokens)}
+        s._suspend_decode_request("bg1")
+        s.batch_generator.insert.return_value = [99]  # new uid on re-insert
+
+        resumed = s._resume_suspended_decodes()
+        assert resumed == 1
+        assert "bg1" not in s._suspended_decodes
+        assert s._decode_resumes == 1
+        s.batch_generator.insert.assert_called_once()
+        # New uid mapping established
+        assert s.request_id_to_uid["bg1"] == 99
+        assert s.uid_to_request_id[99] == "bg1"
+        assert req.batch_uid == 99
+
+    def test_resume_skips_aborted_requests(self):
+        s = _make_scheduler(decode_floor=0.5)
+        req = _make_request("bg1", priority=10)
+        _enqueue_running(s, req, uid=5)
+
+        fake_cache = [MagicMock()]
+        s.batch_generator.remove.return_value = {5: (fake_cache, [1])}
+        s._suspend_decode_request("bg1")
+
+        # Simulate abort: remove from running
+        del s.running["bg1"]
+
+        resumed = s._resume_suspended_decodes()
+        assert resumed == 0
+
+    def test_resume_empty_dict(self):
+        s = _make_scheduler(decode_floor=0.5)
+        resumed = s._resume_suspended_decodes()
+        assert resumed == 0
+
+
+class TestCleanupSuspendedDecode:
+    def test_cleanup_removes_from_dict(self):
+        s = _make_scheduler(decode_floor=0.5)
+        req = _make_request("bg1", priority=10)
+        _enqueue_running(s, req, uid=5)
+
+        fake_cache = [MagicMock()]
+        s.batch_generator.remove.return_value = {5: (fake_cache, [1])}
+        s._suspend_decode_request("bg1")
+        assert "bg1" in s._suspended_decodes
+
+        s._cleanup_suspended_decode("bg1")
+        assert "bg1" not in s._suspended_decodes
+
+    def test_cleanup_noop_for_unknown(self):
+        s = _make_scheduler(decode_floor=0.5)
+        s._cleanup_suspended_decode("nonexistent")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Tests: apply_decode_floor
+# ---------------------------------------------------------------------------
+
+class TestApplyDecodeFloor:
+    def test_floor_zero_noop(self):
+        s = _make_scheduler(decode_floor=0.0)
+        bg1 = _make_request("bg1", priority=10)
+        _enqueue_running(s, bg1, uid=1)
+        s._apply_decode_floor()
+        assert s._decode_suspensions == 0
+
+    def test_no_interactive_resumes_all(self):
+        s = _make_scheduler(decode_floor=0.5)
+        bg1 = _make_request("bg1", priority=10)
+        _enqueue_running(s, bg1, uid=1)
+        fake_cache = [MagicMock()]
+        s.batch_generator.remove.return_value = {1: (fake_cache, [1])}
+        s._suspend_decode_request("bg1")
+        s.batch_generator.insert.return_value = [1]
+
+        s._apply_decode_floor()
+        assert s._decode_resumes == 1
+        assert "bg1" not in s._suspended_decodes
+
+    def test_suspend_excess_when_interactive_active(self):
+        s = _make_scheduler(decode_floor=0.5)
+        interactive = _make_request("chat1", priority=0)
+        bg1 = _make_request("bg1", priority=10)
+        bg2 = _make_request("bg2", priority=10)
+        _enqueue_running(s, interactive, uid=1)
+        _enqueue_running(s, bg1, uid=2)
+        _enqueue_running(s, bg2, uid=3)
+
+        fake_cache = [MagicMock()]
+        s.batch_generator.remove.side_effect = [
+            {2: (fake_cache, [1])},  # suspend bg1
+        ]
+
+        s._apply_decode_floor()
+        # 1 interactive, floor=0.5 → target=1 bg, 2 active → 1 excess
+        assert s._decode_suspensions == 1
+        assert "bg1" in s._suspended_decodes or "bg2" in s._suspended_decodes
+
+    def test_within_budget_no_suspend(self):
+        s = _make_scheduler(decode_floor=0.5)
+        interactive = _make_request("chat1", priority=0)
+        bg1 = _make_request("bg1", priority=10)
+        _enqueue_running(s, interactive, uid=1)
+        _enqueue_running(s, bg1, uid=2)
+
+        s._apply_decode_floor()
+        # 1 interactive, floor=0.5 → target=1 bg, 1 active → within budget
+        assert s._decode_suspensions == 0
+
+    def test_batch_generator_required(self):
+        s = _make_scheduler(decode_floor=0.5)
+        s.batch_generator = None
+        interactive = _make_request("chat1", priority=0)
+        bg1 = _make_request("bg1", priority=10)
+        _enqueue_running(s, interactive, uid=1)
+        _enqueue_running(s, bg1, uid=2)
+
+        s._apply_decode_floor()
+        assert s._decode_suspensions == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: reset clears decode floor state
+# ---------------------------------------------------------------------------
+
+class TestResetClearsDecodeFloor:
+    def test_reset_clears_suspended_decodes(self):
+        s = _make_scheduler(decode_floor=0.5)
+        req = _make_request("bg1", priority=10)
+        _enqueue_running(s, req, uid=5)
+
+        fake_cache = [MagicMock()]
+        s.batch_generator.remove.return_value = {5: (fake_cache, [1])}
+        s._suspend_decode_request("bg1")
+        assert len(s._suspended_decodes) == 1
+
+        s.reset()
+        assert len(s._suspended_decodes) == 0
+        assert s._decode_suspensions == 0
+        assert s._decode_resumes == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: abort cleans up suspended decodes
+# ---------------------------------------------------------------------------
+
+class TestAbortCleansSuspendedDecodes:
+    def test_abort_removes_from_suspended(self):
+        s = _make_scheduler(decode_floor=0.5)
+        req = _make_request("bg1", priority=10)
+        _enqueue_running(s, req, uid=5)
+
+        fake_cache = [MagicMock()]
+        s.batch_generator.remove.return_value = {5: (fake_cache, [1])}
+        s._suspend_decode_request("bg1")
+        assert "bg1" in s._suspended_decodes
+
+        # Abort the request
+        s._do_abort_request("bg1")
+        assert "bg1" not in s._suspended_decodes
+        assert "bg1" not in s.running

--- a/tests/test_scheduler_prefill_preemption.py
+++ b/tests/test_scheduler_prefill_preemption.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for interactive preemption of background chunked prefills.
+
+Strategy: mock model/tokenizer, manipulate scheduler queues directly,
+verify parking/resuming logic without GPU.
+"""
+
+from unittest.mock import MagicMock
+
+from omlx.request import Request, SamplingParams
+from omlx.scheduler import Scheduler, SchedulerConfig, _PrefillState
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_scheduler(
+    prefill_preemption: bool = True,
+    max_num_seqs: int = 8,
+) -> Scheduler:
+    model = MagicMock()
+    model.layers = []
+    tokenizer = MagicMock()
+    tokenizer.eos_token_id = 2
+    config = SchedulerConfig(
+        max_num_seqs=max_num_seqs,
+        prefill_step_size=4,
+        chunked_prefill=True,
+        paged_cache_block_size=0,
+        prefill_preemption=prefill_preemption,
+    )
+    scheduler = Scheduler(model=model, tokenizer=tokenizer, config=config)
+    mock_bg = MagicMock()
+    mock_bg.insert.return_value = [42]
+    mock_bg.next_generated.return_value = iter([])
+    scheduler.batch_generator = mock_bg
+    scheduler._current_sampler_params = ()
+    return scheduler
+
+
+def _make_request(
+    request_id: str = "req-1",
+    n_tokens: int = 10,
+    priority: int = 0,
+) -> Request:
+    req = Request(
+        request_id=request_id,
+        prompt=list(range(n_tokens)),
+        sampling_params=SamplingParams(max_tokens=32),
+        priority=priority,
+    )
+    req.prompt_token_ids = list(range(n_tokens))
+    req.num_prompt_tokens = n_tokens
+    req.remaining_tokens = list(range(n_tokens))
+    return req
+
+
+def _make_prefill_state(
+    request: Request,
+    n_remaining: int = 20,
+) -> _PrefillState:
+    import mlx.core as mx
+
+    tokens_remaining = mx.zeros((1, n_remaining), dtype=mx.int32)
+    return _PrefillState(
+        request=request,
+        cache=[],
+        tokens_remaining=tokens_remaining,
+        last_token=[99],
+        tokens_processed=0,
+        base_size=0,
+        emitted_boundaries={},
+        boundary_enabled=False,
+        block_size=0,
+        total_length=n_remaining + 1,
+        sampler=MagicMock(),
+        sm=MagicMock(),
+        per_row_lps=[],
+    )
+
+
+def _enqueue_prefill(scheduler: Scheduler, request: Request) -> _PrefillState:
+    """Put a request into the prefilling queue with a _PrefillState."""
+    state = _make_prefill_state(request)
+    scheduler.prefilling.append(request)
+    scheduler._prefill_states[request.request_id] = state
+    scheduler.requests[request.request_id] = request
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestHasWaitingInteractive:
+    def test_empty_waiting(self):
+        s = _make_scheduler()
+        assert not s._has_waiting_interactive()
+
+    def test_only_background_waiting(self):
+        s = _make_scheduler()
+        s.waiting.append(_make_request("bg1", priority=10))
+        assert not s._has_waiting_interactive()
+
+    def test_interactive_waiting(self):
+        s = _make_scheduler()
+        s.waiting.append(_make_request("chat1", priority=0))
+        assert s._has_waiting_interactive()
+
+    def test_negative_priority_also_interactive(self):
+        s = _make_scheduler()
+        req = _make_request("fast", priority=-1)
+        s.waiting.append(req)
+        assert s._has_waiting_interactive()
+
+
+class TestHasActiveInteractive:
+    def test_no_running(self):
+        s = _make_scheduler()
+        assert not s._has_active_interactive()
+
+    def test_only_background_running(self):
+        s = _make_scheduler()
+        req = _make_request("bg1", priority=10)
+        s.running[req.request_id] = req
+        assert not s._has_active_interactive()
+
+    def test_interactive_running(self):
+        s = _make_scheduler()
+        req = _make_request("chat1", priority=0)
+        s.running[req.request_id] = req
+        assert s._has_active_interactive()
+
+
+class TestParkBackgroundPrefills:
+    def test_no_parking_when_disabled(self):
+        s = _make_scheduler(prefill_preemption=False)
+        bg = _make_request("bg1", priority=10)
+        _enqueue_prefill(s, bg)
+        s.waiting.append(_make_request("chat1", priority=0))
+
+        parked = s._park_background_prefills_for_interactive()
+        assert parked == 0
+        assert len(s.prefilling) == 1
+        assert len(s._suspended_prefills) == 0
+
+    def test_no_parking_when_no_interactive_waiting(self):
+        s = _make_scheduler()
+        bg = _make_request("bg1", priority=10)
+        _enqueue_prefill(s, bg)
+
+        parked = s._park_background_prefills_for_interactive()
+        assert parked == 0
+        assert len(s.prefilling) == 1
+
+    def test_parks_background_prefills(self):
+        s = _make_scheduler()
+        bg1 = _make_request("bg1", priority=10)
+        bg2 = _make_request("bg2", priority=5)
+        _enqueue_prefill(s, bg1)
+        _enqueue_prefill(s, bg2)
+        s.waiting.append(_make_request("chat1", priority=0))
+
+        parked = s._park_background_prefills_for_interactive()
+        assert parked == 2
+        assert len(s.prefilling) == 0
+        assert len(s._suspended_prefills) == 2
+        assert s._prefill_preemptions == 2
+
+    def test_keeps_interactive_prefills(self):
+        s = _make_scheduler()
+        interactive = _make_request("chat1", priority=0)
+        bg = _make_request("bg1", priority=10)
+        _enqueue_prefill(s, interactive)
+        _enqueue_prefill(s, bg)
+        s.waiting.append(_make_request("chat2", priority=0))
+
+        parked = s._park_background_prefills_for_interactive()
+        assert parked == 1
+        assert len(s.prefilling) == 1
+        assert s.prefilling[0].request_id == "chat1"
+
+    def test_retains_prefill_state_identity(self):
+        s = _make_scheduler()
+        bg = _make_request("bg1", priority=10)
+        state = _enqueue_prefill(s, bg)
+        s.waiting.append(_make_request("chat1", priority=0))
+
+        s._park_background_prefills_for_interactive()
+        _, resumed_state = s._suspended_prefills[0]
+        assert resumed_state is state
+        assert resumed_state.cache == state.cache
+
+
+class TestResumeSuspendedPrefills:
+    def test_no_resume_when_empty(self):
+        s = _make_scheduler()
+        assert s._resume_suspended_prefills() == 0
+
+    def test_resumes_all(self):
+        s = _make_scheduler()
+        bg1 = _make_request("bg1", priority=10)
+        bg2 = _make_request("bg2", priority=5)
+        _enqueue_prefill(s, bg1)
+        _enqueue_prefill(s, bg2)
+        s.waiting.append(_make_request("chat1", priority=0))
+
+        s._park_background_prefills_for_interactive()
+        assert len(s.prefilling) == 0
+
+        resumed = s._resume_suspended_prefills()
+        assert resumed == 2
+        assert len(s.prefilling) == 2
+        assert len(s._suspended_prefills) == 0
+        assert s._prefill_resumes == 2
+
+    def test_preserves_order(self):
+        s = _make_scheduler()
+        bg1 = _make_request("bg1", priority=10)
+        bg2 = _make_request("bg2", priority=5)
+        _enqueue_prefill(s, bg1)
+        _enqueue_prefill(s, bg2)
+        s.waiting.append(_make_request("chat1", priority=0))
+
+        s._park_background_prefills_for_interactive()
+        s._resume_suspended_prefills()
+
+        assert s.prefilling[0].request_id == "bg1"
+        assert s.prefilling[1].request_id == "bg2"
+
+    def test_restores_prefill_states(self):
+        s = _make_scheduler()
+        bg = _make_request("bg1", priority=10)
+        original_state = _enqueue_prefill(s, bg)
+        s.waiting.append(_make_request("chat1", priority=0))
+
+        s._park_background_prefills_for_interactive()
+        s._resume_suspended_prefills()
+
+        assert s._prefill_states["bg1"] is original_state
+
+
+class TestAbortClearsSuspended:
+    def test_abort_removes_from_suspended(self):
+        s = _make_scheduler()
+        bg = _make_request("bg1", priority=10)
+        _enqueue_prefill(s, bg)
+        s.waiting.append(_make_request("chat1", priority=0))
+        s._park_background_prefills_for_interactive()
+        assert len(s._suspended_prefills) == 1
+
+        s._do_abort_request("bg1")
+        assert len(s._suspended_prefills) == 0
+        assert "bg1" not in s._prefill_states
+
+
+class TestResetClearsSuspended:
+    def test_reset_clears_all_suspended_state(self):
+        s = _make_scheduler()
+        bg = _make_request("bg1", priority=10)
+        _enqueue_prefill(s, bg)
+        s.waiting.append(_make_request("chat1", priority=0))
+        s._park_background_prefills_for_interactive()
+        s._prefill_preemptions = 5
+        s._prefill_resumes = 3
+
+        s.reset()
+
+        assert len(s._suspended_prefills) == 0
+        assert s._prefill_rr_cursor == 0
+        assert s._prefill_preemptions == 0
+        assert s._prefill_resumes == 0

--- a/tests/test_scheduler_priority_admission.py
+++ b/tests/test_scheduler_priority_admission.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Scheduler._admit_to_waiting (opt-in priority-ordered admission).
+
+FCFS (the default) must stay byte-identical to the plain-append behavior it
+replaced. PRIORITY policy (OMLX_PRIORITY_SCHEDULING=1) must insert
+lower-priority-value requests ahead of higher-priority-value ones while
+preserving arrival order among requests of equal priority — i.e. every
+existing caller, which leaves priority at its default of 0, observes
+unchanged FCFS ordering even under the PRIORITY policy until something
+actually sets a non-zero priority.
+"""
+
+from collections import deque
+from unittest.mock import MagicMock
+
+import pytest
+
+from omlx.scheduler import Scheduler, SchedulingPolicy
+
+
+@pytest.fixture
+def scheduler():
+    """Bare Scheduler instance (see test_scheduler_admission.py for why)."""
+    s = Scheduler.__new__(Scheduler)
+    s.config = MagicMock()
+    s.waiting = deque()
+    return s
+
+
+def _req(rid: str, priority: int = 0):
+    r = MagicMock()
+    r.request_id = rid
+    r.priority = priority
+    return r
+
+
+def _ids(scheduler):
+    return [r.request_id for r in scheduler.waiting]
+
+
+class TestFcfsUnchanged:
+    """The default policy must be indistinguishable from plain deque.append."""
+
+    def test_appends_to_back_regardless_of_priority(self, scheduler):
+        scheduler.config.policy = SchedulingPolicy.FCFS
+        scheduler._admit_to_waiting(_req("a", priority=0))
+        scheduler._admit_to_waiting(_req("b", priority=-5))  # would outrank under PRIORITY
+        scheduler._admit_to_waiting(_req("c", priority=0))
+        assert _ids(scheduler) == ["a", "b", "c"]
+
+
+class TestPriorityOrdering:
+    def test_empty_queue(self, scheduler):
+        scheduler.config.policy = SchedulingPolicy.PRIORITY
+        scheduler._admit_to_waiting(_req("a"))
+        assert _ids(scheduler) == ["a"]
+
+    def test_equal_priority_preserves_arrival_order(self, scheduler):
+        # Every caller today leaves priority at its default (0) — this is
+        # the case that MUST match today's FCFS behavior exactly.
+        scheduler.config.policy = SchedulingPolicy.PRIORITY
+        for rid in ("a", "b", "c", "d"):
+            scheduler._admit_to_waiting(_req(rid, priority=0))
+        assert _ids(scheduler) == ["a", "b", "c", "d"]
+
+    def test_higher_priority_request_jumps_ahead_of_lower_priority_waiters(
+        self, scheduler
+    ):
+        # Lower numeric value = higher priority (interactive = 0).
+        scheduler.config.policy = SchedulingPolicy.PRIORITY
+        scheduler._admit_to_waiting(_req("bg-1", priority=10))
+        scheduler._admit_to_waiting(_req("bg-2", priority=10))
+        scheduler._admit_to_waiting(_req("interactive", priority=0))
+        assert _ids(scheduler) == ["interactive", "bg-1", "bg-2"]
+
+    def test_new_same_priority_request_goes_behind_existing_same_priority_ones(
+        self, scheduler
+    ):
+        # A second interactive request must NOT jump ahead of the first —
+        # only the priority TIER jumps the background queue, not each new
+        # arrival within a tier.
+        scheduler.config.policy = SchedulingPolicy.PRIORITY
+        scheduler._admit_to_waiting(_req("int-1", priority=0))
+        scheduler._admit_to_waiting(_req("bg-1", priority=10))
+        scheduler._admit_to_waiting(_req("int-2", priority=0))
+        assert _ids(scheduler) == ["int-1", "int-2", "bg-1"]
+
+    def test_three_tier_interleaving(self, scheduler):
+        scheduler.config.policy = SchedulingPolicy.PRIORITY
+        order = [
+            ("bg-1", 10),
+            ("mid-1", 5),
+            ("bg-2", 10),
+            ("int-1", 0),
+            ("mid-2", 5),
+            ("int-2", 0),
+        ]
+        for rid, prio in order:
+            scheduler._admit_to_waiting(_req(rid, priority=prio))
+        # Stable sort by priority: 0s in arrival order, then 5s, then 10s.
+        assert _ids(scheduler) == ["int-1", "int-2", "mid-1", "mid-2", "bg-1", "bg-2"]
+
+    def test_does_not_disturb_a_leading_appendleft_rescheduled_request(self, scheduler):
+        # Simulates a retry/reschedule (cache eviction, corruption, overflow)
+        # that jumped the front via appendleft BEFORE this new admission. A
+        # SAME-tier new arrival must NOT displace it — resumed work with
+        # sunk cost still beats a freshly-arriving request of equal priority.
+        scheduler.config.policy = SchedulingPolicy.PRIORITY
+        scheduler.waiting.appendleft(_req("resumed", priority=10))
+        scheduler._admit_to_waiting(_req("new-bg", priority=10))
+        assert _ids(scheduler) == ["resumed", "new-bg"]
+
+    def test_strictly_higher_priority_arrival_still_outranks_a_resumed_request(
+        self, scheduler
+    ):
+        # A resumed (appendleft'd) request only holds its place against
+        # SAME-or-lower actual priority. A genuinely more urgent new arrival
+        # (e.g. a live interactive turn vs. a resumed BACKGROUND request)
+        # correctly cuts ahead — the whole point of this feature is that
+        # interactive never waits behind background work, resumed or not.
+        scheduler.config.policy = SchedulingPolicy.PRIORITY
+        scheduler.waiting.appendleft(_req("resumed-bg", priority=10))
+        scheduler._admit_to_waiting(_req("interactive", priority=0))
+        assert _ids(scheduler) == ["interactive", "resumed-bg"]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1554,6 +1554,69 @@ class TestGlobalSettings:
         scheduler_config = settings.to_scheduler_config()
         assert scheduler_config.prefill_step_size == 256
 
+    def test_interactive_isolation_defaults_disabled(self):
+        """New interactive-isolation controls must be inert by default."""
+        settings = GlobalSettings()
+        with patch.dict(os.environ, {}, clear=True):
+            scheduler_config = settings.to_scheduler_config()
+
+        assert scheduler_config.prefill_preemption is False
+        assert scheduler_config.interactive_decode_floor == 0.0
+        assert scheduler_config.interactive_cache_ttl_secs == 0.0
+        assert scheduler_config.interactive_cache_max_sessions == 8
+        assert scheduler_config.interactive_cache_max_bytes == 8 * 1024**3
+
+    def test_interactive_isolation_controls_parse_from_env(self):
+        """Operational env controls pass through to SchedulerConfig."""
+        settings = GlobalSettings()
+        with patch.dict(
+            os.environ,
+            {
+                "OMLX_PRIORITY_SCHEDULING": "1",
+                "OMLX_PREFILL_PREEMPTION": "1",
+                "OMLX_INTERACTIVE_DECODE_FLOOR": "0.5",
+                "OMLX_INTERACTIVE_CACHE_TTL_SECS": "120",
+                "OMLX_INTERACTIVE_CACHE_MAX_SESSIONS": "6",
+                "OMLX_INTERACTIVE_CACHE_MAX_BYTES_GB": "4.5",
+            },
+            clear=True,
+        ):
+            scheduler_config = settings.to_scheduler_config()
+
+        assert scheduler_config.prefill_preemption is True
+        assert scheduler_config.interactive_decode_floor == 0.5
+        assert scheduler_config.interactive_cache_ttl_secs == 120.0
+        assert scheduler_config.interactive_cache_max_sessions == 6
+        assert scheduler_config.interactive_cache_max_bytes == int(4.5 * 1024**3)
+
+    def test_prefill_preemption_is_inert_without_priority_policy(self):
+        """Preemption cannot classify interactive work under FCFS."""
+        settings = GlobalSettings()
+        with patch.dict(
+            os.environ,
+            {"OMLX_PREFILL_PREEMPTION": "1"},
+            clear=True,
+        ):
+            scheduler_config = settings.to_scheduler_config()
+
+        assert scheduler_config.prefill_preemption is False
+
+    def test_interactive_decode_floor_rejects_out_of_range_ratio(self):
+        """Decode floor accepts only a probability-like ratio."""
+        settings = GlobalSettings()
+        with (
+            patch.dict(
+                os.environ,
+                {"OMLX_INTERACTIVE_DECODE_FLOOR": "1.1"},
+                clear=True,
+            ),
+            pytest.raises(
+                ValueError,
+                match="OMLX_INTERACTIVE_DECODE_FLOOR must be between 0 and 1",
+            ),
+        ):
+            settings.to_scheduler_config()
+
     def test_to_scheduler_config_initial_cache_blocks(self):
         """Test that initial_cache_blocks passes through to SchedulerConfig."""
         settings = GlobalSettings()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -321,6 +321,7 @@ class TestSchedulerSettings:
             "max_concurrent_requests": 8,
             "embedding_batch_size": 32,
             "chunked_prefill": False,
+            "prefill_step_size": 2048,
         }
 
     def test_from_dict(self):
@@ -1140,6 +1141,11 @@ class TestGlobalSettings:
         errors = settings.validate()
         assert any("embedding_batch_size" in e.lower() for e in errors)
 
+        settings = GlobalSettings()
+        settings.scheduler.prefill_step_size = 63
+        errors = settings.validate()
+        assert any("prefill_step_size" in e.lower() for e in errors)
+
     def test_validate_invalid_cache_size(self):
         """Test validation catches invalid cache size."""
         settings = GlobalSettings()
@@ -1258,6 +1264,17 @@ class TestGlobalSettings:
             ):
                 settings = GlobalSettings.load(base_path=tmpdir)
                 assert settings.scheduler.embedding_batch_size == 24
+
+    def test_env_override_prefill_step_size(self):
+        """Test environment variable override for prefill step size."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(
+                os.environ,
+                {"OMLX_PREFILL_STEP_SIZE": "256"},
+                clear=False,
+            ):
+                settings = GlobalSettings.load(base_path=tmpdir)
+                assert settings.scheduler.prefill_step_size == 256
 
     def test_env_override_scheduler_legacy_fallback(self):
         """Test legacy OMLX_MAX_NUM_SEQS env var is accepted as fallback."""
@@ -1527,6 +1544,15 @@ class TestGlobalSettings:
         assert scheduler_config.completion_batch_size == 128
         assert scheduler_config.embedding_batch_size == 12
         assert scheduler_config.initial_cache_blocks == 256  # default
+        assert scheduler_config.prefill_step_size == 2048  # default
+
+    def test_to_scheduler_config_prefill_step_size(self):
+        """Test that prefill_step_size passes through to SchedulerConfig."""
+        settings = GlobalSettings()
+        settings.scheduler.prefill_step_size = 256
+
+        scheduler_config = settings.to_scheduler_config()
+        assert scheduler_config.prefill_step_size == 256
 
     def test_to_scheduler_config_initial_cache_blocks(self):
         """Test that initial_cache_blocks passes through to SchedulerConfig."""


### PR DESCRIPTION
## Summary
Adds the configuration surface for interactive-isolation scheduling (preemption, decode floor, response cache) as **inert-by-default** fields on `SchedulerConfig`, parsed from `OMLX_*` env vars in `to_scheduler_config`.

- `prefill_preemption`, `interactive_decode_floor`, `interactive_cache_ttl_secs`, `interactive_cache_max_sessions`, `interactive_cache_max_bytes`
- All controls gated behind `OMLX_PRIORITY_SCHEDULING`: under FCFS the policy cannot classify interactive work, so `prefill_preemption` stays `False` regardless of its own toggle. Shipping this is a no-op on the live scheduler until both knobs are explicitly enabled.
- `OMLX_INTERACTIVE_DECODE_FLOOR` validates to `[0, 1]` (raises `ValueError` otherwise).

## Test plan
- 4 new tests in `tests/test_settings.py` (TDD red->green): defaults-disabled, env-parse, preemption-inert-without-priority, decode-floor-range-rejects. All pass.
- Ruff: no new lint errors introduced (remaining 50 are pre-existing in `main`).

## Status
Config layer only. The behavioral engine (prefill parking/resume, decode-floor enforcement, cache read/write) is follow-up work and intentionally not included so this ships without changing live scheduler behavior.

Diff: 3 files changed, 135 insertions(+).