### PR TITLE
fix: remap Laguna router quant sidecars and expand per-layer gate.proj quant keys

### DIFF
--- a/omlx/patches/laguna/laguna_model.py
+++ b/omlx/patches/laguna/laguna_model.py
@@ -619,15 +619,33 @@ class Model(nn.Module):
     def _remap_router_weights(self, weights):
         for layer_idx in range(self.args.num_hidden_layers):
             prefix = f"model.layers.{layer_idx}.mlp"
-            gate_weight = f"{prefix}.gate.weight"
-            if gate_weight in weights:
-                weights[f"{prefix}.gate.proj.weight"] = weights.pop(gate_weight)
 
-            legacy_bias = f"{prefix}.experts.e_score_correction_bias"
-            if legacy_bias in weights:
-                weights[f"{prefix}.gate.e_score_correction_bias"] = weights.pop(
-                    legacy_bias
-                )
+            # Remap the router weight and all quantization sidecars from
+            # ``gate.<suffix>`` to ``gate.proj.<suffix>``.  Quantized
+            # checkpoints produced by oQ / mlx-vlm carry ``gate.scales`` and
+            # ``gate.biases`` alongside ``gate.weight``; remapping only
+            # ``.weight`` leaves the sidecars orphaned and triggers
+            # ``ValueError: Received N parameters not in model`` during
+            # strict weight loading.
+            for suffix in ("weight", "scales", "biases"):
+                old_key = f"{prefix}.gate.{suffix}"
+                if old_key in weights:
+                    weights[f"{prefix}.gate.proj.{suffix}"] = weights.pop(old_key)
+
+            # ``e_score_correction_bias`` appears under two checkpoint
+            # conventions: the legacy ``experts.e_score_correction_bias``
+            # path (referenced in the original upstream PR) and the bare
+            # ``mlp.e_score_correction_bias`` path used by the published
+            # pipenetwork/Laguna-S-2.1 MLX conversions.  Map both to the
+            # module-tree path the model expects.
+            for bias_key in (
+                f"{prefix}.experts.e_score_correction_bias",
+                f"{prefix}.e_score_correction_bias",
+            ):
+                if bias_key in weights:
+                    weights[f"{prefix}.gate.e_score_correction_bias"] = weights.pop(
+                        bias_key
+                    )
         return weights
 
     def _stack_experts(self, weights):

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -80,6 +80,17 @@ def expand_per_layer_quant_keys(cfg: dict) -> dict:
                 variant = _VLM_TEXT_PREFIX + key
             if variant not in quant and variant not in extras:
                 extras[variant] = val
+            # Laguna router overrides: published checkpoints key the
+            # per-layer quantization spec by ``mlp.gate``, but the model's
+            # actual module-tree path is ``mlp.gate.proj`` (the router is
+            # ``LagunaTopKRouter.proj``, not ``gate`` itself).  Without the
+            # matching key, ``nn.quantize`` falls back to the global bits
+            # and builds the router at the wrong width, causing a shape
+            # mismatch during strict weight loading.
+            if key.endswith(".mlp.gate"):
+                proj_variant = key + ".proj"
+                if proj_variant not in quant and proj_variant not in extras:
+                    extras[proj_variant] = val
         if extras:
             quant.update(extras)
     return cfg

--- a/tests/test_laguna_patch.py
+++ b/tests/test_laguna_patch.py
@@ -389,6 +389,144 @@ def test_laguna_sanitize_remaps_gate_and_stacks_experts():
     assert stacked_gate.shape == (2, 128, 64)
 
 
