### PR TITLE
fix(scheduler): self-recover the prefill guard from pooled-buffer wedge

### DIFF
--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -495,7 +495,9 @@ class EngineCore:
 
                 logger.error(f"Engine loop error: {e}\n{traceback.format_exc()}")
                 # Fail all requests and remove from scheduler to prevent
-                # infinite loop (has_requests() must return False).
+                # infinite loop (has_requests() must go False; a pending
+                # idle reclaim may hold it True for one extra step, which
+                # drains and clears it).
                 failed_ids = await loop.run_in_executor(
                     self._mlx_executor, self.scheduler.fail_all_requests
                 )

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -1122,6 +1122,8 @@ class EnginePool:
             return False
 
         evicted_any = False
+        reclaimed_headroom = False
+        reclaim_attempted = False
         async with self._lock:
             while True:
                 current = max(
@@ -1130,12 +1132,29 @@ class EnginePool:
                     self._current_model_memory,
                 )
                 if current + predicted <= target:
-                    return evicted_any
+                    # A model eviction and/or the pooled-buffer reclaim below
+                    # created enough headroom; signal the caller to re-admit.
+                    return evicted_any or reclaimed_headroom
 
                 victim = self._find_lru_prefill_eviction_victim(
                     exclude_model_id=exclude_model_id
                 )
                 if victim is None:
+                    # No idle model left to evict -- the "No idle model
+                    # evicted" case that used to reject outright even when
+                    # tens of GB were reclaimable. Try the cheaper reclaim
+                    # once before giving up: return MLX's pooled Metal buffers
+                    # (freed by finished requests but still cached, so
+                    # get_phys_footprint stays high) to the OS on the
+                    # requesting engine's own MLX thread, then let the loop
+                    # re-measure.
+                    if not reclaim_attempted:
+                        reclaim_attempted = True
+                        if await self._reclaim_pooled_buffers_for_prefill(
+                            exclude_model_id, request_id
+                        ):
+                            reclaimed_headroom = True
+                            continue
                     if evicted_any:
                         logger.info(
                             "Prefill eviction for request %s stopped with no "
@@ -1159,6 +1178,84 @@ class EnginePool:
                 )
                 await self._unload_engine(victim)
                 evicted_any = True
+
+    @staticmethod
+    def _resolve_engine_core_from_engine(engine: object) -> object | None:
+        """Resolve the EngineCore owning an entry's scheduler and MLX thread."""
+        if getattr(engine, "scheduler", None) is not None:
+            return engine
+        try:
+            return engine._engine.engine  # type: ignore[attr-defined]
+        except AttributeError:
+            return None
+
+    async def _reclaim_pooled_buffers_for_prefill(
+        self, model_id: str, request_id: str
+    ) -> int:
+        """Return MLX's pooled Metal buffers to the OS; report bytes freed.
+
+        A warm server's resident baseline creeps between requests: finished
+        requests free their KV / activation arrays into MLX's buffer *cache*
+        (retained for reuse) rather than handing the pages back to the OS, so
+        ``get_phys_footprint`` -- the resident figure the prefill guard reads
+        -- stays high even though the bytes are reclaimable.
+
+        The clear runs on the requesting engine's own MLX thread through the
+        scheduler's ``_reclaim_prefill_headroom``, which synchronizes that
+        engine's generation stream under ``_mx_buffer_access_lock`` before
+        clearing (issues #300, #888, #1106) -- clearing from any other thread
+        could release cached buffers still referenced by in-flight
+        ``mx.async_eval`` command buffers. The engine's step loop is parked
+        awaiting this eviction callback, so its executor is free. A failing
+        reclaim is contained (#435 class): the request is then rejected
+        exactly as if nothing had been reclaimable. ``clear_cache`` releases
+        only unused cached buffers, so arrays an in-flight request still
+        references are never touched, and the shared hot / prefix cache is
+        left intact (it is SSD-backed and reclaimed separately by the
+        enforcer).
+
+        Returns:
+            Bytes handed back to the OS (``get_phys_footprint`` delta, >= 0).
+        """
+        entry = self._entries.get(model_id)
+        engine = entry.engine if entry is not None else None
+        core = (
+            self._resolve_engine_core_from_engine(engine)
+            if engine is not None
+            else None
+        )
+        scheduler = getattr(core, "scheduler", None)
+        reclaim = getattr(scheduler, "_reclaim_prefill_headroom", None)
+        executor = getattr(core, "_mlx_executor", None)
+        if not callable(reclaim) or executor is None:
+            # Engine mid-teardown (executor dropped at close) or an engine
+            # shape without the scheduler helper: skip -- reject as before.
+            return 0
+
+        def _reclaim_on_engine_thread() -> None:
+            gc.collect()
+            reclaim()
+
+        before = get_phys_footprint()
+        loop = asyncio.get_running_loop()
+        try:
+            await loop.run_in_executor(executor, _reclaim_on_engine_thread)
+        except Exception as e:
+            logger.warning(
+                "Pooled-buffer reclaim failed for prefill request %s: %s",
+                request_id,
+                e,
+            )
+            return 0
+        freed = max(0, before - get_phys_footprint())
+        if freed > 0:
+            logger.info(
+                "Reclaimed %s of pooled Metal buffers for prefill request %s "
+                "(no idle model to evict)",
+                format_size(freed),
+                request_id,
+            )
+        return freed
 
     def _other_entries_serving(self, model_id: str) -> bool:
         """True when any loaded entry other than ``model_id`` is serving.

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -7151,6 +7151,9 @@ class Scheduler:
         the case where there is nothing to evict. Setting the flag is
         GIL-atomic; the actual ``_sync_and_clear_cache`` runs on the inference
         thread when step() drains it, and only when the scheduler is idle.
+        The request stays pending across busy steps and counts as work for
+        ``has_requests()``, so an otherwise-idle engine loop keeps stepping
+        until the reclaim runs.
         """
         self._pending_reclaim_request = True
 
