### PR TITLE
Deterministic prefill admission and pressure abort fixes

### DIFF
--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -35,7 +35,11 @@ from typing import (
 
 import mlx.core as mx
 
-from .exceptions import PrefillMemoryExceededError, describe_ceiling_binding
+from .exceptions import (
+    PrefillMemoryAbortedError,
+    PrefillMemoryExceededError,
+    describe_ceiling_binding,
+)
 from .model_registry import get_registry
 from .output_collector import RequestOutputCollector, RequestStreamState
 from .request import Request, RequestOutput, SamplingParams
@@ -51,12 +55,20 @@ logger = logging.getLogger(__name__)
 
 
 def _raise_request_output_error(output: RequestOutput) -> None:
-    if output.error_code == "prefill_memory_exceeded":
+    if output.error_code in ("prefill_memory_exceeded", "prefill_memory_aborted"):
         metadata = output.error_metadata or {}
         request_id = metadata.get("request_id")
         estimated_bytes = metadata.get("estimated_bytes")
         limit_bytes = metadata.get("limit_bytes")
-        raise PrefillMemoryExceededError(
+        # Both are memory-guard outcomes and share the HTTP 400 mapping; the
+        # aborted subclass only changes the wording (admitted then killed
+        # mid-prefill vs rejected before it started).
+        error_type = (
+            PrefillMemoryAbortedError
+            if output.error_code == "prefill_memory_aborted"
+            else PrefillMemoryExceededError
+        )
+        raise error_type(
             message=output.error or "Prefill memory exceeded",
             request_id=str(request_id) if request_id is not None else output.request_id,
             estimated_bytes=(
@@ -742,6 +754,21 @@ class EngineCore:
                         finish_reason="error",
                         new_text=f"\n\n[Error: {error_msg}]",
                         error=error_msg,
+                        # Without a code this surfaced as a bare RuntimeError:
+                        # the JSON keepalive wrapper never saw a memory error,
+                        # so the response generator died mid-body and the
+                        # client got a truncated read plus a 500 traceback
+                        # instead of the same actionable 400 the pre-flight
+                        # guard returns.
+                        error_code="prefill_memory_aborted",
+                        error_metadata={
+                            "request_id": rid,
+                            # Only the limit is reported: the exception's
+                            # estimated_bytes means "predicted peak", and this
+                            # abort fires on measured usage, which the message
+                            # already states.
+                            "limit_bytes": watermark or ceiling or None,
+                        },
                     )
                 )
             self._mark_request_finished(rid)

--- a/omlx/exceptions.py
+++ b/omlx/exceptions.py
@@ -468,6 +468,19 @@ class PrefillMemoryExceededError(OMLXMemoryError):
         self.limit_bytes = limit_bytes
 
 
+class PrefillMemoryAbortedError(PrefillMemoryExceededError):
+    """
+    An admitted request was aborted mid-prefill by the memory enforcer.
+
+    The pre-flight guard let this request in, but process usage crossed the
+    hard watermark while it was prefilling, so the enforcer aborted it to
+    keep the server alive. Subclassing PrefillMemoryExceededError is what
+    routes this to the same HTTP 400 mapping and the JSON keepalive body;
+    the separate type only exists so the wording can say "aborted
+    mid-prefill" instead of "rejected this prompt".
+    """
+
+
 # =============================================================================
 # Engine Pool Exceptions
 # =============================================================================

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from collections import Counter
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -178,6 +180,14 @@ class MemoryMonitor:
         self._score_dtype_size: float = _SDPA_FALLBACK_SCORE_DTYPE_SIZE
         self._num_attention_heads: Optional[int] = None
         self._num_kv_cache_layers: Optional[int] = None
+        # Sliding-window (RotatingKVCache-family) layers as (count, window)
+        # groups. Their resident KV is bounded at window + chunk - 1 tokens
+        # per layer, so they need a capped term instead of the linear
+        # full-attention formula. Empty for non-hybrid models.
+        self._rotating_layer_specs: tuple[tuple[int, int], ...] = ()
+        # Fixed per-sequence recurrent state (GDN/Mamba ArraysCache),
+        # measured once from a live cache after the first prefill chunk.
+        self._fixed_state_bytes: int = 0
 
         # PagedCacheManager for KV cache memory measurement
         self._paged_cache_manager: Optional["PagedCacheManager"] = None
@@ -356,6 +366,7 @@ class MemoryMonitor:
         num_kv_cache_layers: Optional[int] = None,
         compute_dtype_size: Optional[float] = None,
         kv_bytes_per_token: Optional[float] = None,
+        rotating_layer_specs: Sequence[tuple[int, int]] | None = None,
     ) -> None:
         """
         Set model information for memory estimation.
@@ -380,6 +391,10 @@ class MemoryMonitor:
                 per token. Use for compressed-cache architectures such as MLA
                 where stored cache tensors are not representable as uniform
                 ``num_kv_heads * head_dim * 2`` K/V tensors.
+            rotating_layer_specs: Sliding-window layer groups as
+                ``(layer_count, window_tokens)`` pairs, used by
+                ``estimate_resident_kv_bytes`` for the window-capped KV term.
+                These layers are excluded from ``num_kv_cache_layers``.
         """
         self._num_layers = num_layers
         self._num_kv_heads = num_kv_heads
@@ -396,7 +411,20 @@ class MemoryMonitor:
             else None
         )
         self._num_attention_heads = num_attention_heads or num_kv_heads
-        self._num_kv_cache_layers = num_kv_cache_layers or num_layers
+        # ``is not None`` (not truthiness): a genuine 0 means "no
+        # full-attention layers" for rotating-only hybrids, and coercing it
+        # to num_layers would double-count on top of the rotating term.
+        self._num_kv_cache_layers = (
+            num_kv_cache_layers if num_kv_cache_layers is not None else num_layers
+        )
+        self._rotating_layer_specs = tuple(
+            (int(count), int(window))
+            for count, window in (rotating_layer_specs or ())
+            if count > 0 and window > 0
+        )
+        # A new model's fixed state must be re-measured; a stale value from
+        # the previous model would silently mis-charge admission.
+        self._fixed_state_bytes = 0
 
         # Log estimated memory per block
         if num_layers and num_kv_heads and head_dim:
@@ -407,14 +435,37 @@ class MemoryMonitor:
                 if self._kv_bytes_per_token_override
                 else ""
             )
+            rotating_note = (
+                ", rotating "
+                + "+".join(
+                    f"{count}x@{window}" for count, window in self._rotating_layer_specs
+                )
+                if self._rotating_layer_specs
+                else ""
+            )
             logger.info(
                 f"Model info set: {num_layers} layers "
-                f"({self._num_kv_cache_layers} KVCache), "
+                f"({self._num_kv_cache_layers} KVCache{rotating_note}), "
                 f"{num_kv_heads} KV heads, "
                 f"{self._num_attention_heads} Q heads, "
                 f"{head_dim} head_dim. Estimated memory per 64-token block: "
                 f"{format_bytes(sample_block_mem)}{override_note}"
             )
+
+    def set_fixed_state_bytes(self, n: int) -> None:
+        """Record the per-sequence fixed recurrent-state footprint.
+
+        Measured once from live ArraysCache-family caches after the first
+        prefill chunk (state shapes are unknown before the first forward).
+        Cleared by ``set_model_info`` so a model swap never inherits the
+        previous model's measurement.
+        """
+        self._fixed_state_bytes = max(0, int(n))
+
+    @property
+    def fixed_state_bytes(self) -> int:
+        """Measured per-sequence recurrent state bytes (0 until measured)."""
+        return self._fixed_state_bytes
 
     def has_model_info(self) -> bool:
         """Whether ``set_model_info`` has been called with real dims.
@@ -505,6 +556,44 @@ class MemoryMonitor:
         # KVCache layers: memory grows with num_tokens
         per_token = layers * kv_heads * dim * dtype * 2  # keys + values
         return num_tokens * per_token
+
+    def estimate_resident_kv_bytes(
+        self, num_tokens: int, *, chunk_tokens: int = 1
+    ) -> float:
+        """Exact-shape resident KV bytes a prefill of ``num_tokens`` adds.
+
+        Extends ``estimate_prompt_kv_bytes`` (full-attention layers only,
+        linear in tokens) with the two layer groups that formula cannot see:
+
+        - Sliding-window layers: each holds at most ``window + chunk - 1``
+          tokens (``RotatingKVCache._update_concat`` concatenates the chunk
+          before ``_trim``), so their term saturates instead of growing
+          linearly. Priced at the base/compute dtype: rotating layers are
+          pass-through for TurboQuant KV compression, so the fractional
+          ``_dtype_size`` would under-count them ~4x in TQ configurations.
+        - Fixed recurrent state (GDN/Mamba): a per-sequence constant,
+          measured after the first chunk (0 before that — same as today).
+
+        Admission-only: charge this once per request. Never call it from
+        per-chunk sizing paths — the fixed-state term would be re-charged
+        every chunk, and chunk sizing must stay on the frozen
+        ``_predicted_chunk_transient`` signal.
+        """
+        if num_tokens <= 0:
+            return 0
+        total = self.estimate_prompt_kv_bytes(num_tokens)
+
+        if self._rotating_layer_specs:
+            kv_heads = self._num_kv_heads or 0
+            dim = self._head_dim or 0
+            if kv_heads and dim:
+                chunk = max(int(chunk_tokens), 1)
+                per_token = kv_heads * dim * self._score_dtype_size * 2
+                for count, window in self._rotating_layer_specs:
+                    resident = min(num_tokens, window + chunk - 1)
+                    total += count * resident * per_token
+
+        return total + self._fixed_state_bytes
 
     def _uses_fused_sdpa(self, query_tokens: int, kv_len: int) -> bool:
         hd = self._head_dim or 0
@@ -618,8 +707,9 @@ class MemoryMonitor:
 
         # KV growth attributable to this request: only the new tokens.
         # The cached portion is already counted in the caller's current-usage
-        # baseline.
-        kv = self.estimate_prompt_kv_bytes(new_tokens)
+        # baseline. Resident math includes window-capped sliding-window
+        # layers and measured fixed state, not just full-attention KVCache.
+        kv = self.estimate_resident_kv_bytes(new_tokens, chunk_tokens=eff_chunk)
         return attn + kv
 
     def estimate_chunk_transient_bytes(self, n_tokens: int, kv_len: int) -> int:
@@ -721,6 +811,80 @@ def _cfg_get(obj: Any, key: str, default: Any = None) -> Any:
 
 def _pos_int(v: Any) -> bool:
     return isinstance(v, int) and not isinstance(v, bool) and v > 0
+
+
+# Known rotating-cache class names, matching the scheduler-side sets
+# (Scheduler._collect_rotating_window_sizes and the TurboQuant eligibility
+# walk). Backstop only — duck-typing on (positive int max_size, keep attr)
+# is the primary test so renamed omlx subclasses still classify.
+_ROTATING_CACHE_CLASS_NAMES = frozenset(
+    {
+        "RotatingKVCache",
+        "BatchRotatingKVCache",
+        "PrefillReadyRotatingKVCache",
+        "BufferedRotatingKVCache",
+    }
+)
+# Fixed-state recurrent caches (GDN/Mamba). Matches
+# Scheduler._cache_tree_has_arrays_cache plus mlx-lm's MambaCache.
+_ARRAYS_CACHE_CLASS_NAMES = frozenset(
+    {"ArraysCache", "SizedArraysCache", "MambaCache"}
+)
+
+
+def collect_kv_layer_specs(
+    cache_list: Any,
+) -> tuple[int, list[tuple[int, int]], int]:
+    """Classify a ``model.make_cache()`` result into KV-layer groups.
+
+    Returns ``(full_kv_layers, rotating_specs, arrays_layers)`` where
+    ``rotating_specs`` groups sliding-window layers as
+    ``(layer_count, window_tokens)`` pairs. Full-attention layers keep the
+    strict ``type(c) is KVCache`` test the hybrid-layer counting has always
+    used; rotating layers are duck-typed (positive int ``max_size`` plus a
+    ``keep`` attribute) with a class-name backstop, avoiding a dependency on
+    scheduler-side registries. Returns all-zero on any failure so callers
+    degrade to today's behavior.
+    """
+    if cache_list is None:
+        return 0, [], 0
+    try:
+        from mlx_lm.models.cache import CacheList, KVCache
+    except ImportError:
+        return 0, [], 0
+
+    full = 0
+    arrays = 0
+    windows: Counter[int] = Counter()
+
+    def _walk(c: Any) -> None:
+        nonlocal full, arrays
+        if type(c) is KVCache:
+            full += 1
+            return
+        if isinstance(c, CacheList):
+            for inner in c.caches:
+                _walk(inner)
+            return
+        name = type(c).__name__
+        max_size = getattr(c, "max_size", None)
+        if (_pos_int(max_size) and hasattr(c, "keep")) or (
+            name in _ROTATING_CACHE_CLASS_NAMES
+        ):
+            if _pos_int(max_size):
+                windows[max_size] += 1
+            return
+        if name in _ARRAYS_CACHE_CLASS_NAMES:
+            arrays += 1
+
+    try:
+        for c in cache_list:
+            _walk(c)
+    except Exception:
+        return 0, [], 0
+
+    specs = [(count, window) for window, count in sorted(windows.items())]
+    return full, specs, arrays
 
 
 def estimate_mla_kv_bytes_per_token(
@@ -851,26 +1015,25 @@ def set_model_info_from_model(monitor: "MemoryMonitor", model: Any) -> None:
             or num_kv_heads
         )
 
-        # Count KVCache layers for hybrid models. Mirrors
-        # Scheduler._set_model_info_for_monitor: recurse into CacheList so
-        # wrapped full-attention layers are counted, not just bare KVCache.
+        # Classify layer cache types for hybrid models. Mirrors
+        # Scheduler._set_model_info_for_monitor via the shared helper so the
+        # DFlash guard and the scheduler guard price the same layer groups.
         cache_list = None
         num_kv_cache_layers = num_layers
+        rotating_layer_specs: list[tuple[int, int]] = []
         if hasattr(model, "make_cache"):
             try:
                 cache_list = model.make_cache()
-                from mlx_lm.models.cache import CacheList, KVCache
-
-                def _count_kv(c: Any) -> int:
-                    if type(c) is KVCache:
-                        return 1
-                    if isinstance(c, CacheList):
-                        return sum(_count_kv(inner) for inner in c.caches)
-                    return 0
-
-                num_kv_cache_layers = sum(_count_kv(c) for c in cache_list)
-                if num_kv_cache_layers == 0:
-                    num_kv_cache_layers = num_layers  # fallback
+                full_layers, rotating_layer_specs, arrays_layers = (
+                    collect_kv_layer_specs(cache_list)
+                )
+                num_kv_cache_layers = full_layers
+                # Fall back to charging every layer only when classification
+                # found nothing at all. A genuine 0 full-attention count next
+                # to rotating/arrays layers must stay 0, or the rotating term
+                # would be double-counted on top of a linear all-layers term.
+                if full_layers == 0 and not rotating_layer_specs and not arrays_layers:
+                    num_kv_cache_layers = num_layers
             except Exception:
                 pass
 
@@ -894,6 +1057,7 @@ def set_model_info_from_model(monitor: "MemoryMonitor", model: Any) -> None:
                 # dtype_size already equals the compute/activation dtype.
                 compute_dtype_size=dtype_size,
                 kv_bytes_per_token=kv_bytes_per_token,
+                rotating_layer_specs=rotating_layer_specs,
             )
             logger.debug(
                 f"Model info for memory estimation: "

--- a/omlx/prefill_transient_tracker.py
+++ b/omlx/prefill_transient_tracker.py
@@ -12,6 +12,10 @@ from the global PrefillProgressTracker which feeds the admin dashboard.
 
 from __future__ import annotations
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class PrefillTransientTracker:
     """EWMA estimator of MLX prefill chunk transient bytes per token.
