### PR TITLE
feat(specprefill): persist static target prefixes

### DIFF
--- a/omlx/cache/observability.py
+++ b/omlx/cache/observability.py
@@ -101,6 +101,10 @@ def _compute_window(
     d_ssd_disk = delta("ssd_disk_loads")
     d_tokens_matched = delta("prefix_tokens_matched")
     d_tokens_requested = delta("prefix_tokens_requested")
+    d_target_static_hits = delta("target_static_hits")
+    d_target_static_misses = delta("target_static_misses")
+    d_draft_prefix_hits = delta("draft_prefix_hits")
+    d_draft_prefix_misses = delta("draft_prefix_misses")
 
     minutes = elapsed / 60.0
 
@@ -120,6 +124,26 @@ def _compute_window(
         "ssd_hot_rate": round(
             _safe_ratio(d_ssd_hot, d_ssd_hot + d_ssd_disk), 4
         ),
+        "target_static_hits": d_target_static_hits,
+        "target_static_misses": d_target_static_misses,
+        "target_static_hit_rate": round(
+            _safe_ratio(
+                d_target_static_hits,
+                d_target_static_hits + d_target_static_misses,
+            ),
+            4,
+        ),
+        "target_static_tokens_restored": delta("target_static_tokens_restored"),
+        "draft_prefix_hits": d_draft_prefix_hits,
+        "draft_prefix_misses": d_draft_prefix_misses,
+        "draft_prefix_hit_rate": round(
+            _safe_ratio(
+                d_draft_prefix_hits,
+                d_draft_prefix_hits + d_draft_prefix_misses,
+            ),
+            4,
+        ),
+        "draft_prefix_tokens_saved": delta("draft_prefix_tokens_saved"),
     }
 
 
@@ -130,6 +154,10 @@ def _compute_cumulative(counters: dict[str, int]) -> dict[str, Any]:
     ssd_disk = counters.get("ssd_disk_loads", 0)
     tokens_matched = counters.get("prefix_tokens_matched", 0)
     tokens_requested = counters.get("prefix_tokens_requested", 0)
+    target_static_hits = counters.get("target_static_hits", 0)
+    target_static_misses = counters.get("target_static_misses", 0)
+    draft_prefix_hits = counters.get("draft_prefix_hits", 0)
+    draft_prefix_misses = counters.get("draft_prefix_misses", 0)
 
     return {
         "prefix_hits": prefix_hits,
@@ -146,4 +174,26 @@ def _compute_cumulative(counters: dict[str, int]) -> dict[str, Any]:
         "hot_cache_evictions": counters.get("hot_cache_evictions", 0),
         "hot_cache_promotions": counters.get("hot_cache_promotions", 0),
         "ssd_hot_rate": round(_safe_ratio(ssd_hot, ssd_hot + ssd_disk), 4),
+        "target_static_hits": target_static_hits,
+        "target_static_misses": target_static_misses,
+        "target_static_hit_rate": round(
+            _safe_ratio(
+                target_static_hits,
+                target_static_hits + target_static_misses,
+            ),
+            4,
+        ),
+        "target_static_tokens_restored": counters.get(
+            "target_static_tokens_restored", 0
+        ),
+        "draft_prefix_hits": draft_prefix_hits,
+        "draft_prefix_misses": draft_prefix_misses,
+        "draft_prefix_hit_rate": round(
+            _safe_ratio(
+                draft_prefix_hits,
+                draft_prefix_hits + draft_prefix_misses,
+            ),
+            4,
+        ),
+        "draft_prefix_tokens_saved": counters.get("draft_prefix_tokens_saved", 0),
     }

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -24,6 +24,7 @@ from ._rotating_subclass import PrefillReadyRotatingKVCache
 from .hybrid_cache import ModelCacheConfig
 from .interface import CacheManager
 from .paged_cache import (
+    BlockHash,
     BlockTable,
     CacheBlock,
     PagedCacheManager,
@@ -40,6 +41,7 @@ logger = logging.getLogger(__name__)
 # Each entry is two 32-byte hashes; the cap only guards against unbounded
 # growth from many distinct conversation chains over a long-lived process.
 _TIP_LINEAGE_MAX_ENTRIES = 4096
+_EXACT_PREFIX_TERMINAL_KEY = "specprefill-static-exact-v1"
 
 
 @dataclass
@@ -141,6 +143,11 @@ class BlockAwarePrefixCache(CacheManager):
         self._tokens_requested_total = 0
         self._last_partial_tokens_skipped = 0
         self._last_tokens_to_next_block = 0
+        self._exact_prefix_hits = 0
+        self._exact_prefix_misses = 0
+        self._exact_prefix_tokens_restored = 0
+        self._exact_prefix_stores = 0
+        self._exact_prefix_store_failures = 0
 
     def _get_model_num_layers(self, model: Any) -> int:
         """
@@ -440,6 +447,7 @@ class BlockAwarePrefixCache(CacheManager):
         extra_key_token_start: int | None = None,
         extra_key_ranges: list[tuple[int, tuple[Any, ...]]] | None = None,
         hot_cache_write_back: bool = True,
+        _store_exact_terminal: bool = False,
     ) -> BlockTable | None:
         """
         Store computed cache for future reuse.
@@ -462,6 +470,9 @@ class BlockAwarePrefixCache(CacheManager):
                 ArraysCache state instead of placeholders in hybrid models.
             hot_cache_write_back: When False, SSD-backed hot cache is bypassed
                 for newly stored dirty blocks.
+            _store_exact_terminal: Internal exact-prefix mode that persists the
+                trailing partial block and isolates the terminal hash from
+                ordinary prefix matching.
 
         Returns:
             BlockTable for the stored cache, or None on failure
@@ -528,15 +539,21 @@ class BlockAwarePrefixCache(CacheManager):
         # Skipping partial blocks also ensures is_last_block points to
         # the last full block, which is critical for non-sliceable caches
         # (ArraysCache/RotatingKVCache) that use last-block-only storage.
-        num_new_blocks = len(new_tokens) // self.block_size
+        num_new_blocks = (
+            math.ceil(len(new_tokens) / self.block_size)
+            if _store_exact_terminal
+            else len(new_tokens) // self.block_size
+        )
         trailing_partial_tokens = len(new_tokens) % self.block_size
-        self._last_partial_tokens_skipped = trailing_partial_tokens
+        self._last_partial_tokens_skipped = (
+            0 if _store_exact_terminal else trailing_partial_tokens
+        )
         self._last_tokens_to_next_block = (
             self.block_size - trailing_partial_tokens
-            if trailing_partial_tokens > 0
+            if trailing_partial_tokens > 0 and not _store_exact_terminal
             else 0
         )
-        if trailing_partial_tokens > 0:
+        if trailing_partial_tokens > 0 and not _store_exact_terminal:
             self._partial_block_skips += 1
             self._partial_tokens_skipped += trailing_partial_tokens
             logger.debug(
@@ -570,15 +587,20 @@ class BlockAwarePrefixCache(CacheManager):
                 if prev_block and prev_block.block_hash:
                     parent_hash = prev_block.block_hash
 
-            block_extra_keys = resolve_block_extra_keys(
-                global_end,
-                extra_keys=extra_keys,
-                extra_key_token_start=extra_key_token_start,
-                extra_key_ranges=extra_key_ranges,
-            )
+            is_exact_terminal = _store_exact_terminal and i == num_new_blocks - 1
+            block_extra_keys: tuple[Any, ...] | None
+            if is_exact_terminal:
+                block_extra_keys = (_EXACT_PREFIX_TERMINAL_KEY,)
+            else:
+                block_extra_keys = resolve_block_extra_keys(
+                    global_end,
+                    extra_keys=extra_keys,
+                    extra_key_token_start=extra_key_token_start,
+                    extra_key_ranges=extra_key_ranges,
+                )
 
             # Check if this block already exists (deduplication)
-            if len(block_tokens) == self.block_size:
+            if len(block_tokens) == self.block_size and not is_exact_terminal:
                 existing_block = self.paged_cache.find_cached_block(
                     block_tokens,
                     parent_hash,
@@ -617,10 +639,17 @@ class BlockAwarePrefixCache(CacheManager):
                 model_name=self.paged_cache.model_name,
             )
 
-            # Register hash for full blocks (for deduplication)
-            if len(block_tokens) == self.block_size:
+            # Register ordinary full blocks for general prefix matching. The
+            # exact terminal uses a separate hash domain so it can carry the
+            # complete non-sliceable state without colliding with a normal
+            # block that may contain placeholders.
+            if len(block_tokens) == self.block_size and not is_exact_terminal:
                 self.paged_cache.register_block_hash(
                     block, block_tokens, parent_hash, extra_keys=block_extra_keys
+                )
+            elif is_exact_terminal and block.block_hash is not None:
+                self.paged_cache.cached_block_hash_to_block.insert(
+                    block.block_hash, block
                 )
 
             # Extract tensor slice and save to paged SSD
@@ -805,8 +834,12 @@ class BlockAwarePrefixCache(CacheManager):
                 if len(self._rotating_tip_lineage) > _TIP_LINEAGE_MAX_ENTRIES:
                     self._rotating_tip_lineage.clear()
 
-        # Update prefix index
-        self._update_prefix_index(tokens, block_table.block_ids, extra_keys=extra_keys)
+        # Exact terminal blocks are discoverable only through
+        # fetch_exact_prefix(); never expose them to general prefix matching.
+        if not _store_exact_terminal:
+            self._update_prefix_index(
+                tokens, block_table.block_ids, extra_keys=extra_keys
+            )
 
         # Store entry for request tracking
         self._request_tables[request_id] = BlockCacheEntry(
@@ -821,6 +854,151 @@ class BlockAwarePrefixCache(CacheManager):
         )
 
         return block_table
+
+    def store_exact_prefix(
+        self,
+        request_id: str,
+        tokens: list[int],
+        cache_data: list[Any],
+        model_cache_config: ModelCacheConfig | None = None,
+    ) -> BlockTable | None:
+        """Persist a complete prefix, including its exact terminal boundary.
+
+        Ordinary prefix matching remains full-block-only. This path stores one
+        domain-separated terminal block, excludes it from general matching,
+        and restores it only when the complete static-prefix token chain
+        matches. That captures an arbitrary system/tool boundary without
+        making the target model repeatedly prefill its uncached suffix.
+        SSD-backed configurations use write-through so the hot tier is never
+        the only durable copy.
+        """
+        if not tokens or self.paged_ssd_cache is None:
+            return None
+
+        block_table = self.store_cache(
+            request_id,
+            tokens,
+            cache_data,
+            model_cache_config=model_cache_config,
+            hot_cache_write_back=False,
+            _store_exact_terminal=True,
+        )
+        if block_table is None or block_table.num_tokens != len(tokens):
+            self.paged_cache.delete_block_table(request_id)
+            self._request_tables.pop(request_id, None)
+            self._exact_prefix_store_failures += 1
+            return None
+
+        stored_table = block_table.copy(request_id)
+        self._request_tables.pop(request_id, None)
+        self.paged_cache.request_tables.pop(request_id, None)
+        # Drop request ownership while retaining indexed, zero-reference block
+        # metadata so the exact chain remains discoverable and evictable.
+        self.paged_cache.release_for_eviction(block_table.block_ids)
+        self._exact_prefix_stores += 1
+        return stored_table
+
+    def _exact_prefix_hashes(self, tokens: list[int]) -> list[tuple[BlockHash, int]]:
+        """Return deterministic block hashes and token counts for an exact prefix."""
+        block_hashes_and_token_counts: list[tuple[BlockHash, int]] = []
+        parent_hash: BlockHash | None = None
+        terminal_start = ((len(tokens) - 1) // self.block_size) * self.block_size
+
+        for block_start in range(0, len(tokens), self.block_size):
+            block_tokens = tokens[block_start : block_start + self.block_size]
+            extra_keys = (
+                (_EXACT_PREFIX_TERMINAL_KEY,) if block_start == terminal_start else None
+            )
+            block_hash = compute_block_hash(
+                parent_hash,
+                block_tokens,
+                extra_keys=extra_keys,
+                model_name=self.paged_cache.model_name,
+            )
+            block_hashes_and_token_counts.append((block_hash, len(block_tokens)))
+            parent_hash = block_hash
+
+        return block_hashes_and_token_counts
+
+    def fetch_exact_prefix(
+        self,
+        request_id: str,
+        tokens: list[int],
+    ) -> BlockTable | None:
+        """Acquire an all-or-nothing exact prefix chain from hot cache or SSD."""
+        if not tokens or self.paged_ssd_cache is None:
+            return None
+
+        acquired_blocks: list[CacheBlock] = []
+        for block_hash, token_count in self._exact_prefix_hashes(tokens):
+            cached_block = self.paged_cache.cached_block_hash_to_block.get_block(
+                block_hash
+            )
+            if cached_block is None:
+                if not self.paged_ssd_cache.has_block(block_hash):
+                    for block_to_release in acquired_blocks:
+                        self.paged_cache.free_block(block_to_release.block_id)
+                    return None
+                # Recreate only the paged-manager metadata; reconstruction
+                # still loads the tensor payload from the existing cache tier.
+                cached_block = self.paged_cache.allocate_block()
+                if cached_block is None:
+                    for block_to_release in acquired_blocks:
+                        self.paged_cache.free_block(block_to_release.block_id)
+                    return None
+                cached_block.block_hash = block_hash
+                cached_block.token_count = token_count
+                cached_block.ref_count = 0
+                self.paged_cache.cached_block_hash_to_block.insert(
+                    block_hash, cached_block
+                )
+
+            acquired_block = self.paged_cache.acquire_cached_block(
+                cached_block.block_id, block_hash
+            )
+            if acquired_block is None:
+                for previous_block in acquired_blocks:
+                    self.paged_cache.free_block(previous_block.block_id)
+                return None
+            acquired_blocks.append(acquired_block)
+
+        block_table = self.paged_cache.create_block_table(request_id)
+        for acquired_block in acquired_blocks:
+            block_table.add_block(acquired_block.block_id, acquired_block.token_count)
+        self._request_tables[request_id] = BlockCacheEntry(
+            block_table=block_table,
+            last_access=time.time(),
+        )
+        return block_table
+
+    def restore_exact_prefix(
+        self,
+        request_id: str,
+        tokens: list[int],
+        *,
+        promote_to_hot_cache: bool,
+    ) -> list[Any] | None:
+        """Reconstruct a complete exact prefix and release temporary block refs."""
+        block_table = self.fetch_exact_prefix(request_id, tokens)
+        if block_table is None:
+            self._exact_prefix_misses += 1
+            return None
+
+        try:
+            if promote_to_hot_cache:
+                self.preload_blocks(block_table)
+            restored_cache = self.reconstruct_cache(
+                block_table,
+                promote_to_hot_cache=promote_to_hot_cache,
+            )
+            if restored_cache is None or block_table.num_tokens != len(tokens):
+                self._exact_prefix_misses += 1
+                return None
+            self._exact_prefix_hits += 1
+            self._exact_prefix_tokens_restored += len(tokens)
+            return restored_cache
+        finally:
+            self.release_cache(request_id)
 
     def _get_cache_seq_len(self, cache_data: list[dict[str, Any]]) -> int:
         """
@@ -3170,6 +3348,11 @@ class BlockAwarePrefixCache(CacheManager):
             last_tokens_to_next_block=self._last_tokens_to_next_block,
             tokens_matched_total=self._tokens_matched_total,
             tokens_requested_total=self._tokens_requested_total,
+            exact_prefix_hits=self._exact_prefix_hits,
+            exact_prefix_misses=self._exact_prefix_misses,
+            exact_prefix_tokens_restored=self._exact_prefix_tokens_restored,
+            exact_prefix_stores=self._exact_prefix_stores,
+            exact_prefix_store_failures=self._exact_prefix_store_failures,
         )
 
     def get_stats_dict(self) -> dict[str, Any]:
@@ -3198,6 +3381,11 @@ class BlockAwarePrefixCache(CacheManager):
             "last_tokens_to_next_block": self._last_tokens_to_next_block,
             "tokens_matched_total": self._tokens_matched_total,
             "tokens_requested_total": self._tokens_requested_total,
+            "exact_prefix_hits": self._exact_prefix_hits,
+            "exact_prefix_misses": self._exact_prefix_misses,
+            "exact_prefix_tokens_restored": self._exact_prefix_tokens_restored,
+            "exact_prefix_stores": self._exact_prefix_stores,
+            "exact_prefix_store_failures": self._exact_prefix_store_failures,
             "active_requests": len(self._request_tables),
             **paged_stats,
         }
@@ -3213,6 +3401,11 @@ class BlockAwarePrefixCache(CacheManager):
         self._tokens_requested_total = 0
         self._last_partial_tokens_skipped = 0
         self._last_tokens_to_next_block = 0
+        self._exact_prefix_hits = 0
+        self._exact_prefix_misses = 0
+        self._exact_prefix_tokens_restored = 0
+        self._exact_prefix_stores = 0
+        self._exact_prefix_store_failures = 0
         self.paged_cache.reset_stats()
 
     def clear(self) -> int:

--- a/omlx/cache/stats.py
+++ b/omlx/cache/stats.py
@@ -90,6 +90,11 @@ class PrefixCacheStats(BaseCacheStats):
     last_tokens_to_next_block: int = 0
     tokens_matched_total: int = 0
     tokens_requested_total: int = 0
+    exact_prefix_hits: int = 0
+    exact_prefix_misses: int = 0
+    exact_prefix_tokens_restored: int = 0
+    exact_prefix_stores: int = 0
+    exact_prefix_store_failures: int = 0
     _total_queries: int = field(default=0, repr=False)
 
     @property
@@ -115,6 +120,11 @@ class PrefixCacheStats(BaseCacheStats):
         self.last_tokens_to_next_block = 0
         self.tokens_matched_total = 0
         self.tokens_requested_total = 0
+        self.exact_prefix_hits = 0
+        self.exact_prefix_misses = 0
+        self.exact_prefix_tokens_restored = 0
+        self.exact_prefix_stores = 0
+        self.exact_prefix_store_failures = 0
         self._total_queries = 0
 
 

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1722,6 +1722,7 @@ class Scheduler:
         # SpecPrefill: draft model for attention-based sparse prefill
         self._specprefill_draft_model: Any | None = None
         self._draft_paged_ssd_cache_manager: Any | None = None
+        self._draft_prefix_cache: Any | None = None
         # Track active specprefill request for RoPE cleanup
         self._specprefill_active_request_id: str | None = None
 
@@ -6961,7 +6962,7 @@ class Scheduler:
                 "Could not close the previous SpecPrefill draft SSD cache manager"
             )
         self._specprefill_draft_model = draft_model
-        self._draft_prefix_cache: Any | None = None
+        self._draft_prefix_cache = None
         if not draft_model_name:
             logger.info(
                 "SpecPrefill: draft model set without a stable model name "
@@ -8792,6 +8793,13 @@ class Scheduler:
 
                     from .specprefill.target import run_specprefill_target_prefill
 
+                    # all_tokens may start after an ordinary cache hit; exact
+                    # matching needs the complete static prefix from the prompt.
+                    prompt_token_ids = request.prompt_token_ids or []
+                    static_prefix_tokens = list(
+                        prompt_token_ids[: request.specprefill_system_end]
+                    )
+
                     target_result = run_specprefill_target_prefill(
                         target_model=self.model,
                         request=request,
@@ -8805,6 +8813,19 @@ class Scheduler:
                         report_sparse_progress=_report_sparse_progress,
                         sync_and_clear_cache=lambda: _sync_and_clear_cache(self._stream),
                         log=logger,
+                        extract_cache_states=self._extract_cache_states,
+                        # Preserve an ordinary cache hit that already extends
+                        # beyond the static boundary; exact restoration is only
+                        # useful while some system/tool tokens remain.
+                        exact_prefix_cache=(
+                            self.block_aware_cache
+                            if target_plan.system_token_count > 0
+                            else None
+                        ),
+                        static_prefix_tokens=static_prefix_tokens,
+                        promote_static_prefix_to_hot_cache=(
+                            not self._bypass_hot_cache_under_pressure()
+                        ),
                     )
 
                     cache_to_use = target_result.prompt_cache
@@ -11369,7 +11390,25 @@ class Scheduler:
             "prefix_tokens_requested": prefix_stats.tokens_requested_total,
             "prefix_tokens_saved": prefix_stats.tokens_saved,
             "evictions": prefix_stats.evictions,
+            "target_static_hits": prefix_stats.exact_prefix_hits,
+            "target_static_misses": prefix_stats.exact_prefix_misses,
+            "target_static_tokens_restored": (
+                prefix_stats.exact_prefix_tokens_restored
+            ),
         }
+
+        # Target exact-prefix and draft ordinary-prefix reuse are separate
+        # model-specific caches, so expose their counters independently.
+        draft_prefix_cache = self._draft_prefix_cache
+        if draft_prefix_cache is not None:
+            draft_stats = draft_prefix_cache.get_stats()
+            counters.update(
+                {
+                    "draft_prefix_hits": draft_stats.hits,
+                    "draft_prefix_misses": draft_stats.misses,
+                    "draft_prefix_tokens_saved": draft_stats.tokens_saved,
+                }
+            )
 
         if self.paged_ssd_cache_manager is not None:
             ssd = self.paged_ssd_cache_manager.get_stats()
@@ -11400,7 +11439,29 @@ class Scheduler:
             stats["block_size"] = self.config.paged_cache_block_size
 
         if self.block_aware_cache is not None:
-            stats["prefix_cache"] = self.block_aware_cache.get_stats_dict()
+            prefix_stats = self.block_aware_cache.get_stats_dict()
+            stats["prefix_cache"] = prefix_stats
+            specprefill_cache_stats = {
+                "target_static_hits": prefix_stats["exact_prefix_hits"],
+                "target_static_misses": prefix_stats["exact_prefix_misses"],
+                "target_static_tokens_restored": prefix_stats[
+                    "exact_prefix_tokens_restored"
+                ],
+                "target_static_stores": prefix_stats["exact_prefix_stores"],
+                "target_static_store_failures": prefix_stats[
+                    "exact_prefix_store_failures"
+                ],
+            }
+            if self._draft_prefix_cache is not None:
+                draft_stats = self._draft_prefix_cache.get_stats()
+                specprefill_cache_stats.update(
+                    {
+                        "draft_prefix_hits": draft_stats.hits,
+                        "draft_prefix_misses": draft_stats.misses,
+                        "draft_prefix_tokens_saved": draft_stats.tokens_saved,
+                    }
+                )
+            stats["specprefill_cache"] = specprefill_cache_stats
 
         counters = self._collect_cache_counters()
         if counters:

--- a/omlx/specprefill/target.py
+++ b/omlx/specprefill/target.py
@@ -7,7 +7,7 @@ import logging
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
 import mlx.core as mx
 from mlx_lm.models.cache import make_prompt_cache
@@ -22,11 +22,35 @@ class SpecPrefillTargetPrefillResult:
 
     prompt_cache: list[Any]
     tokens_to_process: Sequence[int]
+    static_prefix_cached_tokens: int = 0
+
+
+class ExactPrefixCache(Protocol):
+    """Exact target-prefix operations provided by the tiered prefix cache."""
+
+    def restore_exact_prefix(
+        self,
+        request_id: str,
+        tokens: list[int],
+        *,
+        promote_to_hot_cache: bool,
+    ) -> list[Any] | None: ...
+
+    def store_exact_prefix(
+        self,
+        request_id: str,
+        tokens: list[int],
+        cache_data: list[dict[str, Any]],
+        model_cache_config: Any = ...,
+    ) -> Any: ...
 
 
 CheckAbort = Callable[[int], None]
 ReportProgress = Callable[[int, int], None]
 SyncAndClearCache = Callable[[], None]
+# Issue #2177: helper signature mirroring Scheduler._extract_cache_states.
+# Returns the per-layer extracted state dicts and an optional ModelCacheConfig.
+ExtractCacheStates = Callable[[list[Any]], tuple[list[dict[str, Any]], Any | None]]
 
 
 def run_specprefill_target_prefill(
@@ -43,6 +67,14 @@ def run_specprefill_target_prefill(
     report_sparse_progress: ReportProgress,
     sync_and_clear_cache: SyncAndClearCache,
     log: logging.Logger,
+    # Issue #2177: opt-in static system/tool prefix reuse. When the cache,
+    # tokens, and extraction callback are provided, the first request stores
+    # the prefetched system state in the tiered cache; later requests restore
+    # it and skip the target-model system-prefill loop.
+    extract_cache_states: ExtractCacheStates | None = None,
+    exact_prefix_cache: ExactPrefixCache | None = None,
+    static_prefix_tokens: Sequence[int] | None = None,
+    promote_static_prefix_to_hot_cache: bool = True,
 ) -> SpecPrefillTargetPrefillResult:
     """Prefill system and selected conversation tokens for one request."""
     prompt_cache = None
@@ -70,9 +102,37 @@ def run_specprefill_target_prefill(
         conversation_token_count = plan.conversation_token_count
         generation_kickoff_index = plan.generation_kickoff_index
         prefill_started_at = time.monotonic()
-        prompt_cache = make_prompt_cache(target_model)
+        prompt_cache = (
+            request.prompt_cache
+            if request.cached_tokens > 0 and request.prompt_cache is not None
+            else None
+        )
 
-        if system_token_count > 0:
+        # Issue #2177: try to restore the stable system/tool prefix from the
+        # tiered prefix cache before prefilling. This mirrors how the
+        # draft workflow (``draft.run_specprefill_draft_scoring``) uses
+        # ``draft_prefix_cache.fetch_cache``/``reconstruct_cache`` to reuse the
+        # draft-model prefix instead of re-scoring from scratch.
+        static_prefix_cached_tokens = 0
+        if exact_prefix_cache is not None and static_prefix_tokens:
+            full_static_prefix_tokens = list(static_prefix_tokens)
+            restored_cache = exact_prefix_cache.restore_exact_prefix(
+                f"{request.request_id}:specprefill-static-restore",
+                full_static_prefix_tokens,
+                promote_to_hot_cache=promote_static_prefix_to_hot_cache,
+            )
+            if restored_cache is not None:
+                prompt_cache = restored_cache
+                static_prefix_cached_tokens = len(full_static_prefix_tokens)
+                report_system_progress(system_token_count, system_token_count)
+                log.info(
+                    f"SpecPrefill: restored {static_prefix_cached_tokens} "
+                    "static system-prefix tokens from tiered cache"
+                )
+        if prompt_cache is None:
+            prompt_cache = make_prompt_cache(target_model)
+
+        if system_token_count > 0 and static_prefix_cached_tokens == 0:
             sys_arr = mx.array(all_tokens[:system_token_count])
             system_processed = 0
             while sys_arr.size > prefill_step_size:
@@ -102,6 +162,30 @@ def run_specprefill_target_prefill(
                 f"SpecPrefill: system prompt {system_token_count} tokens full prefill"
             )
 
+            # Issue #2177: capture the just-computed system-prefix KV states so
+            # the next request with the same system prefix can restore them
+            # without re-running the target model. The store path mirrors the
+            # draft workflow's ``store_cache`` call after scoring.
+            if (
+                exact_prefix_cache is not None
+                and static_prefix_tokens
+                and extract_cache_states
+            ):
+                try:
+                    extracted_states, model_cache_config = extract_cache_states(
+                        prompt_cache
+                    )
+                    if extracted_states:
+                        exact_prefix_cache.store_exact_prefix(
+                            f"{request.request_id}:specprefill-static-store",
+                            list(static_prefix_tokens),
+                            extracted_states,
+                            model_cache_config=model_cache_config,
+                        )
+                except Exception as error:
+                    log.debug(
+                        f"SpecPrefill: static prefix tiered-cache store failed: {error}"
+                    )
         selected = selected_indices
         # BatchGenerator processes the generation-kickoff token separately.
         if plan.remove_kickoff_index:
@@ -133,15 +217,21 @@ def run_specprefill_target_prefill(
 
         selected_token_count = int(selected.shape[0])
         prefill_seconds = time.monotonic() - prefill_started_at
+        system_cache_summary = (
+            f"{static_prefix_cached_tokens} static-cached"
+            if static_prefix_cached_tokens > 0
+            else f"{system_token_count} full"
+        )
         log.info(
             f"SpecPrefill: sparse prefill {selected_token_count}/"
             f"{conversation_token_count} conv tokens in {prefill_seconds:.1f}s "
             f"(total {request.num_prompt_tokens}, cached {request.cached_tokens}, "
-            f"system {system_token_count} full, conv {conversation_token_count} sparse)"
+            f"system {system_cache_summary}, conv {conversation_token_count} sparse)"
         )
         return SpecPrefillTargetPrefillResult(
             prompt_cache=prompt_cache,
             tokens_to_process=all_tokens[-1:],
+            static_prefix_cached_tokens=static_prefix_cached_tokens,
         )
     except Exception:
         prompt_cache = None

--- a/tests/integration/test_specprefill_static_prefix_real_model.py
+++ b/tests/integration/test_specprefill_static_prefix_real_model.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in real-model validation for SpecPrefill static-prefix reuse (#2177).
+
+Issue #2177 addresses a specific gap between the two halves of SpecPrefill:
+the small draft model could avoid some repeated scoring work, but the target
+model still prefetched the same system instructions and tool schemas on every
+turn. Unit tests protect the orchestration contract, but they cannot prove that
+real Qwen hybrid caches restore their recurrent state, rotating-cache metadata,
+MLX stream ownership, and target positions correctly.
+
+This test therefore loads an actual Qwen3.6 target and Qwen3.5 draft and runs
+four deliberately distinct phases:
+
+1. A cold request persists the exact target static prefix to SSD.
+2. A new engine restores it after the original engine has shut down.
+3. Hot-cache clearing and pressure reclaim leave the SSD prefix reusable.
+4. Changed system material misses safely and creates a distinct exact chain.
+
+The test never downloads checkpoints, never contacts a running oMLX server,
+never reads or writes the user's persisted model settings, and stores its paged
+cache under pytest's temporary directory. It is marked ``slow`` and requires
+explicit model paths because the known validation pairs use a 27B or 35B target
+plus a 4B draft and consequently need substantial Apple Silicon unified
+memory. Timing is printed by oMLX for human inspection but is intentionally not
+an assertion: target-prefill latency varies with hardware, thermals, and other
+processes, while the phase-specific cache telemetry is deterministic.
+
+Example using the locally available validation pair::
+
+    OMLX_SPECPREFILL_TARGET_PATH="$HOME/.omlx/models/Jundot/Qwen3.6-27B-oQ4e-mtp" \
+    OMLX_SPECPREFILL_DRAFT_PATH="$HOME/.omlx/models/lmstudio-community/Qwen3.5-4B-MLX-4bit" \
+    uv run pytest tests/integration/test_specprefill_static_prefix_real_model.py \
+      -o addopts="" -m slow -s -q
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import gc
+import json
+import logging
+import os
+import platform
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        sys.platform != "darwin" or platform.machine() != "arm64",
+        reason="Real SpecPrefill validation requires macOS on Apple Silicon.",
+    ),
+]
+
+_TARGET_PATH_ENV = "OMLX_SPECPREFILL_TARGET_PATH"
+_DRAFT_PATH_ENV = "OMLX_SPECPREFILL_DRAFT_PATH"
+_PREFIX_CACHE_BLOCK_SIZE_TOKENS = 256
+_STATIC_PREFIX_MINIMUM_TOKENS = 1024
+_SPECPREFILL_THRESHOLD_TOKENS = 128
+_CONVERSATION_MINIMUM_TOKENS = 384
+
+
+def _load_explicit_model_config(
+    environment_variable: str,
+    expected_model_types: tuple[str, ...],
+) -> tuple[Path, dict[str, Any]]:
+    """Return one explicitly selected local checkpoint and validated config.
+
+    Missing variables skip instead of discovering or downloading a convenient
+    model. Once a contributor sets a variable, however, a wrong path is a test
+    configuration error and must fail loudly rather than silently selecting a
+    different architecture that does not exercise the production bug.
+    """
+    configured_path = os.environ.get(environment_variable)
+    if not configured_path:
+        pytest.skip(
+            f"Set {environment_variable} to an existing local checkpoint to run "
+            "the SpecPrefill real-model test."
+        )
+        raise AssertionError("pytest.skip unexpectedly returned")
+
+    model_path = Path(configured_path).expanduser()
+    config_path = model_path / "config.json"
+    if not config_path.is_file():
+        pytest.fail(f"{environment_variable} has no config.json: {config_path}")
+
+    model_config = json.loads(config_path.read_text(encoding="utf-8"))
+    actual_model_type = model_config.get("model_type")
+    if actual_model_type not in expected_model_types:
+        pytest.fail(
+            f"{environment_variable} must identify one of model_type="
+            f"{expected_model_types!r}, not {actual_model_type!r}: {model_path}"
+        )
+    return model_path, model_config
+
+
+def _text_vocab_size(model_config: dict[str, Any]) -> int | None:
+    """Read the shared text vocabulary from nested or flat model configs."""
+    text_config = model_config.get("text_config")
+    if isinstance(text_config, dict):
+        vocab_size = text_config.get("vocab_size")
+    else:
+        vocab_size = model_config.get("vocab_size")
+    return int(vocab_size) if isinstance(vocab_size, int) else None
+
+
+@pytest.fixture(scope="module")
+def specprefill_model_pair() -> tuple[Path, Path]:
+    """Validate the exact target/draft architecture and tokenizer contract."""
+    target_path, target_config = _load_explicit_model_config(
+        _TARGET_PATH_ENV,
+        ("qwen3_5", "qwen3_5_moe"),
+    )
+    draft_path, draft_config = _load_explicit_model_config(
+        _DRAFT_PATH_ENV,
+        ("qwen3_5",),
+    )
+
+    target_vocab_size = _text_vocab_size(target_config)
+    draft_vocab_size = _text_vocab_size(draft_config)
+    if target_vocab_size is None or draft_vocab_size is None:
+        pytest.fail(
+            "Both real-model configs must declare a text vocabulary so the "
+            "SpecPrefill tokenizer compatibility check is meaningful."
+        )
+    if target_vocab_size != draft_vocab_size:
+        pytest.fail(
+            "SpecPrefill target and draft tokenizers are incompatible: "
+            f"target vocab={target_vocab_size}, draft vocab={draft_vocab_size}."
+        )
+    return target_path, draft_path
+
+
+def _repeat_until_token_count(
+    tokenizer: Any,
+    sentence: str,
+    minimum_tokens: int,
+) -> str:
+    """Build natural repeated prose without hard-coding tokenizer ratios."""
+    repetition_count = 1
+    while repetition_count <= 4096:
+        text = sentence * repetition_count
+        if len(tokenizer.encode(text)) >= minimum_tokens:
+            return text
+        repetition_count *= 2
+    raise AssertionError(
+        f"Could not build {minimum_tokens} tokens of test prose for the tokenizer."
+    )
+
+
+def _specprefill_log_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Return actionable SpecPrefill lines for diagnostics."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if "SpecPrefill" in record.getMessage()
+    ]
+
+
+def _assert_log_contains(
+    messages: list[str],
+    expected_fragment: str,
+    *,
+    phase: str,
+) -> None:
+    """Fail with the complete phase telemetry instead of a bare substring error."""
+    assert any(expected_fragment in message for message in messages), (
+        f"{phase} phase did not emit {expected_fragment!r}. "
+        f"Captured SpecPrefill telemetry: {messages}"
+    )
+
+
+def _assert_log_excludes(
+    messages: list[str],
+    forbidden_fragment: str,
+    *,
+    phase: str,
+) -> None:
+    """Explain unexpected cold/warm transitions with all relevant log lines."""
+    assert all(forbidden_fragment not in message for message in messages), (
+        f"{phase} phase unexpectedly emitted {forbidden_fragment!r}. "
+        f"Captured SpecPrefill telemetry: {messages}"
+    )
+
+
+def test_issue_2177_static_prefix_reuse_with_real_qwen_models(
+    specprefill_model_pair: tuple[Path, Path],
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Validate exact SSD reuse across restart and memory reclamation."""
+    target_model_path, draft_model_path = specprefill_model_pair
+
+    # Heavy imports stay below the opt-in fixtures. A normal test collection or
+    # missing-path skip therefore does not initialize MLX, import VLM runtimes,
+    # or accidentally reserve unified memory.
+    import mlx.core as mx
+
+    from omlx.engine.vlm import VLMBatchedEngine
+    from omlx.model_settings import ModelSettings
+    from omlx.scheduler import SchedulerConfig
+
+    async def run_real_model_validation() -> None:
+        caplog.set_level(logging.INFO)
+        model_settings = ModelSettings(
+            enable_thinking=False,
+            specprefill_enabled=True,
+            specprefill_draft_model=str(draft_model_path),
+            specprefill_keep_pct=0.30,
+            specprefill_threshold=_SPECPREFILL_THRESHOLD_TOKENS,
+        )
+        cache_directory = tmp_path / "specprefill-prefix-cache"
+
+        def create_engine() -> VLMBatchedEngine:
+            scheduler_config = SchedulerConfig(
+                max_num_seqs=1,
+                max_num_batched_tokens=512,
+                completion_batch_size=1,
+                prefill_step_size=512,
+                paged_cache_block_size=_PREFIX_CACHE_BLOCK_SIZE_TOKENS,
+                paged_ssd_cache_dir=str(cache_directory),
+                paged_ssd_cache_max_size=4 * 1024**3,
+                hot_cache_max_size=0,
+                model_name=target_model_path.name,
+                model_path=str(target_model_path),
+            )
+            return VLMBatchedEngine(
+                model_name=str(target_model_path),
+                scheduler_config=scheduler_config,
+                model_settings=model_settings,
+                enable_thinking=False,
+            )
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup_repository_symbol",
+                    "description": "Look up a repository symbol without changing files.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"symbol": {"type": "string"}},
+                        "required": ["symbol"],
+                    },
+                },
+            }
+        ]
+        stable_system = ""
+
+        def messages_for(system_text: str, user_text: str) -> list[dict[str, str]]:
+            return [
+                {"role": "system", "content": system_text},
+                {"role": "user", "content": user_text},
+            ]
+
+        async def run_chat(
+            selected_engine: VLMBatchedEngine,
+            messages: list[dict[str, str]],
+        ) -> Any:
+            return await selected_engine.chat(
+                messages,
+                tools=tools,
+                max_tokens=2,
+                temperature=0.0,
+                chat_template_kwargs={"enable_thinking": False},
+                specprefill=True,
+                specprefill_keep_pct=0.30,
+                specprefill_threshold=_SPECPREFILL_THRESHOLD_TOKENS,
+            )
+
+        cold_engine = create_engine()
+        try:
+            await cold_engine.start()
+            assert cold_engine._engine is not None
+            cold_scheduler = cold_engine._engine.engine.scheduler
+            assert cold_scheduler._specprefill_draft_model is not None
+            stable_system = _repeat_until_token_count(
+                cold_engine.tokenizer,
+                "Follow repository rules and inspect evidence before answering. ",
+                _STATIC_PREFIX_MINIMUM_TOKENS,
+            )
+            cold_user_text = _repeat_until_token_count(
+                cold_engine.tokenizer,
+                "Explain how a scheduler preserves cache correctness. ",
+                _CONVERSATION_MINIMUM_TOKENS,
+            )
+
+            boundary_attempt = 0
+            while True:
+                cold_messages = messages_for(stable_system, cold_user_text)
+                prompt_tokens, vlm_embeds, *_ = cold_engine._process_chat_messages(
+                    copy.deepcopy(cold_messages), copy.deepcopy(tools), {}
+                )
+                non_system_prompt = cold_engine.tokenizer.apply_chat_template(
+                    [copy.deepcopy(cold_messages[-1])],
+                    tokenize=False,
+                    add_generation_prompt=True,
+                )
+                system_end = len(prompt_tokens) - len(
+                    cold_engine.tokenizer.encode(non_system_prompt)
+                )
+                if system_end % _PREFIX_CACHE_BLOCK_SIZE_TOKENS != 0:
+                    break
+                boundary_attempt += 1
+                stable_system += f" Deterministic boundary padding {boundary_attempt}."
+            assert vlm_embeds is None
+            assert len(prompt_tokens) - system_end > _SPECPREFILL_THRESHOLD_TOKENS
+
+            with caplog.at_level(logging.INFO):
+                caplog.clear()
+                cold_response = await run_chat(cold_engine, cold_messages)
+                cold_logs = _specprefill_log_messages(caplog)
+            assert cold_response.completion_tokens > 0
+            _assert_log_contains(cold_logs, "tokens full prefill", phase="cold")
+            _assert_log_excludes(cold_logs, "static system-prefix tokens", phase="cold")
+            cold_stats = cold_scheduler.block_aware_cache.get_stats()
+            assert cold_stats.exact_prefix_stores == 1
+            assert cold_scheduler.paged_ssd_cache_manager.get_stats().saves > 0
+        finally:
+            await cold_engine.stop()
+            del cold_engine
+            gc.collect()
+            mx.clear_cache()
+
+        warm_engine = create_engine()
+        try:
+            await warm_engine.start()
+            assert warm_engine._engine is not None
+            warm_scheduler = warm_engine._engine.engine.scheduler
+            warm_user_text = _repeat_until_token_count(
+                warm_engine.tokenizer,
+                "Describe why cache metadata must be restored atomically. ",
+                _CONVERSATION_MINIMUM_TOKENS,
+            )
+
+            with caplog.at_level(logging.INFO):
+                caplog.clear()
+                warm_response = await run_chat(
+                    warm_engine,
+                    messages_for(stable_system, warm_user_text),
+                )
+                warm_logs = _specprefill_log_messages(caplog)
+            assert warm_response.completion_tokens > 0
+            _assert_log_contains(
+                warm_logs,
+                "static system-prefix tokens from tiered cache",
+                phase="restart",
+            )
+            _assert_log_excludes(warm_logs, "tokens full prefill", phase="restart")
+
+            warm_scheduler.paged_ssd_cache_manager.clear_hot_cache()
+            warm_scheduler.request_pressure_reclaim()
+            warm_engine._engine.engine._wake_engine_loop()
+            for _ in range(5000):
+                if not warm_scheduler._pending_pressure_clear:
+                    break
+                await asyncio.sleep(0.001)
+            else:
+                raise AssertionError("Engine loop did not consume pressure reclaim.")
+
+            pressure_user_text = _repeat_until_token_count(
+                warm_engine.tokenizer,
+                "Summarize why SSD cache survives memory reclamation. ",
+                _CONVERSATION_MINIMUM_TOKENS,
+            )
+            caplog.clear()
+            pressure_response = await run_chat(
+                warm_engine,
+                messages_for(stable_system, pressure_user_text),
+            )
+            pressure_logs = _specprefill_log_messages(caplog)
+            assert pressure_response.completion_tokens > 0
+            _assert_log_contains(
+                pressure_logs,
+                "static system-prefix tokens from tiered cache",
+                phase="pressure",
+            )
+            _assert_log_excludes(pressure_logs, "tokens full prefill", phase="pressure")
+
+            changed_system = stable_system + " This instruction changed."
+            caplog.clear()
+            changed_response = await run_chat(
+                warm_engine,
+                messages_for(changed_system, pressure_user_text),
+            )
+            changed_logs = _specprefill_log_messages(caplog)
+            assert changed_response.completion_tokens > 0
+            _assert_log_excludes(
+                changed_logs, "static system-prefix tokens", phase="changed-prefix"
+            )
+            assert warm_scheduler.block_aware_cache.get_stats().exact_prefix_hits >= 2
+            assert warm_scheduler.block_aware_cache.get_stats().exact_prefix_misses >= 1
+        finally:
+            await warm_engine.stop()
+            gc.collect()
+            mx.clear_cache()
+
+    asyncio.run(run_real_model_validation())

