### PR TITLE
Add Baidu Unlimited-OCR support and oQ fixes

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -2447,7 +2447,7 @@ class VLMBatchedEngine(BaseEngine):
             - image_cache_key_ranges: Per-image-turn cache key boundaries with
               cumulative image hashes
         """
-        from mlx_vlm.prompt_utils import apply_chat_template
+        from mlx_vlm.prompt_utils import apply_chat_template, get_chat_template
         from mlx_vlm.utils import load_audio as _load_audio
         from mlx_vlm.utils import prepare_inputs
 
@@ -2549,25 +2549,21 @@ class VLMBatchedEngine(BaseEngine):
                 formatted_messages, **template_kwargs
             )
         except ValueError:
-            # Processor has apply_chat_template but no chat_template set
-            # (e.g. mlx-vlm custom processor without processor_config.json).
-            # Fall back to processor.tokenizer which holds the actual template.
-            fallback = getattr(self._processor, "tokenizer", None)
-            if fallback is not None and fallback is not template_target:
-                try:
-                    prompt = fallback.apply_chat_template(
-                        formatted_messages, **template_kwargs
-                    )
-                except TypeError:
-                    if chat_template_kwargs:
-                        for key in chat_template_kwargs:
-                            template_kwargs.pop(key, None)
-                    template_kwargs.pop("enable_thinking", None)
-                    prompt = fallback.apply_chat_template(
-                        formatted_messages, **template_kwargs
-                    )
-            else:
-                raise
+            # Processor/tokenizer has apply_chat_template but no chat_template
+            # set. Some OCR checkpoints (e.g. raw baidu/Unlimited-OCR) ship no
+            # chat template at all. mlx-vlm's get_chat_template handles this by
+            # rendering the messages into a plain prompt (the <image> tokens are
+            # already in the message content from get_message_json), preferring
+            # processor.chat_template -> processor.tokenizer.chat_template ->
+            # plain rendering, so it subsumes the tokenizer fallback too.
+            template_kwargs.pop("tokenize", None)
+            template_kwargs.pop("add_generation_prompt", None)
+            prompt = get_chat_template(
+                self._processor,
+                formatted_messages,
+                add_generation_prompt=True,
+                **template_kwargs,
+            )
 
         # Tokenize text and preprocess images and audio
         inputs = prepare_inputs(
@@ -2864,6 +2860,17 @@ class VLMBatchedEngine(BaseEngine):
                 template_kwargs.pop("tools", None)
                 template_kwargs.pop("enable_thinking", None)
                 return self._tokenizer.apply_chat_template(messages, **template_kwargs)
+            except ValueError:
+                # Tokenizer exposes apply_chat_template but has no chat_template
+                # set (e.g. raw baidu/Unlimited-OCR ships none). Fall back to
+                # mlx-vlm's plain-message rendering, matching the vision path.
+                from mlx_vlm.prompt_utils import get_chat_template
+
+                return get_chat_template(
+                    self._processor,
+                    messages,
+                    add_generation_prompt=True,
+                )
         else:
             prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
             return prompt + "\nassistant:"

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -62,7 +62,16 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 # OCR model types that require special handling.
-OCR_MODEL_TYPES = {"deepseekocr", "deepseekocr_2", "dots_ocr", "glm_ocr"}
+# unlimited-ocr keeps its dashed config model_type (mlx-vlm resolves it to the
+# unlimited_ocr package via MODEL_REMAPPING), so key it in the dashed form to
+# match VLMBatchedEngine.model_type (== vlm_model.config.model_type).
+OCR_MODEL_TYPES = {
+    "deepseekocr",
+    "deepseekocr_2",
+    "unlimited-ocr",
+    "dots_ocr",
+    "glm_ocr",
+}
 
 # OCR model types and their default markdown conversion prompts.
 # When an OCR model receives a generic user prompt with an image,
@@ -70,6 +79,9 @@ OCR_MODEL_TYPES = {"deepseekocr", "deepseekocr_2", "dots_ocr", "glm_ocr"}
 OCR_MODEL_PROMPTS: Dict[str, str] = {
     "deepseekocr": "Convert the document to markdown.",
     "deepseekocr_2": "Convert the document to markdown.",
+    # baidu/Unlimited-OCR upstream-documented single-page baseline. Multi-page
+    # / PDF workflows use "Multi page parsing." (pass it explicitly).
+    "unlimited-ocr": "document parsing.",
     "dots_ocr": "Convert this page to clean Markdown while preserving reading order.",
     "glm_ocr": "Text Recognition:",
 }
@@ -106,6 +118,10 @@ OCR_MODEL_GENERATION_DEFAULTS: Dict[str, Dict[str, Any]] = {
         "max_tokens": 8192,
     },
     "deepseekocr_2": {
+        "temperature": 0.0,
+        "max_tokens": 8192,
+    },
+    "unlimited-ocr": {
         "temperature": 0.0,
         "max_tokens": 8192,
     },

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -57,6 +57,7 @@ VLM_MODEL_TYPES = {
     "florence2",
     "deepseekocr",
     "deepseekocr_2",
+    "unlimited_ocr",
     "dots_ocr",
     "glm_ocr",
     "minimax_m3_vl",
@@ -147,6 +148,7 @@ VLM_ARCHITECTURES = {
     "Molmo2ForConditionalGeneration",
     "LlavaQwen2ForCausalLM",  # apple/FastVLM (all sizes)
     "Florence2ForConditionalGeneration",
+    "UnlimitedOCRForCausalLM",  # baidu/Unlimited-OCR
 }
 
 # Known embedding model types from mlx-embeddings

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -368,6 +368,11 @@ def _is_vision_tensor(name: str) -> bool:
         for p in (
             "visual.",
             "vision_",
+            # DeepSeek-OCR / Unlimited-OCR SAM encoder. Kept full precision like
+            # the rest of the vision tower: its neck/net_2/net_3 are nn.Conv2d,
+            # which mlx cannot quantize at all, so quantizing them yields
+            # unloadable .scales/.biases the model has no slot for.
+            "sam_model",
             "patch_embed",
             "pos_embed",
             "image_newline",
@@ -2605,9 +2610,16 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
         or None if the model class can't be loaded.
     """
     architectures = config.get("architectures", [])
+    # Detect VLMs by the canonical vision-subconfig predicate (used everywhere
+    # else in oq.py), not just the ForConditionalGeneration arch name. OCR VLMs
+    # like baidu/Unlimited-OCR (UnlimitedOCRForCausalLM) and DeepSeek-OCR
+    # (DeepseekOCR2ForCausalLM) carry a vision_config but a ForCausalLM arch, so
+    # the arch-only heuristic dropped them to the mlx-lm sanitize path (which
+    # can't resolve their model_type) and shipped unsanitized vision weights.
     is_vlm = (
-        any("ForConditionalGeneration" in a for a in architectures) and not text_only
-    )
+        any("ForConditionalGeneration" in a for a in architectures)
+        or _has_vision_subconfig(config)
+    ) and not text_only
 
     if is_vlm:
         try:
@@ -2703,7 +2715,16 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
                 _lm_proxy = type("_LMProxy", (), {})()
                 _lm_proxy.args = text_config
                 proxy.language_model = _lm_proxy
-                w = model_module.Model.sanitize(proxy, weights)
+                # Model.sanitize is an instance method (self, weights) for most
+                # VLMs, but a @staticmethod (weights) for the DeepSeek-OCR family
+                # (deepseekocr / unlimited_ocr). Dispatch on the arg count so the
+                # proxy is only passed when sanitize actually takes a self.
+                _san = model_module.Model.sanitize
+                _san_argc = getattr(getattr(_san, "__code__", None), "co_argcount", 2)
+                if _san_argc >= 2:
+                    w = _san(proxy, weights)
+                else:
+                    w = _san(weights)
 
                 w = sanitize_weights(model_module.VisionModel, w, vision_config)
                 w = sanitize_weights(model_module.LanguageModel, w, text_config)

