### PR TITLE
feat(dflash): add robust Laguna target and draft support

### DIFF
--- a/docs/experimental/dflash_mlx_integration.md
+++ b/docs/experimental/dflash_mlx_integration.md
@@ -1,6 +1,6 @@
 # DFlash-MLX Integration Report
 
-Date: 2026-04-14
+Date: 2026-07-28
 
 ## Overview
 
@@ -53,6 +53,7 @@ DFlashEngine is a `BaseEngine` implementation that:
 | File | Role |
 |------|------|
 | `omlx/engine/dflash.py` | DFlashEngine class — BaseEngine impl, event consumer, fallback routing |
+| `omlx/patches/dflash_laguna.py` | Laguna target adapter, gated drafter, fused-QKV loader, and mixed-cache rollback |
 | `omlx/engine/__init__.py` | DFlashEngine export (required dependency) |
 | `omlx/engine_pool.py` | DFlash routing: checks `dflash_enabled` before engine type switch |
 | `omlx/model_settings.py` | Per-model settings: `dflash_enabled`, `dflash_draft_model`, `dflash_draft_quant_bits` |
@@ -60,16 +61,17 @@ DFlashEngine is a `BaseEngine` implementation that:
 | `omlx/admin/templates/dashboard/_modal_model_settings.html` | UI: toggle, draft model dropdown, quantization selector |
 | `omlx/admin/static/js/dashboard.js` | Frontend settings binding |
 | `omlx/admin/benchmark.py` | Batch test skip guard for DFlashEngine |
-| `tests/test_dflash_engine.py` | Unit tests (14 tests) |
+| `tests/test_dflash_engine.py` | DFlash engine and routing tests |
+| `tests/test_dflash_laguna.py` | Laguna adapter parity, cache rollback, config, and checkpoint-layout tests |
 
 ### Dependency
 
-- `dflash-mlx` pinned to `bstnxbt/dflash-mlx@20d68db` (original repo, v0.1.5.1, includes Gemma4 backend + runtime package refactor)
+- `dflash-mlx` pinned to `bstnxbt/dflash-mlx@9ca0028` (v0.1.10)
 - Listed as required dependency in `pyproject.toml` and `packaging/venvstacks.toml`
 
 ### Supported models
 
-DFlash registers `QwenGdnTargetOps` and `Gemma4TargetOps`. Draft checkpoints currently exist for the Qwen3.x and Gemma4 families:
+DFlash upstream registers `QwenGdnTargetOps` and `Gemma4TargetOps`. oMLX also registers a Laguna backend and the `DFlashLagunaForCausalLM` drafter used by Poolside's official checkpoints:
 
 | Target model | Draft checkpoint |
 |--------------|-----------------|
@@ -86,8 +88,23 @@ DFlash registers `QwenGdnTargetOps` and `Gemma4TargetOps`. Draft checkpoints cur
 | Qwen/Qwen3.6-35B-A3B | z-lab/Qwen3.6-35B-A3B-DFlash |
 | google/gemma-4-31b-it | z-lab/gemma-4-31B-it-DFlash |
 | google/gemma-4-26b-a4b-it | z-lab/gemma-4-26B-A4B-it-DFlash |
+| poolside/Laguna-XS-2.1 | poolside/Laguna-XS-2.1-DFlash |
+| poolside/Laguna-S-2.1 | poolside/Laguna-S-2.1-DFlash |
+| poolside/Laguna-S-2.1-NVFP4(-mlx) | poolside/Laguna-S-2.1-DFlash-NVFP4 |
 
 Other model families (Llama, Gemma3, etc.) are not supported — they require both a trained DFlash draft checkpoint and a compatible target adapter in dflash-mlx.
+
+Laguna target and draft checkpoints must be from the same size family and should
+use Poolside's quantization-matched draft when one is published (for example,
+`Laguna-S-2.1-DFlash-NVFP4` with the NVFP4 target). The adapter validates target
+depth, hidden size, and capture-layer IDs at load time. It implements Laguna's
+per-head/per-element softplus attention gating, partial RoPE,
+per-captured-layer RMS normalization, Poolside's fused `qkv_proj` checkpoint
+layout, mixed full/sliding target caches, and rejection rollback. DDTree
+verification, target KV quantization, and the specialized verify-linear path
+are deliberately disabled for Laguna until they have dedicated
+numerical-parity coverage; ordinary adaptive DFlash verification remains
+available.
 
 Note: the `-DFlash` suffix is specific to DFlash draft checkpoints. Gemma4 also ships an `-assistant` variant (e.g. `gemma-4-26B-A4B-it-assistant`) that targets MTP speculative decoding via mlx-vlm — do not mix these in the DFlash toggle.
 
@@ -182,7 +199,7 @@ DFlash effectiveness degrades with long contexts:
 
 ### 3. Model support
 
-Only Qwen3.5 family has draft checkpoints. Each new model family requires:
+Qwen, Gemma4, and Laguna have compatible target adapters and published draft checkpoints. Each additional model family still requires:
 - A trained DFlash draft checkpoint (block diffusion model matching target hidden dimensions)
 - Support in dflash-mlx's target model handling (hidden state extraction, cache rollback)
 
@@ -271,16 +288,17 @@ DFlash context fallback: 5120 >= 4096, using vlm engine
 
 ## Testing
 
-### Unit tests (`tests/test_dflash_engine.py` — 14 tests)
+### Unit tests
 
 - ModelSettings: default values, serialization roundtrip, removed field handling
 - DFlashEngine: properties, stats, cache stats
 - EnginePool routing: disabled/enabled/draft model checks
+- Laguna: native-forward parity, hidden-state capture, full/rotating-cache rollback, gated draft forward, target binding, and fused-QKV checkpoint loading
 
 ### Manual testing
 
 1. Enable DFlash in admin UI for a supported model
-2. Set draft model path (e.g., `z-lab/Qwen3.5-4B-DFlash`)
+2. Set the matching draft model path (for example, `poolside/Laguna-S-2.1-DFlash-NVFP4` for an NVFP4 Laguna S target)
 3. Reload model
 4. Send short prompt → verify DFlash logs (acceptance ratio, tok/s)
 5. Send long prompt (>4K tokens) → verify fallback to BatchedEngine logs

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -800,7 +800,7 @@
                                     <div class="flex items-start justify-between gap-3">
                                         <div class="min-w-0">
                                             <span class="text-sm font-medium text-neutral-700">DFlash</span>
-                                            <p class="text-xs text-neutral-500 mt-0.5">Block diffusion speculative decoding for 3-4x faster generation. Supports Qwen (3, 3.5, 3.6) and Gemma4 model families. Requires a DFlash draft model checkpoint.<br><strong>Single-stream only: requests run one at a time.</strong><br>* MLX impl by bstnxbt(<a href="https://github.com/bstnxbt/dflash-mlx" target="_blank" rel="noopener" class="text-blue-500 hover:text-blue-700 underline">GitHub</a>)</p>
+                                            <p class="text-xs text-neutral-500 mt-0.5">Block diffusion speculative decoding for faster generation. Supports Qwen (3, 3.5, 3.6), Gemma4, and Laguna model families. Requires a DFlash draft model checkpoint.<br><strong>Single-stream only: requests run one at a time.</strong><br>* MLX impl by bstnxbt(<a href="https://github.com/bstnxbt/dflash-mlx" target="_blank" rel="noopener" class="text-blue-500 hover:text-blue-700 underline">GitHub</a>)</p>
                                             <p x-show="!modelSettings.dflash_compatible && modelSettings.dflash_compatibility_reason"
                                                class="text-xs text-amber-600 mt-1"
                                                x-text="modelSettings.dflash_compatibility_reason"></p>
@@ -834,7 +834,7 @@
                                                     <option :value="m.model_path || m.id" x-text="m.id" :selected="modelSettings.dflash_draft_model === (m.model_path || m.id)"></option>
                                                 </template>
                                             </select>
-                                            <p class="text-xs text-neutral-400 mt-1">DFlash draft checkpoint (e.g. z-lab/Qwen3-4B-DFlash-b16, z-lab/gemma-4-26B-A4B-it-DFlash). Note: -DFlash suffix only; -assistant variants are for MTP.</p>
+                                            <p class="text-xs text-neutral-400 mt-1">DFlash draft checkpoint (e.g. z-lab/Qwen3-4B-DFlash-b16, z-lab/gemma-4-26B-A4B-it-DFlash, poolside/Laguna-S-2.1-DFlash-NVFP4). Note: -DFlash suffix only; -assistant variants are for MTP.</p>
                                         </div>
                                         <div class="bg-neutral-50 rounded-xl">
                                             <div class="flex items-start justify-between gap-3">

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -2,8 +2,8 @@
 """
 DFlash engine for block diffusion speculative decoding.
 
-This engine wraps dflash-mlx (>= 0.1.5) to provide 3-4x faster decoding on
-Apple Silicon for Qwen and Gemma4 model families. By default it serves all
+This engine wraps dflash-mlx (>= 0.1.5) to provide faster decoding on Apple
+Silicon for Qwen, Gemma4, and Laguna model families. By default it serves all
 requests through dflash; setting ``model_settings.dflash_max_ctx`` opts into
 evicting the dflash models and delegating long-context requests to omlx's
 BatchedEngine/VLMBatchedEngine (paged cache, SSD cache, continuous batching).
@@ -42,8 +42,9 @@ logger = logging.getLogger(__name__)
 def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
     """Decide whether ``model_path`` can run on the current dflash backend.
 