@@ -7159,15 +7162,29 @@ class Scheduler:
 
         Only reclaims when truly idle (no running / prefilling / waiting work)
         so we never clear Metal buffers an in-flight decode or prefill still
-        references.
+        references. A request that lands while the scheduler is busy stays
+        pending for a later step instead of being consumed: the enforcer only
+        re-issues it at hard pressure, so a dropped request can strand the
+        server wedged, with a footprint above the prefill admission cap but
+        below the hard line (issue #2179). The flag is cleared before the
+        reclaim runs so a failing reclaim cannot re-fire forever.
         """
         if not self._pending_reclaim_request:
             return
-        self._pending_reclaim_request = False
         if self.running or self.prefilling or self.waiting:
             return
+        self._pending_reclaim_request = False
         before = self._current_usage_bytes()
-        after = self._reclaim_prefill_headroom()
+        # Wrapped in try-except because this can be the first step after an
+        # engine-loop error recovery, when Metal may already be in an error
+        # state -- mx.synchronize() / mx.clear_cache() can throw a C++
+        # exception that causes SIGABRT if uncaught (#435). The flag is
+        # already cleared, so a failing reclaim cannot re-fire.
+        try:
+            after = self._reclaim_prefill_headroom()
+        except Exception as e:
+            logger.warning(f"Idle reclaim failed: {e}")
+            return
         logger.info(
             "Idle reclaim: trimmed Metal transients between turns "
             "(%.1fGB -> %.1fGB)",
@@ -7294,10 +7311,11 @@ class Scheduler:
     def has_requests(self) -> bool:
         """Check if there are any pending or running requests.
 
-        Also returns True when a deferred Metal cache clear is pending,
-        so that the engine loop keeps calling step() until the clear fires.
-        Without this, an idle server would never reach the target step and
-        stale buffers would accumulate indefinitely.
+        Also returns True when a deferred Metal cache clear or an
+        enforcer-requested idle reclaim is pending, so that the engine loop
+        keeps calling step() until they fire. Without this, an idle server
+        would never reach the target step and stale buffers would accumulate
+        indefinitely.
         """
         return bool(
             self.waiting
@@ -7305,6 +7323,7 @@ class Scheduler:
             or self.running
             or self._pending_async_removes
             or self._deferred_clear_at is not None
+            or self._pending_reclaim_request
         )
 
     def _refresh_generation_overflow_recovery_ids(self) -> None:
@@ -9884,7 +9903,12 @@ class Scheduler:
         # Clear protocol-specific output parser sessions
         self._output_parser_sessions.clear()
 
-        # Cancel any pending deferred Metal cache clear
+        # Cancel any pending deferred Metal cache clear. A pending idle
+        # reclaim is deliberately NOT cancelled -- reset() only drops Python
+        # references (which moves bytes INTO the pooled cache), so an
+        # enforcer request must survive to the next idle step; dropping it
+        # anywhere re-opens the wedge, because the enforcer does not
+        # re-issue below hard pressure (issue #2179).
         self._deferred_clear_at = None
 
     def deep_reset(self) -> None:

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -2,6 +2,7 @@
 """Tests for EnginePool functionality."""
 
 import asyncio
+import concurrent.futures
 import json
 import logging
 import shutil
@@ -1504,11 +1505,19 @@ class TestEnginePoolPrefillEviction:
     """Tests for request-time idle LRU eviction before prefill throttling."""
 
     @staticmethod
-    def _entry(model_id: str, size: int, *, active: bool = False) -> EngineEntry:
+    def _entry(
+        model_id: str,
+        size: int,
+        *,
+        active: bool = False,
+        scheduler=None,
+        executor=None,
+    ) -> EngineEntry:
         engine = MagicMock()
         engine.has_active_requests.return_value = active
-        engine.scheduler = None
+        engine.scheduler = scheduler
         engine._engine = None
+        engine._mlx_executor = executor
         return EngineEntry(
             model_id=model_id,
             model_path=f"/models/{model_id}",
@@ -1518,6 +1527,13 @@ class TestEnginePoolPrefillEviction:
             engine=engine,
             last_access=0.0,
         )
+
+    @staticmethod
+    def _reclaim_scheduler(reclaim_fn) -> MagicMock:
+        """Scheduler stub exposing only the reclaim helper the pool calls."""
+        scheduler = MagicMock()
+        scheduler._reclaim_prefill_headroom = MagicMock(side_effect=reclaim_fn)
+        return scheduler
 
     @pytest.mark.asyncio
     async def test_prefill_eviction_evicts_idle_lru_until_target(self):
@@ -1593,6 +1609,233 @@ class TestEnginePoolPrefillEviction:
 
         assert evicted is False
         pool._unload_engine.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_prefill_reclaims_pooled_buffers_when_no_idle_victim(self):
+        """No idle model, but pooled Metal buffers are reclaimable -> reclaim
+        on the requesting engine's own MLX thread, then admit (the
+        crept-baseline bug: reject-before-reclaim)."""
+        gb = 1024**3
+        pool = _make_pool(ceiling=0)
+
+        # phys_footprint starts at a crept 45GB and drops to 25GB once the
+        # scheduler's stream-synchronized reclaim clears the pooled buffers
+        # (freed by finished requests).
+        phys = [45 * gb]
+
+        def reclaim():
+            phys[0] = 25 * gb
+
+        scheduler = self._reclaim_scheduler(reclaim)
+        req = PrefillEvictionRequest(
+            request_id="req-1",
+            model_id="target",
+            current_bytes=45 * gb,
+            target_cap_bytes=40 * gb,
+            predicted_transient_bytes=10 * gb,
+            requested_tokens=2048,
+            reason="prefill_safety_cap",
+        )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            # Only the requesting model is loaded: no idle LRU victim.
+            pool._entries = {
+                "target": self._entry(
+                    "target", 25 * gb, scheduler=scheduler, executor=executor
+                )
+            }
+            pool._current_model_memory = 25 * gb
+            pool._unload_engine = AsyncMock()
+
+            with (
+                patch("omlx.engine_pool.mx.get_active_memory", return_value=0),
+                patch(
+                    "omlx.engine_pool.get_phys_footprint",
+                    side_effect=lambda: phys[0],
+                ),
+            ):
+                admitted = await pool._evict_idle_lru_for_prefill("target", req)
+
+        # 45GB -> 25GB reclaim brings 25 + 10 (predicted) under the 40GB cap.
+        assert admitted is True
+        scheduler._reclaim_prefill_headroom.assert_called_once()
+        pool._unload_engine.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_prefill_rejects_when_reclaim_frees_nothing(self):
+        """No idle victim and nothing reclaimable -> reject exactly as before
+        (fail-loud, no admission)."""
+        gb = 1024**3
+        pool = _make_pool(ceiling=0)
+
+        # The reclaim frees nothing: every resident byte is live.
+        phys = [45 * gb]
+        scheduler = self._reclaim_scheduler(lambda: None)
+        req = PrefillEvictionRequest(
+            request_id="req-1",
+            model_id="target",
+            current_bytes=45 * gb,
+            target_cap_bytes=40 * gb,
+            predicted_transient_bytes=10 * gb,
+            requested_tokens=2048,
+            reason="prefill_safety_cap",
+        )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            pool._entries = {
+                "target": self._entry(
+                    "target", 25 * gb, scheduler=scheduler, executor=executor
+                )
+            }
+            pool._current_model_memory = 25 * gb
+            pool._unload_engine = AsyncMock()
+
+            with (
+                patch("omlx.engine_pool.mx.get_active_memory", return_value=0),
+                patch(
+                    "omlx.engine_pool.get_phys_footprint",
+                    side_effect=lambda: phys[0],
+                ),
+            ):
+                admitted = await pool._evict_idle_lru_for_prefill("target", req)
+
+        assert admitted is False
+        # Reclaim was attempted exactly once, then plain rejection.
+        scheduler._reclaim_prefill_headroom.assert_called_once()
+        pool._unload_engine.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_prefill_reclaim_failure_rejects_as_before(self):
+        """A raising reclaim (#435 class: Metal already in an error state) is
+        contained: the admission decision is the plain rejection, the
+        exception never escapes into the eviction callback."""
+        gb = 1024**3
+        pool = _make_pool(ceiling=0)
+
+        phys = [45 * gb]
+
+        def broken_reclaim():
+            raise RuntimeError("Metal in error state")
+
+        scheduler = self._reclaim_scheduler(broken_reclaim)
+        req = PrefillEvictionRequest(
+            request_id="req-1",
+            model_id="target",
+            current_bytes=45 * gb,
+            target_cap_bytes=40 * gb,
+            predicted_transient_bytes=10 * gb,
+            requested_tokens=2048,
+            reason="prefill_safety_cap",
+        )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            pool._entries = {
+                "target": self._entry(
+                    "target", 25 * gb, scheduler=scheduler, executor=executor
+                )
+            }
+            pool._current_model_memory = 25 * gb
+            pool._unload_engine = AsyncMock()
+
+            with (
+                patch("omlx.engine_pool.mx.get_active_memory", return_value=0),
+                patch(
+                    "omlx.engine_pool.get_phys_footprint",
+                    side_effect=lambda: phys[0],
+                ),
+            ):
+                admitted = await pool._evict_idle_lru_for_prefill("target", req)
+
+        assert admitted is False
+        scheduler._reclaim_prefill_headroom.assert_called_once()
+        pool._unload_engine.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_prefill_reclaim_skipped_when_engine_unresolvable(self):
+        """An entry mid-teardown (no scheduler / executor dropped at close)
+        skips the reclaim and rejects exactly as before -- no crash."""
+        gb = 1024**3
+        pool = _make_pool(ceiling=0)
+        # Default _entry: scheduler=None, _mlx_executor=None.
+        pool._entries = {"target": self._entry("target", 25 * gb)}
+        pool._current_model_memory = 25 * gb
+        pool._unload_engine = AsyncMock()
+
+        phys = [45 * gb]
+        req = PrefillEvictionRequest(
+            request_id="req-1",
+            model_id="target",
+            current_bytes=45 * gb,
+            target_cap_bytes=40 * gb,
+            predicted_transient_bytes=10 * gb,
+            requested_tokens=2048,
+            reason="prefill_safety_cap",
+        )
+
+        with (
+            patch("omlx.engine_pool.mx.get_active_memory", return_value=0),
+            patch(
+                "omlx.engine_pool.get_phys_footprint",
+                side_effect=lambda: phys[0],
+            ),
+        ):
+            admitted = await pool._evict_idle_lru_for_prefill("target", req)
+
+        assert admitted is False
+        pool._unload_engine.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_prefill_reclaim_never_evicts_inflight_model(self):
+        """The only other model is busy with in-flight work: reclaim pooled
+        buffers but never evict it. (Stream-synchronize-before-clear lives
+        inside the scheduler's _sync_and_clear_cache, which the reclaim
+        helper delegates to.)"""
+        gb = 1024**3
+        pool = _make_pool(ceiling=0)
+
+        phys = [48 * gb]
+
+        def reclaim():
+            phys[0] = 30 * gb
+
+        scheduler = self._reclaim_scheduler(reclaim)
+        req = PrefillEvictionRequest(
+            request_id="req-1",
+            model_id="target",
+            current_bytes=48 * gb,
+            target_cap_bytes=40 * gb,
+            predicted_transient_bytes=10 * gb,
+            requested_tokens=2048,
+            reason="prefill_safety_cap",
+        )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            pool._entries = {
+                "busy": self._entry("busy", 20 * gb, active=True),
+                "target": self._entry(
+                    "target", 25 * gb, scheduler=scheduler, executor=executor
+                ),
+            }
+            # Resident model weights (45GB) sit above target-predicted, so
+            # buffer reclaim alone cannot fit -- the busy model must NOT be
+            # sacrificed.
+            pool._current_model_memory = 45 * gb
+            pool._unload_engine = AsyncMock()
+
+            with (
+                patch("omlx.engine_pool.mx.get_active_memory", return_value=0),
+                patch(
+                    "omlx.engine_pool.get_phys_footprint",
+                    side_effect=lambda: phys[0],
+                ),
+            ):
+                admitted = await pool._evict_idle_lru_for_prefill("target", req)
+
+        # Resident weights keep it over cap -> reject, but the busy model lives.
+        assert admitted is False
+        scheduler._reclaim_prefill_headroom.assert_called_once()
+        pool._unload_engine.assert_not_awaited()
+        assert pool._entries["busy"].engine is not None
 
 
 class TestEnginePoolStatus:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1318,6 +1318,119 @@ class TestSchedulerQueryMethods:
 
         assert scheduler.has_requests() is True
 
+    def test_has_requests_with_pending_idle_reclaim(self, mock_model, mock_tokenizer):
+        """A pending idle reclaim counts as work for the engine loop.
+
+        Without this the loop stops calling step() once the queues drain,
+        and an enforcer-requested reclaim that arrived during the last busy
+        steps strands forever (issue 2179's wedge).
+        """
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        assert scheduler.has_requests() is False
+
+        scheduler.request_idle_reclaim()
+
+        assert scheduler.has_requests() is True
+
+    def _install_reclaim_probe(self, scheduler):
+        """Stub the Metal-touching reclaim internals; return the call log."""
+        calls = []
+
+        def fake_reclaim():
+            calls.append(True)
+            return 1 * 1024**3
+
+        scheduler._current_usage_bytes = lambda: 2 * 1024**3
+        scheduler._reclaim_prefill_headroom = fake_reclaim
+        return calls
+
+    @pytest.mark.parametrize("busy_queue", ["waiting", "prefilling", "running"])
+    def test_busy_scheduler_defers_idle_reclaim(
+        self, busy_queue, mock_model, mock_tokenizer
+    ):
+        """A reclaim request landing on a busy scheduler is deferred, not lost.
+
+        The enforcer only re-issues the request at hard pressure, so a
+        consumed-while-busy flag can never be replayed — the drain must keep
+        it pending until an idle step (issue 2179). Every busy arm matters:
+        clearing Metal buffers during an active decode or prefill is the #300
+        crash class, so none of the three may be dropped from the gate.
+        """
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        calls = self._install_reclaim_probe(scheduler)
+        request = Request(
+            request_id="busy-req",
+            prompt="Hello",
+            sampling_params=SamplingParams(),
+        )
+        if busy_queue == "running":
+            scheduler.running[request.request_id] = request
+        else:
+            getattr(scheduler, busy_queue).append(request)
+
+        scheduler.request_idle_reclaim()
+        scheduler._process_pending_reclaim()
+
+        # Never clears Metal buffers while work exists, and the request
+        # must survive the busy drain.
+        assert calls == []
+        assert scheduler._pending_reclaim_request is True
+
+        # First idle step performs the reclaim and retires the request.
+        if busy_queue == "running":
+            scheduler.running.clear()
+        else:
+            getattr(scheduler, busy_queue).clear()
+        scheduler._process_pending_reclaim()
+
+        assert len(calls) == 1
+        assert scheduler._pending_reclaim_request is False
+        assert scheduler.has_requests() is False
+
+    def test_failing_reclaim_does_not_refire(self, mock_model, mock_tokenizer):
+        """A raising reclaim is contained and retired, never retried.
+
+        The flag must be cleared before the reclaim runs and the exception
+        must not escape step(): this can be the first step after an
+        engine-loop error recovery with Metal already in an error state
+        (#435), and a re-firing failure would turn that into an infinite
+        error cycle.
+        """
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        attempts = []
+
+        def broken_reclaim():
+            attempts.append(True)
+            raise RuntimeError("Metal in error state")
+
+        scheduler._current_usage_bytes = lambda: 2 * 1024**3
+        scheduler._reclaim_prefill_headroom = broken_reclaim
+
+        scheduler.request_idle_reclaim()
+        scheduler.step()
+
+        assert len(attempts) == 1
+        assert scheduler._pending_reclaim_request is False
+
+        # The failure is spent: no re-attempt on later steps.
+        scheduler.step()
+        assert len(attempts) == 1
+
+    def test_idle_reclaim_drains_via_step(self, mock_model, mock_tokenizer):
+        """step() on an idle scheduler executes a pending reclaim exactly once."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        calls = self._install_reclaim_probe(scheduler)
+
+        scheduler.request_idle_reclaim()
+        scheduler.step()
+
+        assert len(calls) == 1
+        assert scheduler._pending_reclaim_request is False
+
+        # A second step must not re-fire the retired request.
+        scheduler.step()
+        assert len(calls) == 1
+
     def test_get_num_waiting(self, mock_model, mock_tokenizer):
         """Test get_num_waiting() returns correct count."""
         scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
@@ -1418,6 +1531,7 @@ class TestSchedulerReset:
                 sampling_params=SamplingParams(),
             )
             scheduler.add_request(request)
+        scheduler.request_idle_reclaim()
 
         scheduler.reset()
 
@@ -1425,6 +1539,11 @@ class TestSchedulerReset:
         assert len(scheduler.running) == 0
         assert len(scheduler.requests) == 0
         assert scheduler.batch_generator is None
+        # reset() only drops Python references (bytes move INTO the pooled
+        # cache), so an enforcer reclaim request must survive it: the
+        # enforcer never re-issues below hard pressure, and dropping the
+        # request anywhere re-opens the 2179 wedge.
+        assert scheduler._pending_reclaim_request is True
 
     def test_reset_clears_async_store_cache_bookkeeping(
         self, mock_model, mock_tokenizer


### PR DESCRIPTION

Fixes #2179

## Problem

After a burst of load (long prompt, many parallel agent requests), the prefill memory
guard can enter a state it never leaves: every subsequent request is rejected with
`Prefill context too large for available memory (preflight safety guard ...)` even after
all clients have disconnected and cleared their context. The only recovery is manually
unloading the model. #2179 reports exactly this from a remote-client setup where manual
server access isn't available.

The logs the reporter attached (2026-07-20) show the wedge precisely. After a pressure
spike to 120.8 GB on a 35.5 GB model: the enforcer emergency-aborts the in-flight
request, drains the hot cache to zero, and the footprint settles at 112.75 GB — where it
stays **frozen for 26 minutes**, rejecting every prompt from kv_len 85,553 down to 365
against the byte-identical `current 112.75 GB`, until a manual unload drops it to
0.3 GB with `active_memory: 2.08KB (settled)`. So ~77 GB of the frozen figure was
freed-but-pooled Metal buffers holding no live data.

## Reproduced live, and fixed live (same box, same storm, A/B)

The wedge is reproducible on current main with a tuned storm envelope. Protocol:
single pinned ~20GB GDN-hybrid model under a 45GB custom guard ceiling; a wave of
12 × ~27.5k-token prefills whose transient spike crosses the hard line and the
ceiling within one enforcer tick, so the enforcer emergency-aborts everything in
flight (13/13 requests aborted in both arms — aborted requests skip the
completion-time cache clears). Pinning is the forcing device: it removes eviction
as an escape hatch so the A/B stays on the reclaim path — unpinned, main would
have escaped this particular storm by unloading the idle model at hard pressure;
the field wedge needs no pin because it sat in the dead zone below hard, where
the eviction branch never fires. Same storm workload on both arms (sampled peaks
58.5 vs 64.2GB); the A/B exercises the drain-path fix (the admission-path reclaim
never fired — recovery is too fast for a probe to meet an inflated baseline):

- **main**: the enforcer requested an idle reclaim **45 times** over the 40s
  observed window (footprint stuck above hard, so it re-asks every tick) —
  **zero executed**. The footprint froze at ~58.28GB; even a ~1.8k-token prompt
  was then rejected against a ~20GB model, and the server was still wedged at
  hard pressure at teardown.
- **this branch**: **one** request, executed 127ms later on the first idle step
  — `Idle reclaim: trimmed Metal transients between turns (65.7GB -> 45.2GB)` —
  and the enforcer logged `hard -> ok (current=21.2GB)` **two seconds** after
  the spike. Five subsequent ~27.5k-token prompts and both recovery probes
  served normally.
- Zero engine-loop errors and zero Metal errors on both arms, including the
  branch's reclaim executing ~1.1s after 13 concurrent request aborts on the
  engine's own stream (single M5 run — consistency evidence, not a race proof).

A second, gentler A/B isolates the busy-drop half with **no aborts and no
dependence on pinning** (at the crossing the model is busy serving, and busy
models are never eviction candidates): a storm that crosses the hard line
mid-wave without breaching the emergency line. Both arms: exactly one reclaim
request, landed while the wave was still decoding. **main: never executed** —
consumed by the next busy drain, gone despite 20+ seconds of idle afterward
(the field log's first-three-requests loss mode). **This branch: deferred
through ~5.2s of busy drains and executed on the first idle step at wave end**
(`Idle reclaim: trimmed Metal transients between turns (36.8GB -> 32.5GB)`).
Together the two A/Bs exercise both drain-path gaps end-to-end; the
admission-path reclaim (piece 1) never fired in either — recovery is too fast
for a probe to meet an inflated baseline — so its evidence remains its tests
and the production soak.

## Root cause — two independent gaps, both needed for the wedge

**Gap 1 (admission side).** The resident figure the guard reads (`_current_usage_bytes`
→ `max(active, phys_footprint − hot-cache CPU bytes)`) includes MLX's pooled Metal
buffer cache. When a burst's requests finish, their KV/activation arrays are freed into
the buffer *cache* for reuse — pages are not returned to the OS — so the figure stays at
the burst's high-water mark. The guard rejects against that inflated baseline, and the
eviction fallback finds no *idle* model to evict (the only model is the serving one) and
gives up. The serving path's pool clears (`_sync_and_clear_cache` at prefill start and
between chunks) all run *after* admission — a rejected request never reaches them. The
guard blocks the very code that would deflate its own reading.

**Gap 2 (recovery side).** The enforcer already has the right countermeasure for this
state: `request_idle_reclaim()`, which asks the scheduler to run a synchronized pool
clear at the next idle step. In the reporter's log it fired eight times — and executed
zero times, because of two drain defects:

- `_process_pending_reclaim()` cleared the one-shot flag **before** its idle check, so
  a request landing while the scheduler was still winding down the emergency abort was
  consumed and dropped — silently, with no retry.
- Even a surviving flag would strand: once the scheduler goes idle, the engine loop
  stops calling `step()` (`has_requests()` gate), and `step()` is the only place the
  flag is drained.

The request is also never re-issued below *hard* pressure — and the wedged footprint
(112.75 GB) sat in the dead zone above the admission cap (107.55 GB) but below the hard
line (114 GB). Permanent 400s.

## Fix — one small change per gap, no new settings

1. **Admission path** (`engine_pool.py`): at the exact give-up point ("no idle model
   evicted"), attempt one pooled-buffer reclaim, re-measure once, and admit if that
   created headroom. Otherwise reject exactly as before. INFO log with bytes reclaimed
   when it fires. The reclaim dispatches to the **requesting engine's own MLX thread**
   and delegates to the scheduler's existing `_reclaim_prefill_headroom` — the same
   stream-synchronized, `_mx_buffer_access_lock`-held clear that already runs between
   prefill chunks — because clearing from any other thread could release cached buffers
   still referenced by in-flight `mx.async_eval` command buffers (the documented
   completeMemory-underflow crash class, #300/#888/#1106). The engine's step loop is
   parked awaiting this eviction callback, so its executor is free at that moment;
   `gc.collect()` runs there too, off the event loop.
2. **Drain path** (`scheduler.py`): keep `_pending_reclaim_request` set when the drain
   finds the scheduler busy (clear it only when the reclaim actually runs), and count
   it as work in `has_requests()` — the exact pattern `_deferred_clear_at` already uses
   ("Without this, an idle server would never reach the target step and stale buffers
   would accumulate indefinitely"). The first idle step then performs the reclaim.

In the reporter's timeline: piece 2 recovers the server seconds after the pressure event
(no request needed), and piece 1 independently unblocks it at the first rejected
admission. Either alone breaks the deadlock; together they close both gaps.

## Why safe

- Every clear in this PR goes through the scheduler's `_sync_and_clear_cache` on the
  owning engine's thread: the engine's generation stream is synchronized under
  `_mx_buffer_access_lock` before the pool is touched, so in-flight command buffers and
  the async SSD store worker are both safe (#300/#888/#1106). `clear_cache` then
  releases only *unused* cached buffers — arrays an in-flight request still references
  are untouched, and the hot/prefix cache is left intact (it is reclaimed separately by
  the enforcer).
- Reject-parity: when nothing is reclaimable the admission *outcome* is identical to
  today's rejection; the reject path gains a bounded, once-per-admission reclaim
  attempt on the engine's own thread (whose step loop is parked at that point).
- A busy (in-flight) model is never sacrificed — covered by a dedicated test.
- The idle reclaim only ever runs on a truly idle scheduler (no running / prefilling /
  waiting work) — unchanged semantics; the fix changes only *when the request is allowed
  to wait*, never *when it may act*.
- Failure containment at both call sites (#435 class — Metal can already be in an error
  state when a reclaim runs, e.g. the first step after an engine-loop error recovery):
  a raising reclaim logs a warning and degrades to the plain rejection / a retired
  request. The flag is cleared before the reclaim executes, so a persistent failure
  cannot re-fire; the engine loop's exception recovery still terminates — the pending
  flag costs at most one extra step (the invariant comment there is updated to match).
- The reclaim request is **never silently dropped anywhere**: busy drains keep it,
  `reset()` keeps it (reset only drops Python references, which moves bytes *into* the
  pooled cache — and the enforcer never re-issues below hard pressure, so dropping the
  request anywhere would re-open the wedge). It drains on the first idle step of
  whatever scheduler state follows; after a teardown the loop is gone and the flag is
  garbage-collected with the scheduler.
- An idle engine loop notices a freshly set flag on its next `step_interval` poll
  (~50 ms) — no wake-event plumbing needed.

## Sibling paths

- **VLM engine**: `VLMBatchedEngine` drives the same `Scheduler` class through
  `EngineCore` (no overrides of `step()` / `has_requests()` / `request_idle_reclaim`),
  so both pieces cover it automatically. The reporter's incident was in fact on the VLM
  path (Ornith).
- **DFlash primary mode**: explicitly out of scope. Its preflight
  (`_DFlashPrefillGuard`) raises directly rather than going through the eviction
  fallback, and the enforcer's `hasattr(sched, "request_idle_reclaim")` check skips it,
  so neither piece reaches it — same behavior as today. If the same wedge is ever
  reported under DFlash primary, wiring a reclaim into its guard is the analogous
  follow-up. DFlash fallback mode resolves the real `Scheduler` and is covered.

## Tests

- `test_prefill_reclaims_pooled_buffers_when_no_idle_victim` — the crept-baseline
  scenario: no idle victim, reclaimable pool bytes → reclaim, re-measure, admit.
- `test_prefill_rejects_when_reclaim_frees_nothing` — reject-parity; `clear_cache`
  called exactly once.
- `test_prefill_reclaim_never_evicts_inflight_model` — reclaim alone insufficient →
  the busy model is not evicted; request rejected.
- `test_has_requests_with_pending_idle_reclaim` — a pending reclaim counts as work, so
  the engine loop keeps stepping (red on main).
- `test_busy_scheduler_defers_idle_reclaim` — a request landing on a busy scheduler is
  deferred, not consumed; the first idle drain runs it and retires it (red on main).
- `test_idle_reclaim_drains_via_step` — `step()` executes a pending reclaim exactly
  once; a second step does not re-fire it.
- `test_busy_scheduler_defers_idle_reclaim` is parametrized over all three busy arms
  (`waiting` / `prefilling` / `running`) — dropping any one from the gate is the #300
  crash class, so each is pinned individually.
- `test_failing_reclaim_does_not_refire` — a raising reclaim is contained inside
  `step()`, the flag stays retired, no re-attempt (red without the guard).
- `test_prefill_reclaim_failure_rejects_as_before` and
  `test_prefill_reclaim_skipped_when_engine_unresolvable` — admission-side failure
  containment and the mid-teardown no-engine case both degrade to the plain rejection.
- `test_reset_clears_all_state` (extended) — a pending reclaim *survives* `reset()`
  (see why-safe: dropping it anywhere re-opens the wedge).
- Full `tests/test_scheduler.py` + `test_engine_pool.py` + `test_scheduler_admission.py`
  + `test_scheduler_prefill_memory_guard.py` + `test_engine_core.py`: 397 passed on
  this branch (rebased on current main).

Piece 1's admission logic (trigger point, once-per-admission bound, re-measure,
admit/reject decision) has been running on my own server (M5 Max, 128 GB, multi-model)
since Jul 1 with no regressions; its reclaim fires in practice after long-context agent
bursts (831 MB up to 5.19 GB freed on a single admission), each followed by normal
admission instead of the permanent rejection. An adversarial review pass then rehomed
the clear itself from the global MLX executor onto the requesting engine's thread via
the scheduler's `_sync_and_clear_cache` — the same guarded clear that already runs
between prefill chunks on every long prefill, so that path is heavily
production-exercised too.

## Scope note

The report's secondary observation — the in-memory hot cache can't be reset remotely —
is deliberately out of scope: this change never touches the hot/prefix cache (it is
tracked and shrunk separately by the process-memory enforcer, and
`POST /admin/api/hot-cache/clear` is the existing manual remote reset). The enforcer's
soft/hard thresholds are also untouched: with both gaps closed, the dead zone between
the admission cap and the hard line stops mattering, so no retuning is needed.
