### PR TITLE
fix(metal): drain the GPU stream before the hot-loop cache clears

### DIFF
--- a/omlx/patches/glm_moe_dsa/generate_patch.py
+++ b/omlx/patches/glm_moe_dsa/generate_patch.py
@@ -17,6 +17,8 @@ from typing import Any
 
 import mlx.core as mx
 
+from ...utils.metal_sync import _sync_and_clear_cache
+
 logger = logging.getLogger(__name__)
 
 _APPLIED = False
@@ -193,7 +195,12 @@ def apply_glm_moe_dsa_generate_patch() -> bool:
             self._gen_tokens_counter += len(generation_responses)
             self._steps_counter += 1
             if self._steps_counter % 512 == 0:
-                mx.clear_cache()
+                # GenerationBatch.next() submits the decode step with
+                # mx.async_eval, so the periodic clear has to drain that work
+                # first. self._stream is the stream it rode: BatchGenerator
+                # runs _next() inside ``with mx.stream(self._stream)`` and
+                # oMLX constructs the generator with the per-engine stream.
+                _sync_and_clear_cache(self._stream)
 
         if len(self._generation_batch) >= self.completion_batch_size:
             return prompt_responses, generation_responses

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -34,7 +34,6 @@ from mlx_lm.generate import (
     GenerationBatch,
     PromptProcessingBatch,
     SequenceStateMachine,
-    generation_stream,
 )
 from mlx_lm.models.cache import (
     KVCache as _MLXKVCache,
@@ -63,13 +62,14 @@ from .speculative.vlm_mtp import VLMMTPDrafter, run_vlm_mtp_decode
 from .utils.fatal import FATAL_TEARDOWN_TIMEOUT_S, fatal_exit
 from .utils.generation_config import load_generation_config_token_ids
 from .utils.hardware import format_bytes
+from .utils.metal_sync import (
+    _default_generation_stream,
+    _mx_buffer_access_lock,
+    _sync_and_clear_cache,
+)
 from .utils.proc_memory import get_phys_footprint
 from .utils.sampling import make_sampler as omlx_make_sampler
 from .utils.tokenizer import create_streaming_detokenizer
-
-# Module-level alias so Scheduler.__init__ can fall back to mlx-lm's default
-# stream when no per-engine stream is provided.
-_default_generation_stream = generation_stream
 
 
 def _apply_suppress_token_ids(logits: Any, suppress_token_ids: tuple[int, ...]) -> Any:
@@ -190,45 +190,6 @@ class _StopOutputState:
 
     strings: dict[tuple[int, ...], str]
     pending: deque[tuple[int, RequestOutput]] = field(default_factory=deque)
-
-
-# Serializes Metal buffer-protocol access from the async store-cache worker
-# against inference-thread mx.clear_cache / mx.synchronize calls that can
-# invalidate the underlying buffer pool. Closes a SIGABRT path where
-# _async_store_cache_worker reads tensor bytes via memoryview while the
-# inference thread concurrently issues a reclaim-triggering mx op.
-# See: https://github.com/jundot/omlx/issues/1106
-_mx_buffer_access_lock = threading.RLock()
-
-
-def _sync_and_clear_cache(stream=None):
-    """Synchronize in-flight GPU work before clearing the Metal buffer cache.
-
-    Without synchronization, mx.clear_cache() can release Metal buffers that
-    are still referenced by in-flight command buffers submitted via
-    mx.async_eval(). This causes the GPU driver to hit a
-    'completeMemory() prepare count underflow' kernel panic on M4 hardware
-    (and SIGSEGV/SIGABRT on M3).
-
-    Held under _mx_buffer_access_lock so the async store-cache worker cannot
-    observe a half-reclaimed Metal buffer pool while it is in the middle of
-    reading tensor bytes via the Python buffer protocol (#1106).
-
-    See: https://github.com/jundot/omlx/issues/300, #888, #1106
-    """
-    with _mx_buffer_access_lock:
-        # The engine stream may not have in-flight work on the current thread
-        # (for example, during teardown before that thread submits work). On
-        # some MLX builds mx.synchronize raises "There is no Stream(gpu, 0) in
-        # current thread" in that case; swallow it since there is nothing to
-        # drain.
-        target = stream if stream is not None else _default_generation_stream
-        try:
-            mx.synchronize(target)
-        except RuntimeError:
-            pass
-        mx.synchronize()  # default stream
-        mx.clear_cache()
 
 
 def _safe_sync_stream(stream=None):

--- a/omlx/speculative/vlm_mtp.py
+++ b/omlx/speculative/vlm_mtp.py
@@ -44,6 +44,13 @@ import mlx.nn as nn
 
 from mlx_vlm.speculative import load_drafter as _vlm_load_drafter
 
+# The round loops dispatch their target-verify and cache-rollback forwards
+# inside ``with mx.stream(generation_stream)``, using mlx-vlm's own
+# thread-local stream — a different object from mlx-lm's generation_stream
+# and from the per-engine stream. Draining the MTP work means draining this
+# one, resolved on the thread that advances the round loop.
+from mlx_vlm.speculative.common import generation_stream as _vlm_generation_stream
+
 # PR #1169 (f96138e) moved the MTP round loop helpers from ``mlx_vlm.generate``
 # into ``mlx_vlm.speculative.utils``. Import directly from the new location —
 # the symbols are still ``_``-prefixed but this is now their canonical home.
@@ -55,6 +62,7 @@ except Exception:  # pragma: no cover - compatibility with older mlx-vlm
     def _buffer_mtp_target_cache(*_args: Any, **_kwargs: Any) -> None:
         return None
 
+from ..utils.metal_sync import _sync_and_clear_cache
 from ..utils.model_loading import materialize_lazy_state
 
 logger = logging.getLogger(__name__)
@@ -362,7 +370,15 @@ def run_vlm_mtp_decode(
             # _mtp_rounds_batch in mlx_vlm/speculative/utils.py). On large
             # targets like Gemma 4 31B the buffer pool balloons between
             # those flushes (issue #1416). Clearing per round bounds it.
-            mx.clear_cache()
+            #
+            # The round leaves work in flight on two streams at this yield
+            # boundary: mlx-vlm async_evals the verify hidden state and the
+            # drafter's state arrays. The helper drains the stream it is
+            # given plus the current default stream, so passing mlx-vlm's
+            # stream covers the verify forwards while the default-stream
+            # drain covers the engine stream the scheduler advances this
+            # generator under (``with mx.stream(self._stream)``).
+            _sync_and_clear_cache(_vlm_generation_stream)
             yield tokens
         return
 
@@ -387,5 +403,6 @@ def run_vlm_mtp_decode(
         draft_block_size=draft_block_size,
         token_dtype=token_dtype,
     ):
-        mx.clear_cache()
+        # Same two-stream drain as the batched branch above.
+        _sync_and_clear_cache(_vlm_generation_stream)
         yield tok

--- a/omlx/utils/metal_sync.py
+++ b/omlx/utils/metal_sync.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Sync-before-clear primitive for the Metal buffer cache.
+
+``mx.clear_cache()`` releases buffers from MLX's Metal buffer pool. If work
+that references those buffers is still in flight, the driver can hit a
+kernel panic, so every cache clear in oMLX has to drain the stream that
+carried the work first. This module is the single home for that primitive
+plus the lock that keeps it from racing the async store-cache worker.
+
+Callers on an inference thread pass the stream their work rode on (the
+per-engine stream for scheduler paths, ``BatchGenerator._stream`` inside
+mlx-lm patches, the dependency's own stream where the dependency dispatched
+the work). An mlx ``ThreadLocalStream`` resolves to a different concrete
+``mx.Stream`` per calling thread, so the drain only covers the stream it is
+given, resolved on the calling thread.
+"""
+
+import threading
+
+import mlx.core as mx
+from mlx_lm.generate import generation_stream
+
+# Module-level alias so callers can fall back to mlx-lm's default stream
+# when no per-engine stream is provided.
+_default_generation_stream = generation_stream
+
+# Serializes Metal buffer-protocol access from the async store-cache worker
+# against inference-thread mx.clear_cache / mx.synchronize calls that can
+# invalidate the underlying buffer pool. Closes a SIGABRT path where
+# _async_store_cache_worker reads tensor bytes via memoryview while the
+# inference thread concurrently issues a reclaim-triggering mx op.
+# See: https://github.com/jundot/omlx/issues/1106
+_mx_buffer_access_lock = threading.RLock()
+
+
+def _sync_and_clear_cache(stream=None):
+    """Synchronize in-flight GPU work before clearing the Metal buffer cache.
+
+    Without synchronization, mx.clear_cache() can release Metal buffers that
+    are still referenced by in-flight command buffers submitted via
+    mx.async_eval(). This causes the GPU driver to hit a
+    'completeMemory() prepare count underflow' kernel panic on M4 hardware
+    (and SIGSEGV/SIGABRT on M3).
+
+    Held under _mx_buffer_access_lock so the async store-cache worker cannot
+    observe a half-reclaimed Metal buffer pool while it is in the middle of
+    reading tensor bytes via the Python buffer protocol (#1106).
+
+    See: https://github.com/jundot/omlx/issues/300, #888, #1106
+    """
+    with _mx_buffer_access_lock:
+        # The engine stream may not have in-flight work on the current thread
+        # (for example, during teardown before that thread submits work). On
+        # some MLX builds mx.synchronize raises "There is no Stream(gpu, 0) in
+        # current thread" in that case; swallow it since there is nothing to
+        # drain.
+        target = stream if stream is not None else _default_generation_stream
+        try:
+            mx.synchronize(target)
+        except RuntimeError:
+            pass
+        mx.synchronize()  # default stream
+        mx.clear_cache()

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
+from contextlib import contextmanager
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -1163,3 +1165,139 @@ def test_glm_indexer_decode_rows_skip_fused_scores_kernel(monkeypatch):
     for row in range(s1):
         row_pos = total - s1 + row
         assert max(idx[0, 0, row].tolist()) <= row_pos
+
+
+@contextmanager
+def _glm_generate_patch_installed():
+    """Install the adaptive-prefill generate patch, restore mlx-lm afterwards.
+
+    ``apply_glm_moe_dsa_generate_patch`` rebinds methods on mlx-lm's
+    BatchGenerator / PromptProcessingBatch classes process-wide, so the test
+    restores the originals (and the applied markers) to keep the monkey patch
+    out of other tests. Re-entry is safe: when the patch is already installed
+    the apply call is a no-op and the saved originals are the patched ones.
+    """
+    from omlx.patches.glm_moe_dsa import generate_patch as patch_mod
+
+    gen = importlib.import_module("mlx_lm.generate")
+    saved_methods = {
+        (gen.PromptProcessingBatch, "__init__"): gen.PromptProcessingBatch.__init__,
+        (gen.PromptProcessingBatch, "_copy"): gen.PromptProcessingBatch._copy,
+        (gen.PromptProcessingBatch, "split"): gen.PromptProcessingBatch.split,
+        (gen.PromptProcessingBatch, "prompt"): gen.PromptProcessingBatch.prompt,
+        (gen.BatchGenerator, "__init__"): gen.BatchGenerator.__init__,
+        (gen.BatchGenerator, "_next"): gen.BatchGenerator._next,
+    }
+    saved_step = gen.generate_step
+    saved_applied = patch_mod._APPLIED
+    marker = "_omlx_glm_dsa_adaptive_patched"
+    had_marker = {
+        cls: marker in cls.__dict__
+        for cls in (gen.PromptProcessingBatch, gen.BatchGenerator)
+    }
+
+    patch_mod._APPLIED = False
+    try:
+        patch_mod.apply_glm_moe_dsa_generate_patch()
+        assert getattr(gen.BatchGenerator, marker, False)
+        yield gen
+    finally:
+        for (cls, name), method in saved_methods.items():
+            setattr(cls, name, method)
+        gen.generate_step = saved_step
+        patch_mod._APPLIED = saved_applied
+        for cls, present in had_marker.items():
+            if not present and marker in cls.__dict__:
+                delattr(cls, marker)
+
+
+def _decode_only_batch_generator(stream) -> SimpleNamespace:
+    """Duck-typed BatchGenerator self for the decode branch of ``_next``.
+
+    ``completion_batch_size == 1`` with a one-sequence generation batch makes
+    ``_next`` return right after the decode step, so the probe covers the
+    periodic-clear branch and nothing else.
+    """
+
+    class _GenerationBatch:
+        def __len__(self):
+            return 1
+
+        def next(self):
+            return ["generation"]
+
+    from omlx.patches.glm_moe_dsa.generate_patch import _AdaptivePrefillConfig
+
+    return SimpleNamespace(
+        _omlx_glm_dsa_adaptive_prefill=_AdaptivePrefillConfig(
+            step_size=8192, after=0, min_remaining=0
+        ),
+        _generation_batch=_GenerationBatch(),
+        _gen_tokens_counter=0,
+        _steps_counter=511,
+        completion_batch_size=1,
+        _stream=stream,
+    )
+
+
+def test_glm_adaptive_decode_periodic_clear_drains_generator_stream():
+    """The every-512-steps clear inside the patched decode loop must drain the
+    stream the decode step ran on first.
+
+    ``GenerationBatch.next()`` submits the step with mx.async_eval, so a bare
+    mx.clear_cache() can release Metal buffers an in-flight command buffer
+    still references (issue #300). ``self._stream`` is the stream that work
+    rode: BatchGenerator runs ``_next`` inside ``with mx.stream(self._stream)``
+    and oMLX constructs the generator with the per-engine stream, which
+    resolves to a different concrete mx.Stream than mlx-lm's module-level
+    generation_stream.
+    """
+    mx = pytest.importorskip("mlx.core")
+    from omlx.patches.glm_moe_dsa import generate_patch as patch_mod
+
+    engine_stream = mx.new_thread_local_stream(mx.default_device())
+    bg = _decode_only_batch_generator(engine_stream)
+
+    streams: list = []
+    with (
+        _glm_generate_patch_installed() as gen,
+        patch.object(
+            patch_mod,
+            "_sync_and_clear_cache",
+            side_effect=lambda stream=None: streams.append(stream),
+        ),
+    ):
+        prompt_responses, generation_responses = gen.BatchGenerator._next(bg)
+
+    assert generation_responses == ["generation"]
+    assert prompt_responses == []
+    assert bg._steps_counter == 512
+    assert streams, "periodic decode clear did not drain any stream"
+    assert streams == [engine_stream], (
+        "periodic decode clear released Metal buffers without draining the "
+        f"generator's stream: {streams!r} != {engine_stream!r}"
+    )
+
+
+def test_glm_adaptive_decode_clears_only_on_the_512_step_cadence():
+    """Off-cadence steps must not clear at all — the fix keeps the cadence the
+    memory-bounding commit chose, it only adds the drain."""
+    mx = pytest.importorskip("mlx.core")
+    from omlx.patches.glm_moe_dsa import generate_patch as patch_mod
+
+    bg = _decode_only_batch_generator(mx.new_thread_local_stream(mx.default_device()))
+    bg._steps_counter = 0
+
+    streams: list = []
+    with (
+        _glm_generate_patch_installed() as gen,
+        patch.object(
+            patch_mod,
+            "_sync_and_clear_cache",
+            side_effect=lambda stream=None: streams.append(stream),
+        ),
+    ):
+        gen.BatchGenerator._next(bg)
+
+    assert bg._steps_counter == 1
+    assert streams == []

--- a/tests/test_vlm_mtp.py
+++ b/tests/test_vlm_mtp.py
@@ -196,6 +196,102 @@ def test_run_vlm_mtp_decode_single_scalar_array_unwraps_to_int():
     assert m_single.call_args.kwargs["first_bonus"] == 42
 
 
+class TestMTPRoundClearDrainsGPUWork:
+    """The per-token cache clear must drain the round's GPU work first.
+
+    mlx-vlm submits the MTP verify hidden state and the drafter's state
+    arrays with mx.async_eval, so mx.clear_cache() at the yield boundary can
+    release Metal buffers an in-flight command buffer still references (#300).
+    The drain has to name mlx-vlm's own thread-local stream: that is the
+    stream ``_mtp_rounds`` dispatches the verify/rollback forwards on
+    (``with mx.stream(generation_stream)``), and it is a different object from
+    mlx-lm's generation_stream. The helper's second, no-argument
+    mx.synchronize() covers the engine stream the scheduler advances the
+    generator under.
+    """
+
+    @staticmethod
+    def _recorder() -> tuple[list, object]:
+        streams: list = []
+        return streams, patch.object(
+            vlm_mtp,
+            "_sync_and_clear_cache",
+            side_effect=lambda stream=None: streams.append(stream),
+        )
+
+    def _assert_vlm_stream(self, streams: list, expected_calls: int) -> None:
+        from mlx_lm.generate import generation_stream as mlx_lm_stream
+
+        assert len(streams) == expected_calls, (
+            f"expected {expected_calls} synchronized clear(s), got {streams!r}"
+        )
+        assert all(s is vlm_mtp._vlm_generation_stream for s in streams), (
+            "MTP round cleared the Metal buffer cache without draining "
+            f"mlx-vlm's stream: {streams!r}"
+        )
+        assert vlm_mtp._vlm_generation_stream is not mlx_lm_stream
+
+    def test_single_round_loop_drains_before_every_token_yield(self):
+        """Each token yielded by ``_mtp_rounds`` is preceded by a synchronized
+        clear; the wrapper's own first_bonus yield needs none (no round has
+        run yet)."""
+        drafter = vlm_mtp.VLMMTPDrafter(
+            _fake_drafter_model("gemma4_assistant"), "mtp", "/p"
+        )
+        streams, recording = self._recorder()
+
+        with (
+            recording,
+            patch.object(
+                vlm_mtp, "_mtp_rounds", return_value=iter([(11, None), (22, None)])
+            ),
+            patch.object(vlm_mtp, "_buffer_mtp_target_cache"),
+        ):
+            gen = vlm_mtp.run_vlm_mtp_decode(
+                target_language_model=MagicMock(),
+                drafter=drafter,
+                prompt_cache=[],
+                hidden=mx.zeros((1, 1, 8)),
+                shared_kv_states={},
+                first_bonus=7,
+                max_tokens=4,
+                sampler=MagicMock(),
+            )
+            assert next(gen) == 7
+            assert streams == [], "first_bonus yield must not clear the cache"
+            assert next(gen) == 11
+            self._assert_vlm_stream(streams, 1)
+            assert next(gen) == 22
+            self._assert_vlm_stream(streams, 2)
+
+    def test_batch_round_loop_drains_before_every_round_yield(self):
+        drafter = vlm_mtp.VLMMTPDrafter(
+            _fake_drafter_model("gemma4_assistant"), "mtp", "/p"
+        )
+        streams, recording = self._recorder()
+        yielded = [([1, None, 3], None), ([None, None, None], None)]
+
+        with (
+            recording,
+            patch.object(vlm_mtp, "_mtp_rounds_batch", return_value=iter(yielded)),
+        ):
+            out = list(
+                vlm_mtp.run_vlm_mtp_decode(
+                    target_language_model=MagicMock(),
+                    drafter=drafter,
+                    prompt_cache=[],
+                    hidden=mx.zeros((3, 1, 8)),
+                    shared_kv_states={},
+                    first_bonus=mx.array([1, 2, 3]),
+                    max_tokens=4,
+                    sampler=MagicMock(),
+                )
+            )
+
+        assert out == [[1, 2, 3], [1, None, 3], [None, None, None]]
+        self._assert_vlm_stream(streams, 2)
+
+
 @pytest.mark.parametrize(
     "vlm_mtp_kw, other_kw",
     [


### PR DESCRIPTION
Refs: #300

## Summary

Two decode hot loops released Metal buffer-cache memory with a bare `mx.clear_cache()`, with no synchronization of any kind first — not even an eval. Both run inside `async_eval`-pipelined decode, so the clear can release buffers that an in-flight command buffer still references, which is the pattern `_sync_and_clear_cache()` exists to prevent (#300, #888). This routes both through that helper, each passing the stream its work actually rode, and moves the helper out of `scheduler.py` into `omlx/utils/metal_sync.py` so non-scheduler callers can reach it. Clear cadence is unchanged at both sites; no new settings, no behavior change for the existing call sites.

## Why

`omlx/patches/glm_moe_dsa/generate_patch.py` clears every 512 decode steps in the patched `BatchGenerator._next` (live for the GLM-5.2 family since #1984). The work being cleared over is mlx-lm's `GenerationBatch.next()`, which submits the step with `mx.async_eval`. The stream it rode is the generator's own `self._stream`: mlx-lm runs `_next()` only inside `with mx.stream(self._stream)` (`next()` / `next_generated()`), and oMLX constructs the generator with the per-engine stream (`scheduler.py`, `stream=self._stream`). The scheduler's own periodic clear on the same loop already does `_sync_and_clear_cache(self._stream)` every 1024 tokens — this makes the patched path match it.

`omlx/speculative/vlm_mtp.py` clears at every round-loop yield (added to bound the buffer-pool peak on large targets, #1416 — mlx-vlm itself only clears every 256 tokens). Two streams carry in-flight work at that boundary: mlx-vlm `async_eval`s the verify hidden state and the drafter's state arrays, dispatching the verify and rollback forwards inside `with mx.stream(generation_stream)` on `mlx_vlm.speculative.common.generation_stream`, while the rest of the round (draft block, acceptance walk, `set_shared_kv`) inherits the stream the scheduler advances the generator under — `with mx.stream(self._stream): next(state.generator)`. So the site passes mlx-vlm's stream explicitly, and the helper's second, no-argument `mx.synchronize()` drains the current default stream, which inside that `with` block is the engine stream. Both sets are covered with no new parameter, keeping stream context inherited rather than re-read.

Note that mlx's `ThreadLocalStream` resolves to a different concrete `mx.Stream` per touching thread, and a cross-thread sync of one is a silent no-op — the three streams involved here (mlx-lm's `generation_stream`, mlx-vlm's speculative `generation_stream`, and the per-engine stream) are distinct objects, so naming the right one matters. Both drains happen on the same thread that submitted the work, in the same call frame.

Cost: a micro-benchmark shaped like an MTP yield (heavy verify chain on mlx-vlm's stream, `.tolist()` force as `_speculative_walk` does, drafter tail `async_eval` on the engine stream, then the clear) puts the added drain at 0.11-0.19 ms per yield across two runs — under 1% of a real MTP token on the 31B-class targets that route here, because the verify graph is already forced by the acceptance walk and only the round's tail remains in flight. That is a micro-benchmark, not an e2e MTP run. One tradeoff worth naming: the helper takes `_mx_buffer_access_lock`, so with `paged_ssd_cache_dir` enabled the clear can now wait on the async store-cache worker — the same serialization the scheduler's per-chunk and per-1024-token clears already accept, and it is the point of the lock (#1106).

## Changes

- New `omlx/utils/metal_sync.py`: `_sync_and_clear_cache()`, `_mx_buffer_access_lock`, and the `_default_generation_stream` alias, moved verbatim from `scheduler.py` (docstrings and issue references unchanged).
- `omlx/scheduler.py` imports and re-exports the same three names, so all ~30 existing call sites, `engine_core.py`'s import, the injected `sync_and_clear_cache=` lambdas, and existing tests that patch `omlx.scheduler._sync_and_clear_cache` are untouched. Extraction is behavior-neutral.
- `omlx/patches/glm_moe_dsa/generate_patch.py`: the every-512-steps clear becomes `_sync_and_clear_cache(self._stream)`.
- `omlx/speculative/vlm_mtp.py`: both round-loop clears (single and batched) become `_sync_and_clear_cache(_vlm_generation_stream)`.

The extraction is deliberately minimal and does not convert any other ad-hoc `mx.clear_cache()` site. The remaining ones — `engine/base.py` `_finish_activity` and the ancillary embedding/reranker/tts/stt/sts engines, the `engine_pool.py` load/unload/reclaim paths, `dflash.py` eviction, `vlm.py` diffusion cleanup, `admin/oq_manager.py`, and the `oq.py` eval-then-clear sites — each need their own stream/thread analysis and belong in separate PRs; a shared module is what makes those migrations possible one at a time.

## Tests

`python -m pytest -m "not slow and not integration" -q` → `3 failed, 7303 passed, 52 skipped, 70 deselected`. The 3 failures are pre-existing on a clean checkout of the same base (`test_glm_mtp_patch.py` x2, `test_mtp_prompt_priming.py` x1 — M5 NAX gemm tolerance, ~1e-4 vs 2e-5/1e-4 thresholds, unrelated to this change).

New regression coverage in the existing per-module test files, driving the real code paths and asserting the stream the helper was called with:

- `tests/test_glm_moe_dsa_patch.py`: the periodic decode clear drains the generator's stream; and it still only fires on the 512-step cadence. The first drives the actually-installed patched `BatchGenerator._next`, restoring mlx-lm's originals afterwards so the process-wide monkey patch does not leak into other tests.
- `tests/test_vlm_mtp.py`: every token yield of the single-request round loop, and every row yield of the batched loop, is preceded by a synchronized clear naming mlx-vlm's stream (and not mlx-lm's); the wrapper's own `first_bonus` yield clears nothing.

RED without the fix: reverting just the two sites to `mx.clear_cache()` fails 3 of the 4 (`did not drain any stream` / `expected N synchronized clear(s), got []`). The cadence test passes either way by design — it pins the cadence the memory-bounding change chose, so a future edit cannot quietly turn the periodic clear into a per-step clear.
