### PR TITLE
fix(api): pass chat template kwargs through /v1/responses

### DIFF
--- a/omlx/api/responses_models.py
+++ b/omlx/api/responses_models.py
@@ -123,6 +123,8 @@ class ResponsesRequest(BaseModel):
     stream_options: Optional[Dict[str, Any]] = None
     # Seed for reproducible generation (best-effort)
     seed: Optional[int] = None
+    # Chat template kwargs (e.g. enable_thinking, reasoning_effort)
+    chat_template_kwargs: Optional[Dict[str, Any]] = None
 
     model_config = {"extra": "allow"}
 

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -1203,21 +1203,16 @@ def forced_ct_keys(settings: "ModelSettings | None") -> set[str]:
     return set(settings.forced_ct_kwargs or [])
 
 
-def merge_chat_template_kwargs(
+def merge_chat_template_request_kwargs(
     settings: "ModelSettings | None",
     request_ct_kwargs: "dict[str, Any] | None" = None,
-    *,
-    thinking_budget: "int | None" = None,
-    preserve_thinking_default: "bool | None" = None,
 ) -> "dict[str, Any]":
-    """Resolve the effective chat_template_kwargs for prompt rendering.
+    """Merge model/profile defaults with per-request chat-template kwargs.
 
     Precedence, lowest to highest:
       1. ``settings.chat_template_kwargs``
       2. the dedicated ``enable_thinking`` / ``preserve_thinking`` toggles
       3. per-request kwargs, except keys listed in ``forced_ct_kwargs``
-      4. thinking budget activation when ``enable_thinking`` is still unset
-      5. the model's preserve-thinking default when it is supported and unset
     """
     merged: dict[str, Any] = {}
     forced_keys = forced_ct_keys(settings)
@@ -1236,6 +1231,27 @@ def merge_chat_template_kwargs(
         for key, value in request_ct_kwargs.items():
             if key not in forced_keys:
                 merged[key] = value
+
+    return merged
+
+
+def merge_chat_template_kwargs(
+    settings: "ModelSettings | None",
+    request_ct_kwargs: "dict[str, Any] | None" = None,
+    *,
+    thinking_budget: "int | None" = None,
+    preserve_thinking_default: "bool | None" = None,
+) -> "dict[str, Any]":
+    """Resolve the effective chat_template_kwargs for prompt rendering.
+
+    Precedence, lowest to highest:
+      1. ``settings.chat_template_kwargs``
+      2. the dedicated ``enable_thinking`` / ``preserve_thinking`` toggles
+      3. per-request kwargs, except keys listed in ``forced_ct_kwargs``
+      4. thinking budget activation when ``enable_thinking`` is still unset
+      5. the model's preserve-thinking default when it is supported and unset
+    """
+    merged = merge_chat_template_request_kwargs(settings, request_ct_kwargs)
 
     if (
         thinking_budget is None

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -190,6 +190,7 @@ from .exceptions import (
     PrefillMemoryExceededError,
     SchedulerQueueFullError,
 )
+from .model_settings import forced_ct_keys, merge_chat_template_request_kwargs
 from .server_metrics import get_server_metrics, reset_server_metrics
 
 logging.basicConfig(level=logging.INFO)
@@ -3191,8 +3192,6 @@ async def create_chat_completion(
 
         # Get per-model settings
         max_tool_result_tokens = None
-        merged_ct_kwargs = {}
-        forced_keys: set[str] = set()
         reasoning_parser = None
         settings_guided_grammar = None
         ms = get_model_settings_for_request(request.model)
@@ -3200,20 +3199,10 @@ async def create_chat_completion(
             max_tool_result_tokens = ms.max_tool_result_tokens
             reasoning_parser = ms.reasoning_parser
             settings_guided_grammar = _settings_guided_grammar(ms)
-            if ms.chat_template_kwargs:
-                merged_ct_kwargs.update(ms.chat_template_kwargs)
-            forced_keys = set(ms.forced_ct_kwargs or [])
-            # Dedicated enable_thinking toggle takes precedence over chat_template_kwargs
-            if ms.enable_thinking is not None:
-                merged_ct_kwargs["enable_thinking"] = ms.enable_thinking
-            # preserve_thinking: keep <think> blocks in historical turns (Qwen 3.6+)
-            if ms.preserve_thinking is not None:
-                merged_ct_kwargs["preserve_thinking"] = ms.preserve_thinking
-        # Per-request kwargs override model settings (except forced keys)
-        if request.chat_template_kwargs:
-            for k, v in request.chat_template_kwargs.items():
-                if k not in forced_keys:
-                    merged_ct_kwargs[k] = v
+        merged_ct_kwargs = merge_chat_template_request_kwargs(
+            ms,
+            request.chat_template_kwargs,
+        )
 
         # Extract messages - different engines need different content handling.
         # Templates that expose message.reasoning_content natively (Qwen 3.6+)
@@ -5116,25 +5105,14 @@ async def create_anthropic_message(
 
         # Get per-model settings
         max_tool_result_tokens = None
-        merged_ct_kwargs = {}
-        forced_keys: set[str] = set()
         ms = get_model_settings_for_request(request.model)
         if ms:
             max_tool_result_tokens = ms.max_tool_result_tokens
-            if ms.chat_template_kwargs:
-                merged_ct_kwargs.update(ms.chat_template_kwargs)
-            forced_keys = set(ms.forced_ct_kwargs or [])
-            # Dedicated enable_thinking toggle takes precedence over chat_template_kwargs
-            if ms.enable_thinking is not None:
-                merged_ct_kwargs["enable_thinking"] = ms.enable_thinking
-            # preserve_thinking: keep <think> blocks in historical turns (Qwen 3.6+)
-            if ms.preserve_thinking is not None:
-                merged_ct_kwargs["preserve_thinking"] = ms.preserve_thinking
-        # Per-request kwargs override model settings (except forced keys)
-        if request.chat_template_kwargs:
-            for k, v in request.chat_template_kwargs.items():
-                if k not in forced_keys:
-                    merged_ct_kwargs[k] = v
+        merged_ct_kwargs = merge_chat_template_request_kwargs(
+            ms,
+            request.chat_template_kwargs,
+        )
+        forced_keys = forced_ct_keys(ms)
 
         # Pass Anthropic thinking config to chat template (except forced keys)
         if hasattr(request, "thinking") and request.thinking:
@@ -5655,19 +5633,14 @@ async def create_response(
             )
 
         # Get per-model settings
-        merged_ct_kwargs = {}
         reasoning_parser = None
         ms = get_model_settings_for_request(request.model)
         if ms:
             reasoning_parser = ms.reasoning_parser
-            if ms.chat_template_kwargs:
-                merged_ct_kwargs.update(ms.chat_template_kwargs)
-            # Dedicated enable_thinking toggle takes precedence over chat_template_kwargs
-            if ms.enable_thinking is not None:
-                merged_ct_kwargs["enable_thinking"] = ms.enable_thinking
-            # preserve_thinking: keep <think> blocks in historical turns (Qwen 3.6+)
-            if ms.preserve_thinking is not None:
-                merged_ct_kwargs["preserve_thinking"] = ms.preserve_thinking
+        merged_ct_kwargs = merge_chat_template_request_kwargs(
+            ms,
+            request.chat_template_kwargs,
+        )
 
         # Note: extract_text_content/extract_harmony_messages/extract_multimodal_content
         # are NOT called here because convert_responses_input_to_messages() already

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -470,6 +470,36 @@ class TestResponsesEndpoint:
         assert data["output"][1]["content"][0]["text"] == "Hello!"
         assert data["usage"]["output_tokens_details"]["reasoning_tokens"] == 3
 
+    def test_responses_forwards_request_chat_template_kwargs(
+        self, client, mock_llm_engine
+    ):
+        recorded_chat_kwargs = []
+
+        async def chat(messages, **kwargs):
+            recorded_chat_kwargs.append(kwargs)
+            return MockGenerationOutput(
+                text="pong",
+                prompt_tokens=1,
+                completion_tokens=1,
+                finish_reason="stop",
+            )
+
+        mock_llm_engine.chat = chat
+
+        response = client.post(
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "input": "Say pong",
+                "chat_template_kwargs": {"enable_thinking": False},
+            },
+        )
+
+        assert response.status_code == 200
+        assert recorded_chat_kwargs
+        ct_kwargs = recorded_chat_kwargs[0].get("chat_template_kwargs") or {}
+        assert ct_kwargs["enable_thinking"] is False
+
     def test_response_stream_includes_reasoning_item_for_think_blocks(
         self, client, mock_llm_engine
     ):

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -587,6 +587,56 @@ class TestModelSettingsManager:
         restored = ModelSettings.from_dict(d)
         assert restored.forced_ct_kwargs == ["enable_thinking", "reasoning_effort"]
 
+    def test_merge_chat_template_request_kwargs_request_overrides_model(self):
+        """Request kwargs override model chat-template defaults."""
+        from omlx.model_settings import merge_chat_template_request_kwargs
+
+        settings = ModelSettings(
+            chat_template_kwargs={
+                "enable_thinking": True,
+                "custom_flag": "model",
+            }
+        )
+
+        merged = merge_chat_template_request_kwargs(
+            settings,
+            {"enable_thinking": False},
+        )
+
+        assert merged == {"enable_thinking": False, "custom_flag": "model"}
+
+    def test_merge_chat_template_request_kwargs_dedicated_overrides_raw(self):
+        """Dedicated model fields override model raw chat-template kwargs."""
+        from omlx.model_settings import merge_chat_template_request_kwargs
+
+        settings = ModelSettings(
+            chat_template_kwargs={"enable_thinking": False},
+            enable_thinking=True,
+        )
+
+        assert merge_chat_template_request_kwargs(settings) == {
+            "enable_thinking": True
+        }
+
+    def test_merge_chat_template_request_kwargs_respects_forced_keys(self):
+        """Forced keys block request-level chat-template overrides."""
+        from omlx.model_settings import merge_chat_template_request_kwargs
+
+        settings = ModelSettings(
+            chat_template_kwargs={
+                "enable_thinking": True,
+                "custom_flag": "model",
+            },
+            forced_ct_kwargs=["enable_thinking"],
+        )
+
+        merged = merge_chat_template_request_kwargs(
+            settings,
+            {"enable_thinking": False, "custom_flag": "request"},
+        )
+
+        assert merged == {"enable_thinking": True, "custom_flag": "request"}
+
     def test_thread_safety(self):
         """Test thread-safe access."""
         import threading

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1055,6 +1055,14 @@ class TestResponsesRequest:
         assert req.prompt_cache_key == "test-key"
         assert req.reasoning["effort"] == "high"
 
+    def test_chat_template_kwargs(self):
+        req = ResponsesRequest(
+            model="test",
+            input="Hi",
+            chat_template_kwargs={"enable_thinking": False},
+        )
+        assert req.chat_template_kwargs == {"enable_thinking": False}
+
     def test_extra_fields_allowed(self):
         """Unknown fields should not cause validation errors."""
         req = ResponsesRequest(


### PR DESCRIPTION
## Problem

`/v1/chat/completions` already supports request-level `chat_template_kwargs` correctly, but `/v1/responses` did not apply the same behavior.

For Qwen thinking control, this chat completions request works as expected:

```json
{
  "model": "Qwen3.5-9B-4bit",
  "messages": [{"role": "user", "content": "Say pong"}],
  "chat_template_kwargs": {
    "enable_thinking": false
  }
}
```

`enable_thinking=false` is merged into the kwargs passed to the tokenizer chat template, so Qwen's template disables thinking.

The analogous Responses API request did not work:

```json
{
  "model": "Qwen3.5-9B-4bit",
  "input": "Say pong",
  "chat_template_kwargs": {
    "enable_thinking": false
  }
}
```

`/v1/responses` allowed the field as an unknown extra, but it did not define or merge `request.chat_template_kwargs` into the prompt-rendering path. As a result, callers could not disable Qwen thinking through `/v1/responses` using the same mechanism that already works for `/v1/chat/completions`.

## Fix

- Add `chat_template_kwargs` to `ResponsesRequest`.
- Extract the existing model/request chat-template kwarg merge behavior into `merge_chat_template_request_kwargs()`.
- Use that helper from `/v1/chat/completions`, `/v1/messages`, and `/v1/responses`, so Responses follows the same precedence as the already-working chat completions path:

```text
model chat_template_kwargs
< model dedicated enable_thinking / preserve_thinking settings
< request chat_template_kwargs
```

with existing `forced_ct_kwargs` still preventing request overrides for forced keys.

## Tests

Automated tests:

- `PYTHONPATH=. .venv/bin/pytest tests/test_model_settings.py tests/test_responses.py -q`
- `PYTHONPATH=. python -m pytest tests/test_model_settings.py tests/test_responses.py tests/integration/test_server_endpoints.py::TestResponsesEndpoint::test_responses_forwards_request_chat_template_kwargs -q`

Manual local smoke test on Apple Silicon / MLX:

- Started local server with `Qwen3.5-9B-4bit` from `~/.omlx/models`.
- Confirmed `GET /health` returned healthy and default model `Qwen3.5-9B-4bit`.
- Confirmed `GET /v1/models` listed `Qwen3.5-9B-4bit`.
- Called `/v1/responses` with:

```json
{
  "model": "Qwen3.5-9B-4bit",
  "input": "Say pong",
  "chat_template_kwargs": {
    "enable_thinking": false
  }
}
```

Result: response contained only a message output, no reasoning item, and `output_tokens_details.reasoning_tokens` was `0`.

Control request without `chat_template_kwargs` returned a reasoning item and `output_tokens_details.reasoning_tokens` was `408`, confirming that the new `/v1/responses` request kwarg is actually disabling Qwen thinking.
