### PR TITLE
fix(server): null-guard the specprefill model-settings fallback

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3474,11 +3474,11 @@ async def create_chat_completion(
             chat_kwargs["specprefill"] = request.specprefill
         if request.specprefill_keep_pct is not None:
             chat_kwargs["specprefill_keep_pct"] = request.specprefill_keep_pct
-        elif _server_state.settings_manager and ms.specprefill_keep_pct is not None:
+        elif ms and ms.specprefill_keep_pct is not None:
             chat_kwargs["specprefill_keep_pct"] = ms.specprefill_keep_pct
         if getattr(request, "specprefill_threshold", None) is not None:
             chat_kwargs["specprefill_threshold"] = request.specprefill_threshold
-        elif _server_state.settings_manager and ms.specprefill_threshold is not None:
+        elif ms and ms.specprefill_threshold is not None:
             chat_kwargs["specprefill_threshold"] = ms.specprefill_threshold
 
         if request.stop:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,6 +7,8 @@ import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
+from omlx.api.openai_models import ChatCompletionRequest, Message
+from omlx.engine import BaseEngine
 from omlx.engine_pool import EngineEntry
 from omlx.exceptions import (
     InvalidRequestError,
@@ -23,6 +25,7 @@ from omlx.server import (
     _reset_boundary_snapshots_for_server,
     _resolve_metric_durations,
     app,
+    create_chat_completion,
     get_engine,
     get_max_context_window,
     get_sampling_params,
@@ -580,6 +583,109 @@ class TestModelFallback:
             await get_engine("broken-model", EngineType.LLM)
 
         assert exc_info.value.status_code == 409
+
+
+class TestChatCompletionEmptyModelSettings:
+    """Chat completions must not 500 when no per-model settings resolve.
+
+    ``ChatCompletionRequest.model`` has no ``min_length``, so pydantic
+    accepts ``"model": ""``, and ``get_model_settings_for_request()``
+    returns ``None`` for any falsy model id even when a settings manager is
+    mounted. With ``model_fallback`` enabled the request still resolves to
+    the default engine, so it reaches the SpecPrefill fallback branches with
+    ``ms`` None. Those branches guarded on ``_server_state.settings_manager``
+    rather than on ``ms`` and raised ``AttributeError`` on
+    ``ms.specprefill_keep_pct`` / ``ms.specprefill_threshold``.
+    """
+
+    class _FakePool:
+        """Minimal EnginePool double: "" 404s, model_fallback resolves it."""
+
+        def __init__(self, engine):
+            self._engine = engine
+
+        def resolve_model_id(self, model_id, settings_manager=None):
+            return model_id
+
+        def get_entry(self, model_id):
+            return None
+
+        async def get_engine(self, model_id, _lease=False, runtime_settings=None):
+            if not model_id:
+                raise ModelNotFoundError(model_id, [])
+            return self._engine
+
+        async def release_engine(self, model_id):
+            # Load-bearing on the pre-fix run: the AttributeError unwinds
+            # through `except BaseException: await lease.release()`, which
+            # would otherwise raise a second, masking error.
+            pass
+
+    @pytest.fixture(autouse=True)
+    def setup_server_state(self, tmp_path):
+        state = ServerState()
+        state.global_settings = GlobalSettings()
+        state.global_settings.model.model_fallback = True
+        state.default_model = "default-model"
+        # A real settings manager, so the old `_server_state.settings_manager`
+        # guard was truthy even when the per-request lookup returned None.
+        self.settings_manager = ModelSettingsManager(tmp_path)
+        state.settings_manager = self.settings_manager
+        self.engine = MagicMock(spec=BaseEngine)
+        self.engine.preflight_chat = AsyncMock(return_value=None)
+        self.engine.count_chat_tokens = MagicMock(return_value=5)
+        self.engine.is_diffusion_model = False
+        self.engine.tokenizer = None
+        state.engine_pool = self._FakePool(self.engine)
+        with patch("omlx.server._server_state", state):
+            yield
+
+    @staticmethod
+    def _chat_request(model):
+        # Both response shapes assemble chat_kwargs at the same point and hand
+        # them to engine.preflight_chat(), so either covers the guards; stream=True
+        # avoids the non-streaming branch's _build_chat_completion() coroutine,
+        # which these tests never await.
+        request = ChatCompletionRequest(
+            model=model,
+            messages=[Message(role="user", content="hi")],
+            stream=True,
+        )
+        http_request = MagicMock()
+        http_request.headers = {}
+        return request, http_request
+
+    @pytest.mark.asyncio
+    async def test_empty_model_fallback_resolves_specprefill_defaults(self):
+        """model="" + model_fallback must not 500 with AttributeError."""
+        request, http_request = self._chat_request("")
+
+        # Returning a response at all is the regression signal: before the fix
+        # this call raised AttributeError out of create_chat_completion.
+        response = await create_chat_completion(request, http_request, True)
+
+        assert response.status_code == 200
+        # No per-model settings were resolvable, so neither SpecPrefill knob
+        # is forwarded and the engine keeps its own defaults.
+        kwargs = self.engine.preflight_chat.await_args.kwargs
+        assert "specprefill_keep_pct" not in kwargs
+        assert "specprefill_threshold" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_model_settings_specprefill_still_forwarded(self):
+        """The relaxed guard must still forward configured per-model values."""
+        self.settings_manager.set_settings(
+            "configured-model",
+            ModelSettings(specprefill_keep_pct=0.3, specprefill_threshold=16384),
+        )
+        request, http_request = self._chat_request("configured-model")
+
+        response = await create_chat_completion(request, http_request, True)
+
+        assert response.status_code == 200
+        kwargs = self.engine.preflight_chat.await_args.kwargs
+        assert kwargs["specprefill_keep_pct"] == 0.3
+        assert kwargs["specprefill_threshold"] == 16384
 
 
 class TestGetEngineLLMTypeValidation:


### PR DESCRIPTION
`POST /v1/chat/completions` returns HTTP 500 (`AttributeError: 'NoneType' object has no attribute 'specprefill_keep_pct'`) for a request with `"model": ""` when `model_fallback` is enabled. The two SpecPrefill fallback branches in `create_chat_completion` guard on `_server_state.settings_manager` before dereferencing `ms`, but `ms` is the *per-request* lookup — it is `None` whenever `get_model_settings_for_request()` short-circuits, independently of whether a settings manager is mounted.

## Summary

- Guard the `specprefill_keep_pct` / `specprefill_threshold` model-settings fallbacks on `ms` itself instead of on `_server_state.settings_manager`.
- Adds a `tests/test_server.py` class covering both directions: `"model": ""` no longer 500s and falls back to engine defaults, and a configured per-model SpecPrefill setting is still forwarded.

## Why

`get_model_settings_for_request()` (`omlx/server.py:1429`) returns `None` for any falsy `model_id`, *before* it ever touches the settings manager:

```python
sm = _server_state.settings_manager
if not model_id or sm is None:
    return None
```

`ChatCompletionRequest.model` is a plain `str` with no `min_length` (`omlx/api/openai_models.py:272`), so pydantic accepts `"model": ""`. `get_engine(...)` then raises `ModelNotFoundError` for the empty id, and with `model_fallback` enabled (`omlx/server.py:945-966`) the request is served by the default model instead of 404ing. Execution therefore reaches `omlx/server.py:3477`/`3481` with `ms is None` while `_server_state.settings_manager` is a live `ModelSettingsManager` — the guard is true, the deref crashes, and the client gets a 500 instead of a completion.

Scope, stated plainly: this needs `model_fallback` turned on (it defaults to `False`, `omlx/settings.py:205`) *and* a default model configured, so a stock install is not affected. It also needs a client that sends `"model": ""` — none of oMLX's own integrations do (they all guard `if ctx.model:` before writing the id), so this is a misconfigured or minimal external client. But that combination is exactly what `model_fallback` exists to absorb: its whole purpose is to make an unusable model name resolve to the default model instead of erroring, and here it turns a 404 into a 500.

Note that `ms is None` here really does mean "no per-model settings for this request": both manager lookups are total — `ModelSettingsManager.get_settings()` returns a default `ModelSettings()` rather than `None` for unknown ids (`omlx/model_settings.py:469-484`), and `get_settings_for_request()`, which resolves API-requested names, always returns either a profile merge or falls through to `get_settings()` (`omlx/model_settings.py:486-511`) — so the falsy-`model_id` short-circuit is the only way a mounted manager yields `None`. The old guard was checking a condition that could never distinguish the two.

## Changes

`omlx/server.py`, `create_chat_completion`:

- `elif _server_state.settings_manager and ms.specprefill_keep_pct is not None:` → `elif ms and ms.specprefill_keep_pct is not None:`
- `elif _server_state.settings_manager and ms.specprefill_threshold is not None:` → `elif ms and ms.specprefill_threshold is not None:`

Request-supplied values keep priority; behavior is unchanged whenever `ms` is non-`None`, which is every case the old guard did not crash on.

`tests/test_server.py`: new `TestChatCompletionEmptyModelSettings` (2 tests) against the real `create_chat_completion` coroutine with a mounted `ModelSettingsManager`, asserting the kwargs actually handed to `engine.preflight_chat()`.

## Sibling paths swept

Every other consumer of `get_model_settings_for_request()` already guards on the returned settings object, not on the manager:

| Site | Guard | Verdict |
| --- | --- | --- |
| `get_sampling_params` (`server.py:1263`) | `model_settings and model_settings.<attr>` on all 9 reads | already safe |
| `_resolve_thinking_budget` (`server.py:1423`) | `if ms and ms.thinking_budget_enabled and ...` | already safe |
| `get_max_context_window` (`server.py:1577`) | `if model_settings and model_settings.max_context_window is not None` | already safe |
| `create_chat_completion` settings block (`server.py:3203`) | `if ms:` before reading `max_tool_result_tokens` / `reasoning_parser` / grammar | already safe |
| `create_anthropic_message` (`server.py:5185`) | `if ms:` | already safe |
| `create_response` (`server.py:5710`) | `if ms:` | already safe |
| `merge_chat_template_request_kwargs()` / `forced_ct_keys()` (`model_settings.py:1295`/`:1288`) / `_settings_guided_grammar()` (`server.py:3744`) | all take `settings: ModelSettings | None` and early-return on `None` | already safe |

Swept mechanically as well: across all of `omlx/`, the shape "guard on the settings *manager*, then dereference a settings *object*" matches exactly the two lines this PR changes — and zero lines after it.

Explicitly out of scope:

- Several places do dereference a settings object straight off `settings_manager.get_settings(...)` with no null check (`server.py:2554`, `engine_pool.py:2229`, `admin/routes.py:2104`, `admin/accuracy_benchmark.py:444`). Those are safe for a different reason — `get_settings()` is total, returning a default `ModelSettings()` rather than `None` — so a null guard there would be dead code. Not the same defect; left alone.
- The other generation surfaces (`/v1/messages`, `/v1/responses`, `/v1/completions`) do not read `specprefill_*` from model settings at all, so they cannot hit this deref — but that also means per-model SpecPrefill settings are only honored on `/v1/chat/completions`. That gap is a separate change (and overlaps #1782, which addresses SpecPrefill settings resolution down in the engine layer); not touched here.
- Boundary validation would be the other way to close this: `Field(min_length=1)` on `ChatCompletionRequest.model`, or normalizing `""` to `None` so it takes the existing default-model path at `server.py:902-908`. That is a policy decision, not a null-safety one — today an absent or null `model` is a 422 while `""` is a 404 (or the default model under fallback), and changing that shifts behavior for existing clients. This PR keeps it minimal; happy to follow up with the ingress version if you'd rather fix it there.
- A fallback-served request still echoes the requested id back, so `"model": ""` in gives `"model": ""` out (`server.py:3625` and the streaming chunks). That is pre-existing behavior for every fallback-served request, not something this change introduces.
- The two guards sit next to a pre-existing asymmetry — `request.specprefill_keep_pct` is read directly at `server.py:3475` while `server.py:3479` uses `getattr(request, "specprefill_threshold", None)` even though both fields exist on the model (`openai_models.py:304-308`). Left as-is to keep the diff to the actual defect.

## Tests

```
pytest tests/test_server.py -q
57 passed
```

The full CI gate (`pytest -m "not slow and not integration"`) is 7472 passed, 52 skipped, 3 failed on this branch. All three failures are pre-existing M5 GPU-numerics assertions on my machine — the GLM MTP tolerance pair in `tests/test_glm_mtp_patch.py` plus the MTP prompt-priming seam test in `tests/test_mtp_prompt_priming.py`; all three pass under `MLX_METAL_GPU_ARCH=applegpu_g13s`, and this branch touches only `omlx/server.py` and `tests/test_server.py`, neither of which those files import.

Also verified the new test fails when the fix is reverted:

```
E   AttributeError: 'NoneType' object has no attribute 'specprefill_keep_pct'
omlx/server.py:3477: in create_chat_completion
    elif _server_state.settings_manager and ms.specprefill_keep_pct is not None:
```

Reverting only the second guard reproduces the same failure at the twin `ms.specprefill_threshold` guard (`omlx/server.py:3481`), so the single test pins both branches. `test_model_settings_specprefill_still_forwarded` passes on both the old and the new code by design — it exists to prove the relaxed guard still fires and forwards configured values, not to go red.

