### PR TITLE
fix: credit resident prefix-cache tokens in the prefill memory guard preflight

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -84,9 +84,11 @@ class BatchedEngine(BaseEngine):
         *,
         num_prompt_tokens: int,
         request_id: str | None,
+        cached_tokens: int = 0,
     ) -> None:
         eviction_request = scheduler.preflight_eviction_request(
             num_prompt_tokens=num_prompt_tokens,
+            cached_tokens=cached_tokens,
             request_id=request_id,
         )
         if eviction_request is not None and self._prefill_eviction_callback is not None:
@@ -97,6 +99,7 @@ class BatchedEngine(BaseEngine):
             await self._prefill_eviction_callback(eviction_request)
         scheduler.preflight_or_raise(
             num_prompt_tokens=num_prompt_tokens,
+            cached_tokens=cached_tokens,
             request_id=request_id,
         )
 
@@ -971,7 +974,8 @@ class BatchedEngine(BaseEngine):
         # through the existing handler chain so the response shape stays
         # consistent.
         try:
-            num_tokens = len(self._tokenizer.encode(prompt))
+            encoded = self._tokenizer.encode(prompt)
+            num_tokens = len(encoded)
         except Exception as e:
             logger.warning(
                 "BatchedEngine.preflight_chat: tokenizer.encode raised %s; "
@@ -984,8 +988,12 @@ class BatchedEngine(BaseEngine):
         if scheduler is None:
             _warn_scheduler_unreachable_once(self, "preflight_chat")
             return
+        cached_tokens = scheduler.estimate_cached_prefix_length(encoded)
         await self._preflight_or_raise_with_eviction(
-            scheduler, num_prompt_tokens=num_tokens, request_id=request_id
+            scheduler,
+            num_prompt_tokens=num_tokens,
+            cached_tokens=cached_tokens,
+            request_id=request_id,
         )
 
     async def preflight_completion(
@@ -1001,7 +1009,8 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
         try:
-            num_tokens = len(self._tokenizer.encode(prompt))
+            encoded = self._tokenizer.encode(prompt)
+            num_tokens = len(encoded)
         except Exception as e:
             logger.warning(
                 "BatchedEngine.preflight_completion: tokenizer.encode raised "
@@ -1014,8 +1023,12 @@ class BatchedEngine(BaseEngine):
         if scheduler is None:
             _warn_scheduler_unreachable_once(self, "preflight_completion")
             return
+        cached_tokens = scheduler.estimate_cached_prefix_length(encoded)
         await self._preflight_or_raise_with_eviction(
-            scheduler, num_prompt_tokens=num_tokens, request_id=request_id
+            scheduler,
+            num_prompt_tokens=num_tokens,
+            cached_tokens=cached_tokens,
+            request_id=request_id,
         )
 
     async def stream_chat(

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -849,7 +849,11 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         # ``hydrate_target_cache`` clones every array), so the full prompt's
         # KV is allocated this request — unlike the scheduler's resident
         # paged cache. Subtracting hit tokens here would under-count and
-        # defeat the OOM guard.
+        # defeat the OOM guard. Contrast with ``BatchedEngine.preflight_chat``
+        # / ``VLMBatchedEngine.preflight_chat``, which *do* credit an
+        # estimated cache hit via ``scheduler.estimate_cached_prefix_length``
+        # — safe there because a paged-cache hit reuses resident blocks
+        # in place instead of cloning them.
         self._prefill_guard.preflight_or_raise(
             num_prompt_tokens=num_tokens, request_id=request_id
         )

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1289,9 +1289,11 @@ class VLMBatchedEngine(BaseEngine):
         *,
         num_prompt_tokens: int,
         request_id: str | None,
+        cached_tokens: int = 0,
     ) -> None:
         eviction_request = scheduler.preflight_eviction_request(
             num_prompt_tokens=num_prompt_tokens,
+            cached_tokens=cached_tokens,
             request_id=request_id,
         )
         if eviction_request is not None and self._prefill_eviction_callback is not None:
@@ -1302,6 +1304,7 @@ class VLMBatchedEngine(BaseEngine):
             await self._prefill_eviction_callback(eviction_request)
         scheduler.preflight_or_raise(
             num_prompt_tokens=num_prompt_tokens,
+            cached_tokens=cached_tokens,
             request_id=request_id,
         )
 
@@ -3334,7 +3337,8 @@ class VLMBatchedEngine(BaseEngine):
         # the real chat path surface the same error through the existing
         # handler chain.
         try:
-            num_tokens = len(self._tokenizer.encode(prompt))
+            encoded = self._tokenizer.encode(prompt)
+            num_tokens = len(encoded)
         except Exception as e:
             logger.warning(
                 "VLMBatchedEngine.preflight_chat: tokenizer.encode raised "
@@ -3356,8 +3360,18 @@ class VLMBatchedEngine(BaseEngine):
         if scheduler is None:
             _warn_scheduler_unreachable_once(self, "preflight_chat")
             return
+        # Cache-credit estimate uses the text-only encoded prompt (before
+        # the image-token budget is added above): image placeholders are
+        # not part of this cheap text tokenization, so comparing only the
+        # text prefix against stored sequences stays a safe, conservative
+        # match — it can only find a shorter shared prefix than reality,
+        # never a longer one.
+        cached_tokens = scheduler.estimate_cached_prefix_length(encoded)
         await self._preflight_or_raise_with_eviction(
-            scheduler, num_prompt_tokens=num_tokens, request_id=request_id
+            scheduler,
+            num_prompt_tokens=num_tokens,
+            cached_tokens=cached_tokens,
+            request_id=request_id,
         )
 
     async def preflight_completion(
@@ -3376,7 +3390,8 @@ class VLMBatchedEngine(BaseEngine):
             )
             return
         try:
-            num_tokens = len(self._tokenizer.encode(prompt))
+            encoded = self._tokenizer.encode(prompt)
+            num_tokens = len(encoded)
         except Exception as e:
             logger.warning(
                 "VLMBatchedEngine.preflight_completion: tokenizer.encode "
@@ -3389,8 +3404,12 @@ class VLMBatchedEngine(BaseEngine):
         if scheduler is None:
             _warn_scheduler_unreachable_once(self, "preflight_completion")
             return
+        cached_tokens = scheduler.estimate_cached_prefix_length(encoded)
         await self._preflight_or_raise_with_eviction(
-            scheduler, num_prompt_tokens=num_tokens, request_id=request_id
+            scheduler,
+            num_prompt_tokens=num_tokens,
+            cached_tokens=cached_tokens,
+            request_id=request_id,
         )
 
     async def stream_chat(

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6562,6 +6562,44 @@ class Scheduler:
     # prompt (i.e. the cache was relevant but could not cover the request).
     _REPREFILL_INFO_MIN_TOKENS = 4096
 
+    def _best_matching_probe_seq(
+        self, prompt_token_ids: list[int]
+    ) -> tuple[str | None, array | list[int] | None, int]:
+        """Find the stored reference sequence sharing the longest prefix.
+
+        Scans ``self._cache_probe_seqs`` (deque, maxlen=4) via
+        ``_common_prefix_len``. Shared by ``estimate_cached_prefix_length``
+        (preflight's memory estimate) and ``_log_prefix_divergence``
+        (diagnostics) so there is exactly one implementation of the scan.
+        Returns ``(None, None, -1)`` when there is nothing to compare
+        against.
+        """
+        best_id, best_seq, best_p = None, None, -1
+        for ref_id, seq in list(self._cache_probe_seqs):
+            p = self._common_prefix_len(prompt_token_ids, seq)
+            if p > best_p:
+                best_id, best_seq, best_p = ref_id, seq, p
+        return best_id, best_seq, best_p
+
+    def estimate_cached_prefix_length(self, prompt_token_ids: list[int]) -> int:
+        """Cheap, conservative resident-cache estimate for preflight.
+
+        Returns the exact token-level common-prefix length between
+        ``prompt_token_ids`` and the best-matching stored reference
+        sequence in ``self._cache_probe_seqs``, or 0 when there is no
+        probe history or no shared prefix. This is deliberately the same
+        comparison ``_log_prefix_divergence`` already performs for
+        diagnostics — no heuristics, no similarity scoring, just an exact
+        prefix match — so preflight's peak-memory estimate can credit
+        tokens that are actually likely to be resident instead of always
+        assuming a cold start (see ``engine/batched.py`` and
+        ``engine/vlm.py`` preflight callers).
+        """
+        if not prompt_token_ids or not self._cache_probe_seqs:
+            return 0
+        _, _, best_p = self._best_matching_probe_seq(prompt_token_ids)
+        return max(0, best_p)
+
     def _log_prefix_divergence(self, request: Request) -> None:
         """Prefix-cache miss diagnostics (issues #1003, #2333, #2349).
 
@@ -6578,11 +6616,7 @@ class Scheduler:
         prompt = request.prompt_token_ids or []
         if not prompt or not self._cache_probe_seqs:
             return
-        best_id, best_seq, best_p = None, None, -1
-        for ref_id, seq in list(self._cache_probe_seqs):
-            p = self._common_prefix_len(prompt, seq)
-            if p > best_p:
-                best_id, best_seq, best_p = ref_id, seq, p
+        best_id, best_seq, best_p = self._best_matching_probe_seq(prompt)
         if best_seq is None:
             return
         cached = request.cached_tokens or 0

--- a/tests/test_engine_preflight.py
+++ b/tests/test_engine_preflight.py
@@ -180,10 +180,12 @@ async def test_batched_engine_preflight_runs_eviction_before_final_check():
 
     scheduler.preflight_eviction_request.assert_called_once_with(
         num_prompt_tokens=123,
+        cached_tokens=0,
         request_id="req-evict",
     )
     scheduler.preflight_or_raise.assert_called_once_with(
         num_prompt_tokens=123,
+        cached_tokens=0,
         request_id="req-evict",
     )
     assert order == [("evict", "req-evict"), ("final", "checked")]
@@ -212,6 +214,64 @@ async def test_batched_engine_preflight_chat_raises_for_oversize_prompt(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_batched_engine_preflight_credits_resident_prefix(monkeypatch):
+    """A prompt sharing a long prefix with a stored reference sequence must
+    have preflight's peak estimate charge only the new tokens, not the
+    full prompt length (issue: preflight always assumed cached_tokens=0,
+    even when the scheduler's own paged cache already held most of the
+    prompt — see ``estimate_cached_prefix_length``)."""
+    from omlx.engine.batched import BatchedEngine
+
+    scheduler = _make_scheduler()
+    engine = _build_engine_with_stub_scheduler(BatchedEngine, scheduler)
+    engine._preprocess_messages = lambda m: m
+
+    stored = list(range(80_000))
+    scheduler._cache_probe_seqs.append(("req-old", stored))
+    # Prompt shares the first 80,000 tokens, then has 2,000 genuinely new.
+    prompt_tokens = stored + list(range(500_000, 502_000))
+    engine._tokenizer.encode = MagicMock(return_value=prompt_tokens)
+
+    seen: dict = {}
+
+    def _capture(num_prompt_tokens, **kwargs):
+        seen["num_prompt_tokens"] = num_prompt_tokens
+        seen.update(kwargs)
+
+    scheduler.preflight_or_raise = _capture  # type: ignore[assignment]
+
+    await engine.preflight_chat(messages=[{"role": "user", "content": "x"}])
+
+    assert seen["num_prompt_tokens"] == len(prompt_tokens)
+    assert seen["cached_tokens"] == 80_000
+
+
+@pytest.mark.asyncio
+async def test_batched_engine_preflight_cold_start_unchanged(monkeypatch):
+    """No matching stored sequence: cached_tokens stays 0, identical to
+    today's behavior — the fix must not weaken a genuine cold start."""
+    from omlx.engine.batched import BatchedEngine
+
+    scheduler = _make_scheduler()
+    engine = _build_engine_with_stub_scheduler(BatchedEngine, scheduler)
+    engine._preprocess_messages = lambda m: m
+    engine._tokenizer.encode = MagicMock(return_value=list(range(50_000)))
+
+    seen: dict = {}
+
+    def _capture(num_prompt_tokens, **kwargs):
+        seen["num_prompt_tokens"] = num_prompt_tokens
+        seen.update(kwargs)
+
+    scheduler.preflight_or_raise = _capture  # type: ignore[assignment]
+
+    await engine.preflight_chat(messages=[{"role": "user", "content": "x"}])
+
+    assert seen["num_prompt_tokens"] == 50_000
+    assert seen["cached_tokens"] == 0
+
+
+@pytest.mark.asyncio
 async def test_vlm_engine_preflight_chat_raises_for_oversize_prompt(monkeypatch):
     from omlx.engine.vlm import VLMBatchedEngine
 
@@ -228,6 +288,59 @@ async def test_vlm_engine_preflight_chat_raises_for_oversize_prompt(monkeypatch)
 
     with pytest.raises(PrefillMemoryExceededError):
         await engine.preflight_chat(messages=[{"role": "user", "content": "x"}])
+
+
+@pytest.mark.asyncio
+async def test_vlm_engine_preflight_credits_resident_prefix(monkeypatch):
+    """Mirrors the BatchedEngine cache-credit contract for the VLM preflight
+    path (the text-only encoded prompt, before the image-token budget is
+    added, is what gets compared against stored reference sequences)."""
+    from omlx.engine.vlm import VLMBatchedEngine
+
+    scheduler = _make_scheduler()
+    engine = _build_engine_with_stub_scheduler(VLMBatchedEngine, scheduler)
+
+    stored = list(range(40_000))
+    scheduler._cache_probe_seqs.append(("req-old", stored))
+    prompt_tokens = stored + list(range(500_000, 501_000))
+    engine._tokenizer.encode = MagicMock(return_value=prompt_tokens)
+
+    seen: dict = {}
+
+    def _capture(num_prompt_tokens, **kwargs):
+        seen["num_prompt_tokens"] = num_prompt_tokens
+        seen.update(kwargs)
+
+    scheduler.preflight_or_raise = _capture  # type: ignore[assignment]
+
+    await engine.preflight_chat(messages=[{"role": "user", "content": "x"}])
+
+    assert seen["num_prompt_tokens"] == len(prompt_tokens)
+    assert seen["cached_tokens"] == 40_000
+
+
+@pytest.mark.asyncio
+async def test_vlm_engine_preflight_cold_start_unchanged(monkeypatch):
+    """No matching stored sequence: cached_tokens stays 0 for the VLM path
+    too, identical to today's behavior."""
+    from omlx.engine.vlm import VLMBatchedEngine
+
+    scheduler = _make_scheduler()
+    engine = _build_engine_with_stub_scheduler(VLMBatchedEngine, scheduler)
+    engine._tokenizer.encode = MagicMock(return_value=list(range(30_000)))
+
+    seen: dict = {}
+
+    def _capture(num_prompt_tokens, **kwargs):
+        seen["num_prompt_tokens"] = num_prompt_tokens
+        seen.update(kwargs)
+
+    scheduler.preflight_or_raise = _capture  # type: ignore[assignment]
+
+    await engine.preflight_chat(messages=[{"role": "user", "content": "x"}])
+
+    assert seen["num_prompt_tokens"] == 30_000
+    assert seen["cached_tokens"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_prefix_divergence_probe.py
+++ b/tests/test_prefix_divergence_probe.py
@@ -174,3 +174,49 @@ class TestDivergenceProbe:
 
         assert "first divergence at token 1" in caplog.text
         assert "<decode failed>" in caplog.text
+
+
+class TestEstimateCachedPrefixLength:
+    """Cheap, conservative resident-cache estimate consumed by preflight
+    (see engine/batched.py and engine/vlm.py) — shares the exact same
+    scan as ``_log_prefix_divergence`` via ``_best_matching_probe_seq``.
+    """
+
+    def test_exact_common_prefix_against_stored_sequence(self):
+        sched = _make_scheduler()
+        sched._cache_probe_seqs.append(("req-old", list(range(100))))
+        prompt = list(range(60)) + [999] * 20
+
+        assert sched.estimate_cached_prefix_length(prompt) == 60
+
+    def test_zero_when_no_probe_history(self):
+        sched = _make_scheduler()
+        assert sched.estimate_cached_prefix_length([1, 2, 3]) == 0
+
+    def test_zero_when_no_shared_prefix(self):
+        sched = _make_scheduler()
+        sched._cache_probe_seqs.append(("req-old", [1, 2, 3]))
+        assert sched.estimate_cached_prefix_length([9, 9, 9]) == 0
+
+    def test_zero_for_empty_prompt(self):
+        sched = _make_scheduler()
+        sched._cache_probe_seqs.append(("req-old", [1, 2, 3]))
+        assert sched.estimate_cached_prefix_length([]) == 0
+
+    def test_picks_best_matching_stored_sequence(self):
+        sched = _make_scheduler()
+        sched._cache_probe_seqs.append(("req-a", [9, 9, 9]))
+        sched._cache_probe_seqs.append(("req-b", [1, 2, 3, 4, 5]))
+        prompt = [1, 2, 3, 7, 7]
+
+        assert sched.estimate_cached_prefix_length(prompt) == 3
+
+    def test_never_exceeds_exact_prefix_match(self):
+        """The credited length is exactly the token-level common prefix —
+        no rounding up, no heuristics."""
+        sched = _make_scheduler()
+        sched._cache_probe_seqs.append(("req-old", list(range(20000))))
+        prompt = list(range(20000))
+        prompt[20000 - 1] = -1  # last token diverges
+
+        assert sched.estimate_cached_prefix_length(prompt) == 19999


### PR DESCRIPTION
## Summary

- The prefill memory guard's preflight check (`BatchedEngine`/`VLMBatchedEngine` `preflight_chat`/`preflight_completion` -> `Scheduler.preflight_or_raise`) always estimated peak memory assuming `cached_tokens=0`, regardless of how much of the prompt is already resident in the scheduler's paged prefix cache.
- Confirmed live against a real long-running session: a request with 84,154 prompt tokens and an 81,920-token (97%) paged-cache hit completed cheaply and successfully. The very next turn — a near-superset prompt — was rejected by preflight with `cached=0`, estimating a peak as if the entire ~85k-token prompt were new. Every rejection in that session's logs showed `cached=0`, even moments after a >90% cache hit had just been served.
- This makes long, cache-friendly agentic conversations (the common Claude Code / coding-agent pattern: each turn resends the full growing transcript) progressively more likely to hit false-positive `400`s as they grow, even though the model itself never needed to reprocess that much.

## What changes

- New `Scheduler.estimate_cached_prefix_length()`, factored out of the existing `_log_prefix_divergence` diagnostic (which already computes an exact token-level common-prefix match against the scheduler's last 4 stored reference sequences via `_common_prefix_len`). No new expensive lookup — reuses the same cheap comparison, now consumed by the memory estimate itself instead of only a log line.
- `BatchedEngine`/`VLMBatchedEngine` preflight now keep the tokenizer's encoded token list (previously discarded after taking `len()`) and pass `cached_tokens=scheduler.estimate_cached_prefix_length(encoded)` through to `preflight_eviction_request`/`preflight_or_raise`.
- `DFlashEngine` preflight is unchanged: its cache hit reconstructs (clones) the full prompt's KV into active memory, so charging the full prompt there remains correct. Cross-reference comments added at both sites explaining the difference.
- The estimate stays conservative: an exact token-level prefix match, never a heuristic or extrapolation. A genuine cold start (no probe history, or no shared prefix) still gets today's full-charge behavior — no regression there. The existing mid-generation safety net (`_preflight_safety_rejection`) is untouched and still catches any overshoot during actual execution.

## Test plan

- [x] New scheduler unit tests (`tests/test_prefix_divergence_probe.py`): `estimate_cached_prefix_length` returns the exact common-prefix length, 0 with no probe history, 0 with no shared prefix, picks the best of multiple stored sequences, never rounds up past the exact match.
- [x] New engine preflight tests (`tests/test_engine_preflight.py`): a prompt sharing a long prefix with a stored reference sequence has its peak estimate computed from new tokens only (both `BatchedEngine` and `VLMBatchedEngine`); a prompt with no matching stored sequence produces the same estimate as before this change (cold-start regression guard).
- [x] Existing `DFlashEngine` preflight tests (`tests/test_dflash_prefill_memory_guard.py`) already assert `cached_tokens` is never passed — unaffected, confirming no behavior change there.
- [x] Full suite: 7278 passed, 1 failed (pre-existing, environment-only `torch_stub` subprocess test — reproduced identically via `git stash`, unrelated to this change), 53 skipped.
- [x] Manual verification: reproduced the real incident's shape (81,920-token resident prefix, 84,995-token next turn, real `current`/`ceiling` figures from the incident's server log) directly against the patched `Scheduler.preflight_or_raise` — the previously-rejected pattern is now admitted; the same request with the cache credit forced to 0 (pre-fix behavior) still rejects, reproducing the incident; a genuine cold start of equivalent size still rejects correctly (guard not weakened).