### PR TITLE
Inkling Small support and mixed CacheList fixes

### DIFF
--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -538,6 +538,274 @@ class MiniMaxM3OutputParserSession:
         )
 
 
+_INKLING_MODEL_TYPES = {"inkling", "inkling_mm_model"}
+_INKLING_MESSAGE_MODEL = "<|message_model|>"
+_INKLING_CONTENT_THINKING = "<|content_thinking|>"
+_INKLING_CONTENT_TEXT = "<|content_text|>"
+_INKLING_CONTENT_XML = "<|content_xml|>"
+_INKLING_CONTENT_TOOL_JSON = "<|content_invoke_tool_json|>"
+_INKLING_END_MESSAGE = "<|end_message|>"
+_INKLING_END_SAMPLING = "<|content_model_end_sampling|>"
+_INKLING_MARKERS = (
+    _INKLING_MESSAGE_MODEL,
+    _INKLING_CONTENT_THINKING,
+    _INKLING_CONTENT_TEXT,
+    _INKLING_CONTENT_XML,
+    _INKLING_CONTENT_TOOL_JSON,
+    _INKLING_END_MESSAGE,
+    _INKLING_END_SAMPLING,
+)
+
+
+def _is_inkling_model(
+    model_name: str,
+    model_config: dict[str, Any] | None = None,
+) -> bool:
+    model_type = model_config.get("model_type") if model_config else None
+    if model_type in _INKLING_MODEL_TYPES:
+        return True
+    return "inkling" in model_name.lower()
+
+
+class _InklingChannelSplitter:
+    """Streaming splitter for inkling's channel protocol.
+
+    The assistant turn is a sequence of blocks::
+
+        [<|message_model|>][HEAD]<|content_*|>BODY<|end_message|> ... \
+<|content_model_end_sampling|>
+
+    ``HEAD`` only occurs for tool calls (the function name before
+    ``<|content_invoke_tool_json|>``). Thinking bodies surface on the
+    stream inside oMLX's ``<think>``/``</think>`` markers, text bodies on
+    stream+visible, tool JSON is suppressed (parsed at finalize from the
+    raw text).
+    """
+
+    def __init__(self) -> None:
+        self._buffer = ""
+        self._channel: str | None = None
+        self._head = ""
+        self._think_open = False
+        self.stopped = False
+
+    def _partial_suffix_len(self, text: str) -> int:
+        max_len = min(len(text), max(len(m) for m in _INKLING_MARKERS) - 1)
+        for size in range(max_len, 0, -1):
+            suffix = text[-size:]
+            if any(m.startswith(suffix) for m in _INKLING_MARKERS):
+                return size
+        return 0
+
+    def _emit_body(self, text: str) -> tuple[str, str]:
+        if not text:
+            return "", ""
+        if self._channel in ("text", "xml"):
+            return text, text
+        if self._channel == "thinking":
+            # Thinking flows to BOTH channels wrapped in <think> markers
+            # (minimax pattern): the scheduler accumulates only
+            # visible_text into request.output_text, and the API layer
+            # extracts reasoning_content from the <think> block there.
+            return text, text
+        if self._channel == "tool":
+            return "", ""
+        # Block head: hold until the next marker classifies it.
+        self._head += text
+        return "", ""
+
+    def _flush_head_as_text(self) -> tuple[str, str]:
+        head, self._head = self._head, ""
+        if not head:
+            return "", ""
+        return head, head
+
+    def _handle_marker(self, marker: str) -> tuple[str, str]:
+        stream = visible = ""
+        if marker == _INKLING_CONTENT_THINKING:
+            s, v = self._flush_head_as_text()
+            stream += s
+            visible += v
+            if not self._think_open:
+                stream += "<think>"
+                visible += "<think>"
+                self._think_open = True
+            self._channel = "thinking"
+        elif marker in (_INKLING_CONTENT_TEXT, _INKLING_CONTENT_XML):
+            s, v = self._flush_head_as_text()
+            stream += s
+            visible += v
+            if self._think_open:
+                # A text block after an unterminated thinking block still
+                # closes the visible thinking span.
+                stream += "</think>"
+                visible += "</think>"
+                self._think_open = False
+            self._channel = "text" if marker == _INKLING_CONTENT_TEXT else "xml"
+        elif marker == _INKLING_CONTENT_TOOL_JSON:
+            # Head was the tool name; the JSON payload is parsed at
+            # finalize from the raw text.
+            self._head = ""
+            self._channel = "tool"
+        elif marker == _INKLING_END_MESSAGE:
+            if self._channel == "thinking" and self._think_open:
+                stream += "</think>"
+                visible += "</think>"
+                self._think_open = False
+            s, v = self._flush_head_as_text()
+            stream += s
+            visible += v
+            self._channel = None
+        elif marker == _INKLING_MESSAGE_MODEL:
+            s, v = self._flush_head_as_text()
+            stream += s
+            visible += v
+            self._channel = None
+        elif marker == _INKLING_END_SAMPLING:
+            self.stopped = True
+            self._channel = None
+        return stream, visible
+
+    def feed(self, text: str) -> tuple[str, str]:
+        if not text:
+            return "", ""
+        self._buffer += text
+        stream = visible = ""
+        while True:
+            first_idx = -1
+            first_marker = None
+            for marker in _INKLING_MARKERS:
+                idx = self._buffer.find(marker)
+                if idx >= 0 and (first_idx < 0 or idx < first_idx):
+                    first_idx = idx
+                    first_marker = marker
+            if first_marker is None:
+                break
+            s, v = self._emit_body(self._buffer[:first_idx])
+            stream += s
+            visible += v
+            m_s, m_v = self._handle_marker(first_marker)
+            stream += m_s
+            visible += m_v
+            self._buffer = self._buffer[first_idx + len(first_marker) :]
+
+        keep = self._partial_suffix_len(self._buffer)
+        ready = self._buffer[: len(self._buffer) - keep]
+        self._buffer = self._buffer[len(self._buffer) - keep :]
+        s, v = self._emit_body(ready)
+        return stream + s, visible + v
+
+    def finish(self) -> tuple[str, str]:
+        stream = visible = ""
+        s, v = self._emit_body(self._buffer)
+        stream += s
+        visible += v
+        self._buffer = ""
+        s, v = self._flush_head_as_text()
+        stream += s
+        visible += v
+        if self._think_open:
+            stream += "</think>"
+            visible += "</think>"
+            self._think_open = False
+        return stream, visible
+
+
+class InklingOutputParserSession:
+    """Parser session for inkling channel output (thinking / text / tool)."""
+
+    _TOOL_RE = None  # compiled lazily
+
+    def __init__(self, tokenizer: Any, model_path: str | None = None):
+        import re
+
+        self._tokenizer = tokenizer
+        self._raw_text = ""
+        self._splitter = _InklingChannelSplitter()
+        self._detokenizer = create_streaming_detokenizer(tokenizer, model_path)
+        if self._detokenizer is not None:
+            self._detokenizer.reset()
+        if InklingOutputParserSession._TOOL_RE is None:
+            InklingOutputParserSession._TOOL_RE = re.compile(
+                re.escape(_INKLING_CONTENT_TOOL_JSON)
+                + r"(.*?)(?:"
+                + re.escape(_INKLING_END_MESSAGE)
+                + r"|"
+                + re.escape(_INKLING_END_SAMPLING)
+                + r"|\Z)",
+                re.S,
+            )
+
+    def _decode_token(self, token_id: int) -> str:
+        if self._detokenizer is not None:
+            self._detokenizer.add_token(token_id)
+            return self._detokenizer.last_segment
+        try:
+            return self._tokenizer.decode([token_id], skip_special_tokens=False)
+        except TypeError:
+            return self._tokenizer.decode([token_id])
+
+    def process_token(self, token_id: int) -> OutputParserTokenResult:
+        if self._splitter.stopped:
+            return OutputParserTokenResult(is_stop=True, record_token=False)
+        decoded_text = self._decode_token(token_id)
+        self._raw_text += decoded_text
+        stream_text, visible_text = self._splitter.feed(decoded_text)
+        is_stop = self._splitter.stopped
+        return OutputParserTokenResult(
+            stream_text=stream_text,
+            visible_text=visible_text,
+            is_stop=is_stop,
+            record_token=not is_stop,
+        )
+
+    def finalize(self) -> OutputParserFinalizeResult:
+        stream_text = ""
+        visible_text = ""
+        if self._detokenizer is not None and not self._splitter.stopped:
+            self._detokenizer.finalize()
+            final_text = self._detokenizer.last_segment
+            if final_text:
+                self._raw_text += final_text
+                s, v = self._splitter.feed(final_text)
+                stream_text += s
+                visible_text += v
+        s, v = self._splitter.finish()
+        stream_text += s
+        visible_text += v
+
+        tool_calls: list[dict[str, str]] = []
+        for match in InklingOutputParserSession._TOOL_RE.finditer(self._raw_text):
+            payload = match.group(1).strip()
+            if not payload:
+                continue
+            try:
+                parsed = json.loads(payload)
+            except (json.JSONDecodeError, ValueError):
+                logger.debug("Inkling tool-call payload not valid JSON")
+                continue
+            if not isinstance(parsed, dict) or not parsed.get("name"):
+                continue
+            args = parsed.get("args", {})
+            tool_calls.append(
+                {
+                    "name": str(parsed["name"]),
+                    "arguments": json.dumps(
+                        args if isinstance(args, dict) else {},
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ),
+                }
+            )
+
+        return OutputParserFinalizeResult(
+            stream_text=stream_text,
+            visible_text=visible_text,
+            tool_calls=tool_calls,
+            finish_reason="tool_calls" if tool_calls else None,
+        )
+
+
 def _create_cohere2_moe_filter():
     try:
         from cohere_melody import PyFilter, PyFilterOptions
@@ -762,6 +1030,28 @@ def detect_output_parser(
             ),
             stop_token_ids=set(),
             thinking_end_text="</think>",
+        )
+
+    if _is_inkling_model(model_name, model_config):
+        inkling_stop_ids = set()
+        end_sampling_id = _token_id_for_text(tokenizer, _INKLING_END_SAMPLING)
+        if end_sampling_id is not None:
+            inkling_stop_ids.add(end_sampling_id)
+
+        return OutputParserFactory(
+            kind="inkling",
+            create_session=lambda session_tokenizer: InklingOutputParserSession(
+                session_tokenizer,
+                model_path=session_model_path,
+            ),
+            stop_token_ids=inkling_stop_ids,
+            thinking_start_text=_INKLING_CONTENT_THINKING,
+            thinking_start_output_text="<think>\n",
+            thinking_end_text=_INKLING_END_MESSAGE,
+            thinking_end_trailing_text=(
+                _INKLING_MESSAGE_MODEL + _INKLING_CONTENT_TEXT
+            ),
+            protocol_marker_texts=_INKLING_MARKERS,
         )
 
     if _is_minimax_m3_model(model_name, model_config):

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -11,7 +11,14 @@ from typing import Any, List
 from .openai_models import Message
 
 # Model families whose chat templates consume message.reasoning_content directly.
-_NATIVE_REASONING_MODEL_TYPES = {"minimax_m3", "minimax_m3_vl"}
+_NATIVE_REASONING_MODEL_TYPES = {
+    "minimax_m3",
+    "minimax_m3_vl",
+    # Inkling's chat template renders history reasoning_content back into
+    # <|content_thinking|> blocks.
+    "inkling",
+    "inkling_mm_model",
+}
 
 
 def uses_native_reasoning_content(

--- a/omlx/cache/boundary_snapshot_store.py
+++ b/omlx/cache/boundary_snapshot_store.py
@@ -671,7 +671,17 @@ class BoundarySnapshotSSDStore:
                 # tuples (one per sub-cache, e.g. RotatingKVCache +
                 # PoolingCache for DeepSeek V4). Flatten as
                 # ``layer_{i}_sub_{j}_state_{k}`` keys so reconstruction
-                # can rebuild the nested shape.
+                # can rebuild the nested shape. Mirror the flat branch's
+                # has_tensors gate: a CacheList whose subs hold no tensor
+                # at all (empty KV + untouched conv slots) carries no
+                # restorable state.
+                has_tensors = any(
+                    hasattr(elem, "shape") for sub in state for elem in sub
+                )
+                if not has_tensors:
+                    info["has_state"] = "false"
+                    layer_info.append(info)
+                    continue
                 info["has_state"] = "true"
                 info["sub_count"] = str(len(state))
                 for j, sub_state in enumerate(state):

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -225,6 +225,7 @@ def _cache_compat_signature(
     block_size: int = 0,
     layer_cache_types: list[str] | None = None,
     turboquant_kv_bits: float | None = None,
+    cachelist_subtypes: dict[str, list[str]] | None = None,
 ) -> str:
     """Return a stable compatibility signature for a persisted cache block."""
     payload = {
@@ -240,6 +241,14 @@ def _cache_compat_signature(
     # byte-identical to the previous format.
     if turboquant_kv_bits is not None:
         payload["turboquant_kv_bits"] = float(turboquant_kv_bits)
+    # Mixed CacheList layers (a non-sliceable sub next to a KVCache, e.g.
+    # inkling's CacheList(KVCache, ArraysCache(4))) additionally stamp
+    # their sub composition: the flat "CacheList" type name cannot tell a
+    # 2-slot ArraysCache block from a 4-slot one, and restoring the wrong
+    # arity IndexErrors in the model. Only stamped when such layers exist
+    # so other signatures stay byte-identical to the previous format.
+    if cachelist_subtypes:
+        payload["cachelist_subtypes"] = cachelist_subtypes
     return json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
 
@@ -290,6 +299,141 @@ def _block_turboquant_bits(
             except (TypeError, ValueError):
                 return None
     return None
+
+
+_CACHELIST_NON_SLICEABLE_SUB_CLASSES = frozenset(
+    {
+        "ArraysCache",
+        "SizedArraysCache",
+        "PoolingCache",
+        "BatchPoolingCache",
+        "RotatingKVCache",
+        "BatchRotatingKVCache",
+        "PrefillReadyRotatingKVCache",
+        "BufferedRotatingKVCache",
+    }
+)
+
+_ARRAYS_SUB_CLASSES = frozenset({"ArraysCache", "SizedArraysCache"})
+
+
+def _canonical_sub_name(name: Any) -> str:
+    """Canonicalize one CacheList sub-cache class name for signatures."""
+    canonical = _canonicalize_layer_cache_types([str(name or "")])
+    return canonical[0] if canonical else ""
+
+
+def _signature_cachelist_subtypes(cache_signature: str) -> dict | None:
+    """Extract ``cachelist_subtypes`` from a stored signature, or None."""
+    if not cache_signature:
+        return None
+    try:
+        payload = json.loads(cache_signature)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    subtypes = payload.get("cachelist_subtypes")
+    return subtypes if isinstance(subtypes, dict) else None
+
+
+def _block_cachelist_subtypes(
+    cache_data: list[Any] | None,
+    layer_cache_types: list[str] | None,
+    layer_meta_states: list[tuple] | None,
+) -> dict[str, list[str]] | None:
+    """Describe mixed CacheList layers' sub composition from block payload.
+
+    Only layers whose composition contains a non-sliceable sub class are
+    stamped, so signatures of KVCache-only CacheList models (GLM /
+    deepseek_v32) stay byte-identical to the previous format. ArraysCache
+    descriptors carry the slot count (``"ArraysCache:4"``) read from the
+    block's own stored state: restoring a block with a different slot
+    count IndexErrors inside the model's ``cache[slot]`` access, so the
+    count is part of the layout identity.
+    """
+    if not cache_data or not layer_cache_types:
+        return None
+    subtypes: dict[str, list[str]] = {}
+    for i, cache_type in enumerate(layer_cache_types):
+        if cache_type != "CacheList" or i >= len(cache_data):
+            continue
+        layer_data = cache_data[i]
+        if not (
+            isinstance(layer_data, tuple)
+            and len(layer_data) == 2
+            and layer_data[0] == "__cache_list__"
+            and isinstance(layer_data[1], (list, tuple))
+        ):
+            continue
+        meta_names: list[Any] = []
+        if (
+            layer_meta_states
+            and i < len(layer_meta_states)
+            and isinstance(layer_meta_states[i], (list, tuple))
+            and len(layer_meta_states[i]) >= 1
+            and isinstance(layer_meta_states[i][0], (list, tuple))
+        ):
+            meta_names = list(layer_meta_states[i][0])
+        descriptors: list[str] = []
+        has_non_sliceable = False
+        for j, sub_tensor in enumerate(layer_data[1]):
+            name = _canonical_sub_name(meta_names[j] if j < len(meta_names) else "")
+            element_count = None
+            if (
+                isinstance(sub_tensor, tuple)
+                and len(sub_tensor) >= 3
+                and sub_tensor[0] == "__nstate__"
+            ):
+                if not name:
+                    name = _canonical_sub_name(sub_tensor[1])
+                if isinstance(sub_tensor[2], (list, tuple)):
+                    element_count = len(sub_tensor[2])
+            elif isinstance(sub_tensor, (list, tuple)):
+                element_count = len(sub_tensor)
+            if name in _CACHELIST_NON_SLICEABLE_SUB_CLASSES:
+                has_non_sliceable = True
+            if name in _ARRAYS_SUB_CLASSES and element_count is not None:
+                descriptors.append(f"ArraysCache:{element_count}")
+            else:
+                descriptors.append(name or "?")
+        if descriptors and has_non_sliceable:
+            subtypes[str(i)] = descriptors
+    return subtypes or None
+
+
+def cachelist_subtypes_from_cache_list(
+    cache_list: list[Any] | tuple[Any, ...] | None,
+) -> dict[str, list[str]] | None:
+    """Describe mixed CacheList layers' sub composition from live caches.
+
+    The live-model counterpart of ``_block_cachelist_subtypes`` — produces
+    the expectation the manager compares stored blocks against. Stamps the
+    same layers (composition contains a non-sliceable sub) with the same
+    descriptor format.
+    """
+    if not cache_list:
+        return None
+    subtypes: dict[str, list[str]] = {}
+    for i, cache_obj in enumerate(cache_list):
+        sub_caches = getattr(cache_obj, "caches", None)
+        if type(cache_obj).__name__ != "CacheList" or not sub_caches:
+            continue
+        descriptors: list[str] = []
+        has_non_sliceable = False
+        for sub in sub_caches:
+            name = _canonical_sub_name(type(sub).__name__)
+            if name in _CACHELIST_NON_SLICEABLE_SUB_CLASSES:
+                has_non_sliceable = True
+            if name in _ARRAYS_SUB_CLASSES:
+                slots = getattr(sub, "cache", None)
+                slot_count = len(slots) if isinstance(slots, list) else 0
+                descriptors.append(f"ArraysCache:{slot_count}")
+            else:
+                descriptors.append(name or "?")
+        if descriptors and has_non_sliceable:
+            subtypes[str(i)] = descriptors
+    return subtypes or None
 
 
 def _clamp_rotating_meta_states(
@@ -1216,6 +1360,11 @@ class PagedSSDCacheManager(CacheManager):
         # (the depth is only known once the engine has applied the model's
         # TurboQuant settings, after this manager is constructed).
         self._expected_turboquant_kv_bits: float | None = None
+        # Sub composition of mixed CacheList layers (see
+        # ``cachelist_subtypes_from_cache_list``); learned together with
+        # the layer signature. None disables the check (legacy managers /
+        # models without mixed CacheList layers).
+        self._expected_cachelist_subtypes: dict[str, list[str]] | None = None
         # Set once we have swept stale-signature blocks for the current
         # ``_expected_layer_cache_types`` / ``_expected_turboquant_kv_bits``.
         # Re-assigning the signature (e.g., via
@@ -1698,6 +1847,15 @@ class PagedSSDCacheManager(CacheManager):
             ) != _canonicalize_layer_cache_types(self._expected_layer_cache_types):
                 return False
 
+        # The block must PROVE a matching CacheList sub composition — an
+        # unstamped or mismatched block would rebuild a CacheList whose
+        # sub arity/classes disagree with the live model.
+        if (
+            self._expected_cachelist_subtypes is not None
+            and payload.get("cachelist_subtypes") != self._expected_cachelist_subtypes
+        ):
+            return False
+
         if not self._signature_bits_match(metadata.cache_signature):
             return False
 
@@ -1720,6 +1878,22 @@ class PagedSSDCacheManager(CacheManager):
             == self._expected_turboquant_kv_bits
         )
 
+    def is_signature_compatible(self, cache_signature: str) -> bool:
+        """Per-block signature gate for restore paths that bypass the
+        index scan (hot-cache / pending-write loads never pass through
+        ``_is_compatible_block``). Checks the expectation-gated signature
+        fields: TurboQuant depth and CacheList sub composition.
+        """
+        if not self._signature_bits_match(cache_signature or ""):
+            return False
+        if (
+            self._expected_cachelist_subtypes is not None
+            and _signature_cachelist_subtypes(cache_signature or "")
+            != self._expected_cachelist_subtypes
+        ):
+            return False
+        return True
+
     def _expected_cache_signature(self) -> str:
         if (
             not self._expected_model_name
@@ -1734,6 +1908,7 @@ class PagedSSDCacheManager(CacheManager):
             block_size=self._expected_block_size,
             layer_cache_types=self._expected_layer_cache_types,
             turboquant_kv_bits=self._expected_turboquant_kv_bits,
+            cachelist_subtypes=self._expected_cachelist_subtypes,
         )
 
     def _read_file_metadata(self, file_path: Path) -> PagedSSDBlockMetadata | None:
@@ -2159,6 +2334,11 @@ class PagedSSDCacheManager(CacheManager):
                     block_bits
                     if block_bits is not None
                     else self._expected_turboquant_kv_bits
+                ),
+                # Stamped from the block's own payload (observation), like
+                # the TurboQuant depth above.
+                cachelist_subtypes=_block_cachelist_subtypes(
+                    cache_data, layer_cache_types, layer_meta_states
                 ),
             )
 
@@ -3036,6 +3216,7 @@ class PagedSSDCacheManager(CacheManager):
         layer_cache_types: list[str] | None,
         *,
         turboquant_kv_bits: float | None = None,
+        cachelist_subtypes: dict[str, list[str]] | None = None,
     ) -> bool:
         """Set the live layer-cache signature, replacing stale expectations.
 
@@ -3064,21 +3245,31 @@ class PagedSSDCacheManager(CacheManager):
             old_signature = self._expected_layer_cache_types
             old_canonical = _canonicalize_layer_cache_types(old_signature)
             bits_changed = new_bits != self._expected_turboquant_kv_bits
-            if old_canonical == new_canonical and not bits_changed:
+            subtypes_changed = (
+                cachelist_subtypes != self._expected_cachelist_subtypes
+            )
+            if (
+                old_canonical == new_canonical
+                and not bits_changed
+                and not subtypes_changed
+            ):
                 if old_signature != new_signature:
                     self._expected_layer_cache_types = new_signature
                 return False
 
             self._expected_layer_cache_types = new_signature
             self._expected_turboquant_kv_bits = new_bits
+            self._expected_cachelist_subtypes = cachelist_subtypes
             self._signature_sweep_completed = False
 
         logger.info(
             "PagedSSDCacheManager updated layer cache signature "
-            "(%d layers, %d unique types, turboquant_kv_bits=%s)",
+            "(%d layers, %d unique types, turboquant_kv_bits=%s, "
+            "cachelist_subtypes=%s)",
             len(new_signature),
             len(set(new_canonical or ())),
             new_bits,
+            "yes" if cachelist_subtypes else "no",
         )
         return True
 
@@ -3130,6 +3321,12 @@ class PagedSSDCacheManager(CacheManager):
                     stale.append(h)
                     continue
                 if not self._signature_bits_match(meta.cache_signature):
+                    stale.append(h)
+                    continue
+                if self._expected_cachelist_subtypes is not None and (
+                    _signature_cachelist_subtypes(meta.cache_signature)
+                    != self._expected_cachelist_subtypes
+                ):
                     stale.append(h)
 
         for h in stale:

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -1239,6 +1239,17 @@ class BlockAwarePrefixCache(CacheManager):
                 elif cache_type_name == "CacheList":
                     state = layer_state["state"]  # List[sub_state]
                     sub_class_names = layer_state.get("sub_class_names") or []
+                    if not sub_class_names:
+                        # Snapshot entries and older extract paths carry the
+                        # sub class names only inside the composite
+                        # meta_state ([class_names], [sub_meta_states]).
+                        meta = layer_state.get("meta_state")
+                        if (
+                            isinstance(meta, (list, tuple))
+                            and len(meta) >= 2
+                            and isinstance(meta[0], (list, tuple))
+                        ):
+                            sub_class_names = [str(n) for n in meta[0]]
                     if not isinstance(state, list) or len(state) == 0:
                         block_slices.append((mx.zeros((1,)), mx.zeros((1,))))
                         continue
@@ -1881,6 +1892,27 @@ class BlockAwarePrefixCache(CacheManager):
                         )
                         break
 
+                    # Expectation-gated signature fields (TurboQuant depth,
+                    # CacheList sub composition). Hot-cache / pending-write
+                    # loads bypass the manager's index-scan compatibility
+                    # check, so the restore loop must gate them here.
+                    signature_gate = getattr(
+                        self.paged_ssd_cache, "is_signature_compatible", None
+                    )
+                    if callable(signature_gate) and not signature_gate(
+                        block_metadata.get("cache_signature", "")
+                    ):
+                        logger.warning(
+                            "Cache signature mismatch at block %s "
+                            "(TurboQuant depth or CacheList sub composition). "
+                            "Truncating cached prefix before this block.",
+                            block_id,
+                        )
+                        self._forget_incompatible_ssd_block(
+                            block.block_hash, block.block_id
+                        )
+                        break
+
                     # Track meta_states from first and last blocks
                     # Non-sliceable caches (RotatingKVCache) need last block's meta_state
                     block_layer_meta_states = block_metadata.get("layer_meta_states")
@@ -2079,6 +2111,7 @@ class BlockAwarePrefixCache(CacheManager):
                     non_sliceable_sub_classes = {
                         "PoolingCache",
                         "ArraysCache",
+                        "SizedArraysCache",
                         "BatchPoolingCache",
                     }
 
@@ -2088,25 +2121,42 @@ class BlockAwarePrefixCache(CacheManager):
                             or CacheTypeRegistry.is_rotating_family(class_name)
                         )
 
-                    if len(cl_block_data) > 1:
-                        # Per-block storage: concatenate sliceable sub-caches
-                        # element-wise; pick last block for non-sliceable.
+                    # The store path (_extract_block_tensor_slice) picks ONE
+                    # storage mode for the whole layer: per-block slices only
+                    # when every sub-state is a >=2-element tuple of 4D
+                    # sequence tensors and no sub is a known non-sliceable
+                    # class; otherwise EVERY block stores the full cumulative
+                    # state of ALL subs at that block's boundary. Restore
+                    # mirrors that layer-level decision here. Dispatching per
+                    # sub (concat KVCache subs, last-block the rest) silently
+                    # concatenated a mixed CacheList's cumulative KV snapshots
+                    # into a duplicated sequence (e.g. inkling-style
+                    # CacheList(KVCache, ArraysCache): 4+8+12 tokens instead
+                    # of 12).
+                    any_non_sliceable_sub = any(
+                        _is_non_sliceable_sub_class(
+                            sub_class_names_for_layer[j]
+                            if j < len(sub_class_names_for_layer)
+                            else ""
+                        )
+                        for j in range(num_sub_caches)
+                    )
+                    last_block_elements = [
+                        _sub_state_elements(s) for s in cl_block_data[-1]
+                    ]
+                    stored_slice_mode = not any_non_sliceable_sub and all(
+                        elems is not None
+                        and len(elems) >= 2
+                        and hasattr(elems[0], "shape")
+                        and len(elems[0].shape) == 4
+                        for elems in last_block_elements
+                    )
+
+                    if len(cl_block_data) > 1 and stored_slice_mode:
+                        # Per-block slices: concatenate every sub along the
+                        # sequence axis into the full sequence.
                         concatenated_sub_states = []
                         for j in range(num_sub_caches):
-                            sub_class = (
-                                sub_class_names_for_layer[j]
-                                if j < len(sub_class_names_for_layer)
-                                else ""
-                            )
-                            if _is_non_sliceable_sub_class(sub_class):
-                                # Each saved block already snapshots the
-                                # full state at its boundary — pick the
-                                # last block, which corresponds to the
-                                # latest boundary of the matched prefix.
-                                concatenated_sub_states.append(
-                                    tuple(_sub_state_elements(cl_block_data[-1][j]))
-                                )
-                                continue
                             per_block_elements = [
                                 _sub_state_elements(bd[j]) for bd in cl_block_data
                             ]
@@ -2139,11 +2189,15 @@ class BlockAwarePrefixCache(CacheManager):
                                     cat_elements.append(column[-1])
                             concatenated_sub_states.append(tuple(cat_elements))
                     else:
-                        # Single block: unwrap markers to raw tuples so the
-                        # downstream handler.reconstruct_cache → sub_handler.
+                        # Cumulative snapshots (or a single block): the last
+                        # matched block already holds the complete state of
+                        # every sub at its boundary — a partial prefix match
+                        # restores that boundary's state exactly. Markers are
+                        # unwrapped to raw tuples so the downstream
+                        # handler.reconstruct_cache → sub_handler.
                         # deserialize_state pipeline sees uniform N-tuples.
                         concatenated_sub_states = [
-                            tuple(_sub_state_elements(s)) for s in cl_block_data[0]
+                            tuple(elems) for elems in last_block_elements
                         ]
 
                     # Build meta_state with correct offsets for reconstructed

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -75,6 +75,26 @@ def register_tiled_prefill_head_dim(
     _SDPA_TILED_MIN_KV_LEN = int(min_kv_len)
 
 
+# Bytes/elem of a model-built additive attention bias materialized as a
+# full [n_q_heads, query_tokens, kv_len] tensor per attention call (e.g.
+# inkling's banded relative-position mask). None when the loaded model
+# builds no such tensor. The fused-SDPA head_dim check cannot see this
+# allocation — it happens in model code before SDPA — so admission would
+# otherwise under-count exactly the long-context prefills that OOM.
+_ATTENTION_BIAS_TRANSIENT_DTYPE_SIZE: float | None = None
+
+
+def register_attention_bias_transient(dtype_size: float | None) -> None:
+    """Register (or clear with ``None``) a per-call additive attention-bias
+    materialization so prefill admission prices it. Call in lockstep with
+    model load/swap: the setting is process-wide, like the tiled head_dim
+    registry above."""
+    global _ATTENTION_BIAS_TRANSIENT_DTYPE_SIZE
+    _ATTENTION_BIAS_TRANSIENT_DTYPE_SIZE = (
+        float(dtype_size) if dtype_size else None
+    )
+
+
 def estimate_unfused_sdpa_call_bytes(
     n_q_heads: int,
     query_tokens: int,
@@ -622,9 +642,17 @@ class MemoryMonitor:
         query_tokens = int(query_tokens)
         kv_len = max(int(kv_len), 0)
 
+        # Model-built additive bias (e.g. inkling's banded mask) is
+        # materialized regardless of which SDPA route runs.
+        bias = 0
+        if _ATTENTION_BIAS_TRANSIENT_DTYPE_SIZE is not None:
+            bias = int(
+                n_q * query_tokens * kv_len * _ATTENTION_BIAS_TRANSIENT_DTYPE_SIZE
+            )
+
         output = n_q * query_tokens * hd * 4
         if self._uses_fused_sdpa(query_tokens, kv_len):
-            return output
+            return output + bias
 
         # O(L) tiled-prefill kernel active for this head_dim (e.g. the head_dim
         # 256 sdpa256 patch): the score matrix is never materialized. The peak
@@ -639,10 +667,13 @@ class MemoryMonitor:
             and kv_len >= _SDPA_TILED_MIN_KV_LEN
         ):
             tile_scores = n_q * query_tokens * min(kv_tile, kv_len) * self._score_dtype_size
-            return output + tile_scores
+            return output + tile_scores + bias
 
-        return estimate_unfused_sdpa_call_bytes(
-            n_q, query_tokens, kv_len, hd, self._score_dtype_size
+        return (
+            estimate_unfused_sdpa_call_bytes(
+                n_q, query_tokens, kv_len, hd, self._score_dtype_size
+            )
+            + bias
         )
 
     def estimate_prefill_peak_bytes(

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -65,6 +65,8 @@ VLM_MODEL_TYPES = {
     "phi4_siglip",
     "phi4mm",
     "youtu_vl",
+    "inkling",
+    "inkling_mm_model",  # config model_type of Inkling Small checkpoints
 }
 
 # Text-only model families that are implemented in mlx-vlm rather than
@@ -157,6 +159,7 @@ VLM_ARCHITECTURES = {
     "LlavaQwen2ForCausalLM",  # apple/FastVLM (all sizes)
     "Florence2ForConditionalGeneration",
     "UnlimitedOCRForCausalLM",  # baidu/Unlimited-OCR
+    "InklingForConditionalGeneration",  # thinkingmachines/Inkling-Small
 }
 
 # Known embedding model types from mlx-embeddings

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -425,6 +425,15 @@ def universal_quant_predicate(
     if "linear_attn.out_proj" in path_l:
         return bits(5)
 
+    # Inkling short-conv weights (k/v/attn/mlp_sconv.conv.weight; the
+    # .weight suffix is stripped by _normalize_quant_path) are tiny
+    # depthwise causal convs on nn.Conv1d modules, which have no
+    # to_quantized() — a quantized emission here would make mlx-vlm's
+    # load-time class_predicate try to quantize a Conv1d and fail. Keep
+    # them at source precision like the conv1d rule above.
+    if path_l.endswith("sconv.conv"):
+        return False
+
     boost_map = config.get("_oq_boost_map") or {}
     if path in boost_map:
         return dict(boost_map[path])
@@ -2887,6 +2896,44 @@ def estimate_bpw_and_size(
     )
     logical = idx.logical_metadata()
 
+    # Price on post-sanitize names when a streaming sanitize plan is
+    # discoverable — the quantization loop itself decides on those names.
+    # Some checkpoints store quantizable tensors under source names the
+    # predicate cannot see (inkling's ``experts.w13_weight`` has no
+    # ``.weight`` suffix and fuses gate+up), which priced ~97% of the
+    # model as fp16 passthrough (15.8 bpw for a 4-bit run). Falls back to
+    # the raw header names when discovery is unavailable.
+    plan_view = None
+    try:
+        _sanitize_fn = _build_model_sanitizer(config)
+        if _sanitize_fn is not None:
+            _plan = _discover_sanitize_plan(_sanitize_fn, idx)
+            if _plan:
+                plan_view = _DiscoveredPlan(_plan, idx)
+    except Exception as e:
+        logger.debug("bpw estimate: sanitize-plan discovery unavailable: %s", e)
+
+    if plan_view is not None:
+        planned_logical = {}
+        for out_name, info in plan_view._plan.items():
+            if info.get("transform") == "literal":
+                continue
+            shape = tuple(info.get("shape") or ())
+            dtype = info.get("dtype")
+            sources = info.get("sources") or []
+            if dtype is None and len(sources) == 1:
+                src_meta = logical.get(sources[0])
+                if src_meta is not None:
+                    dtype = src_meta[1]
+            planned_logical[out_name] = (shape, dtype)
+        if planned_logical:
+            logical = planned_logical
+
+    def _source_quant_info(name):
+        if plan_view is not None:
+            return plan_view.source_quant_info(name)
+        return idx.source_quant_info(name)
+
     named_shapes = {}
     for name, (shape, _dtype) in logical.items():
         norm = _normalize_quant_path(name)
@@ -2904,7 +2951,7 @@ def estimate_bpw_and_size(
     fixed_overrides = {}
     _pre_boost_config = {**config, "_oq_boost_map": {}}
     for _path in named_shapes:
-        _info = idx.source_quant_info(f"{_path}.weight")
+        _info = _source_quant_info(f"{_path}.weight")
         if _info is None:
             continue
         _floor_bits, _, _ = _get_predicate_bits(
@@ -2970,7 +3017,7 @@ def estimate_bpw_and_size(
             continue
 
         total_params += n_elements
-        src_info = idx.source_quant_info(name)
+        src_info = _source_quant_info(name)
         if src_info is not None and bits >= src_info["bits"]:
             # Passthrough: packed weight at source bits plus one e8m0
             # uint8 scale byte per group.
@@ -3458,6 +3505,12 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
                     )
 
                     apply_mlx_vlm_minimax_m3_compat_patch()
+                if model_type in ("inkling", "inkling_mm_model"):
+                    from omlx.patches.mlx_vlm_inkling_compat import (
+                        apply_mlx_vlm_inkling_compat_patch,
+                    )
+
+                    apply_mlx_vlm_inkling_compat_patch()
             except Exception as patch_err:
                 logger.debug(f"MiniMax M3 mlx-vlm patch not applied: {patch_err}")
 
@@ -3525,6 +3578,17 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
                     audio_tower = _AUDIO_SENTINEL
                     embed_audio = _AUDIO_SENTINEL
 
+                    # Some sanitizes call sibling instance methods (inkling's
+                    # ``self._map_llm_layer`` / ``self._map_experts``) or read
+                    # class attributes (``self._ATTN``). Resolve anything the
+                    # proxy itself lacks from the model class, binding
+                    # functions so ``self`` stays the proxy.
+                    def __getattr__(self, name):
+                        attr = getattr(model_module.Model, name)
+                        if callable(attr):
+                            return attr.__get__(self, type(self))
+                        return attr
+
                 proxy = _Proxy()
                 proxy.config = model_config
                 # Nested-VLM sanitizes (e.g. MiniMax-M3 minimax_m3_vl) read
@@ -3545,8 +3609,15 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
                 else:
                     w = _san(weights)
 
-                w = sanitize_weights(model_module.VisionModel, w, vision_config)
-                w = sanitize_weights(model_module.LanguageModel, w, text_config)
+                # Not every model package re-exports its tower classes
+                # (inkling's __init__ has no VisionModel); a missing class
+                # simply has no per-tower sanitize to run.
+                vision_cls = getattr(model_module, "VisionModel", None)
+                if vision_cls is not None:
+                    w = sanitize_weights(vision_cls, w, vision_config)
+                language_cls = getattr(model_module, "LanguageModel", None)
+                if language_cls is not None:
+                    w = sanitize_weights(language_cls, w, text_config)
                 return w
 
             logger.info(
@@ -6156,6 +6227,13 @@ def _find_model_layers(model):
         lm = model.language_model.model
         if hasattr(lm, "embed_tokens"):
             embed_fn = lm.embed_tokens
+            # Inkling applies an embed-side RMSNorm (use_embed_norm)
+            # inside InklingModel.embed(); raw embed_tokens would feed
+            # layer 0 un-normalized activations to calibration.
+            if callable(getattr(lm, "embed", None)) and (
+                getattr(lm, "embed_norm", None) is not None
+            ):
+                embed_fn = lm.embed
             layers = lm.layers
     elif hasattr(model, "embed_tokens"):
         embed_fn = model.embed_tokens
@@ -6381,6 +6459,18 @@ def _forward_layer_result(block, inputs, mask, position_ids, layer_idx=None):
                 f"{type(block).__name__}: {e}"
             )
             return None, None
+    if isinstance(position_ids, dict) and position_ids.get("kind") == "inkling":
+        try:
+            result = block(inputs)
+            if isinstance(result, tuple):
+                return result[0], result[1] if len(result) > 1 else None
+            return result, None
+        except (TypeError, ValueError, RuntimeError, AttributeError) as e:
+            logger.debug(
+                f"_forward_layer: inkling signature failed for "
+                f"{type(block).__name__}: {e}"
+            )
+            return None, None
 
     last_exc = None
     for call_args in [
@@ -6532,6 +6622,14 @@ def _prepare_layer_inputs(model, layers, calib_data, inputs):
         mask = create_attention_mask(inputs, None, return_array=True)
         state = {"kind": "glm_moe_dsa", "prev_topk_indices": None}
         return inputs, [mask] * len(layers), state
+    if model_type in ("inkling", "inkling_mm_model"):
+        # Inkling decoder layers build their own banded causal/sliding
+        # masks internally (banded_additive_mask) and take
+        # (x, cache=None, conv_mask=None). Calibration walks cache-less
+        # single sequences, so both stay None; without this branch the
+        # generic signature probe only lands on ``(inputs,)`` after four
+        # caught exceptions per layer.
+        return inputs, [None] * len(layers), {"kind": "inkling"}
     masks = _layer_masks_for_model(model, layers, inputs)
     position_ids = mx.arange(calib_data.shape[1])[None, :]
     return inputs, masks, position_ids

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -3393,6 +3393,9 @@ def _normalize_mtp_in_config(config: dict) -> None:
         for key in ("mtp_num_hidden_layers", "num_nextn_predict_layers"):
             if key in text_cfg and text_cfg[key]:
                 text_cfg[key] = 0
+    # Inkling nests the declaration under a top-level mtp_config block.
+    if isinstance(config.get("mtp_config"), dict):
+        config.pop("mtp_config", None)
 
 
 def _normalize_text_only_in_config(config: dict) -> None:

--- a/omlx/patches/arrays_cache_extract.py
+++ b/omlx/patches/arrays_cache_extract.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""None-guard for ``mlx_lm.models.cache.ArraysCache.extract``.
+
+Upstream ``ArraysCache.filter``/``extend``/``merge`` all tolerate ``None``
+slots (a slot stays ``None`` until the layer's first forward touches it,
+and ``merge`` of all-empty caches produces a cache whose every slot is
+``None``), but ``extract`` indexes each slot unconditionally::
+
+    cache.cache = [c[idx : idx + 1] for c in self.cache]
+
+A request that is aborted or removed with ``return_prompt_caches=True``
+before its first forward reaches ``BatchGenerator.extract_cache`` →
+``CacheList.extract`` → ``ArraysCache.extract`` with such all-``None``
+slots and dies on ``TypeError: 'NoneType' object is not subscriptable``.
+Models wrapping ArraysCache inside CacheList per layer (inkling-style
+hybrid attention + short-conv) hit this on every early abort.
+
+The patch replaces ``extract`` with the same body plus the guard
+``filter`` already uses. It retires itself automatically once upstream
+adds the guard (detected by probing an all-``None`` extract).
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_APPLIED = False
+
+
+def apply_arrays_cache_extract_guard() -> bool:
+    """Install the None-guarded ``ArraysCache.extract``. Idempotent."""
+    global _APPLIED
+    if _APPLIED:
+        return True
+    try:
+        from mlx_lm.models.cache import ArraysCache
+    except ImportError:
+        return False
+
+    if getattr(ArraysCache.extract, "_omlx_none_guard", False):
+        _APPLIED = True
+        return True
+
+    # Upstream already guarded? Probe with an all-None cache.
+    try:
+        probe = ArraysCache(1)
+        ArraysCache.extract(probe, 0)
+        _APPLIED = True
+        return True
+    except TypeError:
+        pass
+    except Exception:
+        return False
+
+    original_extract = ArraysCache.extract
+
+    def _extract_with_none_guard(self, idx):
+        cache = ArraysCache(len(self.cache))
+        cache.cache = [
+            None if c is None else c[idx : idx + 1] for c in self.cache
+        ]
+        return cache
+
+    _extract_with_none_guard._omlx_none_guard = True
+    _extract_with_none_guard._omlx_original = original_extract
+    ArraysCache.extract = _extract_with_none_guard
+    _APPLIED = True
+    return True
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+__all__ = ["apply_arrays_cache_extract_guard", "is_applied"]

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -497,6 +497,16 @@ def _is_mtp_eligible(gen_batch: Any) -> bool:
 def _is_mtp_batch_eligible(gen_batch: Any) -> bool:
     if not _mtp_common_eligible(gen_batch):
         return False
+    model = getattr(gen_batch, "model", None)
+    if getattr(model, "_omlx_mtp_rowwise_unsupported", False) or getattr(
+        getattr(model, "_language_model", None),
+        "_omlx_mtp_rowwise_unsupported",
+        False,
+    ):
+        # Multi-block window heads (inkling) keep per-request cycle state
+        # on the cache list; the row-wise extract/merge path does not
+        # model that.
+        return False
     uids = getattr(gen_batch, "uids", None)
     if uids is None or len(uids) <= 1:
         return False
@@ -1952,6 +1962,15 @@ def _chain_next_drafts(
     )
     if _HEAD_HIDDEN_POST_NORM and not head_prenorm and hidden_rows.ndim == 3:
         hidden_rows = _trunk_norm_module(model)(hidden_rows)
+
+    # Multi-block heads (inkling) route fold/chain by a per-cycle pass
+    # counter on the cache list; reset it before the fold. Single-block
+    # heads have no hook and are unaffected.
+    begin = getattr(model, "mtp_begin_cycle", None) or getattr(
+        getattr(model, "_language_model", None), "mtp_begin_cycle", None
+    )
+    if begin is not None:
+        begin(state.mtp_cache, depth)
 
     n = committed.shape[0]
     logits, head_hidden = model.mtp_forward(

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -1944,7 +1944,13 @@ def _chain_next_drafts(
         state.draft_accept_lps = []
         return
 
-    if _HEAD_HIDDEN_POST_NORM and hidden_rows.ndim == 3:
+    # Models whose MTP head normalizes its hidden input internally
+    # (inkling: per-block hidden_norm, chain_hidden_post_norm=False) mark
+    # themselves and receive the raw pre-norm trunk hidden.
+    head_prenorm = getattr(model, "_omlx_mtp_head_prenorm", False) or getattr(
+        getattr(model, "_language_model", None), "_omlx_mtp_head_prenorm", False
+    )
+    if _HEAD_HIDDEN_POST_NORM and not head_prenorm and hidden_rows.ndim == 3:
         hidden_rows = _trunk_norm_module(model)(hidden_rows)
 
     n = committed.shape[0]

--- a/omlx/patches/mlx_lm_mtp/prompt_priming.py
+++ b/omlx/patches/mlx_lm_mtp/prompt_priming.py
@@ -344,6 +344,12 @@ def take_primed(
     ``(mtp_cache, hist_offset)`` — or None, in which case the caller keeps
     the current unprimed behaviour.
     """
