### PR TITLE
fix: guard the prefill transient EWMA against single-sample outliers

### DIFF
--- a/omlx/prefill_transient_tracker.py
+++ b/omlx/prefill_transient_tracker.py
@@ -32,6 +32,18 @@ class PrefillTransientTracker:
     # genuinely recurring giant transient still reaches the guard through
     # the last-delta/EWMA terms of _predicted_chunk_transient.
     _OBSERVED_MAX_CLAMP_BYTES = 4 * 1024**3
+    # A sample whose per_token exceeds the current EWMA by more than this
+    # ratio is treated as measurement noise (a tail/residual prefill chunk,
+    # not a genuine cost-per-token regime change) and excluded from the EWMA
+    # blend. Chosen from a real incident (2026-07-29, Qwen3.6-35B-A3B):
+    # baseline samples ranged ~525-1867 KB/token (largest legitimate
+    # fluctuation ~1.7x the running EWMA) before a single n=185 tail chunk
+    # measured 10497.1 KB/token — a ~13.6x jump off an EWMA of 773.3 KB/token
+    # — and pushed the EWMA to 3690.5 KB/token in one update, poisoning every
+    # later admission check for the rest of the process lifetime. 8x sits
+    # above the largest observed legitimate fluctuation and below the
+    # observed outlier.
+    _EWMA_OUTLIER_RATIO = 8.0
 
     def __init__(self, model_id: str = "") -> None:
         self._model_id = model_id
@@ -62,6 +74,13 @@ class PrefillTransientTracker:
         floor; charging the big-chunk max at admission rejected every
         prompt at a 21GB ceiling). Big-chunk transients stay the throttle's
         domain via the EWMA/last-delta terms.
