### PR TITLE
fix(cache): reconstruct prefix blocks per payload format, not chain metadata

### DIFF
--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -1856,6 +1856,12 @@ class BlockAwarePrefixCache(CacheManager):
                     # Always update last to track the most recent
                     last_block_meta_states = block_layer_meta_states
                     all_block_meta_states.append(block_layer_meta_states)
+                else:
+                    # A block can load with data but no metadata at all. Keep
+                    # all_block_meta_states index-aligned with all_block_data
+                    # so per-block (bits, seed) resolution never reads a
+                    # neighbor block's meta.
+                    all_block_meta_states.append(None)
 
                 # Validate loaded data (pass cache types for hybrid models)
                 if not self._validate_block_cache_data(block_data, layer_cache_types):
@@ -2165,51 +2171,177 @@ class BlockAwarePrefixCache(CacheManager):
                     reconstructed_caches.append(cache)
                     continue
 
-                # === TurboQuantKVCache: concat NamedTuple states, reconstruct ===
-                if cache_type_name in ("TurboQuantKVCache", "BatchTurboQuantKVCache"):
-                    from ..turboquant_kv import (
-                        _concat_state_token_axis,
-                        _rebuild_codecs,
-                        _state_length,
-                    )
-
-                    key_states, value_states = [], []
-                    for block_data in all_block_data:
+                # === TurboQuant KV: payload-driven per-block handling ===
+                # One block chain can mix payload formats: blocks stored
+                # while TurboQuant KV conversion was active carry tagged
+                # ('__turboquant_v2__', (ks, vs)) NamedTuple states, while
+                # blocks stored without the conversion (chains written by
+                # versions that skipped it on chunked-prefill completion,
+                # or stored under a different TQ setting) carry plain dense
+                # (keys, values) tensors in the SAME chain via dedup.
+                # The per-block layer_cache_types mismatch check above
+                # truncates such chains when every block's type metadata is
+                # present and accurate, but block metadata is optional at
+                # load time (missing/corrupt metadata files, failed
+                # layer_cache_types round-trips, chains typed from a later
+                # block when the first block lacks types) — so the payload
+                # itself is the ground truth. Each block must be dispatched
+                # on its own payload format: typing the whole chain from
+                # the chain-level metadata feeds dense arrays into
+                # TurboQuant _concat_state (AttributeError: 'array' object
+                # has no attribute 'norms') and rejects the hit. The
+                # reverse mixing direction (dense-typed chain with
+                # TQ-tagged blocks appended later) is routed here by payload
+                # scan for the same reason.
+                if cache_type_name in (
+                    "TurboQuantKVCache",
+                    "BatchTurboQuantKVCache",
+                ) or (
+                    handler.supports_block_slicing
+                    and self._layer_has_turboquant_payload(all_block_data, layer_idx)
+                ):
+                    entries: list[tuple[int, str, Any, Any]] = []
+                    for block_idx, block_data in enumerate(all_block_data):
                         if layer_idx >= len(block_data):
                             continue
                         bd = block_data[layer_idx]
-                        if isinstance(bd, tuple) and len(bd) == 2:
-                            if isinstance(bd[0], str) and bd[0] == "__turboquant_v2__":
-                                ks, vs = bd[1]
-                            else:
-                                ks, vs = bd
-                            key_states.append(ks)
-                            value_states.append(vs)
-                    if not key_states:
+                        if not (isinstance(bd, tuple) and len(bd) == 2):
+                            logger.warning(
+                                f"TQ layer {layer_idx}: block {block_idx} has "
+                                f"unsupported payload type "
+                                f"{type(bd).__name__}. Rejecting cache hit."
+                            )
+                            return None
+                        if isinstance(bd[0], str) and bd[0] == "__turboquant_v2__":
+                            ks, vs = bd[1]
+                            entries.append((block_idx, "tq", ks, vs))
+                        elif self._is_placeholder_state(bd):
+                            # Empty-slice placeholder written by the TQ store
+                            # path: this block carries no KV for the layer,
+                            # so the chain cannot be reconstructed.
+                            logger.info(
+                                f"TQ layer {layer_idx}: block {block_idx} is "
+                                f"an empty-slice placeholder. Rejecting cache "
+                                f"hit; request will reprocess from scratch."
+                            )
+                            return None
+                        elif (
+                            hasattr(bd[0], "shape")
+                            and len(bd[0].shape) == 4
+                            and hasattr(bd[1], "shape")
+                        ):
+                            # Plain dense KV slice stored without TQ
+                            # conversion (e.g. chunked-prefill completion).
+                            entries.append((block_idx, "plain", bd[0], bd[1]))
+                        else:
+                            logger.warning(
+                                f"TQ layer {layer_idx}: block {block_idx} "
+                                f"payload is neither a tagged TurboQuant "
+                                f"state nor a dense KV slice. Rejecting "
+                                f"cache hit."
+                            )
+                            return None
+                    if not entries:
                         logger.debug(f"TQ layer {layer_idx}: no block data")
                         return None
-                    # Concatenate along token dimension
-                    cat_ks = _concat_state_token_axis(key_states)
-                    cat_vs = _concat_state_token_axis(value_states)
-                    try:
-                        from mlx_vlm.turboquant import TurboQuantKVCache
 
