### PR TITLE
fix(scheduler): pass the engine stream to prefill-cleanup cache clears

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -4733,7 +4733,7 @@ class Scheduler:
                 self.requests.pop(rid, None)
                 self._clear_request_admission_bookkeeping(rid)
                 get_prefill_tracker().remove(rid)
-                _sync_and_clear_cache()
+                _sync_and_clear_cache(self._stream)
                 rejected.append(_prefill_memory_exception_output(rid, e))
                 continue
             except RuntimeError as e:
@@ -4746,7 +4746,7 @@ class Scheduler:
                 # Drop Metal cache pool buffers held by the aborted chunk's
                 # forward / mx.eval transients. Without this, enforcer keeps
                 # seeing the burst footprint until the next mx.clear_cache().
-                _sync_and_clear_cache()
+                _sync_and_clear_cache(self._stream)
                 # Try a bounded requeue before surfacing the failure: a
                 # memory-pressure prefill gets a fresh, better-throttled
                 # attempt. Only after the retry budget is exhausted (or for
@@ -8903,7 +8903,7 @@ class Scheduler:
                         self.requests.pop(request.request_id, None)
                         self._clear_request_admission_bookkeeping(request.request_id)
                         get_prefill_tracker().remove(request.request_id)
-                        _sync_and_clear_cache()
+                        _sync_and_clear_cache(self._stream)
                         rejected_outputs.append(
                             _prefill_memory_exception_output(request.request_id, e)
                         )
@@ -8926,7 +8926,7 @@ class Scheduler:
                         get_prefill_tracker().remove(request.request_id)
                         # Drop Metal cache pool buffers held by the aborted
                         # first chunk's forward / mx.eval transients.