@@ -22,6 +26,12 @@ class PrefillTransientTracker:
     """
 
     _EWMA_ALPHA = 0.3  # weight on the most recent chunk
+    # Candidates above this are rejected from the running max: a one-off
+    # Metal/pool spike this large is not a repeatable chunk transient, and
+    # charging it at admission would refuse prompts that always fit. A
+    # genuinely recurring giant transient still reaches the guard through
+    # the last-delta/EWMA terms of _predicted_chunk_transient.
+    _OBSERVED_MAX_CLAMP_BYTES = 4 * 1024**3
 
     def __init__(self, model_id: str = "") -> None:
         self._model_id = model_id
@@ -30,18 +40,49 @@ class PrefillTransientTracker:
         # Last observed delta for debug log inspection.
         self._last_delta_bytes: int = 0
         self._last_n_tokens: int = 0
+        # Largest floor-size chunk transient seen this session: a stable
+        # flat bound for admission and the pre-chunk guard's pass/abort
+        # gates, matching the floor-chunk charge they price. Never used
+        # for chunk sizing.
+        self._observed_max_bytes: int = 0
 
-    def update(self, n_tokens: int, transient_bytes: int) -> None:
+    def update(
+        self, n_tokens: int, transient_bytes: int, *, floor_sample: bool = False
+    ) -> None:
         """Record one chunk observation.
 
         Negative deltas (MLX cache pool reclaim larger than this chunk's
         allocation) are skipped — they would bias the EWMA toward zero
         and underestimate the next chunk's footprint.
+
+        ``floor_sample`` marks a chunk at the throttle's floor size. Only
+        those feed the running max: admission charges the floor chunk, and
+        chunk-transient maxima are NOT size-invariant across models
+        (Qwen3.6 measured ~3.0GB at 2048-token chunks vs far less at the
+        floor; charging the big-chunk max at admission rejected every
+        prompt at a 21GB ceiling). Big-chunk transients stay the throttle's
+        domain via the EWMA/last-delta terms.
         """
         if n_tokens <= 0:
             return
         if transient_bytes <= 0:
             return
+
+        # The very first sample after a model load carries weight page-fault
+        # and load-residue noise, so it seeds the EWMA but is excluded from
+        # the running max.
+        if floor_sample and self._samples > 0:
+            if transient_bytes <= self._OBSERVED_MAX_CLAMP_BYTES:
+                if transient_bytes > self._observed_max_bytes:
+                    self._observed_max_bytes = transient_bytes
+            else:
+                logger.debug(
+                    "PrefillTransientTracker(%s): rejected %d-byte outlier "
+                    "from observed max (clamp %d)",
+                    self._model_id,
+                    transient_bytes,
+                    self._OBSERVED_MAX_CLAMP_BYTES,
+                )
 
         per_token = transient_bytes / n_tokens
         if self._samples == 0:
@@ -85,9 +126,15 @@ class PrefillTransientTracker:
         """Token count of the most recently measured chunk."""
         return self._last_n_tokens
 
+    @property
+    def observed_max_bytes(self) -> int:
+        """Largest accepted chunk transient this session (0 if none yet)."""
+        return self._observed_max_bytes
+
     def reset(self) -> None:
         """Drop all observations (e.g. on model reload or after a long idle)."""
         self._ewma_per_token = 0.0
         self._samples = 0
         self._last_delta_bytes = 0
         self._last_n_tokens = 0
+        self._observed_max_bytes = 0

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -384,6 +384,10 @@ class ProcessMemoryEnforcer:
         # admission control. Updated on every poll iteration.
         self._pressure_level: str = "ok"
         self._over_ceiling_polls: int = 0
+        # Consecutive hard-pressure polls we have deferred the busy-request
+        # abort while a fat Metal buffer pool drains at the next prefill
+        # chunk / step boundary. See the grace check in _check_and_enforce.
+        self._busy_abort_grace_polls: int = 0
         # Last value passed to mx.set_wired_limit (0 if not yet applied
         # or the call failed). Used by the admin dashboard to surface a
         # warning when the kernel iogpu.wired_limit_mb is below this.
@@ -1005,6 +1009,17 @@ class ProcessMemoryEnforcer:
     # _periodic_clear_threshold_bytes floor). Above it, a clear meaningfully
     # returns memory to the OS.
     _POOL_RECLAIM_FLOOR = 2 * 1024**3
+    # Max consecutive hard-pressure polls the busy-request abort is deferred
+    # while a reclaimable pool drains. Prefill chunks run ~5s at full step
+    # size, so 5 one-second polls cover at least one chunk boundary.
+    _BUSY_ABORT_GRACE_POLLS_MAX = 5
+
+    def _pool_bytes(self) -> int:
+        """MLX buffer-pool size, 0 when unreadable (mocked mx in tests)."""
+        try:
+            return int(mx.get_cache_memory())
+        except (TypeError, ValueError):
+            return 0
 
     def _request_scheduler_cache_reclaim(self, freed_hot: int) -> None:
         """Ask each scheduler to run its step-boundary Metal cache clear.
