### PR TITLE
fix(engine_pool): abort in-flight requests before manual engine unload

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -1118,8 +1118,15 @@ class BatchedEngine(BaseEngine):
             return self._engine.get_cache_stats()
         return None
 
-    async def abort_all_requests(self) -> int:
+    async def abort_all_requests(
+        self,
+        error_message: str | None = None,
+        error_code: str = "prefill_memory_aborted",
+        reason: str = "due to memory pressure",
+    ) -> int:
         """Abort all active requests without stopping the engine."""
         if self._engine and self._engine.engine:
-            return await self._engine.engine.abort_all_requests()
+            return await self._engine.engine.abort_all_requests(
+                error_message=error_message, error_code=error_code, reason=reason
+            )
         return 0

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -4158,7 +4158,12 @@ class VLMBatchedEngine(BaseEngine):
             return self._engine.get_cache_stats()
         return None
 
-    async def abort_all_requests(self) -> int:
+    async def abort_all_requests(
+        self,
+        error_message: str | None = None,
+        error_code: str = "prefill_memory_aborted",
+        reason: str = "due to memory pressure",
+    ) -> int:
         """Abort all active requests."""
         if self.is_diffusion_model:
             cancel_events = list(getattr(self, "_diffusion_cancel_events", ()))
@@ -4166,5 +4171,7 @@ class VLMBatchedEngine(BaseEngine):
                 cancel_event.set()
             return len(cancel_events)
         if self._engine and self._engine.engine:
-            return await self._engine.engine.abort_all_requests()
+            return await self._engine.engine.abort_all_requests(
+                error_message=error_message, error_code=error_code, reason=reason
+            )
         return 0

--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -36,6 +36,7 @@ from typing import (
 import mlx.core as mx
 
 from .exceptions import (
+    ModelUnloadedError,
     PrefillMemoryAbortedError,
     PrefillMemoryExceededError,
     describe_ceiling_binding,
@@ -50,6 +51,7 @@ from .utils.compile_cache import (
 )
 from .utils.fatal import FATAL_TEARDOWN_TIMEOUT_S, fatal_exit
 from .utils.hardware import format_bytes
+from .utils.proc_memory import get_phys_footprint
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +77,13 @@ def _raise_request_output_error(output: RequestOutput) -> None:
                 int(estimated_bytes) if estimated_bytes is not None else None
             ),
             limit_bytes=int(limit_bytes) if limit_bytes is not None else None,
+        )
+    if output.error_code == "model_unloaded":
+        metadata = output.error_metadata or {}
+        request_id = metadata.get("request_id")
+        raise ModelUnloadedError(
+            message=output.error or "Request aborted: model was unloaded",
+            request_id=str(request_id) if request_id is not None else output.request_id,
         )
     raise RuntimeError(output.error)
 
@@ -688,98 +697,121 @@ class EngineCore:
 
         return result
 
-    async def abort_all_requests(self) -> int:
+    async def abort_all_requests(
+        self,
+        error_message: Optional[str] = None,
+        error_code: str = "prefill_memory_aborted",
+        reason: str = "due to memory pressure",
+    ) -> int:
         """Abort all active requests without stopping the engine.
 
         Sends error output to all active collectors and marks requests
         for deferred abort in the scheduler. Cleanup is handled by
         the consumer (stream_outputs/generate).
-        """
-        from .utils.proc_memory import get_phys_footprint
 
+        Args:
+            error_message: Message put on each aborted request's output and
+                new_text. None (the default, used by the memory enforcer)
+                builds the usage/ceiling/watermark diagnosis below. Callers
+                with an unrelated reason (e.g. a manual model unload) should
+                pass their own message so clients are not told a fabricated
+                memory diagnosis.
+            error_code: Error code put on each aborted request's output.
+                Defaults to "prefill_memory_aborted" so existing callers keep
+                today's HTTP 400 / JSON-keepalive classification unchanged.
+            reason: Human-readable clause for the summary log line below.
+        """
         request_ids = list(self._output_collectors.keys())
-        ceiling = 0
-        watermark = 0
-        sched = self.scheduler
-        if sched is not None:
-            ceiling = int(getattr(sched, "_memory_hard_limit_bytes", 0) or 0)
-            watermark = int(getattr(sched, "_memory_hard_watermark_bytes", 0) or 0)
-        usage = get_phys_footprint()
-        usage_gb = usage / (1024**3)
-        ceiling_gb = ceiling / (1024**3) if ceiling > 0 else 0.0
-        watermark_gb = watermark / (1024**3) if watermark > 0 else 0.0
-        # Name the component ceiling that actually produced this abort. A
-        # generic "loosen memory_guard_tier" leaves users who are already on
-        # `aggressive` with nothing to try (#2362); the ladder points at the
-        # constraint that is really binding, or falls back to the same
-        # generic advice when the enforcer has not propagated a breakdown.
-        binding, advice = describe_ceiling_binding(
-            static=int(getattr(sched, "_memory_static_ceiling_bytes", 0) or 0),
-            dynamic=int(getattr(sched, "_memory_dynamic_ceiling_bytes", 0) or 0),
-            metal_cap=int(getattr(sched, "_memory_metal_cap_bytes", 0) or 0),
-            tier=str(getattr(sched, "_memory_guard_tier", "") or ""),
-            current=usage,
-            fmt=format_bytes,
-            tail="reduce context length",
-        )
-        advice = f"{advice}."
-        ceiling_label = f"{binding} ceiling" if binding != "effective" else "ceiling"
+
+        if error_message is None:
+            ceiling = 0
+            watermark = 0
+            sched = self.scheduler
+            if sched is not None:
+                ceiling = int(getattr(sched, "_memory_hard_limit_bytes", 0) or 0)
+                watermark = int(
+                    getattr(sched, "_memory_hard_watermark_bytes", 0) or 0
+                )
+            usage = get_phys_footprint()
+            usage_gb = usage / (1024**3)
+            ceiling_gb = ceiling / (1024**3) if ceiling > 0 else 0.0
+            watermark_gb = watermark / (1024**3) if watermark > 0 else 0.0
+            # Name the component ceiling that actually produced this abort. A
+            # generic "loosen memory_guard_tier" leaves users who are already on
+            # `aggressive` with nothing to try (#2362); the ladder points at the
+            # constraint that is really binding, or falls back to the same
+            # generic advice when the enforcer has not propagated a breakdown.
+            binding, advice = describe_ceiling_binding(
+                static=int(getattr(sched, "_memory_static_ceiling_bytes", 0) or 0),
+                dynamic=int(getattr(sched, "_memory_dynamic_ceiling_bytes", 0) or 0),
+                metal_cap=int(getattr(sched, "_memory_metal_cap_bytes", 0) or 0),
+                tier=str(getattr(sched, "_memory_guard_tier", "") or ""),
+                current=usage,
+                fmt=format_bytes,
+                tail="reduce context length",
+            )
+            advice = f"{advice}."
+            ceiling_label = (
+                f"{binding} ceiling" if binding != "effective" else "ceiling"
+            )
+            # Name the watermark that actually tripped; printing only the
+            # ceiling reads as "usage below limit yet aborted" (#2321).
+            if watermark > 0 and ceiling > 0:
+                error_message = (
+                    f"Request aborted: process memory limit exceeded "
+                    f"(usage {usage_gb:.1f} GB, abort threshold "
+                    f"(hard watermark) {watermark_gb:.1f} GB, "
+                    f"{ceiling_label} {ceiling_gb:.1f} GB). "
+                    f"{advice}"
+                )
+            elif ceiling > 0:
+                error_message = (
+                    f"Request aborted: process memory limit exceeded "
+                    f"(usage {usage_gb:.1f} GB, "
+                    f"{ceiling_label} {ceiling_gb:.1f} GB). "
+                    f"{advice}"
+                )
+            else:
+                error_message = (
+                    f"Request aborted: process memory limit exceeded "
+                    f"(usage {usage_gb:.1f} GB). "
+                    f"{advice}"
+                )
+            limit_bytes = watermark or ceiling or None
+        else:
+            limit_bytes = None
+
         for rid in request_ids:
             self.scheduler.abort_request(rid)
             collector = self._output_collectors.get(rid)
             if collector is not None:
-                # Name the watermark that actually tripped; printing only the
-                # ceiling reads as "usage below limit yet aborted" (#2321).
-                if watermark > 0 and ceiling > 0:
-                    error_msg = (
-                        f"Request aborted: process memory limit exceeded "
-                        f"(usage {usage_gb:.1f} GB, abort threshold "
-                        f"(hard watermark) {watermark_gb:.1f} GB, "
-                        f"{ceiling_label} {ceiling_gb:.1f} GB). "
-                        f"{advice}"
-                    )
-                elif ceiling > 0:
-                    error_msg = (
-                        f"Request aborted: process memory limit exceeded "
-                        f"(usage {usage_gb:.1f} GB, "
-                        f"{ceiling_label} {ceiling_gb:.1f} GB). "
-                        f"{advice}"
-                    )
-                else:
-                    error_msg = (
-                        f"Request aborted: process memory limit exceeded "
-                        f"(usage {usage_gb:.1f} GB). "
-                        f"{advice}"
-                    )
                 collector.put(
                     RequestOutput(
                         request_id=rid,
                         finished=True,
                         finish_reason="error",
-                        new_text=f"\n\n[Error: {error_msg}]",
-                        error=error_msg,
+                        new_text=f"\n\n[Error: {error_message}]",
+                        error=error_message,
                         # Without a code this surfaced as a bare RuntimeError:
                         # the JSON keepalive wrapper never saw a memory error,
                         # so the response generator died mid-body and the
                         # client got a truncated read plus a 500 traceback
                         # instead of the same actionable 400 the pre-flight
                         # guard returns.
-                        error_code="prefill_memory_aborted",
+                        error_code=error_code,
                         error_metadata={
                             "request_id": rid,
                             # Only the limit is reported: the exception's
                             # estimated_bytes means "predicted peak", and this
                             # abort fires on measured usage, which the message
                             # already states.
-                            "limit_bytes": watermark or ceiling or None,
+                            "limit_bytes": limit_bytes,
                         },
                     )
                 )
             self._mark_request_finished(rid)
         if request_ids:
-            logger.warning(
-                f"Aborted {len(request_ids)} requests due to memory pressure"
-            )
+            logger.warning(f"Aborted {len(request_ids)} requests {reason}")
             self._wake_engine_loop()
         return len(request_ids)
 
@@ -1311,12 +1343,19 @@ class AsyncEngineCore:
             return False
         return await engine.abort_request(request_id)
 
-    async def abort_all_requests(self) -> int:
+    async def abort_all_requests(
+        self,
+        error_message: Optional[str] = None,
+        error_code: str = "prefill_memory_aborted",
+        reason: str = "due to memory pressure",
+    ) -> int:
         """Abort all active requests without stopping the engine."""
         engine = getattr(self, "engine", None)
         if engine is None:
             return 0
-        return await engine.abort_all_requests()
+        return await engine.abort_all_requests(
+            error_message=error_message, error_code=error_code, reason=reason
+        )
 
     async def stream_outputs(
         self,

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import gc
+import inspect
 import json
 import logging
 import time
@@ -103,6 +104,8 @@ class EngineEntry:
     ) = None  # Loaded engine instance
     last_access: float = 0.0  # Timestamp for LRU (0 if never loaded)
     is_loading: bool = False  # Prevent concurrent loads
+    is_unloading: bool = False  # Reentrancy guard: one _unload_engine() at a time
+    unload_done: asyncio.Event | None = None  # Set when the in-flight unload finishes
     loading_started_at: float | None = None  # Timestamp when current load started
     is_pinned: bool = False  # Never evict if True
     abort_loading: bool = False  # Set by memory enforcer to abort in-progress load
@@ -1363,7 +1366,7 @@ class EnginePool:
         """
         candidates = []
         for mid, e in self._entries.items():
