### PR TITLE
fix: credit prefill preflight cached_tokens only for hot-cache-verified blocks

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -2891,6 +2891,30 @@ class PagedSSDCacheManager(CacheManager):
                 return True
         return False
 
+    def is_hot_cached(self, block_hash: bytes) -> bool:
+        """
+        Check hot-cache membership without disturbing cache state.
+
+        Unlike ``_hot_cache_get``, this does not move the entry to MRU
+        position or touch the hot-cache budget tracker — safe to call from
+        a preflight probe that must not perturb real eviction order for a
+        request that may end up rejected or re-estimated.
+
+        Only the hot cache counts: a pending-write-buffer entry still
+        needs ``_arrays_from_tensors_raw()`` reconstruction, and an
+        SSD-index-only entry needs a real ``mx.load()`` restore, so
+        neither is "already materialized" in the sense this check exists
+        for (see ``model-ssd-kv-restoration-cost`` for the measurements).
+
+        Args:
+            block_hash: Content hash for the block.
+
+        Returns:
+            True if the block is currently present in the hot cache.
+        """
+        with self._hot_cache_lock:
+            return block_hash in self._hot_cache
+
     def preload_matched_blocks(self, block_hashes: list[bytes]) -> int:
         """
         Parallel-load matched blocks from SSD into hot cache.

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -84,9 +84,21 @@ class BatchedEngine(BaseEngine):
         *,
         num_prompt_tokens: int,
         request_id: str | None,
+        token_ids: list[int] | None = None,
     ) -> None:
+        # ``token_ids`` lets the guard credit the prefix verified present in
+        # PagedSSDCacheManager's hot cache right now (see
+        # ``Scheduler.live_resident_prefix_length`` and the
+        # ``scope-cache-credit-live-resident`` change) instead of always
+        # assuming cached_tokens=0 this early. Omitted (None) preserves the
+        # previous cached_tokens=0 behavior, e.g. for completion paths that
+        # don't have a token list handy.
+        cached_tokens = 0
+        if token_ids is not None:
+            cached_tokens = scheduler.live_resident_prefix_length(token_ids)
         eviction_request = scheduler.preflight_eviction_request(
             num_prompt_tokens=num_prompt_tokens,
+            cached_tokens=cached_tokens,
             request_id=request_id,
         )
         if eviction_request is not None and self._prefill_eviction_callback is not None:
@@ -97,6 +109,7 @@ class BatchedEngine(BaseEngine):
             await self._prefill_eviction_callback(eviction_request)
         scheduler.preflight_or_raise(
             num_prompt_tokens=num_prompt_tokens,
+            cached_tokens=cached_tokens,
             request_id=request_id,
         )
 
@@ -971,7 +984,7 @@ class BatchedEngine(BaseEngine):
         # through the existing handler chain so the response shape stays
         # consistent.
         try:
-            num_tokens = len(self._tokenizer.encode(prompt))
+            token_ids = self._tokenizer.encode(prompt)
         except Exception as e:
             logger.warning(
                 "BatchedEngine.preflight_chat: tokenizer.encode raised %s; "
@@ -985,7 +998,10 @@ class BatchedEngine(BaseEngine):
             _warn_scheduler_unreachable_once(self, "preflight_chat")
             return
         await self._preflight_or_raise_with_eviction(
-            scheduler, num_prompt_tokens=num_tokens, request_id=request_id
+            scheduler,
+            num_prompt_tokens=len(token_ids),
+            request_id=request_id,
+            token_ids=token_ids,
         )
 
     async def preflight_completion(
@@ -1001,7 +1017,7 @@ class BatchedEngine(BaseEngine):
         if not self._loaded:
             await self.start()
         try:
-            num_tokens = len(self._tokenizer.encode(prompt))
+            token_ids = self._tokenizer.encode(prompt)
         except Exception as e:
             logger.warning(
                 "BatchedEngine.preflight_completion: tokenizer.encode raised "
@@ -1015,7 +1031,10 @@ class BatchedEngine(BaseEngine):
             _warn_scheduler_unreachable_once(self, "preflight_completion")
             return
         await self._preflight_or_raise_with_eviction(
-            scheduler, num_prompt_tokens=num_tokens, request_id=request_id
+            scheduler,
+            num_prompt_tokens=len(token_ids),
+            request_id=request_id,
+            token_ids=token_ids,
         )
 
     async def stream_chat(

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -855,7 +855,11 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         # ``hydrate_target_cache`` clones every array), so the full prompt's
         # KV is allocated this request — unlike the scheduler's resident
         # paged cache. Subtracting hit tokens here would under-count and
-        # defeat the OOM guard.
+        # defeat the OOM guard. Unaffected by
+        # ``scope-cache-credit-live-resident``'s hot-cache-verified credit
+        # on the BatchedEngine/VLMBatchedEngine paths — that credit exists
+        # precisely because those paths' cache hits do NOT reconstruct
+        # into active memory when hot-cache-verified; this one always does.
         self._prefill_guard.preflight_or_raise(
             num_prompt_tokens=num_tokens, request_id=request_id
         )

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1289,9 +1289,17 @@ class VLMBatchedEngine(BaseEngine):
         *,
         num_prompt_tokens: int,
         request_id: str | None,
+        token_ids: list[int] | None = None,
     ) -> None:
+        # See BatchedEngine._preflight_or_raise_with_eviction for the
+        # rationale (scope-cache-credit-live-resident): omitted token_ids
+        # preserves the previous cached_tokens=0 behavior.
+        cached_tokens = 0
+        if token_ids is not None:
+            cached_tokens = scheduler.live_resident_prefix_length(token_ids)
         eviction_request = scheduler.preflight_eviction_request(
             num_prompt_tokens=num_prompt_tokens,
+            cached_tokens=cached_tokens,
             request_id=request_id,
         )
         if eviction_request is not None and self._prefill_eviction_callback is not None:
@@ -1302,6 +1310,7 @@ class VLMBatchedEngine(BaseEngine):
             await self._prefill_eviction_callback(eviction_request)
         scheduler.preflight_or_raise(
             num_prompt_tokens=num_prompt_tokens,
+            cached_tokens=cached_tokens,
             request_id=request_id,
         )
 
@@ -3358,7 +3367,7 @@ class VLMBatchedEngine(BaseEngine):
         # the real chat path surface the same error through the existing
         # handler chain.
         try:
-            num_tokens = len(self._tokenizer.encode(prompt))
+            text_token_ids = self._tokenizer.encode(prompt)
         except Exception as e:
             logger.warning(
                 "VLMBatchedEngine.preflight_chat: tokenizer.encode raised "
@@ -3369,7 +3378,7 @@ class VLMBatchedEngine(BaseEngine):
             return
         # Count images from the ORIGINAL messages (the stripped
         # ``text_messages`` no longer has the image content-parts).
-        num_tokens += _count_image_tokens_real(
+        num_tokens = len(text_token_ids) + _count_image_tokens_real(
             messages,
             getattr(self, "_processor", None),
             upper_bound=_derive_image_token_upper_bound(
@@ -3380,8 +3389,16 @@ class VLMBatchedEngine(BaseEngine):
         if scheduler is None:
             _warn_scheduler_unreachable_once(self, "preflight_chat")
             return
+        # text_token_ids only (no image extra_keys): a text-only match
+        # still hashes differently from a real image-bearing block (whose
+        # hash includes the image extra key), so this can only under-credit
+        # (safe), never mismatch a wrong block. See
+        # scope-cache-credit-live-resident's design for the full rationale.
         await self._preflight_or_raise_with_eviction(
-            scheduler, num_prompt_tokens=num_tokens, request_id=request_id
+            scheduler,
+            num_prompt_tokens=num_tokens,
+            request_id=request_id,
+            token_ids=text_token_ids,
         )
 
     async def preflight_completion(
@@ -3400,7 +3417,7 @@ class VLMBatchedEngine(BaseEngine):
             )
             return
         try:
-            num_tokens = len(self._tokenizer.encode(prompt))
+            token_ids = self._tokenizer.encode(prompt)
         except Exception as e:
             logger.warning(
                 "VLMBatchedEngine.preflight_completion: tokenizer.encode "
@@ -3414,7 +3431,10 @@ class VLMBatchedEngine(BaseEngine):
             _warn_scheduler_unreachable_once(self, "preflight_completion")
             return
         await self._preflight_or_raise_with_eviction(
-            scheduler, num_prompt_tokens=num_tokens, request_id=request_id
+            scheduler,
+            num_prompt_tokens=len(token_ids),
+            request_id=request_id,
+            token_ids=token_ids,
         )
 
     async def stream_chat(

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -8088,6 +8088,61 @@ class Scheduler:
             return safety_rejection
         return None
 
+    def live_resident_prefix_length(
+        self,
+        tokens: list[int],
+        *,
+        extra_keys: tuple | None = None,
+        extra_key_token_start: int | None = None,
+        extra_key_ranges: list | None = None,
+    ) -> int:
+        """Token count of the contiguous prompt prefix verified hot-cached now.
+
+        For the early prefill preflight (``preflight_or_raise``, called
+        before a request is queued and before any real ``fetch_cache()``
+        happens): a content-only prefix match is not a safe basis for a
+        memory credit, because ``PagedCacheManager.get_computed_blocks()``
+        (used by ``find_shared_prefix``) lazily registers SSD-index-only
+        blocks too — those still need a real restore via
+        ``PagedSSDCacheManager.preload_matched_blocks()`` /
+        ``load_block()``, measured at roughly 1.5-1.6x a block's own
+        steady-state footprint (see the ``model-ssd-kv-restoration-cost``
+        change). Only blocks confirmed present in the hot cache right now
+        are free of that cost, confirmed by zero measured restoration
+        delta for same-process hot-cache hits.
+
+        Stops at the first non-hot-cached block: KV state is reconstructed
+        in order, so a hot-cached block deeper in the match is useless if
+        an earlier block still needs restoring.
+
+        Returns 0 when the paged SSD cache isn't configured, or when
+        nothing matches.
+        """
+        if self.block_aware_cache is None or self.paged_ssd_cache_manager is None:
+            return 0
+        paged_cache = self.block_aware_cache.paged_cache
+        if paged_cache is None:
+            return 0
+        block_ids, remaining_tokens = paged_cache.find_shared_prefix(
+            tokens,
+            extra_keys=extra_keys,
+            extra_key_token_start=extra_key_token_start,
+            extra_key_ranges=extra_key_ranges,
+        )
+        if not block_ids:
+            return 0
+        matched_tokens = len(tokens) - len(remaining_tokens)
+        block_size = paged_cache.block_size
+        verified_tokens = 0
+        for block_id in block_ids:
+            block = paged_cache.allocated_blocks.get(block_id)
+            if block is None or block.block_hash is None:
+                break
+            if not self.paged_ssd_cache_manager.is_hot_cached(block.block_hash):
+                break
+            verified_tokens += block_size
+        return min(verified_tokens, matched_tokens)
+
     def _admission_estimate(
         self,
         *,

--- a/tests/test_engine_preflight.py
+++ b/tests/test_engine_preflight.py
@@ -180,10 +180,12 @@ async def test_batched_engine_preflight_runs_eviction_before_final_check():
 
     scheduler.preflight_eviction_request.assert_called_once_with(
         num_prompt_tokens=123,
+        cached_tokens=0,
         request_id="req-evict",
     )
     scheduler.preflight_or_raise.assert_called_once_with(
         num_prompt_tokens=123,
+        cached_tokens=0,
         request_id="req-evict",
     )
     assert order == [("evict", "req-evict"), ("final", "checked")]
@@ -483,6 +485,161 @@ async def test_vlm_preflight_chat_swallows_tokenizer_errors(caplog):
 
     assert not raise_called["yes"]
     assert any("tokenizer.encode raised" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# scope-cache-credit-live-resident: hot-cache-verified cached_tokens
+# propagation through preflight_chat / preflight_completion.
+# ---------------------------------------------------------------------------
+
+
+def _build_engine_with_mock_scheduler(engine_cls, encoded_tokens):
+    """Like ``_build_engine_with_stub_scheduler`` but with a fully mocked
+    scheduler, so we can assert exactly what cached_tokens value reaches
+    ``preflight_or_raise`` without a real Scheduler/PagedCacheManager.
+    """
+    scheduler = MagicMock()
+    engine = _build_engine_with_stub_scheduler(engine_cls, scheduler)
+    engine._tokenizer.encode = MagicMock(return_value=encoded_tokens)
+    return engine, scheduler
+
+
+@pytest.mark.asyncio
+async def test_batched_engine_preflight_chat_credits_live_resident_tokens():
+    """cached_tokens on the early check now comes from
+    live_resident_prefix_length(token_ids), not a hardcoded 0."""
+    from omlx.engine.batched import BatchedEngine
+
+    tokens = list(range(500))
+    engine, scheduler = _build_engine_with_mock_scheduler(BatchedEngine, tokens)
+    engine._preprocess_messages = lambda m: m
+    scheduler.live_resident_prefix_length.return_value = 320
+
+    await engine.preflight_chat(messages=[{"role": "user", "content": "x"}])
+
+    scheduler.live_resident_prefix_length.assert_called_once_with(tokens)
+    scheduler.preflight_or_raise.assert_called_once_with(
+        num_prompt_tokens=500, cached_tokens=320, request_id=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_batched_engine_preflight_chat_zero_credit_for_ssd_only_match():
+    """A find_shared_prefix() content match that isn't hot-cache-verified
+    must NOT be credited here -- restoring it costs real memory
+    (model-ssd-kv-restoration-cost)."""
+    from omlx.engine.batched import BatchedEngine
+
+    tokens = list(range(500))
+    engine, scheduler = _build_engine_with_mock_scheduler(BatchedEngine, tokens)
+    engine._preprocess_messages = lambda m: m
+    scheduler.live_resident_prefix_length.return_value = 0
+
+    await engine.preflight_chat(messages=[{"role": "user", "content": "x"}])
+
+    scheduler.preflight_or_raise.assert_called_once_with(
+        num_prompt_tokens=500, cached_tokens=0, request_id=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_batched_engine_preflight_completion_credits_live_resident_tokens():
+    from omlx.engine.batched import BatchedEngine
+
+    tokens = list(range(200))
+    engine, scheduler = _build_engine_with_mock_scheduler(BatchedEngine, tokens)
+    scheduler.live_resident_prefix_length.return_value = 128
+
+    await engine.preflight_completion(prompt="hello")
+
+    scheduler.live_resident_prefix_length.assert_called_once_with(tokens)
+    scheduler.preflight_or_raise.assert_called_once_with(
+        num_prompt_tokens=200, cached_tokens=128, request_id=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_vlm_engine_preflight_chat_credits_text_only_tokens():
+    """VLM's early check credits only the text-token match -- image content
+    is stripped before templating, so the live_resident_prefix_length probe
+    must run on text tokens only, while num_prompt_tokens still includes the
+    separate image-token budget on top."""
+    from omlx.engine.vlm import VLMBatchedEngine
+
+    text_tokens = list(range(300))
+    engine, scheduler = _build_engine_with_mock_scheduler(VLMBatchedEngine, text_tokens)
+    scheduler.live_resident_prefix_length.return_value = 256
+
+    await engine.preflight_chat(messages=[{"role": "user", "content": "x"}])
+
+    scheduler.live_resident_prefix_length.assert_called_once_with(text_tokens)
+    scheduler.preflight_or_raise.assert_called_once_with(
+        num_prompt_tokens=300, cached_tokens=256, request_id=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_vlm_engine_preflight_chat_credit_excludes_image_token_budget():
+    """The image-token upper-bound budget must never be credited as
+    cached -- only real text tokens are checked against the hot cache."""
+    from omlx.engine.vlm import VLMBatchedEngine
+
+    text_tokens = list(range(300))
+    engine, scheduler = _build_engine_with_mock_scheduler(VLMBatchedEngine, text_tokens)
+    scheduler.live_resident_prefix_length.return_value = 256
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": _TINY_PNG_DATA_URI}},
+                {"type": "text", "text": "describe this"},
+            ],
+        }
+    ]
+    await engine.preflight_chat(messages=messages)
+
+    # num_prompt_tokens = 300 text tokens + image budget (> 0); cached_tokens
+    # stays exactly what the text-only probe returned, never inflated by
+    # the image budget.
+    args, kwargs = scheduler.preflight_or_raise.call_args
+    assert kwargs["cached_tokens"] == 256
+    assert kwargs["num_prompt_tokens"] > 300
+
+
+@pytest.mark.asyncio
+async def test_batched_engine_preflight_cold_start_still_gets_full_charge(
+    monkeypatch,
+):
+    """Regression guard: a prompt with no cache configured at all (the
+    _make_scheduler() real-scheduler case) still gets cached_tokens=0,
+    i.e. today's full-charge behavior for a genuine cold start."""
+    from omlx.engine.batched import BatchedEngine
+
+    scheduler = _make_scheduler()
+    scheduler._prefill_memory_guard = True
+    scheduler._memory_hard_limit_bytes = 10**18  # effectively unbounded
+
+    import omlx.scheduler as scheduler_mod
+
+    monkeypatch.setattr(scheduler_mod.mx, "get_active_memory", lambda: 0)
+    monkeypatch.setattr(scheduler_mod, "get_phys_footprint", lambda: 0)
+
+    calls = []
+    real_preflight = scheduler.preflight_or_raise
+
+    def _spy(**kwargs):
+        calls.append(kwargs)
+        return real_preflight(**kwargs)
+
+    scheduler.preflight_or_raise = _spy  # type: ignore[assignment]
+
+    engine = _build_engine_with_stub_scheduler(BatchedEngine, scheduler)
+    engine._preprocess_messages = lambda m: m
+
+    await engine.preflight_chat(messages=[{"role": "user", "content": "x"}])
+
+    assert calls and calls[0]["cached_tokens"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -2766,6 +2766,124 @@ class TestPreloadMatchedBlocks:
         manager2.close()
 
 
+class TestIsHotCached:
+    """Tests for PagedSSDCacheManager.is_hot_cached() (scope-cache-credit-live-resident)."""
+
+    @pytest.fixture
+    def mx(self):
+        try:
+            import mlx.core as mx
+
+            return mx
+        except ImportError:
+            pytest.skip("MLX not available")
+
+    def _save_test_blocks(self, manager, mx, count=4, layers=2):
+        """Save test blocks and flush them to SSD (not hot cache)."""
+        hashes = []
+        for i in range(count):
+            block_hash = f"is_hot_cached_test_block_{i:04d}".encode()
+            cache_data = [
+                (mx.zeros((1, 4, 64, 64)), mx.zeros((1, 4, 64, 64)))
+                for _ in range(layers)
+            ]
+            manager.save_block(
+                block_hash=block_hash,
+                cache_data=cache_data,
+                token_count=64,
+                model_name="test-model",
+                layer_cache_types=["KVCache"] * layers,
+            )
+            hashes.append(block_hash)
+
+        # Flush writer to ensure blocks are on SSD, then reopen cold
+        # (hot cache empty, SSD index populated).
+        manager.close()
+        new_manager = PagedSSDCacheManager(
+            cache_dir=manager._cache_dir,
+            max_size_bytes=1024**3,
+            hot_cache_max_bytes=512 * 1024**2,
+        )
+        return new_manager, hashes
+
+    def test_true_when_promoted_via_preload(self, tmp_path, mx):
+        """Blocks preloaded into hot cache are reported as hot-cached."""
+        manager = PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_cache",
+            max_size_bytes=1024**3,
+            hot_cache_max_bytes=512 * 1024**2,
+        )
+        manager2, hashes = self._save_test_blocks(manager, mx, count=4)
+
+        for h in hashes:
+            assert manager2.is_hot_cached(h) is False
+
+        loaded = manager2.preload_matched_blocks(hashes)
+        assert loaded == 4
+
+        for h in hashes:
+            assert manager2.is_hot_cached(h) is True
+
+        manager2.close()
+
+    def test_false_for_ssd_index_only_block(self, tmp_path, mx):
+        """A block present only in the SSD index (not preloaded) is not hot-cached."""
+        manager = PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_cache",
+            max_size_bytes=1024**3,
+            hot_cache_max_bytes=512 * 1024**2,
+        )
+        manager2, hashes = self._save_test_blocks(manager, mx, count=1)
+
+        # SSD index has the block, hot cache does not.
+        assert manager2.has_block(hashes[0]) is True
+        assert manager2.is_hot_cached(hashes[0]) is False
+
+        manager2.close()
+
+    def test_false_for_unknown_hash(self, tmp_path, mx):
+        """A hash never seen by this cache is not hot-cached."""
+        manager = PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_cache",
+            max_size_bytes=1024**3,
+            hot_cache_max_bytes=512 * 1024**2,
+        )
+        assert manager.is_hot_cached(b"never_seen_hash") is False
+        manager.close()
+
+    def test_no_lru_or_budget_side_effects(self, tmp_path, mx):
+        """Unlike _hot_cache_get, is_hot_cached must not reorder LRU or touch budget."""
+        manager = PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_cache",
+            max_size_bytes=1024**3,
+            hot_cache_max_bytes=512 * 1024**2,
+        )
+        manager2, hashes = self._save_test_blocks(manager, mx, count=2)
+
+        # Promote both, deterministically, in order (single-threaded via
+        # load_block, not the concurrent preload pool).
+        assert manager2.load_block(hashes[0]) is not None
+        assert manager2.load_block(hashes[1]) is not None
+
+        order_before = list(manager2._hot_cache.keys())
+        assert order_before == [hashes[0], hashes[1]]
+
+        # Repeated is_hot_cached() calls on the LRU-oldest entry must not
+        # move it to MRU position.
+        for _ in range(3):
+            assert manager2.is_hot_cached(hashes[0]) is True
+
+        order_after = list(manager2._hot_cache.keys())
+        assert order_after == order_before
+
+        # Contrast: _hot_cache_get() DOES move it to MRU, proving the
+        # ordering above wasn't already a no-op for this cache.
+        manager2._hot_cache_get(hashes[0])
+        assert list(manager2._hot_cache.keys()) == [hashes[1], hashes[0]]
+
+        manager2.close()
+
+
 class TestPreloadBlocks:
     """Tests for BlockAwarePrefixCache.preload_blocks()."""
 

