### PR TITLE
fix(server): include model name in per-request log summaries

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2801,8 +2801,10 @@ async def create_embeddings(
             raise HTTPException(status_code=400, detail=str(e))
 
         elapsed = time.perf_counter() - start_time
+        resolved_model = resolve_model_id(request.model) or request.model
         logger.info(
-            f"Embedding: {len(embedding_inputs)} inputs, {output.dimensions} dims, "
+            f"Embedding: model={resolved_model}, "
+            f"{len(embedding_inputs)} inputs, {output.dimensions} dims, "
             f"{output.total_tokens} tokens, max_length={max_length}, "
             f"truncation={request.truncation} in {elapsed:.3f}s"
         )
@@ -2811,7 +2813,7 @@ async def create_embeddings(
             completion_tokens=0,
             cached_tokens=0,
             prefill_duration=elapsed,
-            model_id=resolve_model_id(request.model) or request.model,
+            model_id=resolved_model,
         )
 
         data = []
@@ -2926,8 +2928,9 @@ async def create_rerank(
         )
 
     elapsed = time.perf_counter() - start_time
+    resolved_model = resolve_model_id(request.model) or request.model
     logger.info(
-        f"Rerank: {len(documents_raw)} docs, "
+        f"Rerank: model={resolved_model}, {len(documents_raw)} docs, "
         f"{output.total_tokens} tokens in {elapsed:.3f}s"
     )
     get_server_metrics().record_request_complete(
@@ -2935,7 +2938,7 @@ async def create_rerank(
         completion_tokens=0,
         cached_tokens=0,
         prefill_duration=elapsed,
-        model_id=resolve_model_id(request.model) or request.model,
+        model_id=resolved_model,
     )
 
     # Format response - results sorted by score (descending). Strings wrap
@@ -3104,8 +3107,11 @@ async def create_completion(
 
             elapsed = time.perf_counter() - start_time
             tokens_per_sec = total_completion_tokens / elapsed if elapsed > 0 else 0
+            resolved_model = resolve_model_id(request.model) or request.model
             logger.info(
-                f"Completion: {total_completion_tokens} tokens in {elapsed:.2f}s ({tokens_per_sec:.1f} tok/s), prompt: {total_prompt_tokens}"
+                f"Completion: model={resolved_model}, "
+                f"{total_completion_tokens} tokens in {elapsed:.2f}s "
+                f"({tokens_per_sec:.1f} tok/s), prompt: {total_prompt_tokens}"
             )
 
             prefill_duration = (
@@ -3120,7 +3126,7 @@ async def create_completion(
                 cached_tokens=total_cached_tokens,
                 prefill_duration=prefill_duration,
                 generation_duration=gen_duration,
-                model_id=resolve_model_id(request.model) or request.model,
+                model_id=resolved_model,
             )
 
             return CompletionResponse(
@@ -3564,7 +3570,8 @@ async def create_chat_completion(
                 is_diffusion=is_diffusion,
             )
             logger.info(
-                f"Chat completion: {output.completion_tokens} tokens in {elapsed:.2f}s "
+                f"Chat completion: model={resolved_model}, "
+                f"{output.completion_tokens} tokens in {elapsed:.2f}s "
                 f"({speed_text}), prompt: {output.prompt_tokens}, "
                 f"finish_reason={output.finish_reason}, max_tokens={max_tokens}, "
                 f"request_max_tokens={request.max_tokens}"
@@ -4202,13 +4209,14 @@ async def stream_completion(
             prefill_duration=ttft,
             generation_duration=gen_duration,
         )
+        resolved_model = resolve_model_id(request.model) or request.model
         get_server_metrics().record_request_complete(
             prompt_tokens=last_output.prompt_tokens,
             completion_tokens=last_output.completion_tokens,
             cached_tokens=last_output.cached_tokens,
             prefill_duration=metric_prefill_duration,
             generation_duration=metric_gen_duration,
-            model_id=resolve_model_id(request.model) or request.model,
+            model_id=resolved_model,
         )
         speed_duration = total_duration if is_diffusion else gen_duration
         tokens_per_sec = (
@@ -4220,7 +4228,8 @@ async def stream_completion(
             is_diffusion=is_diffusion,
         )
         logger.info(
-            f"Completion: {last_output.completion_tokens} tokens in "
+            f"Completion: model={resolved_model}, "
+            f"{last_output.completion_tokens} tokens in "
             f"{total_duration:.2f}s ({speed_text}), "
             f"prompt: {last_output.prompt_tokens}"
         )
@@ -4670,7 +4679,8 @@ async def stream_chat_completion(
             is_diffusion=is_diffusion,
         )
         logger.info(
-            f"Chat completion: {last_output.completion_tokens} tokens in "
+            f"Chat completion: model={resolved_model or request.model}, "
+            f"{last_output.completion_tokens} tokens in "
             f"{total_duration:.2f}s ({speed_text}), "
             f"prompt: {last_output.prompt_tokens}, finish_reason={finish_reason}, "
             f"max_tokens={kwargs.get('max_tokens')}, "
@@ -5386,7 +5396,8 @@ async def create_anthropic_message(
             elapsed = time.perf_counter() - start_time
             tokens_per_sec = output.completion_tokens / elapsed if elapsed > 0 else 0
             logger.info(
-                f"Anthropic message: {output.completion_tokens} tokens in {elapsed:.2f}s "
+                f"Anthropic message: model={resolved_model}, "
+                f"{output.completion_tokens} tokens in {elapsed:.2f}s "
                 f"({tokens_per_sec:.1f} tok/s)"
             )
 
@@ -5877,7 +5888,8 @@ async def create_response(
             elapsed = time.perf_counter() - start_time
             tokens_per_sec = output.completion_tokens / elapsed if elapsed > 0 else 0
             logger.info(
-                f"Responses API: {output.completion_tokens} tokens in {elapsed:.2f}s "
+                f"Responses API: model={resolved_model}, "
+                f"{output.completion_tokens} tokens in {elapsed:.2f}s "
                 f"({tokens_per_sec:.1f} tok/s)"
             )
 

--- a/tests/integration/test_e2e_streaming.py
+++ b/tests/integration/test_e2e_streaming.py
@@ -576,6 +576,61 @@ class TestStreamingHelperFunctions:
         assert data["choices"][0]["delta"].get("role") == "assistant"
 
     @pytest.mark.asyncio
+    async def test_stream_completion_summary_log_names_the_model(self, caplog):
+        """The per-request summary must identify the serving model.
+
+        With several models loaded, interleaved summaries are otherwise
+        unattributable.
+        """
+        from omlx.server import stream_completion
+        from omlx.api.openai_models import CompletionRequest
+
+        engine = MockBaseEngine()
+        request = CompletionRequest(model="test-model", prompt="Hello", stream=True)
+
+        with caplog.at_level("INFO", logger="omlx.server"):
+            async for _ in stream_completion(engine, "Hello", request):
+                pass
+
+        summaries = [r.message for r in caplog.records if "Completion: " in r.message]
+        assert summaries, "no completion summary was logged"
+        assert "model=test-model" in summaries[-1]
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_summary_log_names_resolved_model(self, caplog):
+        """The summary reports the resolved model, not the requested alias."""
+        from omlx.server import stream_chat_completion
+        from omlx.api.openai_models import ChatCompletionRequest, Message
+
+        engine = MockBaseEngine()
+        request = ChatCompletionRequest(
+            model="my-alias",
+            messages=[Message(role="user", content="Hi")],
+            stream=True,
+        )
+
+        messages = [{"role": "user", "content": "Hi"}]
+        with caplog.at_level("INFO", logger="omlx.server"):
+            async for _ in stream_chat_completion(
+                engine,
+                messages,
+                request,
+                max_tokens=256,
+                temperature=0.7,
+                top_p=0.9,
+                top_k=40,
+                resolved_model="real-model-id",
+            ):
+                pass
+
+        summaries = [
+            r.message for r in caplog.records if "Chat completion: " in r.message
+        ]
+        assert summaries, "no chat completion summary was logged"
+        assert "model=real-model-id" in summaries[-1]
+        assert "model=my-alias" not in summaries[-1]
+
+    @pytest.mark.asyncio
     async def test_stream_chat_completion_prompt_opened_thinking_streams_as_reasoning(self):
         """If the rendered prompt opens <think>, initial deltas are reasoning."""
         from omlx.api.openai_models import ChatCompletionRequest, Message

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -968,6 +968,28 @@ class TestChatCompletionEndpoint:
         assert mock_engine_pool.get_engine_calls[-1]["_lease"] is True
         assert mock_engine_pool.release_calls == ["test-model"]
 
+    def test_chat_completion_summary_log_names_the_model(self, client, caplog):
+        """The per-request summary must identify the serving model.
+
+        With several models loaded, interleaved summaries are otherwise
+        unattributable.
+        """
+        with caplog.at_level("INFO", logger="omlx.server"):
+            response = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+            )
+
+        assert response.status_code == 200
+        summaries = [
+            r.message for r in caplog.records if "Chat completion: " in r.message
+        ]
+        assert summaries, "no chat completion summary was logged"
+        assert "model=test-model" in summaries[-1]
+
     def test_chat_completion_basic(self, client):
         """Test basic chat completion request."""
         response = client.post(


### PR DESCRIPTION
Fixes #99.

## Summary

- Every per-request INFO summary now leads with `model=<resolved id>` — completion and chat completion (streaming and non-streaming), embedding, rerank, Anthropic messages, and Responses API.
- With several models loaded (the multi-model subagent scenario from #99), interleaved summary lines can now be attributed to the model that served them.

## Why

#99's live-view half was covered by the Active Models card (#233), but the log half you called out there ("the logs don't actually show model names right now either") is still open: the model appears only in the DEBUG-level request-received line, so at default log level a session hitting several models produces `Chat completion: 128 tokens in 0.89s ...` lines that can't be attributed to a model.

Before / after:

```
Chat completion: 128 tokens in 0.89s (143.3 tok/s), prompt: 1024, finish_reason=stop, ...
Chat completion: model=Qwen3.5-4B-MLX-4bit, 128 tokens in 0.89s (143.3 tok/s), prompt: 1024, finish_reason=stop, ...
```

## Changes

- `omlx/server.py`: eight `logger.info` summary sites gain a leading `model=` field (matching the existing `model=` style of the DEBUG request-received lines). No other text changes, no new log lines, no level changes.
- The value logged is the resolved model id, taken from the same expression the adjacent `record_request_complete(model_id=...)` call already used. Where that expression was inline (`resolve_model_id(request.model) or request.model`), it is hoisted into a local and reused by both, so the log line and the metric can never disagree and resolution still runs once per request.
- Sibling sweep: streaming + non-streaming covered on both OpenAI endpoints; embeddings and rerank covered; Anthropic messages and Responses API summaries covered. Explicitly out of scope (pre-existing): the *streaming* Anthropic-messages and *streaming* Responses paths emit no summary line at all today (metrics only) — adding brand-new INFO lines there is a separate behavioral change. Also pre-existing and unchanged: with `model_fallback` enabled (default off), the resolved id names the requested model even when the default served the request — this mirrors what the metrics field already records.

## Tests

- Three tests added to the existing classes (`TestStreamingHelperFunctions` in `tests/integration/test_e2e_streaming.py`, `TestChatCompletionEndpoint` in `tests/integration/test_server_endpoints.py`) asserting the summary line names the resolved model, including the alias→resolved case; all three run under the CI marker filter.
- `pytest tests/integration/test_e2e_streaming.py tests/integration/test_server_endpoints.py -q` → `223 passed, 51 deselected`.
- Full suite: `7270 passed, 52 skipped, 70 deselected`, plus 3 failures that also fail on unmodified `main` on this machine (M5 numeric-tolerance tests in `test_glm_mtp_patch.py` / `test_mtp_prompt_priming.py`, unrelated to this change — verified by re-running them on a clean tree).
- Also verified all three new tests fail when the fix is reverted.
