### PR TITLE
Prompt Priming for the Lightning MTP Head

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -78,6 +78,7 @@ from types import SimpleNamespace
 from typing import Any, Deque, Dict, List, Optional, Tuple
 
 from . import cache_rollback as _rollback_mod
+from . import prompt_priming as _prompt_priming
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +184,12 @@ def apply() -> bool:
             _drop_mtp_state(batch, "donor-extended")
             _drop_invalid_mtp_state(self, "extend")
             _drop_invalid_mtp_batch_state(self, "extend")
+            # Priming only serves a singleton timeline: once this batch
+            # holds >1 rows, the context can never be consumed — release
+            # its head cache now instead of riding the merged decode.
+            uids = getattr(self, "uids", None)
+            if not uids or len(uids) != 1:
+                _prompt_priming.drop_ctx(getattr(self, "prompt_cache", None))
             return result
 
         def patched_filter(self, keep, *args, **kwargs):
@@ -703,7 +710,15 @@ def _drop_mtp_state(
     *,
     log_stats: bool = False,
 ) -> Optional[_MtpState]:
-    """Delete attached MTP state, optionally surfacing stats for external finish."""
+    """Delete attached MTP state, optionally surfacing stats for external finish.
+
+    Deliberately does NOT drop the prompt-priming context: mlx-lm's insert
+    flow routes every fresh singleton through ``extend()`` (donor merge),
+    which drops MTP state defensively — but the priming context must survive
+    that hop or activation always sees an unprimed cache. The context is
+    released at activation (``take_primed``), on real multi-row merges
+    (``patched_extend``), or with the cache itself at request end.
+    """
     state = getattr(gen_batch, "_omlx_mtp_state", None)
     if state is None:
         return None
@@ -998,8 +1013,9 @@ def _prepare_mtp_state_for_next(gen_batch: Any) -> Optional[_MtpState]:
         return None
 
     logger.info(
-        "MTP path activated for uid=%s (model has mtp_forward, batch=1)",
+        "MTP path activated for uid=%s (model has mtp_forward, batch=1, primed=%d)",
         state.uid,
+        max(0, int(getattr(state, "hist_offset", 0)) - 1),
     )
     return state
 
@@ -1399,11 +1415,10 @@ def _trunk_norm_module(model: Any):
     return inner.model.norm
 
 
-# The MTP head is fed the trunk's *post-norm* hidden and chains on its own
-# post-norm output. Measured on Qwen3.6-27B this accepts a few points higher
-# than PR 990's pre-norm at every depth. Draft-side only, so output identity
-# is unaffected regardless.
-_HEAD_HIDDEN_POST_NORM = True
+# Single source of truth lives in prompt_priming: the prefill-time priming
+# folds and the decode-time history folds here must use the same hidden
+# variant or the primed history would be inconsistent with the chained one.
+_HEAD_HIDDEN_POST_NORM = _prompt_priming.HEAD_HIDDEN_POST_NORM
 
 
 def _mtp_head_trim_to(mtp_cache: List[Any], offset: int) -> None:
@@ -1853,7 +1868,13 @@ def _post_init_mtp(gen_batch: Any) -> None:
                     gen_batch.model, "_omlx_mtp_marginal_ms", None
                 ),
             )
-        state.mtp_cache = gen_batch.model.make_mtp_cache()
+        primed = _prompt_priming.take_primed(
+            gen_batch.model, gen_batch.prompt_cache, main_tok
+        )
+        if primed is not None:
+            state.mtp_cache, state.hist_offset = primed
+        else:
+            state.mtp_cache = gen_batch.model.make_mtp_cache()
         state.next_main = _ensure_uint32(next_main_tok)
         state.queue.append((int(main_tok.tolist()[0]), main_lp, "init"))
         state.queue.append(
@@ -1871,6 +1892,9 @@ def _post_init_mtp(gen_batch: Any) -> None:
 
     # MTP head sees (hidden_at_main, next_main_tok) and proposes the draft
     # that the *next* verify cycle will check against forward([next_main, draft]).
+    # The legacy depth-1 cycle rebuilds head history per cycle and never
+    # consumes a primed cache; release any capture leftovers.
+    _prompt_priming.drop_ctx(gen_batch.prompt_cache)
     mtp_cache = gen_batch.model.make_mtp_cache()
     hidden_at_main = hidden[:, -1:, :]  # (1, 1, H)
     next_ids = next_main_tok.reshape(1, 1)

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -189,7 +189,7 @@ def apply() -> bool:
             # its head cache now instead of riding the merged decode.
             uids = getattr(self, "uids", None)
             if not uids or len(uids) != 1:
-                _prompt_priming.drop_ctx(getattr(self, "prompt_cache", None))
+                _prompt_priming.drop_ctx(getattr(self, "model", None))
             return result
 
         def patched_filter(self, keep, *args, **kwargs):
@@ -1894,7 +1894,7 @@ def _post_init_mtp(gen_batch: Any) -> None:
     # that the *next* verify cycle will check against forward([next_main, draft]).
     # The legacy depth-1 cycle rebuilds head history per cycle and never
     # consumes a primed cache; release any capture leftovers.
-    _prompt_priming.drop_ctx(gen_batch.prompt_cache)
+    _prompt_priming.drop_ctx(gen_batch.model)
     mtp_cache = gen_batch.model.make_mtp_cache()
     hidden_at_main = hidden[:, -1:, :]  # (1, 1, H)
     next_ids = next_main_tok.reshape(1, 1)

--- a/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
+++ b/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
@@ -26,6 +26,8 @@ import logging
 import sys
 from typing import Any, Dict, List, Optional
 
+from . import prompt_priming
+
 logger = logging.getLogger(__name__)
 
 
@@ -307,6 +309,16 @@ def _patch_model(dsv4: Any) -> None:
         if return_hidden:
             h, h_raw = self.model(inputs, cache, return_raw_hidden=True)
             return self.lm_head(h), h_raw
+        if not n_confirmed and prompt_priming.capture_eligible(self, cache):
+            # Prompt-priming capture needs the head-input hidden (the raw 4D
+            # Hyper-stream activation), which the stock branch discards
+            # inside self.model — same compute, one extra returned tensor.
+            h, h_raw = self.model(inputs, cache, return_raw_hidden=True)
+            try:
+                prompt_priming.maybe_capture(self, inputs, h_raw, cache)
+            except Exception:
+                logger.debug("MTP prompt-priming capture failed", exc_info=True)
+            return self.lm_head(h)
         h = self.model(inputs, cache)
         return self.lm_head(h)
 

--- a/omlx/patches/mlx_lm_mtp/glm_moe_dsa_model.py
+++ b/omlx/patches/mlx_lm_mtp/glm_moe_dsa_model.py
@@ -43,6 +43,8 @@ import logging
 import sys
 from typing import Any, Dict
 
+from . import prompt_priming
+
 logger = logging.getLogger(__name__)
 
 
@@ -375,6 +377,13 @@ def _patch_model(glm: Any) -> None:
             out, h_raw = self.model(inputs, cache, return_raw_hidden=True)
             return self.lm_head(out), h_raw
         out = self.model(inputs, cache)
+        if not n_confirmed:
+            # ``out`` is the post-final-norm hidden — exactly the variant the
+            # GLM head consumes — so capture rides the stock forward free.
+            try:
+                prompt_priming.maybe_capture(self, inputs, out, cache)
+            except Exception:
+                logger.debug("MTP prompt-priming capture failed", exc_info=True)
         return self.lm_head(out)
 
     def make_mtp_cache(self):

--- a/omlx/patches/mlx_lm_mtp/prompt_priming.py
+++ b/omlx/patches/mlx_lm_mtp/prompt_priming.py
@@ -12,29 +12,39 @@ available for free. Each chunk is folded into a head cache immediately and
 the chunk hidden is discarded — only a single (1, 1, H) pending row carries
 across chunks.
 
-Transport: the priming context is attached as an attribute on the first
-prompt-cache entry that exposes an integer ``offset`` (the first
-full-attention ``KVCache``). The scheduler's singleton merge passthrough
-preserves cache-entry identity from external prefill through
-``GenerationBatch.prompt_cache``, so ``_post_init_mtp`` can pop the primed
-cache at MTP activation with no registry and no lifetime bookkeeping — the
-context dies with the request's cache.
+Transport: the context lives in a single slot on the patched language-model
+instance (the ``host``). Cache-entry attributes cannot carry it — mlx-lm's
+insert merge rebuilds every layer cache that lacks filter/extract support
+(all of DeepSeek-V4's and GLM-5.2's CacheList entries, and TurboQuant
+replaces KVCache entries at end of prefill) — while the model instance is
+the one object every forward and the activation both see. The engine thread
+serializes forwards, and the offset-contiguity invariant below makes the
+single slot safe across interleaved requests: a chunk from a different
+request can never look contiguous with another request's timeline (its
+first forward starts at offset 0), so it invalidates or restarts the slot,
+and the activating request is always the slot's last writer.
 
 Fail-safe invariant: every capture verifies the anchor offset advanced
 contiguously since the previous capture (``expected_offset``). Any rewind,
