### PR TITLE
Fix #766: SpecPrefill AttributeError re-wrapping leftover _OffsetAdjustedRoPE

### DIFF
--- a/omlx/patches/specprefill.py
+++ b/omlx/patches/specprefill.py
@@ -706,7 +706,7 @@ class _PositionMappedRoPE:
             self._dims = _get_dims(original_rope)
             self._pre_scale = _get_pre_scale(original_rope)
         else:
-            self._dims = original_rope.dims
+            self._dims = _get_dims(original_rope)
             self._base = original_rope.base
             self._scale = original_rope.scale
 
@@ -735,6 +735,24 @@ class _OffsetAdjustedRoPE:
 
     def __call__(self, x, offset=0):
         return self._original(x, offset=offset + self._adjustment)
+
+    def __getattr__(self, name):
+        # Delegate unknown attrs (e.g. .dims, .base, ._freqs) to the wrapped
+        # rope so this wrapper is transparent if it is ever re-wrapped. See #766.
+        return getattr(object.__getattribute__(self, "_original"), name)
+
+
+def _unwrap_rope(rope):
+    """Peel any sparse-prefill RoPE wrappers down to the genuine module.
+
+    If a prior sparse_prefill left an _OffsetAdjustedRoPE installed (cleanup_rope
+    not called between multi-turn requests), re-wrapping it would nest wrappers
+    and, before this fix, crash in _PositionMappedRoPE. Always start from the
+    genuine rope. See #766.
+    """
+    while isinstance(rope, (_OffsetAdjustedRoPE, _PositionMappedRoPE)):
+        rope = rope._original
+    return rope
 
 
 def _get_dims(rope_module):
@@ -835,9 +853,13 @@ def sparse_prefill(
     if has_rope:
         for layer_idx, layer in attn_layers:
             attn = _get_attn_module(layer)
-            original_ropes[layer_idx] = attn.rope
+            # Start from the genuine rope: a prior sparse_prefill may have left
+            # an _OffsetAdjustedRoPE installed if cleanup_rope wasn't called
+            # (multi-turn + partial cache hit). See #766.
+            genuine = _unwrap_rope(attn.rope)
+            original_ropes[layer_idx] = genuine
             attn.rope = _PositionMappedRoPE(
-                attn.rope, selected_positions, cache_start=cache_start
+                genuine, selected_positions, cache_start=cache_start
             )
 
     try:

--- a/tests/test_specprefill.py
+++ b/tests/test_specprefill.py
@@ -608,3 +608,58 @@ class TestEngineCorePropagation:
         req = core.scheduler.add_request.call_args[0][0]
         assert not hasattr(req, "_specprefill_threshold")
         assert not hasattr(req, "_specprefill_keep_pct")
+
+
+class TestRoPEReWrap:
+    """Regression tests for #766 — re-wrapping a leftover _OffsetAdjustedRoPE.
+
+    If a prior sparse_prefill left an _OffsetAdjustedRoPE installed (cleanup_rope
+    not called, e.g. an aborted request or a multi-turn partial cache hit), the
+    next sparse_prefill used to capture that wrapper as `original` and re-wrap it
+    in _PositionMappedRoPE, whose __init__ dereferenced `original_rope.dims` and
+    raised `'_OffsetAdjustedRoPE' object has no attribute 'dims'`.
+    """
+
+    class _GenuineRoPE:
+        dims = 128
+        base = 10000.0
+        scale = 1.0
+
+        def __call__(self, x, offset=0):
+            return x
+
+    def test_offset_adjusted_delegates_attrs(self):
+        from omlx.patches.specprefill import _OffsetAdjustedRoPE
+
+        wrapped = _OffsetAdjustedRoPE(self._GenuineRoPE(), adjustment=5)
+        # unknown attrs delegate to the wrapped rope
+        assert wrapped.dims == 128
+        assert wrapped.base == 10000.0
+
+    def test_unwrap_peels_to_genuine(self):
+        from omlx.patches.specprefill import (
+            _OffsetAdjustedRoPE,
+            _PositionMappedRoPE,
+            _unwrap_rope,
+        )
+
+        genuine = self._GenuineRoPE()
+        positions = mx.arange(16)
+        assert _unwrap_rope(genuine) is genuine
+        assert _unwrap_rope(_OffsetAdjustedRoPE(genuine, 5)) is genuine
+        assert (
+            _unwrap_rope(_PositionMappedRoPE(_OffsetAdjustedRoPE(genuine, 5), positions))
+            is genuine
+        )
+
+    def test_rewrap_leftover_does_not_crash(self):
+        from omlx.patches.specprefill import (
+            _OffsetAdjustedRoPE,
+            _PositionMappedRoPE,
+        )
+
+        genuine = self._GenuineRoPE()
+        leftover = _OffsetAdjustedRoPE(genuine, adjustment=5)
+        # Previously raised AttributeError on original_rope.dims (#766)
+        pm = _PositionMappedRoPE(leftover, mx.arange(16))
+        assert pm._dims == 128


### PR DESCRIPTION
Fixes the `AttributeError: '_OffsetAdjustedRoPE' object has no attribute 'dims'` half of #766. (This PR does **not** touch the BatchTurboQuantKVCache part of that issue.)

Reproduces on 0.5.1 and `main`; observed on Qwen3.6-35B-A3B (not Gemma-specific).

## Root cause
In `omlx/patches/specprefill.py`:

1. `_OffsetAdjustedRoPE` has no `__getattr__` delegation (unlike the query-capture wrapper in the same file).
2. `sparse_prefill()`'s `finally` installs `_OffsetAdjustedRoPE` on each attention layer when `adjustment > 0` and does not restore the genuine rope. If `cleanup_rope()` isn't called before the next `sparse_prefill()` — e.g. an **aborted/interrupted request**, or a **multi-turn continuation with a partial cache hit** — the leftover wrapper stays installed.
3. The next `sparse_prefill()` captures that leftover `_OffsetAdjustedRoPE` as `original` and re-wraps it in `_PositionMappedRoPE`. Its `__init__` non-custom-freqs branch does `self._dims = original_rope.dims`, and `_OffsetAdjustedRoPE` has neither `dims` nor `__getattr__` → `AttributeError`.

`_get_dims()` already exists and is used in the custom-freqs branch, but the `else` branch still dereferenced `.dims` directly.

Because it's caught upstream and falls back to dense prefill, requests still complete, but the log fills with errors and the SpecPrefill TTFT win is lost.

## Fix (3 edits)
- Add `__getattr__` delegation to `_OffsetAdjustedRoPE` so the wrapper is transparent if ever re-wrapped.
- Add `_unwrap_rope()` and use it at the `sparse_prefill()` capture site so a leftover wrapper is peeled to the genuine rope before re-wrapping. This also prevents **nested** wrappers, which `cleanup_rope()` only unwraps one level of.
- Use `_get_dims()` in the `_PositionMappedRoPE` `else` branch for consistency.

## Repro (no model needed)
```python
from omlx.patches.specprefill import _PositionMappedRoPE, _OffsetAdjustedRoPE
import mlx.core as mx
class Genuine:
    dims=128; base=10000.0; scale=1.0
    def __call__(self, x, offset=0): return x
leftover = _OffsetAdjustedRoPE(Genuine(), adjustment=5)  # left by a prior sparse_prefill
_PositionMappedRoPE(leftover, mx.arange(16))             # -> AttributeError on .dims (before this PR)
```

## Tests
Added `TestRoPEReWrap` in `tests/test_specprefill.py` covering: `__getattr__` delegation, `_unwrap_rope()` peeling (including nested), and that re-wrapping a leftover no longer raises.
