### PR TITLE
feat(specprefill): memoize importance-score selection by prompt hash (#1079)

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1666,6 +1666,12 @@ class Scheduler:
 
         # SpecPrefill: draft model for attention-based sparse prefill
         self._specprefill_draft_model: Any | None = None
+        self._specprefill_draft_model_name: str | None = None
+        from .specprefill.selection_cache import SpecPrefillSelectionCache
+
+        # #1079: memoize the score->select result so identical prompts (agent
+        # retry loops, shared prefixes) skip the ~seconds-long re-scoring.
+        self._specprefill_selection_cache = SpecPrefillSelectionCache()
         self._draft_paged_ssd_cache_manager: Any | None = None
         # Track active specprefill request for RoPE cleanup
         self._specprefill_active_request_id: str | None = None
@@ -6468,6 +6474,9 @@ class Scheduler:
                 "Could not close the previous SpecPrefill draft SSD cache manager"
             )
         self._specprefill_draft_model = draft_model
+        self._specprefill_draft_model_name = draft_model_name
+        # Selections are specific to this draft model; drop any from a prior one.
+        self._specprefill_selection_cache.clear()
         self._draft_prefix_cache: Any | None = None
         if not draft_model_name:
             logger.info(
@@ -6908,19 +6917,45 @@ class Scheduler:
             return
 
         from .specprefill.draft import run_specprefill_draft_scoring
+        from .specprefill.selection_cache import build_selection_key, memoize_scoring
 
-        run_specprefill_draft_scoring(
+        def _run_scoring() -> None:
+            run_specprefill_draft_scoring(
+                request=request,
+                plan=plan,
+                draft_model=self._specprefill_draft_model,
+                draft_prefix_cache=self._draft_prefix_cache,
+                model_id=self.config.model_name,
+                prefill_step_size=self.config.prefill_step_size,
+                stream=self._stream,
+                extract_cache_states=self._extract_cache_states,
+                sync_and_clear_cache=lambda: _sync_and_clear_cache(self._stream),
+                log=logger,
+            )
+
+        # #1079: an identical prompt (same draft model + scoring params) yields
+        # the same selection, so reuse it instead of re-running the ~seconds-long
+        # lookahead + importance + chunk-select pipeline. The draft KV cache
+        # (fed as existing_cache above) only skips the draft *prefill*; the
+        # scoring on top of it still runs -- that is what this short-circuits.
+        selection_key = build_selection_key(
+            draft_model_id=self._specprefill_draft_model_name or "unnamed-draft",
+            tokens_to_score=plan.tokens_to_score,
+            keep_pct=plan.keep_pct,
+        )
+        reused = memoize_scoring(
+            cache=self._specprefill_selection_cache,
+            key=selection_key,
             request=request,
             plan=plan,
-            draft_model=self._specprefill_draft_model,
-            draft_prefix_cache=self._draft_prefix_cache,
-            model_id=self.config.model_name,
-            prefill_step_size=self.config.prefill_step_size,
-            stream=self._stream,
-            extract_cache_states=self._extract_cache_states,
-            sync_and_clear_cache=lambda: _sync_and_clear_cache(self._stream),
-            log=logger,
+            run_scoring=_run_scoring,
         )
+        if reused:
+            logger.info(
+                "SpecPrefill: selection cache hit, reused "
+                f"{request.specprefill_indices.shape[0]}/{plan.n_to_score} "
+                "tokens (skipped re-scoring)"
+            )
 
     def _cleanup_specprefill(self, request_id: str) -> None:
         """Clean up SpecPrefill RoPE patches when a request finishes."""
@@ -9984,6 +10019,7 @@ class Scheduler:
         self.paged_cache_manager = None
         self._draft_prefix_cache = None
         self._specprefill_draft_model = None
+        self._specprefill_selection_cache.clear()
         self.block_aware_cache = None
         self.memory_monitor = None
         self._boundary_snapshot_store = None
@@ -10054,6 +10090,7 @@ class Scheduler:
         self._close_specprefill_draft_cache_manager()
         self._draft_prefix_cache = None
         self._specprefill_draft_model = None
+        self._specprefill_selection_cache.clear()
         if self.paged_ssd_cache_manager is not None:
             self.paged_ssd_cache_manager.close()
             self.paged_ssd_cache_manager = None

--- a/omlx/specprefill/selection_cache.py
+++ b/omlx/specprefill/selection_cache.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Memoization of SpecPrefill importance-scoring selections (#1079).
+
+SpecPrefill's ``score -> select`` pipeline is a pure function of
+``(tokens_to_score, draft model, keep_pct, chunk_size, n_lookahead, pool_kernel)``.
+omlx already caches the *draft model's KV* across requests (``_draft_prefix_cache``),
+but re-runs the whole lookahead + importance + chunk-select pipeline for every
+request even when the prompt is byte-identical to a recent one -- wasting seconds
+per request in agent retry loops that resend the same prompt.
+
+This module caches the *output* of that pipeline (the selected token indices),
+keyed on the deterministic inputs, so an identical prompt reuses the prior
+selection instead of re-scoring. It is orthogonal to the draft KV cache: one
+caches scoring's *input*, the other caches scoring's *result*. The draft KV cache
+cannot subsume it -- the selection is what the scoring produces, so nothing keyed
+on the selection can be looked up without first re-deriving it; only a cache keyed
+on the raw prompt (available before scoring) can short-circuit the scoring itself.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from collections import OrderedDict
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+
+from .policy import SpecPrefillScoringPlan
+
+# Mirror the scoring constants baked into the current draft workflow so a future
+# change to any of them cannot silently reuse a stale selection. See
+# ``score_tokens`` (n_lookahead=8, pool_kernel=13) and ``select_chunks``
+# (chunk_size=32) in ``omlx.patches.specprefill``.
+SCORING_CHUNK_SIZE = 32
+SCORING_N_LOOKAHEAD = 8
+SCORING_POOL_KERNEL = 13
+
+# One selection is a few hundred KB at most; 64 distinct prompts is generous for
+# the agent-retry / shared-prefix workloads this targets.
+DEFAULT_MAX_ENTRIES = 64
+
+SelectionKey = tuple
+
+
+def _hash_tokens(tokens: Sequence[int]) -> str:
+    """Stable content hash of a token-id sequence (list / ndarray / mx.array)."""
+    try:
+        arr = np.asarray(tokens, dtype=np.int64)
+    except Exception:
+        arr = np.asarray(list(tokens), dtype=np.int64)
+    return hashlib.sha256(np.ascontiguousarray(arr).tobytes()).hexdigest()
+
+
+def _indices_to_list(indices: Any) -> list[int]:
+    """Convert an mx.array (or any array-like) of indices to a plain int list."""
+    tolist = getattr(indices, "tolist", None)
+    if callable(tolist):
+        return [int(i) for i in tolist()]
+    return [int(i) for i in np.asarray(indices).reshape(-1).tolist()]
+
+
+def build_selection_key(
+    *,
+    draft_model_id: str,
+    tokens_to_score: Sequence[int],
+    keep_pct: float,
+    chunk_size: int = SCORING_CHUNK_SIZE,
+    n_lookahead: int = SCORING_N_LOOKAHEAD,
+    pool_kernel: int = SCORING_POOL_KERNEL,
+    scorer: str = "draft",
+) -> SelectionKey:
+    """Build a cache key over the deterministic inputs of the selection.
+
+    ``tokens_to_score`` is the system-prefix-stripped suffix that scoring
+    actually runs on (see ``plan_specprefill_scoring``); the selection indices
+    are relative to it, so it -- not the raw prompt -- is what we key on.
+    ``scorer`` reserves room for the #1078 self-layer scorer to coexist under the
+    same memoization.
+    """
+    return (
+        draft_model_id,
+        scorer,
+        _hash_tokens(tokens_to_score),
+        round(float(keep_pct), 6),
+        int(chunk_size),
+        int(n_lookahead),
+        int(pool_kernel),
+    )
+
+
+class SpecPrefillSelectionCache:
+    """Bounded, thread-safe LRU mapping a selection key to selected indices.
+
+    Values are plain python int lists (never ``mx.array``) so cached entries do
+    not pin Metal buffers or capture lazy graphs.
+    """
+
+    def __init__(self, max_entries: int = DEFAULT_MAX_ENTRIES) -> None:
+        self._max_entries = max(1, int(max_entries))
+        self._store: OrderedDict[SelectionKey, list[int]] = OrderedDict()
+        self._lock = threading.Lock()
+        self.hits = 0
+        self.misses = 0
+
+    def get(self, key: SelectionKey) -> list[int] | None:
+        with self._lock:
+            value = self._store.get(key)
+            if value is None:
+                self.misses += 1
+                return None
+            self._store.move_to_end(key)
+            self.hits += 1
+            return list(value)
+
+    def put(self, key: SelectionKey, indices: Sequence[int]) -> None:
+        with self._lock:
+            self._store[key] = [int(i) for i in indices]
+            self._store.move_to_end(key)
+            while len(self._store) > self._max_entries:
+                self._store.popitem(last=False)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._store)
+
+
+def apply_cached_selection(
+    request: Any, plan: SpecPrefillScoringPlan, selected: Sequence[int]
+) -> None:
+    """Populate ``request`` from a cached selection, mirroring draft scoring.
+
+    Only the selection itself is reused; the per-request position bookkeeping is
+    recomputed from *this* request's ``cached_tokens`` because prefix-cache
+    warmth can differ run to run. Mirrors ``run_specprefill_draft_scoring``.
+    """
+    request.specprefill_indices = mx.array(list(selected), dtype=mx.int32)
+    request.specprefill_total_tokens = plan.n_to_score
+    request.specprefill_position_offset = request.cached_tokens + plan.effective_system
+    # Scheduler-owned dynamic field.
+    request._specprefill_system_tokens = plan.effective_system
+
+
+def memoize_scoring(
+    *,
+    cache: SpecPrefillSelectionCache | None,
+    key: SelectionKey,
+    request: Any,
+    plan: SpecPrefillScoringPlan,
+    run_scoring: Callable[[], None],
+) -> bool:
+    """Reuse a cached selection, or run scoring and cache its result.
+
+    Returns ``True`` on a cache hit (scoring skipped), ``False`` on a miss.
+    On a miss, ``run_scoring`` is expected to set ``request.specprefill_indices``
+    (draft scoring sets it to ``None`` on failure -- which is deliberately not
+    cached, so a transient failure never poisons future requests).
+    """
+    if cache is not None:
+        cached = cache.get(key)
+        if cached is not None:
+            apply_cached_selection(request, plan, cached)
+            return True
+
+    run_scoring()
+
+    if cache is not None:
+        selected = getattr(request, "specprefill_indices", None)
+        if selected is not None:
+            cache.put(key, _indices_to_list(selected))
+    return False

--- a/tests/test_specprefill_selection_cache.py
+++ b/tests/test_specprefill_selection_cache.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SpecPrefill selection memoization (#1079).
+
+The core guarantee: a byte-identical prompt (same draft model + scoring params)
+runs the score->select pipeline exactly once and reuses the selection thereafter,
+while still recomputing the per-request position bookkeeping.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from omlx.specprefill.policy import SpecPrefillScoringPlan
+from omlx.specprefill.selection_cache import (
+    SpecPrefillSelectionCache,
+    apply_cached_selection,
+    build_selection_key,
+    memoize_scoring,
+)
+
+
+def _plan(tokens, keep_pct=0.5, effective_system=0):
+    return SpecPrefillScoringPlan(
+        tokens_to_score=list(tokens),
+        effective_system=effective_system,
+        keep_pct=keep_pct,
+        n_to_score=len(tokens),
+    )
+
+
+def _request(cached_tokens=0):
+    return SimpleNamespace(
+        specprefill_indices=None,
+        specprefill_total_tokens=None,
+        specprefill_position_offset=None,
+        _specprefill_system_tokens=None,
+        cached_tokens=cached_tokens,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# LRU cache
+# --------------------------------------------------------------------------- #
+def test_lru_evicts_least_recently_used_beyond_capacity():
+    cache = SpecPrefillSelectionCache(max_entries=2)
+    cache.put(("a",), [1])
+    cache.put(("b",), [2])
+    cache.put(("c",), [3])  # evicts oldest "a"
+    assert cache.get(("a",)) is None
+    assert cache.get(("b",)) == [2]
+    assert cache.get(("c",)) == [3]
+    assert len(cache) == 2
+
+
+def test_get_refreshes_recency_so_touched_entry_survives():
+    cache = SpecPrefillSelectionCache(max_entries=2)
+    cache.put(("a",), [1])
+    cache.put(("b",), [2])
+    assert cache.get(("a",)) == [1]  # "a" is now most-recently used
+    cache.put(("c",), [3])  # should evict "b", not "a"
+    assert cache.get(("a",)) == [1]
+    assert cache.get(("b",)) is None
+
+
+def test_cached_values_are_copies_not_caller_aliases():
+    cache = SpecPrefillSelectionCache()
+    original = [1, 2, 3]
+    cache.put(("k",), original)
+    original.append(999)  # mutate after put
+    got = cache.get(("k",))
+    assert got == [1, 2, 3]
+    got.append(0)  # mutate after get
+    assert cache.get(("k",)) == [1, 2, 3]
+
+
+def test_hit_and_miss_counters():
+    cache = SpecPrefillSelectionCache()
+    cache.get(("missing",))
+    cache.put(("k",), [1])
+    cache.get(("k",))
+    assert cache.misses == 1
+    assert cache.hits == 1
+
+
+# --------------------------------------------------------------------------- #
+# Cache key
+# --------------------------------------------------------------------------- #
+def test_key_is_stable_for_identical_inputs():
+    a = build_selection_key(draft_model_id="d", tokens_to_score=[1, 2, 3, 4], keep_pct=0.5)
+    b = build_selection_key(draft_model_id="d", tokens_to_score=[1, 2, 3, 4], keep_pct=0.5)
+    assert a == b
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"tokens_to_score": [1, 2, 3, 5]},  # one token differs
+        {"keep_pct": 0.3},
+        {"draft_model_id": "other-draft"},
+        {"chunk_size": 16},
+        {"n_lookahead": 4},
+        {"pool_kernel": 0},
+        {"scorer": "self_layers"},
+    ],
+)
+def test_key_changes_when_any_deterministic_input_changes(mutation):
+    base = {"draft_model_id": "d", "tokens_to_score": [1, 2, 3, 4], "keep_pct": 0.5}
+    assert build_selection_key(**base) != build_selection_key(**{**base, **mutation})
+
+
+def test_key_handles_non_list_token_sequences():
+    # tokens_to_score may arrive as a list or an mx.array slice.
+    as_list = build_selection_key(draft_model_id="d", tokens_to_score=[7, 8, 9], keep_pct=0.5)
+    as_array = build_selection_key(
+        draft_model_id="d", tokens_to_score=mx.array([7, 8, 9]), keep_pct=0.5
+    )
+    assert as_list == as_array
+
+
+# --------------------------------------------------------------------------- #
+# apply_cached_selection
+# --------------------------------------------------------------------------- #
+def test_apply_reuses_selection_and_recomputes_position_bookkeeping():
+    plan = _plan(range(6), keep_pct=0.5, effective_system=2)
+    req = _request(cached_tokens=7)
+    apply_cached_selection(req, plan, [0, 1, 4, 5])
+    assert req.specprefill_indices.tolist() == [0, 1, 4, 5]
+    assert req.specprefill_indices.dtype == mx.int32
+    assert req.specprefill_total_tokens == 6
+    # position_offset must be recomputed from THIS request's cached_tokens.
+    assert req.specprefill_position_offset == 7 + 2
+    assert req._specprefill_system_tokens == 2
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end memoization (the fix)
+# --------------------------------------------------------------------------- #
+def test_identical_prompt_scores_once_and_reuses_selection():
+    cache = SpecPrefillSelectionCache()
+    tokens = list(range(9000))  # realistically long scoring target
+    plan = _plan(tokens, keep_pct=0.5)
+    key = build_selection_key(draft_model_id="d", tokens_to_score=tokens, keep_pct=0.5)
+
+    scoring_calls = {"n": 0}
+
+    def scoring_for(req):
+        def _run():
+            scoring_calls["n"] += 1
+            # Emulate run_specprefill_draft_scoring's effect on the request.
+            req.specprefill_indices = mx.array([0, 1, 2, 3, 4], dtype=mx.int32)
+            req.specprefill_total_tokens = plan.n_to_score
+
+        return _run
+
+    r1 = _request(cached_tokens=0)
+    hit1 = memoize_scoring(cache=cache, key=key, request=r1, plan=plan, run_scoring=scoring_for(r1))
+
+    # Same prompt again, but a different prefix-cache warmth (cached_tokens).
+    r2 = _request(cached_tokens=100)
+    hit2 = memoize_scoring(cache=cache, key=key, request=r2, plan=plan, run_scoring=scoring_for(r2))
+
+    assert scoring_calls["n"] == 1  # <-- the whole point: scored once, not twice
+    assert hit1 is False
+    assert hit2 is True
+    assert r2.specprefill_indices.tolist() == [0, 1, 2, 3, 4]  # selection reused
+    assert r2.specprefill_total_tokens == plan.n_to_score
+    # Recomputed for THIS request even on a cache hit.
+    assert r2.specprefill_position_offset == 100
+
+
+def test_different_prompts_each_score():
+    cache = SpecPrefillSelectionCache()
+    calls = {"n": 0}
+
+    def run_for(req, idx):
+        def _run():
+            calls["n"] += 1
+            req.specprefill_indices = mx.array([idx], dtype=mx.int32)
+
+        return _run
+
+    for i in range(3):
+        plan = _plan(range(9000 + i))  # each prompt differs
+        key = build_selection_key(
+            draft_model_id="d", tokens_to_score=plan.tokens_to_score, keep_pct=plan.keep_pct
+        )
+        req = _request()
+        memoize_scoring(cache=cache, key=key, request=req, plan=plan, run_scoring=run_for(req, i))
+
+    assert calls["n"] == 3  # no false sharing across distinct prompts
+
+
+def test_failed_scoring_is_not_cached():
+    cache = SpecPrefillSelectionCache()
+    plan = _plan(range(100))
+    key = build_selection_key(
+        draft_model_id="d", tokens_to_score=plan.tokens_to_score, keep_pct=plan.keep_pct
+    )
+    req = _request()
+
+    def failing_scoring():
+        # run_specprefill_draft_scoring sets indices to None on failure.
+        req.specprefill_indices = None
+
+    hit = memoize_scoring(cache=cache, key=key, request=req, plan=plan, run_scoring=failing_scoring)
+    assert hit is False
+    assert len(cache) == 0  # a transient failure must not poison future requests
+
+
+def test_none_cache_falls_back_to_plain_scoring():
+    # Defensive: memoize_scoring with cache=None just runs scoring.
+    plan = _plan(range(50))
+    key = build_selection_key(
+        draft_model_id="d", tokens_to_score=plan.tokens_to_score, keep_pct=plan.keep_pct
+    )
+    req = _request()
+    ran = {"n": 0}
+
+    def _run():
+        ran["n"] += 1
+        req.specprefill_indices = mx.array([0], dtype=mx.int32)
+
+    hit = memoize_scoring(cache=None, key=key, request=req, plan=plan, run_scoring=_run)
+    assert hit is False
+    assert ran["n"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# Scheduler integration: the real _try_specprefill_scoring memoizes end-to-end
+# --------------------------------------------------------------------------- #
+def test_scheduler_try_specprefill_scoring_scores_identical_prompt_once(monkeypatch):
+    """Drive the real Scheduler method twice with a byte-identical prompt.
+
+    Proves the wiring (admission plan -> key -> memoize -> reuse) short-circuits
+    the draft scoring on the second, identical request.
+    """
+    import omlx.specprefill.draft as draft_mod
+    from omlx.scheduler import Scheduler
+
+    calls = {"n": 0}
+
+    def fake_scoring(*, request, plan, **_):
+        calls["n"] += 1
+        request.specprefill_indices = mx.array([0, 1, 2, 3], dtype=mx.int32)
+        request.specprefill_total_tokens = plan.n_to_score
+
+    monkeypatch.setattr(draft_mod, "run_specprefill_draft_scoring", fake_scoring)
+
+    sched = SimpleNamespace(
+        _specprefill_draft_model=object(),  # non-None => SpecPrefill applies
+        _specprefill_draft_model_name="draft-model-x",
+        _specprefill_selection_cache=SpecPrefillSelectionCache(),
+        _draft_prefix_cache=None,
+        config=SimpleNamespace(model_name="target-model", prefill_step_size=2048),
+        _stream=None,
+        _extract_cache_states=lambda used: ([], None),
+    )
+
+    def make_request(cached_tokens):
+        return SimpleNamespace(
+            _specprefill_enabled=True,
+            vlm_inputs_embeds=None,
+            remaining_tokens=list(range(9000)),  # > DEFAULT_THRESHOLD (8192)
+            prompt_token_ids=None,
+            specprefill_system_end=0,
+            cached_tokens=cached_tokens,
+            _specprefill_threshold=None,
+            _specprefill_keep_pct=0.5,
+            specprefill_indices=None,
+            specprefill_total_tokens=None,
+            specprefill_position_offset=None,
+            _specprefill_system_tokens=None,
+        )
+
+    r1 = make_request(cached_tokens=0)
+    Scheduler._try_specprefill_scoring(sched, r1)
+
+    r2 = make_request(cached_tokens=42)  # same prompt, different prefix-cache warmth
+    Scheduler._try_specprefill_scoring(sched, r2)
+
+    assert calls["n"] == 1  # <-- scored once across two identical requests
+    assert r1.specprefill_indices.tolist() == [0, 1, 2, 3]
+    assert r2.specprefill_indices.tolist() == [0, 1, 2, 3]  # reused, not re-scored
+    assert r2.specprefill_position_offset == 42  # recomputed for THIS request


### PR DESCRIPTION
## Summary

Closes #1079.

- Memoize the SpecPrefill `score → select` result (the selected token indices) so a byte-identical prompt reuses the prior selection instead of re-running the scoring pipeline.
- Keyed on the deterministic scoring inputs: a content hash of `tokens_to_score`, the draft model, `keep_pct`, and the chunk/lookahead/pool sizes.
- New module `omlx/specprefill/selection_cache.py`, wired into `scheduler._try_specprefill_scoring`. `draft.py` is untouched.

## Motivation

SpecPrefill's `score → select` pipeline is a pure function of `(tokens_to_score, draft model, keep_pct, chunk_size, n_lookahead, pool_kernel)`, but it is re-run for every request even when the prompt is byte-identical to a recent one. The draft KV cache (`_draft_prefix_cache`) only skips the draft **prefill**; the lookahead + importance + chunk-select scoring on top of it still runs every time.

In agent retry loops (a client resending the same prompt after a bad generation), this repeats the full multi-second scoring for an identical prompt:

```
22:40:38  SpecPrefill: scored 23444 tokens in 4.1s, selected 11744/23444 (draft cache hit 22528)
22:40:59  SpecPrefill: scored 23444 tokens in 4.1s, selected 11744/23444   <- same prompt, re-scored
22:41:12  SpecPrefill: scored 23444 tokens in 4.1s, selected 11744/23444   <- again
```

The `draft cache hit` shows the draft KV is already reused; it is the scoring *on top of it* that is redundant.

## Approach

Cache the **output** of scoring (the selected indices), not its input. This is orthogonal to the draft KV cache — one caches scoring's input, the other its result — and it is the only layer that can short-circuit the scoring: the KV caches are keyed (directly or indirectly) on the selection, which is what scoring *produces*, so nothing keyed on it can be looked up without first re-deriving it. The selection cache keys on the raw prompt, which is available *before* scoring.

- The **key** is built from `tokens_to_score` — the system-prefix-stripped suffix scoring actually runs on (`plan_specprefill_scoring`), since the selected indices are relative to it — plus the draft model, `keep_pct`, and the scoring constants (`chunk_size=32`, `n_lookahead=8`, `pool_kernel=13`). A `scorer` field reserves room for a future self-layer scorer (#1078) to share the same memoization.
- **On a hit**, only the selection is reused; the per-request position bookkeeping (`specprefill_position_offset`, `_specprefill_system_tokens`) is recomputed from *this* request's `cached_tokens`, since prefix-cache warmth can differ run to run.
- **Values** are stored as plain `int` lists (never `mx.array`), so entries don't pin Metal buffers or capture lazy graphs.
- A **failed scoring** (`specprefill_indices is None`) is not cached, so a transient failure cannot poison future requests.
- The cache is bounded (LRU, 64 entries) and cleared on draft-model swap (`set_specprefill_draft_model`) and on teardown.
- As a side effect, freezing the selection also stabilizes it: the current path samples lookahead tokens unseeded (`temp=0.6, top_p=0.95`), so the specific indices can otherwise drift run to run for the same prompt.

## Tests

New `tests/test_specprefill_selection_cache.py` (19 tests): LRU eviction/recency, key determinism and sensitivity to every scoring input, per-request recompute on a hit, failed-scoring-not-cached, and a scheduler-integration test that drives the real `_try_specprefill_scoring` twice with an identical prompt and asserts the draft scoring runs **exactly once**.

```
uv run pytest tests/test_specprefill*.py tests/test_scheduler.py \
  tests/test_engine_core.py tests/test_engine_preflight.py tests/test_per_engine_threads.py
=> 382 passed
```