-trim, or unknown cache path breaks the equality and invalidates the context,
-degrading to the current unprimed behaviour — never to a wrong history.
+trim, request switch, or unknown cache path breaks the equality and
+invalidates the context, degrading to the current unprimed behaviour —
+never to a wrong history.
 
-Capture sites (both call :func:`maybe_capture` after the backbone forward):
+Capture sites (each calls :func:`maybe_capture` after the backbone forward):
 
-- mlx-lm text path: the patched ``qwen3_5.TextModel.__call__``
-  (``qwen35_model._patch_text_model``), which computes the trunk-normed
-  hidden inline.
-- mlx-vlm path: a wrap on the inner ``Qwen3_5Model.__call__``
-  (``qwen35_vlm_runtime``), whose return value *is* the trunk-normed hidden.
-  The outer ``LanguageModel`` is reached via a weakref stamped at init.
+- mlx-lm qwen3_5 text path: the patched ``TextModel.__call__``
+  (``qwen35_model``), which computes the trunk-normed hidden inline.
+- mlx-vlm qwen3_5 path: a wrap on the inner ``Qwen3_5Model.__call__``
+  (``qwen35_vlm_runtime``), whose return value *is* the trunk-normed
+  hidden; the MoE inner model inherits it. The outer ``LanguageModel`` is
+  reached via a weakref stamped at init.
+- DeepSeek-V4 (``deepseek_v4_model``): the patched ``Model.__call__``
+  requests ``return_raw_hidden`` and passes the raw 4D Hyper-stream hidden
+  (the head input variant; no trunk norm).
+- GLM-5.2 (``glm_moe_dsa_model``): the patched ``Model.__call__`` passes
+  the post-final-norm hidden it already computes.
 
-Both sites skip ``return_hidden=True`` forwards (MTP verify cycles and the
+All sites skip ``return_hidden=True`` forwards (MTP verify cycles and the
 activation forward in ``_post_init_mtp``); the final (hidden[prompt[-1]],
 main_tok) pair is folded by :func:`take_primed` at activation instead.
 """
@@ -102,11 +112,11 @@ def _suppressed() -> bool:
 
 @dataclass
 class _PrimeCtx:
-    """Streaming priming state riding a request's prompt cache."""
+    """Streaming priming state in the host model's single slot."""
 
     mtp_cache: List[Any] = field(default_factory=list)
-    # Trunk-normed hidden of the newest seen token, (1, 1, H) — pairs with
-    # the first token of the next chunk (or with main_tok at activation).
+    # Head-input hidden of the newest seen token, (1, 1, ..., H) — pairs
+    # with the first token of the next chunk (or main_tok at activation).
     pending_hidden: Optional[Any] = None
     # Folded (hidden, next_token) pairs == head-cache offset.
     folded: int = 0
@@ -115,23 +125,22 @@ class _PrimeCtx:
     expected_offset: int = 0
     valid: bool = True
 
-    def __deepcopy__(self, memo):
-        # PromptProcessingBatch._copy() deep-copies caches for partial prompt
-        # splits; a duplicated priming timeline cannot stay contiguous with
-        # either copy, so the clone starts over (invalid, no tensors).
-        clone = _PrimeCtx()
-        clone.valid = False
-        memo[id(self)] = clone
-        return clone
-
 
 def _anchor(cache: Optional[List[Any]]) -> Optional[Any]:
-    """First cache entry with a plain-int offset (first full-attention KVCache)."""
+    """First cache entry with a plain-int offset.
+
+    Container layers (``CacheList``-style, exposing ``.caches`` — DeepSeek-V4
+    and GLM-5.2 backbones) are searched one level deep: the container itself
+    has no offset but its first sub-cache (RotatingKVCache / KVCache) does.
+    """
     if not cache:
         return None
     for c in cache:
         if type(getattr(c, "offset", None)) is int:
             return c
+        for sub in getattr(c, "caches", ()) or ():
+            if type(getattr(sub, "offset", None)) is int:
+                return sub
     return None
 
 
@@ -145,64 +154,59 @@ def _activation_offset(cache: Optional[List[Any]]) -> Optional[int]:
     """
     if not cache:
         return None
-    for c in cache:
-        offset = getattr(c, "offset", None)
+
+    def _read(entry: Any) -> Optional[int]:
+        offset = getattr(entry, "offset", None)
         if type(offset) is int:
             return offset
         if offset is not None and getattr(offset, "size", 0) == 1:
             try:
                 return int(offset.reshape(()).item())
             except Exception:
-                continue
+                return None
+        return None
+
+    for c in cache:
+        got = _read(c)
+        if got is not None:
+            return got
+        for sub in getattr(c, "caches", ()) or ():
+            got = _read(sub)
+            if got is not None:
+                return got
     return None
 
 
-def _attach_target(cache: List[Any]) -> Any:
-    """Cache entry the context rides on.
+def _host_candidates(model: Any):
+    """The model itself plus the wrapped language model, if any.
 
-    Must survive the request's whole prefill→insert lifetime. The int-offset
-    KVCache entries do NOT qualify: TurboQuant conversion replaces them
-    (``prompt_cache[i] = TurboQuantKVCache.from_cache(...)``) at the end of
-    prefill, which would silently discard the context. The recurrent-layer
-    entries (ArraysCache family, no int offset) are never replaced, so prefer
-    the first of those; an all-attention model falls back to the first entry
-    and degrades to unprimed if that entry gets swapped.
+    Mirrors ``batch_generator._resolve_mtp_chain_depth``: the host that
+    carries the slot is the patched language-model instance — the outer
+    adapter / VLM wrapper for qwen paths, the Model itself for DeepSeek/GLM.
     """
-    for c in cache:
-        if type(getattr(c, "offset", None)) is not int:
-            return c
-    return cache[0]
+    yield model
+    for attr in ("language_model", "_language_model"):
+        inner = getattr(model, attr, None)
+        if inner is not None and inner is not model:
+            yield inner
 
 
-def _store_ctx(cache: List[Any], ctx: _PrimeCtx) -> None:
-    target = _attach_target(cache)
-    for c in cache:
-        if c is not target and getattr(c, _CTX_ATTR, None) is not None:
-            try:
-                delattr(c, _CTX_ATTR)
-            except AttributeError:
-                pass
-    setattr(target, _CTX_ATTR, ctx)
-
-
-def _find_ctx(cache: Optional[List[Any]]) -> Optional[_PrimeCtx]:
-    if not cache:
-        return None
-    for c in cache:
-        ctx = getattr(c, _CTX_ATTR, None)
+def _find_ctx(model: Any) -> Optional[_PrimeCtx]:
+    for host in _host_candidates(model):
+        ctx = getattr(host, _CTX_ATTR, None)
         if ctx is not None:
             return ctx
     return None
 
 
-def drop_ctx(cache: Optional[List[Any]]) -> None:
-    """Remove any priming context from a request's prompt cache."""
-    if not cache:
+def drop_ctx(model: Any) -> None:
+    """Remove any priming context from the model's host slot."""
+    if model is None:
         return
-    for c in cache:
-        if getattr(c, _CTX_ATTR, None) is not None:
+    for host in _host_candidates(model):
+        if getattr(host, _CTX_ATTR, None) is not None:
             try:
-                delattr(c, _CTX_ATTR)
+                delattr(host, _CTX_ATTR)
             except AttributeError:
                 pass
 
@@ -212,6 +216,23 @@ def _host_eligible(host: Any) -> bool:
         getattr(host, "_omlx_mtp_decode_enabled", False)
         and getattr(host, "_omlx_mtp_chain", False)
         and getattr(host, "mtp", None) is not None
+    )
+
+
+def capture_eligible(host: Any, cache: Optional[List[Any]]) -> bool:
+    """Cheap pre-check for capture sites that must decide the forward shape.
+
+    The DeepSeek/GLM backbones only expose the head-input hidden when asked
+    (``return_raw_hidden``), so their patched ``__call__`` consults this
+    before choosing the call form. Everything here is re-checked inside
+    :func:`maybe_capture`; this exists purely to keep the ineligible path
+    identical to stock.
+    """
+    return (
+        not _suppressed()
+        and priming_enabled()
+        and cache is not None
+        and _host_eligible(host)
     )
 
 
