### PR TITLE
Support bidirectional Ministral3 oQ calibration

### DIFF
--- a/docs/oQ_Quantization.md
+++ b/docs/oQ_Quantization.md
@@ -191,6 +191,7 @@ Code samples include real-world patterns (class definitions, import chains, mult
 | Nemotron-Cascade MoE | Full | Per-expert dense GPTQ |
 | Llama, Mistral, dense models | Full | Standard layer structure |
 | VLM models | Full (text) | Vision weights kept fp16 |
+| Ministral3 encoder (bidirectional) | Full | Non-causal `is_causal=false` encoder; Llama-4 attention scale |
 
 ### Streaming Path (oQ)
 
@@ -198,6 +199,17 @@ All models supported by mlx-lm/mlx-vlm. No architecture restrictions.
 Source checkpoints may use BF16/FP16 or reconstructable floating-point block
 formats, including native FP8 and MXFP8. oQ restores FP8/MXFP8 weight semantics
 from the checkpoint scales before applying the selected oQ or oQe format.
+
+## Bidirectional / Encoder Calibration
+
+oQ calibration defaults to causal (autoregressive) attention. For bidirectional
+encoder checkpoints such as **Ministral3** (`is_causal: false`), oQ automatically
+detects the encoder layout, loads the bare encoder without MLX-LM's causal-LM
+wrapper, and applies the Llama-4 attention scale instead of positional indices.
+Causal masking is disabled per-layer so sensitivity forward passes use full
+attention, matching the model's intended bidirectional behaviour. This lets oQ
+produce mixed-precision quantization for encoder-only or dual-mode checkpoints
+that were previously unsupported.
 
 ## Acknowledgments
 

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -2442,6 +2442,38 @@ def _sensitivity_lm_config_override(config: dict) -> dict | None:
     return None
 
 
+def _is_ministral3_encoder_config(config: dict) -> bool:
+    """Return True for the bidirectional Ministral3 encoder checkpoint layout."""
+    architectures = config.get("architectures") or []
+    if isinstance(architectures, str):
+        architectures = [architectures]
+    return (
+        str(config.get("model_type", "")).lower().replace("-", "_") == "ministral3"
+        and "Ministral3Model" in architectures
+        and config.get("is_causal") is False
+    )
+
+
+def _load_ministral3_encoder_for_sensitivity(
+    model_path: str,
+    *,
+    lazy: bool = True,
+    model_config: dict | None = None,
+):
+    """Load a bare Ministral3 encoder without MLX-LM's causal-LM wrapper."""
+    from mlx_lm.models.ministral3 import LanguageModel, ModelArgs
+    from mlx_lm.tokenizer_utils import load as load_tokenizer
+    from mlx_lm.utils import load_model
+
+    model, _ = load_model(
+        Path(model_path),
+        lazy=lazy,
+        model_config=model_config,
+        get_model_classes=lambda config: (LanguageModel, ModelArgs),
+    )
+    return model, load_tokenizer(Path(model_path))
+
+
 def make_predicate(config: dict, oq_level: int = 4) -> Callable:
     """Create a quant_predicate closure for mlx-lm's quantize_model."""
 
@@ -5535,6 +5567,24 @@ def _find_model_layers(model):
 
 def _forward_layer_result(block, inputs, mask, position_ids):
     """Forward pass through a transformer layer, returning output and aux."""
+    if isinstance(position_ids, dict) and position_ids.get("kind") == "ministral3":
+        try:
+            result = block(
+                inputs,
+                position_ids["attn_scale"],
+                mask,
+                None,
+            )
+            if isinstance(result, tuple):
+                return result[0], result[1] if len(result) > 1 else None
+            return result, None
+        except (TypeError, ValueError, RuntimeError, AttributeError) as e:
+            logger.debug(
+                f"_forward_layer: Ministral3 signature failed for "
+                f"{type(block).__name__}: {e}"
+            )
+            return None, None
+
     if isinstance(position_ids, dict) and position_ids.get("kind") == "glm_moe_dsa":
         try:
             result = block(
@@ -5664,7 +5714,7 @@ def _restore_saved_weights(block, saved):
             modules_by_path[path].weight = weight
 
 
-def _prepare_layer_inputs(model, layers, calib_data, inputs):
+def _prepare_layer_inputs(model, layers, calib_data, inputs, config=None):
     """Model-specific (inputs, per-layer masks, 4th forward arg) for
     block-level sensitivity forwards.
 
@@ -5700,6 +5750,27 @@ def _prepare_layer_inputs(model, layers, calib_data, inputs):
         mask = create_attention_mask(inputs, None, return_array=True)
         state = {"kind": "glm_moe_dsa", "prev_topk_indices": None}
         return inputs, [mask] * len(layers), state
+    if model_type == "ministral3":
+        from mlx_lm.models.ministral3 import _get_llama_4_attn_scale
+
+        args = getattr(getattr(model, "model", None), "args", None)
+        if args is None:
+            args = getattr(model, "args", None)
+        rope = getattr(args, "rope_parameters", {}) or {}
+        attn_scale = _get_llama_4_attn_scale(
+            calib_data.shape[1],
+            0,
+            rope.get("llama_4_scaling_beta", 0.1),
+            rope.get("original_max_position_embeddings", 16384),
+        ).astype(inputs.dtype)
+        is_causal = True if config is None else config.get("is_causal", True)
+        masks = (
+            _layer_masks_for_model(model, layers, inputs)
+            if is_causal
+            else [None] * len(layers)
+        )
+        state = {"kind": "ministral3", "attn_scale": attn_scale}
+        return inputs, masks, state
     masks = _layer_masks_for_model(model, layers, inputs)
     position_ids = mx.arange(calib_data.shape[1])[None, :]
     return inputs, masks, position_ids
@@ -6031,7 +6102,7 @@ def _collect_imatrix_from_model(
 
                 inputs = embed_fn(batch)
                 inputs, layer_masks, position_ids = _prepare_layer_inputs(
-                    model, layers, batch, inputs
+                    model, layers, batch, inputs, config
                 )
 
                 for layer_idx, block in enumerate(layers):
@@ -6249,14 +6320,21 @@ def _collect_imatrix(
 
             tokenizer = load_tokenizer(Path(model_path))
         else:
-            from omlx.utils.model_loading import lm_load_compat as lm_load
+            if _is_ministral3_encoder_config(config):
+                model, tokenizer = _load_ministral3_encoder_for_sensitivity(
+                    model_path,
+                    lazy=True,
+                    model_config=_sensitivity_lm_config_override(config),
+                )
+            else:
+                from omlx.utils.model_loading import lm_load_compat as lm_load
 
-            model, tokenizer = lm_load(
-                model_path,
-                lazy=True,
-                trust_remote_code=trust_remote_code,
-                model_config=_sensitivity_lm_config_override(config),
-            )
+                model, tokenizer = lm_load(
+                    model_path,
+                    lazy=True,
+                    trust_remote_code=trust_remote_code,
+                    model_config=_sensitivity_lm_config_override(config),
+                )
     except Exception as e:
         logger.error("oQe imatrix: model load failed (%s)", e)
         return {}, {"dataset": calib_dataset, "processed_samples": 0}
@@ -6432,7 +6510,7 @@ def _measure_sensitivity_from_model(
 
     inputs = embed_fn(calib_data)
     inputs, layer_masks, position_ids = _prepare_layer_inputs(
-        model, layers, calib_data, inputs
+        model, layers, calib_data, inputs, config
     )
     sensitivity = {}
 
@@ -6566,14 +6644,21 @@ def _measure_sensitivity(
 
             tokenizer = load_tokenizer(Path(model_path))
         else:
-            from omlx.utils.model_loading import lm_load_compat as lm_load
+            if _is_ministral3_encoder_config(config):
+                model, tokenizer = _load_ministral3_encoder_for_sensitivity(
+                    model_path,
+                    lazy=True,
+                    model_config=_sensitivity_lm_config_override(config),
+                )
+            else:
+                from omlx.utils.model_loading import lm_load_compat as lm_load
 
-            model, tokenizer = lm_load(
-                model_path,
-                lazy=True,
-                trust_remote_code=trust_remote_code,
-                model_config=_sensitivity_lm_config_override(config),
-            )
+                model, tokenizer = lm_load(
+                    model_path,
+                    lazy=True,
+                    trust_remote_code=trust_remote_code,
+                    model_config=_sensitivity_lm_config_override(config),
+                )
     except Exception as e:
         logger.error(f"Sensitivity measurement: model load failed ({e})")
         return {}
@@ -6943,11 +7028,17 @@ def _measure_sensitivity_from_quantized_model(
                 set_mtp_active(True)
                 restore_mtp_active = lambda: set_mtp_active(prev_active)  # noqa: E731
 
-            model, tokenizer = lm_load(
-                model_path,
-                lazy=True,
-                trust_remote_code=trust_remote_code,
-            )
+            if _is_ministral3_encoder_config(config):
+                model, tokenizer = _load_ministral3_encoder_for_sensitivity(
+                    model_path,
+                    lazy=True,
+                )
+            else:
+                model, tokenizer = lm_load(
+                    model_path,
+                    lazy=True,
+                    trust_remote_code=trust_remote_code,
+                )
     except Exception as e:
         logger.error(f"Sensitivity proxy load failed ({e})")
         return {}
@@ -6987,7 +7078,7 @@ def _measure_sensitivity_from_quantized_model(
 
     inputs = embed_fn(calib_data)
     inputs, layer_masks, position_ids = _prepare_layer_inputs(
-        model, layers, calib_data, inputs
+        model, layers, calib_data, inputs, config
     )
     sensitivity = {}
 

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -48,6 +48,7 @@ from omlx.oq import (
     _imatrix_requires_expert_counts,
     _ImatrixCaptureWrapper,
     _is_audio_tensor,
+    _is_ministral3_encoder_config,
     _is_moe_router,
     _is_vision_tensor,
     _LazyTensorIndex,
@@ -58,6 +59,7 @@ from omlx.oq import (
     _normalize_sensitivity_map_override,
     _oqe_calibration_batch_plan,
     _perturb_bits_for,
+    _prepare_layer_inputs,
     _progress_total_bytes,
     _quantize_chunked,
     _sensitivity_lm_config_override,
@@ -664,6 +666,40 @@ class TestOqDtypeModelSupport:
             quantize_oq_streaming(str(src), str(out), oq_level=4, dtype="float16")
 
         assert not out.exists()
+
+
+class TestMinistral3EncoderSupport:
+    def test_detects_bidirectional_encoder_layout(self):
+        assert _is_ministral3_encoder_config(
+            {
+                "model_type": "ministral3",
+                "architectures": ["Ministral3Model"],
+                "is_causal": False,
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            {
+                "model_type": "ministral3",
+                "architectures": ["Ministral3ForCausalLM"],
+                "is_causal": True,
+            },
+            {
+                "model_type": "ministral3",
+                "architectures": ["Ministral3Model"],
+                "is_causal": True,
+            },
+            {
+                "model_type": "mistral3",
+                "architectures": ["Mistral3Model"],
+                "is_causal": False,
+            },
+        ],
+    )
+    def test_rejects_non_encoder_layouts(self, config):
+        assert not _is_ministral3_encoder_config(config)
 
 
 class TestShouldSkipTensor:
@@ -1578,6 +1614,53 @@ class TestForwardLayer:
         assert isinstance(result, mx.array)
         assert aux == "next_topk"
         assert seen == [("mask", None, "prev_topk")]
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_ministral3_state_uses_embedding_signature(self):
+        tensor = mx.ones((2, 4, 8))
+        attn_scale = mx.ones((1, 1, 4, 1))
+        seen = []
+
+        def ministral_block(x, scale, mask, cache):
+            seen.append((scale, mask, cache))
+            return x + 1
+
+        state = {"kind": "ministral3", "attn_scale": attn_scale}
+        result, aux = _forward_layer_result(ministral_block, tensor, None, state)
+
+        assert isinstance(result, mx.array)
+        assert aux is None
+        assert seen == [(attn_scale, None, None)]
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_ministral3_embedding_calibration_is_bidirectional(self):
+        class Args:
+            rope_parameters = {
+                "llama_4_scaling_beta": 0.1,
+                "original_max_position_embeddings": 16384,
+            }
+
+        class Inner:
+            args = Args()
+
+        class Model:
+            model_type = "ministral3"
+            model = Inner()
+
+        calib_data = mx.ones((2, 4), dtype=mx.int32)
+        inputs = mx.ones((2, 4, 8))
+        prepared, masks, state = _prepare_layer_inputs(
+            Model(),
+            [object(), object()],
+            calib_data,
+            inputs,
+            {"is_causal": False},
+        )
+
+        assert prepared is inputs
+        assert masks == [None, None]
+        assert state["kind"] == "ministral3"
+        assert state["attn_scale"].shape == (4, 1)
 
 
 # =============================================================================


### PR DESCRIPTION
## What changed

- detect bidirectional `Ministral3Model` encoder checkpoints during oQ calibration
- load the bare MLX-LM `LanguageModel` so top-level encoder weight names load correctly
- pass Ministral3's attention scaling through block-level sensitivity forwards
- preserve non-causal attention for embedding checkpoints in standard, oQe imatrix, and quantized-proxy calibration paths
- add focused tests for checkpoint detection, the encoder block signature, and bidirectional mask selection

## Why

Embedding checkpoints such as `nvidia/Nemotron-3-Embed-1B-BF16` use the
`Ministral3Model` architecture with `is_causal: false` and top-level
`layers.*` weights. The normal causal-LM loader wraps the model and expects a
different weight namespace, while the generic sensitivity forward also
constructs a causal mask and calls the transformer block with the wrong
signature.

As a result, OMLX could not perform its real sensitivity calibration for this
model family. This change keeps the existing causal-LM paths unchanged and
special-cases only the declared bidirectional encoder layout.

## Impact

OMLX oQ conversion can now calibrate and quantize compatible bidirectional
Ministral3 embedding checkpoints using their intended attention behavior.

## Validation

- `python -m pytest -q tests/test_oq.py` — 324 passed
- `git diff --check`
- end-to-end `nvidia/Nemotron-3-Embed-1B-BF16` to oQ5 conversion completed on
  Apple Silicon
- resulting 2,048-dimensional embeddings remained L2-normalized
- BF16-to-oQ5 cosine similarity measured 0.9946–0.9959 across a query,
  relevant passage, and unrelated passage
