### PR TITLE
Add live menubar inference and system stats, plus appearance pane

### DIFF
--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -11,6 +11,522 @@
         }
       }
     },
+    "appearance.row.alltime_activity" : {
+      "comment" : "Appearance row label for the ALL menubar item toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All Time Activity"
+          }
+        }
+      }
+    },
+    "appearance.row.alltime_activity.sub" : {
+      "comment" : "Appearance row sublabel for the ALL menubar item toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Average speeds across all sessions (ALL)."
+          }
+        }
+      }
+    },
+    "appearance.row.average_activity" : {
+      "comment" : "Appearance row label for the AVG menubar item toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Average Session Activity"
+          }
+        }
+      }
+    },
+    "appearance.row.average_activity.sub" : {
+      "comment" : "Appearance row sublabel for the AVG menubar item toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Average speeds since the server started (AVG)."
+          }
+        }
+      }
+    },
+    "appearance.row.cpu_item" : {
+      "comment" : "Appearance row label for the CPU usage bar menubar item toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CPU"
+          }
+        }
+      }
+    },
+    "appearance.row.cpu_item.sub" : {
+      "comment" : "Appearance row sublabel for the CPU usage bar menubar item toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CPU usage as a vertical bar."
+          }
+        }
+      }
+    },
+    "appearance.row.gpu_item" : {
+      "comment" : "Appearance row label for the GPU usage bar menubar item toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GPU"
+          }
+        }
+      }
+    },
+    "appearance.row.gpu_item.sub" : {
+      "comment" : "Appearance row sublabel for the GPU usage bar menubar item toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GPU usage as a vertical bar."
+          }
+        }
+      }
+    },
+    "appearance.row.live_activity" : {
+      "comment" : "Appearance row label for the LIV menubar item toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Activity"
+          }
+        }
+      }
+    },
+    "appearance.row.live_activity.sub" : {
+      "comment" : "Appearance row sublabel for the LIV menubar item toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Current speeds across running requests (LIV)."
+          }
+        }
+      }
+    },
+    "appearance.row.memory_item" : {
+      "comment" : "Appearance row label for the memory usage bar menubar item toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memory"
+          }
+        }
+      }
+    },
+    "appearance.row.memory_item.sub" : {
+      "comment" : "Appearance row sublabel for the memory usage bar menubar item toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memory usage as a vertical bar (MEM)."
+          }
+        }
+      }
+    },
+    "appearance.row.refresh_interval" : {
+      "comment" : "Appearance row label for the menubar refresh cadence picker",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh Interval"
+          }
+        }
+      }
+    },
+    "appearance.row.refresh_interval.sub" : {
+      "comment" : "Appearance row sublabel for the menubar refresh cadence picker",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How often menu bar items and their graphs update."
+          }
+        }
+      }
+    },
+    "appearance.row.show_dock_icon" : {
+      "comment" : "Appearance row label for the permanent Dock icon toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Dock Icon"
+          }
+        }
+      }
+    },
+    "appearance.row.show_dock_icon.sub" : {
+      "comment" : "Appearance row sublabel for the permanent Dock icon toggle",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep the Dock icon visible even when no window is open."
+          }
+        }
+      }
+    },
+    "appearance.section.general" : {
+      "comment" : "Appearance screen section header for the basic options",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
+        }
+      }
+    },
+    "appearance.section.menubar_items" : {
+      "comment" : "Appearance screen section header for the metric item toggles",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menu Bar Items"
+          }
+        }
+      }
+    },
+    "appearance.section.menubar_items.sub" : {
+      "comment" : "Appearance screen section subtitle explaining the metric items",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Each item shows prompt-processing and token-generation speed in the menu bar. Click one for details and a live graph."
+          }
+        }
+      }
+    },
+    "menubar.item.system_stats" : {
+      "comment" : "Menubar parent item opening the CPU/GPU/Memory submenu",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System Stats"
+          }
+        }
+      }
+    },
+    "menubar.metric.activity" : {
+      "comment" : "Header above the throughput graphs in a menubar metric popover",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activity"
+          }
+        }
+      }
+    },
+    "menubar.metric.dashboard" : {
+      "comment" : "Button in a menubar metric popover that opens the web dashboard",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dashboard"
+          }
+        }
+      }
+    },
+    "menubar.metric.live_unavailable" : {
+      "comment" : "Note in the LIV popover when live stats need admin authentication",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Set an API key to enable live activity"
+          }
+        }
+      }
+    },
+    "menubar.metric.server_off" : {
+      "comment" : "Note in a menubar metric popover while the server is not running",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server is off"
+          }
+        }
+      }
+    },
+    "menubar.metric.settings" : {
+      "comment" : "Button in a menubar metric popover that opens the Appearance settings pane",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        }
+      }
+    },
+    "menubar.metric.title.alltime" : {
+      "comment" : "Popover title for the all-time-average menubar item",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All Time"
+          }
+        }
+      }
+    },
+    "menubar.metric.title.average" : {
+      "comment" : "Popover title for the session-average menubar item",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Average Session"
+          }
+        }
+      }
+    },
+    "menubar.metric.title.live" : {
+      "comment" : "Popover title for the live-throughput menubar item",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Activity"
+          }
+        }
+      }
+    },
+    "menubar.system.active" : {
+      "comment" : "Memory panel legend row for active memory",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active"
+          }
+        }
+      }
+    },
+    "menubar.system.compressed" : {
+      "comment" : "Memory panel legend row for compressed memory",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compressed"
+          }
+        }
+      }
+    },
+    "menubar.system.cpu_caption" : {
+      "comment" : "CPU panel caption under the usage bars",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E (amber) / P (blue) usage"
+          }
+        }
+      }
+    },
+    "menubar.system.e_cores" : {
+      "comment" : "CPU panel row label for efficiency-core usage",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E-cores"
+          }
+        }
+      }
+    },
+    "menubar.system.free" : {
+      "comment" : "Memory panel legend row for free memory",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Free"
+          }
+        }
+      }
+    },
+    "menubar.system.gpu_caption" : {
+      "comment" : "GPU panel caption under the usage bars",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GPU (green) / GPU mem (cyan)"
+          }
+        }
+      }
+    },
+    "menubar.system.gpu_memory" : {
+      "comment" : "GPU panel row label for accelerator in-use memory",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GPU memory"
+          }
+        }
+      }
+    },
+    "menubar.system.in_use" : {
+      "comment" : "GPU memory value; placeholder is a byte size like 2.60 GB",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ in use"
+          }
+        }
+      }
+    },
+    "menubar.system.load_avg" : {
+      "comment" : "CPU panel row label for the 1/5/15-minute load averages",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Load avg"
+          }
+        }
+      }
+    },
+    "menubar.system.memory_title" : {
+      "comment" : "Title of the Memory panel in the System Stats submenu",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Memory"
+          }
+        }
+      }
+    },
+    "menubar.system.p_cores" : {
+      "comment" : "CPU panel row label for performance-core usage",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "P-cores"
+          }
+        }
+      }
+    },
+    "menubar.system.thermal" : {
+      "comment" : "CPU panel row label for the system thermal state",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thermal"
+          }
+        }
+      }
+    },
+    "menubar.system.uptime" : {
+      "comment" : "CPU panel row label for system uptime",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uptime"
+          }
+        }
+      }
+    },
+    "menubar.system.wired" : {
+      "comment" : "Memory panel legend row for wired memory",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wired"
+          }
+        }
+      }
+    },
+    "sidebar.appearance" : {
+      "comment" : "Sidebar row label / navigation title for the Appearance section",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appearance"
+          }
+        }
+      }
+    },
     "—" : {
       "localizations" : {
         "ru" : {
@@ -4874,24 +5390,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Настройки…"
-          }
-        }
-      }
-    },
-    "menubar.item.show_live_activity_in_menu_bar" : {
-      "comment" : "Menubar item that toggles current request activity text beside the oMLX icon",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Live Activity in Menu Bar"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показывать активность в строке меню"
           }
         }
       }

--- a/apps/omlx-mac/Sources/App/AppDelegate.swift
+++ b/apps/omlx-mac/Sources/App/AppDelegate.swift
@@ -55,6 +55,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// the user can click it to bring the window back.
     private var dropDockIconOnNextClose: Bool = false
 
+    /// Appearance → "Show Dock Icon". While true, every `.accessory` drop is
+    /// suppressed so the Dock icon stays up with no window open.
+    private var dockIconAlwaysVisible: Bool {
+        MenubarMetricPrefs.showDockIcon
+    }
+
+    /// Last value of the pref that was acted on, so the chatty
+    /// UserDefaults notification only triggers policy work on real flips.
+    private var lastAppliedDockIconPref: Bool?
+
     func requestQuit() {
         explicitQuitRequested = true
         NSApp.terminate(nil)
@@ -73,7 +83,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // If close() was vetoed and only orderOut hid the window,
         // willCloseNotification didn't fire — drop policy explicitly.
         let stillVisible = NSApp.windows.contains { $0.styleMask.contains(.titled) && $0.isVisible }
-        if !stillVisible {
+        if !stillVisible, !dockIconAlwaysVisible {
             NSApp.setActivationPolicy(.accessory)
         }
         dropDockIconOnNextClose = false
@@ -127,6 +137,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         installWindowObservers()
+        // Seed without applying: launch flow (accessory flip / welcome)
+        // owns the initial policy; only later real flips act.
+        lastAppliedDockIconPref = dockIconAlwaysVisible
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(defaultsDidChange(_:)),
+            name: UserDefaults.didChangeNotification,
+            object: UserDefaults.standard
+        )
         services.updates.setTerminateForUpdate { [weak self] in
             if let self {
                 self.requestQuit()
@@ -225,8 +244,41 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self.presentAppView()
             },
             openAppView: { [weak self] in self?.presentAppView() },
+            openAppearanceSettings: { [weak self] in
+                guard let self else { return }
+                self.services.requestedSection = .appearance
+                self.presentAppView()
+            },
             requestQuit:  { [weak self] in self?.requestQuit() }
         )
+    }
+
+    /// UserDefaults writes can come from any thread; hop before touching
+    /// the activation policy.
+    @objc nonisolated private func defaultsDidChange(_ note: Notification) {
+        Task { @MainActor in
+            self.applyDockIconPreference()
+        }
+    }
+
+    /// Applies a "Show Dock Icon" flip immediately: ON shows the icon right
+    /// away; OFF returns to menubar-only unless a window is currently open
+    /// (then the regular auto rule takes over on its next close).
+    private func applyDockIconPreference() {
+        let pref = dockIconAlwaysVisible
+        guard pref != lastAppliedDockIconPref else { return }
+        lastAppliedDockIconPref = pref
+
+        if pref {
+            if NSApp.activationPolicy() != .regular {
+                NSApp.setActivationPolicy(.regular)
+            }
+            return
+        }
+        let anyVisible = NSApp.windows.contains { $0.isVisible && isAppOwnedWindow($0) }
+        if !anyVisible, NSApp.activationPolicy() != .accessory {
+            NSApp.setActivationPolicy(.accessory)
+        }
     }
 
     private func bootstrapServer(config: AppConfig) {
@@ -272,7 +324,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Defer the policy flip so the status item has time to register
         // with WindowServer before we hide the Dock icon (mirrors
         // switchToAccessoryPolicy_ in app.py:324-327).
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
+            guard self?.dockIconAlwaysVisible != true else { return }
             NSApp.setActivationPolicy(.accessory)
             NSApp.activate(ignoringOtherApps: true)
         }
@@ -332,7 +385,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // Dock Quit / Welcome wizard finish). Red-button close keeps the
             // Dock icon up so clicking it can re-open the window via
             // applicationShouldHandleReopen.
-            if !stillVisible, shouldDropDockIcon {
+            if !stillVisible, shouldDropDockIcon, !self.dockIconAlwaysVisible {
                 NSApp.setActivationPolicy(.accessory)
             }
         }

