### PR TITLE
fix(tokenizer): select the HF-native backend for mistral-common models

### DIFF
--- a/omlx/utils/tokenizer.py
+++ b/omlx/utils/tokenizer.py
@@ -399,6 +399,24 @@ def _is_laguna_model(model_name: str) -> bool:
     return config is not None and config.get("model_type") == "laguna"
 
 
+def _is_mistral_common_model(model_name: str) -> bool:
+    """True for local model dirs transformers would route to MistralCommonBackend.
+
+    transformers keys that routing on ``tekken.json`` (its
+    ``_has_tekken_tokenizer_file`` check), so mirror the same trigger here.
+    The ``tokenizer.json`` requirement guards the fallback target: audio-only
+    mistral exports (Voxtral) ship ``tekken.json`` without an HF-native
+    ``tokenizer.json``, and for those there is no TokenizersBackend to select.
+    """
+    try:
+        model_path = Path(model_name)
+        return (model_path / "tekken.json").is_file() and (
+            model_path / "tokenizer.json"
+        ).is_file()
+    except OSError:
+        return False
+
+
 def get_tokenizer_config(
     model_name: str,
     trust_remote_code: bool = False,
@@ -437,6 +455,25 @@ def get_tokenizer_config(
         logger.debug(
             "Laguna detected: enabling the Mistral tokenizer regex fix and "
             "the laguna tool parser"
+        )
+
+    if _is_mistral_common_model(model_name):
+        # MistralCommonBackend renders chat templates whose output cannot be
+        # re-encoded faithfully: encoding the rendered string turns control
+        # tokens ([INST], [AVAILABLE_TOOLS], [TOOL_CALLS], ...) into literal
+        # text tokens, corrupting every prompt built through the
+        # render-then-encode pipeline (empty replies / prompt echo / dead tool
+        # calling on Devstral 2 and Mistral Small). Passing fix_mistral_regex
+        # makes AutoTokenizer select the HF-native TokenizersBackend instead —
+        # honoring the backend the repo itself declares — and enables the
+        # Tekken pre-tokenizer regex fix where transformers' own config
+        # detection applies. AutoTokenizer's routing
+        # gate for this kwarg shipped in transformers 5.12.1 (the pyproject
+        # floor); older 5.x swallows it and keeps the broken backend.
+        config.setdefault("fix_mistral_regex", True)
+        logger.debug(
+            "mistral-common model detected: forcing HF-native tokenizer "
+            "backend via fix_mistral_regex"
         )
 
     return config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,11 @@ dependencies = [
     # mlx-vlm custom processors bypass HF AutoProcessor, so torch is not required
     # Keep <5.13 until the broader dependency set gets a dedicated resolver
     # smoke test with transformers 5.13+. The mlx-lm pin above includes the
-    # known NewlineTokenizer registration fix.
-    "transformers>=5.7.0,<5.13",
+    # known NewlineTokenizer registration fix. Floor 5.12.1: AutoTokenizer's
+    # fix_mistral_regex backend gate (used by get_tokenizer_config for
+    # mistral-common models) first shipped in 5.12.1 — on older 5.x the kwarg
+    # is silently swallowed and Tekken prompts stay corrupted.
+    "transformers>=5.12.1,<5.13",
     # transformers 5.x's tokenization_mistral_common module imports
     # ReasoningEffort from mistral_common (added in 1.10). The audio extras
     # transitively pull mistral-common via mlx-audio[stt], which historically
@@ -188,7 +191,7 @@ dev = [
     # in the dev environment so the test actually runs.
     #
     # Held at 0.2.3: xgrammar 0.2.4/0.2.5 cap transformers at <5,
-    # which conflicts with our transformers>=5.7.0 pin and makes
+    # which conflicts with our transformers>=5.12.1 pin and makes
     # pip/uv dev installs unresolvable (#2289). Bump again once
     # upstream lifts the cap.
     "xgrammar==0.2.3",

--- a/tests/test_utils_tokenizer.py
+++ b/tests/test_utils_tokenizer.py
@@ -500,3 +500,58 @@ class TestApplyQwen3Fix:
         assert result["use_fast"] is True
         assert result["padding_side"] == "left"
         assert result["eos_token"] == "<|im_end|>"
+
+
+class TestMistralCommonTokenizerConfig:
+    """get_tokenizer_config forces the HF-native backend for mistral-common repos.
+
+    transformers routes repos that ship tekken.json (Devstral 2 / Mistral
+    Small Tekken exports) to MistralCommonBackend, whose rendered chat
+    template cannot be re-encoded faithfully — control tokens become literal
+    text and every prompt built via render-then-encode is corrupted. Passing
+    fix_mistral_regex selects TokenizersBackend instead (gate shipped in
+    transformers 5.12.1, the pyproject floor).
+    """
+
+    def _make_mistral_repo(self, tmp_path):
+        _write_json(tmp_path / "tekken.json", {"version": "v13"})
+        _write_json(tmp_path / "tokenizer.json", {"version": "1.0"})
+        return tmp_path
+
+    def test_mistral_common_repo_gets_fix_mistral_regex(self, tmp_path):
+        repo = self._make_mistral_repo(tmp_path)
+        config = get_tokenizer_config(str(repo))
+        assert config["fix_mistral_regex"] is True
+
+    def test_symlinked_repo_detected(self, tmp_path):
+        """Served model dirs are frequently symlinks; is_file() must follow."""
+        real = tmp_path / "real"
+        real.mkdir()
+        self._make_mistral_repo(real)
+        link = tmp_path / "link"
+        link.symlink_to(real)
+        config = get_tokenizer_config(str(link))
+        assert config["fix_mistral_regex"] is True
+
+    def test_plain_repo_without_tekken_json_untouched(self, tmp_path):
+        _write_json(tmp_path / "tokenizer.json", {"version": "1.0"})
+        config = get_tokenizer_config(str(tmp_path))
+        assert "fix_mistral_regex" not in config
+
+    def test_audio_only_export_without_tokenizer_json_untouched(self, tmp_path):
+        """Voxtral-shaped exports ship tekken.json with no HF-native
+        tokenizer.json; there is no TokenizersBackend to select — do not
+        inject the kwarg."""
+        _write_json(tmp_path / "tekken.json", {"version": "v13"})
+        config = get_tokenizer_config(str(tmp_path))
+        assert "fix_mistral_regex" not in config
+
+    def test_hf_repo_id_untouched(self):
+        """Remote repo ids are not local paths; detection stays conservative."""
+        config = get_tokenizer_config("mlx-community/Devstral-Small-2-24B-4bit")
+        assert "fix_mistral_regex" not in config
+
+    def test_other_family_fixes_unaffected(self, tmp_path):
+        repo = self._make_mistral_repo(tmp_path)
+        config = get_tokenizer_config(str(repo))
+        assert "eos_token" not in config


### PR DESCRIPTION
Fixes #2291.

## Summary

- Mistral/Devstral tool calling (and prompt fidelity in general) is broken because transformers 5.x routes Tekken/mistral-common repos to `MistralCommonBackend`, whose rendered chat template cannot be re-encoded faithfully — control tokens (`[INST]`, `[AVAILABLE_TOOLS]`, `[TOOL_CALLS]`) reach the model as literal text.
- Fix: when a local model dir ships mistral-common tokenizer files (`tekken.json` + `tokenizer.json`), `get_tokenizer_config()` now injects `fix_mistral_regex=True`, which makes AutoTokenizer select the HF-native `TokenizersBackend` — the class the repo's own `tokenizer_config.json` declares — and enables transformers' Tekken pre-tokenizer regex fix where its config detection applies.
- With a faithful prompt, the existing tool-call marker machinery works end to end: `tool_calls` + `finish_reason: "tool_calls"`, streaming and non-streaming, plus the full tool-result round-trip.

## Why (root cause — the issue's stop-token theory doesn't hold)

The engine renders chat templates to a string and re-encodes (`_apply_chat_template(tokenize=False)` → `tokenizer.encode(...)`). Under `MistralCommonBackend` that round-trip destroys every control token: `[INST]` encodes to 4 text tokens instead of id 3, `[TOOL_CALLS]` to 6 text tokens instead of id 9 (transformers itself warns `apply_chat_template(..., tokenize=False)` is unsafe on this backend). The model therefore sees a text-form document, not its trained chat format. Downstream behavior is quant-dependent, which is what produced the two reported signatures:

- 24B **8-bit** (the issue's exact model): emits `</s>` immediately → empty message, `completion_tokens: 0`, `finish_reason: "stop"` — reproduced byte-for-byte, including the 99 prompt tokens.
- 24B 4-bit: roleplays the text-form conversation → prompt echo / run-on invented `[INST]` turns (also affects tool-less chat, where it just looks like verbosity).

The generated `[TOOL_CALLS]` token is never treated as a stop token — no stop-token source contains id 9 (`_get_stop_tokens()`, per-request state machine, BatchGenerator construction, generation_config; all traced). The 0-token signature is the model's own immediate EOS on a malformed prompt, which is why the issue's priming experiment "worked": appending text-form `[TOOL_CALLS]` extends the text-form document.

## Changes

- `omlx/utils/tokenizer.py`: new `_is_mistral_common_model()` — keyed on `tekken.json` (the same trigger transformers' `_has_tekken_tokenizer_file` uses for backend routing) plus `tokenizer.json` (guards the fallback target: audio-only exports like Voxtral ship `tekken.json` with no HF-native tokenizer, and for those there is nothing to select). `get_tokenizer_config()` injects `fix_mistral_regex=True` (same slot as the existing Qwen3 and LFM2 fixes; all four call sites — batched engine, both draft-model paths, `models/llm.py` — inherit it).
- `pyproject.toml`: transformers floor `5.7.0 → 5.12.1`. AutoTokenizer's `fix_mistral_regex` routing gate first shipped in 5.12.1 (verified absent in the 5.12.0 tag, present in 5.12.1); on older 5.x the kwarg is silently swallowed and the corruption persists, so shipping the fix without the floor would be a silent no-op for pinned-low installs.
- `tests/test_utils_tokenizer.py`: `TestMistralCommonTokenizerConfig` — injection on a tekken+tokenizer dir, symlinked-dir detection (the common serving layout), no injection for tokenizer-only dirs / tekken-only (Voxtral-shaped) dirs / remote repo ids, and no interference with other family fixes.

## Why this is safe

- **Scoped**: the kwarg is injected only for local dirs shipping `tekken.json` + `tokenizer.json` — mirroring transformers' own routing trigger. Every other model resolves an unchanged config (asserted by tests).
- **Honors the repo's own declaration**: these conversions declare the tokenizers backend in their tokenizer_config.json and ship `chat_template.jinja` + `tokenizer.json` precisely for HF-native use; transformers' model-type re-routing is what overrides them. `fix_mistral_regex` is transformers' own gate for selecting the declared backend (`tokenization_auto.py` skips `MistralCommonBackend` whenever the kwarg is present) and `=True` additionally enables their recommended Tekken regex fix where transformers' config detection applies — it does for these exports, which declare `transformers_version: 5.0.0.dev0`, below transformers' 5.0.0 skip cutoff; for conversions stamped with a real 5.x version it is routing-only, which is the actual bug fix.
- **Version boundary handled explicitly**: below 5.12.1 the kwarg does nothing — hence the floor bump rather than a silent partial fix.
- Token-level equivalence verified: HF-native render+encode produces ids identical to `MistralCommonBackend.apply_chat_template(tokenize=True)` (the golden path) for the same messages+tools.

## Sibling paths

- Covered by construction: non-streaming, streaming (SSE `tool_calls` delta verified), `/v1/completions` (raw text now round-trips control tokens), `count_chat_tokens`, and the draft-model tokenizer-config sites.
- Named out of scope:
  - The VLM engine cannot load this family at all on the current pins (`'MistralTokenizer' object has no attribute 'vocab'` from mlx-vlm, before any omlx code runs) — it falls back to the text engine, which this PR fixes. The vision path for Devstral Small 2 is a separate mlx-vlm-side issue. Worth noting for future pin bumps: the family's coverage is partly contingent on that load failure — if a later mlx-vlm makes the VLM engine load `mistral3` composites, its processor-side tokenizer constructions bypass this injection and would need the same treatment.
  - DFlash-served targets load their tokenizer through `dflash_mlx.runtime.loading.load_target_bundle`, which calls mlx-lm `load()` without a `tokenizer_config` — a mistral-common target served with DFlash enabled would still get the broken backend. No DFlash draft exists for a mistral-family model today; the same injection applies at that boundary if one appears.
  - Custom-quantization loads (`maybe_load_custom_quantization`) take their tokenizer from the quantized bundle's processor and never consult `get_tokenizer_config` — a custom-quantized mistral-common model would still hit the broken backend. Same one-line fix applies there if that combination ever materializes; kept out to stay minimal.
  - Models served from a bare HF repo id (not a local dir) aren't detected — omlx serves local model dirs, and remote-id detection would need a Hub call in a hot path.

## Tests

- `python -m pytest tests/test_utils_tokenizer.py -q` → **49 passed** (6 new; count includes upstream's 2 new Laguna S-2.1 tests after rebasing onto v0.5.3).
- Re-verified live after the v0.5.3 rebase (4-bit arm, isolated server on the rebased branch, temp 0): `tool_calls` = `get_weather({"city": "Paris"})`, `finish_reason: "tool_calls"`, prompt_tokens 79; no-tools chat clean (`"Paris"`, `stop`).
- Also verified the new tests fail when the fix is reverted (the injection and symlink-detection cases go red).
- Real-model verification on an isolated server (M5 Max, temp 0, both `mlx-community/mistralai_Devstral-Small-2-24B-Instruct-2512-MLX-8Bit` — the issue's exact model — and `Devstral-Small-2-24B-Instruct-2512-4bit`):

| arm | before | after |
|---|---|---|
| 8-bit + tools (issue's exact request) | empty message, 0 completion tokens, `stop` | `tool_calls` = `get_weather({"city": "Paris"})`, `finish_reason: "tool_calls"` |
| 4-bit + tools | prompt-echo garbage, no tool_calls | `tool_calls`, `finish_reason: "tool_calls"` |
| 8-bit, no tools | answer + run-on invented `[INST]` turns (`length`) | clean 8-token answer (`stop`) |
| 8-bit + tools, `stream: true` | — | proper `tool_calls` delta chunk + `finish_reason: "tool_calls"` |
| multi-turn with tool result | — | correct final answer from the tool output |
| prompt_tokens (tools request) | 99 (control tokens as text) | 79 (control ids) |
