### PR TITLE
fix(scheduler): route chunked-prefill'd requests to external VLM MTP (#2219)

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -4292,6 +4292,36 @@ class Scheduler:
 
         Precondition: state.sampler, state.sm, state.per_row_lps are set.
         """
+        # #2219: both chunked-completion paths (inline first chunk and
+        # _advance_chunked_prefills) funnel through here, but external VLM MTP
+        # routing only existed on the non-chunked prefill exit -- so any prompt
+        # long enough to be chunk-prefilled silently bypassed VLM MTP. Re-apply
+        # the decision at this shared choke point, BEFORE the TurboQuant convert
+        # below, so the drafter's final forward sees the un-quantized cache. A
+        # declined route (e.g. the single-in-flight drafter is busy) falls
+        # through to BatchGenerator, matching short-prompt behaviour.
+        if self._vlm_mtp_drafter is not None and state.cache is not None:
+            vlm_mtp_uid = self._route_to_vlm_mtp(
+                request, state.cache, state.last_token, state.sampler, state.sm
+            )
+            if vlm_mtp_uid is not None:
+                self.request_id_to_uid[request.request_id] = vlm_mtp_uid
+                self.uid_to_request_id[vlm_mtp_uid] = request.request_id
+                now = time.monotonic()
+                request.batch_uid = vlm_mtp_uid
+                request.status = RequestStatus.RUNNING
+                request.generation_started_at = now
+                request.last_activity_at = now
+                self.running[request.request_id] = request
+                scheduled.append(request)
+                self.total_prompt_tokens += request.num_prompt_tokens
+                logger.debug(
+                    "Scheduled chunked-prefill request %s via vlm_mtp (uid=%d)",
+                    request.request_id,
+                    vlm_mtp_uid,
+                )
+                return
+
         self._finalize_chunked_prefill_cache_for_insert(request, state.cache)
 
         if request.sampling_params.seed is not None:

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -4292,6 +4292,9 @@ class Scheduler:
 
         Precondition: state.sampler, state.sm, state.per_row_lps are set.
         """
+        if request.sampling_params.seed is not None:
+            mx.random.seed(request.sampling_params.seed)
+
         # #2219: both chunked-completion paths (inline first chunk and
         # _advance_chunked_prefills) funnel through here, but external VLM MTP
         # routing only existed on the non-chunked prefill exit -- so any prompt
@@ -4323,9 +4326,6 @@ class Scheduler:
                 return
 
         self._finalize_chunked_prefill_cache_for_insert(request, state.cache)
-
-        if request.sampling_params.seed is not None:
-            mx.random.seed(request.sampling_params.seed)
 
         per_row_lps = state.per_row_lps if state.per_row_lps is not None else []
         # insert() merges the prompt cache into the batch KV caches with lazy

--- a/tests/test_vlm_mtp_chunked_prefill.py
+++ b/tests/test_vlm_mtp_chunked_prefill.py
@@ -28,10 +28,11 @@ from omlx.scheduler import Scheduler
 
 
 def _make_fixture(monkeypatch, drafter_returns_uid):
-    calls = {"route": 0, "bg_insert": 0}
+    calls = {"route": 0, "bg_insert": 0, "events": []}
 
     def fake_route(request, cache, last_tokens, sampler, sm):
         calls["route"] += 1
+        calls["events"].append("route")
         return -7 if drafter_returns_uid else None  # negative uid, or ineligible
 
     def fake_bg_insert(*args, **kwargs):
@@ -86,7 +87,9 @@ def test_chunked_prefilled_request_routes_to_vlm_mtp_when_eligible(monkeypatch):
     Scheduler._insert_prefilled_request(sched, request, state, scheduled)
 
     assert calls["route"] == 1, "vlm_mtp routing was never considered (the #2219 bug)"
-    assert calls["bg_insert"] == 0, "request went to BatchGenerator despite eligible vlm_mtp"
+    assert (
+        calls["bg_insert"] == 0
+    ), "request went to BatchGenerator despite eligible vlm_mtp"
     # negative-uid bookkeeping mirrors the non-chunked routing path
     assert request.batch_uid == -7
     assert request.status == RequestStatus.RUNNING
@@ -95,6 +98,24 @@ def test_chunked_prefilled_request_routes_to_vlm_mtp_when_eligible(monkeypatch):
     assert sched.running["req-long-text"] is request
     assert request in scheduled
     assert sched.total_prompt_tokens == 32768