+def test_sanitize_remaps_quant_router_sidecars():
+    """``_remap_router_weights`` remaps ``gate.scales`` and ``gate.biases`` too.
+
+    Quantized checkpoints produced by oQ / mlx-vlm carry quantization
+    sidecars alongside ``gate.weight``.  Remapping only ``.weight`` leaves
+    ``gate.scales`` and ``gate.biases`` orphaned, triggering
+    ``ValueError: Received N parameters not in model``.
+    """
+    from omlx.patches.laguna import apply_laguna_patch
+
+    apply_laguna_patch()
+
+    from mlx_lm.models import laguna
+
+    args = laguna.ModelArgs(
+        **_minimal_laguna_config(
+            num_experts=2,
+            num_experts_per_tok=1,
+            moe_intermediate_size=128,
+            shared_expert_intermediate_size=128,
+        )
+    )
+    model = laguna.Model(args)
+
+    weights = {
+        "model.embed_tokens.weight": mx.zeros((1024, 64)),
+        "lm_head.weight": mx.zeros((1024, 64)),
+        "model.norm.weight": mx.ones((64,)),
+        # Router weight + quant sidecars keyed under ``gate`` (not ``gate.proj``)
+        "model.layers.0.mlp.gate.weight": mx.zeros((2, 64)),
+        "model.layers.0.mlp.gate.scales": mx.zeros((2, 64)),
+        "model.layers.0.mlp.gate.biases": mx.zeros((2, 64)),
+        # Expert weights (pre-stacked layout)
+        "model.layers.0.mlp.experts.0.gate_proj.weight": mx.zeros((128, 64)),
+        "model.layers.0.mlp.experts.1.gate_proj.weight": mx.zeros((128, 64)),
+        "model.layers.0.mlp.experts.0.up_proj.weight": mx.zeros((128, 64)),
+        "model.layers.0.mlp.experts.1.up_proj.weight": mx.zeros((128, 64)),
+        "model.layers.0.mlp.experts.0.down_proj.weight": mx.zeros((64, 128)),
+        "model.layers.0.mlp.experts.1.down_proj.weight": mx.zeros((64, 128)),
+    }
+
+    out = model.sanitize(weights)
+
+    # All three router tensors are remapped from gate.<suffix> to
+    # gate.proj.<suffix>
+    assert "model.layers.0.mlp.gate.proj.weight" in out
+    assert "model.layers.0.mlp.gate.proj.scales" in out
+    assert "model.layers.0.mlp.gate.proj.biases" in out
+
+    # No orphaned keys remain under the old ``gate.`` prefix
+    assert not any(
+        k.startswith("model.layers.0.mlp.gate.") and ".proj." not in k
+        for k in out
+        if "e_score_correction_bias" not in k
+    )
+
+
+def test_sanitize_remaps_bare_score_correction_bias():
+    """Bare ``mlp.e_score_correction_bias`` maps to ``gate.e_score_correction_bias``.
+
+    The published pipenetwork/Laguna-S-2.1 MLX conversions store the
+    router correction bias at ``mlp.e_score_correction_bias`` (without the
+    ``experts.`` prefix the legacy sanitizer branch checked for).
+    """
+    from omlx.patches.laguna import apply_laguna_patch
+
+    apply_laguna_patch()
+
+    from mlx_lm.models import laguna
+
+    args = laguna.ModelArgs(
+        **_minimal_laguna_config(
+            num_experts=2,
+            num_experts_per_tok=1,
+            moe_intermediate_size=128,
+            shared_expert_intermediate_size=128,
+        )
+    )
+    model = laguna.Model(args)
+
+    weights = {
+        "model.embed_tokens.weight": mx.zeros((1024, 64)),
+        "lm_head.weight": mx.zeros((1024, 64)),
+        "model.norm.weight": mx.ones((64,)),
+        "model.layers.0.mlp.gate.weight": mx.zeros((2, 64)),
+        "model.layers.0.mlp.e_score_correction_bias": mx.zeros((2,)),
+        "model.layers.0.mlp.experts.0.gate_proj.weight": mx.zeros((128, 64)),
+        "model.layers.0.mlp.experts.1.gate_proj.weight": mx.zeros((128, 64)),
+        "model.layers.0.mlp.experts.0.up_proj.weight": mx.zeros((128, 64)),
+        "model.layers.0.mlp.experts.1.up_proj.weight": mx.zeros((128, 64)),
+        "model.layers.0.mlp.experts.0.down_proj.weight": mx.zeros((64, 128)),
+        "model.layers.0.mlp.experts.1.down_proj.weight": mx.zeros((64, 128)),
+    }
+
+    out = model.sanitize(weights)
+
+    assert "model.layers.0.mlp.gate.e_score_correction_bias" in out
+    assert "model.layers.0.mlp.e_score_correction_bias" not in out
+
+
+def test_sanitize_remaps_experts_prefixed_score_correction_bias():
+    """Legacy ``experts.e_score_correction_bias`` still maps correctly."""
+    from omlx.patches.laguna import apply_laguna_patch
+
+    apply_laguna_patch()
+
+    from mlx_lm.models import laguna
+
+    args = laguna.ModelArgs(
+        **_minimal_laguna_config(
+            num_experts=2,
+            num_experts_per_tok=1,
+            moe_intermediate_size=128,
+            shared_expert_intermediate_size=128,
+        )
+    )
+    model = laguna.Model(args)
+
+    weights = {
+        "model.embed_tokens.weight": mx.zeros((1024, 64)),
+        "lm_head.weight": mx.zeros((1024, 64)),
+        "model.norm.weight": mx.ones((64,)),
+        "model.layers.0.mlp.gate.weight": mx.zeros((2, 64)),
+        "model.layers.0.mlp.experts.e_score_correction_bias": mx.zeros((2,)),
+        "model.layers.0.mlp.experts.0.gate_proj.weight": mx.zeros((128, 64)),
+        "model.layers.0.mlp.experts.1.gate_proj.weight": mx.zeros((128, 64)),
+        "model.layers.0.mlp.experts.0.up_proj.weight": mx.zeros((128, 64)),
+        "model.layers.0.mlp.experts.1.up_proj.weight": mx.zeros((128, 64)),
+        "model.layers.0.mlp.experts.0.down_proj.weight": mx.zeros((64, 128)),
+        "model.layers.0.mlp.experts.1.down_proj.weight": mx.zeros((64, 128)),
+    }
+
+    out = model.sanitize(weights)
+
+    assert "model.layers.0.mlp.gate.e_score_correction_bias" in out
+    assert "model.layers.0.mlp.experts.e_score_correction_bias" not in out
+
+
 def test_sanitize_dequantizes_fp8_block_weights():
     """FP8 e4m3 weight + f32 block scales convert to 8-bit affine triples."""
     from omlx.patches.laguna import apply_laguna_patch

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -585,6 +585,36 @@ class TestExpandPerLayerQuantKeys:
         assert swapped in cfg["quantization"]
         assert cfg["quantization"][swapped]["bits"] == 8
 
