### PR TITLE
fix(admin): recognize reasoning-field variants in external benchmark streaming

### DIFF
--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -252,18 +252,21 @@ def _compute_single_metrics(
 
     ttft_ms = ttft_s * 1000
     if generation_measured and completion_tokens > 1 and gen_duration > 0:
-        tpot_ms = (gen_duration / (completion_tokens - 1)) * 1000
-        gen_tps = completion_tokens / gen_duration
+        tpot_ms: float | None = (gen_duration / (completion_tokens - 1)) * 1000
+        gen_tps: float | None = completion_tokens / gen_duration
     else:
-        tpot_ms = 0.0
-        gen_tps = 0.0
+        # Generation timing could not be measured (e.g. all content arrived
+        # in a single burst with no measurable inter-token span) — report
+        # unmeasured rather than a misleading 0.0.
+        tpot_ms = None
+        gen_tps = None
     processing_tps = prompt_tokens / max(prefill_duration, 1e-9)
     total_throughput = (prompt_tokens + completion_tokens) / max(e2e_duration, 1e-9)
 
     return {
         "ttft_ms": round(ttft_ms, 1),
-        "tpot_ms": round(tpot_ms, 2),
-        "gen_tps": round(gen_tps, 1),
+        "tpot_ms": round(tpot_ms, 2) if tpot_ms is not None else None,
+        "gen_tps": round(gen_tps, 1) if gen_tps is not None else None,
         "processing_tps": round(processing_tps, 1),
         "e2e_latency_s": round(e2e_duration, 3),
         "total_throughput": round(total_throughput, 1),
@@ -567,12 +570,18 @@ async def _run_external_batch_test(
     max_first_token = max(s.first_content_time for s in stats_list)
     pp_tps = total_prompt_tokens / max(max_first_token - wall_start, 1e-9)
 
-    # tg TPS: total generated tokens / generation wall time
-    tg_tps = total_gen_tokens / max(wall_end - max_first_token, 1e-9)
+    # tg TPS: total generated tokens / generation wall time. When the
+    # aggregate generation window collapses to zero or less (e.g. every
+    # request's content arrived at ~the same instant the batch finished),
+    # the rate is unmeasurable — report None instead of flooring the
+    # denominator, which would otherwise produce an inflated, meaningless
+    # tok/s figure.
+    gen_window = wall_end - max_first_token
+    tg_tps = round(total_gen_tokens / gen_window, 1) if gen_window > 0 else None
 
     return {
         "pp_tps": round(pp_tps, 1),
-        "tg_tps": round(tg_tps, 1),
+        "tg_tps": tg_tps,
         "avg_ttft_ms": round(avg_ttft_ms, 1),
         "e2e_latency_s": round(wall_time, 3),
         "total_gen_tokens": total_gen_tokens,

--- a/omlx/admin/external_api.py
+++ b/omlx/admin/external_api.py
@@ -398,7 +398,10 @@ class ExternalAPIClient:
                     content = delta.get("content")
                     if content:
                         text_parts.append(content)
-                    if content or delta.get("reasoning_content"):
+                    has_reasoning = any(
+                        delta.get(name) for name in _REASONING_FIELD_NAMES
+                    )
+                    if content or has_reasoning:
                         now = time.perf_counter()
                         if first_content_time is None:
                             first_content_time = now

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -3073,8 +3073,16 @@
 
             benchGetSpeedup(batchResult) {
                 const baseline = this.benchSingleResults.find(r => r.pp === 1024);
-                if (!baseline || !baseline.gen_tps || baseline.gen_tps <= 0) return 0;
+                if (!baseline || !baseline.gen_tps || baseline.gen_tps <= 0) return null;
+                if (batchResult.tg_tps === null || batchResult.tg_tps === undefined) return null;
                 return batchResult.tg_tps / baseline.gen_tps;
+            },
+
+            // Unmeasured metrics (tpot_ms/gen_tps/tg_tps) come through as
+            // null rather than a misleading 0.0 — render them as N/A.
+            benchFmtNum(value, decimals, suffix = '') {
+                if (value === null || value === undefined) return 'N/A';
+                return value.toFixed(decimals) + suffix;
             },
 
             benchFormatMemory(bytes) {
@@ -3112,9 +3120,9 @@
                         const row = [
                             rpad(`pp${r.pp}/tg${r.tg}`, 16),
                             pad(r.ttft_ms.toFixed(1), 10),
-                            pad(r.tpot_ms.toFixed(2), 10),
+                            pad(this.benchFmtNum(r.tpot_ms, 2), 10),
                             pad(r.processing_tps.toFixed(1) + ' tok/s', 12),
-                            pad(r.gen_tps.toFixed(1) + ' tok/s', 12),
+                            pad(this.benchFmtNum(r.gen_tps, 1, ' tok/s'), 12),
                             pad(r.e2e_latency_s.toFixed(3), 10),
                             pad(r.total_throughput.toFixed(1) + ' tok/s', 12),
                             pad(this.benchFormatMemory(r.peak_memory_bytes), 10),
@@ -3136,7 +3144,7 @@
                     if (baseline) {
                         const row = [
                             rpad('1x', 8),
-                            pad(baseline.gen_tps.toFixed(1) + ' tok/s', 12),
+                            pad(this.benchFmtNum(baseline.gen_tps, 1, ' tok/s'), 12),
                             pad('1.00x', 8),
                             pad(baseline.processing_tps.toFixed(1) + ' tok/s', 12),
                             pad(baseline.processing_tps.toFixed(1) + ' tok/s', 12),
@@ -3146,11 +3154,11 @@
                         lines.push(row.join('  '));
                     }
                     for (const r of results) {
-                        const speedup = baseline && baseline.gen_tps > 0 ? (r.tg_tps / baseline.gen_tps).toFixed(2) + 'x' : '-';
+                        const speedup = this.benchGetSpeedup(r);
                         const row = [
                             rpad(r.batch_size + 'x', 8),
-                            pad(r.tg_tps.toFixed(1) + ' tok/s', 12),
-                            pad(speedup, 8),
+                            pad(this.benchFmtNum(r.tg_tps, 1, ' tok/s'), 12),
+                            pad(speedup !== null ? speedup.toFixed(2) + 'x' : 'N/A', 8),
                             pad(r.pp_tps.toFixed(1) + ' tok/s', 12),
                             pad((r.pp_tps / r.batch_size).toFixed(1) + ' tok/s', 12),
                             pad(r.avg_ttft_ms.toFixed(1), 10),

--- a/omlx/admin/templates/dashboard/_bench.html
+++ b/omlx/admin/templates/dashboard/_bench.html
@@ -283,9 +283,9 @@
                                         <tr class="border-b border-neutral-100 hover:bg-neutral-50">
                                             <td class="px-4 py-3 font-medium text-neutral-900" x-text="'pp' + r.pp + '/tg' + r.tg"></td>
                                             <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.ttft_ms.toFixed(1)"></td>
-                                            <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.tpot_ms.toFixed(2)"></td>
+                                            <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="benchFmtNum(r.tpot_ms, 2)"></td>
                                             <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.processing_tps.toFixed(1) + ' tok/s'"></td>
-                                            <td class="px-4 py-3 text-right tabular-nums font-medium text-neutral-900" x-text="r.gen_tps.toFixed(1) + ' tok/s'"></td>
+                                            <td class="px-4 py-3 text-right tabular-nums font-medium text-neutral-900" x-text="benchFmtNum(r.gen_tps, 1, ' tok/s')"></td>
                                             <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.e2e_latency_s.toFixed(3) + 's'"></td>
                                             <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.total_throughput.toFixed(1) + ' tok/s'"></td>
                                             <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="benchFormatMemory(r.peak_memory_bytes)"></td>
@@ -332,8 +332,8 @@
                                     <template x-for="r in benchBatchResults" :key="r.batch_size">
                                         <tr class="border-b border-neutral-100 hover:bg-neutral-50">
                                             <td class="px-4 py-3 font-medium text-neutral-900" x-text="r.batch_size + 'x'"></td>
-                                            <td class="px-4 py-3 text-right tabular-nums font-medium text-neutral-900" x-text="r.tg_tps.toFixed(1) + ' tok/s'"></td>
-                                            <td class="px-4 py-3 text-right tabular-nums font-medium" :class="benchGetSpeedup(r) >= 1.5 ? 'text-green-600' : 'text-neutral-700'" x-text="benchGetSpeedup(r).toFixed(2) + 'x'"></td>
+                                            <td class="px-4 py-3 text-right tabular-nums font-medium text-neutral-900" x-text="benchFmtNum(r.tg_tps, 1, ' tok/s')"></td>
+                                            <td class="px-4 py-3 text-right tabular-nums font-medium" :class="benchGetSpeedup(r) !== null && benchGetSpeedup(r) >= 1.5 ? 'text-green-600' : 'text-neutral-700'" x-text="benchGetSpeedup(r) !== null ? benchGetSpeedup(r).toFixed(2) + 'x' : 'N/A'"></td>
                                             <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.pp_tps.toFixed(1) + ' tok/s'"></td>
                                             <td class="px-4 py-3 text-right tabular-nums text-neutral-500" x-text="(r.pp_tps / r.batch_size).toFixed(1) + ' tok/s'"></td>
                                             <td class="px-4 py-3 text-right tabular-nums text-neutral-700" x-text="r.avg_ttft_ms.toFixed(1)"></td>

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -198,10 +198,12 @@ class TestComputeMetrics:
             peak_memory=0,
             cached_tokens=0,
         )
-        # Should not raise, values should be finite
+        # Should not raise, values should be finite. Decode rate is
+        # unmeasurable (not 0.0 tok/s, which would misleadingly read as
+        # a real stall) so it reports None.
         assert metrics["ttft_ms"] == 0.0
-        assert metrics["gen_tps"] == 0.0
-        assert metrics["tpot_ms"] == 0.0
+        assert metrics["gen_tps"] is None
+        assert metrics["tpot_ms"] is None
 
     def test_native_duration_overrides(self):
         """Native engine timings can override streaming timing artifacts."""
@@ -233,8 +235,8 @@ class TestComputeMetrics:
             cached_tokens=0,
         )
 
-        assert metrics["gen_tps"] == 0.0
-        assert metrics["tpot_ms"] == 0.0
+        assert metrics["gen_tps"] is None
+        assert metrics["tpot_ms"] is None
         assert metrics["total_throughput"] == pytest.approx(1898.7, abs=0.1)
 
 
@@ -351,8 +353,8 @@ class TestRunSingleTest:
             )
 
         assert metrics["ttft_ms"] == pytest.approx(200.0)
-        assert metrics["gen_tps"] == 0.0
-        assert metrics["tpot_ms"] == 0.0
+        assert metrics["gen_tps"] is None
+        assert metrics["tpot_ms"] is None
 
 
 # =============================================================================
@@ -1229,6 +1231,107 @@ class TestRunExternalBenchmark:
         batch = [r for r in run.results if r["test_type"] == "batch"][0]
         assert batch["batch_size"] == 2
         assert batch["total_gen_tokens"] == 200
+
+    async def test_single_result_unmeasurable_span_reports_none(self):
+        """A true single-chunk dump (first_content_time == last_content_time
+        == end_time) must report tg TPS as unmeasured, not 0.0."""
+        from omlx.admin.external_api import StreamStats
+
+        collapsed_stats = StreamStats(
+            prompt_tokens=1000,
+            completion_tokens=128,
+            cached_tokens=0,
+            start_time=0.0,
+            first_content_time=0.5,
+            last_content_time=0.5,
+            end_time=0.5,
+            text="x" * 16,
+        )
+        run = self._make_run(prompt_lengths=[1024])
+        client = self._mock_client(collapsed_stats)
+
+        with patch(
+            "omlx.admin.benchmark.ExternalAPIClient", return_value=client
+        ):
+            await run_benchmark(run, MagicMock())
+
+        result = run.results[0]
+        assert result["gen_tps"] is None
+        assert result["tpot_ms"] is None
+
+    async def test_batch_collapsed_window_reports_none_not_inflated(self):
+        """When every request's content collapses to ~the batch completion
+        instant, tg TPS must be unmeasured, not an astronomically inflated
+        number produced by flooring a near-zero denominator.
+
+        Exercises _run_external_batch_test directly with a patched
+        perf_counter so the aggregate window is deterministically <= 0,
+        independent of real wall-clock timing.
+        """
+        from omlx.admin.benchmark import _run_external_batch_test
+        from omlx.admin.external_api import StreamStats
+
+        collapsed = StreamStats(
+            prompt_tokens=1000,
+            completion_tokens=128,
+            cached_tokens=0,
+            start_time=0.0,
+            # first_content_time lands *after* the wall_end the patched
+            # clock below will report, modeling the observed real-world
+            # collapse (content detected right at/after batch completion).
+            first_content_time=100.10,
+            last_content_time=100.10,
+            end_time=100.10,
+            text="x" * 16,
+        )
+        client = MagicMock()
+        client.stream_chat_completion = AsyncMock(return_value=collapsed)
+
+        with patch(
+            "omlx.admin.benchmark.time.perf_counter",
+            side_effect=[100.0, 100.05],  # wall_start, wall_end
+        ):
+            result = await _run_external_batch_test(
+                client=client,
+                prompts=["p1", "p2"],
+                max_tokens=128,
+                batch_size=2,
+            )
+
+        assert result["tg_tps"] is None
+
+    async def test_batch_measurable_window_computes_tg_tps(self):
+        """A real, positive aggregate generation window still computes a
+        normal tg_tps — no regression from the None-guard."""
+        from omlx.admin.benchmark import _run_external_batch_test
+        from omlx.admin.external_api import StreamStats
+
+        measured = StreamStats(
+            prompt_tokens=1000,
+            completion_tokens=128,
+            cached_tokens=0,
+            start_time=0.0,
+            first_content_time=0.5,
+            last_content_time=1.5,
+            end_time=1.6,
+            text="x" * 16,
+        )
+        client = MagicMock()
+        client.stream_chat_completion = AsyncMock(return_value=measured)
+
+        with patch(
+            "omlx.admin.benchmark.time.perf_counter",
+            side_effect=[0.0, 1.6],  # wall_start, wall_end
+        ):
+            result = await _run_external_batch_test(
+                client=client,
+                prompts=["p1", "p2"],
+                max_tokens=128,
+                batch_size=2,
+            )
+
+        # total_gen_tokens=256, gen window = wall_end(1.6) - max_first_token(0.5) = 1.1s
+        assert result["tg_tps"] == pytest.approx(256 / 1.1, abs=0.1)
 
     async def test_missing_usage_fails_run(self):
         from omlx.admin.external_api import ExternalEndpointError

--- a/tests/test_external_api.py
+++ b/tests/test_external_api.py
@@ -289,6 +289,59 @@ class TestStreamChatCompletion:
         assert stats.text == "answer"
         assert stats.first_content_time < stats.last_content_time
 
+    async def test_reasoning_field_variant_sets_timing_but_not_text(self):
+        """Some providers (e.g. Ollama) name the field 'reasoning', not
+        'reasoning_content'. Timing must still be detected (#opsx fix-external-bench-reasoning-field)."""
+
+        def handler(request):
+            return httpx.Response(
+                200,
+                content=_sse_body([
+                    {"choices": [{"delta": {"reasoning": "thinking..."}}]},
+                    _content_chunk("answer"),
+                    _usage_chunk(),
+                ]),
+            )
+
+        client = _client(handler)
+        try:
+            stats = await client.stream_chat_completion(
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=8,
+                temperature=0.0,
+            )
+        finally:
+            await client.aclose()
+        assert stats.text == "answer"
+        assert stats.first_content_time < stats.last_content_time
+
+    async def test_reasoning_only_field_variant_measures_full_span(self):
+        """When a thinking model spends its whole budget on 'reasoning' deltas
+        and never emits 'content', decode timing must still span the reasoning
+        chunks instead of collapsing to end_time."""
+
+        def handler(request):
+            return httpx.Response(
+                200,
+                content=_sse_body([
+                    {"choices": [{"delta": {"reasoning": "step one "}}]},
+                    {"choices": [{"delta": {"reasoning": "step two"}}]},
+                    _usage_chunk(completion=2),
+                ]),
+            )
+
+        client = _client(handler)
+        try:
+            stats = await client.stream_chat_completion(
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=8,
+                temperature=0.0,
+            )
+        finally:
+            await client.aclose()
+        assert stats.text == ""
+        assert stats.first_content_time <= stats.last_content_time
+
     async def test_auth_error_message_without_key(self):
         def handler(request):
             return httpx.Response(401, json={"error": {"message": "bad key"}})


### PR DESCRIPTION
## Summary

- Benchmarking an external OpenAI-compatible endpoint (Admin → Benchmarks → External) against a reasoning/thinking model whose provider emits `delta.reasoning` instead of `delta.reasoning_content` (e.g. Ollama serving `qwen3.6:35b-mlx`) produced unusable results: single-request `tg TPS` read `0.0` for every prompt length, and continuous-batching `tg TPS` read multi-million tok/s.
- Root cause: `ExternalAPIClient.stream_chat_completion()` only checked the hardcoded key `delta.get("reasoning_content")` for decode-timing purposes, even though the module already defines `_REASONING_FIELD_NAMES = ("reasoning_content", "reasoning", "analysis")` for exactly this kind of provider variance (it's just never wired into the streaming path). With no field match, and `content` empty for the whole response (the model spends its `max_tokens` budget on reasoning), `first_content_time`/`last_content_time` both collapse to `end_time`, giving `gen_duration == 0`. In the batch aggregation the same collapse divides through a `1e-9` floor, producing an unbounded, meaningless tok/s figure instead of an honest "unmeasured" result.
- Confirmed via a live raw-SSE capture (per-line timestamps) against a local Ollama endpoint that the server streams incrementally with realistic ~11ms inter-token gaps — this is a client-side detection bug, not a server limitation.

## Changes

- `omlx/admin/external_api.py`: `stream_chat_completion()` now checks all of `_REASONING_FIELD_NAMES`, not just `reasoning_content`.
- `omlx/admin/benchmark.py`: `_compute_single_metrics()` reports `tpot_ms`/`gen_tps` as `None` (not `0.0`) when generation timing is genuinely unmeasured; `_run_external_batch_test()` reports `tg_tps` as `None` instead of dividing through the `1e-9` floor when the aggregate generation window collapses to zero or less.
- `omlx/admin/static/js/dashboard.js` + `omlx/admin/templates/dashboard/_bench.html`: render `N/A` (via a shared `benchFmtNum()` helper) instead of crashing or showing a misleading `0.0 tok/s` when a metric is unmeasured; `benchGetSpeedup()` returns `null` instead of `0` in that case.
- Tests: new coverage for the `reasoning` field-name variant, the single-chunk-dump unmeasured case, and the batch near-zero-window guard (both the collapsed and the normal/measurable case, with a patched clock for determinism).

## Test plan

- [x] `pytest tests/test_external_api.py tests/test_benchmark.py -q` — 136/136 passed
- [x] Full repo suite (`pytest tests/`, excluding two files broken by an unrelated `huggingface_hub` API change) — 6758 passed, 15 pre-existing failures/errors, all in files this change doesn't touch or import (`mlx_vlm` restructuring, hardware-specific TurboQuant numerics), confirmed via disjoint `git diff --name-only` against `main`
- [x] Live re-run of the original repro against Ollama (`qwen3.6:35b-mlx`) through the actual fixed client code: single-request `gen_tps` now `114.8 tok/s` / `tpot_ms=8.78` (previously `0.0`/`0.0`); batch(2x) `tg_tps=177.4 tok/s` (previously multi-million tok/s)

Developed with the help of Claude Code; investigated and verified against a live Ollama endpoint before opening this PR.