### PR TITLE
feat: add durable idempotency lookup for Responses API

### DIFF
--- a/omlx/api/responses_utils.py
+++ b/omlx/api/responses_utils.py
@@ -2,6 +2,7 @@
 """Conversion utilities for the OpenAI Responses API."""
 
 import copy
+import hashlib
 import json
 import logging
 import uuid
@@ -32,6 +33,10 @@ class ResponseStateNotFoundError(ResponseStateError):
 
 class ResponseStateCorruptError(ResponseStateError):
     """Raised when a stored response chain is incomplete or invalid."""
+
+
+class ResponseIdempotencyConflictError(ResponseStateError):
+    """Raised when an idempotency key is reused for a different request."""
 
 
 def _try_parse_json(s: str):
@@ -524,7 +529,20 @@ class ResponseStore:
 
     def _evict_oldest(self) -> None:
         while len(self._store) > self._max_size:
-            response_id, _record = self._store.popitem(last=False)
+            # ponytail: claims are never evicted; add explicit retention with
+            # persisted tombstones if bounded idempotency history is needed.
+            candidate = next(
+                (
+                    response_id
+                    for response_id, record in self._store.items()
+                    if not record.get("idempotency_key_hash")
+                ),
+                None,
+            )
+            if candidate is None:
+                break
+            response_id = candidate
+            del self._store[response_id]
             self._remove_persisted_record(response_id)
 
     def _load_persisted_records(self) -> None:
@@ -547,6 +565,18 @@ class ResponseStore:
             key=lambda record: (record.get("created_at", 0), record["response_id"])
         )
         for record in loaded:
+            public_response = record.get("public_response", {})
+            if (
+                record.get("idempotency_key_hash")
+                and public_response.get("status") == "in_progress"
+            ):
+                public_response["status"] = "failed"
+                public_response["error"] = {
+                    "code": "server_restarted",
+                    "message": "The server restarted before the response completed.",
+                }
+                record["public_response"] = public_response
+                self._persist_record(record)
             self._store[record["response_id"]] = record
         self._evict_oldest()
 
@@ -554,10 +584,85 @@ class ResponseStore:
         """Store response state, evicting oldest records if needed."""
         record = self._normalize_record(response_id, response_data)
         if response_id in self._store:
+            existing = self._store[response_id]
+            for key in ("idempotency_key_hash", "request_fingerprint"):
+                if key in existing:
+                    record[key] = existing[key]
             self._store.move_to_end(response_id)
         self._store[response_id] = record
         self._persist_record(record)
         self._evict_oldest()