+    def test_adds_gate_proj_variant_for_laguna_router_overrides(self):
+        """Laguna checkpoints key router quant overrides as ``mlp.gate``.
+
+        The model's runtime module path is ``mlp.gate.proj`` (the router
+        ``nn.Linear`` is ``LagunaTopKRouter.proj``).  Without the ``.proj``
+        variant, ``nn.quantize`` falls back to the global bits and builds
+        the router at the wrong width, causing a shape mismatch on load.
+        """
+        cfg = {
+            "quantization": {
+                "bits": 4,
+                "group_size": 64,
+                "model.layers.1.mlp.gate": {"bits": 8, "group_size": 64},
+                "model.layers.2.mlp.gate": {"bits": 8, "group_size": 64},
+            }
+        }
+
+        model_loading.expand_per_layer_quant_keys(cfg)
+
+        assert (
+            cfg["quantization"]["model.layers.1.mlp.gate.proj"]
+            == {"bits": 8, "group_size": 64}
+        )
+        assert (
+            cfg["quantization"]["model.layers.2.mlp.gate.proj"]
+            == {"bits": 8, "group_size": 64}
+        )
+        # The original key is preserved (other code paths may still use it)
+        assert "model.layers.1.mlp.gate" in cfg["quantization"]
+
 
 class TestMaterializeLazyState:
     def test_covers_arrays_in_plain_helper_objects(self):


### PR DESCRIPTION
## Summary

- Quantized Laguna S-2.1 checkpoints from the `pipenetwork/Laguna-S-2.1-MLX-*` family fail to load on v0.5.3 with `ValueError: Received 141 parameters not in model`, followed by a router shape mismatch once the key naming is resolved
- Two bugs in the weight-loading path: `_remap_router_weights` only remapped `gate.weight` (not `gate.scales`/`gate.biases` or the bare `e_score_correction_bias` path), and `expand_per_layer_quant_keys` did not emit the `.gate.proj` variant for per-layer router quant overrides
- The `poolside/Laguna-S-2.1-*` conversions tested in #2322 already use the `gate.proj.*` naming directly, so they bypass the sanitizer and load fine — the bug only surfaces on checkpoints that use the legacy `gate.*` convention that `_remap_router_weights` was written to handle
- No engine changes; everything is in sanitize plus the config normalization hook, same as the original Laguna support

