### PR TITLE
fix(oq): load text-only VLM bases via mlx-lm

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -127,6 +127,25 @@ def _validate_oq_dtype_for_model(config: dict, dtype: str) -> None:
         )
 
 
+def _is_vlm_load(config: dict) -> bool:
+    """VLM routing predicate for oQ's model-load helpers.
+
+    Mirrors the VLM decision in :func:`_build_model_sanitizer`, but for the
+    sensitivity / imatrix / proxy load paths: route a checkpoint through
+    mlx-vlm only when it carries a vision sub-config *and* its model_type is
+    not one mlx-lm serves text-only (e.g. ``mimo_v2``). Without the text-only
+    exclusion these paths send a text-only-supported multimodal base -- which
+    still ships a ``vision_config`` -- to mlx-vlm, where ``get_model_and_args``
+    cannot resolve the model_type and falls through to the
+    ``mlx_vlm.speculative.drafters.<type>`` lookup and fails.
+    """
+    model_type = str(config.get("model_type", "")).lower().replace("-", "_")
+    return (
+        _has_vision_subconfig(config)
+        and model_type not in MLX_LM_TEXT_ONLY_MODEL_TYPES
+    )
+
+
 def _uses_quantized_source_sensitivity(config: dict) -> bool:
     """Return whether source sensitivity must perturb quantized modules."""
     quantization_config = config.get("quantization_config") or {}
@@ -6076,7 +6095,7 @@ def _collect_imatrix(
         maybe_apply_pre_load_patches,
     )
 
-    is_vlm = _has_vision_subconfig(config)
+    is_vlm = _is_vlm_load(config)
     has_mtp_weights = _checkpoint_has_mtp_weights(model_path)
     maybe_apply_pre_load_patches(model_path, for_vlm=is_vlm)
 
@@ -6378,10 +6397,11 @@ def _measure_sensitivity(
         maybe_apply_pre_load_patches,
     )
 
-    # Treat any model with a vision sub-config (vision_config / vit_config /
-    # mm_vision_tower) as a VLM for the MTP attach decision. The classifier
-    # in model_discovery._has_vision_subconfig owns the canonical predicate.
-    is_vlm = _has_vision_subconfig(config)
+    # Route the MTP attach / load decision via _is_vlm_load: a vision
+    # sub-config (vision_config / vit_config / mm_vision_tower) means VLM,
+    # except for model types mlx-lm serves text-only (e.g. mimo_v2), which
+    # ship a vision_config but must load through the patched mlx-lm class.
+    is_vlm = _is_vlm_load(config)
     has_mtp_weights = _checkpoint_has_mtp_weights(model_path)
 
     # Reuse the centralised pre-load dispatch so every current and future