@@ -1024,13 +1039,9 @@ class ProcessMemoryEnforcer:
         already-wedged case where hot cache is empty but pooled buffers are
         stranded).
         """
-        raw_pool = mx.get_cache_memory()
-        try:
-            pool_bytes = int(raw_pool)
-        except (TypeError, ValueError):
-            # A non-numeric reading (e.g. a wholesale-mocked mx in unit
-            # tests) cannot justify a clear; treat it as an empty pool.
-            pool_bytes = 0
+        # A non-numeric reading (e.g. a wholesale-mocked mx in unit tests)
+        # cannot justify a clear; _pool_bytes treats it as an empty pool.
+        pool_bytes = self._pool_bytes()
         if freed_hot <= 0 and pool_bytes <= self._POOL_RECLAIM_FLOOR:
             return
         requested = 0
@@ -1424,6 +1435,12 @@ class ProcessMemoryEnforcer:
         else:
             new_level = "hard"
 
+        if new_level != "hard":
+            # The hard episode ended (drain worked or the load finished):
+            # the next one gets a fresh abort-grace budget. Must happen
+            # before the ok-level early return below.
+            self._busy_abort_grace_polls = 0
+
         if new_level != prev_level:
             self._pressure_level = new_level
             self._propagate_memory_limit()
@@ -1528,6 +1545,33 @@ class ProcessMemoryEnforcer:
                 if new_level == "hard":
                     busy_victim = self._find_lru_busy_non_pinned_victim_locked()
                     if busy_victim is not None:
+                        # Reclaim-before-abort grace: when the MLX buffer pool
+                        # alone holds more than the reclaim floor, the pressure
+                        # clear requested above can very likely recover below
+                        # the watermark without killing anything (measured:
+                        # aborts fired 0.1GB over the watermark with 3.7GB of
+                        # pooled buffers on the table). The drain runs on the
+                        # inference thread at the next prefill-chunk or step
+                        # boundary, so give it a bounded number of polls.
+                        # Never defers an emergency (at/over the ceiling).
+                        if (
+                            not emergency
+                            and self._busy_abort_grace_polls
+                            < self._BUSY_ABORT_GRACE_POLLS_MAX
+                            and self._pool_bytes() > self._POOL_RECLAIM_FLOOR
+                        ):
+                            self._busy_abort_grace_polls += 1
+                            logger.info(
+                                "Hard memory pressure on '%s': deferring "
+                                "request abort (poll %d/%d) while %s of "
+                                "pooled Metal buffers drain",
+                                busy_victim,
+                                self._busy_abort_grace_polls,
+                                self._BUSY_ABORT_GRACE_POLLS_MAX,
+                                _format_gb(self._pool_bytes()),
+                            )
+                            break
+                        self._busy_abort_grace_polls = 0
                         entry = self._engine_pool._entries.get(busy_victim)
                         aborted = 0
                         if (
@@ -1639,6 +1683,10 @@ class ProcessMemoryEnforcer:
             post_level = "hard"
         if post_ceiling <= 0 or post_current < post_ceiling:
             self._over_ceiling_polls = 0
+        if post_level != "hard":
+            # Same reset as the pre-action check: eviction inside this tick
+            # may already have ended the hard episode.
+            self._busy_abort_grace_polls = 0
         if post_level != self._pressure_level:
             self._pressure_level = post_level
             self._propagate_memory_limit()

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1306,6 +1306,16 @@ def _get_attr_or_key(obj: Any, name: str) -> Any:
     return value
 
 
+# Fraction of the room between current usage and the enforcer's abort
+# watermark that one prefill chunk may plan to consume once the sizing target
+# is already exceeded. Must stay below 1.0: a chunk sized to land exactly on
+# the watermark is a chunk planning to be aborted. OMLX_PREFILL_WATERMARK_SHARE
+# overrides it for A/B measurement.
+def _chunk_snap_enabled() -> bool:
+    """OMLX_CHUNK_SNAP=0 disables chunk quantization (A/B measurement)."""
+    return os.environ.get("OMLX_CHUNK_SNAP", "1") != "0"
+
+
 def _model_declares_llama4(model: Any) -> bool:
     """Return True if the loaded model/config tree declares Llama 4."""
     seen: set[int] = set()
@@ -1674,6 +1684,11 @@ class Scheduler:
         self._prefill_safe_zone_ratio: float = 0.80
         self._prefill_min_chunk_tokens: int = 256
         self._prefill_abort_margin: float = self._PREFILL_ABORT_MARGIN
+        # Requests that already emitted the INFO throttle notice. The per-chunk
+        # shrink log is DEBUG, so a throttled prefill used to be silent at the
+        # default level even while it ran an order of magnitude slower; one
+        # line per request keeps that visible without a line per chunk.
+        self._throttle_notified_requests: set[str] = set()
         self._pending_prefill_eviction_request: PrefillEvictionRequest | None = None
         self._memory_admission_blocked_request_id: str | None = None
         self._memory_admission_blocked_since: float = 0.0
@@ -3154,6 +3169,7 @@ class Scheduler:
                 _throttle_post,
                 request_id=request.request_id,
                 loop_label="external",
+                kv_len=base_size + processed_tokens,
             )
 
             processed_tokens += n_to_process
@@ -3550,6 +3566,10 @@ class Scheduler:
         per_token = self._predicted_chunk_transient(n_tokens, kv_len) / n_tokens
         safe_n = int((cap - current) / per_token) if per_token > 0 else n_tokens
         n_fit = max(min_chunk, min(n_tokens, safe_n))
+        # Same quantization as the adaptive throttle: an off-grid size here
+        # would reintroduce the near-miss buffers _snap_chunk_size exists to
+        # avoid.
+        n_fit = self._snap_chunk_size(n_fit, n_tokens)
         if n_fit < n_tokens:
             logger.debug(
                 "[guard:%s] shrink %d -> %d at progress=%d kv_len=%d "
@@ -3563,6 +3583,33 @@ class Scheduler:
                 cap / 1024**3,
             )
         return n_fit
+
+    def _snap_chunk_size(self, n: int, requested: int) -> int:
+        """Quantize a throttled chunk to a multiple of the min-chunk floor.
+
+        A sliding-window layer allocates ``max_size + n - 1`` per chunk
+        (mlx_lm RotatingKVCache._update_concat), so each distinct chunk size
+        asks MLX for a distinct buffer size. MLX only reuses a pooled buffer
+        within ``min(2*size, size + 2*page_size)`` of the request, which above
+        ~32KB is a near-exact match (mlx/backend/common/buffer_cache.h). The
+        throttle used to emit 33, 34, 36, 40, 41, 56 ... as headroom/per_token
+        happened to land, so the pool filled with buffers 1-3% off from each
+        other and none could serve the next request.
+
+        Traced over one 20k gemma-4 prefill: of 10,143 requests for the
+        chunk-32 buffer, 5,329 missed, and the pool's nearest candidate was
+        only 0.9-3% larger in most of them — buffers left by neighbouring
+        chunk sizes. Quantizing collapses those onto one size per multiple.
+
+        Chunks at or below the floor keep their size (a short tail before a
+        block boundary), and an unthrottled chunk is returned untouched.
+        """
+        if not _chunk_snap_enabled():
+            return n
+        grid = max(1, self._prefill_min_chunk_tokens)
+        if n >= requested or n <= grid:
+            return n
+        return (n // grid) * grid
 
     def _adaptive_chunk_size(
         self,
@@ -3676,7 +3723,12 @@ class Scheduler:
         # Secondary clamp: once in the watermark caution zone, cap by the
         # discrete tiers so a mispredicting EWMA can't run an oversized chunk
         # in deep pressure. Skipped below the watermark so a low-baseline chunk
-        # with ample headroom isn't needlessly shrunk.
+        # with ample headroom isn't needlessly shrunk. Descending through the
+        # tiers instead of dropping to the floor once the target is crossed was
+        # measured and rejected: gemma-4 at a 31.56GB ceiling aborted at both
+        # 60k and 70k tokens, because the chunks spent at 512/256/128 while
+        # already over the target pushed usage past the abort watermark before
+        # the ladder reached the floor.
         band_ratio = -1.0
         if current >= soft_watermark and hard_cap > soft_watermark:
             band = hard_cap - soft_watermark
@@ -3686,6 +3738,36 @@ class Scheduler:
             else:
                 bucket = self._PREFILL_STEP_TIERS[1]  # 512
             n = max(min_chunk, min(n, bucket))
+
+        n = self._snap_chunk_size(n, requested)
+
+        if n < requested and request_id not in self._throttle_notified_requests:
+            self._throttle_notified_requests.add(request_id)
+            binding_str, advice = describe_ceiling_binding(
+                static=self._memory_static_ceiling_bytes,
+                dynamic=self._memory_dynamic_ceiling_bytes,
+                metal_cap=self._memory_metal_cap_bytes,
+                tier=self._memory_guard_tier,
+                current=current,
+                fmt=format_bytes,
+                tail="reduce context length",
+            )
+            logger.info(
+                "Prefill throttled for %s: chunk %d -> %d "
+                "(usage %.2fGB vs sizing target %.2fGB, %s ceiling %.2fGB, "
+                "per_token=%.1fKB, floor=%d). Prefill runs slower until usage "
+                "drops. %s.",
+                request_id,
+                requested,
+                n,
+                current / 1024**3,
+                target / 1024**3,
+                binding_str,
+                hard_cap / 1024**3,
+                per_token / 1024,
+                min_chunk,
+                advice,
+            )
 
         if n < requested:
             logger.debug(
@@ -3799,6 +3881,7 @@ class Scheduler:
     def _clear_request_admission_bookkeeping(self, request_id: str) -> None:
         self._cache_freshness_waits.pop(request_id, None)
         self._prefix_cache_prepared.discard(request_id)
+        self._throttle_notified_requests.discard(request_id)
         self._clear_memory_admission_blocker(request_id)
         self._clear_store_cache_admission_blocker(request_id)
 
@@ -3956,8 +4039,21 @@ class Scheduler:
         *,
         request_id: str,
         loop_label: str,
+        kv_len: int = 0,
     ) -> None:
-        """Feed one chunk's measured transient into the EWMA tracker."""
+        """Feed one chunk's measured transient into the EWMA tracker.
+
+        ``kv_len`` is logged, not used: the phys delta this records is far
+        noisier than it looks — over one 13k prefill on Qwen3.6, 262 chunks of
+        the SAME 32 tokens produced 5.2MB to 812.4MB (155x), because the delta
+        largely tracks MLX buffer-pool growth rather than the chunk. Sampling
+        phys during the chunk reproduces the delta exactly (it is monotonic
+        within a chunk), and MLX's active high-water is 2x-tight but excludes
+        the pool, which is real occupancy under set_cache_limit(total). So no
+        better per-chunk signal was found, and anything sized from this number
+        has to stay conservative. Keeping kv_len in the log is what made that
+        analysis possible.
+        """
         delta = post_bytes - pre_bytes
         min_chunk = max(1, self._prefill_min_chunk_tokens)
         if n_tokens < min_chunk:
@@ -3982,11 +4078,11 @@ class Scheduler:
             return
         self._prefill_transient_tracker.update(n_tokens, delta)
         logger.debug(
-            "[throttle:%s] measure rid=%s n=%d transient=%.2fMB "
-            "per_token=%.1fKB ewma=%.1fKB samples=%d",
+            "[throttle:%s] measure rid=%s n=%d kv_len=%d transient=%.2fMB per_token=%.1fKB ewma=%.1fKB samples=%d",
             loop_label,
             request_id,
             n_tokens,
+            kv_len,
             delta / 1024**2,
             (delta / max(n_tokens, 1)) / 1024,
             self._prefill_transient_tracker.bytes_per_token / 1024,
@@ -4184,6 +4280,7 @@ class Scheduler:
             _throttle_post,
             request_id=state.request.request_id,
             loop_label="chunked_step",
+            kv_len=state.base_size + state.tokens_processed,
         )
         state.tokens_processed += n
 
@@ -7637,9 +7734,7 @@ class Scheduler:
         if new_tokens == 0:
             return None
 
-        peak = self.memory_monitor.estimate_prefill_peak_bytes(
-            new_tokens, self.config.prefill_step_size, cached_tokens=cached_tokens
-        )
+        peak = self._admission_peak_bytes(new_tokens, cached_tokens)
         if peak == 0:
             return None  # can't estimate, skip
 
@@ -7693,6 +7788,33 @@ class Scheduler:
             )
             return safety_rejection
         return None
