### PR TITLE
fix(discovery): skip incompletely downloaded sharded models

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -1082,6 +1082,7 @@ def _missing_weight_shards(model_dir: Path) -> tuple[int, list[str], str] | None
     None when the directory is complete or makes no shard promises.
     """
     idx_path = model_dir / "model.safetensors.index.json"
+    index_missing: tuple[int, list[str]] | None = None
     if idx_path.is_file():
         try:
             index = json.loads(idx_path.read_text())
@@ -1102,9 +1103,22 @@ def _missing_weight_shards(model_dir: Path) -> tuple[int, list[str], str] | None
                     if isinstance(v, str) and not (model_dir / v).is_file()
                 }
             )
-            if missing:
+            if not missing:
+                return None
+            referenced_count = len(
+                {v for v in weight_map.values() if isinstance(v, str)}
+            )
+            if len(missing) < referenced_count:
                 return len(missing), missing[:3], "model.safetensors.index.json"
-            return None
+            # Every shard the index references is absent. An interrupted
+            # download keeps the shards it already fetched, so
+            # zero-of-referenced is not that shape — it is a stale index
+            # describing a different sharding of the same checkpoint (seen
+            # in the wild: a 4-shard weight_map shipped over 2 actual
+            # shards). Loaders glob model*.safetensors and never consult
+            # the index, so fall through and judge by the shard files
+            # actually present.
+            index_missing = (len(missing), missing[:3])
 
     try:
         shard_names = [
@@ -1144,7 +1158,36 @@ def _missing_weight_shards(model_dir: Path) -> tuple[int, list[str], str] | None
                     f"{prefix}-{str(i).zfill(width)}-of-{total}.safetensors"
                 )
     if missing_count:
-        return missing_count, examples, "shard filename numbering (no index file)"
+        return (
+            missing_count,
+            examples,
+            (
+                "shard filename numbering (no shard referenced by the stale "
+                "index exists; judging by the shards present)"
+                if index_missing is not None
+                else "shard filename numbering (no index file)"
+            ),
+        )
+    if index_missing is not None:
+        if groups or (model_dir / "model.safetensors").is_file():
+            # A self-consistent complete shard set (or a consolidated
+            # single-file checkpoint) is present: the index is stale, the
+            # weights are whole. Register the model; loaders read the shard
+            # files directly and never consult the index.
+            n_missing, examples = index_missing
+            logger.warning(
+                f"Model at {model_dir} ships a stale "
+                f"model.safetensors.index.json: none of the {n_missing} "
+                f"shard(s) it references exist (e.g. {', '.join(examples)}), "
+                f"but the weight files present form a complete set — "
+                f"registering the model anyway."
+            )
+            return None
+        # No weight files at all: config + index landed first, shards did not
+        # (interrupted download before the first shard finished) — skip, and
+        # report against the only manifest available.
+        n_missing, examples = index_missing
+        return n_missing, examples, "model.safetensors.index.json"
     return None
 
 

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -1065,6 +1065,89 @@ def _is_model_dir(path: Path) -> bool:
     return (path / "config.json").exists() and not _is_adapter_dir(path)
 
 
+_SHARD_FILE_RE = re.compile(r"-(\d+)-of-(\d+)\.safetensors$")
+
+
+def _missing_weight_shards(model_dir: Path) -> tuple[int, list[str], str] | None:
+    """Detect weight shards missing from an incompletely downloaded checkpoint.
+
+    An interrupted download leaves config.json (fetched first) plus a subset of
+    the weight shards, so the directory would otherwise register as a normal,
+    load-ready model. Verify against the checkpoint's own manifest:
+    model.safetensors.index.json when it is readable, else the
+    ``-NNNNN-of-NNNNN`` shard filename numbering (the index file itself may not
+    have been downloaded yet).
+
+    Returns (missing count, up to 3 example names, manifest description), or
+    None when the directory is complete or makes no shard promises.
+    """
+    idx_path = model_dir / "model.safetensors.index.json"
+    if idx_path.is_file():
+        try:
+            index = json.loads(idx_path.read_text())
+        except (OSError, ValueError):
+            # Unreadable/corrupt index (a non-UTF-8 file raises
+            # UnicodeDecodeError, a ValueError): fall back to the filename
+            # numbering below — loaders surface the index defect itself.
+            index = None
+        weight_map = index.get("weight_map") if isinstance(index, dict) else None
+        if isinstance(weight_map, dict) and weight_map:
+            # Resolve values against the model dir (the HF index convention),
+            # so ./-prefixed or subpath entries are not misreported: only
+            # files the manifest references that are provably absent count.
+            missing = sorted(
+                {
+                    v
+                    for v in weight_map.values()
+                    if isinstance(v, str) and not (model_dir / v).is_file()
+                }
+            )
+            if missing:
+                return len(missing), missing[:3], "model.safetensors.index.json"
+            return None
+
+    try:
+        shard_names = [
+            f.name
+            for f in model_dir.iterdir()
+            if f.is_file() and f.suffix == ".safetensors"
+        ]
+    except OSError:
+        return None
+    groups: dict[tuple[str, str], set[int]] = {}
+    for name in shard_names:
+        m = _SHARD_FILE_RE.search(name)
+        if m:
+            key = (name[: m.start()], m.group(2))
+            groups.setdefault(key, set()).add(int(m.group(1)))
+    missing_count = 0
+    examples: list[str] = []
+    for (prefix, total), present in sorted(groups.items()):
+        expected_total = int(total)
+        # Count distinct in-range indices so stray or duplicate-padding names
+        # can't mask a gap; tolerate 0-based numbering alongside the 1-based
+        # HF convention.
+        base = 1
+        present_n = len({i for i in present if 1 <= i <= expected_total})
+        zero_based_n = len({i for i in present if 0 <= i < expected_total})
+        if zero_based_n > present_n:
+            base, present_n = 0, zero_based_n
+        if present_n >= expected_total:
+            continue
+        missing_count += expected_total - present_n
+        width = len(total)
+        for i in range(base, base + expected_total):
+            if len(examples) >= 3:
+                break
+            if i not in present:
+                examples.append(
+                    f"{prefix}-{str(i).zfill(width)}-of-{total}.safetensors"
+                )
+    if missing_count:
+        return missing_count, examples, "shard filename numbering (no index file)"
+    return None
+
+
 def model_directory_access_error(path: Path) -> str | None:
     """Return a user-facing error if a model directory cannot be scanned."""
     try:
@@ -1296,6 +1379,18 @@ def _register_model(
     try:
         if _is_unsupported_model(model_dir):
             logger.info(f"Skipping unsupported model: {model_id}")
+            return
+
+        incomplete = _missing_weight_shards(model_dir)
+        if incomplete:
+            n_missing, examples, manifest = incomplete
+            logger.warning(
+                f"Skipping incomplete model '{model_id}': {n_missing} weight "
+                f"shard(s) referenced by {manifest} are missing from "
+                f"{model_dir} (e.g. {', '.join(examples)}) — likely an "
+                f"interrupted or still-running download; re-run the download "
+                f"to resume it (finished shards are kept and reused)."
+            )
             return
 
         model_type = detect_model_type(model_dir)

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -830,6 +830,172 @@ class TestDiscoverModels:
         assert "/first/dup" in caplog.text
         assert str(second) in caplog.text
 
+    def test_discover_skips_incomplete_download_with_index(self, tmp_path, caplog):
+        """A partially downloaded sharded model (index present, shard missing)
+        is excluded from discovery, with a warning naming the missing shard."""
+        model_dir = tmp_path / "big-model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        index = {
+            "weight_map": {
+                "layer.a": "model-00001-of-00002.safetensors",
+                "layer.b": "model-00002-of-00002.safetensors",
+            }
+        }
+        (model_dir / "model.safetensors.index.json").write_text(json.dumps(index))
+        (model_dir / "model-00001-of-00002.safetensors").write_bytes(b"0" * 1000)
+
+        with caplog.at_level(logging.WARNING):
+            models = discover_models(tmp_path)
+
+        assert models == {}
+        assert "incomplete model 'big-model'" in caplog.text
+        assert "model-00002-of-00002.safetensors" in caplog.text
+
+    def test_discover_skips_incomplete_download_without_index(self, tmp_path, caplog):
+        """Interrupted before the index file itself landed (upstream issue 459's
+        actual on-disk shape): only the shard filename numbering promises 14
+        shards; one is on disk."""
+        model_dir = tmp_path / "big-model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        (model_dir / "model-00004-of-00014.safetensors").write_bytes(b"0" * 1000)
+
+        with caplog.at_level(logging.WARNING):
+            models = discover_models(tmp_path)
+
+        assert models == {}
+        assert "incomplete model 'big-model'" in caplog.text
+        assert "13 weight shard(s)" in caplog.text
+
+    def test_discover_complete_sharded_model_with_index(self, tmp_path, caplog):
+        """All shards referenced by the index are on disk — registers normally,
+        and an extra safetensors file the index does not reference (e.g. an oQ
+        model-mtp.safetensors) does not confuse the check."""
+        model_dir = tmp_path / "sharded"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        index = {
+            "weight_map": {
+                "layer.a": "model-00001-of-00002.safetensors",
+                "layer.b": "model-00002-of-00002.safetensors",
+            }
+        }
+        (model_dir / "model.safetensors.index.json").write_text(json.dumps(index))
+        (model_dir / "model-00001-of-00002.safetensors").write_bytes(b"0" * 1000)
+        (model_dir / "model-00002-of-00002.safetensors").write_bytes(b"0" * 1000)
+        (model_dir / "model-mtp.safetensors").write_bytes(b"0" * 1000)
+
+        with caplog.at_level(logging.WARNING):
+            models = discover_models(tmp_path)
+        assert "sharded" in models
+        assert "incomplete model" not in caplog.text
+
+    def test_discover_complete_sharded_model_without_index(self, tmp_path, caplog):
+        """A full 1..N shard set with no index file registers normally."""
+        model_dir = tmp_path / "sharded"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        for i in (1, 2, 3):
+            (model_dir / f"model-0000{i}-of-00003.safetensors").write_bytes(b"0" * 1000)
+
+        with caplog.at_level(logging.WARNING):
+            models = discover_models(tmp_path)
+        assert "sharded" in models
+        assert "incomplete model" not in caplog.text
+
+    def test_discover_index_with_subpath_weight_map_values(self, tmp_path):
+        """weight_map values are resolved against the model directory (the HF
+        index convention), so ./-prefixed or subfolder entries are not
+        misreported as missing."""
+        model_dir = tmp_path / "subpath"
+        model_dir.mkdir()
+        (model_dir / "weights").mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        index = {
+            "weight_map": {
+                "layer.a": "./model-00001-of-00002.safetensors",
+                "layer.b": "weights/model-00002-of-00002.safetensors",
+            }
+        }
+        (model_dir / "model.safetensors.index.json").write_text(json.dumps(index))
+        (model_dir / "model-00001-of-00002.safetensors").write_bytes(b"0" * 1000)
+        (model_dir / "weights" / "model-00002-of-00002.safetensors").write_bytes(
+            b"0" * 1000
+        )
+
+        models = discover_models(tmp_path)
+        assert "subpath" in models
+
+    def test_discover_corrupt_index_falls_back_to_shard_numbering(
+        self, tmp_path, caplog
+    ):
+        """An unreadable index (here non-UTF-8 bytes, the UnicodeDecodeError
+        trap) must not crash discovery into the generic 'Failed to discover'
+        path: the filename-numbering fallback still separates a complete set
+        from a gapped one."""
+        ok = tmp_path / "ok-model"
+        ok.mkdir()
+        (ok / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        (ok / "model.safetensors.index.json").write_bytes(b"\x80\x81 not json")
+        (ok / "model-00001-of-00002.safetensors").write_bytes(b"0" * 1000)
+        (ok / "model-00002-of-00002.safetensors").write_bytes(b"0" * 1000)
+
+        gapped = tmp_path / "gapped-model"
+        gapped.mkdir()
+        (gapped / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        (gapped / "model.safetensors.index.json").write_bytes(b"\x80\x81 not json")
+        (gapped / "model-00001-of-00002.safetensors").write_bytes(b"0" * 1000)
+
+        with caplog.at_level(logging.WARNING):
+            models = discover_models(tmp_path)
+
+        assert "ok-model" in models
+        assert "gapped-model" not in models
+        assert "incomplete model 'gapped-model'" in caplog.text
+        assert "Failed to discover" not in caplog.text
+
+    def test_discover_zero_based_shard_numbering_registers(self, tmp_path, caplog):
+        """A complete 0-based shard set (non-HF numbering variant) is not a
+        false positive."""
+        model_dir = tmp_path / "zero-based"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        for i in (0, 1, 2):
+            (model_dir / f"model-0000{i}-of-00003.safetensors").write_bytes(b"0" * 1000)
+
+        with caplog.at_level(logging.WARNING):
+            models = discover_models(tmp_path)
+        assert "zero-based" in models
+        assert "incomplete model" not in caplog.text
+
+    def test_discover_duplicate_padding_cannot_mask_a_gap(self, tmp_path, caplog):
+        """Two spellings of the same shard index don't add up to a complete
+        set: distinct indices are counted, not filenames."""
+        model_dir = tmp_path / "padded"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        (model_dir / "model-00001-of-00002.safetensors").write_bytes(b"0" * 1000)
+        (model_dir / "model-0001-of-00002.safetensors").write_bytes(b"0" * 1000)
+
+        with caplog.at_level(logging.WARNING):
+            models = discover_models(tmp_path)
+        assert models == {}
+        assert "incomplete model 'padded'" in caplog.text
+
+    def test_discover_subdirectory_weights_not_flagged(self, tmp_path):
+        """Weights living only in a subdirectory (estimate_model_size's
+        **/*.safetensors fallback layout) make no top-level shard promises and
+        register normally."""
+        model_dir = tmp_path / "nested"
+        model_dir.mkdir()
+        (model_dir / "weights").mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        (model_dir / "weights" / "part.safetensors").write_bytes(b"0" * 1000)
+
+        models = discover_models(tmp_path)
+        assert "nested" in models
+
     def test_discover_model_dir_is_itself_a_model(self, tmp_path):
         """Test that pointing directly at a model directory works."""
         model_dir = tmp_path / "Qwen3-5-9B-MLX-4bit"

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -891,6 +891,77 @@ class TestDiscoverModels:
         assert "sharded" in models
         assert "incomplete model" not in caplog.text
 
+    def test_discover_stale_index_complete_other_shards_registers(
+        self, tmp_path, caplog
+    ):
+        """A repo shipping an index left over from a DIFFERENT sharding (none
+        of its referenced files exist) over a complete on-disk shard set is
+        stale-index, not incomplete-download: register, warn (real case:
+        mlx-community/Qwen3-Embedding-8B-mxfp8, 4-shard index over 2 shards)."""
+        model_dir = tmp_path / "stale-index"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        index = {
+            "weight_map": {
+                f"layer.{i}": f"model-0000{i}-of-00004.safetensors"
+                for i in range(1, 5)
+            }
+        }
+        (model_dir / "model.safetensors.index.json").write_text(json.dumps(index))
+        (model_dir / "model-00001-of-00002.safetensors").write_bytes(b"0" * 1000)
+        (model_dir / "model-00002-of-00002.safetensors").write_bytes(b"0" * 1000)
+
+        with caplog.at_level(logging.WARNING):
+            models = discover_models(tmp_path)
+
+        assert "stale-index" in models
+        assert "stale" in caplog.text
+        assert "incomplete model" not in caplog.text
+
+    def test_discover_stale_index_no_weights_skips(self, tmp_path, caplog):
+        """config.json + index landed first, zero shards on disk (interrupted
+        before the first shard finished): still skipped as incomplete."""
+        model_dir = tmp_path / "no-weights"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        index = {
+            "weight_map": {
+                "layer.a": "model-00001-of-00002.safetensors",
+                "layer.b": "model-00002-of-00002.safetensors",
+            }
+        }
+        (model_dir / "model.safetensors.index.json").write_text(json.dumps(index))
+
+        with caplog.at_level(logging.WARNING):
+            models = discover_models(tmp_path)
+
+        assert models == {}
+        assert "incomplete model 'no-weights'" in caplog.text
+
+    def test_discover_stale_index_partial_other_shards_skips(
+        self, tmp_path, caplog
+    ):
+        """Stale index AND the differently-numbered on-disk set has its own
+        gap: skip, reporting against the shards actually present."""
+        model_dir = tmp_path / "stale-partial"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps({"model_type": "llama"}))
+        index = {
+            "weight_map": {
+                f"layer.{i}": f"model-0000{i}-of-00004.safetensors"
+                for i in range(1, 5)
+            }
+        }
+        (model_dir / "model.safetensors.index.json").write_text(json.dumps(index))
+        (model_dir / "model-00001-of-00002.safetensors").write_bytes(b"0" * 1000)
+
+        with caplog.at_level(logging.WARNING):
+            models = discover_models(tmp_path)
+
+        assert models == {}
+        assert "incomplete model 'stale-partial'" in caplog.text
+        assert "model-00002-of-00002.safetensors" in caplog.text
+
     def test_discover_complete_sharded_model_without_index(self, tmp_path, caplog):
         """A full 1..N shard set with no index file registers normally."""
         model_dir = tmp_path / "sharded"


### PR DESCRIPTION
Addresses #459.

## Summary
- Model discovery now verifies a sharded checkpoint's weight files against the checkpoint's own manifest before registering it, and skips the directory with an actionable warning when shards are missing.
- This removes the false-complete **model listing** from #459: after an interrupted download plus a restart, the partial directory no longer shows up as a normal, load-ready model. (The empty download-task list after a restart is the other half of the issue — see the follow-up note under out-of-scope.)

## Why
An interrupted download leaves `config.json` (fetched in the first seconds) plus whichever weight shards finalized. Discovery treats "`config.json` exists" as "model present" (`_is_model_dir`) and `estimate_model_size()` sums whatever shards happen to be on disk — so the partial directory registers as a normal model, while the download queue (the in-memory `_tasks` dict, rebuilt empty on every server start) forgets the interrupted task. The model list then presents the partial model as complete, exactly as reported.

Reproduced live with a real 66.9 GB download (`poolside/Laguna-XS-2.1`, 14 shards), hard-killed at 47% with 1 shard finalized, then relaunched:

- `GET /admin/api/hf/tasks` after restart → `{"tasks": []}`
- `GET /admin/api/models` → the model listed as load-ready at "5.01 GB" (discovery's size estimate over the single finalized shard — the full checkpoint is 66.9 GB), with no indication anything is wrong
- server.log: `Download queued: poolside/Laguna-XS-2.1` … no `Download completed` … then post-restart `Discovered model: Laguna-XS-2.1 (type: llm, engine: batched, size: 5.01GB)`

One wrinkle the repro surfaced: at kill time `model.safetensors.index.json` was **not yet on disk** (there is no guarantee it lands ahead of the shards), so the completeness check cannot rely on the index alone — hence the filename-numbering fallback below.

## Changes
`omlx/model_discovery.py` — new `_missing_weight_shards()` helper plus a guard in `_register_model()` before type detection:

- **Index branch**: every string `weight_map` value must exist, resolved against the model directory per the HF index convention — so `./`-prefixed or subfolder entries are not misreported, and only files the manifest provably references and that are provably absent count. A corrupt / non-UTF-8 / non-dict index falls through to the numbering check instead of raising (`UnicodeDecodeError` is a `ValueError`, not a `JSONDecodeError` — the same trap `_is_helper_checkpoint` already documents for config.json).
- **No-index branch**: `-NNNNN-of-NNNNN.safetensors` groups must contain all N distinct indices (1-based per the HF convention, 0-based tolerated). Counting is by distinct in-range index, so duplicate-padding spellings of one shard cannot mask a gap.
- On missing shards: one WARNING naming the count, up to 3 example filenames, and pointing at resume ("finished shards are kept and reused" — consistent with `_cleanup_partial`, which deliberately preserves finalized shards; the message says "interrupted or still-running" because a rescan triggered by one download completing can see another still in flight), then the directory is skipped.

## Why this is safe (layouts verified to keep registering)
- Single-file `model.safetensors`, GGUF dirs, and adapters (which never reach `_register_model`) make no shard promises → unchanged. Sharded checkpoints of every engine type (embedding/reranker/audio/VLM) make the same manifest promises and get the same check, which is intended.
- Index plus extra non-indexed safetensors (e.g. oQ's `model-mtp.safetensors`): extras ignored, the index stays authoritative.
- Weights only in subdirectories (`estimate_model_size`'s `**/*.safetensors` layout): no top-level promises → unchanged.
- Mid-quantization oQ outputs (`-of-PLACEHOLDER`): don't match the numeric pattern.
- A skipped directory is still listed and deletable in the admin Local Models UI — those routes walk the disk independently of discovery. Loaded/loading engines are preserved by `EnginePool.discover_models`, so nothing serving is disrupted.

Named out-of-scope siblings (not bundled):
- `.bin`-sharded checkpoints (`pytorch_model.bin.index.json`) are not checked.
- An interruption before **any** shard landed still surfaces as the pre-existing `Failed to discover model … No model weights found` ERROR rather than the new message.
- Task persistence / auto-resume across restarts. With this fix the state is honest, and re-running the download resumes from the kept shards — verified live: the re-triggered download left the finalized shard untouched (its mtime predates the kill) and fetched only the remaining 13. A downloader-side startup reconciliation that restores a retryable task entry is feasible, since the repo id is reconstructible from the directory path (`target_dir = model_dir / repo_id`). Happy to follow up in that direction if you want it.
- Discovery now parses each sharded model's index.json per scan (server start / admin refresh). If that is a concern for very large indexes I can gate it behind a cheap filename pre-check.

## Tests
9 new cases in `tests/test_model_discovery.py` (existing file): interrupted-with-index, interrupted-without-index (the issue's actual on-disk shape), complete-with-index plus an extra unindexed file, complete-without-index, subpath `weight_map` values, corrupt/non-UTF-8 index fallback (both a complete and a gapped set), 0-based numbering, duplicate-padding gap masking, subdirectory-weights layout.

`PYTHONPATH=. python -m pytest tests/test_model_discovery.py -q` → **178 passed**.
Full `-m "not slow and not integration"` suite → 7473 passed; 3 failures in MTP verify-kernel tests reproduce identically on clean main on this machine (Apple-silicon numerics, unrelated paths).
The two core regression tests were verified to FAIL with the fix reverted.
Also verified against the real interrupted directory (snapshotted before resuming): fixed discovery excludes it ("13 weight shard(s) … missing"); after the download completed, the same directory registers normally (discovery estimate 65.41 GiB, from the same estimator that reported 5.01 GB when partial).
Finally, live-validated on an isolated server instance running the fixed code, with a second real download (5 shards, ~21 GB): two more SIGKILL→restart cycles — this time with the index on disk, exercising the index branch — excluded the partial directory with warnings that tracked the on-disk state across resumes (4 missing, then 1 missing naming the exact shard); the final resume fetched only the missing shard (108 s; the earlier shards' mtimes were untouched across both resumes), after which the model registered normally, as did a concurrent second download via the completion-triggered rescan.