-    DFlash 0.1.5 registers QwenGdnTargetOps and Gemma4TargetOps. The
-    top-level ``model_type`` is the canonical discriminator: Gemma4 multimodal
+    DFlash 0.1.10 registers QwenGdnTargetOps and Gemma4TargetOps; oMLX adds a
+    Laguna target/draft adapter. The top-level ``model_type`` is the canonical
+    discriminator: Gemma4 multimodal
     configs use ``gemma4`` at the top, while MTP-only variants (e.g. the
     Gemma4 ``-assistant`` checkpoint) declare ``gemma4_assistant`` even
     though their nested ``text_config.model_type`` is still ``gemma4_text``.
@@ -66,9 +67,10 @@ def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
 
     is_qwen = "qwen" in model_type
     is_gemma4 = model_type in ("gemma4", "gemma4_text")
-    if not (is_qwen or is_gemma4):
+    is_laguna = model_type == "laguna"
+    if not (is_qwen or is_gemma4 or is_laguna):
         return False, (
-            f"DFlash supports only Qwen and Gemma4 models "
+            f"DFlash supports only Qwen, Gemma4, and Laguna models "
             f"(model_type='{cfg.get('model_type', '')}')"
         )
     return True, ""
@@ -331,6 +333,7 @@ class DFlashEngine(BaseEngine):
 
         def _load_models():
             from dflash_mlx.draft_backend import EagerDraftBackend
+            from dflash_mlx.engine.target_ops import bind_draft_to_target
             from dflash_mlx.runtime.loading import (
                 load_draft_bundle,
                 load_target_bundle,
@@ -345,6 +348,13 @@ class DFlashEngine(BaseEngine):
             maybe_apply_pre_load_patches(
                 self._model_name, model_settings=self._model_settings
             )
+
+            # dflash-mlx 0.1.10 has no Laguna backend. Register oMLX's strict
+            # TargetOps plus the official gated Laguna drafter specialization
+            # before load_target_bundle resolves either architecture.
+            from ..patches.dflash_laguna import install_dflash_laguna_backend
+
+            install_dflash_laguna_backend()
 
             # Wrap dflash's hook installers so we can revert the class-level
             # __call__ patches when this engine stops. Without this, a later
@@ -362,6 +372,30 @@ class DFlashEngine(BaseEngine):
                 ),
                 verify_config=getattr(runtime_context, "verify", None),
             )
+
+            # Keep DFlash targets on the same post-load MoE fast path as the
+            # regular batched engine.  Laguna uses mlx-lm's SwitchGLU for its
+            # routed experts, so fusing gate+up removes one gather_qmm launch
+            # per MoE layer in both target prefill and block verification.
+            if (
+                getattr(
+                    self._model_settings,
+                    "moe_gate_up_fusion_enabled",
+                    True,
+                )
+                is not False
+            ):
+                try:
+                    from ..patches.qwen35_moe_gate_up import (
+                        apply_qwen35_moe_gate_up_fusion,
+                    )
+
+                    apply_qwen35_moe_gate_up_fusion(target_bundle.model)
+                except Exception:
+                    logger.debug(
+                        "DFlash target MoE gate+up fusion not applied",
+                        exc_info=True,
+                    )
             draft, draft_meta = load_draft_bundle(
                 self._draft_model_path,
                 draft_quant=(
@@ -373,6 +407,11 @@ class DFlashEngine(BaseEngine):
                     if self._draft_quant_enabled
                     else None
                 ),
+            )
+            bind_draft_to_target(
+                draft,
+                target_bundle.model,
+                target_ops=target_bundle.target_ops,
             )
             draft_backend = EagerDraftBackend()
             return target_bundle, draft, draft_backend

--- a/omlx/patches/dflash_laguna.py
+++ b/omlx/patches/dflash_laguna.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
+from dflash_mlx.cache.snapshot import TargetHiddenChunks
 from dflash_mlx.engine.target_ops import TargetCapabilities
 from dflash_mlx.model import (
     ContextOnlyDraftKVCache,
@@ -33,6 +34,20 @@ from mlx_lm.models.qwen3 import MLP
 from mlx_lm.models.rope_utils import initialize_rope
 
 _BACKEND_PATH = "omlx.patches.dflash_laguna:LagunaTargetOps"
+
+
+def _normalize_target_hidden(
+    norm: nn.RMSNorm,
+    target_hidden: mx.array | TargetHiddenChunks,
+) -> mx.array | TargetHiddenChunks:
+    """Normalize sparse target context without materializing trimmed spans."""
+    if isinstance(target_hidden, TargetHiddenChunks):
+        return TargetHiddenChunks(
+            total_len=int(target_hidden.total_len),
+            chunks=tuple(norm(chunk) for chunk in target_hidden.chunks),
+            spans=target_hidden.spans,
+        )
+    return norm(target_hidden)
 
 
 def _model_type(model: Any) -> str:
@@ -553,12 +568,12 @@ class LagunaDFlashDecoderLayer(DFlashDecoderLayer):
         self,
         hidden_states: mx.array,
         *,
-        target_hidden: mx.array,
+        target_hidden: mx.array | TargetHiddenChunks,
         cache: Any | None = None,
     ) -> mx.array:
         residual = hidden_states
         attention_input = self.input_layernorm(hidden_states)
-        context_input = self.input_layernorm(target_hidden)
+        context_input = _normalize_target_hidden(self.input_layernorm, target_hidden)
         hidden_states = self.self_attn(
             attention_input, target_hidden=context_input, cache=cache
         )
@@ -568,10 +583,11 @@ class LagunaDFlashDecoderLayer(DFlashDecoderLayer):
         return residual + hidden_states
 
     def advance_projected_context_cache(
-        self, *, target_hidden: mx.array, cache: Any
+        self, *, target_hidden: mx.array | TargetHiddenChunks, cache: Any
     ) -> None:
         self.self_attn.append_projected_context_cache(
-            target_hidden=self.input_layernorm(target_hidden), cache=cache
+            target_hidden=_normalize_target_hidden(self.input_layernorm, target_hidden),
+            cache=cache,
         )
 
 

