### PR TITLE
fix(scheduler): measure prefill chunk transients as peak spike, not footprint delta

### DIFF
--- a/omlx/prefill_transient_tracker.py
+++ b/omlx/prefill_transient_tracker.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 class PrefillTransientTracker:
     """EWMA estimator of MLX prefill chunk transient bytes per token.
 
-    Updated post-chunk from `phys_footprint()` deltas. The first chunk
-    has no measurement yet — callers fall back to a static estimate
+    Updated post-chunk from the measured peak-over-end spike (memory that
+    was allocated during the chunk and released again by the end of its
+    eval — see scheduler._measure_chunk_spike). The first chunk has no
+    measurement yet — callers fall back to a static estimate
     (MemoryMonitor.estimate_prefill_peak_bytes) until samples > 0.
     """
 
@@ -34,9 +36,9 @@ class PrefillTransientTracker:
     def update(self, n_tokens: int, transient_bytes: int) -> None:
         """Record one chunk observation.
 
-        Negative deltas (MLX cache pool reclaim larger than this chunk's
-        allocation) are skipped — they would bias the EWMA toward zero
-        and underestimate the next chunk's footprint.
+        Non-positive observations (the chunk produced no measurable spike)
+        are skipped — they would bias the EWMA toward zero and
+        underestimate the next chunk's footprint.
         """
         if n_tokens <= 0:
             return

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -211,6 +211,33 @@ def _safe_sync_stream(stream=None):
             raise
 
 
+def _measure_chunk_spike(peak_pre: int) -> int:
+    """Come-and-went Metal memory for the prefill chunk that just ran.
+
+    ``peak_pre`` is ``mx.get_peak_memory()`` sampled immediately before the
+    chunk. When the chunk pushed the process high-water mark above it, the
+    spike is ``peak - end_of_chunk_active``: memory that was allocated during
+    the chunk and released again by the time its eval finished (SDPA/MoE
+    intermediates). Resident growth (this chunk's KV append, lazily
+    materialized warm-restore arrays) stays in ``mx.get_active_memory()`` and
+    is deliberately NOT charged to the chunk — it is already part of the
+    guard's ``current`` baseline at the next check, and the static estimate
+    in ``_predicted_chunk_transient`` covers the per-chunk KV term (#1842).
+
+    Returns 0 (no sample) when the chunk did not set a new high-water mark —
+    its local peak is then unobservable without resetting the global counter,
+    which would corrupt concurrent readers (the admin benchmark brackets
+    ``stream_generate`` with reset/get, see admin/benchmark.py). In the
+    regime where the throttle matters — memory climbing toward the cap —
+    successive chunks keep setting new highs, so samples flow exactly when
+    they are needed; otherwise callers fall back to the static estimate.
+    """
+    peak_post = mx.get_peak_memory()
+    if peak_post <= peak_pre:
+        return 0
+    return int(peak_post - mx.get_active_memory())
+
+
 def _env_int(name: str, default: int = 0) -> int:
     value = os.environ.get(name)
     if value is None or value == "":
@@ -3075,7 +3102,7 @@ class Scheduler:
                 request_id=request.request_id,
             )
 
-            _throttle_pre = get_phys_footprint()
+            _peak_pre = mx.get_peak_memory()
             # External prefill bypasses BatchGenerator, so it must establish
             # the per-engine stream context itself. Native lazy primitives
             # otherwise bind to the worker's unrelated default stream and can
@@ -3105,11 +3132,9 @@ class Scheduler:
                     embeds_array = embeds_array[:, n_to_process:]
                     if extra_kwargs:
                         extra_kwargs = _advance_vlm_extra(extra_kwargs, n_to_process)
-            _throttle_post = get_phys_footprint()
             self._record_chunk_transient(
                 n_to_process,
-                _throttle_pre,
-                _throttle_post,
+                _measure_chunk_spike(_peak_pre),
                 request_id=request.request_id,
                 loop_label="external",
             )
