### PR TITLE
fix(api): preserve partial prefill flag through message drop/merge (#2357)

### DIFF
--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -711,6 +711,11 @@ def _drop_void_assistant_messages(messages: list[dict]) -> list[dict]:
     Messages with ``tool_responses`` (Gemma 4 format) or ``reasoning_content``
     (Qwen 3.6+ native reasoning field) are never dropped even when content is
     empty — they carry their own payload the template renders.
+
+    A ``partial`` assistant message is also never dropped: partial mode is an
+    explicit request to continue from this turn (add_generation_prompt off), so
+    dropping an empty prefill would silently lose that intent and the caller
+    would get a fresh turn instead (#2357).
     """
     return [
         msg
@@ -721,6 +726,7 @@ def _drop_void_assistant_messages(messages: list[dict]) -> list[dict]:
             and not msg.get("tool_calls")
             and not msg.get("tool_responses")
             and not msg.get("reasoning_content")
+            and not msg.get("partial")
         )
     ]
 
@@ -796,6 +802,13 @@ def _merge_consecutive_roles(messages: list[dict]) -> list[dict]:
                     prev["content"] = prev_content + "\n\n" + new_content
             elif new_content:
                 prev["content"] = new_content
+            # Carry partial mode onto the merged turn. Without this, merging a
+            # trailing ``partial`` assistant into a preceding assistant drops
+            # the flag, and the prefill-continuation request is silently lost
+            # (#2357). partial is only meaningful on the final message, which
+            # is exactly what prev becomes here.
+            if msg.get("partial"):
+                prev["partial"] = True
         else:
             merged.append(msg.copy())
 

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -2951,6 +2951,42 @@ class TestExtractTextContentPreservesNamePartial:
         result = extract_text_content(messages)
         assert result[0].get("partial") is True
 
+    def test_partial_survives_empty_assistant_not_dropped(self):
+        """An empty partial assistant is not void-dropped, so the flag survives
+        the extraction tail and detect_and_strip_partial still sees it (#2357)."""
+        messages = [
+            Message(role="user", content="Continue"),
+            Message(role="assistant", content="", partial=True),
+        ]
+        result = extract_text_content(messages)
+        assert detect_and_strip_partial(result) is True
+
+    def test_partial_survives_merge_into_prior_assistant(self):
+        """A trailing partial assistant merged into a preceding assistant carries
+        the flag onto the merged turn, so partial mode is not lost (#2357)."""
+        messages = [
+            Message(role="user", content="hi"),
+            Message(role="assistant", content="prev"),
+            Message(role="assistant", content="start", partial=True),
+        ]
+        result = extract_text_content(messages)
+        # The two assistant turns collapse to one (strict-template alternation),
+        # and that single final turn keeps partial=True.
+        assert result[-1]["role"] == "assistant"
+        assert detect_and_strip_partial(result) is True
+
+    def test_non_partial_consecutive_assistants_still_merge(self):
+        """Regression guard: preserving partial must not change ordinary merging
+        of consecutive non-partial assistant messages."""
+        messages = [
+            Message(role="user", content="hi"),
+            Message(role="assistant", content="a"),
+            Message(role="assistant", content="b"),
+        ]
+        result = extract_text_content(messages)
+        assert detect_and_strip_partial(result) is False
+        assert result[-1]["content"] == "a\n\nb"
+
     def test_no_name_when_absent(self):
         """name key is absent when not set on source message."""
         messages = [


### PR DESCRIPTION
## Summary

`partial: true` on a final assistant message is meant to continue that turn (prefill) instead of starting a new one, but in two message shapes the flag was silently dropped before it took effect, so the caller got a fresh assistant turn with a new `<think>` block instead. This fixes those two shapes. Addresses #2357.

## Root cause

`detect_and_strip_partial` reads `partial` off the final message, but it runs after `extract_text_content` has already collapsed the message list through `_drop_void_assistant_messages` and `_merge_consecutive_roles`. Two collapses discard the flag before it is read:

1. An empty partial assistant message (an empty prefill) is treated as a void assistant turn and dropped.
2. A trailing partial assistant that follows another assistant message is merged into it, and the merge does not copy the `partial` key onto the combined turn.

In both cases `is_partial` comes back `False`, `add_generation_prompt` stays on, and the template opens a fresh turn.

## Fix

- Exempt `partial` messages from `_drop_void_assistant_messages`, alongside the existing `tool_responses` and `reasoning_content` exemptions.
- Carry `partial` onto the merged turn in `_merge_consecutive_roles`. The merge itself is kept, so strict templates (Gemma 3) still see alternating roles; only the flag is preserved.

## Verification

- Unit tests for both shapes plus a guard that ordinary non-partial consecutive assistants still merge unchanged. Full `test_api_utils.py` green.
- Render level, using a Qwen3.5 tokenizer: with the flag preserved the prompt ends by continuing the seeded assistant text; without it the prompt appends a fresh `<|im_start|>assistant` turn with a new `<think>`. The fix routes through `continue_final_message` and suppresses the new turn.

## Note for the reporter

A single non-empty partial assistant message already works on current `main`, so if your request was that shape the behavior you saw may have a different cause (for example the client not sending the `partial` field). If you can share the exact request body from a failing call, I can confirm it matches one of the two shapes above or keep digging.