--- a/omlx/patches/dflash_laguna.py
+++ b/omlx/patches/dflash_laguna.py
@@ -1,0 +1,717 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Laguna target and draft adapters for the pinned dflash-mlx runtime.
+
+dflash-mlx 0.1.10 exposes a target-backend registry, but only ships Qwen and
+Gemma4 implementations.  Laguna also needs a draft specialization: Poolside's
+official checkpoints use per-head gated attention and normalize every captured
+target-hidden slice before the shared projection.
+
+The installer below extends dflash-mlx through those existing extension
+points.  It is intentionally process-global and idempotent, matching the
+runtime's own backend and hook registries.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+from dflash_mlx.engine.target_ops import TargetCapabilities
+from dflash_mlx.model import (
+    ContextOnlyDraftKVCache,
+    DFlashAttention,
+    DFlashDecoderLayer,
+    DFlashDraftModel,
+    DFlashDraftModelArgs,
+    FullContextDraftKVCache,
+)
+from mlx_lm.models import cache as cache_mod
+from mlx_lm.models.base import create_attention_mask, scaled_dot_product_attention
+from mlx_lm.models.qwen3 import MLP
+from mlx_lm.models.rope_utils import initialize_rope
+
+_BACKEND_PATH = "omlx.patches.dflash_laguna:LagunaTargetOps"
+
+
+def _model_type(model: Any) -> str:
+    args = getattr(model, "args", None)
+    if args is None and hasattr(model, "language_model"):
+        args = getattr(model.language_model, "args", None)
+    value = getattr(args, "model_type", None)
+    if value is not None:
+        return str(value).lower()
+    value = getattr(model, "model_type", None)
+    if value is not None:
+        return str(value).lower()
+    config = getattr(model, "config", None)
+    if isinstance(config, dict):
+        return str(config.get("model_type", "")).lower()
+    return ""
+
+
+def _trim_recent_cache(cache_entry: Any, n: int) -> int:
+    """Remove the newest ``n`` positions, including from a rotating KV ring."""
+    n = max(0, int(n))
+    offset = int(getattr(cache_entry, "offset", 0) or 0)
+    n = min(offset, n)
+    if n <= 0:
+        return 0
+
+    # RotatingKVCache.trim() cannot rewind an already wrapped ring.  Put the
+    # retained values in temporal order before shortening it, as dflash's
+    # Gemma4 backend does for speculative rejection.
+    if isinstance(cache_entry, cache_mod.RotatingKVCache):
+        keys = getattr(cache_entry, "keys", None)
+        values = getattr(cache_entry, "values", None)
+        if keys is not None and values is not None:
+            keys = cache_entry._temporal_order(keys)
+            values = cache_entry._temporal_order(values)
+            keep_len = max(0, int(keys.shape[2]) - n)
+            cache_entry.keys = keys[..., :keep_len, :]
+            cache_entry.values = values[..., :keep_len, :]
+            cache_entry._idx = keep_len
+        else:
+            cache_entry._idx = max(0, int(getattr(cache_entry, "_idx", 0) or 0) - n)
+        cache_entry.offset = offset - n
+        return n
+
+    if hasattr(cache_entry, "trim"):
+        return int(cache_entry.trim(n))
+    if hasattr(cache_entry, "offset"):
+        cache_entry.offset = offset - n
+        return n
+    return 0
+
+
+class LagunaTargetOps:
+    """dflash-mlx target contract for Laguna's mixed full/SWA decoder."""
+
+    backend_name = "laguna"
+
+    def model_type(self, target_model: Any) -> str:
+        return _model_type(target_model)
+
+    def supports_model(self, target_model: Any) -> bool:
+        if self.model_type(target_model) != "laguna":
+            return False
+        try:
+            inner = self.text_model(target_model)
+        except AttributeError:
+            return False
+        return (
+            hasattr(inner, "layers")
+            and hasattr(inner, "embed_tokens")
+            and hasattr(inner, "fa_idx")
+        )
+
+    def family(self, target_model: Any) -> str:
+        del target_model
+        return "laguna_swa"
+
+    def capabilities_for(self, target_model: Any) -> TargetCapabilities:
+        del target_model
+        return TargetCapabilities(
+            supports_dflash=True,
+            supports_recurrent_rollback=False,
+            supports_kv_trim=True,
+            supports_prefix_snapshot=True,
+            supports_rotating_cache_snapshot=True,
+            supports_shared_kv=False,
+            supports_target_hidden_capture=True,
+            # dflash's specialized verify linears are numerically gated only
+            # for its upstream Qwen/Gemma4 backends.  Stock MLX qmm remains
+            # correct for Laguna until an equivalent parity suite exists.
+            supports_verify_linear=False,
+            supports_full_context_draft_layers=False,
+            supports_tree_verify=False,
+        )
+
+    def supports_tree_cache(self, cache_entries: list[Any]) -> bool:
+        del cache_entries
+        return False
+
+    def text_wrapper(self, target_model: Any) -> Any:
+        language_model = getattr(target_model, "language_model", None)
+        if language_model is not None and hasattr(language_model, "model"):
+            return language_model
+        if hasattr(target_model, "model"):
+            return target_model
+        raise AttributeError(
+            f"Unsupported Laguna model wrapper: {type(target_model)!r}"
+        )
+
+    def text_model(self, target_model: Any) -> Any:
+        wrapper = self.text_wrapper(target_model)
+        inner = getattr(wrapper, "model", None)
+        if inner is None:
+            raise AttributeError(f"Unsupported Laguna text model: {type(wrapper)!r}")
+        return inner
+
+    def embed_tokens(self, target_model: Any) -> Any:
+        return self.text_model(target_model).embed_tokens
+
+    def logits_from_hidden(
+        self, target_model: Any, hidden_states: mx.array
+    ) -> mx.array:
+        wrapper = self.text_wrapper(target_model)
+        if bool(getattr(wrapper.args, "tie_word_embeddings", False)):
+            return wrapper.model.embed_tokens.as_linear(hidden_states)
+        return wrapper.lm_head(hidden_states)
+
+    def make_cache(
+        self,
+        target_model: Any,
+        *,
+        enable_speculative_linear_cache: bool,
+        quantize_kv_cache: bool = False,
+        target_fa_window: int | None = None,
+    ) -> list[Any]:
+        del enable_speculative_linear_cache
+        if quantize_kv_cache:
+            raise ValueError("Laguna target KV quantization is not supported yet")
+        if target_fa_window is not None and int(target_fa_window) > 0:
+            raise ValueError("Laguna uses its config-defined SWA/full attention cache")
+        wrapper = self.text_wrapper(target_model)
+        make_cache = getattr(wrapper, "make_cache", None)
+        if make_cache is None:
+            make_cache = getattr(target_model, "make_cache", None)
+        if make_cache is None:
+            raise AttributeError("Laguna target must expose make_cache()")
+        return make_cache()
+
+    def install_speculative_hooks(self, target_model: Any) -> None:
+        # Laguna has no recurrent state.  Stock MLX attention plus explicit KV
+        # trimming is sufficient for block verification and rejection.
+        self.text_model(target_model)._dflash_speculative_hooks_installed = True
+
+    def forward_with_hidden_capture(
+        self,
+        target_model: Any,
+        *,
+        input_ids: mx.array | None = None,
+        cache: list[Any] | None = None,
+        input_embeddings: mx.array | None = None,
+        capture_layer_ids: set[int] | None = None,
+        logits_last_only: bool = False,
+    ) -> tuple[mx.array, list[mx.array] | dict[int, mx.array]]:
+        inner = self.text_model(target_model)
+        h = (
+            input_embeddings
+            if input_embeddings is not None
+            else inner.embed_tokens(input_ids)
+        )
+        if cache is None:
+            cache = [None] * len(inner.layers)
+        elif len(cache) != len(inner.layers):
+            raise ValueError(
+                f"Laguna cache length {len(cache)} != layer count {len(inner.layers)}"
+            )
+
+        capture_all = capture_layer_ids is None
+        if capture_all:
+            captured: list[mx.array] | dict[int, mx.array] = [h]
+        else:
+            capture_layer_ids = set(capture_layer_ids)
+            captured = {0: h} if 0 in capture_layer_ids else {}
+
+        full_mask = create_attention_mask(h, cache[inner.fa_idx])
+        sliding_mask = None
+        if inner.swa_idx is not None:
+            sliding_mask = create_attention_mask(
+                h,
+                cache[inner.swa_idx],
+                window_size=inner.args.sliding_window,
+            )
+
+        for layer_idx, (layer, layer_cache) in enumerate(
+            zip(inner.layers, cache, strict=True)
+        ):
+            mask = (
+                sliding_mask
+                if layer.attention_type == "sliding_attention"
+                else full_mask
+            )
+            h = layer(h, mask, layer_cache)
+            capture_key = layer_idx + 1
+            if capture_all:
+                captured.append(h)
+            elif capture_layer_ids is not None and capture_key in capture_layer_ids:
+                captured[capture_key] = h
+
+        normalized = inner.norm(h)
+        if logits_last_only and isinstance(captured, dict):
+            captured[-1] = normalized
+        logits_hidden = normalized[:, -1:, :] if logits_last_only else normalized
+        return self.logits_from_hidden(target_model, logits_hidden), captured
+
+    def verify_block(
+        self,
+        *,
+        target_model: Any,
+        verify_ids: mx.array,
+        target_cache: list[Any],
+        capture_layer_ids: set[int] | None = None,
+    ) -> tuple[mx.array, list[mx.array] | dict[int, mx.array]]:
+        if int(verify_ids.shape[1]) <= 0:
+            raise ValueError("verify block must contain at least one token")
+        return self.forward_with_hidden_capture(
+            target_model,
+            input_ids=verify_ids,
+            cache=target_cache,
+            capture_layer_ids=capture_layer_ids,
+        )
+
+    def verify_tree_block(
+        self,
+        *,
+        target_model: Any,
+        tree_inputs: Any,
+        target_cache: list[Any],
+        capture_layer_ids: set[int] | None = None,
+    ) -> tuple[mx.array, list[mx.array] | dict[int, mx.array]]:
+        del target_model, tree_inputs, target_cache, capture_layer_ids
+        raise NotImplementedError("Laguna DDTree verification is not implemented")
+
+    def restore_after_tree_acceptance(
+        self, cache_entries: list[Any], *, accepted_tree_indices: list[int]
+    ) -> int:
+        del cache_entries, accepted_tree_indices
+        raise NotImplementedError("Laguna DDTree cache commit is not implemented")
+
+    def extract_context_feature(
+        self,
+        captured_dict: dict[int, mx.array] | list[mx.array],
+        target_layer_ids: list[int],
+    ) -> mx.array:
+        return mx.concatenate(
+            [captured_dict[int(layer_id) + 1] for layer_id in target_layer_ids],
+            axis=-1,
+        )
+
+    def arm_rollback(self, cache_entries: list[Any], *, prefix_len: int) -> None:
+        del cache_entries, prefix_len
+
+    def restore_after_acceptance(
+        self,
+        cache_entries: list[Any],
+        *,
+        target_len: int,
+        acceptance_length: int,
+        drafted_tokens: int = 0,
+    ) -> int:
+        del acceptance_length, drafted_tokens
+        started = time.perf_counter_ns()
+        trimmed = False
+        for cache_entry in cache_entries:
+            offset = int(getattr(cache_entry, "offset", 0) or 0)
+            if offset > int(target_len):
+                _trim_recent_cache(cache_entry, offset - int(target_len))
+                trimmed = True
+        return time.perf_counter_ns() - started if trimmed else 0
+
+    def cleanup_generation_caches(
+        self, target_cache: list[Any], draft_cache: list[Any]
+    ) -> None:
+        draft_cache.clear()
+        target_cache.clear()
+
+
+class LagunaDFlashDraftModelArgs(DFlashDraftModelArgs):
+    """Normalize Poolside's Laguna DFlash config for dflash-mlx."""
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> LagunaDFlashDraftModelArgs:
+        data = dict(params)
+        dflash_config = dict(data.get("dflash_config") or {})
+        data.setdefault("block_size", dflash_config.get("block_size"))
+        data.setdefault("num_target_layers", dflash_config.get("num_target_layers"))
+        data.setdefault("tie_word_embeddings", True)
+        base = DFlashDraftModelArgs.from_dict(data)
+        obj = cls(
+            **{
+                name: getattr(base, name)
+                for name in DFlashDraftModelArgs.__dataclass_fields__
+            }
+        )
+        obj.gating = data.get("gating", "per-head")
+        obj.partial_rotary_factor = data.get("partial_rotary_factor")
+        obj.rope_parameters = data.get("rope_parameters")
+        obj.architectures = tuple(data.get("architectures") or ())
+        obj.draft_vocab_size = int(data.get("draft_vocab_size", obj.vocab_size))
+
+        if not obj.layer_types:
+            raise ValueError("Laguna DFlash draft requires layer_types")
+        if len(set(obj.layer_types)) != 1:
+            raise ValueError("Laguna DFlash draft layers must use one attention type")
+        gating = str(obj.gating).replace("_", "-").lower()
+        if gating not in ("per-head", "per-element"):
+            raise ValueError(f"Unsupported Laguna DFlash gating mode: {obj.gating!r}")
+        obj.gating = gating
+        return obj
+
+
+class LagunaDFlashAttention(DFlashAttention):
+    """DFlash attention with Laguna RoPE and softplus output gating."""
+
+    def __init__(self, args: LagunaDFlashDraftModelArgs, layer_idx: int):
+        super().__init__(args, layer_idx)
+        self.gate_per_head = args.gating == "per-head"
+        gate_dim = self.n_heads if self.gate_per_head else self.n_heads * self.head_dim
+        self.g_proj = nn.Linear(args.hidden_size, gate_dim, bias=False)
+
+        rope_config = dict(args.rope_parameters or args.rope_scaling or {})
+        rope_config.setdefault("rope_type", "default")
+        partial = float(args.partial_rotary_factor or 1.0)
+        rope_config.setdefault("partial_rotary_factor", partial)
+        self.rope = initialize_rope(
+            int(self.head_dim * partial),
+            base=float(rope_config.get("rope_theta", args.rope_theta)),
+            traditional=False,
+            scaling_config=rope_config,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def _apply_gate(self, x: mx.array, output: mx.array) -> mx.array:
+        batch, block_len, _ = output.shape
+        gate = nn.softplus(self.g_proj(x).astype(mx.float32)).astype(output.dtype)
+        if self.gate_per_head:
+            shape = output.shape
+            output = (
+                output.reshape(batch, block_len, self.n_heads, self.head_dim)
+                * gate[..., None]
+            ).reshape(shape)
+        else:
+            output = output * gate
+        return output
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        *,
+        target_hidden: mx.array,
+        cache: Any | None = None,
+    ) -> mx.array:
+        batch, block_len, _ = hidden_states.shape
+        ctx_len = int(target_hidden.shape[1])
+
+        queries = self.q_proj(hidden_states)
+        queries = self.q_norm(
+            queries.reshape(batch, block_len, self.n_heads, -1)
+        ).transpose(0, 2, 1, 3)
+
+        context_hidden, context_spans = self._context_segments_for_cache(
+            target_hidden, cache
+        )
+        selected_ctx_len = int(context_hidden.shape[1])
+        context_keys = self.k_proj(context_hidden)
+        context_keys = self.k_norm(
+            context_keys.reshape(batch, selected_ctx_len, self.n_kv_heads, -1)
+        ).transpose(0, 2, 1, 3)
+        context_values = (
+            self.v_proj(context_hidden)
+            .reshape(batch, selected_ctx_len, self.n_kv_heads, -1)
+            .transpose(0, 2, 1, 3)
+        )
+
+        noise_keys = self.k_proj(hidden_states)
+        noise_keys = self.k_norm(
+            noise_keys.reshape(batch, block_len, self.n_kv_heads, -1)
+        ).transpose(0, 2, 1, 3)
+        noise_values = (
+            self.v_proj(hidden_states)
+            .reshape(batch, block_len, self.n_kv_heads, -1)
+            .transpose(0, 2, 1, 3)
+        )
+
+        if isinstance(cache, FullContextDraftKVCache):
+            cache_offset = int(cache.offset)
+            query_offset = cache_offset + ctx_len
+            queries = self.rope(queries, offset=query_offset)
+            context_keys, context_values, context_positions = (
+                self._rope_context_segments(
+                    context_keys,
+                    context_values,
+                    cache_offset=cache_offset,
+                    spans=context_spans,
+                )
+            )
+            noise_keys = self.rope(noise_keys, offset=query_offset)
+            cache.append_context(
+                context_keys,
+                context_values,
+                ctx_len,
+                positions=context_positions,
+                advance_positions=ctx_len,
+            )
+            keys, values = cache.fetch_with_block(noise_keys, noise_values)
+            mask = None
+            if self.sliding_window is not None:
+                noise_positions = mx.arange(
+                    query_offset, query_offset + block_len, dtype=mx.int32
+                )
+                cached_positions = cache.position_indices()
+                key_positions = (
+                    noise_positions
+                    if cached_positions is None
+                    else mx.concatenate([cached_positions, noise_positions], axis=0)
+                )
+                mask = self._attention_mask(
+                    block_len=block_len,
+                    query_offset=query_offset,
+                    key_len=int(keys.shape[-2]),
+                    key_positions=key_positions,
+                )
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache=None, scale=self.scale, mask=mask
+            )
+        elif isinstance(cache, ContextOnlyDraftKVCache):
+            cache_offset = int(cache.offset)
+            query_offset = cache_offset + ctx_len
+            queries = self.rope(queries, offset=query_offset)
+            context_keys, context_values, context_positions = (
+                self._rope_context_segments(
+                    context_keys,
+                    context_values,
+                    cache_offset=cache_offset,
+                    spans=context_spans,
+                )
+            )
+            noise_keys = self.rope(noise_keys, offset=query_offset)
+            cache.append_context(
+                context_keys,
+                context_values,
+                ctx_len,
+                positions=context_positions,
+                advance_positions=ctx_len,
+            )
+            cached_keys, cached_values = cache.fetch()
+            keys = mx.concatenate([cached_keys, noise_keys], axis=-2)
+            values = mx.concatenate([cached_values, noise_values], axis=-2)
+            cached_positions = cache.position_indices()
+            noise_positions = mx.arange(
+                query_offset, query_offset + block_len, dtype=mx.int32
+            )
+            key_positions = mx.concatenate([cached_positions, noise_positions], axis=0)
+            mask = self._attention_mask(
+                block_len=block_len,
+                query_offset=query_offset,
+                key_len=int(keys.shape[-2]),
+                key_positions=key_positions,
+            )
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache=None, scale=self.scale, mask=mask
+            )
+        elif cache is not None:
+            cache_offset = int(getattr(cache, "offset", 0) or 0)
+            query_offset = cache_offset + ctx_len
+            queries = self.rope(queries, offset=query_offset)
+            context_keys = self.rope(context_keys, offset=cache_offset)
+            noise_keys = self.rope(noise_keys, offset=query_offset)
+            keys = mx.concatenate([context_keys, noise_keys], axis=-2)
+            values = mx.concatenate([context_values, noise_values], axis=-2)
+            keys, values = cache.update_and_fetch(keys, values)
+            mask = self._attention_mask(
+                block_len=block_len,
+                query_offset=query_offset,
+                key_len=int(keys.shape[-2]),
+            )
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache=cache, scale=self.scale, mask=mask
+            )
+        else:
+            queries = self.rope(queries, offset=ctx_len)
+            context_keys = self.rope(context_keys, offset=0)
+            noise_keys = self.rope(noise_keys, offset=ctx_len)
+            keys = mx.concatenate([context_keys, noise_keys], axis=-2)
+            values = mx.concatenate([context_values, noise_values], axis=-2)
+            mask = self._attention_mask(
+                block_len=block_len,
+                query_offset=ctx_len,
+                key_len=int(keys.shape[-2]),
+            )
+            output = scaled_dot_product_attention(
+                queries, keys, values, cache=None, scale=self.scale, mask=mask
+            )
+
+        output = output.transpose(0, 2, 1, 3).reshape(batch, block_len, -1)
+        return self.o_proj(self._apply_gate(hidden_states, output))
+
+
+class LagunaDFlashDecoderLayer(DFlashDecoderLayer):
+    def __init__(self, args: LagunaDFlashDraftModelArgs, layer_idx: int):
+        nn.Module.__init__(self)
+        self.self_attn = LagunaDFlashAttention(args, layer_idx)
+        self.mlp = MLP(args.hidden_size, args.intermediate_size)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        *,
+        target_hidden: mx.array,
+        cache: Any | None = None,
+    ) -> mx.array:
+        residual = hidden_states
+        attention_input = self.input_layernorm(hidden_states)
+        context_input = self.input_layernorm(target_hidden)
+        hidden_states = self.self_attn(
+            attention_input, target_hidden=context_input, cache=cache
+        )
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.mlp(self.post_attention_layernorm(hidden_states))
+        return residual + hidden_states
+
+    def advance_projected_context_cache(
+        self, *, target_hidden: mx.array, cache: Any
+    ) -> None:
+        self.self_attn.append_projected_context_cache(
+            target_hidden=self.input_layernorm(target_hidden), cache=cache
+        )
+
+
+class LagunaDFlashDraftModel(DFlashDraftModel):
+    """MLX representation of Poolside's DFlashLagunaForCausalLM."""
+
+    def __init__(self, args: LagunaDFlashDraftModelArgs):
+        nn.Module.__init__(self)
+        self.args = args
+        self.model_type = "dflash_laguna"
+        self.layers = [
+            LagunaDFlashDecoderLayer(args, layer_idx)
+            for layer_idx in range(args.num_hidden_layers)
+        ]
+        self.target_layer_ids = list(
+            (args.dflash_config or {}).get("target_layer_ids") or ()
+        )
+        if not self.target_layer_ids:
+            raise ValueError("Laguna DFlash draft requires target_layer_ids")
+        self.aux_hidden_norms = [
+            nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+            for _ in self.target_layer_ids
+        ]
+        self.fc = nn.Linear(
+            len(self.target_layer_ids) * args.hidden_size,
+            args.hidden_size,
+            bias=False,
+        )
+        self.hidden_norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.block_size = int(args.block_size)
+        self.mask_token_id = int(
+            (args.dflash_config or {}).get("mask_token_id", 0) or 0
+        )
+        self.embed_scale = 1.0
+
+    def bind_target_model(self, target_model: Any, *, target_ops: Any) -> None:
+        if target_ops.family(target_model) != "laguna_swa":
+            raise ValueError("Laguna DFlash draft requires a Laguna target")
+        text_model = target_ops.text_model(target_model)
+        target_layers = len(text_model.layers)
+        if target_layers != int(self.args.num_target_layers):
+            raise ValueError(
+                "Laguna target/draft layer mismatch: "
+                f"{target_layers} != {self.args.num_target_layers}"
+            )
+        if max(self.target_layer_ids) >= target_layers:
+            raise ValueError("Laguna DFlash target_layer_ids exceed target depth")
+        target_hidden = int(getattr(text_model.args, "hidden_size", 0) or 0)
+        if target_hidden != int(self.args.hidden_size):
+            raise ValueError(
+                "Laguna target/draft hidden-size mismatch: "
+                f"{target_hidden} != {self.args.hidden_size}"
+            )
+        self.embed_scale = getattr(text_model, "embed_scale", 1.0)
+
+    def project_target_hidden(self, target_hidden: mx.array) -> mx.array:
+        expected = len(self.target_layer_ids) * int(self.args.hidden_size)
+        if int(target_hidden.shape[-1]) != expected:
+            raise ValueError(
+                "Laguna DFlash target feature width mismatch: "
+                f"{target_hidden.shape[-1]} != {expected}"
+            )
+        slices = mx.split(target_hidden, len(self.target_layer_ids), axis=-1)
+        normalized = [
+            norm(hidden_slice)
+            for norm, hidden_slice in zip(self.aux_hidden_norms, slices, strict=True)
+        ]
+        return self.hidden_norm(self.fc(mx.concatenate(normalized, axis=-1)))
+
+    def sanitize(self, weights: dict[str, mx.array]) -> dict[str, mx.array]:
+        """Split Poolside's fused QKV tensors into dflash-mlx projections."""
+        weights = dict(weights)
+        q_dim = int(self.args.num_attention_heads) * int(self.args.head_dim)
+        kv_dim = int(self.args.num_key_value_heads) * int(self.args.head_dim)
+        total_dim = q_dim + 2 * kv_dim
+
+        # The official BF16 checkpoints use ``qkv_proj.weight``.  MLX
+        # quantized linears additionally carry ``scales`` and ``biases``;
+        # those tensors are also partitioned by output channel on axis zero.
+        for layer_idx in range(len(self.layers)):
+            fused_prefix = f"layers.{layer_idx}.self_attn.qkv_proj."
+            for suffix in ("weight", "bias", "scales", "biases"):
+                fused_key = fused_prefix + suffix
+                fused = weights.pop(fused_key, None)
+                if fused is None:
+                    continue
+                if int(fused.shape[0]) != total_dim:
+                    raise ValueError(
+                        f"Unexpected Laguna {fused_key} output width: "
+                        f"{fused.shape[0]} != {total_dim}"
+                    )
+                query, key, value = mx.split(fused, [q_dim, q_dim + kv_dim], axis=0)
+                split_prefix = f"layers.{layer_idx}.self_attn."
+                weights[split_prefix + "q_proj." + suffix] = query
+                weights[split_prefix + "k_proj." + suffix] = key
+                weights[split_prefix + "v_proj." + suffix] = value
+        return weights
+
+
+def _is_laguna_draft_config(config: dict[str, Any]) -> bool:
+    architectures = tuple(str(a) for a in (config.get("architectures") or ()))
+    return (
+        str(config.get("model_type", "")).lower() == "laguna"
+        and "DFlashLagunaForCausalLM" in architectures
+    )
+
+
+def install_dflash_laguna_backend() -> bool:
+    """Register Laguna target ops and draft classes in dflash-mlx."""
+    from dflash_mlx.engine import target_ops
+    from dflash_mlx.runtime import loading
+
+    changed = False
+    if _BACKEND_PATH not in target_ops.TARGET_BACKENDS:
+        target_ops.TARGET_BACKENDS.append(_BACKEND_PATH)
+        changed = True
+
+    current = loading._get_dflash_model_classes
+    if not getattr(current, "_omlx_laguna_draft", False):
+
+        def get_dflash_model_classes(config: dict[str, Any]):
+            resolved = current(config)
+            if not _is_laguna_draft_config(config):
+                return resolved
+            # Respect a future upstream specialization automatically.
+            if resolved != (DFlashDraftModel, DFlashDraftModelArgs):
+                return resolved
+            return LagunaDFlashDraftModel, LagunaDFlashDraftModelArgs
+
+        get_dflash_model_classes._omlx_laguna_draft = True
+        get_dflash_model_classes._omlx_original = current
+        loading._get_dflash_model_classes = get_dflash_model_classes
+        changed = True
+    return changed
+
+
+__all__ = [
+    "LagunaDFlashDraftModel",
+    "LagunaDFlashDraftModelArgs",
+    "LagunaTargetOps",
+    "install_dflash_laguna_backend",
+]

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -422,7 +422,7 @@ class TestDFlashEngineInit:
 
             from omlx.engine import dflash as dflash_mod
             from omlx.engine.dflash import DFlashEngine
