### PR TITLE
fix(oq): clamp the sensitivity perturbation to a valid affine group size

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -7447,12 +7447,33 @@ def _measure_sensitivity(
 
 
 _REQUANT_VALID_BITS = {2, 3, 4, 5, 6, 8}
+_AFFINE_GROUP_SIZES = (32, 64, 128)
 
 
 def _perturb_bits_for(bits: int):
     """Closest valid re-quantization width below ``bits``, or None."""
     lower = [b for b in _REQUANT_VALID_BITS if b < bits]
     return max(lower) if lower else None
+
+
+def _affine_perturb_group_size(group_size: int, in_dim: int):
+    """Group size for an affine perturbation re-quant of a row of ``in_dim``.
+
+    The sensitivity perturbation always re-quantizes with ``mode="affine"``,
+    and affine kernels only implement group sizes 32/64/128. The source
+    module's own group size is therefore not always reusable: nvfp4 modules
+    carry ``group_size=16``, which mx.quantize rejects. Keep the module's size
+    whenever affine supports it, so affine/mxfp4/mxfp8 sources perturb exactly
+    as before; otherwise take the supported size closest to it (smallest on a
+    tie) that still divides the row. Returns None when none divides it, in
+    which case the module cannot be perturbed and is skipped.
+    """
+    usable = [g for g in _AFFINE_GROUP_SIZES if in_dim % g == 0]
+    if not usable:
+        return None
+    if group_size in usable:
+        return group_size
+    return min(usable, key=lambda g: (abs(g - group_size), g))
 
 
 def _build_proxy_for_sensitivity(
@@ -7883,15 +7904,28 @@ def _measure_sensitivity_from_quantized_model(
                 bits=bits,
                 mode=mode,
             )
-            saved[p] = (m.weight, m.scales, getattr(m, "biases", None), bits, mode)
+            # Affine kernels only ship group sizes 32/64/128, so the module's
+            # own size cannot always be reused for the perturbation re-quant.
+            perturb_gs = _affine_perturb_group_size(gs, w_float.shape[-1])
+            if perturb_gs is None:
+                logger.debug(
+                    f"Sensitivity perturbation skipped for {p}: no affine group "
+                    f"size divides an input dim of {w_float.shape[-1]}"
+                )
+                continue
+            saved[p] = (m.weight, m.scales, getattr(m, "biases", None), bits, mode, gs)
             qw, sc, *rest = mx.quantize(
-                w_float, group_size=gs, bits=perturb_bits, mode="affine"
+                w_float, group_size=perturb_gs, bits=perturb_bits, mode="affine"
             )
             m.weight = qw
             m.scales = sc
             m.biases = rest[0] if rest else None
             m.bits = perturb_bits
             m.mode = "affine"
+            # The perturbed forward reads group_size off the module, so it has
+            # to track the re-quantized layout; the restore below puts the
+            # source module's own size back.
+            m.group_size = perturb_gs
             # Force re-quant materialization so the next forward sees the
             # perturbed weights instead of the lazy reference to the originals.
             if m.biases is not None:
@@ -7912,7 +7946,7 @@ def _measure_sensitivity_from_quantized_model(
         modules_by_path = dict(
             tree_flatten(block.leaf_modules(), is_leaf=nn.Module.is_module)
         )
-        for p, (w, s, b, orig_bits, orig_mode) in saved.items():
+        for p, (w, s, b, orig_bits, orig_mode, orig_gs) in saved.items():
             if p in modules_by_path:
                 mod = modules_by_path[p]
                 mod.weight = w
@@ -7923,6 +7957,7 @@ def _measure_sensitivity_from_quantized_model(
                     del mod.biases
                 mod.bits = orig_bits
                 mod.mode = orig_mode
+                mod.group_size = orig_gs
 
         if out_perturbed is not None:
             # Cast to float32 first: float16 squared differences overflow

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -28,6 +28,7 @@ from omlx.oq import (
     OQ_LEVELS,
     OQImatrixCollector,
     OQImatrixEntry,
+    _affine_perturb_group_size,
     _bpw_targets_for_level,
     _build_proxy_for_sensitivity,
     _build_quant_plan,
@@ -3584,6 +3585,40 @@ class TestPerturbBitsFor:
         assert _perturb_bits_for(2) is None
 
 
+class TestAffinePerturbGroupSize:
+    """The perturbation re-quant is always affine, which ships only 32/64/128."""
+
+    @pytest.mark.parametrize("gs", [32, 64, 128])
+    def test_supported_group_sizes_are_kept(self, gs):
+        # A module quantized at gs always has in_dim % gs == 0, so the
+        # perturbation of every affine/mxfp4/mxfp8 source is byte-identical
+        # to what it was before the nvfp4 clamp existed.
+        assert _affine_perturb_group_size(gs, 4096) == gs
+
+    def test_nvfp4_group_16_clamps_to_nearest_supported(self):
+        # nvfp4 is the only MLX mode with group_size=16; 32 is both the
+        # nearest supported size and the finest, so it adds the least
+        # grouping error on top of the bit-width reduction being measured.
+        assert _affine_perturb_group_size(16, 4096) == 32
+
+    def test_unsupported_sizes_pick_the_nearest_divisor(self):
+        assert _affine_perturb_group_size(8, 1024) == 32
+        assert _affine_perturb_group_size(256, 1024) == 128
+        # 96 is equidistant from 64 and 128; the smaller (finer) size wins.
+        assert _affine_perturb_group_size(96, 1024) == 64
+
+    def test_own_size_wins_over_a_closer_but_indivisible_one(self):
+        # 192 is not a multiple of 128, so a gs=64 module keeps 64 rather
+        # than being pushed to a size that cannot quantize its rows.
+        assert _affine_perturb_group_size(64, 192) == 64
+
+    def test_none_when_no_supported_size_divides_the_row(self):
+        # in_dim % 16 == 0 but in_dim % 32 != 0: reachable for an nvfp4
+        # module, and re-quantizing it at any affine size would raise.
+        assert _affine_perturb_group_size(16, 48) is None
+        assert _affine_perturb_group_size(16, 112) is None
+
+
 class TestShouldQuantizeTensorWeightGuard:
     def test_non_weight_2d_params_not_quantized(self):
         assert not _should_quantize_tensor("model.layers.0.attn_hc.fn", (24, 16384))
@@ -4827,6 +4862,136 @@ class TestMeasureSensitivityQuantizedVlm:
         assert vlm_load.call_args.kwargs["trust_remote_code"] is True
         tokenizer_load.assert_called_once_with(Path("/fake/minimax-proxy"))
         lm_load.assert_not_called()
+
+
+def _toy_quantized_model(hidden, group_size, bits, mode, seed=11):
+    """One-block model whose single Linear is quantized in ``mode``.
+
+    Returns (model, proj) so the test can inspect the module the perturbation
+    loop mutates. Defined inside the function so the file still imports
+    without MLX.
+    """
+
+    class _Block(nn.Module):
+        def __init__(self, proj):
+            super().__init__()
+            self.proj = proj
+
+        def __call__(self, x, mask=None, cache=None, position_ids=None):
+            return x + self.proj(x)
+
+    class _Inner(nn.Module):
+        def __init__(self, layers):
+            super().__init__()
+            self.embed_tokens = nn.Embedding(64, hidden)
+            self.layers = layers
+
+    class _Toy(nn.Module):
+        def __init__(self, layers):
+            super().__init__()
+            self.model = _Inner(layers)
+
+    # Explicit key rather than mx.random.seed: no global RNG state to leak
+    # into whichever test runs next.
+    weight = mx.random.normal((hidden, hidden), key=mx.random.key(seed)).astype(
+        mx.bfloat16
+    )
+    proj = nn.QuantizedLinear(
+        hidden, hidden, bias=False, group_size=group_size, bits=bits, mode=mode
+    )
+    packed = mx.quantize(weight, group_size=group_size, bits=bits, mode=mode)
+    proj.weight, proj.scales = packed[0], packed[1]
+    proj.biases = packed[2] if len(packed) > 2 else None
+    mx.eval(proj.weight, proj.scales)
+    return _Toy([_Block(proj)]), proj
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestMeasureSensitivityQuantizedGroupSize:
+    """The perturbation loop re-quantizes with mode="affine", whose kernels
+    only implement group sizes 32/64/128. nvfp4 source modules carry
+    group_size=16, so reusing the module's own size raised ValueError out of
+    mx.quantize and killed the whole quantization job (issue 2354).
+    """
+
+    def _measure(self, monkeypatch, model):
+        from omlx import oq as oq_mod
+
+        monkeypatch.setitem(
+            sys.modules,
+            "omlx.utils.model_loading",
+            MagicMock(
+                maybe_apply_pre_load_patches=MagicMock(),
+                _has_mtp_heads=MagicMock(return_value=False),
+                _checkpoint_has_mtp_weights=MagicMock(return_value=False),
+                lm_load_compat=MagicMock(return_value=(model, MagicMock())),
+            ),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "omlx.patches.mlx_lm_mtp",
+            MagicMock(apply_mlx_lm_mtp_patch=MagicMock(return_value=False)),
+        )
+        monkeypatch.setattr(
+            oq_mod,
+            "_load_calibration_data",
+            MagicMock(return_value=mx.array([[1, 2, 3, 4, 5, 6, 7, 8]])),
+        )
+        return oq_mod._measure_sensitivity_from_quantized_model("/fake/proxy", {}, 4)
+
+    def test_nvfp4_source_is_measured_and_restored(self, monkeypatch):
+        model, proj = _toy_quantized_model(64, 16, 4, "nvfp4")
+        weight_before, scales_before = proj.weight, proj.scales
+
+        result = self._measure(monkeypatch, model)
+
+        # A score at all means mx.quantize accepted the perturbation *and*
+        # the perturbed forward ran: _forward_layer_result swallows ValueError,
+        # so a module left claiming group_size=16 with affine weights would
+        # drop the layer from the map instead of raising.
+        assert set(result) == {0}
+        assert result[0] > 0
+        # Every quantization attribute is back on the source module, or the
+        # next layer's baseline forward would run on a perturbed one.
+        assert (proj.group_size, proj.bits, proj.mode) == (16, 4, "nvfp4")
+        assert mx.array_equal(proj.weight, weight_before)
+        assert mx.array_equal(proj.scales, scales_before)
+        # nvfp4 has no zero point; the affine perturbation's biases must not
+        # survive the restore.
+        assert proj.get("biases") is None
+
+    @pytest.mark.parametrize("group_size", [32, 64])
+    def test_affine_source_behaviour_is_unchanged(self, monkeypatch, group_size):
+        model, proj = _toy_quantized_model(128, group_size, 8, "affine")
+        weight_before, scales_before, biases_before = (
+            proj.weight,
+            proj.scales,
+            proj.biases,
+        )
+
+        result = self._measure(monkeypatch, model)
+
+        assert set(result) == {0}
+        assert result[0] > 0
+        assert (proj.group_size, proj.bits, proj.mode) == (group_size, 8, "affine")
+        assert mx.array_equal(proj.weight, weight_before)
+        assert mx.array_equal(proj.scales, scales_before)
+        assert mx.array_equal(proj.biases, biases_before)
+
+    def test_row_no_affine_group_size_divides_is_skipped(self, monkeypatch):
+        # 48 is a legal nvfp4 row (48 % 16 == 0) but no affine group size
+        # divides it, so clamping alone would trade one mx.quantize ValueError
+        # for another ("last dimension ... divisible by 32"). The module is
+        # left alone instead, which shows up as a zero score for the layer.
+        model, proj = _toy_quantized_model(48, 16, 4, "nvfp4")
+        weight_before = proj.weight
+
+        result = self._measure(monkeypatch, model)
+
+        assert set(result) == {0}
+        assert result[0] == 0.0
+        assert (proj.group_size, proj.bits, proj.mode) == (16, 4, "nvfp4")
+        assert mx.array_equal(proj.weight, weight_before)
 
 
 # =============================================================================


### PR DESCRIPTION
An oQ job whose `sensitivity_model_path` points at an NVFP4 checkpoint dies with `ValueError: [quantize] The requested group size 16 is not supported`. The perturbation loop in `_measure_sensitivity_from_quantized_model` re-quantizes every module with `mode="affine"` while reusing the source module's own group size — nvfp4 is the one MLX mode with `group_size=16`, affine kernels implement only 32/64/128, so the pairing is invalid by construction and takes the whole quantization job down with it.

## Summary

- Pick a supported affine group size for the perturbation re-quant instead of reusing the module's: keep 32/64/128 as-is, clamp anything else (nvfp4's 16) to the closest supported size that divides the row, skip the module when none does.
- Keep the perturbed module's `group_size` attribute in sync with the re-quantized weights and restore it afterwards — the perturbed forward reads it, and without the sync the layer silently drops out of the sensitivity map instead of erroring.
- Adds 11 tests to `tests/test_oq.py` driving the real `_measure_sensitivity_from_quantized_model` over a tiny synthetic nvfp4 model, plus the affine group sizes as the regression direction.

## Why

`_measure_sensitivity_from_quantized_model` measures a layer's sensitivity by re-quantizing each of its modules one valid bit-width down and comparing the block output against the baseline. It reads the module's own quantization triple to undo the source quantization (`omlx/oq.py:7889-7906`), which is correct, but then hardcodes `mode="affine"` for the re-quant while still passing `group_size=gs`:

```python
gs = getattr(m, "group_size", 64)          # 16 on an nvfp4 module
mode = getattr(m, "mode", "affine")        # "nvfp4"
w_float = mx.dequantize(..., group_size=gs, bits=bits, mode=mode)   # fine
qw, sc, *rest = mx.quantize(w_float, group_size=gs, bits=perturb_bits, mode="affine")
```

`mx.quantize` accepts group size 16 only for `mode="nvfp4"`; under `mode="affine"` it raises before touching the array (`main`'s `omlx/oq.py:7887-7889`). Every nvfp4 module hits it, so the first block of the first layer aborts the run — the failure is total, not partial, and it lands after imatrix collection has already been paid for.

The reporter's second point is real and load-bearing, not cosmetic. `nn.QuantizedLinear.__call__` (mlx 0.32.0) passes `group_size=self.group_size, bits=self.bits, mode=self.mode` straight into `mx.quantized_matmul`, so once the perturbation group size can differ from the module's, leaving the attribute at 16 makes the perturbed forward raise (`[quantized_matmul] The shapes of the weight and scales are incompatible based on bits and group_size` — reproduced live against the pinned mlx 0.32.0). That exception is swallowed by `_forward_layer_result`'s `except (TypeError, ValueError, RuntimeError, AttributeError)` (`omlx/oq.py:6398`), which returns `None` — so the layer is dropped from the sensitivity map with nothing but a debug line. A clamp without the attribute sync trades a loud crash for a silent hole in the ranking; I measured this directly (see Tests). The same is true for the MoE experts: `QuantizedSwitchLinear.input_dims` is `scales.shape[2] * self.group_size` and its fast-path predicates gate on `self.group_size == 32` / `== 64` (`omlx/patches/deepseek_v4/switch_layers.py:201-235`), all of which need the attribute to describe the weights actually present.

The divisibility guard exists because clamping alone can substitute one `mx.quantize` error for another: a `48`-wide row is legal nvfp4 (`48 % 16 == 0`) but no affine group size divides it, and re-quantizing it at 32 raises `The last dimension of the matrix needs to be divisible by the quantization group size 32`. Skipping is the right answer rather than raising — the run still produces a ranking, and the "no fake oQ" rule is about refusing to invent sensitivity data, not about aborting over one unperturbable module. It mirrors the `perturb_bits is None: continue` just above and the identical `module.weight.shape[-1] % gs != 0` skip the fp16 QDQ path already uses (`omlx/oq.py:6479`). A block whose every module is skipped comes back with score 0.0, which is the sensitivity map's documented shape for unmeasured layers (`omlx/oq.py:5084`) — the layer keeps its base bits and merely sorts last for boosts (`omlx/oq.py:832`); nothing is ever pushed below base on the strength of a skipped measurement.

Behaviour for every source that works today is bit-identical: a module quantized at group size `g` always satisfies `in_dim % g == 0`, so for `g` in 32/64/128 the helper returns `g` and nothing downstream changes. Only group sizes affine cannot express take a different path, and today those raise.

## Changes

`omlx/oq.py`:

- New `_AFFINE_GROUP_SIZES = (32, 64, 128)` and `_affine_perturb_group_size(group_size, in_dim)` next to `_perturb_bits_for` (`omlx/oq.py:7450`, `omlx/oq.py:7459`). Returns the module's own size when affine supports it and it divides the row, otherwise the supported size closest to it, ties breaking smaller — for nvfp4's 16 that is 32, the nearest and finest, adding the least grouping error on top of the bit-width reduction being measured — or `None` when none divides. Since 128 | n implies 64 | n implies 32 | n, every nvfp4 module in a run either clamps to 32 or is skipped, so clamped modules all perturb identically and layer scores stay comparable.
- The perturbation loop uses it (`omlx/oq.py:7909-7919`), skips with a debug line when it returns `None`, and sets `m.group_size = perturb_gs` alongside the existing `m.bits` / `m.mode` writes (`omlx/oq.py:7928`).
- `saved[p]` carries the source group size and the restore loop puts it back (`omlx/oq.py:7916`, `omlx/oq.py:7949`, `omlx/oq.py:7960`). `saved` is function-local with exactly one unpack site, so widening the tuple has no other consumer.

No new setting, no signature change, no behaviour change for any source that quantizes today.

`tests/test_oq.py`: `TestAffinePerturbGroupSize` (7) and `TestMeasureSensitivityQuantizedGroupSize` (4).

## Sibling paths swept

Every `mx.quantize` call in the tree — plus the GLM DSA `nn.QuantizedLinear` constructor site — checked for "hardcoded mode with a group size that comes from somewhere else":

| Site | Shape | Verdict |
| --- | --- | --- |
| `_measure_sensitivity_from_quantized_model` (`oq.py:7917`) | `mode="affine"` literal + `group_size` from the source module | the defect, fixed here |
| `_quantize_chunked` (`oq.py:4983`, `oq.py:4990`) | `group_size`, `bits`, `mode` all parameters of the same call | consistent triple, safe |
| `_qdq_weight_only` (`oq.py:6458`) | same triple threaded through from `_get_predicate_bits` | consistent triple, safe |
| `_temporary_quantize_block` (`oq.py:6469-6483`) | fp16 QDQ path; predicate supplies all three and already guards `weight.shape[-1] % gs != 0` | safe, and the precedent for the skip added here |
| `omlx/patches/glm_moe_dsa/deepseek_v32.py:182-189` | `nn.QuantizedLinear(..., group_size=64, bits=8, mode="affine")` | both literals, affine-legal |
| `patches/m5_gather_qmm.py:63`, `patches/laguna/laguna_model.py:615` | literal `group_size=32/64`, default affine mode | affine-legal |
| `patches/bonsai_qmv.py:348` | capability probe: literal `group_size=64, bits=1`, default mode, inside `try` — a rejection is the probed signal | both literals, probe by design, safe |
| `patches/deepseek_v4/switch_layers.py:179`, `:358`; `patches/glm_moe_dsa/switch_layers.py:54`, `:155` | group size and mode both come from the module/`to_quantized` argument | consistent triple, safe |
| `patches/glm_moe_dsa/deepseek_v32.py:1031`, `:1037` | implicit affine mode; `group_size` inferred from the checkpoint's own scales shapes (`:1018-1019`) and shared with the paired `mx.dequantize` (`:1020-1022`) | self-consistent round trip, safe |

Grepped `mode="affine"` across `omlx/`: aside from this PR's own helper docstring, three hits — the line this PR changes, a pre-existing docstring, and the GLM DSA constructor above. There is no second instance of the pattern.

Explicitly out of scope:

- Activation-quantized modules. `nn.QQLinear` accepts only `nvfp4`/`mxfp8` (`mx.qqmm` raises `Only 'nvfp4' and 'mxfp8' quantization modes are supported` for anything else), so a source loaded with `quantize_activations` (`omlx/patches/deepseek_v4/utils_patch.py:206-220`) has its perturbed forward rejected and the layer dropped. That is pre-existing on `main` for mxfp8 QQLinear sources — group size 32 is affine-legal, so they already reach the affine re-quant and already lose the forward. This PR does not introduce it; it does mean nvfp4 + `quantize_activations` moves from "hard crash" to "same degradation mxfp8 already has". The degradation is still loud at the job level: if every layer's forward fails, the sensitivity map comes back empty and the caller raises ("sensitivity measurement produced no scores", `omlx/oq.py:5442`) rather than quantizing on fake data. Choosing a mode-appropriate perturbation for activation-quantized modules is a separate change with its own design question (what a perturbation of a QQLinear should even be), and it needs a real activation-quantized checkpoint to validate.
- The skip logs at debug rather than warning. A per-module warning would be noisy on a large MoE, and the layer still gets a score from its other modules. If you would rather see it surfaced once per run I can aggregate and log a single line at the end of the measurement.
- The restore loop's `del mod.biases` leaves an nvfp4 module without the `biases = None` attribute its `__init__` set, where before it was present-and-`None`. Benign: `QuantizedLinear.__call__` reads `self.get("biases")`, which is `None` either way, and the perturbation loop itself uses `getattr(m, "biases", None)`. Pre-existing shape, already exercised by mxfp4/mxfp8 sources; not touched.
- `_measure_sensitivity` (the fp16 QDQ path) is untouched. It never forces a mode, so it cannot hit this.
- Whether the nvfp4-derived ranking is *as good* as an fp16 one is not something I can claim. The mechanism, restore invariants, and a completed real-checkpoint measurement are verified (see Tests); the reporter's completed 48-layer run and 4.60 bpw oQ4e output on `poolside/Laguna-S-2.1` are the ranking-quality evidence to date.

## Tests

```
PYTHONPATH=. python -m pytest tests/test_oq.py -q
369 passed
```

358 of those are pre-existing; the 11 new ones are `TestAffinePerturbGroupSize` (7) and `TestMeasureSensitivityQuantizedGroupSize` (4). Nearest neighbours, since the change is inside the oQ sensitivity path (including `test_oq_combine.py` and `test_oq_fused_qkv_virtual.py` from the current oQ wave on `main`):

```
PYTHONPATH=. python -m pytest tests/test_oq_manager.py tests/test_oq_fp8_dequant.py tests/test_oq_combine.py tests/test_oq_fused_qkv_virtual.py tests/test_oqe_calibration_packaging.py tests/test_turboquant.py -q
122 passed, 1 skipped
```

`TestMeasureSensitivityQuantizedGroupSize` builds a one-block model whose single `nn.QuantizedLinear` is really quantized with `mx.quantize(mode=...)`, hands it to the real `_measure_sensitivity_from_quantized_model`, and asserts on the returned map and on the module's state afterwards — no log sniffing, no reimplementation of the loop.

Reverting the source hunk in the perturbation loop reproduces the reported failure through the real function:

```
tests/test_oq.py:4946: in test_nvfp4_source_is_measured_and_restored
    result = self._measure(monkeypatch, model)
tests/test_oq.py:4940: in _measure
    return oq_mod._measure_sensitivity_from_quantized_model("/fake/proxy", {}, 4)
omlx/oq.py:7887: in _measure_sensitivity_from_quantized_model
    qw, sc, *rest = mx.quantize(
E   ValueError: [quantize] The requested group size 16 is not supported. The supported group sizes are 32, 64, and 128.
2 failed, 2 passed
```

The second failure is `test_row_no_affine_group_size_divides_is_skipped`, on the same line. Keeping the clamp but reverting only the `group_size` attribute sync gives the silent-hole failure mode described above, which is why that half is in this PR rather than left for later:

```
tests/test_oq.py:4952: in test_nvfp4_source_is_measured_and_restored
    assert set(result) == {0}
E   assert set() == {0}
E     Extra items in the right set:
E     0
1 failed, 3 passed
```

`test_affine_source_behaviour_is_unchanged[32]` and `[64]` pass on both the old and the new code by design — they exist to pin that the affine sources still perturb and restore identically, not to go red.

Also verified against a real NVFP4 checkpoint: the 40-layer `Laguna-XS-2.1` NVFP4 mlx export (`{"group_size": 16, "bits": 4, "mode": "nvfp4"}` — the smaller sibling of the reporter's `Laguna-S-2.1`), driven through the real `sensitivity_model_path` route with the production arguments (`num_samples=128, seq_length=256`). On unmodified `main` it dies with the issue's verbatim error at `omlx/oq.py:7887`; on this branch the measurement completes in 49s with all 40 layers in the map and 39 nonzero scores. The one 0.0 is layer 0, and it is the checkpoint's doing, not the fix's: that export ships layer 0 unquantized (no `scales` tensors in its weight index), so there is nothing to perturb — the function's pre-existing shape for such a layer. The new skip branch never fires on this checkpoint (every quantized row is 32-divisible), so the indivisible-row case remains covered by the synthetic tests only.

Full `pytest -m "not slow and not integration"` gate on this branch: 7480 passed, 52 skipped, 3 failed — the three failures are the known M5-generation NAX numerics tolerance class (`test_glm_mtp_patch.py::TestSmallLRouting` ×2 and `test_mtp_prompt_priming.py::TestCaptureFold::test_take_primed_completes_seam`, cf. #2135); all three fail identically on unmodified `main` on this machine and pass under `MLX_METAL_GPU_ARCH=applegpu_g13s`.

Fixes #2354

