### PR TITLE
feat(admin): attribute active requests to harness sessions

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -4535,6 +4535,17 @@ def _build_active_models_data() -> dict:
     total_active = 0
     total_waiting = 0
 
+    def request_attribution(req) -> dict:
+        """Return display-only attribution attached to a scheduler request."""
+        if req is None:
+            return {}
+        return dict(getattr(req, "metadata", {}) or {})
+
+    def request_attribution_fields(req) -> dict:
+        """Return an optional response fragment without changing legacy rows."""
+        attribution = request_attribution(req)
+        return {"attribution": attribution} if attribution else {}
+
     for model_info in status.get("models", []):
         if not model_info.get("loaded") and not model_info.get("is_loading"):
             continue
@@ -4587,6 +4598,7 @@ def _build_active_models_data() -> dict:
                         "queue_position": idx,
                         "elapsed_seconds": max(0.0, now - req.arrival_time),
                         "prompt_tokens": getattr(req, "num_prompt_tokens", 0),
+                        **request_attribution_fields(req),
                     }
                     for idx, req in enumerate(waiting_queue, start=1)
                 ]
@@ -4599,6 +4611,10 @@ def _build_active_models_data() -> dict:
                 activities = snapshot.get("activities", [])
 
         prefilling = tracker.get_model_progress(model_id)
+        for progress in prefilling:
+            attribution = request_attribution(running_by_id.get(progress["request_id"]))
+            if attribution:
+                progress["attribution"] = attribution
         prefilling_ids = {p["request_id"] for p in prefilling}
         if has_scheduler_snapshot:
             active_request_ids = set(running_by_id) | prefilling_ids
@@ -4631,6 +4647,7 @@ def _build_active_models_data() -> dict:
                     "last_activity_age_seconds": last_activity_age,
                     "prompt_tokens": getattr(req, "num_prompt_tokens", 0) if req else 0,
                     "max_tokens": getattr(req, "max_tokens", None) if req else None,
+                    **request_attribution_fields(req),
                 }
             )
 

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -2755,6 +2755,23 @@
                 return 'last token ' + this.formatDurationShort(seconds) + ' ago';
             },
 