-            from omlx.patches import dflash_lifecycle
+            from omlx.patches import dflash_lifecycle, qwen35_moe_gate_up
         except ImportError:
             pytest.skip("dflash-mlx not installed")
 
@@ -445,7 +445,13 @@ class TestDFlashEngineInit:
         def fake_load_draft_bundle(model_ref, **kwargs):
             captured["draft_model_ref"] = model_ref
             captured["draft_kwargs"] = kwargs
-            return SimpleNamespace(), {}
+
+            class FakeDraft:
+                def bind_target_model(self, target_model, *, target_ops):
+                    captured["bound_target"] = target_model
+                    captured["bound_target_ops"] = target_ops
+
+            return FakeDraft(), {}
 
         monkeypatch.setattr(
             dflash_loading, "load_target_bundle", fake_load_target_bundle
@@ -460,6 +466,11 @@ class TestDFlashEngineInit:
             dflash_lifecycle,
             "install_dflash_lifecycle_wrap",
             lambda: True,
+        )
+        monkeypatch.setattr(
+            qwen35_moe_gate_up,
+            "apply_qwen35_moe_gate_up_fusion",
+            lambda model: captured.setdefault("fused_target", model),
         )
         monkeypatch.setattr(
             dflash_mod,
@@ -484,6 +495,9 @@ class TestDFlashEngineInit:
             assert captured["draft_model_ref"] == "test-draft"
             assert verify_config.mode == "off"
             assert captured["quantize_kv_cache"] is False
+            assert captured["fused_target"] is engine._target_model
+            assert captured["bound_target"] is engine._target_model
+            assert captured["bound_target_ops"] is engine._target_ops
         finally:
             await engine.stop()
 
@@ -640,7 +654,7 @@ class TestDFlashEngineInit:
             ),
         )
         ctx = engine._build_runtime_context()