-                        tq_bits = 4.0
-                        tq_seed = 0
-                        ms = None
-                        if first_block_meta_states and layer_idx < len(
-                            first_block_meta_states
-                        ):
-                            ms = first_block_meta_states[layer_idx]
-                        if isinstance(ms, (list, tuple)) and len(ms) >= 3:
-                            tq_bits = float(ms[1])
-                            tq_seed = int(ms[2])
-                        tq = TurboQuantKVCache(bits=tq_bits, seed=tq_seed)
-                        tq.keys = cat_ks
-                        tq.values = cat_vs
-                        tq.offset = _state_length(cat_ks)
-                        _rebuild_codecs(tq, cat_ks, cat_vs)
-                        reconstructed_caches.append(tq)
+                    # Group consecutive TQ blocks that share (bits, seed) so
+                    # each run concatenates in quantized form and dequantizes
+                    # once. A homogeneous TQ chain stays a single run — one
+                    # concat + one codec rebuild, restored as a quantized
+                    # TurboQuantKVCache (upstream #1842: restored long-context
+                    # prefixes stay quantized, avoiding full-state
+                    # materialization). Mixed chains (plain dense blocks, or
+                    # runs with differing (bits, seed)) are dequantized per run
+                    # and merged into a dense KVCache; mx.concatenate promotes
+                    # any dense blocks to the dequantized float32, matching the
+                    # dtype the TQ reconstruction path has always emitted. The
+                    # healed request trades TurboQuant's memory savings for
+                    # that one restored prefix.
+                    try:
+                        from mlx_lm.models.cache import KVCache
+
+                        groups: list[tuple[str, Any, Any]] = []
+                        for block_idx, kind, part_k, part_v in entries:
+                            if kind == "plain":
+                                groups.append(("plain", part_k, part_v))
+                                continue
+                            params = self._tq_block_params(
+                                all_block_meta_states,
+                                first_block_meta_states,
+                                block_idx,
+                                layer_idx,
+                            )
+                            if params is None:
+                                logger.warning(
+                                    f"TQ layer {layer_idx}: block {block_idx} "
+                                    f"has no TurboQuant (bits, seed) metadata "
+                                    f"and no server-configured KV bit depth "
+                                    f"is available. Rejecting cache hit "
+                                    f"instead of guessing the codec width."
+                                )
+                                return None
+                            if (
+                                groups
+                                and groups[-1][0] == "tq"
+                                and groups[-1][2] == params
+                            ):
+                                groups[-1][1].append((part_k, part_v))
+                            else:
+                                groups.append(("tq", [(part_k, part_v)], params))
+
+                        # Homogeneous TQ chain (single quantized run, no dense
+                        # blocks): keep it quantized end-to-end like the
+                        # pre-payload-driven path, so restored prefixes don't
+                        # materialize full state.
+                        if len(groups) == 1 and groups[0][0] == "tq":
+                            from mlx_vlm.turboquant import TurboQuantKVCache
+
+                            from ..turboquant_kv import (
+                                _concat_state_token_axis,
+                                _rebuild_codecs,
+                                _state_length,
+                            )
+
+                            tq_bits, tq_seed = groups[0][2]
+                            run_states = groups[0][1]
+                            cat_ks = _concat_state_token_axis(
+                                [ks for ks, _ in run_states]
+                            )
+                            cat_vs = _concat_state_token_axis(
+                                [vs for _, vs in run_states]
+                            )
+                            tq = TurboQuantKVCache(bits=tq_bits, seed=tq_seed)
+                            tq.keys = cat_ks
+                            tq.values = cat_vs
+                            tq.offset = _state_length(cat_ks)
+                            _rebuild_codecs(tq, cat_ks, cat_vs)
+                            reconstructed_caches.append(tq)
+                            continue
+
+                        key_parts = []
+                        value_parts = []
+                        for group in groups:
+                            if group[0] == "plain":
+                                key_parts.append(group[1])
+                                value_parts.append(group[2])
+                                continue
+                            tq_bits, tq_seed = group[2]
+                            dq = self._dequantize_tq_run(
+                                group[1], tq_bits, tq_seed, layer_idx
+                            )
+                            if dq is None:
+                                return None
+                            key_parts.append(dq[0])
+                            value_parts.append(dq[1])
+
+                        keys = mx.concatenate(key_parts, axis=2)
+                        values = mx.concatenate(value_parts, axis=2)
+                        cache = KVCache()
+                        cache.keys = keys
+                        cache.values = values
+                        cache.offset = keys.shape[2]
+                        reconstructed_caches.append(cache)
                     except Exception as e:
                         logger.error(
                             f"TQ layer {layer_idx}: reconstruction failed: {e}"
@@ -2452,6 +2584,111 @@ class BlockAwarePrefixCache(CacheManager):
             import traceback
 
             logger.debug(traceback.format_exc())
+            return None
+
+    @staticmethod
+    def _layer_has_turboquant_payload(
+        all_block_data: list[list[Any]],
+        layer_idx: int,
+    ) -> bool:
+        """True if any block's payload for this layer is TurboQuant-tagged.
+
+        Used to route dense-typed (KVCache) layers whose chain later
+        accumulated TQ-converted blocks into the payload-driven TurboQuant
+        reconstruction path. layer_cache_types comes from the first block
+        only, so the chain-level type cannot detect this mixing.
+        """
+        for block_data in all_block_data:
+            if layer_idx >= len(block_data):
+                continue
+            bd = block_data[layer_idx]
+            if (
+                isinstance(bd, tuple)
+                and len(bd) == 2
+                and isinstance(bd[0], str)
+                and bd[0] == "__turboquant_v2__"
+            ):
+                return True
+        return False
+
+    def _tq_block_params(
+        self,
+        all_block_meta_states: list[Any],
+        first_block_meta_states: Any,
+        block_idx: int,
+        layer_idx: int,
+    ) -> tuple[float, int] | None:
+        """Resolve (bits, seed) for one block's TurboQuant payload.
+
+        Prefers the block's own per-block meta_state (TurboQuantKVCache
+        stores ``(offset, bits, seed)``; mixed chains can carry different
+        parameters per block), then the first block's chain-level meta, then
+        the server-configured TurboQuant KV bit depth (blocks admitted for
+        reconstruction already passed the bit-depth eligibility check, and
+        seed 0 is the universal codec default). Returns None when none of
+        these resolve: rebuilding a codec at a guessed width dequantizes to
+        plausible-but-wrong tensors — silent output corruption after a cache
+        hit — so the caller must reject the hit and re-prefill instead.
+        """
+        candidates = []
+        if block_idx < len(all_block_meta_states):
+            bms = all_block_meta_states[block_idx]
+            if bms and layer_idx < len(bms):
+                candidates.append(bms[layer_idx])
+        if first_block_meta_states and layer_idx < len(first_block_meta_states):
+            candidates.append(first_block_meta_states[layer_idx])
+        for ms in candidates:
+            if isinstance(ms, (list, tuple)) and len(ms) >= 3:
+                try:
+                    return float(ms[1]), int(ms[2])
+                except (TypeError, ValueError):
+                    continue
+        expected_bits = getattr(
+            self.paged_ssd_cache, "_expected_turboquant_kv_bits", None
+        )
+        if isinstance(expected_bits, (int, float)):
+            return float(expected_bits), 0
+        return None
+
+    def _dequantize_tq_run(
+        self,
+        run_states: list[tuple[Any, Any]],
+        bits: float,
+        seed: int,
+        layer_idx: int,
+    ) -> tuple[Any, Any] | None:
+        """Dequantize a run of consecutive TurboQuant block slices to dense KV.
+
+        Concatenates the quantized (ks, vs) states in block order and
+        dequantizes once, with codecs rebuilt deterministically from
+        (bits, seed). TurboQuant states are per-token (no cross-token
+        coupling), so dequantizing a run equals dequantizing its blocks
+        individually and concatenating — which makes payload-driven
+        per-block reconstruction valid.
+
+        Returns:
+            (keys, values) dense float32 arrays, or None when the run cannot
+            be decoded (caller rejects the cache hit).
+        """
+        from mlx_vlm.turboquant import TurboQuantKVCache
+
+        from ..turboquant_kv import _concat_state, _rebuild_codecs
+
+        try:
+            cat_ks = None
+            cat_vs = None
+            for ks, vs in run_states:
+                cat_ks = _concat_state(cat_ks, ks)
+                cat_vs = _concat_state(cat_vs, vs)
+            tq = TurboQuantKVCache(bits=bits, seed=seed)
+            _rebuild_codecs(tq, cat_ks, cat_vs)
+            return tq.dequantize(cat_ks, cat_vs)
+        except Exception as e:
+            logger.error(
+                f"TQ layer {layer_idx}: failed to dequantize "
+                f"{len(run_states)} block state(s) "
+                f"(bits={bits}, seed={seed}): {e}"
+            )
             return None
 
     def _fallback_reconstruct_layer(

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -3000,3 +3000,518 @@ class TestCanonicalLayerCacheTypes:
         # TurboQuant must remain distinct from plain KVCache.
         assert "TurboQuantKVCache" in result
         assert result != ["ArraysCache", "KVCache", "KVCache"]
+
+
+class TestTurboQuantMixedPayloadReconstruction:
+    """Payload-driven reconstruction of TurboQuant prefix-cache chains.
+
+    A block chain can mix payload formats: blocks stored while TurboQuant KV
+    conversion was active carry tagged ``('__turboquant_v2__', (ks, vs))``
+    NamedTuple states, while blocks stored without conversion (chains
+    written by versions that skipped it on chunked-prefill completion, or
+    stored under a different TQ setting) carry plain dense
+    ``(keys, values)`` tensors in the SAME chain via dedup.
+
+    The per-block ``layer_cache_types`` mismatch check truncates such chains
+    when every block's type metadata is present and accurate (covered by
+    ``TestTurboQuantFormatMismatchRecovery``), but block metadata is
+    optional at load time: metadata files can be missing or corrupt, the
+    ``layer_cache_types`` JSON can fail to round-trip, and a chain whose
+    first block lacks types gets typed from a later block. These tests model
+    such metadata-blind chains (mixed payloads with absent
+    ``layer_cache_types``), where the payload itself is the only ground
+    truth. Typing the whole chain from chain-level metadata fed dense arrays
+    into TurboQuant ``_concat_state`` and crashed with
+    ``AttributeError: 'array' object has no attribute 'norms'``, rejecting
+    the entire cache hit (full re-prefill on long-context hybrid models).
+    """
+
+    BLOCK = 4
+    HEADS = 2
+    HDIM = 64
+
+    @pytest.fixture
+    def mx(self):
+        """Import MLX or skip."""
+        try:
+            import mlx.core as mx
+
+            return mx
+        except ImportError:
+            pytest.skip("MLX not available")
+
+    @pytest.fixture
+    def tq_mod(self):
+        """Import mlx_vlm.turboquant or skip."""
+        return pytest.importorskip("mlx_vlm.turboquant")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_cache(self, num_layers=1):
+        """Build a prefix cache with a mocked SSD manager."""
+        from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
+
+        mock_ssd = MagicMock(spec=PagedSSDCacheManager)
+        paged_cache = PagedCacheManager(
+            block_size=self.BLOCK,
+            max_blocks=100,
+            model_name="test-model",
+            initial_blocks=100,
+        )
+        cache = BlockAwarePrefixCache(
+            model=MockModel(num_layers=num_layers),
+            paged_cache_manager=paged_cache,
+            paged_ssd_cache_manager=mock_ssd,
+        )
+        return cache, paged_cache, mock_ssd
+
+    def _alloc_block_table(self, paged_cache, n_blocks):
+        """Allocate n hashed blocks and a block table referencing them."""
+        blocks = []
+        for i in range(n_blocks):
+            b = paged_cache.allocate_block()
+            b.block_hash = f"hash{i}".encode()
+            b.token_count = self.BLOCK
+            b.ref_count = 2  # Simulate fetch_cache having incremented ref
+            blocks.append(b)
+        return BlockTable(
+            request_id="req-001",
+            block_ids=[b.block_id for b in blocks],
+            num_tokens=n_blocks * self.BLOCK,
+        )
+
+    @staticmethod
+    def _unwrap(state):
+        """Unwrap a _QuantizedStateProxy to the raw NamedTuple state."""
+        return state._state if hasattr(state, "_state") else state
+
+    def _tq_quantize(self, mx, tq_mod, keys, values, bits=4.0, seed=0):
+        """Quantize (keys, values) with a real TurboQuantKVCache.
+
+        Returns (tq_cache, ks_state, vs_state, ref_keys, ref_values) where
+        ref_* is the full-state dequantized reference.
+        """
+        tq = tq_mod.TurboQuantKVCache(bits=bits, seed=seed)
+        tq.update_and_fetch(keys, values)
+        ks = self._unwrap(tq.keys)
+        vs = self._unwrap(tq.values)
+        ref_keys, ref_values = tq.dequantize(ks, vs)
+        mx.eval(ref_keys, ref_values)
+        return tq, ks, vs, ref_keys, ref_values
+
+    def _tq_block_payload(self, tq_mod, ks, vs, block_idx):
+        """Build one block's tagged TurboQuant payload by state slicing."""
+        start = block_idx * self.BLOCK
+        end = start + self.BLOCK
+        return (
+            "__turboquant_v2__",
+            (
+                tq_mod._slice_state_range(ks, start, end),
+                tq_mod._slice_state_range(vs, start, end),
+            ),
+        )
+
+    def _metadata(self, layer_cache_types, layer_meta_states, num_layers):
+        return {
+            "model_name": "test-model",
+            "num_layers": num_layers,
+            "block_size": self.BLOCK,
+            "layer_cache_types": layer_cache_types,
+            "layer_meta_states": layer_meta_states,
+        }
+
+    # ------------------------------------------------------------------
+    # Mixed-format chains (the issue regression)
+    # ------------------------------------------------------------------
+
+    def test_mixed_chain_tq_head_plain_tail_reconstructs(self, mx, tq_mod):
+        """Chain typed TurboQuant (first block) with a plain dense tail block.
+
+        Regression for the multi-turn pattern: turn 1 stores TQ-converted
+        blocks; a later turn appends a plain dense block to the same chain.
+        The tail block's layer_cache_types is absent (block metadata is
+        optional at load time), so the type-mismatch truncation cannot see
+        the format change. Reconstruction must dequantize the TQ blocks per
+        block and pass the dense block through instead of rejecting the hit.
+        """
+        from mlx_lm.models.cache import KVCache
+
+        cache, paged_cache, mock_ssd = self._make_cache(num_layers=1)
+        block_table = self._alloc_block_table(paged_cache, 3)
+
+        # Blocks 0-1: TurboQuant-converted store (8 tokens quantized)
+        full_keys = mx.random.normal((1, self.HEADS, 2 * self.BLOCK, self.HDIM))
+        full_values = mx.random.normal((1, self.HEADS, 2 * self.BLOCK, self.HDIM))
+        tq, ks, vs, ref_keys, ref_values = self._tq_quantize(
+            mx, tq_mod, full_keys, full_values
+        )
+
+        # Block 2: plain dense store (skipped TQ conversion), stored
+        # without layer_cache_types metadata.
+        plain_k = mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(
+            mx.float16
+        )
+        plain_v = mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(
+            mx.float16
+        )
+
+        tq_metadata = self._metadata(["TurboQuantKVCache"], [tq.meta_state], 1)
+        plain_metadata = self._metadata(None, [()], 1)
+
+        mock_ssd.load_block_with_metadata.side_effect = [
+            ([self._tq_block_payload(tq_mod, ks, vs, 0)], tq_metadata),
+            ([self._tq_block_payload(tq_mod, ks, vs, 1)], tq_metadata),
+            ([(plain_k, plain_v)], plain_metadata),
+        ]
+
+        result = cache.reconstruct_cache(block_table)
+
+        assert result is not None, "mixed TQ+plain chain must reconstruct"
+        assert len(result) == 1
+        layer0 = result[0]
+        assert isinstance(layer0, KVCache)
+        assert layer0.offset == 3 * self.BLOCK
+        assert layer0.keys.shape == (1, self.HEADS, 3 * self.BLOCK, self.HDIM)
+
+        # TQ blocks: per-block dequantize must equal the full-state
+        # dequantize reference (TQ states are per-token).
+        assert mx.allclose(
+            layer0.keys[:, :, : 2 * self.BLOCK, :], ref_keys, atol=1e-5
+        )
+        assert mx.allclose(
+            layer0.values[:, :, : 2 * self.BLOCK, :], ref_values, atol=1e-5
+        )
+        # Plain block: passed through unmodified (promoted dtype only).
+        assert mx.allclose(
+            layer0.keys[:, :, 2 * self.BLOCK :, :],
+            plain_k.astype(layer0.keys.dtype),
+            atol=1e-3,
+        )
+        assert mx.allclose(
+            layer0.values[:, :, 2 * self.BLOCK :, :],
+            plain_v.astype(layer0.values.dtype),
+            atol=1e-3,
+        )
+
+    def test_mixed_chain_plain_head_tq_tail_reconstructs(self, mx, tq_mod):
+        """Chain typed KVCache (first block dense) with TQ-tagged tail blocks.
+
+        The reverse mixing direction: the chain-level type from the first
+        block routes through the standard KVCache branch. The TQ tail
+        blocks carry no layer_cache_types metadata (only their per-block
+        meta_states), so the type-mismatch truncation cannot see them; the
+        payload scan must route the layer into the TurboQuant branch, which
+        decodes tagged blocks with their own per-block meta instead of
+        unpacking the tag string as a tensor.
+        """
+        from mlx_lm.models.cache import KVCache
+
+        cache, paged_cache, mock_ssd = self._make_cache(num_layers=1)
+        block_table = self._alloc_block_table(paged_cache, 3)
+
+        # Block 0: plain dense store
+        plain_k = mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(
+            mx.float16
+        )
+        plain_v = mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(
+            mx.float16
+        )
+
+        # Blocks 1-2: TurboQuant-converted store, stored without
+        # layer_cache_types metadata.
+        full_keys = mx.random.normal((1, self.HEADS, 2 * self.BLOCK, self.HDIM))
+        full_values = mx.random.normal((1, self.HEADS, 2 * self.BLOCK, self.HDIM))
+        tq, ks, vs, ref_keys, ref_values = self._tq_quantize(
+            mx, tq_mod, full_keys, full_values
+        )
+
+        plain_metadata = self._metadata(["KVCache"], [()], 1)
+        tq_metadata = self._metadata(None, [tq.meta_state], 1)
+
+        mock_ssd.load_block_with_metadata.side_effect = [
+            ([(plain_k, plain_v)], plain_metadata),
+            ([self._tq_block_payload(tq_mod, ks, vs, 0)], tq_metadata),
+            ([self._tq_block_payload(tq_mod, ks, vs, 1)], tq_metadata),
+        ]
+
+        result = cache.reconstruct_cache(block_table)
+
+        assert result is not None, "mixed plain+TQ chain must reconstruct"
+        assert len(result) == 1
+        layer0 = result[0]
+        assert isinstance(layer0, KVCache)
+        assert layer0.offset == 3 * self.BLOCK
+        assert layer0.keys.shape == (1, self.HEADS, 3 * self.BLOCK, self.HDIM)
+
+        assert mx.allclose(
+            layer0.keys[:, :, : self.BLOCK, :],
+            plain_k.astype(layer0.keys.dtype),
+            atol=1e-3,
+        )
+        assert mx.allclose(
+            layer0.keys[:, :, self.BLOCK :, :], ref_keys, atol=1e-5
+        )
+        assert mx.allclose(
+            layer0.values[:, :, self.BLOCK :, :], ref_values, atol=1e-5
+        )
+
+    def test_mixed_chain_hybrid_model_with_arrays_cache_layer(self, mx, tq_mod):
+        """Hybrid (Qwen3.5-style) layout: TQ attention layer + ArraysCache GDN
+        layer, with a plain dense block (no layer_cache_types metadata)
+        appended to the TQ chain."""
+        from mlx_lm.models.cache import KVCache
+
+        cache, paged_cache, mock_ssd = self._make_cache(num_layers=2)
+        block_table = self._alloc_block_table(paged_cache, 3)
+
+        full_keys = mx.random.normal((1, self.HEADS, 2 * self.BLOCK, self.HDIM))
+        full_values = mx.random.normal((1, self.HEADS, 2 * self.BLOCK, self.HDIM))
+        tq, ks, vs, _, _ = self._tq_quantize(mx, tq_mod, full_keys, full_values)
+
+        plain_k = mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(
+            mx.float16
+        )
+        plain_v = mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(
+            mx.float16
+        )
+
+        placeholder = (mx.zeros((1,)), mx.zeros((1,)))
+        # ArraysCache (GDN) real state lives in the last stored block.
+        conv_state = mx.ones((1, 3, 64))
+        ssm_state = mx.ones((1, 32, 16, 16))
+
+        tq_metadata = self._metadata(
+            ["TurboQuantKVCache", "ArraysCache"], [tq.meta_state, ()], 2
+        )
+        plain_metadata = self._metadata(None, [(), ()], 2)
+
+        mock_ssd.load_block_with_metadata.side_effect = [
+            ([self._tq_block_payload(tq_mod, ks, vs, 0), placeholder], tq_metadata),
+            ([self._tq_block_payload(tq_mod, ks, vs, 1), placeholder], tq_metadata),
+            ([(plain_k, plain_v), (conv_state, ssm_state)], plain_metadata),
+        ]
+
+        result = cache.reconstruct_cache(block_table)
+
+        assert result is not None, "hybrid mixed chain must reconstruct"
+        assert len(result) == 2
+        assert isinstance(result[0], KVCache)
+        assert result[0].offset == 3 * self.BLOCK
+        # GDN layer reconstructed from the last block's real state.
+        assert not isinstance(result[1], KVCache)
+
+    # ------------------------------------------------------------------
+    # Homogeneous chains: zero behavior change
+    # ------------------------------------------------------------------
+
+    def test_all_tq_chain_reconstructs_unchanged(self, mx, tq_mod):
+        """Uniform TQ chain stays quantized (single-run fast path).
+
+        A homogeneous TQ chain is a single run, so it is restored as a
+        quantized ``TurboQuantKVCache`` (upstream #1842: restored
+        long-context prefixes stay quantized and avoid full-state
+        materialization) rather than being dequantized into a dense
+        ``KVCache``. The dequantized state must still match the full-state
+        reference (TQ states are per-token, so per-block concat equals the
+        full-state concat).
+        """
+        cache, paged_cache, mock_ssd = self._make_cache(num_layers=1)
+        block_table = self._alloc_block_table(paged_cache, 3)
+
+        full_keys = mx.random.normal((1, self.HEADS, 3 * self.BLOCK, self.HDIM))
+        full_values = mx.random.normal((1, self.HEADS, 3 * self.BLOCK, self.HDIM))
+        tq, ks, vs, ref_keys, ref_values = self._tq_quantize(
+            mx, tq_mod, full_keys, full_values
+        )
+
+        tq_metadata = self._metadata(["TurboQuantKVCache"], [tq.meta_state], 1)
+        mock_ssd.load_block_with_metadata.side_effect = [
+            ([self._tq_block_payload(tq_mod, ks, vs, i)], tq_metadata)
+            for i in range(3)
+        ]
+
+        result = cache.reconstruct_cache(block_table)
+
+        assert result is not None
+        layer0 = result[0]
+        assert isinstance(layer0, tq_mod.TurboQuantKVCache)
+        assert layer0.offset == 3 * self.BLOCK
+        rebuilt_keys, rebuilt_values = layer0.dequantize()
+        assert mx.allclose(rebuilt_keys, ref_keys, atol=1e-5)
+        assert mx.allclose(rebuilt_values, ref_values, atol=1e-5)
+
+    def test_all_plain_chain_reconstructs_unchanged(self, mx):
+        """Uniform dense chain keeps exact values and stored dtype."""
+        from mlx_lm.models.cache import KVCache
+
+        cache, paged_cache, mock_ssd = self._make_cache(num_layers=1)
+        block_table = self._alloc_block_table(paged_cache, 3)
+
+        slices = [
+            (
+                mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(
+                    mx.float16
+                ),
+                mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(
+                    mx.float16
+                ),
+            )
+            for _ in range(3)
+        ]
+
+        plain_metadata = self._metadata(["KVCache"], [()], 1)
+        mock_ssd.load_block_with_metadata.side_effect = [
+            ([s], plain_metadata) for s in slices
+        ]
+
+        result = cache.reconstruct_cache(block_table)
+
+        assert result is not None
+        layer0 = result[0]
+        assert isinstance(layer0, KVCache)
+        assert layer0.offset == 3 * self.BLOCK
+        assert layer0.keys.dtype == mx.float16
+        expected_keys = mx.concatenate([k for k, _ in slices], axis=2)
+        expected_values = mx.concatenate([v for _, v in slices], axis=2)
+        assert mx.array_equal(layer0.keys, expected_keys)
+        assert mx.array_equal(layer0.values, expected_values)
+
+    # ------------------------------------------------------------------
+    # Corrupt / placeholder payloads: clean rejection
+    # ------------------------------------------------------------------
+
+    def test_tq_chain_placeholder_block_rejected(self, mx, tq_mod):
+        """A (1,) empty-slice placeholder in a TQ-typed chain rejects the hit
+        cleanly (None) instead of corrupting the concatenated KV."""
+        cache, paged_cache, mock_ssd = self._make_cache(num_layers=1)
+        block_table = self._alloc_block_table(paged_cache, 2)
+
+        full_keys = mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM))
+        full_values = mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM))
+        tq, ks, vs, _, _ = self._tq_quantize(mx, tq_mod, full_keys, full_values)
+
+        placeholder = (mx.zeros((1,)), mx.zeros((1,)))
+        tq_metadata = self._metadata(["TurboQuantKVCache"], [tq.meta_state], 1)
+
+        mock_ssd.load_block_with_metadata.side_effect = [
+            ([self._tq_block_payload(tq_mod, ks, vs, 0)], tq_metadata),
+            ([placeholder], tq_metadata),
+        ]
+
+        assert cache.reconstruct_cache(block_table) is None
+
+    def test_plain_chain_tq_placeholder_block_rejected(self, mx):
+        """A (1,) placeholder from a TQ-regime store inside a KVCache-typed
+        chain rejects the hit cleanly (None)."""
+        cache, paged_cache, mock_ssd = self._make_cache(num_layers=1)
+        block_table = self._alloc_block_table(paged_cache, 2)
+
+        plain_k = mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(
+            mx.float16
+        )
+        plain_v = mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(
+            mx.float16
+        )
+        placeholder = (mx.zeros((1,)), mx.zeros((1,)))
+        plain_metadata = self._metadata(["KVCache"], [()], 1)
+
+        mock_ssd.load_block_with_metadata.side_effect = [
+            ([(plain_k, plain_v)], plain_metadata),
+            ([placeholder], plain_metadata),
+        ]
+
+        assert cache.reconstruct_cache(block_table) is None
+
+    def test_tq_chain_corrupt_payload_rejected(self, mx, tq_mod):
+        """A payload that is neither tagged, placeholder, nor dense 4D KV
+        rejects the hit cleanly (None) instead of producing wrong KV."""
+        cache, paged_cache, mock_ssd = self._make_cache(num_layers=1)
+        block_table = self._alloc_block_table(paged_cache, 2)
+
+        full_keys = mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM))
+        full_values = mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM))
+        tq, ks, vs, _, _ = self._tq_quantize(mx, tq_mod, full_keys, full_values)
+
+        corrupt = (mx.zeros((2, 2)), mx.zeros((2, 2)))  # 2D, not a KV slice
+        tq_metadata = self._metadata(["TurboQuantKVCache"], [tq.meta_state], 1)
+
+        mock_ssd.load_block_with_metadata.side_effect = [
+            ([self._tq_block_payload(tq_mod, ks, vs, 0)], tq_metadata),
+            ([corrupt], tq_metadata),
+        ]
+
+        assert cache.reconstruct_cache(block_table) is None
+
+    def test_tq_chain_absent_meta_uses_configured_bits(self, mx, tq_mod):
+        """Uniform TQ chain whose (bits, seed) metadata never round-tripped.
+
+        Block 0's metadata carries no layer_meta_states (the JSON failed to
+        round-trip); block 1 loads with no metadata at all. Neither
+        per-block nor chain-level meta can resolve (bits, seed). The
+        server-configured TurboQuant KV bit depth is authoritative for
+        admitted blocks (cache eligibility already keys on it), so
+        reconstruction must rebuild the codec at that depth — 8 bits here —
+        rather than the historical bits=4.0 guess, which dequantized 8-bit
+        states into plausible-but-wrong tensors: silent output corruption
+        after a cache hit instead of a loud failure.
+        """
+        cache, paged_cache, mock_ssd = self._make_cache(num_layers=1)
+        mock_ssd._expected_turboquant_kv_bits = 8.0
+        block_table = self._alloc_block_table(paged_cache, 2)
+
+        full_keys = mx.random.normal((1, self.HEADS, 2 * self.BLOCK, self.HDIM))
+        full_values = mx.random.normal(
+            (1, self.HEADS, 2 * self.BLOCK, self.HDIM)
+        )
+        tq, ks, vs, ref_keys, ref_values = self._tq_quantize(
+            mx, tq_mod, full_keys, full_values, bits=8.0
+        )
+
+        no_meta_states = self._metadata(["TurboQuantKVCache"], None, 1)
+        mock_ssd.load_block_with_metadata.side_effect = [
+            ([self._tq_block_payload(tq_mod, ks, vs, 0)], no_meta_states),
+            ([self._tq_block_payload(tq_mod, ks, vs, 1)], None),
+        ]
+
+        result = cache.reconstruct_cache(block_table)
+
+        assert result is not None, "configured bit depth must resolve the codec"
+        assert len(result) == 1
+        layer0 = result[0]
+        assert layer0.offset == 2 * self.BLOCK
+        got_keys, got_values = layer0.dequantize(
+            self._unwrap(layer0.keys), self._unwrap(layer0.values)
+        )
+        assert mx.allclose(got_keys, ref_keys, atol=1e-5)
+        assert mx.allclose(got_values, ref_values, atol=1e-5)
+
+    def test_tq_chain_unresolvable_params_rejected(self, mx, tq_mod):
+        """No meta anywhere and no configured bit depth: reject, don't guess.
+
+        Historically this path silently rebuilt the codec at bits=4.0. For a
+        chain stored at any other depth that dequantizes to wrong-width
+        tensors and the request degenerates after the cache hit (upstream
+        issue: `!!!!` output after prefix-cache restores). A rejected hit
+        merely re-prefills — strictly safer than plausible-but-wrong KV.
+        """
+        cache, paged_cache, mock_ssd = self._make_cache(num_layers=1)
+        mock_ssd._expected_turboquant_kv_bits = None
+        block_table = self._alloc_block_table(paged_cache, 2)
+
+        full_keys = mx.random.normal((1, self.HEADS, 2 * self.BLOCK, self.HDIM))
+        full_values = mx.random.normal(
+            (1, self.HEADS, 2 * self.BLOCK, self.HDIM)
+        )
+        tq, ks, vs, _, _ = self._tq_quantize(
+            mx, tq_mod, full_keys, full_values, bits=8.0
+        )
+
+        no_meta_states = self._metadata(["TurboQuantKVCache"], None, 1)
+        mock_ssd.load_block_with_metadata.side_effect = [
+            ([self._tq_block_payload(tq_mod, ks, vs, 0)], no_meta_states),
+            ([self._tq_block_payload(tq_mod, ks, vs, 1)], None),
+        ]
+
+        assert cache.reconstruct_cache(block_table) is None


