### PR TITLE
fix(vlm): advance rope positions across multi-token decode windows

### DIFF
--- a/omlx/models/vlm.py
+++ b/omlx/models/vlm.py
@@ -253,12 +253,24 @@ class VLMModelAdapter(nn.Module):
     def _position_ids_from_starts(
         self, starts: mx.array, batch_size: int, seq_len: int
     ) -> mx.array:
-        """Build model-specific decode position_ids from per-row start offsets."""
+        """Build model-specific decode position_ids from per-row start offsets.
+
+        Positions are sequential from each row's start: row r covers
+        ``starts[r] .. starts[r] + seq_len - 1``. At single-token decode
+        (seq_len == 1) this reduces to the start offset itself; for
+        multi-token windows (the MTP verify rows) each position must
+        advance, or every draft row gets rope-rotated at the *first* row's
+        position — measured on Qwen3.6-35B-A3B as verify keys diverging
+        O(1) from an AR-built cache while values matched, breaking
+        verify/decode parity (and silently mis-rotating the KV the verify
+        writes for accepted rows).
+        """
         starts = starts.reshape(-1)[:batch_size]
+        steps = mx.arange(seq_len, dtype=starts.dtype)
+        seq_positions = starts[:, None] + steps[None, :]
         if self._uses_minimax_m3_positions:
-            steps = mx.arange(seq_len, dtype=starts.dtype)
-            return starts[:, None] + steps[None, :]
-        return mx.broadcast_to(starts[None, :, None], (3, batch_size, seq_len))
+            return seq_positions
+        return mx.broadcast_to(seq_positions[None, :, :], (3, batch_size, seq_len))
 
     def get_last_rope_deltas(self) -> float:
         """Extract rope_deltas from language model after VLM prefill.

--- a/tests/test_vlm_model_adapter.py
+++ b/tests/test_vlm_model_adapter.py
@@ -535,6 +535,42 @@ class TestPerRequestMRoPEDecode:
         assert pos_ids[1, 0].item() == 80.0
         assert pos_ids[1, 1].item() == 81.0
 
+    def test_mrope_multi_token_window_advances_positions(self):
+        """Regression: each row of an mRoPE window must advance from its start.
+
+        Multi-token windows (speculative-decode verify) previously broadcast each
+        row's start offset across the whole window, so every position in the
+        window was rope-rotated at the first position. That silently corrupted the
+        keys the verify wrote back into the cache. The consuming attention builds
+        its own positions as arange(offset, offset + L) when none are supplied;
+        the positions we pass must match that.
+        """
+        import mlx.core as mx
+
+        from omlx.models.vlm import VLMModelAdapter
+
+        vlm = self._make_mrope_vlm_model()
+        adapter = VLMModelAdapter(vlm)
+        assert adapter._uses_minimax_m3_positions is False
+
+        adapter.set_batch_rope_deltas(mx.array([-50.0, 0.0]))
+
+        input_ids = mx.zeros((2, 2), dtype=mx.int32)
+        cache_layer = MagicMock()
+        cache_layer.offset = mx.array([100, 80])
+        cache = [cache_layer]
+
+        adapter(input_ids, cache=cache)
+
+        call_kwargs = vlm.language_model.call_args[1]
+        pos_ids = call_kwargs["position_ids"]
+        assert pos_ids.shape == (3, 2, 2)
+        for section in range(3):
+            assert pos_ids[section, 0, 0].item() == 50.0
+            assert pos_ids[section, 0, 1].item() == 51.0
+            assert pos_ids[section, 1, 0].item() == 80.0
+            assert pos_ids[section, 1, 1].item() == 81.0
+
     def test_get_last_rope_deltas(self):
         """get_last_rope_deltas extracts value from language model."""
         import mlx.core as mx


### PR DESCRIPTION
`VLMModelAdapter._position_ids_from_starts` broadcasts each row's start offset across the whole window, so for `seq_len > 1` every position in the window is rope-rotated at the *first* position instead of advancing.

The consuming attention builds its own positions when none are supplied (`mlx_vlm/models/qwen3_vl_moe/language.py`):

```python
if position_ids is None:
    position_ids = mx.arange(cache.offset, cache.offset + L)
    position_ids = mx.tile(mx.expand_dims(position_ids, 0), (3, 1, 1))
```

so the positions this method passes must advance to match. Prefill (`get_rope_index`) and the MiniMax branch already do — the default mRoPE branch was the only position builder in the stack emitting a constant, and it was never updated when multi-token decode windows were added.

### Why it matters

Multi-token windows arise in speculative-decode verify, where the effect is not just a wrong forward: the mis-rotated keys are **committed into the KV cache on accept**.

Measured on Qwen3.6-35B-A3B, verify attention keys diverged O(1) from an autoregressively-built cache while values matched bit-exactly — the signature of a position error, since rope rotates q and k but not v. With positions advancing, a T-row verify matches T single-row decodes exactly (logits and every layer's cache state) on the prefixes we certified.

### Scope

- **Single-token decode is unchanged by construction.** At `seq_len == 1` the step offsets are `[0]`, so positions reduce to the start offset itself — same shape, same dtype, same values as before.
- Affects the **mRoPE default branch only** (Qwen2/2.5/3-VL-class). MiniMax is a no-op; text-only serving does not use this adapter.
- Two call sites, both decode/verify dispatch; the output is consumed only by the attention rope, so there is no path that was compensating for the old behaviour.

### Tests

Adds a regression test covering multi-token advancement on the default branch — previously only the `seq_len == 1` case and the MiniMax branch (already correct) were pinned. Against the unfixed code it fails with `assert 50 == 51.0`; with the fix the full adapter suite passes (32 tests).