-        runtime = getattr(ctx, "runtime")
+        runtime = ctx.runtime
         assert runtime.draft_window_size == 512
         assert runtime.draft_sink_size == 16
         assert runtime.verify_mode == "dflash"
@@ -657,7 +671,7 @@ class TestDFlashEngineInit:
             draft_model_path="test-draft",
         )
         ctx = engine._build_runtime_context()
-        runtime = getattr(ctx, "runtime")
+        runtime = ctx.runtime
         assert runtime.draft_window_size == 1024
         assert runtime.draft_sink_size == 64
         assert runtime.verify_mode == "adaptive"
@@ -681,7 +695,7 @@ class TestDFlashEngineInit:
             omlx_ssd_cache_dir=tmp_path,
         )
         ctx = engine._build_runtime_context()
-        runtime = getattr(ctx, "runtime")
+        runtime = ctx.runtime
         assert runtime.prefix_cache_l2_max_bytes == 5 * 1024**3
 
     def test_l2_max_bytes_defaults_to_20gib(self, tmp_path):
@@ -701,7 +715,7 @@ class TestDFlashEngineInit:
             omlx_ssd_cache_dir=tmp_path,
         )
         ctx = engine._build_runtime_context()
-        runtime = getattr(ctx, "runtime")
+        runtime = ctx.runtime
         assert runtime.prefix_cache_l2_max_bytes == 20 * 1024**3
 
 
