### PR TITLE
fix(vlm): inject DeepSeek V4 DSML tool-calling into VLM tokenizer

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1777,10 +1777,15 @@ class VLMBatchedEngine(BaseEngine):
         mlx_lm's — it recognises additional markers such as Gemma4's <|tool_call>
         and loads the correct per-model parser.  Falls back to mlx_lm if the
         mlx_vlm.tool_parsers package is not present.
+
+        For models whose parser isn't in mlx_vlm/mlx_lm (e.g. DeepSeek V4 DSML),
+        fall back to omlx's bundled tool parser modules.
         """
         chat_template = getattr(tokenizer, "chat_template", None)
         if not chat_template:
             return
+
+        tool_module = None
 
         # Prefer mlx_vlm.tool_parsers (superset; knows about Gemma4 etc.)
         try:
@@ -1790,13 +1795,13 @@ class VLMBatchedEngine(BaseEngine):
             )
 
             tool_parser_type = _infer_tool_parser(chat_template)
-            if tool_parser_type is None:
-                return
-            try:
-                tool_module = load_tool_module(tool_parser_type)
-            except ImportError:
-                logger.warning(f"VLM tool parser module not found: {tool_parser_type}")
-                return
+            if tool_parser_type is not None:
+                try:
+                    tool_module = load_tool_module(tool_parser_type)
+                except ImportError:
+                    logger.warning(
+                        f"VLM tool parser module not found: {tool_parser_type}"
+                    )
         except ImportError:
             # Fallback: mlx_lm only (no Gemma4 support)
             try:
@@ -1805,18 +1810,35 @@ class VLMBatchedEngine(BaseEngine):
                 from mlx_lm.tokenizer_utils import (
                     _infer_tool_parser as _mlx_lm_infer,
                 )
+
+                tool_parser_type = _mlx_lm_infer(chat_template)
+                if tool_parser_type is not None:
+                    try:
+                        tool_module = importlib.import_module(
+                            f"mlx_lm.tool_parsers.{tool_parser_type}"
+                        )
+                    except ImportError:
+                        logger.warning(
+                            f"VLM tool parser module not found: {tool_parser_type}"
+                        )
             except ImportError:
-                return
-            tool_parser_type = _mlx_lm_infer(chat_template)
-            if tool_parser_type is None:
-                return
-            try:
-                tool_module = importlib.import_module(
-                    f"mlx_lm.tool_parsers.{tool_parser_type}"
-                )
-            except ImportError:
-                logger.warning(f"VLM tool parser module not found: {tool_parser_type}")
-                return
+                pass
+
+        # Fallback: omlx bundled parsers for models not yet upstream.
+        if tool_module is None and isinstance(chat_template, str):
+            if "<｜DSML｜tool_calls>" in chat_template:
+                try:
+                    from ..patches.deepseek_v4 import tool_parser_v4
+
+                    tool_module = tool_parser_v4
+                    tool_parser_type = "deepseek_v4"
+                except ImportError:
+                    logger.warning(
+                        "DeepSeek V4 tool parser not found in omlx patches"
+                    )
+
+        if tool_module is None:
+            return
 
         tool_call_start = tool_module.tool_call_start
         tool_call_end = tool_module.tool_call_end

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -681,6 +681,21 @@ class TestInjectToolCalling:
         assert tokenizer.has_tool_calling is True
         assert isinstance(tokenizer.tool_call_start, str)
 
+    def test_injects_deepseek_v4_dsml_fallback(self):
+        """Chat template with DSML markers → omlx bundled parser."""
+        engine = _make_engine()
+        tokenizer = MockVLMTokenizer(
+            chat_template="some template with <｜DSML｜tool_calls> markers",
+            vocab={"<｜DSML｜tool_calls>": 100, "</｜DSML｜tool_calls>": 101},
+        )
+
+        engine._inject_tool_calling(tokenizer)
+
+        assert tokenizer.has_tool_calling is True
+        assert tokenizer.tool_call_start == "<｜DSML｜tool_calls>"
+        assert tokenizer.tool_call_end == "</｜DSML｜tool_calls>"
+        assert callable(tokenizer.tool_parser)
+
 
 # ---------------------------------------------------------------------------
 # TestApplyChatTemplate


### PR DESCRIPTION
## Problem

`VLMBatchedEngine._inject_tool_calling()` depends on `mlx_vlm.tool_parsers._infer_tool_parser()` and `mlx_lm.tokenizer_utils._infer_tool_parser()` to identify the correct tool parser for a model's chat template. Neither of these upstream inference functions recognise DeepSeek V4's DSML markers (`<｜DSML｜tool_calls>`), so `_inject_tool_calling` silently returns without setting `has_tool_calling`, `tool_call_start`, `tool_call_end`, or `tool_parser` on the VLM tokenizer.

This causes downstream components (`ToolCallStreamFilter`, `parse_tool_calls`, `sanitize_tool_call_markup`) to be unable to detect and strip DSML markup from streaming deltas, thinking blocks, and final responses. Raw `<｜DSML｜tool_calls>` tags leak into the API response text visible to Claude Code and other clients.

## Fix

Added a fallback path at the end of `_inject_tool_calling`: when both `mlx_vlm` and `mlx_lm` fail to infer a parser type, check if the chat template contains `"<｜DSML｜tool_calls>"`. If it does, load `omlx.patches.deepseek_v4.tool_parser_v4` — oMLX's bundled DeepSeek V4 parser — and inject its attributes onto the tokenizer.

This follows the same pattern as the existing upstream parsers and is consistent with the existing `detect_output_parser` logic in `omlx/adapter/output_parser.py`.

## Test

Added `test_injects_deepseek_v4_dsml_fallback` to `tests/test_vlm_engine.py` that verifies the injection sets the correct `tool_call_start`, `tool_call_end`, `has_tool_calling`, and a callable `tool_parser`.

All existing tests pass:
- 8/8 `_inject_tool_calling` tests (including the new one)
- 234/234 tool_calling tests
- 3/3 DeepSeek V4 output parser tests
- 334/334 VLM engine tests

## Related

The same root cause also affects the scheduler's output parser detection timing. `_inject_tool_calling` runs after `AsyncEngineCore` creates the scheduler (which deep-copies the tokenizer), so the scheduler's copy lacks the DSML attributes. A follow-up fix would move the injection earlier in the VLM start sequence.