@@ -3851,44 +3876,50 @@ class Scheduler:
     def _record_chunk_transient(
         self,
         n_tokens: int,
-        pre_bytes: int,
-        post_bytes: int,
+        transient_bytes: int,
         *,
         request_id: str,
         loop_label: str,
     ) -> None:
-        """Feed one chunk's measured transient into the EWMA tracker."""
-        delta = post_bytes - pre_bytes
+        """Feed one chunk's measured transient spike into the EWMA tracker.
+
+        ``transient_bytes`` is the come-and-went spike from
+        ``_measure_chunk_spike`` — NOT a resident-memory delta. A value of 0
+        means the chunk produced no observable sample (it did not set a new
+        process high-water mark); the tracker is left untouched so the
+        throttle falls back to its static estimate.
+        """
         min_chunk = max(1, self._prefill_min_chunk_tokens)
         if n_tokens < min_chunk:
             logger.debug(
-                "[throttle:%s] measure rid=%s n=%d delta=%.2fMB "
+                "[throttle:%s] measure rid=%s n=%d spike=%.2fMB "
                 "(skipped: tail < min_chunk=%d)",
                 loop_label,
                 request_id,
                 n_tokens,
-                delta / 1024**2,
+                transient_bytes / 1024**2,
                 min_chunk,
             )
             return
-        if delta <= 0:
+        if transient_bytes <= 0:
             logger.debug(
-                "[throttle:%s] measure rid=%s n=%d delta=%dB (skipped: <=0)",
+                "[throttle:%s] measure rid=%s n=%d spike=%dB "
+                "(skipped: no new peak)",
                 loop_label,
                 request_id,
                 n_tokens,
-                delta,
+                transient_bytes,
             )
             return
-        self._prefill_transient_tracker.update(n_tokens, delta)
+        self._prefill_transient_tracker.update(n_tokens, transient_bytes)
         logger.debug(
-            "[throttle:%s] measure rid=%s n=%d transient=%.2fMB "
+            "[throttle:%s] measure rid=%s n=%d spike=%.2fMB "
             "per_token=%.1fKB ewma=%.1fKB samples=%d",
             loop_label,
             request_id,
             n_tokens,
-            delta / 1024**2,
-            (delta / max(n_tokens, 1)) / 1024,
+            transient_bytes / 1024**2,
+            (transient_bytes / max(n_tokens, 1)) / 1024,
             self._prefill_transient_tracker.bytes_per_token / 1024,
             self._prefill_transient_tracker.samples,
         )
@@ -4067,7 +4098,7 @@ class Scheduler:
             request_id=state.request.request_id,
         )
 
-        _throttle_pre = get_phys_footprint()
+        _peak_pre = mx.get_peak_memory()
         # Chunked prefill also bypasses BatchGenerator and must establish the
         # same per-engine stream context as the regular external prefill path.
         # The chunk views stay inside it for the same reason (single-stream
@@ -4077,11 +4108,9 @@ class Scheduler:
             state.tokens_remaining = state.tokens_remaining[:, n:]
             self.model(chunk, cache=state.cache)
             mx.eval([c.state for c in state.cache])
