### PR TITLE
perf(cache): store large fp32 boundary-snapshot states as int8

### DIFF
--- a/omlx/cache/boundary_snapshot_store.py
+++ b/omlx/cache/boundary_snapshot_store.py
@@ -42,19 +42,27 @@ logger = logging.getLogger(__name__)
 # Max pending writes before save() blocks.
 _MAX_PENDING_WRITES = 128
 
-# Large fp32 snapshot states (hybrid-model SSM states) are stored as int8
-# with per-row fp32 scales: 4x smaller serialize copies, pending buffers,
-# and files; error bounded by rowmax/254. Disable via OMLX_SNAPSHOT_Q8=0.
+# Mamba2-family SSM states (fp32, shape (B, num_heads, head_dim, state_size))
+# are stored as int8 with per-row fp32 scales: 4x smaller serialize copies,
+# pending buffers, and files; error bounded by rowmax/254. 8-bit storage is
+# established as accuracy-safe for this state type (Quamba/Quamba2, ICML'25);
+# other fp32 cache states (e.g. gated-deltanet recurrent states) are NOT
+# covered by that result and stay fp32. The caller identifies eligible layers
+# semantically via ``ssm_state_shapes`` (see ``save``); a tensor is quantized
+# only when it also matches the expected per-layer state shape and dtype.
+# Disable via OMLX_SNAPSHOT_Q8=0.
 _Q8_ENABLED = os.environ.get("OMLX_SNAPSHOT_Q8", "1") != "0"
 _Q8_MIN_ELEMS = 65536
 
 
-def _q8_eligible(elem) -> bool:
+def _q8_eligible(elem, expected_shape) -> bool:
     return (
         _Q8_ENABLED
         and HAS_MLX
+        and expected_shape is not None
         and elem.dtype == mx.float32
-        and elem.ndim >= 2
+        and elem.ndim == 4
+        and tuple(elem.shape[1:]) == tuple(expected_shape)
         and elem.size >= _Q8_MIN_ELEMS
     )
 
@@ -157,6 +165,7 @@ class BoundarySnapshotSSDStore:
         token_count: int,
         snapshot_cache: list[Any],
         extract_cache_states_fn: Callable,
+        ssm_state_shapes: dict[int, tuple[int, ...]] | None = None,
     ) -> bool:
         """Serialize snapshot to SSD (non-blocking).
 
@@ -173,6 +182,12 @@ class BoundarySnapshotSSDStore:
         extract_cache_states_fn : callable
             ``Scheduler._extract_cache_states`` — converts raw cache objects
             to ``List[Dict[str, Any]]``.
+        ssm_state_shapes : dict, optional
+            Per-layer expected Mamba2 SSM state shape (without the batch
+            axis), e.g. ``{i: (num_heads, head_dim, state_size)}``. Only
+            fp32 states on these layers that match the expected shape are
+            stored as int8; everything else stays in its native dtype.
+            ``None`` disables int8 storage for this snapshot.
 
         Returns
         -------
@@ -189,8 +204,12 @@ class BoundarySnapshotSSDStore:
                 return False
 
             # 2. Flatten tensors + metadata for safetensors serialization.
+            # When int8 storage applies, _serialize_extracted also swaps the
+            # affected elements of ``extracted`` for their dequantized values
+            # so every read path (pending fast path, raw bytes, disk) restores
+            # the exact same representation regardless of writer timing.
             tensors_raw, metadata = self._serialize_extracted(
-                extracted, request_id, token_count
+                extracted, request_id, token_count, ssm_state_shapes
             )
 
             # 3. Buffer in pending writes for instant read-back.
@@ -669,13 +688,21 @@ class BoundarySnapshotSSDStore:
         extracted: list[dict[str, Any]],
         request_id: str,
         token_count: int,
+        ssm_state_shapes: dict[int, tuple[int, ...]] | None = None,
     ) -> tuple[dict[str, tuple[bytes, str, list[int]]], dict[str, str]]:
         """Convert extracted cache states to tensors_raw + metadata.
 
         Must be called on the inference thread (for mx.eval / _extract_tensor_bytes).
