### PR TITLE
fix(deepseek_v4): preserve cross-window overlap during decode for ratio=4 compressors

### DIFF
--- a/omlx/patches/deepseek_v4/cache_extras.py
+++ b/omlx/patches/deepseek_v4/cache_extras.py
@@ -35,6 +35,17 @@ class PoolingCache(_BaseCache):
         self.pooled = None
         self._undo = None
 
+        # Previous completed window's raw (pre-compression) KV/gate. Only
+        # used by overlap (ratio==4) compressors: decode hands a single
+        # window to _overlap_compress_kv, whose `kv_a[:, :-1]` lane-A shift
+        # collapses to zero-padding and drops the cross-window overlap that
+        # native DS4 keeps via a rolling double buffer (ds4.c
+        # compressor_decode_one). Carrying the last window here lets the
+        # Compressor prepend it so decode preserves the overlap. Simple
+        # (ratio==128) layers leave these None.
+        self.prev_win_kv = None
+        self.prev_win_gate = None
+
     @property
     def offset(self):
         return 0 if self.pooled is None else self.pooled.shape[1]
@@ -62,6 +73,8 @@ class PoolingCache(_BaseCache):
                 self.pooled,
                 kv,
                 gate,
+                self.prev_win_kv,
+                self.prev_win_gate,
             )
         else:
             self._undo = None
@@ -163,6 +176,13 @@ class PoolingCache(_BaseCache):
             self.accumulate_windows(buf_kv, buf_gate, 0)
         self.pooled = pooled
         self._undo = None
+        # prev_win is runtime-only and not part of the persisted 3-tuple, so
+        # a state restore (SSD eviction/recovery) cannot rebuild it. The next
+        # window completed after restore pools with a zero lane-A once, then
+        # prev_win repopulates — a single-window overlap loss, not the
+        # persistent per-window loss the original decode bug caused.
+        self.prev_win_kv = None
+        self.prev_win_gate = None
 
     @property
     def meta_state(self):
@@ -197,11 +217,15 @@ class PoolingCache(_BaseCache):
             return n
         if not self._can_undo(n):
             return 0
-        buf_kv, buf_gate, rem_prev, pooled_prev, kv, gate = self._undo
+        buf_kv, buf_gate, rem_prev, pooled_prev, kv, gate, prev_kv, prev_gate = (
+            self._undo
+        )
         self._undo = None
         k = kv.shape[1] - n
         self.pooled = pooled_prev
         self.remainder = rem_prev
+        self.prev_win_kv = prev_kv
+        self.prev_win_gate = prev_gate
         if buf_kv is not None:
             self.buf_kv[:, :rem_prev] = buf_kv
             self.buf_gate[:, :rem_prev] = buf_gate
@@ -254,6 +278,12 @@ class BatchPoolingCache(_BaseCache):
         self._processed = [0] * batch_size
         self._undo = None
 
+        # Previous completed window's raw KV/gate per batch row, for overlap
+        # (ratio==4) compressors — see PoolingCache.prev_win_kv docstring.
+        # None until a row completes its first window.
+        self.prev_win_kv = None
+        self.prev_win_gate = None
+
     @property
     def offset(self):
         return mx.array(self._pool_lengths, dtype=mx.int32)
@@ -291,6 +321,8 @@ class BatchPoolingCache(_BaseCache):
                 list(self._processed),
                 kv,
                 gate,
+                self.prev_win_kv,
+                self.prev_win_gate,
             )
         else:
             self._undo = None
@@ -445,6 +477,8 @@ class BatchPoolingCache(_BaseCache):
     def state(self, v):
         self.buf_kv, self.buf_gate, self.pooled = v
         self._undo = None
+        self.prev_win_kv = None
+        self.prev_win_gate = None
 
     @property
     def meta_state(self):
@@ -480,7 +514,9 @@ class BatchPoolingCache(_BaseCache):
             return n
         if not self._can_undo(n):
             return 0