-        _throttle_post = get_phys_footprint()
         self._record_chunk_transient(
             n,
-            _throttle_pre,
-            _throttle_post,
+            _measure_chunk_spike(_peak_pre),
             request_id=state.request.request_id,
             loop_label="chunked_step",
         )

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -414,7 +414,6 @@ def test_record_chunk_transient_skips_tail_samples():
 
     ns._record_chunk_transient(
         64,
-        0,
         32 * 1024**2,
         request_id="req-tail",
         loop_label="unit",
@@ -423,13 +422,67 @@ def test_record_chunk_transient_skips_tail_samples():
 
     ns._record_chunk_transient(
         256,
-        0,
         32 * 1024**2,
         request_id="req-full",
         loop_label="unit",
     )
     assert tracker.samples == 1
     assert tracker.last_delta_bytes == 32 * 1024**2
+
+
+def test_record_chunk_transient_skips_no_sample_chunks():
+    """A 0-byte observation (no new peak) must leave the tracker untouched."""
+    tracker = PrefillTransientTracker()
+    ns = SimpleNamespace(
+        _prefill_min_chunk_tokens=32,
+        _prefill_transient_tracker=tracker,
+    )
+    ns._record_chunk_transient = Scheduler._record_chunk_transient.__get__(
+        ns, Scheduler
+    )
+
+    ns._record_chunk_transient(
+        256,
+        0,
+        request_id="req-nopeak",
+        loop_label="unit",
+    )
+    assert tracker.samples == 0
+    assert tracker.bytes_per_token == 0.0
+
+
+def test_measure_chunk_spike_is_peak_over_end_active():
+    """When the chunk sets a new high-water mark, the spike is the
+    come-and-went memory: peak minus end-of-chunk active."""
+    with (
+        patch.object(sched_mod.mx, "get_peak_memory", return_value=16 * _GB),
+        patch.object(sched_mod.mx, "get_active_memory", return_value=10 * _GB),
+    ):
+        assert sched_mod._measure_chunk_spike(12 * _GB) == 6 * _GB
+
+
+def test_measure_chunk_spike_no_new_peak_yields_no_sample():
+    """A chunk that stays under the prior high-water mark is unobservable
+    (its local peak cannot be read without resetting the global counter) —
+    it must yield 0 so the throttle falls back to the static estimate."""
+    with (
+        patch.object(sched_mod.mx, "get_peak_memory", return_value=20 * _GB),
+        patch.object(sched_mod.mx, "get_active_memory", return_value=10 * _GB),
+    ):
+        assert sched_mod._measure_chunk_spike(20 * _GB) == 0
+
+
+def test_measure_chunk_spike_ignores_resident_growth():
+    """Resident growth (warm-restore materialization, KV append) must NOT be
+    charged to the chunk (#1842 defect 1): it stays in active memory, so a
+    chunk whose allocations all stayed resident measures a zero spike even
+    though the footprint grew by gigabytes."""
+    with (
+        patch.object(sched_mod.mx, "get_peak_memory", return_value=18 * _GB),
+        patch.object(sched_mod.mx, "get_active_memory", return_value=18 * _GB),
+    ):
+        # Footprint grew 6GB (12 -> 18) but nothing came-and-went.
+        assert sched_mod._measure_chunk_spike(12 * _GB) == 0
 
 
 def test_step_prefill_reclaims_before_first_guard():
@@ -470,7 +523,10 @@ def test_step_prefill_reclaims_before_first_guard():
         ),
         patch.object(sched_mod.mx, "stream"),
         patch.object(sched_mod.mx, "eval", lambda *args: events.append("eval")),
-        patch.object(sched_mod, "get_phys_footprint", side_effect=[100, 300]),
+        # peak: 100 pre-chunk, 300 post-chunk (new high-water mark);
+        # end-of-chunk active 250 -> spike = 300 - 250 = 50.
+        patch.object(sched_mod.mx, "get_peak_memory", side_effect=[100, 300]),
+        patch.object(sched_mod.mx, "get_active_memory", return_value=250),
     ):
         done = ns._step_prefill_chunk(state)
 
@@ -478,8 +534,7 @@ def test_step_prefill_reclaims_before_first_guard():
     assert events[:3] == ["sync", "adaptive", "guard"]
     ns._record_chunk_transient.assert_called_once_with(
         2,
-        100,
-        300,
+        50,
         request_id="req-prefill",
         loop_label="chunked_step",
     )


### PR DESCRIPTION
## What

