### PR TITLE
fix(vlm): honour partial mode in the VLM chat-template renders

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -144,6 +144,30 @@ def _read_config_model_type(model_path: str | Path) -> str | None:
     return model_type if isinstance(model_type, str) else None
 
 
+def _is_missing_chat_template_error(exc: ValueError) -> bool:
+    """True when apply_chat_template failed because no chat template is set.
+
+    transformers raises ValueError both for a missing template and for real
+    render errors (e.g. continue_final_message combined with
+    add_generation_prompt). Only the missing-template case may fall back to
+    mlx-vlm's plain rendering; anything else must propagate. Both the
+    tokenizer and the processor spellings must match: the vision render
+    prefers the processor's apply_chat_template, the counting render uses
+    the tokenizer.
+    """
+    message = str(exc)
+    return (
+        # tokenizer wording (transformers tokenizers; the pair mlx-vlm's
+        # prompt_utils._missing_template_error also matches)
+        "chat_template is not set" in message
+        or "no template argument was passed" in message
+        # processor wording (transformers ProcessorMixin; mlx-vlm processors
+        # that render their own template, e.g. phi3_v)
+        or "does not have a chat template" in message
+        or "No chat template found" in message
+    )
+
+
 def _apply_minimax_m3_thinking_mode(
     model_type: str | None,
     template_kwargs: dict[str, Any],
@@ -2441,6 +2465,7 @@ class VLMBatchedEngine(BaseEngine):
         audio: list | None = None,
         chat_template_kwargs: dict[str, Any] | None = None,
         tools: list[dict] | None = None,
+        is_partial: bool | None = None,
     ) -> Tuple[
         List[int],
         Optional[mx.array],
@@ -2460,6 +2485,10 @@ class VLMBatchedEngine(BaseEngine):
             messages: Chat messages (text-only, media already extracted)
             images: List of PIL Image objects
             audio: List of audio data (BytesIO buffers, tuples, or numpy arrays)
+            is_partial: Explicit partial-mode signal from the API server.
+                ``True``/``False`` — the server has already decided.  ``None``
+                (default) — auto-detect from ``messages`` for direct engine
+                callers.
 
         Returns:
             Tuple of (
@@ -2546,12 +2575,20 @@ class VLMBatchedEngine(BaseEngine):
                 if image_count > 0:
                     image_message_ranges.append((idx, image_count))
 
-        # Strip partial field from messages (VLM always uses add_generation_prompt=True)
+        if is_partial is None:
+            # get_message_json() keeps only (role, content), so the flag has to
+            # be read from the pre-format messages for direct engine callers.
+            is_partial = detect_and_strip_partial(messages)
+        # Tool and reasoning_content turns are appended verbatim by
+        # _format_messages_for_vlm_template(), so a residual key can survive
+        # formatting; the chat template must never see the non-standard field.
         detect_and_strip_partial(formatted_messages)
         template_kwargs = {
             "tokenize": False,
-            "add_generation_prompt": True,
+            "add_generation_prompt": not is_partial,
         }
+        if is_partial:
+            template_kwargs["continue_final_message"] = True
         if self._enable_thinking is not None:
             template_kwargs["enable_thinking"] = self._enable_thinking
         # Per-model/request kwargs override global defaults (e.g. enable_thinking,
@@ -2579,7 +2616,9 @@ class VLMBatchedEngine(BaseEngine):
             prompt = template_target.apply_chat_template(
                 formatted_messages, **template_kwargs
             )
-        except ValueError:
+        except ValueError as exc:
+            if not _is_missing_chat_template_error(exc):
+                raise
             # Processor/tokenizer has apply_chat_template but no chat_template
             # set. Some OCR checkpoints (e.g. raw baidu/Unlimited-OCR) ship no
             # chat template at all. mlx-vlm's get_chat_template handles this by
@@ -2589,6 +2628,17 @@ class VLMBatchedEngine(BaseEngine):
             # plain rendering, so it subsumes the tokenizer fallback too.
             template_kwargs.pop("tokenize", None)
             template_kwargs.pop("add_generation_prompt", None)
+            # get_chat_template() has no continue_final_message equivalent, so
+            # partial mode cannot be honoured on this fallback. Drop the kwarg
+            # and say so rather than passing it through as an unknown argument.
+            template_kwargs.pop("continue_final_message", None)
+            if is_partial:
+                logger.warning(
+                    "Partial mode requested but %s exposes no chat template; "
+                    "mlx-vlm plain rendering always starts a new assistant "
+                    "turn, so the final message will not be continued.",
+                    self._model_name,
+                )
             prompt = get_chat_template(
                 self._processor,
                 formatted_messages,
@@ -2859,21 +2909,26 @@ class VLMBatchedEngine(BaseEngine):
         """Apply chat template for text-only messages (no images).
 
         Args:
-            is_partial: Accepted for API parity with BatchedEngine but not
-                acted upon — VLM always uses ``add_generation_prompt=True``.
-                The ``partial`` key is still cleaned from message dicts.
+            is_partial: Explicit partial-mode signal from the API server.
+                ``True``/``False`` — the server has already decided; the
+                ``partial`` key is cleaned from message dicts but no detection
+                is performed.  ``None`` (default) — auto-detect from messages
+                for direct engine callers.
         """
         if hasattr(self._tokenizer, "apply_chat_template"):
-            # Strip partial field (VLM always uses add_generation_prompt=True)
             if is_partial is None:
-                detect_and_strip_partial(messages)
+                is_partial = detect_and_strip_partial(messages)
             else:
+                # Server already resolved partial; just clean residual keys
+                # so the chat template never sees the non-standard field.
                 for msg in messages:
                     msg.pop("partial", None)
             template_kwargs = {
                 "tokenize": False,
-                "add_generation_prompt": True,
+                "add_generation_prompt": not is_partial,
             }
+            if is_partial:
+                template_kwargs["continue_final_message"] = True
             if tools:
                 template_kwargs["tools"] = tools
             if self._enable_thinking is not None:
@@ -2891,12 +2946,22 @@ class VLMBatchedEngine(BaseEngine):
                 template_kwargs.pop("tools", None)
                 template_kwargs.pop("enable_thinking", None)
                 return self._tokenizer.apply_chat_template(messages, **template_kwargs)
-            except ValueError:
+            except ValueError as exc:
+                if not _is_missing_chat_template_error(exc):
+                    raise
                 # Tokenizer exposes apply_chat_template but has no chat_template
                 # set (e.g. raw baidu/Unlimited-OCR ships none). Fall back to
                 # mlx-vlm's plain-message rendering, matching the vision path.
                 from mlx_vlm.prompt_utils import get_chat_template
 
+                if is_partial:
+                    logger.warning(
+                        "Partial mode requested but %s exposes no chat "
+                        "template; mlx-vlm plain rendering always starts a "
+                        "new assistant turn, so the final message will not "
+                        "be continued.",
+                        self._model_name,
+                    )
                 return get_chat_template(
                     self._processor,
                     messages,
@@ -3573,6 +3638,7 @@ class VLMBatchedEngine(BaseEngine):
         text_messages, images, audio = extract_images_from_messages(messages)
 
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
+        partial = kwargs.pop("is_partial", None)
 
         # Keep VLM-capable models on one prompt-rendering path, even before the
         # first image arrives. Otherwise the conversation switches prompt families
@@ -3592,6 +3658,7 @@ class VLMBatchedEngine(BaseEngine):
             audio=audio if audio else None,
             chat_template_kwargs=ct_kwargs,
             tools=template_tools,
+            is_partial=partial,
         )
 
         if images:

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -1048,6 +1048,7 @@ class TestProcessChatMessages:
             audio=None,
             chat_template_kwargs=None,
             tools=None,
+            is_partial=None,
         )
 
     @patch("omlx.engine.vlm.extract_images_from_messages")
@@ -1764,29 +1765,230 @@ class TestCountChatTokens:
 
 
 class TestPartialModeVLM:
-    """Tests for partial mode in VLM engine — always ignored."""
+    """Partial mode must continue the final assistant message on VLM engines.
 
-    def test_apply_chat_template_partial_ignored(self):
-        """VLM _apply_chat_template strips partial but always uses add_generation_prompt=True."""
+    ``VLMBatchedEngine`` renders chat prompts in two places on the
+    chat-completions path — the generation path (``_process_chat_messages``
+    → ``_prepare_vision_inputs``) and the token-counting path
+    (``count_chat_tokens`` / ``preflight_chat`` → ``_apply_chat_template``).
+    Both used to hardcode
+    ``add_generation_prompt=True``, so a request whose final assistant message
+    carries ``partial: true`` rendered byte-identically to one without it.
+    """
+
+    _PARTIAL_MESSAGES = [
+        {"role": "user", "content": "Count from 1 to 10."},
+        {"role": "assistant", "content": "1, 2, 3, 4,", "partial": True},
+    ]
+
+    @staticmethod
+    def _plain_messages():
+        return [
+            {"role": "user", "content": "Count from 1 to 10."},
+            {"role": "assistant", "content": "1, 2, 3, 4,"},
+        ]
+
+    def test_apply_chat_template_honours_explicit_partial(self):
+        """is_partial=True → continue the final message instead of a new turn."""
         mock_tokenizer = MagicMock()
         mock_tokenizer.apply_chat_template.return_value = "<formatted>"
         engine = _make_loaded_engine(tokenizer=mock_tokenizer)
 
-        messages = [
-            {"role": "user", "content": "Hello"},
-            {"role": "assistant", "content": "{", "partial": True},
-        ]
+        # The server strips `partial` at the API boundary and forwards the
+        # resolved decision, so the messages here carry no `partial` key.
+        engine._apply_chat_template(self._plain_messages(), is_partial=True)
 
-        engine._apply_chat_template(messages)
+        call_kwargs = mock_tokenizer.apply_chat_template.call_args[1]
+        assert call_kwargs["add_generation_prompt"] is False
+        assert call_kwargs["continue_final_message"] is True
+
+    def test_apply_chat_template_autodetects_partial(self):
+        """Direct engine callers still get detection from the message key."""
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "<formatted>"
+        engine = _make_loaded_engine(tokenizer=mock_tokenizer)
+
+        engine._apply_chat_template([dict(m) for m in self._PARTIAL_MESSAGES])
+
+        call_kwargs = mock_tokenizer.apply_chat_template.call_args[1]
+        assert call_kwargs["add_generation_prompt"] is False
+        assert call_kwargs["continue_final_message"] is True
+
+        # partial field is never handed to the chat template
+        call_msgs = mock_tokenizer.apply_chat_template.call_args[0][0]
+        for msg in call_msgs:
+            assert "partial" not in msg
+
+    def test_apply_chat_template_without_partial_starts_new_turn(self):
+        """No partial signal → unchanged behavior."""
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.return_value = "<formatted>"
+        engine = _make_loaded_engine(tokenizer=mock_tokenizer)
+
+        engine._apply_chat_template(self._plain_messages(), is_partial=False)
 
         call_kwargs = mock_tokenizer.apply_chat_template.call_args[1]
         assert call_kwargs["add_generation_prompt"] is True
         assert "continue_final_message" not in call_kwargs
 
-        # partial field should be stripped from messages
-        call_msgs = mock_tokenizer.apply_chat_template.call_args[0][0]
-        for msg in call_msgs:
-            assert "partial" not in msg
+    @staticmethod
+    def _vision_engine():
+        """Engine whose processor renders the prompt, as on the real chat path."""
+        engine = _make_loaded_engine(model_type="qwen2_5_vl")
+        mock_processor = MagicMock()
+        mock_processor.apply_chat_template.return_value = "<vision prompt>"
+        mock_processor.tokenizer = engine._tokenizer
+        engine._processor = mock_processor
+        return engine
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    def test_generation_path_honours_partial(self, mock_prepare):
+        """_process_chat_messages forwards partial into the real VLM render.
+
+        This is the path a text-only /v1/chat/completions request takes on a
+        VLM-capable checkpoint: chat()/stream_chat() hand their kwargs to
+        _process_chat_messages, which renders via _prepare_vision_inputs.
+        """
+        engine = self._vision_engine()
+        mock_prepare.return_value = {
+            "input_ids": mx.array([[1, 2, 3]]),
+            "pixel_values": None,
+        }
+
+        engine._process_chat_messages(
+            self._plain_messages(), tools=None, kwargs={"is_partial": True}
+        )
+
+        call_kwargs = engine._processor.apply_chat_template.call_args[1]
+        assert call_kwargs["add_generation_prompt"] is False
+        assert call_kwargs["continue_final_message"] is True
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    def test_generation_path_without_partial_starts_new_turn(self, mock_prepare):
+        """The same request without the flag keeps opening a new turn."""
+        engine = self._vision_engine()
+        mock_prepare.return_value = {
+            "input_ids": mx.array([[1, 2, 3]]),
+            "pixel_values": None,
+        }
+
+        engine._process_chat_messages(
+            self._plain_messages(), tools=None, kwargs={"is_partial": False}
+        )
+
+        call_kwargs = engine._processor.apply_chat_template.call_args[1]
+        assert call_kwargs["add_generation_prompt"] is True
+        assert "continue_final_message" not in call_kwargs
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    def test_no_chat_template_fallback_drops_continue_final_message(
+        self, mock_prepare
+    ):
+        """Checkpoints with no chat template cannot continue a message.
+
+        mlx-vlm's get_chat_template() has no continue_final_message
+        equivalent, so the kwarg must be dropped rather than forwarded as an
+        unknown argument (which would raise TypeError).
+        """
+        engine = self._vision_engine()
+        engine._processor.apply_chat_template.side_effect = ValueError(
+            "Cannot use apply_chat_template because this processor does not "
+            "have a chat template."
+        )
+        mock_prepare.return_value = {
+            "input_ids": mx.array([[1, 2, 3]]),
+            "pixel_values": None,
+        }
+
+        with patch(
+            "mlx_vlm.prompt_utils.get_chat_template",
+            return_value="<plain prompt>",
+        ) as mock_gct:
+            engine._process_chat_messages(
+                self._plain_messages(), tools=None, kwargs={"is_partial": True}
+            )
+
+        assert "continue_final_message" not in mock_gct.call_args[1]
+        assert mock_gct.call_args[1]["add_generation_prompt"] is True
+
+    def test_missing_template_error_signatures(self):
+        """The fallback guard matches every real missing-template spelling.
+
+        The tokenizer (transformers PreTrainedTokenizerBase), the processor
+        (transformers ProcessorMixin), and mlx-vlm processors that render
+        their own template (phi3_v) each spell the error differently; all of
+        them must fall back, and real render errors must not.
+        """
+        from omlx.engine.vlm import _is_missing_chat_template_error
+
+        missing = [
+            "Cannot use chat template functions because "
+            "tokenizer.chat_template is not set and no template argument "
+            "was passed!",
+            "Cannot use apply_chat_template because this processor does not "
+            "have a chat template.",
+            "No chat template found. Please provide a chat_template argument "
+            "or ensure the tokenizer has a chat_template attribute.",
+        ]
+        for message in missing:
+            assert _is_missing_chat_template_error(ValueError(message))
+        assert not _is_missing_chat_template_error(
+            ValueError(
+                "continue_final_message and add_generation_prompt "
+                "are not compatible"
+            )
+        )
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    @patch("mlx_vlm.utils.prepare_inputs")
+    def test_generation_path_render_value_error_propagates(self, mock_prepare):
+        """A ValueError that is not the missing-template signature must raise.
+
+        transformers raises ValueError when continue_final_message meets
+        add_generation_prompt (e.g. a request combining partial mode with
+        chat_template_kwargs). Falling back would silently return a
+        non-partial render under a misleading no-chat-template warning.
+        """
+        engine = self._vision_engine()
+        engine._processor.apply_chat_template.side_effect = ValueError(
+            "continue_final_message and add_generation_prompt are not compatible"
+        )
+        mock_prepare.return_value = {
+            "input_ids": mx.array([[1, 2, 3]]),
+            "pixel_values": None,
+        }
+
+        with patch(
+            "mlx_vlm.prompt_utils.get_chat_template",
+            return_value="<plain prompt>",
+        ) as mock_gct:
+            with pytest.raises(ValueError, match="not compatible"):
+                engine._process_chat_messages(
+                    self._plain_messages(), tools=None, kwargs={"is_partial": True}
+                )
+        mock_gct.assert_not_called()
+
+    def test_count_path_render_value_error_propagates(self):
+        """The token-counting render applies the same narrow fallback."""
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.apply_chat_template.side_effect = ValueError(
+            "continue_final_message and add_generation_prompt are not compatible"
+        )
+        engine = _make_loaded_engine(tokenizer=mock_tokenizer)
+        engine._processor = MagicMock()
+
+        with patch(
+            "mlx_vlm.prompt_utils.get_chat_template",
+            return_value="<plain>",
+        ) as mock_gct:
+            with pytest.raises(ValueError, match="not compatible"):
+                engine._apply_chat_template(
+                    self._plain_messages(), is_partial=True
+                )
+        mock_gct.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`"partial": true` on the final assistant message of a `/v1/chat/completions` request is validated by the schema but has no effect at render time on any model served by `VLMBatchedEngine`: the engine accepts the server's resolved `is_partial` signal and discards it, because both of its chat-completions renders hardcode `add_generation_prompt=True`. The request renders byte-identically to one without the flag — same `usage.prompt_tokens`, same completion, a fresh assistant turn instead of a continuation.

## Summary

- Render with `add_generation_prompt=not is_partial` plus `continue_final_message=True` in both `VLMBatchedEngine` chat-completions renders, matching what `BatchedEngine._apply_chat_template()` has always done.
- Thread the flag through `_process_chat_messages()` → `_prepare_vision_inputs()`, which is the render the actual generation path uses.
- mlx-vlm's `get_chat_template()` fallback for checkpoints that ship no chat template cannot continue a message at all, so it now logs a warning instead of silently starting a new turn. Both fallbacks are also narrowed to the actual missing-template `ValueError` signatures; any other render error now propagates instead of being silently converted into a non-partial prompt.
- Adds regression coverage in `tests/test_vlm_engine.py` for both renders, in both directions, plus the fail-loud behavior of the narrowed fallbacks.

## Why

This bites a wider set of models than "vision models". `engine_type` is `vlm` for any checkpoint whose `config.json` carries a non-empty `vision_config`, and `VLMBatchedEngine` then serves that model for *every* request, including text-only conversations — `_process_chat_messages()` deliberately keeps VLM-capable models on one prompt-rendering path so the conversation does not switch prompt families on the first image-bearing turn. `Qwen3.6-35B-A3B` is such a checkpoint — the local oQ4 conversion of that family carries `model_type: qwen3_5_moe` with a populated `vision_config`, `image_token_id` and `video_token_id`, so it discovers as `engine: vlm`. The reporter runs the oQ6-mtp bundle of the same family; I have not inspected that exact checkpoint, but every symptom in the report matches this routing.

The server side is correct and does its job. `create_chat_completion()` resolves partial mode once at the API boundary with `detect_and_strip_partial(messages)` (`omlx/server.py:3276`), forwards the decision explicitly as `chat_kwargs["is_partial"]` (`omlx/server.py:3470`), and both the streaming branch (`stream_chat_completion()` → `engine.stream_chat()`) and the non-streaming branch (`engine.chat()`) pass it through untouched. `BatchedEngine._apply_chat_template()` consumes it properly (`omlx/engine/batched.py:554-568`). Nothing upstream of the engine drops the flag.

`VLMBatchedEngine` is where it dies, in both of the places it renders a chat prompt on the chat-completions path.

The generation path: `chat()` / `stream_chat()` → `_process_chat_messages()` → `_prepare_vision_inputs()`, which called `detect_and_strip_partial(formatted_messages)` purely for its stripping side effect, discarded the return value, and set `"add_generation_prompt": True` unconditionally (`omlx/engine/vlm.py:2550-2553` on `main`). `_prepare_vision_inputs()` did not even take an `is_partial` parameter, so there was nothing to honour. Worth noting that the discarded auto-detection could not have worked for ordinary messages either: `_format_messages_for_vlm_template()` rebuilds them through mlx-vlm's `get_message_json()`, which keeps only `(role, content)`, so the non-standard `partial` key was already gone before that call ran (tool and reasoning turns are appended verbatim — which is why the residual-key strip stays; see Changes).

The counting path: `count_chat_tokens()` and `preflight_chat()` → `_apply_chat_template()`, which *did* accept `is_partial` — and documented, in its own docstring, that it ignored it: *"Accepted for API parity with BatchedEngine but not acted upon — VLM always uses `add_generation_prompt=True`"* (`omlx/engine/vlm.py:2857-2875` on `main`).

That combination is exactly the reported symptom set. The schema validates the field (so `"partial": "banana"` is a clean 422), the flag survives every hop the reporter traced, and then the render throws it away — which is also why reading the tagged source did not reveal it: the chain through `openai_models.py` → `server.py` → `engine/batched.py` really is correct end-to-end, and `engine/batched.py` is not the engine that served the request.

Reproduced with the real Qwen3.6-35B-A3B chat template (7,764 chars, loaded from the checkpoint, no weights) driving both `VLMBatchedEngine` render paths directly — the generation render (`_process_chat_messages()` → `_prepare_vision_inputs()`) and the counting render (`_apply_chat_template()`) — with the reporter's conversation shape:

```
--- non-stream ---                                    (before)
  no partial : 39tok  '...<|im_start|>assistant\n<think>\n\n</think>\n\n1, 2, 3, 4,<|im_end|>\n<|im_start|>assistant\n<think>\n'
  partial    : 39tok  '...<|im_start|>assistant\n<think>\n\n</think>\n\n1, 2, 3, 4,<|im_end|>\n<|im_start|>assistant\n<think>\n'
  => IDENTICAL

--- non-stream ---                                    (after)
  no partial : 39tok  '...<|im_start|>assistant\n<think>\n\n</think>\n\n1, 2, 3, 4,<|im_end|>\n<|im_start|>assistant\n<think>\n'
  partial    : 32tok  '...<|im_start|>assistant\n<think>\n\n</think>\n\n1, 2, 3, 4,'
```

The counting path gives the same 39/39 → 39/32 shape, so `usage.prompt_tokens` and the preflight agree with the generation render on both sides of the fix. The same harness against `BatchedEngine._apply_chat_template()` differs 39 → 32 before and after the change, confirming the text engine was never affected.

## Changes

`omlx/engine/vlm.py`:

- `_prepare_vision_inputs()` takes a new trailing `is_partial: bool | None = None` (`vlm.py:2468`) and builds `"add_generation_prompt": not is_partial` plus `continue_final_message=True` (`vlm.py:2588-2591`). When the caller passes `None`, detection now reads the *pre-format* messages, since `get_message_json()` has already dropped the key by the time `formatted_messages` exists; the existing `detect_and_strip_partial(formatted_messages)` call stays, because the tool / `tool_responses` / `reasoning_content` branch of the formatter appends source dicts verbatim and a residual key must never reach the template.
- `_process_chat_messages()` pops `is_partial` out of `kwargs` and forwards it into the render (`vlm.py:3641`, `vlm.py:3661`), mirroring how `chat_template_kwargs` is already handled there.
- `_apply_chat_template()` now consumes `is_partial` the same way `BatchedEngine` does (`vlm.py:2902`, `vlm.py:2928-2931`), so `count_chat_tokens()` / `preflight_chat()` agree with the prompt the generation path builds — on processors that delegate chat templating to the tokenizer, which is the common case; the self-rendering exception is named out of scope below. Its docstring no longer advertises the field as inert.
- Both `except ValueError` fallbacks to mlx-vlm's `get_chat_template()` — the path for checkpoints that expose `apply_chat_template` but ship no chat template, e.g. raw `baidu/Unlimited-OCR` — warn when partial mode was requested (`vlm.py:2634-2641`, `vlm.py:2957-2964`). `get_chat_template()` has no `continue_final_message` equivalent, so the vision-path fallback also drops the kwarg rather than forwarding it as an unknown argument.
- Those two fallbacks are also **narrowed to the genuine missing-template signatures** (new `_is_missing_chat_template_error()`, `vlm.py:147-168`; guards at `vlm.py:2619-2621` and `vlm.py:2949-2951`). The helper matches both the tokenizer spellings — the pair mlx-vlm's own `prompt_utils._missing_template_error` matches — and the processor spellings (transformers `ProcessorMixin`, and mlx-vlm processors that render their own template, e.g. phi3_v), because the vision render prefers the processor's `apply_chat_template` while the counting render uses the tokenizer; the three real spellings — four substrings, since the tokenizer message carries two — are pinned by `test_missing_template_error_signatures`. This matters *because* of this fix: with `continue_final_message` now in play, transformers raises `ValueError("continue_final_message and add_generation_prompt are not compatible")` when a request combines partial mode with `add_generation_prompt` via `chat_template_kwargs` — and the previously-bare `except ValueError` would have swallowed it, logged a factually wrong "exposes no chat template" warning, and silently returned a non-partial render. Real render errors now propagate; only the genuine no-template case falls back (matching `BatchedEngine`, which re-raises render failures at `batched.py:587-591`).

Ordering is unchanged: request-supplied `chat_template_kwargs` are still merged last and still win, exactly as in `BatchedEngine`.

Zero change to the rendered prompt for requests that do not set `partial`. `is_partial` is `False` (server path) or `None` (direct engine callers, where detection returns `False`); both make `not is_partial` evaluate `True` and leave `continue_final_message` unset, so the prompt is byte-identical to before. The one other behavioral change is the narrowed fallback above: a render `ValueError` that is not the missing-template case now propagates instead of silently degrading to a plain non-partial render — the fail-loud direction.

`tests/test_vlm_engine.py`: `TestPartialModeVLM` (`test_vlm_engine.py:1767`) rewritten from one test pinning the ignore-it behavior to nine covering both renders in both directions, including `test_generation_path_honours_partial`, which runs the real `_process_chat_messages()` → `_prepare_vision_inputs()` chain with `mlx_vlm.utils.prepare_inputs` patched (against a mock processor) and asserts on the kwargs the processor's `apply_chat_template()` actually receives; `test_no_chat_template_fallback_drops_continue_final_message`, which pins that the no-chat-template fallback strips the kwarg instead of handing `get_chat_template()` an argument it does not accept; two `..._render_value_error_propagates` tests pinning that a non-missing-template `ValueError` raises on both renders instead of falling back; and `test_missing_template_error_signatures`, which pins the three real missing-template spellings (tokenizer and processor) against the guard, plus one real render error that must not match. `TestProcessChatMessages::test_text_only_uses_vlm_prepare_path` gains the new `is_partial=None` argument in its call assertion.

## Sibling paths swept

Every render on the `/v1/chat/completions` path, plus the adjacent renderers that reuse these entry points:

| Path | Render site | Status |
| --- | --- | --- |
| `/v1/chat/completions` → `BatchedEngine` | `batched.py:554-568` | already correct, untouched |
| `/v1/chat/completions` → `DFlashEngine` | `dflash.py:750-762`, count paths `dflash.py:789`/`dflash.py:807`, pops at `dflash.py:1616`/`dflash.py:1695` | already correct, untouched |
| `/v1/chat/completions` → `DFlashEngine` VLM fallback | constructs a `VLMBatchedEngine` delegate (`dflash.py:676-684`) and forwards `**kwargs` to it in `chat()`/`stream_chat()` (`dflash.py:1578`, `dflash.py:1653`) | fixed via the delegate |
| `/v1/chat/completions` → `VLMBatchedEngine`, generation | `vlm.py:2588-2591` | **fixed** |
| `/v1/chat/completions` → `VLMBatchedEngine`, counting / preflight | `vlm.py:2928-2931` | **fixed** |
| `/v1/chat/completions` → `VLMBatchedEngine`, no-chat-template fallback | `vlm.py:2619`, `vlm.py:2949` | cannot be honoured; now warns, and only fires for genuine missing-template errors |
| `/v1/chat/completions` thinking-state probe | `server.py:4279-4299` | already forwards `is_partial` to the engine renderer; picks up the fix automatically |
| Admin cache probe | `admin/routes.py:5105-5115` calls `engine._apply_chat_template()` without `is_partial` | picks up auto-detection from the message key; the probe's stated purpose is hash parity with the generation render, which it previously lacked for partial conversations |
| `omlx/models/llm.py` direct chat | `llm.py:289-293` | already correct, untouched |
| `/v1/completions` | raw prompt, no chat template | not applicable |

The Anthropic-path token estimates (`server.py:4829`, `server.py:5568`) hardcode `add_generation_prompt=True`; the Anthropic schema cannot express `partial` (see below), so those stay out of scope.

Explicitly out of scope:

- **The Harmony (gpt-oss) and Gemma 4 message extractors drop the `partial` key.** `extract_text_content()` and `extract_multimodal_content()` copy it onto the output dict (`api/utils.py:1004`, `api/utils.py:1173`), but `extract_harmony_messages()` and `extract_gemma4_messages()` do not, so `detect_and_strip_partial()` at the API boundary always returns `False` for those families and partial mode is inert on them too — for a completely different reason, in a different layer (extraction, not render — the same extraction layer #2426 patches, but in the per-family extractors, `extract_harmony_messages()` in `api/utils.py` and `extract_gemma4_messages()` in `omlx/adapter/gemma4.py`, rather than the shared drop/merge helpers, so #2426 does not cover it either). I verified this by driving all four extractors with a `partial: true` message. Happy to send it as a separate PR; it wants its own decision about whether the Harmony protocol and the Gemma 4 `tool_responses` shape can even express a continuation.
- **`/v1/responses` hardcodes `is_partial=False`** (`server.py:5788`) and does not forward it to `count_chat_tokens()`. Partial is unsupported there by construction, not broken — a feature gap, not this defect.
- **`/v1/messages` (Anthropic)** calls `detect_and_strip_partial()` (`server.py:5270`) but the Anthropic request schema has no `partial` field, so it can never fire from wire input. That call is defensive only and is left alone.
- **The diffusion prompt render** also hardcodes `add_generation_prompt=True`, and `_validate_diffusion_request()` does not reject `partial` (it checks tools / audio / stop / grammar / specprefill only), so a diffusion request carrying `partial: true` remains accepted-and-ignored. Continuing a prefilled assistant message is meaningless for a text-to-image model, so honouring it makes no sense; whether to *reject* it there is a separate validation decision. Left as-is and named here rather than silently skipped.
- **Processors that render their Jinja template themselves** (mlx-vlm's molmo and phi3_v styles do `template.render(..., **kwargs)`) accept `continue_final_message` as just another template variable: transformers' continuation trimming lives in its render call, not in the template, so on those checkpoints a partial render suppresses the generation prompt but does not trim the final turn's end marker, and the tokenizer-rendered counting path can disagree with the processor-rendered generation path. Gating on per-processor capability deserves its own change; named here rather than silently absorbed.
- **`_inject_specprefill_system_end()` renders its non-system sub-prompt without `is_partial`**, so with SpecPrefill enabled *and* a system prompt *and* partial mode, the protected-region boundary is short by the length of the generation-prompt suffix (measured: `system_end` 16 → 9 tokens on the repro template). The shape is pre-existing in `BatchedEngine` (`batched.py:674-676`), but on the VLM path it becomes *reachable* only with this change — before it, both renders were always non-partial, so there was no skew to expose. It is a bounded, guarded (`if system_end > 0`, inside `try`/`except`) heuristic skew that never changes what is rendered. Deliberately not folded into this fix; it belongs in its own change covering both engines, and I am happy to send that follow-up.

One note on the report itself: it says `BatchedEngine`, but `Qwen3.6-35B-A3B` ships a `vision_config`, so it is discovered as `engine: vlm` and served by `VLMBatchedEngine`. That is consistent with every symptom in the report and, I think, explains why tracing `engine/batched.py` from the tagged source looked correct — it *is* correct; it just is not the engine on that request's path.

Relationship to #2426: complementary, not competing — different layer, no file overlap. #2426 preserves the `partial` flag through two extraction-layer collapses in `api/utils.py` (an empty partial assistant being void-dropped; a trailing partial assistant being merged into a preceding one) so that `detect_and_strip_partial()` can still see the flag at the API boundary. This PR makes the VLM engine honour the flag once the boundary has seen it. The two failure modes sit on orthogonal axes — message shape vs. serving engine: with only #2426 merged, a single non-empty partial assistant still renders as a fresh turn on every `vision_config` checkpoint, because both VLM renders discard `is_partial` (which matches the reported symptom, given the routing note above); with only this PR merged, the two collapsed shapes still lose the flag before any engine is consulted. Merging both covers every shape and engine named above; the per-family extractor gap (Harmony / Gemma 4, out of scope for both PRs) remains either way.

## Tests

```
pytest tests/test_vlm_engine.py -q
105 passed
```

Neighbouring suites for every file this change can reach:

```
pytest tests/test_vlm_specprefill.py -q             7 passed
pytest tests/test_dflash_multimodal_fallback.py -q  22 passed
pytest tests/test_batched_engine.py -q              42 passed
pytest tests/test_dflash_engine.py -q               80 passed
pytest tests/test_api_utils.py -q                   223 passed
pytest tests/test_server.py -q                      55 passed
```

With the `omlx/engine/vlm.py` half of the commit reverted and the tests kept, exactly the seven below go red:

```
FAILED TestPartialModeVLM::test_apply_chat_template_honours_explicit_partial
FAILED TestPartialModeVLM::test_apply_chat_template_autodetects_partial
FAILED TestPartialModeVLM::test_generation_path_honours_partial
FAILED TestPartialModeVLM::test_missing_template_error_signatures
FAILED TestPartialModeVLM::test_generation_path_render_value_error_propagates
FAILED TestPartialModeVLM::test_count_path_render_value_error_propagates
FAILED TestProcessChatMessages::test_text_only_uses_vlm_prepare_path
7 failed, 98 passed
```

The representative assertion in the render tests is `add_generation_prompt` arriving as `True` where the test expects `False`.

The narrowing half was also revert-proven on its own: with the partial-mode threading in place but the guard neutralized to accept every `ValueError`, the two `..._render_value_error_propagates` tests and `test_missing_template_error_signatures` fail (3 failed / 102 passed — the guard's negative case, plus the two renders where the error is swallowed and the plain-render fallback fires); with the narrowing in place all pass.

The two that stay green on both old and new code are the negative-direction tests (`..._without_partial_starts_new_turn`); they exist to pin the zero-behavior-change claim, not to go red. `test_no_chat_template_fallback_drops_continue_final_message` is likewise green on old code (nothing set the kwarg there), but it does go red if you change that `template_kwargs.pop(...)` to a `get(...)` — it pins the drop, not the defect.

Addresses #2357