+
+        For layers listed in ``ssm_state_shapes``, fp32 states matching the
+        expected SSM state shape are stored as int8 (see ``save``). Each
+        quantized element of ``extracted`` is replaced in place with its
+        dequantized value, so the pending-writes fast path returns the same
+        representation as the raw-bytes and disk read paths.
         """
         arrays: dict[str, Any] = {}  # name -> mx.array
         layer_info: list[dict[str, str]] = []
+        dequantized: list[Any] = []  # replacements to materialize with arrays
 
         for i, layer_state in enumerate(extracted):
             class_name = layer_state.get("class_name", "KVCache")
@@ -720,6 +747,11 @@ class BoundarySnapshotSSDStore:
                 if has_tensors:
                     info["has_state"] = "true"
                     info["state_count"] = str(len(state))
+                    expected_shape = (
+                        ssm_state_shapes.get(i) if ssm_state_shapes else None
+                    )
+                    new_state = list(state)
+                    quantized_any = False
                     for k, elem in enumerate(state):
                         if not hasattr(elem, "shape"):
                             # Non-tensor element (None, scalar). Mark it so
@@ -729,13 +761,21 @@ class BoundarySnapshotSSDStore:
                         if _has_zero_dim(elem):
                             arrays[f"layer_{i}_state_{k}"] = mx.zeros((1,))
                             info[f"zero_dim_{k}"] = _encode_shape(elem.shape)
-                        elif _q8_eligible(elem):  # int8 snapshot state
+                        elif _q8_eligible(elem, expected_shape):  # int8 SSM state
                             q8, q8s = _q8_quantize(elem)
                             arrays[f"layer_{i}_state_{k}"] = q8
                             arrays[f"layer_{i}_state_{k}_q8s"] = q8s
                             info[f"q8_{k}"] = "1"
+                            dq = _q8_dequantize(q8, q8s)
+                            new_state[k] = dq
+                            dequantized.append(dq)
+                            quantized_any = True
                         else:
                             arrays[f"layer_{i}_state_{k}"] = elem
+                    if quantized_any:
+                        layer_state["state"] = (
+                            tuple(new_state) if isinstance(state, tuple) else new_state
+                        )
                 else:
                     info["has_state"] = "false"
             else:
@@ -743,9 +783,12 @@ class BoundarySnapshotSSDStore:
 
             layer_info.append(info)
 
-        # Materialize lazy tensors on inference thread.
-        if arrays:
-            mx.eval(*arrays.values())
+        # Materialize lazy tensors on inference thread. The dequantized
+        # replacements must be concrete here too: the pending fast path may
+        # hand them to a different thread, which cannot evaluate ops bound
+        # to this thread's stream.
+        if arrays or dequantized:
+            mx.eval(*arrays.values(), *dequantized)
 
         # Extract raw bytes (Metal-safe memoryview copy).
         tensors_raw = {}

--- a/omlx/cache/boundary_snapshot_store.py
+++ b/omlx/cache/boundary_snapshot_store.py
@@ -42,6 +42,33 @@ logger = logging.getLogger(__name__)
 # Max pending writes before save() blocks.
 _MAX_PENDING_WRITES = 128
 
+# Large fp32 snapshot states (hybrid-model SSM states) are stored as int8
+# with per-row fp32 scales: 4x smaller serialize copies, pending buffers,
+# and files; error bounded by rowmax/254. Disable via OMLX_SNAPSHOT_Q8=0.
+_Q8_ENABLED = os.environ.get("OMLX_SNAPSHOT_Q8", "1") != "0"
+_Q8_MIN_ELEMS = 65536
+
+
+def _q8_eligible(elem) -> bool:
+    return (
+        _Q8_ENABLED
+        and HAS_MLX
+        and elem.dtype == mx.float32
+        and elem.ndim >= 2
+        and elem.size >= _Q8_MIN_ELEMS
+    )
+
+
+def _q8_quantize(elem):
+    scale = mx.max(mx.abs(elem), axis=-1, keepdims=True) / 127.0
+    scale = mx.maximum(scale, 1e-12)
+    q = mx.round(elem / scale).astype(mx.int8)
+    return q, scale.astype(mx.float32)
+
+
+def _q8_dequantize(q, scale):
+    return q.astype(mx.float32) * scale
+
 
 def reset_boundary_snapshot_root(base_dir: Path) -> None:
     """Remove all boundary snapshot sessions for a server lifecycle boundary."""
@@ -702,6 +729,11 @@ class BoundarySnapshotSSDStore:
                         if _has_zero_dim(elem):
                             arrays[f"layer_{i}_state_{k}"] = mx.zeros((1,))
                             info[f"zero_dim_{k}"] = _encode_shape(elem.shape)
+                        elif _q8_eligible(elem):  # int8 snapshot state
+                            q8, q8s = _q8_quantize(elem)
+                            arrays[f"layer_{i}_state_{k}"] = q8
+                            arrays[f"layer_{i}_state_{k}_q8s"] = q8s
+                            info[f"q8_{k}"] = "1"
                         else:
                             arrays[f"layer_{i}_state_{k}"] = elem
                 else:
@@ -849,6 +881,13 @@ class BoundarySnapshotSSDStore:
                     zd_shape = tuple(int(d) for d in info[zd_marker].split(","))
                     restored = _restore_tensor_from_bytes(raw, dtype_str, [1])
                     elements.append(mx.zeros(zd_shape, dtype=restored.dtype))
+                elif (  # int8 snapshot state
+                    info.get(f"q8_{k}") == "1" and f"{key}_q8s" in tensors_raw
+                ):
+                    q8 = _restore_tensor_from_bytes(raw, dtype_str, shape)
+                    sraw, sdt, sshape = tensors_raw[f"{key}_q8s"]
+                    q8s = _restore_tensor_from_bytes(sraw, sdt, sshape)
+                    elements.append(_q8_dequantize(q8, q8s))
                 else:
                     elements.append(_restore_tensor_from_bytes(raw, dtype_str, shape))
             return tuple(elements)
@@ -983,6 +1022,11 @@ class BoundarySnapshotSSDStore:
                 if zd_marker in info:
                     zd_shape = tuple(int(d) for d in info[zd_marker].split(","))
                     elements.append(mx.zeros(zd_shape, dtype=tensor.dtype))
+                elif (  # int8 snapshot state
+                    info.get(f"q8_{k}") == "1"
+                    and arrays.get(f"{key}_q8s") is not None
+                ):
+                    elements.append(_q8_dequantize(tensor, arrays[f"{key}_q8s"]))
                 else:
                     elements.append(tensor)
             return tuple(elements)

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1772,6 +1772,9 @@ class Scheduler:
         self._boundary_snapshot_required: bool | None = None
         # SSD store for offloading boundary snapshots (initialized in _init_tiered_cache).
         self._boundary_snapshot_store: BoundarySnapshotSSDStore | None = None
+        # Lazy per-layer map of expected Mamba2 SSM state shapes, used to
+        # scope int8 boundary-snapshot storage (None until first computed).
+        self._ssm_q8_state_shapes: dict[int, tuple[int, ...]] | None = None
 
         # paged SSD cache for KV state persistence (oMLX only supports paged SSD-based caching)
         self.paged_cache_manager: PagedCacheManager | None = None
@@ -5010,6 +5013,51 @@ class Scheduler:
             with mx.stream(self._stream):
                 mx.eval(*leaves)
 
+    def _mamba2_ssm_state_shapes(self) -> dict[int, tuple[int, ...]]:
+        """Per-layer expected Mamba2 SSM state shape, for int8 snapshots.
+
+        Walks the model's layers once and records, for each layer whose
+        mixer is a Mamba2-family SSM (has ``num_heads`` / ``head_dim`` /
+        ``ssm_state_size`` plus ``conv1d`` and ``A_log``), the expected
+        state shape ``(num_heads, head_dim, ssm_state_size)`` without the
+        batch axis. This is the state type whose 8-bit storage is
+        accuracy-validated (Quamba2); other fp32 recurrent states (e.g.
+        gated-deltanet) deliberately do not match and stay fp32 in
+        boundary snapshots.
+        """
+        if self._ssm_q8_state_shapes is not None:
+            return self._ssm_q8_state_shapes
+
+        shapes: dict[int, tuple[int, ...]] = {}
+        model = getattr(self, "model", None)
+        layers = getattr(model, "layers", None)
+        if layers is None:
+            layers = getattr(getattr(model, "model", None), "layers", None)
+        try:
+            for i, layer in enumerate(layers or []):
+                modules = getattr(layer, "modules", None)
+                if not callable(modules):
+                    continue
+                for m in modules():
+                    num_heads = getattr(m, "num_heads", None)
+                    head_dim = getattr(m, "head_dim", None)
+                    state_size = getattr(m, "ssm_state_size", None)
+                    if (
+                        isinstance(num_heads, int)
+                        and isinstance(head_dim, int)
+                        and isinstance(state_size, int)
+                        and getattr(m, "conv1d", None) is not None
+                        and getattr(m, "A_log", None) is not None
+                    ):
+                        shapes[i] = (num_heads, head_dim, state_size)
+                        break
+        except Exception as e:
+            logger.debug("Mamba2 SSM state shape scan failed: %s", e)
+            shapes = {}
+
+        self._ssm_q8_state_shapes = shapes
+        return shapes
+
     def _on_prefill_boundary_snapshot(
         self,
         request_id: str,
@@ -5056,6 +5104,7 @@ class Scheduler:
                     token_count,
                     snapshot_cache,
                     self._extract_cache_states,
+                    ssm_state_shapes=self._mamba2_ssm_state_shapes(),
                 )
             if saved:
                 self._boundary_cache_snapshots[request_id][token_count] = None
@@ -5240,6 +5289,7 @@ class Scheduler:
                     total_tokens,
                     snapshot_cache,
                     self._extract_cache_states,
+                    ssm_state_shapes=self._mamba2_ssm_state_shapes(),
                 )
             if saved:
                 self._boundary_cache_snapshots[request.request_id][total_tokens] = None

--- a/tests/test_q8_boundary_snapshots.py
+++ b/tests/test_q8_boundary_snapshots.py
@@ -1,0 +1,121 @@
+"""Round-trip tests for int8 boundary-snapshot state storage.
+
+Simulates a Nemotron-3-Super snapshot: 40 ArraysCache layers with bf16 conv
+state + fp32 ssm state, plus 8 KVCache layers set to None (sliceable layers
+are skipped in snapshots). Exercises both readers: the raw-bytes pending
+path (load before flush) and the safetensors disk path (load after flush,
+pending cleared)."""
+
+import time
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from omlx.cache.boundary_snapshot_store import (  # noqa: E402
+    BoundarySnapshotSSDStore,
+)
+
+pytestmark = pytest.mark.skipif(
+    not mx.metal.is_available(), reason="Metal is not available"
+)
+
+
+def fake_extract(snapshot_cache):
+    extracted = []
+    for entry in snapshot_cache:
+        if entry is None:
+            extracted.append(
+                {
+                    "state": (),
+                    "meta_state": (),
+                    "class_name": "KVCache",
+                    "cache_type": "KVCache",
+                }
+            )
+        else:
+            conv, ssm = entry
+            extracted.append(
+                {
+                    "state": (conv, ssm),
+                    "meta_state": ("6",),
+                    "class_name": "ArraysCache",
+                    "cache_type": "ArraysCache",
+                }
+            )
+    return extracted, {}
+
+
+def rel(a, b):
+    a, b = a.astype(mx.float32), b.astype(mx.float32)
+    return (mx.abs(a - b).max() / (mx.abs(b).max() + 1e-8)).item()
+
+
+def test_q8_round_trip(tmp_path):
+    mx.random.seed(11)
+    layers = []
+    for i in range(8):
+        if i % 4 == 3:  # sprinkle "attention" layers
+            layers.append(None)
+        else:
+            conv = (mx.random.normal((1, 3, 2560)) * 0.5).astype(mx.bfloat16)
+            ssm = mx.random.normal((1, 32, 64, 128)).astype(mx.float32) * 0.3
+            layers.append((conv, ssm))
+    mx.eval(*[a for lay in layers if lay for a in lay])
+
+    store = BoundarySnapshotSSDStore(tmp_path)
+
+    ok = store.save("req1", 2048, layers, fake_extract)
+    assert ok, "save failed"
+
+    # ---- pending-path load (raw bytes) — force _deserialize, not the
+    # cheap 'extracted' echo, by removing it
+    with store._pending_lock:
+        entry = store._pending_writes[("req1", 2048)]
+        raw_bytes = sum(len(v[0]) for v in entry["tensors_raw"].values())
+        entry.pop("extracted", None)
+    loaded_pending = store.load("req1", 2048)
+    assert loaded_pending is not None, "pending load failed"
+
+    # ---- wait for the writer thread to flush, then clear pending -> disk
+    for _ in range(100):
+        with store._pending_lock:
+            if ("req1", 2048) not in store._pending_writes:
+                break
+        time.sleep(0.05)
+    else:
+        # some versions keep pending entries until cleanup; drop manually
+        with store._pending_lock:
+            store._pending_writes.pop(("req1", 2048), None)
+    loaded_disk = store.load("req1", 2048)
+    assert loaded_disk is not None, "disk load failed"
+
+    files = list(store._snapshot_dir.rglob("*.safetensors"))
+    disk_bytes = sum(f.stat().st_size for f in files)
+
+    worst_ssm, worst_conv = 0.0, 0.0
+    for name, loaded in (("pending", loaded_pending), ("disk", loaded_disk)):
+        for i, layer in enumerate(layers):
+            if layer is None:
+                assert (
+                    loaded[i]["state"] == ()
+                    or loaded[i]["state"] is None
+                    or len(loaded[i]["state"]) == 0
+                )
+                continue
+            conv, ssm = layer
+            lconv, lssm = loaded[i]["state"]
+            ec, es = rel(lconv, conv), rel(lssm, ssm)
+            worst_conv, worst_ssm = max(worst_conv, ec), max(worst_ssm, es)
+            assert ec == 0.0, f"{name} layer {i}: conv changed ({ec})"
+            assert es < 1.2e-2, f"{name} layer {i}: ssm err {es}"
+
+    fp32_bytes = sum(
+        lay[1].size * 4 + lay[0].size * 2 for lay in layers if lay is not None
+    )
+    # 4x on the fp32 ssm payload (conv bf16 stays exact and unquantized)
+    assert raw_bytes < 0.35 * fp32_bytes
+    assert disk_bytes < 0.35 * fp32_bytes
+    assert worst_conv == 0.0
+    assert worst_ssm < 1.2e-2
+    store.cleanup_all()

--- a/tests/test_q8_boundary_snapshots.py
+++ b/tests/test_q8_boundary_snapshots.py
@@ -1,10 +1,15 @@
 """Round-trip tests for int8 boundary-snapshot state storage.
 