+            requestAttributionLabel(request) {
+                const a = request?.attribution || {};
+                return [a.source, a.channel, a.agent, a.session_name]
+                    .filter(Boolean)
+                    .join(' · ');
+            },
+
+            requestAttributionTitle(request) {
+                const a = request?.attribution || {};
+                const ids = [];
+                if (a.session_id) ids.push('session: ' + a.session_id);
+                if (a.conversation_id) ids.push('conversation: ' + a.conversation_id);
+                if (a.external_request_id) ids.push('external request: ' + a.external_request_id);
+                ids.push('oMLX request: ' + request.request_id);
+                return ids.join('\n');
+            },
+
             formatActivityMetadata(activity) {
                 const parts = [];
                 if (activity.input_count != null) parts.push(activity.input_count + ' inputs');

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -263,6 +263,10 @@
                                         <div class="mt-2 ml-5 space-y-1.5">
                                             <template x-for="pp in m.prefilling" :key="pp.request_id">
                                                 <div class="flex items-center gap-2">
+                                                    <span x-show="requestAttributionLabel(pp)"
+                                                          class="text-[10px] font-medium text-neutral-700 max-w-64 truncate"
+                                                          :title="requestAttributionTitle(pp)"
+                                                          x-text="requestAttributionLabel(pp)"></span>
                                                     <span class="text-[10px] font-mono text-neutral-400 w-16 truncate" x-text="pp.request_id.substring(0, 8)"></span>
                                                     <div class="flex-1 h-1.5 bg-neutral-100 rounded-full overflow-hidden max-w-[120px]">
                                                         <div class="h-full bg-blue-400 rounded-full transition-all duration-300"
@@ -284,6 +288,10 @@
                                         <div class="mt-1.5 ml-5 space-y-1.5">
                                             <template x-for="gen in m.generating" :key="gen.request_id">
                                                 <div class="flex flex-wrap items-center gap-x-4 gap-y-1">
+                                                    <span x-show="requestAttributionLabel(gen)"
+                                                          class="text-[10px] font-medium text-neutral-700 max-w-64 truncate"
+                                                          :title="requestAttributionTitle(gen)"
+                                                          x-text="requestAttributionLabel(gen)"></span>
                                                     <span class="text-[10px] font-mono text-neutral-400 w-16 truncate" x-text="gen.request_id.substring(0, 8)"></span>
                                                     <span class="inline-flex items-center gap-2 min-w-[104px] whitespace-nowrap">
                                                         <span class="w-2 h-2 rounded-full flex-shrink-0 bg-green-400 animate-pulse"></span>
@@ -348,6 +356,10 @@
                                         <div class="mt-1.5 ml-5 space-y-1.5">
                                             <template x-for="wait in m.waiting" :key="wait.request_id">
                                                 <div class="flex items-center gap-2">
+                                                    <span x-show="requestAttributionLabel(wait)"
+                                                          class="text-[10px] font-medium text-neutral-700 max-w-64 truncate"
+                                                          :title="requestAttributionTitle(wait)"
+                                                          x-text="requestAttributionLabel(wait)"></span>
                                                     <span class="text-[10px] font-mono text-neutral-400 w-16 truncate" x-text="wait.request_id.substring(0, 8)"></span>
                                                     <span class="w-2 h-2 rounded-full bg-amber-300"></span>
                                                     <span class="text-[10px] text-amber-600 font-medium" x-text="window.t('status.active_models.waiting') + ' #' + wait.queue_position"></span>

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -738,10 +738,12 @@ class BatchedEngine(BaseEngine):
         # SpecPrefill: forward per-request overrides to the engine, mirroring
         # stream_generate so the non-streaming path is not silently ignored.
         specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
+        request_metadata = kwargs.pop("request_metadata", None)
 
         output = await self._engine.generate(
             prompt=prompt,
             sampling_params=sampling_params,
+            request_metadata=request_metadata,
             **specprefill_kwargs,
         )
 
@@ -810,6 +812,8 @@ class BatchedEngine(BaseEngine):
             seed=kwargs.get("seed", None),
         )
 
+        request_metadata = kwargs.pop("request_metadata", None)
+
         # SpecPrefill: pass per-request overrides to engine
         specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
 
@@ -818,6 +822,7 @@ class BatchedEngine(BaseEngine):
             prompt=prompt,
             sampling_params=sampling_params,
             skip_cache_store=bool(kwargs.get("skip_cache_store", False)),
+            request_metadata=request_metadata,
             **specprefill_kwargs,
         )
 

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -3112,6 +3112,8 @@ class VLMBatchedEngine(BaseEngine):
             seed=kwargs.get("seed", None),
         )
 
+        request_metadata = kwargs.pop("request_metadata", None)
+
         # SpecPrefill: forward per-request overrides to the engine, mirroring
         # stream_generate so the non-streaming path is not silently ignored.
         specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
@@ -3119,6 +3121,7 @@ class VLMBatchedEngine(BaseEngine):
         output = await self._engine.generate(
             prompt=prompt,
             sampling_params=sampling_params,
+            request_metadata=request_metadata,
             vlm_inputs_embeds=vlm_inputs_embeds,
             vlm_extra_kwargs=vlm_extra_kwargs,
             vlm_image_hash=vlm_image_hash,
@@ -3222,6 +3225,8 @@ class VLMBatchedEngine(BaseEngine):
             seed=kwargs.get("seed", None),
         )
 
+        request_metadata = kwargs.pop("request_metadata", None)
+
         # SpecPrefill: pass per-request overrides
         specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
 
