### PR TITLE
fix(oq): use compatible loader for oQe calibration

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -5714,7 +5714,7 @@ def _collect_imatrix(
 
             tokenizer = load_tokenizer(Path(model_path))
         else:
-            from mlx_lm import load as lm_load
+            from omlx.utils.model_loading import lm_load_compat as lm_load
 
             model, tokenizer = lm_load(
                 model_path,

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -3956,6 +3956,29 @@ class TestMeasureSensitivityVlmMtp:
         assert mock_load.call_args.kwargs["trust_remote_code"] is True
 
 
+class TestCollectImatrixTextLoad:
+    def test_uses_compat_loader_without_trust_remote_code(self, monkeypatch):
+        """oQe calibration works with current mlx-lm, which removed this kwarg."""
+        from omlx import oq as oq_mod
+        import omlx.utils.model_loading as real_ml
+
+        mock_load = MagicMock(return_value=(MagicMock(), MagicMock()))
+        monkeypatch.setitem(sys.modules, "mlx_lm", MagicMock(load=mock_load))
+        monkeypatch.setattr(real_ml, "_LM_LOAD_ACCEPTS_TRC", False)
+        monkeypatch.setattr(real_ml, "_has_mtp_heads", MagicMock(return_value=False))
+        monkeypatch.setattr(
+            real_ml, "_checkpoint_has_mtp_weights", MagicMock(return_value=False)
+        )
+        monkeypatch.setattr(real_ml, "maybe_apply_pre_load_patches", MagicMock())
+        monkeypatch.setattr(
+            oq_mod, "_collect_imatrix_from_model", MagicMock(return_value=({}, {}))
+        )
+
+        oq_mod._collect_imatrix("/fake/text", {}, trust_remote_code=True)
+
+        assert "trust_remote_code" not in mock_load.call_args.kwargs
+
+
 class TestMeasureSensitivityQuantizedVlm:
     def test_quantized_vlm_proxy_uses_vlm_loader(self, monkeypatch):
         from omlx import oq as oq_mod


### PR DESCRIPTION
## Summary
- route oQe text-model calibration through `lm_load_compat`
- preserve `trust_remote_code` forwarding on older mlx-lm versions while omitting the removed keyword on current mlx-lm
- add a regression test for the current mlx-lm loader signature

## Root cause
The oQe imatrix path called `mlx_lm.load` directly. Current mlx-lm no longer accepts `trust_remote_code`, causing calibration to fail after the RAM-safe proxy had been built. Other oQ paths already use the compatibility wrapper.

## Validation
- `.venv/bin/python -m pytest tests/test_oq.py::TestCollectImatrixTextLoad tests/test_oq.py::TestMeasureSensitivityVlmMtp -q`
- Result: 9 passed