@@ -780,6 +794,17 @@ class TestDFlashCompatibility:
         assert compatible is True
         assert reason == ""
 
+    def test_laguna_is_compatible(self, tmp_path):
+        """oMLX supplies the target and gated-drafter adapters for Laguna."""
+        try:
+            from omlx.engine.dflash import is_dflash_compatible
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+        self._write_config(tmp_path, "laguna")
+        compatible, reason = is_dflash_compatible(tmp_path)
+        assert compatible is True
+        assert reason == ""
+
     def test_gemma4_assistant_is_incompatible(self, tmp_path):
         """MTP -assistant variants declare gemma4_assistant at the top level
         even though their text_config.model_type is gemma4_text. The toggle
@@ -821,6 +846,7 @@ class TestDFlashCompatibility:
         assert compatible is False
         assert "Qwen" in reason
         assert "Gemma4" in reason
+        assert "Laguna" in reason
 
 
 class TestDFlashEnginePoolRouting:

--- a/tests/test_dflash_laguna.py
+++ b/tests/test_dflash_laguna.py
@@ -249,6 +249,141 @@ def test_target_ops_prefix_snapshot_round_trip_preserves_mixed_cache():
     _assert_close(actual, expected)
 
 
+def test_laguna_draft_decodes_trimmed_prefix_snapshot():
+    from dflash_mlx.cache.codecs import build_snapshot
+    from dflash_mlx.cache.fingerprints import DFlashPrefixKey
+    from dflash_mlx.draft_backend import EagerDraftBackend
+    from dflash_mlx.engine.events import SummaryEvent
+    from dflash_mlx.runtime import stream_dflash_generate
+    from dflash_mlx.runtime.context import build_offline_runtime_context
+
+    from omlx.patches.dflash_laguna import (
+        LagunaDFlashDraftModel,
+        LagunaDFlashDraftModelArgs,
+        LagunaTargetOps,
+    )
+
+    target = _target_model()
+    ops = LagunaTargetOps()
+    draft = LagunaDFlashDraftModel(
+        LagunaDFlashDraftModelArgs.from_dict(_draft_config())
+    )
+    draft.bind_target_model(target, target_ops=ops)
+
+    prefix_ids = [1, 2, 3, 4, 5, 6, 7]
+    target_cache = ops.make_cache(target, enable_speculative_linear_cache=True)
+    logits, captured = ops.forward_with_hidden_capture(
+        target,
+        input_ids=mx.array([prefix_ids], dtype=mx.int32),
+        cache=target_cache,
+        capture_layer_ids={1, 4},
+    )
+    target_hidden = ops.extract_context_feature(captured, [0, 3])
+    projected = draft.project_target_hidden(target_hidden)
+    snapshot = build_snapshot(
+        token_ids=prefix_ids,
+        target_cache=target_cache,
+        target_hidden=projected,
+        last_logits=logits[:, -1, :],
+        key=DFlashPrefixKey(
+            target_model_id="tiny-laguna-target",
+            draft_model_id="tiny-laguna-draft",
+            capture_layer_ids=(0, 3),
+            draft_sink_size=2,
+            draft_window_size=4,
+            template_hash="template",
+            prompt_policy_hash="policy",
+        ),
+        draft_model=draft,
+        trim_target_hidden=True,
+        draft_sink_size=2,
+        draft_window_size=4,
+    )
+
+    assert snapshot.target_hidden_chunk_spans == ((0, 2), (3, 7))
+
+    def generate(prefix_snapshot=None, *, hit_kind="miss"):
+        return list(
+            stream_dflash_generate(
+                target_model=target,
+                target_ops=ops,
+                tokenizer=None,
+                draft_model=draft,
+                draft_backend=EagerDraftBackend(),
+                prompt_tokens_override=prefix_ids,
+                max_new_tokens=3,
+                block_tokens=4,
+                stop_token_ids=[],
+                prefix_snapshot=prefix_snapshot,
+                prefix_hit_kind=hit_kind,
+                publish_generation_snapshot=False,
+                runtime_context=build_offline_runtime_context(
+                    draft_sink_size=2,
+                    draft_window_size=4,
+                ),
+            )
+        )
+
+    cold_events = generate()
+    events = generate(snapshot, hit_kind="l1")
+    cold_summary = next(
+        event for event in cold_events if isinstance(event, SummaryEvent)
+    )
+    summary = next(event for event in events if isinstance(event, SummaryEvent))
+    assert summary.generated_token_ids == cold_summary.generated_token_ids
+    assert summary.generation_tokens == 3
+    assert summary.hit_kind == "l1"
+    assert summary.fallback_ar is False
+
+
+def test_laguna_draft_advances_trimmed_projected_context():
+    from dflash_mlx.cache.snapshot import TargetHiddenChunks
+    from dflash_mlx.draft_backend import EagerDraftBackend
+
+    from omlx.patches.dflash_laguna import (
+        LagunaDFlashDraftModel,
+        LagunaDFlashDraftModelArgs,
+    )
+
+    draft = LagunaDFlashDraftModel(
+        LagunaDFlashDraftModelArgs.from_dict(_draft_config())
+    )
+    backend = EagerDraftBackend()
+    dense = mx.arange(7 * 32, dtype=mx.float32).reshape(1, 7, 32)
+    sparse = TargetHiddenChunks(
+        total_len=7,
+        chunks=(dense[:, :2, :], dense[:, 3:, :]),
+        spans=((0, 2), (3, 7)),
+    )
+    dense_cache = backend.make_cache(
+        draft_model=draft,
+        sink_size=2,
+        window_size=4,
+    )
+    sparse_cache = backend.make_cache(
+        draft_model=draft,
+        sink_size=2,
+        window_size=4,
+    )
+
+    draft.advance_projected_context_cache(
+        draft_context=dense,
+        cache=dense_cache,
+    )
+    draft.advance_projected_context_cache(
+        draft_context=sparse,
+        cache=sparse_cache,
+    )
+
+    for dense_entry, sparse_entry in zip(dense_cache, sparse_cache, strict=True):
+        dense_keys, dense_values = dense_entry.fetch()
+        sparse_keys, sparse_values = sparse_entry.fetch()
+        _assert_close(sparse_keys, dense_keys)
+        _assert_close(sparse_values, dense_values)
+        _assert_close(sparse_entry.position_indices(), dense_entry.position_indices())
+        assert sparse_entry.offset == dense_entry.offset == 7
+
+
 def test_laguna_draft_normalizes_nested_config_and_builds_gated_layers():
     from omlx.patches.dflash_laguna import (
         LagunaDFlashDraftModel,

--- a/tests/test_dflash_laguna.py
+++ b/tests/test_dflash_laguna.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for oMLX's Laguna extension to dflash-mlx."""
+
+import mlx.core as mx
+import pytest
+
+pytest.importorskip("dflash_mlx")
+
+
+def _target_config(**overrides):
+    config = dict(
+        model_type="laguna",
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=256,
+        rms_norm_eps=1e-6,
+        qkv_bias=False,
+        attention_bias=False,
+        gating="per-head",
+        tie_word_embeddings=False,
+        rope_theta=500000.0,
+        rope_parameters={"rope_type": "default", "rope_theta": 500000.0},
+        partial_rotary_factor=1.0,
+        sliding_window=4,
+        layer_types=[
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+        ],
+        num_attention_heads_per_layer=[4, 4, 4, 4],
+        num_experts=0,
+        mlp_only_layers=[],
+    )
+    config.update(overrides)
+    return config
+
+
+def _draft_config(**overrides):
+    config = dict(
+        model_type="laguna",
+        architectures=["DFlashLagunaForCausalLM"],
+        vocab_size=128,
+        draft_vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=256,
+        rms_norm_eps=1e-6,
+        attention_bias=False,
+        rope_theta=500000.0,
+        rope_parameters={"rope_type": "default", "rope_theta": 500000.0},
+        partial_rotary_factor=0.5,
+        sliding_window=4,
+        layer_types=["sliding_attention", "sliding_attention"],
+        gating="per-head",
+        dflash_config={
+            "block_size": 4,
+            "mask_token_id": 12,
+            "num_target_layers": 4,
+            "target_layer_ids": [0, 3],
+            "causal": True,
+        },
+    )
+    config.update(overrides)
+    return config
+
+
+def _target_model():
+    from omlx.patches.laguna import apply_laguna_patch
+
+    apply_laguna_patch()
+    from mlx_lm.models import laguna
+
+    return laguna.Model(laguna.ModelArgs(**_target_config()))
+
+
+def _assert_close(actual, expected, atol=1e-5):
+    mx.eval(actual, expected)
+    assert float(mx.max(mx.abs(actual - expected)).item()) <= atol
+
+
+def test_installer_registers_target_backend_and_laguna_draft_classes():
+    from dflash_mlx.engine import target_ops
+    from dflash_mlx.runtime import loading
+
+    from omlx.patches.dflash_laguna import (
+        LagunaDFlashDraftModel,
+        LagunaDFlashDraftModelArgs,
+        install_dflash_laguna_backend,
+    )
+
+    install_dflash_laguna_backend()
+
+    assert "omlx.patches.dflash_laguna:LagunaTargetOps" in target_ops.TARGET_BACKENDS
+    assert loading._get_dflash_model_classes(_draft_config()) == (
+        LagunaDFlashDraftModel,
+        LagunaDFlashDraftModelArgs,
+    )
+
+
+def test_target_ops_matches_native_forward_and_captures_requested_layers():
+    from omlx.patches.dflash_laguna import LagunaTargetOps
+
+    model = _target_model()
+    ops = LagunaTargetOps()
+    inputs = mx.array([[1, 2, 3]], dtype=mx.int32)
+
+    expected = model(inputs, cache=model.make_cache())
+    actual, captured = ops.forward_with_hidden_capture(
+        model,
+        input_ids=inputs,
+        cache=model.make_cache(),
+        capture_layer_ids={1, 4},
+    )
+
+    _assert_close(actual, expected)
+    assert set(captured) == {1, 4}
+    assert ops.extract_context_feature(captured, [0, 3]).shape == (1, 3, 64)
+
+
+def test_target_ops_rewinds_full_and_rotating_cache_after_rejection():
+    from omlx.patches.dflash_laguna import LagunaTargetOps
+
+    model = _target_model()
+    ops = LagunaTargetOps()
+    cache = ops.make_cache(
+        model,
+        enable_speculative_linear_cache=True,
+    )
+    ops.forward_with_hidden_capture(
+        model,
+        input_ids=mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32),
+        cache=cache,
+        capture_layer_ids={1},
+    )
+    ops.verify_block(
+        target_model=model,
+        verify_ids=mx.array([[6, 7, 8]], dtype=mx.int32),
+        target_cache=cache,
+        capture_layer_ids={1},
+    )
+
+    assert {int(entry.offset) for entry in cache} == {8}
+    ops.restore_after_acceptance(
+        cache,
+        target_len=6,
+        acceptance_length=1,
+        drafted_tokens=3,
+    )
+    assert {int(entry.offset) for entry in cache} == {6}
+
+    # Rewinding a wrapped ring must preserve the same usable history as a
+    # clean prefill of the accepted prefix, not merely restore its offset.
+    clean_cache = ops.make_cache(model, enable_speculative_linear_cache=True)
+    ops.forward_with_hidden_capture(
+        model,
+        input_ids=mx.array([[1, 2, 3, 4, 5, 6]], dtype=mx.int32),
+        cache=clean_cache,
+        capture_layer_ids={1},
+    )
+    expected, _ = ops.forward_with_hidden_capture(
+        model,
+        input_ids=mx.array([[9]], dtype=mx.int32),
+        cache=clean_cache,
+        capture_layer_ids={1},
+    )
+    actual, _ = ops.forward_with_hidden_capture(
+        model,
+        input_ids=mx.array([[9]], dtype=mx.int32),
+        cache=cache,
+        capture_layer_ids={1},
+    )
+    _assert_close(actual, expected)
+
+
+def test_target_ops_prefix_snapshot_round_trip_preserves_mixed_cache():
+    from dflash_mlx.cache.codecs import build_snapshot, hydrate_target_cache
+    from dflash_mlx.cache.fingerprints import DFlashPrefixKey
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    from omlx.patches.dflash_laguna import LagunaTargetOps
+
+    model = _target_model()
+    ops = LagunaTargetOps()
+    capabilities = ops.capabilities_for(model)
+    assert capabilities.supports_prefix_snapshot is True
+    assert capabilities.supports_rotating_cache_snapshot is True
+
+    prefix_ids = [1, 2, 3, 4, 5, 6, 7]
+    cache = ops.make_cache(model, enable_speculative_linear_cache=True)
+    logits, captured = ops.forward_with_hidden_capture(
+        model,
+        input_ids=mx.array([prefix_ids], dtype=mx.int32),
+        cache=cache,
+        capture_layer_ids={1, 4},
+    )
+    target_hidden = ops.extract_context_feature(captured, [0, 3])
+    snapshot = build_snapshot(
+        token_ids=prefix_ids,
+        target_cache=cache,
+        target_hidden=target_hidden,
+        last_logits=logits[:, -1, :],
+        key=DFlashPrefixKey(
+            target_model_id="tiny-laguna-target",
+            draft_model_id="tiny-laguna-draft",
+            capture_layer_ids=(0, 3),
+            draft_sink_size=2,
+            draft_window_size=4,
+            template_hash="template",
+            prompt_policy_hash="policy",
+        ),
+        trim_target_hidden=False,
+    )
+
+    template = ops.make_cache(model, enable_speculative_linear_cache=True)
+    hydrated = hydrate_target_cache(snapshot, template)
+
+    assert isinstance(hydrated[0], KVCache)
+    assert all(isinstance(entry, RotatingKVCache) for entry in hydrated[1:])
+    assert [int(entry.offset) for entry in hydrated] == [len(prefix_ids)] * 4
+    assert [len(state) for state in snapshot.fa_states] == [3, 4, 4, 4]
+    assert [int(entry._idx) for entry in hydrated[1:]] == [
+        int(state[3]) for state in snapshot.fa_states[1:]
+    ]
+
+    # A restored cache must produce the same continuation as the live cache,
+    # including after the sliding-attention rings have wrapped.
+    expected, _ = ops.forward_with_hidden_capture(
+        model,
+        input_ids=mx.array([[8]], dtype=mx.int32),
+        cache=cache,
+        capture_layer_ids={1},
+    )
+    actual, _ = ops.forward_with_hidden_capture(
+        model,
+        input_ids=mx.array([[8]], dtype=mx.int32),
+        cache=hydrated,
+        capture_layer_ids={1},
+    )
+    _assert_close(actual, expected)
+
+
+def test_laguna_draft_normalizes_nested_config_and_builds_gated_layers():
+    from omlx.patches.dflash_laguna import (
+        LagunaDFlashDraftModel,
+        LagunaDFlashDraftModelArgs,
+    )
+
+    args = LagunaDFlashDraftModelArgs.from_dict(_draft_config())
+    draft = LagunaDFlashDraftModel(args)
+
+    assert args.block_size == 4
+    assert args.num_target_layers == 4
+    assert args.tie_word_embeddings is True
+    assert draft.target_layer_ids == [0, 3]
+    assert len(draft.aux_hidden_norms) == 2
+    assert draft.layers[0].self_attn.g_proj.weight.shape[0] == 4
+    assert draft.layers[0].self_attn.rope.dims == 4
+
+
+def test_laguna_draft_forward_uses_aux_norms_and_binds_matching_target():
+    from omlx.patches.dflash_laguna import (
+        LagunaDFlashDraftModel,
+        LagunaDFlashDraftModelArgs,
+        LagunaTargetOps,
+    )
+
+    target = _target_model()
+    draft = LagunaDFlashDraftModel(
+        LagunaDFlashDraftModelArgs.from_dict(_draft_config())
+    )
+    draft.bind_target_model(target, target_ops=LagunaTargetOps())
+
+    result = draft(
+        noise_embedding=mx.zeros((1, 3, 32)),
+        target_hidden=mx.zeros((1, 5, 64)),
+    )
+    mx.eval(result)
+    assert result.shape == (1, 3, 32)
+
+
+def test_laguna_draft_sanitize_splits_poolside_fused_qkv_layout():
+    from omlx.patches.dflash_laguna import (
+        LagunaDFlashDraftModel,
+        LagunaDFlashDraftModelArgs,
+    )
+
+    draft = LagunaDFlashDraftModel(
+        LagunaDFlashDraftModelArgs.from_dict(_draft_config())
+    )
+    # q=4*8, k=2*8, v=2*8: this is the layout used by Poolside's
+    # model.safetensors, scaled down to the tiny test configuration.
+    fused = mx.arange(64 * 32).reshape(64, 32)
+    fused_scales = mx.arange(64 * 2).reshape(64, 2)
+    weights = draft.sanitize(
+        {
+            "layers.0.self_attn.qkv_proj.weight": fused,
+            "layers.0.self_attn.qkv_proj.scales": fused_scales,
+            "norm.weight": mx.ones(32),
+        }
+    )
+
+    assert "layers.0.self_attn.qkv_proj.weight" not in weights
+    assert weights["layers.0.self_attn.q_proj.weight"].shape == (32, 32)
+    assert weights["layers.0.self_attn.k_proj.weight"].shape == (16, 32)
+    assert weights["layers.0.self_attn.v_proj.weight"].shape == (16, 32)
+    assert weights["layers.0.self_attn.q_proj.scales"].shape == (32, 2)
+    assert weights["layers.0.self_attn.k_proj.scales"].shape == (16, 2)
+    assert weights["layers.0.self_attn.v_proj.scales"].shape == (16, 2)
+    _assert_close(weights["layers.0.self_attn.q_proj.weight"], fused[:32])
+    _assert_close(weights["layers.0.self_attn.k_proj.weight"], fused[32:48])
+    _assert_close(weights["layers.0.self_attn.v_proj.weight"], fused[48:])
+
+
+def test_laguna_draft_rejects_mixed_attention_flavors():
+    from omlx.patches.dflash_laguna import LagunaDFlashDraftModelArgs
+
+    with pytest.raises(ValueError, match="one attention type"):
+        LagunaDFlashDraftModelArgs.from_dict(
+            _draft_config(layer_types=["full_attention", "sliding_attention"])
+        )