@@ -245,17 +266,17 @@ def maybe_capture(
     seq_len = int(inputs.shape[1])
     offset_after = anchor.offset  # forward already ran; offset includes S
 
-    ctx = _find_ctx(cache)
+    ctx = getattr(host, _CTX_ATTR, None)
     if ctx is not None and (
         not ctx.valid or ctx.expected_offset != offset_after - seq_len
     ):
-        # Rewind / trim / unknown path between captures: never guess.
-        drop_ctx(cache)
+        # Rewind / trim / request switch / unknown path: never guess.
+        drop_ctx(host)
         ctx = None
     window = prime_window()
     if window and offset_after > window:
         if ctx is not None:
-            drop_ctx(cache)
+            drop_ctx(host)
         return
     if ctx is None:
         if seq_len <= 1:
@@ -264,7 +285,7 @@ def maybe_capture(
         ctx = _PrimeCtx(mtp_cache=host.make_mtp_cache())
         if not ctx.mtp_cache:
             return
-        _store_ctx(cache, ctx)
+        setattr(host, _CTX_ATTR, ctx)
 
     if ctx.pending_hidden is not None:
         if seq_len > 1:
@@ -282,7 +303,11 @@ def maybe_capture(
         pairs_hidden = normed[:, :-1]
         pairs_tokens = inputs[:, 1:]
 
-    host.mtp(pairs_hidden, pairs_tokens, host.model.embed_tokens, ctx.mtp_cache)
+    # Fold through the public mtp_forward so every family's head layout
+    # (module, block list, CacheList head caches) is handled by its own
+    # model patch. The returned logits are never evaluated — nothing pulls
+    # on them, so the lm_head tail costs nothing.
+    host.mtp_forward(pairs_hidden, pairs_tokens, ctx.mtp_cache, logits_keep=1)
     ctx.folded += int(pairs_tokens.shape[1])
     ctx.pending_hidden = normed[:, -1:]
     ctx.expected_offset = offset_after
@@ -290,7 +315,11 @@ def maybe_capture(
     # accumulates across a long prefill; the (1,1,H) pending row is evaluated
     # alongside so the chunk's full hidden can be freed.
     evals = [ctx.pending_hidden]
+    flat = []
     for c in ctx.mtp_cache:
+        subs = getattr(c, "caches", None)
+        flat.extend(subs if subs else (c,))
+    for c in flat:
         keys = getattr(c, "keys", None)
         values = getattr(c, "values", None)
         if keys is not None:
@@ -315,10 +344,10 @@ def take_primed(
     ``(mtp_cache, hist_offset)`` — or None, in which case the caller keeps
     the current unprimed behaviour.
     """
-    ctx = _find_ctx(cache)
+    ctx = _find_ctx(model)
     if ctx is None:
         return None
-    drop_ctx(cache)
+    drop_ctx(model)
     if not (ctx.valid and ctx.folded > 0 and ctx.pending_hidden is not None):
         return None
     offset = _activation_offset(cache)
@@ -342,9 +371,9 @@ def take_primed(
     return ctx.mtp_cache, ctx.folded + 1
 
 
-def prime_ctx_stats(cache: Optional[List[Any]]) -> Optional[int]:
+def prime_ctx_stats(model: Any) -> Optional[int]:
     """Folded pair count of a live context (introspection / tests)."""
-    ctx = _find_ctx(cache)
+    ctx = _find_ctx(model)
     return ctx.folded if ctx is not None else None
 
 

--- a/omlx/patches/mlx_lm_mtp/prompt_priming.py
+++ b/omlx/patches/mlx_lm_mtp/prompt_priming.py
@@ -1,0 +1,360 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MTP-head prompt priming: fold the prompt into the head cache during prefill.
+
+Without priming the MTP head starts generation with an empty KV cache — its
+first drafts see none of the prompt and acceptance starts context-starved,
+recovering only as committed generation tokens accumulate (MTPLX measured
+committed-history priming at 0.90 acceptance vs 0.26 unprimed on depth-1
+real-code prompts). This module rides the existing prefill forwards: every
+backbone chunk forward already computes the trunk-normed hidden for all chunk
+positions, so the (hidden[t], token[t+1]) pairs the head history needs are
+available for free. Each chunk is folded into a head cache immediately and
+the chunk hidden is discarded — only a single (1, 1, H) pending row carries
+across chunks.
+
+Transport: the priming context is attached as an attribute on the first
+prompt-cache entry that exposes an integer ``offset`` (the first
+full-attention ``KVCache``). The scheduler's singleton merge passthrough
+preserves cache-entry identity from external prefill through
+``GenerationBatch.prompt_cache``, so ``_post_init_mtp`` can pop the primed
+cache at MTP activation with no registry and no lifetime bookkeeping — the
+context dies with the request's cache.
+
+Fail-safe invariant: every capture verifies the anchor offset advanced
+contiguously since the previous capture (``expected_offset``). Any rewind,
+trim, or unknown cache path breaks the equality and invalidates the context,
+degrading to the current unprimed behaviour — never to a wrong history.
+
+Capture sites (both call :func:`maybe_capture` after the backbone forward):
+
+- mlx-lm text path: the patched ``qwen3_5.TextModel.__call__``
+  (``qwen35_model._patch_text_model``), which computes the trunk-normed
+  hidden inline.
+- mlx-vlm path: a wrap on the inner ``Qwen3_5Model.__call__``
+  (``qwen35_vlm_runtime``), whose return value *is* the trunk-normed hidden.
+  The outer ``LanguageModel`` is reached via a weakref stamped at init.
+
+Both sites skip ``return_hidden=True`` forwards (MTP verify cycles and the
+activation forward in ``_post_init_mtp``); the final (hidden[prompt[-1]],
+main_tok) pair is folded by :func:`take_primed` at activation instead.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# The MTP head is fed the trunk's *post-norm* hidden and chains on its own
+# post-norm output. Measured on Qwen3.6-27B this accepts a few points higher
+# than PR 990's pre-norm at every depth. Draft-side only, so output identity
+# is unaffected regardless. Priming folds must use the same variant as the
+# decode-time history folds in batch_generator, hence the single definition
+# here.
+HEAD_HIDDEN_POST_NORM = True
+
+_CTX_ATTR = "_omlx_mtp_prime_ctx"
+
+_SUPPRESS = threading.local()
+
+
+def priming_enabled() -> bool:
+    """Prompt priming is on by default for MTP-enabled models."""
+    return os.environ.get("OMLX_MTP_PROMPT_PRIMING", "1").strip().lower() not in (
+        "0",
+        "false",
+        "off",
+    )
+
+
+def prime_window() -> int:
+    """Max prompt length (tokens) to prime; 0 = unlimited.
+
+    Escape hatch for the head-cache memory cost on very long prompts (one
+    full-attention layer of KV over the prompt). Prompts longer than the
+    window run unprimed — a coarse cap, not a suffix window, because the
+    prompt length is unknown while chunks stream through the model.
+    """
+    try:
+        return max(0, int(os.environ.get("OMLX_MTP_PRIME_WINDOW", "0")))
+    except ValueError:
+        return 0
+
+
+@contextmanager
+def suppress_capture():
+    """Disable capture on this thread for the duration of the block."""
+    _SUPPRESS.value = True
+    try:
+        yield
+    finally:
+        _SUPPRESS.value = False
+
+
+def _suppressed() -> bool:
+    return bool(getattr(_SUPPRESS, "value", False))
+
+
+@dataclass
+class _PrimeCtx:
+    """Streaming priming state riding a request's prompt cache."""
+
+    mtp_cache: List[Any] = field(default_factory=list)
+    # Trunk-normed hidden of the newest seen token, (1, 1, H) — pairs with
+    # the first token of the next chunk (or with main_tok at activation).
+    pending_hidden: Optional[Any] = None
+    # Folded (hidden, next_token) pairs == head-cache offset.
+    folded: int = 0
+    # Anchor cache offset observed after the last captured forward. The next
+    # capture requires offset_now - S == expected_offset (contiguity).
+    expected_offset: int = 0
+    valid: bool = True
+
+    def __deepcopy__(self, memo):
+        # PromptProcessingBatch._copy() deep-copies caches for partial prompt
+        # splits; a duplicated priming timeline cannot stay contiguous with
+        # either copy, so the clone starts over (invalid, no tensors).
+        clone = _PrimeCtx()
+        clone.valid = False
+        memo[id(self)] = clone
+        return clone
+
+
+def _anchor(cache: Optional[List[Any]]) -> Optional[Any]:
+    """First cache entry with a plain-int offset (first full-attention KVCache)."""
+    if not cache:
+        return None
+    for c in cache:
+        if type(getattr(c, "offset", None)) is int:
+            return c
+    return None
+
+
+def _activation_offset(cache: Optional[List[Any]]) -> Optional[int]:
+    """Attention-layer offset at MTP activation, tolerant of batch caches.
+
+    Between the last capture and activation, ``insert()`` runs mlx-lm's
+    cache merge: scalar ``KVCache`` entries without singleton passthrough
+    become batch caches whose ``offset`` is a 1-element ``mx.array``. The
+    one-off ``int()`` sync here is activation-time only, never per-chunk.
+    """
+    if not cache:
+        return None
+    for c in cache:
+        offset = getattr(c, "offset", None)
+        if type(offset) is int:
+            return offset
+        if offset is not None and getattr(offset, "size", 0) == 1:
+            try:
+                return int(offset.reshape(()).item())
+            except Exception:
+                continue
+    return None
+
+
+def _attach_target(cache: List[Any]) -> Any:
+    """Cache entry the context rides on.
+
+    Must survive the request's whole prefill→insert lifetime. The int-offset
+    KVCache entries do NOT qualify: TurboQuant conversion replaces them
+    (``prompt_cache[i] = TurboQuantKVCache.from_cache(...)``) at the end of
+    prefill, which would silently discard the context. The recurrent-layer
+    entries (ArraysCache family, no int offset) are never replaced, so prefer
+    the first of those; an all-attention model falls back to the first entry
+    and degrades to unprimed if that entry gets swapped.
+    """
+    for c in cache:
+        if type(getattr(c, "offset", None)) is not int:
+            return c
+    return cache[0]
+
+
+def _store_ctx(cache: List[Any], ctx: _PrimeCtx) -> None:
+    target = _attach_target(cache)
+    for c in cache:
+        if c is not target and getattr(c, _CTX_ATTR, None) is not None:
+            try:
+                delattr(c, _CTX_ATTR)
+            except AttributeError:
+                pass
+    setattr(target, _CTX_ATTR, ctx)
+
+
+def _find_ctx(cache: Optional[List[Any]]) -> Optional[_PrimeCtx]:
+    if not cache:
+        return None
+    for c in cache:
+        ctx = getattr(c, _CTX_ATTR, None)
+        if ctx is not None:
+            return ctx
+    return None
+
+
+def drop_ctx(cache: Optional[List[Any]]) -> None:
+    """Remove any priming context from a request's prompt cache."""
+    if not cache:
+        return
+    for c in cache:
+        if getattr(c, _CTX_ATTR, None) is not None:
+            try:
+                delattr(c, _CTX_ATTR)
+            except AttributeError:
+                pass
+
+
+def _host_eligible(host: Any) -> bool:
+    return bool(
+        getattr(host, "_omlx_mtp_decode_enabled", False)
+        and getattr(host, "_omlx_mtp_chain", False)
+        and getattr(host, "mtp", None) is not None
+    )
+
+
+def maybe_capture(
+    host: Any, inputs: Any, normed: Any, cache: Optional[List[Any]]
+) -> None:
+    """Fold this forward's (hidden, next_token) pairs into the priming cache.
+
+    ``host`` is the patched language model (mlx-lm ``TextModel`` or mlx-vlm
+    ``LanguageModel``) exposing ``mtp`` / ``model.embed_tokens`` /
+    ``make_mtp_cache``. ``normed`` is the trunk-normed hidden for all
+    positions of ``inputs`` (1, S, H). Host-side bookkeeping only — the head
+    forward is dispatched lazily and no GPU sync happens here.
+
+    Call sites guard the cheap negatives (return_hidden / n_confirmed /
+    inputs_embeds / batch>1) before calling; everything here re-checks what
+    is load-bearing and bails silently, so a miss degrades to unprimed.
+    """
+    if _suppressed() or not priming_enabled():
+        return
+    if cache is None or not _host_eligible(host):
+        return
+    if inputs is None or getattr(inputs, "ndim", 0) != 2 or inputs.shape[0] != 1:
+        return
+    anchor = _anchor(cache)
+    if anchor is None:
+        return
+
+    import mlx.core as mx
+
+    seq_len = int(inputs.shape[1])
+    offset_after = anchor.offset  # forward already ran; offset includes S
+
+    ctx = _find_ctx(cache)
+    if ctx is not None and (
+        not ctx.valid or ctx.expected_offset != offset_after - seq_len
+    ):
+        # Rewind / trim / unknown path between captures: never guess.
+        drop_ctx(cache)
+        ctx = None
+    window = prime_window()
+    if window and offset_after > window:
+        if ctx is not None:
+            drop_ctx(cache)
+        return
+    if ctx is None:
+        if seq_len <= 1:
+            # A lone decode step cannot start a prompt timeline.
+            return
+        ctx = _PrimeCtx(mtp_cache=host.make_mtp_cache())
+        if not ctx.mtp_cache:
+            return
+        _store_ctx(cache, ctx)
+
+    if ctx.pending_hidden is not None:
+        if seq_len > 1:
+            pairs_hidden = mx.concatenate(
+                [ctx.pending_hidden, normed[:, :-1]], axis=1
+            )
+        else:
+            pairs_hidden = ctx.pending_hidden
+        pairs_tokens = inputs
+    else:
+        if seq_len <= 1:
+            ctx.pending_hidden = normed[:, -1:]
+            ctx.expected_offset = offset_after
+            return
+        pairs_hidden = normed[:, :-1]
+        pairs_tokens = inputs[:, 1:]
+
+    host.mtp(pairs_hidden, pairs_tokens, host.model.embed_tokens, ctx.mtp_cache)
+    ctx.folded += int(pairs_tokens.shape[1])
+    ctx.pending_hidden = normed[:, -1:]
+    ctx.expected_offset = offset_after
+    # Materialize the head-cache buffers per chunk so the fold graph never
+    # accumulates across a long prefill; the (1,1,H) pending row is evaluated
+    # alongside so the chunk's full hidden can be freed.
+    evals = [ctx.pending_hidden]
+    for c in ctx.mtp_cache:
+        keys = getattr(c, "keys", None)
+        values = getattr(c, "values", None)
+        if keys is not None:
+            evals.append(keys)
+        if values is not None:
+            evals.append(values)
+    mx.async_eval(evals)
+
+
+def take_primed(
+    model: Any,
+    cache: Optional[List[Any]],
+    main_tok: Any,
+) -> Optional[tuple]:
+    """Pop the priming context at MTP activation and finish the seam.
+
+    Called from ``_post_init_mtp`` after its 1-token backbone forward at
+    ``main_tok`` (which capture skipped — it runs with return_hidden=True).
+    Validates that the context is contiguous up to exactly that forward,
+    folds the final (hidden[prompt[-1]], main_tok) pair through the public
+    ``mtp_forward`` (adapter/outer-model level), and returns
+    ``(mtp_cache, hist_offset)`` — or None, in which case the caller keeps
+    the current unprimed behaviour.
+    """
+    ctx = _find_ctx(cache)
+    if ctx is None:
+        return None
+    drop_ctx(cache)
+    if not (ctx.valid and ctx.folded > 0 and ctx.pending_hidden is not None):
+        return None
+    offset = _activation_offset(cache)
+    if offset is None or ctx.expected_offset != offset - 1:
+        logger.debug(
+            "MTP priming discarded: seam offset mismatch (ctx=%s cache=%s)",
+            ctx.expected_offset,
+            offset,
+        )
+        return None
+    try:
+        model.mtp_forward(
+            ctx.pending_hidden,
+            main_tok.reshape(1, 1),
+            ctx.mtp_cache,
+            logits_keep=1,
+        )
+    except Exception as exc:
+        logger.debug("MTP priming discarded: seam fold failed: %s", exc)
+        return None
+    return ctx.mtp_cache, ctx.folded + 1
+
+
+def prime_ctx_stats(cache: Optional[List[Any]]) -> Optional[int]:
+    """Folded pair count of a live context (introspection / tests)."""
+    ctx = _find_ctx(cache)
+    return ctx.folded if ctx is not None else None
+
+
+__all__ = [
+    "HEAD_HIDDEN_POST_NORM",
+    "priming_enabled",
+    "prime_window",
+    "suppress_capture",
+    "maybe_capture",
+    "take_primed",
+    "drop_ctx",
+    "prime_ctx_stats",
+]

--- a/omlx/patches/mlx_lm_mtp/qwen35_model.py
+++ b/omlx/patches/mlx_lm_mtp/qwen35_model.py
@@ -51,6 +51,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
+from . import prompt_priming
+
 logger = logging.getLogger(__name__)
 
 def _is_our_method(cls: Any, attr: str, marker: str) -> bool:
@@ -490,6 +492,15 @@ def _patch_text_model(q35: Any) -> None:
             n_confirmed=n_confirmed,
         )
         normed = self.model.norm(hidden)
+        if not return_hidden and not n_confirmed and input_embeddings is None:
+            # Prompt-priming capture rides prefill/decode forwards; verify
+            # cycles (return_hidden) and confirmed-split forwards are the MTP
+            # cycle's own and must not double-fold head history. A capture
+            # failure must never break the forward itself.
+            try:
+                prompt_priming.maybe_capture(self, inputs, normed, cache)
+            except Exception:
+                logger.debug("MTP prompt-priming capture failed", exc_info=True)
         if self.args.tie_word_embeddings:
             out = self.model.embed_tokens.as_linear(normed)
         else:

--- a/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py
@@ -36,6 +36,7 @@ in ``maybe_apply_pre_load_patches`` which satisfies that requirement.
 from __future__ import annotations
 
 import logging
+import weakref
 from typing import Any
 
 import mlx.core as mx
@@ -235,6 +236,10 @@ def _patch_vlm_language_model(q35moe_lang: Any) -> None:
 
             self._omlx_mtp_chain = True
             self._omlx_mtp_depth = get_mtp_depth()
+            # Qwen3_5MoeModel inherits the dense Qwen3_5Model.__call__, so
+            # the prompt-priming capture wrap installed by the dense runtime
+            # already runs here — it only needs the host backref to engage.
+            self.model._omlx_mtp_prime_host = weakref.ref(self)
 
     def __call__(self, inputs, inputs_embeds=None, mask=None, cache=None, **kwargs):
         """Backbone forward with optional MTP-cycle return shape.

--- a/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
@@ -36,10 +36,13 @@ before loading the model, satisfying the ordering for inference. The oQ path in
 from __future__ import annotations
 
 import logging
+import weakref
 from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
+
+from ..mlx_lm_mtp import prompt_priming
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +65,7 @@ def apply() -> bool:
     _patch_text_config(q35_config)
     _register_mtp_classes_for_vlm(q35_lang)
     _patch_vlm_language_model(q35_lang)
+    _patch_inner_model_capture(q35_lang)
     # VLMModelAdapter pass-throughs are installed by the MoE runtime patch
     # too; the function is idempotent so calling it twice is safe.
     _patch_vlm_model_adapter()
@@ -252,6 +256,11 @@ def _patch_vlm_language_model(q35_lang: Any) -> None:
 
             self._omlx_mtp_chain = True
             self._omlx_mtp_depth = get_mtp_depth()
+            # Prompt-priming capture runs inside the inner Qwen3_5Model
+            # forward, which has no reference back to this LanguageModel
+            # (the mtp module / make_mtp_cache live here). A weakref avoids
+            # a tracked module cycle in the nn.Module tree.
+            self.model._omlx_mtp_prime_host = weakref.ref(self)
 
     def __call__(self, inputs, inputs_embeds=None, mask=None, cache=None, **kwargs):
         """Backbone forward with optional MTP-cycle return shape.
@@ -331,6 +340,60 @@ def _patch_vlm_language_model(q35_lang: Any) -> None:
     cls.mtp_forward = mtp_forward
     cls.make_mtp_cache = make_mtp_cache
     cls._omlx_mtp_runtime_patched = True
+
+
+# ---------------------------------------------------------------------------
+# Inner Qwen3_5Model — prompt-priming capture on prefill/decode forwards.
+# ---------------------------------------------------------------------------
+
+def _patch_inner_model_capture(q35_lang: Any) -> None:
+    """Wrap ``Qwen3_5Model.__call__`` to fold prompt chunks into the MTP head.
+
+    The inner model's return value is the trunk-normed hidden for every
+    position of the forward — exactly what the head history fold needs — and
+    scheduler prefill reaches it via the outer ``LanguageModel.__call__``
+    delegate, so this single wrap covers external prefill, chunked prefill
+    and the seam decode steps.
+
+    Skips: image/recursive calls (``inputs_embeds``), MTP verify and other
+    capture forwards (any of ``capture_layer_ids`` / ``hidden_sink`` /
+    ``gdn_sink``), unknown extra positional call shapes, and hosts without
+    an MTP head (weakref unset). All real gating lives in
+    ``prompt_priming.maybe_capture`` and fails safe to unprimed.
+    """
+    cls = q35_lang.Qwen3_5Model
+    if getattr(cls, "_omlx_mtp_prime_capture_patched", False):
+        return
+
+    original_call = cls.__call__
+
+    def __call__(
+        self, inputs, inputs_embeds=None, mask=None, cache=None, *args, **kwargs
+    ):
+        out = original_call(
+            self, inputs, inputs_embeds, mask, cache, *args, **kwargs
+        )
+        if (
+            inputs_embeds is None
+            and cache is not None
+            and not args
+            and kwargs.get("capture_layer_ids") is None
+            and kwargs.get("hidden_sink") is None
+            and kwargs.get("gdn_sink") is None
+        ):
+            host_ref = getattr(self, "_omlx_mtp_prime_host", None)
+            host = host_ref() if host_ref is not None else None
+            if host is not None:
+                try:
+                    prompt_priming.maybe_capture(host, inputs, out, cache)
+                except Exception:
+                    logger.debug(
+                        "MTP prompt-priming capture failed", exc_info=True
+                    )
+        return out
+
+    cls.__call__ = __call__
+    cls._omlx_mtp_prime_capture_patched = True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mtp_prompt_priming.py
+++ b/tests/test_mtp_prompt_priming.py
@@ -129,10 +129,10 @@ class TestCaptureFold:
         cache = _make_cache(model)
         _chunked_prefill(model, cache, tokens, [5, 5, 3])
 
-        folded = prompt_priming.prime_ctx_stats(cache)
+        folded = prompt_priming.prime_ctx_stats(model)
         assert folded == n - 1
 
-        ctx = prompt_priming._find_ctx(cache)
+        ctx = prompt_priming._find_ctx(model)
         assert ctx is not None and ctx.valid
         assert ctx.mtp_cache[0].offset == n - 1
         mx.eval([c.state for c in ctx.mtp_cache])
@@ -150,7 +150,7 @@ class TestCaptureFold:
         tokens = _tokens(n, seed=1)
         cache = _make_cache(model)
         _chunked_prefill(model, cache, tokens, [4, 3, 1])
-        assert prompt_priming.prime_ctx_stats(cache) == n - 1
+        assert prompt_priming.prime_ctx_stats(model) == n - 1
 
     def test_take_primed_completes_seam(self, model):
         n = 9
@@ -166,7 +166,7 @@ class TestCaptureFold:
         mtp_cache, hist_offset = primed
         assert hist_offset == n
         assert mtp_cache[0].offset == n
-        assert prompt_priming._find_ctx(cache) is None
+        assert prompt_priming._find_ctx(model) is None
 
         ref_cache = _reference_head_cache(model, tokens, extra_tok=main_tok)
         mx.eval([c.state for c in mtp_cache])
@@ -180,23 +180,23 @@ class TestCaptureSkips:
         monkeypatch.setenv("OMLX_MTP_PROMPT_PRIMING", "0")
         cache = _make_cache(model)
         _chunked_prefill(model, cache, _tokens(6), [6])
-        assert prompt_priming.prime_ctx_stats(cache) is None
+        assert prompt_priming.prime_ctx_stats(model) is None
 
     def test_suppress_capture(self, model):
         cache = _make_cache(model)
         with prompt_priming.suppress_capture():
             _chunked_prefill(model, cache, _tokens(6), [6])
-        assert prompt_priming.prime_ctx_stats(cache) is None
+        assert prompt_priming.prime_ctx_stats(model) is None
 
     def test_single_token_forward_does_not_start_ctx(self, model):
         cache = _make_cache(model)
         _chunked_prefill(model, cache, _tokens(1), [1])
-        assert prompt_priming.prime_ctx_stats(cache) is None
+        assert prompt_priming.prime_ctx_stats(model) is None
 
     def test_return_hidden_forward_skipped(self, model):
         cache = _make_cache(model)
         model(_tokens(6)[None, :], cache=cache, return_hidden=True)
-        assert prompt_priming.prime_ctx_stats(cache) is None
+        assert prompt_priming.prime_ctx_stats(model) is None
 
     def test_batch_forward_skipped(self, model):
         cache = _make_cache(model)
@@ -206,26 +206,26 @@ class TestCaptureSkips:
             model(toks, cache=cache)
         except Exception:
             pass
-        assert prompt_priming.prime_ctx_stats(cache) is None
+        assert prompt_priming.prime_ctx_stats(model) is None
 
     def test_offset_rewind_invalidates_and_restarts(self, model):
         tokens = _tokens(12, seed=4)
         cache = _make_cache(model)
         _chunked_prefill(model, cache, tokens[:8], [8])
-        assert prompt_priming.prime_ctx_stats(cache) == 7
+        assert prompt_priming.prime_ctx_stats(model) == 7
         # External trim breaks contiguity: the old timeline must not survive.
         for c in cache:
             if hasattr(c, "trim") and type(getattr(c, "offset", None)) is int:
                 c.trim(2)
         _chunked_prefill(model, cache, tokens[8:], [4])
         # Restarted mid-prompt: only the new chunk's internal pairs.
-        assert prompt_priming.prime_ctx_stats(cache) == 3
+        assert prompt_priming.prime_ctx_stats(model) == 3
 
     def test_window_cap_disables_long_prompts(self, model, monkeypatch):
         monkeypatch.setenv("OMLX_MTP_PRIME_WINDOW", "4")
         cache = _make_cache(model)
         _chunked_prefill(model, cache, _tokens(10, seed=5), [5, 5])
-        assert prompt_priming.prime_ctx_stats(cache) is None
+        assert prompt_priming.prime_ctx_stats(model) is None
 
     def test_take_primed_requires_seam_offset(self, model):
         """No activation forward ran: seam mismatch must discard the ctx."""
@@ -233,20 +233,33 @@ class TestCaptureSkips:
         cache = _make_cache(model)
         _chunked_prefill(model, cache, tokens, [7])
         assert prompt_priming.take_primed(model, cache, _tokens(1, seed=7)) is None
-        assert prompt_priming._find_ctx(cache) is None
+        assert prompt_priming._find_ctx(model) is None
 
-    def test_ctx_attaches_to_non_kv_entry(self, model):
-        """TurboQuant replaces int-offset KVCache entries at end of prefill;
-        the ctx must ride an entry conversion never touches (issue found in
-        the first real-server smoke: primed=0 with turboquant_kv on)."""
+    def test_ctx_lives_on_host_not_cache(self, model):
+        """The slot rides the model instance: cache entries are rebuilt by
+        the insert merge (and TurboQuant conversion) on several families, so
+        cache-attribute transport silently loses the context (found in the
+        first real-server smokes: primed=0 with turboquant_kv / DeepSeek)."""
         cache = _make_cache(model)
         _chunked_prefill(model, cache, _tokens(6, seed=20), [6])
-        target = None
-        for c in cache:
-            if getattr(c, "_omlx_mtp_prime_ctx", None) is not None:
-                target = c
-        assert target is not None
-        assert type(getattr(target, "offset", None)) is not int
+        assert getattr(model, "_omlx_mtp_prime_ctx", None) is not None
+        assert all(
+            getattr(c, "_omlx_mtp_prime_ctx", None) is None for c in cache
+        )
+
+    def test_interleaved_request_restarts_slot(self, model):
+        """A second request's prefill on the same model can never continue
+        the first request's timeline: its offsets restart at zero, which
+        breaks contiguity and restarts the slot."""
+        cache_a = _make_cache(model)
+        _chunked_prefill(model, cache_a, _tokens(10, seed=23), [10])
+        assert prompt_priming.prime_ctx_stats(model) == 9
+        cache_b = _make_cache(model)
+        _chunked_prefill(model, cache_b, _tokens(6, seed=24), [6])
+        assert prompt_priming.prime_ctx_stats(model) == 5
+        # Request A activating now must not see B's history.
+        model(_tokens(1, seed=25)[None, :], cache=cache_a, return_hidden=True)
+        assert prompt_priming.take_primed(model, cache_a, _tokens(1, seed=25)) is None
 
     def test_ctx_survives_kv_entry_replacement(self, model):
         """Simulate the TurboQuant convert: swap every KVCache entry for a
@@ -271,19 +284,9 @@ class TestCaptureSkips:
     def test_drop_ctx(self, model):
         cache = _make_cache(model)
         _chunked_prefill(model, cache, _tokens(6, seed=8), [6])
-        assert prompt_priming.prime_ctx_stats(cache) is not None
-        prompt_priming.drop_ctx(cache)
-        assert prompt_priming.prime_ctx_stats(cache) is None
-
-    def test_deepcopy_clone_is_invalid(self, model):
-        import copy
-
-        cache = _make_cache(model)
-        _chunked_prefill(model, cache, _tokens(6, seed=9), [6])
-        ctx = prompt_priming._find_ctx(cache)
-        clone = copy.deepcopy(ctx)
-        assert clone.valid is False
-        assert clone.folded == 0
+        assert prompt_priming.prime_ctx_stats(model) is not None
+        prompt_priming.drop_ctx(model)
+        assert prompt_priming.prime_ctx_stats(model) is None
 
 
 class TestActivationHandoff:
@@ -328,7 +331,7 @@ class TestActivationHandoff:
         # n prompt-pair folds via capture+seam, +1 from _chain_next_drafts.
         assert state.hist_offset == n + 1
         assert state.mtp_cache[0].offset >= n
-        assert prompt_priming._find_ctx(cache) is None
+        assert prompt_priming._find_ctx(model) is None
 
     def test_post_init_without_ctx_is_unprimed(self, model):
         from omlx.patches.mlx_lm_mtp import batch_generator as bg

--- a/tests/test_mtp_prompt_priming.py
+++ b/tests/test_mtp_prompt_priming.py
@@ -1,0 +1,352 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for MTP prompt priming (omlx/patches/mlx_lm_mtp/prompt_priming.py).
+
+Uses a tiny random-weight qwen3_5 TextModel (mlx-lm path) so the capture hook
+in the patched ``TextModel.__call__`` and the activation handoff in
+``_post_init_mtp`` run for real. The mlx-vlm capture site shares
+``maybe_capture`` / ``take_primed``, so the fold math is covered here; its
+wiring is exercised by the real-model smoke test.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from omlx.patches.mlx_lm_mtp import prompt_priming
+
+
+TINY_CONFIG = {
+    "model_type": "qwen3_5",
+    "hidden_size": 64,
+    "intermediate_size": 128,
+    "num_hidden_layers": 4,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "vocab_size": 256,
+    "linear_num_value_heads": 2,
+    "linear_num_key_heads": 2,
+    "linear_key_head_dim": 16,
+    "linear_value_head_dim": 16,
+    "linear_conv_kernel_dim": 3,
+    "full_attention_interval": 2,
+    "tie_word_embeddings": True,
+    "rms_norm_eps": 1e-5,
+    "head_dim": 32,
+    "rope_theta": 1000.0,
+    "partial_rotary_factor": 0.5,
+    "max_position_embeddings": 128,
+    "mtp_num_hidden_layers": 1,
+}
+
+
+def _make_tiny_model():
+    from mlx_lm.models.qwen3_5 import TextModel, TextModelArgs
+
+    args = TextModelArgs.from_dict(TINY_CONFIG)
+    model = TextModel(args)
+    mx.eval(model.parameters())
+    return model
+
+
+def _make_cache(model):
+    from mlx_lm.models.cache import make_prompt_cache
+
+    return make_prompt_cache(model)
+
+
+def _tokens(n, seed=0):
+    mx.random.seed(seed)
+    return mx.random.randint(0, TINY_CONFIG["vocab_size"], (n,)).astype(mx.uint32)
+
+
+def _kv_entries(mtp_cache):
+    out = []
+    for c in mtp_cache:
+        keys, values = c.state
+        out.append((keys, values))
+    return out
+
+
+def _reference_head_cache(model, tokens, extra_tok=None):
+    """Fold the whole prompt through the head in one shot (oracle)."""
+    fresh = _make_cache(model)
+    logits, hidden = model(tokens[None, :], cache=fresh, return_hidden=True)
+    normed = model.model.norm(hidden)
+    ref_cache = model.make_mtp_cache()
+    pair_tokens = tokens[1:]
+    pair_hidden = normed[:, :-1]
+    if extra_tok is not None:
+        pair_tokens = mx.concatenate([pair_tokens, extra_tok])
+        pair_hidden = normed
+    model.mtp(
+        pair_hidden,
+        pair_tokens[None, :].astype(mx.uint32),
+        model.model.embed_tokens,
+        ref_cache,
+    )
+    mx.eval([c.state for c in ref_cache])
+    return ref_cache
+
+
+@pytest.fixture(autouse=True)
+def _apply_patch():
+    try:
+        from omlx.patches.mlx_lm_mtp import qwen35_model, set_mtp_active
+    except ImportError:
+        pytest.skip("omlx.patches.mlx_lm_mtp not importable")
+    if not qwen35_model.apply():
+        pytest.skip("qwen35_model patch refused to apply")
+    prev = None
+    from omlx.patches.mlx_lm_mtp import is_mtp_active
+
+    prev = is_mtp_active()
+    set_mtp_active(True)
+    yield
+    set_mtp_active(prev)
+
+
+@pytest.fixture()
+def model():
+    return _make_tiny_model()
+
+
+def _chunked_prefill(model, cache, tokens, chunks):
+    """Drive the patched TextModel.__call__ chunk by chunk (capture rides it)."""
+    start = 0
+    for size in chunks:
+        chunk = tokens[start : start + size]
+        model(chunk[None, :], cache=cache)
+        start += size
+    assert start == tokens.shape[0]
+
+
+class TestCaptureFold:
+    def test_chunked_capture_matches_oneshot_fold(self, model):
+        n = 13
+        tokens = _tokens(n)
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, tokens, [5, 5, 3])
+
+        folded = prompt_priming.prime_ctx_stats(cache)
+        assert folded == n - 1
+
+        ctx = prompt_priming._find_ctx(cache)
+        assert ctx is not None and ctx.valid
+        assert ctx.mtp_cache[0].offset == n - 1
+        mx.eval([c.state for c in ctx.mtp_cache])
+
+        ref_cache = _reference_head_cache(model, tokens)
+        for (k, v), (rk, rv) in zip(
+            _kv_entries(ctx.mtp_cache), _kv_entries(ref_cache)
+        ):
+            assert mx.allclose(k, rk, rtol=1e-4, atol=1e-4)
+            assert mx.allclose(v, rv, rtol=1e-4, atol=1e-4)
+
+    def test_chunk_size_one_seam_is_dense(self, model):
+        """A trailing S==1 forward (the __init__ _step seam) still folds."""
+        n = 8
+        tokens = _tokens(n, seed=1)
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, tokens, [4, 3, 1])
+        assert prompt_priming.prime_ctx_stats(cache) == n - 1
+
+    def test_take_primed_completes_seam(self, model):
+        n = 9
+        tokens = _tokens(n, seed=2)
+        main_tok = _tokens(1, seed=3)
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, tokens, [6, 3])
+        # Activation forward runs with return_hidden=True: capture skips it.
+        model(main_tok[None, :], cache=cache, return_hidden=True)
+
+        primed = prompt_priming.take_primed(model, cache, main_tok)
+        assert primed is not None
+        mtp_cache, hist_offset = primed
+        assert hist_offset == n
+        assert mtp_cache[0].offset == n
+        assert prompt_priming._find_ctx(cache) is None
+
+        ref_cache = _reference_head_cache(model, tokens, extra_tok=main_tok)
+        mx.eval([c.state for c in mtp_cache])
+        for (k, v), (rk, rv) in zip(_kv_entries(mtp_cache), _kv_entries(ref_cache)):
+            assert mx.allclose(k, rk, rtol=1e-4, atol=1e-4)
+            assert mx.allclose(v, rv, rtol=1e-4, atol=1e-4)
+
+
+class TestCaptureSkips:
+    def test_env_off_disables_capture(self, model, monkeypatch):
+        monkeypatch.setenv("OMLX_MTP_PROMPT_PRIMING", "0")
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, _tokens(6), [6])
+        assert prompt_priming.prime_ctx_stats(cache) is None
+
+    def test_suppress_capture(self, model):
+        cache = _make_cache(model)
+        with prompt_priming.suppress_capture():
+            _chunked_prefill(model, cache, _tokens(6), [6])
+        assert prompt_priming.prime_ctx_stats(cache) is None
+
+    def test_single_token_forward_does_not_start_ctx(self, model):
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, _tokens(1), [1])
+        assert prompt_priming.prime_ctx_stats(cache) is None
+
+    def test_return_hidden_forward_skipped(self, model):
+        cache = _make_cache(model)
+        model(_tokens(6)[None, :], cache=cache, return_hidden=True)
+        assert prompt_priming.prime_ctx_stats(cache) is None
+
+    def test_batch_forward_skipped(self, model):
+        cache = _make_cache(model)
+        toks = _tokens(12).reshape(2, 6)
+        # Batched cache shapes differ; just assert no ctx is created.
+        try:
+            model(toks, cache=cache)
+        except Exception:
+            pass
+        assert prompt_priming.prime_ctx_stats(cache) is None
+
+    def test_offset_rewind_invalidates_and_restarts(self, model):
+        tokens = _tokens(12, seed=4)
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, tokens[:8], [8])
+        assert prompt_priming.prime_ctx_stats(cache) == 7
+        # External trim breaks contiguity: the old timeline must not survive.
+        for c in cache:
+            if hasattr(c, "trim") and type(getattr(c, "offset", None)) is int:
+                c.trim(2)
+        _chunked_prefill(model, cache, tokens[8:], [4])
+        # Restarted mid-prompt: only the new chunk's internal pairs.
+        assert prompt_priming.prime_ctx_stats(cache) == 3
+
+    def test_window_cap_disables_long_prompts(self, model, monkeypatch):
+        monkeypatch.setenv("OMLX_MTP_PRIME_WINDOW", "4")
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, _tokens(10, seed=5), [5, 5])
+        assert prompt_priming.prime_ctx_stats(cache) is None
+
+    def test_take_primed_requires_seam_offset(self, model):
+        """No activation forward ran: seam mismatch must discard the ctx."""
+        tokens = _tokens(7, seed=6)
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, tokens, [7])
+        assert prompt_priming.take_primed(model, cache, _tokens(1, seed=7)) is None
+        assert prompt_priming._find_ctx(cache) is None
+
+    def test_ctx_attaches_to_non_kv_entry(self, model):
+        """TurboQuant replaces int-offset KVCache entries at end of prefill;
+        the ctx must ride an entry conversion never touches (issue found in
+        the first real-server smoke: primed=0 with turboquant_kv on)."""
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, _tokens(6, seed=20), [6])
+        target = None
+        for c in cache:
+            if getattr(c, "_omlx_mtp_prime_ctx", None) is not None:
+                target = c
+        assert target is not None
+        assert type(getattr(target, "offset", None)) is not int
+
+    def test_ctx_survives_kv_entry_replacement(self, model):
+        """Simulate the TurboQuant convert: swap every KVCache entry for a
+        fresh object carrying the same state, then finish activation."""
+        from mlx_lm.models.cache import KVCache
+
+        n = 9
+        tokens = _tokens(n, seed=21)
+        main_tok = _tokens(1, seed=22)
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, tokens, [6, 3])
+        for i, c in enumerate(cache):
+            if isinstance(c, KVCache):
+                clone = KVCache()
+                clone.keys, clone.values, clone.offset = c.keys, c.values, c.offset
+                cache[i] = clone
+        model(main_tok[None, :], cache=cache, return_hidden=True)
+        primed = prompt_priming.take_primed(model, cache, main_tok)
+        assert primed is not None
+        assert primed[1] == n
+
+    def test_drop_ctx(self, model):
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, _tokens(6, seed=8), [6])
+        assert prompt_priming.prime_ctx_stats(cache) is not None
+        prompt_priming.drop_ctx(cache)
+        assert prompt_priming.prime_ctx_stats(cache) is None
+
+    def test_deepcopy_clone_is_invalid(self, model):
+        import copy
+
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, _tokens(6, seed=9), [6])
+        ctx = prompt_priming._find_ctx(cache)
+        clone = copy.deepcopy(ctx)
+        assert clone.valid is False
+        assert clone.folded == 0
+
+
+class TestActivationHandoff:
+    def _gen_batch(self, model, cache, tokens):
+        def greedy(lp):
+            return mx.argmax(lp, axis=-1).astype(mx.uint32)
+
+        return SimpleNamespace(
+            model=model,
+            prompt_cache=cache,
+            uids=[0],
+            samplers=[None],
+            fallback_sampler=greedy,
+            logits_processors=[],
+            tokens=[list(int(t) for t in tokens.tolist())],
+            _next_tokens=None,
+            _next_logprobs=None,
+            _token_context=[None],
+        )
+
+    def test_post_init_uses_primed_cache(self, model):
+        from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+        n = 10
+        tokens = _tokens(n, seed=10)
+        cache = _make_cache(model)
+        # Standard __init__ semantics: prefill everything, then _step on the
+        # last token sampled main_tok. Emulate with a chunked prefill over
+        # tokens[:-1] plus an S==1 step on tokens[-1].
+        _chunked_prefill(model, cache, tokens[:-1], [6, 3])
+        logits = model(tokens[-1:][None, :], cache=cache)
+        lp = logits[0, -1] - mx.logsumexp(logits[0, -1])
+        main_tok = mx.argmax(lp, keepdims=True).astype(mx.uint32)
+
+        gen_batch = self._gen_batch(model, cache, tokens)
+        gen_batch._next_tokens = main_tok
+        gen_batch._next_logprobs = [lp]
+
+        bg._post_init_mtp(gen_batch)
+        state = getattr(gen_batch, "_omlx_mtp_state", None)
+        assert state is not None
+        # n prompt-pair folds via capture+seam, +1 from _chain_next_drafts.
+        assert state.hist_offset == n + 1
+        assert state.mtp_cache[0].offset >= n
+        assert prompt_priming._find_ctx(cache) is None
+
+    def test_post_init_without_ctx_is_unprimed(self, model):
+        from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+        n = 10
+        tokens = _tokens(n, seed=11)
+        cache = _make_cache(model)
+        with prompt_priming.suppress_capture():
+            _chunked_prefill(model, cache, tokens[:-1], [9])
+            logits = model(tokens[-1:][None, :], cache=cache)
+        lp = logits[0, -1] - mx.logsumexp(logits[0, -1])
+        main_tok = mx.argmax(lp, keepdims=True).astype(mx.uint32)
+
+        gen_batch = self._gen_batch(model, cache, tokens)
+        gen_batch._next_tokens = main_tok
+        gen_batch._next_logprobs = [lp]
+
+        bg._post_init_mtp(gen_batch)
+        state = getattr(gen_batch, "_omlx_mtp_state", None)
+        assert state is not None
+        assert state.hist_offset == 1


### PR DESCRIPTION
The MTP head starts every request with an empty KV cache, so its drafts never see the prompt and acceptance suffers most on code where it has to guess identifiers it was never shown. This PR primes the head during prefill: the chunk forwards already compute the hidden for every prompt position, so the (hidden, next token) pairs get folded into the head cache on the way through, costing 1-2% of prefill.

Measured on Qwen3.6-27B-oQ4e-mtp (M3 Ultra, turboquant_kv 4-bit, temp 0.6, tg 512, 2 reps per cell):

| cell | before tg (accept) | after tg (accept) |
|---|---|---|
| code-1k | 46.0 (70%) | 54.4 (84%) |
| code-4k | 49.6 (70%) | 56.0 (80%) |
| code-16k | 42.1 (72%) | 47.7 (84%) |
| prose-1k | 47.6 (72%) | 54.2 (84%) |
| prose-4k | 53.9 (75%) | 57.5 (81%) |
| prose-16k | 42.2 (72%) | 44.6 (78%) |
| math-1k | 49.2 (75%) | 53.7 (83%) |
| math-4k | 52.1 (73%) | 56.2 (80%) |
| math-16k | 44.3 (75%) | 46.5 (80%) |

Greedy output stays byte-identical, since only the draft side changes.

Follow-up in the same PR: the priming context now lives in a single slot on the model instance instead of riding a cache entry, since DeepSeek-V4 and GLM-5.2 rebuild every cache entry at insert and the old transport could never engage there. An offset-contiguity check keeps the slot safe across interleaved requests. This extends priming to Qwen3.5-MoE, DeepSeek-V4 and GLM-5.2, measured on code-1k (temp 0.6, tg 512, 2 reps, turboquant off):

| model (code-1k) | before tg (accept) | after tg (accept) |
|---|---|---|
| Qwen3.6-35B-A3B-oQ4-mtp | 132.0 (77-82%) | 139.8 (82-83%) |
| GLM-5.2-oQ4e-mtp | 18.0 (63-67%) | 20.9 (76-77%) |
| DeepSeek-V4-Flash-oQ2.5e-mtp | 38.3 (70-77%) | 39.7 (74-76%) |

DeepSeek-V4 is unchanged because its head cache is a 128-token sliding window, so primed history only survives near the window edge; there is no cost either.
