### PR TITLE
fix(mtp): honor models whose return_hidden output is already post-norm in _trunk_norm_module

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -1379,6 +1379,12 @@ def _trunk_norm_module(model: Any):
 
     Walks both wrapper conventions: mlx-lm's outer ``Model.language_model``
     and oMLX's ``VLMModelAdapter._language_model`` (mlx-vlm path).
+
+    Models whose ``return_hidden`` output is already post-norm mark
+    ``_omlx_mtp_head_hidden_normed`` (instance or inner language model) and
+    get an identity here — applying the trunk norm again would double-norm
+    the head inputs, and the ``inner.model.norm`` walk does not fit every
+    backbone layout (e.g. ``backbone.norm_f``).
     """
     inner = model
     for attr in ("language_model", "_language_model"):
@@ -1386,6 +1392,10 @@ def _trunk_norm_module(model: Any):
         if candidate is not None:
             inner = candidate
             break
+    if getattr(model, "_omlx_mtp_head_hidden_normed", False) or getattr(
+        inner, "_omlx_mtp_head_hidden_normed", False
+    ):
+        return lambda x: x
     return inner.model.norm
 
 

--- a/tests/test_mtp_trunk_norm.py
+++ b/tests/test_mtp_trunk_norm.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from omlx.patches.mlx_lm_mtp.batch_generator import _trunk_norm_module
+
+
+def _norm():
+    return lambda x: ("normed", x)
+
+
+class TestTrunkNormModule:
+    def test_unmarked_model_resolves_inner_norm(self):
+        norm = _norm()
+        model = SimpleNamespace(model=SimpleNamespace(norm=norm))
+        assert _trunk_norm_module(model) is norm
+
+    def test_unmarked_language_model_wrapper(self):
+        norm = _norm()
+        inner = SimpleNamespace(model=SimpleNamespace(norm=norm))
+        model = SimpleNamespace(language_model=inner)
+        assert _trunk_norm_module(model) is norm
+
+    def test_marked_instance_returns_identity(self):
+        model = SimpleNamespace(
+            _omlx_mtp_head_hidden_normed=True,
+            model=SimpleNamespace(norm=_norm()),
+        )
+        fn = _trunk_norm_module(model)
+        sentinel = object()
+        assert fn(sentinel) is sentinel
+
+    def test_marked_inner_language_model_returns_identity(self):
+        inner = SimpleNamespace(
+            _omlx_mtp_head_hidden_normed=True,
+            model=SimpleNamespace(norm=_norm()),
+        )
+        model = SimpleNamespace(language_model=inner)
+        fn = _trunk_norm_module(model)
+        sentinel = object()
+        assert fn(sentinel) is sentinel


### PR DESCRIPTION
## Problem

`_trunk_norm_module` bakes in two assumptions from the qwen35/deepseek patches: the backbone's final norm lives at `inner.model.norm`, and the hidden returned by `model(..., return_hidden=True)` is pre-norm. The chain draft path then applies the trunk norm unconditionally:

```python
if _HEAD_HIDDEN_POST_NORM and hidden_rows.ndim == 3:
    hidden_rows = _trunk_norm_module(model)(hidden_rows)
```

A model patch whose `return_hidden` hidden is already post-norm gets double-normed here — silently degrading draft acceptance — and one whose backbone attribute isn't `.model` (e.g. `.backbone` with `norm_f`) raises AttributeError inside the draft cycle, which the fallback machinery swallows as a generic MTP step fallback.

## Change

Model patches can mark `_omlx_mtp_head_hidden_normed = True` on the instance (or on the resolved inner language model); `_trunk_norm_module` then returns an identity callable. The wrapper walk and the unmarked path are unchanged, so this is a no-op for every existing model patch.

A follow-up PR (nemotron_h MTP support) is the first user: its `return_hidden` returns post-`norm_f` hidden.

## Testing

`tests/test_mtp_trunk_norm.py`: marked instance returns identity; marked inner `language_model` returns identity; unmarked paths resolve `inner.model.norm` as before. Existing MTP suites (`test_mlx_lm_mtp_patch.py`, `test_mtp_depth_controller.py`) pass unchanged.

Co-authored with Claude Fable 5 (Anthropic).