-        buf_kv, buf_gate, remainder, pool_lengths, processed, kv, gate = self._undo
+        buf_kv, buf_gate, remainder, pool_lengths, processed, kv, gate, prev_kv, prev_gate = (
+            self._undo
+        )
         self._undo = None
         k = kv.shape[1] - n
         # The undo path only triggers when some row completed a window,
@@ -492,6 +528,8 @@ class BatchPoolingCache(_BaseCache):
         self.remainder = list(remainder)
         self._pool_lengths = list(pool_lengths)
         self._processed = list(processed)
+        self.prev_win_kv = prev_kv
+        self.prev_win_gate = prev_gate
         if k > 0:
             # Replay the confirmed prefix; _can_undo guarantees it stays in
             # the buffer, so no window is recompressed.
@@ -530,6 +568,9 @@ class BatchPoolingCache(_BaseCache):
         self._pool_lengths = [self._pool_lengths[i] for i in idx_list]
         self._lengths = [self._lengths[i] for i in idx_list]
         self._processed = [self._processed[i] for i in idx_list]
+        # prev_win is runtime-only; reset after filter to avoid stale indices
+        self.prev_win_kv = None
+        self.prev_win_gate = None
 
     def extend(self, other):
         # Merge the remainder buffers

--- a/omlx/patches/deepseek_v4/cache_extras.py
+++ b/omlx/patches/deepseek_v4/cache_extras.py
@@ -644,6 +644,9 @@ class BatchPoolingCache(_BaseCache):
         self._pool_lengths = self._pool_lengths + other._pool_lengths
         self._lengths = self._lengths + other._lengths
         self._processed = self._processed + other._processed
+        # Batch dimension changed; reset runtime-only prev_win state.
+        self.prev_win_kv = None
+        self.prev_win_gate = None
 
     def extract(self, idx):
         cache = PoolingCache(self.ratio)

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -605,7 +605,7 @@ class Compressor(nn.Module):
                 if self.overlap
                 else None
             )
-            if self.overlap and prev_kv is not None and prev_kv.shape[1] > 0:
+            if self.overlap and prev_kv is not None and prev_kv.shape[1] > 0 and prev_kv.shape[0] == kv.shape[0]:
                 kv = mx.concatenate([prev_kv, kv], axis=1)
                 gate = mx.concatenate([prev_gate, gate], axis=1)
                 new_pooled = compress_func(kv, gate, self.ape, self.head_dim)

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -588,7 +588,38 @@ class Compressor(nn.Module):
             )
             kv = mx.unflatten(ready_kv, 1, (-1, self.compress_ratio))
             gate = mx.unflatten(ready_gate, 1, (-1, self.compress_ratio))
