### PR TITLE
feat(sdpa256): log the first tiled-route engagement per reason

### DIFF
--- a/omlx/patches/sdpa256_attention.py
+++ b/omlx/patches/sdpa256_attention.py
@@ -69,6 +69,24 @@ _HEADROOM_PROVIDER: "weakref.WeakMethod | None" = None
 # OMLX_SDPA256_TILED override, parsed at apply time: True = always tiled,
 # False = never tiled, None = memory-aware auto.
 _FORCE_TILED: bool | None = None
+# Tiled-route reasons already logged. The tiled pass trades substantial
+# prefill throughput at long kv_len for O(L) memory, and nothing surfaced the
+# route decision before (issue #2283 took an A/B repro to diagnose), so the
+# first engagement per reason logs at INFO; repeats stay silent to keep the
+# hot path quiet.
+_TILED_ROUTE_LOGGED: "set[str]" = set()
+
+
+def _note_tiled_route(reason: str, detail: str) -> None:
+    if reason in _TILED_ROUTE_LOGGED:
+        return
+    _TILED_ROUTE_LOGGED.add(reason)
+    logger.info(
+        "sdpa256: head-dim-256 prefill taking the tiled (memory-safe, slower) "
+        "path: %s. The unfused fast path resumes when guard headroom allows; "
+        "OMLX_SDPA256_TILED=1/0 forces the route.",
+        detail,
+    )
 
 
 def set_unfused_headroom_provider(method) -> None:
@@ -96,13 +114,23 @@ def _tiled_route_required(queries, keys) -> bool:
     transient would not fit under the guard ceiling — or when no headroom
     info is available, keeping the memory-safe #2025 behavior."""
     if _FORCE_TILED is not None:
+        if _FORCE_TILED:
+            _note_tiled_route("forced", "forced by OMLX_SDPA256_TILED=1")
         return _FORCE_TILED
     try:
         provider = _HEADROOM_PROVIDER() if _HEADROOM_PROVIDER is not None else None
         if provider is None:
+            _note_tiled_route(
+                "no-provider",
+                "no guard headroom provider registered "
+                "(prefill memory guard disabled, or scheduler gone)",
+            )
             return True
         headroom = provider()
         if headroom is None or headroom < 0:
+            _note_tiled_route(
+                "no-ceiling", "guard reports no active memory ceiling"
+            )
             return True
         batch, n_q, q_len, _ = queries.shape
         transient = estimate_unfused_sdpa_call_bytes(
@@ -112,8 +140,18 @@ def _tiled_route_required(queries, keys) -> bool:
             HEAD_DIM,
             score_dtype_size=queries.dtype.size,
         )
-        return transient > headroom
+        if transient > headroom:
+            _note_tiled_route(
+                "insufficient-headroom",
+                f"unfused transient ~{transient / 2**20:.0f}MiB exceeds live "
+                f"guard headroom ~{headroom / 2**20:.0f}MiB at "
+                f"kv_len={keys.shape[-2]}",
+            )
+            return True
+        return False
     except Exception:
