### PR TITLE
Bump to omlx customized dflash and surface phase timings

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -82,6 +82,32 @@ def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
     return True, ""
 
 
+def _format_phase_timings(phase_timings_us: object) -> str:
+    """Compact per-phase summary for the completion log, in milliseconds.
+
+    The dflash SummaryEvent reports where each cycle's time went
+    (prefill / draft / verify / replay / commit); without surfacing it the
+    server log gives no way to tell which phase dominates a slow request.
+    """
+    if not isinstance(phase_timings_us, dict) or not phase_timings_us:
+        return ""
+
+    def _ms(key: str) -> str:
+        try:
+            return f"{float(phase_timings_us.get(key, 0.0)) / 1000.0:.1f}"
+        except (TypeError, ValueError):
+            return "0.0"
+
+    return (
+        f", phases[prefill={_ms('prefill')}ms"
+        f" draft={_ms('draft')}ms"
+        f"(first={_ms('draft_prefill')}/incr={_ms('draft_incremental')})"
+        f" verify={_ms('verify')}ms"
+        f" replay={_ms('replay')}ms"
+        f" commit={_ms('commit')}ms]"
+    )
+
+
 class _DFlashPrefillGuard:
     """Prefill-memory guard target for DFlash's primary (speculative) path,
     which bypasses the Scheduler entirely.
@@ -1113,6 +1139,9 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                     elapsed_s = elapsed_us / 1e6 if elapsed_us else 0
                     gen_tps = gen_tokens / elapsed_s if elapsed_s > 0 else 0
                     fallback = bool(event.fallback_ar)
+                    phase_summary = _format_phase_timings(
+                        getattr(event, "phase_timings_us", None)
+                    )
                     logger.info(
                         f"DFlash generation complete: "
                         f"{gen_tokens} tokens, "
@@ -1120,6 +1149,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         f"acceptance={accept_ratio:.1%}, "
                         f"cycles={cycles}"
                         f"{', fallback=AR' if fallback else ''}"
+                        f"{phase_summary}"
                     )
                     metrics = {
                         "prompt_tokens": int(event.prompt_token_count),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,11 +115,11 @@ dependencies = [
     # omlx.patches.mlx_vlm_minimax_m3_compat because upstream removed it.
     "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@78b96eb5462141447b9a6b4943ef553891da56dd",
     "Pillow>=9.0.0",
-    # dflash-mlx v0.1.10+omlx.1 (1011d0d) - jundot fork of bstnxbt 0.1.10 (9ca0028).
-    # Carries the trimmed-sidecar prefix cache fix: upstream rejects every
-    # collected sidecar because the coverage check contradicts the sink+window
-    # hidden trim, so repeat-prompt L1 hits never fire.
-    "dflash-mlx @ git+https://github.com/jundot/dflash-mlx@1011d0df95b77df1003b67138e595827894d3408",
+    # dflash-mlx v0.1.10+omlx.2 (cb5cd28) - jundot fork of bstnxbt 0.1.10 (9ca0028).
+    # Carries the trimmed-sidecar prefix cache fix (repeat-prompt L1 hits never
+    # fired upstream) and the single-host-sync decode cycle (one D2H transfer
+    # per cycle instead of four syncs plus a hard eval).
+    "dflash-mlx @ git+https://github.com/jundot/dflash-mlx@cb5cd2888b31d31214e221f2be7101bd125c4122",
     "markitdown[pdf,docx,pptx]==0.1.6",
 ]
 

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -1404,3 +1404,38 @@ class TestDFlashRuntimeCacheStats:
         )
         assert counters["ssd_hot_hits"] == 0
         assert counters["ssd_disk_loads"] == 5
+
+
+class TestFormatPhaseTimings:
+    def test_empty_or_invalid_returns_empty(self):
+        from omlx.engine.dflash import _format_phase_timings
+
+        assert _format_phase_timings(None) == ""
+        assert _format_phase_timings({}) == ""
+        assert _format_phase_timings("nope") == ""
+
+    def test_formats_all_phases_in_ms(self):
+        from omlx.engine.dflash import _format_phase_timings
+
+        out = _format_phase_timings(
+            {
+                "prefill": 2417_200.0,
+                "draft": 289_600.0,
+                "draft_prefill": 12_100.0,
+                "draft_incremental": 277_500.0,
+                "verify": 24_172_100.0,
+                "replay": 4_700.0,
+                "commit": 3_100.0,
+            }
+        )
+        assert out == (
+            ", phases[prefill=2417.2ms draft=289.6ms(first=12.1/incr=277.5)"
+            " verify=24172.1ms replay=4.7ms commit=3.1ms]"
+        )
+
+    def test_missing_keys_render_zero(self):
+        from omlx.engine.dflash import _format_phase_timings
+
+        out = _format_phase_timings({"verify": 1000.0})
+        assert "verify=1.0ms" in out
+        assert "prefill=0.0ms" in out


### PR DESCRIPTION
This bumps the dflash-mlx pin to 0.1.10+omlx.2 (jundot/dflash-mlx#2), which collapses the speculative decode cycle from four device-to-host syncs plus a hard eval down to a single transfer per cycle. Output is byte-identical across all 12 A/B combos (greedy tg512, 2 pairs x 3 context lengths x 2 reps), and decode tok/s improves across the board on M3 Ultra:

| pair (code prompt) | 1k | 4k | 16k |
|---|---|---|---|
| Qwen3-4B-bf16 + Qwen3-4B-DFlash-b16 | 57.9 → 60.6 (+4.8%) | 46.1 → 48.0 (+4.3%) | 37.9 → 39.2 (+3.5%) |
| gemma-4-26b-a4b-it-4bit + gemma-4-26B-A4B-it-DFlash | 124.6 → 143.9 (+15%) | 119.0 → 138.0 (+16%) | 98.9 → 118.3 (+20%) |

It also extends the DFlash completion log with a per-phase summary (`phases[prefill/draft/verify/replay/commit]`) built from the SummaryEvent the server already receives, so a slow request shows which phase dominated. Outside profile mode these are host-side launch costs, the GPU wait only shows up in the total.