+
+    def _admission_peak_bytes(self, new_tokens: int, cached_tokens: int) -> float:
+        """Peak this prefill will actually reach, for admission decisions.
+
+        ``estimate_prefill_peak_bytes`` prices the SDPA term at the chunk size
+        it is handed, and every admission site handed it
+        ``config.prefill_step_size`` (2048). But when memory is tight the
+        adaptive throttle runs the same prefill at
+        ``prefill_min_chunk_tokens``, so admission was refusing prompts on a
+        peak no chunk that request would ever submit could produce — measured
+        on gemma-4 at a 31.56GB ceiling, 80k tokens was rejected for a 3.15GB
+        KV+SDPA estimate while 60k ran to completion at 32-token chunks.
+
+        Charging the floor chunk instead leaves the KV term, which chunking
+        cannot reduce, as the real limit. Nothing about safety moves: the
+        throttle, the pre-chunk guard and the enforcer's abort all still run,
+        and this only lowers an up-front refusal to a level the request will
+        actually operate at.
+        """
+        monitor = self.memory_monitor
+        if monitor is None:
+            return 0.0
+        floor_chunk = max(1, self._prefill_min_chunk_tokens)
+        chunk = min(self.config.prefill_step_size, floor_chunk)
+        return monitor.estimate_prefill_peak_bytes(
+            new_tokens, chunk, cached_tokens=cached_tokens
+        )
 
     def _format_rejection_message(
         self,
@@ -7766,9 +7888,7 @@ class Scheduler:
         if new_tokens == 0:
             return
 
-        peak = self.memory_monitor.estimate_prefill_peak_bytes(
-            new_tokens, self.config.prefill_step_size, cached_tokens=cached_tokens
-        )
+        peak = self._admission_peak_bytes(new_tokens, cached_tokens)
         if peak == 0:
             return
 
@@ -7852,9 +7972,7 @@ class Scheduler:
         current = self._current_usage_bytes(refresh_mlx_active=False)
         request_id = request_id or "preflight"
 
-        peak = self.memory_monitor.estimate_prefill_peak_bytes(
-            new_tokens, self.config.prefill_step_size, cached_tokens=cached_tokens
-        )
+        peak = self._admission_peak_bytes(new_tokens, cached_tokens)
         if peak and current + peak > self._memory_hard_limit_bytes:
             return PrefillEvictionRequest(
                 request_id=request_id,
@@ -8967,6 +9085,10 @@ class Scheduler:
         tracker = get_prefill_tracker()
         for rid in finished_ids:
             tracker.remove(rid)
+            # _clear_request_admission_bookkeeping only runs on abort/failure
+            # paths, so a request that was throttled and then completed
+            # normally would keep its id here forever.
+            self._throttle_notified_requests.discard(rid)
 
         for request_id in finished_ids:
             request = self.running.get(request_id)

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -124,6 +124,22 @@ class _PreflightRejection:
 
 
 @dataclass
+class _AdmissionEstimate:
+    """Single deterministic admission estimate shared by every preflight
+    path: ``current + kv_exact + transient`` is compared against both the
+    dynamic hard limit and the prefill safety cap. ``kv_exact`` is the
+    exact-shape resident KV (full + window-capped rotating + fixed state),
+    ``transient`` the floor-chunk charge including the session's observed
+    max chunk transient."""
+
+    kv_exact: int
+    transient: int
+    floor_chunk: int
+    kv_len: int
+    estimated: int
+
+
+@dataclass
 class _VLMMTPDecodeState:
     """Per-request state for vlm_mtp decode that bypasses BatchGenerator.
 
@@ -317,13 +333,18 @@ class _StoreCacheGate:
 try:
     from .cache.boundary_snapshot_store import BoundarySnapshotSSDStore
     from .cache.paged_ssd_cache import PagedSSDCacheManager
-    from .memory_monitor import MemoryMonitor, estimate_mla_kv_bytes_per_token
+    from .memory_monitor import (
+        MemoryMonitor,
+        collect_kv_layer_specs,
+        estimate_mla_kv_bytes_per_token,
+    )
 
     HAS_TIERED_CACHE = True
 except ImportError:
     PagedSSDCacheManager = None
     BoundarySnapshotSSDStore = None
     MemoryMonitor = None
+    collect_kv_layer_specs = None
     estimate_mla_kv_bytes_per_token = None
     HAS_TIERED_CACHE = False
 
@@ -1702,6 +1723,11 @@ class Scheduler:
         self._prefill_transient_tracker = PrefillTransientTracker(
             model_id=_tracker_model_id
         )
+        # One-shot probe of the GDN/Mamba fixed recurrent-state footprint,
+        # armed by _set_model_info_for_monitor when ArraysCache layers exist
+        # and taken after the first prefill chunk's eval.
+        self._fixed_state_measure_armed: bool = False
+        self._fixed_state_recorded: bool = False
         # Let the sdpa256 head_dim-256 prefill route ask for live guard
         # headroom so it only takes the slow O(L) tiled pass when the faster
         # unfused fallback would not fit (issue #2204). Weakly held; harmless
@@ -3171,6 +3197,15 @@ class Scheduler:
                 loop_label="external",
                 kv_len=base_size + processed_tokens,
             )
+            self._maybe_record_fixed_state_bytes(prompt_cache)
+            # Enforcer-requested hard-pressure drain. The flag's normal
+            # consumption point is the end-of-step cleanup, but this loop
+            # runs inside a single step() for the whole prefill — minutes at
+            # a time — so without a chunk-boundary drain the enforcer's
+            # reclaim request can never land before its abort escalation
+            # (measured: aborts 0.1GB over the watermark with 3.7GB pooled).
+            if self._consume_pressure_clear():
+                _sync_and_clear_cache(self._stream)
 
             processed_tokens += n_to_process
 
@@ -3378,6 +3413,32 @@ class Scheduler:
             per_token = max(per_token, float(static) / n_tokens)
         return per_token * n_tokens * self._PREFILL_TRANSIENT_SAFETY
 
+    def _admission_transient_bound(self, n_tokens: int, kv_len: int) -> float:
+        """Transient charge for admission and the guard's pass/abort gates.
+
+        The largest FLOOR-SIZE chunk transient observed this session is a
+        floor no prediction should undercut: a throttled prefill cannot get
+        under it by shrinking (gemma-4 measured 786-1177MB at 32-token
+        chunks), so admitting below it converts a deterministic pre-abort
+        into a probabilistic mid-prefill abort. Only floor-size samples
+        feed the max — big-chunk transients differ by an order of magnitude
+        on some models (Qwen3.6: ~3GB at 2048 tokens) and belong to the
+        throttle, which shrinks chunks long before admission's charge is
+        relevant. The observed max gets no extra safety multiplier — it is
+        already the max of noisy samples, kv_len growth is covered by the
+        predicted term, and the abort cap itself keeps a margin below the
+        ceiling.
+
+        Never use this for chunk *sizing* — the throttle and the guard's
+        shrink arithmetic stay on ``_predicted_chunk_transient``; a flat
+        size-invariant bound would zero out their proportional response.
+        """
+        bound = self._predicted_chunk_transient(n_tokens, kv_len)
+        tracker = self._prefill_transient_tracker
+        if tracker is not None:
+            bound = max(bound, float(tracker.observed_max_bytes))
+        return bound
+
     def _prefill_abort_cap(self) -> int:
         """Safety cap a chunk's predicted peak must stay under.
 
@@ -3387,6 +3448,25 @@ class Scheduler:
         """
         cap = self._memory_abort_limit_bytes or self._memory_hard_limit_bytes
         return int(cap * self._prefill_abort_margin) if cap > 0 else 0
+
+    def _admission_limit_bytes(self) -> int:
+        """The line admission estimates must stay under.
+
+        The enforcer kills running requests at the hard WATERMARK
+        (ceiling * hard_threshold, typically 95%), not at the raw hard
+        limit — the remaining 5% is its reaction margin. Admitting a
+        request whose predicted peak lands in that band means it starts,
+        burns a minute of prefill, and dies at the watermark anyway
+        (measured: every residual mid-abort across three A/B regimes sat
+        in this band). Comparing against the watermark converts those into
+        upfront 400s. Falls back to the hard limit before the enforcer has
+        propagated a watermark.
+        """
+        hard_limit = self._memory_hard_limit_bytes
+        watermark = self._memory_hard_watermark_bytes
+        if hard_limit > 0 and watermark > 0:
+            return min(hard_limit, watermark)
+        return hard_limit or watermark
 
     def _prefill_abort_description(self) -> tuple[int, int, float]:
         """Return (base cap, safety cap, margin) for diagnostics."""
@@ -3501,12 +3581,12 @@ class Scheduler:
             return n_tokens
         min_chunk = max(1, self._prefill_min_chunk_tokens)
         current = self._current_usage_bytes()
-        if current + self._predicted_chunk_transient(n_tokens, kv_len) <= cap:
+        if current + self._admission_transient_bound(n_tokens, kv_len) <= cap:
             return n_tokens
 
         # Predicted to breach — reclaim transients and re-measure once.
         current = self._reclaim_prefill_headroom()
-        min_transient = self._predicted_chunk_transient(min_chunk, kv_len)
+        min_transient = self._admission_transient_bound(min_chunk, kv_len)
         if current + min_transient > cap:
             maybe_raise_eviction = getattr(
                 self, "_raise_prefill_eviction_if_available", None
@@ -4076,9 +4156,11 @@ class Scheduler:
                 delta,
             )
             return
-        self._prefill_transient_tracker.update(n_tokens, delta)
+        self._prefill_transient_tracker.update(
+            n_tokens, delta, floor_sample=n_tokens <= min_chunk
+        )
         logger.debug(
-            "[throttle:%s] measure rid=%s n=%d kv_len=%d transient=%.2fMB per_token=%.1fKB ewma=%.1fKB samples=%d",
+            "[throttle:%s] measure rid=%s n=%d kv_len=%d transient=%.2fMB per_token=%.1fKB ewma=%.1fKB observed_max=%.1fMB samples=%d",
             loop_label,
             request_id,
             n_tokens,
@@ -4086,8 +4168,46 @@ class Scheduler:
             delta / 1024**2,
             (delta / max(n_tokens, 1)) / 1024,
             self._prefill_transient_tracker.bytes_per_token / 1024,
+            self._prefill_transient_tracker.observed_max_bytes / 1024**2,
             self._prefill_transient_tracker.samples,
         )
+
+    def _maybe_record_fixed_state_bytes(self, cache_list: Any) -> None:
+        """Measure the GDN/Mamba fixed recurrent-state footprint once.
+
+        ArraysCache state shapes are unknown until the first forward, so
+        this probe runs right after the first prefill chunk's eval and
+        feeds the per-sequence constant term of
+        ``MemoryMonitor.estimate_resident_kv_bytes``. One-shot: after the
+        first attempt (successful or empty) the hot path is a flag check.
+        """
+        if self._fixed_state_recorded or not self._fixed_state_measure_armed:
+            return
+        if self.memory_monitor is None or not cache_list:
+            return
+
+        def _walk(c: Any) -> int:
+            sub = getattr(c, "caches", None)
+            if isinstance(sub, (list, tuple)):
+                return sum(_walk(inner) for inner in sub)
+            if type(c).__name__ in ("ArraysCache", "SizedArraysCache", "MambaCache"):
+                state = getattr(c, "state", None)
+                if isinstance(state, (list, tuple)):
+                    return sum(int(getattr(a, "nbytes", 0) or 0) for a in state)
+            return 0
+
+        try:
+            total = sum(_walk(c) for c in cache_list)
+        except Exception as e:
+            logger.debug(f"Fixed-state probe failed: {e}")
+            return
+        self._fixed_state_recorded = True
+        if total > 0:
+            self.memory_monitor.set_fixed_state_bytes(total)
+            logger.debug(
+                "Fixed recurrent state measured: %.1fMB per sequence",
+                total / 1024**2,
+            )
 
     def _reclaim_prefill_headroom(self) -> int:
         """Reclaim Metal headroom mid-prefill and return the re-measured usage.
@@ -4282,6 +4402,7 @@ class Scheduler:
             loop_label="chunked_step",
             kv_len=state.base_size + state.tokens_processed,
         )
+        self._maybe_record_fixed_state_bytes(state.cache)
         state.tokens_processed += n
 
         # Boundary snapshot
@@ -7729,20 +7850,20 @@ class Scheduler:
 
         prompt_tokens = request.num_prompt_tokens
         cached_tokens = request.cached_tokens or 0
-        new_tokens = max(prompt_tokens - cached_tokens, 0)
-
-        if new_tokens == 0:
-            return None
-
-        peak = self._admission_peak_bytes(new_tokens, cached_tokens)
-        if peak == 0:
-            return None  # can't estimate, skip
 
         current = self._current_usage_bytes()
-        estimated = current + peak
-        hard_limit = self._memory_hard_limit_bytes
+        est = self._admission_estimate(
+            num_prompt_tokens=prompt_tokens,
+            cached_tokens=cached_tokens,
+            current=current,
+        )
+        if est is None:
+            return None  # can't estimate, skip
 
-        if estimated > hard_limit:
+        hard_limit = self._admission_limit_bytes()
+        peak = est.kv_exact + est.transient
+
+        if est.estimated > hard_limit:
             # Try LRU eviction first (upstream's predictive-throttle
             # path): if eviction can free enough headroom this raises
             # ``_PrefillEvictionNeeded`` and the request is paused for
@@ -7754,28 +7875,26 @@ class Scheduler:
                 current=current,
                 target_cap=hard_limit,
                 predicted_transient=peak,
-                requested_tokens=min(new_tokens, self.config.prefill_step_size),
+                requested_tokens=est.floor_chunk,
                 reason="prefill_preflight",
             )
 
             message = self._format_rejection_message(
-                estimated=estimated,
+                estimated=est.estimated,
                 current=current,
                 peak=peak,
                 hard_limit=hard_limit,
             )
             return _PreflightRejection(
                 message=message,
-                estimated_bytes=int(estimated),
+                estimated_bytes=int(est.estimated),
                 limit_bytes=int(hard_limit),
             )
         safety_rejection = self._preflight_safety_rejection(
-            num_prompt_tokens=prompt_tokens,
-            cached_tokens=cached_tokens,
+            est=est,
             current_usage_bytes=current,
         )
         if safety_rejection is not None:
-            requested_tokens = min(max(1, self._prefill_min_chunk_tokens), new_tokens)
             self._raise_prefill_eviction_if_available(
                 request_id=request.request_id,
                 current=current,
@@ -7783,37 +7902,62 @@ class Scheduler:
                 predicted_transient=max(
                     0, int(safety_rejection.estimated_bytes) - int(current)
                 ),
-                requested_tokens=requested_tokens,
+                requested_tokens=est.floor_chunk,
                 reason="prefill_safety_cap",
             )
             return safety_rejection
         return None
 
-    def _admission_peak_bytes(self, new_tokens: int, cached_tokens: int) -> float:
-        """Peak this prefill will actually reach, for admission decisions.
+    def _admission_estimate(
+        self,
+        *,
+        num_prompt_tokens: int,
+        cached_tokens: int,
+        current: int,
+    ) -> _AdmissionEstimate | None:
+        """Deterministic admission estimate shared by every preflight path.
 
-        ``estimate_prefill_peak_bytes`` prices the SDPA term at the chunk size
-        it is handed, and every admission site handed it
-        ``config.prefill_step_size`` (2048). But when memory is tight the
-        adaptive throttle runs the same prefill at
-        ``prefill_min_chunk_tokens``, so admission was refusing prompts on a
-        peak no chunk that request would ever submit could produce — measured
-        on gemma-4 at a 31.56GB ceiling, 80k tokens was rejected for a 3.15GB
-        KV+SDPA estimate while 60k ran to completion at 32-token chunks.
+        One formula: ``current + kv_exact + transient`` where
 
