### PR TITLE
fix: support Qwen3-VL image embeddings

### DIFF
--- a/omlx/models/mlx_embeddings_compat.py
+++ b/omlx/models/mlx_embeddings_compat.py
@@ -42,6 +42,39 @@ def patch_qwen3_vl_processor_for_torch_free_image_loading() -> None:
         qwen3_vl_processor, "AutoImageProcessor", None
     )
 
+    class OMLXQwen3VLImageProcessor(Qwen3VLImageProcessor):
+        """Preserve batched image nesting expected by ProcessorMixin.
+
+        Transformers passes multimodal chat-template images as a nested
+        ``list[list[image]]``. mlx-vlm's Qwen3-VL override only handles a flat
+        list, so an inner list is converted to a one-dimensional numpy array
+        instead of a ``(C, H, W)`` image.
+        """
+
+        def fetch_images(self, images):
+            if isinstance(images, (list, tuple)):
+                return [self.fetch_images(image) for image in images]
+            if isinstance(images, str) and images.strip().lower().startswith(
+                "data:image/"
+            ):
+                from omlx.utils.image import load_image
+
+                images = load_image(images, field="items[].image")
+            return super().fetch_images(images)[0]
+
+        def __call__(self, images, **kwargs):
+            flattened = []
+
+            def append_images(value):
+                if isinstance(value, (list, tuple)):
+                    for image in value:
+                        append_images(image)
+                else:
+                    flattened.append(value)
+
+            append_images(images)
+            return super().__call__(flattened, **kwargs)
+
     class TorchFreeQwen3VLAutoImageProcessor:
         _omlx_original_auto_image_processor = original_auto_image_processor
 
@@ -52,7 +85,7 @@ def patch_qwen3_vl_processor_for_torch_free_image_loading() -> None:
                 pretrained_model_name_or_path,
                 default_patch_size=16,
             )
-            return Qwen3VLImageProcessor(**image_kwargs)
+            return OMLXQwen3VLImageProcessor(**image_kwargs)
 
     qwen3_vl_processor.AutoImageProcessor = TorchFreeQwen3VLAutoImageProcessor
 

--- a/tests/test_mlx_embeddings_compat.py
+++ b/tests/test_mlx_embeddings_compat.py
@@ -46,6 +46,15 @@ def test_qwen3_vl_auto_image_processor_uses_mlx_vlm_torch_free_loader(monkeypatc
         def __init__(self, **kwargs):
             captured["kwargs"] = kwargs
 
+        def fetch_images(self, images):
+            if not isinstance(images, list):
+                images = [images]
+            return [type(image).__name__ for image in images]
+
+        def __call__(self, images, **kwargs):
+            del kwargs
+            return images
+
     def fake_image_kwargs(model_path, default_patch_size=16):
         captured["model_path"] = model_path
         captured["default_patch_size"] = default_patch_size
@@ -93,6 +102,21 @@ def test_qwen3_vl_auto_image_processor_uses_mlx_vlm_torch_free_loader(monkeypatc
     assert captured["model_path"] == "/models/Qwen3-VL-Embedding-8B-8bit-mlx"
     assert captured["default_patch_size"] == 16
     assert captured["kwargs"] == {"patch_size": 16, "merge_size": 2}
+
+    nested_images = image_processor.fetch_images([["first-image"], ["second-image"]])
+    assert nested_images == [["str"], ["str"]]
+    assert image_processor(nested_images) == ["str", "str"]
+
+    nested_data_uri = image_processor.fetch_images(
+        [
+            [
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCA"
+                "QAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+            ]
+        ]
+    )
+    assert nested_data_uri == [["Image"]]
+    assert image_processor(nested_data_uri) == ["Image"]
 
 
 def test_qwen3_vl_build_processor_gets_multimodal_token_id_fields(monkeypatch):


### PR DESCRIPTION
## Summary
- adapt the injected torch-free Qwen3-VL image processor to Transformers nested chat-template batches
- decode validated inline image data URIs with the existing oMLX image loader
- flatten decoded image batches before mlx-vlm preprocessing
- add regression coverage for nested images and inline data URIs

## Root cause
Transformers passes multimodal chat-template images as nested lists. The mlx-vlm Qwen3-VL processor handled only flat lists, converting an inner list to a one-dimensional array. After preserving the batch structure, inline data URIs were also treated as filesystem paths. Both paths prevented image and mixed embeddings while text embeddings remained healthy.

## Validation
- ruff check passed for changed files
- 93 related tests passed
- real mlx-community/Qwen3-VL-Embedding-2B-6bit produced finite normalized 2048-dimensional text, image, and mixed vectors
- temporary fork server returned HTTP 200 and normalized 768-dimensional vectors for text, image, and mixed API requests
- full non-slow suite: 6981 passed, 54 skipped; 2 unrelated GLM numerical tolerance tests failed because the local checkout lacks the optional native Metal kernels, and both reproduce independently