### PR TITLE
fix(specprefill): always keep a trailing token window in chunk selection

### DIFF
--- a/omlx/patches/specprefill.py
+++ b/omlx/patches/specprefill.py
@@ -9,7 +9,7 @@ Based on arxiv.org/abs/2502.02789 and waybarrios/vllm-mlx PR #180.
 
 Pipeline:
   1. score_tokens()  — draft model scores token importance via attention
-  2. select_chunks() — chunk-based top-K% selection
+  2. select_chunks() — chunk-based top-K% selection + mandatory tail window
   3. sparse_prefill() — target prefill with manual RoPE at original positions
   4. cleanup_rope()  — restore original RoPE after generation
 
@@ -588,14 +588,32 @@ def score_tokens(
 
 
 def select_chunks(
-    importance: mx.array, keep_pct: float = 0.3, chunk_size: int = 32
+    importance: mx.array,
+    keep_pct: float = 0.3,
+    chunk_size: int = 32,
+    tail_tokens: int = 512,
 ) -> mx.array:
     """Select top-K% token chunks by average importance.
+
+    The final ``ceil(tail_tokens / chunk_size)`` chunks are always selected
+    (covering at least ``tail_tokens - chunk_size + 1`` trailing tokens).
+    Chat templates end with structural markers (tool-result closers,
+    end-of-turn, the generation prompt) whose chunks can lose the
+    importance ranking; when they do, the target model is left
+    mid-structure and emits malformed output (e.g. a bare </tool_response>
+    then EOS) instead of an answer. The mandatory tail chunks are drawn
+    from the normal keep budget first: when the budget covers the tail
+    (keep_n >= 16 chunks at the defaults, i.e. scored regions >= 2,401
+    tokens at keep_pct=0.2) the selected count is unchanged and only the
+    composition shifts; on smaller inputs the floor takes precedence over
+    ``keep_pct``.
 
     Args:
         importance: (M,) per-token importance scores
         keep_pct: fraction of chunks to keep (default 0.3)
         chunk_size: tokens per chunk (default 32)
+        tail_tokens: trailing-token window always selected, rounded up to
+            whole chunks (default 512, 0 disables the floor)
 
     Returns:
         sorted mx.array of kept token indices
@@ -606,16 +624,22 @@ def select_chunks(
 
     n_chunks = math.ceil(M / chunk_size)
     keep_n = max(1, math.ceil(n_chunks * keep_pct))
+    n_tail_chunks = (
+        min(n_chunks, math.ceil(tail_tokens / chunk_size)) if tail_tokens > 0 else 0
+    )
+    ranked_end = n_chunks - n_tail_chunks
 
     chunk_scores = []
-    for i in range(n_chunks):
+    for i in range(ranked_end):
         start = i * chunk_size
         end = min(start + chunk_size, M)
         chunk_scores.append(mx.mean(importance[start:end]).item())
 
-    top_chunks = sorted(range(n_chunks), key=lambda i: chunk_scores[i], reverse=True)[
-        :keep_n
+    budget = max(0, keep_n - n_tail_chunks)
+    top_chunks = sorted(range(ranked_end), key=lambda i: chunk_scores[i], reverse=True)[
+        :budget
     ]
+    top_chunks.extend(range(ranked_end, n_chunks))
     top_chunks.sort()
 
     indices = []

--- a/tests/test_specprefill.py
+++ b/tests/test_specprefill.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for SpecPrefill (attention-based sparse prefill)."""
 
-import math
-
 import pytest
 
 try:
@@ -16,20 +14,20 @@ pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
 
 
 class TestSelectChunks:
-    """Tests for select_chunks() — chunk-based top-K% selection."""
+    """Tests for select_chunks() — top-K% selection with a mandatory tail."""
 
     def test_basic_selection(self):
         from omlx.patches.specprefill import select_chunks
 
-        # 128 tokens, importance peaks in the first 32 tokens
-        importance = mx.zeros(128)
+        # 4096 tokens (128 chunks), importance peaks in the first chunk.
+        importance = mx.zeros(4096)
         importance = importance.at[:32].add(1.0)
         selected = select_chunks(importance, keep_pct=0.25, chunk_size=32)
-        # Should keep 1 chunk (25% of 4 chunks)
-        assert selected.shape[0] == 32
-        # Should be the first chunk (indices 0-31)
-        assert selected[0].item() == 0
-        assert selected[-1].item() == 31
+        # Keeps 32 chunks (25% of 128): the tail window plus top-ranked ones.
+        assert selected.shape[0] == 32 * 32
+        indices = set(selected.tolist())
+        # The high-importance first chunk wins a ranked slot.
+        assert set(range(32)) <= indices
 
     def test_keep_100_percent(self):
         from omlx.patches.specprefill import select_chunks
@@ -41,12 +39,11 @@ class TestSelectChunks:
     def test_sorted_output(self):
         from omlx.patches.specprefill import select_chunks
 
-        # Make middle and end chunks important
-        importance = mx.zeros(128)
+        # Make two early chunks important; 4096 tokens total.
+        importance = mx.zeros(4096)
         importance = importance.at[32:64].add(2.0)
         importance = importance.at[96:128].add(1.0)
-        selected = select_chunks(importance, keep_pct=0.5, chunk_size=32)
-        # Should select 2 chunks, sorted by position
+        selected = select_chunks(importance, keep_pct=0.25, chunk_size=32)
         indices = selected.tolist()
         assert indices == sorted(indices)
         assert 32 in indices
@@ -63,14 +60,70 @@ class TestSelectChunks:
     def test_non_divisible_chunks(self):
         from omlx.patches.specprefill import select_chunks
 
-        # 100 tokens with chunk_size=32 → 4 chunks (last has 4 tokens)
-        importance = mx.ones(100)
+        # 4100 tokens with chunk_size=32 → 129 chunks (last has 4 tokens).
+        # keep_n = 65 chunks; 64 full chunks + the 4-token final chunk.
+        importance = mx.ones(4100)
         selected = select_chunks(importance, keep_pct=0.5, chunk_size=32)
-        n_chunks = math.ceil(100 / 32)
-        keep_n = math.ceil(n_chunks * 0.5)
-        expected_tokens = min(keep_n * 32, 100)
-        # Allow for last chunk being smaller
-        assert selected.shape[0] <= expected_tokens + 32
+        assert selected.shape[0] == 64 * 32 + 4
+
+    def test_tail_floor_kept_when_unimportant(self):
+        from omlx.patches.specprefill import select_chunks
+
+        # Importance mass entirely in the front half; the tail scores zero.
+        # Without the mandatory tail window the final chunks (chat-template
+        # closers + generation prompt) would be dropped — the 2439 failure.
+        importance = mx.zeros(8192)
+        importance = importance.at[:2048].add(1.0)
+        selected = select_chunks(importance, keep_pct=0.2, chunk_size=32)
+        indices = set(selected.tolist())
+        assert set(range(8192 - 512, 8192)) <= indices
+
+    def test_tail_floor_within_budget_at_scale(self):
+        from omlx.patches.specprefill import select_chunks
+
+        # When the keep budget covers the tail, the tail comes out of the
+        # budget and the selected-token count matches the plain top-K
+        # formula: 8192 tokens → 256 chunks, keep 20% → 52 chunks → 1664.
+        importance = (mx.arange(8192) % 97).astype(mx.float32)
+        selected = select_chunks(importance, keep_pct=0.2, chunk_size=32)
+        assert selected.shape[0] == 1664
+
+    def test_tail_floor_dominates_small_input(self):
+        from omlx.patches.specprefill import select_chunks
+
+        # Just above the admission threshold with a small keep budget the
+        # floor wins over keep_pct: exactly the 16 tail chunks (512 tokens,
+        # indices 544..1055) are selected — keep_n (4) is below the tail.
+        importance = mx.zeros(1056)
+        selected = select_chunks(importance, keep_pct=0.1, chunk_size=32)
+        indices = set(selected.tolist())
+        assert indices == set(range(1056 - 512, 1056))
+
+    def test_tail_floor_non_aligned_input(self):
+        from omlx.patches.specprefill import select_chunks
+
+        # Non-chunk-aligned M: the tail window is chunk-aligned, so it
+        # covers the final partial chunk plus the 15 full chunks before it
+        # (481 trailing tokens here — at least tail_tokens - chunk_size + 1).
+        importance = mx.zeros(8193)
+        importance = importance.at[:2048].add(1.0)
+        selected = select_chunks(importance, keep_pct=0.2, chunk_size=32)
+        indices = set(selected.tolist())
+        assert set(range(241 * 32, 8193)) <= indices
+
+    def test_tail_floor_disabled(self):
+        from omlx.patches.specprefill import select_chunks
+
+        # tail_tokens=0 restores pure top-K: an unimportant tail is dropped
+        # and the budget is exactly keep_n chunks (32 of 128 → 1024 tokens).
+        importance = mx.zeros(4096)
+        importance = importance.at[:2048].add(1.0)
+        selected = select_chunks(
+            importance, keep_pct=0.25, chunk_size=32, tail_tokens=0
+        )
+        indices = set(selected.tolist())
+        assert (4096 - 1) not in indices
+        assert selected.shape[0] == 32 * 32
 
 
 class TestManualRoPE:


### PR DESCRIPTION
Fixes #2439.

## Summary

- `select_chunks()` now always selects the final 16 chunks (512 tokens at chunk_size=32, at least 481 when the last chunk is partial) of the scored region, so the chat template's closing structure — tool-result closers, end-of-turn markers, the generation prompt — can no longer be dropped by the importance ranking.
- The mandatory tail chunks are drawn from the existing keep budget first: whenever the budget covers the tail (`keep_n >= 16`, i.e. scored regions ≥ 2,401 tokens at keep=20%, ≥ 4,801 at keep=10%) the selected chunk count is unchanged and the token count can move only through the final partial chunk (≤31 tokens, never upward) — the composition shifts, the cost does not.
- Rewrites the `TestSelectChunks` cases at a scale where both mechanisms are visible through the real default path, and adds five tail-window tests (including a non-chunk-aligned input).

## Why

Sparse selection is purely top-K by draft-attention importance; the only protected region is the system prompt (`specprefill_system_end`). Everything after it — every user turn, tool call, tool result, and every chat-template marker between them — competes in the importance lottery in 32-token chunks. When the trailing chunks lose, the target model's KV ends mid-structure: its most recent visible context can be an unclosed `<tool_response>` block, with the generation prompt never prefilled. The single generation-kickoff token is then decoded against that context, and the most probable continuation is exactly what #2439 captured: one bare `</tool_response>` token (a single token in Qwen3.6's vocabulary, id 248067) and an immediate stop.

