### PR TITLE
feat(specprefill): MLA query extractor for DeepSeek/GLM-family drafts

### DIFF
--- a/omlx/patches/specprefill.py
+++ b/omlx/patches/specprefill.py
@@ -162,6 +162,38 @@ def _nemotron_h_extract_queries(attn, x, cache=None, **kwargs):
     return queries
 
 
+def _mla_extract_queries(attn, x, cache=None, **kwargs):
+    """DeepSeek/GLM MLA: (optionally low-rank) q projection + partial RoPE.
+
+    MLA caches store keys in a split layout, so queries are built in the
+    matching layout. Absorbed variants (``embed_q``, e.g. glm4_moe_lite)
+    cache the compressed latent as keys and the roped positional slice as
+    values; queries are q_nope absorbed into latent space, concatenated
+    with the roped q_pe. Expanded variants (``kv_b_proj``) cache full
+    per-head keys; queries are concat(q_nope, roped q_pe) directly.
+    Queries are pre-scaled so the scorer's generic 1/sqrt(d) recovers the
+    module's true attention scale (including any yarn mscale correction).
+    """
+    B, L, D = x.shape
+    n_heads = getattr(
+        attn,
+        "num_heads",
+        getattr(attn, "num_attention_heads", getattr(attn, "n_heads", None)),
+    )
+    if getattr(attn, "q_proj", None) is not None:
+        q = attn.q_proj(x)
+    else:
+        q = attn.q_b_proj(attn.q_a_layernorm(attn.q_a_proj(x)))
+    q = q.reshape(B, L, n_heads, attn.q_head_dim).transpose(0, 2, 1, 3)
+    q_nope, q_pe = mx.split(q, [attn.qk_nope_head_dim], axis=-1)
+    offset = cache.offset if cache is not None else 0
+    q_pe = attn.rope(q_pe, offset)
+    if getattr(attn, "embed_q", None) is not None:
+        q_nope = attn.embed_q(q_nope)
+    queries = mx.concatenate([q_nope, q_pe], axis=-1)
+    return queries * (attn.scale * queries.shape[-1] ** 0.5)
+
+
 # ---------------------------------------------------------------------------
 # Model topology helpers
 # ---------------------------------------------------------------------------
@@ -300,9 +332,21 @@ def _is_gemma4_attention(attn_obj) -> bool:
     return "shared_kv" in params and "offset" in params
 
 
+def _is_mla_attention(attn_obj) -> bool:
+    """Detect DeepSeek/GLM-style Multi-head Latent Attention.
+
+    The shared latent KV projection (kv_a_proj_with_mqa) is the definitive
+    MLA marker; it is present in both the low-rank-q (q_a_proj/q_b_proj)
+    and full-q (plain q_proj) variants.
+    """
+    return hasattr(attn_obj, "kv_a_proj_with_mqa")
+
+
 def _detect_query_extractor(attn_obj) -> Callable:
     """Auto-detect the appropriate query extractor for the model architecture."""
-    if _uses_gated_q_proj(attn_obj):
+    if _is_mla_attention(attn_obj):
+        return _mla_extract_queries
+    elif _uses_gated_q_proj(attn_obj):
         return _qwen35_extract_queries
     elif _is_gemma4_attention(attn_obj):
         return _gemma4_extract_queries