The adaptive prefill throttle currently feeds its EWMA tracker with a
**phys-footprint delta** measured across each chunk
(`get_phys_footprint()` before/after in `_do_external_prefill` and
`_step_prefill_chunk`). That delta includes everything that became
resident during the chunk — most importantly the warm-restored chain's
lazy materialization (proportional to **kv_len**, not chunk size) and
Metal buffer-pool growth — so the per-token estimate is poisoned upward
at long context. The guard then multiplies the poisoned estimate into a
predicted transient of many GB, shrinks chunks to a crawl, and finally
rejects healthy requests at the pre-chunk guard.

This is **defect 1 of #1842** (@hojin12312's report — the measurements
there show a 1024-token chunk at 137K kv_len recording a 15.1 GB
"transient" and per-token estimates up to 40 MB/token). Defects 2–4 and
the sub-`min_chunk` tail-skip landed in a803e629; the measurement change
itself — the main fix for defect 1 — is still open. This PR implements
it.

## How

- Sample `mx.get_peak_memory()` immediately before the chunk. After the
  chunk's eval, when the peak advanced, record
  `peak − mx.get_active_memory()` — the memory that was allocated during
  the chunk and released again by the end of its eval (the SDPA/MoE
  transient). Resident growth (KV append, restore materialization) stays
  in `mx.get_active_memory()` and is **not** charged to the chunk: it is
  already part of the guard's `current` baseline at the next check, so
  the old delta double-counted it.
- The global peak counter is **not reset**: a per-chunk
  `mx.reset_peak_memory()` would corrupt concurrent readers — the admin
  benchmark brackets `stream_generate` with reset/get
  (`admin/benchmark.py`). When a chunk sets no new high-water mark its
  local peak is unobservable, so no sample is recorded and the throttle
  falls back to the static estimate — which remains the `max()` floor in
  `_predicted_chunk_transient`, leaving cold/unfused protection
  unchanged. In the regime where the throttle actually matters (memory
  climbing toward the cap) successive chunks keep setting new highs, so
  samples flow exactly when they are needed.
- `_record_chunk_transient` now takes the measured spike directly;
  0 means "no sample" and leaves the tracker untouched.

Files: `omlx/scheduler.py` (+ new `_measure_chunk_spike` helper),
`omlx/prefill_transient_tracker.py` (docstrings),
`tests/test_prefill_oom_graceful.py`.

## How verified

- **Unit tests**: `test_prefill_oom_graceful.py`,
  `test_prefill_transient_tracker.py`, `test_scheduler_chunked_prefill.py`,
  `test_scheduler.py` — 261 passed. New tests cover the spike math
  (peak-over-end-active), the no-new-peak abstention, and that
  resident-only growth records **no** sample (the core of defect 1).
- **Live A/B smoke** (M5 Max 128GB, Qwen3-4B-Instruct-2507-4bit,
  14,016-token prompt, 7 prefill chunks, identical request against this
  branch vs its base commit):
  - old delta: 1281 MB on chunk 1 (~2× the true spike) and a 2.8×
    chunk-to-chunk swing, 232–640 KB/token;
  - spike measurement: stable 308–385 KB/token across all 7 chunks
    (603–770 MB), no first-chunk distortion.
- **Scope honesty**: I did not reproduce the 136K→150K multi-turn
  ceiling change reported in #1842 — that regime needs the warm-restore
  + hot-cache setup of the original report. The mechanism (resident
  growth misattributed to the chunk) is what this PR removes, and the
  cold-prefill A/B above shows the measurement noise/inflation directly.
- `ruff check` on the touched files: finding set identical to base
  (zero new findings).

Closes the remaining defect of #1842 (defects 2–4 landed in a803e629).
Credit for the root-cause analysis and the fix design to @hojin12312.

---

Verified against `main` @ `41772940` before submitting: cherry-picks clean (auto-merge over a803e629), `mx.get_peak_memory` is still absent from `scheduler.py` so defect 1 is untouched, and the throttle feed points still sample `get_phys_footprint()` deltas.