-            if e.engine is None or e.is_pinned:
+            if e.engine is None or e.is_pinned or e.is_unloading:
                 continue
             if e.in_use > 0:
                 continue
@@ -1386,7 +1389,7 @@ class EnginePool:
         victims: list[str] = []
         blocked: list[str] = []
         for mid, e in self._entries.items():
-            if mid == model_id or e.engine is None:
+            if mid == model_id or e.engine is None or e.is_unloading:
                 continue
             if type(e.engine).__name__ != "DFlashEngine":
                 continue
@@ -1432,7 +1435,13 @@ class EnginePool:
 
     def _is_idle_for_prefill_eviction(self, entry: EngineEntry) -> bool:
         engine = entry.engine
-        if engine is None or entry.is_pinned or entry.is_loading or entry.in_use > 0:
+        if (
+            engine is None
+            or entry.is_pinned
+            or entry.is_loading
+            or entry.in_use > 0
+            or entry.is_unloading
+        ):
             return False
         if self._entry_has_active_requests(entry):
             return False
@@ -1657,196 +1666,259 @@ class EnginePool:
         if not entry or entry.engine is None:
             return
 
-        logger.info(f"Unloading model: {model_id} (immediate abort)")
-        distributed = self._distributed_deployment_for_entry(entry) is not None
-        resident_size = self._entry_resident_size(entry)
-        pre_unload_active = 0 if distributed else mx.get_active_memory()
+        if entry.is_unloading:
+            # Someone else's teardown is already in flight for this
+            # model_id. Capture the Event into a local before awaiting:
+            # the in-flight call's `finally` clears entry.unload_done once
+            # it wakes waiters, but this local reference stays valid.
+            # Waiting (instead of returning immediately) matters because
+            # some callers hold self._lock across this call (the settings-
+            # variant and force-LM reload paths in get_engine) and proceed
+            # to reload immediately after -- a silent no-op return would
+            # let them reload while the in-flight teardown is still
+            # tearing the old engine down.
+            ev = entry.unload_done
+            if ev is not None:
+                await ev.wait()
+            return
+        entry.is_unloading = True
+        entry.unload_done = asyncio.Event()
 
         try:
-            await entry.engine.stop()
-        except Exception as e:
-            if distributed:
-                # Keep the supervisor reachable and the planned memory
-                # accounted so a later unload can retry process teardown.
-                logger.error(
-                    f"Distributed teardown failed for {model_id}; "
-                    "keeping the engine registered for retry",
-                    exc_info=True,
+            logger.info(f"Unloading model: {model_id} (immediate abort)")
+            distributed = (
+                self._distributed_deployment_for_entry(entry) is not None
+            )
+            resident_size = self._entry_resident_size(entry)
+            pre_unload_active = 0 if distributed else mx.get_active_memory()
+
+            abort = getattr(entry.engine, "abort_all_requests", None)
+            if inspect.iscoroutinefunction(abort):
+                try:
+                    aborted = await abort(
+                        error_message=(
+                            f"Request aborted: model '{model_id}' was unloaded"
+                        ),
+                        error_code="model_unloaded",
+                        reason=f"to unload model '{model_id}'",
+                    )
+                    if aborted:
+                        logger.warning(
+                            f"Aborted {aborted} tracked request(s) "
+                            f"before unloading {model_id}"
+                        )
+                except Exception as e:
+                    logger.warning(
+                        f"Error aborting in-flight requests for {model_id}: {e}"
+                    )
+            else:
+                logger.debug(
+                    f"Engine for {model_id} has no async abort_all_requests; "
+                    f"in-flight requests (if any) are not aborted before unload"
                 )
-                self._wake_process_memory_enforcer()
-                raise
-            logger.warning(f"Error stopping engine for {model_id}: {e}")
 
-        # #1595: the immediate-abort stop() above tears the engine down without the normal
-        # per-request completion callbacks, so a non-streaming engine's active_requests
-        # counter can leak a phantom count (a stale engine then looks permanently busy).
-        # Reset it on teardown so has_active_requests() and the status API stay consistent.
-        reset = getattr(entry.engine, "_reset_activity_tracking", None)
-        if callable(reset):
-            try:
-                reset()
-            except Exception as e:
-                logger.warning(f"Error resetting activity counter for {model_id}: {e}")
-
-        # Yield to the event loop before dropping the engine reference.
-        #
-        # When abort_all_requests() fires before _unload_engine(), it sets
-        # asyncio Events for each active request.  Server-side streaming
-        # generators are then scheduled in the asyncio ready queue, but they
-        # cannot run until the event loop gets control.  EngineCore.close()
-        # (called inside stop()) blocks the event loop with synchronous
-        # .result() calls on the MLX executor -- scheduler.shutdown() and
-        # scheduler.deep_reset() -- so those generators are still suspended
-        # when stop() returns.
-        #
-        # If we set entry.engine = None and call gc.collect() immediately,
-        # the generators are still alive with a local 'engine' variable
-        # referencing the BatchedEngine, keeping its refcount above zero.
-        # The model's ~20 GB of MLX weight tensors therefore remain "active"
-        # in Metal memory, the settle barrier times out, and subsequent load
-        # attempts fail with 507 because the ceiling is still exceeded.
-        #
-        # A few asyncio.sleep(0) calls drain the ready queue -- generator
-        # tear-down is at most a few frames deep -- so that by the time we
-        # clear entry.engine and run gc.collect(), no coroutine frame holds
-        # a stale engine reference.
-        for _ in range(5):
+            # The abort above has no internal awaits (see
+            # EngineCore.abort_all_requests), so it runs to completion without
+            # yielding to the event loop. Two bare asyncio.sleep(0) calls give
+            # woken consumer generators a turn each to drain their terminal
+            # output before stop()/close() below clears the collectors out from
+            # under them (same trick used again further down, after stop()).
+            await asyncio.sleep(0)
             await asyncio.sleep(0)
 
-        # Clear engine reference before settle barrier
-        entry.engine = None
-        entry.last_access = 0.0
-        entry.actual_size = None
-        entry.abort_requested = False
-        entry.pending_unload_reason = None
-        entry.runtime_settings_signature = None
+            try:
+                await entry.engine.stop()
+            except Exception as e:
+                if distributed:
+                    # Keep the supervisor reachable and the planned memory
+                    # accounted so a later unload can retry process teardown.
+                    logger.error(
+                        f"Distributed teardown failed for {model_id}; "
+                        "keeping the engine registered for retry",
+                        exc_info=True,
+                    )
+                    self._wake_process_memory_enforcer()
+                    raise
+                logger.warning(f"Error stopping engine for {model_id}: {e}")
 
-        if distributed:
-            # Cluster weights live in supervised rank processes, not this
-            # process's Metal allocator. Successful supervisor teardown is
-            # the memory barrier; polling mx.get_active_memory() here would
-            # wait against an unrelated gauge and then run emergency reclaim.
-            gc.collect()
-            self._current_model_memory = max(
-                0,
-                self._current_model_memory - resident_size,
-            )
-            logger.info(
-                f"Unloaded distributed model: {model_id}, "
-                f"released local shard process "
-                f"({format_size(resident_size)} planned)"
-            )
-            self._wake_process_memory_enforcer()
-            return
+            # #1595: the immediate-abort stop() above tears the engine down without the normal
+            # per-request completion callbacks, so a non-streaming engine's active_requests
+            # counter can leak a phantom count (a stale engine then looks permanently busy).
+            # Reset it on teardown so has_active_requests() and the status API stay consistent.
+            reset = getattr(entry.engine, "_reset_activity_tracking", None)
+            if callable(reset):
+                try:
+                    reset()
+                except Exception as e:
+                    logger.warning(f"Error resetting activity counter for {model_id}: {e}")
 
-        # Force garbage collection to release memory.
-        # Run mx.clear_cache on the global MLX executor to avoid concurrent
-        # Metal operations with running engines. See issue #85.
-        # Synchronize before clearing to prevent releasing Metal buffers
-        # still referenced by in-flight command buffers. See issue #300.
-        gc.collect()
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            get_mlx_executor(), lambda: (mx.synchronize(), mx.clear_cache())
-        )
+            # Yield to the event loop before dropping the engine reference.
+            #
+            # When abort_all_requests() fires before _unload_engine(), it sets
+            # asyncio Events for each active request.  Server-side streaming
+            # generators are then scheduled in the asyncio ready queue, but they
+            # cannot run until the event loop gets control.  EngineCore.close()
+            # (called inside stop()) blocks the event loop with synchronous
+            # .result() calls on the MLX executor -- scheduler.shutdown() and
+            # scheduler.deep_reset() -- so those generators are still suspended
+            # when stop() returns.
+            #
+            # If we set entry.engine = None and call gc.collect() immediately,
+            # the generators are still alive with a local 'engine' variable
+            # referencing the BatchedEngine, keeping its refcount above zero.
+            # The model's ~20 GB of MLX weight tensors therefore remain "active"
+            # in Metal memory, the settle barrier times out, and subsequent load
+            # attempts fail with 507 because the ceiling is still exceeded.
+            #
+            # A few asyncio.sleep(0) calls drain the ready queue -- generator
+            # tear-down is at most a few frames deep -- so that by the time we
+            # clear entry.engine and run gc.collect(), no coroutine frame holds
+            # a stale engine reference.
+            for _ in range(5):
+                await asyncio.sleep(0)
 