+        _note_tiled_route("probe-error", "guard headroom probe failed")
+        logger.debug("sdpa256 headroom probe failed", exc_info=True)
         return True  # headroom info unavailable -> memory-safe default
 
 

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -13,6 +13,7 @@ Covers (without needing the full Qwen3.6 model):
     fits, and falls back to always-tiled without headroom info.
 """
 
+import logging
 import math
 
 import mlx.core as mx
@@ -248,6 +249,7 @@ def _sdpa256_provider_reset(monkeypatch):
 
     monkeypatch.setattr(sdpa256, "_HEADROOM_PROVIDER", None, raising=False)
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", None, raising=False)
+    monkeypatch.setattr(sdpa256, "_TILED_ROUTE_LOGGED", set(), raising=False)
     return sdpa256
 
 
@@ -322,6 +324,70 @@ def test_parse_force_tiled_env(monkeypatch):
     assert sdpa256._parse_force_tiled_env() is True
     monkeypatch.setenv("OMLX_SDPA256_TILED", "0")
     assert sdpa256._parse_force_tiled_env() is False
+
+
+# --- tiled-route engagement logging (issue #2283) --------------------------
+
+
+def _tiled_log_records(caplog):
+    return [
+        r
+        for r in caplog.records
+        if r.levelname == "INFO" and "tiled" in r.getMessage()
+    ]
+
+
+def test_tiled_route_logs_once_when_no_provider(_sdpa256_provider_reset, caplog):
+    """Guard-off servers land on the tiled path silently (issue #2283); the
+    first engagement must say so at INFO, repeats must stay quiet."""
+    sdpa256 = _sdpa256_provider_reset
+    q, k, _ = _qkv(2048, 16384)
+    with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
+        assert sdpa256._should_route(q, k, None, "causal", None) is True
+        records = _tiled_log_records(caplog)
+        assert len(records) == 1
+        msg = records[0].getMessage()
+        assert "no guard headroom provider" in msg
+        assert "OMLX_SDPA256_TILED" in msg
+        # Second engagement for the same reason: no new record.
+        assert sdpa256._should_route(q, k, None, "causal", None) is True
+        assert len(_tiled_log_records(caplog)) == 1
+
+
+def test_tiled_route_logs_headroom_numbers(_sdpa256_provider_reset, caplog):
+    sdpa256 = _sdpa256_provider_reset
+    q, k, _ = _qkv(2048, 16384)
+    owner = _HeadroomOwner(1)  # 1 byte of headroom: unfused can't fit
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
+        assert sdpa256._should_route(q, k, None, "causal", None) is True
+    records = _tiled_log_records(caplog)
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert "exceeds live guard headroom" in msg
+    assert "kv_len=16384" in msg
+    assert "MiB" in msg
+
+
+def test_tiled_route_logs_forced_env(_sdpa256_provider_reset, caplog, monkeypatch):
+    sdpa256 = _sdpa256_provider_reset
+    monkeypatch.setattr(sdpa256, "_FORCE_TILED", True, raising=False)
+    q, k, _ = _qkv(2048, 16384)
+    with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
+        assert sdpa256._should_route(q, k, None, "causal", None) is True
+    records = _tiled_log_records(caplog)
+    assert len(records) == 1
+    assert "OMLX_SDPA256_TILED=1" in records[0].getMessage()
+
+
+def test_unfused_route_logs_nothing(_sdpa256_provider_reset, caplog):
+    sdpa256 = _sdpa256_provider_reset
+    q, k, _ = _qkv(2048, 16384)
+    owner = _HeadroomOwner(1 << 40)  # ample headroom: fast path
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
+        assert sdpa256._should_route(q, k, None, "causal", None) is False
+    assert _tiled_log_records(caplog) == []
 
 
 def test_scheduler_headroom_provider_math():


### PR DESCRIPTION
Refs #2283.

## Summary

The head-dim-256 prefill router (#2025/#2155/#2204 lineage) silently chooses between the fast unfused pass and the ~2×-slower O(L)-memory tiled pass. Nothing surfaces the decision, so a user on the tiled path at long context sees only the throughput loss — #2283 took a full source A/B to diagnose what one log line would have said. This adds that log line: the first tiled engagement per reason logs at INFO, repeats stay silent.

## Behavior

One INFO per distinct reason per process, naming the reason and the recovery lever: forced by `OMLX_SDPA256_TILED=1` · no headroom provider registered (guard disabled / scheduler gone — the #2283 case) · guard reports no active ceiling · unfused transient exceeds live headroom (with the MiB numbers and kv_len) · headroom probe failed. The probe-failure branch also gains a `logger.debug(..., exc_info=True)` for the traceback it previously swallowed. Routing behavior is unchanged — the diff only adds observability on the already-taken branches.

## Why safe

The dedup check is a set lookup that runs only on tiled-returning branches, and only the first occurrence per reason formats a message — the hot prefill path cost is one `in` check. No new env vars, no behavioral toggles, no change to any routing decision (the `transient > headroom` restructure is a pure if/return equivalence). Module state is one bounded set (max 5 entries).

## Tests

`tests/test_sdpa256_attention.py`: 4 new cases — logs once (not twice) when no provider is registered, logs the MiB/kv_len numbers on insufficient headroom, logs the forced-env reason, and stays silent on the unfused path. Existing provider-reset fixture extended to isolate the new logged-reasons set. Suite: 22 passed. RED-proof: the 3 emission tests fail on the parent commit (no records); the silence test is a preservation guard.

`PYTHONPATH=. python -m pytest tests/test_sdpa256_attention.py -q` → 22 passed.

## Out of scope (named in the issue thread, your calls)

The guard-off → always-tiled default and a reclaim-before-surrender attempt at the routing point are design decisions — this PR only makes whichever choice the router takes visible.