@@ -3229,6 +3234,7 @@ class VLMBatchedEngine(BaseEngine):
         request_id = await engine.add_request(
             prompt=prompt,
             sampling_params=sampling_params,
+            request_metadata=request_metadata,
             vlm_inputs_embeds=vlm_inputs_embeds,
             vlm_extra_kwargs=vlm_extra_kwargs,
             vlm_image_hash=vlm_image_hash,

--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -533,6 +533,7 @@ class EngineCore:
         prompt: Union[str, List[int]],
         sampling_params: Optional[SamplingParams] = None,
         request_id: Optional[str] = None,
+        request_metadata: Optional[Dict[str, str]] = None,
         images: Optional[List[Any]] = None,
         videos: Optional[List[Any]] = None,
         vlm_inputs_embeds: Optional[Any] = None,
@@ -553,6 +554,7 @@ class EngineCore:
             prompt: Input prompt (string or token IDs)
             sampling_params: Generation parameters
             request_id: Optional custom request ID
+            request_metadata: Optional bounded labels for admin observability
             images: Optional images for multimodal
             videos: Optional videos for multimodal
             vlm_inputs_embeds: Pre-computed vision+text embeddings for VLM
@@ -575,6 +577,7 @@ class EngineCore:
             request_id=request_id,
             prompt=prompt,
             sampling_params=sampling_params,
+            metadata=dict(request_metadata or {}),
             images=images,
             videos=videos,
             vlm_inputs_embeds=vlm_inputs_embeds,

--- a/omlx/request.py
+++ b/omlx/request.py
@@ -211,6 +211,10 @@ class Request:
         0  # Per-request prefill-headroom eviction phase counter
     )
 
+    # Caller-supplied observability labels. Appended to preserve positional
+    # compatibility; never used for tokenization, priority, or cache keys.
+    metadata: Dict[str, str] = field(default_factory=dict)
+
     @property
     def num_output_tokens(self) -> int:
         """Number of output tokens generated so far."""

--- a/omlx/request_attribution.py
+++ b/omlx/request_attribution.py
@@ -1,0 +1,37 @@
+"""Bounded, display-only attribution for inference requests."""
+
+from collections.abc import Mapping
+
+REQUEST_ATTRIBUTION_HEADERS = {
+    "x-omlx-source": "source",
+    "x-omlx-agent": "agent",
+    "x-omlx-channel": "channel",
+    "x-omlx-session-name": "session_name",
+    "x-omlx-session-id": "session_id",
+    "x-omlx-conversation-id": "conversation_id",
+    "x-request-id": "external_request_id",
+}
+REQUEST_ATTRIBUTION_MAX_VALUE_LENGTH = 160
+
+
+def request_attribution_from_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    """Extract bounded attribution labels from case-insensitive HTTP headers."""
+    attribution: dict[str, str] = {}
+    for header, key in REQUEST_ATTRIBUTION_HEADERS.items():
+        value = headers.get(header)
+        if not value:
+            continue
+        # Collapse whitespace/control characters before returning values to the
+        # admin API. The template renders with x-text, but keep the API safe too.
+        value = " ".join(value.split())[:REQUEST_ATTRIBUTION_MAX_VALUE_LENGTH]
+        if value:
+            attribution[key] = value
+
+    # Best-effort fallback only; precise harness/session data must be explicit.
+    if "source" not in attribution:
+        user_agent = (headers.get("user-agent") or "").lower()
+        for source in ("openclaw", "hermes", "pi"):
+            if source in user_agent:
+                attribution["source"] = source
+                break
+    return attribution

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -178,6 +178,7 @@ from .engine import BaseEngine, VLMBatchedEngine
 from .engine.embedding import EmbeddingEngine
 from .engine.reranker import RerankerEngine
 from .engine_pool import EnginePool