+    # Hosts with their own priming shape (inkling's sliding-window
+    # multi-block fold) own the whole activation seam.
+    for host in _host_candidates(model):
+        hook = getattr(host, "mtp_take_primed", None)
+        if callable(hook):
+            return hook(cache, main_tok)
     ctx = _find_ctx(model)
     if ctx is None:
         return None

--- a/omlx/patches/mlx_vlm_inkling_compat/__init__.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/__init__.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inkling (Thinking Machines) compatibility layer for the pinned mlx-vlm.
+
+The `inkling` model package landed in mlx-vlm PR #1637 and was extended
+for Inkling Small in PR #1756 (pcuenca/mlx-vlm@73e4cb6), both newer than
+oMLX's mlx-vlm pin (`78b96eb`). This vendors the PR-head model package
+plus the three shared modules it imports that do not exist at the pin
+(`mlx_vlm.models.{mlp,switch_layers,activations}` — the pin sources
+SwitchGLU from mlx-lm, whose activation contract differs), and wires the
+discovery surface oMLX needs:
+
+- installs the vendored packages onto the real `mlx_vlm.models` namespace
+  (`__path__` append) so `get_model_and_args` can import them; relative
+  imports (`..base`, `..cache`) resolve against the real pinned mlx-vlm.
+  If a future pin bump ships these modules upstream, the real ones win
+  automatically (the vendor path is searched last).
+- adds `inkling_mm_model -> inkling` to `mlx_vlm.utils.MODEL_REMAPPING`
+  (checkpoints declare `model_type: "inkling_mm_model"`).
+- registers `inkling`/`inkling_mm_model` in `prompt_utils.MODEL_CONFIG`
+  and wraps `get_message_json` with LIST_WITH_IMAGE_FIRST semantics
+  (image parts first, then text), matching PR #1756. Audio parts are not
+  emitted yet: oMLX serves inkling text+vision first, and the vendored
+  processor rejects audio arrays with a clear error.
+- registers the vendored torch-free `InklingProcessor` with
+  `AutoProcessor` (the reference processors only exist in transformers
+  5.14+, above oMLX's <5.13 pin).
+- wraps `mlx_vlm.utils.load_config` to translate a ModelOpt
+  `hf_quant_config.json` (quant_algo NVFP4) into MLX quantization config
+  `{group_size: 16, bits: 4, mode: "nvfp4"}`, porting PR #1756's
+  `load_model` hunk, so the official NVFP4 checkpoint loads natively on
+  stock MLX 0.32 nvfp4 kernels.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_VENDOR_MLX_VLM = Path(__file__).resolve().parent / "vendor" / "mlx_vlm"
+
+# Checkpoints carry "inkling_mm_model"; the module directory is "inkling".
+_MODEL_TYPES = ("inkling", "inkling_mm_model")
+_MODULE_NAME = "inkling"
+
+_APPLIED = False
+
+
+def apply_mlx_vlm_inkling_compat_patch() -> bool:
+    """Install the vendored inkling module and mlx-vlm discovery hooks."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        _install_vendor_namespace()
+        _import_vendor_modules()
+
+        import mlx_vlm.prompt_utils as prompt_utils
+        import mlx_vlm.utils as vlm_utils
+
+        _patch_model_remapping(vlm_utils)
+        _patch_prompt_utils(prompt_utils)
+        _patch_load_config(vlm_utils)
+        _register_auto_processor()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Inkling mlx-vlm compat patch failed: %s", exc)
+        return False
+
+    _APPLIED = True
+    logger.info("Inkling mlx-vlm compatibility patch applied")
+    return True
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+def _install_vendor_namespace() -> None:
+    import mlx_vlm
+    import mlx_vlm.models
+
+    _append_package_path(mlx_vlm, _VENDOR_MLX_VLM)
+    _append_package_path(mlx_vlm.models, _VENDOR_MLX_VLM / "models")
+
+
+def _append_package_path(package: Any, path: Path) -> None:
+    package_path = getattr(package, "__path__", None)
+    if package_path is None:
+        return
+    path_str = str(path)
+    if path_str not in package_path:
+        package_path.append(path_str)
+
+
+def _import_vendor_modules() -> None:
+    # The shared shims must be importable before the model package, whose
+    # language module does `from ..mlp import SwiGLUMLP` etc.
+    importlib.import_module("mlx_vlm.models.activations")
+    importlib.import_module("mlx_vlm.models.mlp")
+    importlib.import_module("mlx_vlm.models.switch_layers")
+    importlib.import_module(f"mlx_vlm.models.{_MODULE_NAME}")
+
+
+def _patch_model_remapping(vlm_utils: Any) -> None:
+    remapping = getattr(vlm_utils, "MODEL_REMAPPING", None)
+    if isinstance(remapping, dict):
+        remapping.setdefault("inkling_mm_model", _MODULE_NAME)
+
+
+def _is_inkling(model_name: Any) -> bool:
+    return isinstance(model_name, str) and model_name.lower() in _MODEL_TYPES
+
+
+def _patch_prompt_utils(prompt_utils: Any) -> None:
+    # apply_chat_template short-circuits to text-only formatting for any
+    # model_type missing from MODEL_CONFIG, dropping image parts entirely.
+    # Register both keys; the mapped format is never consulted because the
+    # get_message_json wrapper intercepts inkling first.
+    model_config = getattr(prompt_utils, "MODEL_CONFIG", None)
+    message_format = getattr(prompt_utils, "MessageFormat", None)
+    if isinstance(model_config, dict) and message_format is not None:
+        placeholder = getattr(message_format, "LIST_WITH_IMAGE_FIRST", None) or getattr(
+            message_format, "LIST_WITH_IMAGE", None
+        )
+        if placeholder is not None:
+            for model_type in _MODEL_TYPES:
+                model_config.setdefault(model_type, placeholder)
+
+    original = getattr(prompt_utils, "get_message_json", None)
+    if original is None or getattr(original, "_omlx_inkling_compat", False):
+        return
+
+    def patched_get_message_json(
+        model_name: str,
+        prompt: str,
+        role: str = "user",
+        skip_image_token: bool = False,
+        skip_audio_token: bool = False,
+        num_images: int = 0,
+        num_audios: int = 0,
+        **kwargs,
+    ):
+        if _is_inkling(model_name):
+            text = "" if prompt is None else str(prompt)
+            content: list[dict[str, Any]] | str
+            if role == "user" and not skip_image_token and num_images > 0:
+                content = [{"type": "image"} for _ in range(num_images)]
+                content.append({"type": "text", "text": text})
+            else:
+                content = text
+            return {"role": role, "content": content}
+        return original(
+            model_name,
+            prompt,
+            role=role,
+            skip_image_token=skip_image_token,
+            skip_audio_token=skip_audio_token,
+            num_images=num_images,
+            num_audios=num_audios,
+            **kwargs,
+        )
+
+    patched_get_message_json._omlx_inkling_compat = True
+    patched_get_message_json._omlx_original = original
+    prompt_utils.get_message_json = patched_get_message_json
+
+
+def _patch_load_config(vlm_utils: Any) -> None:
+    original = getattr(vlm_utils, "load_config", None)
+    if original is None or getattr(original, "_omlx_inkling_compat", False):
+        return
+
+    def patched_load_config(model_path, **kwargs):
+        config = original(model_path, **kwargs)
+        try:
+            if (
+                isinstance(config, dict)
+                and config.get("model_type") in _MODEL_TYPES
+                and not config.get("quantization")
+                and not config.get("quantization_config")
+            ):
+                hf_quant_path = Path(model_path) / "hf_quant_config.json"
+                if hf_quant_path.exists():
+                    with open(hf_quant_path, encoding="utf-8") as f:
+                        hf_quant = json.load(f).get("quantization", {})
+                    if hf_quant.get("quant_algo") == "NVFP4":
+                        # nvfp4 implies group_size=16 (PR #1756). The
+                        # sanitize in the vendored model passes the packed
+                        # expert codes/scales through byte-identically.
+                        config["quantization"] = config["quantization_config"] = {
+                            "group_size": 16,
+                            "bits": 4,
+                            "mode": "nvfp4",
+                        }
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Inkling hf_quant_config translation failed: %s", exc)
+        return config
+
+    patched_load_config._omlx_inkling_compat = True
+    patched_load_config._omlx_original = original
+    vlm_utils.load_config = patched_load_config
+
+
+def _register_auto_processor() -> None:
+    from mlx_vlm.models.base import install_auto_processor_patch
+
+    # Import through the installed namespace (the vendor tree has no
+    # package __init__ chain of its own).
+    processing = importlib.import_module(
+        f"mlx_vlm.models.{_MODULE_NAME}.processing_inkling"
+    )
+    install_auto_processor_patch(list(_MODEL_TYPES), processing.InklingProcessor)
+
+
+__all__ = ["apply_mlx_vlm_inkling_compat_patch", "is_applied"]

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/activations.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/activations.py
@@ -1,0 +1,40 @@
+from functools import partial
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+@partial(mx.compile, shapeless=True)
+def swiglu(gate, x):
+    return nn.silu(gate) * x
+
+
+def xielu(x, alpha_p, alpha_n, beta, eps):
+    alpha_p = nn.softplus(alpha_p)
+    alpha_n = beta + nn.softplus(alpha_n)
+    return mx.where(
+        x > 0,
+        alpha_p * mx.square(x) + beta * x,
+        (mx.expm1(mx.minimum(x, eps)) - x) * alpha_n + beta * x,
+    )
+
+
+class XieLU(nn.Module):
+    def __init__(
+        self,
+        alpha_p_init=0.8,
+        alpha_n_init=0.8,
+        beta=0.5,
+        eps=-1e-6,
+    ):
+        super().__init__()
+        alpha_p_tensor = mx.array(alpha_p_init)
+        alpha_n_tensor = mx.array(alpha_n_init - beta)
+        self.alpha_p = mx.log(mx.exp(alpha_p_tensor) - 1)
+        self.alpha_n = mx.log(mx.exp(alpha_n_tensor) - 1)
+
+        self.beta = mx.array(beta)
+        self.eps = mx.array(eps)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return xielu(x, self.alpha_p, self.alpha_n, self.beta, self.eps)

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/README.md
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/README.md
@@ -1,0 +1,25 @@
+# Vendored: mlx_vlm/models/inkling
+
+Source: mlx-vlm PR #1756 head (`pcuenca/mlx-vlm@73e4cb6878691062fc55c1f969f0eedaa6ca3caf`),
+which extends the base inkling package from PR #1637 (`Blaizzy/mlx-vlm@03f3603`)
+for Inkling Small. MIT licensed like the rest of mlx-vlm.
+
+Byte-identical to the PR head except for changes marked with `OMLX:`
+comments in `language.py` (batched right-padded prefill support:
+conv_mask wiring, lengths-aware conv state writes, per-sequence key
+masking and log-tau positions, per-layer cache.advance; and an explicit
+error for configs missing `dense_intermediate_size`).
+
+`processing_inkling.py` is NOT from mlx-vlm: it is a torch-free numpy/PIL
+port of transformers 5.14's Inkling processors (Apache-2.0), needed
+because oMLX pins transformers <5.13. Audio (dMel) extraction is not
+implemented yet (text+vision first).
+
+The sibling shims `../mlp.py`, `../switch_layers.py`, `../activations.py`
+are byte-identical copies from the same PR head; they do not exist at the
+oMLX mlx-vlm pin (`78b96eb`). The `__path__`-append install searches the
+real package first, so a future pin bump that ships any of these upstream
+automatically retires the vendored copy.
+
+Retire this whole package when the mlx-vlm pin advances past PR #1756's
+merge (and transformers reaches 5.14+ for the processors).

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/README.md
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/README.md
@@ -7,8 +7,19 @@ for Inkling Small. MIT licensed like the rest of mlx-vlm.
 Byte-identical to the PR head except for changes marked with `OMLX:`
 comments in `language.py` (batched right-padded prefill support:
 conv_mask wiring, lengths-aware conv state writes, per-sequence key
-masking and log-tau positions, per-layer cache.advance; and an explicit
-error for configs missing `dense_intermediate_size`).
+masking and log-tau positions, per-layer cache.advance; an explicit
+error for configs missing `dense_intermediate_size`; MTP verify
+rollback conv-input stashes, with an opt-in rolling window
+`_omlx_stash_rows` for the MTP head-block caches).
+
+The Lightning MTP runtime (`patches/mlx_vlm_mtp/inkling_vlm_runtime.py`)
+deliberately does NOT follow upstream mlx-vlm's
+`speculative/drafters/inkling_mtp` drafter: that reference only folds
+block 0 and snapshot-restores per round, leaving depth blocks 1..7 with
+empty caches (measured per-depth agreement 0.68/0.45/0.19/0.00). It
+follows vLLM's Inkling MTP semantics instead (vllm-project/vllm#48768:
+per-depth stateful caches, uniform-window chained passes, double-normed
+embedding input), measured 0.87/0.76/0.67/0.61 with the same weights.
 
 `processing_inkling.py` is NOT from mlx-vlm: it is a torch-free numpy/PIL
 port of transformers 5.14's Inkling processors (Apache-2.0), needed

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/__init__.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/__init__.py
@@ -1,0 +1,12 @@
+from .config import AudioConfig, ModelConfig, TextConfig, VisionConfig
+from .inkling import Model
+from .language import LanguageModel
+
+__all__ = [
+    "Model",
+    "ModelConfig",
+    "TextConfig",
+    "VisionConfig",
+    "AudioConfig",
+    "LanguageModel",
+]

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/audio.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/audio.py
@@ -1,0 +1,27 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import AudioConfig
+
+
+class AudioModel(nn.Module):
+    """dMel audio front end (HiggsAudioV2-style): each of ``n_mel_bins`` mel channels is
+    discretized into ``mel_vocab_size`` buckets; per-channel bins are offset into a single
+    embedding table, looked up, and summed, then RMS-normed into LM space."""
+
+    def __init__(self, config: AudioConfig):
+        super().__init__()
+        self.model_type = config.model_type
+        self.n_mel_bins = config.n_mel_bins
+        self.mel_vocab_size = config.mel_vocab_size
+        self.embed_audio_tokens = nn.Embedding(
+            config.n_mel_bins * config.mel_vocab_size, config.text_hidden_size
+        )
+        self.norm = nn.RMSNorm(config.text_hidden_size, eps=config.rms_norm_eps)
+
+    def __call__(self, audio_input_ids):
+        """audio_input_ids: [..., frames, n_mel_bins] of bucket indices -> [..., frames, hidden]."""
+        offsets = mx.arange(self.n_mel_bins) * self.mel_vocab_size
+        embeds = self.embed_audio_tokens(audio_input_ids + offsets)
+        embeds = embeds.sum(axis=-2)
+        return self.norm(embeds)

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/config.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/config.py
@@ -1,0 +1,106 @@
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str = "inkling"
+    hidden_size: int = 6144
+    num_hidden_layers: int = 66
+    vocab_size: int = 201024
+    unpadded_vocab_size: Optional[int] = None
+    rms_norm_eps: float = 1e-6
+    tie_word_embeddings: bool = False
+    use_embed_norm: bool = True
+    logits_mup_width_multiplier: float = 1.0
+    max_position_embeddings: int = 1048576
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    swa_num_attention_heads: int = 64
+    swa_num_key_value_heads: int = 16
+    swa_head_dim: int = 128
+    sliding_window_size: int = 512
+    local_layer_ids: Optional[List[int]] = None
+    layer_types: Optional[List[str]] = None
+    d_rel: int = 16
+    rel_extent: int = 1024
+    log_scaling_n_floor: Optional[int] = None
+    log_scaling_alpha: float = 0.1
+    sconv_kernel_size: int = 4
+    dense_mlp_idx: int = 0
+    mlp_layer_types: Optional[List[str]] = None
+    # inkling nomenclature uses intermediate_size for MoE, then dense_intermediate_size
+    intermediate_size: int = 24576
+    dense_intermediate_size: Optional[int] = None
+    n_routed_experts: int = 256
+    num_experts_per_tok: int = 6
+    n_shared_experts: int = 2
+    route_scale: float = 8.0
+
+    def layer_is_sliding(self, i: int) -> bool:
+        """Sliding-window (local) vs global full-attention layer. Real checkpoints set
+        either ``layer_types`` (0.6B) or ``local_layer_ids`` (975B); the modulo is the
+        reference default (every 6th layer global)."""
+        if self.layer_types is not None:
+            return self.layer_types[i] == "hybrid_sliding"
+        if self.local_layer_ids is not None:
+            return i in set(self.local_layer_ids)
+        return bool((i + 1) % 6)
+
+    def layer_is_dense(self, i: int) -> bool:
+        if self.mlp_layer_types is not None:
+            return self.mlp_layer_types[i] == "dense"
+        return i < self.dense_mlp_idx
+
+
+@dataclass
+class VisionConfig(BaseModelConfig):
+    model_type: str = "inkling_vision"
+    patch_size: int = 40
+    temporal_patch_size: int = 2
+    num_channels: int = 3
+    n_layers: int = 4  # HMLP encoder layers
+    text_hidden_size: int = 6144
+    rms_norm_eps: float = 1e-6
+
+
+@dataclass
+class AudioConfig(BaseModelConfig):
+    model_type: str = "inkling_audio"
+    n_mel_bins: int = 80
+    mel_vocab_size: int = 16
+    text_hidden_size: int = 6144
+    rms_norm_eps: float = 1e-6
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: Union[TextConfig, dict, None] = None
+    vision_config: Union[VisionConfig, dict, None] = None
+    audio_config: Union[AudioConfig, dict, None] = None
+    model_type: str = "inkling"
+    image_token_id: int = 200054
+    audio_token_id: int = 200053
+    vocab_size: int = 201024
+    eos_token_id: Optional[List[int]] = None
+
+    def __post_init__(self):
+        # Coerce dict sub-configs (from config.json) into typed dataclasses, and wire the
+        # shared text hidden size into the towers so their projections land in LM space.
+        if self.text_config is None:
+            self.text_config = TextConfig()
+        elif isinstance(self.text_config, dict):
+            self.text_config = TextConfig.from_dict(self.text_config)
+        if self.vision_config is None:
+            self.vision_config = VisionConfig()
+        elif isinstance(self.vision_config, dict):
+            self.vision_config = VisionConfig.from_dict(self.vision_config)
+        if self.audio_config is None:
+            self.audio_config = AudioConfig()
+        elif isinstance(self.audio_config, dict):
+            self.audio_config = AudioConfig.from_dict(self.audio_config)
+        self.vision_config.text_hidden_size = self.text_config.hidden_size
+        self.audio_config.text_hidden_size = self.text_config.hidden_size

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/inkling.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/inkling.py
@@ -1,0 +1,258 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from ..base import InputEmbeddingsFeatures
+from .audio import AudioModel
+from .config import ModelConfig
+from .language import LanguageModel
+from .vision import VisionModel
+
+
+def masked_scatter(input_tensor, mask, source):
+    """MLX port of torch.Tensor.masked_scatter: fill mask==True slots with source in order."""
+    mask = mask.astype(mx.bool_)
+    if not mask.any():
+        return input_tensor
+    shape = input_tensor.shape
+    flat = input_tensor.flatten()
+    mask_flat = mask.flatten()
+    source_flat = source.flatten()
+    positions = mx.cumsum(mask_flat.astype(mx.int32)) - 1
+    positions = mx.clip(positions, 0, source_flat.size - 1)
+    selected = source_flat[positions]
+    return mx.where(mask_flat, selected, flat).reshape(shape)
+
+
+def _split_gate_up(v):
+    """De-interleave a fused [..., 2*inter, hidden] gate/up weight into (gate, up).
+
+    Return contiguous halves for performance; `gather_mm / `gather_qmm` are much slower when fed strided views
+    """
+    *lead, two_i, hidden = v.shape
+    w = v.reshape(*lead, two_i // 2, 2, hidden)
+    return mx.contiguous(w[..., 0, :]), mx.contiguous(w[..., 1, :])
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.model_type = config.model_type
+        self.config = config
+        config.vision_config.text_hidden_size = config.text_config.hidden_size
+        config.audio_config.text_hidden_size = config.text_config.hidden_size
+        self.language_model = LanguageModel(config.text_config)
+        self.vision_tower = VisionModel(config.vision_config)
+        self.audio_tower = AudioModel(config.audio_config)
+
+    def get_image_features(self, pixel_values):
+        return self.vision_tower(pixel_values)
+
+    def get_audio_features(self, audio_input_ids, audio_input_ids_mask=None):
+        if audio_input_ids_mask is not None:
+            flat = audio_input_ids.reshape(-1, audio_input_ids.shape[-1])
+            keep = np.nonzero(np.array(audio_input_ids_mask).reshape(-1))[0]
+            frames = flat[mx.array(keep)]
+        else:
+            frames = audio_input_ids.reshape(-1, audio_input_ids.shape[-1])
+        return self.audio_tower(frames)
+
+    def get_input_embeddings(self, input_ids, pixel_values=None, **kwargs):
+        h = self.language_model.model.embed(input_ids)
+
+        if pixel_values is not None:
+            feats = self.get_image_features(pixel_values).astype(h.dtype)
+            mask = mx.broadcast_to(
+                (input_ids == self.config.image_token_id)[..., None], h.shape
+            )
+            h = masked_scatter(h, mask, feats)
+
+        audio_input_ids = kwargs.get("audio_input_ids", None)
+        if audio_input_ids is not None:
+            feats = self.get_audio_features(
+                audio_input_ids, kwargs.get("audio_input_ids_mask", None)
+            ).astype(h.dtype)
+            mask = mx.broadcast_to(
+                (input_ids == self.config.audio_token_id)[..., None], h.shape
+            )
+            h = masked_scatter(h, mask, feats)
+        return InputEmbeddingsFeatures(inputs_embeds=h)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache: Optional[list] = None,
+        **kwargs,
+    ):
+        spec_kwargs = {
+            k: kwargs.pop(k)
+            for k in ("return_hidden", "return_shared_kv", "skip_logits")
+            if k in kwargs
+        }
+        embeds = self.get_input_embeddings(
+            input_ids, pixel_values=pixel_values, **kwargs
+        )
+        return self.language_model(
+            inputs_embeds=embeds.inputs_embeds, cache=cache, **spec_kwargs
+        )
+
+    _ATTN = {
+        "wq_du": "q_proj",
+        "wk_dv": "k_proj",
+        "wv_dv": "v_proj",
+        "wr_du": "r_proj",
+        "wo_ud": "o_proj",
+    }
+
+    def _map_llm_layer(self, base, sub, v):
+        out = {}
+        if sub.startswith("attn."):
+            name, leaf = sub[len("attn.") :].rsplit(".", 1)
+            if name in self._ATTN:
+                out[base + f"self_attn.{self._ATTN[name]}.weight"] = v
+            elif name in ("q_norm", "k_norm"):
+                out[base + f"self_attn.{name}.weight"] = v
+            elif name in ("k_sconv", "v_sconv"):
+                out[base + f"self_attn.{name}.conv.weight"] = v.transpose(0, 2, 1)
+            elif name == "rel_logits_proj":
+                out[base + "self_attn.rel_proj"] = v
+            else:
+                out[base + "self_attn." + name + "." + leaf] = v
+        elif sub == "attn_norm.weight":
+            out[base + "input_layernorm.weight"] = v
+        elif sub == "mlp_norm.weight":
+            out[base + "post_attention_layernorm.weight"] = v
+        elif sub == "attn_sconv.weight":
+            out[base + "attn_sconv.conv.weight"] = v.transpose(0, 2, 1)
+        elif sub == "mlp_sconv.weight":
+            out[base + "mlp_sconv.conv.weight"] = v.transpose(0, 2, 1)
+        elif sub.startswith("mlp."):
+            m = sub[len("mlp.") :]
+            p = base + "mlp."
+            if m == "gate.weight":
+                out[p + "gate_weight"] = v
+            elif m == "gate.bias":
+                out[p + "e_score_correction_bias"] = v
+            elif m in ("gate.global_scale", "global_scale"):
+                out[p + "global_scale"] = v
+            elif m == "shared_experts.shared_w13_weight":
+                g, u = _split_gate_up(v)
+                out[p + "shared_experts.gate_proj.weight"] = g
+                out[p + "shared_experts.up_proj.weight"] = u
+            elif m == "shared_experts.shared_w2_weight":
+                out[p + "shared_experts.down_proj.weight"] = v
+            elif m == "w13_dn.weight":
+                g, u = _split_gate_up(v)
+                out[p + "gate_proj.weight"] = g
+                out[p + "up_proj.weight"] = u
+            elif m == "w2_md.weight":
+                out[p + "down_proj.weight"] = v
+            else:
+                out[p + m] = v
+        else:
+            out[base + sub] = v
+        return out
+
+    def _map_experts(self, i, buf):
+        """Emit MLX-native switch-MLP weights for one MoE layer.
+
+        ``buf`` maps ``"w13"``/``"w2"`` to a dict of the raw checkpoint tensors
+        (``weight`` plus, when NVFP4-quantized, ``scale``/``scale2``). NVFP4
+        experts are stored as ModelOpt two-level nvfp4: uint8-packed E2M1 codes
+        (bit-identical to MLX's uint32 layout via ``view``), per-block E4M3
+        ``scale`` (already MLX's ``.scales`` byte layout), and a per-expert
+        ``scale2``. We pass the codes and block scales through untouched and
+        route ``scale2`` to ``InklingSwitchGLU`` (``gate_scale``/``out_scale``).
+        Layer ``dense_mlp_idx`` (the first MoE layer) is excluded from
+        quantization and arrives as bf16, handled by the plain-split branch.
+        """
+        out = {}
+        p = f"language_model.model.layers.{i}.mlp.switch_mlp."
+        w13, w2 = buf["w13"], buf["w2"]
+        quantized = w13["weight"].dtype == mx.uint8
+        if quantized:
+            gw, uw = _split_gate_up(w13["weight"].view(mx.uint32))
+            gs, us = _split_gate_up(w13["scale"])
+            out[p + "gate_proj.weight"] = gw
+            out[p + "gate_proj.scales"] = gs
+            out[p + "up_proj.weight"] = uw
+            out[p + "up_proj.scales"] = us
+            out[p + "down_proj.weight"] = w2["weight"].view(mx.uint32)
+            out[p + "down_proj.scales"] = w2["scale"]
+            s13 = w13["scale2"].astype(mx.float32)
+            s2 = w2["scale2"].astype(mx.float32)
+            out[p + "gate_scale"] = s13
+            out[p + "out_scale"] = s13 * s2
+        else:
+            gw, uw = _split_gate_up(w13["weight"])
+            out[p + "gate_proj.weight"] = gw
+            out[p + "up_proj.weight"] = uw
+            out[p + "down_proj.weight"] = w2["weight"]
+            n = gw.shape[0]
+            out[p + "gate_scale"] = mx.ones((n,))
+            out[p + "out_scale"] = mx.ones((n,))
+        return out
+
+    def sanitize(self, weights):
+        out = {}
+        experts = {}  # layer index -> {"w13"|"w2": {"weight"|"scale"|"scale2": array}}
+        for k, v in weights.items():
+            if ".mtp" in k or k.startswith("model.mtp") or k.endswith("training_args"):
+                continue
+            # Routed-expert tensors (base weight + NVFP4 sidecars) are buffered and
+            # folded per layer once both w13 and w2 are seen; input_amax /
+            # original_shape are calibration metadata with no inference use.
+            if ".mlp.experts.w13_weight" in k or ".mlp.experts.w2_weight" in k:
+                head, tail = k.split(".mlp.experts.")
+                i = head.split("layers.")[1]
+                which = "w13" if tail.startswith("w13") else "w2"
+                leaf = tail.split("_weight", 1)[1].lstrip(".") or "weight"
+                if leaf in ("input_amax", "original_shape"):
+                    continue
+                experts.setdefault(i, {}).setdefault(which, {})[leaf] = v
+                continue
+            if k == "model.llm.embed.weight":
+                out["language_model.model.embed_tokens.weight"] = v
+            elif k == "model.llm.unembed.weight":
+                out["language_model.lm_head.weight"] = v
+            elif k in ("model.llm.embed_norm.weight", "model.llm.norm.weight"):
+                out["language_model.model." + k[len("model.llm.") :]] = v
+            elif k.startswith("model.llm.layers."):
+                i, sub = k[len("model.llm.layers.") :].split(".", 1)
+                out.update(
+                    self._map_llm_layer(f"language_model.model.layers.{i}.", sub, v)
+                )
+            elif k.startswith("model.visual."):
+                sub = k[len("model.visual.") :]
+                if sub.startswith("layers.linear_"):
+                    j = sub[len("layers.linear_") :].split(".")[0]
+                    out[f"vision_tower.encoder_layers.{j}.projection.weight"] = v
+                elif sub.startswith("layers.norm_"):
+                    j = sub[len("layers.norm_") :].split(".")[0]
+                    out[f"vision_tower.encoder_layers.{j}.layer_norm.weight"] = v
+                else:
+                    out["vision_tower." + sub] = v
+            elif k.startswith("model.audio."):
+                sub = k[len("model.audio.") :]
+                if sub == "encoder.weight":
+                    out["audio_tower.embed_audio_tokens.weight"] = v
+                elif sub == "final_norm.weight":
+                    out["audio_tower.norm.weight"] = v
+                else:
+                    out["audio_tower." + sub] = v
+            else:
+                out[k] = v
+        for i, buf in experts.items():
+            out.update(self._map_experts(i, buf))
+        return out
+
+    def make_cache(self):
+        return self.language_model.make_cache()
+
+    @property
+    def layers(self):
+        return self.language_model.model.layers

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/inkling.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/inkling.py
@@ -202,6 +202,12 @@ class Model(nn.Module):
         experts = {}  # layer index -> {"w13"|"w2": {"weight"|"scale"|"scale2": array}}
         for k, v in weights.items():
             if ".mtp" in k or k.startswith("model.mtp") or k.endswith("training_args"):
+                # OMLX: single-checkpoint Lightning MTP keeps and remaps
+                # the head weights when the runtime patch installs a hook
+                # (upstream always drops them). None → upstream behavior.
+                hook = globals().get("_OMLX_MTP_SANITIZE_HOOK")
+                if hook is not None and not k.endswith("training_args"):
+                    out.update(hook(k, v))
                 continue
             # Routed-expert tensors (base weight + NVFP4 sidecars) are buffered and
             # folded per layer once both w13 and w2 are seen; input_amax /

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/language.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/language.py
@@ -180,7 +180,21 @@ class InklingShortConvolution(nn.Module):
             if stash is None:
                 stash = {}
                 cache._omlx_verify_xp = stash
-            stash[self.conv_idx] = xp
+            # OMLX: MTP head-block conv caches set ``_omlx_stash_rows`` so
+            # the stash keeps a ROLLING input window instead of just the
+            # last forward — the multi-block head cycle rewinds provisional
+            # rows across cycles whose windows can be longer than the last
+            # forward. Trunk caches leave it unset and keep the exact
+            # last-forward stash (byte-identical path).
+            rows = getattr(cache, "_omlx_stash_rows", 0)
+            if rows:
+                prev = stash.get(self.conv_idx)
+                roll = xp if prev is None else mx.concatenate([prev, xf], axis=1)
+                if roll.shape[1] > rows:
+                    roll = roll[:, -rows:, :]
+                stash[self.conv_idx] = roll
+            else:
+                stash[self.conv_idx] = xp
         else:
             xp = mx.pad(xf, [(0, 0), (K - 1, 0), (0, 0)])
         out = self.conv(xp.astype(self.conv.weight.dtype)).astype(mx.float32)

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/language.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/language.py
@@ -170,6 +170,17 @@ class InklingShortConvolution(nn.Module):
                 cache[self.conv_idx] = mx.take_along_axis(xp, positions, axis=1)
             else:
                 cache[self.conv_idx] = xp[:, -(K - 1) :, :]
+            # OMLX: keep the padded conv input of the LAST forward so an
+            # MTP verify rollback can reslice the state at any accepted
+            # boundary (state after keeping j tokens = xp[:, j : j+K-1]).
+            # Conv states cannot be trimmed like KV; without this, rejected
+            # draft tokens would stay baked into the sliding window. A lazy
+            # array reference, overwritten every forward — no extra compute.
+            stash = getattr(cache, "_omlx_verify_xp", None)
+            if stash is None:
+                stash = {}
+                cache._omlx_verify_xp = stash
+            stash[self.conv_idx] = xp
         else:
             xp = mx.pad(xf, [(0, 0), (K - 1, 0), (0, 0)])
         out = self.conv(xp.astype(self.conv.weight.dtype)).astype(mx.float32)

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/language.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/language.py
@@ -60,13 +60,21 @@ def _restore_cache_state(caches, snapshot):
             c.state = _clone_cache_tree(s)
 
 
+# OMLX: S / LQ / Q_OFF / B are RUNTIME params (uint32 buffer), not template
+# constants. Every template tuple compiles its own Metal pipeline, and these
+# values change every decode step (cache growth) and every MTP verify/head
+# cycle — templating them forced a pipeline recompile per step on the seven
+# global layers and per pass on the MTP head blocks. Only genuinely static
+# per-layer constants (dtype, H, D_REL, REL_EXTENT, SLIDING) stay templated.
 _MASK_SRC = r"""
     uint j  = thread_position_in_grid.x;   // key   position [0, S)
     uint i  = thread_position_in_grid.y;   // query position [0, LQ)
     uint bh = thread_position_in_grid.z;   // b * H + h
+    uint S = params[0], LQ = params[1], B = params[3];
+    int q_off = (int)params[2];
     if (i >= LQ || j >= S || bh >= B * H) return;
     uint b = bh / H, h = bh % H;
-    int dist = (int(i) + int(Q_OFF)) - int(j);   // backward distance
+    int dist = (int(i) + q_off) - int(j);   // backward distance
     T val;
     if (dist < 0) {
         val = (T)(-1e30f);                                   // causal
@@ -86,7 +94,7 @@ _MASK_SRC = r"""
 """
 _mask_kernel = mx.fast.metal_kernel(
     name="inkling_banded_mask",
-    input_names=["rel", "proj"],
+    input_names=["rel", "proj", "params"],
     output_names=["out"],
     source=_MASK_SRC,
 )
@@ -101,15 +109,12 @@ def banded_additive_mask(rel, proj, q_offset, S, sliding, rel_extent):
     B, LQ, H, d_rel = rel.shape
     dtype = rel.dtype
     if mx.default_device() == mx.gpu:
+        params = mx.array([S, LQ, int(q_offset), B], dtype=mx.uint32)
         return _mask_kernel(
-            inputs=[rel, proj],
+            inputs=[rel, proj, params],
             template=[
                 ("T", dtype),
-                ("B", B),
                 ("H", H),
-                ("LQ", LQ),
-                ("S", S),
-                ("Q_OFF", q_offset),
                 ("D_REL", d_rel),
                 ("REL_EXTENT", rel_extent),
                 ("SLIDING", sliding),

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/language.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/language.py
@@ -1,0 +1,580 @@
+# Vendored from mlx-vlm PR #1756 (pcuenca/mlx-vlm@73e4cb6, models/inkling).
+# oMLX modifications, each marked with an "OMLX:" comment at the site:
+# - batched right-padded prefill support: conv_mask wiring from
+#   ArraysCache.make_mask, lengths-aware conv state writes, per-sequence
+#   key-validity masking and log-tau positions in attention, and per-layer
+#   cache.advance. Upstream never passes conv_mask (single-request
+#   mlx_vlm.generate has no padding), so batch prefill would pollute the
+#   short-conv states and attend to padded keys.
+# - explicit error when a config with dense MLP layers lacks
+#   dense_intermediate_size (upstream crashes with an opaque TypeError).
+import os  # OMLX: sliding-window slice kill switch
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+# OMLX: compute-only optimization — sliding layers (35 of 42 on Inkling
+# Small) never attend past their 512-token window, but upstream runs SDPA
+# over the FULL cached sequence and cuts via the additive mask, making
+# every sliding layer O(S) per decoded token. Slicing K/V to the window
+# before SDPA is numerically equivalent (masked keys carry -1e30 and
+# contribute exactly 0 after softmax; distances are shift-invariant).
+# Kill switch for A/B measurement: OMLX_INKLING_SLIDING_SLICE=0.
+_SLIDING_WINDOW_SLICE = os.environ.get("OMLX_INKLING_SLIDING_SLICE", "1") != "0"
+
+from ..base import LanguageModelOutput, scaled_dot_product_attention
+from ..cache import ArraysCache, CacheList, KVCache
+from ..mlp import SwiGLUMLP
+from ..switch_layers import SwitchGLU, _gather_sort, _scatter_unsort
+from .config import TextConfig as ModelConfig
+
+
+def _clone_cache_tree(value):
+    if isinstance(value, mx.array):
+        return mx.array(value)
+    if isinstance(value, tuple):
+        return tuple(_clone_cache_tree(v) for v in value)
+    if isinstance(value, list):
+        return [_clone_cache_tree(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _clone_cache_tree(v) for k, v in value.items()}
+    return value
+
+
+def _snapshot_cache_state(caches):
+    """Deep-copy the full state of every cache so a speculative block can be
+    rolled back by replay. Inkling's short-conv slots keep only the last K-1
+    inputs and cannot be trimmed, so we restore-and-replay instead."""
+    snapshot = [None if c is None else _clone_cache_tree(c.state) for c in caches]
+    arrays = [v for _, v in tree_flatten(snapshot) if isinstance(v, mx.array)]
+    if arrays:
+        mx.eval(arrays)
+    return snapshot
+
+
+def _restore_cache_state(caches, snapshot):
+    for c, s in zip(caches, snapshot):
+        if c is not None and s is not None:
+            c.state = _clone_cache_tree(s)
+
+
+_MASK_SRC = r"""
+    uint j  = thread_position_in_grid.x;   // key   position [0, S)
+    uint i  = thread_position_in_grid.y;   // query position [0, LQ)
+    uint bh = thread_position_in_grid.z;   // b * H + h
+    if (i >= LQ || j >= S || bh >= B * H) return;
+    uint b = bh / H, h = bh % H;
+    int dist = (int(i) + int(Q_OFF)) - int(j);   // backward distance
+    T val;
+    if (dist < 0) {
+        val = (T)(-1e30f);                                   // causal
+    } else if (SLIDING > 0 && dist >= (int)SLIDING) {
+        val = (T)(-1e30f);                                   // sliding-window cap
+    } else if (dist < (int)REL_EXTENT) {
+        float acc = 0.0f;
+        uint rbase = ((b * LQ + i) * H + h) * D_REL;
+        uint pcol = (uint)dist;
+        for (uint d = 0; d < D_REL; ++d)
+            acc += (float)rel[rbase + d] * (float)proj[d * REL_EXTENT + pcol];
+        val = (T)acc;
+    } else {
+        val = (T)0;                                          // in-context, outside band
+    }
+    out[((b * H + h) * LQ + i) * S + j] = val;
+"""
+_mask_kernel = mx.fast.metal_kernel(
+    name="inkling_banded_mask",
+    input_names=["rel", "proj"],
+    output_names=["out"],
+    source=_MASK_SRC,
+)
+
+
+def _rup(a, m):
+    return ((a + m - 1) // m) * m
+
+
+def banded_additive_mask(rel, proj, q_offset, S, sliding, rel_extent):
+    """rel: [B, LQ, H, d_rel]; proj: [d_rel, rel_extent] -> additive mask [B, H, LQ, S]."""
+    B, LQ, H, d_rel = rel.shape
+    dtype = rel.dtype
+    if mx.default_device() == mx.gpu:
+        return _mask_kernel(
+            inputs=[rel, proj],
+            template=[
+                ("T", dtype),
+                ("B", B),
+                ("H", H),
+                ("LQ", LQ),
+                ("S", S),
+                ("Q_OFF", q_offset),
+                ("D_REL", d_rel),
+                ("REL_EXTENT", rel_extent),
+                ("SLIDING", sliding),
+            ],
+            grid=(_rup(S, 8), _rup(LQ, 8), B * H),
+            threadgroup=(8, 8, 1),
+            output_shapes=[(B, H, LQ, S)],
+            output_dtypes=[dtype],
+        )[0]
+    rl = (rel @ proj).transpose(0, 2, 1, 3)
+    qp = mx.arange(LQ) + q_offset
+    kp = mx.arange(S)
+    dist = qp[:, None] - kp[None, :]
+    gidx = mx.broadcast_to(mx.clip(dist, 0, rel_extent - 1)[None, None], (B, H, LQ, S))
+    pb = mx.take_along_axis(rl, gidx, axis=-1)
+    pb = mx.where((dist >= rel_extent)[None, None], mx.array(0.0, dtype), pb)
+    neg = dist < 0
+    if sliding > 0:
+        neg = neg | (dist >= sliding)
+    return mx.where(neg[None, None], mx.array(-1e30, dtype), pb).astype(dtype)
+
+
+class InklingShortConvolution(nn.Module):
+    """Depthwise causal 1-D conv over the previous ``kernel_size - 1`` states, plus a
+    residual add. Kept in fp32 for stability (matches the reference). ``conv_idx`` selects
+    this conv's slot in the layer's shared conv cache."""
+
+    def __init__(self, channels: int, kernel_size: int, conv_idx: int):
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.conv_idx = conv_idx
+        self.conv = nn.Conv1d(
+            channels, channels, kernel_size, groups=channels, bias=False
+        )
+
+    def __call__(self, x: mx.array, cache=None, mask: Optional[mx.array] = None):
+        dt = x.dtype
+        xf = x.astype(mx.float32)
+        res = xf
+        if mask is not None:
+            xf = mx.where(mask[..., None], xf, 0)
+        K = self.kernel_size
+        if cache is not None:
+            state = cache[self.conv_idx]
+            if state is None:
+                state = mx.zeros((xf.shape[0], K - 1, xf.shape[-1]), dtype=xf.dtype)
+            xp = mx.concatenate([state, xf], axis=1)
+            # OMLX: right-padded batch prefill writes the last K-1 VALID
+            # rows per sequence, not the padded tail (mlx-lm qwen3_5's
+            # lengths-aware conv state gather). ``lengths`` counts the
+            # remaining valid tokens for the current chunk; a sequence
+            # already fully consumed keeps its carried state (ends=0
+            # selects the first K-1 rows of xp, which ARE the state).
+            lengths = getattr(cache, "lengths", None)
+            if lengths is not None:
+                ends = mx.clip(lengths, 0, xf.shape[1])
+                positions = (ends[:, None] + mx.arange(K - 1))[..., None]
+                cache[self.conv_idx] = mx.take_along_axis(xp, positions, axis=1)
+            else:
+                cache[self.conv_idx] = xp[:, -(K - 1) :, :]
+        else:
+            xp = mx.pad(xf, [(0, 0), (K - 1, 0), (0, 0)])
+        out = self.conv(xp.astype(self.conv.weight.dtype)).astype(mx.float32)
+        return (out + res).astype(dt)
+
+
+class InklingAttention(nn.Module):
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.is_sliding = config.layer_is_sliding(layer_idx)
+        self.head_dim = config.swa_head_dim if self.is_sliding else config.head_dim
+        self.n_heads = (
+            config.swa_num_attention_heads
+            if self.is_sliding
+            else config.num_attention_heads
+        )
+        self.n_kv = (
+            config.swa_num_key_value_heads
+            if self.is_sliding
+            else config.num_key_value_heads
+        )
+        self.sliding = config.sliding_window_size if self.is_sliding else 0
+        self.rel_extent = (
+            config.sliding_window_size if self.is_sliding else config.rel_extent
+        )
+        self.d_rel = config.d_rel
+        self.scale = 1.0 / self.head_dim
+        self.log_floor = None if self.is_sliding else config.log_scaling_n_floor
+        self.log_alpha = config.log_scaling_alpha
+
+        self.q_proj = nn.Linear(
+            config.hidden_size, self.n_heads * self.head_dim, bias=False
+        )
+        self.k_proj = nn.Linear(
+            config.hidden_size, self.n_kv * self.head_dim, bias=False
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size, self.n_kv * self.head_dim, bias=False
+        )
+        self.r_proj = nn.Linear(
+            config.hidden_size, self.n_heads * self.d_rel, bias=False
+        )
+        self.o_proj = nn.Linear(
+            self.n_heads * self.head_dim, config.hidden_size, bias=False
+        )
+        self.k_sconv = InklingShortConvolution(
+            self.n_kv * self.head_dim, config.sconv_kernel_size, conv_idx=0
+        )
+        self.v_sconv = InklingShortConvolution(
+            self.n_kv * self.head_dim, config.sconv_kernel_size, conv_idx=1
+        )
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.rel_proj = mx.zeros((self.d_rel, self.rel_extent))
+
+    def __call__(self, x, cache=None, conv_mask=None):
+        B, L, _ = x.shape
+        kv = cache[0] if cache is not None else None
+        conv = cache[1] if cache is not None else None
+
+        q = self.q_proj(x)
+        k = self.k_sconv(self.k_proj(x), cache=conv, mask=conv_mask)
+        v = self.v_sconv(self.v_proj(x), cache=conv, mask=conv_mask)
+        r = self.r_proj(x).reshape(B, L, self.n_heads, self.d_rel)
+
+        q = self.q_norm(q.reshape(B, L, self.n_heads, self.head_dim)).transpose(
+            0, 2, 1, 3
+        )
+        k = self.k_norm(k.reshape(B, L, self.n_kv, self.head_dim)).transpose(0, 2, 1, 3)
+        v = v.reshape(B, L, self.n_kv, self.head_dim).transpose(0, 2, 1, 3)
+
+        if kv is not None:
+            k, v = kv.update_and_fetch(k, v)
+        S = k.shape[2]
+        # OMLX: buffer-coordinate query offset. Upstream read ``kv.offset``,
+        # which is a per-sequence ARRAY on a merged BatchKVCache (batched
+        # requests) and cannot feed the scalar Q_OFF kernel template. The
+        # banded distances are shift-invariant under left padding, so
+        # buffer coordinates (first query at S - L) give identical
+        # distances for every layout; for the plain single-request cache
+        # S - L equals the pre-update kv.offset upstream used.
+        offset = S - L
+
+        # OMLX: sliding layers only attend the last (sliding + L - 1)
+        # keys; slice K/V to that window so per-token cost stays O(window)
+        # instead of O(S). Distances are shift-invariant under the uniform
+        # cut; log-tau never applies here (log_floor is None on sliding
+        # layers), and the padding bounds below shift with ``cut``.
+        cut = 0
+        if (
+            _SLIDING_WINDOW_SLICE
+            and self.sliding > 0
+            and S > self.sliding + L - 1
+        ):
+            cut = S - (self.sliding + L - 1)
+            k = k[:, :, cut:, :]
+            v = v[:, :, cut:, :]
+            S = k.shape[2]
+            offset = S - L
+
+        mask = banded_additive_mask(
+            r, self.rel_proj.astype(x.dtype), offset, S, self.sliding, self.rel_extent
+        )
+
+        # OMLX: mask padded key positions per sequence. Right-padded
+        # prefill chunks carry ``lengths`` on the conv cache (remaining
+        # valid tokens; the absolute valid end in buffer coordinates is
+        # (S - L) + lengths_b, which also stays correct once lengths goes
+        # negative for an already-consumed short sequence). Merged batches
+        # carry ``left_padding`` on the KV cache (front holes, valid keys
+        # are j >= lp_b). Both can be active for a restored-prefix batch,
+        # so the conditions combine.
+        lengths = getattr(conv, "lengths", None) if conv is not None else None
+        left_padding = getattr(kv, "left_padding", None) if kv is not None else None
+        valid_k = None
+        if lengths is not None:
+            valid_k = mx.arange(S) < (offset + lengths)[:, None]
+        if left_padding is not None:
+            # OMLX: left_padding is an absolute buffer position; shift it
+            # into the sliced coordinate frame.
+            lower = mx.arange(S) >= (left_padding - cut)[:, None]
+            valid_k = lower if valid_k is None else (valid_k & lower)
+        if valid_k is not None:
+            mask = mx.where(
+                valid_k[:, None, None, :], mask, mx.array(-1e30, mask.dtype)
+            )
+
+        if self.log_floor is not None:
+            qpos = (mx.arange(L) + offset + 1).astype(mx.float32)
+            if left_padding is not None:
+                # OMLX: per-sequence true positions under left padding.
+                qpos = qpos[None, :] - left_padding[:, None].astype(mx.float32)
+                tau_shape = (B, 1, L, 1)
+            else:
+                tau_shape = (1, 1, L, 1)
+            tau = 1.0 + self.log_alpha * mx.log(mx.maximum(qpos / self.log_floor, 1.0))
+            tau = tau.reshape(tau_shape).astype(x.dtype)
+            q = q * tau
+            mask = mx.where(mask > -1e29, mask * tau, mask)
+
+        out = scaled_dot_product_attention(
+            q, k, v, cache=None, scale=self.scale, mask=mask
+        )
+        out = out.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(out)
+
+
+class InklingDenseMLP(SwiGLUMLP):
+    """Dense SwiGLU MLP (shared ``SwiGLUMLP``) with a learned output scale."""
+
+    def __init__(self, config: ModelConfig):
+        # OMLX: fail with a clear message instead of an opaque TypeError.
+        # Real Inkling checkpoints always set dense_intermediate_size in
+        # config.json; guessing a fallback would build wrong shapes.
+        if config.dense_intermediate_size is None:
+            raise ValueError(
+                "inkling config declares dense MLP layers but has no "
+                "dense_intermediate_size; the checkpoint config.json is "
+                "expected to define it"
+            )
+        super().__init__(config.hidden_size, config.dense_intermediate_size)
+        self.global_scale = mx.ones((1,))
+
+    def __call__(self, x):
+        return super().__call__(x) * self.global_scale
+
+
+class InklingSwitchGLU(SwitchGLU):
+    def __init__(self, input_dims, hidden_dims, num_experts, **kwargs):
+        super().__init__(input_dims, hidden_dims, num_experts, **kwargs)
+        self.gate_scale = mx.ones((num_experts,))  # s13 (fused gate/up scale2)
+        self.out_scale = mx.ones((num_experts,))  # s13 * s2
+
+    def _per_expert(self, scale, idx, like):
+        s = scale[idx].astype(like.dtype)
+        return s.reshape(s.shape + (1,) * (like.ndim - s.ndim))
+
+    def __call__(self, x, indices) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(x, indices)
+        x_up = self.up_proj(x, idx, sorted_indices=do_sort)
+        x_gate = self.gate_proj(x, idx, sorted_indices=do_sort)
+        x_gate = x_gate * self._per_expert(self.gate_scale, idx, x_gate)
+        x = self.down_proj(self.activation(x_up, x_gate), idx, sorted_indices=do_sort)
+        x = x * self._per_expert(self.out_scale, idx, x)
+        if do_sort:
+            x = _scatter_unsort(x, inv_order, indices.shape)
+        return x.squeeze(-2)
+
+
+class InklingSparseMoE(nn.Module):
+    """Sigmoid-gated fine-grained MoE: top-k routed experts (+ correction-bias selection)
+    plus always-on shared experts, weighted by a logsigmoid/logsumexp softmax."""
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.n_routed = config.n_routed_experts
+        self.n_shared = config.n_shared_experts
+        self.top_k = config.num_experts_per_tok
+        self.route_scale = config.route_scale
+        self.gate_weight = mx.zeros((self.n_routed + self.n_shared, config.hidden_size))
+        self.e_score_correction_bias = mx.zeros((self.n_routed,))
+        self.global_scale = mx.ones((1,))
+        self.switch_mlp = InklingSwitchGLU(
+            config.hidden_size, config.intermediate_size, self.n_routed
+        )
+        self.shared_experts = SwitchGLU(
+            config.hidden_size, config.intermediate_size, self.n_shared
+        )
+
+    def __call__(self, x):
+        B, L, D = x.shape
+        xf = x.reshape(-1, D)
+        logits = xf @ self.gate_weight.astype(x.dtype).T
+        scores = mx.sigmoid(logits.astype(mx.float32))
+        sfc = scores[:, : self.n_routed] + self.e_score_correction_bias
+        idx = mx.argpartition(-sfc, self.top_k - 1, axis=-1)[:, : self.top_k]
+
+        routed_logits = logits[:, : self.n_routed]
+        shared_logits = logits[:, -self.n_shared :]
+        tl = mx.concatenate(
+            [mx.take_along_axis(routed_logits, idx, axis=-1), shared_logits], axis=-1
+        ).astype(mx.float32)
+        lp = -mx.logaddexp(mx.zeros_like(tl), -tl)
+        w = (
+            mx.exp(lp - mx.logsumexp(lp, axis=-1, keepdims=True))
+            * self.route_scale
+            * self.global_scale
+        )
+        shared_gammas = w[:, -self.n_shared :]
+        topk_w = w[:, : self.top_k]
+
+        yr = (self.switch_mlp(xf, idx) * topk_w[..., None].astype(x.dtype)).sum(axis=-2)
+        sh_idx = mx.broadcast_to(
+            mx.arange(self.n_shared)[None], (xf.shape[0], self.n_shared)
+        )
+        ys = (
+            self.shared_experts(xf, sh_idx) * shared_gammas[..., None].astype(x.dtype)
+        ).sum(axis=-2)
+        return (yr + ys).reshape(B, L, D).astype(x.dtype)
+
+
+class InklingDecoderLayer(nn.Module):
+    def __init__(self, config: ModelConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = InklingAttention(config, layer_idx)
+        self.mlp = (
+            InklingDenseMLP(config)
+            if config.layer_is_dense(layer_idx)
+            else InklingSparseMoE(config)
+        )
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.attn_sconv = InklingShortConvolution(
+            config.hidden_size, config.sconv_kernel_size, conv_idx=2
+        )
+        self.mlp_sconv = InklingShortConvolution(
+            config.hidden_size, config.sconv_kernel_size, conv_idx=3
+        )
+
+    def __call__(self, x, cache=None, conv_mask=None):
+        conv = cache[1] if cache is not None else None
+        r = self.self_attn(self.input_layernorm(x), cache=cache, conv_mask=conv_mask)
+        h = x + self.attn_sconv(r, cache=conv, mask=conv_mask)
+        r = self.mlp(self.post_attention_layernorm(h))
+        out = h + self.mlp_sconv(r, cache=conv, mask=conv_mask)
+        # OMLX: advance the shared conv cache once per consumed chunk so
+        # lengths/left_padding track the remaining sequence across chunked
+        # prefill (qwen3_5 pattern; no-op without padding bookkeeping).
+        if conv is not None and hasattr(conv, "advance"):
+            conv.advance(x.shape[1])
+        return out
+
+
+class InklingModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.embed_norm = (
+            nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            if config.use_embed_norm
+            else None
+        )
+        self.layers = [
+            InklingDecoderLayer(config, i) for i in range(config.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def embed(self, input_ids):
+        h = self.embed_tokens(input_ids)
+        if self.embed_norm is not None:
+            h = self.embed_norm(h)
+        return h
+
+    def __call__(
+        self,
+        inputs,
+        cache=None,
+        input_embeddings: Optional[mx.array] = None,
+        skip_final_norm: bool = False,
+    ):
+        h = input_embeddings if input_embeddings is not None else self.embed(inputs)
+        if cache is None:
+            cache = [None] * len(self.layers)
+        # OMLX: derive the padding mask once per forward from the first
+        # layer's conv cache (every layer shares the same bookkeeping and
+        # advances its own copy equally). None when no padding is active,
+        # which keeps the single-request path byte-identical to upstream.
+        conv_mask = None
+        first = cache[0] if cache else None
+        if first is not None:
+            conv0 = first[1]
+            if conv0 is not None and hasattr(conv0, "make_mask"):
+                conv_mask = conv0.make_mask(h.shape[1])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, cache=c, conv_mask=conv_mask)
+        return h if skip_final_norm else self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.model = InklingModel(config)
+        if not config.tie_word_embeddings:
+            self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def _logits_from_norm(self, h):
+        h = h / self.config.logits_mup_width_multiplier
+        if self.config.tie_word_embeddings:
+            logits = self.model.embed_tokens.as_linear(h)
+        else:
+            logits = self.lm_head(h)
+        uv = self.config.unpadded_vocab_size
+        if uv is not None and uv < logits.shape[-1]:
+            logits = logits[..., :uv]
+        return logits
+
+    def __call__(
+        self,
+        inputs=None,
+        cache=None,
+        input_embeddings=None,
+        inputs_embeds=None,
+        return_hidden: bool = False,
+        return_shared_kv: bool = False,
+        skip_logits: bool = False,
+        **kwargs,
+    ):
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        if inputs_embeds is None:
+            inputs_embeds = input_embeddings
+        pre_norm = self.model(inputs, cache, inputs_embeds, skip_final_norm=True)
+        logits = (
+            None if skip_logits else self._logits_from_norm(self.model.norm(pre_norm))
+        )
+        return LanguageModelOutput(
+            logits=logits,
+            hidden_states=[pre_norm] if return_hidden else None,
+            shared_kv_states={} if return_shared_kv else None,
+        )
+
+    def speculative_logits_from_hidden(self, hidden: mx.array) -> mx.array:
+        return self._logits_from_norm(self.model.norm(hidden))
+
+    def speculative_argmax_from_hidden(self, hidden: mx.array) -> Optional[mx.array]:
+        return mx.argmax(self.speculative_logits_from_hidden(hidden), axis=-1)
+
+    def speculative_verify_hidden(self, inputs: mx.array, cache):
+        snapshot = _snapshot_cache_state(cache)
+        out = self(
+            inputs,
+            cache=cache,
+            return_hidden=True,
+            return_shared_kv=True,
+            skip_logits=True,
+        )
+        return out.hidden_states[-1], out.shared_kv_states, (snapshot, inputs)
+
+    def rollback_speculative_cache(
+        self, caches, gdn_states, accepted, block_size
+    ) -> int:
+        if isinstance(accepted, mx.array):
+            accepted = int(accepted.max().item()) if accepted.size else 0
+        elif not isinstance(accepted, int):
+            accepted = max(int(a) for a in accepted)
+        snapshot, verify_inputs = gdn_states
+        _restore_cache_state(caches, snapshot)
+        keep = accepted + 1
+        if keep > 0:
+            self(verify_inputs[:, :keep], cache=caches, skip_logits=True)
+        return accepted
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        return [CacheList(KVCache(), ArraysCache(4)) for _ in self.model.layers]

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/processing_inkling.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/processing_inkling.py
@@ -1,0 +1,329 @@
+# Torch-free port of transformers' Inkling processors (transformers
+# 5.14+, src/transformers/models/inkling/{image_processing,processing}_
+# inkling.py, Apache-2.0). oMLX pins transformers <5.13, so the classes
+# are vendored here on numpy/PIL following the mlx-vlm custom-processor
+# pattern (see unlimited_ocr's processing_unlimitedocr.py).
+#
+# Differences from the transformers reference, on purpose:
+# - PIL resampling instead of torchvision (bit-parity with torchvision
+#   interpolation is not achievable either way; the checkpoint config
+#   selects resample=3 / bicubic).
+# - Audio (dMel feature extraction) is not implemented yet: oMLX serves
+#   inkling text+vision first. Passing audio raises a clear error.
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+from transformers import PreTrainedTokenizerFast
+
+
+class InklingImageProcessor:
+    """Patchifying image processor: divides an image into 40x40 patches
+    (padding partial edges with -1.0 before rescale/normalize), duplicates
+    each patch along a temporal axis of 2, and reports per-image patch
+    counts for placeholder-token expansion.
+
+    Output layout matches the reference exactly: ``pixel_values``
+    [num_patches, T=2, H, W, C] float32, ``num_patches`` [num_images].
+    """
+
+    model_input_names = ["pixel_values"]
+
+    def __init__(
+        self,
+        size=None,
+        image_mean=None,
+        image_std=None,
+        resample=3,
+        rescale_factor=1.0 / 255.0,
+        do_convert_rgb=True,
+        do_resize=True,
+        do_rescale=True,
+        do_normalize=True,
+        rescale_image_frac=None,
+        rescale_image_max_upscaled_long_edge=2048,
+        **kwargs,
+    ):
+        size = size or {"height": 40, "width": 40}
+        if size["height"] != size["width"]:
+            raise ValueError(f"Can resize only to square size but got {size}")
+        self.size = size
+        self.patch_size = int(size["height"])
+        self.image_mean = np.asarray(
+            image_mean or (0.48145466, 0.4578275, 0.40821073), dtype=np.float32
+        )
+        self.image_std = np.asarray(
+            image_std or (0.26862954, 0.26130258, 0.27577711), dtype=np.float32
+        )
+        self.resample = int(resample)
+        self.rescale_factor = float(rescale_factor)
+        self.do_convert_rgb = bool(do_convert_rgb)
+        self.do_rescale = bool(do_rescale)
+        self.do_normalize = bool(do_normalize)
+        self.rescale_image_frac = rescale_image_frac
+        self.rescale_image_max_upscaled_long_edge = rescale_image_max_upscaled_long_edge
+
+    def _pre_scale(self, image: Image.Image) -> Image.Image:
+        if self.rescale_image_frac is None:
+            return image
+        width, height = image.size
+        long_edge = max(height, width)
+        target_long_edge = long_edge * self.rescale_image_frac
+        if self.rescale_image_max_upscaled_long_edge is not None:
+            target_long_edge = min(
+                target_long_edge,
+                max(self.rescale_image_max_upscaled_long_edge, long_edge),
+            )
+        ratio = target_long_edge / long_edge
+        if ratio == 1.0:
+            return image
+        # Half-up rounding to match the reference.
+        new_h = math.floor(height * ratio + 0.5)
+        new_w = math.floor(width * ratio + 0.5)
+        return image.resize((new_w, new_h), resample=self.resample)
+
+    def _patchify(self, image: Image.Image) -> np.ndarray:
+        """[H, W, C] -> [num_patches, P, P, C] float32 with -1.0 padding.
+
+        Grid mirrors the reference ``divide_to_patches``: rows =
+        ceil(H / P), cols = W // P + 1 (the extra column is intentional
+        upstream behavior).
+        """
+        p = self.patch_size
+        arr = np.asarray(image, dtype=np.float32)
+        if arr.ndim == 2:
+            arr = np.stack([arr] * 3, axis=-1)
+        height, width = arr.shape[:2]
+        num_rows = (height + p - 1) // p
+        num_cols = width // p + 1
+
+        patches = []
+        for i in range(num_rows):
+            for j in range(num_cols):
+                patch = arr[i * p : i * p + p, j * p : j * p + p]
+                if patch.shape[0] != p or patch.shape[1] != p:
+                    padded = np.full((p, p, arr.shape[-1]), -1.0, dtype=np.float32)
+                    padded[: patch.shape[0], : patch.shape[1]] = patch
+                    patch = padded
+                patches.append(patch)
+        return np.stack(patches, axis=0)
+
+    def preprocess(self, images):
+        if not isinstance(images, (list, tuple)):
+            images = [images]
+        per_image_patches = []
+        num_patches = []
+        for image in images:
+            if not isinstance(image, Image.Image):
+                image = Image.fromarray(np.asarray(image))
+            if self.do_convert_rgb:
+                image = image.convert("RGB")
+            image = self._pre_scale(image)
+            patches = self._patchify(image)
+            if self.do_rescale:
+                patches = patches * self.rescale_factor
+            if self.do_normalize:
+                patches = (patches - self.image_mean) / self.image_std
+            # Temporal duplication: [P, H, W, C] -> [P, T=2, H, W, C].
+            patches = np.repeat(patches[:, None], 2, axis=1)
+            per_image_patches.append(patches.astype(np.float32))
+            num_patches.append(patches.shape[0])
+        return {
+            "pixel_values": np.concatenate(per_image_patches, axis=0),
+            "num_patches": np.asarray(num_patches, dtype=np.int32),
+        }
+
+    def __call__(self, images, **kwargs):
+        return self.preprocess(images)
+
+
+class InklingProcessor:
+    """Tokenizer + image-processor front end for Inkling checkpoints.
+
+    The chat template renders one ``<|unused_200054|>`` placeholder per
+    image; ``__call__`` expands the i-th occurrence to ``num_patches[i]``
+    copies so ``masked_scatter`` in the model lines up with the vision
+    tower's per-patch soft tokens.
+    """
+
+    def __init__(
+        self,
+        tokenizer,
+        image_processor=None,
+        image_token="<|unused_200054|>",
+        audio_token="<|unused_200053|>",
+        image_bos_token="<|content_image|>",
+        audio_bos_token="<|content_audio_input|>",
+        **kwargs,
+    ):
+        self.tokenizer = tokenizer
+        self.image_processor = image_processor or InklingImageProcessor()
+        # No dMel feature extractor yet (text+vision first).
+        self.feature_extractor = None
+        self.image_token = image_token
+        self.audio_token = audio_token
+        self.image_bos_token = image_bos_token
+        self.audio_bos_token = audio_bos_token
+        self.image_token_id = tokenizer.convert_tokens_to_ids(image_token)
+        self.audio_token_id = tokenizer.convert_tokens_to_ids(audio_token)
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        for ignored in (
+            "trust_remote_code",
+            "revision",
+            "force_download",
+            "quantize_activations",
+            "strict",
+            "use_fast",
+        ):
+            kwargs.pop(ignored, None)
+        path = Path(pretrained_model_name_or_path)
+        if not path.exists():
+            from huggingface_hub import snapshot_download
+
+            path = Path(snapshot_download(str(pretrained_model_name_or_path)))
+
+        processor_config = {}
+        processor_config_path = path / "processor_config.json"
+        if processor_config_path.exists():
+            with open(processor_config_path, encoding="utf-8") as f:
+                processor_config = json.load(f)
+
+        image_processor = InklingImageProcessor(
+            **processor_config.get("image_processor", {})
+        )
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(path)
+        _ensure_special_tokens(tokenizer, path)
+
+        init_kwargs = {
+            key: processor_config[key]
+            for key in (
+                "image_token",
+                "audio_token",
+                "image_bos_token",
+                "audio_bos_token",
+            )
+            if key in processor_config
+        }
+        init_kwargs.update(kwargs)
+        return cls(tokenizer=tokenizer, image_processor=image_processor, **init_kwargs)
+
+    # --- transformers ProcessorMixin surface used by mlx-vlm / omlx ---
+
+    def apply_chat_template(self, *args, **kwargs):
+        return self.tokenizer.apply_chat_template(*args, **kwargs)
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    @property
+    def model_input_names(self):
+        names = list(self.image_processor.model_input_names)
+        names += list(self.tokenizer.model_input_names)
+        return list(dict.fromkeys(names))
+
+    def __call__(
+        self,
+        text=None,
+        images=None,
+        audio=None,
+        audios=None,
+        padding=True,
+        padding_side="left",
+        add_special_tokens=False,
+        return_tensors=None,
+        **kwargs,
+    ):
+        if audio or audios:
+            raise ValueError(
+                "the omlx inkling processor does not support audio input yet "
+                "(text+vision only)"
+            )
+        if text is None:
+            raise ValueError("text is required")
+        texts = [text] if isinstance(text, str) else list(text)
+
+        outputs = {}
+        if images is not None and (
+            not hasattr(images, "__len__") or len(images) > 0
+        ):
+            image_outputs = self.image_processor.preprocess(images)
+            outputs["pixel_values"] = image_outputs["pixel_values"]
+            num_patches = [int(n) for n in image_outputs["num_patches"]]
+
+            expanded = []
+            image_cursor = 0
+            for prompt in texts:
+                pieces = prompt.split(self.image_token)
+                needed = len(pieces) - 1
+                if image_cursor + needed > len(num_patches):
+                    raise ValueError(
+                        f"prompt references {needed} images at offset "
+                        f"{image_cursor} but only {len(num_patches)} were "
+                        "provided"
+                    )
+                rebuilt = pieces[0]
+                for piece in pieces[1:]:
+                    rebuilt += (
+                        self.image_token * num_patches[image_cursor] + piece
+                    )
+                    image_cursor += 1
+                expanded.append(rebuilt)
+            if image_cursor != len(num_patches):
+                raise ValueError(
+                    f"{len(num_patches)} images provided but prompts contain "
+                    f"{image_cursor} image placeholders"
+                )
+            texts = expanded
+
+        encoded = self.tokenizer(
+            texts,
+            padding=padding,
+            padding_side=padding_side,
+            add_special_tokens=add_special_tokens,
+            return_tensors="np",
+        )
+        outputs["input_ids"] = encoded["input_ids"]
+        outputs["attention_mask"] = encoded["attention_mask"]
+        return outputs
+
+
+def _ensure_special_tokens(tokenizer, model_path: Path) -> None:
+    """Give the tokenizer usable pad/eos handles.
+
+    Inkling checkpoints expose neither a pad nor an eos token *string*
+    (only ``eos_token_id`` in config.json), which breaks every
+    ``tokenizer.pad_token`` fallback in mlx-vlm. Mirrors the fix in
+    mlx-vlm PR #1756's ``load_processor``.
+    """
+    if tokenizer.pad_token is not None:
+        return
+    eos_ids = None
+    config_path = model_path / "config.json"
+    if config_path.exists():
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                eos_ids = json.load(f).get("eos_token_id")
+        except (OSError, ValueError):
+            eos_ids = None
+    if eos_ids is None:
+        eos_ids = tokenizer.eos_token_id
+    if eos_ids is None:
+        return
+    eos_id = eos_ids[0] if isinstance(eos_ids, (list, tuple)) else eos_ids
+    try:
+        token = tokenizer.convert_ids_to_tokens(int(eos_id))
+        if tokenizer.eos_token is None:
+            tokenizer.eos_token = token
+        tokenizer.pad_token = token
+    except Exception:
+        tokenizer.pad_token_id = int(eos_id)
+
+
+__all__ = ["InklingImageProcessor", "InklingProcessor"]

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/vision.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/vision.py
@@ -1,0 +1,135 @@
+import itertools
+import math
+
+import mlx.nn as nn
+import numpy as np
+
+from .config import VisionConfig
+
+
+def _prime_factors(n: int):
+    factors = []
+    while n % 2 == 0:
+        factors.append(2)
+        n //= 2
+    p = 3
+    while p * p <= n:
+        while n % p == 0:
+            factors.append(p)
+            n //= p
+        p += 2
+    if n > 1:
+        factors.append(n)
+    return factors
+
+
+def _linear_sum_assignment(cost: np.ndarray):
+    """Minimal-cost injective assignment of rows -> distinct columns (R <= C).
+    Dependency-free stand-in for scipy.optimize.linear_sum_assignment (the grids are tiny).
+    """
+    R, C = cost.shape
+    best_cost, best = None, None
+    for perm in itertools.permutations(range(C), R):
+        s = sum(cost[r, perm[r]] for r in range(R))
+        if best_cost is None or s < best_cost:
+            best_cost, best = s, perm
+    return list(range(R)), list(best)
+
+
+def plan_out_scales(temporal_patch_size, patch_size, n_layers, n_channels):
+    """Per-layer (t, h, w, c) grids for the HMLP encoder — faithful port of the reference."""
+    h = np.cumprod(np.array(_prime_factors(patch_size)[::-1], dtype=np.int64))
+    t = np.cumprod(np.array(_prime_factors(temporal_patch_size)[::-1], dtype=np.int64))
+    h_ch = np.ceil(h**2 * n_channels / 64).astype(np.int64) * 64
+    t_ch = np.ceil(h[-1] ** 2 * n_channels * t / 64).astype(np.int64) * 64
+
+    base = np.array([[1, 1, 1, n_channels]], dtype=np.int64)
+    spatial = np.stack([np.ones_like(h), h, h, h_ch], axis=1)
+    temporal = np.stack(
+        [t, np.full_like(t, h[-1]), np.full_like(t, h[-1]), t_ch], axis=1
+    )
+    scales = np.concatenate([base, spatial, temporal], axis=0)
+
+    size_reduction = np.prod(scales[:, :-1], axis=1).astype(np.float64)
+    total_elements = patch_size * patch_size * temporal_patch_size * n_channels
+    log_ideal = np.linspace(0.0, math.log(total_elements), n_layers + 1)
+    cost = np.abs(log_ideal[:, None] - np.log(size_reduction)[None, :])
+
+    if n_layers + 1 >= scales.shape[0]:
+        idxs = np.argmin(cost, axis=1)
+    else:
+        _, idxs = _linear_sum_assignment(cost)
+        idxs = np.array(idxs)
+    idxs[0] = 0
+    idxs[-1] = scales.shape[0] - 1
+    return scales[idxs]
+
+
+def fold_timespace_to_depth(x, t_fold, hw_fold):
+    """(B, T, H, W, C) -> (B, T//t, H//hw, W//hw, C * t * hw * hw)."""
+    B, T, H, W, C = x.shape
+    tn, hn, wn = T // t_fold, H // hw_fold, W // hw_fold
+    x = x.reshape(B, tn, t_fold, hn, hw_fold, wn, hw_fold, C)
+    x = x.transpose(0, 1, 3, 5, 2, 4, 6, 7)
+    return x.reshape(B, tn, hn, wn, t_fold * hw_fold * hw_fold * C)
+
+
+class InklingVisionEncoderLayer(nn.Module):
+    def __init__(self, input_dim, output_dim, t_fold, hw_fold, add_norm, eps):
+        super().__init__()
+        self.t_fold = t_fold
+        self.hw_fold = hw_fold
+        self.add_norm = add_norm
+        self.projection = nn.Linear(input_dim, output_dim, bias=False)
+        if add_norm:
+            self.layer_norm = nn.RMSNorm(output_dim, eps=eps)
+
+    def __call__(self, x):
+        if self.hw_fold > 1 or self.t_fold > 1:
+            x = fold_timespace_to_depth(x, self.t_fold, self.hw_fold)
+        x = self.projection(x)
+        if self.add_norm:
+            x = nn.gelu(self.layer_norm(x))
+        return x
+
+
+class VisionModel(nn.Module):
+    """Hierarchical-MLP (HMLP) patchifier: progressively folds space/time into channels and
+    projects each patch to one LM-space soft token. No attention."""
+
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.model_type = config.model_type
+        n_layers = config.n_layers
+        scales = plan_out_scales(
+            config.temporal_patch_size,
+            config.patch_size,
+            n_layers,
+            config.num_channels,
+        )
+        n_last = n_layers - 1
+        self.encoder_layers = []
+        for i in range(len(scales) - 1):
+            s, e = scales[i], scales[i + 1]
+            shuffle_mult = int((e[0] // s[0]) * (e[1] // s[1]) * (e[2] // s[2]))
+            output_dim = config.text_hidden_size if i == n_last else int(e[3])
+            self.encoder_layers.append(
+                InklingVisionEncoderLayer(
+                    input_dim=int(s[3]) * shuffle_mult,
+                    output_dim=output_dim,
+                    t_fold=int(e[0] // s[0]),
+                    hw_fold=int(e[1] // s[1]),
+                    add_norm=i != n_last,
+                    eps=config.rms_norm_eps,
+                )
+            )
+        self.final_norm = nn.RMSNorm(config.text_hidden_size, eps=config.rms_norm_eps)
+
+    def __call__(self, pixel_values):
+        """pixel_values: [num_patches, T, H, W, C] -> [num_patches, text_hidden_size]."""
+        num_patches = pixel_values.shape[0]
+        h = pixel_values
+        for layer in self.encoder_layers:
+            h = layer(h)
+        h = self.final_norm(h)
+        return h.reshape(num_patches, -1)

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/mlp.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/mlp.py
@@ -1,0 +1,68 @@
+import mlx.nn as nn
+
+from .activations import swiglu
+
+
+class SwiGLUMLP(nn.Module):
+    def __init__(self, dim, hidden_dim, bias=False):
+        super().__init__()
+        self.gate_proj = nn.Linear(dim, hidden_dim, bias=bias)
+        self.up_proj = nn.Linear(dim, hidden_dim, bias=bias)
+        self.down_proj = nn.Linear(hidden_dim, dim, bias=bias)
+
+    def __call__(self, x):
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class DeepseekMLP(nn.Module):
+    def __init__(self, config, hidden_size=None, intermediate_size=None):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size if hidden_size is None else hidden_size
+        self.intermediate_size = (
+            config.intermediate_size if intermediate_size is None else intermediate_size
+        )
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+
+    def __call__(self, x):
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class GELUMLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.activation_fn = nn.GELU(approx="precise")
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size, bias=True)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size, bias=True)
+
+    def __call__(self, x):
+        x = self.fc1(x)
+        x = self.activation_fn(x)
+        x = self.fc2(x)
+        return x
+
+
+class FastGELUMLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.activation_fn = nn.GELU(approx="fast")
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+
+    def __call__(self, x):
+        x = self.activation_fn(self.fc1(x))
+        x = self.fc2(x)
+        return x
+
+
+class TanhGELUMLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size, bias=True)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size, bias=True)
+        self.act = nn.GELU(approx="tanh")
+
+    def __call__(self, x):
+        return self.fc2(self.act(self.fc1(x)))

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/switch_layers.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/switch_layers.py
@@ -1,0 +1,228 @@
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .activations import swiglu
+
+
+def _gather_sort(x, indices):
+    *_, M = indices.shape
+    indices = indices.flatten()
+    order = mx.argsort(indices)
+    inv_order = mx.argsort(order)
+    return x.flatten(0, -3)[order // M], indices[order], inv_order
+
+
+def _scatter_unsort(x, inv_order, shape=None):
+    x = x[inv_order]
+    if shape is not None:
+        x = mx.unflatten(x, 0, shape)
+    return x
+
+
+class QuantizedSwitchLinear(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        output_dims: int,
+        num_experts: int,
+        bias: bool = True,
+        group_size: int = 64,
+        bits: int = 4,
+        mode: str = "affine",
+    ):
+        super().__init__()
+
+        scale = math.sqrt(1 / input_dims)
+        self.weight, self.scales, *biases = mx.quantize(
+            mx.random.uniform(
+                low=-scale,
+                high=scale,
+                shape=(num_experts, output_dims, input_dims),
+            ),
+            group_size=group_size,
+            bits=bits,
+            mode=mode,
+        )
+        self.biases = biases[0] if biases else None
+
+        if bias:
+            self.bias = mx.zeros((num_experts, output_dims))
+
+        self.group_size = group_size
+        self.bits = bits
+        self.mode = mode
+
+        self.freeze()
+
+    @property
+    def input_dims(self):
+        return self.scales.shape[2] * self.group_size
+
+    @property
+    def output_dims(self):
+        return self.weight.shape[1]
+
+    @property
+    def num_experts(self):
+        return self.weight.shape[0]
+
+    def __call__(self, x, indices, sorted_indices=False):
+        x = mx.gather_qmm(
+            x,
+            self["weight"],
+            self["scales"],
+            self.get("biases"),
+            rhs_indices=indices,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+            sorted_indices=sorted_indices,
+        )
+        if "bias" in self:
+            x = x + mx.expand_dims(self["bias"][indices], -2)
+        return x
+
+
+class SwitchLinear(nn.Module):
+    def __init__(
+        self, input_dims: int, output_dims: int, num_experts: int, bias: bool = True
+    ):
+        super().__init__()
+        scale = math.sqrt(1 / input_dims)
+        self.weight = mx.random.uniform(
+            low=-scale,
+            high=scale,
+            shape=(num_experts, output_dims, input_dims),
+        )
+
+        if bias:
+            self.bias = mx.zeros((num_experts, output_dims))
+
+    @property
+    def input_dims(self):
+        return self.weight.shape[2]
+
+    @property
+    def output_dims(self):
+        return self.weight.shape[1]
+
+    @property
+    def num_experts(self):
+        return self.weight.shape[0]
+
+    def __call__(self, x, indices, sorted_indices=False):
+        x = mx.gather_mm(
+            x,
+            self["weight"].swapaxes(-1, -2),
+            rhs_indices=indices,
+            sorted_indices=sorted_indices,
+        )
+        if "bias" in self:
+            x = x + mx.expand_dims(self["bias"][indices], -2)
+        return x
+
+    def to_quantized(self, group_size: int = 64, bits: int = 4, mode: str = "affine"):
+        num_experts, output_dims, input_dims = self.weight.shape
+        ql = QuantizedSwitchLinear(
+            input_dims,
+            output_dims,
+            num_experts,
+            False,
+            group_size,
+            bits,
+            mode=mode,
+        )
+        ql.weight, ql.scales, *biases = mx.quantize(
+            self.weight, group_size, bits, mode=mode
+        )
+        ql.biases = biases[0] if biases else None
+
+        if "bias" in self:
+            ql.bias = self.bias
+        return ql
+
+
+class SwiGLU(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def __call__(self, x, gate):
+        return swiglu(gate, x)
+
+
+class SwitchGLU(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=SwiGLU(),
+        bias: bool = False,
+    ):
+        super().__init__()
+
+        self.gate_proj = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.up_proj = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.down_proj = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
+        self.activation = activation
+
+    def __call__(self, x, indices) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(x, indices)
+        if self.training:
+            idx = mx.stop_gradient(idx)
+        x_up = self.up_proj(x, idx, sorted_indices=do_sort)
+        x_gate = self.gate_proj(x, idx, sorted_indices=do_sort)
+        x = self.down_proj(
+            self.activation(x_up, x_gate),
+            idx,
+            sorted_indices=do_sort,
+        )
+
+        if do_sort:
+            x = _scatter_unsort(x, inv_order, indices.shape)
+
+        return x.squeeze(-2)
+
+
+class SwitchMLP(nn.Module):
+    def __init__(
+        self,
+        input_dims: int,
+        hidden_dims: int,
+        num_experts: int,
+        activation=nn.GELU(approx="precise"),
+        bias: bool = False,
+    ):
+        super().__init__()
+
+        self.fc1 = SwitchLinear(input_dims, hidden_dims, num_experts, bias=bias)
+        self.fc2 = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
+        self.activation = activation
+
+    def __call__(self, x, indices) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _gather_sort(x, indices)
+        if self.training:
+            idx = mx.stop_gradient(idx)
+        x = self.fc1(x, idx, sorted_indices=do_sort)
+        x = self.activation(x)
+        x = self.fc2(x, idx, sorted_indices=do_sort)
+
+        if do_sort:
+            x = _scatter_unsort(x, inv_order, indices.shape)
+
+        return x.squeeze(-2)

--- a/omlx/patches/mlx_vlm_mtp/__init__.py
+++ b/omlx/patches/mlx_vlm_mtp/__init__.py
@@ -65,12 +65,14 @@ def apply_mlx_vlm_mtp_patch() -> bool:
     handled by each sub-patcher via class-level flags — no module-wide
     cache flag, keeping behavior consistent with mlx_lm_mtp.
     """
-    from . import qwen35_moe_vlm_model, qwen35_vlm_model
+    from . import inkling_vlm_runtime, qwen35_moe_vlm_model, qwen35_vlm_model
 
     if not qwen35_vlm_model.apply():
         logger.debug("Qwen3.5 VLM MTP sanitize patch did not apply")
     if not qwen35_moe_vlm_model.apply():
         logger.debug("Qwen3.5 MoE VLM MTP sanitize patch did not apply")
+    if not inkling_vlm_runtime.apply_sanitize():
+        logger.debug("Inkling MTP sanitize hook did not apply")
 
     return True
 
@@ -93,7 +95,12 @@ def apply_mlx_vlm_mtp_runtime_patch() -> bool:
     Should be called *before* ``mlx_vlm.utils.load(...)`` so the
     instantiated LanguageModel picks up the patched ``__init__``.
     """
-    from . import gemma4_vlm_runtime, qwen35_moe_vlm_runtime, qwen35_vlm_runtime
+    from . import (
+        gemma4_vlm_runtime,
+        inkling_vlm_runtime,
+        qwen35_moe_vlm_runtime,
+        qwen35_vlm_runtime,
+    )
 
     moe_ok = qwen35_moe_vlm_runtime.apply()
     if not moe_ok:
@@ -104,5 +111,8 @@ def apply_mlx_vlm_mtp_runtime_patch() -> bool:
     gemma4_ok = gemma4_vlm_runtime.apply()
     if not gemma4_ok:
         logger.debug("Gemma 4 VLM runtime MTP patch did not apply")
+    inkling_ok = inkling_vlm_runtime.apply()
+    if not inkling_ok:
+        logger.debug("Inkling VLM runtime MTP patch did not apply")
 
-    return moe_ok or dense_ok or gemma4_ok
+    return moe_ok or dense_ok or gemma4_ok or inkling_ok

--- a/omlx/patches/mlx_vlm_mtp/inkling_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/inkling_vlm_runtime.py
@@ -1,0 +1,486 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime Lightning MTP for the vendored Inkling VLM.
+
+Single-checkpoint port of mlx-vlm's separate-checkpoint
+``speculative/drafters/inkling_mtp`` drafter (commit d688082), matching
+vLLM's multi-depth Inkling MTP (vllm-project/vllm#48768): the checkpoint
+ships one MTP block per draft depth (``mtp_config.num_nextn_predict_layers``,
+8 on Inkling Small), each block being embed/hidden RMSNorms + a 2H->H
+input projection + one dense ``InklingDecoderLayer``. The final norm and
+LM head are the trunk's own (``speculative_logits_from_hidden``); the
+drafter checkpoint's norm is a copy of ``model.llm.norm`` upstream.
+
+Depth mapping onto the omlx chain cycle mirrors the drafter exactly:
+
+* the history fold (``logits_keep=1`` on the persistent
+  ``make_mtp_cache()`` list) always runs block 0 and seeds the first
+  draft token from its logits;
+* chain step j runs block ``min(j, depth-1)`` — the batch generator
+  hands the chain a ``_clone_mtp_head_cache`` copy (``_omlx_mtp_head_clone``),
+  which is the clone-and-discard equivalent of the drafter's
+  snapshot/restore, so blocks past 0 never accumulate committed state.
+  The clone comes back as a plain list while the persistent cache is an
+  ``_InklingMTPCacheList``, which is how ``mtp_forward`` tells a fold
+  from a chain step.
+
+Backbone verify rollback cannot trim the short-conv states, so the
+vendored conv stashes its padded input every forward and
+``rollback_speculative_cache`` reslices the state at the accepted
+boundary (``xp[:, keep : keep + K - 1]``) while trimming the KV subs —
+no replay forward, unlike upstream's snapshot/replay.
+
+The head consumes PRE-norm trunk hidden (per-block ``hidden_norm``,
+``chain_hidden_post_norm: false``), signalled to the fold via
+``_omlx_mtp_head_prenorm``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+logger = logging.getLogger(__name__)
+
+_APPLIED = False
+_SANITIZE_APPLIED = False
+
+_ATTN = {
+    "wq_du": "q_proj",
+    "wk_dv": "k_proj",
+    "wv_dv": "v_proj",
+    "wr_du": "r_proj",
+    "wo_ud": "o_proj",
+}
+
+
+class _InklingMTPCacheList(list):
+    """Marker list type for the persistent per-block MTP cache."""
+
+
+def _map_transformer_block(sub: str, v: mx.array) -> dict:
+    """Checkpoint ``transformer_block.<sub>`` -> InklingDecoderLayer names.
+
+    Port of the upstream drafter's mapping (drafters/inkling_mtp)."""
+    out = {}
+    p = "transformer_block."
+    if sub.startswith("attn."):
+        name, leaf = sub[len("attn.") :].rsplit(".", 1)
+        if name in _ATTN:
+            out[p + f"self_attn.{_ATTN[name]}.weight"] = v
+        elif name in ("q_norm", "k_norm"):
+            out[p + f"self_attn.{name}.weight"] = v
+        elif name in ("k_sconv", "v_sconv"):
+            out[p + f"self_attn.{name}.conv.weight"] = v.transpose(0, 2, 1)
+        elif name == "rel_logits_proj":
+            out[p + "self_attn.rel_proj"] = v
+        else:
+            out[p + "self_attn." + name + "." + leaf] = v
+    elif sub == "attn_norm.weight":
+        out[p + "input_layernorm.weight"] = v
+    elif sub == "mlp_norm.weight":
+        out[p + "post_attention_layernorm.weight"] = v
+    elif sub == "attn_sconv.weight":
+        out[p + "attn_sconv.conv.weight"] = v.transpose(0, 2, 1)
+    elif sub == "mlp_sconv.weight":
+        out[p + "mlp_sconv.conv.weight"] = v.transpose(0, 2, 1)
+    elif sub.startswith("mlp."):
+        from mlx_vlm.models.inkling.inkling import _split_gate_up
+
+        m = sub[len("mlp.") :]
+        mp = p + "mlp."
+        if m == "w13_dn.weight":
+            g, u = _split_gate_up(v)
+            out[mp + "gate_proj.weight"] = g
+            out[mp + "up_proj.weight"] = u
+        elif m == "w2_md.weight":
+            out[mp + "down_proj.weight"] = v
+        elif m in ("gate.global_scale", "global_scale"):
+            out[mp + "global_scale"] = v
+        else:
+            out[mp + m] = v
+    else:
+        out[p + sub] = v
+    return out
+
+
+def _mtp_sanitize_hook(key: str, value: mx.array) -> dict:
+    """Map a raw ``model.mtp.layers.N.*`` checkpoint key onto the attached
+    ``language_model.mtp.blocks.N.*`` parameter names."""
+    for prefix in ("model.mtp.layers.", "mtp.layers."):
+        if key.startswith(prefix):
+            i, sub = key[len(prefix) :].split(".", 1)
+            base = f"language_model.mtp.blocks.{i}."
+            if sub in (
+                "embed_norm.weight",
+                "hidden_norm.weight",
+                "input_proj.weight",
+            ):
+                return {base + sub: value}
+            if sub.startswith("transformer_block."):
+                tb = sub[len("transformer_block.") :]
+                return {
+                    base + nk: nv for nk, nv in _map_transformer_block(tb, value).items()
+                }
+            return {base + sub: value}
+    return {}
+
+
+def apply_sanitize() -> bool:
+    """Install the sanitize hook that keeps and remaps mtp.* weights.
+
+    Called from ``apply_mlx_vlm_mtp_patch`` (oQ preserve_mtp path) and
+    from ``apply()`` below. Requires the inkling compat vendor namespace.
+    """
+    global _SANITIZE_APPLIED
+    if _SANITIZE_APPLIED:
+        return True
+    try:
+        from omlx.patches.mlx_vlm_inkling_compat import (
+            apply_mlx_vlm_inkling_compat_patch,
+        )
+
+        apply_mlx_vlm_inkling_compat_patch()
+        import mlx_vlm.models.inkling.inkling as inkling_mod
+    except Exception as e:
+        logger.debug(f"inkling module not importable for MTP sanitize: {e}")
+        return False
+    inkling_mod._OMLX_MTP_SANITIZE_HOOK = _mtp_sanitize_hook
+    _SANITIZE_APPLIED = True
+    return True
+
+
+def apply() -> bool:
+    """Apply the inkling runtime Lightning MTP patches. Idempotent."""
+    global _APPLIED
+    if _APPLIED:
+        return True
+
+    if not apply_sanitize():
+        return False
+    try:
+        import mlx_vlm.models.inkling as inkling_pkg
+        import mlx_vlm.models.inkling.language as inkling_lang
+    except Exception as e:
+        logger.debug(f"inkling language module not importable: {e}")
+        return False
+
+    _patch_model_config(inkling_pkg)
+    _register_mtp_classes(inkling_lang)
+    _patch_language_model(inkling_lang)
+    _patch_inner_model_capture(inkling_lang)
+
+    # Shared VLMModelAdapter pass-throughs (idempotent).
+    from .qwen35_vlm_runtime import _patch_vlm_model_adapter
+
+    _patch_vlm_model_adapter()
+
+    _APPLIED = True
+    logger.info("mlx-vlm inkling runtime MTP patch applied")
+    return True
+
+
+def _patch_model_config(inkling_pkg: Any) -> None:
+    """Carry the top-level ``mtp_config`` block onto the TextConfig.
+
+    Two hops are required: ``BaseModelConfig.from_dict`` filters by
+    dataclass signature (dropping ``mtp_config``), and mlx-vlm's
+    ``load_model`` REBUILDS ``text_config`` afterwards via
+    ``update_module_configs`` → ``TextConfig.from_dict``, discarding any
+    attribute stamped on the first instance. So the ModelConfig wrap
+    injects the flattened keys into the raw ``text_config`` dict (the
+    same object update_module_configs reads), and the TextConfig wrap
+    lifts them onto every rebuilt instance."""
+    cls = inkling_pkg.ModelConfig
+    if not getattr(cls, "_omlx_mtp_from_dict_patched", False):
+        original_from_dict = cls.from_dict.__func__
+
+        def patched_from_dict(cls_inner, params):
+            mtp_cfg = (params or {}).get("mtp_config") or {}
+            depth = int(
+                mtp_cfg.get("num_nextn_predict_layers")
+                or mtp_cfg.get("num_mtp_layers")
+                or 0
+            )
+            if depth and isinstance(params.get("text_config"), dict):
+                params["text_config"].setdefault("mtp_num_hidden_layers", depth)
+                params["text_config"].setdefault(
+                    "mtp_local_layer_ids", mtp_cfg.get("local_layer_ids")
+                )
+            return original_from_dict(cls_inner, params)
+
+        cls.from_dict = classmethod(patched_from_dict)
+        cls._omlx_mtp_from_dict_patched = True
+
+    text_cls = inkling_pkg.TextConfig
+    if not getattr(text_cls, "_omlx_mtp_from_dict_patched", False):
+        original_text_from_dict = text_cls.from_dict.__func__
+
+        def patched_text_from_dict(cls_inner, params):
+            instance = original_text_from_dict(cls_inner, params)
+            params = params or {}
+            instance.mtp_num_hidden_layers = int(
+                params.get("mtp_num_hidden_layers", 0) or 0
+            )
+            instance.mtp_local_layer_ids = params.get("mtp_local_layer_ids")
+            return instance
+
+        text_cls.from_dict = classmethod(patched_text_from_dict)
+        text_cls._omlx_mtp_from_dict_patched = True
+
+
+def _register_mtp_classes(inkling_lang: Any) -> None:
+    if hasattr(inkling_lang, "InklingMTPModule"):
+        return
+
+    from dataclasses import replace
+
+    InklingDecoderLayer = inkling_lang.InklingDecoderLayer
+
+    class InklingMTPBlock(nn.Module):
+        def __init__(self, config, layer_idx: int):
+            super().__init__()
+            self.embed_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.hidden_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.input_proj = nn.Linear(
+                2 * config.hidden_size, config.hidden_size, bias=False
+            )
+            self.transformer_block = InklingDecoderLayer(config, layer_idx)
+
+    class InklingMTPModule(nn.Module):
+        """Per-depth MTP blocks (upstream drafter layout, trunk-bound)."""
+
+        def __init__(self, text_config):
+            super().__init__()
+            n = int(getattr(text_config, "mtp_num_hidden_layers", 0) or 0)
+            local = set(getattr(text_config, "mtp_local_layer_ids", None) or [])
+            layer_config = replace(
+                text_config,
+                num_hidden_layers=n,
+                layer_types=[
+                    "hybrid_sliding" if i in local else "hybrid" for i in range(n)
+                ],
+                mlp_layer_types=["dense"] * n,
+                local_layer_ids=None,
+            )
+            self.blocks = [InklingMTPBlock(layer_config, i) for i in range(n)]
+
+        def __call__(
+            self,
+            hidden_states: mx.array,
+            next_token_ids: mx.array,
+            embed_tokens,
+            cache,
+            block_idx: int = 0,
+        ) -> mx.array:
+            # block_idx defaults to 0 for generic callers that use the
+            # qwen-style 4-arg head signature (oQe's MTP-head imatrix
+            # pass); the chain routing in mtp_forward always passes it.
+            block = self.blocks[block_idx]
+            token_embed = embed_tokens(next_token_ids)
+            h = mx.concatenate(
+                [block.hidden_norm(hidden_states), block.embed_norm(token_embed)],
+                axis=-1,
+            )
+            h = block.input_proj(h)
+            block_cache = cache[block_idx] if cache is not None else None
+            return block.transformer_block(h, cache=block_cache)
+
+    inkling_lang.InklingMTPBlock = InklingMTPBlock
+    inkling_lang.InklingMTPModule = InklingMTPModule
+
+
+def _patch_language_model(inkling_lang: Any) -> None:
+    cls = inkling_lang.LanguageModel
+    if "_omlx_mtp_runtime_patched" in cls.__dict__:
+        return
+
+    from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
+
+    original_init = cls.__init__
+    original_call = cls.__call__
+
+    def __init__(self, config):
+        from . import is_mtp_attach_enabled
+        from ..mlx_lm_mtp import is_mtp_active
+
+        original_init(self, config)
+        n_mtp = int(getattr(config, "mtp_num_hidden_layers", 0) or 0)
+        attach_enabled = bool(is_mtp_attach_enabled())
+        self._omlx_mtp_decode_enabled = bool(
+            n_mtp > 0 and attach_enabled and is_mtp_active()
+        )
+        if n_mtp > 0 and attach_enabled:
+            self.mtp = inkling_lang.InklingMTPModule(config)
+        if self._omlx_mtp_decode_enabled:
+            import weakref
+
+            from ..mlx_lm_mtp import get_mtp_depth
+
+            self._omlx_mtp_chain = True
+            self._omlx_mtp_depth = min(int(get_mtp_depth()), n_mtp)
+            # Chain steps must run on a per-cycle clone: blocks past 0
+            # never hold committed state (drafter snapshot/restore
+            # equivalent) and block 0's history stays draft-free.
+            self._omlx_mtp_head_clone = True
+            # The head normalizes its hidden input per block
+            # (chain_hidden_post_norm=false) — fold must NOT trunk-norm.
+            self._omlx_mtp_head_prenorm = True
+            # Prompt-priming capture runs inside InklingModel.__call__,
+            # which has no reference back to this LanguageModel; without
+            # priming the head enters decode cold (its block-0 cache never
+            # saw the prompt) and the adaptive controller parks the
+            # request at depth 0 before the fold can warm it up.
+            self.model._omlx_mtp_prime_host = weakref.ref(self)
+
+    def __call__(self, inputs=None, cache=None, **kwargs):
+        out = original_call(self, inputs, cache=cache, **kwargs)
+        if (
+            kwargs.get("return_hidden")
+            and cache is not None
+            and getattr(self, "_omlx_mtp_decode_enabled", False)
+            and inputs is not None
+            and getattr(out, "gdn_states", None) is None
+        ):
+            # Rollback marker: the conv-input stashes written during this
+            # forward cover exactly these verify positions.
+            out.gdn_states = {"verify_len": int(inputs.shape[1])}
+        return out
+
+    def mtp_forward(
+        self,
+        hidden_states,
+        next_token_ids,
+        mtp_cache,
+        return_hidden: bool = False,
+        logits_keep: int = 0,
+    ):
+        if isinstance(mtp_cache, _InklingMTPCacheList):
+            # History fold — always block 0; a fold starts a new cycle.
+            block_idx = 0
+            self._omlx_inkling_chain_step = 0
+        else:
+            step = int(getattr(self, "_omlx_inkling_chain_step", 0))
+            block_idx = min(step, len(self.mtp.blocks) - 1)
+            self._omlx_inkling_chain_step = step + 1
+        head_hidden = self.mtp(
+            hidden_states,
+            next_token_ids,
+            self.model.embed_tokens,
+            mtp_cache,
+            block_idx,
+        )
+        logits_source = head_hidden
+        if logits_keep and logits_source.shape[1] > logits_keep:
+            logits_source = logits_source[:, -logits_keep:, :]
+        logits = self.speculative_logits_from_hidden(logits_source)
+        if return_hidden:
+            return logits, head_hidden
+        return logits
+
+    def make_mtp_cache(self):
+        if hasattr(self, "mtp"):
+            return _InklingMTPCacheList(
+                CacheList(KVCache(), ArraysCache(4)) for _ in self.mtp.blocks
+            )
+        return _InklingMTPCacheList()
+
+    def rollback_speculative_cache(self, caches, gdn_states, accepted, block_size):
+        """Trim KV subs and reslice conv states at the accepted boundary.
+
+        Replaces the vendored snapshot/replay rollback (an extra backbone
+        forward per cycle) with an O(1) reslice from the conv-input
+        stashes the vendored ``InklingShortConvolution`` records."""
+        if isinstance(accepted, mx.array):
+            accepted = int(accepted.max().item()) if accepted.size else 0
+        elif not isinstance(accepted, int):
+            accepted = max(int(a) for a in accepted)
+        verify_len = None
+        if isinstance(gdn_states, dict):
+            verify_len = gdn_states.get("verify_len")
+        if verify_len is None:
+            verify_len = int(block_size)
+        keep = accepted + 1
+        trim_n = int(verify_len) - keep
+        for c in caches:
+            if c is None:
+                continue
+            kv, conv = c[0], c[1]
+            if trim_n > 0 and hasattr(kv, "trim"):
+                kv.trim(trim_n)
+            stash = getattr(conv, "_omlx_verify_xp", None)
+            if not stash:
+                continue
+            for idx, xp in stash.items():
+                k_minus_1 = int(xp.shape[1]) - int(verify_len)
+                if k_minus_1 <= 0:
+                    continue
+                conv[idx] = xp[:, keep : keep + k_minus_1, :]
+        return accepted
+
+    cls.__init__ = __init__
+    cls.__call__ = __call__
+    cls.mtp_forward = mtp_forward
+    cls.make_mtp_cache = make_mtp_cache
+    cls.rollback_speculative_cache = rollback_speculative_cache
+    cls._omlx_mtp_runtime_patched = True
+
+
+def _patch_inner_model_capture(inkling_lang: Any) -> None:
+    """Wrap ``InklingModel.__call__`` to fold prompt chunks into the head.
+
+    The LanguageModel always calls the inner model with
+    ``skip_final_norm=True``, so the captured hidden is the PRE-norm trunk
+    output — the convention this head consumes. Image prompts arrive via
+    ``input_embeddings`` and are skipped (same limitation as qwen); all
+    real gating lives in ``prompt_priming.maybe_capture`` and fails safe
+    to an unprimed entry.
+    """
+    cls = inkling_lang.InklingModel
+    if getattr(cls, "_omlx_mtp_prime_capture_patched", False):
+        return
+
+    from ..mlx_lm_mtp import prompt_priming
+
+    original_call = cls.__call__
+
+    def __call__(
+        self,
+        inputs,
+        cache=None,
+        input_embeddings=None,
+        skip_final_norm=False,
+        **kwargs,
+    ):
+        out = original_call(
+            self,
+            inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            skip_final_norm=skip_final_norm,
+            **kwargs,
+        )
+        if (
+            input_embeddings is None
+            and cache is not None
+            and skip_final_norm
+            and inputs is not None
+        ):
+            host_ref = getattr(self, "_omlx_mtp_prime_host", None)
+            host = host_ref() if host_ref is not None else None
+            if host is not None:
+                try:
+                    prompt_priming.maybe_capture(host, inputs, out, cache)
+                except Exception:
+                    logger.debug(
+                        "Inkling MTP prompt-priming capture failed", exc_info=True
+                    )
+        return out
+
+    cls.__call__ = __call__
+    cls._omlx_mtp_prime_capture_patched = True
+
+
+__all__ = ["apply", "apply_sanitize"]

--- a/omlx/patches/mlx_vlm_mtp/inkling_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/inkling_vlm_runtime.py
@@ -547,6 +547,25 @@ def _patch_language_model(inkling_lang: Any) -> None:
         cache.win_hid = out
         cache.chain_step = 1
         cache.frontier = f_new
+        # Materialize the cycle bookkeeping (KV buffers, conv states, stash
+        # rolls, ring) without a host sync. Nothing else ever evaluates the
+        # stash rolls or trimmed states, so left lazy they accumulate a
+        # deepening cross-cycle graph that every eval re-walks (measured
+        # 26-59 ms/cycle vs 9 ms materialized). Covers last cycle's chain
+        # appends too — this runs after the trims that consume them.
+        evals = [cache.ring_hid, cache.ring_tok]
+        for j in range(active):
+            kv, conv = cache[j][0], cache[j][1]
+            if kv.keys is not None:
+                evals.append(kv.keys)
+                evals.append(kv.values)
+            slots = getattr(conv, "cache", None)
+            if isinstance(slots, list):
+                evals.extend(a for a in slots if a is not None)
+            stash = getattr(conv, "_omlx_verify_xp", None)
+            if stash:
+                evals.extend(stash.values())
+        mx.async_eval(evals)
         return out
 
     def _mtp_chain(self, cache, next_token_ids, step):

--- a/omlx/patches/mlx_vlm_mtp/inkling_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/inkling_vlm_runtime.py
@@ -1,43 +1,69 @@
 # SPDX-License-Identifier: Apache-2.0
 """Runtime Lightning MTP for the vendored Inkling VLM.
 
-Single-checkpoint port of mlx-vlm's separate-checkpoint
-``speculative/drafters/inkling_mtp`` drafter (commit d688082), matching
-vLLM's multi-depth Inkling MTP (vllm-project/vllm#48768): the checkpoint
-ships one MTP block per draft depth (``mtp_config.num_nextn_predict_layers``,
-8 on Inkling Small), each block being embed/hidden RMSNorms + a 2H->H
-input projection + one dense ``InklingDecoderLayer``. The final norm and
-LM head are the trunk's own (``speculative_logits_from_hidden``); the
-drafter checkpoint's norm is a copy of ``model.llm.norm`` upstream.
+Single-checkpoint runtime for the checkpoint's multi-depth MTP head
+(``mtp_config.num_nextn_predict_layers``, 8 on Inkling Small), each block
+being embed/hidden RMSNorms + a 2H->H input projection + one dense
+``InklingDecoderLayer``.
 
-Depth mapping onto the omlx chain cycle mirrors the drafter exactly:
+The cycle semantics follow vLLM's Inkling MTP (vllm-project/vllm#48768),
+NOT mlx-vlm's separate-checkpoint ``speculative/drafters/inkling_mtp``
+drafter. The drafter only ever folds block 0 and restores a pre-round
+snapshot, so blocks 1..7 run every draft step with an EMPTY cache — that
+collapses deep-depth agreement (measured 0.68/0.45/0.19/0.00 per depth).
+The reference semantics keep EVERY block stateful over the whole
+accepted sequence, and a cycle is k chained passes over one uniform
+token window (measured 0.87/0.76/0.67/0.61 with the same head weights):
 
-* the history fold (``logits_keep=1`` on the persistent
-  ``make_mtp_cache()`` list) always runs block 0 and seeds the first
-  draft token from its logits;
-* chain step j runs block ``min(j, depth-1)`` — the batch generator
-  hands the chain a ``_clone_mtp_head_cache`` copy (``_omlx_mtp_head_clone``),
-  which is the clone-and-discard equivalent of the drafter's
-  snapshot/restore, so blocks past 0 never accumulate committed state.
-  The clone comes back as a plain list while the persistent cache is an
-  ``_InklingMTPCacheList``, which is how ``mtp_forward`` tells a fold
-  from a chain step.
+* pass j runs block j over the window, consuming pass j-1's full-window
+  hidden output and the token stream left-shifted by one with the newly
+  sampled draft appended; positions stay in trunk coordinates;
+* block j's cache row at slot p is valid only while its input token
+  index p+1+j stays committed, so each fold trims every active block
+  back to the uniform window start
+  ``w0 = min_j min(end_j, F_new-1-j)`` and refolds the gap from a small
+  ring of recent (token, trunk-hidden) pairs — the incremental
+  equivalent of vLLM's snapshot re-prefill of ``num_rejected-1`` slots;
+* the embedding side is DOUBLE-normed:
+  ``block.embed_norm(backbone.embed_norm(embed(ids)))``. Feeding the raw
+  embedding drops depth-0 agreement 0.87 -> 0.58 (vLLM documents the
+  same cliff);
+* head logits skip the trunk final norm by default
+  (``chain_hidden_post_norm: false`` — raw block output through the LM
+  head with the muP divide). ``OMLX_INKLING_MTP_FINAL_NORM=trunk``
+  restores the trunk-norm readout (measured equivalent).
 
-Backbone verify rollback cannot trim the short-conv states, so the
-vendored conv stashes its padded input every forward and
-``rollback_speculative_cache`` reslices the state at the accepted
-boundary (``xp[:, keep : keep + K - 1]``) while trimming the KV subs —
-no replay forward, unlike upstream's snapshot/replay.
+All cycle bookkeeping lives on the ``_InklingMTPCacheList`` instance the
+batch generator threads through the cycle, so request switches isolate
+naturally. ``mtp_begin_cycle`` (called by the generator before the fold)
+resets the pass counter; there is no per-cycle head clone
+(``_omlx_mtp_head_clone`` False) — provisional draft rows append to the
+persistent per-block caches and the next fold's trim removes whatever
+verify rejected. Head-block conv caches keep a ROLLING input stash
+(``_omlx_stash_rows``) so those rewinds can reach across cycles.
+
+Backbone verify rollback is unchanged: the vendored conv stashes its
+padded input every forward and ``rollback_speculative_cache`` reslices
+the state at the accepted boundary while trimming the KV subs.
 
 The head consumes PRE-norm trunk hidden (per-block ``hidden_norm``,
 ``chain_hidden_post_norm: false``), signalled to the fold via
 ``_omlx_mtp_head_prenorm``.
+
+Prompt priming captures (token, pre-norm hidden) pairs into a sliding
+window ring during prefill (no head forwards), then ``mtp_take_primed``
+folds all active blocks chained over that window at activation
+(``OMLX_INKLING_MTP_PRIME_WINDOW``, default 1024: sliding head blocks
+warm fully past 512 rows; the two global blocks cover their full
+rel_extent=1024 band — only band-outside long-range keys are lost).
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+import os
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -46,6 +72,14 @@ logger = logging.getLogger(__name__)
 
 _APPLIED = False
 _SANITIZE_APPLIED = False
+
+# Ring of recent committed (token, trunk-hidden) pairs kept for gap
+# refolds. Bounds the fold window; beyond it deep blocks accept a stale
+# clamp (draft quality only — verify guarantees output exactness).
+_RING = 64
+# Rolling conv-input stash coverage for head blocks: max rewind = ring
+# + max chain depth margin (K-1 state rows are added at cache creation).
+_STASH_ROWS = _RING + 16
 
 _ATTN = {
     "wq_du": "q_proj",
@@ -57,7 +91,70 @@ _ATTN = {
 
 
 class _InklingMTPCacheList(list):
-    """Marker list type for the persistent per-block MTP cache."""
+    """Persistent per-block MTP cache list + cycle bookkeeping.
+
+    All mutable cycle state lives here (not on the model): the batch
+    generator creates a fresh list per request, so request switches and
+    ``_drop_mtp_state`` isolate the bookkeeping automatically.
+
+    Logical coordinates count committed PAIRS (pair p = (trunk hidden at
+    token p, token p+1)). ``frontier`` is the committed pair count F;
+    ``pos_base`` is the logical index of every block's buffer row 0 (all
+    active blocks share one buffer origin — priming folds them together
+    and unprimed activation starts them all empty). Block j's logical
+    end is ``pos_base + kv_j.offset``; its rows past ``F - 1 - j`` were
+    computed from draft tokens and are provisional until the next fold's
+    trim.
+    """
+
+    frontier: int = 0
+    pos_base: int = 0
+    # -1 => the next mtp_forward call is the cycle fold (pass 0);
+    # mtp_begin_cycle resets it, chain calls increment it.
+    chain_step: int = -1
+    cycle_depth: int = 1
+    sconv_k: int = 4
+    # Per-block committed-valid row counts (logical). Rows past this were
+    # written from draft tokens and stay provisional until refolded —
+    # tracked explicitly because a block skipped by lower-depth cycles
+    # keeps stale trailing rows that ``frontier`` growth would otherwise
+    # falsely legitimize.
+    valid_rows = None  # list[int]
+    ring_tok = None  # (1, r) uint32, committed t_{p+1}, tail of history
+    ring_hid = None  # (1, r, H) trunk pre-norm hidden at p
+    win_tok = None  # (1, L) current cycle token stream
+    win_hid = None  # (1, L, H) previous pass full-window output
+    clamp_logged: bool = False
+
+
+@dataclass
+class _InklingPrimeCtx:
+    """Sliding-window prompt capture (no head forwards until activation)."""
+
+    tok_chunks: List[Any] = field(default_factory=list)  # (1, s) each
+    hid_chunks: List[Any] = field(default_factory=list)  # (1, s, H) each
+    total: int = 0
+    pending_hidden: Optional[Any] = None
+    expected_offset: int = 0
+    valid: bool = True
+
+
+def _prime_window() -> int:
+    try:
+        return int(os.environ.get("OMLX_INKLING_MTP_PRIME_WINDOW", "1024"))
+    except ValueError:
+        return 1024
+
+
+_FINAL_NORM_MODE: Optional[str] = None
+
+
+def _final_norm_mode() -> str:
+    global _FINAL_NORM_MODE
+    if _FINAL_NORM_MODE is None:
+        mode = os.environ.get("OMLX_INKLING_MTP_FINAL_NORM", "none").lower()
+        _FINAL_NORM_MODE = mode if mode in ("none", "trunk") else "none"
+    return _FINAL_NORM_MODE
 
 
 def _map_transformer_block(sub: str, v: mx.array) -> dict:
@@ -321,10 +418,14 @@ def _patch_language_model(inkling_lang: Any) -> None:
 
             self._omlx_mtp_chain = True
             self._omlx_mtp_depth = min(int(get_mtp_depth()), n_mtp)
-            # Chain steps must run on a per-cycle clone: blocks past 0
-            # never hold committed state (drafter snapshot/restore
-            # equivalent) and block 0's history stays draft-free.
-            self._omlx_mtp_head_clone = True
+            # No per-cycle clone: provisional draft rows append to the
+            # persistent per-block caches and the next fold trims them
+            # (vLLM re-prefill equivalent). The generator's
+            # _mtp_head_trim_to no-ops on CacheList entries (no .offset).
+            self._omlx_mtp_head_clone = False
+            # Row-wise batch MTP threads per-row extract/merge state the
+            # multi-block window bookkeeping does not model.
+            self._omlx_mtp_rowwise_unsupported = True
             # The head normalizes its hidden input per block
             # (chain_hidden_post_norm=false) — fold must NOT trunk-norm.
             self._omlx_mtp_head_prenorm = True
@@ -336,6 +437,11 @@ def _patch_language_model(inkling_lang: Any) -> None:
             self.model._omlx_mtp_prime_host = weakref.ref(self)
 
     def __call__(self, inputs=None, cache=None, **kwargs):
+        # Prompt-priming capture must only see prefill forwards. Verify /
+        # activation forwards pass return_hidden=True; capturing those
+        # breaks the ctx offset-contiguity chain (the v1 primed=0 bug),
+        # so gate the inner-model capture hook on this flag.
+        self.model._omlx_prime_capture_ok = not kwargs.get("return_hidden", False)
         out = original_call(self, inputs, cache=cache, **kwargs)
         if (
             kwargs.get("return_hidden")
@@ -349,6 +455,114 @@ def _patch_language_model(inkling_lang: Any) -> None:
             out.gdn_states = {"verify_len": int(inputs.shape[1])}
         return out
 
+    def _mtp_readout(self, h_last):
+        # chain_hidden_post_norm=false: raw block output through the LM
+        # head (muP divide + vocab clip live in _logits_from_norm).
+        if _final_norm_mode() == "trunk":
+            return self.speculative_logits_from_hidden(h_last)
+        return self._logits_from_norm(h_last)
+
+    def _mtp_run_block(self, block_idx, block_cache, hid_win, tok_win):
+        block = self.mtp.blocks[block_idx]
+        # Double-normed embedding side: backbone embed_norm (model.embed)
+        # then the block's own embed_norm. Raw embeddings collapse
+        # depth-0 agreement 0.87 -> 0.58.
+        emb = self.model.embed(tok_win)
+        x = mx.concatenate(
+            [block.hidden_norm(hid_win), block.embed_norm(emb)], axis=-1
+        )
+        x = block.input_proj(x)
+        return block.transformer_block(x, cache=block_cache)
+
+    def mtp_begin_cycle(self, mtp_cache, depth):
+        if not isinstance(mtp_cache, _InklingMTPCacheList) or not len(mtp_cache):
+            return
+        mtp_cache.cycle_depth = max(1, min(int(depth), len(self.mtp.blocks)))
+        mtp_cache.chain_step = -1
+
+    def _mtp_fold(self, cache, hidden_states, next_token_ids):
+        """Cycle pass 0: trim provisional rows, refold the gap, run block 0
+        over the uniform window ``[w0, F_new)``."""
+        n = int(next_token_ids.shape[1])
+        tok_row = next_token_ids.reshape(1, n)
+        if cache.ring_tok is None:
+            cache.ring_tok = tok_row
+            cache.ring_hid = hidden_states
+        else:
+            cache.ring_tok = mx.concatenate([cache.ring_tok, tok_row], axis=1)
+            cache.ring_hid = mx.concatenate(
+                [cache.ring_hid, hidden_states], axis=1
+            )
+        if cache.ring_tok.shape[1] > _RING:
+            cache.ring_tok = cache.ring_tok[:, -_RING:]
+            cache.ring_hid = cache.ring_hid[:, -_RING:]
+
+        f_new = cache.frontier + n
+        active = max(1, min(cache.cycle_depth, len(cache)))
+        k = cache.sconv_k
+        if cache.valid_rows is None:
+            cache.valid_rows = [0] * len(cache)
+        w0 = f_new - 1
+        floor = f_new - int(cache.ring_tok.shape[1])
+        for j in range(active):
+            kv, conv = cache[j][0], cache[j][1]
+            w0 = min(w0, cache.valid_rows[j])
+            stash = getattr(conv, "_omlx_verify_xp", None)
+            if kv.offset:
+                cap = 0
+                if stash:
+                    cap = min(int(x.shape[1]) for x in stash.values()) - (k - 1)
+                floor = max(floor, cache.pos_base + kv.offset - cap)
+        if floor > w0:
+            # Ring/stash-bounded clamp: deep blocks keep some stale
+            # provisional rows. Draft quality only — verify stays exact.
+            if not cache.clamp_logged:
+                logger.debug(
+                    "inkling MTP fold clamped: w0 %d -> %d", w0, floor
+                )
+                cache.clamp_logged = True
+            w0 = floor
+        for j in range(active):
+            kv, conv = cache[j][0], cache[j][1]
+            r = cache.pos_base + kv.offset - w0
+            if r <= 0:
+                continue
+            stash = conv._omlx_verify_xp
+            for idx, roll in stash.items():
+                trimmed = roll[:, : roll.shape[1] - r, :]
+                conv[idx] = trimmed[:, -(k - 1) :, :]
+                stash[idx] = trimmed
+            kv.trim(r)
+
+        length = f_new - w0
+        win_tok = cache.ring_tok[:, -length:]
+        win_hid = cache.ring_hid[:, -length:]
+        out = self._mtp_run_block(0, cache[0], win_hid, win_tok)
+        for j in range(active):
+            # Conservative committed bound: the window's trailing j rows
+            # of pass j come from draft tokens; everything before is
+            # committed after this cycle's passes.
+            cache.valid_rows[j] = max(cache.valid_rows[j], f_new - 1 - j)
+        cache.win_tok = win_tok
+        cache.win_hid = out
+        cache.chain_step = 1
+        cache.frontier = f_new
+        return out
+
+    def _mtp_chain(self, cache, next_token_ids, step):
+        """Cycle pass j: shift the token stream left, append the newest
+        draft, run block j chained on pass j-1's window output."""
+        block_idx = min(step, len(cache) - 1)
+        cache.chain_step = step + 1
+        cache.win_tok = mx.concatenate(
+            [cache.win_tok[:, 1:], next_token_ids.reshape(1, 1)], axis=1
+        )
+        out = self._mtp_run_block(
+            block_idx, cache[block_idx], cache.win_hid, cache.win_tok
+        )
+        cache.win_hid = out
+        return out
+
     def mtp_forward(
         self,
         hidden_states,
@@ -357,35 +571,32 @@ def _patch_language_model(inkling_lang: Any) -> None:
         return_hidden: bool = False,
         logits_keep: int = 0,
     ):
-        if isinstance(mtp_cache, _InklingMTPCacheList):
-            # History fold — always block 0; a fold starts a new cycle.
-            block_idx = 0
-            self._omlx_inkling_chain_step = 0
+        step = getattr(mtp_cache, "chain_step", -1)
+        if step < 0:
+            head_hidden = self._mtp_fold(mtp_cache, hidden_states, next_token_ids)
         else:
-            step = int(getattr(self, "_omlx_inkling_chain_step", 0))
-            block_idx = min(step, len(self.mtp.blocks) - 1)
-            self._omlx_inkling_chain_step = step + 1
-        head_hidden = self.mtp(
-            hidden_states,
-            next_token_ids,
-            self.model.embed_tokens,
-            mtp_cache,
-            block_idx,
-        )
-        logits_source = head_hidden
-        if logits_keep and logits_source.shape[1] > logits_keep:
-            logits_source = logits_source[:, -logits_keep:, :]
-        logits = self.speculative_logits_from_hidden(logits_source)
+            head_hidden = self._mtp_chain(mtp_cache, next_token_ids, step)
+        # Only the last slot is ever consumed (fold logits_keep=1, chain
+        # samples logits[:, -1]) — readout one row, not the window.
+        logits = self._mtp_readout(head_hidden[:, -1:, :])
         if return_hidden:
             return logits, head_hidden
         return logits
 
     def make_mtp_cache(self):
-        if hasattr(self, "mtp"):
-            return _InklingMTPCacheList(
-                CacheList(KVCache(), ArraysCache(4)) for _ in self.mtp.blocks
-            )
-        return _InklingMTPCacheList()
+        if not hasattr(self, "mtp"):
+            return _InklingMTPCacheList()
+        cache = _InklingMTPCacheList(
+            CacheList(KVCache(), ArraysCache(4)) for _ in self.mtp.blocks
+        )
+        k = int(getattr(self.config, "sconv_kernel_size", 4) or 4)
+        cache.sconv_k = k
+        cache.valid_rows = [0] * len(cache)
+        for cl in cache:
+            # Rolling conv-input stash (vendored conv honors this) so the
+            # fold prologue can rewind provisional rows across cycles.
+            cl[1]._omlx_stash_rows = _STASH_ROWS + k - 1
+        return cache
 
     def rollback_speculative_cache(self, caches, gdn_states, accepted, block_size):
         """Trim KV subs and reslice conv states at the accepted boundary.
@@ -420,29 +631,162 @@ def _patch_language_model(inkling_lang: Any) -> None:
                 conv[idx] = xp[:, keep : keep + k_minus_1, :]
         return accepted
 
+    def mtp_take_primed(self, cache, main_tok):
+        """Consume the sliding-window prompt capture at MTP activation.
+
+        Folds all active blocks chained over the captured window (pass j
+        covers slots ``[0, W_eff-1-j]`` with the token stream shifted by
+        j — every input is committed, so no draft handling) and returns
+        the seeded ``(cache_list, hist_offset)`` for the generator."""
+        from ..mlx_lm_mtp import prompt_priming
+
+        ctx = getattr(self, prompt_priming._CTX_ATTR, None)
+        prompt_priming.drop_ctx(self)
+        if not isinstance(ctx, _InklingPrimeCtx):
+            return None
+        if not (ctx.valid and ctx.total > 0 and ctx.pending_hidden is not None):
+            return None
+        offset = prompt_priming._activation_offset(cache)
+        if offset is None or ctx.expected_offset != offset - 1:
+            logger.debug(
+                "inkling MTP priming discarded: seam offset mismatch (%s vs %s)",
+                ctx.expected_offset,
+                offset,
+            )
+            return None
+        try:
+            seam_tok = main_tok.reshape(1, 1).astype(ctx.tok_chunks[0].dtype)
+            tok = mx.concatenate(ctx.tok_chunks + [seam_tok], axis=1)
+            hid = mx.concatenate(ctx.hid_chunks + [ctx.pending_hidden], axis=1)
+            f = int(tok.shape[1])
+            w_eff = min(f, _prime_window())
+            tok = tok[:, -w_eff:]
+            hid = hid[:, -w_eff:]
+            head_cache = self.make_mtp_cache()
+            if not len(head_cache):
+                return None
+            active = max(1, min(int(getattr(self, "_omlx_mtp_depth", 1)), len(head_cache)))
+            win_hid = hid
+            for j in range(active):
+                cols = w_eff - j
+                if cols <= 0:
+                    break
+                win_hid = self._mtp_run_block(
+                    j, head_cache[j], win_hid[:, :cols], tok[:, j:]
+                )
+            head_cache.frontier = f
+            head_cache.pos_base = f - w_eff
+            head_cache.valid_rows = [
+                max(0, f - 1 - j) if j < active else 0
+                for j in range(len(head_cache))
+            ]
+            r = min(_RING, w_eff)
+            head_cache.ring_tok = tok[:, -r:]
+            head_cache.ring_hid = hid[:, -r:]
+            evals = []
+            for cl in head_cache:
+                if cl[0].offset:
+                    evals.extend(cl[0].state)
+            if evals:
+                mx.async_eval(evals)
+            return head_cache, f
+        except Exception as exc:
+            logger.debug("inkling MTP priming fold failed: %s", exc)
+            return None
+
     cls.__init__ = __init__
     cls.__call__ = __call__
+    cls._mtp_readout = _mtp_readout
+    cls._mtp_run_block = _mtp_run_block
+    cls._mtp_fold = _mtp_fold
+    cls._mtp_chain = _mtp_chain
+    cls.mtp_begin_cycle = mtp_begin_cycle
     cls.mtp_forward = mtp_forward
     cls.make_mtp_cache = make_mtp_cache
+    cls.mtp_take_primed = mtp_take_primed
     cls.rollback_speculative_cache = rollback_speculative_cache
     cls._omlx_mtp_runtime_patched = True
 
 
+def _inkling_prime_capture(host, inputs, hidden, cache) -> None:
+    """Accumulate (token, pre-norm hidden) pairs into a sliding window.
+
+    Unlike the generic ``prompt_priming.maybe_capture`` this runs NO head
+    forwards during prefill — ``mtp_take_primed`` folds all blocks in one
+    chained pass at activation. Chunks past the priming window slide out
+    instead of invalidating the context, so long prompts stay primeable.
+    Contiguity gating mirrors the generic capture (anchor offset chain);
+    any mismatch drops the context and degrades to an unprimed entry.
+    """
+    from ..mlx_lm_mtp import prompt_priming
+
+    if prompt_priming._suppressed() or not prompt_priming.priming_enabled():
+        return
+    if cache is None or not prompt_priming._host_eligible(host):
+        return
+    if inputs is None or getattr(inputs, "ndim", 0) != 2 or inputs.shape[0] != 1:
+        return
+    anchor = prompt_priming._anchor(cache)
+    if anchor is None:
+        return
+    seq_len = int(inputs.shape[1])
+    offset_after = anchor.offset
+
+    ctx = getattr(host, prompt_priming._CTX_ATTR, None)
+    if ctx is not None and (
+        not isinstance(ctx, _InklingPrimeCtx)
+        or not ctx.valid
+        or ctx.expected_offset != offset_after - seq_len
+    ):
+        prompt_priming.drop_ctx(host)
+        ctx = None
+    if ctx is None:
+        if seq_len <= 1:
+            # A lone decode step cannot start a prompt timeline.
+            return
+        ctx = _InklingPrimeCtx()
+        setattr(host, prompt_priming._CTX_ATTR, ctx)
+
+    if ctx.pending_hidden is not None:
+        if seq_len > 1:
+            hid_chunk = mx.concatenate(
+                [ctx.pending_hidden, hidden[:, :-1]], axis=1
+            )
+        else:
+            hid_chunk = ctx.pending_hidden
+        tok_chunk = inputs
+    else:
+        if seq_len <= 1:
+            ctx.pending_hidden = hidden[:, -1:]
+            ctx.expected_offset = offset_after
+            return
+        hid_chunk = hidden[:, :-1]
+        tok_chunk = inputs[:, 1:]
+    ctx.tok_chunks.append(tok_chunk)
+    ctx.hid_chunks.append(hid_chunk)
+    ctx.total += int(tok_chunk.shape[1])
+    window = _prime_window()
+    while ctx.tok_chunks and ctx.total - int(ctx.tok_chunks[0].shape[1]) >= window:
+        ctx.total -= int(ctx.tok_chunks.pop(0).shape[1])
+        ctx.hid_chunks.pop(0)
+    ctx.pending_hidden = hidden[:, -1:]
+    ctx.expected_offset = offset_after
+    mx.async_eval([hid_chunk, ctx.pending_hidden])
+
+
 def _patch_inner_model_capture(inkling_lang: Any) -> None:
-    """Wrap ``InklingModel.__call__`` to fold prompt chunks into the head.
+    """Wrap ``InklingModel.__call__`` to capture prompt chunks for priming.
 
     The LanguageModel always calls the inner model with
     ``skip_final_norm=True``, so the captured hidden is the PRE-norm trunk
     output — the convention this head consumes. Image prompts arrive via
     ``input_embeddings`` and are skipped (same limitation as qwen); all
-    real gating lives in ``prompt_priming.maybe_capture`` and fails safe
-    to an unprimed entry.
+    real gating lives in ``_inkling_prime_capture`` and fails safe to an
+    unprimed entry.
     """
     cls = inkling_lang.InklingModel
     if getattr(cls, "_omlx_mtp_prime_capture_patched", False):
         return
-
-    from ..mlx_lm_mtp import prompt_priming
 
     original_call = cls.__call__
 
@@ -467,12 +811,13 @@ def _patch_inner_model_capture(inkling_lang: Any) -> None:
             and cache is not None
             and skip_final_norm
             and inputs is not None
+            and getattr(self, "_omlx_prime_capture_ok", False)
         ):
             host_ref = getattr(self, "_omlx_mtp_prime_host", None)
             host = host_ref() if host_ref is not None else None
             if host is not None:
                 try:
-                    prompt_priming.maybe_capture(host, inputs, out, cache)
+                    _inkling_prime_capture(host, inputs, out, cache)
                 except Exception:
                     logger.debug(
                         "Inkling MTP prompt-priming capture failed", exc_info=True

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -2877,6 +2877,24 @@ class Scheduler:
             if class_name in ("MiniMaxM3KVCache", "MiniMaxM3BatchKVCache"):
                 return False
             if isinstance(c, CacheList):
+                # A KVCache member inside a CacheList converts fine at
+                # runtime, but the prefix/SSD store paths dispatch on the
+                # layer class ("CacheList") and have no TurboQuant
+                # sub-state serialization: the converted member's
+                # NamedTuple state is flattened to an anonymous tuple on
+                # store and rebuilt as a corrupt dense cache on restore.
+                # Until CacheList-level TQ serialization exists, exclude
+                # composite layers that contain a convertible KVCache
+                # (e.g. inkling's CacheList(KVCache, ArraysCache)).
+                if any(type(inner) is KVCache for inner in c.caches):
+                    if not getattr(self, "_tq_cachelist_guard_logged", False):
+                        self._tq_cachelist_guard_logged = True
+                        logger.info(
+                            "TurboQuant KV disabled: composite CacheList "
+                            "layers with KVCache members have no TQ "
+                            "store/restore path yet"
+                        )
+                    return False
                 return all(_ok(inner) for inner in c.caches)
             return False
 
@@ -5488,17 +5506,13 @@ class Scheduler:
             if saved:
                 self._boundary_cache_snapshots[request_id][token_count] = None
             else:
-                # In-memory fallback: this snapshot will be sliced later on the
-                # store-cache worker thread (via _BoundarySnapshotProvider ->
-                # _extract_cache_states). MLX streams are thread-local, so the
-                # worker cannot materialize a lazy op bound to THIS (owner) thread's
-                # stream. Force it concrete now, on the capturing thread, so the
-                # worker only ever slices already-evaluated buffers.
-                self._eval_snapshot_cache(snapshot_cache)
-                self._boundary_cache_snapshots[request_id][token_count] = snapshot_cache
+                self._boundary_cache_snapshots[request_id][token_count] = (
+                    self._prefill_snapshot_value(snapshot_cache)
+                )
         else:
-            self._eval_snapshot_cache(snapshot_cache)
-            self._boundary_cache_snapshots[request_id][token_count] = snapshot_cache
+            self._boundary_cache_snapshots[request_id][token_count] = (
+                self._prefill_snapshot_value(snapshot_cache)
+            )
 
         self._boundary_snapshot_required = True
         logger.debug(
@@ -5506,6 +5520,85 @@ class Scheduler:
             request_id,
             token_count,
         )
+
+    _PREFILL_SNAPSHOT_MARKER = "__prefill_extracted__"
+
+    def _prefill_snapshot_value(self, snapshot_cache: list[Any]) -> Any:
+        """In-memory snapshot value: pre-extracted states when possible.
+
+        Falls back to the raw cache objects when extraction fails (stub or
+        unknown cache classes). The raw fallback cannot alias-corrupt: the
+        consumer runs the same extraction and skips the snapshot on the
+        same failure, while every extractable cache is decoupled here.
+        """
+        extracted = self._extract_prefill_snapshot_states(snapshot_cache)
+        if extracted is not None:
+            return extracted
+        self._eval_snapshot_cache(snapshot_cache)
+        return snapshot_cache
+
+    def _extract_prefill_snapshot_states(
+        self, snapshot_cache: list[Any]
+    ) -> tuple[str, list[dict[str, Any]]] | None:
+        """Extract-and-eval boundary states captured mid-prefill.
+
+        The prefill path snapshots the request's LIVE per-layer cache
+        objects (the request has no BatchGenerator uid yet, so there is no
+        ``extract_cache`` copy to take). Storing those objects aliases
+        every boundary to the prefill's final state — KVCache mutates its
+        preallocated buffer in place, so a later ``.state`` read returns
+        the newest content for every recorded boundary. Extract the state
+        eagerly on the capturing thread instead, and evaluate the leaves
+        so the async store-cache worker never re-dispatches a lazy op to
+        this thread's stream (#1568). Consumers accept the resulting
+        pre-extracted marker alongside raw decode-path snapshots (those
+        are already decoupled copies from ``extract_cache``).
+        """
+        def _copy_containers(value: Any) -> Any:
+            # ArraysCache.state returns its live slot LIST (not a copy);
+            # the model rebinds slots in place, so container structure
+            # must be copied at the boundary. The arrays themselves are
+            # safe to share: slot updates rebind, and buffer setitem
+            # copies on write once a second reference exists.
+            if isinstance(value, list):
+                return [_copy_containers(v) for v in value]
+            if isinstance(value, tuple):
+                return tuple(_copy_containers(v) for v in value)
+            return value
+
+        try:
+            stream = getattr(self, "_stream", None) or mx.default_stream(
+                mx.default_device()
+            )
+            with mx.stream(stream):
+                extracted, _ = self._extract_cache_states(snapshot_cache)
+                if not extracted:
+                    return None
+                for layer_state in extracted:
+                    layer_state["state"] = _copy_containers(layer_state.get("state"))
+                    layer_state["meta_state"] = _copy_containers(
+                        layer_state.get("meta_state")
+                    )
+                leaves: list[Any] = []
+
+                def _collect(value: Any) -> None:
+                    if isinstance(value, mx.array):
+                        leaves.append(value)
+                    elif isinstance(value, (list, tuple)):
+                        for item in value:
+                            _collect(item)
+                    elif isinstance(value, dict):
+                        for item in value.values():
+                            _collect(item)
+
+                for layer_state in extracted:
+                    _collect(layer_state.get("state"))
+                if leaves:
+                    mx.eval(leaves)
+            return (self._PREFILL_SNAPSHOT_MARKER, extracted)
+        except Exception as e:
+            logger.debug("Failed to extract prefill boundary snapshot: %s", e)
+            return None
 
     def _detect_boundary_snapshot_need(self) -> bool:
         """
@@ -5762,9 +5855,21 @@ class Scheduler:
                 self.requests.get(request_id), "_model_cache_config", None
             )
         elif latest_snapshot is not None:
-            extracted_cache, model_cache_config = self._extract_cache_states(
-                latest_snapshot
-            )
+            if (
+                isinstance(latest_snapshot, tuple)
+                and len(latest_snapshot) == 2
+                and latest_snapshot[0] == self._PREFILL_SNAPSHOT_MARKER
+            ):
+                # Pre-extracted prefill snapshot (states were captured and
+                # evaluated at the boundary; the live caches have moved on).
+                extracted_cache = latest_snapshot[1]
+                model_cache_config = getattr(
+                    self.requests.get(request_id), "_model_cache_config", None
+                )
+            else:
+                extracted_cache, model_cache_config = self._extract_cache_states(
+                    latest_snapshot
+                )
             if not extracted_cache:
                 return None
         else:
@@ -5781,6 +5886,15 @@ class Scheduler:
             if snap is None:
                 if self._boundary_snapshot_store is not None:
                     provider_tcs.append(tc)
+                continue
+
+            if (
+                isinstance(snap, tuple)
+                and len(snap) == 2
+                and snap[0] == self._PREFILL_SNAPSHOT_MARKER
+            ):
+                extracted_in_memory[tc] = snap[1]
+                provider_tcs.append(tc)
                 continue
 
             extracted_snapshot, _ = self._extract_cache_states(snap)
@@ -6376,6 +6490,11 @@ class Scheduler:
                                         sub_class_names,
                                         sub_meta_states,
                                     ),
+                                    # prefix_cache's store path reads this to
+                                    # tag __nstate__ markers and to record
+                                    # per-sub class names in SSD metadata;
+                                    # without it both stay unnamed.
+                                    "sub_class_names": sub_class_names,
                                     "class_name": "CacheList",
                                     "cache_type": "CacheList",
                                 }
@@ -6405,6 +6524,7 @@ class Scheduler:
                             {
                                 "state": sub_states,
                                 "meta_state": (sub_class_names, sub_meta_states),
+                                "sub_class_names": sub_class_names,
                                 "class_name": "CacheList",
                                 "cache_type": "CacheList",
                             }
@@ -10927,13 +11047,15 @@ class Scheduler:
 
     def _infer_live_layer_cache_types(
         self,
-    ) -> tuple[list[str], float | None] | None:
+    ) -> tuple[list[str], float | None, dict[str, list[str]] | None] | None:
         """Infer the layer-cache signature that future SSD saves will use.
 
-        Returns ``(layer_cache_types, turboquant_kv_bits)`` — the predicted
-        per-layer type names plus the depth requests will quantize at (None
-        when TurboQuant is inactive or ineligible) — or None when no
-        signature can be inferred.
+        Returns ``(layer_cache_types, turboquant_kv_bits,
+        cachelist_subtypes)`` — the predicted per-layer type names, the
+        depth requests will quantize at (None when TurboQuant is inactive
+        or ineligible), and the sub composition of mixed CacheList layers
+        (None when the model has none) — or None when no signature can be
+        inferred.
         """
         if not HAS_CACHE_TYPE_HANDLERS or ModelCacheConfig is None:
             return None
@@ -10967,8 +11089,16 @@ class Scheduler:
         if not layer_cache_types:
             return None
 
+        try:
+            from .cache.paged_ssd_cache import cachelist_subtypes_from_cache_list
+
+            cachelist_subtypes = cachelist_subtypes_from_cache_list(cache_list)
+        except Exception as e:
+            logger.debug("Failed to infer CacheList sub composition: %s", e)
+            cachelist_subtypes = None
+
         if self._turboquant_kv_bits is None:
-            return layer_cache_types, None
+            return layer_cache_types, None, cachelist_subtypes
 
         try:
             eligible = self._turboquant_eligible(cache_list)
@@ -10979,7 +11109,7 @@ class Scheduler:
             logger.debug("Failed to evaluate TurboQuant SSD signature: %s", e)
             return None
         if not eligible:
-            return layer_cache_types, None
+            return layer_cache_types, None, cachelist_subtypes
 
         kv_indices = [
             i for i, c in enumerate(cache_list) if _is_turboquant_kv_family_cache(c)
@@ -10995,7 +11125,7 @@ class Scheduler:
         # inside CacheList layers report bare "CacheList" names at every
         # depth, so the bits field is the only signature discriminator for
         # them (#2045).
-        return layer_cache_types, float(self._turboquant_kv_bits)
+        return layer_cache_types, float(self._turboquant_kv_bits), cachelist_subtypes
 
     def refresh_ssd_layer_signature(self) -> list[str] | None:
         """Set the SSD manager's live layer signature before prefix lookup."""
@@ -11012,7 +11142,7 @@ class Scheduler:
                     "for this session (stale-depth blocks are not swept)."
                 )
             return None
-        layer_cache_types, turboquant_kv_bits = inferred
+        layer_cache_types, turboquant_kv_bits, cachelist_subtypes = inferred
 
         try:
             set_signature = getattr(manager, "set_expected_layer_signature", None)
@@ -11020,6 +11150,7 @@ class Scheduler:
                 set_signature(
                     layer_cache_types,
                     turboquant_kv_bits=turboquant_kv_bits,
+                    cachelist_subtypes=cachelist_subtypes,
                 )
             else:
                 manager.adopt_layer_signature_if_unset(layer_cache_types)

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -11028,6 +11028,25 @@ class Scheduler:
                 # Fixed recurrent state (GDN/Mamba) can only be measured from
                 # a live cache after the first forward; arm a one-shot probe.
                 self._fixed_state_measure_armed = arrays_cache_layers > 0
+
+                # Inkling builds its banded relative-position bias as a full
+                # [H, LQ, S] tensor before SDPA; register the transient so
+                # prefill admission prices it (cleared for other models —
+                # the registry is process-wide across model swaps).
+                try:
+                    from .memory_monitor import register_attention_bias_transient
+
+                    model_type = str(getattr(self.model, "model_type", "") or "")
+                    register_attention_bias_transient(
+                        base_dtype_size
+                        if model_type in ("inkling", "inkling_mm_model")
+                        else None
+                    )
+                except Exception:
+                    logger.debug(
+                        "attention-bias transient registration failed",
+                        exc_info=True,
+                    )
                 logger.debug(
                     f"Model info for memory estimation: "
                     f"layers={num_layers} ({num_kv_cache_layers} KVCache, "

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -264,6 +264,13 @@ def maybe_apply_pre_load_patches(
     if apply_m5_gather_qmm_workaround():
         logger.info("M5 sorted gather_qmm reroute installed (issue #2267)")
 
+    # Model-independent: ArraysCache.extract lacks the None-slot guard its
+    # filter/extend/merge siblings have; early-aborted requests on
+    # CacheList(KVCache, ArraysCache) models crash without it.
+    from ..patches.arrays_cache_extract import apply_arrays_cache_extract_guard
+
+    apply_arrays_cache_extract_guard()
+
     config_path = Path(model_name) / "config.json"
     if not config_path.exists():
         return

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -404,6 +404,17 @@ def maybe_apply_pre_load_patches(
                 model_name,
             )
 
+    if for_vlm and model_type in ("inkling", "inkling_mm_model"):
+        from ..patches.mlx_vlm_inkling_compat import (
+            apply_mlx_vlm_inkling_compat_patch,
+        )
+
+        if apply_mlx_vlm_inkling_compat_patch():
+            logger.info(
+                "Inkling mlx-vlm compatibility patch applied for %s",
+                model_name,
+            )
+
     # Apply the MTP patch whenever the model has MTP heads on a compatible
     # model_type — even when mtp_enabled is False. The patch is required
     # for *sanitize correctness*: stock mlx-lm Model.sanitize triggers a

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -464,6 +464,13 @@ def maybe_apply_pre_load_patches(
                 # vs 1.53x capped at 3); the controller still settles shallow
                 # on low-accept content.
                 set_mtp_depth(8)
+            elif model_type in ("inkling", "inkling_mm_model"):
+                # The checkpoint ships one MTP block per draft depth; cap
+                # the chain at the shipped depth (8 on Inkling Small).
+                mtp_cfg = config.get("mtp_config") or {}
+                set_mtp_depth(
+                    int(mtp_cfg.get("num_nextn_predict_layers", 0) or 0) or 3
+                )
             else:
                 set_mtp_depth(3)
             if mtp_enabled:
@@ -653,6 +660,10 @@ def _has_mtp_heads(config: dict) -> bool:
         return True
     if int(text_cfg.get("num_nextn_predict_layers", 0) or 0) > 0:
         return True
+    # Inkling nests the head declaration under a top-level mtp_config.
+    mtp_cfg = config.get("mtp_config") or {}
+    if int(mtp_cfg.get("num_nextn_predict_layers", 0) or 0) > 0:
+        return True
     return False
 
 
@@ -759,6 +770,7 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
         or model_type.startswith("nemotron_h")
         or model_type == "glm_moe_dsa"
         or model_type == "gemma4"
+        or model_type in ("inkling", "inkling_mm_model")
     )
 
 

--- a/tests/test_inkling_vlm_mtp.py
+++ b/tests/test_inkling_vlm_mtp.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inkling Lightning MTP runtime tests (single-checkpoint head)."""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    import mlx.core as mx
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+
+
+@pytest.fixture(scope="module")
+def runtime():
+    from omlx.patches.mlx_vlm_mtp import inkling_vlm_runtime
+    from omlx.patches.mlx_lm_mtp import set_mtp_active, set_mtp_depth
+
+    assert inkling_vlm_runtime.apply()
+    set_mtp_active(True)
+    set_mtp_depth(4)
+    yield inkling_vlm_runtime
+    set_mtp_active(False)
+
+
+def _mtp_language_model():
+    import importlib
+
+    from tests.test_mlx_vlm_inkling_compat import _tiny_text_config
+
+    language = importlib.import_module("mlx_vlm.models.inkling.language")
+    config = _tiny_text_config()
+    config.mtp_num_hidden_layers = 3
+    config.mtp_local_layer_ids = [0, 2]
+    mx.random.seed(21)
+    model = language.LanguageModel(config)
+    mx.eval(model.parameters())
+    return model
+
+
+def test_config_plumb_and_attach(runtime):
+    import importlib
+
+    inkling_pkg = importlib.import_module("mlx_vlm.models.inkling")
+    config = inkling_pkg.ModelConfig.from_dict(
+        {
+            "model_type": "inkling_mm_model",
+            "text_config": {"hidden_size": 32, "num_hidden_layers": 2},
+            "mtp_config": {
+                "num_nextn_predict_layers": 8,
+                "local_layer_ids": [0, 2, 4, 5, 6, 7],
+                "chain_hidden_post_norm": False,
+            },
+        }
+    )
+    assert config.text_config.mtp_num_hidden_layers == 8
+    assert config.text_config.mtp_local_layer_ids == [0, 2, 4, 5, 6, 7]
+
+    model = _mtp_language_model()
+    assert hasattr(model, "mtp")
+    assert len(model.mtp.blocks) == 3
+    assert model._omlx_mtp_decode_enabled
+    assert model._omlx_mtp_chain
+    assert model._omlx_mtp_head_clone
+    assert model._omlx_mtp_head_prenorm
+    assert model._omlx_mtp_depth == 3  # clamped to the shipped block count
+
+
+def test_mtp_forward_fold_and_chain_routing(runtime):
+    from omlx.patches.mlx_lm_mtp.batch_generator import _clone_mtp_head_cache
+
+    model = _mtp_language_model()
+    mtp_cache = model.make_mtp_cache()
+    assert len(mtp_cache) == 3
+
+    hidden = mx.random.normal((1, 5, 32))
+    tokens = mx.array([[3, 9, 4, 7, 1]])
+    logits, head_hidden = model.mtp_forward(
+        hidden, tokens, mtp_cache, return_hidden=True, logits_keep=1
+    )
+    mx.eval(logits, head_hidden)
+    assert logits.shape == (1, 1, 128)
+    # The fold runs block 0 on the persistent cache only.
+    assert mtp_cache[0][0].state[0].shape[2] == 5
+    assert mtp_cache[1][0].offset == 0
+    assert mtp_cache[2][0].offset == 0
+
+    # Chain steps run on a per-cycle clone and advance block 0 -> 1 -> 2.
+    chain_cache = _clone_mtp_head_cache(mtp_cache)
+    h = head_hidden[:, -1:]
+    tok = mx.array([[11]])
+    for expected_block, expected_len in ((0, 6), (1, 1), (2, 1)):
+        logits, h = model.mtp_forward(h, tok, chain_cache, return_hidden=True)
+        h = h[:, -1:]
+        mx.eval(logits)
+        assert chain_cache[expected_block][0].state[0].shape[2] == expected_len, (
+            f"chain step should have used block {expected_block}"
+        )
+    # The persistent cache is untouched by chain steps.
+    assert mtp_cache[0][0].state[0].shape[2] == 5
+    assert mtp_cache[1][0].offset == 0
+
+    # A new fold resets the chain counter.
+    model.mtp_forward(hidden[:, -1:], tokens[:, -1:], mtp_cache, logits_keep=1)
+    assert model._omlx_inkling_chain_step == 0
+
+
+def test_verify_rollback_matches_sequential_decode(runtime):
+    """Rolling back a rejected verify chunk must leave the backbone cache
+    equivalent to having decoded only the accepted tokens one by one."""
+    model = _mtp_language_model()
+    prompt = mx.array([[5, 17, 42, 91, 12, 63]])
+    step_tokens = [7, 33, 54, 76]  # verify chunk; accept first 3, reject last
+
+    ref_cache = model.make_cache()
+    model(prompt, cache=ref_cache)
+    for tok in step_tokens[:3]:
+        model(mx.array([[tok]]), cache=ref_cache)
+
+    cache = model.make_cache()
+    model(prompt, cache=cache)
+    verify = mx.array([step_tokens])
+    out = model(verify, cache=cache, return_hidden=True)
+    assert isinstance(out.gdn_states, dict)
+    assert out.gdn_states["verify_len"] == 4
+
+    accepted = model.rollback_speculative_cache(
+        cache, out.gdn_states, accepted=2, block_size=4
+    )
+    assert accepted == 2
+    for layer_cache, ref_layer in zip(cache, ref_cache):
+        assert layer_cache[0].offset == ref_layer[0].offset
+        for slot in range(4):
+            got = layer_cache[1][slot]
+            want = ref_layer[1][slot]
+            assert got is not None and want is not None
+            diff = mx.max(mx.abs(got - want)).item()
+            assert diff < 1e-4, f"conv slot {slot} diverged after rollback: {diff}"
+
+    ref_out = model(mx.array([[100]]), cache=ref_cache)
+    test_out = model(mx.array([[100]]), cache=cache)
+    mx.eval(ref_out.logits, test_out.logits)
+    diff = mx.max(mx.abs(test_out.logits - ref_out.logits)).item()
+    assert diff < 1e-3, f"post-rollback logits diverged: {diff}"
+
+
+def test_sanitize_hook_maps_mtp_keys(runtime):
+    import importlib
+
+    inkling_mod = importlib.import_module("mlx_vlm.models.inkling.inkling")
+    model = inkling_mod.Model.__new__(inkling_mod.Model)
+
+    hidden, inter = 8, 4
+    w13 = mx.arange(2 * inter * hidden, dtype=mx.float32).reshape(2 * inter, hidden)
+    weights = {
+        "model.mtp.layers.0.input_proj.weight": mx.zeros((hidden, 2 * hidden)),
+        "model.mtp.layers.0.embed_norm.weight": mx.ones((hidden,)),
+        "model.mtp.layers.0.transformer_block.attn.wq_du.weight": mx.zeros(
+            (hidden, hidden)
+        ),
+        "model.mtp.layers.0.transformer_block.attn.k_sconv.weight": mx.zeros(
+            (hidden, 4, 1)
+        ),
+        "model.mtp.layers.0.transformer_block.mlp.w13_dn.weight": w13,
+        "model.llm.embed.weight": mx.zeros((16, hidden)),
+    }
+    out = inkling_mod.Model.sanitize(model, weights)
+    base = "language_model.mtp.blocks.0."
+    assert base + "input_proj.weight" in out
+    assert base + "embed_norm.weight" in out
+    assert base + "transformer_block.self_attn.q_proj.weight" in out
+    assert out[base + "transformer_block.self_attn.k_sconv.conv.weight"].shape == (
+        hidden,
+        1,
+        4,
+    )
+    gate = out[base + "transformer_block.mlp.gate_proj.weight"]
+    ref = w13.reshape(inter, 2, hidden)
+    assert mx.array_equal(gate, ref[:, 0, :])
+    assert "language_model.model.embed_tokens.weight" in out
+
+
+def test_prompt_priming_capture(runtime):
+    """Chunked prefill through the LanguageModel must fold the prompt
+    into a priming context (block-0 head cache) so MTP enters warm."""
+    from omlx.patches.mlx_lm_mtp import prompt_priming
+
+    model = _mtp_language_model()
+    cache = model.make_cache()
+    tokens = mx.array([[3, 9, 4, 7, 1, 8, 2, 6]])
+    model(tokens, cache=cache)
+
+    ctx = getattr(model, prompt_priming._CTX_ATTR, None)
+    assert ctx is not None, "priming context was not captured"
+    assert ctx.mtp_cache[0][0].state[0].shape[2] > 0, (
+        "priming fold did not reach the block-0 head cache"
+    )
+    assert ctx.mtp_cache[1][0].offset == 0

--- a/tests/test_inkling_vlm_mtp.py
+++ b/tests/test_inkling_vlm_mtp.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Inkling Lightning MTP runtime tests (single-checkpoint head)."""
+"""Inkling Lightning MTP runtime tests (uniform-window multi-block cycle)."""
 
 from __future__ import annotations
 
@@ -17,8 +17,8 @@ pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
 
 @pytest.fixture(scope="module")
 def runtime():
-    from omlx.patches.mlx_vlm_mtp import inkling_vlm_runtime
     from omlx.patches.mlx_lm_mtp import set_mtp_active, set_mtp_depth
+    from omlx.patches.mlx_vlm_mtp import inkling_vlm_runtime
 
     assert inkling_vlm_runtime.apply()
     set_mtp_active(True)
@@ -40,6 +40,56 @@ def _mtp_language_model():
     model = language.LanguageModel(config)
     mx.eval(model.parameters())
     return model
+
+
+def _hidden_table(n, hidden=32, seed=7):
+    mx.random.seed(seed)
+    return mx.random.normal((1, n, hidden)) * 0.1
+
+
+def _run_cycles(model, cache, toks, table, script):
+    """Drive the generator contract: per cycle fold m+1 committed pairs,
+    then depth-1 chain calls. ``script`` entries are (m_accepted, depth)
+    where the m accepted drafts of a cycle equal the next cycle's first m
+    committed tokens (fed to the chain as matching drafts)."""
+    f = 0
+    prev_depth = None
+    for i, (m, depth) in enumerate(script):
+        n = m + 1
+        assert prev_depth is None or m <= prev_depth, "script accepts > drafts"
+        assert f + n <= len(toks)
+        hid = table[:, f : f + n]
+        ids = mx.array([toks[f : f + n]], dtype=mx.uint32)
+        model.mtp_begin_cycle(cache, depth)
+        model.mtp_forward(hid, ids, cache, return_hidden=True, logits_keep=1)
+        f += n
+        next_m = script[i + 1][0] if i + 1 < len(script) else 0
+        for j in range(1, depth):
+            # Chain call j feeds draft j-1. Drafts the next cycle accepts
+            # must equal the tokens it then commits; the rest are wrong.
+            true_idx = f + j - 1
+            if j - 1 < next_m and true_idx < len(toks):
+                tok = toks[true_idx]
+            else:
+                tok = (toks[true_idx] + 63) % 128 if true_idx < len(toks) else 1
+            draft = mx.array([[tok]], dtype=mx.uint32)
+            model.mtp_forward(cache.win_hid[:, -1:], draft, cache, return_hidden=True)
+        prev_depth = depth
+    return f
+
+
+def _reference_blocks(model, toks, table, f, depth):
+    """One-shot chained fold over the full committed history: pass j
+    covers slots [0, f-1-j] with the token stream shifted by j."""
+    from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
+
+    caches = [CacheList(KVCache(), ArraysCache(4)) for _ in model.mtp.blocks]
+    win_hid = table[:, :f]
+    for j in range(depth):
+        cols = f - j
+        ids = mx.array([toks[j:f]], dtype=mx.uint32)
+        win_hid = model._mtp_run_block(j, caches[j], win_hid[:, :cols], ids)
+    return caches
 
 
 def test_config_plumb_and_attach(runtime):
@@ -65,48 +115,109 @@ def test_config_plumb_and_attach(runtime):
     assert len(model.mtp.blocks) == 3
     assert model._omlx_mtp_decode_enabled
     assert model._omlx_mtp_chain
-    assert model._omlx_mtp_head_clone
     assert model._omlx_mtp_head_prenorm
+    # No per-cycle clone and no row-wise batch path: provisional rows live
+    # on the persistent caches and the next fold trims them.
+    assert model._omlx_mtp_head_clone is False
+    assert model._omlx_mtp_rowwise_unsupported is True
     assert model._omlx_mtp_depth == 3  # clamped to the shipped block count
 
 
-def test_mtp_forward_fold_and_chain_routing(runtime):
-    from omlx.patches.mlx_lm_mtp.batch_generator import _clone_mtp_head_cache
-
+def test_cycle_routing_uses_block_j(runtime):
+    """Chain call j must run block j (vLLM draft-j <- block-j mapping),
+    with provisional rows appended to the persistent caches."""
     model = _mtp_language_model()
-    mtp_cache = model.make_mtp_cache()
-    assert len(mtp_cache) == 3
+    cache = model.make_mtp_cache()
+    assert len(cache) == 3
 
-    hidden = mx.random.normal((1, 5, 32))
-    tokens = mx.array([[3, 9, 4, 7, 1]])
-    logits, head_hidden = model.mtp_forward(
-        hidden, tokens, mtp_cache, return_hidden=True, logits_keep=1
+    hid = _hidden_table(1)
+    model.mtp_begin_cycle(cache, 3)
+    logits, _ = model.mtp_forward(
+        hid, mx.array([[5]], dtype=mx.uint32), cache, return_hidden=True, logits_keep=1
     )
-    mx.eval(logits, head_hidden)
     assert logits.shape == (1, 1, 128)
-    # The fold runs block 0 on the persistent cache only.
-    assert mtp_cache[0][0].state[0].shape[2] == 5
-    assert mtp_cache[1][0].offset == 0
-    assert mtp_cache[2][0].offset == 0
+    # Fold = pass 0 on block 0 only.
+    assert [cl[0].offset for cl in cache] == [1, 0, 0]
 
-    # Chain steps run on a per-cycle clone and advance block 0 -> 1 -> 2.
-    chain_cache = _clone_mtp_head_cache(mtp_cache)
-    h = head_hidden[:, -1:]
-    tok = mx.array([[11]])
-    for expected_block, expected_len in ((0, 6), (1, 1), (2, 1)):
-        logits, h = model.mtp_forward(h, tok, chain_cache, return_hidden=True)
-        h = h[:, -1:]
-        mx.eval(logits)
-        assert chain_cache[expected_block][0].state[0].shape[2] == expected_len, (
-            f"chain step should have used block {expected_block}"
-        )
-    # The persistent cache is untouched by chain steps.
-    assert mtp_cache[0][0].state[0].shape[2] == 5
-    assert mtp_cache[1][0].offset == 0
+    model.mtp_forward(
+        cache.win_hid[:, -1:], mx.array([[7]], dtype=mx.uint32), cache, return_hidden=True
+    )
+    assert [cl[0].offset for cl in cache] == [1, 1, 0], "chain 1 must run block 1"
+    model.mtp_forward(
+        cache.win_hid[:, -1:], mx.array([[9]], dtype=mx.uint32), cache, return_hidden=True
+    )
+    assert [cl[0].offset for cl in cache] == [1, 1, 1], "chain 2 must run block 2"
+    assert cache.frontier == 1
 
-    # A new fold resets the chain counter.
-    model.mtp_forward(hidden[:, -1:], tokens[:, -1:], mtp_cache, logits_keep=1)
-    assert model._omlx_inkling_chain_step == 0
+    # Next fold trims every provisional row back to the uniform window
+    # start and refolds block 0 over it; deep blocks refold during their
+    # own chain passes.
+    model.mtp_begin_cycle(cache, 3)
+    model.mtp_forward(
+        hid, mx.array([[6]], dtype=mx.uint32), cache, return_hidden=True, logits_keep=1
+    )
+    assert cache.frontier == 2
+    assert [cl[0].offset for cl in cache] == [2, 0, 0]
+
+
+def test_committed_prefix_matches_oneshot_oracle(runtime):
+    """After a mixed accept/reject cycle script, every block's committed
+    rows must equal a from-scratch chained fold over the full history."""
+    model = _mtp_language_model()
+    cache = model.make_mtp_cache()
+    toks = [(i * 13 + 3) % 128 for i in range(30)]
+    table = _hidden_table(30)
+    script = [(0, 3), (2, 3), (1, 3), (2, 3), (0, 2), (1, 3), (2, 3), (0, 3)]
+    f = _run_cycles(model, cache, toks, table, script)
+
+    ref = _reference_blocks(model, toks, table, f, 3)
+    for j in range(3):
+        valid = f - 1 - j
+        live_k, live_v = cache[j][0].state
+        ref_k, ref_v = ref[j][0].state
+        assert live_k.shape[2] >= valid and ref_k.shape[2] >= valid
+        dk = mx.max(mx.abs(live_k[:, :, :valid] - ref_k[:, :, :valid])).item()
+        dv = mx.max(mx.abs(live_v[:, :, :valid] - ref_v[:, :, :valid])).item()
+        assert dk < 1e-4 and dv < 1e-4, f"block {j} diverged: k={dk} v={dv}"
+
+
+def test_full_rejection_gap_rewrite(runtime):
+    """Consecutive all-reject cycles exercise the trim + conv-rewind path
+    every fold; committed rows must still match the one-shot oracle."""
+    model = _mtp_language_model()
+    cache = model.make_mtp_cache()
+    toks = [(i * 7 + 11) % 128 for i in range(16)]
+    table = _hidden_table(16, seed=9)
+    script = [(0, 3)] * 8
+    f = _run_cycles(model, cache, toks, table, script)
+    assert f == 8
+
+    ref = _reference_blocks(model, toks, table, f, 3)
+    for j in range(3):
+        valid = f - 1 - j
+        live_k, _ = cache[j][0].state
+        ref_k, _ = ref[j][0].state
+        dk = mx.max(mx.abs(live_k[:, :, :valid] - ref_k[:, :, :valid])).item()
+        assert dk < 1e-4, f"block {j} diverged after gap rewrites: {dk}"
+
+
+def test_variable_depth_lag_heals(runtime):
+    """Dropping to depth 1 leaves deep blocks lagging; raising the depth
+    again must refold them from the ring back to the oracle state."""
+    model = _mtp_language_model()
+    cache = model.make_mtp_cache()
+    toks = [(i * 5 + 2) % 128 for i in range(24)]
+    table = _hidden_table(24, seed=11)
+    script = [(0, 3), (1, 3), (0, 1), (0, 1), (0, 1), (0, 3), (1, 3)]
+    f = _run_cycles(model, cache, toks, table, script)
+
+    ref = _reference_blocks(model, toks, table, f, 3)
+    for j in range(3):
+        valid = f - 1 - j
+        live_k, _ = cache[j][0].state
+        ref_k, _ = ref[j][0].state
+        dk = mx.max(mx.abs(live_k[:, :, :valid] - ref_k[:, :, :valid])).item()
+        assert dk < 1e-4, f"block {j} did not heal after depth dip: {dk}"
 
 
 def test_verify_rollback_matches_sequential_decode(runtime):
@@ -184,19 +295,72 @@ def test_sanitize_hook_maps_mtp_keys(runtime):
     assert "language_model.model.embed_tokens.weight" in out
 
 
-def test_prompt_priming_capture(runtime):
-    """Chunked prefill through the LanguageModel must fold the prompt
-    into a priming context (block-0 head cache) so MTP enters warm."""
+def test_prompt_priming_capture_and_take(runtime):
+    """Chunked prefill captures the pair window (no head forwards); at
+    activation mtp_take_primed folds every block with the lag invariant
+    end_j = F - j."""
     from omlx.patches.mlx_lm_mtp import prompt_priming
 
     model = _mtp_language_model()
     cache = model.make_cache()
-    tokens = mx.array([[3, 9, 4, 7, 1, 8, 2, 6]])
-    model(tokens, cache=cache)
+    ids = mx.array([[3, 9, 4, 7, 1, 8, 2, 6, 12, 15, 22, 30]])
+    model(ids[:, :6], cache=cache)
+    model(ids[:, 6:], cache=cache)
 
     ctx = getattr(model, prompt_priming._CTX_ATTR, None)
     assert ctx is not None, "priming context was not captured"
-    assert ctx.mtp_cache[0][0].state[0].shape[2] > 0, (
-        "priming fold did not reach the block-0 head cache"
+    assert ctx.total == 11  # P-1 pairs captured, head caches untouched
+    assert ctx.pending_hidden is not None
+
+    # The activation forward (return_hidden=True) must NOT capture — the
+    # v1 primed=0 bug: it broke the ctx offset chain before take_primed.
+    out = model(mx.array([[41]]), cache=cache, return_hidden=True)
+    assert out is not None
+    ctx2 = getattr(model, prompt_priming._CTX_ATTR, None)
+    assert ctx2 is ctx and ctx.total == 11
+
+    primed = prompt_priming.take_primed(model, cache, mx.array([41]))
+    assert primed is not None, "activation seam rejected the capture"
+    head_cache, hist = primed
+    assert hist == 12  # 11 prompt pairs + seam pair
+    assert head_cache.frontier == 12
+    assert head_cache.pos_base == 0
+    for j in range(model._omlx_mtp_depth):
+        assert head_cache[j][0].offset == 12 - j, f"block {j} lag broken"
+
+    # The primed cache must drive a normal cycle.
+    model.mtp_begin_cycle(head_cache, 3)
+    logits, _ = model.mtp_forward(
+        _hidden_table(1), mx.array([[9]], dtype=mx.uint32), head_cache,
+        return_hidden=True, logits_keep=1,
     )
-    assert ctx.mtp_cache[1][0].offset == 0
+    assert logits.shape == (1, 1, 128)
+    assert head_cache.frontier == 13
+
+
+def test_prompt_priming_window_slides(runtime, monkeypatch):
+    """Prompts longer than the priming window slide chunks out instead of
+    invalidating the context."""
+    from omlx.patches.mlx_lm_mtp import prompt_priming
+
+    monkeypatch.setenv("OMLX_INKLING_MTP_PRIME_WINDOW", "8")
+    model = _mtp_language_model()
+    cache = model.make_cache()
+    ids = mx.array([[(i * 3 + 1) % 128 for i in range(18)]])
+    model(ids[:, :6], cache=cache)
+    model(ids[:, 6:12], cache=cache)
+    model(ids[:, 12:], cache=cache)
+
+    ctx = getattr(model, prompt_priming._CTX_ATTR, None)
+    assert ctx is not None
+    assert ctx.total >= 8, "window slide dropped below the priming window"
+
+    model(mx.array([[50]]), cache=cache, return_hidden=True)  # activation seam
+    primed = prompt_priming.take_primed(model, cache, mx.array([50]))
+    assert primed is not None
+    head_cache, hist = primed
+    w_eff = 8
+    assert hist == ctx.total + 1
+    assert head_cache.pos_base == hist - w_eff
+    for j in range(model._omlx_mtp_depth):
+        assert head_cache[j][0].offset == w_eff - j

--- a/tests/test_mlx_vlm_inkling_compat.py
+++ b/tests/test_mlx_vlm_inkling_compat.py
@@ -1,0 +1,391 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inkling mlx-vlm compatibility patch tests.
+
+Covers the vendor install/discovery surface (unlimited-ocr test pattern),
+the torch-free processor pieces, the NVFP4 config translation, and the
+batched right-padded prefill parity that the vendored conv_mask wiring
+(G2) exists for.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+try:
+    import mlx.core as mx
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+
+
+@pytest.fixture(scope="module")
+def applied():
+    from omlx.patches.mlx_vlm_inkling_compat import (
+        apply_mlx_vlm_inkling_compat_patch,
+        is_applied,
+    )
+
+    apply_mlx_vlm_inkling_compat_patch()
+    assert is_applied()
+    return True
+
+
+def test_vendor_module_resolves(applied):
+    import mlx_vlm.utils as vlm_utils
+
+    assert vlm_utils.MODEL_REMAPPING.get("inkling_mm_model") == "inkling"
+
+    import importlib
+
+    module = importlib.import_module("mlx_vlm.models.inkling")
+    assert hasattr(module, "Model")
+    assert hasattr(module, "LanguageModel")
+
+    # get_model_and_args resolves the checkpoint model_type.
+    arch, model_type = _get_model_and_args(vlm_utils, "inkling_mm_model")
+    assert model_type == "inkling"
+    assert arch is module
+
+
+def _get_model_and_args(vlm_utils, model_type):
+    config = {"model_type": model_type}
+    result = vlm_utils.get_model_and_args(config)
+    # Signature drift guard: pinned mlx-vlm returns (arch_module, model_type)
+    # or (arch, model_type, quant) depending on version.
+    return result[0], result[1]
+
+
+def test_prompt_formatting_image_first(applied):
+    from mlx_vlm.prompt_utils import get_message_json
+
+    message = get_message_json(
+        "inkling_mm_model", "describe this", role="user", num_images=2
+    )
+    assert message["role"] == "user"
+    content = message["content"]
+    assert isinstance(content, list)
+    assert content[0] == {"type": "image"}
+    assert content[1] == {"type": "image"}
+    assert content[2]["type"] == "text"
+    assert content[2]["text"] == "describe this"
+
+    # Assistant/no-image turns stay plain strings.
+    assistant = get_message_json("inkling", "hello", role="assistant")
+    assert assistant["content"] == "hello"
+
+
+def test_other_models_untouched(applied):
+    from mlx_vlm.prompt_utils import get_message_json
+
+    message = get_message_json("qwen2_vl", "hi", role="user", num_images=1)
+    assert message["role"] == "user"
+    assert message["content"] != [{"type": "image"}, {"type": "text", "text": "hi"}]
+
+
+def test_load_config_translates_nvfp4(applied, tmp_path):
+    import mlx_vlm.utils as vlm_utils
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "inkling_mm_model", "vocab_size": 128})
+    )
+    (tmp_path / "hf_quant_config.json").write_text(
+        json.dumps({"quantization": {"quant_algo": "NVFP4"}})
+    )
+    config = vlm_utils.load_config(tmp_path)
+    assert config["quantization"] == {"group_size": 16, "bits": 4, "mode": "nvfp4"}
+
+    # Non-inkling checkpoints are not touched.
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "config.json").write_text(json.dumps({"model_type": "llama"}))
+    (other / "hf_quant_config.json").write_text(
+        json.dumps({"quantization": {"quant_algo": "NVFP4"}})
+    )
+    config = vlm_utils.load_config(other)
+    assert "quantization" not in config
+
+
+def test_image_processor_patch_grid(applied):
+    import importlib
+
+    import numpy as np
+    from PIL import Image
+
+    processing_inkling = importlib.import_module(
+        "mlx_vlm.models.inkling.processing_inkling"
+    )
+
+    proc = processing_inkling.InklingImageProcessor()
+    image = Image.fromarray(
+        np.full((100, 50, 3), 128, dtype=np.uint8)
+    )  # H=100, W=50
+    out = proc.preprocess([image])
+    # rows = ceil(100/40) = 3, cols = 50//40 + 1 = 2 (reference grid).
+    assert out["num_patches"].tolist() == [6]
+    assert out["pixel_values"].shape == (6, 2, 40, 40, 3)
+    # Padded region carries -1.0 pre-rescale: (-1 * 1/255 - mean) / std.
+    # Patch 1 covers x = [40, 80); the image ends at x = 50, so patch-local
+    # x >= 10 is padding.
+    padded_pixel = out["pixel_values"][1, 0, 0, 20, 0]
+    expected = (-1.0 / 255.0 - proc.image_mean[0]) / proc.image_std[0]
+    assert abs(float(padded_pixel) - float(expected)) < 1e-5
+    # Temporal duplication is exact.
+    assert np.array_equal(
+        out["pixel_values"][:, 0], out["pixel_values"][:, 1]
+    )
+
+
+def _tiny_text_config():
+    from mlx_vlm.models.inkling.config import TextConfig
+
+    return TextConfig(
+        hidden_size=32,
+        num_hidden_layers=2,
+        vocab_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        swa_num_attention_heads=4,
+        swa_num_key_value_heads=2,
+        swa_head_dim=8,
+        sliding_window_size=8,
+        layer_types=["hybrid_sliding", "full"],
+        d_rel=4,
+        rel_extent=4,
+        log_scaling_n_floor=4,
+        sconv_kernel_size=4,
+        mlp_layer_types=["dense", "sparse"],
+        intermediate_size=16,
+        dense_intermediate_size=32,
+        n_routed_experts=4,
+        num_experts_per_tok=2,
+        n_shared_experts=1,
+        tie_word_embeddings=True,
+    )
+
+
+def _tiny_language_model():
+    from mlx_vlm.models.inkling.language import LanguageModel
+
+    mx.random.seed(7)
+    model = LanguageModel(_tiny_text_config())
+    # Give routing and rel-bias non-degenerate weights.
+    for layer in model.model.layers:
+        attn = layer.self_attn
+        attn.rel_proj = (
+            mx.random.normal(attn.rel_proj.shape).astype(attn.rel_proj.dtype) * 0.05
+        )
+        if hasattr(layer.mlp, "gate_weight"):
+            layer.mlp.gate_weight = (
+                mx.random.normal(layer.mlp.gate_weight.shape) * 0.05
+            )
+    mx.eval(model.parameters())
+    return model
+
+
+def test_tiny_model_single_forward(applied):
+    model = _tiny_language_model()
+    cache = model.make_cache()
+    tokens = mx.array([[1, 5, 9, 13, 17]])
+    out = model(tokens, cache=cache)
+    assert out.logits.shape == (1, 5, 128)
+    step = model(mx.array([[21]]), cache=cache)
+    assert step.logits.shape == (1, 1, 128)
+    kv_state = cache[0][0].state
+    assert kv_state[0].shape[2] == 6
+    conv_slots = list(cache[0][1].state)
+    assert len(conv_slots) == 4
+    assert all(s is not None for s in conv_slots)
+
+
+def test_dense_intermediate_size_required(applied):
+    from mlx_vlm.models.inkling.language import LanguageModel
+
+    config = _tiny_text_config()
+    config.dense_intermediate_size = None
+    with pytest.raises(ValueError, match="dense_intermediate_size"):
+        LanguageModel(config)
+
+
+def test_batched_right_padded_prefill_parity(applied):
+    """G2: a short request prefILLED inside a right-padded batch must end
+    with the same conv states and next-token logits as the same request
+    run alone. Without the vendored conv_mask / lengths-aware state /
+    key-masking wiring, the pad rows pollute the short-conv states and
+    the attention keys."""
+    from mlx_lm.models.cache import CacheList
+
+    model = _tiny_language_model()
+
+    tokens_a = [3, 17, 44, 91, 12, 7, 63]  # length 7
+    tokens_b = [8, 22, 5, 99, 41, 33, 27, 54, 76, 11, 90, 2]  # length 12
+    la, lb = len(tokens_a), len(tokens_b)
+
+    # Single-request reference for A.
+    cache_a = model.make_cache()
+    logits_a = model(mx.array([tokens_a]), cache=cache_a).logits
+    mx.eval(logits_a)
+
+    # Batched: merge fresh per-request caches (the BatchGenerator path),
+    # right-pad, chunked prefill, finalize.
+    cache_1 = model.make_cache()
+    cache_2 = model.make_cache()
+    merged = [
+        CacheList.merge([c1, c2]) for c1, c2 in zip(cache_1, cache_2)
+    ]
+    padded = [tokens_a + [0] * (lb - la), tokens_b]
+    for c in merged:
+        c.prepare(lengths=[la, lb], right_padding=[lb - la, 0])
+
+    chunk = 5
+    batch_tokens = mx.array(padded)
+    logits_chunks = []
+    for start in range(0, lb, chunk):
+        out = model(batch_tokens[:, start : start + chunk], cache=merged)
+        logits_chunks.append(out.logits)
+    logits_batch = mx.concatenate(logits_chunks, axis=1)
+    for c in merged:
+        c.finalize()
+    mx.eval(logits_batch)
+
+    # Conv states of A inside the batch == single-run states.
+    for layer_idx in range(2):
+        batch_conv = merged[layer_idx][1]
+        single_conv = cache_a[layer_idx][1]
+        for slot in range(4):
+            got = batch_conv[slot][0:1]
+            want = single_conv[slot]
+            assert mx.max(mx.abs(got - want)).item() < 1e-4, (
+                f"layer {layer_idx} conv slot {slot} diverged in batch "
+                "(pad pollution)"
+            )
+
+    # Last valid-token logits of A == single-run logits.
+    diff = mx.max(
+        mx.abs(logits_batch[0, la - 1] - logits_a[0, -1])
+    ).item()
+    assert diff < 1e-3, f"prefill logits diverged: {diff}"
+
+    # One decode step: exercises left_padding key masking + per-seq tau.
+    step_a = model(mx.array([[100]]), cache=cache_a).logits
+    step_batch = model(mx.array([[100], [101]]), cache=merged).logits
+    mx.eval(step_a, step_batch)
+    diff = mx.max(mx.abs(step_batch[0, 0] - step_a[0, 0])).item()
+    assert diff < 1e-3, f"decode logits diverged: {diff}"
+
+
+def test_sanitize_maps_bf16_checkpoint_keys(applied):
+    """The vendored sanitize must cover the bf16 original repo's key
+    layout: attn projections, sconv transpose, router bias, and the
+    interleaved w13 expert de-interleave."""
+    import importlib
+
+    inkling_mod = importlib.import_module("mlx_vlm.models.inkling.inkling")
+
+    model = inkling_mod.Model.__new__(inkling_mod.Model)  # sanitize is pure
+
+    hidden, inter, n_experts = 8, 4, 2
+    w13 = mx.arange(n_experts * 2 * inter * hidden, dtype=mx.float32).reshape(
+        n_experts, 2 * inter, hidden
+    )
+    w2 = mx.ones((n_experts, hidden, inter))
+    sconv = mx.arange(hidden * 4, dtype=mx.float32).reshape(hidden, 4, 1)
+    weights = {
+        "model.llm.layers.1.attn.wq_du.weight": mx.zeros((hidden, hidden)),
+        "model.llm.layers.1.attn.rel_logits_proj.proj": mx.zeros((4, 8)),
+        "model.llm.layers.1.attn.k_sconv.weight": sconv,
+        "model.llm.layers.1.attn_sconv.weight": sconv,
+        "model.llm.layers.1.mlp.gate.weight": mx.zeros((n_experts + 1, hidden)),
+        "model.llm.layers.1.mlp.gate.bias": mx.zeros((n_experts,)),
+        "model.llm.layers.1.mlp.gate.global_scale": mx.ones((1,)),
+        "model.llm.layers.1.mlp.experts.w13_weight": w13,
+        "model.llm.layers.1.mlp.experts.w2_weight": w2,
+        "model.llm.embed.weight": mx.zeros((16, hidden)),
+        "model.llm.unembed.weight": mx.zeros((16, hidden)),
+        "model.mtp.layers.0.input_proj.weight": mx.zeros((4, 4)),
+    }
+    out = inkling_mod.Model.sanitize(model, weights)
+
+    prefix = "language_model.model.layers.1."
+    assert prefix + "self_attn.q_proj.weight" in out
+    assert prefix + "self_attn.rel_proj" in out
+    assert out[prefix + "self_attn.k_sconv.conv.weight"].shape == (hidden, 1, 4)
+    assert out[prefix + "attn_sconv.conv.weight"].shape == (hidden, 1, 4)
+    assert prefix + "mlp.gate_weight" in out
+    assert prefix + "mlp.e_score_correction_bias" in out
+    assert prefix + "mlp.global_scale" in out
+    assert "language_model.model.embed_tokens.weight" in out
+    assert "language_model.lm_head.weight" in out
+    assert not any(".mtp" in k for k in out)
+
+    gate = out[prefix + "mlp.switch_mlp.gate_proj.weight"]
+    up = out[prefix + "mlp.switch_mlp.up_proj.weight"]
+    assert gate.shape == (n_experts, inter, hidden)
+    # w13 rows interleave gate/up: gate = rows 0,2,4..., up = rows 1,3,5...
+    ref = w13.reshape(n_experts, inter, 2, hidden)
+    assert mx.array_equal(gate, ref[:, :, 0, :])
+    assert mx.array_equal(up, ref[:, :, 1, :])
+    assert mx.array_equal(out[prefix + "mlp.switch_mlp.down_proj.weight"], w2)
+    # bf16 path synthesizes identity per-expert scales.
+    assert mx.array_equal(
+        out[prefix + "mlp.switch_mlp.gate_scale"], mx.ones((n_experts,))
+    )
+
+
+def test_sliding_window_slice_parity(applied, monkeypatch):
+    """Slicing sliding-layer K/V to the window must match full-sequence
+    SDPA (masked keys contribute exactly zero after softmax)."""
+    import importlib
+
+    language = importlib.import_module("mlx_vlm.models.inkling.language")
+    model = _tiny_language_model()
+    # window (sliding_window_size=8) well exceeded by prompt + decode.
+    tokens = [(i * 37 + 11) % 128 for i in range(24)]
+
+    def run():
+        cache = model.make_cache()
+        logits = [model(mx.array([tokens]), cache=cache).logits[:, -1]]
+        for step in range(4):
+            logits.append(model(mx.array([[step + 1]]), cache=cache).logits[:, -1])
+        out = mx.concatenate(logits, axis=0)
+        mx.eval(out)
+        return out
+
+    monkeypatch.setattr(language, "_SLIDING_WINDOW_SLICE", False)
+    reference = run()
+    monkeypatch.setattr(language, "_SLIDING_WINDOW_SLICE", True)
+    sliced = run()
+
+    diff = mx.max(mx.abs(reference - sliced)).item()
+    assert diff < 2e-5, f"sliding-window slice diverged: {diff}"
+
+
+def test_attention_bias_transient_registration():
+    """The banded-mask transient must be priced into the SDPA estimate
+    when registered, and cleared registrations must restore the base
+    estimate (process-wide registry across model swaps)."""
+    from omlx.memory_monitor import (
+        MemoryMonitor,
+        register_attention_bias_transient,
+    )
+
+    monitor = MemoryMonitor.__new__(MemoryMonitor)
+    monitor._head_dim = 128
+    monitor._num_attention_heads = 32
+    monitor._num_kv_heads = 8
+    monitor._score_dtype_size = 2
+
+    try:
+        register_attention_bias_transient(None)
+        base = monitor._estimate_sdpa_activation_bytes(2048, 65536)
+        register_attention_bias_transient(2)
+        with_bias = monitor._estimate_sdpa_activation_bytes(2048, 65536)
+        assert with_bias - base == 32 * 2048 * 65536 * 2
+    finally:
+        register_attention_bias_transient(None)
+    assert monitor._estimate_sdpa_activation_bytes(2048, 65536) == base

--- a/tests/test_mlx_vlm_inkling_compat.py
+++ b/tests/test_mlx_vlm_inkling_compat.py
@@ -321,7 +321,10 @@ def test_sanitize_maps_bf16_checkpoint_keys(applied):
     assert prefix + "mlp.global_scale" in out
     assert "language_model.model.embed_tokens.weight" in out
     assert "language_model.lm_head.weight" in out
-    assert not any(".mtp" in k for k in out)
+    # Raw mtp keys never leak; with the Lightning MTP hook installed
+    # (process-wide once any MTP-aware sanitize ran) they map to
+    # language_model.mtp.*, otherwise they are dropped.
+    assert not any(k.startswith("model.mtp") for k in out)
 
     gate = out[prefix + "mlp.switch_mlp.gate_proj.weight"]
     up = out[prefix + "mlp.switch_mlp.up_proj.weight"]

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -365,6 +365,18 @@ class TestDetectModelType:
         (tmp_path / "config.json").write_text(json.dumps(config))
         assert detect_model_type(tmp_path) == "vlm"
 
+    def test_detect_inkling_as_vlm(self, tmp_path):
+        """Inkling Small (thinkingmachines) is served by mlx-vlm."""
+        config = {
+            "model_type": "inkling_mm_model",
+            "architectures": ["InklingForConditionalGeneration"],
+            "vision_config": {"patch_size": 40},
+            "audio_config": {"n_mel_bins": 80},
+            "text_config": {"hidden_size": 4096},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "vlm"
+
     def test_detect_minimax_m3_vl_as_vlm(self, tmp_path):
         """MiniMax M3 VL is served by mlx-vlm."""
         config = {

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -5629,3 +5629,365 @@ class TestCalibrationFootprint:
         }
 
         assert _calibration_footprint_bytes(index, 100, config) == 400
+
+
+# =============================================================================
+# Inkling (Thinking Machines) support
+# =============================================================================
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestInklingQuantPredicate:
+    """Predicate behavior on inkling's sanitized tensor names."""
+
+    @pytest.fixture
+    def inkling_config(self):
+        return {
+            "model_type": "inkling_mm_model",
+            "vision_config": {"patch_size": 40},
+            "audio_config": {"n_mel_bins": 80},
+            "text_config": {
+                "hidden_size": 4096,
+                "num_hidden_layers": 42,
+                "n_routed_experts": 256,
+            },
+        }
+
+    @pytest.fixture
+    def module(self):
+        return MagicMock(spec=[])
+
+    def test_sconv_conv_weights_skipped(self, inkling_config, module):
+        # nn.Conv1d has no to_quantized(); a quantized emission would break
+        # the mlx-vlm load-time class_predicate.
+        for name in (
+            "language_model.model.layers.3.self_attn.k_sconv.conv.weight",
+            "language_model.model.layers.3.self_attn.v_sconv.conv.weight",
+            "language_model.model.layers.3.attn_sconv.conv.weight",
+            "language_model.model.layers.3.mlp_sconv.conv.weight",
+        ):
+            assert (
+                universal_quant_predicate(name, module, inkling_config) is False
+            ), name
+
+    def test_routed_experts_quantized(self, inkling_config, module):
+        result = universal_quant_predicate(
+            "language_model.model.layers.3.mlp.switch_mlp.gate_proj.weight",
+            module,
+            inkling_config,
+        )
+        assert result is not False
+
+    def test_shared_experts_q8(self, inkling_config, module):
+        result = universal_quant_predicate(
+            "language_model.model.layers.3.mlp.shared_experts.gate_proj.weight",
+            module,
+            inkling_config,
+        )
+        assert isinstance(result, dict) and result["bits"] == 8
+
+    def test_towers_skipped(self, inkling_config, module):
+        assert (
+            universal_quant_predicate(
+                "vision_tower.encoder_layers.0.projection.weight",
+                module,
+                inkling_config,
+            )
+            is False
+        )
+        assert (
+            universal_quant_predicate(
+                "audio_tower.embed_audio_tokens.weight", module, inkling_config
+            )
+            is False
+        )
+
+    def test_router_and_scales_not_tensor_candidates(self):
+        # gate_weight / rel_proj / gate_scale lack the ".weight" suffix and
+        # never reach the predicate.
+        assert not _should_quantize_tensor(
+            "language_model.model.layers.3.mlp.gate_weight", (258, 4096)
+        )
+        assert not _should_quantize_tensor(
+            "language_model.model.layers.3.self_attn.rel_proj", (16, 1024)
+        )
+        assert not _should_quantize_tensor(
+            "language_model.model.layers.3.mlp.switch_mlp.gate_scale", (256,)
+        )
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestInklingSanitizeDiscovery:
+    """The vendored inkling sanitize must be replayable by the streaming
+    sanitize-plan discovery (expert buffering + interleaved w13 split +
+    synthesized identity scales + sconv transpose)."""
+
+    def _plan(self, tmp_path):
+        import importlib
+
+        from omlx.patches.mlx_vlm_inkling_compat import (
+            apply_mlx_vlm_inkling_compat_patch,
+        )
+
+        apply_mlx_vlm_inkling_compat_patch()
+        inkling_mod = importlib.import_module("mlx_vlm.models.inkling.inkling")
+        model = inkling_mod.Model.__new__(inkling_mod.Model)
+
+        hidden, inter, n_experts = 8, 4, 2
+        tensors = {
+            "model.llm.layers.1.mlp.experts.w13_weight": np.zeros(
+                (n_experts, 2 * inter, hidden), dtype=np.float16
+            ),
+            "model.llm.layers.1.mlp.experts.w2_weight": np.zeros(
+                (n_experts, hidden, inter), dtype=np.float16
+            ),
+            "model.llm.layers.1.mlp.shared_experts.shared_w13_weight": np.zeros(
+                (2 * inter, hidden), dtype=np.float16
+            ),
+            "model.llm.layers.1.mlp.gate.weight": np.zeros(
+                (n_experts + 1, hidden), dtype=np.float16
+            ),
+            "model.llm.layers.1.attn.wq_du.weight": np.zeros(
+                (hidden, hidden), dtype=np.float16
+            ),
+            "model.llm.layers.1.attn.k_sconv.weight": np.zeros(
+                (hidden, 4, 1), dtype=np.float16
+            ),
+            "model.llm.embed.weight": np.zeros((16, hidden), dtype=np.float16),
+            "model.mtp.layers.0.input_proj.weight": np.zeros(
+                (4, 4), dtype=np.float16
+            ),
+        }
+        path = tmp_path / "weights.safetensors"
+        _write_safetensors(str(path), tensors)
+        idx = _LazyTensorIndex([str(path)])
+
+        def sanitize_fn(weights):
+            return inkling_mod.Model.sanitize(model, weights)
+
+        return _discover_sanitize_plan(sanitize_fn, idx)
+
+    def test_plan_is_replayable(self, tmp_path):
+        plan = self._plan(tmp_path)
+        assert plan is not None
+
+        prefix = "language_model.model.layers.1."
+        gate = plan[prefix + "mlp.switch_mlp.gate_proj.weight"]
+        assert gate["sources"] == ["model.llm.layers.1.mlp.experts.w13_weight"]
+        assert tuple(gate["shape"]) == (2, 4, 8)
+
+        down = plan[prefix + "mlp.switch_mlp.down_proj.weight"]
+        assert down["transform"] == "passthrough"
+
+        # Synthesized identity scales become literal plan entries.
+        assert plan[prefix + "mlp.switch_mlp.gate_scale"]["transform"] == "literal"
+        assert plan[prefix + "mlp.switch_mlp.out_scale"]["transform"] == "literal"
+
+        sconv = plan[prefix + "self_attn.k_sconv.conv.weight"]
+        assert tuple(sconv["shape"]) == (8, 1, 4)
+
+        assert plan["language_model.model.embed_tokens.weight"]["transform"] == (
+            "passthrough"
+        )
+        # MTP weights are dropped by sanitize.
+        assert not any(".mtp" in k for k in plan)
+
+    def test_plan_materializes_interleaved_split(self, tmp_path):
+        """Replaying the discovered plan must reproduce the de-interleave
+        exactly (gate = even rows, up = odd rows of w13)."""
+        import importlib
+
+        from omlx.patches.mlx_vlm_inkling_compat import (
+            apply_mlx_vlm_inkling_compat_patch,
+        )
+
+        apply_mlx_vlm_inkling_compat_patch()
+        inkling_mod = importlib.import_module("mlx_vlm.models.inkling.inkling")
+        model = inkling_mod.Model.__new__(inkling_mod.Model)
+
+        hidden, inter, n_experts = 8, 4, 2
+        w13 = (
+            np.arange(n_experts * 2 * inter * hidden)
+            .reshape(n_experts, 2 * inter, hidden)
+            .astype(np.float16)
+        )
+        tensors = {
+            "model.llm.layers.1.mlp.experts.w13_weight": w13,
+            "model.llm.layers.1.mlp.experts.w2_weight": np.ones(
+                (n_experts, hidden, inter), dtype=np.float16
+            ),
+        }
+        path = tmp_path / "weights.safetensors"
+        _write_safetensors(str(path), tensors)
+        idx = _LazyTensorIndex([str(path)])
+
+        def sanitize_fn(weights):
+            return inkling_mod.Model.sanitize(model, weights)
+
+        plan = _discover_sanitize_plan(sanitize_fn, idx)
+        materialized = _DiscoveredPlan(plan, idx)
+
+        prefix = "language_model.model.layers.1.mlp.switch_mlp."
+        gate = np.asarray(materialized.pop(prefix + "gate_proj.weight"))
+        up = np.asarray(materialized.pop(prefix + "up_proj.weight"))
+        ref = w13.reshape(n_experts, inter, 2, hidden)
+        np.testing.assert_array_equal(gate, ref[:, :, 0, :])
+        np.testing.assert_array_equal(up, ref[:, :, 1, :])
+        scale = np.asarray(materialized.pop(prefix + "gate_scale"))
+        np.testing.assert_array_equal(scale, np.ones(n_experts, dtype=np.float32))
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestInklingLayerWalk:
+    """Calibration layer-walk wiring for inkling."""
+
+    def _model(self):
+        import importlib
+
+        from omlx.patches.mlx_vlm_inkling_compat import (
+            apply_mlx_vlm_inkling_compat_patch,
+        )
+
+        apply_mlx_vlm_inkling_compat_patch()
+        compat = importlib.import_module("tests.test_mlx_vlm_inkling_compat")
+        return compat._tiny_language_model()
+
+    def test_prepare_layer_inputs_uses_inkling_branch(self):
+        from types import SimpleNamespace
+
+        from omlx.oq import _prepare_layer_inputs
+
+        lm = self._model()
+        wrapper = SimpleNamespace(model_type="inkling_mm_model")
+        inputs = mx.random.normal((1, 6, 32))
+        calib = mx.zeros((1, 6), dtype=mx.int32)
+        out_inputs, masks, state = _prepare_layer_inputs(
+            wrapper, lm.model.layers, calib, inputs
+        )
+        assert out_inputs is inputs
+        assert masks == [None, None]
+        assert isinstance(state, dict) and state.get("kind") == "inkling"
+
+    def test_forward_layer_result_runs_block(self):
+        from omlx.oq import _forward_layer_result
+
+        lm = self._model()
+        inputs = mx.random.normal((1, 6, 32))
+        out, aux = _forward_layer_result(
+            lm.model.layers[0], inputs, None, {"kind": "inkling"}
+        )
+        assert out is not None
+        assert out.shape == (1, 6, 32)
+
+    def test_find_model_layers_routes_through_embed_norm(self):
+        from types import SimpleNamespace
+
+        from omlx.oq import _find_model_layers
+
+        lm = self._model()
+        vlm = SimpleNamespace(language_model=lm)
+        embed_fn, layers = _find_model_layers(vlm)
+        assert layers is lm.model.layers
+        # use_embed_norm=True checkpoints must calibrate through
+        # InklingModel.embed(), not raw embed_tokens.
+        assert embed_fn == lm.model.embed
+        tokens = mx.array([[1, 2, 3]])
+        normed = embed_fn(tokens)
+        raw = lm.model.embed_tokens(tokens)
+        assert float(mx.max(mx.abs(normed - raw))) > 0.0
+
+    def test_oqe_capture_matches_vendored_switch_children(self):
+        from omlx.oq import _OQE_SWITCH_LINEAR_CLASSES
+
+        lm = self._model()
+        sparse = lm.model.layers[1].mlp
+        assert type(sparse.switch_mlp.gate_proj).__name__ in (
+            _OQE_SWITCH_LINEAR_CLASSES
+        )
+        assert type(sparse.shared_experts.down_proj).__name__ in (
+            _OQE_SWITCH_LINEAR_CLASSES
+        )
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestInklingModelSanitizer:
+    def test_vlm_sanitize_chain_handles_helper_methods(self):
+        """The oQ VLM sanitize chain runs Model.sanitize on a _Proxy, and
+        inkling's sanitize calls sibling instance methods — the proxy must
+        resolve them from the model class (regression: proxy AttributeError
+        aborted proxy builds for sensitivity/imatrix)."""
+        from omlx.oq import _build_model_sanitizer
+
+        config = {
+            "model_type": "inkling_mm_model",
+            "architectures": ["InklingForConditionalGeneration"],
+            "vision_config": {"patch_size": 40},
+            "audio_config": {"n_mel_bins": 80},
+            "text_config": {"hidden_size": 8, "num_hidden_layers": 2},
+        }
+        sanitize_fn = _build_model_sanitizer(config)
+        assert sanitize_fn is not None
+
+        hidden, inter, n_experts = 8, 4, 2
+        weights = {
+            "model.llm.layers.1.mlp.experts.w13_weight": mx.zeros(
+                (n_experts, 2 * inter, hidden)
+            ),
+            "model.llm.layers.1.mlp.experts.w2_weight": mx.zeros(
+                (n_experts, hidden, inter)
+            ),
+            "model.llm.layers.1.attn.wq_du.weight": mx.zeros((hidden, hidden)),
+            "model.llm.embed.weight": mx.zeros((16, hidden)),
+        }
+        out = sanitize_fn(weights)
+        prefix = "language_model.model.layers.1."
+        assert prefix + "mlp.switch_mlp.gate_proj.weight" in out
+        assert prefix + "self_attn.q_proj.weight" in out
+        assert "language_model.model.embed_tokens.weight" in out
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestEstimateBpwPostSanitizeNames:
+    def test_inkling_style_fused_source_names_are_priced(self, tmp_path):
+        """Source names without a .weight suffix (experts.w13_weight) must
+        be priced through the sanitize plan — the raw scan treated ~97% of
+        an inkling checkpoint as fp16 passthrough (15.8 bpw)."""
+        from omlx.patches.mlx_vlm_inkling_compat import (
+            apply_mlx_vlm_inkling_compat_patch,
+        )
+
+        apply_mlx_vlm_inkling_compat_patch()
+
+        src = tmp_path / "Inkling-Tiny"
+        src.mkdir()
+        hidden, inter, n_experts = 64, 64, 4
+        tensors = {
+            "model.llm.layers.1.mlp.experts.w13_weight": np.zeros(
+                (n_experts, 2 * inter, hidden), dtype=np.float16
+            ),
+            "model.llm.layers.1.mlp.experts.w2_weight": np.zeros(
+                (n_experts, hidden, inter), dtype=np.float16
+            ),
+            "model.llm.embed.weight": np.zeros((256, hidden), dtype=np.float16),
+        }
+        _write_safetensors(str(src / "weights.safetensors"), tensors)
+        (src / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "inkling_mm_model",
+                    "architectures": ["InklingForConditionalGeneration"],
+                    "vision_config": {"patch_size": 40},
+                    "audio_config": {"n_mel_bins": 80},
+                    "text_config": {
+                        "hidden_size": hidden,
+                        "num_hidden_layers": 2,
+                        "n_routed_experts": n_experts,
+                    },
+                }
+            )
+        )
+
+        est = estimate_bpw_and_size(str(src), 4)
+        # Experts dominate the parameter count; a raw-name scan reports
+        # ~15-16 bpw because none of them end in ".weight".
+        assert est["effective_bpw"] < 8.0, est

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -5789,8 +5789,10 @@ class TestInklingSanitizeDiscovery:
         assert plan["language_model.model.embed_tokens.weight"]["transform"] == (
             "passthrough"
         )
-        # MTP weights are dropped by sanitize.
-        assert not any(".mtp" in k for k in plan)
+        # MTP keys are either dropped (no Lightning MTP hook installed) or
+        # mapped to language_model.mtp.* (hook active, process-wide once any
+        # MTP-aware sanitize ran); raw model.mtp.* names must never leak.
+        assert not any(k.startswith("model.mtp") for k in plan)
 
     def test_plan_materializes_interleaved_split(self, tmp_path):
         """Replaying the discovered plan must reproduce the de-interleave

--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -833,3 +833,132 @@ class TestOutputParserFactory:
         thinking, content = extract_thinking(output_text)
         assert thinking == "Let me think about this"
         assert content == "Four"
+
+
+class InklingTokenizer:
+    def __init__(self, token_map: dict[int, str]):
+        self._token_map = token_map
+        self._reverse = {v: k for k, v in token_map.items()}
+
+    def convert_tokens_to_ids(self, token: str) -> int | None:
+        return self._reverse.get(token)
+
+    def encode(self, text: str, add_special_tokens: bool = False):
+        return [self._reverse[text]] if text in self._reverse else [0, 1]
+
+    def decode(self, token_ids, skip_special_tokens: bool = True):
+        return "".join(self._token_map[token_id] for token_id in token_ids)
+
+    @property
+    def detokenizer(self):
+        return FakeDetokenizer(lambda token_id: self._token_map[token_id])
+
+
+class TestInklingOutputParserSession:
+    def _factory(self, token_map):
+        tokenizer = InklingTokenizer(token_map)
+        factory = detect_output_parser(
+            "inkling-small",
+            tokenizer,
+            {"model_type": "inkling_mm_model"},
+        )
+        assert factory is not None
+        assert factory.kind == "inkling"
+        return tokenizer, factory
+
+    def _run(self, session, token_ids):
+        stream, visible, stopped = [], [], False
+        for token_id in token_ids:
+            result = session.process_token(token_id)
+            stream.append(result.stream_text)
+            visible.append(result.visible_text)
+            if result.is_stop:
+                stopped = True
+                break
+        final = session.finalize()
+        stream.append(final.stream_text)
+        visible.append(final.visible_text)
+        return "".join(stream), "".join(visible), stopped, final
+
+    def test_thinking_then_text(self):
+        token_map = {
+            1: "<|content_thinking|>",
+            2: "let me ",
+            3: "reason",
+            4: "<|end_message|>",
+            5: "<|message_model|>",
+            6: "<|content_text|>",
+            7: "Answer",
+            8: "<|content_model_end_sampling|>",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        stream, visible, stopped, final = self._run(session, [1, 2, 3, 4, 5, 6, 7, 8])
+
+        assert stream == "<think>let me reason</think>Answer"
+        assert visible == stream
+        assert stopped
+        assert final.tool_calls == []
+        assert 8 in factory.stop_token_ids
+
+    def test_tool_call_suppressed_and_parsed(self):
+        token_map = {
+            1: "<|content_thinking|>",
+            2: "need weather",
+            3: "<|end_message|>",
+            4: "<|message_model|>",
+            5: "get_weather",
+            6: "<|content_invoke_tool_json|>",
+            7: '{"name":"get_weather","args":{"city":"Seoul"}}',
+            8: "<|end_message|>",
+            9: "<|content_model_end_sampling|>",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        stream, visible, stopped, final = self._run(
+            session, [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        )
+
+        assert stream == "<think>need weather</think>"
+        assert visible == stream
+        assert stopped
+        assert len(final.tool_calls) == 1
+        assert final.tool_calls[0]["name"] == "get_weather"
+        assert json.loads(final.tool_calls[0]["arguments"]) == {"city": "Seoul"}
+        assert final.finish_reason == "tool_calls"
+
+    def test_partial_marker_across_tokens(self):
+        token_map = {
+            1: "<|content_",
+            2: "text|>an",
+            3: "swer<|end_",
+            4: "message|>",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        stream, visible, stopped, final = self._run(session, [1, 2, 3, 4])
+
+        assert visible == "answer"
+        assert "<|content_text|>" not in stream
+        assert not stopped
+
+    def test_unterminated_thinking_closed_at_finalize(self):
+        token_map = {
+            1: "<|content_thinking|>",
+            2: "half a thought",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        stream, visible, stopped, final = self._run(session, [1, 2])
+
+        assert stream == "<think>half a thought</think>"
+        assert visible == stream
+
+    def test_non_inkling_models_unaffected(self):
+        tokenizer = InklingTokenizer({0: "a", 1: "b"})
+        factory = detect_output_parser(
+            "llama-3-8b",
+            tokenizer,
+            {"model_type": "llama"},
+        )
+        assert factory is None

--- a/tests/test_prefix_cache_cachelist_mixed.py
+++ b/tests/test_prefix_cache_cachelist_mixed.py
@@ -1,0 +1,450 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Mixed CacheList(KVCache, ArraysCache) prefix/SSD round-trip guards.
+
+Inkling-style models return ``CacheList(KVCache(), ArraysCache(4))`` for
+every layer (hybrid attention + 4 short-conv slots). The store path
+decides slicing per LAYER: ``all_sub_sliceable`` is False whenever any
+sub-state's first element is not 4D (ArraysCache conv state is 3D), so
+every block stores the FULL cumulative state of ALL subs at that block's
+boundary (from boundary snapshots). The restore path decides per SUB:
+only ArraysCache/Pooling/rotating subs take the last block, while a
+KVCache sub is concatenated across blocks as if the blocks held per-block
+slices. Concatenating cumulative snapshots duplicates the KV sequence
+(4+8+12 tokens instead of 12) and corrupts positions.
+
+Existing CacheList users never hit this: GLM/deepseek_v32/longcat are
+KVCache+KVCache (all_sub_sliceable=True, real per-block slices stored),
+DeepSeek-V4 is RotatingKVCache+PoolingCache (every sub takes last block).
+qwen3.5/3.6 mix ArraysCache and KVCache at the LAYER level (bare caches,
+no CacheList), which routes per-layer handlers and never enters the
+CacheList branch.
+
+These tests build production-shaped layer dicts (via CacheListHandler
+extract, matching scheduler._extract_cache_states output — note: no
+top-level ``sub_class_names`` key) and round-trip them through a real
+hot-cache-only PagedSSDCacheManager.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from omlx.cache.paged_cache import BlockTable, PagedCacheManager
+from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
+from omlx.cache.prefix_cache import BlockAwarePrefixCache
+from omlx.cache.type_registry import CacheTypeRegistry
+
+try:
+    import mlx.core as mx
+    from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+
+BLOCK_SIZE = 4
+NUM_LAYERS = 1
+# Inkling conv slots: k/v sconv operate on n_kv*head_dim channels,
+# attn/mlp sconv on hidden — per-slot channel counts differ.
+CONV_CHANNELS = (16, 16, 32, 32)
+
+
+class MockModel:
+    def __init__(self, num_layers: int = NUM_LAYERS):
+        self._num_layers = num_layers
+        self.layers = [MagicMock() for _ in range(num_layers)]
+
+    @property
+    def args(self):
+        a = MagicMock()
+        a.num_hidden_layers = self._num_layers
+        return a
+
+
+def _make_cache(tmp_path):
+    """A prefix cache wired to a real hot-cache-only SSD manager."""
+    paged_cache = PagedCacheManager(
+        block_size=BLOCK_SIZE,
+        max_blocks=100,
+        model_name="test-model",
+        initial_blocks=100,
+    )
+    ssd = PagedSSDCacheManager(
+        cache_dir=tmp_path / "ssd_cache",
+        max_size_bytes=100 * 1024**2,
+        hot_cache_max_bytes=10 * 1024**2,
+        hot_cache_only=True,
+        expected_model_name="test-model",
+    )
+    cache = BlockAwarePrefixCache(
+        model=MockModel(),
+        paged_cache_manager=paged_cache,
+        paged_ssd_cache_manager=ssd,
+    )
+    return cache, ssd
+
+
+def _position_kv(seq_len):
+    """KV tensors whose value at position p equals p — duplication shows."""
+    pos = mx.arange(seq_len, dtype=mx.float32).reshape(1, 1, seq_len, 1)
+    keys = mx.broadcast_to(pos, (1, 2, seq_len, 8))
+    values = keys + 1000.0
+    return mx.contiguous(keys), mx.contiguous(values)
+
+
+def _build_mixed_cachelist(seq_len, none_slots=()):
+    """A real CacheList(KVCache, ArraysCache(4)) advanced to seq_len tokens.
+
+    Conv slot i is filled with ``seq_len + i / 10`` so each boundary's
+    snapshot is distinguishable; slots listed in none_slots stay None.
+    """
+    kv = KVCache()
+    keys, values = _position_kv(seq_len)
+    kv.update_and_fetch(keys, values)
+
+    arrays = ArraysCache(size=4)
+    for i, channels in enumerate(CONV_CHANNELS):
+        if i in none_slots:
+            continue
+        arrays[i] = mx.full((1, 3, channels), seq_len + i / 10.0, dtype=mx.float32)
+
+    cache_list = CacheList(kv, arrays)
+    mx.eval([t for t in [keys, values] + list(arrays.cache) if t is not None])
+    return cache_list
+
+
+def _layer_dict(cache_list):
+    """Production-shaped layer dict (scheduler._extract_cache_states)."""
+    handler = CacheTypeRegistry.get_handler_by_class_name("CacheList")
+    state_dict = handler.extract_state(cache_list)
+    return {
+        "state": list(state_dict["sub_states"]),
+        "meta_state": (
+            list(state_dict["sub_class_names"]),
+            list(state_dict["sub_meta_states"]),
+        ),
+        "class_name": "CacheList",
+        "cache_type": "CacheList",
+    }
+
+
+def _cache_data(seq_len, none_slots=()):
+    return [_layer_dict(_build_mixed_cachelist(seq_len, none_slots))]
+
+
+def _store_blocks(cache, num_blocks, request_id="req-mixed"):
+    """Store num_blocks blocks with cumulative boundary snapshots."""
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    boundary_snapshots = {
+        BLOCK_SIZE * (i + 1): _cache_data(BLOCK_SIZE * (i + 1))
+        for i in range(num_blocks)
+    }
+    table = cache.store_cache(
+        request_id,
+        tokens,
+        _cache_data(len(tokens)),
+        boundary_snapshots=boundary_snapshots,
+    )
+    return table
+
+
+def _assert_restored(result, expected_seq_len):
+    """Restored layer must be a CacheList holding exactly expected_seq_len
+    KV tokens (position-encoded) and the conv snapshot of that boundary."""
+    assert result is not None
+    assert len(result) == NUM_LAYERS
+    restored = result[0]
+    assert type(restored).__name__ == "CacheList"
+    sub_caches = list(restored.caches)
+    assert len(sub_caches) == 2
+
+    kv = sub_caches[0]
+    kv_state = kv.state
+    keys = kv_state[0]
+    assert keys.shape[2] == expected_seq_len, (
+        f"restored KV holds {keys.shape[2]} tokens, "
+        f"expected {expected_seq_len} (cumulative-snapshot duplication?)"
+    )
+    expected_keys, expected_values = _position_kv(expected_seq_len)
+    assert mx.max(mx.abs(keys - expected_keys)).item() == 0.0
+    assert mx.max(mx.abs(kv_state[1] - expected_values)).item() == 0.0
+
+    arrays = sub_caches[1]
+    slots = list(arrays.state)
+    assert len(slots) == 4
+    for i, (slot, channels) in enumerate(zip(slots, CONV_CHANNELS)):
+        assert slot is not None
+        assert slot.dtype == mx.float32
+        assert tuple(slot.shape) == (1, 3, channels)
+        assert (
+            mx.max(mx.abs(slot - (expected_seq_len + i / 10.0))).item() == 0.0
+        ), f"conv slot {i} does not match boundary {expected_seq_len} snapshot"
+
+
+def test_single_block_roundtrip(tmp_path):
+    """One block: last-block state stored and restored verbatim."""
+    cache, _ = _make_cache(tmp_path)
+    table = _store_blocks(cache, num_blocks=1, request_id="req-single")
+    assert table is not None
+    assert len(table.block_ids) == 1
+
+    result = cache.reconstruct_cache(table)
+    _assert_restored(result, expected_seq_len=BLOCK_SIZE)
+
+
+def test_multiblock_restore_no_kv_duplication(tmp_path):
+    """G1 core: 3 cumulative-snapshot blocks must restore to the LAST
+    boundary's state (12 tokens), not the concatenation of all three
+    cumulative KV snapshots (4+8+12 = 24 tokens)."""
+    cache, _ = _make_cache(tmp_path)
+    table = _store_blocks(cache, num_blocks=3)
+    assert table is not None
+    assert len(table.block_ids) == 3
+
+    result = cache.reconstruct_cache(table)
+    _assert_restored(result, expected_seq_len=3 * BLOCK_SIZE)
+
+
+def test_partial_prefix_restores_matched_boundary(tmp_path):
+    """Restoring only the first 2 of 3 blocks must yield block 2's
+    cumulative boundary state (8 tokens) for ALL subs."""
+    cache, _ = _make_cache(tmp_path)
+    table = _store_blocks(cache, num_blocks=3, request_id="req-partial")
+    assert table is not None
+    assert len(table.block_ids) == 3
+
+    for bid in table.block_ids[:2]:
+        cache.paged_cache.allocated_blocks[bid].ref_count += 1
+    partial = BlockTable(
+        request_id="req-partial-restore",
+        block_ids=list(table.block_ids[:2]),
+        num_tokens=2 * BLOCK_SIZE,
+    )
+    result = cache.reconstruct_cache(partial)
+    _assert_restored(result, expected_seq_len=2 * BLOCK_SIZE)
+
+
+def test_block_signature_stamps_sub_composition(tmp_path):
+    """Saved mixed-CacheList blocks stamp their sub composition (incl.
+    ArraysCache slot count) into the compatibility signature."""
+    import json
+
+    from omlx.cache.paged_ssd_cache import _signature_cachelist_subtypes
+
+    cache, ssd = _make_cache(tmp_path)
+    table = _store_blocks(cache, num_blocks=1, request_id="req-sig")
+    assert table is not None
+
+    block = cache.paged_cache.allocated_blocks[table.block_ids[0]]
+    _, meta = ssd.load_block_with_metadata(block.block_hash)
+    assert meta is not None
+    subtypes = _signature_cachelist_subtypes(meta.get("cache_signature", ""))
+    assert subtypes == {"0": ["KVCache", "ArraysCache:4"]}
+    # The flat type list stays "CacheList" (dispatch strings unchanged).
+    types = meta["layer_cache_types"]
+    if isinstance(types, str):
+        types = json.loads(types)
+    assert list(types) == ["CacheList"]
+
+
+def test_live_subtypes_descriptor_matches_block_stamp():
+    """cachelist_subtypes_from_cache_list (expectation side) must produce
+    the same descriptor the save path stamps from block payloads."""
+    from omlx.cache.paged_ssd_cache import cachelist_subtypes_from_cache_list
+
+    live = [_build_mixed_cachelist(seq_len=4)]
+    assert cachelist_subtypes_from_cache_list(live) == {
+        "0": ["KVCache", "ArraysCache:4"]
+    }
+    # KVCache-only CacheList layers are not stamped (GLM/deepseek_v32
+    # signatures stay byte-identical to the previous format).
+    assert cachelist_subtypes_from_cache_list([CacheList(KVCache(), KVCache())]) is (
+        None
+    )
+
+
+def test_stale_sub_composition_swept(tmp_path):
+    """A stored block whose ArraysCache slot count disagrees with the live
+    model expectation must be swept, not restored into an IndexError."""
+    cache, ssd = _make_cache(tmp_path)
+    table = _store_blocks(cache, num_blocks=1, request_id="req-stale")
+    assert table is not None
+
+    # Live model now expects 2 conv slots per layer (composition changed).
+    changed = ssd.set_expected_layer_signature(
+        ["CacheList"],
+        cachelist_subtypes={"0": ["KVCache", "ArraysCache:2"]},
+    )
+    assert changed is True
+    # Hot-cache-only managers keep no disk index to sweep; the per-block
+    # signature gate in reconstruct_cache must reject the stale block.
+    ssd.invalidate_stale_layer_signature()
+    assert cache.reconstruct_cache(table) is None
+
+    # Matching expectation keeps blocks restorable.
+    cache2, ssd2 = _make_cache(tmp_path / "match")
+    table2 = _store_blocks(cache2, num_blocks=1, request_id="req-match")
+    changed = ssd2.set_expected_layer_signature(
+        ["CacheList"],
+        cachelist_subtypes={"0": ["KVCache", "ArraysCache:4"]},
+    )
+    assert changed is True
+    assert ssd2.invalidate_stale_layer_signature() == 0
+    _assert_restored(cache2.reconstruct_cache(table2), expected_seq_len=BLOCK_SIZE)
+
+
+def test_prefill_snapshot_decoupled_from_live_cache():
+    """In-memory prefill boundary snapshots must capture the state AT the
+    boundary. Storing the live cache objects aliased every boundary to
+    the prefill's final state (KVCache mutates its buffer in place)."""
+    from types import SimpleNamespace
+
+    from omlx.scheduler import Scheduler
+
+    live = _build_mixed_cachelist(seq_len=BLOCK_SIZE)
+
+    stub = SimpleNamespace(
+        block_aware_cache=object(),
+        config=SimpleNamespace(paged_cache_block_size=BLOCK_SIZE),
+        _cache_list_needs_boundary_snapshot=lambda cache: True,
+        _boundary_cache_snapshots={},
+        _boundary_snapshot_store=None,
+        _boundary_snapshot_required=False,
+        _stream=mx.default_stream(mx.default_device()),
+        _PREFILL_SNAPSHOT_MARKER=Scheduler._PREFILL_SNAPSHOT_MARKER,
+    )
+    stub._extract_cache_states = lambda caches: Scheduler._extract_cache_states(
+        stub, caches
+    )
+    stub._extract_prefill_snapshot_states = (
+        lambda caches: Scheduler._extract_prefill_snapshot_states(stub, caches)
+    )
+    stub._prefill_snapshot_value = lambda caches: Scheduler._prefill_snapshot_value(
+        stub, caches
+    )
+    stub._eval_snapshot_cache = lambda caches: None
+
+    Scheduler._on_prefill_boundary_snapshot(stub, "req-alias", [live], BLOCK_SIZE)
+
+    # Prefill continues: the live cache doubles its sequence and the conv
+    # slots move on.
+    keys, values = _position_kv(BLOCK_SIZE)
+    live.caches[0].update_and_fetch(keys + 100.0, values + 100.0)
+    for i, channels in enumerate(CONV_CHANNELS):
+        live.caches[1][i] = mx.full((1, 3, channels), -1.0, dtype=mx.float32)
+
+    stored = stub._boundary_cache_snapshots["req-alias"][BLOCK_SIZE]
+    assert isinstance(stored, tuple)
+    assert stored[0] == Scheduler._PREFILL_SNAPSHOT_MARKER
+    extracted = stored[1]
+    kv_state = extracted[0]["state"][0]
+    assert kv_state[0].shape[2] == BLOCK_SIZE, (
+        "boundary snapshot follows the live cache (aliasing) — "
+        f"holds {kv_state[0].shape[2]} tokens instead of {BLOCK_SIZE}"
+    )
+    conv_slot0 = extracted[0]["state"][1][0]
+    assert mx.max(mx.abs(conv_slot0 - BLOCK_SIZE)).item() == 0.0
+
+
+def test_boundary_store_mixed_cachelist_roundtrip(tmp_path):
+    """BoundarySnapshotSSDStore round-trips a mixed CacheList layer:
+    nested shape, None conv slots, and fp32 dtype all preserved."""
+    from omlx.cache.boundary_snapshot_store import BoundarySnapshotSSDStore
+
+    store = BoundarySnapshotSSDStore(base_dir=tmp_path)
+
+    keys, values = _position_kv(8)
+    c0 = mx.full((1, 3, 16), 8.0, dtype=mx.float32)
+    c2 = mx.full((1, 3, 32), 8.2, dtype=mx.float32)
+    mx.eval(keys, values, c0, c2)
+
+    extracted = [
+        {
+            "state": [(keys, values), [c0, None, c2, None]],
+            "meta_state": (["KVCache", "ArraysCache"], [("8",), ()]),
+            "class_name": "CacheList",
+            "cache_type": "CacheList",
+        }
+    ]
+    tensors_raw, metadata = store._serialize_extracted(
+        extracted, request_id="req-bss", token_count=8
+    )
+    result = store._deserialize(tensors_raw, metadata)
+    assert result is not None and len(result) == 1
+    state = result[0]["state"]
+    assert isinstance(state, list) and len(state) == 2
+    kv_sub, arrays_sub = state[0], state[1]
+    assert mx.max(mx.abs(kv_sub[0] - keys)).item() == 0.0
+    assert arrays_sub[1] is None and arrays_sub[3] is None
+    assert arrays_sub[0].dtype == mx.float32
+    assert mx.max(mx.abs(arrays_sub[0] - c0)).item() == 0.0
+    assert tuple(arrays_sub[2].shape) == (1, 3, 32)
+
+    # Tensor-less CacheList layer (empty KV + untouched conv slots) is
+    # recorded as state-less instead of a phantom "has_state" entry.
+    empty = [
+        {
+            "state": [(), [None, None, None, None]],
+            "meta_state": (["KVCache", "ArraysCache"], [(), ()]),
+            "class_name": "CacheList",
+            "cache_type": "CacheList",
+        }
+    ]
+    tensors_raw2, metadata2 = store._serialize_extracted(
+        empty, request_id="req-bss-empty", token_count=0
+    )
+    assert not tensors_raw2
+    import json as _json
+
+    info = _json.loads(metadata2["layer_info"])[0]
+    assert info["has_state"] == "false"
+
+    store.shutdown()
+
+
+def test_arrays_cache_extract_none_guard():
+    """Extract from an ArraysCache with untouched (None) slots — the state
+    of a request aborted before its first forward — must not crash.
+    filter/extend/merge already tolerate None slots; extract lacked the
+    guard until the omlx patch."""
+    from omlx.patches.arrays_cache_extract import (
+        apply_arrays_cache_extract_guard,
+    )
+
+    assert apply_arrays_cache_extract_guard() is True
+
+    ac = ArraysCache(size=4)
+    ac[0] = mx.ones((2, 3, 8))
+    out = ac.extract(1)
+    assert out.cache[0].shape == (1, 3, 8)
+    assert out.cache[1] is None
+    assert out.cache[2] is None
+
+    all_none = ArraysCache(size=4).extract(0)
+    assert all(slot is None for slot in all_none.cache)
+
+
+def test_none_conv_slots_roundtrip(tmp_path):
+    """Untouched (None) ArraysCache slots survive the SSD round-trip as
+    None instead of crashing or materializing placeholder tensors."""
+    cache, _ = _make_cache(tmp_path)
+    tokens = list(range(BLOCK_SIZE))
+    table = cache.store_cache(
+        "req-none-slots", tokens, _cache_data(BLOCK_SIZE, none_slots=(1, 3))
+    )
+    assert table is not None
+
+    result = cache.reconstruct_cache(table)
+    assert result is not None
+    restored = result[0]
+    assert type(restored).__name__ == "CacheList"
+    slots = list(restored.caches[1].state)
+    assert slots[1] is None
+    assert slots[3] is None
+    assert slots[0] is not None and slots[2] is not None
+    kv_state = restored.caches[0].state
+    assert kv_state[0].shape[2] == BLOCK_SIZE

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -937,10 +937,16 @@ def test_turboquant_eligible_gate():
     assert elig([KVCache(), ChunkedKVCache(8192)]) is False
     assert elig([KVCache(), RotatingKVCache(32)]) is True
     assert elig([QuantizedKVCache()]) is False
-    assert elig([CacheList(KVCache(), KVCache())]) is True
     assert elig([ArraysCache(size=2), KVCache()]) is True
-    assert elig([CacheList(ArraysCache(size=2), KVCache())]) is True
-    assert elig([CacheList(KVCache(), RotatingKVCache(32))]) is True
+    # A KVCache member inside a CacheList would convert to a TQ cache the
+    # prefix/SSD store paths cannot serialize (layer dispatches on
+    # "CacheList", no TQ sub-state path) — such layers are excluded until
+    # CacheList-level TQ serialization exists. Members without a KVCache
+    # stay eligible (nothing converts, harmless).
+    assert elig([CacheList(KVCache(), KVCache())]) is False
+    assert elig([CacheList(ArraysCache(size=2), KVCache())]) is False
+    assert elig([CacheList(KVCache(), RotatingKVCache(32))]) is False
+    assert elig([CacheList(RotatingKVCache(32))]) is True
 
 
 def test_turboquant_convert_hybrid_cache_keeps_rotating_passthrough():


### PR DESCRIPTION
## Summary

This PR adds Thinking Machines Inkling Small (266B fine-grained MoE, text+vision) to oMLX: serving with full cache subsystem support, oQ/oQe quantization from the bf16 original, kernel-level performance work, and Lightning MTP speculative decoding using the checkpoint's built-in 8-depth MTP head.

## References and acknowledgements

- The vendored model implementation is based on Blaizzy/mlx-vlm#1756 by @pcuenca, which extends the inkling base from Blaizzy/mlx-vlm#1637. Thanks for the port, it saved me a lot of work.
- The MTP cycle semantics follow vllm-project/vllm#48768. The mlx-vlm drafter diverges from it in ways that collapse deep-depth acceptance (only block 0 keeps history), so I followed the vLLM reference instead.

## What's inside

- Vendored inkling model (text+vision) with fixes on top: batched right-padded prefill (conv_mask wiring), sliding-window K/V compute slicing on the 35 sliding layers, native NVFP4 checkpoint loading, and torch-free processors (oMLX pins transformers below 5.13). Audio is not wired yet.
- Mixed CacheList (KVCache + ArraysCache) correctness across prefix cache, SSD cache, and boundary snapshots. Inkling is the first model mixing sliceable and non-sliceable sub-caches inside one layer, which exposed a store/restore mode mismatch and several smaller gaps.
- Output parser for the model's channel format (thinking, tool calls, end-of-sampling stop).
- oQ/oQe: streaming quantization from the 495GB bf16 original with per-expert imatrix sensitivity, producing 141GB at 4.59 bpw effective.
- Lightning MTP runtime for the built-in 8-depth head, plus two cycle-cost fixes it needed: the head's bookkeeping arrays accumulated lazy graphs across cycles (59ms to 8.2ms per depth-4 cycle once materialized), and the banded mask Metal kernel recompiled every time the cache grew because S and the query offset were template constants (now runtime params, which also benefits plain decode).

## Benchmarks

M3 Ultra 512GB, Inkling-Small-oQ4e-mtp.

Baseline (MTP off, cold prefill):

| context | pp tok/s | tg tok/s |
|---|---|---|
| 1k | 655 | 38.7 |
| 4k | 671 | 38.3 |
| 16k | 641 | 35.1 |
| 32k | 555 | 36.4 |

Lightning MTP (decode tok/s, greedy, prefix-cached prompts):

| cell | MTP off | MTP on | speedup |
|---|---|---|---|
| code 4k | 38.3 | 51.4 | 1.34x |
| code 16k | 35.1 | 43.9 | 1.25x |
| story 4k | 38.2 | 48.1 | 1.26x |
| story 16k | 36.4 | 42.5 | 1.17x |

The adaptive depth controller never parks on these workloads; 512-token generations sustain 1.9 to 2.3 accepted tokens per cycle at 58 to 70% draft accept. mtp_enabled stays opt-in per model.

## Verification

Unit tests cover the mixed-cache store/restore paths, the MTP cycle against a one-shot refold oracle, rollback vs sequential decode at 1e-4, and the sanitize mapping. Real-model smokes: prefix re-hit with identical greedy output, SSD eviction/restore, tool calls, and the MTP matrix above.
