### PR TITLE
feat(omlx-mac): add sub-key generation controls

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/SecurityScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/SecurityScreen.swift
@@ -275,11 +275,30 @@ private struct SubKeysSection: View {
                 Row(label: String(localized: "security.sub_keys.key_label",
                                   defaultValue: "Key",
                                   comment: "Row label for sub-key value input")) {
-                    TextInput(text: $newKey,
-                              placeholder: String(localized: "security.sub_keys.key_placeholder",
-                                                  defaultValue: "sk-omlx-sub-…",
-                                                  comment: "Placeholder text inside the sub-key value input"),
-                              mono: true, width: 220)
+                    HStack(spacing: 6) {
+                        TextInput(text: $newKey,
+                                  placeholder: String(localized: "security.sub_keys.key_placeholder",
+                                                      defaultValue: "sk-omlx-sub-…",
+                                                      comment: "Placeholder text inside the sub-key value input"),
+                                  mono: true, width: 220)
+                        Button {
+                            newKey = APIKeyGenerator.random()
+                        } label: {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                                .font(.system(size: 12, weight: .medium))
+                        }
+                        .buttonStyle(.omlx(.plain, size: .small))
+                        .help(String(localized: "security.api_key.generate",
+                                     defaultValue: "Generate a random key",
+                                     comment: "Tooltip on the API key regenerate button"))
+                        CopyIconButton(
+                            value: newKey,
+                            helpText: String(localized: "security.api_key.copy",
+                                             defaultValue: "Copy to clipboard",
+                                             comment: "Tooltip on the API key copy button")
+                        )
+                        .disabled(newKey.isEmpty)
+                    }
                 }
                 FreeRow {
                     HStack(spacing: 6) {

--- a/apps/omlx-mac/Sources/Theme/Components/CodeChip.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/CodeChip.swift
@@ -47,15 +47,12 @@ struct CodeChip: View {
 
 struct CopyIconButton: View {
     let value: String
+    var helpText = String(localized: "common.copy_model_id",
+                          defaultValue: "Copy model ID",
+                          comment: "Tooltip and accessibility label for a button that copies a model identifier")
 
     @Environment(\.omlxTheme) private var theme
     @State private var copied = false
-
-    private var helpText: String {
-        String(localized: "common.copy_model_id",
-               defaultValue: "Copy model ID",
-               comment: "Tooltip and accessibility label for a button that copies a model identifier")
-    }
 
     var body: some View {
         Button(action: copy) {


### PR DESCRIPTION
## Summary

Add generate/regenerate and copy controls to the macOS sub-key creation form, reusing the existing key generator, clipboard button, and localization.

This makes sub-key creation match the main API key flow without backend changes.

## Testing

- Native macOS test suite
- Manual verification in the debug app
