### PR TITLE
feat(mtp): nemotron_h support — depth-1 cycle and Lightning MTP chain

### DIFF
--- a/omlx/patches/mlx_lm_mtp/__init__.py
+++ b/omlx/patches/mlx_lm_mtp/__init__.py
@@ -101,6 +101,8 @@ def apply_mlx_lm_mtp_patch() -> bool:
         cache_rollback,
         deepseek_v4_model,
         glm_moe_dsa_model,
+        nemotron_h_chain,
+        nemotron_h_model,
         qwen35_model,
     )
 
@@ -114,6 +116,10 @@ def apply_mlx_lm_mtp_patch() -> bool:
         logger.debug("DeepSeek-V4 MTP patch did not apply (likely missing base patch)")
     if not glm_moe_dsa_model.apply():
         logger.debug("GLM-5.2 MTP patch did not apply (likely missing base patch)")
+    if not nemotron_h_model.apply():
+        logger.debug("nemotron_h MTP patch did not apply (likely import error)")
+    elif not nemotron_h_chain.apply():
+        logger.debug("nemotron_h MTP chain patch did not apply")
     if not batch_generator.apply():
         logger.warning(
             "BatchGenerator MTP dispatch patch failed; MTP path will be inactive"

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -1379,6 +1379,12 @@ def _trunk_norm_module(model: Any):
 
     Walks both wrapper conventions: mlx-lm's outer ``Model.language_model``
     and oMLX's ``VLMModelAdapter._language_model`` (mlx-vlm path).
+
+    Models whose ``return_hidden`` output is already post-norm mark
+    ``_omlx_mtp_head_hidden_normed`` (instance or inner language model) and
+    get an identity here — applying the trunk norm again would double-norm
+    the head inputs, and the ``inner.model.norm`` walk does not fit every
+    backbone layout (e.g. ``backbone.norm_f``).
     """
     inner = model
     for attr in ("language_model", "_language_model"):
@@ -1386,6 +1392,10 @@ def _trunk_norm_module(model: Any):
         if candidate is not None:
             inner = candidate
             break
+    if getattr(model, "_omlx_mtp_head_hidden_normed", False) or getattr(
+        inner, "_omlx_mtp_head_hidden_normed", False
+    ):
+        return lambda x: x
     return inner.model.norm
 
 

--- a/omlx/patches/mlx_lm_mtp/nemotron_h_chain.py
+++ b/omlx/patches/mlx_lm_mtp/nemotron_h_chain.py
@@ -18,16 +18,19 @@ the qwen35_model chain contract to the Nemotron-H hybrid trunk:
   bit-identical to the original forward for those positions (same stock
   ssm path, same single-chunk math).
 - Stamps ``_omlx_mtp_chain`` / ``_omlx_mtp_depth`` (from ``get_mtp_depth()``,
-  i.e. the ``mtp_num_draft_tokens`` model setting, default 3) on MTP-bearing
+  i.e. the ``mtp_num_draft_tokens`` model setting; nemotron_h defaults to a
+  fixed depth-1 cycle — the stock head is depth-1 trained) on MTP-bearing
   instances, plus ``_omlx_mtp_head_hidden_normed`` — nemotron's
-  ``return_hidden`` hidden is already post-``norm_f``, so the chain's trunk
-  norm hook must be an identity for this model (qwen returns pre-norm).
+  ``return_hidden`` hidden is already post-``norm_f``, so
+  ``_trunk_norm_module`` returns identity for this model (qwen returns
+  pre-norm).
 
 Greedy speculative decoding is lossless: outputs are identical to the
 depth-1/no-MTP greedy stream; only throughput changes.
 """
 
 import logging
+import threading
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +60,6 @@ def apply() -> bool:
     _patch_mtp_forward(nh)
     _patch_partial_rollback(nh)
     _patch_init_markers(nh)
-    _patch_trunk_norm()
     logger.info(
         "nemotron_h MTP chain patch applied "
         "(depth-k drafting, sequential fused verify, replay-free rollback)"
@@ -79,8 +81,17 @@ def apply() -> bool:
 # The per-position capture is armed around the window call; if anything
 # about the call shape is unexpected (mask set, no state, capture missed a
 # layer) the code falls back to the raw-input stash + replay path.
+# Thread-local: two models decoding concurrently in one process must not
+# interleave arm/read across threads.
 # --------------------------------------------------------------------------- #
-_capture = {"armed": False, "ssm": None, "conv": None}
+class _Capture(threading.local):
+    def __init__(self):
+        self.armed = False
+        self.ssm = None
+        self.conv = None
+
+
+_capture = _Capture()
 
 
 def _patch_mixer(nh):
@@ -93,18 +104,18 @@ def _patch_mixer(nh):
         S = hidden_states.shape[1]
         if cache is not None and 0 < n_confirmed < S:
             conv0, ssm0 = cache[0], cache[1]  # zero-copy pre-forward refs
-            _capture["armed"] = mask is None
-            _capture["ssm"] = None
-            _capture["conv"] = None
+            _capture.armed = mask is None
+            _capture.ssm = None
+            _capture.conv = None
             try:
                 out = base_call(self, hidden_states, mask, cache)
             finally:
-                armed = _capture["armed"]
-                ssm_states = _capture["ssm"]
-                conv_tails = _capture["conv"]
-                _capture["armed"] = False
-                _capture["ssm"] = None
-                _capture["conv"] = None
+                armed = _capture.armed
+                ssm_states = _capture.ssm
+                conv_tails = _capture.conv
+                _capture.armed = False
+                _capture.ssm = None
+                _capture.conv = None
             if (
                 armed
                 and ssm_states is not None
@@ -165,7 +176,7 @@ def _patch_ssm_sequential():
     ):
         S = hidden_states.shape[1]
         if (
-            _capture["armed"]
+            _capture.armed
             and 1 < S < 32
             and state is not None
             and mask is None
@@ -189,7 +200,7 @@ def _patch_ssm_sequential():
                 )
                 ys.append(y)
                 states.append(s)
-            _capture["ssm"] = states
+            _capture.ssm = states
             return mx.concatenate(ys, axis=1), s
         return inner(
             hidden_states, A_log, B, C, D, dt, dt_bias, state,
@@ -218,7 +229,7 @@ def _patch_conv_capture(nh):
 
     def _conv(self, conv_input, cache=None, mask=None):
         if (
-            _capture["armed"]
+            _capture.armed
             and cache is not None
             and mask is None
             and getattr(cache, "lengths", None) is None
@@ -236,7 +247,7 @@ def _patch_conv_capture(nh):
             for i in range(S):
                 seq = mx.concatenate([prev, conv_input[:, : i + 1]], axis=1)
                 tails.append(seq[:, -n_keep:, :])
-            _capture["conv"] = tails
+            _capture.conv = tails
         return orig_conv(self, conv_input, cache, mask)
 
     setattr(_conv, _MARKER, True)
@@ -375,28 +386,3 @@ def _patch_init_markers(nh):
 
     Model.__init__ = __init__
     Model._omlx_nh_chain_init = True
-
-
-# --------------------------------------------------------------------------- #
-# batch_generator._trunk_norm_module: identity for already-normed hidden
-# --------------------------------------------------------------------------- #
-def _patch_trunk_norm():
-    from . import batch_generator as bg
-
-    if getattr(bg._trunk_norm_module, _MARKER, False):
-        return
-    orig = bg._trunk_norm_module
-
-    def _trunk_norm_module(model):
-        if getattr(model, "_omlx_mtp_head_hidden_normed", False):
-            return lambda x: x
-        for attr in ("language_model", "_language_model"):
-            inner = getattr(model, attr, None)
-            if inner is not None and getattr(
-                inner, "_omlx_mtp_head_hidden_normed", False
-            ):
-                return lambda x: x
-        return orig(model)
-
-    setattr(_trunk_norm_module, _MARKER, True)
-    bg._trunk_norm_module = _trunk_norm_module

--- a/omlx/patches/mlx_lm_mtp/nemotron_h_chain.py
+++ b/omlx/patches/mlx_lm_mtp/nemotron_h_chain.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Depth-k Lightning MTP chain enablement for nemotron_h.
+
+Layered on top of nemotron_h_model (the PR-990 depth-1 base patch). Ports
+the qwen35_model chain contract to the Nemotron-H hybrid trunk:
+
+- ``Mixer.__call__`` (verify windows, ``0 < n_confirmed < S``): run the whole
+  window as ONE pristine chunk, keep zero-copy *pre-forward* (conv, ssm)
+  state refs in ``cache.rollback_state`` and the raw mixer input in
+  ``cache._mtp_draft_stash``. Nothing extra is paid on full accepts.
+- ``Model.mtp_forward``: adds ``return_hidden`` / ``logits_keep`` (chain
+  drafting interface). Legacy 3-positional calls behave as before.
+- ``Model.mtp_partial_rollback``: after a depth-k verify over
+  ``[confirmed, d1..dk]`` with ``m`` accepted drafts — attention KV layers
+  trim ``k - m``; Mamba layers restore the pre-forward refs and replay the
+  kept ``1 + m`` tokens from the stash through the pristine mixer forward
+  (a handful of tiny kernels, paid only on rejections). The replay is
+  bit-identical to the original forward for those positions (same stock
+  ssm path, same single-chunk math).
+- Stamps ``_omlx_mtp_chain`` / ``_omlx_mtp_depth`` (from ``get_mtp_depth()``,
+  i.e. the ``mtp_num_draft_tokens`` model setting, default 3) on MTP-bearing
+  instances, plus ``_omlx_mtp_head_hidden_normed`` — nemotron's
+  ``return_hidden`` hidden is already post-``norm_f``, so the chain's trunk
+  norm hook must be an identity for this model (qwen returns pre-norm).
+
+Greedy speculative decoding is lossless: outputs are identical to the
+depth-1/no-MTP greedy stream; only throughput changes.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_MARKER = "_omlx_nh_chain"
+
+
+def _is_ours(cls, attr):
+    fn = cls.__dict__.get(attr)
+    return getattr(fn, _MARKER, False)
+
+
+def apply() -> bool:
+    try:
+        from mlx_lm.models import nemotron_h as nh
+    except Exception:
+        logger.debug("mlx_lm nemotron_h not importable; chain patch skipped")
+        return False
+
+    # Require the base MTP patch (provides n_confirmed plumbing + MTPModule).
+    if not getattr(nh.Model, "_omlx_nh_mtp_init", False):
+        logger.debug("nemotron_h base MTP patch missing; chain patch skipped")
+        return False
+
+    _patch_mixer(nh)
+    _patch_ssm_sequential()
+    _patch_conv_capture(nh)
+    _patch_mtp_forward(nh)
+    _patch_partial_rollback(nh)
+    _patch_init_markers(nh)
+    _patch_trunk_norm()
+    logger.info(
+        "nemotron_h MTP chain patch applied "
+        "(depth-k drafting, sequential fused verify, replay-free rollback)"
+    )
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# Mixer: chain verify semantics.
+#
+# Verify windows keep the BATCHED projections (in_proj/conv/out_proj stream
+# each layer's weights once for the whole window) but run the SSM scan
+# SEQUENTIALLY with the fused single-step decode kernel:
+#   - measured faster than ssm_attn's chunked graph at window sizes 2-8
+#     (0.35 vs 0.63 ms/layer at S=2 -> ~11 ms/cycle across 40 layers), and
+#   - numerically identical to the plain decode path (same kernel), and
+#   - yields PER-POSITION (conv, ssm) states as a free byproduct, so a
+#     partial rollback is a pure ref restore — no replay, no re-streaming.
+# The per-position capture is armed around the window call; if anything
+# about the call shape is unexpected (mask set, no state, capture missed a
+# layer) the code falls back to the raw-input stash + replay path.
+# --------------------------------------------------------------------------- #
+_capture = {"armed": False, "ssm": None, "conv": None}
+
+
+def _patch_mixer(nh):
+    Mixer = nh.NemotronHMamba2Mixer
+    if _is_ours(Mixer, "__call__"):
+        return
+    base_call = Mixer.__call__  # the base-patched version (two-chunk split)
+
+    def __call__(self, hidden_states, mask, cache=None, n_confirmed=0):
+        S = hidden_states.shape[1]
+        if cache is not None and 0 < n_confirmed < S:
+            conv0, ssm0 = cache[0], cache[1]  # zero-copy pre-forward refs
+            _capture["armed"] = mask is None
+            _capture["ssm"] = None
+            _capture["conv"] = None
+            try:
+                out = base_call(self, hidden_states, mask, cache)
+            finally:
+                armed = _capture["armed"]
+                ssm_states = _capture["ssm"]
+                conv_tails = _capture["conv"]
+                _capture["armed"] = False
+                _capture["ssm"] = None
+                _capture["conv"] = None
+            if (
+                armed
+                and ssm_states is not None
+                and conv_tails is not None
+                and len(ssm_states) == S
+                and len(conv_tails) == S
+            ):
+                cache._mtp_pos_states = list(zip(conv_tails, ssm_states))
+            else:
+                cache._mtp_pos_states = None
+            # Raw-input stash: replay fallback when per-position capture
+            # didn't engage (masked window, exotic path).
+            cache.rollback_state = (conv0, ssm0)
+            cache._mtp_draft_stash = hidden_states
+            return out
+        return base_call(self, hidden_states, mask, cache)
+
+    __call__._omlx_nh_mtp = True   # base patch idempotency: don't re-wrap
+    setattr(__call__, _MARKER, True)
+    Mixer.__call__ = __call__
+
+
+_ssm_seq_applied = False
+
+
+def _patch_ssm_sequential():
+    """Wrap mlx_lm ssm_update: on armed chain-verify windows run the fused
+    single-step kernel per position, capturing each state.
+
+    Layering note: the SSD prefill patch also wraps ssm_update. Both wrappers
+    fall through cleanly (SSD only claims T>=32 unmasked prefill; this one
+    only claims armed tiny windows), so either application order works. A
+    module flag — not a function attribute — guards idempotency, because a
+    later SSD re-wrap would hide the attribute.
+    """
+    global _ssm_seq_applied
+    import mlx.core as mx
+    from mlx_lm.models import ssm as ssm_mod
+
+    if _ssm_seq_applied:
+        return
+    _ssm_seq_applied = True
+    inner = ssm_mod.ssm_update  # whatever is installed (incl. SSD prefill wrap)
+    kernel_step = ssm_mod.ssm_update_kernel
+
+    def ssm_update(
+        hidden_states,
+        A_log,
+        B,
+        C,
+        D,
+        dt,
+        dt_bias,
+        state=None,
+        time_step_limit=(0.001, 100.0),
+        mask=None,
+        lengths=None,
+    ):
+        S = hidden_states.shape[1]
+        if (
+            _capture["armed"]
+            and 1 < S < 32
+            and state is not None
+            and mask is None
+            and lengths is None
+            and mx.default_device() == mx.gpu
+        ):
+            ys = []
+            states = []
+            s = state
+            for i in range(S):
+                y, s = kernel_step(
+                    hidden_states[:, i : i + 1],
+                    A_log,
+                    B[:, i],
+                    C[:, i],
+                    D,
+                    dt[:, i : i + 1],
+                    dt_bias,
+                    s,
+                    time_step_limit,
+                )
+                ys.append(y)
+                states.append(s)
+            _capture["ssm"] = states
+            return mx.concatenate(ys, axis=1), s
+        return inner(
+            hidden_states, A_log, B, C, D, dt, dt_bias, state,
+            time_step_limit, mask, lengths,
+        )
+
+    setattr(ssm_update, _MARKER, True)
+    ssm_mod.ssm_update = ssm_update
+    try:
+        from mlx_lm.models import nemotron_h as nh_mod
+
+        nh_mod.ssm_update = ssm_update
+    except Exception:
+        pass
+
+
+def _patch_conv_capture(nh):
+    """Wrap Mixer._conv: on armed windows also record the per-position conv
+    cache tails (last conv_kernel-1 columns of [prev_tail | window input])."""
+    import mlx.core as mx
+
+    Mixer = nh.NemotronHMamba2Mixer
+    if getattr(Mixer.__dict__.get("_conv"), _MARKER, False):
+        return
+    orig_conv = Mixer._conv
+
+    def _conv(self, conv_input, cache=None, mask=None):
+        if (
+            _capture["armed"]
+            and cache is not None
+            and mask is None
+            and getattr(cache, "lengths", None) is None
+            and conv_input.shape[1] > 1
+        ):
+            n_keep = self.conv_kernel_size - 1
+            prev = cache[0]
+            if prev is None:
+                prev = mx.zeros(
+                    (conv_input.shape[0], n_keep, self.conv_dim),
+                    dtype=conv_input.dtype,
+                )
+            S = conv_input.shape[1]
+            tails = []
+            for i in range(S):
+                seq = mx.concatenate([prev, conv_input[:, : i + 1]], axis=1)
+                tails.append(seq[:, -n_keep:, :])
+            _capture["conv"] = tails
+        return orig_conv(self, conv_input, cache, mask)
+
+    setattr(_conv, _MARKER, True)
+    Mixer._conv = _conv
+
+
+# --------------------------------------------------------------------------- #
+# Model.mtp_forward: return_hidden / logits_keep (chain drafting interface)
+# --------------------------------------------------------------------------- #
+def _patch_mtp_forward(nh):
+    Model = nh.Model
+    if _is_ours(Model, "mtp_forward"):
+        return
+
+    def mtp_forward(
+        self, hidden, next_ids, mtp_cache, return_hidden=False, logits_keep=None
+    ):
+        out = self.mtp(hidden, next_ids, self.backbone.embeddings, mtp_cache)
+        sliced = out[:, -logits_keep:] if logits_keep else out
+        logits = self.lm_head(sliced)
+        if return_hidden:
+            return logits, out
+        return logits
+
+    mtp_forward._omlx_nh_mtp = True
+    setattr(mtp_forward, _MARKER, True)
+    Model.mtp_forward = mtp_forward
+
+
+# --------------------------------------------------------------------------- #
+# Model.mtp_partial_rollback: trim KV, restore+replay Mamba state
+# --------------------------------------------------------------------------- #
+def _patch_partial_rollback(nh):
+    Model = nh.Model
+    if _is_ours(Model, "mtp_partial_rollback"):
+        return
+
+    def mtp_partial_rollback(self, cache, accepted: int, num_drafts: int) -> bool:
+        layers = self.backbone.layers
+        trim_n = num_drafts - accepted
+        keep = 1 + accepted  # confirmed token + accepted drafts
+
+        # Validate everything before mutating anything (partial rollbacks
+        # desync per-layer cache lengths and corrupt later forwards).
+        plan = []
+        cur = 0
+        for layer in layers:
+            bt = layer.block_type
+            if bt == "M":
+                if cur >= len(cache):
+                    return False
+                c = cache[cur]
+                cur += 1
+                if trim_n > 0 and (
+                    getattr(c, "rollback_state", None) is None
+                    or getattr(c, "_mtp_draft_stash", None) is None
+                ):
+                    return False
+                plan.append(("M", layer, c))
+            elif bt == "*":
+                if cur >= len(cache):
+                    return False
+                c = cache[cur]
+                cur += 1
+                if trim_n > 0 and not (
+                    hasattr(c, "is_trimmable") and c.is_trimmable()
+                ):
+                    return False
+                plan.append(("*", layer, c))
+            # 'E' / '-' blocks are stateless: no cache entry.
+        if cur != len(cache):
+            return False
+
+        if trim_n <= 0:
+            # Full accept: nothing to undo; drop the stashes so the refs
+            # don't pin the pre-forward arrays.
+            for kind, _, c in plan:
+                if kind == "M":
+                    c.rollback_state = None
+                    c._mtp_draft_stash = None
+                    c._mtp_pos_states = None
+            return True
+
+        for kind, layer, c in plan:
+            if kind == "M":
+                pos = getattr(c, "_mtp_pos_states", None)
+                if pos is not None and len(pos) >= keep:
+                    # Fast path: the sequential verify captured per-position
+                    # (conv, ssm) states — restore refs, no recompute at all.
+                    conv_m, ssm_m = pos[keep - 1]
+                    c[0] = conv_m
+                    c[1] = ssm_m
+                else:
+                    # Fallback: restore pre-window refs and replay the kept
+                    # prefix through the pristine mixer forward.
+                    conv0, ssm0 = c.rollback_state
+                    stash = c._mtp_draft_stash
+                    c[0] = conv0
+                    c[1] = ssm0
+                    replay = stash[:, :keep]
+                    c.rollback_state = None
+                    c._mtp_draft_stash = None
+                    c._mtp_pos_states = None
+                    layer.mixer(replay, None, c)
+                    continue
+                c.rollback_state = None
+                c._mtp_draft_stash = None
+                c._mtp_pos_states = None
+            else:
+                c.trim(trim_n)
+        return True
+
+    setattr(mtp_partial_rollback, _MARKER, True)
+    Model.mtp_partial_rollback = mtp_partial_rollback
+
+
+# --------------------------------------------------------------------------- #
+# __init__ wrap: stamp chain markers on MTP-bearing instances
+# --------------------------------------------------------------------------- #
+def _patch_init_markers(nh):
+    Model = nh.Model
+    if getattr(Model, "_omlx_nh_chain_init", False):
+        return
+    orig_init = Model.__init__
+
+    def __init__(self, args):
+        orig_init(self, args)
+        if hasattr(self, "mtp"):
+            from . import get_mtp_depth
+
+            self._omlx_mtp_chain = True
+            self._omlx_mtp_depth = get_mtp_depth()
+            # return_hidden hidden is post-norm_f already: the chain's
+            # trunk-norm hook must be identity for this model.
+            self._omlx_mtp_head_hidden_normed = True
+
+    Model.__init__ = __init__
+    Model._omlx_nh_chain_init = True
+
+
+# --------------------------------------------------------------------------- #
+# batch_generator._trunk_norm_module: identity for already-normed hidden
+# --------------------------------------------------------------------------- #
+def _patch_trunk_norm():
+    from . import batch_generator as bg
+
+    if getattr(bg._trunk_norm_module, _MARKER, False):
+        return
+    orig = bg._trunk_norm_module
+
+    def _trunk_norm_module(model):
+        if getattr(model, "_omlx_mtp_head_hidden_normed", False):
+            return lambda x: x
+        for attr in ("language_model", "_language_model"):
+            inner = getattr(model, attr, None)
+            if inner is not None and getattr(
+                inner, "_omlx_mtp_head_hidden_normed", False
+            ):
+                return lambda x: x
+        return orig(model)
+
+    setattr(_trunk_norm_module, _MARKER, True)
+    bg._trunk_norm_module = _trunk_norm_module

--- a/omlx/patches/mlx_lm_mtp/nemotron_h_model.py
+++ b/omlx/patches/mlx_lm_mtp/nemotron_h_model.py
@@ -1,0 +1,306 @@
+"""oMLX Native-MTP patch for nemotron_h (hybrid Mamba2 + attention + MoE).
+
+Adds multi-token-prediction speculative decoding for nemotron_h, mirroring the
+qwen3_5 (hybrid GatedDeltaNet) + deepseek_v4 (eh_proj MTP head) patches.
+
+Verified head recipe (mtp_probe.py, 2026-06-06): fuse `[enorm(embed_next) ‖ hnorm(hidden)]`
+through eh_proj, where `hidden` is the main model's POST-norm_f hidden; then an attention
+block + an MoE block + final_layernorm + shared lm_head. ~52% draft acceptance.
+
+Patches (all idempotent, self-healing via a marker attr):
+  - NemotronHMamba2Mixer.__call__: accept n_confirmed; split confirmed/draft, snapshot
+    (conv,ssm) -> cache.rollback_state at the boundary.
+  - NemotronHBlock.__call__: thread n_confirmed to the Mamba mixer.
+  - NemotronHModel.__call__ / Model.__call__: thread n_confirmed, add return_hidden
+    (returns post-norm_f hidden for the MTP head).
+  - Model: attach .mtp (MTPModule) when active; add mtp_forward / make_mtp_cache.
+  - Model.sanitize: keep + remap + stack mtp.* weights when .mtp is present.
+
+This module is import-installed by patches/mlx_lm_mtp/__init__.py and gated by
+utils/model_loading.py `_is_mtp_compatible` (model_type.startswith("nemotron_h")).
+"""
+import contextlib
+import logging
+
+import mlx.core as mx
+import mlx.nn as nn
+
+logger = logging.getLogger("omlx.mtp.nemotron_h")
+_MARKER = "_omlx_nh_mtp"
+
+# MTP activation: in-package this defers to omlx.patches.mlx_lm_mtp.is_mtp_active;
+# standalone (quant/tests) it falls back to a module-level flag.
+_MTP_ACTIVE_STANDALONE = False
+
+
+def set_mtp_active(value: bool) -> None:
+    global _MTP_ACTIVE_STANDALONE
+    _MTP_ACTIVE_STANDALONE = bool(value)
+
+
+def _is_active() -> bool:
+    try:
+        from . import is_mtp_active  # type: ignore
+        return is_mtp_active()
+    except Exception:
+        return _MTP_ACTIVE_STANDALONE
+
+
+def _is_ours(cls, attr):
+    return getattr(cls.__dict__.get(attr, None), _MARKER, False)
+
+
+def apply() -> bool:
+    try:
+        from mlx_lm.models import nemotron_h as nh
+    except Exception as e:  # pragma: no cover
+        logger.debug("nemotron_h not importable; skipping MTP patch: %s", e)
+        return False
+    # Upstream may eventually ship mtp_forward; defer to it.
+    if hasattr(nh.Model, "mtp_forward") and not _is_ours(nh.Model, "mtp_forward"):
+        return True
+    _patch_args(nh)
+    _register_mtp_module(nh)
+    _patch_mamba_mixer(nh)
+    _patch_block(nh)
+    _patch_backbone(nh)
+    _patch_model(nh)
+    return True
+
+
+def _patch_args(nh):
+    """nemotron_h ModelArgs doesn't declare num_nextn_predict_layers, and
+    BaseModelArgs.from_dict drops unknown keys. Surface it as an instance attr
+    so the patched Model.__init__ can decide whether to attach the MTP head."""
+    A = nh.ModelArgs
+    if getattr(A, "_omlx_nh_mtp_args", False):
+        return
+    orig = A.from_dict.__func__  # unwrap classmethod
+
+    def patched_from_dict(cls, params):
+        inst = orig(cls, params)
+        inst.num_nextn_predict_layers = int(params.get("num_nextn_predict_layers", 0) or 0)
+        return inst
+
+    A.from_dict = classmethod(patched_from_dict)
+    A._omlx_nh_mtp_args = True
+
+
+# --------------------------------------------------------------------------- #
+# MTP head module
+# --------------------------------------------------------------------------- #
+def _register_mtp_module(nh):
+    if hasattr(nh, "MTPModule") and getattr(nh.MTPModule, _MARKER, False):
+        return
+    NemotronHAttention = nh.NemotronHAttention
+    NemotronHMoE = nh.NemotronHMoE
+    create_attention_mask = nh.create_attention_mask
+
+    class _MTPLayer0(nn.Module):
+        """Fusion + attention sublayer. Param paths mirror disk `mtp.layers.0.*`."""
+
+        def __init__(self, args):
+            super().__init__()
+            H = args.hidden_size
+            eps = args.layer_norm_epsilon
+            self.eh_proj = nn.Linear(2 * H, H, bias=False)
+            self.enorm = nn.RMSNorm(H, eps=eps)
+            self.hnorm = nn.RMSNorm(H, eps=eps)
+            self.norm = nn.RMSNorm(H, eps=eps)
+            self.mixer = NemotronHAttention(args)
+
+    class _MTPLayer1(nn.Module):
+        """MoE sublayer + final norm. Param paths mirror disk `mtp.layers.1.*`."""
+
+        def __init__(self, args):
+            super().__init__()
+            H = args.hidden_size
+            eps = args.layer_norm_epsilon
+            self.norm = nn.RMSNorm(H, eps=eps)
+            self.mixer = NemotronHMoE(args)
+            self.final_layernorm = nn.RMSNorm(H, eps=eps)
+
+    class MTPModule(nn.Module):
+        """nemotron_h MTP predict-layer (pattern '*E'): fuse -> attn block -> moe block -> norm.
+        Structured so parameter paths exactly match the on-disk `mtp.layers.{0,1}.*` names
+        (only the routed experts are stacked, in sanitize)."""
+
+        def __init__(self, args):
+            super().__init__()
+            self.layers = [_MTPLayer0(args), _MTPLayer1(args)]
+
+        def __call__(self, hidden, next_ids, embed_tokens, cache):
+            # hidden: (B,1,H) post-norm_f from backbone; next_ids: (B,1)
+            l0, l1 = self.layers
+            e = l0.enorm(embed_tokens(next_ids))
+            h = l0.hnorm(hidden)
+            fused = l0.eh_proj(mx.concatenate([e, h], axis=-1))
+            kv = cache[0] if cache else None
+            mask = create_attention_mask(fused, kv) if fused.shape[1] > 1 else None
+            x = fused + l0.mixer(l0.norm(fused), mask=mask, cache=kv)
+            x = x + l1.mixer(l1.norm(x))
+            return l1.final_layernorm(x)
+
+    MTPModule._omlx_nh_mtp = True
+    nh.MTPModule = MTPModule
+
+
+# --------------------------------------------------------------------------- #
+# Mamba2 mixer: n_confirmed split + rollback snapshot
+# --------------------------------------------------------------------------- #
+def _patch_mamba_mixer(nh):
+    Mixer = nh.NemotronHMamba2Mixer
+    if _is_ours(Mixer, "__call__"):
+        return
+    orig = Mixer.__call__  # processes a full chunk, chaining state via cache[0]/cache[1]
+
+    def __call__(self, hidden_states, mask, cache=None, n_confirmed=0):
+        S = hidden_states.shape[1]
+        if cache is not None and 0 < n_confirmed < S:
+            mc = mask[:, :n_confirmed] if mask is not None else None
+            md = mask[:, n_confirmed:] if mask is not None else None
+            out_c = orig(self, hidden_states[:, :n_confirmed], mc, cache)
+            # snapshot confirmed (conv,ssm) state before processing drafts
+            cache.rollback_state = (cache[0], cache[1])
+            out_d = orig(self, hidden_states[:, n_confirmed:], md, cache)
+            return mx.concatenate([out_c, out_d], axis=1)
+        return orig(self, hidden_states, mask, cache)
+
+    __call__._omlx_nh_mtp = True
+    Mixer.__call__ = __call__
+
+
+def _patch_block(nh):
+    Block = nh.NemotronHBlock
+    if _is_ours(Block, "__call__"):
+        return
+
+    def __call__(self, x, mask=None, cache=None, n_confirmed=0):
+        h = self.norm(x)
+        if self.block_type == "M":
+            h = self.mixer(h, mask, cache, n_confirmed=n_confirmed)
+        elif self.block_type == "*":
+            h = self.mixer(h, mask=mask, cache=cache)
+        else:
+            h = self.mixer(h)
+        return x + h
+
+    __call__._omlx_nh_mtp = True
+    Block.__call__ = __call__
+
+
+def _patch_backbone(nh):
+    NemotronHModel = nh.NemotronHModel
+    if _is_ours(NemotronHModel, "__call__"):
+        return
+    create_attention_mask = nh.create_attention_mask
+    create_ssm_mask = nh.create_ssm_mask
+
+    def __call__(self, inputs, cache=None, n_confirmed=0):
+        h = self.embeddings(inputs)
+        if cache is None:
+            cache = [None] * len(self.layers)
+        attn_mask = create_attention_mask(h, cache[self.fa_idx])
+        ssm_mask = create_ssm_mask(h, cache[self.ssm_idx])
+        cc = 0
+        for layer in self.layers:
+            if layer.block_type in ("M", "*"):
+                c = cache[cc]
+                cc += 1
+            else:
+                c = None
+            mask = attn_mask if layer.block_type == "*" else ssm_mask
+            if layer.block_type == "M":
+                h = layer(h, mask=mask, cache=c, n_confirmed=n_confirmed)
+            else:
+                h = layer(h, mask=mask, cache=c)
+        return self.norm_f(h)
+
+    __call__._omlx_nh_mtp = True
+    NemotronHModel.__call__ = __call__
+
+
+# --------------------------------------------------------------------------- #
+# Model: __call__(return_hidden, n_confirmed) + mtp_forward + make_mtp_cache + sanitize
+# --------------------------------------------------------------------------- #
+def _patch_model(nh):
+    Model = nh.Model
+    KVCache = nh.KVCache
+
+    # --- __init__ wrap: attach .mtp when active ---
+    if not getattr(Model, "_omlx_nh_mtp_init", False):
+        orig_init = Model.__init__
+
+        def __init__(self, args):
+            orig_init(self, args)
+            n = int(getattr(args, "num_nextn_predict_layers", 0) or 0)
+            active = bool(n > 0 and _is_active())
+            # omlx >= 0.5 batch_generator gates the whole MTP decode path on
+            # this per-instance marker (see set_mtp_active docstring); without
+            # it drafting is silently skipped even with the head attached.
+            self._omlx_mtp_decode_enabled = active
+            if active:
+                self.mtp = nh.MTPModule(args)
+
+        Model.__init__ = __init__
+        Model._omlx_nh_mtp_init = True
+
+    # --- __call__: return_hidden + n_confirmed ---
+    if not _is_ours(Model, "__call__"):
+        def __call__(self, inputs, cache=None, return_hidden=False, n_confirmed=0):
+            hidden = self.backbone(inputs, cache=cache, n_confirmed=n_confirmed)  # post-norm_f
+            logits = self.lm_head(hidden)
+            if return_hidden:
+                return logits, hidden
+            return logits
+
+        __call__._omlx_nh_mtp = True
+        Model.__call__ = __call__
+
+    # --- mtp_forward / make_mtp_cache ---
+    def mtp_forward(self, hidden, next_ids, mtp_cache):
+        out = self.mtp(hidden, next_ids, self.backbone.embeddings, mtp_cache)
+        return self.lm_head(out)
+
+    def make_mtp_cache(self):
+        return [KVCache()] if hasattr(self, "mtp") else []
+
+    mtp_forward._omlx_nh_mtp = True
+    Model.mtp_forward = mtp_forward
+    Model.make_mtp_cache = make_mtp_cache
+
+    # --- sanitize: keep + remap + stack mtp.* when .mtp present ---
+    if not _is_ours(Model, "sanitize"):
+        orig_sanitize = Model.sanitize
+
+        def sanitize(self, weights):
+            has_mtp = hasattr(self, "mtp")
+            has_mtp_w = any(k.startswith("mtp.") for k in weights)
+            if has_mtp and not has_mtp_w:
+                # config declares an MTP head but the checkpoint stripped the weights
+                with contextlib.suppress(Exception):
+                    del self.mtp
+                has_mtp = False
+
+            mtp_w = {k: v for k, v in weights.items() if k.startswith("mtp.")}
+            base = {k: v for k, v in weights.items() if not k.startswith("mtp.")}
+            out = orig_sanitize(self, base)   # stacks main experts, strips its own mtp (none here)
+
+            if has_mtp and mtp_w:
+                E = self.args.n_routed_experts
+                ep = "mtp.layers.1.mixer.experts"
+                # MTPModule param paths already mirror disk names; only stack routed experts.
+                for k, v in mtp_w.items():
+                    if f"{ep}." not in k:
+                        out[k] = v
+                if f"{ep}.0.up_proj.weight" in mtp_w:
+                    out["mtp.layers.1.mixer.switch_mlp.fc1.weight"] = mx.stack(
+                        [mtp_w[f"{ep}.{e}.up_proj.weight"] for e in range(E)]
+                    )
+                    out["mtp.layers.1.mixer.switch_mlp.fc2.weight"] = mx.stack(
+                        [mtp_w[f"{ep}.{e}.down_proj.weight"] for e in range(E)]
+                    )
+            return out
+
+        sanitize._omlx_nh_mtp = True
+        Model.sanitize = sanitize

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -305,7 +305,15 @@ def maybe_apply_pre_load_patches(
             # (M >= 3), whose numerics can diverge from the unrouted path at
             # bf16 tail-ULP level.
             depth = getattr(model_settings, "mtp_num_draft_tokens", None)
-            set_mtp_depth(int(depth) if depth else 3)
+            if depth:
+                set_mtp_depth(int(depth))
+            elif model_type.startswith("nemotron_h"):
+                # The stock nemotron_h head is depth-1 trained; the adaptive
+                # controller's exploration costs ~10% throughput vs fixed
+                # depth 1 on it.
+                set_mtp_depth(1)
+            else:
+                set_mtp_depth(3)
             if mtp_enabled:
                 logger.info(
                     "Native MTP patch applied for %s (model_type=%s, active)",
@@ -557,8 +565,9 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
     """Decide whether the native MTP patch can be applied to this model.
 
     Supports Qwen3.5/3.6 (mlx-lm PR 990), DeepSeek-V4-Flash (Blaizzy/mlx-lm
-    fork PR 15) and GLM-5.2 (glm_moe_dsa). The model also has to declare
-    MTP heads in the config; otherwise the patch is a no-op.
+    fork PR 15), GLM-5.2 (glm_moe_dsa) and Nemotron-H hybrids (nemotron_h).
+    The model also has to declare MTP heads in the config; otherwise the
+    patch is a no-op.
     """
     if not _has_mtp_heads(config):
         return False
@@ -568,6 +577,7 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
         model_type.startswith("qwen3_5")
         or model_type.startswith("qwen3_6")
         or model_type.startswith("deepseek_v4")
+        or model_type.startswith("nemotron_h")
         or model_type == "glm_moe_dsa"
     )
 

--- a/tests/test_mtp_trunk_norm.py
+++ b/tests/test_mtp_trunk_norm.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from omlx.patches.mlx_lm_mtp.batch_generator import _trunk_norm_module
+
+
+def _norm():
+    return lambda x: ("normed", x)
+
+
+class TestTrunkNormModule:
+    def test_unmarked_model_resolves_inner_norm(self):
+        norm = _norm()
+        model = SimpleNamespace(model=SimpleNamespace(norm=norm))
+        assert _trunk_norm_module(model) is norm
+
+    def test_unmarked_language_model_wrapper(self):
+        norm = _norm()
+        inner = SimpleNamespace(model=SimpleNamespace(norm=norm))
+        model = SimpleNamespace(language_model=inner)
+        assert _trunk_norm_module(model) is norm
+
+    def test_marked_instance_returns_identity(self):
+        model = SimpleNamespace(
+            _omlx_mtp_head_hidden_normed=True,
+            model=SimpleNamespace(norm=_norm()),
+        )
+        fn = _trunk_norm_module(model)
+        sentinel = object()
+        assert fn(sentinel) is sentinel
+
+    def test_marked_inner_language_model_returns_identity(self):
+        inner = SimpleNamespace(
+            _omlx_mtp_head_hidden_normed=True,
+            model=SimpleNamespace(norm=_norm()),
+        )
+        model = SimpleNamespace(language_model=inner)
+        fn = _trunk_norm_module(model)
+        sentinel = object()
+        assert fn(sentinel) is sentinel

--- a/tests/test_nemotron_mtp_patch.py
+++ b/tests/test_nemotron_mtp_patch.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+nh = pytest.importorskip("mlx_lm.models.nemotron_h")
+
+from omlx.patches.mlx_lm_mtp import (  # noqa: E402
+    nemotron_h_chain,
+    nemotron_h_model,
+    set_mtp_active,
+)
+
+TINY_CONFIG = {
+    "model_type": "nemotron_h",
+    "vocab_size": 128,
+    "hidden_size": 64,
+    "intermediate_size": 128,
+    "num_hidden_layers": 2,
+    "max_position_embeddings": 256,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "head_dim": 16,
+    "attention_bias": False,
+    "mamba_num_heads": 4,
+    "mamba_head_dim": 16,
+    "mamba_proj_bias": False,
+    "ssm_state_size": 32,
+    "conv_kernel": 4,
+    "n_groups": 2,
+    "mlp_bias": False,
+    "layer_norm_epsilon": 1e-5,
+    "use_bias": False,
+    "use_conv_bias": True,
+    "hybrid_override_pattern": ["M", "*"],
+    "n_routed_experts": 4,
+    "num_experts_per_tok": 2,
+    "moe_intermediate_size": 32,
+    "moe_shared_expert_intermediate_size": 32,
+    "n_shared_experts": 1,
+    "n_group": 1,
+    "topk_group": 1,
+    "norm_topk_prob": True,
+    "routed_scaling_factor": 1.0,
+    "num_nextn_predict_layers": 1,
+}
+
+
+@pytest.fixture(autouse=True)
+def _apply_patches():
+    assert nemotron_h_model.apply()
+    assert nemotron_h_chain.apply()
+    yield
+    set_mtp_active(False)
+
+
+class TestApply:
+    def test_idempotent(self):
+        mixer_call = nh.NemotronHMamba2Mixer.__call__
+        assert nemotron_h_model.apply()
+        assert nemotron_h_chain.apply()
+        assert nh.NemotronHMamba2Mixer.__call__ is mixer_call
+
+    def test_markers(self):
+        assert getattr(nh.NemotronHMamba2Mixer.__call__, "_omlx_nh_chain", False)
+        assert getattr(nh.Model.mtp_forward, "_omlx_nh_chain", False)
+        assert callable(getattr(nh.Model, "mtp_partial_rollback", None))
+
+
+class TestModelStamps:
+    def test_mtp_attached_and_flagged_when_active(self):
+        set_mtp_active(True)
+        model = nh.Model(nh.ModelArgs.from_dict(TINY_CONFIG))
+        assert hasattr(model, "mtp")
+        assert model._omlx_mtp_decode_enabled
+        assert model._omlx_mtp_chain
+        assert model._omlx_mtp_head_hidden_normed
+
+    def test_no_mtp_when_inactive(self):
+        set_mtp_active(False)
+        model = nh.Model(nh.ModelArgs.from_dict(TINY_CONFIG))
+        assert not hasattr(model, "mtp")
+        assert not model._omlx_mtp_decode_enabled
+
+    def test_mtp_forward_return_hidden(self):
+        set_mtp_active(True)
+        model = nh.Model(nh.ModelArgs.from_dict(TINY_CONFIG))
+        hidden = mx.zeros((1, 1, TINY_CONFIG["hidden_size"]))
+        ids = mx.zeros((1, 1), dtype=mx.uint32)
+        cache = model.make_mtp_cache()
+        logits, head_hidden = model.mtp_forward(
+            hidden, ids, cache, return_hidden=True, logits_keep=1
+        )
+        mx.eval(logits, head_hidden)
+        assert logits.shape == (1, 1, TINY_CONFIG["vocab_size"])
+        assert head_hidden.shape == hidden.shape
+
+
+class TestVerifyCapture:
+    def _mixer_and_cache(self):
+        from mlx_lm.models.cache import ArraysCache
+
+        args = nh.ModelArgs.from_dict(TINY_CONFIG)
+        mixer = nh.NemotronHMamba2Mixer(args)
+        mx.eval(mixer.parameters())
+        return mixer, ArraysCache(size=2)
+
+    def test_per_position_restore_matches_prefix_recompute(self):
+        mx.random.seed(0)
+        mixer, cache = self._mixer_and_cache()
+        prefix = mx.random.normal((1, 3, TINY_CONFIG["hidden_size"]))
+        window = mx.random.normal((1, 4, TINY_CONFIG["hidden_size"]))
+        mx.eval(prefix, window)
+
+        # Establish state, then run a verify window with capture armed.
+        mixer(prefix, None, cache)
+        mixer(window, None, cache, n_confirmed=1)
+        assert cache._mtp_pos_states is not None
+        assert len(cache._mtp_pos_states) == 4
+
+        # Restore to keep=2 (confirmed + 1 accepted draft).
+        conv_m, ssm_m = cache._mtp_pos_states[1]
+
+        # Reference: fresh cache, prefix + the kept 2 window tokens.
+        mixer2, cache2 = self._mixer_and_cache()
+        mixer2.update(mixer.parameters())
+        mx.eval(mixer2.parameters())
+        mixer2(prefix, None, cache2)
+        mixer2(window[:, :2], None, cache2)
+        mx.eval(conv_m, ssm_m, cache2[0], cache2[1])
+
+        assert mx.allclose(conv_m, cache2[0], atol=1e-5).item()
+        assert mx.allclose(ssm_m, cache2[1], atol=1e-4, rtol=1e-3).item()

--- a/tests/test_nemotron_mtp_patch.py
+++ b/tests/test_nemotron_mtp_patch.py
@@ -54,6 +54,16 @@ def _apply_patches():
     set_mtp_active(False)
 
 
+class TestLoaderGate:
+    def test_nemotron_h_is_mtp_compatible(self):
+        # The stock loader must route nemotron_h through the MTP patch;
+        # without this gate the whole feature is inert on a stock server.
+        from omlx.utils.model_loading import _is_mtp_compatible
+
+        assert _is_mtp_compatible({"num_nextn_predict_layers": 1}, "nemotron_h")
+        assert not _is_mtp_compatible({}, "nemotron_h")
+
+
 class TestApply:
     def test_idempotent(self):
         mixer_call = nh.NemotronHMamba2Mixer.__call__


### PR DESCRIPTION
## Summary

- Adds MTP speculative decoding for `nemotron_h` (Nemotron-3-Super-120B-A12B ships a trained `mtp.*` head that mlx-lm currently discards in `sanitize`), including the depth-k Lightning MTP chain with the adaptive depth controller.
- Nemotron-H is a Mamba/Transformer hybrid (40 Mamba2 + 8 attention + 40 MoE layers), so verify rollback has to restore recurrent state, not just trim KV. The approach here makes partial rollback a pure ref restore — no replay forward.
- Measured (Nemotron-3-Super-120B, 5-bit affine, M3 Ultra), 400-token greedy generations: 44.2 tok/s no-MTP -> 51.9 tok/s (+17%), 69.8% draft acceptance; sampled t=1.1: 46.2 -> ~47-49.

## Model patch (`nemotron_h_model.py`)

Mirrors the qwen35/deepseek structure: `MTPModule` with parameter paths matching the on-disk `mtp.layers.{0,1}.*` names (fuse `eh_proj(concat(enorm(embed(t+1)), hnorm(h_t)))` -> attention sublayer -> MoE sublayer -> final norm; only routed experts stacked in `sanitize`), `mtp_forward` with the chain interface (`return_hidden`, `logits_keep`), `make_mtp_cache` (`[KVCache()]`, trimmable, so no head-clone mode), `n_confirmed` plumbing through backbone/block/mixer, and the per-instance `_omlx_mtp_decode_enabled` stamp in `__init__`.

## Verify cycle on a hybrid trunk (`nemotron_h_chain.py`)

Verify windows keep the batched projections (each layer's weights stream once for the whole window) but run the SSM scan sequentially with the existing fused single-step kernel:

- faster than the chunked `ssm_attn` graph at window sizes 2-8 (0.35 vs 0.63 ms/layer at S=2; ~40 Mamba layers per cycle);
- numerically identical to the plain decode path (same kernel), so draft/verify distributions stay aligned;
- yields per-position (conv, ssm) states as a free byproduct, so partial rollback restores `cache._mtp_pos_states[keep-1]` — no replay forward. Conv tails are reconstructed from the window input inside a `_conv` wrap; a raw-input stash + replay path remains as fallback for masked windows.

Cycle backbone: 29.5 ms vs 22.6 ms for a plain decode step (37.1 ms with the qwen35-style whole-window verify + replay); rollback cache time 15 ms vs 176 ms per 400-token run.

nemotron_h's `return_hidden` returns post-`norm_f` hidden, so the model patch stamps `_omlx_mtp_head_hidden_normed` (from #2277) to keep the chain's head inputs from being double-normed.

## Depth guidance

The stock head is depth-1-trained (sampled acceptance ~50-59%), so the loader defaults nemotron_h to a fixed depth-1 cycle (greedy 51.9 vs 46.9 with the adaptive controller). Setting `mtp_num_draft_tokens` overrides this for checkpoints with a stronger head.

## Testing

- `tests/test_nemotron_mtp_patch.py`: apply idempotence and markers, decode-flag/chain stamps on a tiny model, `mtp_forward` chain interface shapes, and per-position captured states vs a fresh prefix recompute.
- Per-position captured states vs prefix-reference runs on real shapes: ~1e-7 (fp32 state math).
- Greedy speculative output equals its non-speculative greedy stream (lossless); sampled acceptance uses the standard batched Leviathan/Chen path unchanged.
- `MTP[...]` per-sequence stats verified end to end (cycles, per-depth accepts, backbone/mtp/sample/cache timings).
- Running in production on our single-node M3 Ultra deployment.

## Issues

Builds on #2277 (branch is based on it; the first commit here is that fix).

Co-authored with Claude Fable 5 (Anthropic).