### PR DESCRIPTION
Fixes #729. Addresses the strongest code-supported mechanism behind #2255.

## Summary

- Prefix-cache reconstruction now dispatches each block on its **own payload format** instead of typing the whole chain from chain-level metadata, so mixed TurboQuant/dense chains reconstruct instead of crashing (`AttributeError: 'array' object has no attribute 'norms'`, #729) and forcing a full re-prefill.
- When a block's `(bits, seed)` cannot be resolved from metadata, the codec is **no longer rebuilt at a guessed `bits=4.0/seed=0`** — it falls back to the server-configured TurboQuant KV bit depth, and if that is also unavailable the hit is **rejected and re-prefilled** instead of guessed. A guessed width dequantizes to plausible-but-wrong tensors: silent output corruption after a cache hit, the mechanism that best matches the degenerate-output report in #2255.

## Why

A block chain can legitimately mix payload formats: blocks stored while TurboQuant KV conversion was active carry tagged `('__turboquant_v2__', (ks, vs))` states, while blocks stored without it (chunked-prefill completions on older versions, or a different TQ setting) carry plain dense `(keys, values)` — in the same chain, via dedup. The per-block `layer_cache_types` mismatch check only truncates such chains when every block's metadata is present and accurate, but block metadata is optional at load time: files can be missing or corrupt, and the JSON can fail to round-trip. For metadata-blind chains, reconstruction typed everything from the chain-level type and fed dense arrays into TurboQuant `_concat_state` (the #729 crash) — or, worse, rebuilt codecs from a hardcoded `bits=4.0` default that silently dequantizes wrong-width tensors for any chain stored at a different depth.

## Changes

- `omlx/cache/prefix_cache.py`
  - `reconstruct_cache`: payload-driven per-block dispatch. Consecutive TurboQuant blocks sharing `(bits, seed)` group into runs that concatenate quantized and dequantize once; dense blocks pass through; empty-slice placeholders and unrecognized payloads reject the hit with a clear log. A homogeneous TQ chain remains a single run restored as a quantized `TurboQuantKVCache` (preserving #1842's no-full-materialization behavior); all-dense chains take the untouched dense path — uniform chains see zero behavior change.
  - `_tq_block_params`: resolution order is now per-block meta → chain-level (first-block) meta → server-configured `_expected_turboquant_kv_bits` (the same attribute the block-eligibility signature is keyed on, so an admitted block's depth provably matches it; seed is always the codec default 0 — no omlx path constructs a TurboQuant cache with another seed, though seed is not part of the eligibility signature) → `None`, which makes the caller reject the hit instead of guessing.
  - Block metadata list stays index-aligned with block data when a block loads without metadata, so per-block resolution can never read a neighbor block's parameters (previously possible in principle; observable only for mixed-parameter chains with dropped metadata).

## Tests

`python -m pytest tests/test_prefix_cache.py tests/test_paged_ssd_cache.py tests/test_turboquant.py -q` → **308 passed** (103 in `test_prefix_cache.py`: 93 pre-existing + 10 new).

New tests, all in the existing per-module file, driving the real `reconstruct_cache` through the `load_block_with_metadata` seam:
- 3 mixed-chain reconstruction tests (TQ head + dense tail, dense head + TQ tail, hybrid model with an ArraysCache layer) — verified to FAIL with the fix reverted.
- 2 behavior-preservation guards: homogeneous TQ chains and all-dense chains reconstruct exactly as before.
- 3 safe-rejection guards: placeholder payloads (both chain typings) and corrupt payloads return `None` (re-prefill), never wrong KV.
- 2 params-resolution tests — verified to FAIL with the fix reverted: metadata-blind uniform chain resolves the codec from the configured bit depth and dequantizes byte-equal to the full-state reference; with no configured depth either, the hit is rejected instead of silently rebuilding at 4 bits.

Also verified against the parent commit (`5a39ba3a`): 5 of the 10 new tests fail there — the 3 mixed-chain tests with the original crash signature, plus both params-resolution tests (the parent's hardcoded `bits=4.0` dequantizes one chain at the wrong width and reconstructs another it should reject).

Live verification on the reported model family (Qwen3.5 122B A10B hybrid, TurboQuant KV 8-bit, default `skip_last`): stored a ~4k-token prefix (2 × 2048-token blocks; the chain organically mixes ArraysCache/TurboQuantKVCache/KVCache layers), then stripped `layer_meta_states` from the block files — `cache_signature` left intact, so bit-depth eligibility still admits them — to reproduce a metadata-blind chain. On this branch the hit heals through the configured-bits fallback at cache-hit speed (2.2s end-to-end vs 5.3s cold, coherent output). On the parent commit the same request aborts mid-generation — `[reshape] Cannot reshape array of size 1401 into shape (1,2,1401)` inside TurboQuant norms handling (the `bits=4.0` guess applied to 8-bit states) — and the stream returns an empty completion: reconstruction "succeeds" and the corruption detonates at the first attention dequantize, the delayed-failure shape #2255 reports.

Reconstruction micro-benchmark (M5 Max, 4-layer × 4k-token chains, real quantized states): homogeneous-TQ and all-dense reconstruction are unchanged vs the parent (within GPU dispatch noise at N=30; all-dense 0.99×); the per-block payload scan costs ~0.6µs per layer; a healed mixed chain reconstructs in ~3.8ms.

## Why this is safe

- I could not construct a healthy chain the old code reconstructed but the new code rejects: every new `return None` maps to a payload the old path either also rejected (via a caught crash) or silently corrupted (the old loop skipped non-2-tuple blocks, dropping their KV and misaligning positions). Reject-loud is strictly more correct in each case.
- Reconstruction is single-entry: hot-tier and SSD restores both converge on `reconstruct_cache`; `boundary_snapshot_store` performs no TurboQuant reconstruction (store-side only); GDN/`ArraysCache` layers are excluded by the existing `supports_block_slicing` gate; VLM and LLM engines share the path. No sibling reconstruct path diverges.
- The configured-bit-depth fallback only engages where the old code guessed `4.0` unconditionally — configurations whose metadata round-trips (the healthy common case) never reach it.

## Trade-offs / out of scope

- A mixed chain heals by dequantizing to a dense cache for that one restored request, trading TurboQuant's memory savings for correctness on a rare recovery path (measured: 128 MiB fp32 vs 16.5 MiB quantized for a 4k-token, 4-layer chain). Homogeneous chains keep the quantized restore.
- `_rebuild_codecs` reproducibility for fractional bit-widths (its docstring guarantees integers only) is a pre-existing property this PR narrows exposure to but does not change — flagging it here as a known residual; happy to follow up separately if you want it hardened.

Field context: #2255 reports degenerate (`!!!!`) output beginning exactly when prefix-cache hits started working, on the same model family as #729 (Qwen 3.5 122B hybrid). The silent wrong-width rebuild fixed here is the strongest code-supported mechanism for that symptom, but the reporter has not confirmed it (whether TurboQuant KV was enabled in that setup is not stated in the thread) — which is why this PR claims #729 and only "addresses" #2255.

A note on #729's attribution: the report (and #1793's cross-reference to it) blames the hybrid model's GDN `ArraysCache` layer, which indeed lacks `.norms` — but every `.norms` access in omlx's cache code is `hasattr`-guarded; the unguarded accesses live in mlx_vlm's TurboQuant state handling, reached only through the TurboQuant reconstruction branch. The error therefore signals a non-TurboQuant payload routed into TurboQuant reconstruction — the mechanism fixed here. The hybrid-model test reproduces the reported setup (ArraysCache layer present) and fails on the parent commit with the reported error string.

## Adjacent open reports (same signature, not claimed)

- #1793: the store-side cause was fixed in 0b7a226, and its tail hardening already heals poisoned chains in one turn by truncating and re-storing the mixed tail. This change narrows the remaining cost: a mixed tail now reconstructs instead of being truncated and re-prefilled.
- #1822 (`skip_last` → the same error on every reconstruction, reported on 0.4.3): payload-driven dispatch routes dense payloads out of TurboQuant reconstruction regardless of how the chain is typed, which covers the reported mechanism (a dense payload in a TurboQuant-typed chain) — worth a retest on this branch before closing.
