### PR TITLE
fix(server): give python -m omlx.server a working admin settings path (#2282)

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -6790,9 +6790,33 @@ model and sampling defaults are managed via the admin page.
     if args.mcp_config:
         os.environ["OMLX_MCP_CONFIG"] = args.mcp_config
 
+    # Load settings and hand them to init_server the way the omlx CLI
+    # does. The admin page resolves settings through
+    # _server_state.global_settings, so booting without them leaves
+    # _get_global_settings() returning None and the initial API-key
+    # setup form crashing with a 500 (#2282). Passing api_key keeps the
+    # two entry points enforcing the same auth. Scheduler/cache wiring
+    # stays CLI-only on purpose; this entry point remains minimal.
+    from .settings import init_settings
+
+    settings = init_settings()
+    settings.ensure_directories()
+
+    # Match the cli.py launcher: keep freed GPU buffers in the pool so
+    # allocator::free() never releases a buffer the GPU may still be
+    # using (kernel panics on M4 otherwise; see cli.py and issue #300).
+    # EnginePool eviction also assumes this cache limit is in place.
+    import mlx.core as mx
+
+    total_mem = mx.device_info().get("memory_size", 0)
+    if total_mem > 0:
+        mx.set_cache_limit(total_mem)
+
     # Initialize server
     init_server(
         model_dirs=args.model_dir,
+        api_key=settings.auth.api_key,
+        global_settings=settings,
     )
 
     # Start server
@@ -6802,4 +6826,15 @@ model and sampling defaults are managed via the admin page.
 
 
 if __name__ == "__main__":
+    # ``python -m omlx.server`` executes this file as the ``__main__``
+    # module, but the admin routes import it back as ``omlx.server`` at
+    # request time. Without this alias that import executes the module a
+    # SECOND time, and the fresh copy's module-level set_admin_getters()
+    # call repoints the admin state getters at a server state that
+    # init_server() never touched, so the settings main() wires in are
+    # invisible to /admin (#2282). Alias the canonical name to this
+    # instance so every later import resolves to the running server.
+    import sys
+
+    sys.modules.setdefault("omlx.server", sys.modules[__name__])
     main()

--- a/tests/test_server_main.py
+++ b/tests/test_server_main.py
@@ -1,0 +1,153 @@
+"""Regression tests for the ``python -m omlx.server`` entry point.
+
+This path has broken twice: #2241 (main() passed kwargs init_server() no
+longer accepts, TypeError at startup) and #2282 (the admin initial
+API-key setup form 500s on a missing GlobalSettings). #2282 has two
+layers: main() never loaded settings, and, deeper, running the file as
+``__main__`` means the admin routes' request-time ``from ..server
+import`` executes the module a second time and repoints the admin state
+getters at a server state init_server() never touched. The in-process
+tests cover the first layer against the real ``init_server``; only the
+subprocess test can catch the second, because a normal import has a
+single module instance by construction.
+"""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def module_entry(monkeypatch, tmp_path):
+    """Run server.main() as ``python -m omlx.server --model-dir <tmp>``."""
+    from omlx import server
+    from omlx.settings import reset_settings
+
+    # main() loads GlobalSettings. OMLX_BASE_PATH is first in its base
+    # path resolution order, so setting it (plus HOME for any other ~
+    # expansion) keeps the test away from the real user configuration;
+    # HOME alone is not enough when a macOS app bootstrap file exists.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OMLX_BASE_PATH", str(tmp_path / "omlx-base"))
+    reset_settings()
+
+    # Reset the middleware stack so init_server's add_middleware works
+    # even if another test in this process already started the app.
+    server.app.middleware_stack = None
+
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    argv = ["omlx.server", "--model-dir", str(model_dir)]
+    with (
+        patch.object(sys, "argv", argv),
+        # Keep the process-wide allocator setting out of the test run.
+        patch("mlx.core.set_cache_limit"),
+        patch("uvicorn.run") as uvicorn_run,
+    ):
+        server.main()
+
+    yield server, uvicorn_run
+    reset_settings()
+
+
+def test_main_reaches_uvicorn_with_model_dir(module_entry):
+    _, uvicorn_run = module_entry
+    uvicorn_run.assert_called_once()
+
+
+def test_main_wires_global_settings(module_entry):
+    # The admin routes resolve settings via _server_state.global_settings;
+    # None here is what turned the API-key setup form into a 500 (#2282).
+    server, _ = module_entry
+    assert server._server_state.global_settings is not None
+
+
+def test_admin_api_key_setup_succeeds(module_entry):
+    # Reporter's repro for #2282: boot via python -m, submit the initial
+    # API-key setup form. Must not 500 on a missing GlobalSettings.
+    from fastapi.testclient import TestClient
+
+    server, _ = module_entry
+    client = TestClient(server.app)
+    resp = client.post(
+        "/admin/api/setup-api-key",
+        json={"api_key": "test-key-1234", "api_key_confirm": "test-key-1234"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json().get("success") is True
+    assert server._server_state.api_key == "test-key-1234"
+
+
+def test_module_entry_api_key_setup_end_to_end(tmp_path):
+    # The double-import layer of #2282 only exists when the module runs
+    # as ``__main__``, so this must be a real ``python -m omlx.server``
+    # subprocess; every in-process test is structurally blind to it.
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["OMLX_BASE_PATH"] = str(tmp_path / "base")
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "omlx.server",
+            "--model-dir",
+            str(model_dir),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    base = f"http://127.0.0.1:{port}"
+    try:
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                pytest.fail(f"server exited early:\n{proc.stdout.read()}")
+            try:
+                urllib.request.urlopen(f"{base}/health", timeout=1)
+                break
+            except (urllib.error.URLError, OSError):
+                time.sleep(0.25)
+        else:
+            pytest.fail("server did not become healthy within 60s")
+
+        req = urllib.request.Request(
+            f"{base}/admin/api/setup-api-key",
+            data=json.dumps(
+                {"api_key": "e2e-key-1234", "api_key_confirm": "e2e-key-1234"}
+            ).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            resp = urllib.request.urlopen(req, timeout=10)
+        except urllib.error.HTTPError as e:
+            pytest.fail(f"setup-api-key returned {e.code}: {e.read().decode()}")
+        assert resp.status == 200
+        assert json.load(resp).get("success") is True
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=15)

--- a/tests/test_server_main.py
+++ b/tests/test_server_main.py
@@ -54,6 +54,20 @@ def module_entry(monkeypatch, tmp_path):
     ):
         server.main()
 
+    # Other suites patch admin_routes._get_global_settings and can leak
+    # a mock into this process; re-run the canonical wiring so the
+    # in-process tests see main()'s state exactly as a fresh interpreter
+    # would (the subprocess test below covers the fresh process for
+    # real, wiring included).
+    from omlx.admin.routes import set_admin_getters
+
+    set_admin_getters(
+        server.get_server_state,
+        server.get_engine_pool,
+        lambda: server._server_state.settings_manager,
+        lambda: server._server_state.global_settings,
+    )
+
     yield server, uvicorn_run
     reset_settings()
 


### PR DESCRIPTION
Fixes #2282.

This PR originally fixed the #2241 TypeError in this entry point. #2242 landed the same kwarg correction first, so I have rebased and retargeted the branch at what is still broken in `python -m omlx.server`: the admin page cannot configure an API key, which is #2282 (and, per the issue title, the open question of whether this path should work at all; this PR is the reporter's option 2).

## Root cause: two layers

**Layer 1, the one in the issue report.** `main()` calls `init_server()` without `global_settings`, so `_get_global_settings()` returns `None` inside `setup_api_key` and the write at `routes.py:1540` (`global_settings.auth.api_key = ...`) raises `AttributeError` on `None`, a 500 for every initial API-key setup.

**Layer 2, which the report could not see.** Wiring settings into `main()` is not enough. `python -m omlx.server` executes `server.py` as the `__main__` module. When the first admin request arrives, `setup_api_key` runs `from ..server import _server_state`, which imports the file a second time under its canonical name `omlx.server`. That second execution runs the module-level `set_admin_getters(...)` again and repoints the admin state getters at the fresh copy's `_server_state`, which `init_server()` never touched. The uvicorn server keeps serving the `__main__` app while `/admin` reads settings from a parallel universe. I verified this live: with only the layer-1 fix applied, the reporter's repro still returns 500.

## The fix

- `main()` now loads settings via `init_settings()` and passes `api_key` and `global_settings` to `init_server()`, the same shape as the `omlx serve` path in `cli.py`. Scheduler and cache wiring stay CLI-only on purpose; the module entry point remains minimal.
- The `__main__` block aliases `sys.modules["omlx.server"]` to the running instance before serving, so every later import resolves to the module uvicorn is actually serving. `setdefault` keeps an already-imported canonical module if one ever exists.
- `main()` also mirrors the `mx.set_cache_limit(total_mem)` guard from `cli.py` (issue #300: allocator::free() can release a Metal buffer the GPU is still using, kernel panics on M4; EnginePool eviction assumes the limit is set). Happy to split this into its own PR if it is scoped too wide here.

## Tests

`tests/test_server_main.py`, four tests:

- Three in-process tests run `main()` against the real `init_server` (uvicorn and the cache-limit side effect stubbed): entry point boots, `_server_state.global_settings` is wired, and the setup-api-key endpoint succeeds via TestClient.
- One subprocess test boots a real `python -m omlx.server` on a free port and submits the setup form end to end. This is the only kind of test that can catch layer 2; every in-process test has a single module instance by construction and is structurally blind to the double execution.

Red/green: the subprocess test fails on current main (500) and passes with the fix.

## Live verification (M5 Air, main @ 4690cbda)

Reporter's literal repro, `python -m omlx.server --model-dir <dir>` then submitting the initial API-key form:

- unpatched main: HTTP 500, `AttributeError: 'NoneType' object has no attribute 'auth'` at `routes.py:1540`
- layer-1 fix only: still HTTP 500, same traceback, via the second module instance
- full fix: HTTP 200, `{"success": true}`, key persisted to `settings.json`, session cookie set

Full test suite run locally on the branch; only the pre-existing M5 failures unrelated to this change (#2267 and the two GLM MTP SmallLRouting tests).
