### PR TITLE
refactor: route chat completions and Anthropic messages through the shared kwargs resolver

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -34,6 +34,7 @@ from ..api.markitdown import MARKITDOWN_MODEL_ID, markitdown_model_visible
 from ..api.openai_models import _coerce_tool_call_arguments
 from ..api.utils import _try_parse_json
 from ..model_profiles import EXCLUDED_FROM_PROFILES
+from ..model_settings import merge_chat_template_kwargs
 from ..settings import BURST_DECODE_MODES, SubKeyEntry, burst_decode_env
 from ..utils.release_check import normalize_update_channel, select_latest_release
 from .auth import (
@@ -4953,6 +4954,38 @@ def _normalize_probe_tool_calls(messages: list[dict]) -> list[dict]:
     return normalized
 
 
+def _probe_chat_template_kwargs(request: "CacheProbeRequest") -> dict | None:
+    """Chat-template kwargs the scheduler would actually prefill this with.
+
+    The probe answers "is this prompt cached", so it has to render byte-for
+    byte what a real turn renders. Rendering with the caller's kwargs alone
+    ignores the model's own settings — a model with enable_thinking set (or
+    any forced/persisted chat_template_kwargs) then hashes a prompt that is
+    never prefilled, and since the block walk stops at the first miss, every
+    block reports cold.
+    """
+    settings = None
+    if _get_settings_manager is not None:
+        try:
+            manager = _get_settings_manager()
+            if manager is not None:
+                settings = manager.get_settings_for_request(
+                    request.model_id,
+                    resolved_model_id=request.model_id,
+                )
+        except Exception:
+            # A settings lookup failure must not break probing outright —
+            # fall back to the caller's kwargs (pre-fix behaviour).
+            logger.warning(
+                "cache probe: model settings lookup failed for %s; "
+                "rendering with request kwargs only",
+                request.model_id,
+                exc_info=True,
+            )
+            settings = None
+    return merge_chat_template_kwargs(settings, request.chat_template_kwargs) or None
+
+
 @router.post("/api/cache/probe")
 async def probe_cache(
     request: CacheProbeRequest,
@@ -5035,7 +5068,7 @@ async def probe_cache(
             prompt = engine._apply_chat_template(
                 messages,
                 template_tools,
-                chat_template_kwargs=request.chat_template_kwargs,
+                chat_template_kwargs=_probe_chat_template_kwargs(request),
             )
         else:
             prompt = tokenizer.apply_chat_template(

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -1194,3 +1194,48 @@ class ModelSettingsManager:
             del self._templates[name]
             self._save_templates()
             return True
+
+
+def forced_ct_keys(settings: "ModelSettings | None") -> set[str]:
+    """Chat-template keys a request is not allowed to override."""
+    if settings is None:
+        return set()
+    return set(settings.forced_ct_kwargs or [])
+
+
+def merge_chat_template_kwargs(
+    settings: "ModelSettings | None",
+    request_ct_kwargs: "dict[str, Any] | None" = None,
+) -> "dict[str, Any]":
+    """Resolve the chat_template_kwargs a prompt should be rendered with.
+
+    Precedence, lowest to highest:
+      1. ``settings.chat_template_kwargs``
+      2. the dedicated ``enable_thinking`` / ``preserve_thinking`` toggles
+      3. per-request kwargs, except keys listed in ``forced_ct_kwargs``
+
+    Anything that renders a prompt for a model must go through here. The
+    chat completions path and the admin cache probe previously each spelled
+    this out; the probe's copy omitted the model settings entirely, so it
+    hashed a prompt the scheduler never prefills — every block of every
+    probe came back cold for any model with a thinking toggle set.
+    """
+    merged: dict[str, Any] = {}
+    forced_keys = forced_ct_keys(settings)
+
+    if settings is not None:
+        if settings.chat_template_kwargs:
+            merged.update(settings.chat_template_kwargs)
+        # Dedicated toggles take precedence over chat_template_kwargs.
+        if settings.enable_thinking is not None:
+            merged["enable_thinking"] = settings.enable_thinking
+        # preserve_thinking: keep <think> blocks in historical turns (Qwen 3.6+)
+        if settings.preserve_thinking is not None:
+            merged["preserve_thinking"] = settings.preserve_thinking
+
+    if request_ct_kwargs:
+        for key, value in request_ct_kwargs.items():
+            if key not in forced_keys:
+                merged[key] = value
+
+    return merged

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -190,6 +190,7 @@ from .exceptions import (
     PrefillMemoryExceededError,
     SchedulerQueueFullError,
 )
+from .model_settings import forced_ct_keys, merge_chat_template_kwargs
 from .server_metrics import get_server_metrics, reset_server_metrics
 
 logging.basicConfig(level=logging.INFO)
@@ -3178,8 +3179,6 @@ async def create_chat_completion(
 
         # Get per-model settings
         max_tool_result_tokens = None
-        merged_ct_kwargs = {}
-        forced_keys: set[str] = set()
         reasoning_parser = None
         settings_guided_grammar = None
         ms = get_model_settings_for_request(request.model)
@@ -3187,20 +3186,7 @@ async def create_chat_completion(
             max_tool_result_tokens = ms.max_tool_result_tokens
             reasoning_parser = ms.reasoning_parser
             settings_guided_grammar = _settings_guided_grammar(ms)
-            if ms.chat_template_kwargs:
-                merged_ct_kwargs.update(ms.chat_template_kwargs)
-            forced_keys = set(ms.forced_ct_kwargs or [])
-            # Dedicated enable_thinking toggle takes precedence over chat_template_kwargs
-            if ms.enable_thinking is not None:
-                merged_ct_kwargs["enable_thinking"] = ms.enable_thinking
-            # preserve_thinking: keep <think> blocks in historical turns (Qwen 3.6+)
-            if ms.preserve_thinking is not None:
-                merged_ct_kwargs["preserve_thinking"] = ms.preserve_thinking
-        # Per-request kwargs override model settings (except forced keys)
-        if request.chat_template_kwargs:
-            for k, v in request.chat_template_kwargs.items():
-                if k not in forced_keys:
-                    merged_ct_kwargs[k] = v
+        merged_ct_kwargs = merge_chat_template_kwargs(ms, request.chat_template_kwargs)
 
         # Extract messages - different engines need different content handling.
         # Templates that expose message.reasoning_content natively (Qwen 3.6+)
@@ -5095,25 +5081,11 @@ async def create_anthropic_message(
 
         # Get per-model settings
         max_tool_result_tokens = None
-        merged_ct_kwargs = {}
-        forced_keys: set[str] = set()
         ms = get_model_settings_for_request(request.model)
         if ms:
             max_tool_result_tokens = ms.max_tool_result_tokens
-            if ms.chat_template_kwargs:
-                merged_ct_kwargs.update(ms.chat_template_kwargs)
-            forced_keys = set(ms.forced_ct_kwargs or [])
-            # Dedicated enable_thinking toggle takes precedence over chat_template_kwargs
-            if ms.enable_thinking is not None:
-                merged_ct_kwargs["enable_thinking"] = ms.enable_thinking
-            # preserve_thinking: keep <think> blocks in historical turns (Qwen 3.6+)
-            if ms.preserve_thinking is not None:
-                merged_ct_kwargs["preserve_thinking"] = ms.preserve_thinking
-        # Per-request kwargs override model settings (except forced keys)
-        if request.chat_template_kwargs:
-            for k, v in request.chat_template_kwargs.items():
-                if k not in forced_keys:
-                    merged_ct_kwargs[k] = v
+        forced_keys = forced_ct_keys(ms)
+        merged_ct_kwargs = merge_chat_template_kwargs(ms, request.chat_template_kwargs)
 
         # Pass Anthropic thinking config to chat template (except forced keys)
         if hasattr(request, "thinking") and request.thinking:

--- a/tests/test_admin_cache_probe.py
+++ b/tests/test_admin_cache_probe.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 import omlx.admin.routes as admin_routes
 import omlx.server  # noqa: F401 — triggers set_admin_getters
 from omlx.cache.paged_cache import compute_block_hash
+from omlx.model_settings import ModelSettings, merge_chat_template_kwargs
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -448,3 +449,97 @@ class TestCacheProbeResponseShape:
         assert "blocks_ram" not in result
         assert "ram_hit_tokens" not in result
         assert "prefix_index_hits" not in result
+
+
+class TestCacheProbeChatTemplateKwargs:
+    """The probe must render the prompt the scheduler would actually prefill.
+
+    Regression: the probe rendered with the caller's kwargs alone and never
+    consulted the model's own settings. For any model with enable_thinking
+    set, it hashed a prompt no real turn produces — and because the block
+    walk stops at the first miss, *every* block came back cold and the cache
+    looked empty even while it was being written.
+    """
+
+    @staticmethod
+    def _rendered_kwargs(settings, request_kwargs=None, lookup_raises=False):
+        """Run probe_cache and return the kwargs handed to the template."""
+        request = admin_routes.CacheProbeRequest(
+            model_id=MODEL_ID,
+            messages=[{"role": "user", "content": "hello"}],
+            chat_template_kwargs=request_kwargs,
+        )
+        entry = _make_engine_entry(_make_tokenizer([1, 2, 3, 4]), _make_scheduler())
+        seen = {}
+
+        def render(messages, tools, **kwargs):
+            seen["ct"] = kwargs.get("chat_template_kwargs")
+            return "rendered prompt"
+
+        entry.engine._apply_chat_template = render
+
+        manager = MagicMock(spec=[])
+        if lookup_raises:
+            manager.get_settings_for_request = MagicMock(
+                side_effect=RuntimeError("settings store unavailable")
+            )
+        else:
+            manager.get_settings_for_request = MagicMock(return_value=settings)
+
+        with (
+            patch.object(
+                admin_routes, "_get_engine_pool", return_value=_pool_with({MODEL_ID: entry})
+            ),
+            patch.object(admin_routes, "_get_settings_manager", return_value=manager),
+        ):
+            asyncio.run(admin_routes.probe_cache(request, is_admin=True))
+        return seen["ct"]
+
+    def test_model_thinking_toggle_reaches_the_template(self):
+        """The bug: this toggle was dropped, so the probe hashed the wrong prompt."""
+        settings = ModelSettings()
+        settings.enable_thinking = False
+        assert self._rendered_kwargs(settings) == {"enable_thinking": False}
+
+    def test_persisted_template_kwargs_reach_the_template(self):
+        settings = ModelSettings()
+        settings.chat_template_kwargs = {"custom": "value"}
+        assert self._rendered_kwargs(settings) == {"custom": "value"}
+
+    def test_preserve_thinking_toggle_reaches_the_template(self):
+        settings = ModelSettings()
+        settings.preserve_thinking = True
+        assert self._rendered_kwargs(settings) == {"preserve_thinking": True}
+
+    def test_request_kwargs_override_model_settings(self):
+        settings = ModelSettings()
+        settings.enable_thinking = False
+        rendered = self._rendered_kwargs(settings, {"enable_thinking": True})
+        assert rendered == {"enable_thinking": True}
+
+    def test_forced_keys_win_over_request_kwargs(self):
+        settings = ModelSettings()
+        settings.enable_thinking = False
+        settings.forced_ct_kwargs = ["enable_thinking"]
+        rendered = self._rendered_kwargs(settings, {"enable_thinking": True})
+        assert rendered == {"enable_thinking": False}
+
+    def test_settings_lookup_failure_falls_back_to_request_kwargs(self):
+        """A settings failure must degrade, not break probing outright."""
+        rendered = self._rendered_kwargs(
+            None, {"enable_thinking": True}, lookup_raises=True
+        )
+        assert rendered == {"enable_thinking": True}
+
+    def test_no_settings_and_no_kwargs_renders_none(self):
+        assert self._rendered_kwargs(None) is None
+
+    def test_probe_and_chat_path_resolve_identical_kwargs(self):
+        """Anti-drift: both paths must agree, since disagreement is the bug."""
+        settings = ModelSettings()
+        settings.enable_thinking = False
+        settings.chat_template_kwargs = {"custom": "value"}
+        request_kwargs = {"custom": "override"}
+        assert self._rendered_kwargs(settings, request_kwargs) == (
+            merge_chat_template_kwargs(settings, request_kwargs)
+        )


### PR DESCRIPTION
> **Stacked on #2256 — merge that first.** This branch contains #2256's commit as its base, so the diff below shows both. Only the second commit (`refactor: route chat completions...`) belongs to this PR. Once #2256 lands, this rebases to a single 4-line-net change in `server.py`.

## Why

`/v1/chat/completions` and `/v1/messages` each spell out the `chat_template_kwargs` merge by hand — persisted kwargs, then the `enable_thinking` / `preserve_thinking` toggles, then per-request kwargs except `forced_ct_kwargs` — in blocks byte-identical to each other and to the copy the admin cache probe used to carry.

That third copy is what caused #2256: the probe's version omitted the model settings entirely, so it hashed a prompt the scheduler never prefills and reported every block cold while the cache was being written and hit normally. Three hand-maintained copies of one contract is how that happens, and nothing stops the next divergence.

## What

Point both endpoints at `model_settings.merge_chat_template_kwargs()`, added in #2256 and already used by the probe. `server.py` loses 32 lines and gains 4.

Behaviour is unchanged — same precedence, same forced-key handling. `forced_ct_keys()` stays exposed because the Anthropic path still needs the forced-key set for its own `thinking` config, which is applied after the merge.

## Risk

This touches the hot chat-completions path to consolidate logic, so it is deliberately separate from the fix in #2256 — that one is a read-only admin endpoint and can land on its own merits.

No behavioural change, so no new tests. `test_server.py`, `test_admin_cache_probe.py`, `test_model_settings.py`, `test_external_api.py`: 165 passed. `test_probe_and_chat_path_resolve_identical_kwargs` (added in #2256) now holds by construction rather than by coincidence.
