### PR TITLE
launch/claude: mark argv[0] so external tools can identify omlx-launched sessions

### DIFF
--- a/omlx/integrations/claude.py
+++ b/omlx/integrations/claude.py
@@ -66,7 +66,14 @@ class ClaudeCodeIntegration(Integration):
             env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(ctx.context_window)
 
         binary = self._find_claude_binary()
-        argv = [binary, *ctx.extra_args]
+        # argv[0] is cosmetic to the OS/claude itself (verified: claude does not
+        # inspect its own argv[0]) but is what tools like `ps` and zellij's
+        # session-resurrection command discovery see. Marking it lets external
+        # tooling tell an omlx-launched session apart from a bare `claude`
+        # invocation or one launched through a different wrapper (e.g. ollama's
+        # `--model` flag), which is otherwise impossible once execvpe replaces
+        # this process.
+        argv = ["claude-omlx", *ctx.extra_args]
         print(f"Launching Claude Code with model {ctx.model}...")
         if ctx.context_window:
             print(f"Auto-compact window: {ctx.context_window:,} tokens")

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1355,7 +1355,7 @@ class TestClaudeCodeIntegration:
         ):
             cc.launch(ctx(port=8000, api_key="key", model="qwen3.5"))
 
-        assert captured["argv"] == ["claude"]
+        assert captured["argv"] == ["claude-omlx"]
 
     def test_launch_forwards_extra_args(self):
         cc = ClaudeCodeIntegration()
@@ -1380,7 +1380,7 @@ class TestClaudeCodeIntegration:
                 )
             )
 
-        assert captured["argv"] == ["claude", "--resume", "abc123"]
+        assert captured["argv"] == ["claude-omlx", "--resume", "abc123"]
 
     def test_launch_forwards_short_resume(self):
         cc = ClaudeCodeIntegration()
@@ -1405,7 +1405,7 @@ class TestClaudeCodeIntegration:
                 )
             )
 
-        assert captured["argv"] == ["claude", "-r", "xyz"]
+        assert captured["argv"] == ["claude-omlx", "-r", "xyz"]
 
 
 class TestCopilotIntegration:


### PR DESCRIPTION
## Summary
- `launch claude` now execs with `argv[0] = "claude-omlx"` instead of the real binary name/path.
- Claude Code does not inspect its own `argv[0]` (verified `--version`/`--print` behave identically either way), so this has no effect on Claude Code's behavior.
- It gives external tooling that reads `ps`/cmdline (session managers, process monitors, terminal multiplexer session-resurrection features) a zero-cost way to identify that a running `claude` process was launched through omlx, which is otherwise impossible once `execvpe` replaces the omlx process - the env vars this function sets to route Claude Code at the local server are invisible to anything inspecting the process from outside.

## Test plan
- [x] `python3 -c "import os; os.execvpe('claude', ['claude-omlx', '--version'], os.environ.copy())"` still runs the real claude binary and prints the version correctly.
- [x] `ps` shows `claude-omlx` in the command column for a process launched this way, confirming external tools can key off it.