### PR TITLE
fix(specprefill): forward SpecPrefill kwargs on the non-streaming path (#2274)

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -622,6 +622,66 @@ class BatchedEngine(BaseEngine):
         )
         return len(self._tokenizer.encode(prompt))
 
+    @staticmethod
+    def _pop_specprefill_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Pop SpecPrefill per-request overrides out of ``kwargs``.
+
+        The engine's ``add_request`` accepts these as dedicated arguments, so
+        they must be forwarded explicitly rather than left in ``**kwargs``.
+        Shared by ``generate`` and ``stream_generate`` so both request paths
+        honour SpecPrefill overrides identically.
+        """
+        specprefill_kwargs: dict[str, Any] = {}
+        for key in (
+            "specprefill",
+            "specprefill_keep_pct",
+            "specprefill_threshold",
+            "specprefill_system_end",
+        ):
+            if kwargs.get(key) is not None:
+                specprefill_kwargs[key] = kwargs.pop(key)
+        return specprefill_kwargs
+
+    def _inject_specprefill_system_end(
+        self,
+        messages: list[dict[str, Any]],
+        prompt: str,
+        template_tools: Any,
+        ct_kwargs: dict[str, Any] | None,
+        kwargs: dict[str, Any],
+    ) -> None:
+        """Compute the system-prompt token boundary and add it to ``kwargs``.
+
+        SpecPrefill protects the system-prompt region from token dropping. The
+        boundary is derived by subtracting the non-system prompt token count
+        from the full prompt token count (system-only messages usually can't be
+        templated on their own). Shared by ``chat`` and ``stream_chat`` so the
+        non-streaming path protects the system prompt identically. No-op unless
+        the model has SpecPrefill enabled and the request has a system prompt.
+        """
+        specprefill_model_enabled = (
+            getattr(self._model_settings, "specprefill_enabled", False)
+            if self._model_settings
+            else False
+        )
+        if not (specprefill_model_enabled and kwargs.get("specprefill") is not False):
+            return
+        non_system = [
+            m for m in messages if m.get("role") not in ("system", "developer")
+        ]
+        if len(non_system) < len(messages) and non_system:
+            try:
+                non_system_prompt = self._apply_chat_template(
+                    non_system, template_tools, chat_template_kwargs=ct_kwargs
+                )
+                full_tokens = len(self._tokenizer.encode(prompt))
+                non_system_tokens = len(self._tokenizer.encode(non_system_prompt))
+                system_end = full_tokens - non_system_tokens
+                if system_end > 0:
+                    kwargs["specprefill_system_end"] = system_end
+            except Exception as e:
+                logger.debug(f"SpecPrefill: system_end calc failed: {e}")
+
     async def generate(
         self,
         prompt: str,
@@ -675,9 +735,14 @@ class BatchedEngine(BaseEngine):
             seed=kwargs.get("seed", None),
         )
 
+        # SpecPrefill: forward per-request overrides to the engine, mirroring
+        # stream_generate so the non-streaming path is not silently ignored.
+        specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
+
         output = await self._engine.generate(
             prompt=prompt,
             sampling_params=sampling_params,
+            **specprefill_kwargs,
         )
 
         text = clean_special_tokens(output.output_text)
@@ -746,21 +811,7 @@ class BatchedEngine(BaseEngine):
         )
 
         # SpecPrefill: pass per-request overrides to engine
-        specprefill_kwargs = {}
-        if kwargs.get("specprefill") is not None:
-            specprefill_kwargs["specprefill"] = kwargs.pop("specprefill")
-        if kwargs.get("specprefill_keep_pct") is not None:
-            specprefill_kwargs["specprefill_keep_pct"] = kwargs.pop(
-                "specprefill_keep_pct"
-            )
-        if kwargs.get("specprefill_threshold") is not None:
-            specprefill_kwargs["specprefill_threshold"] = kwargs.pop(
-                "specprefill_threshold"
-            )
-        if kwargs.get("specprefill_system_end") is not None:
-            specprefill_kwargs["specprefill_system_end"] = kwargs.pop(
-                "specprefill_system_end"
-            )
+        specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
 
         engine = self._engine
         request_id = await engine.add_request(
@@ -858,6 +909,11 @@ class BatchedEngine(BaseEngine):
             template_tools,
             chat_template_kwargs=ct_kwargs,
             is_partial=partial,
+        )
+
+        # SpecPrefill: protect the system-prompt region, mirroring stream_chat.
+        self._inject_specprefill_system_end(
+            messages, prompt, template_tools, ct_kwargs, kwargs
         )
 
         return await self.generate(
@@ -1011,30 +1067,10 @@ class BatchedEngine(BaseEngine):
             is_partial=partial,
         )
 
-        # SpecPrefill: compute system prompt token count for protection.
-        # Can't template system-only messages (most templates require user),
-        # so compute by subtracting non-system from full prompt tokens.
-        specprefill_model_enabled = (
-            getattr(self._model_settings, "specprefill_enabled", False)
-            if self._model_settings
-            else False
+        # SpecPrefill: protect the system-prompt region from token dropping.
+        self._inject_specprefill_system_end(
+            messages, prompt, template_tools, ct_kwargs, kwargs
         )
-        if specprefill_model_enabled and kwargs.get("specprefill") is not False:
-            non_system = [
-                m for m in messages if m.get("role") not in ("system", "developer")
-            ]
-            if len(non_system) < len(messages) and non_system:
-                try:
-                    non_system_prompt = self._apply_chat_template(
-                        non_system, template_tools, chat_template_kwargs=ct_kwargs
-                    )
-                    full_tokens = len(self._tokenizer.encode(prompt))
-                    non_system_tokens = len(self._tokenizer.encode(non_system_prompt))
-                    system_end = full_tokens - non_system_tokens
-                    if system_end > 0:
-                        kwargs["specprefill_system_end"] = system_end
-                except Exception as e:
-                    logger.debug(f"SpecPrefill: system_end calc failed: {e}")
 
         async for output in self.stream_generate(
             prompt=prompt,

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -807,3 +807,143 @@ class TestApplyChatTemplatePartialMode:
         # continue_final_message=True (not add_generation_prompt=True).
         assert count_kwargs["continue_final_message"] is True
         assert count_kwargs["add_generation_prompt"] is False
+
+
+class TestBatchedEngineSpecPrefillForwarding:
+    """Non-streaming path must forward SpecPrefill overrides (issue #2274).
+
+    The synchronous generate()/chat() methods previously dropped SpecPrefill
+    kwargs, so a configured keep_pct silently fell back to the engine default.
+    """
+
+    @staticmethod
+    def _fake_output():
+        return SimpleNamespace(
+            output_text="hi",
+            prompt_tokens=5,
+            completion_tokens=2,
+            finish_reason="stop",
+            tool_calls=None,
+            cached_tokens=0,
+            first_token_at=None,
+        )
+
+    def test_pop_specprefill_kwargs_extracts_and_pops(self):
+        from omlx.engine.batched import BatchedEngine
+
+        kwargs = {
+            "specprefill_keep_pct": 0.25,
+            "specprefill_threshold": 100,
+            "specprefill_system_end": 12,
+            "specprefill": True,
+            "temperature": 0.7,
+        }
+        extracted = BatchedEngine._pop_specprefill_kwargs(kwargs)
+
+        assert extracted == {
+            "specprefill_keep_pct": 0.25,
+            "specprefill_threshold": 100,
+            "specprefill_system_end": 12,
+            "specprefill": True,
+        }
+        # Popped out of the original dict; unrelated kwargs are untouched.
+        assert kwargs == {"temperature": 0.7}
+
+    def test_pop_specprefill_kwargs_ignores_none_values(self):
+        from omlx.engine.batched import BatchedEngine
+
+        kwargs = {"specprefill_keep_pct": None, "specprefill": None}
+        assert BatchedEngine._pop_specprefill_kwargs(kwargs) == {}
+
+    @pytest.mark.asyncio
+    async def test_generate_forwards_specprefill_kwargs(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        engine._loaded = True
+        engine._engine = SimpleNamespace(
+            generate=AsyncMock(return_value=self._fake_output())
+        )
+
+        await engine.generate(
+            "a prompt",
+            specprefill_keep_pct=0.25,
+            specprefill_threshold=100,
+        )
+
+        call_kwargs = engine._engine.generate.call_args.kwargs
+        assert call_kwargs["specprefill_keep_pct"] == 0.25
+        assert call_kwargs["specprefill_threshold"] == 100
+
+    @pytest.mark.asyncio
+    async def test_generate_omits_specprefill_when_absent(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        engine._loaded = True
+        engine._engine = SimpleNamespace(
+            generate=AsyncMock(return_value=self._fake_output())
+        )
+
+        await engine.generate("a prompt")
+
+        call_kwargs = engine._engine.generate.call_args.kwargs
+        assert "specprefill_keep_pct" not in call_kwargs
+        assert "specprefill_threshold" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_chat_injects_specprefill_system_end(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        engine._loaded = True
+        engine._model_settings = SimpleNamespace(specprefill_enabled=True)
+        engine._preprocess_messages = lambda m: m
+        engine._engine = SimpleNamespace(
+            generate=AsyncMock(return_value=self._fake_output())
+        )
+
+        # Full (system+user) prompt renders longer than the non-system prompt,
+        # so system_end = full_tokens - non_system_tokens = 10 - 4 = 6.
+        def fake_template(msgs, *args, **kwargs):
+            has_system = any(m["role"] == "system" for m in msgs)
+            return "SYS_AND_USER" if has_system else "USER_ONLY"
+
+        engine._apply_chat_template = fake_template
+        engine._tokenizer = MagicMock()
+        engine._tokenizer.encode.side_effect = lambda text: (
+            [0] * 10 if "SYS" in text else [0] * 4
+        )
+
+        messages = [
+            {"role": "system", "content": "you are helpful"},
+            {"role": "user", "content": "hello"},
+        ]
+        await engine.chat(messages)
+
+        call_kwargs = engine._engine.generate.call_args.kwargs
+        assert call_kwargs["specprefill_system_end"] == 6
+
+    @pytest.mark.asyncio
+    async def test_chat_skips_system_end_when_specprefill_disabled(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        engine._loaded = True
+        engine._model_settings = SimpleNamespace(specprefill_enabled=False)
+        engine._preprocess_messages = lambda m: m
+        engine._apply_chat_template = lambda msgs, *a, **k: "PROMPT"
+        engine._tokenizer = MagicMock()
+        engine._tokenizer.encode.side_effect = lambda text: [0] * 8
+        engine._engine = SimpleNamespace(
+            generate=AsyncMock(return_value=self._fake_output())
+        )
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+        ]
+        await engine.chat(messages)
+
+        call_kwargs = engine._engine.generate.call_args.kwargs
+        assert "specprefill_system_end" not in call_kwargs


### PR DESCRIPTION


BatchedEngine.generate() dropped specprefill_* overrides and chat() skipped the specprefill_system_end computation, so non-streaming requests fell back to the engine's default keep rate and left the system prompt unprotected. Streaming requests were unaffected.

Factor the shared logic into _pop_specprefill_kwargs() and _inject_specprefill_system_end() helpers and use them in both the streaming and non-streaming paths so they behave identically. Add unit tests covering the non-streaming forwarding and system-end computation.