-                        _sync_and_clear_cache()
+                        _sync_and_clear_cache(self._stream)
                         if self._requeue_or_fail_prefill(request, e):
                             continue
                         rejected_outputs.append(
@@ -8986,7 +8986,7 @@ class Scheduler:
                     self.requests.pop(request.request_id, None)
                     self._clear_request_admission_bookkeeping(request.request_id)
                     get_prefill_tracker().remove(request.request_id)
-                    _sync_and_clear_cache()
+                    _sync_and_clear_cache(self._stream)
                     rejected_outputs.append(
                         _prefill_memory_exception_output(request.request_id, e)
                     )
@@ -9008,7 +9008,7 @@ class Scheduler:
                     get_prefill_tracker().remove(request.request_id)
                     # Drop Metal cache pool buffers held by the aborted
                     # chunk's forward / mx.eval transients.
-                    _sync_and_clear_cache()
+                    _sync_and_clear_cache(self._stream)
                     if self._requeue_or_fail_prefill(request, e):
                         continue
                     rejected_outputs.append(

--- a/tests/test_scheduler_chunked_prefill.py
+++ b/tests/test_scheduler_chunked_prefill.py
@@ -20,6 +20,7 @@ from omlx.scheduler import (
     PrefillEvictionRequest,
     Scheduler,
     SchedulerConfig,
+    _default_generation_stream,
     _PrefillAbortedError,
     _PrefillEvictionNeeded,
     _PrefillState,
@@ -1191,3 +1192,182 @@ class TestScheduleWaitingSpecPrefillGuard:
         assert scheduled == []
         assert rejected == []
         assert req in sched.waiting
+
+
+# ---------------------------------------------------------------------------
+# Prefill error paths must drain the ENGINE stream before clearing the cache
+# ---------------------------------------------------------------------------
+
+
+class TestPrefillCleanupUsesEngineStream:
+    """Every prefill error/rejection path must pass the per-engine stream to
+    _sync_and_clear_cache, like its sibling success/abort branches do.
+
+    mx.clear_cache() can release Metal buffers that in-flight command buffers
+    still reference (#300), so the clear must be preceded by a drain of the
+    stream that carried the work. The drain only covers the stream it is given:
+    an mlx ThreadLocalStream resolves to a *different* concrete mx.Stream per
+    calling thread, so a no-argument call drains mlx-lm's generation_stream and
+    the calling thread's default stream -- never the engine stream the prefill
+    forward and the BatchGenerator's async_eval actually ran on.
+    """
+
+    @staticmethod
+    def _engine_scheduler(**kwargs) -> Scheduler:
+        """Scheduler with a per-engine stream, the way EngineCore builds it."""
+        sched = _make_scheduler(**kwargs)
+        sched._stream = mx.new_thread_local_stream(mx.default_device())
+        assert sched._stream is not _default_generation_stream
+        return sched
+
+    @staticmethod
+    def _capacity_error(request_id: str) -> PrefillMemoryExceededError:
+        return PrefillMemoryExceededError(
+            message="Prefill context too large for available memory",
+            request_id=request_id,
+            estimated_bytes=123,
+            limit_bytes=100,
+        )
+
+    @staticmethod
+    def _recorder() -> tuple[list, object]:
+        """Patch the module-level helper so calls record the stream argument."""
+        streams: list = []
+        return streams, patch(
+            "omlx.scheduler._sync_and_clear_cache",
+            side_effect=lambda stream=None: streams.append(stream),
+        )
+
+    def _assert_engine_stream(self, streams: list, sched: Scheduler) -> None:
+        assert streams, "prefill cleanup did not clear the Metal buffer cache"
+        assert all(s is sched._stream for s in streams), (
+            "prefill cleanup cleared the cache without draining the engine "
+            f"stream: {streams!r} != {sched._stream!r}"
+        )
+
+    def _queued_chunked_request(self, sched: Scheduler) -> Request:
+        req = _make_request("r1")
+        sched.requests[req.request_id] = req
+        sched.prefilling.append(req)
+        sched._prefill_states[req.request_id] = _make_prefill_state(sched, req)
+        return req
+
+    # _advance_chunked_prefills(): in-flight chunk
+
+    def test_advance_chunked_capacity_rejection_drains_engine_stream(self):
+        sched = self._engine_scheduler()
+        req = self._queued_chunked_request(sched)
+        streams, recording = self._recorder()
+
+        with (
+            recording,
+            patch.object(
+                sched,
+                "_step_prefill_chunk",
+                side_effect=self._capacity_error(req.request_id),
+            ),
+        ):
+            rejected: list = []
+            sched._advance_chunked_prefills([], rejected)
+
+        assert len(rejected) == 1
+        self._assert_engine_stream(streams, sched)
+
+    def test_advance_chunked_runtime_error_drains_engine_stream(self):
+        sched = self._engine_scheduler()
+        self._queued_chunked_request(sched)
+        streams, recording = self._recorder()
+
+        with (
+            recording,
+            patch.object(
+                sched, "_step_prefill_chunk", side_effect=RuntimeError("kernel panic")
+            ),
+        ):
+            rejected: list = []
+            sched._advance_chunked_prefills([], rejected)
+
+        assert len(rejected) == 1
+        self._assert_engine_stream(streams, sched)
+
+    # _schedule_waiting(): first chunk of a chunked prefill
+
+    def test_first_chunk_capacity_rejection_drains_engine_stream(self):
+        sched = self._engine_scheduler()
+        req = _make_request("r1", n_tokens=10)  # > step_size + 1 → chunked fork
+        sched.add_request(req)
+        streams, recording = self._recorder()
+
+        with (
+            recording,
+            patch.object(
+                sched, "_begin_prefill", return_value=_make_prefill_state(sched, req)
+            ),
+            patch.object(
+                sched,
+                "_step_prefill_chunk",
+                side_effect=self._capacity_error(req.request_id),
+            ),
+        ):
+            _, rejected = sched._schedule_waiting()
+
+        assert len(rejected) == 1
+        self._assert_engine_stream(streams, sched)
+
+    def test_first_chunk_runtime_error_drains_engine_stream(self):
+        sched = self._engine_scheduler()
+        req = _make_request("r1", n_tokens=10)
+        sched.add_request(req)
+        streams, recording = self._recorder()
+
+        with (
+            recording,
+            patch.object(
+                sched, "_begin_prefill", return_value=_make_prefill_state(sched, req)
+            ),
+            patch.object(
+                sched, "_step_prefill_chunk", side_effect=RuntimeError("kernel panic")
+            ),
+        ):
+            _, rejected = sched._schedule_waiting()
+
+        assert len(rejected) == 1
+        self._assert_engine_stream(streams, sched)
+
+    # _schedule_waiting(): non-chunked full prefill
+
+    def test_non_chunked_capacity_rejection_drains_engine_stream(self):
+        sched = self._engine_scheduler()
+        req = _make_request("r1", n_tokens=3)  # short → normal prefill path
+        sched.add_request(req)
+        streams, recording = self._recorder()
+
+        with (
+            recording,
+            patch.object(
+                sched,
+                "_do_external_prefill",
+                side_effect=self._capacity_error(req.request_id),
+            ),
+        ):
+            _, rejected = sched._schedule_waiting()
+
+        assert len(rejected) == 1
+        self._assert_engine_stream(streams, sched)
+
+    def test_non_chunked_runtime_error_drains_engine_stream(self):
+        sched = self._engine_scheduler()
+        req = _make_request("r1", n_tokens=3)
+        sched.add_request(req)
+        streams, recording = self._recorder()
+
+        with (
+            recording,
+            patch.object(
+                sched, "_do_external_prefill", side_effect=RuntimeError("kernel panic")
+            ),
+        ):
+            _, rejected = sched._schedule_waiting()
+
+        assert len(rejected) == 1
+        self._assert_engine_stream(streams, sched)


### PR DESCRIPTION
Refs #300, #1146.

## Summary

Six prefill error/rejection handlers in `omlx/scheduler.py` call `_sync_and_clear_cache()` with no stream argument, while the sibling abort/success branches in the same `try`/`except` ladders pass `self._stream`. The no-arg form does not drain the engine's stream, so `mx.clear_cache()` runs while the prefill forward and the BatchGenerator's `async_eval` work are still in flight on it — the buffer-release pattern the helper was written to prevent (#300). This passes `self._stream` at all six, matching the siblings; no signature change, no other behavior change.

## Why

`_sync_and_clear_cache(stream=None)` falls back to `_default_generation_stream` (the import-time binding to `mlx_lm.generate.generation_stream`) and then to a plain `mx.synchronize()`. Both are the wrong stream on an engine executor thread: an mlx `ThreadLocalStream` is a per-thread slot handle, so each distinct `ThreadLocalStream` resolves to its own concrete `mx.Stream` on whatever thread touches it.

Measured on the engine thread with the pinned mlx 0.32.0, the three streams involved are all different — `self._stream` → `Stream(gpu, 1)`, `_default_generation_stream` → `Stream(gpu, 2)`, and the thread default that the bare `mx.synchronize()` drains → `Stream(gpu, 0)`.

Driving the real helper on a worker thread standing in for the engine executor, with a dependent matmul chain queued on the engine stream via `mx.async_eval`: the bare call returns in 0.1–0.2 ms and leaves 69–70 ms of engine-stream work still in flight when `mx.clear_cache()` runs, while `_sync_and_clear_cache(self._stream)` blocks the full 69.5–70.1 ms and leaves 0.0 ms outstanding. Consistent across three trials.

The failure is silent: no `RuntimeError` is raised on any of these calls in 0.32.0, so the helper's swallowed-exception branch never fires and nothing shows up in the logs. This is the same cross-thread thread-local-stream behavior you traced in the #1146 merge comment (both `mx.synchronize()` forms returning in ~0.1 ms from a foreign thread right after a heavy dispatch, on 0.31.2) — the 0.1–0.2 ms bare-call return above is that same no-op, measured on 0.32.0.

All six sites are memory-pressure handlers (capacity rejection and hard-memory-limit `RuntimeError`), so they run precisely when the buffer pool is most contended. I have not attributed any reported panic to them — this is the invariant, restored on the paths that lost it.

How they drifted: `0169f159` added three bare calls when the helper took no stream argument; `56860b32` added `stream=` the next day and swept the other call sites but missed these three; `4c64f163` later copy-pasted the stale pattern to three more.

## Changes

`omlx/scheduler.py` — `_sync_and_clear_cache()` → `_sync_and_clear_cache(self._stream)` at six sites across three `try`/`except` ladders:

`_advance_chunked_prefills`, in-flight chunk — the `PrefillMemoryExceededError` and `RuntimeError` handlers, whose `_PrefillAbortedError` sibling and prefill-complete branch already pass `self._stream`.

`_schedule_waiting`, first chunk of a chunked prefill — the same two handlers, whose `_PrefillAbortedError` sibling and `done` branch already pass `self._stream`.

`_schedule_waiting`, non-chunked full prefill — the same two handlers. This ladder has no in-ladder guarded sibling, but its callee `_do_external_prefill` runs its forward under `with mx.stream(self._stream)` and its own internal clears are already stream-scoped, so `self._stream` is the stream that carried the work here too.

## Sibling sweep

`rg -n "_sync_and_clear_cache\(\)" omlx/` after the change leaves exactly one call site, and it is correct as-is:

`omlx/patches/qwen35_moe_gate_up.py:215` — the per-layer drain during load-time MoE gate/up fusion. Examined and deliberately unchanged: it runs at model-load time from the fusion pass, with no scheduler or engine in scope, so there is no engine stream to pass.

Also examined and left alone: `omlx/admin/routes.py:4964,4966` pass `_sync_and_clear_cache` as a bare callable to `run_in_executor(get_mlx_executor(), ...)`. Those are the documented fallbacks for when no engine executor is available (every model unloaded, or the engine executor already shut down); the per-engine branch just above at :4954 already forwards the scheduler's stream.

## Tests

Six new cases in the existing `tests/test_scheduler_chunked_prefill.py` (`TestPrefillCleanupUsesEngineStream`), one per fixed site. Each builds a `Scheduler` with a real per-engine `mx.new_thread_local_stream` the way `EngineCore` does and asserts it is not the module-level fallback, so the assertion cannot pass vacuously; then drives the real `_advance_chunked_prefills` / `_schedule_waiting` handler with the error injected at `_step_prefill_chunk` / `_do_external_prefill` and asserts every `_sync_and_clear_cache` call the handler made received `scheduler._stream`.

RED proof — with the tests in place and `omlx/scheduler.py` reverted to `main`, all six fail with `[None] != ThreadLocalStream(...)`; with the fix, all six pass.

```
PYTHONPATH=. python -m pytest tests/test_scheduler_chunked_prefill.py -q
59 passed in 2.47s

PYTHONPATH=. python -m pytest -m "not slow and not integration" -q
3 failed, 7305 passed, 52 skipped, 70 deselected in 267.21s
```

The three failures are pre-existing on `main` and unrelated — ~1e-4 gemm tolerance failures on this machine against `2e-5`/`1e-4` asserts in `test_glm_mtp_patch.py` (×2) and `test_mtp_prompt_priming.py` (×1). Re-running just those three with the branch stashed and the worktree verified clean at `main` reproduces them identically.