+
+
+def test_seed_is_applied_before_vlm_mtp_sampling(monkeypatch):
+    """A successful VLM MTP route must honor the request seed before sampling."""
+    sched, request, state, scheduled, calls = _make_fixture(
+        monkeypatch, drafter_returns_uid=True
+    )
+    request.sampling_params.seed = 123
+
+    monkeypatch.setattr(
+        scheduler_mod.mx.random,
+        "seed",
+        lambda seed: calls["events"].append(("seed", seed)),
+    )
+
+    Scheduler._insert_prefilled_request(sched, request, state, scheduled)
+
+    assert calls["events"] == [("seed", 123), "route"]
 
 
 def test_falls_back_to_batch_generator_when_drafter_ineligible(monkeypatch):

--- a/tests/test_vlm_mtp_chunked_prefill.py
+++ b/tests/test_vlm_mtp_chunked_prefill.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reproduction + fix test for #2219.
+
+External VLM MTP routing lives only on the non-chunked prefill exit
+(``scheduler.py`` ~8504). Chunked-prefill'd requests complete via
+``_insert_prefilled_request`` and go straight to ``BatchGenerator``, so any prompt
+long enough to be chunked silently bypasses VLM MTP.
+
+These tests drive ``_insert_prefilled_request`` -- the single choke point both
+chunked-completion paths funnel through -- and assert that, when a vlm_mtp drafter
+is present and eligible, the request is routed to VLM MTP instead of
+BatchGenerator. They FAIL on the unfixed code (reproducing the bug) and pass once
+the routing is applied at the top of ``_insert_prefilled_request``.
+
+No model is loaded: the drafter and BatchGenerator are faked, so the routing
+decision is tested in isolation.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+import omlx.scheduler as scheduler_mod
+from omlx.request import RequestStatus
+from omlx.scheduler import Scheduler
+
+
+def _make_fixture(monkeypatch, drafter_returns_uid):
+    calls = {"route": 0, "bg_insert": 0}
+
+    def fake_route(request, cache, last_tokens, sampler, sm):
+        calls["route"] += 1
+        return -7 if drafter_returns_uid else None  # negative uid, or ineligible
+
+    def fake_bg_insert(*args, **kwargs):
+        calls["bg_insert"] += 1
+        return [101]  # a positive BatchGenerator uid
+
+    # Module-level helpers reached only on the BatchGenerator path.
+    monkeypatch.setattr(scheduler_mod, "_register_uid_rows", lambda *a, **k: None)
+    monkeypatch.setattr(scheduler_mod, "_batch_generator_all_tokens", lambda r: [])
+
+    sched = SimpleNamespace(
+        _vlm_mtp_drafter=object(),  # a drafter is configured
+        _route_to_vlm_mtp=fake_route,
+        _finalize_chunked_prefill_cache_for_insert=lambda req, cache: None,
+        _stream=mx.default_stream(mx.default_device()),
+        batch_generator=SimpleNamespace(insert=fake_bg_insert),
+        model=SimpleNamespace(),  # no register_rope_delta attr -> skipped
+        request_id_to_uid={},
+        uid_to_request_id={},
+        running={},
+        total_prompt_tokens=0,
+    )
+
+    request = SimpleNamespace(
+        request_id="req-long-text",
+        sampling_params=SimpleNamespace(seed=None, max_tokens=1024),
+        num_prompt_tokens=32768,  # long enough to have been chunk-prefilled
+        rope_deltas=0.0,
+        cached_tokens=0,
+        batch_uid=None,
+        status=None,
+        generation_started_at=None,
+        last_activity_at=None,
+    )
+    state = SimpleNamespace(
+        cache=[object()],  # non-empty prefilled cache
+        last_token=[42],
+        sampler=lambda x: x,
+        sm=object(),
+        per_row_lps=[],
+    )
+    return sched, request, state, [], calls
+
+
+def test_chunked_prefilled_request_routes_to_vlm_mtp_when_eligible(monkeypatch):
+    """#2219: a chunked-prefill'd request with an eligible vlm_mtp drafter must be
+    routed to VLM MTP, not silently dropped into BatchGenerator."""
+    sched, request, state, scheduled, calls = _make_fixture(
+        monkeypatch, drafter_returns_uid=True
+    )
+
+    Scheduler._insert_prefilled_request(sched, request, state, scheduled)
+
+    assert calls["route"] == 1, "vlm_mtp routing was never considered (the #2219 bug)"
+    assert calls["bg_insert"] == 0, "request went to BatchGenerator despite eligible vlm_mtp"
+    # negative-uid bookkeeping mirrors the non-chunked routing path
+    assert request.batch_uid == -7
+    assert request.status == RequestStatus.RUNNING
+    assert sched.request_id_to_uid["req-long-text"] == -7
+    assert sched.uid_to_request_id[-7] == "req-long-text"
+    assert sched.running["req-long-text"] is request
+    assert request in scheduled
+    assert sched.total_prompt_tokens == 32768
+
+
+def test_falls_back_to_batch_generator_when_drafter_ineligible(monkeypatch):
+    """When _route_to_vlm_mtp declines (e.g. drafter busy under concurrency), the
+    request must fall through to BatchGenerator -- not error or double-schedule."""
+    sched, request, state, scheduled, calls = _make_fixture(
+        monkeypatch, drafter_returns_uid=False
+    )
+
+    Scheduler._insert_prefilled_request(sched, request, state, scheduled)
+
+    assert calls["route"] == 1  # routing was considered
+    assert calls["bg_insert"] == 1  # but fell back to BatchGenerator
+    assert request.batch_uid == 101  # got the BatchGenerator uid
+    assert request in scheduled
+
+
+def test_routed_request_is_scheduled_exactly_once(monkeypatch):
+    """A vlm_mtp-routed request must not also hit the BatchGenerator insert."""
+    sched, request, state, scheduled, calls = _make_fixture(
+        monkeypatch, drafter_returns_uid=True
+    )
+
+    Scheduler._insert_prefilled_request(sched, request, state, scheduled)
+
+    assert len(scheduled) == 1
+    assert calls["route"] + calls["bg_insert"] == 1  # exactly one path taken