### PR DESCRIPTION
## Acknowledgement

First of all, many thanks to **Jun Kim**, the maintainer of this repository, for the excellent work on oMLX. The project has been extremely useful to me, and its architecture and integration points are thoughtful and well designed. I hope this contribution is useful to the project in return.

## Summary

This PR extends the existing DFlash engine to support Poolside Laguna targets and their official DFlash draft checkpoints.

- register a strict, idempotent Laguna `TargetOps` backend through dflash-mlx's existing extension points;
- add the gated Laguna draft specialization used by Poolside checkpoints;
- support fused-QKV checkpoint loading, partial RoPE, per-head/per-element attention gates, captured-layer RMS normalization, mixed full/sliding target caches, and rejection rollback;
- validate target/draft family, depth, hidden size, and capture-layer compatibility at load time;
- explicitly bind every DFlash draft to its target, preserving the target embedding scale for Gemma4 while remaining a no-op for Qwen and Laguna;
- apply the existing MoE gate+up fusion path to compatible DFlash targets;
- expose Laguna as a supported DFlash family in the admin UI and documentation;
- add Laguna adapter, rollback, checkpoint-layout, configuration, and prefix-cache round-trip coverage.

## Design priority

While implementing this PR, I deliberately prioritized **robust inference and exact target-model behavior over absolute peak performance**.

