### PR TITLE
fix(cache): probe with the model's resolved chat template kwargs

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -34,6 +34,7 @@ from ..api.markitdown import MARKITDOWN_MODEL_ID, markitdown_model_visible
 from ..api.openai_models import _coerce_tool_call_arguments
 from ..api.utils import _try_parse_json
 from ..model_profiles import EXCLUDED_FROM_PROFILES
+from ..model_settings import merge_chat_template_kwargs
 from ..settings import BURST_DECODE_MODES, SubKeyEntry, burst_decode_env
 from ..utils.release_check import normalize_update_channel, select_latest_release
 from .auth import (
@@ -4953,6 +4954,38 @@ def _normalize_probe_tool_calls(messages: list[dict]) -> list[dict]:
     return normalized
 
 
+def _probe_chat_template_kwargs(request: "CacheProbeRequest") -> dict | None:
+    """Chat-template kwargs the scheduler would actually prefill this with.
+
+    The probe answers "is this prompt cached", so it has to render byte-for
+    byte what a real turn renders. Rendering with the caller's kwargs alone
+    ignores the model's own settings — a model with enable_thinking set (or
+    any forced/persisted chat_template_kwargs) then hashes a prompt that is
+    never prefilled, and since the block walk stops at the first miss, every
+    block reports cold.
+    """
+    settings = None
+    if _get_settings_manager is not None:
+        try:
+            manager = _get_settings_manager()
+            if manager is not None:
+                settings = manager.get_settings_for_request(
+                    request.model_id,
+                    resolved_model_id=request.model_id,
+                )
+        except Exception:
+            # A settings lookup failure must not break probing outright —
+            # fall back to the caller's kwargs (pre-fix behaviour).
+            logger.warning(
+                "cache probe: model settings lookup failed for %s; "
+                "rendering with request kwargs only",
+                request.model_id,
+                exc_info=True,
+            )
+            settings = None
+    return merge_chat_template_kwargs(settings, request.chat_template_kwargs) or None
+
+
 @router.post("/api/cache/probe")
 async def probe_cache(
     request: CacheProbeRequest,
@@ -5035,7 +5068,7 @@ async def probe_cache(
             prompt = engine._apply_chat_template(
                 messages,
                 template_tools,
-                chat_template_kwargs=request.chat_template_kwargs,
+                chat_template_kwargs=_probe_chat_template_kwargs(request),
             )
         else:
             prompt = tokenizer.apply_chat_template(

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -1194,3 +1194,48 @@ class ModelSettingsManager:
             del self._templates[name]
             self._save_templates()
             return True
+
+
+def forced_ct_keys(settings: "ModelSettings | None") -> set[str]:
+    """Chat-template keys a request is not allowed to override."""
+    if settings is None:
+        return set()
+    return set(settings.forced_ct_kwargs or [])
+
+
+def merge_chat_template_kwargs(
+    settings: "ModelSettings | None",
+    request_ct_kwargs: "dict[str, Any] | None" = None,
+) -> "dict[str, Any]":
+    """Resolve the chat_template_kwargs a prompt should be rendered with.
+
+    Precedence, lowest to highest:
+      1. ``settings.chat_template_kwargs``
+      2. the dedicated ``enable_thinking`` / ``preserve_thinking`` toggles
+      3. per-request kwargs, except keys listed in ``forced_ct_kwargs``
+
+    Anything that renders a prompt for a model must go through here. The
+    chat completions path and the admin cache probe previously each spelled
+    this out; the probe's copy omitted the model settings entirely, so it
+    hashed a prompt the scheduler never prefills — every block of every
+    probe came back cold for any model with a thinking toggle set.
+    """
+    merged: dict[str, Any] = {}
+    forced_keys = forced_ct_keys(settings)
+
+    if settings is not None:
+        if settings.chat_template_kwargs:
+            merged.update(settings.chat_template_kwargs)
+        # Dedicated toggles take precedence over chat_template_kwargs.
+        if settings.enable_thinking is not None:
+            merged["enable_thinking"] = settings.enable_thinking
+        # preserve_thinking: keep <think> blocks in historical turns (Qwen 3.6+)
+        if settings.preserve_thinking is not None:
+            merged["preserve_thinking"] = settings.preserve_thinking
+
+    if request_ct_kwargs:
+        for key, value in request_ct_kwargs.items():
+            if key not in forced_keys:
+                merged[key] = value
+
+    return merged

--- a/tests/test_admin_cache_probe.py
+++ b/tests/test_admin_cache_probe.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 import omlx.admin.routes as admin_routes
 import omlx.server  # noqa: F401 — triggers set_admin_getters
 from omlx.cache.paged_cache import compute_block_hash
+from omlx.model_settings import ModelSettings, merge_chat_template_kwargs
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -448,3 +449,97 @@ class TestCacheProbeResponseShape:
         assert "blocks_ram" not in result
         assert "ram_hit_tokens" not in result
         assert "prefix_index_hits" not in result
+
+
+class TestCacheProbeChatTemplateKwargs:
+    """The probe must render the prompt the scheduler would actually prefill.
+
+    Regression: the probe rendered with the caller's kwargs alone and never
+    consulted the model's own settings. For any model with enable_thinking
+    set, it hashed a prompt no real turn produces — and because the block
+    walk stops at the first miss, *every* block came back cold and the cache
+    looked empty even while it was being written.
+    """
+
+    @staticmethod
+    def _rendered_kwargs(settings, request_kwargs=None, lookup_raises=False):
+        """Run probe_cache and return the kwargs handed to the template."""
+        request = admin_routes.CacheProbeRequest(
+            model_id=MODEL_ID,
+            messages=[{"role": "user", "content": "hello"}],
+            chat_template_kwargs=request_kwargs,
+        )
+        entry = _make_engine_entry(_make_tokenizer([1, 2, 3, 4]), _make_scheduler())
+        seen = {}
+
+        def render(messages, tools, **kwargs):
+            seen["ct"] = kwargs.get("chat_template_kwargs")
+            return "rendered prompt"
+
+        entry.engine._apply_chat_template = render
+
+        manager = MagicMock(spec=[])
+        if lookup_raises:
+            manager.get_settings_for_request = MagicMock(
+                side_effect=RuntimeError("settings store unavailable")
+            )
+        else:
+            manager.get_settings_for_request = MagicMock(return_value=settings)
+
+        with (
+            patch.object(
+                admin_routes, "_get_engine_pool", return_value=_pool_with({MODEL_ID: entry})
+            ),
+            patch.object(admin_routes, "_get_settings_manager", return_value=manager),
+        ):
+            asyncio.run(admin_routes.probe_cache(request, is_admin=True))
+        return seen["ct"]
+
+    def test_model_thinking_toggle_reaches_the_template(self):
+        """The bug: this toggle was dropped, so the probe hashed the wrong prompt."""
+        settings = ModelSettings()
+        settings.enable_thinking = False
+        assert self._rendered_kwargs(settings) == {"enable_thinking": False}
+
+    def test_persisted_template_kwargs_reach_the_template(self):
+        settings = ModelSettings()
+        settings.chat_template_kwargs = {"custom": "value"}
+        assert self._rendered_kwargs(settings) == {"custom": "value"}
+
+    def test_preserve_thinking_toggle_reaches_the_template(self):
+        settings = ModelSettings()
+        settings.preserve_thinking = True
+        assert self._rendered_kwargs(settings) == {"preserve_thinking": True}
+
+    def test_request_kwargs_override_model_settings(self):
+        settings = ModelSettings()
+        settings.enable_thinking = False
+        rendered = self._rendered_kwargs(settings, {"enable_thinking": True})
+        assert rendered == {"enable_thinking": True}
+
+    def test_forced_keys_win_over_request_kwargs(self):
+        settings = ModelSettings()
+        settings.enable_thinking = False
+        settings.forced_ct_kwargs = ["enable_thinking"]
+        rendered = self._rendered_kwargs(settings, {"enable_thinking": True})
+        assert rendered == {"enable_thinking": False}
+
+    def test_settings_lookup_failure_falls_back_to_request_kwargs(self):
+        """A settings failure must degrade, not break probing outright."""
+        rendered = self._rendered_kwargs(
+            None, {"enable_thinking": True}, lookup_raises=True
+        )
+        assert rendered == {"enable_thinking": True}
+
+    def test_no_settings_and_no_kwargs_renders_none(self):
+        assert self._rendered_kwargs(None) is None
+
+    def test_probe_and_chat_path_resolve_identical_kwargs(self):
+        """Anti-drift: both paths must agree, since disagreement is the bug."""
+        settings = ModelSettings()
+        settings.enable_thinking = False
+        settings.chat_template_kwargs = {"custom": "value"}
+        request_kwargs = {"custom": "override"}
+        assert self._rendered_kwargs(settings, request_kwargs) == (
+            merge_chat_template_kwargs(settings, request_kwargs)
+        )


### PR DESCRIPTION
The admin cache probe (`POST /admin/api/cache/probe`) reports every block of every prompt as cold for any model that has a thinking toggle set, while the SSD cache is being written and hit normally. Cache-status UIs built on the probe show an empty cache.

## Cause

The probe renders the prompt with the caller's `chat_template_kwargs` alone. `/v1/chat/completions` merges the model's own settings first:

1. persisted `chat_template_kwargs`
2. the dedicated `enable_thinking` / `preserve_thinking` toggles
3. per-request kwargs, except `forced_ct_kwargs`

The probe skipped steps 1 and 2, so it rendered a prompt no request ever produces. The probe exists to answer "is this prompt cached", which only works if it renders byte-for-byte what a real turn renders.

## Measured

GLM-5.2-oQ4e-mtp with `thinking_default=False`, same message list each time:

| | tokens | result |
|---|---|---|
| generation (`/v1/chat/completions`) | 1095 | prefills, writes cache |
| probe, as shipped | 1101 | `blocks_cold: 5`, `ssd_hit_tokens: 0` |
| probe, `enable_thinking=False` passed by hand | 1095 | 4/5 blocks cached |
| probe, after this patch (no manual kwargs) | 1095 | 4/5 blocks cached |

Six tokens at the front changes the first block's chain hash. The walk stops at the first retrievability miss, so every later block is reported cold too — which is why it presents as a uniformly empty cache rather than a partial miss.

Confirmed against a live server: the same generation reports `prompt_tokens_details.cached_tokens: 1024`, i.e. the scheduler hit the same 4 blocks the probe now reports. The 1 remaining cold block is correct — the trailing partial block is never persisted (`Skipping trailing partial block: 72 token(s) not persisted`).

Reproduces on any model whose template has an `enable_thinking` switch; not model- or quantization-specific.

## Fix

The merge contract was spelled out in three places — chat completions, Anthropic messages, and the probe — and the probe's copy is the one that drifted. Extracted into `model_settings.merge_chat_template_kwargs()` and routed all three through it, so a future change cannot fix one renderer and miss another. The two `server.py` call sites are behaviour-preserving refactors; `forced_ct_keys()` is split out because the Anthropic path still needs the forced-key set for its own `thinking` handling.

A settings lookup failure in the probe falls back to the caller's kwargs (pre-fix behaviour) rather than failing the probe outright.

## Tests

`TestCacheProbeChatTemplateKwargs` covers each precedence rule at the probe boundary: model toggles reach the template, persisted kwargs reach it, request kwargs override model settings, forced keys win over request kwargs, a lookup failure degrades gracefully, and the probe agrees with the shared resolver. All five behavioural assertions fail on the pre-fix probe and pass after.

`tests/test_admin_cache_probe.py`, `test_model_settings.py`, `test_server.py`, `test_config.py`, `test_engine_pool.py`, `test_external_api.py`, `test_grammar.py`: 398 passed, 3 skipped. No new ruff findings on the touched files.