--- a/apps/omlx-mac/Sources/AppView/AppSection.swift
+++ b/apps/omlx-mac/Sources/AppView/AppSection.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 enum AppSection: String, Hashable, CaseIterable, Identifiable, Sendable {
-    case server, status, network, performance, logs
+    case server, status, appearance, network, performance, logs
     case models, downloads, integrations, quantization
     case throughputBench, accuracyBench
     case security, about
@@ -34,6 +34,10 @@ enum AppSection: String, Hashable, CaseIterable, Identifiable, Sendable {
             return String(localized: "sidebar.status",
                           defaultValue: "Status",
                           comment: "Sidebar row label / navigation title for the Status section")
+        case .appearance:
+            return String(localized: "sidebar.appearance",
+                          defaultValue: "Appearance",
+                          comment: "Sidebar row label / navigation title for the Appearance section")
         case .logs:
             return String(localized: "sidebar.logs",
                           defaultValue: "Logs",
@@ -79,6 +83,7 @@ enum AppSection: String, Hashable, CaseIterable, Identifiable, Sendable {
         case .network:         return "network"
         case .performance:     return "bolt.fill"
         case .status:          return "gauge.with.dots.needle.50percent"
+        case .appearance:      return "paintbrush"
         case .logs:            return "scroll"
         case .models:          return "cube.transparent"
         case .downloads:       return "icloud.and.arrow.down"

--- a/apps/omlx-mac/Sources/AppView/AppView.swift
+++ b/apps/omlx-mac/Sources/AppView/AppView.swift
@@ -98,6 +98,7 @@ struct AppView: View {
     private func screen(for section: AppSection) -> some View {
         switch section {
         case .server:       ServerScreen()
+        case .appearance:   AppearanceScreen()
         case .network:      NetworkScreen()
         case .performance:  PerformanceScreen()
         case .status:       StatusScreen()
@@ -441,6 +442,7 @@ private struct SettingsSidebar: View {
         List(selection: $selection) {
             Section {
                 SidebarRow(section: .status)
+                SidebarRow(section: .appearance)
                 SidebarRow(section: .server)
                 SidebarRow(section: .network)
                 SidebarRow(section: .performance)

--- a/apps/omlx-mac/Sources/AppView/Screens/AppearanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/AppearanceScreen.swift
@@ -1,0 +1,196 @@
+// Appearance pane: menubar refresh cadence, the Dock-icon override, and the
+// per-metric menubar item toggles. Everything here is app-local UserDefaults
+// (settings.json is server-owned); the menubar controller and AppDelegate
+// pick changes up through the UserDefaults change notification, so the
+// screen needs no view model and no onChange plumbing.
+
+import SwiftUI
+
+struct AppearanceScreen: View {
+    @AppStorage(MenubarMetricPrefs.refreshIntervalKey)
+    private var refreshInterval = 1.0
+    @AppStorage(MenubarMetricPrefs.showDockIconKey)
+    private var showDockIcon = false
+    @AppStorage(MenubarMetricPrefs.liveKey)
+    private var showLiveActivity = false
+    @AppStorage(MenubarMetricPrefs.averageKey)
+    private var showAverageActivity = false
+    @AppStorage(MenubarMetricPrefs.alltimeKey)
+    private var showAlltimeActivity = false
+    @AppStorage(MenubarMetricPrefs.cpuItemKey)
+    private var showCPUItem = false
+    @AppStorage(MenubarMetricPrefs.gpuItemKey)
+    private var showGPUItem = false
+    @AppStorage(MenubarMetricPrefs.memoryItemKey)
+    private var showMemoryItem = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SectionHeader(String(
+                localized: "appearance.section.general",
+                defaultValue: "General",
+                comment: "Appearance screen section header for the basic options"
+            ))
+            ListGroup {
+                Row(
+                    label: String(
+                        localized: "appearance.row.refresh_interval",
+                        defaultValue: "Refresh Interval",
+                        comment: "Appearance row label for the menubar refresh cadence picker"
+                    ),
+                    sublabel: String(
+                        localized: "appearance.row.refresh_interval.sub",
+                        defaultValue: "How often menu bar items and their graphs update.",
+                        comment: "Appearance row sublabel for the menubar refresh cadence picker"
+                    )
+                ) {
+                    Popup(selection: $refreshInterval, width: 110, options: [
+                        (0.5, "0.5 s"),
+                        (1.0, "1 s"),
+                        (2.0, "2 s"),
+                        (3.0, "3 s"),
+                    ])
+                }
+                Row(
+                    label: String(
+                        localized: "appearance.row.show_dock_icon",
+                        defaultValue: "Show Dock Icon",
+                        comment: "Appearance row label for the permanent Dock icon toggle"
+                    ),
+                    sublabel: String(
+                        localized: "appearance.row.show_dock_icon.sub",
+                        defaultValue: "Keep the Dock icon visible even when no window is open.",
+                        comment: "Appearance row sublabel for the permanent Dock icon toggle"
+                    ),
+                    isLast: true
+                ) {
+                    Toggle("", isOn: $showDockIcon)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                }
+            }
+
+            SectionHeader(
+                String(
+                    localized: "appearance.section.menubar_items",
+                    defaultValue: "Menu Bar Items",
+                    comment: "Appearance screen section header for the metric item toggles"
+                ),
+                subtitle: String(
+                    localized: "appearance.section.menubar_items.sub",
+                    defaultValue: "Each item shows prompt-processing and token-generation speed in the menu bar. Click one for details and a live graph.",
+                    comment: "Appearance screen section subtitle explaining the metric items"
+                )
+            )
+            .padding(.top, 18)
+            ListGroup {
+                Row(
+                    label: String(
+                        localized: "appearance.row.live_activity",
+                        defaultValue: "Live Activity",
+                        comment: "Appearance row label for the LIV menubar item toggle"
+                    ),
+                    sublabel: String(
+                        localized: "appearance.row.live_activity.sub",
+                        defaultValue: "Current speeds across running requests (LIV).",
+                        comment: "Appearance row sublabel for the LIV menubar item toggle"
+                    )
+                ) {
+                    Toggle("", isOn: $showLiveActivity)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                }
+                Row(
+                    label: String(
+                        localized: "appearance.row.average_activity",
+                        defaultValue: "Average Session Activity",
+                        comment: "Appearance row label for the AVG menubar item toggle"
+                    ),
+                    sublabel: String(
+                        localized: "appearance.row.average_activity.sub",
+                        defaultValue: "Average speeds since the server started (AVG).",
+                        comment: "Appearance row sublabel for the AVG menubar item toggle"
+                    )
+                ) {
+                    Toggle("", isOn: $showAverageActivity)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                }
+                Row(
+                    label: String(
+                        localized: "appearance.row.alltime_activity",
+                        defaultValue: "All Time Activity",
+                        comment: "Appearance row label for the ALL menubar item toggle"
+                    ),
+                    sublabel: String(
+                        localized: "appearance.row.alltime_activity.sub",
+                        defaultValue: "Average speeds across all sessions (ALL).",
+                        comment: "Appearance row sublabel for the ALL menubar item toggle"
+                    )
+                ) {
+                    Toggle("", isOn: $showAlltimeActivity)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                }
+                Row(
+                    label: String(
+                        localized: "appearance.row.cpu_item",
+                        defaultValue: "CPU",
+                        comment: "Appearance row label for the CPU usage bar menubar item toggle"
+                    ),
+                    sublabel: String(
+                        localized: "appearance.row.cpu_item.sub",
+                        defaultValue: "CPU usage as a vertical bar.",
+                        comment: "Appearance row sublabel for the CPU usage bar menubar item toggle"
+                    )
+                ) {
+                    Toggle("", isOn: $showCPUItem)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                }
+                Row(
+                    label: String(
+                        localized: "appearance.row.gpu_item",
+                        defaultValue: "GPU",
+                        comment: "Appearance row label for the GPU usage bar menubar item toggle"
+                    ),
+                    sublabel: String(
+                        localized: "appearance.row.gpu_item.sub",
+                        defaultValue: "GPU usage as a vertical bar.",
+                        comment: "Appearance row sublabel for the GPU usage bar menubar item toggle"
+                    )
+                ) {
+                    Toggle("", isOn: $showGPUItem)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                }
+                Row(
+                    label: String(
+                        localized: "appearance.row.memory_item",
+                        defaultValue: "Memory",
+                        comment: "Appearance row label for the memory usage bar menubar item toggle"
+                    ),
+                    sublabel: String(
+                        localized: "appearance.row.memory_item.sub",
+                        defaultValue: "Memory usage as a vertical bar (MEM).",
+                        comment: "Appearance row sublabel for the memory usage bar menubar item toggle"
+                    ),
+                    isLast: true
+                ) {
+                    Toggle("", isOn: $showMemoryItem)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                }
+            }
+        }
+    }
+}
+
+#Preview("AppearanceScreen") {
+    ScrollView {
+        AppearanceScreen()
+            .padding(24)
+    }
+    .frame(width: 640, height: 520)
+    .omlxThemed()
+}

--- a/apps/omlx-mac/Sources/Menubar/MenubarController.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarController.swift
@@ -21,13 +21,7 @@
 // recreate-and-retry before alerting.
 
 import AppKit
-
-@MainActor
-private final class MenubarStatusContentView: NSView {
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        nil
-    }
-}
+import SwiftUI
 
 @MainActor
 final class MenubarController: NSObject {
@@ -41,15 +35,17 @@ final class MenubarController: NSObject {
     private let client: OMLXClient?
     private let openModelSettings: (String) -> Void
     private let openAppView: () -> Void
+    private let openAppearanceSettings: () -> Void
     private let requestQuit: () -> Void
 
     private var statusItem: NSStatusItem
-    private let statusContentView = MenubarStatusContentView()
-    private let activityLabel = NSTextField(labelWithString: "")
-    private let statusIconView = NSImageView()
-    private var statusContentConstraints: [NSLayoutConstraint] = []
-    private var activityLabelConstraints: [NSLayoutConstraint] = []
     private let menu = NSMenu()
+
+    /// Shared throughput model + the optional LIV/AVG/ALL status items it
+    /// feeds. The store outlives poller re-points (port changes) so the
+    /// popover graphs keep their history.
+    private let metricsStore = MenubarMetricsStore()
+    private var metricItemsController: MenubarMetricItemsController!
 
     private var statsPoller: MenubarStatsPoller?
     /// Endpoint the live `statsPoller` was started against, so a runtime
@@ -78,7 +74,17 @@ final class MenubarController: NSObject {
     private var modelsFetchTask: Task<Void, Never>?
     private var statsParentItem: NSMenuItem!
     private var statsSubmenu: NSMenu!
-    private var showLiveActivityInMenuBarItem: NSMenuItem!
+    private var systemStatsParentItem: NSMenuItem!
+    private var systemStatsSubmenu: NSMenu!
+    private let systemStatsSampler = SystemStatsSampler()
+    private var systemItemsController: SystemMenubarItemsController!
+    private var systemStatsTimer: Timer?
+    private var systemStatsTimerInterval: TimeInterval = 0
+    private var systemStatsSubmenuOpen = false
+    private var lastSystemTickAt: Date?
+    private var cpuPanelHost: NSHostingView<AnyView>?
+    private var gpuPanelHost: NSHostingView<AnyView>?
+    private var memoryPanelHost: NSHostingView<AnyView>?
     private var adminPanelItem: NSMenuItem!
     private var webAdminItem: NSMenuItem!
     private var chatItem: NSMenuItem!
@@ -86,17 +92,6 @@ final class MenubarController: NSObject {
 
     private let iconOutline: NSImage?
     private let iconFilled: NSImage?
-
-    private static let showLiveActivityInMenuBarDefaultsKey = "showLiveActivityInMenuBar"
-
-    private var isLiveActivityEnabled: Bool {
-        get {
-            UserDefaults.standard.bool(forKey: Self.showLiveActivityInMenuBarDefaultsKey)
-        }
-        set {
-            UserDefaults.standard.set(newValue, forKey: Self.showLiveActivityInMenuBarDefaultsKey)
-        }
-    }
 
     // MARK: - Init
 
@@ -108,6 +103,7 @@ final class MenubarController: NSObject {
         client: OMLXClient? = nil,
         openModelSettings: @escaping (String) -> Void = { _ in },
         openAppView: @escaping () -> Void = {},
+        openAppearanceSettings: @escaping () -> Void = {},
         requestQuit: @escaping () -> Void = { NSApp.terminate(nil) }
     ) {
         self.server = server
@@ -117,51 +113,74 @@ final class MenubarController: NSObject {
         self.client = client
         self.openModelSettings = openModelSettings
         self.openAppView = openAppView
+        self.openAppearanceSettings = openAppearanceSettings
         self.requestQuit = requestQuit
 
-        // The item grows left as activity text appears. Its custom content
-        // keeps the bird pinned inside the rightmost square segment.
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
 
         // Cap icons at 18×18 pt (the standard macOS menubar icon size).
         // Our SVGs are 497×497 natural; without this, the status item
         // auto-sizes to that natural width and dominates the menubar.
         // Mirrors Python's _load_menubar_icon (app.py:973).
+        // SF Symbol fallback covers an asset-catalog miss in Debug builds.
         let menubarIconSize = NSSize(width: 18, height: 18)
+        let fallback = NSImage(
+            systemSymbolName: "cube.transparent",
+            accessibilityDescription: "oMLX"
+        )
 
-        let outline = NSImage(named: "MenubarOutline")
+        let outline = NSImage(named: "MenubarOutline") ?? fallback
         outline?.size = menubarIconSize
         outline?.isTemplate = true
         self.iconOutline = outline
 
-        let filled = NSImage(named: "MenubarFilled")
+        let filled = NSImage(named: "MenubarFilled") ?? fallback
         filled?.size = menubarIconSize
         filled?.isTemplate = true
         self.iconFilled = filled
 
         super.init()
 
-        statusIconView.image = outline
-        // SF Symbol fallback for asset-catalog miss in Debug builds.
-        if statusIconView.image == nil {
-            let fallback = NSImage(
-                systemSymbolName: "cube.transparent",
-                accessibilityDescription: "oMLX"
-            )
-            fallback?.isTemplate = true
-            statusIconView.image = fallback
-        }
         statusItem.behavior = []
         statusItem.menu = menu
-        configureStatusItemContent()
+        statusItem.button?.image = outline
+        statusItem.button?.setAccessibilityLabel("oMLX")
+        statusItem.button?.toolTip = "oMLX"
         // This menu is state-driven by refreshMenuState(). If AppKit's
         // automatic target/action enabling stays on, stopped-server items
         // such as Web Dashboard and Chat can be re-enabled while opening.
         menu.autoenablesItems = false
         menu.delegate = self
 
+        metricItemsController = MenubarMetricItemsController(
+            store: metricsStore,
+            openAppearanceSettings: { [weak self] in
+                self?.openAppearanceSettings()
+            },
+            openDashboard: { [weak self] in
+                self?.openWebAdmin()
+            }
+        )
+        systemItemsController = SystemMenubarItemsController()
+        metricItemsController.willShowPopover = { [weak self] in
+            self?.systemItemsController.closeAllPopovers()
+        }
+        systemItemsController.willShowPopover = { [weak self] in
+            self?.metricItemsController.closeAllPopovers()
+        }
+
         buildMenu()
         refreshMenuState()
+
+        // Appearance toggles are written by the settings screen (and only
+        // read here); the defaults notification is the one propagation path
+        // that also works while the server is down and the poller is silent.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(defaultsDidChange(_:)),
+            name: UserDefaults.didChangeNotification,
+            object: UserDefaults.standard
+        )
 
         if let server {
             NotificationCenter.default.addObserver(
@@ -188,6 +207,7 @@ final class MenubarController: NSObject {
 
         startStatsPoller()
         startVisibilityWatcher()
+        applyMetricPreferences()
 
         if let bootstrapError {
             DispatchQueue.main.async { [weak self] in
@@ -253,6 +273,18 @@ final class MenubarController: NSObject {
 
         menu.addItem(.separator())
 
+        systemStatsParentItem = item(String(localized: "menubar.item.system_stats",
+                                            defaultValue: "System Stats",
+                                            comment: "Menubar parent item opening the CPU/GPU/Memory submenu"),
+                                     action: nil,
+                                     symbol: "cpu")
+        systemStatsSubmenu = NSMenu()
+        systemStatsSubmenu.autoenablesItems = false
+        systemStatsSubmenu.delegate = self
+        systemStatsParentItem.submenu = systemStatsSubmenu
+        buildSystemStatsSubmenu()
+        menu.addItem(systemStatsParentItem)
+
         statsParentItem = item(String(localized: "menubar.item.serving_stats",
                                       defaultValue: "Serving Stats",
                                       comment: "Menubar parent item opening the Serving Stats submenu"),
@@ -263,17 +295,6 @@ final class MenubarController: NSObject {
         menu.addItem(statsParentItem)
         rebuildStatsSubmenu()
         rebuildModelsSubmenu()
-
-        showLiveActivityInMenuBarItem = item(
-            String(
-                localized: "menubar.item.show_live_activity_in_menu_bar",
-                defaultValue: "Show Live Activity in Menu Bar",
-                comment: "Menubar item that toggles current request activity text beside the oMLX icon"
-            ),
-            action: #selector(toggleLiveActivityInMenuBar),
-            symbol: nil
-        )
-        menu.addItem(showLiveActivityInMenuBarItem)
 
         menu.addItem(.separator())
 
@@ -389,37 +410,12 @@ final class MenubarController: NSObject {
         chatItem.isEnabled = availability.chat
 
         refreshUpdateMenuItem()
-        showLiveActivityInMenuBarItem.state = isLiveActivityEnabled ? .on : .off
 
-        // Icon swap — outline when not actively serving, filled otherwise
+        // Icon swap — outline when not actively serving, filled otherwise.
+        // Live throughput lives in the dedicated LIV/AVG/ALL metric items,
+        // so the main item stays a fixed square icon.
         let serving = state.isRunningLike
-        statusIconView.image = serving ? iconFilled : iconOutline
-        statusIconView.image?.isTemplate = true
-        let liveActivity = statsPoller?.liveStats?.liveActivity
-        let activityTitle = MenubarController.menuBarButtonTitle(
-            serverState: state,
-            liveActivity: liveActivity,
-            isLiveActivityEnabled: isLiveActivityEnabled
-        )
-        activityLabel.stringValue = activityTitle
-        let statusItemPresentation = MenubarController.menuBarStatusItemPresentation(
-            activityTitle: activityTitle,
-            activityTextWidth: activityLabel.intrinsicContentSize.width,
-            statusBarThickness: NSStatusBar.system.thickness
-        )
-        activityLabel.isHidden = statusItemPresentation.activityTitle.isEmpty
-        statusItem.length = statusItemPresentation.itemLength
-        setActivityLabelLayoutReserved(
-            statusItemPresentation.reservesActivityLabelSpace
-        )
-        let statusItemToolTip = MenubarController.menuBarButtonToolTip(
-            serverState: state,
-            liveActivity: liveActivity,
-            isLiveActivityEnabled: isLiveActivityEnabled
-        )
-        statusItem.button?.toolTip = statusItemToolTip
-        statusItem.button?.setAccessibilityValue(statusItemPresentation.accessibilityValue)
-        statusItem.button?.setAccessibilityHelp(statusItemToolTip)
+        statusItem.button?.image = serving ? iconFilled : iconOutline
     }
 
     private func refreshUpdateMenuItem() {
@@ -499,6 +495,114 @@ final class MenubarController: NSObject {
                        comment: "Menubar status header when the server failed; placeholder is the failure message"),
                 .systemRed
             )
+        }
+    }
+
+    // MARK: - System Stats submenu
+
+    /// CPU / GPU / Memory panels as custom-view items. The hosting views
+    /// are created once; the sampling timer swaps their root views with
+    /// fresh snapshots only while the submenu is open.
+    private func buildSystemStatsSubmenu() {
+        systemStatsSubmenu.removeAllItems()
+
+        let snapshot = SystemStatsSnapshot()
+        let interval = MenubarMetricPrefs.refreshInterval
+        let cpu = NSHostingView(rootView: AnyView(
+            CPUStatsPanel(snapshot: snapshot, refreshInterval: interval).omlxThemed()
+        ))
+        let gpu = NSHostingView(rootView: AnyView(
+            GPUStatsPanel(snapshot: snapshot, refreshInterval: interval).omlxThemed()
+        ))
+        let memory = NSHostingView(rootView: AnyView(
+            MemoryStatsPanel(snapshot: snapshot).omlxThemed()
+        ))
+        cpuPanelHost = cpu
+        gpuPanelHost = gpu
+        memoryPanelHost = memory
+
+        systemStatsSubmenu.addItem(panelItem(hosting: cpu))
+        systemStatsSubmenu.addItem(.separator())
+        systemStatsSubmenu.addItem(panelItem(hosting: gpu))
+        systemStatsSubmenu.addItem(.separator())
+        systemStatsSubmenu.addItem(panelItem(hosting: memory))
+    }
+
+    private func panelItem(hosting view: NSHostingView<AnyView>) -> NSMenuItem {
+        view.frame.size = view.fittingSize
+        let item = NSMenuItem()
+        item.view = view
+        item.isEnabled = false
+        return item
+    }
+
+    /// One sampler timer serves both consumers: the System Stats submenu
+    /// panels (while open) and the CPU/GPU/MEM status items (while any is
+    /// enabled). It runs only when at least one consumer needs it, and joins
+    /// the common run-loop modes because menu tracking parks the main run
+    /// loop in the event-tracking mode, where default-mode timers (and
+    /// main-queue hops) never fire.
+    private var needsSystemSampling: Bool {
+        systemStatsSubmenuOpen || MenubarMetricPrefs.enabledSystemItems.any
+    }
+
+    private func reconcileSystemSampling() {
+        let interval = MenubarMetricPrefs.refreshInterval
+        if needsSystemSampling {
+            if systemStatsTimer == nil || systemStatsTimerInterval != interval {
+                startSystemSamplingTimer(interval: interval)
+            }
+        } else if systemStatsTimer != nil {
+            systemStatsTimer?.invalidate()
+            systemStatsTimer = nil
+        }
+    }
+
+    private func startSystemSamplingTimer(interval: TimeInterval) {
+        systemStatsTimer?.invalidate()
+        systemStatsTimerInterval = interval
+        systemSamplingTick()
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.systemSamplingTick()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        systemStatsTimer = timer
+    }
+
+    private func systemSamplingTick() {
+        // Timer start and menu-open both request an immediate paint; a
+        // back-to-back double sample would produce a zero-length CPU tick
+        // delta (no usable reading), so collapse them.
+        if let last = lastSystemTickAt, Date().timeIntervalSince(last) < 0.1 {
+            return
+        }
+        lastSystemTickAt = Date()
+        let snapshot = systemStatsSampler.sample()
+        if systemStatsSubmenuOpen {
+            updateSystemStatsPanels(with: snapshot)
+        }
+        systemItemsController.apply(snapshot)
+    }
+
+    private func updateSystemStatsPanels(with snapshot: SystemStatsSnapshot) {
+        let interval = MenubarMetricPrefs.refreshInterval
+        cpuPanelHost?.rootView = AnyView(
+            CPUStatsPanel(snapshot: snapshot, refreshInterval: interval).omlxThemed()
+        )
+        gpuPanelHost?.rootView = AnyView(
+            GPUStatsPanel(snapshot: snapshot, refreshInterval: interval).omlxThemed()
+        )
+        memoryPanelHost?.rootView = AnyView(
+            MemoryStatsPanel(snapshot: snapshot).omlxThemed()
+        )
+        for host in [cpuPanelHost, gpuPanelHost, memoryPanelHost] {
+            guard let host else { continue }
+            let fitting = host.fittingSize
+            if host.frame.size != fitting {
+                host.frame.size = fitting
+            }
         }
     }
 
@@ -618,7 +722,7 @@ final class MenubarController: NSObject {
             name: MenubarStatsPoller.didUpdateNotification,
             object: p
         )
-        p.setLiveActivityPollingEnabled(isLiveActivityEnabled)
+        p.setEnabledMetrics(MenubarMetricPrefs.enabledMetrics)
         p.start()
         self.statsPoller = p
         self.statsPollerBaseURL = baseURL
@@ -648,69 +752,11 @@ final class MenubarController: NSObject {
         let newStatusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         newStatusItem.behavior = []
         newStatusItem.menu = menu
+        newStatusItem.button?.setAccessibilityLabel("oMLX")
+        newStatusItem.button?.toolTip = "oMLX"
         statusItem = newStatusItem
-        configureStatusItemContent()
         refreshMenuState()
         return newStatusItem
-    }
-
-    private func configureStatusItemContent() {
-        guard let statusButton = statusItem.button else { return }
-
-        statusButton.title = ""
-        statusButton.image = nil
-        statusButton.setAccessibilityLabel("oMLX")
-        statusContentView.removeFromSuperview()
-        statusContentView.translatesAutoresizingMaskIntoConstraints = false
-        statusButton.addSubview(statusContentView)
-
-        activityLabel.translatesAutoresizingMaskIntoConstraints = false
-        activityLabel.font = statusButton.font
-        activityLabel.textColor = .labelColor
-        activityLabel.alignment = .right
-        activityLabel.lineBreakMode = .byClipping
-        statusIconView.translatesAutoresizingMaskIntoConstraints = false
-        statusIconView.imageScaling = .scaleProportionallyDown
-        statusIconView.contentTintColor = .labelColor
-        statusContentView.addSubview(activityLabel)
-        statusContentView.addSubview(statusIconView)
-
-        let iconCenterTrailingOffset = NSStatusBar.system.thickness / 2
-        NSLayoutConstraint.deactivate(statusContentConstraints)
-        NSLayoutConstraint.deactivate(activityLabelConstraints)
-        statusContentConstraints = [
-            statusContentView.leadingAnchor.constraint(equalTo: statusButton.leadingAnchor),
-            statusContentView.trailingAnchor.constraint(equalTo: statusButton.trailingAnchor),
-            statusContentView.topAnchor.constraint(equalTo: statusButton.topAnchor),
-            statusContentView.bottomAnchor.constraint(equalTo: statusButton.bottomAnchor),
-            statusIconView.widthAnchor.constraint(equalToConstant: Self.statusIconSize),
-            statusIconView.heightAnchor.constraint(equalToConstant: Self.statusIconSize),
-            statusIconView.centerYAnchor.constraint(equalTo: statusContentView.centerYAnchor),
-            statusIconView.centerXAnchor.constraint(
-                equalTo: statusContentView.trailingAnchor,
-                constant: -iconCenterTrailingOffset
-            )
-        ]
-        activityLabelConstraints = [
-            activityLabel.leadingAnchor.constraint(
-                greaterThanOrEqualTo: statusContentView.leadingAnchor,
-                constant: Self.activityLeadingPadding
-            ),
-            activityLabel.trailingAnchor.constraint(
-                equalTo: statusIconView.leadingAnchor,
-                constant: -Self.activityToIconSpacing
-            ),
-            activityLabel.centerYAnchor.constraint(equalTo: statusContentView.centerYAnchor)
-        ]
-        NSLayoutConstraint.activate(statusContentConstraints)
-    }
-
-    private func setActivityLabelLayoutReserved(_ reservesActivityLabelSpace: Bool) {
-        if reservesActivityLabelSpace {
-            NSLayoutConstraint.activate(activityLabelConstraints)
-        } else {
-            NSLayoutConstraint.deactivate(activityLabelConstraints)
-        }
     }
 
     // MARK: - Notification handlers
@@ -734,9 +780,11 @@ final class MenubarController: NSObject {
             unloadingIDs.removeAll()
             loadingIDs.removeAll()
             modelsFetched = false
+            metricsStore.markServerStopped()
         default:
             break
         }
+        metricItemsController.sync()
 
         if case .failed(let message) = server.state,
            MenubarController.shouldShowGenericFailureAlert(message: message) {
@@ -757,6 +805,23 @@ final class MenubarController: NSObject {
            let lastStatusSuccessAt = poller.lastStatusSuccessAt {
             server?.recordAuxiliaryHealthSuccess(at: lastStatusSuccessAt)
         }
+        // A failure tick (server going away) posts once with stale snapshots
+        // still cached — surface it as unknown ("–") rather than freezing
+        // the last good numbers on the glyphs.
+        let tickOK = statsPoller?.lastTickWasSuccess ?? false
+        metricsStore.applyTick(
+            live: tickOK
+                ? MenubarMetricsStore.liveRates(from: statsPoller?.liveStats)
+                : nil,
+            average: tickOK
+                ? MenubarMetricsStore.averageRates(from: statsPoller?.sessionStats)
+                : nil,
+            alltime: tickOK
+                ? MenubarMetricsStore.averageRates(from: statsPoller?.alltimeStats)
+                : nil,
+            serverRunning: serverIsRunning && tickOK
+        )
+        metricItemsController.sync()
         // Stats only need to redraw if the submenu is open or about to open;
         // menuWillOpen (NSMenuDelegate) handles the latter, so for now we
         // rebuild eagerly — the next render will pick up fresh values.
@@ -768,14 +833,28 @@ final class MenubarController: NSObject {
         refreshUpdateMenuItem()
     }
 
-    // MARK: - Actions
-
-    @objc private func toggleLiveActivityInMenuBar() {
-        isLiveActivityEnabled.toggle()
-        statsPoller?.setLiveActivityPollingEnabled(isLiveActivityEnabled)
-        refreshMenuState()
-        rebuildStatsSubmenu()
+    /// UserDefaults writes can come from any thread; hop to the main actor
+    /// before touching the poller or the status items.
+    @objc nonisolated private func defaultsDidChange(_ note: Notification) {
+        Task { @MainActor in
+            self.applyMetricPreferences()
+        }
     }
+
+    /// Pushes the current Appearance toggles into the poller and reconciles
+    /// every optional status item plus the system sampling timer. Cheap and
+    /// idempotent: the poller guards on equality, sync() only re-rasterizes
+    /// on signature changes, and the reconcile is a nil-check when nothing
+    /// flipped — so the chattiness of the defaults notification doesn't
+    /// matter.
+    private func applyMetricPreferences() {
+        statsPoller?.setEnabledMetrics(MenubarMetricPrefs.enabledMetrics)
+        metricItemsController.sync()
+        systemItemsController.sync()
+        reconcileSystemSampling()
+    }
+
+    // MARK: - Actions
 
     @objc private func startServer() {
         guard let server else { return }
@@ -1273,74 +1352,6 @@ extension MenubarController {
         server?.host ?? fallback
     }
 
-    /// Keeps live activity text out of a stopped or transitioning status item.
-    /// Internal so the policy is unit-tested without constructing NSStatusItem.
-    static func menuBarButtonTitle(
-        serverState: ServerProcess.State,
-        liveActivity: MenubarStatsPoller.Stats.LiveActivity?,
-        isLiveActivityEnabled: Bool
-    ) -> String {
-        guard isLiveActivityEnabled, serverState.isRunningLike else {
-            return ""
-        }
-        return liveActivity?.menuBarTitle ?? ""
-    }
-
-    struct MenuBarStatusItemPresentation: Equatable {
-        let itemLength: CGFloat
-        let iconCenterTrailingOffset: CGFloat
-        let activityTitle: String
-        let reservesActivityLabelSpace: Bool
-        let accessibilityValue: String?
-    }
-
-    private static let statusIconSize: CGFloat = 18
-    private static let activityLeadingPadding: CGFloat = 6
-    private static let activityToIconSpacing: CGFloat = 6
-
-    static func menuBarStatusItemPresentation(
-        activityTitle: String,
-        activityTextWidth: CGFloat,
-        statusBarThickness: CGFloat
-    ) -> MenuBarStatusItemPresentation {
-        let iconCenterTrailingOffset = statusBarThickness / 2
-        let itemLength: CGFloat
-        if activityTitle.isEmpty {
-            itemLength = NSStatusItem.squareLength
-        } else {
-            itemLength = ceil(
-                activityLeadingPadding
-                    + activityTextWidth
-                    + activityToIconSpacing
-                    + statusIconSize / 2
-                    + iconCenterTrailingOffset
-            )
-        }
-
-        return MenuBarStatusItemPresentation(
-            itemLength: itemLength,
-            iconCenterTrailingOffset: iconCenterTrailingOffset,
-            activityTitle: activityTitle,
-            reservesActivityLabelSpace: !activityTitle.isEmpty,
-            accessibilityValue: activityTitle.isEmpty ? nil : activityTitle
-        )
-    }
-
-    static func menuBarButtonToolTip(
-        serverState: ServerProcess.State,
-        liveActivity: MenubarStatsPoller.Stats.LiveActivity?,
-        isLiveActivityEnabled: Bool
-    ) -> String {
-        guard !menuBarButtonTitle(
-            serverState: serverState,
-            liveActivity: liveActivity,
-            isLiveActivityEnabled: isLiveActivityEnabled
-        ).isEmpty else {
-            return "oMLX"
-        }
-        return liveActivity?.detail ?? "oMLX"
-    }
-
     /// Builds the browser URL for the web admin dashboard. Uses the
     /// `/admin/auto-login` endpoint so the dashboard opens without the
     /// manual login form: the server validates the main API key, sets the
@@ -1427,9 +1438,30 @@ extension MenubarController {
 
 extension MenubarController: NSMenuDelegate {
     func menuWillOpen(_ menu: NSMenu) {
+        if menu === systemStatsSubmenu {
+            systemStatsSubmenuOpen = true
+            reconcileSystemSampling()
+            // The reconcile may have found the timer already running (bar
+            // items enabled) — paint the panels immediately in that case.
+            systemSamplingTick()
+            return
+        }
+        // One menubar dropdown at a time — the metric popovers don't dismiss
+        // on a click that lands on our own main status item.
+        metricItemsController.closeAllPopovers()
+        systemItemsController.closeAllPopovers()
         refreshMenuState()
         rebuildStatsSubmenu()
         rebuildModelsSubmenu()
         scheduleModelsRefresh()
+    }
+
+    func menuDidClose(_ menu: NSMenu) {
+        // The submenu posts its own close; the main-menu close is the
+        // belt-and-suspenders for teardown paths that skip it.
+        if menu === systemStatsSubmenu || menu === self.menu {
+            systemStatsSubmenuOpen = false
+            reconcileSystemSampling()
+        }
     }
 }

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricGlyph.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricGlyph.swift
@@ -1,0 +1,244 @@
+// Compact menubar readout for a metric status item: a vertical three-letter
+// tag (LIV / AVG / ALL) followed by two aligned rows, "P: <prompt tok/s>"
+// stacked over "T: <generation tok/s>". The readout is rasterized into an
+// NSImage because a status-item button only renders bitmap content reliably,
+// and every image assignment forces the menubar to re-composite the item —
+// so callers gate assignments with `signature`, which captures the only
+// inputs that can change the pixels.
+
+import AppKit
+
+enum MenubarMetricGlyph {
+    /// Standard menubar content height in points.
+    static let glyphHeight: CGFloat = 18
+
+    /// Worst-case value string that reserves the value column, keeping the
+    /// status item at a constant width while readings fluctuate.
+    static let valueTemplate = "9999tk/s"
+
+    private static let rowLabels = ("P:", "T:")
+
+    /// nil / non-finite → "–" (unknown, distinct from an idle 0). Values are
+    /// shown as whole tok/s, compacting to "12.3ktk/s" from 10k upward so
+    /// the reserved column never overflows.
+    static func formatTps(_ value: Double?) -> String {
+        guard let value, value.isFinite else {
+            return "–"
+        }
+        let clamped = max(0, value)
+        if clamped >= 10_000 {
+            return String(format: "%.1fktk/s", clamped / 1_000)
+        }
+        return "\(Int(clamped.rounded()))tk/s"
+    }
+
+    /// Cheap pixel-change detector: same signature ⇒ identical glyph, so the
+    /// caller can skip the re-raster and the image reassignment entirely.
+    static func signature(
+        tag: String,
+        promptValue: String,
+        generationValue: String,
+        darkMenubar: Bool
+    ) -> String {
+        "\(tag)|\(promptValue)|\(generationValue)|\(darkMenubar ? "dark" : "light")"
+    }
+
+    // MARK: - Shared tag column
+
+    private struct TagColumn {
+        let characters: [NSString]
+        let attributes: [NSAttributedString.Key: Any]
+        let width: CGFloat
+
+        /// One character per equal vertical slot, top to bottom.
+        func draw(height: CGFloat, originX: CGFloat = 0) {
+            let slotHeight = height / CGFloat(max(1, characters.count))
+            for (index, character) in characters.enumerated() {
+                let size = character.size(withAttributes: attributes)
+                let slotBottom = height - CGFloat(index + 1) * slotHeight
+                character.draw(
+                    at: NSPoint(
+                        x: originX + (width - size.width) / 2,
+                        y: slotBottom + (slotHeight - size.height) / 2
+                    ),
+                    withAttributes: attributes
+                )
+            }
+        }
+    }
+
+    private static func tagColumn(_ tag: String, ink: NSColor) -> TagColumn {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 6.5, weight: .bold),
+            .foregroundColor: ink.withAlphaComponent(0.85),
+        ]
+        let characters = tag.map { String($0) as NSString }
+        let width = characters
+            .map { ceil($0.size(withAttributes: attributes).width) }
+            .max() ?? 6
+        return TagColumn(characters: characters, attributes: attributes, width: width)
+    }
+
+    // MARK: - Two-line readout (LIV / AVG / ALL)
+
+    static func image(
+        tag: String,
+        promptValue: String,
+        generationValue: String,
+        darkMenubar: Bool
+    ) -> NSImage {
+        let ink: NSColor = darkMenubar ? .white : .black
+        let column = tagColumn(tag, ink: ink)
+        let rowFont = NSFont.systemFont(ofSize: 8.5, weight: .medium)
+        let labelAttributes: [NSAttributedString.Key: Any] = [
+            .font: rowFont,
+            .foregroundColor: ink.withAlphaComponent(0.7),
+        ]
+        let valueAttributes: [NSAttributedString.Key: Any] = [
+            .font: rowFont,
+            .foregroundColor: ink.withAlphaComponent(0.95),
+        ]
+
+        let labels = (rowLabels.0 as NSString, rowLabels.1 as NSString)
+        let labelWidth = ceil(max(
+            labels.0.size(withAttributes: labelAttributes).width,
+            labels.1.size(withAttributes: labelAttributes).width
+        ))
+        let values = (promptValue as NSString, generationValue as NSString)
+        let valueWidth = ceil(
+            [valueTemplate as NSString, values.0, values.1]
+                .map { $0.size(withAttributes: valueAttributes).width }
+                .max() ?? 0
+        )
+
+        let tagGap: CGFloat = 3
+        let columnGap: CGFloat = 4
+        let height = glyphHeight
+        let width = ceil(column.width + tagGap + labelWidth + columnGap + valueWidth) + 2
+
+        let image = NSImage(
+            size: NSSize(width: width, height: height),
+            flipped: false
+        ) { _ in
+            column.draw(height: height)
+
+            // Two rows: labels pinned left, values right-aligned inside the
+            // reserved column so digits line up and the width never moves.
+            let rowLeft = column.width + tagGap
+            let valueRight = rowLeft + labelWidth + columnGap + valueWidth
+            let rowHeight = values.0.size(withAttributes: valueAttributes).height
+            let halfHeight = height / 2
+            let topBaseline = halfHeight + (halfHeight - rowHeight) / 2
+            let bottomBaseline = (halfHeight - rowHeight) / 2
+
+            labels.0.draw(
+                at: NSPoint(x: rowLeft, y: topBaseline),
+                withAttributes: labelAttributes
+            )
+            labels.1.draw(
+                at: NSPoint(x: rowLeft, y: bottomBaseline),
+                withAttributes: labelAttributes
+            )
+            values.0.draw(
+                at: NSPoint(
+                    x: valueRight - values.0.size(withAttributes: valueAttributes).width,
+                    y: topBaseline
+                ),
+                withAttributes: valueAttributes
+            )
+            values.1.draw(
+                at: NSPoint(
+                    x: valueRight - values.1.size(withAttributes: valueAttributes).width,
+                    y: bottomBaseline
+                ),
+                withAttributes: valueAttributes
+            )
+            return true
+        }
+        // Hand-inked for the actual menubar appearance — template tinting
+        // would discard the two-tone label/value contrast.
+        image.isTemplate = false
+        return image
+    }
+
+    // MARK: - Vertical usage bar (CPU / GPU / MEM)
+
+    /// Bar fill resolution: one step per Retina pixel row of the 18 pt
+    /// glyph. The signature quantizes to this grid so sub-pixel usage
+    /// jitter never forces a re-raster the eye couldn't see anyway.
+    static let barLevelSteps = 36
+
+    /// nil / non-finite → -1 (empty track).
+    static func quantizedBarLevel(_ fraction: Double?) -> Int {
+        guard let fraction, fraction.isFinite else {
+            return -1
+        }
+        return Int((min(1, max(0, fraction)) * Double(barLevelSteps)).rounded())
+    }
+
+    /// One enabled host metric = one segment. Enabled segments share a
+    /// single status item so the menubar doesn't scatter them across
+    /// separate squares with system-managed gaps between.
+    typealias BarSegment = (tag: String, fraction: Double?)
+
+    static func barsSignature(segments: [BarSegment], darkMenubar: Bool) -> String {
+        let body = segments
+            .map { "\($0.tag):\(quantizedBarLevel($0.fraction))" }
+            .joined(separator: "|")
+        return "\(body)|\(darkMenubar ? "dark" : "light")"
+    }
+
+    /// Stacked tag + vertical bar per segment, drawn side by side into one
+    /// image. Each bar fills bottom-up against a full-height track,
+    /// 100% = full glyph height.
+    static func barsImage(segments: [BarSegment], darkMenubar: Bool) -> NSImage {
+        let ink: NSColor = darkMenubar ? .white : .black
+        let columns = segments.map { tagColumn($0.tag, ink: ink) }
+        let tagGap: CGFloat = 3
+        let barWidth: CGFloat = 8
+        let groupGap: CGFloat = 6
+        let radius: CGFloat = 2
+        let height = glyphHeight
+        let segmentWidths = columns.map { ceil($0.width + tagGap + barWidth) }
+        let width = segmentWidths.reduce(0, +)
+            + groupGap * CGFloat(max(0, segments.count - 1)) + 2
+
+        let image = NSImage(
+            size: NSSize(width: width, height: height),
+            flipped: false
+        ) { _ in
+            var originX: CGFloat = 0
+            for (index, segment) in segments.enumerated() {
+                let column = columns[index]
+                column.draw(height: height, originX: originX)
+
+                let barX = originX + column.width + tagGap
+                ink.withAlphaComponent(0.18).setFill()
+                NSBezierPath(
+                    roundedRect: NSRect(x: barX, y: 0, width: barWidth, height: height),
+                    xRadius: radius,
+                    yRadius: radius
+                ).fill()
+
+                let level = quantizedBarLevel(segment.fraction)
+                if level >= 0 {
+                    let fillHeight = max(
+                        1.5, height * CGFloat(level) / CGFloat(barLevelSteps)
+                    )
+                    ink.withAlphaComponent(0.9).setFill()
+                    NSBezierPath(
+                        roundedRect: NSRect(
+                            x: barX, y: 0, width: barWidth, height: fillHeight
+                        ),
+                        xRadius: radius,
+                        yRadius: radius
+                    ).fill()
+                }
+                originX += segmentWidths[index] + groupGap
+            }
+            return true
+        }
+        image.isTemplate = false
+        return image
+    }
+}

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricItemsController.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricItemsController.swift
@@ -1,0 +1,176 @@
+// Owns the optional per-metric status items (LIV / AVG / ALL). sync()
+// reconciles the items against the Appearance toggles and repaints their
+// glyphs — but only when a cheap value signature says the pixels actually
+// changed, because every button.image assignment makes the menubar
+// re-composite the item even if nothing is visibly different. Each item
+// opens a transient popover whose SwiftUI content exists only while shown.
+
+import AppKit
+import SwiftUI
+
+@MainActor
+final class MenubarMetricItemsController: NSObject, NSPopoverDelegate {
+
+    private struct ItemSpec {
+        let kind: MenubarMetricsStore.Kind
+        let defaultsKey: String
+        /// Fixed Latin tag drawn vertically in the glyph — deliberately not
+        /// localized, like the rest of the menubar readout.
+        let tag: String
+    }
+
+    private static let specs: [ItemSpec] = [
+        ItemSpec(kind: .live, defaultsKey: MenubarMetricPrefs.liveKey, tag: "LIV"),
+        ItemSpec(kind: .average, defaultsKey: MenubarMetricPrefs.averageKey, tag: "AVG"),
+        ItemSpec(kind: .alltime, defaultsKey: MenubarMetricPrefs.alltimeKey, tag: "ALL"),
+    ]
+
+    private struct ItemEntry {
+        let item: NSStatusItem
+        let popover: NSPopover
+        var lastSignature: String?
+    }
+
+    private var entries: [MenubarMetricsStore.Kind: ItemEntry] = [:]
+    private let store: MenubarMetricsStore
+    private let openAppearanceSettings: () -> Void
+    private let openDashboard: () -> Void
+    /// Set by MenubarController to close the other controller's popovers so
+    /// menubar dropdowns stay mutually exclusive.
+    var willShowPopover: (() -> Void)?
+
+    init(
+        store: MenubarMetricsStore,
+        openAppearanceSettings: @escaping () -> Void,
+        openDashboard: @escaping () -> Void
+    ) {
+        self.store = store
+        self.openAppearanceSettings = openAppearanceSettings
+        self.openDashboard = openDashboard
+        super.init()
+    }
+
+    /// Reconciles status items with the Appearance toggles and refreshes
+    /// their glyphs. Called on every poller tick, on UserDefaults changes,
+    /// and on server-state transitions; cheap and idempotent when nothing
+    /// changed.
+    func sync() {
+        for spec in Self.specs {
+            guard UserDefaults.standard.bool(forKey: spec.defaultsKey) else {
+                if let entry = entries.removeValue(forKey: spec.kind) {
+                    entry.popover.performClose(nil)
+                    NSStatusBar.system.removeStatusItem(entry.item)
+                }
+                continue
+            }
+
+            if entries[spec.kind] == nil {
+                entries[spec.kind] = makeEntry(for: spec)
+            }
+            guard let button = entries[spec.kind]?.item.button else {
+                continue
+            }
+
+            // Ink follows the status button's own appearance — the menubar
+            // can be dark over a dark wallpaper while the app is light.
+            let darkMenubar = button.effectiveAppearance
+                .bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            let rates = store.rates[spec.kind]
+            let promptValue = MenubarMetricGlyph.formatTps(rates?.promptTps)
+            let generationValue = MenubarMetricGlyph.formatTps(rates?.generationTps)
+            let signature = MenubarMetricGlyph.signature(
+                tag: spec.tag,
+                promptValue: promptValue,
+                generationValue: generationValue,
+                darkMenubar: darkMenubar
+            )
+            if entries[spec.kind]?.lastSignature != signature {
+                button.image = MenubarMetricGlyph.image(
+                    tag: spec.tag,
+                    promptValue: promptValue,
+                    generationValue: generationValue,
+                    darkMenubar: darkMenubar
+                )
+                button.toolTip = "oMLX · \(spec.kind.displayName)"
+                entries[spec.kind]?.lastSignature = signature
+            }
+        }
+    }
+
+    /// Closes every open metric popover, optionally keeping one. Also called
+    /// when the main oMLX menu opens so dropdowns never stack.
+    func closeAllPopovers(except kept: MenubarMetricsStore.Kind? = nil) {
+        for (kind, entry) in entries where kind != kept && entry.popover.isShown {
+            entry.popover.performClose(nil)
+        }
+    }
+
+    private func makeEntry(for spec: ItemSpec) -> ItemEntry {
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        item.autosaveName = "omlx.metric.\(spec.kind.rawValue)"
+
+        let popover = NSPopover()
+        popover.behavior = .transient
+        popover.delegate = self
+
+        if let button = item.button {
+            button.target = self
+            button.action = #selector(metricButtonClicked(_:))
+            button.identifier = NSUserInterfaceItemIdentifier(spec.kind.rawValue)
+            button.setAccessibilityLabel("oMLX \(spec.tag)")
+        }
+        return ItemEntry(item: item, popover: popover, lastSignature: nil)
+    }
+
+    @objc private func metricButtonClicked(_ sender: NSStatusBarButton) {
+        guard
+            let raw = sender.identifier?.rawValue,
+            let kind = MenubarMetricsStore.Kind(rawValue: raw),
+            let entry = entries[kind]
+        else {
+            return
+        }
+
+        if entry.popover.isShown {
+            entry.popover.performClose(nil)
+            return
+        }
+
+        // Transient popovers don't dismiss reliably when the click lands on
+        // another of our own status buttons, so enforce one-at-a-time here.
+        willShowPopover?()
+        closeAllPopovers(except: kind)
+
+        // Content is built on open and torn down on close (popoverDidClose):
+        // while the popover is closed no SwiftUI view observes the store, so
+        // ticks cost nothing beyond the data update itself.
+        let hosting = NSHostingController(
+            rootView: MetricPopoverView(
+                kind: kind,
+                store: store,
+                openSettings: { [weak self] in
+                    self?.closeAllPopovers()
+                    self?.openAppearanceSettings()
+                },
+                openDashboard: { [weak self] in
+                    self?.closeAllPopovers()
+                    self?.openDashboard()
+                }
+            )
+            .omlxThemed()
+        )
+        hosting.sizingOptions = [.preferredContentSize]
+        entry.popover.contentViewController = hosting
+        // Seed the real fitting size so the popover never opens on (or
+        // sticks at) its default frame.
+        entry.popover.contentSize = hosting.sizeThatFits(
+            in: NSSize(width: 1_000, height: 2_000)
+        )
+        entry.popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
+        entry.popover.contentViewController?.view.window?.makeKey()
+    }
+
+    func popoverDidClose(_ notification: Notification) {
+        (notification.object as? NSPopover)?.contentViewController = nil
+    }
+}

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricPopover.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricPopover.swift
@@ -1,0 +1,244 @@
+// Dropdown content for a menubar metric item: what the reading is, the
+// current PP/TG numbers, a rolling activity graph per series, and shortcuts
+// to the Appearance settings pane and the web dashboard. Hosted in an
+// NSPopover whose content controller only exists while the popover is open,
+// so a closed dropdown costs zero SwiftUI updates.
+
+import SwiftUI
+
+struct MetricPopoverView: View {
+    let kind: MenubarMetricsStore.Kind
+    let store: MenubarMetricsStore
+    let openSettings: () -> Void
+    let openDashboard: () -> Void
+
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        let rates = store.rates[kind]
+        let series = store.history[kind] ?? MenubarMetricsStore.Series()
+
+        VStack(alignment: .leading, spacing: 6) {
+            sectionHeader(kind.displayName)
+
+            valueRow(
+                label: "PP",
+                value: Self.popoverTps(rates?.promptTps),
+                tint: theme.blueDot
+            )
+            valueRow(
+                label: "TG",
+                value: Self.popoverTps(rates?.generationTps),
+                tint: theme.greenDot
+            )
+
+            if let note = statusNote {
+                Text(note)
+                    .font(.omlxText(11))
+                    .foregroundStyle(theme.textTertiary)
+            }
+
+            Divider().padding(.vertical, 2)
+
+            sectionHeader(String(
+                localized: "menubar.metric.activity",
+                defaultValue: "Activity",
+                comment: "Header above the throughput graphs in a menubar metric popover"
+            ))
+
+            graphCaption("PP tk/s")
+            MetricSparkline(values: series.promptTps, color: theme.blueDot)
+            graphCaption("TG tk/s")
+            MetricSparkline(values: series.generationTps, color: theme.greenDot)
+
+            Divider().padding(.vertical, 2)
+
+            HStack(spacing: 8) {
+                Button {
+                    openSettings()
+                } label: {
+                    Label(
+                        String(
+                            localized: "menubar.metric.settings",
+                            defaultValue: "Settings",
+                            comment: "Button in a menubar metric popover that opens the Appearance settings pane"
+                        ),
+                        systemImage: "gearshape"
+                    )
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.omlx(.normal, size: .small))
+
+                Button {
+                    openDashboard()
+                } label: {
+                    Label(
+                        String(
+                            localized: "menubar.metric.dashboard",
+                            defaultValue: "Dashboard",
+                            comment: "Button in a menubar metric popover that opens the web dashboard"
+                        ),
+                        systemImage: "globe"
+                    )
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.omlx(.primary, size: .small))
+                .disabled(!store.serverIsRunning)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(width: 260)
+    }
+
+    private var statusNote: String? {
+        if !store.serverIsRunning {
+            return String(
+                localized: "menubar.metric.server_off",
+                defaultValue: "Server is off",
+                comment: "Note in a menubar metric popover while the server is not running"
+            )
+        }
+        if kind == .live, store.rates[.live] == nil {
+            // The server answers but /admin/api/activity does not — the
+            // admin API key is missing or rejected.
+            return String(
+                localized: "menubar.metric.live_unavailable",
+                defaultValue: "Set an API key to enable live activity",
+                comment: "Note in the LIV popover when live stats need admin authentication"
+            )
+        }
+        return nil
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.omlxText(10, weight: .bold))
+            .kerning(1)
+            .foregroundStyle(theme.accent)
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private func valueRow(label: String, value: String, tint: Color) -> some View {
+        HStack {
+            Circle()
+                .fill(tint)
+                .frame(width: 6, height: 6)
+            Text(label)
+                .font(.omlxText(12, weight: .medium))
+                .foregroundStyle(theme.textSecondary)
+            Spacer()
+            Text(value)
+                .font(.omlxMono(12, weight: .medium))
+                .foregroundStyle(theme.text)
+        }
+    }
+
+    private func graphCaption(_ text: String) -> some View {
+        Text(text)
+            .font(.omlxMono(9))
+            .foregroundStyle(theme.textTertiary)
+    }
+
+    /// Popover readout: one decimal below 100 tk/s, whole numbers above,
+    /// "–" for unknown.
+    static func popoverTps(_ value: Double?) -> String {
+        guard let value, value.isFinite else {
+            return "–"
+        }
+        let clamped = max(0, value)
+        if clamped < 100 {
+            return String(format: "%.1f tk/s", clamped)
+        }
+        return "\(Int(clamped.rounded())) tk/s"
+    }
+}
+
+extension MenubarMetricsStore.Kind {
+    var displayName: String {
+        switch self {
+        case .live:
+            return String(
+                localized: "menubar.metric.title.live",
+                defaultValue: "Live Activity",
+                comment: "Popover title for the live-throughput menubar item"
+            )
+        case .average:
+            return String(
+                localized: "menubar.metric.title.average",
+                defaultValue: "Average Session",
+                comment: "Popover title for the session-average menubar item"
+            )
+        case .alltime:
+            return String(
+                localized: "menubar.metric.title.alltime",
+                defaultValue: "All Time",
+                comment: "Popover title for the all-time-average menubar item"
+            )
+        }
+    }
+}
+
+/// Rolling line graph for one throughput series. Drawn with a single Canvas
+/// pass (no charting framework): the per-tick redraw is one path build, and
+/// the trace is decorative — the numbers above carry the accessible value —
+/// so it opts out of the accessibility tree entirely.
+struct MetricSparkline: View {
+    let values: [Double]
+    let color: Color
+    var height: CGFloat = 22
+    /// Fixed Y range for bounded series (e.g. 0...1 usage fractions).
+    /// nil auto-scales to the data so small variations stay visible.
+    var domain: ClosedRange<Double>? = nil
+
+    var body: some View {
+        Canvas { context, size in
+            guard values.count > 1, size.width > 0, size.height > 0 else {
+                return
+            }
+            let low = domain?.lowerBound ?? (values.min() ?? 0)
+            let high = domain?.upperBound ?? (values.max() ?? 0)
+            // Without a fixed domain, 5% headroom keeps peaks off the top
+            // edge; a flat series draws mid-height instead of hugging the
+            // floor.
+            let span = domain.map { $0.upperBound - $0.lowerBound }
+                ?? (high - low) * 1.05
+            let isFlat = span <= .ulpOfOne
+            let stepX = size.width / CGFloat(values.count - 1)
+
+            var trace = Path()
+            for (index, value) in values.enumerated() {
+                let normalized = isFlat ? 0.5 : (value - low) / span
+                let point = CGPoint(
+                    x: CGFloat(index) * stepX,
+                    y: size.height * (1 - CGFloat(normalized))
+                )
+                if index == 0 {
+                    trace.move(to: point)
+                } else {
+                    trace.addLine(to: point)
+                }
+            }
+
+            var fillArea = trace
+            fillArea.addLine(to: CGPoint(x: size.width, y: size.height))
+            fillArea.addLine(to: CGPoint(x: 0, y: size.height))
+            fillArea.closeSubpath()
+            context.fill(
+                fillArea,
+                with: .linearGradient(
+                    Gradient(colors: [color.opacity(0.25), .clear]),
+                    startPoint: .zero,
+                    endPoint: CGPoint(x: 0, y: size.height)
+                )
+            )
+            context.stroke(
+                trace,
+                with: .color(color),
+                style: StrokeStyle(lineWidth: 1.2, lineJoin: .round)
+            )
+        }
+        .frame(height: height)
+        .accessibilityHidden(true)
+    }
+}

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricPrefs.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricPrefs.swift
@@ -1,0 +1,70 @@
+// Appearance preferences shared by the menubar metric items, the stats
+// poller, and the Appearance settings screen. All values live in
+// UserDefaults (settings.json is server-owned and never sees these).
+
+import Foundation
+
+enum MenubarMetricPrefs {
+    /// Reused legacy key: users who had the inline live-activity text ON
+    /// automatically get the LIV status item (migration by key reuse).
+    static let liveKey = "showLiveActivityInMenuBar"
+    static let averageKey = "menubar.showAverageActivity"
+    static let alltimeKey = "menubar.showAlltimeActivity"
+    /// Double seconds. Absent → 1.0; anything outside the picker set is
+    /// clamped back to 1.0 so a corrupt write can't stall or spin the poller.
+    static let refreshIntervalKey = "menubar.refreshInterval"
+    /// Bool, default false = today's auto behavior (Dock icon only while a
+    /// window is open). True keeps the Dock icon visible permanently.
+    static let showDockIconKey = "showDockIcon"
+
+    static let refreshIntervalChoices: [Double] = [0.5, 1.0, 2.0, 3.0]
+
+    static var refreshInterval: TimeInterval {
+        let raw = UserDefaults.standard.object(forKey: refreshIntervalKey) as? Double ?? 1.0
+        return refreshIntervalChoices.contains(raw) ? raw : 1.0
+    }
+
+    static var showDockIcon: Bool {
+        UserDefaults.standard.bool(forKey: showDockIconKey)
+    }
+
+    static var enabledMetrics: EnabledMetrics {
+        let defaults = UserDefaults.standard
+        return EnabledMetrics(
+            live: defaults.bool(forKey: liveKey),
+            average: defaults.bool(forKey: averageKey),
+            alltime: defaults.bool(forKey: alltimeKey)
+        )
+    }
+
+    // Host-metric bar items (CPU / GPU / MEM). These drive the system
+    // sampler, not the server-stats poller.
+    static let cpuItemKey = "menubar.showCPU"
+    static let gpuItemKey = "menubar.showGPU"
+    static let memoryItemKey = "menubar.showMemory"
+
+    static var enabledSystemItems: EnabledSystemItems {
+        let defaults = UserDefaults.standard
+        return EnabledSystemItems(
+            cpu: defaults.bool(forKey: cpuItemKey),
+            gpu: defaults.bool(forKey: gpuItemKey),
+            memory: defaults.bool(forKey: memoryItemKey)
+        )
+    }
+}
+
+struct EnabledSystemItems: Equatable, Sendable {
+    var cpu: Bool
+    var gpu: Bool
+    var memory: Bool
+
+    var any: Bool { cpu || gpu || memory }
+}
+
+struct EnabledMetrics: Equatable, Sendable {
+    var live: Bool
+    var average: Bool
+    var alltime: Bool
+
+    var any: Bool { live || average || alltime }
+}

--- a/apps/omlx-mac/Sources/Menubar/MenubarMetricsStore.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarMetricsStore.swift
@@ -1,0 +1,117 @@
+// Shared model behind the menubar metric items (LIV / AVG / ALL) and their
+// popovers. The stats poller feeds one applyTick() per poll cycle; the
+// status-item glyphs and any open popover read the latest rates plus a
+// fixed-capacity history window for the activity graphs.
+
+import Foundation
+import Observation
+
+/// Aggregate throughput reading for one metric item.
+struct MetricRates: Equatable, Sendable {
+    /// Prompt-processing speed in tok/s. nil = unknown (fetch failed,
+    /// admin auth unavailable, or server off) — distinct from an idle 0.
+    var promptTps: Double?
+    /// Token-generation speed in tok/s.
+    var generationTps: Double?
+}
+
+@MainActor
+@Observable
+final class MenubarMetricsStore {
+    enum Kind: String, CaseIterable, Sendable {
+        case live
+        case average
+        case alltime
+    }
+
+    struct Series: Equatable, Sendable {
+        var promptTps: [Double] = []
+        var generationTps: [Double] = []
+    }
+
+    /// Samples kept per series — at the default 1 s cadence the activity
+    /// graphs cover the last minute.
+    nonisolated static let historyCapacity = 60
+
+    private(set) var rates: [Kind: MetricRates] = [:]
+    private(set) var history: [Kind: Series] = [:]
+    private(set) var serverIsRunning = false
+
+    /// One call per poller tick. Unknown readings surface as nil rates (the
+    /// glyph shows "–") but roll a 0 into the history so the graph timeline
+    /// stays contiguous.
+    func applyTick(
+        live: MetricRates?,
+        average: MetricRates?,
+        alltime: MetricRates?,
+        serverRunning: Bool
+    ) {
+        serverIsRunning = serverRunning
+        record(.live, live)
+        record(.average, average)
+        record(.alltime, alltime)
+    }
+
+    /// Server transitioned to stopped/failed: blank the readings and freeze
+    /// the history where it was.
+    func markServerStopped() {
+        serverIsRunning = false
+        rates = [:]
+    }
+
+    private func record(_ kind: Kind, _ reading: MetricRates?) {
+        rates[kind] = reading
+        var series = history[kind] ?? Series()
+        Self.append(&series.promptTps, reading?.promptTps ?? 0)
+        Self.append(&series.generationTps, reading?.generationTps ?? 0)
+        history[kind] = series
+    }
+
+    nonisolated static func append(_ series: inout [Double], _ value: Double) {
+        series.append(value)
+        let overflow = series.count - historyCapacity
+        if overflow > 0 {
+            series.removeFirst(overflow)
+        }
+    }
+}
+
+// MARK: - Rate aggregation (pure, unit-testable)
+
+extension MenubarMetricsStore {
+    /// Instantaneous rates summed across every in-flight request of every
+    /// model. A decoded-but-idle activity payload yields 0/0; a missing
+    /// payload (fetch disabled or failed) yields nil.
+    nonisolated static func liveRates(
+        from stats: MenubarStatsPoller.Stats?
+    ) -> MetricRates? {
+        guard let models = stats?.activeModels?.models else {
+            return nil
+        }
+        var promptTps = 0.0
+        var generationTps = 0.0
+        for model in models {
+            for prefill in model.prefilling ?? [] {
+                promptTps += max(0, prefill.speed ?? 0)
+            }
+            for generation in model.generating ?? [] {
+                generationTps += max(0, generation.tokensPerSecond ?? 0)
+            }
+        }
+        return MetricRates(promptTps: promptTps, generationTps: generationTps)
+    }
+
+    /// Cumulative-average rates as reported by the stats endpoints (used for
+    /// both the session and the all-time scope).
+    nonisolated static func averageRates(
+        from stats: MenubarStatsPoller.Stats?
+    ) -> MetricRates? {
+        guard let stats else {
+            return nil
+        }
+        return MetricRates(
+            promptTps: stats.avgPrefillTps,
+            generationTps: stats.avgGenerationTps
+        )
+    }
+}

--- a/apps/omlx-mac/Sources/Menubar/MenubarStatsPoller.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarStatsPoller.swift
@@ -224,16 +224,21 @@ final class MenubarStatsPoller {
     private let baseURL: URL
     private let apiKey: String?
     private let idleInterval: TimeInterval
-    private let liveActivityInterval: TimeInterval
     private let session: URLSession
     private var task: Task<Void, Never>?
-    /// Number of ticks between all-time fetches. Current request activity
-    /// needs steady refresh; all-time stats only show in the "All-Time"
-    /// submenu, so polling them at the same rate burns server CPU for no UX
-    /// benefit. At the one-second live interval this fetches every 30 seconds.
-    private let alltimeRefreshInterval: TimeInterval = 30
+    /// Seconds between all-time fetches. All-time averages only change when a
+    /// request completes and the endpoint is heavyweight (it also builds
+    /// active_models/engines/runtime_cache), so it is never polled at the
+    /// user-facing refresh interval: 5 s keeps an enabled ALL menubar item
+    /// feeling live, 30 s is plenty for the Serving Stats submenu.
+    private var alltimeRefreshInterval: TimeInterval {
+        enabledMetrics.alltime ? 5 : 30
+    }
     private var tickCount = 0
-    private var isLiveActivityPollingEnabled = false
+    private(set) var enabledMetrics = EnabledMetrics(
+        live: false, average: false, alltime: false
+    )
+    private(set) var lastTickWasSuccess = false
 
     private(set) var sessionStats: Stats?
     private(set) var liveStats: Stats?
@@ -244,13 +249,11 @@ final class MenubarStatsPoller {
         baseURL: URL,
         apiKey: String?,
         interval: TimeInterval = 2.0,
-        liveActivityInterval: TimeInterval = 1.0,
         sessionConfiguration: URLSessionConfiguration? = nil
     ) {
         self.baseURL = baseURL
         self.apiKey = apiKey
         self.idleInterval = interval
-        self.liveActivityInterval = liveActivityInterval
 
         let cfg = sessionConfiguration ?? URLSessionConfiguration.default
         // `HTTPCookieStorage()` returns a detached instance that never
@@ -284,19 +287,30 @@ final class MenubarStatsPoller {
         task = nil
     }
 
-    func setLiveActivityPollingEnabled(_ isEnabled: Bool) {
-        guard isLiveActivityPollingEnabled != isEnabled else {
+    func setEnabledMetrics(_ metrics: EnabledMetrics) {
+        guard enabledMetrics != metrics else {
             return
         }
 
-        isLiveActivityPollingEnabled = isEnabled
-        if !isEnabled {
+        let liveTurnedOff = enabledMetrics.live && !metrics.live
+        let alltimeTurnedOn = !enabledMetrics.alltime && metrics.alltime
+        enabledMetrics = metrics
+        if liveTurnedOff {
             clearLiveStats()
+        }
+        if alltimeTurnedOn {
+            // Force an all-time fetch on the next tick so a freshly enabled
+            // ALL item doesn't sit on "–" for up to a full cadence period.
+            tickCount = 0
         }
     }
 
+    /// Any enabled menubar metric item polls at the user-configured refresh
+    /// interval (read live from UserDefaults so setting changes apply on the
+    /// next loop pass); otherwise the idle 2 s cadence keeps the Serving
+    /// Stats submenu fresh at minimal cost.
     var currentPollingInterval: TimeInterval {
-        isLiveActivityPollingEnabled ? liveActivityInterval : idleInterval
+        enabledMetrics.any ? MenubarMetricPrefs.refreshInterval : idleInterval
     }
 
     deinit {
@@ -317,14 +331,14 @@ final class MenubarStatsPoller {
             let s = try await fetchPublicStatus()
             self.sessionStats = s
             self.lastStatusSuccessAt = Date()
-            if isLiveActivityPollingEnabled {
+            if enabledMetrics.live {
                 do {
                     let live = try await fetchAdminActivity()
-                    if isLiveActivityPollingEnabled {
+                    if enabledMetrics.live {
                         self.liveStats = live
                     }
                 } catch {
-                    if isLiveActivityPollingEnabled {
+                    if enabledMetrics.live {
                         clearLiveStats(shouldPostUpdate: false)
                     }
                 }
@@ -333,13 +347,23 @@ final class MenubarStatsPoller {
                let alltime = try? await fetchAdminStats(scope: "alltime") {
                 self.alltimeStats = alltime
             }
+            lastTickWasSuccess = true
             NotificationCenter.default.post(
                 name: Self.didUpdateNotification, object: self
             )
         } catch {
             // Suppress: server may be transitioning, paused, or 401-pending.
             // Next tick retries; we log only the once-per-tick failure mode.
-            clearLiveStats()
+            let wasSuccess = lastTickWasSuccess
+            lastTickWasSuccess = false
+            clearLiveStats(shouldPostUpdate: false)
+            if wasSuccess {
+                // Exactly one "server went away" repaint for the menubar
+                // metric items, instead of silence or per-tick spam.
+                NotificationCenter.default.post(
+                    name: Self.didUpdateNotification, object: self
+                )
+            }
         }
     }
 

--- a/apps/omlx-mac/Sources/Menubar/SystemMenubarItemsController.swift
+++ b/apps/omlx-mac/Sources/Menubar/SystemMenubarItemsController.swift
@@ -1,0 +1,168 @@
+// Owns the combined host-metric status item. Every enabled metric
+// (CPU / GPU / MEM) renders as one tag+bar segment inside a single status
+// item, so enabling several doesn't scatter them across separate menubar
+// squares with system-managed gaps between. Snapshot-driven —
+// MenubarController's sampling timer pushes a fresh SystemStatsSnapshot via
+// apply(_:) while any metric is enabled; the glyph re-rasters only when a
+// pixel-quantized bar level (or the enabled set / appearance) changes.
+// Clicking opens one transient popover stacking the enabled panels.
+
+import AppKit
+import SwiftUI
+
+@MainActor
+final class SystemMenubarItemsController: NSObject, NSPopoverDelegate {
+
+    private var statusItem: NSStatusItem?
+    private var popover: NSPopover?
+    private var lastSignature: String?
+    private var lastSnapshot = SystemStatsSnapshot()
+    /// Set by MenubarController to close the other controller's popovers so
+    /// menubar dropdowns stay mutually exclusive.
+    var willShowPopover: (() -> Void)?
+
+    private var enabledKinds: [SystemStatKind] {
+        let items = MenubarMetricPrefs.enabledSystemItems
+        var kinds: [SystemStatKind] = []
+        if items.cpu { kinds.append(.cpu) }
+        if items.gpu { kinds.append(.gpu) }
+        if items.memory { kinds.append(.memory) }
+        return kinds
+    }
+
+    /// Stores the snapshot and reconciles + repaints. Called on every
+    /// sampling tick.
+    func apply(_ snapshot: SystemStatsSnapshot) {
+        lastSnapshot = snapshot
+        sync()
+    }
+
+    /// Reconciles the combined item with the Appearance toggles using the
+    /// last snapshot. Also called on UserDefaults changes.
+    func sync() {
+        let kinds = enabledKinds
+        guard !kinds.isEmpty else {
+            tearDownItem()
+            return
+        }
+
+        if statusItem == nil {
+            makeItem()
+        }
+        guard let button = statusItem?.button else {
+            return
+        }
+
+        let darkMenubar = button.effectiveAppearance
+            .bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        let segments: [MenubarMetricGlyph.BarSegment] = kinds.map {
+            (tag: $0.tag, fraction: fraction(for: $0))
+        }
+        let signature = MenubarMetricGlyph.barsSignature(
+            segments: segments, darkMenubar: darkMenubar
+        )
+        if lastSignature != signature {
+            button.image = MenubarMetricGlyph.barsImage(
+                segments: segments, darkMenubar: darkMenubar
+            )
+            button.toolTip = "oMLX · " + segments
+                .map { "\($0.tag) \(StatsFormat.percent($0.fraction))" }
+                .joined(separator: " · ")
+            lastSignature = signature
+        }
+
+        if let popover, popover.isShown,
+           let hosting = popover.contentViewController as? NSHostingController<AnyView> {
+            hosting.rootView = panelStackRoot(for: kinds)
+        }
+    }
+
+    func closeAllPopovers() {
+        if popover?.isShown == true {
+            popover?.performClose(nil)
+        }
+    }
+
+    private func fraction(for kind: SystemStatKind) -> Double? {
+        switch kind {
+        case .cpu:
+            return lastSnapshot.cpuTotalUsage
+        case .gpu:
+            return lastSnapshot.gpuUsage
+        case .memory:
+            return lastSnapshot.memory.totalBytes > 0
+                ? lastSnapshot.memory.usedFraction
+                : nil
+        }
+    }
+
+    private func panelStackRoot(for kinds: [SystemStatKind]) -> AnyView {
+        AnyView(
+            SystemStatsPanelStack(
+                kinds: kinds,
+                snapshot: lastSnapshot,
+                refreshInterval: MenubarMetricPrefs.refreshInterval
+            )
+            .padding(.vertical, 4)
+            .omlxThemed()
+        )
+    }
+
+    private func hostingController(for kinds: [SystemStatKind]) -> NSHostingController<AnyView> {
+        let hosting = NSHostingController(rootView: panelStackRoot(for: kinds))
+        // Keep preferredContentSize tracking the SwiftUI fitting size so the
+        // popover follows the fixed panel width instead of freezing on the
+        // default frame it opens with.
+        hosting.sizingOptions = [.preferredContentSize]
+        return hosting
+    }
+
+    private func makeItem() {
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        item.autosaveName = "omlx.system.combined"
+
+        let popover = NSPopover()
+        popover.behavior = .transient
+        popover.delegate = self
+
+        if let button = item.button {
+            button.target = self
+            button.action = #selector(systemButtonClicked(_:))
+            button.setAccessibilityLabel("oMLX system stats")
+        }
+        self.statusItem = item
+        self.popover = popover
+        self.lastSignature = nil
+    }
+
+    private func tearDownItem() {
+        guard let item = statusItem else { return }
+        popover?.performClose(nil)
+        NSStatusBar.system.removeStatusItem(item)
+        statusItem = nil
+        popover = nil
+        lastSignature = nil
+    }
+
+    @objc private func systemButtonClicked(_ sender: NSStatusBarButton) {
+        guard let popover else { return }
+        if popover.isShown {
+            popover.performClose(nil)
+            return
+        }
+        willShowPopover?()
+        let hosting = hostingController(for: enabledKinds)
+        popover.contentViewController = hosting
+        // Seed the popover with the real fitting size so it never flashes
+        // (or sticks at) the default popover frame on first open.
+        popover.contentSize = hosting.sizeThatFits(
+            in: NSSize(width: 1_000, height: 2_000)
+        )
+        popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .minY)
+        popover.contentViewController?.view.window?.makeKey()
+    }
+
+    func popoverDidClose(_ notification: Notification) {
+        (notification.object as? NSPopover)?.contentViewController = nil
+    }
+}

--- a/apps/omlx-mac/Sources/Menubar/SystemStatsPanels.swift
+++ b/apps/omlx-mac/Sources/Menubar/SystemStatsPanels.swift
@@ -1,0 +1,402 @@
+// The three panels inside the menubar's System Stats submenu: CPU, GPU,
+// and Memory. Each is a value-driven SwiftUI view fed a SystemStatsSnapshot
+// by MenubarController's sampling timer, hosted in an NSMenuItem custom
+// view. Value-driven (no observation) so updates render synchronously even
+// while the menu run loop is in tracking mode.
+
+import SwiftUI
+
+private let panelWidth: CGFloat = 270
+
+// MARK: - CPU
+
+struct CPUStatsPanel: View {
+    let snapshot: SystemStatsSnapshot
+    let refreshInterval: TimeInterval
+
+    @Environment(\.omlxTheme) private var theme
+
+    private var eColor: Color { Color(nsColor: .systemOrange) }
+    private var pColor: Color { Color(nsColor: .systemBlue) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            StatsPanelHeader(title: "CPU")
+            UsageBarRow(
+                label: String(localized: "menubar.system.e_cores",
+                              defaultValue: "E-cores",
+                              comment: "CPU panel row label for efficiency-core usage"),
+                value: StatsFormat.percent(snapshot.eCoreUsage),
+                fraction: snapshot.eCoreUsage ?? 0,
+                color: eColor
+            )
+            UsageBarRow(
+                label: String(localized: "menubar.system.p_cores",
+                              defaultValue: "P-cores",
+                              comment: "CPU panel row label for performance-core usage"),
+                value: StatsFormat.percent(snapshot.pCoreUsage),
+                fraction: snapshot.pCoreUsage ?? 0,
+                color: pColor
+            )
+            StatsPanelCaption(
+                text: String(localized: "menubar.system.cpu_caption",
+                             defaultValue: "E (amber) / P (blue) usage",
+                             comment: "CPU panel caption under the usage bars"),
+                window: StatsFormat.window(sampleCount: snapshot.eHistory.count,
+                                           interval: refreshInterval)
+            )
+            ZStack {
+                MetricSparkline(values: snapshot.pHistory, color: pColor,
+                                height: 26, domain: 0...1)
+                MetricSparkline(values: snapshot.eHistory, color: eColor,
+                                height: 26, domain: 0...1)
+            }
+            Divider()
+            StatsValueRow(
+                label: String(localized: "menubar.system.thermal",
+                              defaultValue: "Thermal",
+                              comment: "CPU panel row label for the system thermal state"),
+                value: SystemMetricsPoller.label(
+                    for: SystemMetricsPoller.severity(for: snapshot.thermalState)
+                )
+            )
+            StatsValueRow(
+                label: String(localized: "menubar.system.load_avg",
+                              defaultValue: "Load avg",
+                              comment: "CPU panel row label for the 1/5/15-minute load averages"),
+                value: SystemStatsSampler.formatLoadAverages(snapshot.loadAverages)
+            )
+            StatsValueRow(
+                label: String(localized: "menubar.system.uptime",
+                              defaultValue: "Uptime",
+                              comment: "CPU panel row label for system uptime"),
+                value: SystemStatsSampler.formatUptime(snapshot.uptimeSeconds)
+            )
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .frame(width: panelWidth)
+    }
+}
+
+// MARK: - GPU
+
+struct GPUStatsPanel: View {
+    let snapshot: SystemStatsSnapshot
+    let refreshInterval: TimeInterval
+
+    @Environment(\.omlxTheme) private var theme
+
+    private var gpuColor: Color { Color(nsColor: .systemGreen) }
+    private var gpuMemColor: Color { Color(nsColor: .systemCyan) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            StatsPanelHeader(title: "GPU")
+            UsageBarRow(
+                label: "GPU",
+                value: StatsFormat.percent(snapshot.gpuUsage),
+                fraction: snapshot.gpuUsage ?? 0,
+                color: gpuColor
+            )
+            UsageBarRow(
+                label: String(localized: "menubar.system.gpu_memory",
+                              defaultValue: "GPU memory",
+                              comment: "GPU panel row label for accelerator in-use memory"),
+                value: snapshot.gpuMemoryInUseBytes.map {
+                    String(localized: "menubar.system.in_use",
+                           defaultValue: "\(SystemStatsSampler.formatBytes($0)) in use",
+                           comment: "GPU memory value; placeholder is a byte size like 2.60 GB")
+                } ?? "–",
+                fraction: gpuMemoryFraction,
+                color: gpuMemColor
+            )
+            StatsPanelCaption(
+                text: String(localized: "menubar.system.gpu_caption",
+                             defaultValue: "GPU (green) / GPU mem (cyan)",
+                             comment: "GPU panel caption under the usage bars"),
+                window: StatsFormat.window(sampleCount: snapshot.gpuHistory.count,
+                                           interval: refreshInterval)
+            )
+            MetricSparkline(values: snapshot.gpuHistory, color: gpuColor,
+                            height: 26, domain: 0...1)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .frame(width: panelWidth)
+    }
+
+    private var gpuMemoryFraction: Double {
+        guard let inUse = snapshot.gpuMemoryInUseBytes,
+              snapshot.memory.totalBytes > 0
+        else {
+            return 0
+        }
+        return min(1, Double(inUse) / Double(snapshot.memory.totalBytes))
+    }
+}
+
+// MARK: - Memory
+
+struct MemoryStatsPanel: View {
+    let snapshot: SystemStatsSnapshot
+
+    @Environment(\.omlxTheme) private var theme
+
+    private var wiredColor: Color { Color(nsColor: .systemBlue) }
+    private var activeColor: Color { Color(nsColor: .systemRed) }
+    private var compressedColor: Color { Color(nsColor: .systemPurple) }
+
+    var body: some View {
+        let memory = snapshot.memory
+        VStack(alignment: .leading, spacing: 6) {
+            StatsPanelHeader(title: String(
+                localized: "menubar.system.memory_title",
+                defaultValue: "Memory",
+                comment: "Title of the Memory panel in the System Stats submenu"
+            ))
+            HStack {
+                Text("\(SystemMetricsPoller.formatBytesAsGB(memory.usedBytes)) / \(StatsFormat.wholeGB(memory.totalBytes)) GB")
+                    .font(.omlxMono(12, weight: .semibold))
+                    .foregroundStyle(theme.text)
+                Spacer()
+                Text(StatsFormat.percent(memory.usedFraction))
+                    .font(.omlxMono(12))
+                    .foregroundStyle(theme.textSecondary)
+            }
+            SegmentedUsageBar(
+                total: memory.totalBytes,
+                segments: [
+                    (memory.wiredBytes, wiredColor),
+                    (memory.activeBytes, activeColor),
+                    (memory.compressedBytes, compressedColor),
+                ]
+            )
+            legendRow(color: wiredColor,
+                      label: String(localized: "menubar.system.wired",
+                                    defaultValue: "Wired",
+                                    comment: "Memory panel legend row for wired memory"),
+                      bytes: memory.wiredBytes)
+            legendRow(color: activeColor,
+                      label: String(localized: "menubar.system.active",
+                                    defaultValue: "Active",
+                                    comment: "Memory panel legend row for active memory"),
+                      bytes: memory.activeBytes)
+            legendRow(color: compressedColor,
+                      label: String(localized: "menubar.system.compressed",
+                                    defaultValue: "Compressed",
+                                    comment: "Memory panel legend row for compressed memory"),
+                      bytes: memory.compressedBytes)
+            legendRow(color: theme.textTertiary.opacity(0.4),
+                      label: String(localized: "menubar.system.free",
+                                    defaultValue: "Free",
+                                    comment: "Memory panel legend row for free memory"),
+                      bytes: memory.freeBytes)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .frame(width: panelWidth)
+    }
+
+    private func legendRow(color: Color, label: String, bytes: UInt64) -> some View {
+        HStack(spacing: 6) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(color)
+                .frame(width: 8, height: 8)
+            Text(label)
+                .font(.omlxText(11.5))
+                .foregroundStyle(theme.textSecondary)
+            Spacer()
+            Text(SystemStatsSampler.formatBytes(bytes))
+                .font(.omlxMono(11.5))
+                .foregroundStyle(theme.text)
+        }
+    }
+}
+
+// MARK: - Combined popover stack
+
+/// The enabled panels stacked into one popover for the combined CPU/GPU/MEM
+/// status item, separated like the System Stats submenu.
+struct SystemStatsPanelStack: View {
+    let kinds: [SystemStatKind]
+    let snapshot: SystemStatsSnapshot
+    let refreshInterval: TimeInterval
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(kinds.enumerated()), id: \.element) { index, kind in
+                if index > 0 {
+                    SectionRule()
+                }
+                panel(for: kind)
+            }
+        }
+        // Pin the stack to the panel width. Without this, any width-flexible
+        // child (a divider) makes the hosting controller's fitting width
+        // echo whatever the popover proposed — and a popover proposes its
+        // default ~320 pt frame on first open, which then sticks, leaving a
+        // dead right margin whenever two or more panels are stacked.
+        .frame(width: panelWidth)
+    }
+
+    @ViewBuilder
+    private func panel(for kind: SystemStatKind) -> some View {
+        switch kind {
+        case .cpu:
+            CPUStatsPanel(snapshot: snapshot, refreshInterval: refreshInterval)
+        case .gpu:
+            GPUStatsPanel(snapshot: snapshot, refreshInterval: refreshInterval)
+        case .memory:
+            MemoryStatsPanel(snapshot: snapshot)
+        }
+    }
+}
+
+// MARK: - Shared pieces
+
+/// Panel-width section rule (14 pt inset each side, like a padded Divider).
+/// Both frames are fixed widths on purpose: a width-flexible child at the
+/// stack level would let the hosting controller's fitting width track the
+/// popover's proposed frame instead of the panel width.
+struct SectionRule: View {
+    var containerWidth: CGFloat = panelWidth
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        Rectangle()
+            .fill(theme.rowSep)
+            .frame(width: containerWidth - 28, height: 1)
+            .frame(width: containerWidth)
+            .padding(.vertical, 4)
+            .accessibilityHidden(true)
+    }
+}
+
+private struct StatsPanelHeader: View {
+    let title: String
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        Text(title.uppercased())
+            .font(.omlxText(10, weight: .bold))
+            .kerning(1)
+            .foregroundStyle(theme.accent)
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
+}
+
+private struct StatsPanelCaption: View {
+    let text: String
+    let window: String
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        Text(window.isEmpty ? text : "\(text) · \(window)")
+            .font(.omlxText(9.5))
+            .foregroundStyle(theme.textTertiary)
+    }
+}
+
+private struct UsageBarRow: View {
+    let label: String
+    let value: String
+    let fraction: Double
+    let color: Color
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack {
+                Text(label)
+                    .font(.omlxText(12, weight: .medium))
+                    .foregroundStyle(theme.text)
+                Spacer()
+                Text(value)
+                    .font(.omlxMono(12))
+                    .foregroundStyle(theme.text)
+            }
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(theme.textTertiary.opacity(0.18))
+                    Capsule()
+                        .fill(color)
+                        .frame(width: max(
+                            4, geo.size.width * min(1, max(0, fraction))
+                        ))
+                }
+            }
+            .frame(height: 5)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct StatsValueRow: View {
+    let label: String
+    let value: String
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.omlxText(12))
+                .foregroundStyle(theme.textSecondary)
+            Spacer()
+            Text(value)
+                .font(.omlxMono(12))
+                .foregroundStyle(theme.text)
+        }
+    }
+}
+
+private struct SegmentedUsageBar: View {
+    let total: UInt64
+    let segments: [(bytes: UInt64, color: Color)]
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        GeometryReader { geo in
+            HStack(spacing: 1) {
+                ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
+                    let fraction = total > 0
+                        ? Double(segment.bytes) / Double(total)
+                        : 0
+                    if fraction > 0.001 {
+                        Rectangle()
+                            .fill(segment.color)
+                            .frame(width: max(2, geo.size.width * fraction))
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .background(theme.textTertiary.opacity(0.18))
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+        .frame(height: 9)
+        .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Formatting helpers (pure, unit-tested)
+
+enum StatsFormat {
+    /// 0.153 → "15%"; nil → "–"
+    static func percent(_ fraction: Double?) -> String {
+        guard let fraction, fraction.isFinite else { return "–" }
+        return "\(Int((min(1, max(0, fraction)) * 100).rounded()))%"
+    }
+
+    /// 512_000_000_000 → "512" (whole decimal GB for machine totals)
+    static func wholeGB(_ bytes: UInt64) -> String {
+        "\(Int((Double(bytes) / 1_000_000_000).rounded()))"
+    }
+
+    /// History window caption: 60 samples at 1 s → "60s"; at 0.5 s → "30s".
+    /// Empty history → empty string (caption shows no window).
+    static func window(sampleCount: Int, interval: TimeInterval) -> String {
+        guard sampleCount > 1, interval > 0 else { return "" }
+        return "\(Int((Double(sampleCount) * interval).rounded()))s"
+    }
+}

--- a/apps/omlx-mac/Sources/Menubar/SystemStatsSampler.swift
+++ b/apps/omlx-mac/Sources/Menubar/SystemStatsSampler.swift
@@ -1,0 +1,339 @@
+// Host-level stats behind the menubar's System Stats submenu. Everything
+// here is public API only: Mach per-CPU tick counters (E/P cluster split
+// via hw.perflevel sysctls), the IOKit accelerator performance dictionary
+// for GPU utilization and in-use memory, vm_statistics64 for the memory
+// breakdown, getloadavg, and kern.boottime. Power draw, core frequencies,
+// and die temperature would need private frameworks and are intentionally
+// out of scope; ProcessInfo's thermal state stands in for temperature.
+//
+// The sampler is polled by MenubarController only while the System Stats
+// submenu is open — there is no background sampling cost. CPU usage comes
+// from deltas of cumulative tick counters, so the first tick after a long
+// gap still yields a valid average over that window.
+
+import AppKit
+import Darwin.Mach
+import IOKit
+
+/// The host metrics the menubar can surface, in display order.
+enum SystemStatKind: String, CaseIterable, Hashable, Sendable {
+    case cpu
+    case gpu
+    case memory
+
+    var tag: String {
+        switch self {
+        case .cpu: return "CPU"
+        case .gpu: return "GPU"
+        case .memory: return "MEM"
+        }
+    }
+}
+
+struct SystemStatsSnapshot: Sendable {
+    struct Memory: Sendable {
+        var totalBytes: UInt64 = 0
+        var wiredBytes: UInt64 = 0
+        var activeBytes: UInt64 = 0
+        var compressedBytes: UInt64 = 0
+        /// Derived as total − (wired + active + compressed) so the four
+        /// legend rows always sum to the machine total.
+        var freeBytes: UInt64 = 0
+        var usedBytes: UInt64 { wiredBytes + activeBytes + compressedBytes }
+        var usedFraction: Double {
+            totalBytes > 0 ? Double(usedBytes) / Double(totalBytes) : 0
+        }
+    }
+
+    /// Fractions 0...1; nil while a reading is unavailable.
+    var eCoreUsage: Double?
+    var pCoreUsage: Double?
+    /// All-core average, for the single-bar CPU menubar item.
+    var cpuTotalUsage: Double?
+    var gpuUsage: Double?
+    var gpuMemoryInUseBytes: UInt64?
+    var memory = Memory()
+    var loadAverages: [Double] = []
+    var uptimeSeconds: TimeInterval = 0
+    var thermalState: ProcessInfo.ThermalState = .nominal
+
+    var eHistory: [Double] = []
+    var pHistory: [Double] = []
+    var gpuHistory: [Double] = []
+}
+
+@MainActor
+final class SystemStatsSampler {
+
+    struct CPUTicks: Equatable, Sendable {
+        var busy: UInt64
+        var total: UInt64
+    }
+
+    private var previousTicks: [CPUTicks]?
+    private var eHistory: [Double] = []
+    private var pHistory: [Double] = []
+    private var gpuHistory: [Double] = []
+    private let eCoreCount = SystemStatsSampler.readECoreCount()
+
+    func sample() -> SystemStatsSnapshot {
+        var snapshot = SystemStatsSnapshot()
+
+        if let ticks = Self.readCPUTicks() {
+            if let previous = previousTicks,
+               let usage = Self.clusterUsage(
+                   previous: previous, current: ticks, eCoreCount: eCoreCount
+               ) {
+                snapshot.eCoreUsage = usage.e
+                snapshot.pCoreUsage = usage.p
+                snapshot.cpuTotalUsage = usage.total
+                MenubarMetricsStore.append(&eHistory, usage.e)
+                MenubarMetricsStore.append(&pHistory, usage.p)
+            }
+            previousTicks = ticks
+        }
+
+        if let gpu = Self.readGPUStatistics() {
+            snapshot.gpuUsage = gpu.usage
+            snapshot.gpuMemoryInUseBytes = gpu.memoryInUseBytes
+            if let usage = gpu.usage {
+                MenubarMetricsStore.append(&gpuHistory, usage)
+            }
+        }
+
+        snapshot.memory = Self.readMemory()
+        var loads = [Double](repeating: 0, count: 3)
+        if getloadavg(&loads, 3) == 3 {
+            snapshot.loadAverages = loads
+        }
+        snapshot.uptimeSeconds = Self.readUptime()
+        snapshot.thermalState = ProcessInfo.processInfo.thermalState
+
+        snapshot.eHistory = eHistory
+        snapshot.pHistory = pHistory
+        snapshot.gpuHistory = gpuHistory
+        return snapshot
+    }
+
+    // MARK: - CPU
+
+    /// Logical-CPU count of the efficiency cluster. Apple Silicon enumerates
+    /// the E cluster first in Mach's per-CPU arrays; `hw.perflevel1` is the
+    /// efficiency level whenever two performance levels exist. 0 (Intel or
+    /// unknown) makes every core count as P.
+    nonisolated private static func readECoreCount() -> Int {
+        var levels: Int32 = 0
+        var size = MemoryLayout<Int32>.size
+        guard sysctlbyname("hw.nperflevels", &levels, &size, nil, 0) == 0,
+              levels >= 2
+        else {
+            return 0
+        }
+        var count: Int32 = 0
+        size = MemoryLayout<Int32>.size
+        guard sysctlbyname("hw.perflevel1.logicalcpu", &count, &size, nil, 0) == 0 else {
+            return 0
+        }
+        return Int(count)
+    }
+
+    /// Cumulative busy/total ticks per logical CPU, in kernel enumeration
+    /// order (E cluster first on Apple Silicon).
+    nonisolated private static func readCPUTicks() -> [CPUTicks]? {
+        var cpuCount: natural_t = 0
+        var info: processor_info_array_t?
+        var infoCount: mach_msg_type_number_t = 0
+        let result = host_processor_info(
+            mach_host_self(),
+            PROCESSOR_CPU_LOAD_INFO,
+            &cpuCount,
+            &info,
+            &infoCount
+        )
+        guard result == KERN_SUCCESS, let info else { return nil }
+        defer {
+            vm_deallocate(
+                mach_task_self_,
+                vm_address_t(bitPattern: info),
+                vm_size_t(infoCount) * vm_size_t(MemoryLayout<integer_t>.stride)
+            )
+        }
+
+        let stride = Int(CPU_STATE_MAX)
+        var ticks: [CPUTicks] = []
+        ticks.reserveCapacity(Int(cpuCount))
+        for cpu in 0..<Int(cpuCount) {
+            let base = cpu * stride
+            let user = UInt64(UInt32(bitPattern: info[base + Int(CPU_STATE_USER)]))
+            let system = UInt64(UInt32(bitPattern: info[base + Int(CPU_STATE_SYSTEM)]))
+            let nice = UInt64(UInt32(bitPattern: info[base + Int(CPU_STATE_NICE)]))
+            let idle = UInt64(UInt32(bitPattern: info[base + Int(CPU_STATE_IDLE)]))
+            let busy = user &+ system &+ nice
+            ticks.append(CPUTicks(busy: busy, total: busy &+ idle))
+        }
+        return ticks
+    }
+
+    /// Average busy fraction per cluster between two tick readings. The
+    /// counters are 32-bit in the kernel and wrap; a wrapped or shrunk
+    /// counter invalidates that CPU's delta, and a reading with no usable
+    /// delta at all yields nil. Exposed for unit tests.
+    nonisolated static func clusterUsage(
+        previous: [CPUTicks],
+        current: [CPUTicks],
+        eCoreCount: Int
+    ) -> (e: Double, p: Double, total: Double)? {
+        guard previous.count == current.count, !current.isEmpty else {
+            return nil
+        }
+        var eBusy = 0.0, eTotal = 0.0
+        var pBusy = 0.0, pTotal = 0.0
+        for index in current.indices {
+            let prev = previous[index]
+            let cur = current[index]
+            guard cur.total > prev.total, cur.busy >= prev.busy else { continue }
+            let busy = Double(cur.busy - prev.busy)
+            let total = Double(cur.total - prev.total)
+            if index < eCoreCount {
+                eBusy += busy
+                eTotal += total
+            } else {
+                pBusy += busy
+                pTotal += total
+            }
+        }
+        let allBusy = eBusy + pBusy
+        let allTotal = eTotal + pTotal
+        guard allTotal > 0 else { return nil }
+        return (
+            e: eTotal > 0 ? min(1, eBusy / eTotal) : 0,
+            p: pTotal > 0 ? min(1, pBusy / pTotal) : 0,
+            total: min(1, allBusy / allTotal)
+        )
+    }
+
+    // MARK: - GPU
+
+    /// Reads the accelerator's PerformanceStatistics dictionary (public
+    /// IOKit registry, no entitlements). Apple Silicon exposes one AGX
+    /// service conforming to IOAccelerator with "Device Utilization %" and
+    /// "In use system memory".
+    nonisolated private static func readGPUStatistics()
+        -> (usage: Double?, memoryInUseBytes: UInt64?)?
+    {
+        var iterator: io_iterator_t = 0
+        guard IOServiceGetMatchingServices(
+            kIOMainPortDefault,
+            IOServiceMatching("IOAccelerator"),
+            &iterator
+        ) == KERN_SUCCESS else {
+            return nil
+        }
+        defer { IOObjectRelease(iterator) }
+
+        while true {
+            let service = IOIteratorNext(iterator)
+            guard service != 0 else { break }
+            defer { IOObjectRelease(service) }
+
+            var propertiesRef: Unmanaged<CFMutableDictionary>?
+            guard IORegistryEntryCreateCFProperties(
+                service, &propertiesRef, kCFAllocatorDefault, 0
+            ) == KERN_SUCCESS,
+                let properties = propertiesRef?.takeRetainedValue() as? [String: Any],
+                let statistics = properties["PerformanceStatistics"] as? [String: Any]
+            else {
+                continue
+            }
+
+            let usage = (statistics["Device Utilization %"] as? NSNumber)
+                .map { min(1, max(0, $0.doubleValue / 100)) }
+            let memory = (statistics["In use system memory"] as? NSNumber)
+                .map { UInt64(truncating: $0) }
+            if usage != nil || memory != nil {
+                return (usage: usage, memoryInUseBytes: memory)
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Memory
+
+    nonisolated private static func readMemory() -> SystemStatsSnapshot.Memory {
+        var memory = SystemStatsSnapshot.Memory()
+        memory.totalBytes = ProcessInfo.processInfo.physicalMemory
+
+        var size = mach_msg_type_number_t(
+            MemoryLayout<vm_statistics64_data_t>.stride / MemoryLayout<integer_t>.stride
+        )
+        var stats = vm_statistics64_data_t()
+        let result = withUnsafeMutablePointer(to: &stats) { ptr -> kern_return_t in
+            ptr.withMemoryRebound(to: integer_t.self, capacity: Int(size)) { rebound in
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, rebound, &size)
+            }
+        }
+        var pageSize: vm_size_t = 0
+        guard result == KERN_SUCCESS,
+              host_page_size(mach_host_self(), &pageSize) == KERN_SUCCESS
+        else {
+            return memory
+        }
+
+        let page = UInt64(pageSize)
+        memory.wiredBytes = UInt64(stats.wire_count) * page
+        memory.activeBytes = UInt64(stats.active_count) * page
+        memory.compressedBytes = UInt64(stats.compressor_page_count) * page
+        memory.freeBytes = memory.totalBytes > memory.usedBytes
+            ? memory.totalBytes - memory.usedBytes
+            : 0
+        return memory
+    }
+
+    // MARK: - Misc readings
+
+    /// Wall-clock uptime from kern.boottime (ProcessInfo.systemUptime stops
+    /// while the machine sleeps, which reads oddly next to `uptime`).
+    nonisolated private static func readUptime() -> TimeInterval {
+        var boottime = timeval()
+        var size = MemoryLayout<timeval>.size
+        guard sysctlbyname("kern.boottime", &boottime, &size, nil, 0) == 0,
+              boottime.tv_sec > 0
+        else {
+            return ProcessInfo.processInfo.systemUptime
+        }
+        let booted = TimeInterval(boottime.tv_sec)
+        return max(0, Date().timeIntervalSince1970 - booted)
+    }
+
+    // MARK: - Formatting (pure, unit-tested)
+
+    /// "8d 18h" / "5h 12m" / "42m"
+    nonisolated static func formatUptime(_ seconds: TimeInterval) -> String {
+        let minutes = Int(seconds) / 60
+        let hours = minutes / 60
+        let days = hours / 24
+        if days >= 1 {
+            return "\(days)d \(hours % 24)h"
+        }
+        if hours >= 1 {
+            return "\(hours)h \(minutes % 60)m"
+        }
+        return "\(max(0, minutes))m"
+    }
+
+    /// "3.50 · 2.67 · 2.33"
+    nonisolated static func formatLoadAverages(_ loads: [Double]) -> String {
+        guard !loads.isEmpty else { return "–" }
+        return loads.map { String(format: "%.2f", $0) }.joined(separator: " · ")
+    }
+
+    /// "237.29 GB" / "730 MB" — legend-row byte formatting, decimal units
+    /// to match how macOS reports memory sizes.
+    nonisolated static func formatBytes(_ bytes: UInt64) -> String {
+        let gb = Double(bytes) / 1_000_000_000
+        if gb >= 1 {
+            return String(format: "%.2f GB", gb)
+        }
+        return String(format: "%.0f MB", Double(bytes) / 1_000_000)
+    }
+}

--- a/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/MenubarControllerPortTests.swift
@@ -251,130 +251,6 @@ final class MenubarControllerPortTests: XCTestCase {
         XCTAssertEqual(activity.detail, "Laguna XS.2 · 321 tok/s · 47s left")
     }
 
-    func testMenuBarButtonTitleRequiresTheLiveActivityPreference() throws {
-        let data = try XCTUnwrap(
-            """
-            {
-              "active_models": {
-                "models": [
-                  {
-                    "id": "Laguna XS.2",
-                    "generating": [
-                      {
-                        "request_id": "generation-1",
-                        "generated_tokens": 128,
-                        "tokens_per_second": 42.1,
-                        "elapsed_seconds": 3.0
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-            """.data(using: .utf8)
-        )
-        let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
-        let activity = try XCTUnwrap(stats.liveActivity)
-
-        XCTAssertEqual(
-            MenubarController.menuBarButtonTitle(
-                serverState: .running(pid: 123),
-                liveActivity: activity,
-                isLiveActivityEnabled: false
-            ),
-            ""
-        )
-        XCTAssertEqual(
-            MenubarController.menuBarButtonTitle(
-                serverState: .stopped,
-                liveActivity: activity,
-                isLiveActivityEnabled: true
-            ),
-            ""
-        )
-        XCTAssertEqual(
-            MenubarController.menuBarButtonTitle(
-                serverState: .running(pid: 123),
-                liveActivity: activity,
-                isLiveActivityEnabled: true
-            ),
-            "GEN 42.1 tok/s"
-        )
-    }
-
-    func testLiveActivityUsesOneStatusItemWithBirdPinnedToItsRightEdge() {
-        let idlePresentation = MenubarController.menuBarStatusItemPresentation(
-            activityTitle: "",
-            activityTextWidth: 0,
-            statusBarThickness: 24
-        )
-        let activePresentation = MenubarController.menuBarStatusItemPresentation(
-            activityTitle: "PP 55% · 6k/11k",
-            activityTextWidth: 100,
-            statusBarThickness: 24
-        )
-
-        XCTAssertEqual(idlePresentation.itemLength, NSStatusItem.squareLength)
-        XCTAssertEqual(activePresentation.itemLength, 133)
-        XCTAssertEqual(idlePresentation.iconCenterTrailingOffset, 12)
-        XCTAssertEqual(activePresentation.iconCenterTrailingOffset, 12)
-        XCTAssertFalse(idlePresentation.reservesActivityLabelSpace)
-        XCTAssertTrue(activePresentation.reservesActivityLabelSpace)
-        XCTAssertEqual(activePresentation.activityTitle, "PP 55% · 6k/11k")
-        XCTAssertNil(idlePresentation.accessibilityValue)
-        XCTAssertEqual(activePresentation.accessibilityValue, "PP 55% · 6k/11k")
-    }
-
-    func testMenuBarToolTipRequiresVisibleLiveActivity() throws {
-        let data = try XCTUnwrap(
-            """
-            {
-              "active_models": {
-                "models": [
-                  {
-                    "id": "Laguna XS.2",
-                    "generating": [
-                      {
-                        "generated_tokens": 128,
-                        "tokens_per_second": 42.1,
-                        "elapsed_seconds": 3.0
-                      }
-                    ]
-                  }
-                ]
-              }
-            }
-            """.data(using: .utf8)
-        )
-        let stats = try JSONDecoder().decode(MenubarStatsPoller.Stats.self, from: data)
-        let activity = try XCTUnwrap(stats.liveActivity)
-
-        XCTAssertEqual(
-            MenubarController.menuBarButtonToolTip(
-                serverState: .running(pid: 123),
-                liveActivity: activity,
-                isLiveActivityEnabled: true
-            ),
-            "Laguna XS.2 · 128 tok · 3s"
-        )
-        XCTAssertEqual(
-            MenubarController.menuBarButtonToolTip(
-                serverState: .running(pid: 123),
-                liveActivity: activity,
-                isLiveActivityEnabled: false
-            ),
-            "oMLX"
-        )
-        XCTAssertEqual(
-            MenubarController.menuBarButtonToolTip(
-                serverState: .stopped,
-                liveActivity: activity,
-                isLiveActivityEnabled: true
-            ),
-            "oMLX"
-        )
-    }
-
     func testLiveActivityShowsGenerationWhenNoPrefillIsActive() throws {
         let data = try XCTUnwrap(
             """
@@ -461,7 +337,7 @@ final class MenubarControllerPortTests: XCTestCase {
             apiKey: "test-key",
             sessionConfiguration: sessionConfiguration
         )
-        poller.setLiveActivityPollingEnabled(true)
+        poller.setEnabledMetrics(EnabledMetrics(live: true, average: false, alltime: false))
 
         await poller.refreshOnce()
 
@@ -471,7 +347,11 @@ final class MenubarControllerPortTests: XCTestCase {
         XCTAssertEqual(MenubarStatsURLProtocol.recordedActivityRequestCount(), 1)
     }
 
-    func testPollingOnlyAcceleratesAfterLiveActivityOptIn() {
+    func testPollingFollowsRefreshIntervalOnlyWhileAMetricItemIsEnabled() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: MenubarMetricPrefs.refreshIntervalKey)
+        defer { defaults.removeObject(forKey: MenubarMetricPrefs.refreshIntervalKey) }
+
         let poller = MenubarStatsPoller(
             baseURL: URL(string: "http://omlx.test")!,
             apiKey: "test-key"
@@ -479,10 +359,23 @@ final class MenubarControllerPortTests: XCTestCase {
 
         XCTAssertEqual(poller.currentPollingInterval, 2.0)
 
-        poller.setLiveActivityPollingEnabled(true)
-        XCTAssertEqual(poller.currentPollingInterval, 1.0)
+        poller.setEnabledMetrics(EnabledMetrics(live: true, average: false, alltime: false))
+        XCTAssertEqual(poller.currentPollingInterval, 1.0, "absent pref defaults to 1 s")
 
-        poller.setLiveActivityPollingEnabled(false)
+        defaults.set(0.5, forKey: MenubarMetricPrefs.refreshIntervalKey)
+        XCTAssertEqual(poller.currentPollingInterval, 0.5)
+
+        defaults.set(42.0, forKey: MenubarMetricPrefs.refreshIntervalKey)
+        XCTAssertEqual(poller.currentPollingInterval, 1.0, "out-of-set values clamp to 1 s")
+
+        poller.setEnabledMetrics(EnabledMetrics(live: false, average: true, alltime: false))
+        defaults.set(3.0, forKey: MenubarMetricPrefs.refreshIntervalKey)
+        XCTAssertEqual(
+            poller.currentPollingInterval, 3.0,
+            "any enabled metric item drives the configured cadence, not just live"
+        )
+
+        poller.setEnabledMetrics(EnabledMetrics(live: false, average: false, alltime: false))
         XCTAssertEqual(poller.currentPollingInterval, 2.0)
     }
 
@@ -494,7 +387,7 @@ final class MenubarControllerPortTests: XCTestCase {
             apiKey: nil,
             sessionConfiguration: sessionConfiguration
         )
-        poller.setLiveActivityPollingEnabled(true)
+        poller.setEnabledMetrics(EnabledMetrics(live: true, average: false, alltime: false))
 
         await poller.refreshOnce()
 
@@ -510,7 +403,7 @@ final class MenubarControllerPortTests: XCTestCase {
             apiKey: "test-key",
             sessionConfiguration: sessionConfiguration
         )
-        poller.setLiveActivityPollingEnabled(true)
+        poller.setEnabledMetrics(EnabledMetrics(live: true, average: false, alltime: false))
         let observer = NotificationCenter.default.addObserver(
             forName: MenubarStatsPoller.didUpdateNotification,
             object: poller,
@@ -534,7 +427,7 @@ final class MenubarControllerPortTests: XCTestCase {
             sessionConfiguration: sessionConfiguration
         )
 
-        poller.setLiveActivityPollingEnabled(false)
+        poller.setEnabledMetrics(EnabledMetrics(live: false, average: false, alltime: false))
         await poller.refreshOnce()
 
         XCTAssertEqual(poller.sessionStats?.totalPromptTokens, 99)
@@ -550,7 +443,7 @@ final class MenubarControllerPortTests: XCTestCase {
             apiKey: "test-key",
             sessionConfiguration: sessionConfiguration
         )
-        poller.setLiveActivityPollingEnabled(true)
+        poller.setEnabledMetrics(EnabledMetrics(live: true, average: false, alltime: false))
 
         await poller.refreshOnce()
         XCTAssertNotNil(poller.liveStats?.liveActivity)
@@ -569,7 +462,7 @@ final class MenubarControllerPortTests: XCTestCase {
             apiKey: "test-key",
             sessionConfiguration: sessionConfiguration
         )
-        poller.setLiveActivityPollingEnabled(true)
+        poller.setEnabledMetrics(EnabledMetrics(live: true, average: false, alltime: false))
 
         await poller.refreshOnce()
         XCTAssertNotNil(poller.liveStats?.liveActivity)
@@ -578,6 +471,36 @@ final class MenubarControllerPortTests: XCTestCase {
         await poller.refreshOnce()
 
         XCTAssertNil(poller.liveStats)
+    }
+
+    func testRefreshOncePostsExactlyOneNotificationWhenServerGoesAway() async {
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [MenubarStatsURLProtocol.self]
+        let poller = MenubarStatsPoller(
+            baseURL: URL(string: "http://omlx.test")!,
+            apiKey: "test-key",
+            sessionConfiguration: sessionConfiguration
+        )
+        let observer = NotificationCenter.default.addObserver(
+            forName: MenubarStatsPoller.didUpdateNotification,
+            object: poller,
+            queue: nil
+        ) { _ in
+            MenubarStatsURLProtocol.recordUpdateNotification()
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        await poller.refreshOnce()
+        XCTAssertEqual(MenubarStatsURLProtocol.recordedUpdateNotificationCount(), 1)
+
+        // First failing tick after a success: one "server went away" repaint…
+        MenubarStatsURLProtocol.setPublicStatusResponseStatusCode(500)
+        await poller.refreshOnce()
+        XCTAssertEqual(MenubarStatsURLProtocol.recordedUpdateNotificationCount(), 2)
+
+        // …then silence while the server stays down (no per-tick spam).
+        await poller.refreshOnce()
+        XCTAssertEqual(MenubarStatsURLProtocol.recordedUpdateNotificationCount(), 2)
     }
 
     // MARK: - displayPort

--- a/apps/omlx-mac/Tests/oMLXTests/MenubarMetricTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/MenubarMetricTests.swift
@@ -1,0 +1,175 @@
+// Unit coverage for the menubar metric items' data path: rate aggregation
+// from poller payloads, the history ring buffer, and the glyph formatting /
+// signature logic that gates status-item re-rasters.
+
+import Foundation
+import XCTest
+@testable import oMLX
+
+@MainActor
+final class MenubarMetricTests: XCTestCase {
+
+    private func decodeStats(_ json: String) throws -> MenubarStatsPoller.Stats {
+        try JSONDecoder().decode(
+            MenubarStatsPoller.Stats.self,
+            from: XCTUnwrap(json.data(using: .utf8))
+        )
+    }
+
+    // MARK: - Live rate aggregation
+
+    func testLiveRatesSumAcrossModelsAndRequests() throws {
+        let stats = try decodeStats(
+            """
+            {
+              "active_models": {
+                "models": [
+                  {
+                    "id": "model-a",
+                    "prefilling": [
+                      {"processed": 10, "total": 100, "speed": 300.0},
+                      {"processed": 20, "total": 100, "speed": 200.5}
+                    ],
+                    "generating": [
+                      {"generated_tokens": 5, "tokens_per_second": 40.0}
+                    ]
+                  },
+                  {
+                    "id": "model-b",
+                    "generating": [
+                      {"generated_tokens": 9, "tokens_per_second": 2.5}
+                    ]
+                  }
+                ]
+              }
+            }
+            """
+        )
+
+        let rates = try XCTUnwrap(MenubarMetricsStore.liveRates(from: stats))
+        XCTAssertEqual(rates.promptTps, 500.5)
+        XCTAssertEqual(rates.generationTps, 42.5)
+    }
+
+    func testLiveRatesAreZeroWhenDecodedButIdle() throws {
+        let stats = try decodeStats(#"{"active_models": {"models": []}}"#)
+
+        let rates = try XCTUnwrap(MenubarMetricsStore.liveRates(from: stats))
+        XCTAssertEqual(rates.promptTps, 0)
+        XCTAssertEqual(rates.generationTps, 0)
+    }
+
+    func testLiveRatesAreNilWithoutAnActivityPayload() throws {
+        XCTAssertNil(MenubarMetricsStore.liveRates(from: nil))
+
+        let statsWithoutActivity = try decodeStats(#"{"total_prompt_tokens": 3}"#)
+        XCTAssertNil(MenubarMetricsStore.liveRates(from: statsWithoutActivity))
+    }
+
+    func testAverageRatesPassThroughSnapshotFields() throws {
+        XCTAssertNil(MenubarMetricsStore.averageRates(from: nil))
+
+        let stats = try decodeStats(
+            #"{"avg_prefill_tps": 512.3, "avg_generation_tps": 48.7}"#
+        )
+        let rates = try XCTUnwrap(MenubarMetricsStore.averageRates(from: stats))
+        XCTAssertEqual(rates.promptTps, 512.3)
+        XCTAssertEqual(rates.generationTps, 48.7)
+    }
+
+    // MARK: - History ring buffer
+
+    func testHistoryAppendCapsAtCapacityDroppingOldest() {
+        var series: [Double] = []
+        for value in 0..<(MenubarMetricsStore.historyCapacity + 5) {
+            MenubarMetricsStore.append(&series, Double(value))
+        }
+
+        XCTAssertEqual(series.count, MenubarMetricsStore.historyCapacity)
+        XCTAssertEqual(series.first, 5)
+        XCTAssertEqual(series.last, Double(MenubarMetricsStore.historyCapacity + 4))
+    }
+
+    func testApplyTickRecordsRatesAndRollsHistory() {
+        let store = MenubarMetricsStore()
+        store.applyTick(
+            live: MetricRates(promptTps: 100, generationTps: 10),
+            average: MetricRates(promptTps: 200, generationTps: 20),
+            alltime: nil,
+            serverRunning: true
+        )
+
+        XCTAssertTrue(store.serverIsRunning)
+        XCTAssertEqual(store.rates[.live]?.promptTps, 100)
+        XCTAssertEqual(store.rates[.average]?.generationTps, 20)
+        XCTAssertNil(store.rates[.alltime])
+        // Unknown readings still roll a 0 so the graph timeline stays contiguous.
+        XCTAssertEqual(store.history[.alltime]?.promptTps, [0])
+        XCTAssertEqual(store.history[.live]?.promptTps, [100])
+        XCTAssertEqual(store.history[.live]?.generationTps, [10])
+    }
+
+    func testMarkServerStoppedBlanksRatesButFreezesHistory() {
+        let store = MenubarMetricsStore()
+        store.applyTick(
+            live: MetricRates(promptTps: 100, generationTps: 10),
+            average: MetricRates(promptTps: 200, generationTps: 20),
+            alltime: MetricRates(promptTps: 300, generationTps: 30),
+            serverRunning: true
+        )
+
+        store.markServerStopped()
+
+        XCTAssertFalse(store.serverIsRunning)
+        XCTAssertNil(store.rates[.live])
+        XCTAssertNil(store.rates[.average])
+        XCTAssertNil(store.rates[.alltime])
+        XCTAssertEqual(store.history[.live]?.promptTps, [100])
+        XCTAssertEqual(store.history[.alltime]?.generationTps, [30])
+    }
+
+    // MARK: - Glyph formatting
+
+    func testFormatTpsCoversUnknownWholeAndCompactRanges() {
+        XCTAssertEqual(MenubarMetricGlyph.formatTps(nil), "–")
+        XCTAssertEqual(MenubarMetricGlyph.formatTps(.infinity), "–")
+        XCTAssertEqual(MenubarMetricGlyph.formatTps(-3), "0tk/s")
+        XCTAssertEqual(MenubarMetricGlyph.formatTps(0), "0tk/s")
+        XCTAssertEqual(MenubarMetricGlyph.formatTps(24.4), "24tk/s")
+        XCTAssertEqual(MenubarMetricGlyph.formatTps(999.6), "1000tk/s")
+        XCTAssertEqual(MenubarMetricGlyph.formatTps(12_345), "12.3ktk/s")
+    }
+
+    func testSignatureIsStableForIdenticalReadingsAndTracksEveryInput() {
+        let base = MenubarMetricGlyph.signature(
+            tag: "LIV", promptValue: "500t/s", generationValue: "24t/s",
+            darkMenubar: false
+        )
+
+        XCTAssertEqual(
+            base,
+            MenubarMetricGlyph.signature(
+                tag: "LIV", promptValue: "500t/s", generationValue: "24t/s",
+                darkMenubar: false
+            ),
+            "identical readings must not trigger a re-raster"
+        )
+
+        XCTAssertNotEqual(base, MenubarMetricGlyph.signature(
+            tag: "AVG", promptValue: "500t/s", generationValue: "24t/s",
+            darkMenubar: false
+        ))
+        XCTAssertNotEqual(base, MenubarMetricGlyph.signature(
+            tag: "LIV", promptValue: "501t/s", generationValue: "24t/s",
+            darkMenubar: false
+        ))
+        XCTAssertNotEqual(base, MenubarMetricGlyph.signature(
+            tag: "LIV", promptValue: "500t/s", generationValue: "25t/s",
+            darkMenubar: false
+        ))
+        XCTAssertNotEqual(base, MenubarMetricGlyph.signature(
+            tag: "LIV", promptValue: "500t/s", generationValue: "24t/s",
+            darkMenubar: true
+        ))
+    }
+}

--- a/apps/omlx-mac/Tests/oMLXTests/SystemStatsTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/SystemStatsTests.swift
@@ -1,0 +1,177 @@
+// Unit coverage for the System Stats submenu's pure computation: E/P
+// cluster usage from Mach tick deltas, and the formatting helpers the
+// panels render.
+
+import Foundation
+import XCTest
+@testable import oMLX
+
+final class SystemStatsTests: XCTestCase {
+
+    private typealias Ticks = SystemStatsSampler.CPUTicks
+
+    // MARK: - Cluster usage
+
+    func testClusterUsageSplitsECoresFirstAndAveragesPerCluster() throws {
+        // 2 E-cores + 2 P-cores; deltas: E = 50%/100%, P = 0%/25%.
+        let previous = [
+            Ticks(busy: 100, total: 1_000),
+            Ticks(busy: 100, total: 1_000),
+            Ticks(busy: 100, total: 1_000),
+            Ticks(busy: 100, total: 1_000),
+        ]
+        let current = [
+            Ticks(busy: 150, total: 1_100),
+            Ticks(busy: 200, total: 1_100),
+            Ticks(busy: 100, total: 1_100),
+            Ticks(busy: 125, total: 1_100),
+        ]
+
+        let usage = try XCTUnwrap(SystemStatsSampler.clusterUsage(
+            previous: previous, current: current, eCoreCount: 2
+        ))
+        XCTAssertEqual(usage.e, 0.75, accuracy: 0.0001)
+        XCTAssertEqual(usage.p, 0.125, accuracy: 0.0001)
+        XCTAssertEqual(usage.total, 0.4375, accuracy: 0.0001,
+                       "all-core average = 175 busy of 400 total ticks")
+    }
+
+    func testClusterUsageWithNoECoresCountsEverythingAsP() throws {
+        let previous = [Ticks(busy: 0, total: 100)]
+        let current = [Ticks(busy: 50, total: 200)]
+
+        let usage = try XCTUnwrap(SystemStatsSampler.clusterUsage(
+            previous: previous, current: current, eCoreCount: 0
+        ))
+        XCTAssertEqual(usage.e, 0)
+        XCTAssertEqual(usage.p, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(usage.total, 0.5, accuracy: 0.0001)
+    }
+
+    // MARK: - Menubar bar glyph quantization
+
+    func testBarLevelQuantizationGatesReRasters() {
+        XCTAssertEqual(MenubarMetricGlyph.quantizedBarLevel(nil), -1)
+        XCTAssertEqual(MenubarMetricGlyph.quantizedBarLevel(0), 0)
+        XCTAssertEqual(MenubarMetricGlyph.quantizedBarLevel(1), 36)
+        XCTAssertEqual(MenubarMetricGlyph.quantizedBarLevel(1.7), 36, "clamps above 100%")
+        XCTAssertEqual(MenubarMetricGlyph.quantizedBarLevel(0.5), 18)
+
+        // Sub-pixel jitter maps to the same signature — no repaint…
+        XCTAssertEqual(
+            MenubarMetricGlyph.barsSignature(
+                segments: [("MEM", 0.500)], darkMenubar: true
+            ),
+            MenubarMetricGlyph.barsSignature(
+                segments: [("MEM", 0.501)], darkMenubar: true
+            )
+        )
+        // …while a visible change, appearance flip, or a different enabled
+        // set does repaint.
+        XCTAssertNotEqual(
+            MenubarMetricGlyph.barsSignature(
+                segments: [("MEM", 0.5)], darkMenubar: true
+            ),
+            MenubarMetricGlyph.barsSignature(
+                segments: [("MEM", 0.55)], darkMenubar: true
+            )
+        )
+        XCTAssertNotEqual(
+            MenubarMetricGlyph.barsSignature(
+                segments: [("MEM", 0.5)], darkMenubar: true
+            ),
+            MenubarMetricGlyph.barsSignature(
+                segments: [("MEM", 0.5)], darkMenubar: false
+            )
+        )
+        XCTAssertNotEqual(
+            MenubarMetricGlyph.barsSignature(
+                segments: [("CPU", 0.3), ("MEM", 0.5)], darkMenubar: true
+            ),
+            MenubarMetricGlyph.barsSignature(
+                segments: [("MEM", 0.5)], darkMenubar: true
+            )
+        )
+        // Identical multi-segment readings stay stable.
+        XCTAssertEqual(
+            MenubarMetricGlyph.barsSignature(
+                segments: [("CPU", 0.3), ("GPU", nil), ("MEM", 0.5)],
+                darkMenubar: true
+            ),
+            MenubarMetricGlyph.barsSignature(
+                segments: [("CPU", 0.3), ("GPU", nil), ("MEM", 0.5)],
+                darkMenubar: true
+            )
+        )
+    }
+
+    func testClusterUsageSkipsWrappedCountersAndRejectsEmptyDeltas() {
+        // Wrapped counter (current < previous) must not poison the average…
+        let previous = [Ticks(busy: 500, total: 1_000), Ticks(busy: 0, total: 100)]
+        let current = [Ticks(busy: 10, total: 20), Ticks(busy: 100, total: 200)]
+        let usage = SystemStatsSampler.clusterUsage(
+            previous: previous, current: current, eCoreCount: 0
+        )
+        XCTAssertEqual(usage?.p ?? -1, 1.0, accuracy: 0.0001)
+
+        // …and a reading with no usable delta at all yields nil.
+        XCTAssertNil(SystemStatsSampler.clusterUsage(
+            previous: previous, current: previous, eCoreCount: 0
+        ))
+        XCTAssertNil(SystemStatsSampler.clusterUsage(
+            previous: [], current: [], eCoreCount: 0
+        ))
+        XCTAssertNil(SystemStatsSampler.clusterUsage(
+            previous: previous, current: Array(current.prefix(1)), eCoreCount: 0
+        ))
+    }
+
+    // MARK: - Formatting
+
+    func testFormatUptimeBuckets() {
+        XCTAssertEqual(SystemStatsSampler.formatUptime(42 * 60), "42m")
+        XCTAssertEqual(SystemStatsSampler.formatUptime(5 * 3_600 + 12 * 60), "5h 12m")
+        XCTAssertEqual(
+            SystemStatsSampler.formatUptime(8 * 86_400 + 18 * 3_600),
+            "8d 18h"
+        )
+        XCTAssertEqual(SystemStatsSampler.formatUptime(0), "0m")
+    }
+
+    func testFormatLoadAverages() {
+        XCTAssertEqual(
+            SystemStatsSampler.formatLoadAverages([3.5, 2.666, 2.334]),
+            "3.50 · 2.67 · 2.33"
+        )
+        XCTAssertEqual(SystemStatsSampler.formatLoadAverages([]), "–")
+    }
+
+    func testFormatBytesUsesDecimalUnitsWithMBFallback() {
+        XCTAssertEqual(SystemStatsSampler.formatBytes(730_000_000), "730 MB")
+        XCTAssertEqual(SystemStatsSampler.formatBytes(8_550_000_000), "8.55 GB")
+        XCTAssertEqual(SystemStatsSampler.formatBytes(237_290_000_000), "237.29 GB")
+    }
+
+    func testStatsFormatHelpers() {
+        XCTAssertEqual(StatsFormat.percent(nil), "–")
+        XCTAssertEqual(StatsFormat.percent(0.153), "15%")
+        XCTAssertEqual(StatsFormat.percent(1.7), "100%", "fractions clamp to 100%")
+        XCTAssertEqual(StatsFormat.wholeGB(512_000_000_000), "512")
+        XCTAssertEqual(StatsFormat.window(sampleCount: 60, interval: 1.0), "60s")
+        XCTAssertEqual(StatsFormat.window(sampleCount: 60, interval: 0.5), "30s")
+        XCTAssertEqual(StatsFormat.window(sampleCount: 0, interval: 1.0), "")
+    }
+
+    func testMemorySnapshotDerivesFreeAndUsedFraction() {
+        var memory = SystemStatsSnapshot.Memory()
+        memory.totalBytes = 512_000_000_000
+        memory.wiredBytes = 8_550_000_000
+        memory.activeBytes = 237_290_000_000
+        memory.compressedBytes = 730_000_000
+        memory.freeBytes = memory.totalBytes - memory.usedBytes
+
+        XCTAssertEqual(memory.usedBytes, 246_570_000_000)
+        XCTAssertEqual(memory.usedFraction, 0.4816, accuracy: 0.001)
+        XCTAssertEqual(memory.freeBytes, 265_430_000_000)
+    }
+}

--- a/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
+++ b/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
@@ -29,6 +29,14 @@
 		3BB000000000000000000001 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000001 /* AppConfig.swift */; };
 		3BB000000000000000000002 /* MenubarStatsPoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000002 /* MenubarStatsPoller.swift */; };
 		3BB000000000000000000003 /* MenubarVisibilityWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000003 /* MenubarVisibilityWatcher.swift */; };
+		3BB000000000000000000010 /* MenubarMetricPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000010 /* MenubarMetricPrefs.swift */; };
+		3BB000000000000000000011 /* MenubarMetricsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000011 /* MenubarMetricsStore.swift */; };
+		3BB000000000000000000012 /* MenubarMetricGlyph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000012 /* MenubarMetricGlyph.swift */; };
+		3BB000000000000000000013 /* MenubarMetricItemsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000013 /* MenubarMetricItemsController.swift */; };
+		3BB000000000000000000014 /* MenubarMetricPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000014 /* MenubarMetricPopover.swift */; };
+		3BB000000000000000000015 /* SystemStatsSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000015 /* SystemStatsSampler.swift */; };
+		3BB000000000000000000016 /* SystemStatsPanels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000016 /* SystemStatsPanels.swift */; };
+		3BB000000000000000000017 /* SystemMenubarItemsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000017 /* SystemMenubarItemsController.swift */; };
 		3BB000000000000000000004 /* ShellEnvWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000004 /* ShellEnvWriter.swift */; };
 		3BB000000000000000000005 /* APIKeyGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC000000000000000000005 /* APIKeyGenerator.swift */; };
 		4BB000000000000000000001 /* PortConflictResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC000000000000000000001 /* PortConflictResolver.swift */; };
@@ -38,6 +46,7 @@
 		6BB000000000000000000002 /* AppSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC000000000000000000002 /* AppSection.swift */; };
 		6BB000000000000000000004 /* ServerScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC000000000000000000004 /* ServerScreen.swift */; };
 		6BB000000000000000000005 /* StatusScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC000000000000000000005 /* StatusScreen.swift */; };
+		6BB000000000000000000011 /* AppearanceScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC000000000000000000011 /* AppearanceScreen.swift */; };
 		6BB000000000000000000006 /* LogsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC000000000000000000006 /* LogsScreen.swift */; };
 		6BB000000000000000000007 /* ModelsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC000000000000000000007 /* ModelsScreen.swift */; };
 		6BB000000000000000000008 /* DownloadsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CC000000000000000000008 /* DownloadsScreen.swift */; };
@@ -107,6 +116,8 @@
 		DBB00000000000000000000E /* ServerProcessIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */; };
 		DBB00000000000000000000F /* LocalizationSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC00000000000000000000F /* LocalizationSmokeTests.swift */; };
 		DBB000000000000000000100 /* MenubarControllerPortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000100 /* MenubarControllerPortTests.swift */; };
+		DBB000000000000000000111 /* MenubarMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000111 /* MenubarMetricTests.swift */; };
+		DBB000000000000000000112 /* SystemStatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000112 /* SystemStatsTests.swift */; };
 		DBB000000000000000000101 /* ModelCardDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000101 /* ModelCardDTO.swift */; };
 		DBB000000000000000000102 /* ModelCardSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000102 /* ModelCardSheet.swift */; };
 		DBB000000000000000000103 /* ModelCardDTODecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000103 /* ModelCardDTODecodeTests.swift */; };
@@ -155,6 +166,14 @@
 		3CC000000000000000000001 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		3CC000000000000000000002 /* MenubarStatsPoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarStatsPoller.swift; sourceTree = "<group>"; };
 		3CC000000000000000000003 /* MenubarVisibilityWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarVisibilityWatcher.swift; sourceTree = "<group>"; };
+		3CC000000000000000000010 /* MenubarMetricPrefs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarMetricPrefs.swift; sourceTree = "<group>"; };
+		3CC000000000000000000011 /* MenubarMetricsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarMetricsStore.swift; sourceTree = "<group>"; };
+		3CC000000000000000000012 /* MenubarMetricGlyph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarMetricGlyph.swift; sourceTree = "<group>"; };
+		3CC000000000000000000013 /* MenubarMetricItemsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarMetricItemsController.swift; sourceTree = "<group>"; };
+		3CC000000000000000000014 /* MenubarMetricPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarMetricPopover.swift; sourceTree = "<group>"; };
+		3CC000000000000000000015 /* SystemStatsSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsSampler.swift; sourceTree = "<group>"; };
+		3CC000000000000000000016 /* SystemStatsPanels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsPanels.swift; sourceTree = "<group>"; };
+		3CC000000000000000000017 /* SystemMenubarItemsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemMenubarItemsController.swift; sourceTree = "<group>"; };
 		3CC000000000000000000004 /* ShellEnvWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvWriter.swift; sourceTree = "<group>"; };
 		3CC000000000000000000005 /* APIKeyGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIKeyGenerator.swift; sourceTree = "<group>"; };
 		4CC000000000000000000001 /* PortConflictResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortConflictResolver.swift; sourceTree = "<group>"; };
@@ -164,6 +183,7 @@
 		6CC000000000000000000002 /* AppSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSection.swift; sourceTree = "<group>"; };
 		6CC000000000000000000004 /* ServerScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerScreen.swift; sourceTree = "<group>"; };
 		6CC000000000000000000005 /* StatusScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusScreen.swift; sourceTree = "<group>"; };
+		6CC000000000000000000011 /* AppearanceScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceScreen.swift; sourceTree = "<group>"; };
 		6CC000000000000000000006 /* LogsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsScreen.swift; sourceTree = "<group>"; };
 		6CC000000000000000000007 /* ModelsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsScreen.swift; sourceTree = "<group>"; };
 		6CC000000000000000000008 /* DownloadsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsScreen.swift; sourceTree = "<group>"; };
@@ -234,6 +254,8 @@
 		DCC00000000000000000000F /* LocalizationSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationSmokeTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000010 /* oMLXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = oMLXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCC000000000000000000100 /* MenubarControllerPortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarControllerPortTests.swift; sourceTree = "<group>"; };
+		DCC000000000000000000111 /* MenubarMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarMetricTests.swift; sourceTree = "<group>"; };
+		DCC000000000000000000112 /* SystemStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemStatsTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000101 /* ModelCardDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCardDTO.swift; sourceTree = "<group>"; };
 		DCC000000000000000000102 /* ModelCardSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCardSheet.swift; sourceTree = "<group>"; };
 		DCC000000000000000000103 /* ModelCardDTODecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelCardDTODecodeTests.swift; sourceTree = "<group>"; };
@@ -301,6 +323,8 @@
 				DCC00000000000000000000E /* ServerProcessIntegrationTests.swift */,
 				DCC00000000000000000000F /* LocalizationSmokeTests.swift */,
 				DCC000000000000000000100 /* MenubarControllerPortTests.swift */,
+				DCC000000000000000000111 /* MenubarMetricTests.swift */,
+				DCC000000000000000000112 /* SystemStatsTests.swift */,
 				DCC000000000000000000103 /* ModelCardDTODecodeTests.swift */,
 				DCC000000000000000000104 /* ShellEnvWriterTests.swift */,
 				DCC000000000000000000105 /* ThemeTests.swift */,
@@ -343,6 +367,14 @@
 				1CCCCCCCCCCCCCCCCCCCCCC3 /* MenubarController.swift */,
 				3CC000000000000000000002 /* MenubarStatsPoller.swift */,
 				3CC000000000000000000003 /* MenubarVisibilityWatcher.swift */,
+				3CC000000000000000000010 /* MenubarMetricPrefs.swift */,
+				3CC000000000000000000011 /* MenubarMetricsStore.swift */,
+				3CC000000000000000000012 /* MenubarMetricGlyph.swift */,
+				3CC000000000000000000013 /* MenubarMetricItemsController.swift */,
+				3CC000000000000000000014 /* MenubarMetricPopover.swift */,
+				3CC000000000000000000015 /* SystemStatsSampler.swift */,
+				3CC000000000000000000016 /* SystemStatsPanels.swift */,
+				3CC000000000000000000017 /* SystemMenubarItemsController.swift */,
 			);
 			path = Menubar;
 			sourceTree = "<group>";
@@ -436,6 +468,7 @@
 			children = (
 				6CC000000000000000000004 /* ServerScreen.swift */,
 				6CC000000000000000000005 /* StatusScreen.swift */,
+				6CC000000000000000000011 /* AppearanceScreen.swift */,
 				6CC000000000000000000006 /* LogsScreen.swift */,
 				6CC000000000000000000007 /* ModelsScreen.swift */,
 				6CC000000000000000000008 /* DownloadsScreen.swift */,
@@ -660,6 +693,14 @@
 				3BB000000000000000000005 /* APIKeyGenerator.swift in Sources */,
 				3BB000000000000000000002 /* MenubarStatsPoller.swift in Sources */,
 				3BB000000000000000000003 /* MenubarVisibilityWatcher.swift in Sources */,
+				3BB000000000000000000010 /* MenubarMetricPrefs.swift in Sources */,
+				3BB000000000000000000011 /* MenubarMetricsStore.swift in Sources */,
+				3BB000000000000000000012 /* MenubarMetricGlyph.swift in Sources */,
+				3BB000000000000000000013 /* MenubarMetricItemsController.swift in Sources */,
+				3BB000000000000000000014 /* MenubarMetricPopover.swift in Sources */,
+				3BB000000000000000000015 /* SystemStatsSampler.swift in Sources */,
+				3BB000000000000000000016 /* SystemStatsPanels.swift in Sources */,
+				3BB000000000000000000017 /* SystemMenubarItemsController.swift in Sources */,
 				4BB000000000000000000001 /* PortConflictResolver.swift in Sources */,
 				4BB000000000000000000002 /* SignalHandlers.swift in Sources */,
 				4BB000000000000000000003 /* AppControlServer.swift in Sources */,
@@ -667,6 +708,7 @@
 				6BB000000000000000000002 /* AppSection.swift in Sources */,
 				6BB000000000000000000004 /* ServerScreen.swift in Sources */,
 				6BB000000000000000000005 /* StatusScreen.swift in Sources */,
+				6BB000000000000000000011 /* AppearanceScreen.swift in Sources */,
 				AAD9D51F2FE2843F00FAEA05 /* DownloadsScreenVM.swift in Sources */,
 				6BB000000000000000000006 /* LogsScreen.swift in Sources */,
 				6BB000000000000000000007 /* ModelsScreen.swift in Sources */,
@@ -740,6 +782,8 @@
 				DBB00000000000000000000E /* ServerProcessIntegrationTests.swift in Sources */,
 				DBB00000000000000000000F /* LocalizationSmokeTests.swift in Sources */,
 				DBB000000000000000000100 /* MenubarControllerPortTests.swift in Sources */,
+				DBB000000000000000000111 /* MenubarMetricTests.swift in Sources */,
+				DBB000000000000000000112 /* SystemStatsTests.swift in Sources */,
 				DBB000000000000000000103 /* ModelCardDTODecodeTests.swift in Sources */,
 				DBB000000000000000000104 /* ShellEnvWriterTests.swift in Sources */,
 				DBB000000000000000000105 /* ThemeTests.swift in Sources */,


### PR DESCRIPTION
## What

This adds a proper statistics layer to the menubar app.

- New Appearance pane in settings (Server group, below Status): refresh interval (0.5/1/2/3s), show dock icon, and a toggle per menubar item
- LIV / AVG / ALL menubar items showing prompt-processing and token-generation speed as a two-line readout (live sums across running requests, session averages, all-time averages). The old inline live activity text is replaced by the LIV item and the existing pref key is reused so it migrates automatically
- System Stats submenu above Serving Stats with CPU, GPU and Memory panels: E/P core usage with a rolling graph, load avg, uptime, thermal state, GPU utilization and in-use memory, and a memory breakdown
- Optional CPU/GPU/MEM usage bars in the menubar. Enabled ones merge into a single status item, and clicking opens the matching panels stacked in one popover
- Throughput unit shown as tk/s

## Notes

The menu bar statistics design (panel layouts, glyphs, and graphs) and the glyph rendering approach are adapted from [SiliconScope](https://github.com/kennss/SiliconScope) by Kennt Kim, MIT licensed.

## Screenshots

<img width="992" height="829" alt="Screenshot 2026-07-21 at 00 41 03" src="https://github.com/user-attachments/assets/40600853-9dc6-424e-8c57-5738d27a575f" />
<img width="280" height="281" alt="Screenshot 2026-07-21 at 00 38 31" src="https://github.com/user-attachments/assets/83e231f7-d1a0-4203-add9-790a5a8e2f2c" />
<img width="307" height="560" alt="Screenshot 2026-07-21 at 00 38 42" src="https://github.com/user-attachments/assets/3137e241-8a6b-46fe-9120-3005b5fa9a68" />
<img width="541" height="619" alt="Screenshot 2026-07-21 at 00 38 57" src="https://github.com/user-attachments/assets/2bc7be45-52b0-409c-b769-c7fe4045b02c" />