## Root Causes

### 1. Incomplete router weight remapping (141 orphaned parameters)

`_remap_router_weights` remapped `gate.weight` → `gate.proj.weight` but left the quantization sidecars `gate.scales` and `gate.biases` orphaned. The published `pipenetwork` conversions carry all three under `gate.<suffix>`:

| Checkpoint key | Model expects | Sanitizer remapped? |
|---|---|---|
| `mlp.gate.weight` | `mlp.gate.proj.weight` | ✅ |
| `mlp.gate.scales` | `mlp.gate.proj.scales` | ❌ orphaned |
| `mlp.gate.biases` | `mlp.gate.proj.biases` | ❌ orphaned |
| `mlp.e_score_correction_bias` | `mlp.gate.e_score_correction_bias` | ❌ orphaned |

47 sparse layers × 3 orphaned keys = **141 unmatched parameters**.

The `e_score_correction_bias` check also only looked for the legacy `mlp.experts.e_score_correction_bias` path. The `pipenetwork` conversions store it at the bare `mlp.e_score_correction_bias` path (no `experts.` prefix), so that branch missed it.

### 2. Per-layer quant key mismatch (router built at wrong bit-width)

After fixing the key names, the router weights hit `Expected shape (256, 384) but received shape (256, 768)`. The config's per-layer quant overrides key the router by `model.layers.N.mlp.gate`, but the model's runtime module path is `model.layers.N.mlp.gate.proj` (the `nn.Linear` lives at `LagunaTopKRouter.proj`). Without the matching key, `nn.quantize` falls back to the global 4-bit and builds the router at 256×384 instead of the required 8-bit 256×768.

`expand_per_layer_quant_keys` already handles prefix variants for VLM trees — this adds the same treatment for the `.gate` → `.gate.proj` suffix.

## Changes

- **`omlx/patches/laguna/laguna_model.py`** — `_remap_router_weights`: remap all three router suffixes (`weight`, `scales`, `biases`) from `gate.<suffix>` to `gate.proj.<suffix>`; accept both `mlp.e_score_correction_bias` (published layout) and `mlp.experts.e_score_correction_bias` (legacy layout)
- **`omlx/utils/model_loading.py`** — `expand_per_layer_quant_keys`: emit a `.gate.proj` variant for any per-layer quant key ending in `.mlp.gate`, mirroring the existing VLM-prefix variant logic
- **`tests/test_laguna_patch.py`** — 3 new tests covering quant sidecar remap, bare `e_score_correction_bias`, and legacy `experts.e_score_correction_bias` backward compat
- **`tests/test_model_loading.py`** — 1 new test for the `.gate.proj` quant key expansion

## Verification

**Existing tests (no regressions):**

```bash
pytest tests/test_laguna_patch.py tests/test_model_loading.py -v
```

All 24 existing Laguna tests pass, plus the 4 new tests.

**New tests verified in isolation:**

```
✅ test_sanitize_remaps_quant_router_sidecars: PASSED
✅ test_sanitize_remaps_bare_score_correction_bias: PASSED
✅ test_sanitize_remaps_experts_prefixed_score_correction_bias: PASSED (backward compat)
✅ test_adds_gate_proj_variant_for_laguna_router_overrides: PASSED
```

**Real-model smoke test** on M-series Apple Silicon with `pipenetwork/Laguna-S-2.1-MLX-4bit` (61.64 GB):

- Model loads in 18.5s, zero errors in server log
- `"Say OK if you can hear me"` → `"OK, I can hear you. How can I help you today?"`
- `"What is the capital of France?"` → `"Paris"`
- `"What is 17 * 23?"` → coherent step-by-step reasoning using the distributive property

Applied and verified on the same checkpoint at 6-bit and 8-bit as well.

Fixes #2329