The upstream sources don't cover this case: the SpecPrefill paper (arXiv 2502.02789) treats recency ("proximity bias") purely as a scoring artifact to dilute via look-ahead, and neither the paper's reference implementation nor the vllm-mlx port force-keeps any positions — but they were designed and evaluated on long-document tasks only, never on chat-templated tool transcripts, where the trailing tokens are structurally mandatory regardless of attention score.

This failure family has been reported repeatedly: #419 (empty responses, tools involved, closed on a best-guess), #548 (Claude Code, hallucinated tool-call markers with SpecPrefill on vs clean calls with it off), #1401 (hermes/Codex users, "model claims the data is corrupted", empty responses), and now #2439 with precise instrumentation. #334's diagnosis already named the mechanism ("instructions added at each turn can get dropped because they don't all go through full prefill") — this PR makes the minimal structural part of that guarantee automatic.

## Reproduction and verification on a real model

Protocol (mirrors the issue): Qwen3.6-27B-oQ8-mtp target (the issue used the oQ4e-mtp quant of the same model — same tokenizer and chat template) + lmstudio-community/Qwen3.5-4B-MLX-4bit draft (the issue's exact draft), threshold=1024, keep=20%, temperature 0, an OpenCode-style tool-calling conversation (glob/bash/read rounds, ~8k conv tokens), driven as a real agent loop (tool results appended, resent), fresh cache.

Unfixed (`main` @ 569a3593): rounds 1–3 derail ("the glob results were messy" → retry tool calls), then round 4 collapses to the exact issue symptom — completion of literally one token, content a bare `</tool_response>`, `finish_reason=stop`:

```text
SpecPrefill: scored 9715 tokens in 2.5s, selected 1952/9715 (keep=20%, ...)
SpecPrefill: sparse prefill 1952/9715 conv tokens in 3.3s (...)
Chat completion: ... 1 tokens in 6.09s (0.2 tok/s), prompt: 10215, finish_reason=stop
```

The logs contain a direct mechanism signature: the target-side count normally reads one lower than the draft-side count (the generation-kickoff index is removed from the selected set before sparse prefill — `plan_specprefill_target.remove_kickoff_index`). Rounds 1–3 show that decrement (`selected 1643 → sparse prefill 1642`); the collapsing round shows `1952 → 1952` — the final chunk (the last ≤32 tokens, carrying the closing markers and the generation prompt) lost the importance ranking and was never prefilled. The chunk arithmetic confirms it through a second, independent channel: 1952 = 61 × 32 exactly, meaning all 61 selected chunks were full chunks and the 19-token final chunk was excluded, while every healthy round equals (keep_n − 1) × 32 + the final-chunk remainder (e.g. 1643 = 51 × 32 + 11).

The same fingerprint is present in #2439's own posted log: `selected 1312/6401` followed by `sparse prefill 1312/6401` — no decrement, and 1312 = 41 × 32 exactly while the scored region's final chunk was a single token (6401 mod 32 = 1). The reporter's failing request demonstrably dropped its final chunk, which is precisely the failure this change makes impossible.

Fixed: six rounds through the same loop, every turn structurally valid (well-formed tool calls or answers, no 1-token stops), and every round shows the `N → N-1` decrement — the final-chunk guarantee holds. Round-1 selection is count-identical to unfixed (`selected 1643/8171`, scoring 1.7s both sides); in general the chunk count is invariant at this scale and only the final partial chunk can move the token count (≤31, never upward).

Control (SpecPrefill disabled per-request, same messages, temp 0): correct 10-item grounded answer in one round — confirming the corruption is selection-induced, not model- or prompt-induced.

Prose regression probe (SpecPrefill's intended regime): a ~9k-token single-turn essay + question, keep=20% — sparse selection stays active (`selected 1851/9275`) and the model extracts the essay's three argued points correctly.

Second target family (Qwen3.6-35B-A3B-oQ4-mtp, hybrid GDN/MoE, same draft): the fix serves correctly on the hybrid cache layout (sparse prefill runs, the `N → N-1` tail guarantee holds, no crashes). Two clarifying observations from this pass: selection is draft-and-prompt determined, so both targets received the identical `selected 1643/8171` for the identical round — the selector is truly target-independent; and the 35B exhibits a different degradation under sparse prefill (thinking-scaffold confusion: deliberation prose emitted as content, with the final chunk intact in both arms) — that manifestation is mid-history-driven and is explicitly not fixed by this change (see scope below).

## What this does and does not fix

It fixes the tail-loss failure mode — the one #2439's log demonstrably exhibits: the final chunk (closing markers + generation prompt) can no longer be dropped, so the bare-marker/1-token-stop collapse is impossible. It does not fix every SpecPrefill-induced degradation: mid-history shredding remains, and it has its own failure manifestations — on the 35B pass above, thinking-scaffold confusion occurred with the final chunk intact in both arms, so a tail floor cannot address it. Nor does it make low keep rates semantically sufficient for agent workloads — with keep=20%, mid-history tool results are still 80%-dropped and the model may legitimately re-issue reads (inherent to SpecPrefill, already documented in #334). The earlier field reports (#419, #548, #1401) likely mix both mechanisms — this PR eliminates the tail-loss one. Structure-aware span protection or smarter handling of tool-result history (per the directions listed in #2439) would be follow-up work; this change is the minimal automatic guarantee with no new setting, per the project's automatic-over-tunable stance.

Stated trade-off at small scored regions: below the budget-covers-tail boundary (scored region ≤ 2,400 tokens at keep=20%), the floor takes precedence over the requested keep rate — with the reporter's own threshold=1024 config, a region in (1,024, 2,400] selects a flat 512 tokens against an old 224–480 (up to +288 tokens, sub-second). At aggressive settings (keep=10%, region just over the default 8,192 threshold) the importance-ranked share of the budget shrinks from 26 to 10 chunks in favor of the guaranteed tail. I consider that the right side of the trade — the floor exists precisely because the importance lottery is untrustworthy at the structural tail — but it is a real composition shift and is called out here rather than hidden. At the default threshold (8,192) the budget always covers the tail and cost is unchanged.

## Sibling paths

- `select_chunks` has exactly one production call site (`omlx/specprefill/draft.py`), shared by the LM and VLM engines through the single Scheduler workflow, so streaming/non-streaming/LM/VLM/benchmark paths are all covered by the one change. (SpecPrefill is skipped upstream of the selector for VLM requests carrying image embeds, so "VLM coverage" means text-only requests on VLM-class engines — which is also what the reproduction exercised.)
- `sparse_prefill`'s existing RotatingKVCache tail-merge (which already force-includes trailing tokens for sliding-window layers) composes benignly: it takes a set-union with the selected indices, and union with an already-present tail is idempotent. That merge is also the in-tree precedent for unconditional tail retention — and it corroborates the diagnosis: rotating-cache architectures already had a forced tail, and the malformed-output reports all involve full-attention models. (Review side-find, pre-existing and out of scope: that union re-adds the just-removed kickoff index for rotating-cache models — can file separately.)
- The kickoff-removal math in `plan_specprefill_target` is unchanged; with the floor, the kickoff index is now always present and always removed — the live logs above confirm the count math on every round.

## Tests

`python -m pytest tests/test_specprefill.py tests/test_specprefill_draft.py tests/test_specprefill_policy.py -q` → 66 passed.

Four of the five tail-window tests fail with the fix reverted (verified against the pristine `main` selector); `test_tail_floor_within_budget_at_scale` passes on both sides by design — it pins the cost contract.