-        Charging the floor chunk instead leaves the KV term, which chunking
-        cannot reduce, as the real limit. Nothing about safety moves: the
-        throttle, the pre-chunk guard and the enforcer's abort all still run,
-        and this only lowers an up-front refusal to a level the request will
-        actually operate at.
+        - ``kv_exact`` is the exact-shape resident KV this prefill will
+          allocate (full-attention layers linear in new tokens, sliding
+          window layers capped at window + floor_chunk - 1, MLA override,
+          measured GDN/Mamba fixed state) — the part chunking cannot reduce,
+        - ``transient`` is the floor-chunk charge at the full prompt kv_len,
+          floored by the session's observed max chunk transient (chunk
+          transients are size-invariant, so the throttle cannot get under
+          it by shrinking).
+
+        Charging the floor chunk instead of ``prefill_step_size`` is
+        deliberate: when memory is tight the adaptive throttle runs the same
+        prefill at ``prefill_min_chunk_tokens``, so admission must price the
+        peak a throttled prefill actually produces — measured on gemma-4 at
+        a 31.56GB ceiling, charging the full step rejected 80k tokens while
+        60k ran to completion at 32-token chunks.
+
+        Returns None when nothing can be estimated (no model info and no
+        measurements yet); callers skip the check, as before.
         """
         monitor = self.memory_monitor
         if monitor is None:
-            return 0.0
-        floor_chunk = max(1, self._prefill_min_chunk_tokens)
-        chunk = min(self.config.prefill_step_size, floor_chunk)
-        return monitor.estimate_prefill_peak_bytes(
-            new_tokens, chunk, cached_tokens=cached_tokens
+            return None
+        new_tokens = max(int(num_prompt_tokens) - max(int(cached_tokens), 0), 0)
+        if new_tokens == 0:
+            return None
+        floor_chunk = min(max(1, self._prefill_min_chunk_tokens), new_tokens)
+        kv_len = max(int(num_prompt_tokens) - 1, 1)
+        kv_exact = int(
+            monitor.estimate_resident_kv_bytes(new_tokens, chunk_tokens=floor_chunk)
+        )
+        transient = int(self._admission_transient_bound(floor_chunk, kv_len))
+        if kv_exact <= 0 and transient <= 0:
+            return None
+        return _AdmissionEstimate(
+            kv_exact=kv_exact,
+            transient=transient,
+            floor_chunk=floor_chunk,
+            kv_len=kv_len,
+            estimated=int(current) + kv_exact + transient,
         )
 
     def _format_rejection_message(
@@ -7884,26 +8028,27 @@ class Scheduler:
         if self.memory_monitor is None:
             return
 
-        new_tokens = max(int(num_prompt_tokens) - max(int(cached_tokens), 0), 0)
-        if new_tokens == 0:
-            return
-
-        peak = self._admission_peak_bytes(new_tokens, cached_tokens)
-        if peak == 0:
-            return
-
         current = self._current_usage_bytes(refresh_mlx_active=False)
+        est = self._admission_estimate(
+            num_prompt_tokens=num_prompt_tokens,
+            cached_tokens=cached_tokens,
+            current=current,
+        )
+        if est is None:
+            return
+
         if not request_id:
             import uuid as _uuid
 
             request_id = f"preflight-{_uuid.uuid4().hex[:8]}"
 
-        if current + peak > self._memory_hard_limit_bytes:
+        admission_limit = self._admission_limit_bytes()
+        if est.estimated > admission_limit:
             message = self._format_rejection_message(
-                estimated=current + peak,
+                estimated=est.estimated,
                 current=current,
-                peak=peak,
-                hard_limit=self._memory_hard_limit_bytes,
+                peak=est.kv_exact + est.transient,
+                hard_limit=admission_limit,
             )
 
             logger.warning(
@@ -7916,13 +8061,12 @@ class Scheduler:
             raise PrefillMemoryExceededError(
                 message=message,
                 request_id=request_id,
-                estimated_bytes=int(current + peak),
-                limit_bytes=int(self._memory_hard_limit_bytes),
+                estimated_bytes=int(est.estimated),
+                limit_bytes=int(admission_limit),
             )
 
         safety_rejection = self._preflight_safety_rejection(
-            num_prompt_tokens=num_prompt_tokens,
-            cached_tokens=cached_tokens,
+            est=est,
             current_usage_bytes=current,
         )
         if safety_rejection is None:
@@ -7965,34 +8109,36 @@ class Scheduler:
         if self.memory_monitor is None:
             return None
 
-        new_tokens = max(int(num_prompt_tokens) - max(int(cached_tokens), 0), 0)
-        if new_tokens == 0:
-            return None
-
         current = self._current_usage_bytes(refresh_mlx_active=False)
         request_id = request_id or "preflight"
 
-        peak = self._admission_peak_bytes(new_tokens, cached_tokens)
-        if peak and current + peak > self._memory_hard_limit_bytes:
+        est = self._admission_estimate(
+            num_prompt_tokens=num_prompt_tokens,
+            cached_tokens=cached_tokens,
+            current=current,
+        )
+        if est is None:
+            return None
+
+        admission_limit = self._admission_limit_bytes()
+        if est.estimated > admission_limit:
             return PrefillEvictionRequest(
                 request_id=request_id,
                 model_id=getattr(self.config, "model_name", ""),
                 current_bytes=int(current),
-                target_cap_bytes=int(self._memory_hard_limit_bytes),
-                predicted_transient_bytes=int(peak),
-                requested_tokens=int(min(new_tokens, self.config.prefill_step_size)),
+                target_cap_bytes=int(admission_limit),
+                predicted_transient_bytes=int(est.kv_exact + est.transient),
+                requested_tokens=est.floor_chunk,
                 reason="prefill_preflight",
             )
 
         safety_rejection = self._preflight_safety_rejection(
-            num_prompt_tokens=num_prompt_tokens,
-            cached_tokens=cached_tokens,
+            est=est,
             current_usage_bytes=current,
         )
         if safety_rejection is None:
             return None
 
-        requested_tokens = min(max(1, self._prefill_min_chunk_tokens), new_tokens)
         return PrefillEvictionRequest(
             request_id=request_id,
             model_id=getattr(self.config, "model_name", ""),
@@ -8001,42 +8147,31 @@ class Scheduler:
             predicted_transient_bytes=max(
                 0, int(safety_rejection.estimated_bytes) - int(current)
             ),
-            requested_tokens=int(requested_tokens),
+            requested_tokens=est.floor_chunk,
             reason="prefill_safety_cap",
         )
 
     def _preflight_safety_rejection(
         self,
         *,
-        num_prompt_tokens: int,
-        cached_tokens: int = 0,
+        est: _AdmissionEstimate,
         current_usage_bytes: int,
     ) -> _PreflightRejection | None:
         """Predict whether even the safety floor chunk cannot fit.
 
         This mirrors the mid-prefill ``_guard_prefill_chunk`` rejection, but
-        runs before the route returns a ``StreamingResponse``. It charges the
-        resident KV that will be allocated by the prompt plus the minimum
-        chunk transient at the full prompt context length.
+        runs before the route returns a ``StreamingResponse``. Consumes the
+        shared ``_AdmissionEstimate`` so the guard and every preflight path
+        price the same formula: exact resident KV plus the floor-chunk
+        transient bound at the full prompt context length.
         """
-        if self.memory_monitor is None:
-            return None
         base_cap, cap, margin = self._prefill_abort_description()
         if cap <= 0:
             return None
 
-        new_tokens = max(int(num_prompt_tokens) - max(int(cached_tokens), 0), 0)
-        if new_tokens == 0:
-            return None
-
-        floor_chunk = min(max(1, self._prefill_min_chunk_tokens), new_tokens)
-        kv_len = max(int(num_prompt_tokens) - 1, 1)
-        kv_growth = self.memory_monitor.estimate_prompt_kv_bytes(new_tokens)
-        min_transient = self._predicted_chunk_transient(floor_chunk, kv_len)
-        if kv_growth <= 0 and min_transient <= 0:
-            return None
-
-        estimated = int(current_usage_bytes + kv_growth + min_transient)
+        kv_growth = est.kv_exact
+        min_transient = est.transient
+        estimated = int(current_usage_bytes) + kv_growth + min_transient
         if estimated <= cap:
             return None
 
@@ -8059,8 +8194,8 @@ class Scheduler:
         )
         message = (
             "Prefill context too large for available memory "
-            f"(preflight safety guard, kv_len={kv_len}, "
-            f"min_chunk={floor_chunk}): predicted peak would require "
+            f"(preflight safety guard, kv_len={est.kv_len}, "
+            f"min_chunk={est.floor_chunk}): predicted peak would require "
             f"~{format_bytes(estimated)} "
             f"(current {format_bytes(current_usage_bytes)} + "
             f"KV {format_bytes(kv_growth)} + "
@@ -10452,29 +10587,34 @@ class Scheduler:
                 or num_kv_heads
             )
 
-            # Count KVCache layers for hybrid models
+            # Classify layer cache types for hybrid models
             cache_list_for_tq = None
             actual_kv_cache_layers = None
             num_kv_cache_layers = num_layers
+            rotating_layer_specs: list[tuple[int, int]] = []
+            arrays_cache_layers = 0
             if not hasattr(self.model, "make_cache"):
                 actual_kv_cache_layers = num_layers
-            else:
+            elif collect_kv_layer_specs is not None:
                 try:
                     cache_list = self.model.make_cache()
                     cache_list_for_tq = cache_list
-                    from mlx_lm.models.cache import CacheList, KVCache
-
-                    def _count_kv(c: Any) -> int:
-                        if type(c) is KVCache:
-                            return 1
-                        if isinstance(c, CacheList):
-                            return sum(_count_kv(inner) for inner in c.caches)
-                        return 0
-
-                    actual_kv_cache_layers = sum(_count_kv(c) for c in cache_list)
-                    num_kv_cache_layers = actual_kv_cache_layers
-                    if num_kv_cache_layers == 0:
-                        num_kv_cache_layers = num_layers  # fallback
+                    full_layers, rotating_layer_specs, arrays_cache_layers = (
+                        collect_kv_layer_specs(cache_list)
+                    )
+                    actual_kv_cache_layers = full_layers
+                    num_kv_cache_layers = full_layers
+                    # Fall back to charging every layer only when
+                    # classification found nothing at all. A genuine 0
+                    # full-attention count next to rotating/arrays layers
+                    # must stay 0, or the rotating term would double-count
+                    # on top of a linear all-layers term.
+                    if (
+                        full_layers == 0
+                        and not rotating_layer_specs
+                        and not arrays_cache_layers
+                    ):
+                        num_kv_cache_layers = num_layers
                 except Exception:
                     pass
 
@@ -10535,10 +10675,16 @@ class Scheduler:
                     # dtype, not the (possibly fractional TurboQuant) KV width.
                     compute_dtype_size=base_dtype_size,
                     kv_bytes_per_token=kv_bytes_per_token,
+                    rotating_layer_specs=rotating_layer_specs,
                 )
+                # Fixed recurrent state (GDN/Mamba) can only be measured from
+                # a live cache after the first forward; arm a one-shot probe.
+                self._fixed_state_measure_armed = arrays_cache_layers > 0
                 logger.debug(
                     f"Model info for memory estimation: "
-                    f"layers={num_layers} ({num_kv_cache_layers} KVCache), "
+                    f"layers={num_layers} ({num_kv_cache_layers} KVCache, "
+                    f"rotating={rotating_layer_specs}, "
+                    f"arrays={arrays_cache_layers}), "
                     f"kv_heads={num_kv_heads}, q_heads={num_attention_heads}, "
                     f"head_dim={head_dim}, dtype_size={dtype_size}"
                 )

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -187,6 +187,7 @@ from .exceptions import (
     ModelNotFoundError,
     ModelTooLargeError,
     ModelUnavailableError,
+    PrefillMemoryAbortedError,
     PrefillMemoryExceededError,
     SchedulerQueueFullError,
 )
@@ -697,6 +698,12 @@ async def scheduler_queue_full_handler(
 
 
 def _prefill_memory_error_detail(exc: PrefillMemoryExceededError) -> str:
+    if isinstance(exc, PrefillMemoryAbortedError):
+        # This request was admitted and then killed mid-prefill, so "rejected
+        # this prompt" would be wrong. The message already names usage, the
+        # watermark and the binding ceiling with its own advice, so the
+        # generic ladder below is not appended.
+        return f"oMLX memory guard aborted this request mid-prefill: {str(exc)}"
     return (
         "oMLX prefill memory guard rejected this prompt: "
         f"{str(exc)} "
@@ -710,13 +717,18 @@ def _prefill_memory_openai_error_body(
     *,
     status_code: int = 400,
 ) -> dict:
+    code = (
+        "prefill_memory_aborted"
+        if isinstance(exc, PrefillMemoryAbortedError)
+        else "prefill_memory_exceeded"
+    )
     content = _openai_error_body(
         _prefill_memory_error_detail(exc),
         status_code,
-        code="prefill_memory_exceeded",
+        code=code,
     )
     content["type"] = "error"
-    content["error"]["omlx_code"] = "prefill_memory_exceeded"
+    content["error"]["omlx_code"] = code
     if exc.estimated_bytes is not None:
         content["error"]["estimated_bytes"] = exc.estimated_bytes
     if exc.limit_bytes is not None:

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -18,8 +18,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from omlx.engine_core import AsyncEngineCore, EngineConfig, EngineCore
-from omlx.exceptions import PrefillMemoryExceededError
+from omlx.engine_core import (
+    AsyncEngineCore,
+    EngineConfig,
+    EngineCore,
+    _raise_request_output_error,
+)
+from omlx.exceptions import PrefillMemoryAbortedError, PrefillMemoryExceededError
 from omlx.output_collector import RequestOutputCollector
 from omlx.request import RequestOutput, SamplingParams
 from omlx.scheduler import SchedulerConfig, SchedulerOutput
@@ -1836,3 +1841,50 @@ class TestOrphanedCollectorReaping:
             finally:
                 await engine.stop()
                 engine.close()
+
+
+class TestMemoryAbortErrorSurface:
+    """The mid-prefill memory abort must surface like the pre-flight guard.
+
+    The enforcer's abort output used to carry only ``error``, so
+    ``_raise_request_output_error`` fell through to a bare RuntimeError.
+    Nothing upstream recognized it as a memory rejection: the JSON keepalive
+    wrapper (which already handles PrefillMemoryExceededError) let it escape,
+    the response generator died mid-body, and the client saw a truncated read
+    plus a 500 traceback instead of the actionable 400 the pre-flight path
+    returns for the same condition.
+    """
+
+    def _abort_output(self, **overrides):
+        payload = dict(
+            request_id="req-abort",
+            finished=True,
+            finish_reason="error",
+            error=(
+                "Request aborted: process memory limit exceeded (usage 4.4 GB, "
+                "abort threshold (hard watermark) 4.1 GB, dynamic ceiling 4.3 GB)."
+            ),
+            error_code="prefill_memory_aborted",
+            error_metadata={"request_id": "req-abort", "limit_bytes": 4_100_000_000},
+        )
+        payload.update(overrides)
+        return RequestOutput(**payload)
+
+    def test_abort_code_raises_typed_error(self):
+        with pytest.raises(PrefillMemoryAbortedError) as exc:
+            _raise_request_output_error(self._abort_output())
+        assert exc.value.request_id == "req-abort"
+        assert exc.value.limit_bytes == 4_100_000_000
+
+    def test_abort_error_keeps_the_400_mapping(self):
+        """Subclassing is what routes it to the existing handler / keepalive
+        catch, so the relationship is part of the contract, not an accident."""
+        with pytest.raises(PrefillMemoryExceededError):
+            _raise_request_output_error(self._abort_output())
+
+    def test_uncoded_error_still_raises_runtime_error(self):
+        with pytest.raises(RuntimeError) as exc:
+            _raise_request_output_error(
+                self._abort_output(error_code=None, error_metadata=None)
+            )
+        assert not isinstance(exc.value, PrefillMemoryExceededError)

--- a/tests/test_engine_preflight.py
+++ b/tests/test_engine_preflight.py
@@ -718,9 +718,11 @@ class TestRejectionMessageNamesBindingCeiling:
         ``_preflight_memory_check`` so we can inspect the message it
         returns."""
         # Peak chosen larger than any ceiling tested below so the