-Simulates a Nemotron-3-Super snapshot: 40 ArraysCache layers with bf16 conv
-state + fp32 ssm state, plus 8 KVCache layers set to None (sliceable layers
-are skipped in snapshots). Exercises both readers: the raw-bytes pending
-path (load before flush) and the safetensors disk path (load after flush,
-pending cleared)."""
+int8 storage is scoped: ``save`` only quantizes fp32 states on layers the
+caller has semantically identified as Mamba2-family SSM (via
+``ssm_state_shapes``), and only when the tensor matches the expected
+per-layer state shape. Everything else — including large fp32 recurrent
+states of non-Mamba layers (e.g. gated-deltanet) — is stored bit-exact.
+
+Covers all three read paths (pending fast path, raw-bytes pending path,
+safetensors disk path), which must restore the identical representation
+regardless of writer timing, plus greedy cache-hit output regressions on a
+tiny in-process mlx-lm mamba2 model."""
 
 import time
 
@@ -19,6 +24,9 @@ from omlx.cache.boundary_snapshot_store import (  # noqa: E402
 pytestmark = pytest.mark.skipif(
     not mx.metal.is_available(), reason="Metal is not available"
 )
+
+# Matches the fake Nemotron-style layers built in _make_layers.
+_SSM_SHAPE = (32, 64, 128)
 
 
 def fake_extract(snapshot_cache):
@@ -51,21 +59,43 @@ def rel(a, b):
     return (mx.abs(a - b).max() / (mx.abs(b).max() + 1e-8)).item()
 
 
-def test_q8_round_trip(tmp_path):
-    mx.random.seed(11)
+def _make_layers(n=8, ssm_shape=_SSM_SHAPE):
     layers = []
-    for i in range(8):
+    for i in range(n):
         if i % 4 == 3:  # sprinkle "attention" layers
             layers.append(None)
         else:
             conv = (mx.random.normal((1, 3, 2560)) * 0.5).astype(mx.bfloat16)
-            ssm = mx.random.normal((1, 32, 64, 128)).astype(mx.float32) * 0.3
+            ssm = mx.random.normal((1, *ssm_shape)).astype(mx.float32) * 0.3
             layers.append((conv, ssm))
     mx.eval(*[a for lay in layers if lay for a in lay])
+    return layers
+
+
+def _ssm_shapes(layers, shape=_SSM_SHAPE):
+    return {i: shape for i, lay in enumerate(layers) if lay is not None}
+
+
+def _drain_pending(store, key):
+    for _ in range(100):
+        with store._pending_lock:
+            if key not in store._pending_writes:
+                return
+        time.sleep(0.05)
+    # some versions keep pending entries until cleanup; drop manually
+    with store._pending_lock:
+        store._pending_writes.pop(key, None)
+
+
+def test_q8_round_trip(tmp_path):
+    mx.random.seed(11)
+    layers = _make_layers()
 
     store = BoundarySnapshotSSDStore(tmp_path)
 
-    ok = store.save("req1", 2048, layers, fake_extract)
+    ok = store.save(
+        "req1", 2048, layers, fake_extract, ssm_state_shapes=_ssm_shapes(layers)
+    )
     assert ok, "save failed"
 
     # ---- pending-path load (raw bytes) — force _deserialize, not the
@@ -78,15 +108,7 @@ def test_q8_round_trip(tmp_path):
     assert loaded_pending is not None, "pending load failed"
 
     # ---- wait for the writer thread to flush, then clear pending -> disk
-    for _ in range(100):
-        with store._pending_lock:
-            if ("req1", 2048) not in store._pending_writes:
-                break
-        time.sleep(0.05)
-    else:
-        # some versions keep pending entries until cleanup; drop manually
-        with store._pending_lock:
-            store._pending_writes.pop(("req1", 2048), None)
+    _drain_pending(store, ("req1", 2048))
     loaded_disk = store.load("req1", 2048)
     assert loaded_disk is not None, "disk load failed"
 
@@ -118,4 +140,254 @@ def test_q8_round_trip(tmp_path):
     assert disk_bytes < 0.35 * fp32_bytes
     assert worst_conv == 0.0
     assert worst_ssm < 1.2e-2
+    store.cleanup_all()
+
+
+def test_unscoped_states_stay_fp32(tmp_path):
+    """Without ssm_state_shapes, nothing is quantized — every state restores
+    bit-exact. This is the non-Mamba hybrid case (e.g. gated-deltanet models
+    like Qwen3.5) whose large fp32 recurrent states must NOT be q8."""
+    mx.random.seed(12)
+    layers = _make_layers()
+
+    store = BoundarySnapshotSSDStore(tmp_path)
+    ok = store.save("req1", 2048, layers, fake_extract)
+    assert ok, "save failed"
+
+    with store._pending_lock:
+        store._pending_writes[("req1", 2048)].pop("extracted", None)
+    loaded_pending = store.load("req1", 2048)
+    _drain_pending(store, ("req1", 2048))
+    loaded_disk = store.load("req1", 2048)
+
+    for loaded in (loaded_pending, loaded_disk):
+        assert loaded is not None
+        for i, layer in enumerate(layers):
+            if layer is None:
+                continue
+            for orig, rest in zip(layer, loaded[i]["state"]):
+                assert rest.dtype == orig.dtype
+                assert mx.array_equal(rest, orig).item(), f"layer {i} changed"
+    store.cleanup_all()
+
+
+def test_shape_mismatch_not_quantized(tmp_path):
+    """A scoped layer whose fp32 state does not match the expected SSM shape
+    (e.g. a deltanet-style recurrent state) is stored bit-exact."""
+    mx.random.seed(13)
+    # Large fp32 4-D states, but NOT the registered (32, 64, 128) shape.
+    layers = []
+    conv = (mx.random.normal((1, 3, 2048)) * 0.5).astype(mx.bfloat16)
+    delta = mx.random.normal((1, 16, 128, 128)).astype(mx.float32)
+    layers.append((conv, delta))
+    mx.eval(conv, delta)
+
+    store = BoundarySnapshotSSDStore(tmp_path)
+    ok = store.save(
+        "req1", 2048, layers, fake_extract, ssm_state_shapes={0: _SSM_SHAPE}
+    )
+    assert ok, "save failed"
+
+    with store._pending_lock:
+        store._pending_writes[("req1", 2048)].pop("extracted", None)
+    loaded = store.load("req1", 2048)
+    assert loaded is not None
+    lconv, ldelta = loaded[0]["state"]
+    assert ldelta.dtype == mx.float32
+    assert mx.array_equal(ldelta, delta).item()
+    assert mx.array_equal(lconv, conv).item()
+    store.cleanup_all()
+
+
+def test_all_read_paths_identical(tmp_path):
+    """The pending fast path, raw-bytes pending path, and disk path must
+    restore the identical representation — a cache hit cannot depend on
+    writer timing."""
+    mx.random.seed(14)
+    layers = _make_layers()
+
+    store = BoundarySnapshotSSDStore(tmp_path)
+    ok = store.save(
+        "req1", 2048, layers, fake_extract, ssm_state_shapes=_ssm_shapes(layers)
+    )
+    assert ok, "save failed"
+
+    # Fast path: 'extracted' still present.
+    loaded_fast = store.load("req1", 2048)
+    assert loaded_fast is not None
+
+    # Raw-bytes pending path.
+    with store._pending_lock:
+        store._pending_writes[("req1", 2048)].pop("extracted", None)
+    loaded_raw = store.load("req1", 2048)
+    assert loaded_raw is not None
+
+    # Disk path.
+    _drain_pending(store, ("req1", 2048))
+    loaded_disk = store.load("req1", 2048)
+    assert loaded_disk is not None
+
+    for i, layer in enumerate(layers):
+        if layer is None:
+            continue
+        for k in range(2):
+            fast = loaded_fast[i]["state"][k]
+            raw = loaded_raw[i]["state"][k]
+            disk = loaded_disk[i]["state"][k]
+            assert fast.dtype == raw.dtype == disk.dtype
+            assert mx.array_equal(fast, raw).item(), f"layer {i} elem {k}"
+            assert mx.array_equal(raw, disk).item(), f"layer {i} elem {k}"
+    store.cleanup_all()
+
+
+# ---------------------------------------------------------------------------
+# Greedy cache-hit output regressions on a tiny in-process mamba2 model.
+# ---------------------------------------------------------------------------
+
+
+def _tiny_mamba2():
+    mamba2 = pytest.importorskip("mlx_lm.models.mamba2")
+    args = mamba2.ModelArgs(
+        model_type="mamba2",
+        num_heads=16,
+        head_dim=64,
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=1024,
+        state_size=64,
+        num_hidden_layers=2,
+        layer_norm_epsilon=1e-5,
+        conv_kernel=4,
+        n_groups=4,
+        use_bias=False,
+        use_conv_bias=True,
+        tie_word_embeddings=True,
+        time_step_limit=(0.001, 100.0),
+        time_step_rank="auto",
+    )
+    model = mamba2.Model(args)
+    model.eval()
+    mx.eval(model.parameters())
+    return model
+
+
+def _scan_ssm_shapes(model):
+    """Mirror of Scheduler._mamba2_ssm_state_shapes' mixer predicate."""
+    shapes = {}
+    for i, layer in enumerate(model.layers):
+        for m in layer.modules():
+            num_heads = getattr(m, "num_heads", None)
+            head_dim = getattr(m, "head_dim", None)
+            state_size = getattr(m, "ssm_state_size", None)
+            if (
+                isinstance(num_heads, int)
+                and isinstance(head_dim, int)
+                and isinstance(state_size, int)
+                and getattr(m, "conv1d", None) is not None
+                and getattr(m, "A_log", None) is not None
+            ):
+                shapes[i] = (num_heads, head_dim, state_size)
+                break
+    return shapes
+
+
+def _extract_from_cache(cache):
+    extracted = []
+    for c in cache:
+        extracted.append(
+            {
+                "state": (c[0], c[1]),
+                "meta_state": (),
+                "class_name": "ArraysCache",
+                "cache_type": "ArraysCache",
+            }
+        )
+    return extracted, {}
+
+
+def _restore_cache(model, loaded):
+    cache = model.make_cache()
+    for c, layer_state in zip(cache, loaded):
+        c[0], c[1] = layer_state["state"]
+    return cache
+
+
+def _greedy_continue(model, cache, first_token, n=12):
+    tokens = []
+    tok = first_token
+    for _ in range(n):
+        logits = model(mx.array([[tok]]), cache=cache)
+        tok = mx.argmax(logits[:, -1, :]).item()
+        tokens.append(tok)
+    return tokens
+
+
+def test_cache_hit_greedy_output_parity(tmp_path):
+    """With int8 SSM snapshots active, greedy continuation from a cache hit
+    must be identical whichever read path served it."""
+    mx.random.seed(21)
+    model = _tiny_mamba2()
+    shapes = _scan_ssm_shapes(model)
+    # Predicate must find every mamba2 layer with the real state layout.
+    assert shapes == {0: (16, 64, 64), 1: (16, 64, 64)}
+
+    prompt = [7, 42, 99, 3, 58, 120, 14]
+    cache = model.make_cache()
+    logits = model(mx.array([prompt]), cache=cache)
+    last = mx.argmax(logits[:, -1, :]).item()
+
+    store = BoundarySnapshotSSDStore(tmp_path)
+    ok = store.save("req1", 2048, cache, _extract_from_cache, ssm_state_shapes=shapes)
+    assert ok, "save failed"
+
+    loaded_fast = store.load("req1", 2048)
+    with store._pending_lock:
+        entry = store._pending_writes.get(("req1", 2048))
+        if entry is not None:  # writer may have flushed already
+            entry.pop("extracted", None)
+    loaded_raw = store.load("req1", 2048)
+    _drain_pending(store, ("req1", 2048))
+    loaded_disk = store.load("req1", 2048)
+    assert None not in (loaded_fast, loaded_raw, loaded_disk)
+
+    out_fast = _greedy_continue(model, _restore_cache(model, loaded_fast), last)
+    out_raw = _greedy_continue(model, _restore_cache(model, loaded_raw), last)
+    out_disk = _greedy_continue(model, _restore_cache(model, loaded_disk), last)
+
+    assert out_fast == out_raw == out_disk
+    store.cleanup_all()
+
+
+def test_cache_hit_greedy_output_exact_when_unscoped(tmp_path):
+    """Without SSM scoping (a non-Mamba model), a cache hit must reproduce
+    the uninterrupted greedy continuation exactly."""
+    mx.random.seed(22)
+    model = _tiny_mamba2()
+
+    prompt = [5, 17, 200, 33, 91]
+    cache = model.make_cache()
+    logits = model(mx.array([prompt]), cache=cache)
+    last = mx.argmax(logits[:, -1, :]).item()
+
+    store = BoundarySnapshotSSDStore(tmp_path)
+    ok = store.save("req1", 2048, cache, _extract_from_cache)
+    assert ok, "save failed"
+
+    # Uninterrupted baseline, straight from the live cache.
+    baseline = _greedy_continue(model, cache, last)
+
+    with store._pending_lock:
+        entry = store._pending_writes.get(("req1", 2048))
+        if entry is not None:  # writer may have flushed already
+            entry.pop("extracted", None)
+    loaded_raw = store.load("req1", 2048)
+    _drain_pending(store, ("req1", 2048))
+    loaded_disk = store.load("req1", 2048)
+    assert None not in (loaded_raw, loaded_disk)
+
+    out_raw = _greedy_continue(model, _restore_cache(model, loaded_raw), last)
+    out_disk = _greedy_continue(model, _restore_cache(model, loaded_disk), last)
+
+    assert out_raw == baseline
+    assert out_disk == baseline
     store.cleanup_all()


### PR DESCRIPTION
Hybrid-model boundary snapshots carry the Mamba SSM states in fp32:
about **168 MB per snapshot** for a 40-Mamba-layer Nemotron-3-Super.
Every snapshot is serialized on the inference thread and staged through
the pending-write buffer to SSD (`cache/boundary_snapshot_store.py`).

This PR stores any large fp32 state tensor (≥64k elements, ndim ≥ 2) as
symmetric int8 with per-row (last axis) fp32 scales:

- **a measured 170 MB drops to 46 MB per Nemotron-3-Super snapshot
  (3.7x)** for serialize copies, pending-write RAM, and SSD files;
- elementwise error is bounded by rowmax/254, measured at 4e-3 relative
  worst case. 8-bit SSM states are established as accuracy-safe
  (Quamba/Quamba2, ICML 2025);
- bf16 conv states and KV layers are untouched (bit-exact).

Both readers dequantize transparently (the raw-bytes pending path and the
safetensors disk path). Snapshots are ephemeral per-request files, so
there is no cross-version durability concern: a snapshot written with
this patch is always read by the same code. Opt out with
`OMLX_SNAPSHOT_Q8=0`.

Verified end-to-end on a 9.6k-token two-turn conversation with a hybrid
model: the follow-up turn resumes from a dequantized block-boundary
snapshot with unchanged output and a slightly faster turn (2.59 s vs
2.86 s, from the smaller inference-thread serialize copy).

Tests: round-trip through both reader paths with mixed
ArraysCache/KVCache layers, exactness of conv/KV payloads, size bound,
error bound.