--- a/tests/test_cache_observability.py
+++ b/tests/test_cache_observability.py
@@ -24,6 +24,12 @@ def _make_counters(
     ssd_errors=0,
     hot_cache_evictions=0,
     hot_cache_promotions=0,
+    target_static_hits=0,
+    target_static_misses=0,
+    target_static_tokens_restored=0,
+    draft_prefix_hits=0,
+    draft_prefix_misses=0,
+    draft_prefix_tokens_saved=0,
 ):
     return {
         "prefix_hits": prefix_hits,
@@ -38,6 +44,12 @@ def _make_counters(
         "ssd_errors": ssd_errors,
         "hot_cache_evictions": hot_cache_evictions,
         "hot_cache_promotions": hot_cache_promotions,
+        "target_static_hits": target_static_hits,
+        "target_static_misses": target_static_misses,
+        "target_static_tokens_restored": target_static_tokens_restored,
+        "draft_prefix_hits": draft_prefix_hits,
+        "draft_prefix_misses": draft_prefix_misses,
+        "draft_prefix_tokens_saved": draft_prefix_tokens_saved,
     }
 
 
@@ -119,6 +131,27 @@ class TestCacheRateTrackerRates:
         new = _make_counters(ssd_hot_hits=80, ssd_disk_loads=20)
         result = self._tracker_with_two_snapshots(old, new, elapsed=60.0)
         assert result["windows"]["1m"]["ssd_hot_rate"] == 0.8
+
+    def test_specprefill_target_and_draft_reuse_are_distinct(self):
+        old = _make_counters()
+        new = _make_counters(
+            target_static_hits=3,
+            target_static_misses=1,
+            target_static_tokens_restored=18_000,
+            draft_prefix_hits=7,
+            draft_prefix_misses=2,
+            draft_prefix_tokens_saved=42_000,
+        )
+
+        result = self._tracker_with_two_snapshots(old, new, elapsed=60.0)
+
+        window = result["windows"]["1m"]
+        assert window["target_static_hit_rate"] == 0.75
+        assert window["target_static_tokens_restored"] == 18_000
+        assert window["draft_prefix_hit_rate"] == pytest.approx(7 / 9, abs=0.0001)
+        assert window["draft_prefix_tokens_saved"] == 42_000
+        assert result["cumulative"]["target_static_hits"] == 3
+        assert result["cumulative"]["draft_prefix_hits"] == 7
 
     def test_insufficient_data_returns_empty_window(self):
         tracker = CacheRateTracker(min_interval=0.0)

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -9,6 +9,7 @@ PagedCacheManager for block-based storage with SSD persistence.
 import sys
 import time
 import types
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -18,6 +19,7 @@ from omlx.cache.paged_cache import (
     PagedCacheManager,
     compute_block_hash,
 )
+from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
 from omlx.cache.prefix_cache import BlockAwarePrefixCache, BlockCacheEntry
 from omlx.cache.stats import PrefixCacheStats
 
@@ -53,6 +55,37 @@ class TestBlockCacheEntry:
 
 class TestBlockAwarePrefixCache:
     """Tests for BlockAwarePrefixCache."""
+
+    @staticmethod
+    def _make_ssd_prefix_cache(
+        cache_directory: Path,
+        *,
+        num_layers: int = 1,
+        hot_cache_max_bytes: int = 0,
+        hot_cache_only: bool = False,
+    ) -> tuple[BlockAwarePrefixCache, PagedCacheManager, PagedSSDCacheManager]:
+        ssd_manager = PagedSSDCacheManager(
+            cache_dir=cache_directory,
+            max_size_bytes=100 * 1024**2,
+            hot_cache_max_bytes=hot_cache_max_bytes,
+            hot_cache_only=hot_cache_only,
+            expected_model_name="test-model",
+            expected_num_layers=num_layers,
+            expected_block_size=4,
+        )
+        paged_manager = PagedCacheManager(
+            block_size=4,
+            max_blocks=100,
+            model_name="test-model",
+            initial_blocks=100,
+        )
+        paged_manager.set_paged_ssd_cache_manager(ssd_manager)
+        prefix_cache = BlockAwarePrefixCache(
+            model=MockModel(num_layers=num_layers),
+            paged_cache_manager=paged_manager,
+            paged_ssd_cache_manager=ssd_manager,
+        )
+        return prefix_cache, paged_manager, ssd_manager
 
     @pytest.fixture
     def paged_cache(self):
@@ -160,6 +193,280 @@ class TestBlockAwarePrefixCache:
         """Test store_cache with empty tokens returns None."""
         result = prefix_cache.store_cache("req-001", [], [])
         assert result is None
+
+    def test_exact_prefix_survives_ssd_manager_restart(self, tmp_path):
+        """An exact static prefix includes its partial terminal block on SSD."""
+        import mlx.core as mx
+
+        cache_directory = tmp_path / "exact-prefix"
+        tokens = list(range(7))
+        keys = mx.arange(7, dtype=mx.float32).reshape(1, 1, 7, 1)
+        values = (keys + 10).astype(mx.float32)
+        extracted_cache = [
+            {
+                "state": (keys, values),
+                "meta_state": (7,),
+                "class_name": "KVCache",
+                "cache_type": "KVCache",
+            }
+        ]
+
+        first_prefix_cache, _, first_ssd_manager = self._make_ssd_prefix_cache(
+            cache_directory
+        )
+
+        stored_table = first_prefix_cache.store_exact_prefix(
+            "cold-static-prefix",
+            tokens,
+            extracted_cache,
+        )
+        assert stored_table is not None
+        assert stored_table.num_tokens == len(tokens)
+
+        ordinary_table, ordinary_remaining = first_prefix_cache.fetch_cache(
+            "ordinary-prefix",
+            [*tokens, 8],
+        )
+        assert ordinary_table is not None
+        assert ordinary_table.num_tokens == 4
+        assert ordinary_remaining == [4, 5, 6, 8]
+        first_prefix_cache.release_cache("ordinary-prefix")
+        first_ssd_manager.close()
+
+        restarted_prefix_cache, _, restarted_ssd_manager = (
+            self._make_ssd_prefix_cache(cache_directory)
+        )
+
+        try:
+            restored_table = restarted_prefix_cache.fetch_exact_prefix(
+                "warm-static-prefix",
+                tokens,
+            )
+            assert restored_table is not None
+            restored_cache = restarted_prefix_cache.reconstruct_cache(
+                restored_table,
+                promote_to_hot_cache=False,
+            )
+            assert restored_cache is not None
+            restored_keys, restored_values = restored_cache[0].state
+            assert restored_table.num_tokens == len(tokens)
+            assert mx.array_equal(restored_keys, keys).item()
+            assert mx.array_equal(restored_values, values).item()
+
+            changed_tokens = [*tokens[:-1], 99]
+            assert (
+                restarted_prefix_cache.fetch_exact_prefix(
+                    "changed-static-prefix",
+                    changed_tokens,
+                )
+                is None
+            )
+        finally:
+            restarted_ssd_manager.close()
+
+    def test_aligned_exact_prefix_does_not_reuse_placeholder_terminal(self, tmp_path):
+        """An aligned static tip must not collide with an ordinary chain block."""
+        import mlx.core as mx
+
+        from omlx.cache.hybrid_cache import ModelCacheConfig
+
+        prefix_cache, _, ssd_manager = self._make_ssd_prefix_cache(
+            tmp_path / "aligned-exact-prefix",
+            num_layers=2,
+        )
+        model_cache_config = ModelCacheConfig.from_type_list(
+            ["KVCache", "ArraysCache"],
+            model_name="test-model",
+        )
+        keys = mx.arange(12, dtype=mx.float32).reshape(1, 1, 12, 1)
+        values = keys + 20
+        first_recurrent_state = mx.ones((1, 2), dtype=mx.float32)
+        second_recurrent_state = mx.ones((1, 2), dtype=mx.float32) * 2
+        extracted_cache = [
+            {
+                "state": (keys, values),
+                "meta_state": (12,),
+                "class_name": "KVCache",
+                "cache_type": "KVCache",
+            },
+            {
+                "state": (first_recurrent_state, second_recurrent_state),
+                "meta_state": (),
+                "class_name": "ArraysCache",
+                "cache_type": "ArraysCache",
+            },
+        ]
+
+        try:
+            ordinary_table = prefix_cache.store_cache(
+                "ordinary-longer-prompt",
+                list(range(12)),
+                extracted_cache,
+                model_cache_config=model_cache_config,
+                hot_cache_write_back=False,
+            )
+            assert ordinary_table is not None
+
+            exact_table = prefix_cache.store_exact_prefix(
+                "aligned-static-prefix",
+                list(range(8)),
+                extracted_cache,
+                model_cache_config=model_cache_config,
+            )
+            assert exact_table is not None
+            prefix_cache.clear_request_entry("aligned-static-prefix")
+
+            restored_table = prefix_cache.fetch_exact_prefix(
+                "aligned-static-restore",
+                list(range(8)),
+            )
+            assert restored_table is not None
+            restored_cache = prefix_cache.reconstruct_cache(
+                restored_table,
+                promote_to_hot_cache=False,
+            )
+            assert restored_cache is not None
+            assert restored_cache[0].state[0].shape[2] == 8
+            restored_arrays_cache = restored_cache[1]
+            restored_arrays_cache[0] = mx.zeros((1, 2), dtype=mx.float32)
+            assert mx.array_equal(
+                restored_arrays_cache[0],
+                mx.zeros((1, 2), dtype=mx.float32),
+            ).item()
+            assert mx.array_equal(
+                restored_arrays_cache[1],
+                second_recurrent_state,
+            ).item()
+        finally:
+            ssd_manager.close()
+
+    def test_exact_prefix_missing_terminal_is_a_complete_miss(self, tmp_path):
+        import mlx.core as mx
+
+        prefix_cache, paged_manager, ssd_manager = self._make_ssd_prefix_cache(
+            tmp_path / "missing-exact-terminal"
+        )
+        tokens = list(range(7))
+        keys = mx.ones((1, 1, 7, 1))
+        extracted_cache = [
+            {
+                "state": (keys, keys),
+                "meta_state": (7,),
+                "class_name": "KVCache",
+                "cache_type": "KVCache",
+            }
+        ]
+
+        try:
+            assert (
+                prefix_cache.store_exact_prefix(
+                    "stored-exact-prefix", tokens, extracted_cache
+                )
+                is not None
+            )
+            terminal_hash = prefix_cache._exact_prefix_hashes(tokens)[-1][0]
+            assert ssd_manager.delete_block(terminal_hash)
+
+            assert (
+                prefix_cache.restore_exact_prefix(
+                    "missing-terminal-restore",
+                    tokens,
+                    promote_to_hot_cache=False,
+                )
+                is None
+            )
+            assert "missing-terminal-restore" not in paged_manager.request_tables
+            assert prefix_cache.get_stats().exact_prefix_misses == 1
+        finally:
+            ssd_manager.close()
+
+    def test_exact_prefix_uses_global_hot_tier_without_requiring_it(self, tmp_path):
+        import mlx.core as mx
+
+        prefix_cache, _, ssd_manager = self._make_ssd_prefix_cache(
+            tmp_path / "exact-prefix-hot-tier",
+            hot_cache_max_bytes=10 * 1024**2,
+        )
+        tokens = list(range(7))
+        keys = mx.ones((1, 1, 7, 1))
+        extracted_cache = [
+            {
+                "state": (keys, keys),
+                "meta_state": (7,),
+                "class_name": "KVCache",
+                "cache_type": "KVCache",
+            }
+        ]
+
+        try:
+            assert (
+                prefix_cache.store_exact_prefix(
+                    "write-through-static-prefix", tokens, extracted_cache
+                )
+                is not None
+            )
+            assert ssd_manager.get_stats().hot_cache_entries == 0
+
+            assert (
+                prefix_cache.restore_exact_prefix(
+                    "hot-promoting-restore",
+                    tokens,
+                    promote_to_hot_cache=True,
+                )
+                is not None
+            )
+            assert ssd_manager.get_stats().hot_cache_entries > 0
+
+            ssd_manager.clear_hot_cache()
+            assert (
+                prefix_cache.restore_exact_prefix(
+                    "pressure-bypass-restore",
+                    tokens,
+                    promote_to_hot_cache=False,
+                )
+                is not None
+            )
+            assert ssd_manager.get_stats().hot_cache_entries == 0
+        finally:
+            ssd_manager.close()
+
+    def test_exact_prefix_honors_global_hot_cache_only_mode(self, tmp_path):
+        import mlx.core as mx
+
+        prefix_cache, _, ssd_manager = self._make_ssd_prefix_cache(
+            tmp_path / "unused-hot-only-cache",
+            hot_cache_max_bytes=10 * 1024**2,
+            hot_cache_only=True,
+        )
+        tokens = list(range(7))
+        keys = mx.ones((1, 1, 7, 1))
+        extracted_cache = [
+            {
+                "state": (keys, keys),
+                "meta_state": (7,),
+                "class_name": "KVCache",
+                "cache_type": "KVCache",
+            }
+        ]
+
+        try:
+            assert (
+                prefix_cache.store_exact_prefix(
+                    "hot-only-static-prefix", tokens, extracted_cache
+                )
+                is not None
+            )
+            assert ssd_manager.get_stats().hot_cache_entries > 0
+            assert (
+                prefix_cache.restore_exact_prefix(
+                    "hot-only-restore",
+                    tokens,
+                    promote_to_hot_cache=True,
+                )
+                is not None
+            )
+        finally:
+            ssd_manager.close()
 
     def test_store_cache_creates_block_table(self, prefix_cache):
         """Test store_cache creates a block table."""
@@ -713,9 +1020,7 @@ class TestPrefixIndexLifecycle:
         blocks = paged_cache.get_new_blocks(num)
         for block in blocks:
             block.token_count = paged_cache.block_size
-        prefix_cache._update_prefix_index(
-            tokens, [block.block_id for block in blocks]
-        )
+        prefix_cache._update_prefix_index(tokens, [block.block_id for block in blocks])
         return blocks
 
     def test_lifecycle_hooks_registered(self, prefix_cache, paged_cache):
@@ -780,9 +1085,7 @@ class TestPrefixIndexLifecycle:
         paged_cache.cached_block_hash_to_block.insert(block.block_hash, block)
         assert len(prefix_cache._prefix_index) == 1
 
-        prefix_cache._forget_incompatible_ssd_block(
-            block.block_hash, block.block_id
-        )
+        prefix_cache._forget_incompatible_ssd_block(block.block_hash, block.block_id)
 
         assert len(prefix_cache._prefix_index) == 0
 
@@ -828,9 +1131,7 @@ class TestPrefixIndexValidation:
         blocks = paged_cache.get_new_blocks(num)
         for block in blocks:
             block.token_count = paged_cache.block_size
-        prefix_cache._update_prefix_index(
-            tokens, [block.block_id for block in blocks]
-        )
+        prefix_cache._update_prefix_index(tokens, [block.block_id for block in blocks])
         return blocks
 
     def test_valid_index_hit_returns_full_prefix(self, prefix_cache, paged_cache):
@@ -2659,9 +2960,10 @@ class TestTurboQuantFormatMismatchRecovery:
         assert block_table.num_tokens == 4
         assert blocks[1].ref_count == 1
         mock_ssd.forget_block.assert_called_once_with(blocks[1].block_hash)
-        assert paged_cache.cached_block_hash_to_block.get_block(
-            blocks[1].block_hash
-        ) is None
+        assert (
+            paged_cache.cached_block_hash_to_block.get_block(blocks[1].block_hash)
+            is None
+        )
 
     def test_reconstruct_rejects_stale_first_block_with_manager_signature(self, mx):
         """A live manager signature must make stale block 0 fail its own check."""
@@ -3537,8 +3839,7 @@ class TestTurboQuantMixedPayloadReconstruction:
 
         tq_metadata = self._metadata(["TurboQuantKVCache"], [tq.meta_state], 1)
         mock_ssd.load_block_with_metadata.side_effect = [
-            ([self._tq_block_payload(tq_mod, ks, vs, i)], tq_metadata)
-            for i in range(3)
+            ([self._tq_block_payload(tq_mod, ks, vs, i)], tq_metadata) for i in range(3)
         ]
 
         result = cache.reconstruct_cache(block_table)
@@ -3671,9 +3972,7 @@ class TestTurboQuantMixedPayloadReconstruction:
         block_table = self._alloc_block_table(paged_cache, 2)
 
         full_keys = mx.random.normal((1, self.HEADS, 2 * self.BLOCK, self.HDIM))
-        full_values = mx.random.normal(
-            (1, self.HEADS, 2 * self.BLOCK, self.HDIM)
-        )
+        full_values = mx.random.normal((1, self.HEADS, 2 * self.BLOCK, self.HDIM))
         tq, ks, vs, ref_keys, ref_values = self._tq_quantize(
             mx, tq_mod, full_keys, full_values, bits=8.0
         )
@@ -3710,9 +4009,7 @@ class TestTurboQuantMixedPayloadReconstruction:
         block_table = self._alloc_block_table(paged_cache, 2)
 
         full_keys = mx.random.normal((1, self.HEADS, 2 * self.BLOCK, self.HDIM))
-        full_values = mx.random.normal(
-            (1, self.HEADS, 2 * self.BLOCK, self.HDIM)
-        )
+        full_values = mx.random.normal((1, self.HEADS, 2 * self.BLOCK, self.HDIM))
         tq, ks, vs, _, _ = self._tq_quantize(
             mx, tq_mod, full_keys, full_values, bits=8.0
         )
@@ -3784,12 +4081,8 @@ class TestReconstructionSilentFallbackHardening:
 
     def _plain_slice(self, mx):
         return (
-            mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(
-                mx.float16
-            ),
-            mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(
-                mx.float16
-            ),
+            mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(mx.float16),
+            mx.random.normal((1, self.HEADS, self.BLOCK, self.HDIM)).astype(mx.float16),
         )
 
     def _metadata(self, num_layers=1):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -25,6 +25,7 @@ import mlx.core as mx
 import pytest
 
 import omlx.scheduler as scheduler_module
+from omlx.cache.stats import PrefixCacheStats
 from omlx.request import Request, RequestOutput, RequestStatus, SamplingParams
 from omlx.scheduler import (
     Scheduler,
@@ -3327,8 +3328,66 @@ class TestSchedulerSSDLayerSignature:
             scheduler.shutdown()
 
 
-class TestSpecPrefillDraftCacheSignature:
-    """Regression coverage for SpecPrefill draft-cache isolation (#1925)."""
+class TestSpecPrefillCaches:
+    """Regression coverage for target-prefix reuse and draft-cache isolation."""
+
+    def test_cache_counters_work_before_a_draft_model_is_configured(
+        self, mock_model, mock_tokenizer
+    ):
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = SimpleNamespace(
+            get_stats=lambda: PrefixCacheStats(hits=2, misses=1)
+        )
+        try:
+            counters = scheduler._collect_cache_counters()
+
+            assert counters is not None
+            assert counters["prefix_hits"] == 2
+            assert "draft_prefix_hits" not in counters
+        finally:
+            scheduler.shutdown()
+
+    def test_static_target_prefix_does_not_create_an_independent_ram_cache(
+        self, mock_model, mock_tokenizer
+    ):
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        try:
+            scheduler.set_specprefill_draft_model(object())
+
+            assert not hasattr(scheduler, "_specprefill_static_prefix_kv_cache")
+        finally:
+            scheduler.shutdown()
+
+    def test_cache_counters_distinguish_target_static_and_draft_reuse(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.block_aware_cache = SimpleNamespace(
+            get_stats=lambda: PrefixCacheStats(
+                hits=11,
+                misses=3,
+                tokens_saved=9_000,
+                exact_prefix_hits=4,
+                exact_prefix_misses=1,
+                exact_prefix_tokens_restored=24_000,
+            )
+        )
+        scheduler._draft_prefix_cache = SimpleNamespace(
+            get_stats=lambda: PrefixCacheStats(
+                hits=8,
+                misses=2,
+                tokens_saved=48_000,
+            )
+        )
+        scheduler.paged_ssd_cache_manager = None
+
+        counters = scheduler._collect_cache_counters()
+
+        assert counters is not None
+        assert counters["target_static_hits"] == 4
+        assert counters["target_static_misses"] == 1
+        assert counters["target_static_tokens_restored"] == 24_000
+        assert counters["draft_prefix_hits"] == 8
+        assert counters["draft_prefix_misses"] == 2
+        assert counters["draft_prefix_tokens_saved"] == 48_000
 
     def test_draft_cache_reconstructs_with_target_turboquant_enabled(
         self, mock_tokenizer, tmp_path

--- a/tests/test_specprefill_target.py
+++ b/tests/test_specprefill_target.py
@@ -38,13 +38,85 @@ class _Model:
 
 
 class _CacheLayer:
+    """Mock cache layer that supports the ``.state`` property setter.
+
+    The real mlx-lm cache types (KVCache, RotatingKVCache, ArraysCache) expose
+    a ``state`` property with a setter that stores the KV tensor tuple. The
+    static-prefix KV cache (#2177) restores states by assigning
+    ``layer.state = state``. This mock stores the assigned value so the restore
+    path can be exercised without real MLX tensors.
+    """
+
     def __init__(self) -> None:
-        self.state = object()
+        self._state = (object(),)
+
+    @property
+    def state(self) -> Any:
+        return self._state
+
+    @state.setter
+    def state(self, value: Any) -> None:
+        self._state = value
 
 
-def _all_tokens(system_token_count: int, conversation_token_count: int) -> list[int]:
+class _TieredExactPrefixCache:
+    def __init__(self) -> None:
+        self.tokens: list[int] | None = None
+        self.layer_states: list[dict[str, Any]] | None = None
+        self.restore_promotions: list[bool] = []
+
+    def restore_exact_prefix(
+        self,
+        request_id: str,
+        tokens: list[int],
+        *,
+        promote_to_hot_cache: bool,
+    ) -> list[Any] | None:
+        del request_id
+        self.restore_promotions.append(promote_to_hot_cache)
+        if tokens != self.tokens or self.layer_states is None:
+            return None
+        restored_layers = [_CacheLayer() for _ in self.layer_states]
+        for restored_layer, layer_state in zip(
+            restored_layers, self.layer_states, strict=True
+        ):
+            restored_layer.state = layer_state["state"]
+        return restored_layers
+
+    def store_exact_prefix(
+        self,
+        request_id: str,
+        tokens: list[int],
+        cache_data: list[dict[str, Any]],
+        model_cache_config: Any = None,
+    ) -> object:
+        del request_id, model_cache_config
+        self.tokens = list(tokens)
+        self.layer_states = cache_data
+        return object()
+
+
+def _extract_cache_states(
+    cache: list[Any],
+) -> tuple[list[dict[str, Any]], Any]:
+    return [
+        {
+            "state": layer.state,
+            "meta_state": (),
+            "class_name": "_CacheLayer",
+            "cache_type": "test",
+        }
+        for layer in cache
+    ], None
+
+
+def _all_tokens(
+    system_token_count: int,
+    conversation_token_count: int,
+    conversation_start: int = 1_000,
+) -> list[int]:
     return list(range(system_token_count)) + list(
-        range(1_000, 1_000 + conversation_token_count)
+        range(conversation_start, conversation_start + conversation_token_count)
     )
 
 
@@ -53,11 +125,22 @@ def _run(
     system_token_count: int,
     conversation_token_count: int,
     selected_indices: list[int],
+    cached_tokens: int = 0,
+    request_prompt_cache: list[Any] | None = None,
+    conversation_start: int = 1_000,
+    extract_cache_states: target_workflow.ExtractCacheStates | None = None,
     abort_error: _AbortError | None = None,
     abort_at: int | None = None,
     sparse_abort_error: _AbortError | None = None,
+    exact_prefix_cache: _TieredExactPrefixCache | None = None,
+    static_prefix_tokens: list[int] | None = None,
+    promote_static_prefix_to_hot_cache: bool = True,
 ) -> tuple[Any, _Logger, dict[str, Any]]:
-    all_tokens = _all_tokens(system_token_count, conversation_token_count)
+    all_tokens = _all_tokens(
+        system_token_count,
+        conversation_token_count,
+        conversation_start,
+    )
     plan = plan_specprefill_target(
         all_tokens=all_tokens,
         system_token_count=system_token_count,
@@ -125,7 +208,9 @@ def _run(
 
     with (
         patch.object(target_workflow, "make_prompt_cache", return_value=prompt_cache),
-        patch.object(target_workflow.mx, "eval", side_effect=trace["evaluations"].append),
+        patch.object(
+            target_workflow.mx, "eval", side_effect=trace["evaluations"].append
+        ),
         patch.object(target_workflow.mx, "stream", side_effect=use_stream),
         patch(
             "omlx.patches.specprefill._find_attention_layers",
@@ -140,8 +225,10 @@ def _run(
         result = target_workflow.run_specprefill_target_prefill(
             target_model=model,
             request=SimpleNamespace(
-                cached_tokens=0,
-                num_prompt_tokens=len(all_tokens),
+                request_id="target-request",
+                cached_tokens=cached_tokens,
+                num_prompt_tokens=cached_tokens + len(all_tokens),
+                prompt_cache=request_prompt_cache,
             ),
             plan=plan,
             all_tokens=all_tokens,
@@ -153,6 +240,10 @@ def _run(
             report_sparse_progress=report_sparse_progress,
             sync_and_clear_cache=lambda: trace["syncs"].append(stream),
             log=logger,
+            extract_cache_states=extract_cache_states,
+            exact_prefix_cache=exact_prefix_cache,
+            static_prefix_tokens=static_prefix_tokens,
+            promote_static_prefix_to_hot_cache=promote_static_prefix_to_hot_cache,
         )
     trace.update(
         {
@@ -193,7 +284,11 @@ def test_system_prefill_chunks_reports_checks_abort_and_uses_stream():
 
 @pytest.mark.parametrize(
     ("selected_indices", "expected_selected", "keeps_original"),
-    [([0, 5, 10], [0, 5, 10], True), ([10, 11, 0], [0, 10], False), ([11, 1, 11, 5], [1, 5, 11], False)],
+    [
+        ([0, 5, 10], [0, 5, 10], True),
+        ([10, 11, 0], [0, 10], False),
+        ([11, 1, 11, 5], [1, 5, 11], False),
+    ],
 )
 def test_sparse_prefill_preserves_sparse_inputs(
     selected_indices: list[int], expected_selected: list[int], keeps_original: bool
@@ -230,6 +325,76 @@ def test_runtime_patch_helpers_adjust_rope_log_and_handoff_result():
         "SpecPrefill: sparse prefill 2/10 conv tokens in 1.2s "
         "(total 15, cached 0, system 5 full, conv 10 sparse)",
     ]
+
+
+def test_target_prefill_extends_an_existing_partial_prefix_cache():
+    restored_prefix_cache = [_CacheLayer()]
+
+    _, _, trace = _run(
+        system_token_count=5,
+        conversation_token_count=8,
+        selected_indices=[0, 2, 6],
+        cached_tokens=4,
+        request_prompt_cache=restored_prefix_cache,
+    )
+
+    assert all(cache is restored_prefix_cache for _, cache in trace["model"].calls)
+    assert trace["sparse_calls"][0]["cache"] is restored_prefix_cache
+
+
+def test_github_2177_restores_static_prefix_from_tiered_cache():
+    exact_prefix_cache = _TieredExactPrefixCache()
+    static_prefix_tokens = list(range(5))
+    common_args = {
+        "system_token_count": 5,
+        "conversation_token_count": 12,
+        "selected_indices": [0, 5, 10],
+        "exact_prefix_cache": exact_prefix_cache,
+        "static_prefix_tokens": static_prefix_tokens,
+        "extract_cache_states": _extract_cache_states,
+    }
+
+    _, _, cold_trace = _run(**common_args)
+    warm_result, warm_logger, warm_trace = _run(
+        **common_args,
+        conversation_start=2_000,
+        promote_static_prefix_to_hot_cache=False,
+    )
+
+    assert len(cold_trace["model"].calls) == 2
+    assert warm_trace["model"].calls == []
+    assert warm_result.static_prefix_cached_tokens == len(static_prefix_tokens)
+    assert exact_prefix_cache.restore_promotions == [True, False]
+    assert "system 5 static-cached" in warm_logger.info_messages[-1]
+
+
+def test_static_prefix_hit_supersedes_a_shorter_block_cache_hit():
+    exact_prefix_cache = _TieredExactPrefixCache()
+    static_prefix_tokens = list(range(5))
+    _run(
+        system_token_count=5,
+        conversation_token_count=8,
+        selected_indices=[0, 2, 6],
+        exact_prefix_cache=exact_prefix_cache,
+        static_prefix_tokens=static_prefix_tokens,
+        extract_cache_states=_extract_cache_states,
+    )
+    shorter_block_cache = [_CacheLayer()]
+
+    result, _, warm_trace = _run(
+        system_token_count=3,
+        conversation_token_count=8,
+        selected_indices=[0, 2, 6],
+        cached_tokens=2,
+        request_prompt_cache=shorter_block_cache,
+        exact_prefix_cache=exact_prefix_cache,
+        static_prefix_tokens=static_prefix_tokens,
+        extract_cache_states=_extract_cache_states,
+    )
+
+    assert result.static_prefix_cached_tokens == 5
+    assert result.prompt_cache is not shorter_block_cache
+    assert warm_trace["model"].calls == []
 
 
 def test_scheduler_abort_error_propagates_unchanged():


### PR DESCRIPTION
## Summary

- persist complete SpecPrefill target system/tool prefixes through the existing paged SSD and hot-cache tiers, including arbitrary terminal boundaries
- restore exact target prefixes across requests and server restarts without replacing longer ordinary prefix-cache hits
- expose distinct target-static and draft-prefix API telemetry and cover restart, pressure-reclaim, missing-terminal, and cache-policy behavior

The implementation extends `BlockAwarePrefixCache` with a domain-separated exact terminal block. Ordinary prefix matching remains full-block-only; this PR adds no cache manager, storage tier, or independent memory budget.

## Scope

- target reuse is limited to the stable system/tool prefix; sparse conversation/history KV is not reused
- target and draft caches remain separate model-specific instances over the existing cache infrastructure
- API telemetry is included; dashboard UI is intentionally unchanged

## Testing

- modified unit-test modules: `347 passed`
- full local non-slow/non-integration suite: `7489 passed, 52 skipped`; three unrelated numerical-tolerance failures reproduce identically on `origin/main`
- available model-free slow/integration coverage: `17 passed`; seven TurboQuant tests require an uncached Llama checkpoint
- generic real-model suite with local Qwen3.5-2B: `14 passed`
- Qwen3.6-27B target + Qwen3.5-4B draft restart/pressure test: `1 passed`
- focused Ruff import/error checks and `git diff --check` pass

Closes #2177