-        # rejection branch fires deterministically.
+        # rejection branch fires deterministically. Admission charges the
+        # exact resident KV plus the floor-chunk transient bound; drive the
+        # rejection through the KV term.
         sched.memory_monitor = MagicMock()
-        sched.memory_monitor.estimate_prefill_peak_bytes.return_value = 512 * 1024**3
+        sched.memory_monitor.estimate_resident_kv_bytes.return_value = 512 * 1024**3
 
         import omlx.scheduler as scheduler_mod
 

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -508,3 +508,218 @@ class TestEstimatePrefillPeakBytes:
         assert m.estimate_chunk_transient_bytes(1, 10_000) == (
             self._expected_fallback_sdpa(64, 1, 10_000, 256)
         )
+
+
+class TestCollectKvLayerSpecs:
+    """collect_kv_layer_specs classifies make_cache() results into the
+    full / rotating / arrays layer groups admission math prices."""
+
+    def test_mixed_hybrid_model(self):
+        from mlx_lm.models.cache import (
+            ArraysCache,
+            CacheList,
+            KVCache,
+            RotatingKVCache,
+        )
+
+        from omlx.memory_monitor import collect_kv_layer_specs
+
+        cache_list = [
+            KVCache(),
+            KVCache(),
+            RotatingKVCache(max_size=1024),
+            RotatingKVCache(max_size=1024),
+            RotatingKVCache(max_size=1024),
+            RotatingKVCache(max_size=512),
+            ArraysCache(size=2),
+            ArraysCache(size=2),
+            CacheList(KVCache(), RotatingKVCache(max_size=1024)),
+        ]
+        full, specs, arrays = collect_kv_layer_specs(cache_list)
+        assert full == 3, "CacheList-wrapped KVCache must be counted"
+        assert specs == [(1, 512), (4, 1024)]
+        assert arrays == 2
+
+    def test_duck_typed_rotating_subclass_counts(self):
+        from omlx.memory_monitor import collect_kv_layer_specs
+
+        class _CustomRotating:
+            def __init__(self, max_size):
+                self.max_size = max_size
+                self.keep = 4
+
+        full, specs, arrays = collect_kv_layer_specs(
+            [_CustomRotating(2048), _CustomRotating(2048)]
+        )
+        assert full == 0
+        assert specs == [(2, 2048)]
+        assert arrays == 0
+
+    def test_kvcache_subclass_not_counted_as_full(self):
+        from mlx_lm.models.cache import KVCache
+
+        from omlx.memory_monitor import collect_kv_layer_specs
+
+        class _Sub(KVCache):
+            pass
+
+        full, specs, arrays = collect_kv_layer_specs([_Sub()])
+        assert (full, specs, arrays) == (0, [], 0)
+
+    def test_none_and_failure_degrade_to_zero(self):
+        from omlx.memory_monitor import collect_kv_layer_specs
+
+        assert collect_kv_layer_specs(None) == (0, [], 0)
+        assert collect_kv_layer_specs(object()) == (0, [], 0)
+
+
+class TestEstimateResidentKvBytes:
+    """Exact-shape resident KV: full linear + window-capped rotating +
+    measured fixed state."""
+
+    def _make(self, **kwargs):
+        monitor = MemoryMonitor(max_kv_cache_memory=2 * 1024**3)
+        defaults = dict(
+            num_layers=30,
+            num_kv_heads=8,
+            head_dim=128,
+            dtype_size=2,
+            num_attention_heads=16,
+            compute_dtype_size=2,
+        )
+        defaults.update(kwargs)
+        monitor.set_model_info(**defaults)
+        return monitor
+
+    def test_full_only_matches_prompt_kv_bytes(self):
+        m = self._make(num_kv_cache_layers=30)
+        for n in (1, 512, 100_000):
+            assert m.estimate_resident_kv_bytes(n) == m.estimate_prompt_kv_bytes(n)
+            assert m.estimate_resident_kv_bytes(
+                n, chunk_tokens=256
+            ) == m.estimate_prompt_kv_bytes(n)
+
+    def test_hybrid_rotating_term_below_window_grows_linearly(self):
+        m = self._make(num_kv_cache_layers=5, rotating_layer_specs=[(25, 1024)])
+        n = 512
+        per_layer_token = 8 * 128 * 2 * 2  # kv_heads * dim * dtype * K+V
+        expected = (
+            n * 5 * per_layer_token  # full layers
+            + 25 * n * per_layer_token  # rotating, below window: n tokens
+        )
+        assert m.estimate_resident_kv_bytes(n, chunk_tokens=1) == expected
+
+    def test_hybrid_rotating_term_saturates_at_window_plus_chunk(self):
+        m = self._make(num_kv_cache_layers=5, rotating_layer_specs=[(25, 1024)])
+        n = 100_000
+        per_layer_token = 8 * 128 * 2 * 2
+        for chunk in (1, 32, 256):
+            expected = (
+                n * 5 * per_layer_token
+                + 25 * (1024 + chunk - 1) * per_layer_token
+            )
+            assert m.estimate_resident_kv_bytes(n, chunk_tokens=chunk) == expected
+
+    def test_rotating_priced_at_compute_dtype_not_tq_kv_width(self):
+        # TurboQuant KV: fractional stored width, but rotating layers are
+        # pass-through and stay at the base/compute dtype.
+        tq_width = 0.515625
+        m = self._make(
+            num_kv_cache_layers=5,
+            dtype_size=tq_width,
+            compute_dtype_size=2,
+            rotating_layer_specs=[(25, 1024)],
+        )
+        n = 100_000
+        full_term = n * 5 * 8 * 128 * tq_width * 2
+        rotating_term = 25 * 1024 * 8 * 128 * 2 * 2  # chunk_tokens=1
+        assert m.estimate_resident_kv_bytes(n) == full_term + rotating_term
+
+    def test_mla_override_short_circuits_full_term_only(self):
+        m = self._make(kv_bytes_per_token=1000, rotating_layer_specs=[(2, 64)])
+        n = 10_000
+        rotating_term = 2 * (64 + 31) * 8 * 128 * 2 * 2
+        assert (
+            m.estimate_resident_kv_bytes(n, chunk_tokens=32)
+            == n * 1000 + rotating_term
+        )
+
+    def test_fixed_state_added_and_reset_by_set_model_info(self):
+        m = self._make(num_kv_cache_layers=30)
+        base = m.estimate_resident_kv_bytes(100)
+        m.set_fixed_state_bytes(123_456)
+        assert m.fixed_state_bytes == 123_456
+        assert m.estimate_resident_kv_bytes(100) == base + 123_456
+        # Model swap clears the measurement.
+        m.set_model_info(
+            num_layers=30,
+            num_kv_heads=8,
+            head_dim=128,
+            dtype_size=2,
+            num_attention_heads=16,
+            compute_dtype_size=2,
+            num_kv_cache_layers=30,
+        )
+        assert m.fixed_state_bytes == 0
+        assert m.estimate_resident_kv_bytes(100) == base
+
+    def test_zero_tokens_returns_zero(self):
+        m = self._make(num_kv_cache_layers=30)
+        m.set_fixed_state_bytes(999)
+        assert m.estimate_resident_kv_bytes(0) == 0
+
+    def test_prompt_kv_and_block_memory_bytes_unchanged(self):
+        """Regression pin: the throttle static term and the paged-SSD
+        writer-cap input must not move with the resident-KV extension."""
+        m = self._make(num_kv_cache_layers=5, rotating_layer_specs=[(25, 1024)])
+        per_layer_token = 8 * 128 * 2 * 2
+        # estimate_prompt_kv_bytes: full (num_kv_cache_layers) only.
+        assert m.estimate_prompt_kv_bytes(1000) == 1000 * 5 * per_layer_token
+        # estimate_block_memory: all num_layers, ignores layer classes.
+        assert m.estimate_block_memory(1) == 30 * 8 * 128 * 2 * 2
+
+
+class TestSetModelInfoFromModelRotating:
+    """DFlash mirror: set_model_info_from_model classifies via the shared
+    helper so rotating specs reach the monitor."""
+
+    def _fake_model(self, cache_list, num_layers=30):
+        class _Cfg:
+            num_hidden_layers = num_layers
+            num_key_value_heads = 8
+            num_attention_heads = 16
+            head_dim = 128
+
+        class _Model:
+            config = _Cfg()
+
+            def make_cache(self):
+                return cache_list
+
+        return _Model()
+
+    def test_hybrid_model_populates_rotating_specs(self):
+        from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+        from omlx.memory_monitor import set_model_info_from_model
+
+        cache_list = [KVCache() for _ in range(5)] + [
+            RotatingKVCache(max_size=1024) for _ in range(25)
+        ]
+        monitor = MemoryMonitor(max_kv_cache_memory=2 * 1024**3)
+        set_model_info_from_model(monitor, self._fake_model(cache_list))
+        assert monitor._num_kv_cache_layers == 5
+        assert monitor._rotating_layer_specs == ((25, 1024),)
+
+    def test_rotating_only_model_keeps_zero_full_layers(self):
+        from mlx_lm.models.cache import RotatingKVCache
+
+        from omlx.memory_monitor import set_model_info_from_model
+
+        cache_list = [RotatingKVCache(max_size=512) for _ in range(30)]
+        monitor = MemoryMonitor(max_kv_cache_memory=2 * 1024**3)
+        set_model_info_from_model(monitor, self._fake_model(cache_list))
+        # No all-layers fallback: charging 30 linear layers on top of the
+        # rotating term would double-count.
+        assert monitor._num_kv_cache_layers == 0
+        assert monitor._rotating_layer_specs == ((30, 512),)

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -133,6 +133,9 @@ def _throttle_ctx(
     ns._predicted_chunk_transient = Scheduler._predicted_chunk_transient.__get__(
         ns, Scheduler
     )
+    ns._admission_transient_bound = Scheduler._admission_transient_bound.__get__(
+        ns, Scheduler
+    )
     ns._prefill_abort_cap = Scheduler._prefill_abort_cap.__get__(ns, Scheduler)
     ns._prefill_abort_description = Scheduler._prefill_abort_description.__get__(
         ns, Scheduler
@@ -497,6 +500,32 @@ def test_record_chunk_transient_skips_tail_samples():
     assert tracker.last_delta_bytes == 32 * 1024**2
 
 
+def test_record_chunk_transient_marks_floor_samples_only():
+    """Only floor-size chunks may feed the observed max the admission
+    charge uses; big-chunk transients stay EWMA-only."""
+    tracker = PrefillTransientTracker()
+    ns = SimpleNamespace(
+        _prefill_min_chunk_tokens=32,
+        _prefill_transient_tracker=tracker,
+    )
+    ns._record_chunk_transient = Scheduler._record_chunk_transient.__get__(
+        ns, Scheduler
+    )
+
+    # First sample is always excluded from the max (seed noise).
+    ns._record_chunk_transient(32, 0, 100, request_id="r", loop_label="unit")
+    # Big chunk: EWMA only, never the max.
+    ns._record_chunk_transient(
+        2048, 0, 3 * 1024**3, request_id="r", loop_label="unit"
+    )
+    assert tracker.observed_max_bytes == 0
+    # Floor chunk: enters the max.
+    ns._record_chunk_transient(
+        32, 0, 200 * 1024**2, request_id="r", loop_label="unit"
+    )
+    assert tracker.observed_max_bytes == 200 * 1024**2
+
+
 def test_step_prefill_reclaims_before_first_guard():
     events = []
     request = SimpleNamespace(request_id="req-prefill")
@@ -521,6 +550,7 @@ def test_step_prefill_reclaims_before_first_guard():
         _adaptive_chunk_size=lambda n, **kwargs: events.append("adaptive") or n,
         _guard_prefill_chunk=lambda n, **kwargs: events.append("guard") or n,
         _record_chunk_transient=MagicMock(),
+        _maybe_record_fixed_state_bytes=MagicMock(),
     )
     ns._prefill_step_size_for_progress = (
         Scheduler._prefill_step_size_for_progress.__get__(ns, Scheduler)
@@ -628,3 +658,157 @@ def test_requeue_budget_exhausts_to_clean_error():
     assert Scheduler._requeue_or_fail_prefill(ns, req, err) is True
     assert Scheduler._requeue_or_fail_prefill(ns, req, err) is False
     assert req.prefill_oom_retries == 2
+
+
+# --------------------------------------------------------------------------
+# Scheduler._snap_chunk_size
+# --------------------------------------------------------------------------
+
+
+class TestSnapChunkSize:
+    def _ns(self, min_chunk=32):
+        ns = SimpleNamespace(_prefill_min_chunk_tokens=min_chunk)
+        ns._snap_chunk_size = Scheduler._snap_chunk_size.__get__(ns, Scheduler)
+        return ns
+
+    def test_off_grid_sizes_snap_down_to_multiple(self):
+        ns = self._ns()
+        assert ns._snap_chunk_size(33, 2048) == 32
+        assert ns._snap_chunk_size(63, 2048) == 32
+        assert ns._snap_chunk_size(100, 2048) == 96
+        assert ns._snap_chunk_size(1023, 2048) == 992
+
+    def test_on_grid_sizes_unchanged(self):
+        ns = self._ns()
+        assert ns._snap_chunk_size(64, 2048) == 64
+        assert ns._snap_chunk_size(512, 2048) == 512
+
+    def test_at_or_below_floor_unchanged(self):
+        """A short tail before a block boundary keeps its exact size."""
+        ns = self._ns()
+        assert ns._snap_chunk_size(32, 2048) == 32
+        assert ns._snap_chunk_size(17, 2048) == 17
+
+    def test_unthrottled_chunk_untouched(self):
+        ns = self._ns()
+        assert ns._snap_chunk_size(2048, 2048) == 2048
+        assert ns._snap_chunk_size(2049, 2048) == 2049
+
+    def test_env_toggle_disables_snapping(self, monkeypatch):
+        monkeypatch.setenv("OMLX_CHUNK_SNAP", "0")
+        ns = self._ns()
+        assert ns._snap_chunk_size(33, 2048) == 33
+
+    def test_respects_min_chunk_grid(self):
+        ns = self._ns(min_chunk=256)
+        assert ns._snap_chunk_size(300, 2048) == 256
+        assert ns._snap_chunk_size(700, 2048) == 512
+
+
+# --------------------------------------------------------------------------
+# observed_max transient bound: guard/admission only, never chunk sizing
+# --------------------------------------------------------------------------
+
+
+def test_adaptive_chunk_size_ignores_observed_max():
+    """FROZEN policy pin: the throttle's sizing must not move when the
+    session records a large observed max transient."""
+    hard = 40 * _GB
+    ns = _throttle_ctx(current=int(hard * 0.9), hard=hard, samples_bpt=2 * 1024**2)
+    ns._fake_current = int(hard * 0.9)
+    before = _call(ns, 2048, kv_len=5000)
+    assert before < 2048, "precondition: the throttle must actually shrink"
+
+    ns._prefill_transient_tracker._observed_max_bytes = 8 * _GB
+    after = _call(ns, 2048, kv_len=5000)
+    assert after == before
+
+
+def test_guard_abort_gate_charges_observed_max():
+    """The pre-chunk guard's abort gate prices the flat observed max, so a
+    doomed prefill stops deterministically before the dangerous chunk."""
+    hard = 40 * _GB  # cap = 36GB (0.9 margin)
+    current = 35 * _GB
+    ns = _throttle_ctx(current=current, hard=hard, samples_bpt=1024 * 1024)
+    ns._fake_current = current
+
+    # Without the observed max: min-chunk transient (~42MB) fits, so the
+    # guard shrinks instead of aborting.
+    assert _guard_call(ns, 2048, kv_len=50_000) < 2048
+
+    # 2GB observed max no longer fits under the 1GB headroom: abort.
+    ns._prefill_transient_tracker._observed_max_bytes = 2 * _GB
+    with pytest.raises(PrefillMemoryExceededError):
+        _guard_call(ns, 2048, kv_len=50_000)
+
+
+def test_guard_shrink_math_unchanged_by_observed_max():
+    """When the observed max still fits, the shrink arithmetic stays on the
+    frozen per-token predictor and returns the same chunk."""
+    hard = 40 * _GB
+    current = 35 * _GB
+    ns = _throttle_ctx(current=current, hard=hard, samples_bpt=1024 * 1024)
+    ns._fake_current = current
+    before = _guard_call(ns, 2048, kv_len=50_000)
+    assert before < 2048
+
+    ns._prefill_transient_tracker._observed_max_bytes = 512 * 1024**2
+    after = _guard_call(ns, 2048, kv_len=50_000)
+    assert after == before
+
+
+# --------------------------------------------------------------------------
+# Fixed recurrent-state one-shot probe
+# --------------------------------------------------------------------------
+
+
+class TestMaybeRecordFixedStateBytes:
+    def _ns(self, armed=True):
+        ns = SimpleNamespace(
+            memory_monitor=MagicMock(),
+            _fixed_state_measure_armed=armed,
+            _fixed_state_recorded=False,
+        )
+        ns._maybe_record_fixed_state_bytes = (
+            Scheduler._maybe_record_fixed_state_bytes.__get__(ns, Scheduler)
+        )
+        return ns
+
+    def _arrays_cache(self, nbytes_list):
+        cls = type(
+            "ArraysCache",
+            (),
+            {"state": [SimpleNamespace(nbytes=n) for n in nbytes_list]},
+        )
+        return cls()
+
+    def test_measures_once_and_sums_state_nbytes(self):
+        ns = self._ns()
+        caches = [self._arrays_cache([100, 200]), self._arrays_cache([300])]
+        ns._maybe_record_fixed_state_bytes(caches)
+        ns.memory_monitor.set_fixed_state_bytes.assert_called_once_with(600)
+        assert ns._fixed_state_recorded is True
+        # Second call is a no-op flag check.
+        ns._maybe_record_fixed_state_bytes(caches)
+        ns.memory_monitor.set_fixed_state_bytes.assert_called_once()
+
+    def test_unarmed_never_measures(self):
+        ns = self._ns(armed=False)
+        ns._maybe_record_fixed_state_bytes([self._arrays_cache([100])])
+        ns.memory_monitor.set_fixed_state_bytes.assert_not_called()
+        assert ns._fixed_state_recorded is False
+
+    def test_non_arrays_caches_contribute_zero(self):
+        ns = self._ns()
+        plain = type("KVCache", (), {"state": [SimpleNamespace(nbytes=999)]})()
+        ns._maybe_record_fixed_state_bytes([plain, self._arrays_cache([50])])
+        ns.memory_monitor.set_fixed_state_bytes.assert_called_once_with(50)
+
+    def test_zero_total_marks_recorded_without_setting(self):
+        ns = self._ns()
+        ns._maybe_record_fixed_state_bytes(
+            [type("KVCache", (), {"state": []})()]
+        )
+        ns.memory_monitor.set_fixed_state_bytes.assert_not_called()
+        assert ns._fixed_state_recorded is True
+

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -13,6 +13,7 @@ All tests are unit-level: the throttle/requeue logic is exercised on a light
 fake object so no model load or GPU is required.
 """
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -116,6 +117,8 @@ def _throttle_ctx(
         _prefill_min_chunk_tokens=min_chunk,
         _prefill_abort_margin=abort_margin,
         _prefill_headroom_safety=Scheduler._PREFILL_HEADROOM_SAFETY,
+        # Dedupes the once-per-request INFO throttle notice.
+        _throttle_notified_requests=set(),
         _prefill_transient_tracker=tracker,
         memory_monitor=monitor,
         _PREFILL_STEP_TIERS=Scheduler._PREFILL_STEP_TIERS,
@@ -125,6 +128,7 @@ def _throttle_ctx(
         _last_mlx_active_memory_bytes=0,
     )
     # Bind the real helper methods so the stand-in behaves like a Scheduler.
+    ns._snap_chunk_size = Scheduler._snap_chunk_size.__get__(ns, Scheduler)
     ns._current_usage_bytes = Scheduler._current_usage_bytes.__get__(ns, Scheduler)
     ns._predicted_chunk_transient = Scheduler._predicted_chunk_transient.__get__(
         ns, Scheduler
@@ -236,6 +240,54 @@ def test_throttle_floors_at_min_chunk_when_over_ceiling():
     )
     ns._fake_current = hard + _GB
     assert _call(ns, 2048, kv_len=5000) == 32
+
+
+def test_throttle_emits_one_info_notice_per_request(caplog):
+    """A throttled prefill has to be visible at the default log level.
+
+    The per-chunk shrink line is DEBUG, so a request running an order of
+    magnitude slower used to leave no trace in a normal server log — the
+    gap that made a measured 2.6x slowdown undiagnosable. One INFO line
+    per request, not per chunk: a 6k-token prompt floored at 32 tokens
+    submits ~190 chunks.
+    """
+    hard = 40 * _GB
+    ns = _throttle_ctx(
+        current=hard + _GB, hard=hard, samples_bpt=1_000_000, min_chunk=32
+    )
+    ns._fake_current = hard + _GB
+
+    with caplog.at_level(logging.INFO, logger="omlx.scheduler"):
+        for _ in range(5):
+            _call(ns, 2048, kv_len=5000)
+
+    notices = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.INFO and "Prefill throttled" in r.getMessage()
+    ]
+    assert len(notices) == 1
+    message = notices[0].getMessage()
+    assert "chunk 2048 -> 32" in message
+    assert "floor=32" in message
+
+
+def test_throttle_notice_repeats_for_a_new_request():
+    """The dedupe is per request id, not process-wide."""
+    hard = 40 * _GB
+    ns = _throttle_ctx(
+        current=hard + _GB, hard=hard, samples_bpt=1_000_000, min_chunk=32
+    )
+    ns._fake_current = hard + _GB
+    with (
+        patch.object(sched_mod.mx, "get_active_memory", return_value=0),
+        patch.object(sched_mod, "get_phys_footprint", return_value=ns._fake_current),
+    ):
+        for rid in ("r1", "r2"):
+            Scheduler._adaptive_chunk_size(
+                ns, 2048, request_id=rid, loop_label="test", kv_len=5000
+            )
+    assert ns._throttle_notified_requests == {"r1", "r2"}
 
 
 def test_throttle_predictor_anchors_on_recent_measurement():
@@ -495,6 +547,7 @@ def test_step_prefill_reclaims_before_first_guard():
         300,
         request_id="req-prefill",
         loop_label="chunked_step",
+        kv_len=0,
     )
 
 

--- a/tests/test_prefill_transient_tracker.py
+++ b/tests/test_prefill_transient_tracker.py
@@ -58,6 +58,59 @@ class TestPredict:
         assert t.predict(0) == 0
 
 
+class TestObservedMax:
+    def test_first_sample_excluded_from_max(self):
+        t = PrefillTransientTracker("m")
+        # Load-residue noise seeds EWMA only, even at floor size.
+        t.update(32, 500_000_000, floor_sample=True)
+        assert t.samples == 1
+        assert t.observed_max_bytes == 0
+
+    def test_max_tracks_largest_accepted_floor_sample(self):
+        t = PrefillTransientTracker("m")
+        t.update(32, 900_000_000, floor_sample=True)  # first sample, excluded
+        t.update(32, 100_000_000, floor_sample=True)
+        t.update(32, 700_000_000, floor_sample=True)
+        t.update(32, 300_000_000, floor_sample=True)
+        assert t.observed_max_bytes == 700_000_000
+
+    def test_non_floor_samples_never_enter_max(self):
+        # Qwen3.6 regression: a 3GB transient from an unthrottled
+        # 2048-token chunk must not become the floor-chunk admission
+        # charge, or every prompt at a tight ceiling gets rejected.
+        t = PrefillTransientTracker("m")
+        t.update(32, 100_000_000, floor_sample=True)
+        t.update(2048, 3 * 1024**3)  # big chunk, EWMA only
+        assert t.observed_max_bytes == 0 or t.observed_max_bytes < 1024**3
+        t.update(32, 200_000_000, floor_sample=True)
+        assert t.observed_max_bytes == 200_000_000
+
+    def test_outlier_above_clamp_rejected_not_clamped(self):
+        t = PrefillTransientTracker("m")
+        t.update(32, 100_000_000, floor_sample=True)  # first sample, excluded
+        t.update(32, 200_000_000, floor_sample=True)
+        t.update(32, 5 * 1024**3, floor_sample=True)  # above 4GiB clamp
+        assert t.observed_max_bytes == 200_000_000, "outlier must not enter"
+        assert t.samples == 3, "outlier still feeds the EWMA"
+
+    def test_skipped_samples_do_not_touch_max(self):
+        t = PrefillTransientTracker("m")
+        t.update(32, 100_000_000, floor_sample=True)
+        t.update(32, 200_000_000, floor_sample=True)
+        t.update(0, 900_000_000, floor_sample=True)  # zero tokens: skipped
+        t.update(32, -1, floor_sample=True)  # negative delta: skipped
+        assert t.observed_max_bytes == 200_000_000
+
+    def test_max_does_not_affect_ewma_or_predict(self):
+        t = PrefillTransientTracker("m")
+        t.update(1000, 100_000)  # 100/token
+        t.update(32, 6_400, floor_sample=True)  # 200/token; max = 6_400
+        assert t.observed_max_bytes == 6_400
+        ewma = 0.3 * 200.0 + 0.7 * 100.0
+        assert abs(t.bytes_per_token - ewma) < 0.01
+        assert t.predict(2000, safety_factor=1.0) == int(ewma * 2000)
+
+
 class TestReset:
     def test_reset_clears_all(self):
         t = PrefillTransientTracker("m")
@@ -69,3 +122,4 @@ class TestReset:
         assert t.last_n_tokens == 0
         assert t.last_delta_bytes == 0
         assert t.predict(2048) == 0
+        assert t.observed_max_bytes == 0

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -2782,3 +2782,75 @@ class TestPublicCeilingBreakdown:
             "metal_cap": 0,
             "hard_limit": 0,
         }
+
+
+class TestBusyAbortReclaimGrace:
+    """Reclaim-before-abort grace: a fat MLX buffer pool gets a bounded
+    number of polls to drain before the busy-request abort fires
+    (measured: aborts 0.1GB over the watermark with 3.7GB pooled)."""
+
+    def _busy_setup(self, enforcer):
+        engine = MagicMock()
+        engine.has_active_requests.return_value = False
+        engine.abort_all_requests = AsyncMock(return_value=1)
+        entry = _make_entry("big-model", engine=engine)
+        entry.in_use = 1
+        enforcer._engine_pool._entries = {"big-model": entry}
+        enforcer._engine_pool._find_lru_victim.return_value = None
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_abort_deferred_while_pool_reclaimable(self, enforcer):
+        engine = self._busy_setup(enforcer)
+        with patch("omlx.process_memory_enforcer.mx") as mock_mx:
+            # Fixture thresholds are 1.0: 11GB is over the 10GB watermark
+            # but not emergency (needs ceiling + 2GB or 2 polls over).
+            mock_mx.get_active_memory.return_value = 11 * 1024**3
+            mock_mx.get_cache_memory.return_value = 3 * 1024**3
+            await enforcer._check_and_enforce()
+        engine.abort_all_requests.assert_not_awaited()
+        assert enforcer._busy_abort_grace_polls == 1
+
+    @pytest.mark.asyncio
+    async def test_abort_fires_after_grace_exhausted(self, enforcer):
+        engine = self._busy_setup(enforcer)
+        enforcer._busy_abort_grace_polls = (
+            enforcer._BUSY_ABORT_GRACE_POLLS_MAX
+        )
+        with patch("omlx.process_memory_enforcer.mx") as mock_mx:
+            mock_mx.get_active_memory.return_value = 11 * 1024**3
+            mock_mx.get_cache_memory.return_value = 3 * 1024**3
+            await enforcer._check_and_enforce()
+        engine.abort_all_requests.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_abort_immediate_when_pool_below_floor(self, enforcer):
+        """Custom-regime parity: nothing worth draining -> no deferral."""
+        engine = self._busy_setup(enforcer)
+        with patch("omlx.process_memory_enforcer.mx") as mock_mx:
+            mock_mx.get_active_memory.return_value = 11 * 1024**3
+            mock_mx.get_cache_memory.return_value = 1 * 1024**3
+            await enforcer._check_and_enforce()
+        engine.abort_all_requests.assert_awaited_once()
+        assert enforcer._busy_abort_grace_polls == 0
+
+    @pytest.mark.asyncio
+    async def test_grace_counter_resets_on_recovery(self, enforcer):
+        self._busy_setup(enforcer)
+        enforcer._busy_abort_grace_polls = 3
+        with patch("omlx.process_memory_enforcer.mx") as mock_mx:
+            mock_mx.get_active_memory.return_value = 1 * 1024**3
+            mock_mx.get_cache_memory.return_value = 0
+            await enforcer._check_and_enforce()
+        assert enforcer._busy_abort_grace_polls == 0
+
+    @pytest.mark.asyncio
+    async def test_emergency_aborts_despite_pool(self, enforcer):
+        """At/over the ceiling the grace never applies."""
+        engine = self._busy_setup(enforcer)
+        with patch("omlx.process_memory_enforcer.mx") as mock_mx:
+            # 13GB: >= ceiling + 2GB -> emergency on the first poll.
+            mock_mx.get_active_memory.return_value = 13 * 1024**3
+            mock_mx.get_cache_memory.return_value = 3 * 1024**3
+            await enforcer._check_and_enforce()
+        engine.abort_all_requests.assert_awaited()

--- a/tests/test_scheduler_prefill_memory_guard.py
+++ b/tests/test_scheduler_prefill_memory_guard.py
@@ -718,3 +718,121 @@ def test_exception_during_descent_is_swallowed():
     # Monitor exists but dims stayed None — estimator returns 0 / guard skips.
     assert sched.memory_monitor is not None
     assert sched.memory_monitor._num_layers is None
+
+
+def test_scheduler_init_populates_rotating_specs():
+    """Hybrid make_cache classification reaches the monitor: full layers
+    counted strictly, rotating layers grouped by window."""
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    model = MagicMock()
+    model.layers = []
+    model.config = _ModelConfig()
+    model.make_cache = lambda: (
+        [KVCache() for _ in range(5)]
+        + [RotatingKVCache(max_size=1024) for _ in range(27)]
+    )
+
+    tokenizer = MagicMock()
+    tokenizer.eos_token_id = 2
+    config = SchedulerConfig(
+        max_num_seqs=8, prefill_step_size=2048, paged_cache_block_size=0
+    )
+    scheduler = Scheduler(model=model, tokenizer=tokenizer, config=config)
+
+    monitor = scheduler.memory_monitor
+    assert monitor is not None
+    assert monitor._num_kv_cache_layers == 5
+    assert monitor._rotating_layer_specs == ((27, 1024),)
+    # No ArraysCache layers: the fixed-state probe stays unarmed.
+    assert scheduler._fixed_state_measure_armed is False
+
+
+def test_admission_estimate_is_the_single_formula():
+    """Every preflight path prices current + kv_exact + transient."""
+    scheduler = _make_scheduler()
+    scheduler._prefill_memory_guard = True
+    scheduler._memory_hard_limit_bytes = 10**18
+
+    with (
+        patch("omlx.scheduler.mx.get_active_memory", return_value=0),
+        patch("omlx.scheduler.get_phys_footprint", return_value=0),
+    ):
+        est = scheduler._admission_estimate(
+            num_prompt_tokens=32768, cached_tokens=0, current=0
+        )
+    assert est is not None
+    floor = min(max(1, scheduler._prefill_min_chunk_tokens), 32768)
+    assert est.floor_chunk == floor
+    assert est.kv_len == 32767
+    assert est.kv_exact == int(
+        scheduler.memory_monitor.estimate_resident_kv_bytes(
+            32768, chunk_tokens=floor
+        )
+    )
+    assert est.transient == int(scheduler._admission_transient_bound(floor, 32767))
+    assert est.estimated == est.kv_exact + est.transient
+
+
+def test_preflight_charges_observed_max_transient():
+    """A session's observed max chunk transient converts a would-be
+    mid-prefill abort into an upfront 400."""
+    scheduler = _make_scheduler()
+    scheduler._prefill_memory_guard = True
+    # Keep the safety cap out of the way so the hard limit drives.
+    scheduler._memory_abort_limit_bytes = 10**18
+
+    patches = (
+        patch("omlx.scheduler.mx.get_active_memory", return_value=0),
+        patch("omlx.scheduler.get_phys_footprint", return_value=0),
+    )
+    with patches[0], patches[1]:
+        est = scheduler._admission_estimate(
+            num_prompt_tokens=32768, cached_tokens=0, current=0
+        )
+    assert est is not None
+    scheduler._memory_hard_limit_bytes = int(est.estimated) + 1
+
+    with patches[0], patches[1]:
+        scheduler.preflight_or_raise(num_prompt_tokens=32768)  # fits
+
+    scheduler._prefill_transient_tracker._observed_max_bytes = (
+        est.transient + 2 * 1024**3
+    )
+    with patches[0], patches[1], pytest.raises(PrefillMemoryExceededError):
+        scheduler.preflight_or_raise(num_prompt_tokens=32768)
+
+
+def test_admission_compares_against_hard_watermark():
+    """The enforcer kills at the watermark, so admission must not admit
+    into the watermark..hard-limit band."""
+    scheduler = _make_scheduler()
+    scheduler._prefill_memory_guard = True
+    scheduler._memory_abort_limit_bytes = 10**18  # keep safety cap out
+
+    patches = (
+        patch("omlx.scheduler.mx.get_active_memory", return_value=0),
+        patch("omlx.scheduler.get_phys_footprint", return_value=0),
+    )
+    with patches[0], patches[1]:
+        est = scheduler._admission_estimate(
+            num_prompt_tokens=32768, cached_tokens=0, current=0
+        )
+    assert est is not None
+
+    # Watermark unset: falls back to the hard limit, request fits.
+    scheduler._memory_hard_limit_bytes = int(est.estimated) + 1
+    scheduler._memory_hard_watermark_bytes = 0
+    with patches[0], patches[1]:
+        scheduler.preflight_or_raise(num_prompt_tokens=32768)
+
+    # Watermark below the estimate: the same request is now an upfront 400.
+    scheduler._memory_hard_watermark_bytes = int(est.estimated) - 1
+    with patches[0], patches[1], pytest.raises(PrefillMemoryExceededError) as ei:
+        scheduler.preflight_or_raise(num_prompt_tokens=32768)
+    assert ei.value.limit_bytes == int(est.estimated) - 1
+
+    # Watermark above the estimate: admitted again.
+    scheduler._memory_hard_watermark_bytes = int(est.estimated) + 1
+    with patches[0], patches[1]:
+        scheduler.preflight_or_raise(num_prompt_tokens=32768)

--- a/tests/test_server_prefill_memory_handler.py
+++ b/tests/test_server_prefill_memory_handler.py
@@ -11,7 +11,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from omlx.exceptions import PrefillMemoryExceededError
+from omlx.exceptions import PrefillMemoryAbortedError, PrefillMemoryExceededError
 
 
 def _build_test_app():
@@ -35,6 +35,19 @@ def _build_test_app():
             request_id="req-abc",
             estimated_bytes=46_775_000_000,
             limit_bytes=42_949_672_960,
+        )
+
+    @app.get("/v1/raise-abort")
+    def raise_prefill_aborted():
+        raise PrefillMemoryAbortedError(
+            message=(
+                "Request aborted: process memory limit exceeded "
+                "(usage 4.4 GB, abort threshold (hard watermark) 4.1 GB, "
+                "dynamic ceiling 4.3 GB). "
+                "Raise custom_ceiling_bytes in admin Memory settings."
+            ),
+            request_id="req-abort",
+            limit_bytes=4_100_000_000,
         )
 
     @app.get("/health/raise")
@@ -85,6 +98,30 @@ class TestPrefillMemoryHandler:
         body = resp.json()
         assert body["error"]["estimated_bytes"] == 46_775_000_000
         assert body["error"]["limit_bytes"] == 42_949_672_960
+
+    def test_mid_prefill_abort_reuses_the_400_mapping(self):
+        """The enforcer's mid-prefill abort is the same memory condition as
+        the pre-flight rejection and must reach the client the same way.
+        Before the subclass existed it escaped as a bare RuntimeError, so
+        the client got a truncated body and a 500 traceback instead."""
+        with TestClient(_build_test_app()) as client:
+            resp = client.get("/v1/raise-abort")
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]["code"] == "prefill_memory_aborted"
+        assert body["error"]["omlx_code"] == "prefill_memory_aborted"
+        assert body["error"]["limit_bytes"] == 4_100_000_000
+
+    def test_abort_wording_does_not_claim_the_prompt_was_rejected(self):
+        """This request was admitted and then killed, so the pre-flight
+        wording would misdescribe it — and its message already carries the
+        binding ceiling plus advice, so the generic ladder is not appended."""
+        with TestClient(_build_test_app()) as client:
+            resp = client.get("/v1/raise-abort")
+        msg = resp.json()["error"]["message"]
+        assert "aborted this request mid-prefill" in msg
+        assert "rejected this prompt" not in msg
+        assert "Memory Guard to aggressive" not in msg
 
     def test_non_api_route_uses_plain_detail(self):
         with TestClient(_build_test_app()) as client:


### PR DESCRIPTION
On memory-tight machines a long prompt could pass admission, crawl through prefill for a minute or two, and then get killed at the memory watermark anyway. This PR makes admission catch those prompts up front with an instant 400, and stops the enforcer from killing requests while there are still gigabytes of reclaimable buffer pool to free.

Changes:
- Mid-prefill memory aborts return a typed 400 that names the binding ceiling and how to raise it, instead of a bare 500.
- Throttled prefill chunks snap to multiples of the min-chunk floor so the MLX buffer pool can actually reuse them. +6.8% prefill on gemma-4 and +8.4% on Qwen3.6 under a tight ceiling, neutral elsewhere.
- Admission now computes the real KV footprint per cache type (sliding window, GDN state, MLA) plus a measured transient bound, and checks it against the watermark where requests actually die. One formula for every preflight path.
- When the watermark is crossed mid-prefill but the buffer pool holds more than 2GB, the enforcer waits up to 5 seconds for a pool drain instead of aborting immediately. In the repro that used to kill a request 0.1GB over the line with 3.7GB of idle pool, the request now completes.

Verified before/after on gemma-4, Qwen3.6, Laguna and DeepSeek-V4-Flash under custom ceilings, faked small-machine RAM, and a real iogpu.wired_limit_mb. Highlights: gemma mid-prefill aborts 8 to 0 with max completed context up from 48k to 55k+ words, DSv4 enforcer kills 6 to 0 with the completed boundary up 15%. Roomy setups are unchanged and the throttle's chunk sizing policy is untouched. 488 related unit tests pass.