@@ -6763,7 +6783,7 @@ def _measure_sensitivity_from_quantized_model(
     # load_model replacement for F8_E8M0 checkpoints, MTP sanitize, ...)
     # so the quantized source/proxy loads exactly as in production.
     # Idempotent; harmless for plain mlx-lm proxies.
-    is_vlm = _has_vision_subconfig(config)
+    is_vlm = _is_vlm_load(config)
     has_mtp_weights = _checkpoint_has_mtp_weights(model_path)
     maybe_apply_pre_load_patches(model_path, for_vlm=is_vlm)
 

--- a/tests/test_mimo_v2_patch.py
+++ b/tests/test_mimo_v2_patch.py
@@ -6,6 +6,7 @@ import json
 import sys
 
 import mlx.core as mx
+import pytest
 
 
 def _minimal_config(**overrides):
@@ -235,3 +236,107 @@ def test_oq_uses_mlx_lm_sanitizer_for_multimodal_mimo(monkeypatch):
 
     assert sanitize is not None
     assert sanitize({"visual.ignored": mx.ones((1,))}) == {}
+
+
+def _neutralize_sensitivity_deps(monkeypatch):
+    """Stub _measure_sensitivity's non-routing dependencies.
+
+    Leaves the ``is_vlm``-driven loader selection intact so a test can assert
+    which load path a config takes, without loading a real model or running
+    calibration.
+    """
+    import omlx.oq as oq
+    import omlx.utils.model_loading as ml
+
+    monkeypatch.setattr(ml, "_checkpoint_has_mtp_weights", lambda *_a, **_k: False)
+    monkeypatch.setattr(ml, "_has_mtp_heads", lambda *_a, **_k: False)
+    monkeypatch.setattr(ml, "maybe_apply_pre_load_patches", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        oq,
+        "_measure_sensitivity_from_model",
+        lambda *_a, **_k: {"model.layers.0": 1.0},
+    )
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        ({"model_type": "qwen2_vl", "vision_config": {"hidden_size": 32}}, True),
+        ({"model_type": "mimo_v2", "vision_config": {"hidden_size": 32}}, False),
+        ({"model_type": "mimo-v2", "vision_config": {"hidden_size": 32}}, False),
+        ({"model_type": "llama"}, False),
+        ({"model_type": "mimo_v2"}, False),
+    ],
+    ids=[
+        "genuine_vlm_is_vlm",
+        "text_only_mimo_with_vision_is_not_vlm",
+        "dashed_model_type_normalizes",
+        "plain_llm_is_not_vlm",
+        "mimo_text_only_quant_is_not_vlm",
+    ],
+)
+def test_is_vlm_load_predicate(config, expected):
+    from omlx.oq import _is_vlm_load
+
+    assert _is_vlm_load(config) is expected
+
+
+def test_measure_sensitivity_routes_multimodal_mimo_to_mlx_lm(monkeypatch):
+    # Exception path: a text-only-served mimo base ships a vision_config but must
+    # load via mlx-lm, not fall through to the mlx-vlm drafter lookup.
+    # _measure_sensitivity wraps the load in try/except -> {}, so record the
+    # loader calls rather than raising (a raise would be swallowed).
+    import mlx_vlm.utils as vlm_utils
+
+    import omlx.utils.model_loading as ml
+    from omlx.oq import _measure_sensitivity
+
+    _neutralize_sensitivity_deps(monkeypatch)
+    vlm_calls, lm_calls = [], []
+    monkeypatch.setattr(
+        vlm_utils, "load_model", lambda *_a, **_k: vlm_calls.append(True) or object()
+    )
+    monkeypatch.setattr(
+        ml,
+        "lm_load_compat",
+        lambda *_a, **_k: lm_calls.append(True) or (object(), object()),
+    )
+
+    config = _minimal_config(
+        vision_config={"hidden_size": 32},
+        audio_config={"hidden_size": 16},
+    )
+    result = _measure_sensitivity("/unused/path", config, oq_level=4)
+
+    assert vlm_calls == []
+    assert lm_calls == [True]
+    assert result == {"model.layers.0": 1.0}
+
+
+def test_measure_sensitivity_routes_genuine_vlm_to_mlx_vlm(monkeypatch):
+    # Happy path: a real VLM (vision_config + non-text-only model_type) still
+    # loads through mlx-vlm.
+    import mlx_lm.tokenizer_utils as tok_utils
+    import mlx_vlm.utils as vlm_utils
+
+    import omlx.utils.model_loading as ml
+    from omlx.oq import _measure_sensitivity
+
+    _neutralize_sensitivity_deps(monkeypatch)
+    vlm_calls, lm_calls = [], []
+    monkeypatch.setattr(
+        vlm_utils, "load_model", lambda *_a, **_k: vlm_calls.append(True) or object()
+    )
+    monkeypatch.setattr(tok_utils, "load", lambda *_a, **_k: object())
+    monkeypatch.setattr(
+        ml,
+        "lm_load_compat",
+        lambda *_a, **_k: lm_calls.append(True) or (object(), object()),
+    )
+
+    config = {"model_type": "qwen2_vl", "vision_config": {"hidden_size": 32}}
+    result = _measure_sensitivity("/unused/path", config, oq_level=4)
+
+    assert vlm_calls == [True]
+    assert lm_calls == []
+    assert result == {"model.layers.0": 1.0}


### PR DESCRIPTION
## Summary

Three oQ load paths choose between mlx-lm and mlx-vlm using
`_has_vision_subconfig` alone. A checkpoint whose vendored mlx-lm
implementation exposes only the text backbone still ships a `vision_config`, so
those paths hand it to mlx-vlm, where `get_model_and_args` cannot resolve the
model type, falls through to the `mlx_vlm.speculative.drafters.<type>` lookup,
and fails the load.

MiMo V2.5 is the current case.

## Why this is a routing bug rather than a missing model

The repository already encodes this distinction. `model_discovery.py` lists
`mimo_v2` in `MLX_LM_TEXT_ONLY_MODEL_TYPES`, with the comment that such
checkpoints should route directly "instead of deliberately failing an mlx-vlm
load and relying on the engine-pool fallback".

`_build_model_sanitizer` already consults that set (`oq.py:3069`). The
sensitivity, imatrix and proxy load paths did not, so the same checkpoint was
classified one way when building the sanitizer and another way when loading the
model for calibration.

## Change

Adds `_is_vlm_load(config)`, which is `_has_vision_subconfig(config)` minus the
model types mlx-lm serves text-only, and applies it at the three load sites:

- `_collect_imatrix`
- `_measure_sensitivity`
- `_measure_sensitivity_from_quantized_model`

`_has_vision_subconfig` keeps its existing meaning as the vision classifier and
is unchanged. The new predicate is specifically the load-routing decision, which
is why it lives next to the oQ load helpers rather than in `model_discovery`.

## Tests

`tests/test_mimo_v2_patch.py` covers the predicate directly and both routing
outcomes: a text-only multimodal base with a vision sub-config routes through
mlx-lm, and a genuine VLM still routes through mlx-vlm.

## Effect

Adding a family to `MLX_LM_TEXT_ONLY_MODEL_TYPES` now corrects oQ load routing
at the same time, rather than requiring a second, easily missed edit here.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