### PR DESCRIPTION
## Summary

Fixes #2219.

When external VLM MTP is enabled, text prompts long enough to enter the scheduler's chunked-prefill path are silently decoded through the ordinary `BatchGenerator` instead of VLM MTP, with no warning. Short prompts route correctly; disabling `chunked_prefill` makes the long ones route correctly too.

Root cause: the VLM MTP routing decision exists at a single point on the **non-chunked** prefill exit of `_schedule_waiting`. A chunked-prefill'd request completes via `_insert_prefilled_request` and `continue`s past that point (or, for multi-step chunks, completes in `_advance_chunked_prefills`, which never had the routing code at all), dropping straight into `BatchGenerator`. So the routing is skipped as collateral of the chunked branch's early `continue`, not because of any eligibility check. That also explains the missing warning: chunked requests never enter `_route_to_vlm_mtp`, so none of its fallback log lines can fire.

This is unrelated to #1758 (the native-MTP per-model marker): native MTP is re-checked every decode step inside `BatchGenerator`, so it survives chunked prefill; external VLM MTP is a scheduler-level, one-time routing branch that *bypasses* `BatchGenerator`, decided only on the non-chunked exit.

## Fix

Re-apply the routing at the top of `_insert_prefilled_request` — the single choke point both chunked-completion paths (`_schedule_waiting`'s inline first chunk and `_advance_chunked_prefills`) funnel through. It already holds everything `_route_to_vlm_mtp` needs on `state` (`cache`, `last_token`, `sampler`, `sm`).

- Runs **before** the TurboQuant cache convert (`_finalize_chunked_prefill_cache_for_insert`), so the drafter's final forward sees the un-quantized cache.
- Mirrors the negative-uid bookkeeping of the non-chunked routing path and `return`s, so a routed request is never also inserted into `BatchGenerator`.
- A declined route (e.g. the single-in-flight drafter is already busy under concurrency) falls through to `BatchGenerator`, exactly as short prompts already do.
- Text prompts carry the default `rope_deltas=0.0`, so mRoPE handling matches the non-chunked path.

## Validation

New `tests/test_vlm_mtp_chunked_prefill.py` drives the real `_insert_prefilled_request` with a faked drafter / BatchGenerator (no model loaded) and asserts: an eligible drafter routes to VLM MTP (negative uid + bookkeeping); an ineligible one falls back to `BatchGenerator`; a routed request is scheduled exactly once. These fail on the unfixed code (the routing is never consulted) and pass with the fix.

```
uv run pytest tests/test_vlm_mtp_chunked_prefill.py tests/test_vlm_mtp.py \
  tests/test_scheduler.py tests/test_scheduler_chunked_prefill.py tests/test_engine_core.py
=> 335 passed
```