--- a/tests/test_scheduler_prefill_memory_guard.py
+++ b/tests/test_scheduler_prefill_memory_guard.py
@@ -885,3 +885,112 @@ def test_admission_compares_against_hard_watermark():
     scheduler._memory_hard_watermark_bytes = int(est.estimated) + 1
     with patches[0], patches[1]:
         scheduler.preflight_or_raise(num_prompt_tokens=32768)
+
+
+# ---------------------------------------------------------------------------
+# Scheduler.live_resident_prefix_length (scope-cache-credit-live-resident)
+# ---------------------------------------------------------------------------
+
+
+class TestLiveResidentPrefixLength:
+    """The early preflight check may only credit cached_tokens for the
+    contiguous prefix verified present in PagedSSDCacheManager's hot cache
+    right now -- a find_shared_prefix() content match alone is not enough,
+    since it also lazily registers SSD-index-only blocks that still need a
+    real (non-free) restore. See model-ssd-kv-restoration-cost for the
+    live measurements motivating this split.
+    """
+
+    def test_zero_without_block_aware_cache(self):
+        scheduler = _make_scheduler()
+        scheduler.block_aware_cache = None
+        assert scheduler.live_resident_prefix_length([1, 2, 3]) == 0
+
+    def test_zero_without_ssd_cache_manager(self):
+        scheduler = _make_scheduler()
+        scheduler.block_aware_cache = MagicMock()
+        scheduler.paged_ssd_cache_manager = None
+        assert scheduler.live_resident_prefix_length([1, 2, 3]) == 0
+
+    def test_zero_when_no_shared_prefix(self):
+        scheduler = _make_scheduler()
+        paged_cache = MagicMock()
+        paged_cache.find_shared_prefix.return_value = ([], [1, 2, 3])
+        scheduler.block_aware_cache = MagicMock(paged_cache=paged_cache)
+        scheduler.paged_ssd_cache_manager = MagicMock()
+        assert scheduler.live_resident_prefix_length([1, 2, 3]) == 0
+
+    def test_full_credit_when_every_matched_block_is_hot_cached(self):
+        block_a = SimpleNamespace(block_hash=b"hash-a")
+        block_b = SimpleNamespace(block_hash=b"hash-b")
+        paged_cache = MagicMock()
+        paged_cache.block_size = 64
+        paged_cache.allocated_blocks = {1: block_a, 2: block_b}
+        paged_cache.find_shared_prefix.return_value = ([1, 2], [])
+
+        scheduler = _make_scheduler()
+        scheduler.block_aware_cache = MagicMock(paged_cache=paged_cache)
+        ssd = MagicMock()
+        ssd.is_hot_cached.side_effect = lambda h: h in (b"hash-a", b"hash-b")
+        scheduler.paged_ssd_cache_manager = ssd
+
+        assert scheduler.live_resident_prefix_length(list(range(128))) == 128
+
+    def test_zero_when_matched_block_is_ssd_index_only(self):
+        """A find_shared_prefix() match with no hot-cache backing gets no
+        credit, even though it IS a real cache hit for fetch_cache() later
+        -- restoring it from the SSD index costs real memory."""
+        block_a = SimpleNamespace(block_hash=b"hash-a")
+        paged_cache = MagicMock()
+        paged_cache.block_size = 64
+        paged_cache.allocated_blocks = {1: block_a}
+        paged_cache.find_shared_prefix.return_value = ([1], [])
+
+        scheduler = _make_scheduler()
+        scheduler.block_aware_cache = MagicMock(paged_cache=paged_cache)
+        ssd = MagicMock()
+        ssd.is_hot_cached.return_value = False
+        scheduler.paged_ssd_cache_manager = ssd
+
+        assert scheduler.live_resident_prefix_length(list(range(64))) == 0
+
+    def test_stops_at_first_non_hot_cached_block(self):
+        """A hot-cached block deeper in the match doesn't help if an
+        earlier block still needs restoring -- KV state is sequential."""
+        block_a = SimpleNamespace(block_hash=b"hash-a")  # hot-cached
+        block_b = SimpleNamespace(block_hash=b"hash-b")  # NOT hot-cached
+        block_c = SimpleNamespace(block_hash=b"hash-c")  # hot-cached, unreachable
+        paged_cache = MagicMock()
+        paged_cache.block_size = 64
+        paged_cache.allocated_blocks = {1: block_a, 2: block_b, 3: block_c}
+        paged_cache.find_shared_prefix.return_value = ([1, 2, 3], [])
+
+        scheduler = _make_scheduler()
+        scheduler.block_aware_cache = MagicMock(paged_cache=paged_cache)
+        ssd = MagicMock()
+        ssd.is_hot_cached.side_effect = lambda h: h in (b"hash-a", b"hash-c")
+        scheduler.paged_ssd_cache_manager = ssd
+
+        assert scheduler.live_resident_prefix_length(list(range(192))) == 64
+        # hash-c must never be checked -- the walk stops at hash-b.
+        checked = [c.args[0] for c in ssd.is_hot_cached.call_args_list]
+        assert checked == [b"hash-a", b"hash-b"]
+
+    def test_credit_capped_at_matched_tokens(self):
+        """Never credit more than find_shared_prefix() actually matched,
+        even if block_size * matched_block_count overshoots it."""
+        block_a = SimpleNamespace(block_hash=b"hash-a")
+        paged_cache = MagicMock()
+        paged_cache.block_size = 64
+        paged_cache.allocated_blocks = {1: block_a}
+        # Matched only 1 block but reports 40 remaining tokens out of 64 --
+        # i.e. matched_tokens (24) is less than block_size (64).
+        paged_cache.find_shared_prefix.return_value = ([1], list(range(40)))
+
+        scheduler = _make_scheduler()
+        scheduler.block_aware_cache = MagicMock(paged_cache=paged_cache)
+        ssd = MagicMock()
+        ssd.is_hot_cached.return_value = True
+        scheduler.paged_ssd_cache_manager = ssd
+
+        assert scheduler.live_resident_prefix_length(list(range(64))) == 24


