### PR TITLE
fix(downloader): restore download progress when the dry-run size probe fails

### DIFF
--- a/omlx/admin/hf_downloader.py
+++ b/omlx/admin/hf_downloader.py
@@ -780,6 +780,7 @@ class HFDownloader:
                 # Skip pytorch format when safetensors exist to
                 # avoid downloading redundant weight files.
                 ignore_patterns = None
+                model_info = None
                 try:
                     model_info = await asyncio.wait_for(
                         asyncio.to_thread(
@@ -826,9 +827,19 @@ class HFDownloader:
                     )
                     task.total_size = sum(f.file_size for f in dry_result)
                 except Exception as e:
+                    if (
+                        model_info is not None
+                        and model_info.safetensors
+                        and model_info.safetensors.get("parameters")
+                    ):
+                        task.total_size = _calc_safetensors_disk_size(
+                            model_info.safetensors
+                        )
+                        detail = "Estimated total size from safetensors metadata."
+                    else:
+                        detail = "Progress estimation will be unavailable."
                     logger.warning(
-                        f"Dry run failed for {task.repo_id}: {e}. "
-                        "Progress estimation will be unavailable."
+                        f"Dry run failed for {task.repo_id}: {e}. {detail}"
                     )
 
                 # Start progress polling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,10 @@ dependencies = [
     # See pmarreck/omlx#1 for full repro and root cause.
     "mistral-common>=1.10",
     "tokenizers>=0.19.0",
-    "huggingface-hub>=0.23.0",
+    # The admin downloader calls snapshot_download(dry_run=True); dry_run
+    # was added in huggingface_hub 1.0.0. Declare the floor directly
+    # instead of leaning on transformers' transitive hub requirement.
+    "huggingface-hub>=1.0.0",
     "numpy>=1.24.0,<2.4",
     "tqdm>=4.66.0",
     "pyyaml>=6.0",

--- a/tests/test_hf_downloader.py
+++ b/tests/test_hf_downloader.py
@@ -729,6 +729,77 @@ class TestHFDownloader:
 
             await downloader.shutdown()
 
+    @pytest.mark.asyncio
+    async def test_dry_run_failure_falls_back_to_safetensors_size(self, model_dir):
+        """When dry_run raises, total_size is estimated from safetensors metadata."""
+        model_dir.mkdir(parents=True, exist_ok=True)
+        downloader = HFDownloader(model_dir=str(model_dir))
+
+        task = DownloadTask(task_id="t-fallback", repo_id="owner/model")
+        downloader._tasks[task.task_id] = task
+
+        mock_api = MagicMock()
+        # 7B BF16 model: 7_000_000_000 params * 2 bytes = 14_000_000_000 bytes
+        mock_info = MagicMock()
+        mock_info.safetensors = {
+            "parameters": {"BF16": 7_000_000_000},
+            "total": 7_000_000_000,
+        }
+        mock_api.model_info.return_value = mock_info
+
+        def fake_snapshot_download(**kwargs):
+            if kwargs.get("dry_run"):
+                raise RuntimeError("dry_run not supported")
+            # actual download succeeds immediately (no-op)
+
+        with patch(
+            "omlx.admin.hf_downloader._get_hf_api",
+            return_value=(mock_api, None),
+        ), patch(
+            "omlx.admin.hf_downloader.snapshot_download",
+            side_effect=fake_snapshot_download,
+        ):
+            await downloader._run_download(task.task_id, "")
+
+        # Fallback estimate: 7B BF16 params * 2 bytes/param = 14 GB
+        assert task.total_size == 14_000_000_000
+        assert task.status == DownloadStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_dry_run_failure_no_safetensors_leaves_total_size_zero(self, model_dir):
+        """When dry_run raises and model_info has no safetensors, total_size stays 0."""
+        model_dir.mkdir(parents=True, exist_ok=True)
+        downloader = HFDownloader(model_dir=str(model_dir))
+
+        task = DownloadTask(task_id="t-no-st", repo_id="owner/model")
+        downloader._tasks[task.task_id] = task
+
+        mock_api = MagicMock()
+        mock_info = MagicMock()
+        mock_info.safetensors = None
+        mock_api.model_info.return_value = mock_info
+
+        def fake_snapshot_download(**kwargs):
+            if kwargs.get("dry_run"):
+                raise RuntimeError("dry_run not supported")
+
+        with patch(
+            "omlx.admin.hf_downloader._get_hf_api",
+            return_value=(mock_api, None),
+        ), patch(
+            "omlx.admin.hf_downloader.snapshot_download",
+            side_effect=fake_snapshot_download,
+        ):
+            await downloader._run_download(task.task_id, "")
+
+        # The download itself must still proceed and complete; only the
+        # progress denominator is unavailable. Pinning status/error here
+        # keeps this test from passing vacuously if the fallback handler
+        # ever raised (which would set FAILED while total_size stays 0).
+        assert task.total_size == 0
+        assert task.status == DownloadStatus.COMPLETED
+        assert task.error == ""
+
 
 # =============================================================================
 # API Routes Tests


### PR DESCRIPTION
Fixes #1373.

## Summary

- When the `snapshot_download(dry_run=True)` size probe fails, estimate `task.total_size` from the already-fetched `model_info.safetensors` metadata instead of leaving it at 0 — so the admin UI shows real download progress instead of the pulsing indeterminate bar, for any dry-run failure.
- Dependency-floor hygiene found while root-causing: `dry_run` only exists from huggingface_hub **1.0.0** (no 0.x release has it — verified against the package source at v0.36.2, the last 0.x, and v1.0.0), while oMLX declares `huggingface-hub>=0.23.0`, which predates the `dry_run` call added in #623. Raise the direct floor to `>=1.0.0`.
- No behavior change when the dry-run succeeds, or when no safetensors metadata is available (total_size stays 0 and the existing warning is unchanged).

## Why

Your diagnosis on the thread pinned the mechanism: total_size comes from the dry-run probe, and if it errors or times out, total_size stays 0 while the real download keeps streaming. This PR keeps a real progress denominator on any dry-run failure: the `except Exception` handler now falls back to `_calc_safetensors_disk_size(model_info.safetensors)` — the same helper the model listing uses. Both failure modes you named are covered (errors, and the 30s `asyncio.wait_for` timeout on huge many-file repos; `TimeoutError` lands in the same handler). It's complementary to the xet fix (f8174a95) you suggested might have cleared the reporter's specific case.

While chasing "the real dry_run cause" I checked the dependency contract and want to report it honestly, including the part that *didn't* pan out. `dry_run` was added in huggingface_hub 1.0.0, and oMLX's own floor (0.23.0) predates the call — but this turns out **not** to be a live failure path: `transformers>=5.7.0` (a core dependency) requires `huggingface-hub>=1.5.0` in every version oMLX accepts, so a 0.x hub is not resolvable and the probe's `TypeError` class can't be reached through a metadata-legal install. The floor bump is therefore hygiene rather than a fix: oMLX calls a 1.0.0-only API and should declare that requirement directly instead of leaning on transformers' transitive floor — same discipline as your mcp `>=1.5.0` follow-up (ac11fa6c) after the `cwd` support landed. The reporter's actual dry-run failure cause remains unconfirmed (the thread never got their "Dry run failed for ..." log line); the fallback makes the symptom moot regardless of which class it was.

The estimate tracks what's actually downloaded: it sums stored dtypes' byte widths (quantized repos count packed U32 + scales, not logical parameters), and it fires under the same `safetensors.parameters` condition that sets `ignore_patterns` to skip `*.bin`/`*.pth`, so it approximates the safetensors payload actually fetched, mildly undercounting only non-weight files.

## Changes

- `omlx/admin/hf_downloader.py`
  - Initialize `model_info = None` ahead of its fetch `try`, so the fallback can safely test it when the metadata fetch itself failed (otherwise the reference would be unbound after a fetch timeout).
  - In the dry-run `except Exception` handler: when `model_info.safetensors` carries a `parameters` map, set `task.total_size` via `_calc_safetensors_disk_size`; the warning now states which mode applies ("Estimated total size from safetensors metadata." vs the existing "Progress estimation will be unavailable.").
- `pyproject.toml`: `huggingface-hub>=0.23.0` → `>=1.0.0` (the only declaration site), with a comment noting why, in the style of the neighboring `mistral-common` pin.

## Trade-offs and sibling paths

- On completion, `downloaded_size = task.total_size or dir_size` now reports the estimate (a mild undercount) instead of falling through to the measured directory size in this one branch. Kept as-is for a minimal diff — happy to follow up with a completion-time exact-size override if you'd prefer.
- Sibling sweep: `ms_downloader.py` (ModelScope) has a structurally parallel "Progress estimation will be unavailable" branch, but it sources sizes from `get_model_files` (no separate failable dry-run) and would need a config-based estimate — different SDK, considered and left out of scope here.
- Gated/missing repos are unaffected: their metadata fetch fails first (`model_info` stays None → no estimate), and the real `snapshot_download` still raises into the existing FAILED handlers.
- Noting one adjacent stale floor discovered during the dependency walk, left out of scope as unrelated to this issue: `tokenizers>=0.19.0` — tokenizers 0.19.0 itself caps `huggingface-hub<1.0`, so that floor pair is jointly unsatisfiable at its minima; in practice `transformers>=5.7.0` forces `tokenizers>=0.22.0` (cap `<2.0`), so resolution is unaffected. Happy to bump it to `>=0.22.0` here or separately if you want the metadata consistent.
- The fallback itself needs nothing newer than the current floor: `SafeTensorsInfo` subclasses `dict`, and this file already calls `model_info.safetensors.get("parameters")` and `_calc_safetensors_disk_size(m.safetensors)` in three places.

## Tests

- Two tests added to the existing `TestHFDownloader` class, driving the real `_run_download` path with only the HF API and `snapshot_download` patched: dry-run failure with safetensors metadata → `total_size == 14_000_000_000` (7B BF16 × 2 bytes/param) and status COMPLETED; dry-run failure without metadata → `total_size` stays 0, COMPLETED, no error.
- `python -m pytest tests/test_hf_downloader.py -q` → `105 passed` — and also `105 passed` with huggingface_hub pinned to exactly **1.0.0**, so the new floor is tested, not just declared.
- Verified the fallback test fails when the fix is reverted (the no-metadata test pins the unchanged path, so it passes either way by design).
