### PR TITLE
fix(dflash): hoist transformers 5.x-nested draft config keys to the root

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -341,9 +341,20 @@ class DFlashEngine(BaseEngine):
             # Native MTP load on the same process would see leftover dflash
             # hooks and crash with TypeError on n_confirmed (issue #1388).
             # Idempotent — only wraps once per process.
+            from ..patches.dflash_draft_config import (
+                install_dflash_draft_config_normalizer,
+            )
             from ..patches.dflash_lifecycle import install_dflash_lifecycle_wrap
 
             install_dflash_lifecycle_wrap()
+            # Newer z-lab drafts ship transformers 5.x-style configs that nest
+            # rope_theta under rope_parameters and block_size under
+            # dflash_config, but DFlashDraftModelArgs requires both at the
+            # config root with no defaults. Without this, load_draft_bundle
+            # crashes with a missing-positional-argument TypeError and
+            # engine_pool falls back to the vlm engine (issue #2317).
+            # Idempotent — only wraps once per process.
+            install_dflash_draft_config_normalizer()
 
             target_bundle = load_target_bundle(
                 self._model_name,

--- a/omlx/patches/dflash_draft_config.py
+++ b/omlx/patches/dflash_draft_config.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Normalize transformers 5.x-nested draft configs for dflash-mlx (issue #2317).
+
+``dflash_mlx.runtime.loading.load_draft_bundle`` -> ``mlx_lm.utils.load_model``
+-> ``DFlashDraftModelArgs.from_dict(config)``. ``from_dict`` filters the raw
+config dict down to the dataclass's annotated fields and calls
+``cls(**filtered)``. ``rope_theta: float`` and ``block_size: int`` are
+required positional fields with no defaults.
+
+z-lab retrained their DFlash draft checkpoints in June 2026 with
+transformers 5.7-style configs: ``rope_theta`` moved from the config root
+into a nested ``rope_parameters`` object, and ``block_size`` moved from the
+root into the existing ``dflash_config`` object. Neither key survives
+``from_dict``'s field filter at its new nested location, so construction
+fails with
+``TypeError: DFlashDraftModelArgs.__init__() missing 2 required positional
+arguments: 'rope_theta' and 'block_size'``, and omlx's engine_pool logs
+"DFlash start failed ... Falling back to vlm engine" instead of running the
+speculative draft. Upstream dflash-mlx (pin 9ca0028, v0.1.10) has no fix.
+
+This module hoists the nested values back to the config root before
+``DFlashDraftModelArgs.from_dict`` runs, so both the new (nested) and old
+(root-level) config layouts construct successfully:
+  - ``rope_parameters.rope_theta`` -> root ``rope_theta`` (transformers 5.x
+    folds ``rope_theta`` into ``rope_parameters``, the successor of the
+    older ``rope_scaling`` dict).
+  - ``rope_parameters`` with a non-"default" ``rope_type``/``type`` -> root
+    ``rope_scaling`` (minus ``rope_theta``), since the draft model consumes
+    yarn-style scaling via ``mlx_lm``'s ``initialize_rope(...,
+    scaling_config=args.rope_scaling)``.
+  - ``dflash_config.block_size`` -> root ``block_size``.
+
+Hoisting is fill-only per key: a root-level key that is set (non-null)
+always wins over its nested counterpart, and an explicit ``null`` counts
+as missing (transformers 4.x-derived configs commonly serialize
+``"rope_scaling": null``). Old-layout configs pass through unchanged. One
+deliberate behavior change for hybrid configs: a config that sets root
+``rope_theta``/``block_size`` but still carries a non-"default"
+``rope_parameters`` and no root ``rope_scaling`` (e.g. a checkpoint
+hand-patched per the issue #2317 workaround) now gains the scaling its
+config declares, where it previously loaded with unscaled RoPE. A config
+that is missing a key at both the root and its nested location still
+fails loudly in ``from_dict`` exactly as it does today — this module only
+widens which configs are recognized, it never invents values.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from dflash_mlx.model import DFlashDraftModelArgs
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_dflash_draft_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Hoist transformers 5.x-nested draft config keys back to the root.
+
+    Pure function: never mutates ``config``. Returns a shallow copy with
+    missing root-level ``rope_theta`` / ``rope_scaling`` / ``block_size``
+    filled in from their transformers 5.x nested locations
+    (``rope_parameters`` and ``dflash_config`` respectively). A root key
+    that is set (non-null) is never overwritten; an explicit ``null``
+    counts as missing.
+    """
+    result = dict(config)
+    hoisted: list[str] = []
+
+    rope_parameters = config.get("rope_parameters")
+    if isinstance(rope_parameters, dict):
+        if (
+            result.get("rope_theta") is None
+            and rope_parameters.get("rope_theta") is not None
+        ):
+            result["rope_theta"] = rope_parameters["rope_theta"]
+            hoisted.append("rope_theta<-rope_parameters")
+        if result.get("rope_scaling") is None:
+            # Mirror initialize_rope's key precedence exactly ("type" first,
+            # then "rope_type") so the hoist decision can never disagree
+            # with how mlx_lm reads the synthesized dict.
+            rope_type = (
+                rope_parameters.get("type")
+                or rope_parameters.get("rope_type")
+                or "default"
+            )
+            if rope_type != "default":
+                result["rope_scaling"] = {
+                    key: value
+                    for key, value in rope_parameters.items()
+                    if key != "rope_theta"
+                }
+                hoisted.append("rope_scaling<-rope_parameters")
+
+    dflash_config = config.get("dflash_config")
+    if (
+        isinstance(dflash_config, dict)
+        and result.get("block_size") is None
+        and dflash_config.get("block_size") is not None
+    ):
+        result["block_size"] = dflash_config["block_size"]
+        hoisted.append("block_size<-dflash_config")
+
+    if hoisted:
+        logger.info(
+            "DFlash draft config: hoisted %s to config root (issue #2317)",
+            ", ".join(hoisted),
+        )
+
+    return result
+
+
+def install_dflash_draft_config_normalizer() -> None:
+    """Wrap ``DFlashDraftModelArgs.from_dict`` to normalize nested configs.
+
+    Passes the incoming params dict through
+    ``normalize_dflash_draft_config`` before the original ``from_dict``
+    runs, so transformers 5.x-nested draft configs (``rope_theta`` under
+    ``rope_parameters``, ``block_size`` under ``dflash_config``) construct
+    successfully instead of raising a missing-positional-argument
+    ``TypeError`` (issue #2317).
+
+    Idempotent — only wraps once per process.
+    """
+    if getattr(
+        DFlashDraftModelArgs, "_omlx_draft_config_normalizer_installed", False
+    ):
+        return
+
+    original = DFlashDraftModelArgs.from_dict.__func__
+
+    def wrapped_from_dict(
+        cls: type[DFlashDraftModelArgs], params: dict[str, Any]
+    ) -> DFlashDraftModelArgs:
+        return original(cls, normalize_dflash_draft_config(params))
+
+    DFlashDraftModelArgs.from_dict = classmethod(wrapped_from_dict)
+    DFlashDraftModelArgs._omlx_draft_config_normalizer_installed = True
+    logger.info("DFlash draft config normalizer installed (issue #2317)")

--- a/tests/test_dflash_draft_config.py
+++ b/tests/test_dflash_draft_config.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for omlx.patches.dflash_draft_config (issue #2317)."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+pytest.importorskip("dflash_mlx", reason="dflash-mlx not installed")
+
+# All fields DFlashDraftModelArgs requires with no default, minus
+# rope_theta/block_size (added per-layout below). Values mirror the real
+# z-lab/Qwen3.6-35B-A3B-DFlash config excerpt.
+_BASE_FIELDS = {
+    "model_type": "qwen3",
+    "hidden_size": 2048,
+    "num_hidden_layers": 6,
+    "intermediate_size": 6144,
+    "num_attention_heads": 32,
+    "rms_norm_eps": 1e-06,
+    "vocab_size": 248320,
+    "num_key_value_heads": 8,
+    "max_position_embeddings": 262144,
+    "head_dim": 128,
+    "tie_word_embeddings": False,
+    "num_target_layers": 40,
+    "attention_bias": False,
+    "attention_dropout": 0.0,
+    "layer_types": (
+        "sliding_attention",
+        "sliding_attention",
+        "sliding_attention",
+        "sliding_attention",
+        "sliding_attention",
+        "full_attention",
+    ),
+    "sliding_window": 4096,
+    "use_sliding_window": True,
+}
+
+
+def _new_layout_config() -> dict:
+    """Real z-lab/Qwen3.6-35B-A3B-DFlash config (current, transformers 5.x)."""
+    return {
+        **_BASE_FIELDS,
+        "rope_parameters": {"rope_theta": 10000000, "rope_type": "default"},
+        "dflash_config": {
+            "block_size": 16,
+            "mask_token_id": 248077,
+            "target_layer_ids": [1, 6, 11, 16, 22, 27, 32, 37],
+        },
+    }
+
+
+def _old_layout_config() -> dict:
+    """Same repo's April revision config (working, root-level keys)."""
+    return {
+        **_BASE_FIELDS,
+        "rope_theta": 10000000,
+        "block_size": 16,
+        "rope_scaling": {
+            "beta_fast": 32.0,
+            "beta_slow": 1.0,
+            "factor": 64.0,
+            "original_max_position_embeddings": 4096,
+            "rope_type": "yarn",
+            "type": "yarn",
+        },
+        "dflash_config": {
+            "mask_token_id": 248070,
+            "target_layer_ids": [1, 10, 19, 28, 37],
+        },
+    }
+
+
+class TestNormalizeDflashDraftConfig:
+    """Unit tests for the pure hoisting function."""
+
+    def test_new_layout_hoists_rope_theta_and_block_size(self):
+        from omlx.patches.dflash_draft_config import normalize_dflash_draft_config
+
+        result = normalize_dflash_draft_config(_new_layout_config())
+
+        assert result["rope_theta"] == 10000000
+        assert result["block_size"] == 16
+        # rope_type is "default" — no rope_scaling should be synthesized.
+        assert "rope_scaling" not in result
+
+    def test_old_layout_passes_through_unchanged(self):
+        from omlx.patches.dflash_draft_config import normalize_dflash_draft_config
+
+        config = _old_layout_config()
+        result = normalize_dflash_draft_config(config)
+
+        assert result == config
+
+    def test_root_value_wins_on_conflict(self):
+        from omlx.patches.dflash_draft_config import normalize_dflash_draft_config
+
+        config = {
+            "rope_theta": 999,
+            "block_size": 5,
+            "rope_parameters": {"rope_theta": 111, "rope_type": "default"},
+            "dflash_config": {"block_size": 99},
+        }
+        result = normalize_dflash_draft_config(config)
+
+        assert result["rope_theta"] == 999
+        assert result["block_size"] == 5
+
+    def test_yarn_rope_parameters_hoist_scaling_and_theta(self):
+        from omlx.patches.dflash_draft_config import normalize_dflash_draft_config
+
+        config = {
+            "rope_parameters": {
+                "rope_theta": 5000000,
+                "rope_type": "yarn",
+                "factor": 64.0,
+            },
+        }
+        result = normalize_dflash_draft_config(config)
+
+        assert result["rope_scaling"] == {"rope_type": "yarn", "factor": 64.0}
+        assert result["rope_theta"] == 5000000
+
+    def test_type_key_precedence_mirrors_initialize_rope(self):
+        # mlx_lm's initialize_rope reads "type" first, then "rope_type" —
+        # the hoist decision must use the same precedence or it can disagree
+        # with the consumer when the two keys contradict.
+        from omlx.patches.dflash_draft_config import normalize_dflash_draft_config
+
+        type_wins_yarn = normalize_dflash_draft_config(
+            {
+                "rope_parameters": {
+                    "rope_theta": 1,
+                    "type": "yarn",
+                    "rope_type": "default",
+                    "factor": 2.0,
+                },
+            }
+        )
+        assert type_wins_yarn["rope_scaling"]["type"] == "yarn"
+
+        type_wins_default = normalize_dflash_draft_config(
+            {
+                "rope_parameters": {
+                    "rope_theta": 1,
+                    "type": "default",
+                    "rope_type": "yarn",
+                },
+            }
+        )
+        assert "rope_scaling" not in type_wins_default
+
+    def test_explicit_null_root_keys_count_as_missing(self):
+        # transformers 4.x-derived configs commonly serialize
+        # "rope_scaling": null — an explicit null must not block the hoist.
+        from omlx.patches.dflash_draft_config import normalize_dflash_draft_config
+
+        config = {
+            "rope_theta": None,
+            "rope_scaling": None,
+            "block_size": None,
+            "rope_parameters": {
+                "rope_theta": 5000000,
+                "rope_type": "yarn",
+                "factor": 64.0,
+            },
+            "dflash_config": {"block_size": 16},
+        }
+        result = normalize_dflash_draft_config(config)
+
+        assert result["rope_theta"] == 5000000
+        assert result["block_size"] == 16
+        assert result["rope_scaling"] == {"rope_type": "yarn", "factor": 64.0}
+
+    def test_null_nested_values_are_not_hoisted(self):
+        from omlx.patches.dflash_draft_config import normalize_dflash_draft_config
+
+        config = {
+            "rope_parameters": {"rope_theta": None},
+            "dflash_config": {"block_size": None},
+        }
+        result = normalize_dflash_draft_config(config)
+
+        assert result.get("rope_theta") is None
+        assert result.get("block_size") is None
+
+    def test_non_dict_nested_values_are_ignored(self):
+        from omlx.patches.dflash_draft_config import normalize_dflash_draft_config
+
+        config = {"rope_parameters": "bogus", "dflash_config": 7}
+        result = normalize_dflash_draft_config(config)
+
+        assert result == config
+
+    def test_input_not_mutated(self):
+        from omlx.patches.dflash_draft_config import normalize_dflash_draft_config
+
+        config = _new_layout_config()
+        snapshot = copy.deepcopy(config)
+
+        normalize_dflash_draft_config(config)
+
+        assert config == snapshot
+
+
+class TestInstallDflashDraftConfigNormalizer:
+    """Integration tests against the real dflash-mlx DFlashDraftModelArgs.
+
+    The install is process-global (it monkey-patches the class-level
+    ``from_dict`` classmethod) and is never unwound — unlike
+    ``dflash_lifecycle``'s restore-on-stop idiom, there is nothing to
+    restore: normalization is fill-only per key, so leaving it installed
+    for the rest of the test process is output-identical for old-layout
+    configs (root keys set, no non-"default" ``rope_parameters``).
+    """
+
+    def test_new_layout_constructs_with_hoisted_values(self):
+        from dflash_mlx.model import DFlashDraftModelArgs
+
+        from omlx.patches.dflash_draft_config import (
+            install_dflash_draft_config_normalizer,
+        )
+
+        install_dflash_draft_config_normalizer()
+        args = DFlashDraftModelArgs.from_dict(_new_layout_config())
+
+        assert args.rope_theta == 10000000
+        assert args.block_size == 16
+        assert args.rope_scaling is None
+        assert args.dflash_config["mask_token_id"] == 248077
+        assert args.dflash_config["target_layer_ids"] == [
+            1, 6, 11, 16, 22, 27, 32, 37,
+        ]
+
+    def test_old_layout_still_works(self):
+        from dflash_mlx.model import DFlashDraftModelArgs
+
+        from omlx.patches.dflash_draft_config import (
+            install_dflash_draft_config_normalizer,
+        )
+
+        install_dflash_draft_config_normalizer()
+        args = DFlashDraftModelArgs.from_dict(_old_layout_config())
+
+        assert args.rope_theta == 10000000
+        assert args.block_size == 16
+        assert args.rope_scaling == {
+            "beta_fast": 32.0,
+            "beta_slow": 1.0,
+            "factor": 64.0,
+            "original_max_position_embeddings": 4096,
+            "rope_type": "yarn",
+            "type": "yarn",
+        }
+
+    def test_missing_rope_theta_and_block_size_still_raises(self):
+        from dflash_mlx.model import DFlashDraftModelArgs
+
+        from omlx.patches.dflash_draft_config import (
+            install_dflash_draft_config_normalizer,
+        )
+
+        install_dflash_draft_config_normalizer()
+        # Neither root nor nested layout supplies rope_theta/block_size —
+        # the normalizer must not paper over a genuinely incomplete config.
+        broken = dict(_BASE_FIELDS)
+
+        with pytest.raises(TypeError):
+            DFlashDraftModelArgs.from_dict(broken)
+
+    def test_install_is_idempotent(self):
+        from dflash_mlx.model import DFlashDraftModelArgs
+
+        from omlx.patches.dflash_draft_config import (
+            install_dflash_draft_config_normalizer,
+        )
+
+        install_dflash_draft_config_normalizer()
+        wrapped_once = DFlashDraftModelArgs.from_dict.__func__
+
+        install_dflash_draft_config_normalizer()
+        wrapped_twice = DFlashDraftModelArgs.from_dict.__func__
+
+        # Second install must not re-wrap the already-wrapped classmethod.
+        assert wrapped_once is wrapped_twice
+        assert DFlashDraftModelArgs._omlx_draft_config_normalizer_installed is True
+
+        args = DFlashDraftModelArgs.from_dict(_new_layout_config())
+        assert args.rope_theta == 10000000
+        assert args.block_size == 16


### PR DESCRIPTION
Fixes #2317

## Summary

- z-lab's retrained DFlash draft checkpoints (June 2026, transformers 5.7-style configs) moved `rope_theta` into a nested `rope_parameters` object and `block_size` into the existing `dflash_config` object. `dflash_mlx`'s `DFlashDraftModelArgs.from_dict` filters the config down to annotated dataclass fields and both keys are required positionals, so every current z-lab draft download fails with `DFlashDraftModelArgs.__init__() missing 2 required positional arguments: 'rope_theta' and 'block_size'` and the engine silently falls back to plain generation — exactly the log in the issue.
- Fix: a scoped patch module (`omlx/patches/dflash_draft_config.py`, same pattern as `dflash_lifecycle`) that wraps `from_dict` to hoist the nested values back to the config root before construction, installed at DFlash engine start. Hoisting is fill-only per key: a set (non-null) root key always wins, and a config missing the keys in both layouts still fails loudly exactly as today.

## Why omlx-side

Upstream dflash-mlx has no fix (the pinned 9ca0028 / v0.1.10 is its current HEAD), and the construction happens inside `load_draft_bundle` → `mlx_lm.load_model`, which reads config.json from disk — there is no omlx call site where the dict could be normalized directly, which is what the existing `patches/` machinery is for.

## Field evidence

Three users on the issue confirm the mechanism: manually adding root `rope_theta`/`block_size` fixes it (whipthraxton, confirmed by micahlt), and the values are "present but nested differently in the last DFlash downloads" (zviratko). Diffing the z-lab repo's April revision against the current one shows exactly the two relocations — plus root `rope_scaling` being replaced by `rope_parameters`, which the patch also maps for non-default rope types since the draft model consumes scaling via mlx-lm's `initialize_rope(..., scaling_config=args.rope_scaling)`.

## Verified on the real checkpoint

Downloaded the current `z-lab/Qwen3.6-35B-A3B-DFlash` snapshot and ran the real `load_draft_bundle` path in one fresh process: unpatched → the issue's exact TypeError; patched → full `DFlashDraftModel` construction with `block_size=16`, `mask_token_id=248077`, `target_layer_ids=[1, 6, 11, 16, 22, 27, 32, 37]`, `rope_theta=10000000`. (Reporters already confirmed on the issue that root-level values produce working end-to-end generation — the shim feeds `from_dict` exactly the config the manual workaround does, without editing users' files.)

## Why this is safe

- No bypass path: `mlx_lm.load_model` resolves `from_dict` by attribute lookup at call time and dflash-mlx imports the class (never a bound method), so nothing captures a pre-wrap reference; an adversarial sweep found no other `DFlashDraftModelArgs` construction site in dflash-mlx or omlx, and `DFlashEngine._load_models` — where the installer runs, before `load_draft_bundle` — is the only omlx path that triggers draft-args construction.
- No interference: the `dflash_lifecycle` restore machinery only rewrites `__call__` on classes it recorded, so it can neither revert nor double-wrap `from_dict`; gemma4's `from_dict` special-casing reads only keys the normalizer never touches; the wrap is idempotent (class-attribute guard) and output-identical for every root-keyed config.
- Error containment: mlx-lm's `initialize_rope` ignores unknown extra keys in every supported rope type, and an unrecognized rope_type raises inside `engine.start()` — landing in the same engine-pool fallback catch as today's TypeError, so no new error path escapes to the user.
- Consumer-exact semantics (hardened after adversarial review): the hoist's type-key precedence mirrors `initialize_rope` exactly (`"type"` before `"rope_type"`), and an explicit `null` root key counts as missing (transformers 4.x-derived configs commonly serialize `"rope_scaling": null`), so the hoist decision can never disagree with how mlx-lm reads the result.
- One deliberate behavior change, stated: a hybrid config with hand-added root keys, a non-"default" `rope_parameters` left in place, and no root `rope_scaling` now gains the scaling its config declares, where it previously loaded with unscaled RoPE. For the actual z-lab checkpoints `rope_type` is `"default"`, so users who applied the issue's manual workaround see a no-op; where it does fire it matches training, and draft-side RoPE can only affect acceptance rate, never output correctness (the target verifies every drafted token).

## Sibling sweep

- Model discovery classifies DFlash drafts by the presence of `dflash_config` (`_HELPER_CONFIG_KEYS` in `model_discovery.py`), which the new configs still carry — the draft picker is unaffected and needs no change.
- omlx itself never reads the draft config's root keys (`block_size` / `mask_token_id` / `target_layer_ids` are consumed via `args` inside dflash-mlx), so `from_dict` is the single normalization point. `draft_meta["config"]` keeps the raw nested dict, but omlx discards it and nothing in dflash-mlx reads raw-config `block_size` — worth re-checking on any future dflash-mlx pin bump.
- Out of scope, named: per-layer-type `rope_parameters` dicts (the `{"full_attention": {...}, "sliding_attention": {...}}` shape). A pure per-layer shape has no first-level scalars, so nothing hoists and the load degrades to exactly today's TypeError + fallback. `DFlashDraftModel` has no per-layer rope support at all, so no such draft checkpoint can exist for this model class without a dflash-mlx model change — at which point the constructor contract this shim targets changes anyway.

## Tests

- New `tests/test_dflash_draft_config.py` (13 tests): pure-function coverage (new layout hoists, old layout passes through unchanged, root-wins conflict, yarn `rope_scaling` derivation, `initialize_rope`-mirrored type-key precedence, explicit-null root keys, null nested values not hoisted, non-dict junk ignored, input never mutated) plus real-path tests against the installed `DFlashDraftModelArgs` (new layout constructs with correct values, old layout unchanged including yarn `rope_scaling`, missing-both-layouts still raises TypeError, idempotent install).
- DFlash suites: `pytest tests/test_dflash_draft_config.py tests/test_dflash_engine.py tests/test_dflash_lifecycle.py tests/test_dflash_multimodal_fallback.py tests/test_dflash_prefill_memory_guard.py -q` → **129 passed**. Full CI-equivalent run (`-m "not slow and not integration"`) → **6823 passed**, 2 pre-existing failures that reproduce identically on clean `main` (M5-only NAX numerics, the known #2135 pair; they pass in CI).
- Revert proof in one fresh process: `from_dict` on the real checkpoint's config raises the issue's TypeError before install and constructs correctly after.