-            new_pooled = compress_func(kv, gate, self.ape, self.head_dim)
+
+            # Overlap (ratio==4) pools each window from its own lane-B plus the
+            # previous window's lane-A. _overlap_compress_kv gets lane-A via
+            # `kv_a[:, :-1]` (window-axis shift), which collapses to zero-
+            # padding when only one window is in view (every decode step, and
+            # the first window of any prefill/verify chunk). Prepend the last
+            # completed window carried in the cache so the shift sees a real
+            # predecessor; drop the prepend's own (zero lane-A) pooled output.
+            # Mirrors native DS4's rolling state_kv double buffer
+            # (ds4.c compressor_decode_one). rope runs on the current windows
+            # only with pool_base, so positions stay aligned.
+            prev_kv = getattr(pool_cache, "prev_win_kv", None) if self.overlap else None
+            prev_gate = (
+                getattr(pool_cache, "prev_win_gate", None)
+                if self.overlap
+                else None
+            )
+            if self.overlap and prev_kv is not None and prev_kv.shape[1] > 0:
+                kv = mx.concatenate([prev_kv, kv], axis=1)
+                gate = mx.concatenate([prev_gate, gate], axis=1)
+                new_pooled = compress_func(kv, gate, self.ape, self.head_dim)
+                new_pooled = new_pooled[:, 1:]
+            else:
+                new_pooled = compress_func(kv, gate, self.ape, self.head_dim)
+
+            if self.overlap and pool_cache is not None:
+                # Carry the last window (now in `kv` after any prepend) for
+                # the next step's lane-A. Index -1 of the post-prepend kv is
+                # the current chunk's last window.
+                pool_cache.prev_win_kv = kv[:, -1:]
+                pool_cache.prev_win_gate = gate[:, -1:]
+
             new_pooled = self.norm(new_pooled)
             new_pooled = self.rope(
                 new_pooled[:, None],


### PR DESCRIPTION
## Summary

- **Fix Simplified→Traditional Chinese drift** in DeepSeek V4 Flash during long-generation decode by preserving cross-window overlap in ratio=4 (`SparseCompressedAttention`) compressors
- Root cause: `_overlap_compress_kv` relies on `kv_a[:, :-1]` to carry the previous window's lane-A into the current window's pooling. During decode (single-window input), this shift produces an empty array, collapsing lane-A to zero-padding and losing cross-window overlap entirely

## Technical Details

### The Bug

DS4 Flash uses **overlap compression** (ratio=4) where each pooled token is softmax-pooled from **8 raw tokens** (2×ratio), not 4. This is achieved by splitting KV along `head_dim` into two lanes:
- **lane-A** = previous window's first half (via `kv_a[:, :-1]` window-axis shift)
- **lane-B** = current window's second half

During **prefill** (multiple windows), the shift works correctly — lane-A carries real data from the previous window.

During **decode** (single window), `kv_a[:, :-1]` is empty → lane-A becomes zero-padding → overlap degenerates from 8-token pool to 4-token pool. This is a **structural/logical difference** from DS4, not a precision issue.

### Evidence

| Evidence | Result |
|----------|--------|
| Same 2-bit model, same context: prefill vs decode logits | Prefill → Simplified +12; Decode → Traditional +3.68 |
| fp32 full-activation test | Still Traditional — rules out precision |
| DS4 (Q2/Q4/8-bit) | Never drifts — confirms MLX-specific |
| First ~374 tokens OK, then drift | Cumulative logit drift across 21 layers |
| SwiGLU clamp | Correctly implemented — ruled out |
| RoPE positions | Consistent between modes — ruled out |
| make_mask causal boundary | Static analysis shows correct behavior — ruled out |

### The Fix

Carry `prev_win_kv` / `prev_win_gate` in `PoolingCache` / `BatchPoolingCache`. In `Compressor.__call__`, prepend the previous window to the current chunk before calling `_overlap_compress_kv`, so it sees two windows and the cross-window shift works. Take `[:, 1:]` output to discard the prepended window's own (zero lane-A) pooled result.

This mirrors DS4's `compressor_decode_one` rolling double buffer semantics without modifying the `@mx.compile`-decorated `_overlap_compress_kv` kernel.

### Files Changed

| File | Change |
|------|--------|
| `omlx/patches/deepseek_v4/cache_extras.py` | Added `prev_win_kv`/`prev_win_gate` to `PoolingCache` and `BatchPoolingCache`; extended `_undo` tuples; updated `trim`/`state`/`filter` |
| `omlx/patches/deepseek_v4/deepseek_v4_model.py` | `Compressor.__call__`: prepend prev_win, run compression, take `[:, 1:]`, roll prev_win |

### Verification

400-token greedy generation (temp=0, prompt: "介绍下量化交易"):
- **Before**: Token 375 flips to Traditional Chinese (挑戰/過擬合/歷史數據/實盤)
- **After**: All 400 tokens remain Simplified Chinese (挑战/过拟合/历史数据/实盘), output quality normal

---

Fixes #1873
Fixes #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)