### PR TITLE
fix: release model aliases after filesystem removal

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -735,7 +735,23 @@ def _apply_log_level_runtime(level: str) -> None:
     logging.getLogger("uvicorn.access").setLevel(log_level)
 
 
-async def _apply_model_dirs_runtime(model_dirs: list[str]) -> tuple[bool, str]:
+def _configured_model_dirs(global_settings) -> list[str]:
+    """Return configured roots without resolving away symlink identity."""
+    return [
+        str(path)
+        for path in global_settings.model.get_configured_model_dirs(
+            global_settings.base_path
+        )
+    ]
+
+
+async def _apply_model_dirs_runtime(
+    model_dirs: list[str],
+    *,
+    reconciliation_model_dirs: list[str] | None = None,
+    retire_unobserved_configured: bool = False,
+    prune_missing: bool = True,
+) -> tuple[bool, str]:
     """
     Apply model directories change at runtime by re-scanning models.
 
@@ -744,6 +760,11 @@ async def _apply_model_dirs_runtime(model_dirs: list[str]) -> tuple[bool, str]:
     2. Unload all currently loaded models
     3. Clear the entries dictionary
     4. Re-discover models from the new directories
+
+    ``reconciliation_model_dirs`` supplies logical roots for persistence
+    inventory. Non-deletion refreshes (such as toggling Hugging Face cache
+    visibility) set ``prune_missing=False`` so they can seed inventory without
+    deleting persisted state.
 
     Returns:
         Tuple of (success, message)
@@ -754,7 +775,7 @@ async def _apply_model_dirs_runtime(model_dirs: list[str]) -> tuple[bool, str]:
         model_directory_access_error,
         model_directory_write_error,
     )
-    from ..server import _server_state
+    from ..server import _server_state, reconcile_discovered_model_state
 
     if _server_state.engine_pool is None:
         return False, "Engine pool not initialized"
@@ -814,8 +835,25 @@ async def _apply_model_dirs_runtime(model_dirs: list[str]) -> tuple[bool, str]:
 
     # Re-discover models from new directories
     try:
-        pool.discover_models(active_model_dirs, pinned_models)
+        discovery = pool.discover_models(active_model_dirs, pinned_models)
         if _server_state.settings_manager is not None:
+            if reconciliation_model_dirs is not None:
+                global_settings = _get_global_settings()
+                reconcile_discovered_model_state(
+                    _server_state.settings_manager,
+                    discovery,
+                    reconciliation_model_dirs,
+                    hf_cache_dir=(
+                        global_settings.get_hf_cache_dir()
+                        if global_settings is not None
+                        else None
+                    ),
+                    hf_cache_enabled=bool(
+                        global_settings and global_settings.huggingface.hf_cache_enabled
+                    ),
+                    retire_unobserved_configured=retire_unobserved_configured,
+                    prune_missing=prune_missing,
+                )
             pool.apply_settings_overrides(_server_state.settings_manager)
     except Exception as e:
         return False, f"Failed to discover models: {e}"
@@ -854,9 +892,13 @@ async def _reload_models() -> tuple[bool, str]:
 
     # Get current effective model dirs from global settings
     model_dirs = [str(d) for d in global_settings.get_effective_model_dirs()]
+    reconciliation_model_dirs = _configured_model_dirs(global_settings)
 
     # Unload all, re-discover, re-apply overrides
-    success, msg = await _apply_model_dirs_runtime(model_dirs)
+    success, msg = await _apply_model_dirs_runtime(
+        model_dirs,
+        reconciliation_model_dirs=reconciliation_model_dirs,
+    )
     if not success:
         return False, msg
 
@@ -3458,7 +3500,14 @@ async def update_global_settings(
             effective_dirs = [
                 str(d) for d in global_settings.get_effective_model_dirs(new_dirs)
             ]
-            success, msg = await _apply_model_dirs_runtime(effective_dirs)
+            reconciliation_dirs = new_dirs or [
+                str(Path(global_settings.base_path) / "models")
+            ]
+            success, msg = await _apply_model_dirs_runtime(
+                effective_dirs,
+                reconciliation_model_dirs=reconciliation_dirs,
+                retire_unobserved_configured=True,
+            )
             if success:
                 global_settings.model.model_dirs = new_dirs
                 global_settings.model.model_dir = new_dirs[0] if new_dirs else None
@@ -3620,7 +3669,11 @@ async def update_global_settings(
             effective_dirs = [
                 str(d) for d in global_settings.get_effective_model_dirs()
             ]
-            success, msg = await _apply_model_dirs_runtime(effective_dirs)
+            success, msg = await _apply_model_dirs_runtime(
+                effective_dirs,
+                reconciliation_model_dirs=_configured_model_dirs(global_settings),
+                prune_missing=False,
+            )
             if not success:
                 raise HTTPException(
                     status_code=400,

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -101,6 +101,9 @@ def serve_command(args):
 
     # Initialize global settings first (to get log_level from file if not specified)
     settings = init_settings(base_path=args.base_path, cli_args=args)
+    # Keep the user's configured roots before ensure_directories() filters out
+    # unavailable external/network filesystems for this process.
+    configured_model_dirs = settings.model.get_configured_model_dirs(settings.base_path)
 
     # Register TRACE level (5) — includes full message content
     TRACE = 5
@@ -331,6 +334,7 @@ def serve_command(args):
             scheduler_config=scheduler_config,
             api_key=settings.auth.api_key,
             global_settings=settings,
+            configured_model_dirs=configured_model_dirs,
         )
 
         for h in bind_hosts:

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
+    from .model_discovery import ModelDiscoveryResult
     from .model_settings import ModelSettingsManager
 
 import mlx.core as mx
@@ -44,7 +45,7 @@ from .exceptions import (
     ModelTooLargeError,
     ModelUnavailableError,
 )
-from .model_discovery import discover_models, format_size
+from .model_discovery import format_size
 from .scheduler import SchedulerConfig
 from .utils.proc_memory import get_phys_footprint
 
@@ -344,18 +345,28 @@ class EnginePool:
                     engine._batch_size = batch_size
 
     def discover_models(
-        self, model_dirs: str | list[str], pinned_models: list[str] | None = None
-    ) -> None:
+        self,
+        model_dirs: str | list[str],
+        pinned_models: list[str] | None = None,
+    ) -> ModelDiscoveryResult:
         """
         Discover models in the specified directory or directories.
 
         Args:
             model_dirs: Path or list of paths to directories containing model subdirectories
             pinned_models: List of model IDs to pin (never evict)
+
+        Returns:
+            Discovery result, including per-root scan completeness. This method
+            only updates the in-memory pool; persistence reconciliation is
+            performed explicitly by the server lifecycle.
         """
         from pathlib import Path
 
-        from .model_discovery import discover_models_from_dirs
+        from .model_discovery import (
+            discover_models_from_dirs_with_status,
+            discover_models_with_status,
+        )
 
         if isinstance(model_dirs, str):
             dirs = [Path(model_dirs)]
@@ -363,9 +374,10 @@ class EnginePool:
             dirs = [Path(d) for d in model_dirs]
 
         if len(dirs) == 1:
-            discovered = discover_models(dirs[0])
+            discovery = discover_models_with_status(dirs[0])
         else:
-            discovered = discover_models_from_dirs(dirs)
+            discovery = discover_models_from_dirs_with_status(dirs)
+        discovered = discovery.models
 
         pinned_set = set(pinned_models or [])
 
@@ -414,6 +426,7 @@ class EnginePool:
                 logger.warning(f"Pinned model not found: {model_id}")
 
         logger.info(f"Discovered {len(self._entries)} models")
+        return discovery
 
     _MODEL_TYPE_TO_ENGINE: dict[str, str] = {
         "llm": "batched",

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -18,6 +18,7 @@ import contextlib
 import json
 import logging
 import re
+import stat
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 ModelType = Literal["llm", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", "audio_sts"]
 EngineType = Literal["batched", "vlm", "embedding", "reranker", "audio_stt", "audio_tts", "audio_sts"]
+RootFingerprint = tuple[int, int]
 
 # Known VLM (Vision-Language Model) types from mlx-vlm
 VLM_MODEL_TYPES = {
@@ -352,6 +354,59 @@ class DiscoveredModel:
     source_type: str = "local"  # "local" or "hf_cache"
     source_repo_id: str | None = None  # HuggingFace repo id for cache-backed models
     is_helper: bool = False  # Speculative-decoding drafter (dFlash/Assistant/MTP)
+
+
+@dataclass
+class ModelDiscoveryResult:
+    """Discovered models plus per-root scan and structural-presence evidence.
+
+    ``root_models`` contains loadable models. ``root_model_entries`` also
+    includes structurally present local folders and HF cache entries that are
+    temporarily incomplete, so persistence cleanup can remain conservative
+    without exposing those entries as active models.
+    """
+
+    models: dict[str, DiscoveredModel]
+    root_complete: dict[Path, bool]
+    root_models: dict[Path, frozenset[str]]
+    root_model_entries: dict[Path, frozenset[str]]
+    root_fingerprints: dict[Path, RootFingerprint | None]
+
+
+@dataclass
+class _DiscoveryHealth:
+    """Mutable scan state shared by one root's best-effort traversal."""
+
+    complete: bool = True
+
+
+def _model_root_key(path: Path) -> Path:
+    """Return the normalized physical key used by discovery reports."""
+    try:
+        return path.expanduser().resolve()
+    except (OSError, RuntimeError):
+        return path.expanduser().absolute()
+
+
+def _root_fingerprint(
+    path: Path,
+    *,
+    health: _DiscoveryHealth | None = None,
+) -> RootFingerprint | None:
+    """Return the physical root identity without hiding access failures."""
+    try:
+        root_stat = path.stat()
+    except OSError as e:
+        if health is not None:
+            health.complete = False
+        logger.warning(
+            "Could not fingerprint model root %s: %s: %s",
+            path,
+            type(e).__name__,
+            e,
+        )
+        return None
+    return int(root_stat.st_dev), int(root_stat.st_ino)
 
 
 @dataclass(frozen=True)
@@ -931,14 +986,35 @@ def estimate_model_size(model_path: Path) -> int:
     return int(total_size * overhead_factor)
 
 
-def _is_adapter_dir(path: Path) -> bool:
+def _path_exists(path: Path, *, health: _DiscoveryHealth | None = None) -> bool:
+    """Check path existence without hiding an access failure as absence."""
+    try:
+        path.stat()
+    except FileNotFoundError:
+        return False
+    except OSError as e:
+        if health is not None:
+            health.complete = False
+        logger.warning(
+            "Skipping inaccessible model metadata %s: %s: %s",
+            path,
+            type(e).__name__,
+            e,
+        )
+        return False
+    return True
+
+
+def _is_adapter_dir(path: Path, *, health: _DiscoveryHealth | None = None) -> bool:
     """Check if a directory contains a LoRA/PEFT adapter (has adapter_config.json)."""
-    return (path / "adapter_config.json").exists()
+    return _path_exists(path / "adapter_config.json", health=health)
 
 
-def _is_model_dir(path: Path) -> bool:
+def _is_model_dir(path: Path, *, health: _DiscoveryHealth | None = None) -> bool:
     """Check if a directory contains a valid model (has config.json)."""