### PR DESCRIPTION
## Summary

Follow-up to #2409, which this PR replaces (closing #2409 in favor of this narrower version, per the maintainer's own suggestion there).

- The prefill memory guard's early preflight check (`preflight_chat`/`preflight_completion` → `Scheduler.preflight_or_raise`, before the request is even queued) still always assumes `cached_tokens=0`, causing the same false-positive 400s on cache-friendly agentic conversations #2409 described.
- #2409's fix credited any exact token-content prefix match, regardless of whether the matched blocks were actually resident. The maintainer correctly rejected that: a match against the SSD-backed cache index can still require a real, non-trivial restore.
- I measured that restoration cost directly (see the investigation this PR builds on) against a live `Jundot--Qwen3.6-35B-A3B-oQ6-mtp` model: restoring an evicted block from the SSD index costs roughly 1.5-1.6x that block's own steady-state footprint — real, but same-process reuse *before* eviction (blocks still in `PagedSSDCacheManager`'s hot cache) is genuinely free, confirmed by zero measured restoration cost across repeated tests.

## What changes

- New `PagedSSDCacheManager.is_hot_cached(block_hash)`: read-only hot-cache membership check with no LRU/budget side effects (unlike `_hot_cache_get`, which moves the entry to MRU and touches the budget tracker — not safe to call from a preflight probe that may never turn into a real access).
- New `Scheduler.live_resident_prefix_length(tokens)`: walks `find_shared_prefix()`'s matched blocks from the start and stops at the first block that isn't hot-cache-verified. A block hash present only in the SSD index gets **zero** credit, even though it IS a real cache hit for `fetch_cache()` later — restoring it costs real memory.
- `BatchedEngine`/`VLMBatchedEngine` `preflight_chat`/`preflight_completion` now call this instead of assuming 0. VLM credits text-only tokens (the image-token budget is never part of the credit).
- `DFlashEngine` preflight is untouched (comment added cross-referencing why: its cache hit always reconstructs into active memory, unlike the hot-cache-verified case this PR credits).
- The later, in-scheduler admission check (`_preflight_memory_check`/`_admission_estimate`) is untouched — it already runs after real cache reconstruction, so `current` already reflects any restoration cost by then.

## Test plan

- [x] New tests: `PagedSSDCacheManager.is_hot_cached` (4 cases, including a no-side-effects check contrasted against `_hot_cache_get`), `Scheduler.live_resident_prefix_length` (7 cases: no cache configured, no match, full credit, SSD-index-only zero credit, stops at first non-hot-cached block, credit capped at matched tokens), engine preflight wiring (6 cases: credit propagation, zero-credit passthrough, VLM text-only credit excluding the image budget, cold-start regression guard).
- [x] Full local suite: 7470 passed, 71 skipped, 0 failed.
- [x] Manual verification against a live install running the model above: fresh restart + a 3-turn ~22.4k-token conversation. Turn 1 (content matching a prior session's SSD-indexed blocks, hot cache empty after restart): `cached_tokens=0`, correctly withheld despite the real content match. Turn 2/3 (same process, blocks now hot-cached): `cached_tokens=20480` (10 × 2048-token blocks), correct credit. No false rejections in either case.