For that reason, DDTree verification, target KV quantization, and the specialized verify-linear path remain disabled for Laguna until each has dedicated numerical-parity coverage. The implementation uses ordinary adaptive DFlash verification and fails early on incompatible target/draft combinations instead of attempting a permissive fallback.

## Validation

### oMLX tests

```text
178 passed in 1.63s
```

The run covered:

- `tests/test_dflash_engine.py`
- `tests/test_dflash_laguna.py`
- `tests/test_dflash_lifecycle.py`
- `tests/test_qwen35_moe_gate_up.py`
- `tests/test_dflash_prefill_memory_guard.py`
- `tests/test_model_settings.py`

### dflash-mlx adapter tests

```text
67 passed, 5 skipped in 2.01s
```

The five skipped tests are upstream opt-in real-model tests that expect their default models in the Hugging Face snapshot cache. Real local-model parity for the selected Laguna, Gemma4, and Qwen3.6 pairs was exercised directly by the benchmarks below; every run produced the exact same greedy token sequence as native generation.

## Local benchmarks

### Machine

- MacBook Pro (`Mac16,6`)
- Apple M4 Max
- 16-core CPU: 12 performance + 4 efficiency cores
- 40-core integrated GPU, Metal 4
- 128 GB unified memory
- macOS 26.5.1 (`25F80`)
- Python 3.12.11
- MLX 0.32.0
- mlx-lm 0.31.3
- dflash-mlx 0.1.10
- oMLX 0.5.3, branch head `39c8a016`

### Method

- greedy decoding (`temperature=0`);
- same Fibonacci coding prompt for native and DFlash paths;
- 64 generated tokens;
- one warm-up before measured runs;
- median of 5 measured runs for Laguna and 3 measured runs for Gemma4/Qwen3.6;
- block size 16, `verify_mode=dflash`, CopySpec off;
- draft quantization `w4a16:gs64`;
- prefix cache disabled to isolate single-request generation;
- exact generated-token parity required.

| Target / draft | Native wall | DFlash wall | Native tok/s | DFlash tok/s | Speedup | Acceptance | Exact parity | Peak memory |
|---|---:|---:|---:|---:|---:|---:|:---:|---:|
| `poolside/Laguna-S-2.1-NVFP4-mlx` / `Laguna-S-2.1-DFlash-NVFP4` | 1.968 s | 0.970 s | 32.5 | 66.0 | **2.03x** | 90.6% | yes | 72.69 GB |
| `mlx-community/gemma-4-26b-a4b-it-4bit` / `z-lab/gemma-4-26B-A4B-it-DFlash` | 0.722 s | 0.378 s | 88.6 | 169.2 | **1.91x** | 90.6% | yes | 14.58 GB |
| `mlx-community/Qwen3.6-35B-A3B-4bit` / `z-lab/Qwen3.6-35B-A3B-DFlash` | 0.650 s | 0.262 s | 98.5 | 244.2 | **2.48x** | 92.2% | yes | 19.94 GB |

The cross-family runs also verified the shared changes:

- Gemma4 draft `embed_scale` was bound from `1.0` to the target value `53.066`, with exact output parity;
- Qwen retained `embed_scale=1.0`, and gate+up fusion applied to all 40 MoE layers;
- the Laguna adapter fused 47 MoE layers in the latest rerun;
- Gemma4 remained outside the MoE fusion family filter, as intended.

> Note: the current Qwen3.6 drafter checkpoint was updated to a Transformers 5.7-style config where `block_size` and `rope_theta` are nested under `dflash_config` and `rope_parameters`. dflash-mlx 0.1.10 still expects root-level aliases, so the local benchmark added equivalent root aliases (`16` and `10000000`) without changing weights or semantics. This is an upstream checkpoint/runtime metadata compatibility issue and is not part of this PR.

## Intentionally unsupported Laguna fast paths

- DDTree / tree verification;
- target KV-cache quantization;
- specialized verify-linear replacement.

These can be enabled incrementally once model-specific parity tests demonstrate that rollback, cache state, and logits remain exact.