@@ -420,6 +464,15 @@ def _compute_importance(
             continue
         head_dim = prompt_keys.shape[-1]
         q_stack = mx.concatenate(captures, axis=2)
+        if q_stack.shape[-1] > head_dim and getattr(cache, "values", None) is not None:
+            # Absorbed-MLA caches store the roped positional key slice in
+            # cache.values; concatenate it back so scoring sees the full
+            # split layout the queries were built in. Dim-driven, so
+            # non-MLA architectures never take this branch.
+            prompt_keys = mx.concatenate(
+                [prompt_keys, cache.values[..., :n_prompt, :]], axis=-1
+            )
+            head_dim = prompt_keys.shape[-1]
         if heads_per_group > 1:
             expanded_keys = mx.repeat(prompt_keys, heads_per_group, axis=1)
         else:
@@ -498,6 +551,12 @@ def score_tokens(
     n_kv_heads = getattr(
         attn_obj, "num_key_value_heads", getattr(attn_obj, "n_kv_heads", None)
     )
+    if n_kv_heads is None and _is_mla_attention(attn_obj):
+        # Absorbed-latent MLA caches store a single shared latent head;
+        # expanded variants store all heads.
+        n_kv_heads = (
+            1 if getattr(attn_obj, "embed_q", None) is not None else n_attn_heads
+        )
 
     if query_extractor is None:
         query_extractor = _detect_query_extractor(attn_obj)

--- a/omlx/patches/specprefill.py
+++ b/omlx/patches/specprefill.py
@@ -712,7 +712,12 @@ def manual_rope(x, positions, dims, base=10000.0, scale=1.0):
     rotated = mx.concatenate(
         [x1 * cos_a - x2 * sin_a, x1 * sin_a + x2 * cos_a], axis=-1
     )
-    return mx.concatenate([rotated, x_pass], axis=-1)
+    # Angles are computed in float32 for precision, but the output must
+    # keep the input dtype like native mx RoPE does: a float32 leak here
+    # becomes float32 roped K in the cache, and on mask-fused MLA targets
+    # (GLM DSA passes pe_scores as the sdpa mask) a float32 mask that
+    # cannot promote to the model's bfloat16 output.
+    return mx.concatenate([rotated, x_pass], axis=-1).astype(x.dtype)
 
 
 def manual_rope_with_freqs(x, positions, dims, freqs, pre_scale=1.0):
@@ -756,7 +761,12 @@ def manual_rope_with_freqs(x, positions, dims, freqs, pre_scale=1.0):
     rotated = mx.concatenate(
         [x1 * cos_a - x2 * sin_a, x1 * sin_a + x2 * cos_a], axis=-1
     )
-    return mx.concatenate([rotated, x_pass], axis=-1)
+    # Angles are computed in float32 for precision, but the output must
+    # keep the input dtype like native mx RoPE does: a float32 leak here
+    # becomes float32 roped K in the cache, and on mask-fused MLA targets
+    # (GLM DSA passes pe_scores as the sdpa mask) a float32 mask that
+    # cannot promote to the model's bfloat16 output.
+    return mx.concatenate([rotated, x_pass], axis=-1).astype(x.dtype)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_specprefill_mla.py
+++ b/tests/test_specprefill_mla.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the MLA (Multi-head Latent Attention) SpecPrefill query extractor.
+
+Covers DeepSeek/GLM-family draft models (e.g. glm4_moe_lite / GLM-4.7-Flash),
+whose attention has no plain ``q_proj`` contract: queries go through an
+optional low-rank projection and only the rope slice of the head dim is
+rotated, and the KV cache stores the compressed latent (keys) plus the roped
+positional slice (values).
+"""
+
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+import pytest
+
+from omlx.patches.specprefill import (
+    _detect_query_extractor,
+    _is_mla_attention,
+    _llama_extract_queries,
+    _mla_extract_queries,
+)
+
+
+class TestMlaDetection:
+    def test_detect_mla_low_rank_q(self):
+        attn = MagicMock(
+            spec=[
+                "kv_a_proj_with_mqa",
+                "q_a_proj",
+                "q_a_layernorm",
+                "q_b_proj",
+                "embed_q",
+                "rope",
+                "num_heads",
+                "q_head_dim",
+                "qk_nope_head_dim",
+                "scale",
+            ]
+        )
+        assert _is_mla_attention(attn)
+        assert _detect_query_extractor(attn) is _mla_extract_queries
+
+    def test_detect_mla_full_q_wins_over_llama_fallback(self):
+        # q_lora_rank=None MLA variants expose a plain q_proj; MLA detection
+        # must still win, since the cache layout is latent, not per-head.
+        attn = MagicMock(
+            spec=[
+                "kv_a_proj_with_mqa",
+                "q_proj",
+                "embed_q",
+                "rope",
+                "num_heads",
+                "q_head_dim",
+                "qk_nope_head_dim",
+                "scale",
+            ]
+        )
+        assert _detect_query_extractor(attn) is _mla_extract_queries
+
+    def test_non_mla_dispatch_unchanged(self):
+        attn = MagicMock(spec=["q_proj", "rope", "num_heads"])
+        assert not _is_mla_attention(attn)
+        assert _detect_query_extractor(attn) is _llama_extract_queries
+
+
+class TestMlaExtractorNumerics:
+    """Validate the extractor against the module's own math.
+
+    glm4_moe_lite computes attention in two equivalent formulations: absorbed
+    (decode: q_nope projected into latent space via embed_q) and expanded
+    (prefill: latent keys projected into q_nope space via embed_q with
+    transpose=False). The extractor uses the absorbed form against the cached
+    latent; the reference below uses the module's expanded form with the same
+    weights. Agreement validates layout, RoPE offset handling, and the
+    pre-scaling that maps the scorer's generic 1/sqrt(d) onto the module's
+    true attention scale.
+    """
+
+    def _tiny_args(self, glm, q_lora_rank):
+        return glm.ModelArgs(
+            hidden_size=64,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            q_lora_rank=q_lora_rank,
+            kv_lora_rank=16,
+            qk_rope_head_dim=8,
+            qk_nope_head_dim=16,
+            v_head_dim=16,
+            num_hidden_layers=1,
+            intermediate_size=128,
+            moe_intermediate_size=32,
+        )
+
+    @pytest.mark.parametrize("q_lora_rank", [32, None])
+    def test_scores_match_module_reference(self, q_lora_rank):
+        glm = pytest.importorskip("mlx_lm.models.glm4_moe_lite")
+        from mlx_lm.models.cache import KVCache
+
+        args = self._tiny_args(glm, q_lora_rank)
+        attn = glm.Glm4MoeLiteAttention(args)
+        cache = KVCache()
+        n_prompt = 5
+        x_prompt = mx.random.normal((1, n_prompt, args.hidden_size))
+        attn(x_prompt, mask=None, cache=cache)
+        assert cache.offset == n_prompt
+
+        x_step = mx.random.normal((1, 1, args.hidden_size))
+        queries = _mla_extract_queries(attn, x_step, cache=cache)
+        assert queries.shape == (
+            1,
+            attn.num_heads,
+            1,
+            args.kv_lora_rank + args.qk_rope_head_dim,
+        )
+
+        # Production scoring path: q_stack @ concat(keys, values)^T * 1/sqrt(d)
+        latent = cache.keys[..., :n_prompt, :]
+        k_pe = cache.values[..., :n_prompt, :]
+        keys_cat = mx.concatenate(
+            [
+                mx.broadcast_to(
+                    latent, (1, attn.num_heads, n_prompt, latent.shape[-1])
+                ),
+                mx.broadcast_to(k_pe, (1, attn.num_heads, n_prompt, k_pe.shape[-1])),
+            ],
+            axis=-1,
+        )
+        ext_scores = (queries @ keys_cat.swapaxes(-1, -2)) * (
+            keys_cat.shape[-1] ** -0.5
+        )
+
+        # Reference: the module's own expanded (prefill-branch) formulation.
+        if q_lora_rank is None:
+            q_full = attn.q_proj(x_step)
+        else:
+            q_full = attn.q_b_proj(attn.q_a_layernorm(attn.q_a_proj(x_step)))
+        q_full = q_full.reshape(1, 1, attn.num_heads, attn.q_head_dim).transpose(
+            0, 2, 1, 3
+        )
+        q_nope, q_pe = mx.split(q_full, [attn.qk_nope_head_dim], axis=-1)
+        q_pe = attn.rope(q_pe, cache.offset)
+        k_expanded = attn.embed_q(latent, transpose=False)
+        ref_scores = (
+            q_nope @ k_expanded.swapaxes(-1, -2)
+            + q_pe
+            @ mx.broadcast_to(
+                k_pe, (1, attn.num_heads, n_prompt, k_pe.shape[-1])
+            ).swapaxes(-1, -2)
+        ) * attn.scale
+
+        assert mx.allclose(ext_scores, ref_scores, atol=1e-4, rtol=1e-4)

--- a/tests/test_specprefill_mla.py
+++ b/tests/test_specprefill_mla.py
@@ -149,3 +149,26 @@ class TestMlaExtractorNumerics:
         ) * attn.scale
 
         assert mx.allclose(ext_scores, ref_scores, atol=1e-4, rtol=1e-4)
+
+
+class TestManualRopePreservesDtype:
+    """manual_rope/manual_rope_with_freqs compute angles in float32 but must
+    return the input dtype (like native mx RoPE). A float32 leak becomes
+    float32 roped KV during sparse_prefill, and on mask-fused MLA targets
+    (GLM DSA passes pe_scores as the sdpa mask) a float32 mask that cannot
+    promote to bfloat16 output."""
+
+    def test_manual_rope_bfloat16(self):
+        from omlx.patches.specprefill import manual_rope
+
+        x = mx.random.normal((1, 2, 4, 16)).astype(mx.bfloat16)
+        out = manual_rope(x, mx.array([3, 7, 11, 200]), dims=16)
+        assert out.dtype == mx.bfloat16
+
+    def test_manual_rope_with_freqs_bfloat16(self):
+        from omlx.patches.specprefill import manual_rope_with_freqs
+
+        x = mx.random.normal((1, 2, 4, 16)).astype(mx.bfloat16)
+        freqs = mx.exp(mx.arange(4, dtype=mx.float32))
+        out = manual_rope_with_freqs(x, mx.array([3, 7, 11, 200]), dims=16, freqs=freqs)
+        assert out.dtype == mx.bfloat16


### PR DESCRIPTION
Fixes the SpecPrefill structural gap reported by @anicaise-ai in #2208: MLA-attention drafts (DeepSeek V2/V3 family, GLM-5.x, `glm4_moe_lite`) have no plain `q_proj`, so `_detect_query_extractor` fell through to `_llama_extract_queries` and crashed at scoring time (`'Glm4MoeLiteAttention' object has no attribute 'q_proj'`) after paying the full draft prefill, making an incompatible draft strictly worse than no draft (+42% total latency at 42k in the linked report). Since GLM-5.x targets have no non-MLA tokenizer-compatible small sibling (GLM-4.7-Flash is itself MLA), SpecPrefill was structurally unavailable for exactly the model family with the heaviest prefill cost.

**What this adds**

- `_mla_extract_queries`: builds queries in the layout the MLA cache stores. Absorbed variants (`embed_q`, e.g. `glm4_moe_lite`): `q_nope` projected into latent space, concatenated with the roped `q_pe` slice. Expanded variants (`kv_b_proj`, e.g. `deepseek_v2`): `concat(q_nope, roped q_pe)` directly. Queries are pre-scaled so the scorer's generic `1/sqrt(d)` reproduces the module's true attention scale, including yarn mscale corrections.
- `_is_mla_attention`, keyed on `kv_a_proj_with_mqa`, dispatching ahead of the existing chain: MLA modules have `rope`, so the llama fallback would otherwise claim them (both the low-rank-q and the full-q `q_lora_rank=None` variants).
- `score_tokens` derives `n_kv_heads` for MLA modules, which expose neither `num_key_value_heads` nor `n_kv_heads`: 1 for absorbed latent caches, all heads for expanded.
- `_compute_importance` rebuilds the full split-layout keys for absorbed caches (latent in `cache.keys`, roped positional slice in `cache.values`) via a dim-driven concat that non-MLA architectures never trigger.

**Validation**

- `pytest tests/test_specprefill.py tests/test_specprefill_mla.py -m "not slow"`: 47 passed (42 existing + 5 new), M3 Ultra, editable install at current main.
- The numerics tests validate against `Glm4MoeLiteAttention` itself: the extractor's scoring path (queries against `concat(cache.keys, cache.values)` at the generic scorer scale) is compared with scores computed from the module's own expanded-formulation math on the same random weights, for both `q_lora_rank` set and `None`. Agreement covers the layout, the RoPE offset handling, and the pre-scaling.
- End-to-end (GLM-4.7-Flash drafting for a GLM-5.2 mxfp4/oQ4e target, keep_pct sweeps) is not yet run: our 512GB box is mid benchmark campaign. @anicaise-ai offered in #2208 to benchmark a branch on exactly that pairing; this is that branch. We will post our own e2e numbers in #2208 once our box frees.

**Follow-up, deliberately not in this PR:** a draft-load-time arch compatibility check in `engine/batched.py` (`_load_draft`) would turn any remaining unsupported pairing into a clear load-time error instead of an expensive per-request fallback; #1073/#1074 proposed that shape earlier. Happy to revive it separately if wanted.