--- a/omlx/patches/mlx_vlm_unlimited_ocr_compat/__init__.py
+++ b/omlx/patches/mlx_vlm_unlimited_ocr_compat/__init__.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Baidu Unlimited-OCR compatibility layer for the pinned mlx-vlm.
+
+The `unlimited_ocr` model package landed in mlx-vlm PR #1427 (commit
+`9909cee`, 2026-07-01), which is newer than oMLX's current mlx-vlm pin
+(`78b96eb`, 2026-06-28). Rather than bumping the whole pin (8 upstream
+commits, KEEP-patch re-verification), this vendors the model package and
+wires up only the discovery surface oMLX needs:
+
+- installs the vendored `mlx_vlm.models.unlimited_ocr` package onto the real
+  `mlx_vlm.models` namespace so `get_model_and_args` can import it (its own
+  relative imports `..deepseekocr`/`..base`/`..cache` resolve against the real
+  mlx-vlm package, which already ships `deepseekocr` at the pin),
+- adds the `unlimited-ocr -> unlimited_ocr` entry to `mlx_vlm.utils`'
+  `MODEL_REMAPPING` (without it, `get_model_and_args` tries to import the
+  literal dashed module name and falls through to the
+  `mlx_vlm.speculative.drafters.unlimited-ocr` lookup seen in issue #2314),
+- reproduces the PR's single-`<image>` multi-page prompt semantics
+  (`MessageFormat.SINGLE_IMAGE_TOKEN`) by wrapping `prompt_utils`'
+  `get_message_json` for the `unlimited-ocr` model type, without mutating the
+  frozen `MessageFormat` enum.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_VENDOR_MLX_VLM = Path(__file__).resolve().parent / "vendor" / "mlx_vlm"
+
+# Config model_type carried by baidu/Unlimited-OCR checkpoints. The mlx-vlm
+# module directory is the underscore form (`unlimited_ocr`).
+_MODEL_TYPE = "unlimited-ocr"
+_MODULE_NAME = "unlimited_ocr"
+
+_APPLIED = False
+
+
+def apply_mlx_vlm_unlimited_ocr_compat_patch() -> bool:
+    """Install the vendored Unlimited-OCR module and mlx-vlm discovery hooks."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        _install_vendor_namespace()
+        _import_vendor_modules()
+
+        import mlx_vlm.prompt_utils as prompt_utils
+        import mlx_vlm.utils as vlm_utils
+
+        _patch_model_remapping(vlm_utils)
+        _patch_prompt_utils(prompt_utils)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Unlimited-OCR mlx-vlm compat patch failed: %s", exc)
+        return False
+
+    _APPLIED = True
+    logger.info("Unlimited-OCR mlx-vlm compatibility patch applied")
+    return True
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+def _install_vendor_namespace() -> None:
+    import mlx_vlm
+    import mlx_vlm.models
+
+    _append_package_path(mlx_vlm, _VENDOR_MLX_VLM)
+    _append_package_path(mlx_vlm.models, _VENDOR_MLX_VLM / "models")
+
+
+def _append_package_path(package: Any, path: Path) -> None:
+    package_path = getattr(package, "__path__", None)
+    if package_path is None:
+        return
+    path_str = str(path)
+    if path_str not in package_path:
+        package_path.append(path_str)
+
+
+def _import_vendor_modules() -> None:
+    # Importing the package runs its __init__, which imports
+    # processing_unlimitedocr (install_auto_processor_patch) and unlimitedocr
+    # (AutoProcessor.register) so the processor is discoverable.
+    importlib.import_module(f"mlx_vlm.models.{_MODULE_NAME}")
+
+
+def _patch_model_remapping(vlm_utils: Any) -> None:
+    remapping = getattr(vlm_utils, "MODEL_REMAPPING", None)
+    if isinstance(remapping, dict):
+        remapping.setdefault(_MODEL_TYPE, _MODULE_NAME)
+
+
+def _patch_prompt_utils(prompt_utils: Any) -> None:
+    # apply_chat_template short-circuits to text-only formatting for any
+    # model_type missing from MODEL_CONFIG, which would skip get_message_json
+    # (and the <image> token) entirely. Register the key so the image branch is
+    # taken; the mapped MessageFormat is never consulted because the
+    # get_message_json wrapper below intercepts unlimited-ocr first.
+    model_config = getattr(prompt_utils, "MODEL_CONFIG", None)
+    message_format = getattr(prompt_utils, "MessageFormat", None)
+    if isinstance(model_config, dict) and message_format is not None:
+        placeholder = getattr(message_format, "IMAGE_TOKEN", None)
+        if placeholder is not None:
+            model_config.setdefault(_MODEL_TYPE, placeholder)
+
+    original = getattr(prompt_utils, "get_message_json", None)
+    if original is None or getattr(original, "_omlx_unlimited_ocr_compat", False):
+        return
+
+    def patched_get_message_json(
+        model_name: str,
+        prompt: str,
+        role: str = "user",
+        skip_image_token: bool = False,
+        skip_audio_token: bool = False,
+        num_images: int = 0,
+        num_audios: int = 0,
+        **kwargs,
+    ):
+        if _is_unlimited_ocr(model_name):
+            content = "" if prompt is None else str(prompt)
+            # Unlimited-OCR uses a single literal <image> token for one or many
+            # pages, matching upstream infer_multi (MessageFormat.SINGLE_IMAGE_TOKEN).
+            if role == "user" and not skip_image_token and num_images > 0:
+                content = f"<image>{content}"
+            return {"role": role, "content": content}
+        return original(
+            model_name,
+            prompt,
+            role=role,
+            skip_image_token=skip_image_token,
+            skip_audio_token=skip_audio_token,
+            num_images=num_images,
+            num_audios=num_audios,
+            **kwargs,
+        )
+
+    patched_get_message_json._omlx_unlimited_ocr_compat = True
+    patched_get_message_json._omlx_original = original
+    prompt_utils.get_message_json = patched_get_message_json
+
+
+def _is_unlimited_ocr(model_name: Any) -> bool:
+    return (
+        isinstance(model_name, str)
+        and model_name.lower().replace("_", "-") == _MODEL_TYPE
+    )
+
+
+__all__ = ["apply_mlx_vlm_unlimited_ocr_compat_patch", "is_applied"]

--- a/omlx/patches/mlx_vlm_unlimited_ocr_compat/vendor/mlx_vlm/models/unlimited_ocr/README.md
+++ b/omlx/patches/mlx_vlm_unlimited_ocr_compat/vendor/mlx_vlm/models/unlimited_ocr/README.md
@@ -1,0 +1,359 @@
+# Unlimited-OCR
+
+Unlimited-OCR is Baidu's OCR/document-parsing model for **one-shot long-horizon parsing**.
+
+This README only documents the prompt formats and settings that are either shown by upstream or verified in the MLX implementation.
+
+## Model Architecture
+
+```
+                        input document image(s)
+                                  │
+                                  ▼
+                    ┌─────────────────────────────┐
+                    │ Dynamic image preprocessing │
+                    ├─────────────────────────────┤
+                    │ gundam: 1024 global view    │
+                    │         + 640 local crops   │
+                    │ base:   1024 global view    │
+                    └──────────────┬──────────────┘
+                                   ▼
+                    ┌─────────────────────────────┐
+                    │ SAM ViT-B + CLIP-L features │
+                    │ concatenated → 2048-dim     │
+                    └──────────────┬──────────────┘
+                                   ▼
+                    ┌─────────────────────────────┐
+                    │ Linear projector → 1280 dim │
+                    └──────────────┬──────────────┘
+                                   ▼
+                    ┌─────────────────────────────┐
+                    │ DeepSeek-V2-style decoder   │
+                    │ with R-SWA KV-cache         │
+                    └─────────────────────────────┘
+```
+
+The released checkpoint configuration uses:
+
+- a `deeplip_b_l` vision stack with `sam_vit_b` and `clip-l-14-224` components;
+- a projector from 2048 visual-feature dimensions to the 1280-dimensional language hidden size;
+- a 12-layer DeepSeek-V2-style MoE language decoder with `max_position_embeddings=32768`;
+- `sliding_window_size=128` for Unlimited-OCR's Reference Sliding Window Attention (R-SWA).
+
+The MLX implementation keeps the prompt/prefill KV cache and uses a small ring buffer for generated-token KV entries, matching the upstream R-SWA decode behavior.
+
+## Prompt Formats
+
+When using `mlx_vlm.generate` or `apply_chat_template`, pass the task text only. MLX inserts the `<image>` token for you.
+
+### Single-image document parsing
+
+Upstream Transformers example:
+
+```
+<image>document parsing.
+```
+
+MLX prompt text:
+
+```
+document parsing.
+```
+
+### Multi-page / PDF parsing
+
+Upstream `infer_multi` example:
+
+```
+<image>Multi page parsing.
+```
+
+MLX prompt text:
+
+```
+Multi page parsing.
+```
+
+For multi-page inputs, the MLX prompt template intentionally inserts **one** literal `<image>` token for all pages, matching upstream `infer_multi` behavior.
+
+### Output markers
+
+Document-parsing outputs commonly contain layout tags such as:
+
+```
+<|det|>title [357, 135, 642, 155]<|/det|>Unlimited OCR Works
+<PAGE>
+```
+
+The box coordinates are normalized to the page coordinate system used by the model, typically the 0-1000 range.
+
+You can still try other DeepSeek-OCR-style prompts by keeping the same image and
+generation settings, changing only `--prompt`, and comparing the outputs against
+the upstream-documented `document parsing.` baseline:
+
+```bash
+for prompt in \
+    "document parsing." \
+    "Free OCR." \
+    "<|grounding|>OCR this image." \
+    "<|grounding|>Convert the document to markdown." \
+    "Parse the figure."; do
+    mlx_vlm.generate \
+        --model baidu/Unlimited-OCR \
+        --image document.png \
+        --prompt "$prompt" \
+        --max-tokens 4096
+done
+
+mlx_vlm.generate \
+    --model baidu/Unlimited-OCR \
+    --image document.png \
+    --prompt "Locate <|ref|>Unlimited OCR Works<|/ref|> in the image." \
+    --max-tokens 512
+```
+
+These prompts are experimental for Unlimited-OCR; use the output comparison to
+decide whether a prompt changes behavior usefully for your document.
+
+## CLI Examples
+
+### Single image (`gundam` mode, default)
+
+`gundam` is the upstream single-image configuration: `base_size=1024`, `image_size=640`, `crop_mode=True`. In MLX this is the default (`cropping=True`, `image_size=640`, `base_size=1024`).
+
+```bash
+mlx_vlm.generate \
+    --model baidu/Unlimited-OCR \
+    --image document.png \
+    --prompt "document parsing." \
+    --max-tokens 32768
+```
+
+### Single image in global-view-only `base` mode
+
+`base` mode disables local crops and uses a 1024×1024 global view.
+
+```bash
+mlx_vlm.generate \
+    --model baidu/Unlimited-OCR \
+    --image document.png \
+    --prompt "document parsing." \
+    --max-tokens 32768 \
+    --processor-kwargs '{"cropping": false, "image_size": 1024}'
+```
+
+### Multi-page OCR from rendered PDF pages
+
+The documented Unlimited-OCR PDF workflow renders PDF pages to images first, then passes those images in page order. Upstream uses the `base` configuration for multi-page/PDF workflows.
+
+```bash
+mlx_vlm.generate \
+    --model baidu/Unlimited-OCR \
+    --image page_0001.png page_0002.png page_0003.png \
+    --prompt "Multi page parsing." \
+    --max-tokens 32768 \
+    --processor-kwargs '{"cropping": false, "image_size": 1024}'
+```
+
+One way to render a PDF to ordered page images is:
+
+```bash
+mkdir -p pages
+uv run --with pymupdf python - <<'PY'
+from pathlib import Path
+
+import fitz
+
+pdf_path = Path("document.pdf")
+out_dir = Path("pages")
+out_dir.mkdir(exist_ok=True)
+
+# Upstream examples use 300 DPI. Lower this if you need a quicker smoke test.
+dpi = 300
+matrix = fitz.Matrix(dpi / 72, dpi / 72)
+
+with fitz.open(pdf_path) as doc:
+    for i, page in enumerate(doc):
+        page.get_pixmap(matrix=matrix, alpha=False).save(out_dir / f"page_{i + 1:04d}.png")
+PY
+
+mlx_vlm.generate \
+    --model baidu/Unlimited-OCR \
+    --image pages/page_*.png \
+    --prompt "Multi page parsing." \
+    --max-tokens 32768 \
+    --processor-kwargs '{"cropping": false, "image_size": 1024}'
+```
+
+## Python Script Examples
+
+### Single-image document parsing
+
+```python
+from mlx_vlm import generate, load
+from mlx_vlm.prompt_utils import apply_chat_template
+
+model, processor = load("baidu/Unlimited-OCR")
+
+prompt = apply_chat_template(
+    processor,
+    model.config,
+    "document parsing.",
+    num_images=1,
+)
+
+result = generate(
+    model=model,
+    processor=processor,
+    image="document.png",
+    prompt=prompt,
+    max_tokens=32768,
+    temperature=0.0,
+)
+print(result.text)
+```
+
+### Multi-page / rendered-PDF parsing
+
+```python
+from mlx_vlm import generate, load
+from mlx_vlm.prompt_utils import apply_chat_template
+
+model, processor = load("baidu/Unlimited-OCR")
+
+page_images = ["page_0001.png", "page_0002.png", "page_0003.png"]
+prompt = apply_chat_template(
+    processor,
+    model.config,
+    "Multi page parsing.",
+    num_images=len(page_images),
+)
+
+# Matches upstream infer_multi: one literal <image> token for all pages.
+assert prompt.count("<image>") == 1
+assert prompt.strip() == "<image>Multi page parsing."
+
+result = generate(
+    model=model,
+    processor=processor,
+    image=page_images,
+    prompt=prompt,
+    max_tokens=32768,
+    temperature=0.0,
+    cropping=False,
+    image_size=1024,
+)
+print(result.text)
+```
+
+## Dynamic Resolution
+
+Unlimited-OCR has two upstream image modes:
+
+| Mode | Upstream settings | MLX kwargs | Upstream use |
+|------|-------------------|------------|--------------|
+| `gundam` | `base_size=1024`, `image_size=640`, `crop_mode=True` | `base_size=1024`, `image_size=640`, `cropping=True` | Single-image parsing |
+| `base` | `base_size=1024`, `image_size=1024`, `crop_mode=False` | `base_size=1024`, `image_size=1024`, `cropping=False` | Multi-page/PDF parsing |
+
+### Token layout
+
+- In `base` mode, each page is padded to 1024×1024 and represented as a 16×16 visual grid, with one newline embedding per row and one view-separator embedding: `(16 + 1) × 16 + 1 = 273` image-token positions per page.
+- In `gundam` mode, MLX always adds the 1024×1024 global view. For images larger than 640×640, it also creates dynamic 640×640 local crops using the same crop-grid search as DeepSeek-OCR, capped at 32 crops.
+- For small images where both width and height are `<= 640`, `gundam` mode uses only the global view.
+
+### Controlling the mode
+
+```python
+# Default upstream single-image mode.
+result = generate(
+    model=model,
+    processor=processor,
+    image="document.png",
+    prompt=prompt,
+    max_tokens=32768,
+    cropping=True,
+    image_size=640,
+    base_size=1024,
+)
+
+# Upstream multi-page/PDF mode.
+result = generate(
+    model=model,
+    processor=processor,
+    image=page_images,
+    prompt=prompt,
+    max_tokens=32768,
+    cropping=False,
+    image_size=1024,
+    base_size=1024,
+)
+```
+
+## Generation Defaults
+
+The upstream examples use deterministic sampling. Baidu's reference code also ships a `SlidingWindowNoRepeatNgramProcessor`, but treats it as opt-in: `infer` / `infer_multi` default `no_repeat_ngram_size=0`, while example calls may pass size `35` with a window of `128` for single images or `1024` for multi-page/PDF inputs.
+
+MLX-VLM follows the same opt-in behavior. To keep this model consistent with the rest of the repository, it does not implement or attach an Unlimited-OCR-specific logits processor automatically; if you want this repetition guard, pass your own callable through the existing `logits_processors` argument.
+
+| Setting | Upstream single image | Upstream multi-page/PDF | MLX behavior |
+|---------|-----------------------|--------------------------|--------------|
+| Prompt | `<image>document parsing.` | `<image>Multi page parsing.` | Template inserts `<image>` automatically |
+| Image mode | `gundam` | `base` | Same via `processor_kwargs` / `generate` kwargs |
+| Optional n-gram size | `35` in examples | `35` in examples | Caller-supplied via `logits_processors` |
+| Optional n-gram window | `128` in examples | `1024` in examples | Caller-supplied via `logits_processors` |
+| Output budget | `max_length=32768` | `max_length=32768` | Use `max_tokens` in MLX |
+
+### Optional sliding-window no-repeat n-gram processor
+
+For long OCR runs, especially multi-page PDFs, Baidu's examples may opt in to a sliding-window no-repeat n-gram logits processor. MLX-VLM does not enable this automatically. If your application uses that guard, pass it explicitly through `logits_processors`:
+
+```python
+# Define or import a callable logits processor yourself; MLX-VLM does not
+# provide an Unlimited-OCR-specific one. A local port of upstream
+# SlidingWindowNoRepeatNgramProcessor can use ngram_size=35 and window=1024
+# for multi-page/PDF parsing, or window=128 for single-image parsing.
+no_repeat_ngram_processor = ...
+
+result = generate(
+    model=model,
+    processor=processor,
+    image=page_images,
+    prompt=prompt,
+    max_tokens=32768,
+    temperature=0.0,
+    cropping=False,
+    image_size=1024,
+    logits_processors=[no_repeat_ngram_processor],
+)
+```
+
+## Special Tokens and Markers
+
+| Token / marker | Description |
+|----------------|-------------|
+| `<image>` | Image placeholder inserted by the prompt template |
+| `<PAGE>` | Page separator commonly emitted in multi-page parsing output |
+| `<\|det\|>...<\|/det\|>` | Layout detection span with a label and normalized box coordinates |
+| `<｜begin▁of▁sentence｜>` / `<｜end▁of▁sentence｜>` | BOS / EOS tokens from the released tokenizer |
+| `<｜▁pad▁｜>` | Pad token from the released tokenizer |
+
+## Tips
+
+1. Do not manually add `<image>` to `mlx_vlm.generate` prompts; use `document parsing.` or `Multi page parsing.`.
+2. Use `cropping=False, image_size=1024` for multi-page or PDF workflows.
+3. Render PDFs to images before calling MLX-VLM, and keep filenames zero-padded so shell glob order matches page order.
+4. Use a high `max_tokens` value for dense documents or long PDFs; lower it for quick smoke tests.
+5. Use `temperature=0.0` for deterministic OCR output.
+6. For 4-bit language-model quantization, keep the vision encoder in `float32`; lowering vision precision can hurt OCR quality or make repetition loops much more likely, while a 4-bit LLM can still work with FP32 vision features.
+
+## Limitations
+
+- The documented MLX workflow expects image files; render PDFs to page images first.
+- Upstream documents `base` mode for multi-page/PDF parsing. Dynamic-crop `gundam` mode is intended for single-image parsing.
+- Very dense or long documents can take substantial time and memory even with R-SWA because the full visual/prompt prefill is retained.
+- This README intentionally avoids documenting generic DeepSeek-OCR prompt variants that are not shown in the Baidu Unlimited-OCR repo.
+
+## Implementation Notes
+
+- The upstream repository includes `SlidingWindowNoRepeatNgramProcessor`, but this implementation keeps repetition guards caller-supplied through `logits_processors` rather than adding model-specific sampling code to MLX-VLM.
+- Keep the vision stack in FP32 when using quantized language weights; the no-repeat processor can stop repeated decoding earlier, but it does not fix degraded visual features.

--- a/omlx/patches/mlx_vlm_unlimited_ocr_compat/vendor/mlx_vlm/models/unlimited_ocr/__init__.py
+++ b/omlx/patches/mlx_vlm_unlimited_ocr_compat/vendor/mlx_vlm/models/unlimited_ocr/__init__.py
@@ -1,0 +1,32 @@
+import mlx_vlm.models.unlimited_ocr.processing_unlimitedocr  # noqa: F401 (installs processor patch)
+
+from ..deepseekocr.sam import SAMEncoder
+from ..deepseekocr.vision import VisionModel
+from .config import (
+    MLPConfig,
+    ModelConfig,
+    ProjectorConfig,
+    SAMViTConfig,
+    TextConfig,
+    VisionConfig,
+)
+from .language import LanguageModel, RingSlidingKVCache
+from .processing_unlimitedocr import UnlimitedOCRHFProcessor, UnlimitedOCRProcessor
+from .unlimitedocr import MlpProjector, Model
+
+__all__ = [
+    "LanguageModel",
+    "MLPConfig",
+    "MlpProjector",
+    "Model",
+    "ModelConfig",
+    "ProjectorConfig",
+    "RingSlidingKVCache",
+    "SAMEncoder",
+    "SAMViTConfig",
+    "TextConfig",
+    "UnlimitedOCRHFProcessor",
+    "UnlimitedOCRProcessor",
+    "VisionConfig",
+    "VisionModel",
+]

--- a/omlx/patches/mlx_vlm_unlimited_ocr_compat/vendor/mlx_vlm/models/unlimited_ocr/config.py
+++ b/omlx/patches/mlx_vlm_unlimited_ocr_compat/vendor/mlx_vlm/models/unlimited_ocr/config.py
@@ -1,0 +1,113 @@
+import inspect
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Union
+
+from ..base import BaseModelConfig
+from ..deepseekocr.config import (
+    BatchCollateOutput,
+    Conversation,
+    MLPConfig,
+    ProjectorConfig,
+    SAMViTConfig,
+)
+from ..deepseekocr.config import VisionConfig as DeepseekOCRVisionConfig
+from ..deepseekocr.config import VLChatProcessorOutput
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str = "deepseek_v2"
+    vocab_size: int = 129280
+    hidden_size: int = 1280
+    intermediate_size: int = 6848
+    moe_intermediate_size: int = 896
+    num_hidden_layers: int = 12
+    num_attention_heads: int = 10
+    num_key_value_heads: int = 10
+    n_shared_experts: Optional[int] = 2
+    n_routed_experts: Optional[int] = 64
+    routed_scaling_factor: float = 1.0
+    kv_lora_rank: Optional[int] = None
+    q_lora_rank: Optional[int] = None
+    qk_rope_head_dim: int = 0
+    v_head_dim: int = 128
+    qk_nope_head_dim: int = 0
+    topk_method: str = "greedy"
+    n_group: Optional[int] = 1
+    topk_group: Optional[int] = 1
+    num_experts_per_tok: Optional[int] = 6
+    moe_layer_freq: int = 1
+    first_k_dense_replace: int = 1
+    max_position_embeddings: int = 32768
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 10000.0
+    rope_traditional: bool = False
+    rope_scaling: Dict = None
+    attention_bias: bool = False
+    scoring_func: str = "softmax"
+    attn_type: str = "DeepseekV2Attention"
+    use_mla: bool = False
+    sliding_window_size: Optional[int] = 128
+    sliding_window: Optional[int] = 128
+
+    def __post_init__(self):
+        if self.qk_nope_head_dim == 0:
+            self.attn_type = "LlamaAttention"
+
+        if self.num_key_value_heads is None:
+            self.num_key_value_heads = self.num_attention_heads
+
+
+@dataclass
+class VisionConfig(DeepseekOCRVisionConfig):
+    width: Union[int, Dict] = 1152
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: TextConfig
+    vision_config: VisionConfig
+    projector_config: ProjectorConfig
+    model_type: str
+    ignore_index: int = -100
+    image_token_index: int = 128815
+    vision_feature_select_strategy: str = "default"
+    select_layer: int = -1
+    pad_id: int = 100001
+    num_image_tokens: int = 576
+    vocab_size: int = 129280
+    tile_tag: str = "2D"
+    global_view_pos: str = "head"
+    eos_token_id: Optional[Union[int, List[int]]] = 1
+    quantization: Optional[Dict] = None
+
+    @classmethod
+    def from_dict(cls, params):
+        if "language_config" in params:
+            params["text_config"] = params["language_config"]
+            del params["language_config"]
+
+        return cls(
+            text_config=TextConfig.from_dict(params["text_config"]),
+            vision_config=VisionConfig.from_dict(params["vision_config"]),
+            projector_config=ProjectorConfig.from_dict(params["projector_config"]),
+            **{
+                k: v
+                for k, v in params.items()
+                if k in inspect.signature(cls).parameters
+                and k not in ["text_config", "vision_config", "projector_config"]
+            },
+        )
+
+
+__all__ = [
+    "BatchCollateOutput",
+    "Conversation",
+    "MLPConfig",
+    "ModelConfig",
+    "ProjectorConfig",
+    "SAMViTConfig",
+    "TextConfig",
+    "VLChatProcessorOutput",
+    "VisionConfig",
+]

--- a/omlx/patches/mlx_vlm_unlimited_ocr_compat/vendor/mlx_vlm/models/unlimited_ocr/language.py
+++ b/omlx/patches/mlx_vlm_unlimited_ocr_compat/vendor/mlx_vlm/models/unlimited_ocr/language.py
@@ -1,0 +1,150 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+
+from ..cache import KVCache
+from ..deepseekocr.language import DeepseekV2Model
+from ..deepseekocr.language import LanguageModel as DeepseekLanguageModel
+from .config import TextConfig
+
+
+class RingSlidingKVCache(KVCache):
+    """Unlimited-OCR R-SWA cache.
+
+    Upstream keeps the full prompt/prefill cache, then appends generated tokens
+    until a small decode ring is full. Afterwards, new decode keys/values
+    overwrite that ring while absolute positions keep increasing.
+    """
+
+    def __init__(self, window_size: int):
+        super().__init__()
+        self.window_size = int(window_size)
+        self.prefill_length: Optional[int] = None
+        self._ring_pos = 0
+
+    def update_and_fetch(self, keys, values):
+        seq_len = int(keys.shape[2])
+
+        if self.prefill_length is None:
+            if seq_len > 1:
+                return super().update_and_fetch(keys, values)
+            self.prefill_length = self.offset
+
+        if self.keys is None or self.offset < self.prefill_length + self.window_size:
+            keys, values = super().update_and_fetch(keys, values)
+            if self.offset >= self.prefill_length + self.window_size:
+                self._ring_pos = 0
+            return keys, values
+
+        for idx in range(seq_len):
+            slot = self.prefill_length + self._ring_pos
+            self.keys[..., slot : slot + 1, :] = keys[..., idx : idx + 1, :]
+            self.values[..., slot : slot + 1, :] = values[..., idx : idx + 1, :]
+            self._ring_pos = (self._ring_pos + 1) % self.window_size
+
+        self.offset += seq_len
+        return (
+            self.keys[..., : self.prefill_length + self.window_size, :],
+            self.values[..., : self.prefill_length + self.window_size, :],
+        )
+
+    def make_mask(self, N: int, return_array: bool = False, **kwargs):
+        kwargs.pop("window_size", None)
+        # Prefill/warmup is standard causal attention. Steady-state decode uses
+        # q_len=1 and attends over the retained prompt plus ring slots, matching
+        # upstream SlidingWindowLlamaAttention.
+        if self.prefill_length is not None and self.offset >= (
+            self.prefill_length + self.window_size
+        ):
+            if N == 1 and not return_array:
+                return None
+        return super().make_mask(
+            N, return_array=return_array, window_size=None, **kwargs
+        )
+
+    @property
+    def state(self):
+        if self.keys is None:
+            return None, None
+        end = (
+            self.offset
+            if self.prefill_length is None
+            else min(self.offset, self.prefill_length + self.window_size)
+        )
+        return self.keys[..., :end, :], self.values[..., :end, :]
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values = v
+        self.offset = 0 if self.keys is None else self.keys.shape[2]
+        self.prefill_length = None
+        self._ring_pos = 0
+
+    @property
+    def meta_state(self):
+        return tuple(
+            map(
+                str,
+                (
+                    self.window_size,
+                    -1 if self.prefill_length is None else self.prefill_length,
+                    self.offset,
+                    self._ring_pos,
+                ),
+            )
+        )
+
+    @meta_state.setter
+    def meta_state(self, v):
+        window_size, prefill_length, offset, ring_pos = map(int, v)
+        self.window_size = window_size
+        self.prefill_length = None if prefill_length < 0 else prefill_length
+        self.offset = offset
+        self._ring_pos = ring_pos
+
+
+class DeepseekV2RingSlidingModel(DeepseekV2Model):
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        if inputs_embeds is None:
+            h = self.embed_tokens(x)
+        else:
+            h = inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        if mask is None:
+            mask = self._make_attention_mask(h, cache[0])
+
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+
+        return self.norm(h)
+
+    def _make_attention_mask(self, h: mx.array, cache: Optional[Any]):
+        if cache is not None and hasattr(cache, "make_mask"):
+            return cache.make_mask(h.shape[1], return_array=False, window_size=None)
+        if h.shape[1] == 1:
+            return None
+        return "causal"
+
+
+class LanguageModel(DeepseekLanguageModel):
+    def __init__(self, config: TextConfig):
+        super().__init__(config)
+        self.model = DeepseekV2RingSlidingModel(config)
+
+    def make_cache(self):
+        window_size = self.config.sliding_window_size or self.config.sliding_window
+        if window_size is None:
+            return [KVCache() for _ in self.layers]
+        return [RingSlidingKVCache(window_size) for _ in self.layers]
+
+
+__all__ = ["LanguageModel", "RingSlidingKVCache"]

--- a/omlx/patches/mlx_vlm_unlimited_ocr_compat/vendor/mlx_vlm/models/unlimited_ocr/processing_unlimitedocr.py
+++ b/omlx/patches/mlx_vlm_unlimited_ocr_compat/vendor/mlx_vlm/models/unlimited_ocr/processing_unlimitedocr.py
@@ -1,0 +1,297 @@
+import json
+import math
+from pathlib import Path
+from typing import List
+
+import mlx.core as mx
+from PIL import Image, ImageOps
+from transformers import PreTrainedTokenizerFast
+
+from ..base import install_auto_processor_patch
+from ..deepseekocr.processing_deepseekocr import (
+    DeepseekOCRProcessor,
+    dynamic_preprocess,
+)
+
+
+class UnlimitedOCRProcessor(DeepseekOCRProcessor):
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        kwargs.pop("trust_remote_code", None)
+        kwargs.pop("revision", None)
+        kwargs.pop("force_download", None)
+        kwargs.pop("quantize_activations", None)
+        kwargs.pop("strict", None)
+        path = Path(pretrained_model_name_or_path)
+        if not path.exists():
+            from huggingface_hub import snapshot_download
+
+            path = Path(snapshot_download(pretrained_model_name_or_path))
+
+        processor_config = {}
+        processor_config_path = path / "processor_config.json"
+        if processor_config_path.exists():
+            with open(processor_config_path, encoding="utf-8") as f:
+                processor_config = json.load(f)
+
+        processor_config.pop("processor_class", None)
+        processor_config.update(kwargs)
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(path)
+        return cls(tokenizer=tokenizer, **processor_config)
+
+    def __init__(
+        self,
+        tokenizer: PreTrainedTokenizerFast,
+        candidate_resolutions=((1024, 1024),),
+        patch_size: int = 16,
+        downsample_ratio: int = 4,
+        image_mean=(0.5, 0.5, 0.5),
+        image_std=(0.5, 0.5, 0.5),
+        normalize: bool = True,
+        image_token: str = "<image>",
+        pad_token: str = "<｜▁pad▁｜>",
+        add_special_token: bool = False,
+        sft_format: str = "unlimitedocr",
+        mask_prompt: bool = False,
+        ignore_id: int = -100,
+        **kwargs,
+    ):
+        super().__init__(
+            tokenizer=tokenizer,
+            candidate_resolutions=candidate_resolutions,
+            patch_size=patch_size,
+            downsample_ratio=downsample_ratio,
+            image_mean=image_mean,
+            image_std=image_std,
+            normalize=normalize,
+            image_token=image_token,
+            pad_token=pad_token,
+            add_special_token=add_special_token,
+            sft_format=sft_format,
+            mask_prompt=mask_prompt,
+            ignore_id=ignore_id,
+            **kwargs,
+        )
+
+        # Unlimited-OCR's released tokenizer already contains <image> at 128815.
+        self.image_token_id = tokenizer.vocab.get(image_token, 128815)
+
+    def process_one(
+        self,
+        prompt: str = None,
+        images: List[Image.Image] = None,
+        inference_mode: bool = True,
+        base_size: int = 1024,
+        image_size: int = 640,
+        cropping: bool = True,
+    ):
+        (
+            tokenized_str,
+            images_list,
+            images_seq_mask,
+            images_spatial_crop,
+            num_image_tokens,
+        ) = self.tokenize_with_images(
+            prompt,
+            images,
+            base_size=base_size,
+            image_size=image_size,
+            cropping=cropping,
+        )
+
+        masked_tokenized_str = [
+            token_index if token_index != self.image_token_id else self.ignore_id
+            for token_index in tokenized_str
+        ]
+        input_ids = mx.array(tokenized_str)
+        target_ids = mx.array(masked_tokenized_str)
+        images_seq_mask = mx.array(images_seq_mask)
+
+        target_ids = mx.where(
+            (input_ids < 0) | (input_ids == self.image_token_id),
+            self.ignore_id,
+            target_ids,
+        )
+        input_ids = mx.where(input_ids < 0, self.pad_id, input_ids)
+
+        return {
+            "input_ids": input_ids[None, :],
+            "attention_mask": input_ids != self.pad_id,
+            "labels": target_ids,
+            "images": images_list,
+            "images_seq_mask": images_seq_mask[None, ...],
+            "images_spatial_crop": images_spatial_crop,
+            "num_image_tokens": num_image_tokens,
+        }
+
+    def tokenize_with_images(
+        self,
+        conversation: str,
+        images: List[Image.Image],
+        base_size: int = 1024,
+        image_size: int = 640,
+        cropping: bool = True,
+    ):
+        patch_size = self.patch_size
+        downsample_ratio = self.downsample_ratio
+        valid_img_tokens = 0
+        ratio = 1
+
+        image_draw = images[0].copy()
+
+        w, h = image_draw.size
+
+        ratio = 1 - ((max(w, h) - min(w, h)) / (max(w, h)))
+
+        image_token_count = conversation.count(self.image_token)
+        assert (
+            conversation.count(self.image_token) == len(images)
+            or image_token_count == 1
+        ), f"The number of image tokens in the prompt does not match the number of images: {image_token_count} != {len(images)}"
+        text_splits = conversation.split(self.image_token)
+
+        images_list, images_crop_list, images_seq_mask = [], [], []
+        tokenized_str = []
+        images_spatial_crop = []
+        multi_image_single_token = image_token_count == 1 and len(images) > 1
+        image_items = (
+            [(text_splits[0], image) for image in images]
+            if multi_image_single_token
+            else list(zip(text_splits, images))
+        )
+        for image_idx, (text_sep, image) in enumerate(image_items):
+            if multi_image_single_token and image_idx > 0:
+                text_sep = ""
+            tokenized_sep = self.encode(text_sep, bos=False, eos=False)
+            tokenized_str += tokenized_sep
+            images_seq_mask += [False] * len(tokenized_sep)
+
+            if cropping:
+                if image.size[0] <= 640 and image.size[1] <= 640:
+                    crop_ratio = [1, 1]
+                    images_crop_raw = []
+                else:
+                    images_crop_raw, crop_ratio = dynamic_preprocess(
+                        image, min_num=2, max_num=32, image_size=image_size
+                    )
+
+                global_view = ImageOps.pad(
+                    image,
+                    (base_size, base_size),
+                    color=tuple(int(x * 255) for x in self.image_transform.mean),
+                )
+
+                if base_size == 1024:
+                    valid_img_tokens += int(256 * ratio)
+                elif base_size == 1280:
+                    valid_img_tokens += int(400 * ratio)
+                elif base_size == 640:
+                    valid_img_tokens += int(100 * ratio)
+
+                images_list.append(
+                    self.image_transform(global_view).astype(mx.bfloat16)
+                )
+
+                width_crop_num, height_crop_num = crop_ratio
+                images_spatial_crop.append([width_crop_num, height_crop_num])
+
+                num_image_crops = 0
+                if width_crop_num > 1 or height_crop_num > 1:
+                    num_image_crops = len(images_crop_raw)
+                    for image_crop in images_crop_raw:
+                        images_crop_list.append(
+                            self.image_transform(image_crop).astype(mx.bfloat16)
+                        )
+
+                if image_size == 640:
+                    valid_img_tokens += num_image_crops * 100
+
+                num_queries = math.ceil((image_size // patch_size) / downsample_ratio)
+                num_queries_base = math.ceil(
+                    (base_size // patch_size) / downsample_ratio
+                )
+
+                tokenized_image = (
+                    [self.image_token_id] * num_queries_base + [self.image_token_id]
+                ) * num_queries_base
+                tokenized_image += [self.image_token_id]
+                if width_crop_num > 1 or height_crop_num > 1:
+                    tokenized_image += (
+                        [self.image_token_id] * (num_queries * width_crop_num)
+                        + [self.image_token_id]
+                    ) * (num_queries * height_crop_num)
+                tokenized_str += tokenized_image
+                images_seq_mask += [True] * len(tokenized_image)
+
+            else:
+                if image_size <= 640:
+                    image = image.resize((image_size, image_size))
+
+                global_view = ImageOps.pad(
+                    image,
+                    (image_size, image_size),
+                    color=tuple(int(x * 255) for x in self.image_transform.mean),
+                )
+                images_list.append(
+                    self.image_transform(global_view).astype(mx.bfloat16)
+                )
+
+                if base_size == 1024:
+                    valid_img_tokens += int(256 * ratio)
+                elif base_size == 1280:
+                    valid_img_tokens += int(400 * ratio)
+                elif base_size == 640:
+                    valid_img_tokens += int(100 * 1)
+                elif base_size == 512:
+                    valid_img_tokens += int(64 * 1)
+
+                width_crop_num, height_crop_num = 1, 1
+                images_spatial_crop.append([width_crop_num, height_crop_num])
+
+                num_queries = math.ceil((image_size // patch_size) / downsample_ratio)
+                tokenized_image = (
+                    [self.image_token_id] * num_queries + [self.image_token_id]
+                ) * num_queries
+                tokenized_image += [self.image_token_id]
+
+                tokenized_str += tokenized_image
+                images_seq_mask += [True] * len(tokenized_image)
+
+        tokenized_sep = self.encode(text_splits[-1], bos=False, eos=False)
+        tokenized_str += tokenized_sep
+        images_seq_mask += [False] * len(tokenized_sep)
+
+        bos_id = 0
+        tokenized_str = [bos_id] + tokenized_str
+        images_seq_mask = [False] + images_seq_mask
+
+        images_seq_mask = mx.array(images_seq_mask)
+
+        if len(images_list) == 0:
+            images_ori = mx.zeros((1, 3, image_size, image_size))
+            images_spatial_crop = mx.zeros((1, 2))
+            images_crop = mx.zeros((1, 3, base_size, base_size))
+        else:
+            images_ori = mx.stack(images_list, axis=0)
+            images_spatial_crop = mx.array(images_spatial_crop)
+            if images_crop_list:
+                images_crop = mx.stack(images_crop_list, axis=0)
+            else:
+                images_crop = mx.zeros((1, 3, base_size, base_size))
+
+        assert len(tokenized_str) == len(
+            images_seq_mask
+        ), f"tokenize_with_images func: tokenized_str's length {len(tokenized_str)} is not equal to images_seq_mask's length {len(images_seq_mask)}"
+
+        return (
+            tokenized_str,
+            [images_crop, images_ori],
+            images_seq_mask,
+            images_spatial_crop,
+            valid_img_tokens,
+        )
+
+
+UnlimitedOCRHFProcessor = UnlimitedOCRProcessor
+
+install_auto_processor_patch("unlimited-ocr", UnlimitedOCRProcessor)

--- a/omlx/patches/mlx_vlm_unlimited_ocr_compat/vendor/mlx_vlm/models/unlimited_ocr/unlimitedocr.py
+++ b/omlx/patches/mlx_vlm_unlimited_ocr_compat/vendor/mlx_vlm/models/unlimited_ocr/unlimitedocr.py
@@ -1,0 +1,200 @@
+from typing import Optional
+
+import mlx.core as mx
+import numpy as np
+from transformers import AutoProcessor
+
+from mlx_vlm.models.base import InputEmbeddingsFeatures
+
+from ..deepseekocr.deepseekocr import MlpProjector
+from ..deepseekocr.deepseekocr import Model as DeepseekOCRModel
+from ..deepseekocr.sam import SAMEncoder
+from ..deepseekocr.vision import VisionModel
+from .config import ModelConfig
+from .language import LanguageModel
+from .processing_unlimitedocr import UnlimitedOCRHFProcessor, UnlimitedOCRProcessor
+
+AutoProcessor.register("unlimited-ocr", UnlimitedOCRProcessor)
+
+
+class Model(DeepseekOCRModel):
+    config_class = ModelConfig
+
+    def __init__(self, config: ModelConfig):
+        super().__init__(config)
+        self.language_model = LanguageModel(config.text_config)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        images_spatial_crop: Optional[mx.array] = None,
+        images_seq_mask: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        input_embeds = self.language_model.model.embed_tokens(input_ids)
+
+        if pixel_values is None:
+            return InputEmbeddingsFeatures(inputs_embeds=input_embeds)
+
+        if (
+            self.sam_model is not None
+            and input_ids.shape[1] != 1
+            and mx.sum(pixel_values[1]).item() != 0
+        ):
+            idx = 0
+            patch_idx = 0
+            all_patches = pixel_values[0]
+            all_image_ori = pixel_values[1]
+            batch_size = input_embeds.shape[0]
+            image_token_positions = [
+                np.where(images_seq_mask[batch_idx])[0].tolist()
+                for batch_idx in range(batch_size)
+            ]
+            image_token_offsets = [0] * batch_size
+            single_prompt_multi_image = (
+                batch_size == 1 and len(images_spatial_crop) != batch_size
+            )
+
+            for crop_shape in images_spatial_crop.tolist():
+                images_in_this_batch = []
+                width_crop_num, height_crop_num = int(crop_shape[0]), int(crop_shape[1])
+
+                has_crops = width_crop_num > 1 or height_crop_num > 1
+                num_patches = width_crop_num * height_crop_num if has_crops else 0
+
+                if has_crops and num_patches > 0:
+                    patches = all_patches[patch_idx : patch_idx + num_patches]
+                    patch_idx += num_patches
+                else:
+                    patches = None
+
+                image_ori = all_image_ori[idx : idx + 1]
+
+                if patches is not None and mx.sum(patches).item() != 0:
+                    local_features_1 = self.sam_model(patches.transpose(0, 2, 3, 1))
+                    local_features_2 = self.vision_model(
+                        patches.transpose(0, 2, 3, 1), patch_embeds=local_features_1
+                    )
+                    local_features = mx.concatenate(
+                        (
+                            local_features_2[:, 1:],
+                            local_features_1.flatten(start_axis=1, end_axis=2),
+                        ),
+                        axis=-1,
+                    )
+                    local_features = self.projector(local_features)
+
+                    global_features_1 = self.sam_model(image_ori.transpose(0, 2, 3, 1))
+                    global_features_2 = self.vision_model(
+                        image_ori.transpose(0, 2, 3, 1), global_features_1
+                    )
+                    global_features = mx.concatenate(
+                        (
+                            global_features_2[:, 1:],
+                            global_features_1.flatten(start_axis=1, end_axis=2),
+                        ),
+                        axis=-1,
+                    )
+                    global_features = self.projector(global_features)[0]
+                    hw, n_dim = global_features.shape
+                    h = w = int(hw**0.5)
+                    global_features = global_features.reshape(h, w, n_dim)
+                    global_features = mx.concatenate(
+                        [
+                            global_features,
+                            mx.broadcast_to(
+                                self.image_newline[None, None, :], (h, 1, n_dim)
+                            ),
+                        ],
+                        axis=1,
+                    ).reshape(-1, n_dim)
+
+                    _, hw2, n_dim2 = local_features.shape
+                    h2 = w2 = int(hw2**0.5)
+                    local_features = (
+                        local_features.reshape(
+                            height_crop_num, width_crop_num, h2, w2, n_dim2
+                        )
+                        .transpose(0, 2, 1, 3, 4)
+                        .reshape(height_crop_num * h2, width_crop_num * w2, n_dim2)
+                    )
+                    local_features = mx.concatenate(
+                        [
+                            local_features,
+                            mx.broadcast_to(
+                                self.image_newline[None, None, :],
+                                (height_crop_num * h2, 1, n_dim2),
+                            ),
+                        ],
+                        axis=1,
+                    ).reshape(-1, n_dim2)
+
+                    global_local_features = mx.concatenate(
+                        [local_features, global_features, self.view_separator[None, :]],
+                        axis=0,
+                    )
+                else:
+                    global_features_1 = self.sam_model(image_ori.transpose(0, 2, 3, 1))
+                    global_features_2 = self.vision_model(
+                        image_ori.transpose(0, 2, 3, 1), global_features_1
+                    )
+                    global_features = mx.concatenate(
+                        (
+                            global_features_2[:, 1:],
+                            global_features_1.flatten(start_axis=1, end_axis=2),
+                        ),
+                        axis=-1,
+                    )
+                    global_features = self.projector(global_features)[0]
+                    hw, n_dim = global_features.shape
+                    h = w = int(hw**0.5)
+                    global_features = global_features.reshape(h, w, n_dim)
+                    global_features = mx.concatenate(
+                        [
+                            global_features,
+                            mx.broadcast_to(
+                                self.image_newline[None, None, :], (h, 1, n_dim)
+                            ),
+                        ],
+                        axis=1,
+                    ).reshape(-1, n_dim)
+                    global_local_features = mx.concatenate(
+                        [global_features, self.view_separator[None, :]], axis=0
+                    )
+
+                images_in_this_batch.append(global_local_features)
+
+                if images_in_this_batch:
+                    images_in_this_batch = mx.concatenate(images_in_this_batch, axis=0)
+                    batch_idx = 0 if single_prompt_multi_image else idx
+                    image_indices = image_token_positions[batch_idx]
+                    start = image_token_offsets[batch_idx]
+                    end = start + images_in_this_batch.shape[0]
+                    if end > len(image_indices):
+                        raise ValueError(
+                            "More image features were produced than image token "
+                            "positions in the prompt."
+                        )
+                    input_embeds[batch_idx, image_indices[start:end]] = (
+                        images_in_this_batch
+                    )
+                    image_token_offsets[batch_idx] = end
+
+                idx += 1
+
+        return InputEmbeddingsFeatures(inputs_embeds=input_embeds)
+
+    def make_cache(self):
+        return self.language_model.make_cache()
+
+
+__all__ = [
+    "LanguageModel",
+    "MlpProjector",
+    "Model",
+    "SAMEncoder",
+    "UnlimitedOCRHFProcessor",
+    "UnlimitedOCRProcessor",
+    "VisionModel",
+]

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -366,6 +366,17 @@ def maybe_apply_pre_load_patches(
                 model_name,
             )
 
+    if for_vlm and model_type == "unlimited-ocr":
+        from ..patches.mlx_vlm_unlimited_ocr_compat import (
+            apply_mlx_vlm_unlimited_ocr_compat_patch,
+        )
+
+        if apply_mlx_vlm_unlimited_ocr_compat_patch():
+            logger.info(
+                "Unlimited-OCR mlx-vlm compatibility patch applied for %s",
+                model_name,
+            )
+
     # Apply the MTP patch whenever the model has MTP heads on a compatible
     # model_type — even when mtp_enabled is False. The patch is required
     # for *sanitize correctness*: stock mlx-lm Model.sanitize triggers a

--- a/tests/test_mlx_vlm_unlimited_ocr_compat.py
+++ b/tests/test_mlx_vlm_unlimited_ocr_compat.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the vendored Unlimited-OCR mlx-vlm compatibility layer."""
+
+from __future__ import annotations
+
+
+def test_unlimited_ocr_compat_installs_vendor_module():
+    from omlx.patches.mlx_vlm_unlimited_ocr_compat import (
+        apply_mlx_vlm_unlimited_ocr_compat_patch,
+    )
+
+    apply_mlx_vlm_unlimited_ocr_compat_patch()
+
+    import mlx_vlm.models.unlimited_ocr as unlimited_ocr
+
+    assert hasattr(unlimited_ocr, "Model")
+    assert hasattr(unlimited_ocr, "ModelConfig")
+    assert hasattr(unlimited_ocr, "RingSlidingKVCache")
+
+
+def test_unlimited_ocr_model_remapping_resolves_module():
+    from omlx.patches.mlx_vlm_unlimited_ocr_compat import (
+        apply_mlx_vlm_unlimited_ocr_compat_patch,
+    )
+
+    apply_mlx_vlm_unlimited_ocr_compat_patch()
+
+    from mlx_vlm.utils import MODEL_REMAPPING, get_model_and_args
+
+    assert MODEL_REMAPPING.get("unlimited-ocr") == "unlimited_ocr"
+
+    # Without the remapping, get_model_and_args would try to import the literal
+    # dashed module name and fall through to the speculative-drafter lookup that
+    # produced the "No module named ... unlimited-ocr" error in issue #2314.
+    module, model_type = get_model_and_args(
+        {
+            "model_type": "unlimited-ocr",
+            "architectures": ["UnlimitedOCRForCausalLM"],
+            "vision_config": {},
+            "text_config": {},
+        }
+    )
+
+    assert model_type == "unlimited_ocr"
+    assert module.__name__ == "mlx_vlm.models.unlimited_ocr"
+
+
+def test_unlimited_ocr_prompt_uses_single_image_token():
+    from omlx.patches.mlx_vlm_unlimited_ocr_compat import (
+        apply_mlx_vlm_unlimited_ocr_compat_patch,
+    )
+
+    apply_mlx_vlm_unlimited_ocr_compat_patch()
+
+    from mlx_vlm.prompt_utils import get_message_json
+
+    # Single page: one <image> token.
+    single = get_message_json("unlimited-ocr", "document parsing.", num_images=1)
+    assert single == {"role": "user", "content": "<image>document parsing."}
+
+    # Multi page: still exactly one <image> token for all pages (infer_multi).
+    multi = get_message_json("unlimited-ocr", "Multi page parsing.", num_images=3)
+    assert str(multi["content"]).count("<image>") == 1
+
+    # Non-user / skip_image_token: no image token injected.
+    assistant = get_message_json("unlimited-ocr", "ok", role="assistant", num_images=1)
+    assert assistant == {"role": "assistant", "content": "ok"}
+
+
+def test_unlimited_ocr_prompt_leaves_other_models_untouched():
+    from omlx.patches.mlx_vlm_unlimited_ocr_compat import (
+        apply_mlx_vlm_unlimited_ocr_compat_patch,
+    )
+
+    apply_mlx_vlm_unlimited_ocr_compat_patch()
+
+    from mlx_vlm.prompt_utils import get_message_json
+
+    # deepseekocr must keep going through the original IMAGE_TOKEN_NEWLINE
+    # formatter (newline-suffixed token), not the unlimited-ocr wrapper.
+    message = get_message_json("deepseekocr", "hello", num_images=1)
+    assert message == {"role": "user", "content": "<image>\nhello"}

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -327,6 +327,18 @@ class TestDetectModelType:
         (tmp_path / "config.json").write_text(json.dumps(config))
         assert detect_model_type(tmp_path) == "vlm"
 
+    def test_detect_unlimited_ocr_as_vlm(self, tmp_path):
+        """baidu/Unlimited-OCR is served by mlx-vlm (dashed model_type)."""
+        config = {
+            "model_type": "unlimited-ocr",
+            "architectures": ["UnlimitedOCRForCausalLM"],
+            "vision_config": {"model_type": "vision"},
+            "language_config": {"model_type": "deepseek_v2"},
+            "projector_config": {"model_type": "mlp_projector"},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "vlm"
+
     def test_detect_minimax_m3_vl_as_vlm(self, tmp_path):
         """MiniMax M3 VL is served by mlx-vlm."""
         config = {

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -800,6 +800,34 @@ class TestApplyChatTemplate:
         assert "assistant: Hi" in result
         assert result.endswith("assistant:")
 
+    def test_value_error_fallback_uses_get_chat_template(self):
+        """Tokenizer exposes apply_chat_template but has no chat_template set
+        (ValueError) → fall back to mlx-vlm's get_chat_template plain rendering.
+
+        Covers raw OCR checkpoints like baidu/Unlimited-OCR that ship no
+        chat template; the pre-flight token count must not 400.
+        """
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.side_effect = ValueError(
+            "Cannot use chat template functions because "
+            "tokenizer.chat_template is not set"
+        )
+        engine = _make_loaded_engine(tokenizer=tokenizer)
+        engine._processor = MagicMock()
+
+        messages = [{"role": "user", "content": "document parsing."}]
+        with patch(
+            "mlx_vlm.prompt_utils.get_chat_template",
+            return_value="<image>document parsing.",
+        ) as mock_gct:
+            result = engine._apply_chat_template(messages)
+
+        assert result == "<image>document parsing."
+        mock_gct.assert_called_once()
+        args, kwargs = mock_gct.call_args
+        assert args[0] is engine._processor
+        assert kwargs.get("add_generation_prompt") is True
+
     def test_chat_template_kwargs_override(self):
         """Additional chat_template_kwargs are merged into template kwargs."""
         tokenizer = MagicMock()


### PR DESCRIPTION
## Summary

Adds support for Baidu's Unlimited-OCR (`baidu/Unlimited-OCR`, a DeepSeek-V2 + SAM-ViT-B + CLIP-L document OCR model) so it loads, serves, and quantizes end to end. Closes #2314.

The model implementation itself comes from mlx-vlm PR Blaizzy/mlx-vlm#1427 by @shuuul (MIT). That PR landed after our pinned mlx-vlm commit (78b96eb), so I vendor the `unlimited_ocr` package under `omlx.patches.mlx_vlm_unlimited_ocr_compat` rather than bumping the whole pin, following the existing `minimax_m3_compat` precedent. Full credit for the model, the processor, and the R-SWA language wrapper goes to that PR.

## Changes

Three logical commits:

- **feat: add Baidu Unlimited-OCR model support** — vendor the mlx-vlm `unlimited_ocr` package (verbatim from #1427), install it onto the `mlx_vlm.models` namespace, add the `unlimited-ocr -> unlimited_ocr` remap and the single-`<image>` multi-page prompt semantics, and register the model_type in discovery plus the OCR prompt / generation-default / stop handling. It reuses the `deepseekocr` SAM and CLIP encoder already present at the pin, so no pin bump is needed.
- **fix(vlm): fall back to plain prompt rendering when a VLM ships no chat template** — the raw checkpoint ships no `chat_template`, so `tokenizer.apply_chat_template` raised `ValueError` in the token-count preflight and in vision-input prep and surfaced as HTTP 400. Both paths now fall back to mlx-vlm's `get_chat_template` plain rendering, which is what mlx-vlm generate already does. This covers any template-less VLM.
- **fix(oq): quantize DeepSeek-OCR family VLMs correctly** — three oQ fixes so OCR VLMs quantize into a loadable checkpoint: detect VLMs by the vision sub-config predicate (not just the `ForConditionalGeneration` arch name), dispatch `Model.sanitize` by argument count (the DeepSeek-OCR family defines it as a `staticmethod`), and skip the `sam_model` SAM encoder in `_is_vision_tensor` since its neck and net convs are `nn.Conv2d` that mlx cannot quantize.

## Verification

- Unit tests: the new `test_mlx_vlm_unlimited_ocr_compat.py`, a `test_model_discovery.py` detection case, and a `test_vlm_engine.py` fallback case, plus the existing `test_vlm_engine.py` (255) and `test_oq.py` (281) suites all pass with no regressions.
- Real model, bf16: served `baidu/Unlimited-OCR` through `omlx serve` and `/v1/chat/completions`, correct document parsing with `<|det|>` layout tags, both with an explicit `document parsing.` prompt and with the auto-injected OCR prompt.
- Real model, oQ8: quantized to `Unlimited-OCR-oQ8` (6.6GB -> 3.7GB), loads and serves with OCR quality matching bf16, with the vision tower kept full precision like the `DeepSeek-OCR-2-8bit` reference.