-        # Memory settle barrier: poll actual freed memory instead of
-        # trusting the cumulative _current_model_memory estimate.
-        # Scale tolerance with model size: estimated_size includes a 5%
-        # overhead factor (model_discovery.py) that may not be reflected in
-        # actual freed memory. Use 2 GB floor for small models. See #768.
-        settle_tolerance = max(2 * 1024**3, int(resident_size * 0.05))
-        min_expected_freed = max(0, resident_size - settle_tolerance)
-        settled = False
-        settle_indeterminate = False
-        for _settle_round in range(10):
-            active_now = mx.get_active_memory()
-            actual_freed = pre_unload_active - active_now
-            if actual_freed >= min_expected_freed:
-                settled = True
-                logger.debug(
-                    f"Settle round {_settle_round + 1} for '{model_id}': "
-                    f"freed={format_size(actual_freed)} "
-                    f"(need>={format_size(min_expected_freed)}) - settled"
+            # Clear engine reference before settle barrier
+            entry.engine = None
+            entry.last_access = 0.0
+            entry.actual_size = None
+            entry.abort_requested = False
+            entry.pending_unload_reason = None
+            entry.runtime_settings_signature = None
+
+            if distributed:
+                # Cluster weights live in supervised rank processes, not this
+                # process's Metal allocator. Successful supervisor teardown is
+                # the memory barrier; polling mx.get_active_memory() here would
+                # wait against an unrelated gauge and then run emergency reclaim.
+                gc.collect()
+                self._current_model_memory = max(
+                    0,
+                    self._current_model_memory - resident_size,
                 )
-                break
-            if self._other_entries_serving(model_id):
-                # actual_freed is a delta of the process-global MLX gauge,
-                # so while another engine allocates (prefill/KV growth) the
-                # amount freed by THIS unload is unmeasurable — the delta can
-                # even read negative. Burning settle rounds here serializes
-                # gc/synchronize/clear_cache against live decode for seconds,
-                # under memory pressure, with the enforcer holding the pool
-                # lock. Bail out instead: pre-load admission re-reads the
-                # live gauge, so nothing downstream trusts this sample.
-                settle_indeterminate = True
                 logger.info(
-                    f"Settle for '{model_id}' indeterminate under concurrent "
-                    f"activity (freed={format_size(actual_freed)}, "
-                    f"need>={format_size(min_expected_freed)}); skipping "
-                    f"settle wait"
+                    f"Unloaded distributed model: {model_id}, "
+                    f"released local shard process "
+                    f"({format_size(resident_size)} planned)"
                 )
-                break
-            logger.debug(
-                f"Settle round {_settle_round + 1} for '{model_id}': "
-                f"freed={format_size(actual_freed)} "
-                f"(need>={format_size(min_expected_freed)}) - retry"
-            )
-            await asyncio.sleep(0.5)
+                self._wake_process_memory_enforcer()
+                return
+
+            # Force garbage collection to release memory.
+            # Run mx.clear_cache on the global MLX executor to avoid concurrent
+            # Metal operations with running engines. See issue #85.
+            # Synchronize before clearing to prevent releasing Metal buffers
+            # still referenced by in-flight command buffers. See issue #300.
             gc.collect()
+            loop = asyncio.get_running_loop()
             await loop.run_in_executor(
                 get_mlx_executor(), lambda: (mx.synchronize(), mx.clear_cache())
             )
 
-        # Release memory tracking AFTER barrier
-        self._current_model_memory = max(0, self._current_model_memory - resident_size)
-
-        if settled:
-            logger.info(
-                f"Unloaded model: {model_id}, "
-                f"freed={format_size(actual_freed)} "
-                f"(expected>={format_size(min_expected_freed)}), "
-                f"active_memory: {format_size(active_now)} (settled)"
-            )
-        elif settle_indeterminate:
-            # Settle wait skipped (logged above). Emergency reclaim is
-            # deliberately skipped too: its gc + synchronize + clear_cache
-            # rounds would stall the live engines that made the measurement
-            # indeterminate in the first place. Recovery is not lost:
-            # _wake_process_memory_enforcer() below triggers an immediate
-            # enforcer re-poll, and pre-load admission re-reads the live gauge
-            # alongside the tracked accumulator (the #1623 max() in
-            # get_engine), so any unreleased memory stays visible to both.
-            pass
-        else:
-            # Barrier timed out - try emergency reclaim
-            logger.warning(
-                f"Settle barrier timed out for '{model_id}': "
-                f"freed={format_size(actual_freed)} "
-                f"(need>={format_size(min_expected_freed)})"
-            )
-            for _ in range(3):
+            # Memory settle barrier: poll actual freed memory instead of
+            # trusting the cumulative _current_model_memory estimate.
+            # Scale tolerance with model size: estimated_size includes a 5%
+            # overhead factor (model_discovery.py) that may not be reflected in
+            # actual freed memory. Use 2 GB floor for small models. See #768.
+            settle_tolerance = max(2 * 1024**3, int(resident_size * 0.05))
+            min_expected_freed = max(0, resident_size - settle_tolerance)
+            settled = False
+            settle_indeterminate = False
+            for _settle_round in range(10):
+                active_now = mx.get_active_memory()
+                actual_freed = pre_unload_active - active_now
+                if actual_freed >= min_expected_freed:
+                    settled = True
+                    logger.debug(
+                        f"Settle round {_settle_round + 1} for '{model_id}': "
+                        f"freed={format_size(actual_freed)} "
+                        f"(need>={format_size(min_expected_freed)}) - settled"
+                    )
+                    break
+                if self._other_entries_serving(model_id):
+                    # actual_freed is a delta of the process-global MLX gauge,
+                    # so while another engine allocates (prefill/KV growth) the
+                    # amount freed by THIS unload is unmeasurable — the delta can
+                    # even read negative. Burning settle rounds here serializes
+                    # gc/synchronize/clear_cache against live decode for seconds,
+                    # under memory pressure, with the enforcer holding the pool
+                    # lock. Bail out instead: pre-load admission re-reads the
+                    # live gauge, so nothing downstream trusts this sample.
+                    settle_indeterminate = True
+                    logger.info(
+                        f"Settle for '{model_id}' indeterminate under concurrent "
+                        f"activity (freed={format_size(actual_freed)}, "
+                        f"need>={format_size(min_expected_freed)}); skipping "
+                        f"settle wait"
+                    )
+                    break
+                logger.debug(
+                    f"Settle round {_settle_round + 1} for '{model_id}': "
+                    f"freed={format_size(actual_freed)} "
+                    f"(need>={format_size(min_expected_freed)}) - retry"
+                )
+                await asyncio.sleep(0.5)
                 gc.collect()
                 await loop.run_in_executor(
-                    get_mlx_executor(),
-                    lambda: (mx.synchronize(), mx.clear_cache()),
-                )
-                await asyncio.sleep(1.0)
-            active_after = mx.get_active_memory()
-            if active_after > self._current_model_memory + 5 * 1024**3:
-                logger.error(
-                    f"Emergency reclaim failed for '{model_id}': "
-                    f"active_memory={format_size(active_after)} "
-                    f"exceeds safe threshold "
-                    f"({format_size(self._current_model_memory + 5 * 1024**3)})"
-                )
-            else:
-                logger.info(
-                    f"Emergency reclaim succeeded: "
-                    f"active_memory={format_size(active_after)}"
+                    get_mlx_executor(), lambda: (mx.synchronize(), mx.clear_cache())
                 )
 
-        self._wake_process_memory_enforcer()
+            # Release memory tracking AFTER barrier
+            self._current_model_memory = max(
+                0, self._current_model_memory - resident_size
+            )
+
+            if settled:
+                logger.info(
+                    f"Unloaded model: {model_id}, "
+                    f"freed={format_size(actual_freed)} "
+                    f"(expected>={format_size(min_expected_freed)}), "
+                    f"active_memory: {format_size(active_now)} (settled)"
+                )
+            elif settle_indeterminate:
+                # Settle wait skipped (logged above). Emergency reclaim is
+                # deliberately skipped too: its gc + synchronize + clear_cache
+                # rounds would stall the live engines that made the measurement
+                # indeterminate in the first place. Recovery is not lost:
+                # _wake_process_memory_enforcer() below triggers an immediate
+                # enforcer re-poll, and pre-load admission re-reads the live gauge
+                # alongside the tracked accumulator (the #1623 max() in
+                # get_engine), so any unreleased memory stays visible to both.
+                pass
+            else:
+                # Barrier timed out - try emergency reclaim
+                logger.warning(
+                    f"Settle barrier timed out for '{model_id}': "
+                    f"freed={format_size(actual_freed)} "
+                    f"(need>={format_size(min_expected_freed)})"
+                )
+                for _ in range(3):
+                    gc.collect()
+                    await loop.run_in_executor(
+                        get_mlx_executor(),
+                        lambda: (mx.synchronize(), mx.clear_cache()),
+                    )
+                    await asyncio.sleep(1.0)
+                active_after = mx.get_active_memory()
+                if active_after > self._current_model_memory + 5 * 1024**3:
+                    logger.error(
+                        f"Emergency reclaim failed for '{model_id}': "
+                        f"active_memory={format_size(active_after)} "
+                        f"exceeds safe threshold "
+                        f"({format_size(self._current_model_memory + 5 * 1024**3)})"
+                    )
+                else:
+                    logger.info(
+                        f"Emergency reclaim succeeded: "
+                        f"active_memory={format_size(active_after)}"
+                    )
+
+            self._wake_process_memory_enforcer()
+        finally:
+            entry.is_unloading = False
+            done_event = entry.unload_done
+            if done_event is not None:
+                done_event.set()
+            entry.unload_done = None
 
     def _schedule_failed_load_reclaim(
         self, model_id: str, pre_load_memory: int

--- a/omlx/exceptions.py
+++ b/omlx/exceptions.py
@@ -570,6 +570,26 @@ class ModelBusyError(EnginePoolError):
         )
 
 
+class ModelUnloadedError(EnginePoolError):
+    """
+    An in-flight request was aborted because its model was manually
+    unloaded mid-request.
+
+    Raised by _raise_request_output_error() when a collector output carries
+    error_code="model_unloaded" (set by EnginePool._unload_engine() via
+    EngineCore.abort_all_requests()). A distinct type from the memory-guard
+    exceptions so clients are never told a fabricated memory diagnosis for
+    what is actually an operator-initiated unload.
+
+    Attributes:
+        request_id: The request that was aborted.
+    """
+
+    def __init__(self, message: str, request_id: str | None = None):
+        self.request_id = request_id
+        super().__init__(message)
+
+
 # =============================================================================
 # MCP Errors
 # =============================================================================

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -187,6 +187,7 @@ from .exceptions import (
     ModelNotFoundError,
     ModelTooLargeError,
     ModelUnavailableError,
+    ModelUnloadedError,
     PrefillMemoryAbortedError,
     PrefillMemoryExceededError,
     SchedulerQueueFullError,
@@ -828,6 +829,54 @@ def _prefill_memory_openai_error_body(
     if exc.limit_bytes is not None:
         content["error"]["limit_bytes"] = exc.limit_bytes
     return content
+
+
+def _model_unloaded_openai_error_body(
+    exc: ModelUnloadedError,
+    *,
+    status_code: int = 503,
+) -> dict:
+    """Same body SHAPE as _prefill_memory_openai_error_body(), distinct code.
+
+    No estimated_bytes/limit_bytes: this abort has no memory diagnosis to
+    report, unlike its PrefillMemoryExceededError sibling above. Defaults to
+    503, not 400: an operator-initiated unload is a transient server
+    condition the client can retry, not a malformed/oversized request —
+    OpenAI-SDK clients treat invalid_request_error (what 400 maps to) as
+    do-not-retry.
+    """
+    content = _openai_error_body(str(exc), status_code, code="model_unloaded")
+    content["type"] = "error"
+    content["error"]["omlx_code"] = "model_unloaded"
+    return content
+
+
+@app.exception_handler(ModelUnloadedError)
+async def model_unloaded_handler(request: FastAPIRequest, exc: ModelUnloadedError):
+    """Map a manual-unload abort to HTTP 503 with a clear JSON body.
+
+    Mirrors prefill_memory_exceeded_handler below. Covers a pre-response-
+    start raise (the response has not begun streaming yet, so a normal
+    exception-handler mapping applies) -- without this, ModelUnloadedError
+    would fall through to the generic 500 handler and lose the message.
+    """
+    status_code = 503
+    detail = str(exc)
+    logger.warning(
+        "%s %s → %d: %s",
+        request.method,
+        request.url.path,
+        status_code,
+        detail,
+    )
+    if _is_api_route(request):
+        content = _model_unloaded_openai_error_body(exc, status_code=status_code)
+    else:
+        content = {
+            "detail": detail,
+            "omlx_code": "model_unloaded",
+        }
+    return JSONResponse(status_code=status_code, content=content)
 
 
 @app.exception_handler(PrefillMemoryExceededError)
@@ -2187,6 +2236,9 @@ async def _with_sse_keepalive(
                     if isinstance(e, PrefillMemoryExceededError):
                         logger.warning(f"SSE generator prefill rejected: {e}")
                         error_data = _prefill_memory_openai_error_body(e)
+                    elif isinstance(e, ModelUnloadedError):
+                        logger.warning(f"SSE generator request aborted: {e}")
+                        error_data = _model_unloaded_openai_error_body(e)
                     else:
                         logger.error(f"SSE generator error: {e}")
                         error_data = {
@@ -2286,6 +2338,15 @@ async def _with_json_keepalive(
         except PrefillMemoryExceededError as e:
             logger.warning(f"JSON keepalive prefill rejected: {e}")
             yield json.dumps(_prefill_memory_openai_error_body(e))
+            return
+        except ModelUnloadedError as e:
+            # Same JSON-keepalive body shape as the memory-guard path above,
+            # so clients get a parseable error instead of the truncated read
+            # + dropped connection an unclassified exception would leave
+            # here (the response already started: headers + leading
+            # keepalive space are already on the wire).
+            logger.warning(f"JSON keepalive request aborted: {e}")
+            yield json.dumps(_model_unloaded_openai_error_body(e))
             return
         if result is not None:
             yield result

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -24,7 +24,11 @@ from omlx.engine_core import (
     EngineCore,
     _raise_request_output_error,
 )
-from omlx.exceptions import PrefillMemoryAbortedError, PrefillMemoryExceededError
+from omlx.exceptions import (
+    ModelUnloadedError,
+    PrefillMemoryAbortedError,
+    PrefillMemoryExceededError,
+)
 from omlx.output_collector import RequestOutputCollector
 from omlx.request import RequestOutput, SamplingParams
 from omlx.scheduler import SchedulerConfig, SchedulerOutput
@@ -1292,6 +1296,66 @@ class TestEngineCoreAbortAllRequests:
                 engine.close()
 
     @pytest.mark.asyncio
+    async def test_abort_all_requests_default_reason_preserved(
+        self, mock_model, mock_tokenizer
+    ):
+        """Calling with no args keeps the enforcer's memory-guard contract:
+        the "prefill_memory_aborted" code and the built usage/ceiling text."""
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+
+            try:
+                await engine.start()
+                engine.scheduler.has_requests = lambda: False
+
+                rid = await engine.add_request(prompt="Hello")
+                count = await engine.abort_all_requests()
+                assert count == 1
+
+                collector = engine._output_collectors.get(rid)
+                assert collector is not None
+                output = collector.get_nowait()
+                assert output.error_code == "prefill_memory_aborted"
+                assert "memory limit" in output.error
+            finally:
+                await engine.stop()
+                engine.close()
+
+    @pytest.mark.asyncio
+    async def test_abort_all_requests_custom_reason(self, mock_model, mock_tokenizer):
+        """A caller-supplied error_message/error_code (e.g. a manual model
+        unload) reaches the collector output verbatim, with no fabricated
+        memory-guard diagnosis and a distinct, non-memory error_code."""
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+
+            try:
+                await engine.start()
+                engine.scheduler.has_requests = lambda: False
+
+                rid = await engine.add_request(prompt="Hello")
+                count = await engine.abort_all_requests(
+                    error_message="Request aborted: model 'demo' was unloaded",
+                    error_code="model_unloaded",
+                )
+                assert count == 1
+
+                collector = engine._output_collectors.get(rid)
+                assert collector is not None
+                output = collector.get_nowait()
+                assert output.error_code == "model_unloaded"
+                assert output.error == "Request aborted: model 'demo' was unloaded"
+                assert "memory limit" not in output.error
+                assert "memory limit" not in output.new_text
+            finally:
+                await engine.stop()
+                engine.close()
+
+    @pytest.mark.asyncio
     async def test_abort_all_requests_engine_keeps_running(
         self, mock_model, mock_tokenizer
     ):
@@ -1888,3 +1952,34 @@ class TestMemoryAbortErrorSurface:
                 self._abort_output(error_code=None, error_metadata=None)
             )
         assert not isinstance(exc.value, PrefillMemoryExceededError)
+
+    def test_model_unloaded_code_raises_typed_error(self):
+        """A manual-unload abort must not be classified as a memory error —
+        clients would be told a fabricated memory diagnosis otherwise."""
+        with pytest.raises(ModelUnloadedError) as exc:
+            _raise_request_output_error(
+                self._abort_output(
+                    error="Request aborted: model 'demo' was unloaded",
+                    error_code="model_unloaded",
+                    error_metadata={"request_id": "req-abort", "limit_bytes": None},
+                )
+            )
+        assert exc.value.request_id == "req-abort"
+        assert not isinstance(exc.value, PrefillMemoryExceededError)
+
+    def test_error_code_contract_across_all_three_types(self):
+        """Each error_code must keep raising its own type — the memory
+        codes must not regress when a third, unrelated code is added."""
+        with pytest.raises(PrefillMemoryAbortedError):
+            _raise_request_output_error(self._abort_output())
+        with pytest.raises(PrefillMemoryExceededError):
+            _raise_request_output_error(
+                self._abort_output(error_code="prefill_memory_exceeded")
+            )
+        with pytest.raises(ModelUnloadedError):
+            _raise_request_output_error(
+                self._abort_output(
+                    error="Request aborted: model 'demo' was unloaded",
+                    error_code="model_unloaded",
+                )
+            )

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -828,6 +828,33 @@ class TestEnginePoolLRU:
         # model-a skipped (active requests), model-b selected
         assert victim == "model-b"
 
+    def test_find_lru_victim_skips_mid_unload(self, pool_with_entries):
+        """A model whose _unload_engine() is already in flight must not be
+        picked as a fresh victim.
+
+        Regression guard (F1): the admission eviction loop calls
+        `await self._unload_engine(victim); continue` in a tight while
+        loop held under self._lock. If the finder kept returning a
+        mid-unload entry, _unload_engine's wait-for-completion path would
+        make every iteration block on the SAME in-flight teardown instead
+        of ever converging -- filtering it out here is the belt to the
+        wait-semantics braces in _unload_engine itself.
+        """
+        mock_a = MagicMock()
+        mock_a.has_active_requests.return_value = False
+        pool_with_entries._entries["model-a"].engine = mock_a
+        pool_with_entries._entries["model-a"].last_access = 50  # Older
+        pool_with_entries._entries["model-a"].is_unloading = True
+
+        mock_b = MagicMock()
+        mock_b.has_active_requests.return_value = False
+        pool_with_entries._entries["model-b"].engine = mock_b
+        pool_with_entries._entries["model-b"].last_access = 200  # Newer
+
+        victim = pool_with_entries._find_lru_victim()
+        # model-a skipped (mid-unload), model-b selected
+        assert victim == "model-b"
+
     def test_find_lru_victim_all_active(self, pool_with_entries):
         """Test that None is returned when all models have active requests."""
         for mid in ("model-a", "model-b"):
@@ -1367,6 +1394,231 @@ class TestEnginePoolAsync:
         mock_engine.stop.assert_called_once()
         assert pool.current_model_memory < initial_memory
         assert pool._entries["model-a"].engine is None
+
+    @pytest.mark.asyncio
+    async def test_unload_engine_aborts_inflight_requests_before_stop(
+        self, pool_with_mock_engines
+    ):
+        """_unload_engine must abort in-flight requests before stopping the engine.
+
+        Manual unload used to stop the engine without aborting active requests,
+        leaving their streaming generators awaiting output forever. Ordering
+        matters: abort_all_requests() must fire while the engine is still
+        alive, before stop() tears it down.
+        """
+        pool = pool_with_mock_engines
+        call_order: list[str] = []
+        abort_kwargs: dict = {}
+
+        mock_engine = MagicMock()
+        mock_engine.start = AsyncMock()
+
+        async def fake_abort_all_requests(**kwargs):
+            abort_kwargs.update(kwargs)
+            call_order.append("abort")
+            return 2
+
+        async def fake_stop():
+            call_order.append("stop")
+
+        mock_engine.abort_all_requests = AsyncMock(side_effect=fake_abort_all_requests)
+        mock_engine.stop = AsyncMock(side_effect=fake_stop)
+
+        with patch("omlx.engine_pool.BatchedEngine", return_value=mock_engine):
+            await pool.get_engine("model-a")
+            await pool._unload_engine("model-a")
+
+        mock_engine.abort_all_requests.assert_called_once()
+        mock_engine.stop.assert_called_once()
+        assert call_order == ["abort", "stop"]
+        # The reason must be model-unload-specific, never the fabricated
+        # memory-guard diagnosis (#2321-style client-facing regression).
+        assert abort_kwargs["error_code"] == "model_unloaded"
+        assert "model-a" in abort_kwargs["error_message"]
+        assert "memory" not in abort_kwargs["error_message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unload_engine_skips_non_coroutine_abort_attr(
+        self, pool_with_mock_engines
+    ):
+        """A present-but-non-async abort_all_requests attribute must be
+        skipped outright, not entered and caught as an error.
+
+        A bare MagicMock() auto-generates a plain (non-coroutine) attribute
+        for any name accessed, including abort_all_requests. Awaiting it
+        would raise TypeError; the guard must recognize it is not an
+        async method and never call it at all.
+        """
+        pool = pool_with_mock_engines
+
+        mock_engine = MagicMock()
+        mock_engine.start = AsyncMock()
+        mock_engine.stop = AsyncMock()
+        # mock_engine.abort_all_requests is left as the auto-generated,
+        # non-coroutine MagicMock attribute (the case under test).
+
+        with patch("omlx.engine_pool.BatchedEngine", return_value=mock_engine):
+            await pool.get_engine("model-a")
+            await pool._unload_engine("model-a")
+
+        mock_engine.abort_all_requests.assert_not_called()
+        mock_engine.stop.assert_called_once()
+        assert pool._entries["model-a"].engine is None
+
+    @pytest.mark.asyncio
+    async def test_unload_engine_without_abort_all_requests_still_unloads(
+        self, pool_with_mock_engines
+    ):
+        """Engines without abort_all_requests (e.g. embedding engines) still unload."""
+        pool = pool_with_mock_engines
+
+        mock_engine = MagicMock(spec=["start", "stop"])
+        mock_engine.start = AsyncMock()
+        mock_engine.stop = AsyncMock()
+
+        with patch("omlx.engine_pool.BatchedEngine", return_value=mock_engine):
+            await pool.get_engine("model-a")
+            await pool._unload_engine("model-a")
+
+        mock_engine.stop.assert_called_once()
+        assert pool._entries["model-a"].engine is None
+
+    @pytest.mark.asyncio
+    async def test_unload_engine_survives_abort_all_requests_error(
+        self, pool_with_mock_engines
+    ):
+        """A raising abort_all_requests() must not block teardown (fail-open)."""
+        pool = pool_with_mock_engines
+
+        mock_engine = MagicMock()
+        mock_engine.start = AsyncMock()
+        mock_engine.abort_all_requests = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+        mock_engine.stop = AsyncMock()
+
+        with patch("omlx.engine_pool.BatchedEngine", return_value=mock_engine):
+            await pool.get_engine("model-a")
+            await pool._unload_engine("model-a")
+
+        mock_engine.abort_all_requests.assert_called_once()
+        mock_engine.stop.assert_called_once()
+        assert pool._entries["model-a"].engine is None
+
+    @pytest.mark.asyncio
+    async def test_unload_engine_reentrancy_waits_for_completion(
+        self, pool_with_mock_engines
+    ):
+        """A concurrent unload of the same model waits for the in-flight
+        teardown instead of double-running it.
+
+        Manual unload has no caller-side lock (both HTTP routes call
+        _unload_engine directly). A silent early-return on the second
+        caller (the old reentrancy guard) is a correctness bug of its own:
+        the admission eviction loop holds self._lock across this call in a
+        tight `await self._unload_engine(victim); continue` loop, so a
+        no-op return spins that loop against a victim that never actually
+        goes away. The second caller must block until teardown is
+        genuinely complete, and only then return.
+        """
+        pool = pool_with_mock_engines
+
+        mock_engine = MagicMock()
+        mock_engine.start = AsyncMock()
+        stop_gate = asyncio.Event()
+
+        async def controlled_stop():
+            await stop_gate.wait()
+
+        mock_engine.stop = AsyncMock(side_effect=controlled_stop)
+
+        with patch("omlx.engine_pool.BatchedEngine", return_value=mock_engine):
+            await pool.get_engine("model-a")
+            entry = pool._entries["model-a"]
+            initial_memory = pool.current_model_memory
+            estimated_size = entry.estimated_size
+
+            task1 = asyncio.create_task(pool._unload_engine("model-a"))
+            # Let task1 run up to its block inside stop().
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            assert entry.is_unloading is True
+
+            task2 = asyncio.create_task(pool._unload_engine("model-a"))
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+            # Teardown has not finished -- neither caller has returned, and
+            # the engine reference is still live.
+            assert not task1.done()
+            assert not task2.done()
+            assert entry.engine is not None
+
+            stop_gate.set()
+            await asyncio.gather(task1, task2)
+
+        mock_engine.stop.assert_called_once()
+        assert entry.engine is None
+        assert pool.current_model_memory == initial_memory - estimated_size
+        assert entry.is_unloading is False
+        assert entry.unload_done is None
+
+    @pytest.mark.asyncio
+    async def test_unload_engine_second_caller_yields_to_event_loop(
+        self, pool_with_mock_engines
+    ):
+        """The second caller's wait suspends the event loop, it does not
+        spin it.
+
+        F1 regression shape: proves the second _unload_engine() call is a
+        genuine suspension point by scheduling an independent marker task
+        alongside it and observing the marker runs (and completes) while
+        the second call is still pending -- a synchronous no-op return
+        would instead let the second call finish in the same turn it
+        started, before the marker task gets to run at all.
+        """
+        pool = pool_with_mock_engines
+
+        mock_engine = MagicMock()
+        mock_engine.start = AsyncMock()
+        stop_gate = asyncio.Event()
+
+        async def controlled_stop():
+            await stop_gate.wait()
+
+        mock_engine.stop = AsyncMock(side_effect=controlled_stop)
+
+        marker_ran: list[bool] = []
+
+        async def marker_task():
+            await asyncio.sleep(0)
+            marker_ran.append(True)
+
+        with patch("omlx.engine_pool.BatchedEngine", return_value=mock_engine):
+            await pool.get_engine("model-a")
+            entry = pool._entries["model-a"]
+
+            task1 = asyncio.create_task(pool._unload_engine("model-a"))
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            assert entry.is_unloading is True
+
+            marker = asyncio.create_task(marker_task())
+            task2 = asyncio.create_task(pool._unload_engine("model-a"))
+
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+            # The marker got a full turn (proof task2 yielded instead of
+            # running to completion synchronously), and task2 is still
+            # waiting on the in-flight teardown.
+            assert marker_ran == [True]
+            assert not task2.done()
+
+            stop_gate.set()
+            await asyncio.gather(task1, task2, marker)
+
+        assert entry.engine is None
 
     @pytest.mark.asyncio
     async def test_shutdown_unloads_all(self, pool_with_mock_engines):

--- a/tests/test_server_prefill_memory_handler.py
+++ b/tests/test_server_prefill_memory_handler.py
@@ -11,7 +11,11 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from omlx.exceptions import PrefillMemoryAbortedError, PrefillMemoryExceededError
+from omlx.exceptions import (
+    ModelUnloadedError,
+    PrefillMemoryAbortedError,
+    PrefillMemoryExceededError,
+)
 
 
 def _build_test_app():
@@ -22,6 +26,7 @@ def _build_test_app():
     app.add_exception_handler(
         PrefillMemoryExceededError, srv.prefill_memory_exceeded_handler
     )
+    app.add_exception_handler(ModelUnloadedError, srv.model_unloaded_handler)
 
     @app.get("/v1/raise")
     def raise_prefill_too_large():
@@ -55,6 +60,13 @@ def _build_test_app():
         raise PrefillMemoryExceededError(
             message="Prefill would require ~50 GB peak but limit is 40 GB.",
             request_id="req-xyz",
+        )
+
+    @app.get("/v1/raise-unload")
+    def raise_model_unloaded():
+        raise ModelUnloadedError(
+            message="Request aborted: model 'demo' was unloaded",
+            request_id="req-unload",
         )
 
     return app
@@ -132,6 +144,33 @@ class TestPrefillMemoryHandler:
         assert body["omlx_code"] == "prefill_memory_exceeded"
 
 
+class TestModelUnloadedHandler:
+    """A ModelUnloadedError that escapes before the response starts must
+    reach the client as a clean, typed 503 -- not fall through to the
+    generic 500 handler and lose the message. No current production path
+    raises it that early (generation errors surface inside the keepalive
+    wrappers), so this pins the handler's contract as the backstop for
+    any future pre-response raise site."""
+
+    def test_returns_503(self):
+        with TestClient(_build_test_app()) as client:
+            resp = client.get("/v1/raise-unload")
+        assert resp.status_code == 503
+
+    def test_api_route_uses_openai_error_body(self):
+        with TestClient(_build_test_app()) as client:
+            resp = client.get("/v1/raise-unload")
+        body = resp.json()
+        assert body["type"] == "error"
+        assert body["error"]["message"] == "Request aborted: model 'demo' was unloaded"
+        assert body["error"]["code"] == "model_unloaded"
+        assert body["error"]["omlx_code"] == "model_unloaded"
+        # 503 (server_error), not 400 (invalid_request_error) -- retryable,
+        # operator-initiated, not a malformed/oversized client request.
+        assert body["error"]["type"] == "server_error"
+        assert "memory" not in body["error"]["message"].lower()
+
+
 class TestPostCommitPrefillMemorySurface:
     @pytest.mark.asyncio
     async def test_json_keepalive_emits_openai_error_body(self):
@@ -187,6 +226,85 @@ class TestPostCommitPrefillMemorySurface:
         body = json.loads(data)
         assert body["error"]["code"] == "prefill_memory_exceeded"
         assert body["error"]["omlx_code"] == "prefill_memory_exceeded"
+
+
+class TestPostCommitModelUnloadedSurface:
+    """A manual model unload mid-request must surface the same way the
+    memory-guard abort does above: a clean, parseable JSON error body, not
+    a truncated read.
+
+    Before this wrapper case existed, error_code="model_unloaded" fell
+    through _raise_request_output_error() to a bare RuntimeError, which
+    _with_json_keepalive() did not catch. Since the response had already
+    started (headers + leading keepalive space already on the wire), the
+    uncaught exception left the client with a dropped connection instead
+    of an error body.
+    """
+
+    @pytest.mark.asyncio
+    async def test_json_keepalive_emits_model_unloaded_body(self):
+        import json
+
+        import omlx.server as srv
+
+        class _Request:
+            async def is_disconnected(self):
+                return False
+
+        async def _raise_late():
+            raise ModelUnloadedError(
+                message="Request aborted: model 'demo' was unloaded",
+                request_id="req-unload",
+            )
+
+        chunks = [
+            chunk
+            async for chunk in srv._with_json_keepalive(
+                _Request(), _raise_late(), disconnect_poll=0.001
+            )
+        ]
+        # A truncated/uncaught path would raise out of the loop above
+        # instead of yielding a complete body to parse here.
+        body = json.loads("".join(chunks))
+        assert body["type"] == "error"
+        assert body["error"]["code"] == "model_unloaded"
+        assert body["error"]["omlx_code"] == "model_unloaded"
+        assert body["error"]["message"] == "Request aborted: model 'demo' was unloaded"
+        assert "memory" not in body["error"]["message"].lower()
+        # 503 (transient, retryable), not 400 (invalid_request_error, which
+        # OpenAI-SDK clients treat as do-not-retry) -- an operator unload is
+        # a server condition, not a malformed/oversized request.
+        assert body["error"]["type"] == "server_error"
+
+    @pytest.mark.asyncio
+    async def test_sse_keepalive_emits_model_unloaded_chunk(self):
+        """Drives ``_with_sse_keepalive`` directly: an escaping
+        ModelUnloadedError yields the same code/omlx_code fields as the
+        JSON-keepalive path above. On today's streaming routes the route
+        generator's own except block terminates the stream first, so
+        this branch is the wrapper-level backstop, mirroring the prefill
+        branch beside it."""
+        import json
+
+        import omlx.server as srv
+
+        async def _gen():
+            raise ModelUnloadedError(
+                message="Request aborted: model 'demo' was unloaded",
+                request_id="req-sse-unload",
+            )
+            yield ""
+
+        chunks = [
+            chunk
+            async for chunk in srv._with_sse_keepalive(_gen(), keepalive_chunk=None)
+        ]
+        assert chunks[-1] == "data: [DONE]\n\n"
+        data = chunks[0].removeprefix("data: ").strip()
+        body = json.loads(data)
+        assert body["error"]["code"] == "model_unloaded"
+        assert body["error"]["omlx_code"] == "model_unloaded"
+        assert body["error"]["type"] == "server_error"
 
 
 class TestResponsesEndpointReaches400:


### PR DESCRIPTION
## Summary

- Manually unloading a model (`POST /v1/models/{id}/unload` or the admin route) while a request is in flight leaves that request as a zombie: the stream emits keepalive chunks with no terminal event until the client's own timeout (the non-streaming JSON-keepalive path hangs the same way).
- `_unload_engine` now aborts in-flight requests before `stop()` — the same thing the memory-enforcer teardown already does — with an unload-specific abort reason, so clients see "model was unloaded" instead of a fabricated memory diagnosis.
- Concurrent unloads of the same model now wait for the in-flight teardown to finish instead of double-running it (both HTTP unload routes call `_unload_engine` with no lock), and eviction victim selection skips models mid-unload.

## Why

Both unload endpoints call `_unload_engine` directly. `stop()` tears the engine down without per-request completion callbacks, so a streaming generator awaiting its next output blocks forever and the keepalive wrapper keeps the HTTP stream alive indefinitely. The enforcer path avoids this by calling `abort_all_requests()` before teardown; `_unload_engine`'s own comment block documents that wake-up dance (it already yields to the event loop after `stop()` so woken generators can run) — but nothing on the manual-unload path ever fired the abort.

Measured live (streaming request, unload mid-generation): unfixed, the client hangs to its own timeout — 60s in our probe, receiving only 10-second keepalive chunks after the unload, no `[DONE]`; the server's only record of the request's fate is a client-disconnect 55s after the unload. Fixed: the stream terminates 0.28s after the unload with an error event and `[DONE]`.

Two payload problems surfaced while validating; both are fixed here rather than shipped as-is.

First, `abort_all_requests` hardcoded the memory-guard cause, so reusing it verbatim would send unload-aborted clients a message of the form "Request aborted: process memory limit exceeded (usage 4.5 GB, abort threshold (hard watermark) 102.1 GB, …)" — exactly the class of misleading memory diagnosis behind #2321. The primitive now takes an optional message/code and defaults to the exact current payload, so enforcer callers are byte-for-byte unchanged.

Second, on the non-streaming path an unrecognized error code would escape `_with_json_keepalive` as an uncaught `RuntimeError` after the response has started — the truncated-read failure mode described in the comment above the collector `put()`. A `ModelUnloadedError` counterpart to `PrefillMemoryAbortedError` now routes `model_unloaded` through the same wrapper machinery, emitting the same body shape under code `model_unloaded`.

## Changes

- `engine_core.abort_all_requests` (+ the `AsyncEngineCore`/`BatchedEngine`/`VLMBatchedEngine` wrappers): optional `error_message`/`error_code`/`reason` parameters; defaults reproduce the current memory-guard payload and log wording exactly.
- `engine_pool._unload_engine`: abort with code `model_unloaded` before `stop()`; two `asyncio.sleep(0)` turns so consumers parked on their collectors drain their terminal output before `close()` clears them; `is_unloading` + `unload_done` event on the entry so a concurrent unload waits for the in-flight teardown, and the LRU/prefill-eviction/dflash victim filters skip mid-unload entries (so the admission loop cannot re-select a victim whose teardown is still in flight, and direct callers cannot double-run it). A caller arriving after the engine reference is already cleared returns via the existing engine-gone path without waiting — by then the entry is invisible to the victim finders and the HTTP routes reject it as not loaded. Plus an `inspect.iscoroutinefunction` guard with a debug line when an engine has no async `abort_all_requests`, and a WARNING-level log of the aborted count.
- `exceptions.ModelUnloadedError` + `engine_core._raise_request_output_error` mapping + `model_unloaded` branches in `_with_json_keepalive` and `_with_sse_keepalive` mirroring the memory-guard body shape, plus a dedicated exception handler. The body reports 503/`server_error` — an operator unload is a transient server condition clients may retry, unlike the request-shaped memory rejection. Reach differs by path: the JSON-keepalive branch is live on the non-streaming routes; on the streaming routes each route generator's own `except` block terminates the stream first (generic-shaped error frame carrying the unload message, then `[DONE]`), so the SSE branch and the 503 handler are wrapper/handler-level backstops — sitting exactly where the existing prefill-memory SSE branch sits, behind the same route-level handling.

## Why this is safe

- The abort call itself introduces no suspension point (the chain bottoms out in `EngineCore.abort_all_requests`, which has no internal awaits — AST-checked and empirically confirmed). The two explicit drain turns after it are the only yield points between abort and `stop()`; a request admitted during those turns misses the abort snapshot and meets `stop()` un-aborted — the same fate every in-flight request had before this fix.
- No lock inversion: `scheduler.abort_request` is a GIL-atomic set-add; nothing in the abort path takes the pool lock.
- Idle-gated teardown callers are behavior-unchanged: LRU eviction, TTL sweep, pending-unload, dflash isolation, and the enforcer's idle path all require zero active requests, so the abort finds nothing there. The enforcer's busy-victim path defers its unload through the pending-unload busy-gate, so a second abort never reaches a client. The remaining callers without idle gates — pool shutdown, the admin reload/settings/delete paths, the benchmark harness — inherit the same abort; in-flight requests there zombied the same way before this change.
- Concurrent-unload waiters cannot deadlock: nothing inside `_unload_engine`'s body acquires the pool lock (verified against every acquisition site), so a waiter holding it never blocks the in-flight teardown.
- Existing callers of the abort primitive keep today's behavior via defaulted parameters, pinned by a contract test (no-args call still yields `prefill_memory_aborted` and memory-guard wording).

Sibling coverage: the guarantee applies to the two engines exposing `abort_all_requests` (`BatchedEngine`, `VLMBatchedEngine`). `DFlashEngine` and the non-streaming engines (embedding/reranker/STT/TTS/STS) have no such method and are untouched, so a manual unload of a DFlash-accelerated model mid-stream keeps today's behavior — happy to follow up with an abort hook there if wanted (the skip now logs at debug level). Two smaller consistency gaps left as-is: the VLM diffusion cancel branch ignores the new payload parameters (its cancel path predates them), and the MarkItDown OCR wrapper re-raises pool errors as `RuntimeError` before the keepalive wrapper sees them (client outcome unchanged from before this PR).

Timing residuals, disclosed rather than chased here. The drain turns cover consumers parked on their collector wait — a consumer suspended mid-send on a flow-control-paused socket at the abort instant can still lose its terminal output when `close()` clears the collectors, i.e. the pre-fix zombie narrowed to that corner. The enforcer's busy path avoids this structurally by deferring its unload until every collector has drained; matching that here would mean decoupling the abort from the immediate teardown — happy to do that as a follow-up if wanted. While an unload is in flight, admission that needs to evict skips the mid-unload victim and can return a transient 507 instead of waiting for that memory to land — strictly better than the pre-fix behavior on the same race (double-run teardown); happy to add an `unload_done` wait in the admission loop as a follow-up if wanted. Also pre-existing and deliberately untouched: a request admitted during `stop()`'s teardown window can reload the model and fail the unload's settle barrier (same failure signature on unfixed code, so not introduced here); details on request.

## Tests

`python -m pytest tests/test_engine_pool.py tests/test_engine_core.py tests/test_process_memory_enforcer.py tests/test_vlm_engine.py tests/test_batched_engine.py tests/test_dflash_engine.py tests/test_server_prefill_memory_handler.py -q` → 603 passed, plus 350 tests in adjacent suites (audio, benchmarks, server handlers) and a clean full-repo collect.

New tests: abort-before-stop ordering; reason propagation on the real `abort_all_requests` (output carries `model_unloaded`, no memory wording); the default-payload contract for existing callers; the `model_unloaded` → `ModelUnloadedError` mapping alongside the two memory codes; the JSON-keepalive body for an unload abort (parseable, correct code, no truncation); non-coroutine `abort_all_requests` attributes skipped; an abort that raises doesn't block teardown; concurrent unloads wait for completion (one `stop()`, one memory decrement, both callers return only after the engine is gone) and provably yield to the event loop instead of returning synchronously; mid-unload entries excluded from LRU victim selection; the 503 handler and SSE error-frame code field (both exercised at the wrapper/handler level — backstops on today's routes, per Changes).

Also verified the ordering, reason-propagation, and keepalive tests fail when their respective hunks are reverted.
