### PR TITLE
perf(embedding): group a batch by input length, restore caller order

### DIFF
--- a/omlx/engine/embedding.py
+++ b/omlx/engine/embedding.py
@@ -21,6 +21,15 @@ from .base import BaseNonStreamingEngine
 logger = logging.getLogger(__name__)
 
 
+def _input_length(item: Union[str, Dict[str, str]]) -> int:
+    """Approximate token cost of one embedding input, used only to group similar sizes."""
+    if isinstance(item, str):
+        return len(item)
+    if isinstance(item, dict):
+        return sum(len(v) for v in item.values() if isinstance(v, str))
+    return 0
+
+
 class EmbeddingEngine(BaseNonStreamingEngine):
     """
     Engine for generating text embeddings.
@@ -151,8 +160,14 @@ class EmbeddingEngine(BaseNonStreamingEngine):
             total_tokens = 0
             dimensions = 0
 
-            for start in range(0, len(input_items), batch_size):
-                batch = input_items[start:start + batch_size]
+            # A batch pads every input to its longest member, so a batch of mixed lengths spends
+            # most of its compute on padding. Group similar lengths together and restore the
+            # caller's order before returning, which leaves the response contract unchanged.
+            order = sorted(range(len(input_items)), key=lambda i: _input_length(input_items[i]))
+            ordered_items = [input_items[i] for i in order]
+
+            for start in range(0, len(ordered_items), batch_size):
+                batch = ordered_items[start:start + batch_size]
 
                 def _embed_sync():
                     try:
@@ -177,6 +192,12 @@ class EmbeddingEngine(BaseNonStreamingEngine):
                     token_count=total_tokens,
                     dimensions=dimensions,
                 )
+
+            if len(embeddings) == len(order):
+                restored: List[List[float]] = [[]] * len(order)
+                for position, original_index in enumerate(order):
+                    restored[original_index] = embeddings[position]
+                embeddings = restored
 
             output = EmbeddingOutput(
                 embeddings=embeddings,

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -929,6 +929,44 @@ class TestEmbeddingEngine:
         with pytest.raises(RuntimeError, match="Engine not started"):
             asyncio.run(engine.embed(["Hello"]))
 
+    def test_engine_embed_groups_by_length_and_restores_caller_order(self):
+        """A batch pads to its longest member, so inputs are embedded length-sorted.
+
+        The caller's order must survive that: every embedding comes back on the
+        input it was produced from, or a document silently receives its
+        neighbour's vector.
+        """
+        import asyncio
+
+        from omlx.engine.embedding import EmbeddingEngine
+        from omlx.models.embedding import EmbeddingOutput
+
+        texts = ["cccc", "a", "eeeeeeee", "bb", "dddddd", "a", "", "fffffffffff"]
+        seen_batches = []
+
+        def fake_embed(inputs, **kwargs):
+            seen_batches.append(list(inputs))
+            # the vector identifies the text it was produced from
+            return EmbeddingOutput(
+                embeddings=[[float(len(t))] for t in inputs],
+                total_tokens=sum(len(t) for t in inputs),
+                dimensions=1,
+            )
+
+        engine = EmbeddingEngine("test-model")
+        mock_model = MagicMock()
+        mock_model.embed.side_effect = fake_embed
+        engine._model = mock_model
+        engine._batch_size = 3
+
+        output = asyncio.run(engine.embed(texts))
+
+        assert [v[0] for v in output.embeddings] == [float(len(t)) for t in texts]
+
+        embedded = [t for batch in seen_batches for t in batch]
+        assert sorted(embedded, key=len) == embedded
+        assert sorted(embedded) == sorted(texts)
+
     def test_engine_get_stats(self):
         """Test engine statistics."""
         from omlx.engine.embedding import EmbeddingEngine


### PR DESCRIPTION
## Problem

Each forward pass pads every input to its longest member, so a batch of mixed lengths spends most of its compute on padding. `EmbeddingEngine.embed` slices `input_items` in caller order, so whatever length distribution the caller happens to send is what each batch pays for.

Real corpora are heterogeneous. In one document set the chunks run a **median of 37 characters, a p90 of 400, and a maximum in the thousands** — so a batch is routinely one long input plus dozens of short ones, all padded to the long one. The waste is the common case, not an edge case.

This is invisible from outside: the batching is internal, so a caller cannot fix it by sorting its own request — the engine re-slices whatever it is given.

## Fix

Sort inputs by length before batching, and restore the caller's order before returning. The response contract is unchanged; only the padding disappears.

## Measured

Through `/v1/embeddings`, 256 real chunks, unsorted client input, same server, this patch the only variable:

| | embeddings/sec |
|---|---|
| main | 7.1 |
| this branch | **9.4** (1.32x) |

It also makes `--embedding-batch-size` safe to raise, which today is a trap. Measured from a client that sorts its own input, a 256-input forward batch reaches 16.6/s against 13.5/s at 32 — but with unsorted input the same increase is a **regression**, 8.9 -> 7.0/s, because a larger mixed batch pads more rather than less. After this change the flag scales the way its name implies.

## Correctness

A wrong restore hands a document its neighbour's vector with nothing raising, so it is checked directly. Against a live server, each of the first, middle and last inputs embedded alone matches the same text embedded inside a mixed batch at **cosine 1.000000**.

`tests/test_embedding.py::TestEmbeddingEngine::test_engine_embed_groups_by_length_and_restores_caller_order` asserts both properties — that the engine embeds in non-decreasing length order, and that every embedding returns on its own input. It fails on `main` and passes here.

Full suite: **6934 passed, 74 skipped**.