+
+        A sample whose per-token rate exceeds the current EWMA by more than
+        ``_EWMA_OUTLIER_RATIO`` is excluded from the EWMA blend (see that
+        constant's docstring) — it still counts toward ``samples`` and
+        still updates ``last_delta_bytes``/``last_n_tokens`` raw, so a
+        genuine regime change remains visible via those fields even while
+        the accumulated EWMA is protected from a single noisy reading.
         """
         if n_tokens <= 0:
             return
@@ -87,6 +106,21 @@ class PrefillTransientTracker:
         per_token = transient_bytes / n_tokens
         if self._samples == 0:
             self._ewma_per_token = per_token
+        elif per_token > self._ewma_per_token * self._EWMA_OUTLIER_RATIO:
+            # Reject from the EWMA blend: a single sample this far above
+            # the running rate is more likely a noisy phys_footprint()
+            # delta (see _record_chunk_transient's docstring on
+            # buffer-pool-driven noise) than a real per-token cost jump.
+            # last_delta_bytes/last_n_tokens below still record it raw for
+            # diagnostics — only the accumulated EWMA is protected.
+            logger.debug(
+                "PrefillTransientTracker(%s): rejected %.1f-byte/token "
+                "outlier from EWMA (current %.1f, ratio limit %.1fx)",
+                self._model_id,
+                per_token,
+                self._ewma_per_token,
+                self._EWMA_OUTLIER_RATIO,
+            )
         else:
             self._ewma_per_token = (
                 self._EWMA_ALPHA * per_token

--- a/tests/test_prefill_transient_tracker.py
+++ b/tests/test_prefill_transient_tracker.py
@@ -40,6 +40,65 @@ class TestUpdate:
         assert t.samples == 0
 
 
+class TestEwmaOutlierGuard:
+    """Regression coverage for the 2026-07-29 incident: a single noisy
+    tail-chunk reading poisoned the EWMA (773.3 -> 3690.5 KB/token off one
+    n=185 sample), which then bounded every later admission check for the
+    rest of the process lifetime, independent of cache-credit accuracy."""
+
+    def test_first_sample_never_rejected_even_if_extreme(self):
+        # No prior EWMA to compare a ratio against — must seed unconditionally.
+        t = PrefillTransientTracker("m")
+        t.update(n_tokens=185, transient_bytes=int(10497.1 * 1024 * 185))
+        assert t.samples == 1
+        assert t.bytes_per_token == 10497.1 * 1024
+
+    def test_incident_outlier_rejected_from_ewma(self):
+        t = PrefillTransientTracker("m")
+        # Baseline regime: per-token readings observed in
+        # ~/.omlx/logs/server.log 16:08:48-16:09:39 (KB/token), replayed as
+        # (n_tokens=2048, transient_bytes) pairs.
+        baseline_kb_per_token = [
+            1058.0, 1171.0, 1085.0, 1103.0, 1123.1, 1141.3, 991.2, 1131.2,
+            1099.3, 1839.3, 1867.3, 1186.5, 1031.4, 1529.5, 1117.5,
+        ]
+        for kb in baseline_kb_per_token:
+            t.update(n_tokens=2048, transient_bytes=int(kb * 1024 * 2048))
+        ewma_before_outlier = t.bytes_per_token
+        assert 900 * 1024 < ewma_before_outlier < 2000 * 1024
+
+        # The actual outlier: n=185, per_token=10497.1KB (~13.6x the EWMA
+        # just before it, matching the live 773.3 -> 3690.5 KB/token jump).
+        t.update(n_tokens=185, transient_bytes=int(10497.1 * 1024 * 185))
+
+        # EWMA must stay close to its pre-outlier value, not jump toward
+        # the outlier's per-token rate.
+        assert t.bytes_per_token < ewma_before_outlier * 2
+        assert t.bytes_per_token < 3000 * 1024, (
+            "EWMA must not reach the ~3690.5 KB/token value observed in "
+            "production before this fix"
+        )
+        # The raw sample is still visible for diagnostics.
+        assert t.last_n_tokens == 185
+        assert t.last_delta_bytes == int(10497.1 * 1024 * 185)
+
+    def test_legitimate_fluctuation_within_ratio_still_updates_ewma(self):
+        t = PrefillTransientTracker("m")
+        t.update(n_tokens=2048, transient_bytes=int(1097.3 * 1024 * 2048))
+        ewma_before = t.bytes_per_token
+        # Matches the live 1097.3 -> 1839.3 KB/token jump (~1.68x): well
+        # under the outlier ratio, must be treated as a normal sample.
+        t.update(n_tokens=2048, transient_bytes=int(1839.3 * 1024 * 2048))
+        expected = 0.3 * (1839.3 * 1024) + 0.7 * ewma_before
+        assert abs(t.bytes_per_token - expected) < 1.0
+
+    def test_outlier_still_counts_as_a_sample(self):
+        t = PrefillTransientTracker("m")
+        t.update(n_tokens=2048, transient_bytes=int(1000 * 1024 * 2048))
+        t.update(n_tokens=185, transient_bytes=int(20000 * 1024 * 185))
+        assert t.samples == 2, "rejected-from-EWMA samples still count"
+
+
 class TestPredict:
     def test_predict_zero_when_no_samples(self):
         t = PrefillTransientTracker("m")
@@ -89,9 +148,14 @@ class TestObservedMax:
         t = PrefillTransientTracker("m")
         t.update(32, 100_000_000, floor_sample=True)  # first sample, excluded
         t.update(32, 200_000_000, floor_sample=True)
+        ewma_before = t.bytes_per_token
         t.update(32, 5 * 1024**3, floor_sample=True)  # above 4GiB clamp
         assert t.observed_max_bytes == 200_000_000, "outlier must not enter"
-        assert t.samples == 3, "outlier still feeds the EWMA"
+        assert t.samples == 3, "outlier still counts as a sample"
+        # This 5GiB/32-token reading is also a >8x EWMA outlier (see
+        # TestEwmaOutlierGuard), so it must not move the EWMA either —
+        # it is excluded from both the observed-max and the EWMA now.
+        assert t.bytes_per_token == ewma_before
 
     def test_skipped_samples_do_not_touch_max(self):
         t = PrefillTransientTracker("m")


### PR DESCRIPTION
## Summary

- `PrefillTransientTracker`'s EWMA (`bytes_per_token`, feeding the adaptive prefill throttle and the admission guard's transient charge) had no protection against a single noisy `phys_footprint()` sample, unlike `observed_max_bytes` which already has `floor_sample` gating + a 4GB absolute clamp for exactly this kind of outlier.
- Reproduced live (2026-07-29, Qwen3.6-35B-A3B, `~/.omlx/logs/server.log`): baseline samples ranged ~525-1867 KB/token (largest legitimate fluctuation ~1.7x the running EWMA), then a single `n=185` tail/residual prefill chunk measured 10497.1 KB/token — a ~13.6x jump off an EWMA of 773.3 KB/token — which poisoned the EWMA to 3690.5 KB/token in one update. That inflated value then bounded every later admission check for the rest of the process lifetime, independent of how accurately `cached_tokens` is credited elsewhere.

## What changes

- New `_EWMA_OUTLIER_RATIO = 8.0` constant, chosen above the largest observed legitimate fluctuation (~1.7x) and below the observed incident outlier (~13.6x).
- `PrefillTransientTracker.update()`: a sample whose `per_token` rate exceeds the current EWMA by more than this ratio is excluded from the EWMA blend. It still counts toward `samples` and still updates `last_delta_bytes`/`last_n_tokens`, so a genuine regime change stays visible via those raw fields — only the accumulated EWMA is protected.
- The very first sample after construction/`reset()` still seeds the EWMA unconditionally (no prior value to compare a ratio against).
- `observed_max_bytes` / `floor_sample` / `_OBSERVED_MAX_CLAMP_BYTES` semantics are untouched.

## Test plan

- [x] `tests/test_prefill_transient_tracker.py`: new `TestEwmaOutlierGuard` class — first-sample seeding is unaffected by extreme values, the exact incident outlier is rejected from the EWMA (encoded with the real recorded numbers), a legitimate ~1.7x fluctuation still updates the EWMA normally, and a rejected sample still counts toward `samples`.
- [x] Existing `TestObservedMax::test_outlier_above_clamp_rejected_not_clamped` updated: the same 5GiB/32-token outlier is also a >8x EWMA outlier, so it must not move `bytes_per_token` either (previously only asserted `observed_max_bytes` behavior).
- [x] Full local suite: 19/19 in this file pass; no other files import this module, so no other tests are affected.
- [x] Manual replay: fed the exact transcribed `(n_tokens, per_token)` sequence from the incident window through the patched tracker — it matches production's own EWMA step-for-step up to 773.3 KB/token, then the `n=185` outlier leaves it unchanged instead of jumping to 3690.5 KB/token.