### PR TITLE
fix(memory-guard): drain the pressure reclaim at the step boundary under load (completes #2306 for busy servers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Handles concurrent requests through mlx-lm's BatchGenerator. Max concurrent requ
 
 Context scaling support for running smaller context models with Claude Code. Scales reported token counts so that auto-compact triggers at the right timing, and SSE keep-alive prevents read timeouts during long prefill.
 
+> **Note**: If you see occasional large prefill events mid-session even though your context should be cached, that is Claude Code, not the server. Recent CC versions quietly clear old tool results from the conversation when context usage gets high, which changes earlier tokens and invalidates any server-side prefix cache from that point on. Keeping auto-compact at its default threshold (rather than raising it with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`) reduces how often this happens.
+
 ### Multi-Model Serving
 
 Load LLMs, VLMs, embedding models, and rerankers within the same server. Models are managed through a combination of automatic and manual controls:

--- a/README.md
+++ b/README.md
@@ -189,8 +189,6 @@ Handles concurrent requests through mlx-lm's BatchGenerator. Max concurrent requ
 
 Context scaling support for running smaller context models with Claude Code. Scales reported token counts so that auto-compact triggers at the right timing, and SSE keep-alive prevents read timeouts during long prefill.
 
-> **Note**: If you see occasional large prefill events mid-session even though your context should be cached, that is Claude Code, not the server. Recent CC versions quietly clear old tool results from the conversation when context usage gets high, which changes earlier tokens and invalidates any server-side prefix cache from that point on. Keeping auto-compact at its default threshold (rather than raising it with `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`) reduces how often this happens.
-
 ### Multi-Model Serving
 
 Load LLMs, VLMs, embedding models, and rerankers within the same server. Models are managed through a combination of automatic and manual controls:

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -1015,7 +1015,13 @@ class ProcessMemoryEnforcer:
         already-wedged case where hot cache is empty but pooled buffers are
         stranded).
         """
-        pool_bytes = mx.get_cache_memory()
+        raw_pool = mx.get_cache_memory()
+        try:
+            pool_bytes = int(raw_pool)
+        except (TypeError, ValueError):
+            # A non-numeric reading (e.g. a wholesale-mocked mx in unit
+            # tests) cannot justify a clear; treat it as an empty pool.
+            pool_bytes = 0
         if freed_hot <= 0 and pool_bytes <= self._POOL_RECLAIM_FLOOR:
             return
         requested = 0

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -1433,8 +1433,8 @@ class ProcessMemoryEnforcer:
             # freed bytes never leave the process and phys_footprint does not
             # drop — the enforcer then wrongly concludes "no evictable models"
             # and livelocks until restart. Env gate
-            # OMLX_DISABLE_HOTCACHE_RECLAIM=1 restores stock behavior.
-            if os.environ.get("OMLX_DISABLE_HOTCACHE_RECLAIM") != "1":
+            # OMLX_DISABLE_PRESSURE_RECLAIM=1 restores stock behavior.
+            if os.environ.get("OMLX_DISABLE_PRESSURE_RECLAIM") != "1":
                 self._request_scheduler_cache_reclaim(freed_hot)
             if freed_hot > 0:
                 current = self._current_usage_bytes()

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import os
 import subprocess
 import time
 from contextlib import suppress
@@ -990,6 +991,49 @@ class ProcessMemoryEnforcer:
             )
         return freed_total
 
+    # Pool bytes below which a pressure-triggered clear is not worth the
+    # per-clear IOGPUFamily refcount cost (matches the scheduler's own
+    # _periodic_clear_threshold_bytes floor). Above it, a clear meaningfully
+    # returns memory to the OS.
+    _POOL_RECLAIM_FLOOR = 2 * 1024**3
+
+    def _request_scheduler_cache_reclaim(self, freed_hot: int) -> None:
+        """Ask each scheduler to run its step-boundary Metal cache clear.
+
+        Routes the reclaim through the scheduler's shipped, lock-protected,
+        engine-stream-synchronized ``_sync_and_clear_cache`` path (the same
+        one the periodic clear uses) instead of touching Metal from the
+        enforcer thread — the enforcer must never touch Metal directly.
+        Setting the per-scheduler flag is GIL-atomic; the actual clear fires
+        on the inference thread at the next step boundary, even under load —
+        unlike ``request_idle_reclaim``, which never fires while requests are
+        running and so cannot recover a busy server from hard pressure.
+
+        Fires when a hot-cache shrink just freed references (so the freed
+        buffers, now pooled, can be returned to the OS) OR when the MLX
+        buffer pool alone holds a meaningful amount under pressure (the
+        already-wedged case where hot cache is empty but pooled buffers are
+        stranded).
+        """
+        pool_bytes = mx.get_cache_memory()
+        if freed_hot <= 0 and pool_bytes <= self._POOL_RECLAIM_FLOOR:
+            return
+        requested = 0
+        for entry in self._engine_pool._entries.values():
+            scheduler = self._resolve_scheduler(entry)
+            request = getattr(scheduler, "request_pressure_reclaim", None)
+            if callable(request):
+                request()
+                requested += 1
+        if requested:
+            logger.info(
+                "Requested pressure cache reclaim on %d scheduler(s) "
+                "(freed_hot=%s, pool=%s)",
+                requested,
+                _format_gb(freed_hot),
+                _format_gb(pool_bytes),
+            )
+
     def get_pressure_level(self) -> str:
         """Return cached pressure level: 'ok', 'soft', or 'hard'.
 
@@ -1377,6 +1421,15 @@ class ProcessMemoryEnforcer:
                 current,
                 soft,
             )
+            # Return reclaimable Metal memory to the OS. The shrink above only
+            # drops mx.array references into MLX's buffer-cache pool, which is
+            # pinned by set_cache_limit(total) (the #300 panic guard), so the
+            # freed bytes never leave the process and phys_footprint does not
+            # drop — the enforcer then wrongly concludes "no evictable models"
+            # and livelocks until restart. Env gate
+            # OMLX_DISABLE_HOTCACHE_RECLAIM=1 restores stock behavior.
+            if os.environ.get("OMLX_DISABLE_HOTCACHE_RECLAIM") != "1":
+                self._request_scheduler_cache_reclaim(freed_hot)
             if freed_hot > 0:
                 current = self._current_usage_bytes()
                 emergency = self._is_emergency_pressure(current, ceiling)

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1594,6 +1594,15 @@ class Scheduler:
         # enforcer must never touch Metal directly.
         self._pending_reclaim_request: bool = False
 
+        # Set by ProcessMemoryEnforcer.request_pressure_reclaim() when memory
+        # pressure is hard. Unlike _pending_reclaim_request (idle-gated), this
+        # drains at the next step boundary even under load — the pressure
+        # shrink has already dropped hot-cache refs and _sync_and_clear_cache
+        # synchronizes in-flight work before clearing, so it is safe
+        # mid-decode. GIL-atomic flag; the enforcer never touches Metal
+        # directly.
+        self._pending_pressure_clear: bool = False
+
         # Lock-free admin snapshot. Published at the end of each step() while
         # the engine thread is the sole writer of running/waiting; the admin
         # endpoint reads the dict reference atomically (GIL) and never iterates
@@ -7168,6 +7177,34 @@ class Scheduler:
         """
         self._pending_reclaim_request = True
 
+    def request_pressure_reclaim(self) -> None:
+        """Enqueue a hard-pressure Metal cache clear (thread-safe, no Metal touch).
+
+        Called by ProcessMemoryEnforcer on the asyncio thread when memory
+        pressure is hard. Setting the flag is GIL-atomic; the actual
+        ``_sync_and_clear_cache`` runs on the inference thread at the next
+        step() boundary (see the periodic-cleanup block), which synchronizes
+        in-flight GPU work before clearing — so it is safe even while requests
+        are decoding, unlike the idle-gated ``request_idle_reclaim``.
+        ``has_work`` reports True while this is pending so an otherwise-idle
+        engine keeps stepping until the clear fires.
+        """
+        self._pending_pressure_clear = True
+
+    def _consume_pressure_clear(self) -> bool:
+        """Retire a pending hard-pressure clear (inference-thread side).
+
+        Unlike ``_process_pending_reclaim`` this is deliberately NOT
+        idle-gated: it feeds the step-boundary ``_sync_and_clear_cache``,
+        which synchronizes in-flight work before clearing — the same ordering
+        the shipped periodic clear relies on — so draining while requests are
+        running is safe. One-shot: consuming clears the flag.
+        """
+        if not self._pending_pressure_clear:
+            return False
+        self._pending_pressure_clear = False
+        return True
+
     def _process_pending_reclaim(self) -> None:
         """Drain a deferred idle reclaim request (inference-thread side).
 
@@ -7344,6 +7381,7 @@ class Scheduler:
             or self._pending_async_removes
             or self._deferred_clear_at is not None
             or self._pending_reclaim_request
+            or self._pending_pressure_clear
         )
 
     def _refresh_generation_overflow_recovery_ids(self) -> None:
@@ -9830,6 +9868,14 @@ class Scheduler:
         ):
             should_clear = True
             self._deferred_clear_at = None
+        # Hard-pressure reclaim requested by ProcessMemoryEnforcer. Drains via
+        # the same _sync_and_clear_cache path so freed hot-cache / pooled
+        # buffers are returned to the OS at a synchronized, lock-protected
+        # boundary (safe under load) — the idle-gated reclaim above never
+        # fires while requests are running, which leaves the freed bytes
+        # pooled and the enforcer wedged at hard pressure.
+        if self._consume_pressure_clear():
+            should_clear = True
         if should_clear:
             _sync_and_clear_cache(self._stream)
         if (

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -2691,3 +2691,12 @@ class TestPressureCacheReclaim:
         with patch.object(pme.mx, "get_cache_memory", return_value=3 * 1024**3):
             enforcer._request_scheduler_cache_reclaim(0)
         schedulers[0].request_pressure_reclaim.assert_called_once()
+
+    def test_tolerates_non_numeric_pool_reading(self):
+        """A wholesale-mocked mx (as the wider suite uses) must not break
+        enforcement — a non-numeric cache reading is treated as empty."""
+        schedulers = [MagicMock()]
+        enforcer = self._enforcer(schedulers)
+        with patch.object(pme.mx, "get_cache_memory", return_value=object()):
+            enforcer._request_scheduler_cache_reclaim(0)
+        schedulers[0].request_pressure_reclaim.assert_not_called()

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -2656,3 +2656,38 @@ class TestWiredLimitSuggestionClamp:
         ):
             pme._apply_metal_wired_limit(400 * 1024**3)
         assert [r for r in caplog.records if "jetsam" in r.message]
+
+
+class TestPressureCacheReclaim:
+    """_request_scheduler_cache_reclaim — the under-load drain trigger."""
+
+    def _enforcer(self, schedulers):
+        pool = MagicMock()
+        pool._entries = {
+            f"model-{i}": SimpleNamespace(engine=SimpleNamespace(scheduler=s))
+            for i, s in enumerate(schedulers)
+        }
+        return _make_enforcer(engine_pool=pool)
+
+    def test_fires_when_shrink_freed_refs(self):
+        schedulers = [MagicMock(), MagicMock()]
+        enforcer = self._enforcer(schedulers)
+        with patch.object(pme.mx, "get_cache_memory", return_value=0):
+            enforcer._request_scheduler_cache_reclaim(1 * 1024**3)
+        for s in schedulers:
+            s.request_pressure_reclaim.assert_called_once()
+
+    def test_skips_when_nothing_reclaimable(self):
+        schedulers = [MagicMock()]
+        enforcer = self._enforcer(schedulers)
+        with patch.object(pme.mx, "get_cache_memory", return_value=1 * 1024**3):
+            enforcer._request_scheduler_cache_reclaim(0)
+        schedulers[0].request_pressure_reclaim.assert_not_called()
+
+    def test_fires_on_stranded_pool_without_hot_cache(self):
+        """The already-wedged case: hot cache empty, bytes parked in the pool."""
+        schedulers = [MagicMock()]
+        enforcer = self._enforcer(schedulers)
+        with patch.object(pme.mx, "get_cache_memory", return_value=3 * 1024**3):
+            enforcer._request_scheduler_cache_reclaim(0)
+        schedulers[0].request_pressure_reclaim.assert_called_once()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1365,6 +1365,39 @@ class TestSchedulerQueryMethods:
 
         assert scheduler.has_requests() is True
 
+    def test_has_requests_with_pending_pressure_clear(self, mock_model, mock_tokenizer):
+        """A pending hard-pressure clear counts as work for the engine loop."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        assert scheduler.has_requests() is False
+
+        scheduler.request_pressure_reclaim()
+
+        assert scheduler.has_requests() is True
+
+    def test_pressure_clear_drains_under_load(self, mock_model, mock_tokenizer):
+        """The pressure clear is consumed even while the scheduler is busy.
+
+        This is the under-load complement of the idle-gated reclaim: a busy
+        server never reaches the idle drain, so this flag must be consumed
+        regardless of queue state. It feeds the step-boundary
+        _sync_and_clear_cache, which synchronizes in-flight work before
+        clearing (the same ordering the periodic clear relies on).
+        """
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        request = Request(
+            request_id="busy-req",
+            prompt="Hello",
+            sampling_params=SamplingParams(),
+        )
+        scheduler.running[request.request_id] = request
+
+        scheduler.request_pressure_reclaim()
+
+        assert scheduler._consume_pressure_clear() is True
+        assert scheduler._pending_pressure_clear is False
+        # One-shot: no re-fire without a new enforcer request.
+        assert scheduler._consume_pressure_clear() is False
+
     def _install_reclaim_probe(self, scheduler):
         """Stub the Metal-touching reclaim internals; return the call log."""
         calls = []


### PR DESCRIPTION
## Summary
- On a busy server with pinned/in-use models, hard memory pressure livelocks:
  ```
  Hard memory pressure, no evictable models and no loads in progress: requested idle reclaim on N scheduler(s).
  ```
  once per second until restart, with generation collapsed — the sustained-load wedge reported in #2059.
- #2306 fixed the idle case — the pending reclaim survives until the engine goes idle. But `_process_pending_reclaim` still early-returns while `running / prefilling / waiting` is non-empty, so a server under continuous load never drains it. This adds the under-load half.

## Why phys never recovers
`_shrink_hot_cache_for_pressure` frees hot-cache `mx.array` refs into MLX's buffer pool, which `set_cache_limit(total)` (the #300 guard) pins. The bytes never leave the process, `phys_footprint` doesn't drop, and the enforcer sees "no evictable models" every tick while the reclaimable memory sits in the pool.

## Change
- `scheduler.py`: `request_pressure_reclaim()` — GIL-atomic flag (same idiom as `request_idle_reclaim`), drained in `step()`'s existing periodic-cleanup block via `_sync_and_clear_cache(self._stream)`. `has_work()` stays True while pending so an idle engine still drains it.
- `process_memory_enforcer.py`: at hard pressure, after the shrink, set that flag on each scheduler — when the shrink freed refs, or when the pool alone holds >2 GiB (the already-wedged case). `OMLX_DISABLE_HOTCACHE_RECLAIM=1` restores stock behavior.

**#300 safety:** no new Metal call site. The drain is the same lock-protected, engine-stream-synchronized `_sync_and_clear_cache` the periodic clear already runs every `mlx_cache_cleanup_interval` steps under load — this change just also triggers it at hard pressure. Live KV is untouched (`clear_cache` frees only unreferenced buffers).

## Validation

| Scenario | Stock | Patched |
|---|---|---|
| Pinned 27B, forced 55 GB ceiling, sustained prefills (M3, 256 GB) | spin ×5, never recovers | reclaim fires → `hard -> ok` next tick; 0 spins, 0 forced evictions |
| 3 pinned models, ~3 h agentic soak (M3) | wedged at 199.9 GB until restart | 32 hard-pressure episodes, 32 reclaims, 0 wedges; 213.6 → 113.7 GB in ~1 s |
| Pinned 7B, forced 14 GB ceiling (M4 Max, 48 GB) | 1 hard breach; drained via #2306's idle path when a gap appeared (workload too light to wedge) | 9 pressure reclaims fired under load; **0 panics / SIGABRT**; peak 15.5 → idle 7.1 GB |

The M4 run is the #300 safety check: the step-boundary clear fired repeatedly under load on M4 hardware with no kernel panic. (The livelock repro itself is the M3 rows — a 7B on 48 GB with working SSD eviction self-regulates too well to wedge.)

Unit tests mirror #2306's pattern (pressure flag counts as engine work; consumed at the step boundary even while busy, one-shot; enforcer trigger fires on freed refs or a stranded pool, skips when nothing is reclaimable, and tolerates a mocked `mx`). Full `test_scheduler.py` + `test_process_memory_enforcer.py`: **334 passed** (macOS, M4 Max, py3.13).

Related: #2059, #2179 / #2306, #300.

The scripted repro (pinned-model hard-pressure A/B + the M4 runner) lives on the companion branch [`fix/pressure-reclaim-under-load`](https://github.com/cebertowicz/omlx/tree/fix/pressure-reclaim-under-load/pressure-test) — happy to contribute it under `tests/` in whatever shape you prefer.