+
+    @staticmethod
+    def _idempotency_key_hash(idempotency_key: str) -> str:
+        return hashlib.sha256(idempotency_key.encode("utf-8")).hexdigest()
+
+    @classmethod
+    def response_id_for_idempotency_key(cls, idempotency_key: str) -> str:
+        """Return the stable response ID associated with an idempotency key."""
+        return f"resp_{cls._idempotency_key_hash(idempotency_key)[:24]}"
+
+    def claim_idempotency(
+        self,
+        idempotency_key: str,
+        request_fingerprint: str,
+        public_response: Dict[str, Any],
+    ) -> tuple[bool, Dict[str, Any]]:
+        """Persist a pre-generation claim or return the existing response."""
+        response_id = self.response_id_for_idempotency_key(idempotency_key)
+        existing = self._store.get(response_id)
+        if existing is not None:
+            if existing.get("request_fingerprint") != request_fingerprint:
+                raise ResponseIdempotencyConflictError(
+                    "Idempotency key was already used for a different request."
+                )
+            return False, copy.deepcopy(existing["public_response"])
+
+        claimed_response = copy.deepcopy(public_response)
+        claimed_response["id"] = response_id
+        record = self._normalize_record(response_id, claimed_response)
+        record["idempotency_key_hash"] = self._idempotency_key_hash(idempotency_key)
+        record["request_fingerprint"] = request_fingerprint
+        self._store[response_id] = record
+        self._persist_record(record)
+        self._evict_oldest()
+        return True, copy.deepcopy(claimed_response)
+
+    def get_by_idempotency_key(
+        self,
+        idempotency_key: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Retrieve a claimed response without persisting the raw key."""
+        response_id = self.response_id_for_idempotency_key(idempotency_key)
+        record = self._store.get(response_id)
+        if (
+            record is None
+            or record.get("idempotency_key_hash")
+            != self._idempotency_key_hash(idempotency_key)
+        ):
+            return None
+        self._store.move_to_end(response_id)
+        return copy.deepcopy(record["public_response"])
+
+    def is_idempotent(self, response_id: str) -> bool:
+        record = self._store.get(response_id)
+        return bool(record and record.get("idempotency_key_hash"))
+
+    def fail_idempotency(self, response_id: str, code: str) -> None:
+        """Make an existing in-progress claim terminal without allowing retry."""
+        record = self._store.get(response_id)
+        if record is None or not record.get("idempotency_key_hash"):
+            return
+        public_response = copy.deepcopy(record["public_response"])
+        if public_response.get("status") != "in_progress":
+            return
+        public_response["status"] = "failed"
+        public_response["error"] = {
+            "code": code,
+            "message": "The response failed after its idempotency claim was stored.",
+        }
+        record["public_response"] = public_response
+        self._persist_record(record)
 
     def get_record(self, response_id: str) -> Optional[Dict[str, Any]]:
         """Retrieve a stored response-state record."""

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -40,6 +40,7 @@ The server provides:
 
 import argparse
 import asyncio
+import hashlib
 import inspect
 import json
 import logging
@@ -141,6 +142,7 @@ from .api.responses_models import (
     ResponsesRequest,
 )
 from .api.responses_utils import (
+    ResponseIdempotencyConflictError,
     ResponseStateCorruptError,
     ResponseStateNotFoundError,
     ResponseStore,
@@ -5558,6 +5560,45 @@ def _should_store_response(store_flag: Optional[bool]) -> bool:
     return store_flag is not False
 
 
+def _response_idempotency_key(
+    http_request: FastAPIRequest,
+    *,
+    required: bool = False,
+) -> Optional[str]:
+    key = http_request.headers.get("idempotency-key")
+    if key is None:
+        if required:
+            raise HTTPException(
+                status_code=400,
+                detail="Idempotency-Key header is required.",
+            )
+        return None
+    if not 1 <= len(key) <= 255 or not key.isascii() or not key.isprintable():
+        raise HTTPException(
+            status_code=400,
+            detail="Idempotency-Key must be 1-255 printable ASCII characters.",
+        )
+    return key
+
+
+def _response_request_fingerprint(request: ResponsesRequest) -> str:
+    payload = json.dumps(
+        request.model_dump(mode="json", exclude_none=True),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _require_persistent_response_store() -> None:
+    if _server_state.responses_store.state_dir is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Idempotency requires persistent response state.",
+        )
+
+
 def _resolve_previous_response_messages(previous_response_id: str) -> list[dict]:
     """Resolve a previous_response_id chain into chat messages."""
     try:
@@ -5614,6 +5655,48 @@ async def create_response(
     logger.debug(
         f"Responses API request: model={request.model}, stream={request.stream}"
     )
+
+    idempotency_key = _response_idempotency_key(http_request)
+    idempotent_response_id: Optional[str] = None
+    if idempotency_key is not None:
+        _require_persistent_response_store()
+        if request.stream:
+            raise HTTPException(
+                status_code=400,
+                detail="Idempotency-Key currently requires stream=false.",
+            )
+        if request.store is False:
+            raise HTTPException(
+                status_code=400,
+                detail="Idempotency-Key requires durable response storage.",
+            )
+        initial_response = ResponseObject(
+            id=ResponseStore.response_id_for_idempotency_key(idempotency_key),
+            model=request.model,
+            status="in_progress",
+            previous_response_id=request.previous_response_id,
+            metadata=request.metadata or {},
+        ).model_dump(exclude_none=True)
+        try:
+            claimed, existing_response = (
+                _server_state.responses_store.claim_idempotency(
+                    idempotency_key,
+                    _response_request_fingerprint(request),
+                    initial_response,
+                )
+            )
+        except ResponseIdempotencyConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        idempotent_response_id = initial_response["id"]
+        if not claimed:
+            return JSONResponse(
+                status_code=(
+                    202
+                    if existing_response.get("status") == "in_progress"
+                    else 200
+                ),
+                content=existing_response,
+            )
 
     load_start = time.perf_counter()
     lease = _LLMEngineLease()
@@ -5982,7 +6065,11 @@ async def create_response(
                 cached_tokens=output.cached_tokens,
             )
 
+            response_kwargs = (
+                {"id": idempotent_response_id} if idempotent_response_id else {}
+            )
             response_obj = ResponseObject(
+                **response_kwargs,
                 model=request.model,
                 status="completed",
                 output=output_items,
@@ -5993,6 +6080,7 @@ async def create_response(
                 top_p=top_p,
                 max_output_tokens=request.max_output_tokens,
                 previous_response_id=request.previous_response_id,
+                metadata=request.metadata or {},
             )
 
             # Store response
@@ -6002,17 +6090,38 @@ async def create_response(
                     input_messages=current_input_messages,
                 )
 
-            return response_obj.model_dump_json()
+            return response_obj.model_dump_json(
+                exclude_none=idempotent_response_id is not None
+            )
+
+        async def _build_responses_api_with_failure():
+            try:
+                return await _build_responses_api()
+            except BaseException:
+                if idempotent_response_id:
+                    _server_state.responses_store.fail_idempotency(
+                        idempotent_response_id,
+                        "generation_failed",
+                    )
+                raise
 
         return StreamingResponse(
             _release_after_stream(
-                _with_json_keepalive(http_request, _build_responses_api()),
+                _with_json_keepalive(
+                    http_request,
+                    _build_responses_api_with_failure(),
+                ),
                 lease,
             ),
             media_type="application/json",
         )
 
     except BaseException:
+        if idempotent_response_id:
+            _server_state.responses_store.fail_idempotency(
+                idempotent_response_id,
+                "request_failed",
+            )
         await lease.release()
         raise
 
@@ -6672,6 +6781,27 @@ async def stream_responses_api(
         _store_response_state(final_response, input_messages=input_messages or [])
 
 
+@app.get("/v1/responses/idempotency")
+async def get_response_by_idempotency_key(
+    http_request: FastAPIRequest,
+    _: bool = Depends(verify_api_key),
+):
+    """Retrieve a response claim without repeating the request."""
+    idempotency_key = _response_idempotency_key(http_request, required=True)
+    _require_persistent_response_store()
+    data = _server_state.responses_store.get_by_idempotency_key(idempotency_key)
+    if data is None:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "object": "response.lookup",
+                "status": "not_found",
+                "final": True,
+            },
+        )
+    return data
+
+
 @app.get("/v1/responses/{response_id}")
 async def get_response(
     response_id: str,
@@ -6690,6 +6820,11 @@ async def delete_response(
     _: bool = Depends(verify_api_key),
 ):
     """Delete a stored response."""
+    if _server_state.responses_store.is_idempotent(response_id):
+        raise HTTPException(
+            status_code=409,
+            detail="Idempotent response claims cannot be deleted.",
+        )
     if not _server_state.responses_store.delete(response_id):
         raise HTTPException(status_code=404, detail="Response not found")
     return {"id": response_id, "object": "response.deleted", "deleted": True}

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -445,6 +445,67 @@ class TestResponsesEndpoint:
         assert mock_engine_pool.get_engine_calls[-1]["_lease"] is True
         assert mock_engine_pool.release_calls == ["test-model"]
 
+    def test_idempotency_key_replays_and_supports_authoritative_lookup(
+        self, tmp_path
+    ):
+        from omlx.server import app, _server_state
+
+        state_dir = tmp_path / "response-state"
+        engine = RecordingResponsesEngine()
+        pool = MockEnginePool(llm_engine=engine)
+        original_pool = _server_state.engine_pool
+        original_default = _server_state.default_model
+        original_store = _server_state.responses_store
+        try:
+            _server_state.engine_pool = pool
+            _server_state.default_model = "test-model"
+            _server_state.responses_store = ResponseStore(state_dir=state_dir)
+            client = TestClient(app)
+            headers = {"Idempotency-Key": "forgegraph-attempt-1"}
+            body = {"model": "test-model", "input": "Hello"}
+
+            _server_state.responses_store = ResponseStore()
+            unavailable = client.post("/v1/responses", json=body, headers=headers)
+            assert unavailable.status_code == 503
+            _server_state.responses_store = ResponseStore(state_dir=state_dir)
+
+            first = client.post("/v1/responses", json=body, headers=headers)
+            replay = client.post("/v1/responses", json=body, headers=headers)
+            lookup = client.get("/v1/responses/idempotency", headers=headers)
+            conflict = client.post(
+                "/v1/responses",
+                json={"model": "test-model", "input": "Different"},
+                headers=headers,
+            )
+            missing = client.get(
+                "/v1/responses/idempotency",
+                headers={"Idempotency-Key": "never-claimed"},
+            )
+            missing_header = client.get("/v1/responses/idempotency")
+            delete = client.delete(f"/v1/responses/{first.json()['id']}")
+
+            assert first.status_code == replay.status_code == lookup.status_code == 200
+            assert first.json() == replay.json() == lookup.json()
+            assert len(engine.recorded_messages) == 1
+            assert conflict.status_code == 409
+            assert missing.status_code == 404
+            assert missing.json()["final"] is True
+            assert missing_header.status_code == 400
+            assert delete.status_code == 409
+
+            _server_state.responses_store = ResponseStore(state_dir=state_dir)
+            after_restart = client.post(
+                "/v1/responses",
+                json=body,
+                headers=headers,
+            )
+            assert after_restart.json() == first.json()
+            assert len(engine.recorded_messages) == 1
+        finally:
+            _server_state.engine_pool = original_pool
+            _server_state.default_model = original_default
+            _server_state.responses_store = original_store
+
     def test_response_endpoint_includes_reasoning_item_for_think_blocks(
         self, client, mock_llm_engine
     ):

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -15,6 +15,7 @@ from omlx.api.responses_models import (
     TextFormatConfig,
 )
 from omlx.api.responses_utils import (
+    ResponseIdempotencyConflictError,
     ResponseStateCorruptError,
     ResponseStateNotFoundError,
     ResponseStore,
@@ -818,6 +819,49 @@ class TestResponseStore:
         reloaded = ResponseStore(max_size=10, state_dir=state_dir)
         assert reloaded.get("resp_1")["id"] == "resp_1"
         assert reloaded.get_record("resp_1")["input_messages"][0]["content"] == "Hi"
+
+    def test_idempotency_claim_is_durable_conflict_safe_and_not_evicted(
+        self, tmp_path
+    ):
+        state_dir = tmp_path / "response-state"
+        store = ResponseStore(max_size=1, state_dir=state_dir)
+        initial = {
+            "id": ResponseStore.response_id_for_idempotency_key("attempt-1"),
+            "object": "response",
+            "model": "test-model",
+            "status": "in_progress",
+            "output": [],
+        }
+
+        created, claimed = store.claim_idempotency("attempt-1", "fingerprint", initial)
+        assert created is True
+        assert claimed["status"] == "in_progress"
+        assert store.is_idempotent(initial["id"]) is True
+        assert store.claim_idempotency("attempt-1", "fingerprint", initial)[0] is False
+        with pytest.raises(ResponseIdempotencyConflictError):
+            store.claim_idempotency("attempt-1", "different", initial)
+
+        completed = dict(initial, status="completed")
+        store.put(initial["id"], completed)
+        store.put("resp_regular", {"id": "resp_regular", "status": "completed"})
+        assert store.get("resp_regular") is None
+
+        abandoned = {
+            "id": ResponseStore.response_id_for_idempotency_key("attempt-2"),
+            "object": "response",
+            "model": "test-model",
+            "status": "in_progress",
+            "output": [],
+        }
+        store.claim_idempotency("attempt-2", "fingerprint-2", abandoned)
+
+        reloaded = ResponseStore(max_size=1, state_dir=state_dir)
+        assert reloaded.get_by_idempotency_key("attempt-1")["status"] == "completed"
+        failed = reloaded.get_by_idempotency_key("attempt-2")
+        assert failed["status"] == "failed"
+        assert failed["error"]["code"] == "server_restarted"
+        persisted = "\n".join(path.read_text() for path in state_dir.glob("*.json"))
+        assert "attempt-1" not in persisted
 
     def test_resolve_chain_messages(self, tmp_path):
         state_dir = tmp_path / "response-state"


### PR DESCRIPTION
## Summary

- accept an optional `Idempotency-Key` on non-stream `/v1/responses` requests
- persist a request-fingerprint-bound claim before engine acquisition
- replay the same completed or failed response without another generation
- expose `GET /v1/responses/idempotency` for authoritative lookup
- return a conflict when one key is reused for a different request

## Why

The Responses API currently assigns a server-generated response ID. If
generation completes but the client loses the HTTP response, the client never
learns that ID and cannot distinguish completion from final absence. Retrying
can therefore duplicate expensive or effectful work.

This change binds a client attempt key to durable response state before
generation begins. The raw key is not persisted; only its SHA-256 digest and
the request fingerprint are stored.

## Recovery behavior

- an existing matching claim replays its canonical response
- a mismatched request fingerprint returns HTTP 409
- a persisted `in_progress` claim becomes terminal `failed` after restart
- a missing claim returns authoritative `404` with `final: true`
- idempotent claims cannot be evicted or deleted
- streaming and non-persistent idempotent requests fail closed

## Validation

- `151 passed`:
  - `tests/test_responses.py`
  - `tests/integration/test_server_endpoints.py`
- `compileall` passed
- Ruff fatal rules (`E9,F63,F7,F82`) passed
- `git diff --check` passed

The patch was also exercised locally on Apple Silicon with
`Qwen2.5-7B-Instruct-4bit`:

- duplicate POST and lookup returned the same completed response with one
  generation
- reuse with a different request returned HTTP 409
- a forced process kill after the durable claim recovered as terminal
  `failed/server_restarted` without another generation
- an already-completed response survived the same restart and replayed without
  another generation
- a synthetic client-side lost response was recovered through the lookup
  endpoint without resubmission

## Current limits

- idempotency is intentionally limited to `stream=false`
- claim retention is unbounded until a tombstone/retention policy is defined
- the implementation relies on the current single Uvicorn worker model;
  multi-worker ownership is not claimed