+from .request_attribution import request_attribution_from_headers
 from .exceptions import (
     EnginePoolError,
     InsufficientMemoryError,
@@ -3511,6 +3512,10 @@ async def create_chat_completion(
             request_id=http_request.headers.get("x-request-id"),
             **chat_kwargs,
         )
+
+        request_metadata = request_attribution_from_headers(http_request.headers)
+        if request_metadata:
+            chat_kwargs["request_metadata"] = request_metadata
 
         await _raise_if_llm_lease_abort_requested(lease)
 

--- a/tests/test_request_attribution.py
+++ b/tests/test_request_attribution.py
@@ -1,0 +1,53 @@
+from omlx.request_attribution import (
+    REQUEST_ATTRIBUTION_MAX_VALUE_LENGTH,
+    request_attribution_from_headers,
+)
+
+
+def test_extracts_explicit_request_attribution_headers():
+    metadata = request_attribution_from_headers(
+        {
+            "x-omlx-source": "openclaw",
+            "x-omlx-agent": "main",
+            "x-omlx-channel": "telegram",
+            "x-omlx-session-name": "Support chat",
+            "x-omlx-session-id": "session-123",
+            "x-omlx-conversation-id": "chat-456",
+            "x-request-id": "caller-789",
+        }
+    )
+
+    assert metadata == {
+        "source": "openclaw",
+        "agent": "main",
+        "channel": "telegram",
+        "session_name": "Support chat",
+        "session_id": "session-123",
+        "conversation_id": "chat-456",
+        "external_request_id": "caller-789",
+    }
+
+
+def test_request_attribution_is_bounded_and_control_characters_are_collapsed():
+    metadata = request_attribution_from_headers(
+        {"x-omlx-session-name": "  hello\n\tworld  " + "x" * 300}
+    )
+
+    assert metadata["session_name"].startswith("hello world")
+    assert len(metadata["session_name"]) == REQUEST_ATTRIBUTION_MAX_VALUE_LENGTH
+
+
+def test_known_user_agent_is_only_a_best_effort_source_fallback():
+    assert request_attribution_from_headers({"user-agent": "Hermes-Agent/1.2"}) == {
+        "source": "hermes"
+    }
+    assert request_attribution_from_headers({"user-agent": "python-httpx/0.28"}) == {}
+
+
+def test_explicit_source_wins_over_user_agent():
+    assert (
+        request_attribution_from_headers(
+            {"x-omlx-source": "openclaw", "user-agent": "Hermes-Agent/1.2"}
+        )["source"]
+        == "openclaw"
+    )


### PR DESCRIPTION
## Summary

The Active Models dashboard currently identifies concurrent requests only by an internal UUID. That makes it difficult to distinguish OpenClaw, Hermes, pi, or other harness traffic when several clients share one oMLX server.

This adds optional, display-only request attribution for `/v1/chat/completions`:

- read bounded attribution values from `X-oMLX-*` headers
- carry them through streaming and non-streaming LLM/VLM request paths
- attach them to the scheduler request without changing tokenization, priority, or prefix-cache keys
- show `source · channel · agent · session name` beside the internal request ID for waiting, prefilling, and generating requests
- expose exact session/conversation/external request IDs in the row tooltip
- omit the attribution field entirely when no metadata is supplied, preserving the existing admin API row shape

## Header contract

| Header | Dashboard field |
| --- | --- |
| `X-oMLX-Source` | harness/client, e.g. `openclaw` or `hermes` |
| `X-oMLX-Agent` | agent name/ID |
| `X-oMLX-Channel` | channel/platform |
| `X-oMLX-Session-Name` | human-readable session label |
| `X-oMLX-Session-ID` | exact harness session ID |
| `X-oMLX-Conversation-ID` | exact conversation/chat/thread ID |
| `X-Request-ID` | caller-provided request ID |

Values are whitespace-normalized and limited to 160 characters. If `X-oMLX-Source` is absent, known `User-Agent` values provide a best-effort source-only fallback. Precise session attribution remains opt-in because only the calling harness knows it.

## oMLX 0.5.7 compatibility

Rebased onto current `main` at `50846648` (immediately after tag `v0.5.7`). The conflict resolution preserves the newer:

- `skip_cache_store` forwarding in the batched engine
- non-streaming SpecPrefill forwarding in the VLM engine
- DFlash/fallback scheduler activity discovery in the admin dashboard

## Validation

- `pytest --noconftest tests/test_request_attribution.py -q` (4 passed)
- `pytest tests/test_active_models_visibility.py -q` (15 passed)
- Ruff check and format check for the new parser and tests
- JavaScript syntax check for `dashboard.js`
- Python byte-compilation for the oMLX package
- `git diff --check`

Related context: #650, #1701, #2177.