-    return (path / "config.json").exists() and not _is_adapter_dir(path)
+    return _path_exists(path / "config.json", health=health) and not _is_adapter_dir(
+        path, health=health
+    )
 
 
 def model_directory_access_error(path: Path) -> str | None:
@@ -994,11 +1070,18 @@ def model_directory_write_error(path: Path, *, create: bool = False) -> str | No
     return None
 
 
-def _iter_readable_entries(path: Path, context: str) -> list[Path]:
+def _iter_readable_entries(
+    path: Path,
+    context: str,
+    *,
+    health: _DiscoveryHealth | None = None,
+) -> list[Path]:
     """Return sorted directory entries, or an empty list when scanning fails."""
     try:
         return sorted(path.iterdir())
     except OSError as e:
+        if health is not None:
+            health.complete = False
         logger.warning(
             "Skipping unreadable %s %s: %s: %s",
             context,
@@ -1009,10 +1092,17 @@ def _iter_readable_entries(path: Path, context: str) -> list[Path]:
         return []
 
 
-def _is_readable_dir(path: Path, context: str) -> bool:
+def _is_readable_dir(
+    path: Path,
+    context: str,
+    *,
+    health: _DiscoveryHealth | None = None,
+) -> bool:
     try:
-        return path.is_dir()
+        return stat.S_ISDIR(path.stat().st_mode)
     except OSError as e:
+        if health is not None:
+            health.complete = False
         logger.warning(
             "Skipping inaccessible %s %s: %s: %s",
             context,
@@ -1041,7 +1131,11 @@ def _decode_hf_cache_model_id(path: Path) -> tuple[str, str] | None:
     return f"{parts[0]}--{repo_name}", f"{parts[0]}/{repo_name}"
 
 
-def _resolve_hf_cache_entry(path: Path) -> HfCacheEntry | None:
+def _resolve_hf_cache_entry(
+    path: Path,
+    *,
+    health: _DiscoveryHealth | None = None,
+) -> HfCacheEntry | None:
     """Resolve an HF Hub cache entry (models--Org--Name/) to its active snapshot.
 
     Returns an HfCacheEntry or None if not a valid HF model cache entry.
@@ -1052,7 +1146,11 @@ def _resolve_hf_cache_entry(path: Path) -> HfCacheEntry | None:
     model_id, source_repo_id = decoded
 
     snapshots_dir = path / "snapshots"
-    if not snapshots_dir.is_dir():
+    if not _is_readable_dir(
+        snapshots_dir,
+        "HF cache snapshots directory",
+        health=health,
+    ):
         return None
 
     for ref_name in ("main", "master"):
@@ -1061,24 +1159,51 @@ def _resolve_hf_cache_entry(path: Path) -> HfCacheEntry | None:
         except OSError:
             continue
         snapshot = snapshots_dir / commit_hash
-        if snapshot.is_dir():
+        if _is_readable_dir(snapshot, "HF cache referenced snapshot", health=health):
             return HfCacheEntry(snapshot, model_id, source_repo_id)
 
     snapshots = [
         p
-        for p in _iter_readable_entries(snapshots_dir, "HF cache snapshots")
-        if _is_readable_dir(p, "HF cache snapshot")
+        for p in _iter_readable_entries(
+            snapshots_dir,
+            "HF cache snapshots",
+            health=health,
+        )
+        if _is_readable_dir(p, "HF cache snapshot", health=health)
     ]
     if not snapshots:
         return None
     if len(snapshots) == 1:
         return HfCacheEntry(snapshots[0], model_id, source_repo_id)
 
-    snapshot = max(snapshots, key=lambda p: p.stat().st_mtime)
-    return HfCacheEntry(snapshot, model_id, source_repo_id)
+    latest_snapshot: Path | None = None
+    latest_mtime = float("-inf")
+    for snapshot in snapshots:
+        try:
+            mtime = snapshot.stat().st_mtime
+        except OSError as e:
+            if health is not None:
+                health.complete = False
+            logger.warning(
+                "Skipping inaccessible HF cache snapshot %s: %s: %s",
+                snapshot,
+                type(e).__name__,
+                e,
+            )
+            continue
+        if mtime > latest_mtime:
+            latest_snapshot = snapshot
+            latest_mtime = mtime
+    if latest_snapshot is None:
+        return None
+    return HfCacheEntry(latest_snapshot, model_id, source_repo_id)
 
 
-def _safetensors_has_mlx_metadata(path: Path) -> bool:
+def _safetensors_has_mlx_metadata(
+    path: Path,
+    *,
+    shards: list[Path] | None = None,
+) -> bool:
     """Return True if any model safetensors shard declares MLX format."""
     try:
         from safetensors import safe_open
@@ -1086,7 +1211,8 @@ def _safetensors_has_mlx_metadata(path: Path) -> bool:
         logger.debug(f"safetensors import failed while checking {path}: {e}")
         return False
 
-    for shard in sorted(path.glob("model*.safetensors")):
+    candidates = shards if shards is not None else list(path.glob("model*.safetensors"))
+    for shard in sorted(candidates):
         try:
             with safe_open(str(shard), framework="numpy") as f:
                 metadata = f.metadata() or {}
@@ -1126,14 +1252,30 @@ def _is_helper_checkpoint(model_path: Path) -> bool:
     return is_helper_model_config(config)
 
 
-def _is_hf_cache_mlx_compatible(model_dir: Path, source_repo_id: str) -> bool:
+def _is_hf_cache_mlx_compatible(
+    model_dir: Path,
+    source_repo_id: str,
+    *,
+    health: _DiscoveryHealth | None = None,
+) -> bool:
     """Heuristic for HF cache entries that can be loaded without conversion."""
-    if not _is_model_dir(model_dir):
+    if not _is_model_dir(model_dir, health=health):
         return False
-    if not list(model_dir.glob("model*.safetensors")):
-        logger.debug(f"Skipping HF cache model without model*.safetensors: {source_repo_id}")
+    shards = [
+        entry
+        for entry in _iter_readable_entries(
+            model_dir,
+            "HF cache snapshot",
+            health=health,
+        )
+        if entry.name.startswith("model") and entry.suffix == ".safetensors"
+    ]
+    if not shards:
+        logger.debug(
+            f"Skipping HF cache model without model*.safetensors: {source_repo_id}"
+        )
         return False
-    if _safetensors_has_mlx_metadata(model_dir):
+    if _safetensors_has_mlx_metadata(model_dir, shards=shards):
         return True
 
     repo_lower = source_repo_id.lower()
@@ -1262,34 +1404,83 @@ def discover_models(model_dir: Path) -> dict[str, DiscoveredModel]:
     Returns:
         Dictionary mapping model_id to DiscoveredModel
     """
+    return discover_models_with_status(model_dir).models
+
+
+def discover_models_with_status(
+    model_dir: Path,
+    *,
+    hf_cache_entries_only: bool = False,
+) -> ModelDiscoveryResult:
+    """Discover models and report whether the root was scanned completely.
+
+    Discovery remains best-effort for normal serving: unreadable entries and
+    malformed/incomplete model directories are skipped. Callers making
+    destructive persistence decisions can combine ``root_complete`` with
+    ``root_model_entries`` so access failures defer cleanup while a skipped but
+    structurally present folder protects only its own state.
+    ``hf_cache_entries_only`` records cache-entry presence without loading
+    model metadata; it protects persisted state while HF visibility is disabled.
+    """
+    root_key = _model_root_key(model_dir)
     access_error = model_directory_access_error(model_dir)
     if access_error is not None:
         if "not readable" in access_error:
             logger.warning("Skipping directory %s: %s", model_dir, access_error)
-            return {}
+            return ModelDiscoveryResult(
+                {},
+                {root_key: False},
+                {root_key: frozenset()},
+                {root_key: frozenset()},
+                {root_key: None},
+            )
         raise ValueError(access_error)
 
     models: dict[str, DiscoveredModel] = {}
+    model_entries: set[str] = set()
+    root_has_model_artifact = False
+    health = _DiscoveryHealth()
+    start_fingerprint = _root_fingerprint(model_dir, health=health)
 
-    for subdir in _iter_readable_entries(model_dir, "model directory"):
-        if not _is_readable_dir(subdir, "model entry") or subdir.name.startswith("."):
+    for subdir in _iter_readable_entries(model_dir, "model directory", health=health):
+        if subdir.name.startswith("."):
+            continue
+        if not _is_readable_dir(subdir, "model entry", health=health):
+            root_has_model_artifact |= subdir.suffix in {".safetensors", ".bin"}
             continue
 
-        if _is_adapter_dir(subdir):
+        if hf_cache_entries_only:
+            hf_decoded = _decode_hf_cache_model_id(subdir)
+            if hf_decoded is not None:
+                model_entries.add(hf_decoded[0])
+            continue
+
+        if _is_adapter_dir(subdir, health=health):
+            model_entries.add(subdir.name)
             logger.info(
                 f"Skipping LoRA adapter: {subdir.name} "
                 "(oMLX does not support LoRA/PEFT adapters)"
             )
-        elif _is_model_dir(subdir):
+        elif _is_model_dir(subdir, health=health):
             # Level 1: direct model folder
+            model_entries.add(subdir.name)
             _register_model(models, subdir, subdir.name)
         else:
             # HF Hub cache entry: models--Org--Name/snapshots/<hash>/
-            hf_resolved = _resolve_hf_cache_entry(subdir)
-            if hf_resolved is not None:
+            hf_decoded = _decode_hf_cache_model_id(subdir)
+            if hf_decoded is not None:
+                # The cache entry itself is still present even when it has no
+                # resolvable snapshot yet. Keep this separate from successfully
+                # discovered models so reconciliation can protect prior state
+                # without exposing a non-loadable model.
+                model_entries.add(hf_decoded[0])
+                hf_resolved = _resolve_hf_cache_entry(subdir, health=health)
+                if hf_resolved is None:
+                    continue
                 if _is_hf_cache_mlx_compatible(
                     hf_resolved.snapshot_path,
                     hf_resolved.source_repo_id,
+                    health=health,
                 ):
                     _register_model(
                         models,
@@ -1301,19 +1492,24 @@ def discover_models(model_dir: Path) -> dict[str, DiscoveredModel]:
                 continue
 
             # Level 2: organization folder — scan children
+            # Keep the top-level folder name as conservative structural
+            # evidence too. It is harmless for ordinary organization folders,
+            # and protects a formerly loadable direct model while its metadata
+            # is temporarily absent.
+            model_entries.add(subdir.name)
             has_children = False
-            for child in _iter_readable_entries(subdir, "model group"):
-                if (
-                    not _is_readable_dir(child, "model group entry")
-                    or child.name.startswith(".")
-                ):
+            for child in _iter_readable_entries(subdir, "model group", health=health):
+                if not _is_readable_dir(
+                    child, "model group entry", health=health
+                ) or child.name.startswith("."):
                     continue
-                if _is_adapter_dir(child):
+                model_entries.add(child.name)
+                if _is_adapter_dir(child, health=health):
                     logger.info(
                         f"Skipping LoRA adapter: {child.name} "
                         "(oMLX does not support LoRA/PEFT adapters)"
                     )
-                elif _is_model_dir(child):
+                elif _is_model_dir(child, health=health):
                     has_children = True
                     _register_model(models, child, child.name)
 
@@ -1326,10 +1522,37 @@ def discover_models(model_dir: Path) -> dict[str, DiscoveredModel]:
     # Fallback: if no models found and the directory itself is a model, register it.
     # This supports pointing directly at a single model folder, e.g.:
     #   /Models/Qwen3.5-9B-MLX-4bit/  (contains config.json and weight files)
-    if not models and _is_model_dir(model_dir):
+    root_is_model = (
+        not hf_cache_entries_only
+        and not models
+        and _is_model_dir(model_dir, health=health)
+    )
+    if root_is_model:
+        model_entries.add(model_dir.name)
         _register_model(models, model_dir, model_dir.name)
+    elif not hf_cache_entries_only and not models and root_has_model_artifact:
+        # A directly configured single-model root may temporarily lose its
+        # config while weight files are still present.
+        model_entries.add(model_dir.name)
 
-    return models
+    end_fingerprint = _root_fingerprint(model_dir, health=health)
+    stable_fingerprint = start_fingerprint
+    if start_fingerprint != end_fingerprint:
+        health.complete = False
+        stable_fingerprint = None
+        logger.warning(
+            "Model root identity changed during discovery; treating scan as "
+            "incomplete: %s",
+            model_dir,
+        )
+
+    return ModelDiscoveryResult(
+        models,
+        {root_key: health.complete},
+        {root_key: frozenset(models)},
+        {root_key: frozenset(set(models) | model_entries)},
+        {root_key: stable_fingerprint},
+    )
 
 
 def discover_models_from_dirs(
@@ -1347,21 +1570,37 @@ def discover_models_from_dirs(
     Returns:
         Dictionary mapping model_id to DiscoveredModel
     """
+    return discover_models_from_dirs_with_status(model_dirs).models
+
+
+def discover_models_from_dirs_with_status(
+    model_dirs: list[Path],
+) -> ModelDiscoveryResult:
+    """Discover from multiple roots and retain per-root scan completeness."""
     merged: dict[str, DiscoveredModel] = {}
+    root_complete: dict[Path, bool] = {}
+    root_models: dict[Path, frozenset[str]] = {}
+    root_model_entries: dict[Path, frozenset[str]] = {}
+    root_fingerprints: dict[Path, RootFingerprint | None] = {}
 
     for model_dir in model_dirs:
-        access_error = model_directory_access_error(model_dir)
-        if access_error is not None:
-            logger.warning(f"Skipping directory {model_dir}: {access_error}")
-            continue
-
         try:
-            discovered = discover_models(model_dir)
+            result = discover_models_with_status(model_dir)
         except ValueError as e:
             logger.warning(f"Skipping directory {model_dir}: {e}")
+            root_key = _model_root_key(model_dir)
+            root_complete[root_key] = False
+            root_models[root_key] = frozenset()
+            root_model_entries[root_key] = frozenset()
+            root_fingerprints[root_key] = None
             continue
 
-        for model_id, info in discovered.items():
+        root_complete.update(result.root_complete)
+        root_models.update(result.root_models)
+        root_model_entries.update(result.root_model_entries)
+        root_fingerprints.update(result.root_fingerprints)
+
+        for model_id, info in result.models.items():
             if model_id in merged:
                 logger.warning(
                     f"Duplicate model_id '{model_id}' found in {model_dir}, "
@@ -1370,7 +1609,13 @@ def discover_models_from_dirs(
                 continue
             merged[model_id] = info
 
-    return merged
+    return ModelDiscoveryResult(
+        merged,
+        root_complete,
+        root_models,
+        root_model_entries,
+        root_fingerprints,
+    )
 
 
 def format_size(size_bytes: int) -> str:

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -9,17 +9,18 @@ import copy
 import json
 import logging
 import threading
+from collections.abc import Callable, Collection
 from dataclasses import dataclass, field, fields
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 from .model_profiles import (
     MODEL_SPECIFIC_PROFILE_FIELDS,
     filter_profile_fields,
     filter_universal_fields,
     slugify_profile_api_name,
-    validate_profile_name,
     utcnow,
+    validate_profile_name,
 )
 
 logger = logging.getLogger(__name__)
@@ -287,6 +288,28 @@ class ModelSettings:
         return cls(**filtered_data)
 
 
+@dataclass(frozen=True)
+class ModelRootObservation:
+    """Scan evidence for one configured model-storage root.
+
+    ``configured_path`` deliberately preserves the user-facing path (including
+    a symlink) while ``scanned_path`` is the physical directory that was
+    inspected.  This lets reconciliation detect a symlink or mount changing
+    target without treating it as an unrelated new root. ``present_model_ids``
+    carries structural evidence for temporarily non-loadable local/cache entries.
+    ``fingerprint`` is captured by discovery while the reported IDs are scanned,
+    avoiding a later mount change from being paired with stale scan contents.
+    """
+
+    configured_path: Path
+    scanned_path: Path
+    status: Literal["complete", "incomplete", "optional_missing"]
+    model_ids: frozenset[str]
+    fingerprint: tuple[int, int] | None
+    present_model_ids: frozenset[str] = frozenset()
+    source: Literal["configured", "hf_cache"] = "configured"
+
+
 class ModelSettingsManager:
     """Manager for per-model settings with file persistence.
 
@@ -311,6 +334,7 @@ class ModelSettingsManager:
         self._lock = threading.Lock()
         self._settings: Dict[str, ModelSettings] = {}
         self._profiles: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        self._model_root_inventory: dict[str, dict[str, Any]] = {}
         self._templates: Dict[str, Dict[str, Any]] = {}
 
         # Ensure base directory exists
@@ -329,6 +353,7 @@ class ModelSettingsManager:
         if not self.settings_file.exists():
             logger.debug(f"Settings file not found: {self.settings_file}")
             self._settings = {}
+            self._model_root_inventory = {}
             return
 
         try:
@@ -354,14 +379,45 @@ class ModelSettingsManager:
                         f"Failed to load settings for model '{model_id}': {e}"
                     )
 
+            root_inventory = data.get("model_root_inventory", {})
+            self._model_root_inventory = {}
+            if isinstance(root_inventory, dict):
+                for root, inventory in root_inventory.items():
+                    if not isinstance(root, str) or not isinstance(inventory, dict):
+                        continue
+                    source = inventory.get("source", "configured")
+                    if source not in {"configured", "hf_cache"}:
+                        source = "configured"
+                    model_ids = inventory.get("model_ids", [])
+                    if not isinstance(model_ids, list):
+                        model_ids = []
+                    entry: dict[str, Any] = {
+                        "source": source,
+                        "model_ids": sorted(
+                            model_id
+                            for model_id in model_ids
+                            if isinstance(model_id, str)
+                        ),
+                    }
+                    st_dev = inventory.get("st_dev")
+                    st_ino = inventory.get("st_ino")
+                    if isinstance(st_dev, int) and isinstance(st_ino, int):
+                        entry["st_dev"] = st_dev
+                        entry["st_ino"] = st_ino
+                    if inventory.get("pending_retirement") is True:
+                        entry["pending_retirement"] = True
+                    self._model_root_inventory[root] = entry
+
             logger.info(f"Loaded settings for {len(self._settings)} models")
 
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON in settings file: {e}")
             self._settings = {}
+            self._model_root_inventory = {}
         except Exception as e:
             logger.error(f"Failed to load settings file: {e}")
             self._settings = {}
+            self._model_root_inventory = {}
 
     def _save(self) -> None:
         """Save settings to the JSON file.
@@ -375,6 +431,8 @@ class ModelSettingsManager:
                 for model_id, settings in self._settings.items()
             },
         }
+        if self._model_root_inventory:
+            data["model_root_inventory"] = self._model_root_inventory
 
         try:
             # Write to temp file first, then rename for atomicity
@@ -485,6 +543,307 @@ class ModelSettingsManager:
             if removed:
                 logger.info(f"Deleted settings for model '{model_id}'")
             return removed
+
+    def reconcile_discovered_models(
+        self,
+        active_model_ids: Collection[str],
+        root_observations: Collection[ModelRootObservation],
+        *,
+        retire_unobserved_configured: bool = False,
+        prune_missing: bool = True,
+    ) -> list[str]:
+        """Reconcile state independently for each observed model root.
+
+        A model becomes a deletion candidate only when it disappeared from a
+        root whose scan is complete and whose physical identity is stable.
+        Unavailable, newly empty, replaced, or unobserved roots protect their
+        own last-known models without blocking cleanup for healthy roots.
+        Model state is never restored after it has been removed.
+
+        Args:
+            active_model_ids: IDs returned by the complete discovery pass.
+            root_observations: Scan evidence for configured model-storage roots.
+            retire_unobserved_configured: Mark configured roots omitted by an
+                explicit directory change for retirement once the replacement
+                configured roots are trustworthy.
+            prune_missing: Remove state confirmed absent by this observation.
+                Set to False for non-destructive inventory refreshes such as a
+                completed model download or an HF-cache visibility change.
+
+        Returns:
+            Sorted IDs whose settings and/or profiles were removed.
+        """
+        observations = tuple(root_observations)
+        if not observations:
+            logger.warning(
+                "Skipping persisted model-settings reconciliation because no "
+                "configured model roots were supplied"
+            )
+            return []
+
+        active_ids = set(active_model_ids)
+        with self._lock:
+            inventory_changed = False
+            deletion_candidates: set[str] = set()
+            protected_ids: set[str] = set()
+            observed_keys: set[str] = set()
+            state_ids = set(self._settings) | set(self._profiles)
+            known_before = {
+                model_id
+                for entry in self._model_root_inventory.values()
+                for model_id in self._inventory_model_ids(entry)
+            }
+            configured_observations = [
+                observation
+                for observation in observations
+                if observation.source == "configured"
+            ]
+            configured_roots_trusted = bool(configured_observations)
+            legacy_cleanup_safe = True
+
+            for observation in observations:
+                logical_root = observation.configured_path.expanduser().absolute()
+                root_key = str(logical_root)
+                observed_keys.add(root_key)
+                current_ids = set(observation.model_ids)
+                present_ids = current_ids | set(observation.present_model_ids)
+                previous = self._model_root_inventory.get(root_key)
+
+                # A local/cache entry may be physically present without being
+                # active (for example, while incomplete or when HF visibility
+                # is disabled). Presence still prevents destructive cleanup of
+                # matching persisted state.
+                protected_ids.update(present_ids - active_ids)
+
+                if (
+                    previous is not None
+                    and previous.pop("pending_retirement", None) is not None
+                ):
+                    inventory_changed = True
+
+                if observation.status != "complete":
+                    if (
+                        observation.status == "optional_missing"
+                        and observation.source == "hf_cache"
+                        and previous is None
+                    ):
+                        # The optional HF cache may not have been created yet.
+                        # A missing cache with no prior inventory has no
+                        # last-known state to protect, so it must not block
+                        # migration cleanup for trustworthy configured roots.
+                        continue
+                    logger.warning(
+                        "Deferring model-root reconciliation because the scan "
+                        "was incomplete: %s",
+                        logical_root,
+                    )
+                    configured_roots_trusted &= observation.source != "configured"
+                    legacy_cleanup_safe = False
+                    if previous is None:
+                        self._model_root_inventory[root_key] = {
+                            "source": observation.source,
+                            "model_ids": [],
+                        }
+                        inventory_changed = True
+                    else:
+                        protected_ids.update(self._inventory_model_ids(previous))
+                    continue
+
+                if observation.fingerprint is None:
+                    logger.warning(
+                        "Deferring model-root reconciliation because discovery "
+                        "did not capture a stable identity: %s",
+                        logical_root,
+                    )
+                    configured_roots_trusted &= observation.source != "configured"
+                    legacy_cleanup_safe = False
+                    if previous is None:
+                        self._model_root_inventory[root_key] = {
+                            "source": observation.source,
+                            "model_ids": [],
+                        }
+                        inventory_changed = True
+                    else:
+                        protected_ids.update(self._inventory_model_ids(previous))
+                    continue
+
+                fingerprint = {
+                    "st_dev": observation.fingerprint[0],
+                    "st_ino": observation.fingerprint[1],
+                }
+                previous_fingerprint = self._inventory_fingerprint(previous)
+
+                if previous_fingerprint is None:
+                    if not present_ids:
+                        previous_ids = self._inventory_model_ids(previous)
+                        if observation.source == "hf_cache" and not previous_ids:
+                            # An observed empty optional cache is trustworthy
+                            # when it has no last-known models. Recording its
+                            # identity avoids treating it like a newly mounted
+                            # user-configured model root.
+                            entry = {
+                                **fingerprint,
+                                "source": observation.source,
+                                "model_ids": [],
+                            }
+                            if previous != entry:
+                                self._model_root_inventory[root_key] = entry
+                                inventory_changed = True
+                            continue
+                        logger.info(
+                            "Deferring model-root reconciliation for a new or "
+                            "previously unavailable empty root: %s",
+                            logical_root,
+                        )
+                        configured_roots_trusted &= observation.source != "configured"
+                        legacy_cleanup_safe = False
+                        entry = {
+                            "source": observation.source,
+                            "model_ids": sorted(previous_ids),
+                        }
+                        if previous != entry:
+                            self._model_root_inventory[root_key] = entry
+                            inventory_changed = True
+                        continue
+
+                    previous_ids = self._inventory_model_ids(previous)
+                    entry = {
+                        **fingerprint,
+                        "source": observation.source,
+                        "model_ids": sorted(
+                            current_ids | (previous_ids if not prune_missing else set())
+                        ),
+                    }
+                    if previous != entry:
+                        self._model_root_inventory[root_key] = entry
+                        inventory_changed = True
+                    continue
+
+                previous_ids = self._inventory_model_ids(previous)
+                if previous_fingerprint != fingerprint:
+                    logger.warning(
+                        "Deferring model-root reconciliation because physical "
+                        "identity changed: %s",
+                        logical_root,
+                    )
+                    configured_roots_trusted &= observation.source != "configured"
+                    legacy_cleanup_safe = False
+                    protected_ids.update(previous_ids)
+                    if present_ids:
+                        # Retain the previous IDs for exactly one stable scan.
+                        # Structural model evidence is enough to accept the new
+                        # identity; a later stable scan can then distinguish
+                        # removal from a transient mount change.
+                        entry = {
+                            **fingerprint,
+                            "source": observation.source,
+                            "model_ids": sorted(previous_ids | current_ids),
+                        }
+                        if previous != entry:
+                            self._model_root_inventory[root_key] = entry
+                            inventory_changed = True
+                    continue
+
+                if prune_missing:
+                    retained_ids = current_ids | (previous_ids & present_ids)
+                    deletion_candidates.update(previous_ids - retained_ids)
+                else:
+                    retained_ids = previous_ids | current_ids
+                entry = {
+                    **fingerprint,
+                    "source": observation.source,
+                    "model_ids": sorted(retained_ids),
+                }
+                if previous != entry:
+                    self._model_root_inventory[root_key] = entry
+                    inventory_changed = True
+
+            for root_key in list(self._model_root_inventory):
+                if root_key in observed_keys:
+                    continue
+                entry = self._model_root_inventory[root_key]
+                entry_ids = self._inventory_model_ids(entry)
+                if (
+                    retire_unobserved_configured
+                    and entry.get("source", "configured") == "configured"
+                    and entry.get("pending_retirement") is not True
+                ):
+                    entry["pending_retirement"] = True
+                    inventory_changed = True
+
+                if (
+                    prune_missing
+                    and entry.get("pending_retirement") is True
+                    and configured_roots_trusted
+                ):
+                    deletion_candidates.update(entry_ids)
+                    del self._model_root_inventory[root_key]
+                    inventory_changed = True
+                    continue
+
+                protected_ids.update(entry_ids)
+                legacy_cleanup_safe = False
+
+            if prune_missing and legacy_cleanup_safe:
+                deletion_candidates.update(state_ids - known_before)
+
+            deletion_candidates.difference_update(active_ids)
+            deletion_candidates.difference_update(protected_ids)
+            removed_ids = self._remove_model_state_locked(
+                deletion_candidates,
+                save_inventory=inventory_changed,
+            )
+            if removed_ids:
+                logger.info(
+                    "Pruned persisted state for %d missing model(s): %s",
+                    len(removed_ids),
+                    ", ".join(removed_ids),
+                )
+            return removed_ids
+
+    @staticmethod
+    def _inventory_model_ids(entry: dict[str, Any] | None) -> set[str]:
+        if not entry:
+            return set()
+        model_ids = entry.get("model_ids", [])
+        if not isinstance(model_ids, list):
+            return set()
+        return {model_id for model_id in model_ids if isinstance(model_id, str)}
+
+    @staticmethod
+    def _inventory_fingerprint(
+        entry: dict[str, Any] | None,
+    ) -> dict[str, int] | None:
+        if not entry:
+            return None
+        st_dev = entry.get("st_dev")
+        st_ino = entry.get("st_ino")
+        if not isinstance(st_dev, int) or not isinstance(st_ino, int):
+            return None
+        return {"st_dev": st_dev, "st_ino": st_ino}
+
+    def _remove_model_state_locked(
+        self,
+        model_ids: Collection[str],
+        *,
+        save_inventory: bool = False,
+    ) -> list[str]:
+        """Remove selected model state while the manager lock is held."""
+        candidates = set(model_ids)
+        stale_settings = set(self._settings) & candidates
+        stale_profiles = set(self._profiles) & candidates
+        removed_ids = sorted(stale_settings | stale_profiles)
+
+        for model_id in stale_settings:
+            del self._settings[model_id]
+        for model_id in stale_profiles:
+            del self._profiles[model_id]
+
+        if save_inventory or stale_settings:
+            self._save()
+        if stale_profiles:
+            self._save_profiles()
+        return removed_ids
 
     def get_default_model_id(self) -> Optional[str]:
         """Get the ID of the default model.

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -51,7 +51,7 @@ from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from fastapi import Depends, FastAPI, HTTPException, Response
 from fastapi import Request as FastAPIRequest
@@ -61,6 +61,10 @@ from fastapi.responses import JSONResponse, RedirectResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from omlx._version import __version__
+
+if TYPE_CHECKING:
+    from .model_discovery import ModelDiscoveryResult
+    from .model_settings import ModelSettingsManager
 
 from .api.anthropic_models import (
     MessagesRequest as AnthropicMessagesRequest,
@@ -1634,11 +1638,125 @@ def validate_context_window(
         )
 
 
+def reconcile_discovered_model_state(
+    settings_manager: "ModelSettingsManager",
+    discovery: "ModelDiscoveryResult",
+    configured_model_dirs: list[str | Path],
+    *,
+    hf_cache_dir: str | Path | None = None,
+    hf_cache_enabled: bool = False,
+    retire_unobserved_configured: bool = False,
+    prune_missing: bool = True,
+) -> list[str]:
+    """Reconcile persisted model state after an explicit inventory refresh.
+
+    ``EnginePool.discover_models`` deliberately remains a best-effort,
+    in-memory operation. Server startup, an explicit model-directory change,
+    and the explicit inventory reload are the only lifecycle points allowed to
+    turn complete discovery evidence into deletion of persisted settings.
+    Other refreshes may set ``prune_missing=False`` to seed inventory without
+    interpreting absence as deletion.
+    """
+    from .model_discovery import discover_models_with_status
+    from .model_settings import ModelRootObservation
+
+    observations = []
+    configured_scan_paths: set[Path] = set()
+    for configured_dir in configured_model_dirs:
+        configured_path = Path(configured_dir).expanduser().absolute()
+        try:
+            scanned_path = configured_path.resolve()
+        except (OSError, RuntimeError):
+            scanned_path = configured_path
+        configured_scan_paths.add(scanned_path)
+        complete = discovery.root_complete.get(scanned_path, False)
+        observations.append(
+            ModelRootObservation(
+                configured_path=configured_path,
+                scanned_path=scanned_path,
+                status="complete" if complete else "incomplete",
+                model_ids=discovery.root_models.get(scanned_path, frozenset()),
+                fingerprint=discovery.root_fingerprints.get(scanned_path),
+                present_model_ids=discovery.root_model_entries.get(
+                    scanned_path,
+                    frozenset(),
+                ),
+            )
+        )
+
+    if hf_cache_dir is not None:
+        configured_path = Path(hf_cache_dir).expanduser().absolute()
+        try:
+            scanned_path = configured_path.resolve()
+        except (OSError, RuntimeError):
+            scanned_path = configured_path
+        if scanned_path not in configured_scan_paths:
+            try:
+                structural_evidence = discover_models_with_status(
+                    scanned_path,
+                    hf_cache_entries_only=True,
+                )
+            except ValueError:
+                try:
+                    scanned_path.stat()
+                except FileNotFoundError:
+                    hf_status = "optional_missing"
+                except OSError:
+                    hf_status = "incomplete"
+                else:
+                    hf_status = "incomplete"
+                structural_evidence = None
+            else:
+                hf_status = (
+                    "complete"
+                    if structural_evidence.root_complete.get(scanned_path, False)
+                    else "incomplete"
+                )
+
+            structural_fingerprint = (
+                structural_evidence.root_fingerprints.get(scanned_path)
+                if structural_evidence is not None
+                else None
+            )
+            discovered_fingerprint = discovery.root_fingerprints.get(scanned_path)
+            model_ids = (
+                discovery.root_models.get(scanned_path, frozenset())
+                if hf_cache_enabled and discovered_fingerprint == structural_fingerprint
+                else frozenset()
+            )
+            observations.append(
+                ModelRootObservation(
+                    configured_path=configured_path,
+                    scanned_path=scanned_path,
+                    status=hf_status,
+                    model_ids=model_ids,
+                    fingerprint=structural_fingerprint,
+                    present_model_ids=(
+                        structural_evidence.root_model_entries.get(
+                            scanned_path,
+                            frozenset(),
+                        )
+                        if structural_evidence is not None
+                        else frozenset()
+                    ),
+                    source="hf_cache",
+                )
+            )
+
+    return settings_manager.reconcile_discovered_models(
+        discovery.models,
+        observations,
+        retire_unobserved_configured=retire_unobserved_configured,
+        prune_missing=prune_missing,
+    )
+
+
 def init_server(
     model_dirs: str | list[str],
     scheduler_config=None,
     api_key: str | None = None,
     global_settings: object | None = None,
+    configured_model_dirs: list[str | Path] | None = None,
 ):
     """
     Initialize server with model directories for multi-model serving.
@@ -1648,6 +1766,8 @@ def init_server(
         scheduler_config: Scheduler config for BatchedEngine
         api_key: API key for authentication (optional)
         global_settings: GlobalSettings instance (optional)
+        configured_model_dirs: Pre-validation configured roots. Supplying this
+            preserves unavailable external/network roots that startup skips.
 
     Note:
         - Pinned models and default model are managed via admin page (model_settings.json)
@@ -1737,7 +1857,18 @@ def init_server(
         dir_list = [model_dirs]
     else:
         dir_list = list(model_dirs)
+    reconciliation_model_dirs: list[str | Path] = (
+        list(configured_model_dirs)
+        if configured_model_dirs is not None
+        else list(dir_list)
+    )
     if global_settings and hasattr(global_settings, "get_effective_model_dirs"):
+        if configured_model_dirs is None:
+            reconciliation_model_dirs = list(
+                global_settings.model.get_configured_model_dirs(
+                    global_settings.base_path
+                )
+            )
         dir_list = [str(d) for d in global_settings.get_effective_model_dirs()]
 
     # Create directories if needed
@@ -1756,7 +1887,16 @@ def init_server(
 
     # Discover models (use pinned models from settings file)
     _server_state.engine_pool._settings_manager = _server_state.settings_manager
-    _server_state.engine_pool.discover_models(dir_list, pinned_models)
+    discovery = _server_state.engine_pool.discover_models(dir_list, pinned_models)
+    reconcile_discovered_model_state(
+        _server_state.settings_manager,
+        discovery,
+        reconciliation_model_dirs,
+        hf_cache_dir=(global_settings.get_hf_cache_dir() if global_settings else None),
+        hf_cache_enabled=bool(
+            global_settings and global_settings.huggingface.hf_cache_enabled
+        ),
+    )
     _server_state.engine_pool.apply_settings_overrides(_server_state.settings_manager)
 
     if _server_state.engine_pool.model_count == 0:
@@ -1808,7 +1948,36 @@ def init_server(
         """Re-discover models when a HuggingFace download completes."""
         if _server_state.engine_pool and _server_state.settings_manager:
             pinned = _server_state.settings_manager.get_pinned_model_ids()
-            _server_state.engine_pool.discover_models(dir_list, pinned)
+            refresh_dirs = dir_list
+            refresh_configured_dirs = reconciliation_model_dirs
+            if global_settings and hasattr(
+                global_settings,
+                "get_effective_model_dirs",
+            ):
+                refresh_dirs = [
+                    str(path) for path in global_settings.get_effective_model_dirs()
+                ]
+                refresh_configured_dirs = list(
+                    global_settings.model.get_configured_model_dirs(
+                        global_settings.base_path
+                    )
+                )
+            discovery = _server_state.engine_pool.discover_models(
+                refresh_dirs,
+                pinned,
+            )
+            reconcile_discovered_model_state(
+                _server_state.settings_manager,
+                discovery,
+                refresh_configured_dirs,
+                hf_cache_dir=(
+                    global_settings.get_hf_cache_dir() if global_settings else None
+                ),
+                hf_cache_enabled=bool(
+                    global_settings and global_settings.huggingface.hf_cache_enabled
+                ),
+                prune_missing=False,
+            )
             _server_state.engine_pool.apply_settings_overrides(
                 _server_state.settings_manager
             )

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -207,6 +207,16 @@ class ModelSettings:
         False  # Hide dFlash/Assistant/Draft helper models from /v1/models
     )
 
+    def get_configured_model_dirs(self, base_path: Path) -> list[Path]:
+        """Return configured roots without resolving away symlink identity."""
+        if self.model_dirs:
+            configured = [Path(d) for d in self.model_dirs]
+        elif self.model_dir:
+            configured = [Path(self.model_dir)]
+        else:
+            configured = [base_path / "models"]
+        return [path.expanduser().absolute() for path in configured]
+
     def get_model_dirs(self, base_path: Path) -> list[Path]:
         """
         Get the resolved model directory paths.
@@ -217,11 +227,10 @@ class ModelSettings:
         Returns:
             List of resolved model directory paths.
         """
-        if self.model_dirs:
-            return [Path(d).expanduser().resolve() for d in self.model_dirs]
-        if self.model_dir:
-            return [Path(self.model_dir).expanduser().resolve()]
-        return [base_path / "models"]
+        configured = self.get_configured_model_dirs(base_path)
+        if not self.model_dirs and not self.model_dir:
+            return configured
+        return [path.resolve() for path in configured]
 
     def get_model_dir(self, base_path: Path) -> Path:
         """

--- a/tests/test_admin_reload.py
+++ b/tests/test_admin_reload.py
@@ -50,6 +50,9 @@ class TestReloadModels:
         global_settings = MagicMock()
         global_settings.model.model_dirs = ["/path/to/models"]
         global_settings.model.model_dir = "/path/to/models"
+        global_settings.model.get_configured_model_dirs.return_value = [
+            Path("/path/to/models")
+        ]
         global_settings.get_effective_model_dirs = MagicMock(
             return_value=["/path/to/models"]
         )
@@ -72,7 +75,10 @@ class TestReloadModels:
                     assert success is True
                     assert "5 models" in msg
                     settings_manager._load.assert_called_once()
-                    mock_apply.assert_called_once_with(["/path/to/models"])
+                    mock_apply.assert_called_once_with(
+                        ["/path/to/models"],
+                        reconciliation_model_dirs=["/path/to/models"],
+                    )
                     pool.preload_pinned_models.assert_called_once()
         finally:
             _restore_mocks(originals)
@@ -128,6 +134,9 @@ class TestReloadModels:
         global_settings = MagicMock()
         global_settings.model.model_dirs = ["/bad/path"]
         global_settings.model.model_dir = "/bad/path"
+        global_settings.model.get_configured_model_dirs.return_value = [
+            Path("/bad/path")
+        ]
         global_settings.get_effective_model_dirs = MagicMock(return_value=["/bad/path"])
 
         originals = _setup_mocks(pool, settings_manager, global_settings)
@@ -160,6 +169,9 @@ class TestReloadModels:
         global_settings = MagicMock()
         global_settings.model.model_dirs = []
         global_settings.model.model_dir = "/fallback/path"
+        global_settings.model.get_configured_model_dirs.return_value = [
+            Path("/fallback/path")
+        ]
         global_settings.get_effective_model_dirs = MagicMock(
             return_value=["/fallback/path"]
         )
@@ -178,7 +190,10 @@ class TestReloadModels:
                 ) as mock_apply:
                     success, msg = asyncio.run(admin_routes._reload_models())
                     assert success is True
-                    mock_apply.assert_called_once_with(["/fallback/path"])
+                    mock_apply.assert_called_once_with(
+                        ["/fallback/path"],
+                        reconciliation_model_dirs=["/fallback/path"],
+                    )
         finally:
             _restore_mocks(originals)
 
@@ -276,3 +291,86 @@ class TestApplyModelDirsRuntime:
         assert "from 1 directory" in msg
         assert primary.is_dir()
         pool.discover_models.assert_called_once_with([str(primary.resolve())], [])
+
+    def test_non_directory_refresh_does_not_reconcile_persisted_state(
+        self, tmp_path, monkeypatch
+    ):
+        """HF-cache discovery changes must not act like model deletion."""
+        primary = tmp_path / "primary"
+        primary.mkdir()
+        monkeypatch.setattr(admin_routes, "_hf_downloader", None)
+        monkeypatch.setattr(admin_routes, "_ms_downloader", None)
+        monkeypatch.setattr(admin_routes, "_oq_manager", None)
+        monkeypatch.setattr(admin_routes, "_hf_uploader", None)
+
+        pool = MagicMock()
+        pool.get_loaded_model_ids.return_value = []
+        pool.model_count = 0
+        settings_manager = MagicMock()
+        mock_server_state = MagicMock()
+        mock_server_state.engine_pool = pool
+        mock_server_state.settings_manager = settings_manager
+
+        with (
+            patch.object(omlx.server, "_server_state", mock_server_state),
+            patch("omlx.server.reconcile_discovered_model_state") as reconcile,
+        ):
+            success, _ = asyncio.run(
+                admin_routes._apply_model_dirs_runtime([str(primary)])
+            )
+
+        assert success is True
+        reconcile.assert_not_called()
+        pool.apply_settings_overrides.assert_called_once_with(settings_manager)
+
+    def test_observation_only_refresh_seeds_inventory_without_pruning(
+        self, tmp_path, monkeypatch
+    ):
+        """Non-deletion refreshes pass explicit observation-only policy."""
+        primary = tmp_path / "primary"
+        primary.mkdir()
+        monkeypatch.setattr(admin_routes, "_hf_downloader", None)
+        monkeypatch.setattr(admin_routes, "_ms_downloader", None)
+        monkeypatch.setattr(admin_routes, "_oq_manager", None)
+        monkeypatch.setattr(admin_routes, "_hf_uploader", None)
+
+        discovery = object()
+        pool = MagicMock()
+        pool.get_loaded_model_ids.return_value = []
+        pool.model_count = 0
+        pool.discover_models.return_value = discovery
+        settings_manager = MagicMock()
+        global_settings = MagicMock()
+        global_settings.get_hf_cache_dir.return_value = tmp_path / "hf-cache"
+        global_settings.huggingface.hf_cache_enabled = False
+        mock_server_state = MagicMock()
+        mock_server_state.engine_pool = pool
+        mock_server_state.settings_manager = settings_manager
+
+        with (
+            patch.object(omlx.server, "_server_state", mock_server_state),
+            patch.object(
+                admin_routes,
+                "_get_global_settings",
+                return_value=global_settings,
+            ),
+            patch("omlx.server.reconcile_discovered_model_state") as reconcile,
+        ):
+            success, _ = asyncio.run(
+                admin_routes._apply_model_dirs_runtime(
+                    [str(primary)],
+                    reconciliation_model_dirs=[str(primary)],
+                    prune_missing=False,
+                )
+            )
+
+        assert success is True
+        reconcile.assert_called_once_with(
+            settings_manager,
+            discovery,
+            [str(primary)],
+            hf_cache_dir=tmp_path / "hf-cache",
+            hf_cache_enabled=False,
+            retire_unobserved_configured=False,
+            prune_missing=False,
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -713,6 +713,7 @@ class TestServeCommandFunctions:
             get_log_dir=lambda base_path: log_dir,
         )
         settings.model = SimpleNamespace(
+            get_configured_model_dirs=lambda base_path: [tmp_path / "models"],
             get_model_dirs=lambda base_path: [tmp_path / "models"],
         )
         settings.get_effective_model_dirs = lambda: [tmp_path / "models"]
@@ -877,6 +878,10 @@ class TestServeCommandFunctions:
 
         host, port = "127.0.0.1", 0
         settings = self._make_settings(tmp_path, host=host, port=port)
+        configured_model_dirs = [tmp_path / "models", tmp_path / "nfs-models"]
+        settings.model.get_configured_model_dirs = lambda base_path: list(
+            configured_model_dirs
+        )
         args = self._make_serve_args(tmp_path, host=host, port=port)
         events = []
 
@@ -927,6 +932,10 @@ class TestServeCommandFunctions:
         serve_command(args)
 
         fake_server.init_server.assert_called_once()
+        assert (
+            fake_server.init_server.call_args.kwargs["configured_model_dirs"]
+            == configured_model_dirs
+        )
         assert events == ["bind", "init", "run"]
         assert captured["socket_count"] == 1
         assert captured["socket_name"][0] == host

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -18,6 +18,8 @@ from omlx.model_discovery import (
     detect_model_type,
     discover_models,
     discover_models_from_dirs,
+    discover_models_from_dirs_with_status,
+    discover_models_with_status,
     estimate_model_size,
     format_size,
     is_helper_config_model_type,
@@ -934,6 +936,150 @@ class TestDiscoverModels:
         models = discover_models(tmp_path)
         assert len(models) == 0
 
+    def test_incomplete_model_keeps_structural_entry_evidence(self, tmp_path):
+        """A skipped model folder is not proof that the model was deleted."""
+        model_dir = tmp_path / "mid-copy-model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+
+        result = discover_models_with_status(tmp_path)
+
+        assert result.models == {}
+        assert result.root_complete[tmp_path.resolve()] is True
+        assert result.root_model_entries[tmp_path.resolve()] == frozenset(
+            {"mid-copy-model"}
+        )
+
+    def test_model_folder_without_config_keeps_structural_entry_evidence(
+        self, tmp_path
+    ):
+        """An early or interrupted copy still proves that its folder exists."""
+        model_dir = tmp_path / "mid-copy-model"
+        model_dir.mkdir()
+        (model_dir / "model.safetensors").write_bytes(b"partial")
+
+        result = discover_models_with_status(tmp_path)
+
+        assert result.models == {}
+        assert result.root_complete[tmp_path.resolve()] is True
+        assert result.root_model_entries[tmp_path.resolve()] == frozenset(
+            {"mid-copy-model"}
+        )
+
+    def test_incomplete_direct_model_root_keeps_root_name_evidence(self, tmp_path):
+        """A directly configured single-model root remains structurally present."""
+        model_root = tmp_path / "direct-model"
+        model_root.mkdir()
+        (model_root / "model.safetensors").write_bytes(b"partial")
+
+        result = discover_models_with_status(model_root)
+
+        assert result.models == {}
+        assert result.root_complete[model_root.resolve()] is True
+        assert result.root_model_entries[model_root.resolve()] == frozenset(
+            {"direct-model"}
+        )
+
+    def test_inaccessible_model_metadata_marks_root_scan_incomplete(
+        self, tmp_path, monkeypatch
+    ):
+        """A metadata read failure cannot be silently treated as absence."""
+        model_dir = tmp_path / "protected-model"
+        model_dir.mkdir()
+        config_path = model_dir / "config.json"
+        config_path.write_text(json.dumps({"model_type": "llama"}))
+        (model_dir / "model.safetensors").write_bytes(b"x" * 100)
+
+        original_stat = Path.stat
+
+        def fake_stat(path, *args, **kwargs):
+            if path == config_path:
+                raise PermissionError("Operation not permitted")
+            return original_stat(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", fake_stat)
+        result = discover_models_with_status(tmp_path)
+
+        assert result.models == {}
+        assert result.root_complete[tmp_path.resolve()] is False
+
+    def test_incomplete_hf_snapshot_keeps_structural_entry_evidence(self, tmp_path):
+        """A present HF cache entry is not a confirmed model deletion."""
+        snapshot = tmp_path / "models--mlx-community--demo" / "snapshots" / "revision"
+        snapshot.mkdir(parents=True)
+        (snapshot / "config.json").write_text(
+            json.dumps({"model_type": "llama"}),
+            encoding="utf-8",
+        )
+
+        result = discover_models_with_status(tmp_path)
+
+        assert result.models == {}
+        assert result.root_complete[tmp_path.resolve()] is True
+        assert result.root_models[tmp_path.resolve()] == frozenset()
+        assert result.root_model_entries[tmp_path.resolve()] == frozenset(
+            {"mlx-community--demo"}
+        )
+
+    def test_empty_hf_snapshots_keep_structural_entry_evidence(self, tmp_path):
+        """An empty snapshot tree is still a present HF cache entry."""
+        snapshots = tmp_path / "models--mlx-community--demo" / "snapshots"
+        snapshots.mkdir(parents=True)
+
+        result = discover_models_with_status(tmp_path)
+
+        root = tmp_path.resolve()
+        assert result.models == {}
+        assert result.root_complete[root] is True
+        assert result.root_models[root] == frozenset()
+        assert result.root_model_entries[root] == frozenset({"mlx-community--demo"})
+        assert result.root_fingerprints[root] is not None
+
+    def test_unreadable_hf_snapshots_mark_root_scan_incomplete(
+        self, tmp_path, monkeypatch
+    ):
+        """An inaccessible HF snapshot tree cannot prove model deletion."""
+        snapshots = tmp_path / "models--mlx-community--demo" / "snapshots"
+        snapshots.mkdir(parents=True)
+        original_iterdir = Path.iterdir
+
+        def fake_iterdir(path):
+            if path == snapshots:
+                raise PermissionError("Operation not permitted")
+            return original_iterdir(path)
+
+        monkeypatch.setattr(Path, "iterdir", fake_iterdir)
+        result = discover_models_with_status(tmp_path)
+
+        assert result.models == {}
+        assert result.root_complete[tmp_path.resolve()] is False
+
+    def test_root_identity_change_during_scan_marks_result_incomplete(
+        self, tmp_path, monkeypatch
+    ):
+        """Scan contents cannot be paired with a different mount identity."""
+        model_dir = tmp_path / "model-a"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(
+            json.dumps({"model_type": "llama"}),
+            encoding="utf-8",
+        )
+        (model_dir / "model.safetensors").write_bytes(b"model")
+        fingerprints = iter([(1, 10), (2, 20)])
+
+        def changing_fingerprint(path, *, health=None):
+            return next(fingerprints)
+
+        monkeypatch.setattr(
+            "omlx.model_discovery._root_fingerprint",
+            changing_fingerprint,
+        )
+        result = discover_models_with_status(tmp_path)
+
+        root = tmp_path.resolve()
+        assert result.root_complete[root] is False
+        assert result.root_fingerprints[root] is None
+
     def test_discovered_model_fields(self, tmp_path):
         """Test that DiscoveredModel has all expected fields."""
         model_dir = tmp_path / "test-model"
@@ -1257,6 +1403,21 @@ class TestDiscoverModelsFromDirs:
         models = discover_models_from_dirs([dir_a, dir_b])
         assert len(models) == 1
         assert models["same-model"].model_path == str(dir_a / "same-model")
+
+    def test_status_keeps_model_presence_for_duplicate_root(self, tmp_path):
+        """A duplicate still proves the later root is not newly empty."""
+        dir_a = tmp_path / "dir_a"
+        dir_b = tmp_path / "dir_b"
+        self._make_model(dir_a / "same-model")
+        self._make_model(dir_b / "same-model")
+
+        result = discover_models_from_dirs_with_status([dir_a, dir_b])
+
+        assert result.root_complete == {dir_a.resolve(): True, dir_b.resolve(): True}
+        assert result.root_models == {
+            dir_a.resolve(): frozenset({"same-model"}),
+            dir_b.resolve(): frozenset({"same-model"}),
+        }
 
     def test_empty_list(self, tmp_path):
         """Test with empty directory list."""

--- a/tests/test_model_reconciliation.py
+++ b/tests/test_model_reconciliation.py
@@ -1,0 +1,638 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lifecycle tests for filesystem-driven model-state reconciliation."""
+
+import json
+import shutil
+from pathlib import Path
+
+from omlx.model_discovery import discover_models_from_dirs_with_status
+from omlx.model_settings import ModelSettings, ModelSettingsManager
+from omlx.server import reconcile_discovered_model_state
+from omlx.settings import ModelSettings as GlobalModelSettings
+
+
+def _make_model(root: Path, model_id: str) -> Path:
+    model_dir = root / model_id
+    model_dir.mkdir(parents=True)
+    (model_dir / "config.json").write_text(
+        json.dumps({"model_type": "llama"}), encoding="utf-8"
+    )
+    (model_dir / "model.safetensors").write_bytes(b"model")
+    return model_dir
+
+
+def _make_hf_cache_model(root: Path, model_id: str) -> tuple[Path, Path]:
+    entry = root / f"models--{model_id}"
+    snapshot = entry / "snapshots" / "revision"
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").write_text(
+        json.dumps({"model_type": "llama"}),
+        encoding="utf-8",
+    )
+    weights = snapshot / "model.safetensors"
+    weights.write_bytes(b"model")
+    return entry, weights
+
+
+def _scan(*roots: Path):
+    return discover_models_from_dirs_with_status(list(roots))
+
+
+def _reconcile(
+    manager: ModelSettingsManager,
+    configured_roots: list[Path],
+    *,
+    scanned_roots: list[Path] | None = None,
+    hf_cache_dir: Path | None = None,
+    hf_cache_enabled: bool = False,
+    retire_unobserved_configured: bool = False,
+    prune_missing: bool = True,
+) -> list[str]:
+    discovery = _scan(*(scanned_roots or configured_roots))
+    return reconcile_discovered_model_state(
+        manager,
+        discovery,
+        configured_roots,
+        hf_cache_dir=hf_cache_dir,
+        hf_cache_enabled=hf_cache_enabled,
+        retire_unobserved_configured=retire_unobserved_configured,
+        prune_missing=prune_missing,
+    )
+
+
+def test_first_inventory_releases_legacy_alias_with_empty_hf_cache(tmp_path):
+    """Upgrading users do not need a pre-existing root inventory."""
+    model_root = tmp_path / "models"
+    hf_cache = tmp_path / "hf-cache"
+    _make_model(model_root, "model-a")
+    hf_cache.mkdir()
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings("deleted-model", ModelSettings(model_alias="shared"))
+    manager.save_profile("deleted-model", "fast", "Fast", None, {"temperature": 0.1})
+
+    removed = _reconcile(
+        manager,
+        [model_root],
+        scanned_roots=[model_root, hf_cache],
+        hf_cache_dir=hf_cache,
+        hf_cache_enabled=True,
+    )
+
+    assert removed == ["deleted-model"]
+    assert "deleted-model" not in manager.get_all_settings()
+    assert manager.list_profiles("deleted-model") == []
+
+
+def test_cold_start_releases_alias_after_external_folder_removal(tmp_path):
+    """Deleting a model while oMLX is stopped releases its state on startup."""
+    model_root = tmp_path / "models"
+    _make_model(model_root, "model-a")
+    deleted_dir = _make_model(model_root, "model-b")
+    settings_path = tmp_path / "settings"
+
+    manager = ModelSettingsManager(settings_path)
+    manager.set_settings("model-b", ModelSettings(model_alias="shared"))
+    manager.save_profile("model-b", "fast", "Fast", None, {"top_k": 10})
+    assert _reconcile(manager, [model_root]) == []
+
+    shutil.rmtree(deleted_dir)
+    restarted = ModelSettingsManager(settings_path)
+    assert _reconcile(restarted, [model_root]) == ["model-b"]
+    assert "model-b" not in restarted.get_all_settings()
+    assert restarted.list_profiles("model-b") == []
+
+    restarted.set_settings("model-a", ModelSettings(model_alias="shared"))
+    assert restarted.get_settings("model-a").model_alias == "shared"
+
+    # Reappearance never restores state that reconciliation already deleted.
+    _make_model(model_root, "model-b")
+    assert _reconcile(restarted, [model_root]) == []
+    assert "model-b" not in restarted.get_all_settings()
+    assert restarted.get_settings("model-b").model_alias is None
+
+
+def test_explicit_reload_releases_alias_after_live_folder_removal(tmp_path):
+    """A manual reload reconciles folders removed while oMLX is running."""
+    model_root = tmp_path / "models"
+    _make_model(model_root, "model-a")
+    deleted_dir = _make_model(model_root, "model-b")
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings("model-b", ModelSettings(model_alias="shared"))
+    assert _reconcile(manager, [model_root]) == []
+
+    shutil.rmtree(deleted_dir)
+
+    assert _reconcile(manager, [model_root]) == ["model-b"]
+    assert "model-b" not in manager.get_all_settings()
+
+
+def test_observation_only_refresh_seeds_inventory_after_first_download(tmp_path):
+    """A download into a new empty root enables later offline cleanup."""
+    model_root = tmp_path / "models"
+    model_root.mkdir()
+    settings_path = tmp_path / "settings"
+    manager = ModelSettingsManager(settings_path)
+
+    assert _reconcile(manager, [model_root]) == []
+
+    downloaded_dir = _make_model(model_root, "only-model")
+    assert _reconcile(manager, [model_root], prune_missing=False) == []
+    manager.set_settings("only-model", ModelSettings(model_alias="shared"))
+
+    shutil.rmtree(downloaded_dir)
+    restarted = ModelSettingsManager(settings_path)
+    assert _reconcile(restarted, [model_root]) == ["only-model"]
+    assert "only-model" not in restarted.get_all_settings()
+
+
+def test_observation_only_refresh_never_prunes_missing_state(tmp_path):
+    """A download/visibility refresh records additions without acting as reload."""
+    model_root = tmp_path / "models"
+    removed_dir = _make_model(model_root, "model-a")
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings("model-a", ModelSettings(model_alias="protected"))
+    assert _reconcile(manager, [model_root]) == []
+
+    shutil.rmtree(removed_dir)
+    _make_model(model_root, "model-b")
+    assert _reconcile(manager, [model_root], prune_missing=False) == []
+    assert manager.get_settings("model-a").model_alias == "protected"
+
+    assert _reconcile(manager, [model_root]) == ["model-a"]
+
+
+def test_existing_incomplete_local_folder_does_not_release_alias(tmp_path):
+    """An incomplete folder protects itself without blocking a real removal."""
+    model_root = tmp_path / "models"
+    model_dir = _make_model(model_root, "model-a")
+    removed_dir = _make_model(model_root, "model-b")
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings("model-a", ModelSettings(model_alias="protected"))
+    manager.set_settings("model-b", ModelSettings(model_alias="released"))
+    assert _reconcile(manager, [model_root]) == []
+
+    (model_dir / "config.json").unlink()
+    shutil.rmtree(removed_dir)
+    assert _reconcile(manager, [model_root]) == ["model-b"]
+    assert manager.get_settings("model-a").model_alias == "protected"
+
+    shutil.rmtree(model_dir)
+    assert _reconcile(manager, [model_root]) == ["model-a"]
+
+
+def test_unavailable_nfs_root_only_protects_its_own_models(tmp_path):
+    """A missing NFS/external root cannot block a healthy root's cleanup."""
+    local_root = tmp_path / "local"
+    nfs_root = tmp_path / "nfs"
+    _make_model(local_root, "local-active")
+    local_deleted = _make_model(local_root, "local-deleted")
+    _make_model(nfs_root, "nfs-model")
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings("local-deleted", ModelSettings(model_alias="local-alias"))
+    manager.set_settings("nfs-model", ModelSettings(model_alias="nfs-alias"))
+    assert _reconcile(manager, [local_root, nfs_root]) == []
+
+    shutil.rmtree(local_deleted)
+    shutil.rmtree(nfs_root)
+    removed = _reconcile(
+        manager,
+        [local_root, nfs_root],
+        scanned_roots=[local_root],
+    )
+
+    assert removed == ["local-deleted"]
+    assert "local-deleted" not in manager.get_all_settings()
+    assert manager.get_settings("nfs-model").model_alias == "nfs-alias"
+
+
+def test_same_model_id_found_in_another_root_keeps_state(tmp_path):
+    """Moving a model between still-configured roots is not a deletion."""
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    moved_dir = _make_model(first_root, "model-a")
+    _make_model(second_root, "model-b")
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings("model-a", ModelSettings(model_alias="moved"))
+    assert _reconcile(manager, [first_root, second_root]) == []
+
+    shutil.move(str(moved_dir), second_root / "model-a")
+    assert _reconcile(manager, [first_root, second_root]) == []
+    assert manager.get_settings("model-a").model_alias == "moved"
+
+
+def test_explicit_model_root_change_retires_absent_state(tmp_path):
+    """A trusted replacement root releases IDs absent from the new config."""
+    old_root = tmp_path / "old"
+    new_root = tmp_path / "new"
+    _make_model(old_root, "model-a")
+    _make_model(old_root, "model-b")
+    _make_model(new_root, "model-a")
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings("model-a", ModelSettings(model_alias="kept"))
+    manager.set_settings("model-b", ModelSettings(model_alias="released"))
+    assert _reconcile(manager, [old_root]) == []
+
+    removed = _reconcile(
+        manager,
+        [new_root],
+        retire_unobserved_configured=True,
+    )
+
+    assert removed == ["model-b"]
+    assert manager.get_settings("model-a").model_alias == "kept"
+    assert "model-b" not in manager.get_all_settings()
+
+
+def test_new_empty_replacement_root_defers_retirement(tmp_path):
+    """A newly created mount point is not trusted until it yields models."""
+    old_root = tmp_path / "old"
+    new_root = tmp_path / "new"
+    _make_model(old_root, "old-model")
+    new_root.mkdir()
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings("old-model", ModelSettings(model_alias="protected"))
+    assert _reconcile(manager, [old_root]) == []
+
+    assert (
+        _reconcile(
+            manager,
+            [new_root],
+            retire_unobserved_configured=True,
+        )
+        == []
+    )
+    assert manager.get_settings("old-model").model_alias == "protected"
+
+    _make_model(new_root, "new-model")
+    assert _reconcile(manager, [new_root]) == ["old-model"]
+
+
+def test_mount_identity_change_requires_a_stable_followup_scan(tmp_path):
+    """A changed mount target gets one non-destructive confirmation scan."""
+    volume_a = tmp_path / "volume-a"
+    volume_b = tmp_path / "volume-b"
+    _make_model(volume_a, "old-model")
+    _make_model(volume_b, "new-model")
+    logical_root = tmp_path / "models"
+    logical_root.symlink_to(volume_a, target_is_directory=True)
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings("old-model", ModelSettings(model_alias="protected"))
+    assert _reconcile(manager, [logical_root]) == []
+
+    logical_root.unlink()
+    logical_root.symlink_to(volume_b, target_is_directory=True)
+    assert _reconcile(manager, [logical_root]) == []
+    assert manager.get_settings("old-model").model_alias == "protected"
+
+    assert _reconcile(manager, [logical_root]) == ["old-model"]
+
+
+def test_empty_replacement_mount_never_confirms_deletion(tmp_path):
+    """An empty replacement can be an unmounted disk or network filesystem."""
+    volume_a = tmp_path / "volume-a"
+    volume_b = tmp_path / "volume-b"
+    _make_model(volume_a, "old-model")
+    volume_b.mkdir()
+    logical_root = tmp_path / "models"
+    logical_root.symlink_to(volume_a, target_is_directory=True)
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings("old-model", ModelSettings(model_alias="protected"))
+    assert _reconcile(manager, [logical_root]) == []
+
+    logical_root.unlink()
+    logical_root.symlink_to(volume_b, target_is_directory=True)
+    for _ in range(2):
+        assert _reconcile(manager, [logical_root]) == []
+    assert manager.get_settings("old-model").model_alias == "protected"
+
+
+def test_unavailable_known_hf_cache_does_not_block_local_cleanup(tmp_path):
+    """Known HF state is protected independently from a healthy local root."""
+    local_root = tmp_path / "local"
+    hf_cache = tmp_path / "hf-cache"
+    _make_model(local_root, "local-active")
+    local_deleted = _make_model(local_root, "local-deleted")
+    _make_model(hf_cache, "hf-model")
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings("local-deleted", ModelSettings(model_alias="local-alias"))
+    manager.set_settings("hf-model", ModelSettings(model_alias="hf-alias"))
+    assert (
+        _reconcile(
+            manager,
+            [local_root],
+            scanned_roots=[local_root, hf_cache],
+            hf_cache_dir=hf_cache,
+            hf_cache_enabled=True,
+        )
+        == []
+    )
+
+    shutil.rmtree(local_deleted)
+    shutil.rmtree(hf_cache)
+    removed = _reconcile(
+        manager,
+        [local_root],
+        scanned_roots=[local_root],
+        hf_cache_dir=hf_cache,
+        hf_cache_enabled=True,
+    )
+
+    assert removed == ["local-deleted"]
+    assert manager.get_settings("hf-model").model_alias == "hf-alias"
+
+
+def test_incomplete_hf_snapshot_preserves_state_until_entry_is_deleted(tmp_path):
+    """Structural HF cache presence protects state without exposing the model."""
+    local_root = tmp_path / "local"
+    local_root.mkdir()
+    hf_cache = tmp_path / "hf-cache"
+    model_id = "mlx-community--demo"
+    cache_entry, weights = _make_hf_cache_model(hf_cache, model_id)
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings(model_id, ModelSettings(model_alias="shared"))
+    assert (
+        _reconcile(
+            manager,
+            [local_root],
+            scanned_roots=[local_root, hf_cache],
+            hf_cache_dir=hf_cache,
+            hf_cache_enabled=True,
+        )
+        == []
+    )
+
+    weights.unlink()
+    incomplete = _scan(local_root, hf_cache)
+    hf_key = hf_cache.resolve()
+    assert incomplete.models == {}
+    assert incomplete.root_complete[hf_key] is True
+    assert incomplete.root_models[hf_key] == frozenset()
+    assert incomplete.root_model_entries[hf_key] == frozenset({model_id})
+    assert (
+        reconcile_discovered_model_state(
+            manager,
+            incomplete,
+            [local_root],
+            hf_cache_dir=hf_cache,
+            hf_cache_enabled=True,
+        )
+        == []
+    )
+    assert manager.get_settings(model_id).model_alias == "shared"
+
+    shutil.rmtree(cache_entry)
+    assert _reconcile(
+        manager,
+        [local_root],
+        scanned_roots=[local_root, hf_cache],
+        hf_cache_dir=hf_cache,
+        hf_cache_enabled=True,
+    ) == [model_id]
+    assert model_id not in manager.get_all_settings()
+
+
+def test_empty_hf_snapshot_tree_preserves_state_until_entry_is_deleted(tmp_path):
+    """Removing snapshots alone is not equivalent to removing the cache entry."""
+    local_root = tmp_path / "local"
+    local_root.mkdir()
+    hf_cache = tmp_path / "hf-cache"
+    model_id = "mlx-community--demo"
+    cache_entry, _ = _make_hf_cache_model(hf_cache, model_id)
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings(model_id, ModelSettings(model_alias="shared"))
+    assert (
+        _reconcile(
+            manager,
+            [local_root],
+            scanned_roots=[local_root, hf_cache],
+            hf_cache_dir=hf_cache,
+            hf_cache_enabled=True,
+        )
+        == []
+    )
+
+    shutil.rmtree(cache_entry / "snapshots" / "revision")
+    assert (
+        _reconcile(
+            manager,
+            [local_root],
+            scanned_roots=[local_root, hf_cache],
+            hf_cache_dir=hf_cache,
+            hf_cache_enabled=True,
+        )
+        == []
+    )
+    assert manager.get_settings(model_id).model_alias == "shared"
+
+    shutil.rmtree(cache_entry)
+    assert _reconcile(
+        manager,
+        [local_root],
+        scanned_roots=[local_root, hf_cache],
+        hf_cache_dir=hf_cache,
+        hf_cache_enabled=True,
+    ) == [model_id]
+
+
+def test_incomplete_hf_snapshot_protects_legacy_state_before_inventory(tmp_path):
+    """An upgrade cannot prune a legacy alias while its HF entry still exists."""
+    local_root = tmp_path / "local"
+    _make_model(local_root, "local-active")
+    hf_cache = tmp_path / "hf-cache"
+    model_id = "mlx-community--demo"
+    _, weights = _make_hf_cache_model(hf_cache, model_id)
+    weights.unlink()
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings(model_id, ModelSettings(model_alias="legacy"))
+
+    assert (
+        _reconcile(
+            manager,
+            [local_root],
+            scanned_roots=[local_root, hf_cache],
+            hf_cache_dir=hf_cache,
+            hf_cache_enabled=True,
+        )
+        == []
+    )
+    assert manager.get_settings(model_id).model_alias == "legacy"
+
+
+def test_incomplete_untracked_hf_root_defers_legacy_cleanup(tmp_path, monkeypatch):
+    """An unreadable first HF scan cannot prove that legacy state is stale."""
+    local_root = tmp_path / "local"
+    _make_model(local_root, "local-active")
+    hf_cache = tmp_path / "hf-cache"
+    hf_cache.mkdir()
+    original_iterdir = Path.iterdir
+
+    def fake_iterdir(path):
+        if path == hf_cache:
+            raise PermissionError("Operation not permitted")
+        return original_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", fake_iterdir)
+    discovery = _scan(local_root, hf_cache)
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings(
+        "mlx-community--unreadable",
+        ModelSettings(model_alias="protected"),
+    )
+    removed = reconcile_discovered_model_state(
+        manager,
+        discovery,
+        [local_root],
+        hf_cache_dir=hf_cache,
+        hf_cache_enabled=True,
+    )
+
+    assert removed == []
+    assert manager.get_settings("mlx-community--unreadable").model_alias == "protected"
+
+
+def test_disabled_hf_cache_is_scanned_for_reconciliation_evidence(tmp_path):
+    """Disabling HF visibility does not delete first-inventory model state."""
+    local_root = tmp_path / "local"
+    _make_model(local_root, "local-active")
+    hf_cache = tmp_path / "hf-cache"
+    model_id = "mlx-community--demo"
+    _make_hf_cache_model(hf_cache, model_id)
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings(model_id, ModelSettings(model_alias="protected"))
+    discovery = _scan(local_root)
+    assert model_id not in discovery.models
+
+    removed = reconcile_discovered_model_state(
+        manager,
+        discovery,
+        [local_root],
+        hf_cache_dir=hf_cache,
+        hf_cache_enabled=False,
+    )
+
+    assert removed == []
+    assert manager.get_settings(model_id).model_alias == "protected"
+
+
+def test_disabled_hf_cache_mount_change_converges_without_losing_state(tmp_path):
+    """Structural evidence can confirm a changed disabled-cache identity."""
+    local_root = tmp_path / "local"
+    local_root.mkdir()
+    hf_cache = tmp_path / "hf-cache"
+    model_id = "mlx-community--demo"
+    _make_hf_cache_model(hf_cache, model_id)
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings(model_id, ModelSettings(model_alias="protected"))
+    assert (
+        _reconcile(
+            manager,
+            [local_root],
+            scanned_roots=[local_root, hf_cache],
+            hf_cache_dir=hf_cache,
+            hf_cache_enabled=True,
+        )
+        == []
+    )
+
+    hf_cache.rename(tmp_path / "old-hf-cache")
+    cache_entry, _ = _make_hf_cache_model(hf_cache, model_id)
+    discovery = _scan(local_root)
+
+    for _ in range(2):
+        assert (
+            reconcile_discovered_model_state(
+                manager,
+                discovery,
+                [local_root],
+                hf_cache_dir=hf_cache,
+                hf_cache_enabled=False,
+            )
+            == []
+        )
+    assert manager.get_settings(model_id).model_alias == "protected"
+
+    shutil.rmtree(cache_entry)
+    assert reconcile_discovered_model_state(
+        manager,
+        discovery,
+        [local_root],
+        hf_cache_dir=hf_cache,
+        hf_cache_enabled=False,
+    ) == [model_id]
+
+
+def test_missing_unused_hf_cache_does_not_block_legacy_cleanup(tmp_path):
+    """A never-created optional cache does not stall configured-root migration."""
+    local_root = tmp_path / "local"
+    _make_model(local_root, "local-active")
+    hf_cache = tmp_path / "missing-hf-cache"
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings("deleted-model", ModelSettings(model_alias="released"))
+    discovery = _scan(local_root)
+
+    removed = reconcile_discovered_model_state(
+        manager,
+        discovery,
+        [local_root],
+        hf_cache_dir=hf_cache,
+        hf_cache_enabled=True,
+    )
+
+    assert removed == ["deleted-model"]
+    assert "deleted-model" not in manager.get_all_settings()
+
+
+def test_mount_change_after_scan_cannot_poison_root_fingerprint(tmp_path):
+    """Discovery IDs remain paired with the identity that produced them."""
+    model_root = tmp_path / "models"
+    _make_model(model_root, "model-a")
+
+    manager = ModelSettingsManager(tmp_path / "settings")
+    manager.set_settings("model-a", ModelSettings(model_alias="protected"))
+    assert _reconcile(manager, [model_root]) == []
+
+    stale_discovery = _scan(model_root)
+    detached_root = tmp_path / "detached-models"
+    model_root.rename(detached_root)
+    model_root.mkdir()
+
+    assert (
+        reconcile_discovered_model_state(
+            manager,
+            stale_discovery,
+            [model_root],
+        )
+        == []
+    )
+    assert _reconcile(manager, [model_root]) == []
+    assert manager.get_settings("model-a").model_alias == "protected"
+
+
+def test_configured_paths_preserve_logical_mount_identity(tmp_path):
+    """Configuration retains a symlink while scanning resolves its target."""
+    physical_root = tmp_path / "volume"
+    physical_root.mkdir()
+    logical_root = tmp_path / "models"
+    logical_root.symlink_to(physical_root, target_is_directory=True)
+    settings = GlobalModelSettings(model_dirs=[str(logical_root)])
+
+    assert settings.get_configured_model_dirs(tmp_path) == [logical_root.absolute()]
+    assert settings.get_model_dirs(tmp_path) == [physical_root.resolve()]


### PR DESCRIPTION

## Summary

- Remove a model's persisted alias, settings, and profiles when a trusted inventory refresh confirms that its folder was deleted outside oMLX.
- Cover removal while oMLX is stopped (next startup), removal while it is running (explicit **Reload Models**), and explicit configured model-root changes.
- Protect temporarily unavailable, newly empty, or physically replaced external/network filesystems, such as an NFS mount.

## Problem

The in-app delete endpoint already removes the deleted model's state from `model_settings.json` (see #1321). Deleting a model folder directly from the filesystem bypasses that endpoint, leaving its `model_alias`, settings, and profiles behind. The stale alias then blocks reuse with `400: Alias already in use`.

Treating every model absent from one best-effort discovery pass as deleted would be unsafe. A configured root may be unreadable, an external/network filesystem may not be mounted, or a symlink/mount may now point to a different physical root.

## Approach

### Per-root discovery evidence

Discovery now reports, for each requested root:

- loadable model IDs;
- whether traversal completed without access failures;
- structurally present local folders and Hugging Face cache entries, including temporarily incomplete entries; and
- a stable `st_dev`/`st_ino` root identity captured during the same scan.

The existing `discover_models()` and `discover_models_from_dirs()` helpers keep their dictionary return shape, and discovery itself never mutates persisted state.

### Persisted root inventory

`model_settings.json` gains an additive `model_root_inventory` field containing each logical root's last-known model IDs, source, and physical identity. The existing `models` structure is unchanged, so no settings-version bump is required.

### Explicit reconciliation lifecycle

Missing model state may be pruned only after:

1. server startup;
2. explicit **Reload Models**; or
3. an explicit configured model-directory change.

Download-completion and Hugging Face cache-visibility refreshes run in observation-only mode: they can seed inventory for newly added models, but absence cannot delete persisted state.

### Safety rules

- A model becomes a deletion candidate only after a complete, stable scan of its previously inventoried root confirms it is absent.
- Unavailable or incomplete roots protect their own last-known IDs without blocking confirmed cleanup in healthy roots.
- Newly observed empty roots and physically replaced empty roots are not accepted as deletion evidence.
- A changed non-empty root receives one non-destructive confirmation scan before still-absent IDs may be retired.
- Structurally present but temporarily non-loadable local/HF entries protect their own state without being exposed as active models.
- State is preserved when the same model ID remains active in another configured root.
- Removing only an HF snapshot does not release state; removing the complete entry from a trusted cache does.

Settings and profiles are removed together. Removed state is never restored if the same model ID later reappears.

## Test plan

- [x] Filesystem removal while oMLX is stopped and while it is running.
- [x] Alias release/reuse, settings/profile cleanup, and no restoration.
- [x] Unavailable external/NFS roots, newly empty roots, and mount/symlink identity changes.
- [x] Same-ID moves and duplicates across configured roots.
- [x] Incomplete local folders and Hugging Face cache entries.
- [x] HF cache enabled, disabled, missing, unavailable, and fully removed.
- [x] First download into an initially empty root and observation-only refreshes.
- [x] Focused reconciliation/discovery suite: `189 passed`.
- [x] Directly affected module suite: `625 passed`.
- [x] Full non-slow suite: `6532 passed, 50 skipped, 64 deselected`.
- [x] `git diff --check` and `py_compile` for all changed Python files; Black for the new test and already formatted touched files.

Related to #1321.