### PR TITLE
fix(specprefill): forward SpecPrefill kwargs on the VLM non-streaming path

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -2875,6 +2875,70 @@ class VLMBatchedEngine(BaseEngine):
             prompt = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
             return prompt + "\nassistant:"
 
+    @staticmethod
+    def _pop_specprefill_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Pop SpecPrefill per-request overrides out of ``kwargs``.
+
+        The engine's ``add_request`` accepts these as dedicated arguments, so
+        they must be forwarded explicitly rather than left in ``**kwargs``.
+        Shared by ``generate`` and ``stream_generate`` so both request paths
+        honour SpecPrefill overrides identically.
+        """
+        specprefill_kwargs: dict[str, Any] = {}
+        for key in (
+            "specprefill",
+            "specprefill_keep_pct",
+            "specprefill_threshold",
+            "specprefill_system_end",
+        ):
+            if kwargs.get(key) is not None:
+                specprefill_kwargs[key] = kwargs.pop(key)
+        return specprefill_kwargs
+
+    def _inject_specprefill_system_end(
+        self,
+        messages: list[dict[str, Any]],
+        prompt: str | list[int],
+        kwargs: dict[str, Any],
+    ) -> None:
+        """Compute the system-prompt token boundary and add it to ``kwargs``.
+
+        SpecPrefill protects the system-prompt region from token dropping. The
+        boundary is derived by subtracting the non-system prompt token count
+        from the full prompt token count (system-only messages usually can't be
+        templated on their own). Shared by ``chat`` and ``stream_chat`` so the
+        non-streaming path protects the system prompt identically. No-op unless
+        the model has SpecPrefill enabled and the request has a system prompt.
+
+        ``prompt`` is the already-tokenized VLM prompt (a list of token IDs,
+        per ``_process_chat_messages``), so the full-prompt count is just its
+        length rather than a re-encode.
+        """
+        specprefill_model_enabled = (
+            getattr(self._model_settings, "specprefill_enabled", False)
+            if self._model_settings
+            else False
+        )
+        if not (specprefill_model_enabled and kwargs.get("specprefill") is not False):
+            return
+        non_system = [
+            m for m in messages if m.get("role") not in ("system", "developer")
+        ]
+        if len(non_system) < len(messages) and non_system:
+            try:
+                non_system_prompt = self._tokenizer.apply_chat_template(
+                    non_system,
+                    tokenize=False,
+                    add_generation_prompt=True,
+                )
+                full_tokens = len(prompt)
+                non_system_tokens = len(self._tokenizer.encode(non_system_prompt))
+                system_end = full_tokens - non_system_tokens
+                if system_end > 0:
+                    kwargs["specprefill_system_end"] = system_end
+            except Exception as e:
+                logger.debug(f"SpecPrefill: system_end calc failed: {e}")
+
     async def generate(
         self,
         prompt: str | list[int],
@@ -2951,6 +3015,10 @@ class VLMBatchedEngine(BaseEngine):
             seed=kwargs.get("seed", None),
         )
 
+        # SpecPrefill: forward per-request overrides to the engine, mirroring
+        # stream_generate so the non-streaming path is not silently ignored.
+        specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
+
         output = await self._engine.generate(
             prompt=prompt,
             sampling_params=sampling_params,
@@ -2959,6 +3027,7 @@ class VLMBatchedEngine(BaseEngine):
             vlm_image_hash=vlm_image_hash,
             vlm_cache_key_start=vlm_cache_key_start,
             vlm_cache_key_ranges=vlm_cache_key_ranges,
+            **specprefill_kwargs,
         )
 
         text = clean_special_tokens(output.output_text)
@@ -3056,21 +3125,7 @@ class VLMBatchedEngine(BaseEngine):
         )
 
         # SpecPrefill: pass per-request overrides
-        specprefill_kwargs = {}
-        if kwargs.get("specprefill") is not None:
-            specprefill_kwargs["specprefill"] = kwargs.pop("specprefill")
-        if kwargs.get("specprefill_keep_pct") is not None:
-            specprefill_kwargs["specprefill_keep_pct"] = kwargs.pop(
-                "specprefill_keep_pct"
-            )
-        if kwargs.get("specprefill_threshold") is not None:
-            specprefill_kwargs["specprefill_threshold"] = kwargs.pop(
-                "specprefill_threshold"
-            )
-        if kwargs.get("specprefill_system_end") is not None:
-            specprefill_kwargs["specprefill_system_end"] = kwargs.pop(
-                "specprefill_system_end"
-            )
+        specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
 
         engine = self._engine
         request_id = await engine.add_request(
@@ -3170,6 +3225,9 @@ class VLMBatchedEngine(BaseEngine):
             tools,
             kwargs,
         )
+
+        # SpecPrefill: protect the system-prompt region, mirroring stream_chat.
+        self._inject_specprefill_system_end(messages, prompt, kwargs)
 
         return await self.generate(
             prompt=prompt,
@@ -3387,32 +3445,8 @@ class VLMBatchedEngine(BaseEngine):
             kwargs,
         )
 
-        # SpecPrefill: compute system prompt token count for protection.
-        # Can't template system-only messages (most templates require user),
-        # so compute by subtracting non-system from full prompt tokens.
-        specprefill_model_enabled = (
-            getattr(self._model_settings, "specprefill_enabled", False)
-            if self._model_settings
-            else False
-        )
-        if specprefill_model_enabled and kwargs.get("specprefill") is not False:
-            non_system = [
-                m for m in messages if m.get("role") not in ("system", "developer")
-            ]
-            if len(non_system) < len(messages) and non_system:
-                try:
-                    non_system_prompt = self._tokenizer.apply_chat_template(
-                        non_system,
-                        tokenize=False,
-                        add_generation_prompt=True,
-                    )
-                    full_tokens = len(prompt)
-                    non_system_tokens = len(self._tokenizer.encode(non_system_prompt))
-                    system_end = full_tokens - non_system_tokens
-                    if system_end > 0:
-                        kwargs["specprefill_system_end"] = system_end
-                except Exception as e:
-                    logger.debug(f"SpecPrefill: system_end calc failed: {e}")
+        # SpecPrefill: protect the system-prompt region from token dropping.
+        self._inject_specprefill_system_end(messages, prompt, kwargs)
 
         async for output in self.stream_generate(
             prompt=prompt,

--- a/tests/test_vlm_specprefill.py
+++ b/tests/test_vlm_specprefill.py
@@ -1,6 +1,7 @@
 """Regression tests for SpecPrefill parameter forwarding in VLM engine."""
 
 from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -58,3 +59,139 @@ async def test_vlm_chat_forwards_specprefill_threshold_and_keep_pct():
         assert kwargs["specprefill_threshold"] == 1024
     finally:
         engine._engine._mlx_executor.shutdown(wait=False)
+
+
+class TestVLMEngineSpecPrefillForwarding:
+    """Non-streaming path must forward SpecPrefill overrides (issue #2274/#2281 parity).
+
+    ``generate()``/``chat()`` previously dropped SpecPrefill kwargs on the VLM
+    engine, so a configured keep_pct silently fell back to the engine default.
+    """
+
+    @staticmethod
+    def _fake_output():
+        return SimpleNamespace(
+            output_text="hi",
+            prompt_tokens=5,
+            completion_tokens=2,
+            finish_reason="stop",
+            tool_calls=None,
+            cached_tokens=0,
+            first_token_at=None,
+        )
+
+    def test_pop_specprefill_kwargs_extracts_and_pops(self):
+        kwargs = {
+            "specprefill_keep_pct": 0.25,
+            "specprefill_threshold": 100,
+            "specprefill_system_end": 12,
+            "specprefill": True,
+            "temperature": 0.7,
+        }
+        extracted = VLMBatchedEngine._pop_specprefill_kwargs(kwargs)
+
+        assert extracted == {
+            "specprefill_keep_pct": 0.25,
+            "specprefill_threshold": 100,
+            "specprefill_system_end": 12,
+            "specprefill": True,
+        }
+        # Popped out of the original dict; unrelated kwargs are untouched.
+        assert kwargs == {"temperature": 0.7}
+
+    def test_pop_specprefill_kwargs_ignores_none_values(self):
+        kwargs = {"specprefill_keep_pct": None, "specprefill": None}
+        assert VLMBatchedEngine._pop_specprefill_kwargs(kwargs) == {}
+
+    @pytest.mark.asyncio
+    async def test_generate_forwards_specprefill_kwargs(self):
+        engine = VLMBatchedEngine(model_name="test-vlm")
+        engine._loaded = True
+        engine._engine = SimpleNamespace(
+            generate=AsyncMock(return_value=self._fake_output())
+        )
+
+        await engine.generate(
+            "a prompt",
+            specprefill_keep_pct=0.25,
+            specprefill_threshold=100,
+        )
+
+        call_kwargs = engine._engine.generate.call_args.kwargs
+        assert call_kwargs["specprefill_keep_pct"] == 0.25
+        assert call_kwargs["specprefill_threshold"] == 100
+
+    @pytest.mark.asyncio
+    async def test_generate_omits_specprefill_when_absent(self):
+        engine = VLMBatchedEngine(model_name="test-vlm")
+        engine._loaded = True
+        engine._engine = SimpleNamespace(
+            generate=AsyncMock(return_value=self._fake_output())
+        )
+
+        await engine.generate("a prompt")
+
+        call_kwargs = engine._engine.generate.call_args.kwargs
+        assert "specprefill_keep_pct" not in call_kwargs
+        assert "specprefill_threshold" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_chat_injects_specprefill_system_end(self):
+        engine = VLMBatchedEngine(model_name="test-vlm")
+        engine._loaded = True
+        engine._model_settings = SimpleNamespace(specprefill_enabled=True)
+        engine._engine = MagicMock()
+        engine._engine._mlx_executor = ThreadPoolExecutor(max_workers=1)
+        engine._engine.generate = AsyncMock(return_value=self._fake_output())
+
+        # VLM prompts are pre-tokenized (list[int]) by _process_chat_messages;
+        # full_tokens = len(prompt) = 10, non_system_tokens = 4, so
+        # system_end = 10 - 4 = 6.
+        engine._tokenizer = MagicMock()
+        engine._tokenizer.apply_chat_template.return_value = "USER_ONLY"
+        engine._tokenizer.encode.side_effect = lambda text, **kwargs: [0] * 4
+
+        def _mock_process(messages, tools, kwargs):
+            return list(range(10)), None, None, None, 0, []
+
+        messages = [
+            {"role": "system", "content": "you are helpful"},
+            {"role": "user", "content": "hello"},
+        ]
+        try:
+            with patch.object(engine, "_process_chat_messages", side_effect=_mock_process):
+                await engine.chat(messages)
+        finally:
+            engine._engine._mlx_executor.shutdown(wait=False)
+
+        call_kwargs = engine._engine.generate.call_args.kwargs
+        assert call_kwargs["specprefill_system_end"] == 6
+
+    @pytest.mark.asyncio
+    async def test_chat_skips_system_end_when_specprefill_disabled(self):
+        engine = VLMBatchedEngine(model_name="test-vlm")
+        engine._loaded = True
+        engine._model_settings = SimpleNamespace(specprefill_enabled=False)
+        engine._engine = MagicMock()
+        engine._engine._mlx_executor = ThreadPoolExecutor(max_workers=1)
+        engine._engine.generate = AsyncMock(return_value=self._fake_output())
+
+        engine._tokenizer = MagicMock()
+        engine._tokenizer.apply_chat_template.return_value = "USER_ONLY"
+        engine._tokenizer.encode.side_effect = lambda text, **kwargs: [0] * 4
+
+        def _mock_process(messages, tools, kwargs):
+            return list(range(8)), None, None, None, 0, []
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+        ]
+        try:
+            with patch.object(engine, "_process_chat_messages", side_effect=_mock_process):
+                await engine.chat(messages)
+        finally:
+            engine._engine._mlx_executor.shutdown(wait=False)
+
+        call_kwargs = engine._engine.generate.call_args.kwargs
+        assert "specprefill_system_end" not in call_kwargs


### PR DESCRIPTION
Completes the fix from #2292 (#2274) on the VLM engine. May also explain #2281's "keep rate always 20%" for VLM-hosted models.

## Summary

- `VLMBatchedEngine.generate()` now forwards `specprefill`, `specprefill_keep_pct`, `specprefill_threshold`, `specprefill_system_end` to the engine core, mirroring `stream_generate`.
- `VLMBatchedEngine.chat()` now computes `specprefill_system_end` before delegating, mirroring `stream_chat`.
- Same helper structure as #2292 (`_pop_specprefill_kwargs`, `_inject_specprefill_system_end`), used by all four request paths.

## Why

#2292 fixed the non-streaming SpecPrefill kwarg drop in `BatchedEngine`, but the VLM engine has the identical twin: non-streaming `generate()` built `SamplingParams` and called `self._engine.generate(...)` without the specprefill kwargs, and non-streaming `chat()` never computed the system-prompt boundary. Result: non-streaming requests on VLM-hosted models silently fell back to the default keep rate regardless of configured settings, ignored per-request `specprefill=False`, and left the system prompt unprotected. Streaming requests were unaffected. (Noted on #2274 at the time as the remaining engine.)

## Changes

- `omlx/engine/vlm.py`: added `_pop_specprefill_kwargs()` and `_inject_specprefill_system_end()`; `generate()` pops and forwards; `chat()` injects before delegating to `generate()`; `stream_generate()`/`stream_chat()` now call the helpers instead of their inline copies — no behavior change on streaming: the inject helper is the extracted `stream_chat` inline code verbatim, preserving VLM's pre-tokenized-prompt semantics (`full_tokens = len(prompt)` on the token-ID list from `_process_chat_messages`; bare `tokenizer.apply_chat_template` for the non-system render).
- `tests/test_vlm_specprefill.py`: new `TestVLMEngineSpecPrefillForwarding` class, six tests mirroring #2292's, exercising the real `generate()` / `chat()→generate()` chain.

## Behavior change (worth a release-notes line)

For VLM-hosted models with SpecPrefill configured, non-streaming requests now honor the configured keep rate / threshold / per-request `specprefill=False` and protect the system prompt — previously they always ran the engine default. A model configured with a keep rate lower than the default will drop more tokens on non-streaming calls than before, i.e. the user's configuration now takes effect.

## Sibling sweep

- DFlash fallback `generate`/`chat` forward `**kwargs` to the fallback engine → covered transitively.
- Diffusion lane: rejects `specprefill=True` loudly; both diffusion early-returns precede the pop/inject, so the inject runs at most once per request and never on diffusion paths.
- Out of scope (pre-existing, affects both engines equally): `admin/benchmark.py`'s direct `add_request` passes no specprefill kwargs (deliberate engine-default benching); the Anthropic `/v1/messages` and Responses server handlers never build specprefill overrides (only the OpenAI chat handler does).

## Why this is safe

- No new engine contract: the forwarding lands on `add_request` parameters that are first-class in the engine core and have been exercised in production by the streaming path since before this change; the core's `generate()` is a pure passthrough to the same `add_request`.
- Every failure direction is conservative: an over-estimated `system_end` only shrinks or skips the scored region; an inject failure is caught and degrades to exactly the pre-fix no-protection state; non-positive boundaries are ignored at the core.
- Structural mirror of already-merged #2292, verified line-for-line against `batched.py`; the only deltas are forced by the VLM prompt type (pre-tokenized token-ID list).

## Overlap

#1782 (open) proposes a broader all-paths rework that also touches `vlm.py`, untouched since 2026-07-10. This PR follows the scoped-fix path #2292 established on the batched engine; happy to yield if the broader rework is the preferred direction.

## Tests

- `python -m pytest tests/test_vlm_specprefill.py tests/test_vlm_engine.py -q` → **100 passed** (6 new).
- `python -m pytest tests/test_batched_engine.py -q` → **42 passed** (sibling suite untouched).
- Revert-proof: with `omlx/engine/vlm.py` reverted to the parent commit, the new class fails 4 of 6 — the two absence-assertion guards correctly still pass.
