### PR TITLE
feat(dflash): warn on precision-mismatched draft pairs, surface acceptance in dashboard

### DIFF
--- a/docs/experimental/dflash_mlx_integration.md
+++ b/docs/experimental/dflash_mlx_integration.md
@@ -89,6 +89,7 @@ DFlash upstream registers `QwenGdnTargetOps` and `Gemma4TargetOps`. oMLX also re
 | google/gemma-4-31b-it | z-lab/gemma-4-31B-it-DFlash |
 | google/gemma-4-26b-a4b-it | z-lab/gemma-4-26B-A4B-it-DFlash |
 | poolside/Laguna-XS-2.1 | poolside/Laguna-XS-2.1-DFlash |
+| poolside/Laguna-XS-2.1-NVFP4(-mlx) | poolside/Laguna-XS-2.1-DFlash-NVFP4 |
 | poolside/Laguna-S-2.1 | poolside/Laguna-S-2.1-DFlash |
 | poolside/Laguna-S-2.1-NVFP4(-mlx) | poolside/Laguna-S-2.1-DFlash-NVFP4 |
 
@@ -96,7 +97,15 @@ Other model families (Llama, Gemma3, etc.) are not supported — they require bo
 
 Laguna target and draft checkpoints must be from the same size family and should
 use Poolside's quantization-matched draft when one is published (for example,
-`Laguna-S-2.1-DFlash-NVFP4` with the NVFP4 target). The adapter validates target
+`Laguna-S-2.1-DFlash-NVFP4` with the NVFP4 target). DFlash drafts predict from
+hidden states captured inside the target, so a precision-mismatched pair (a
+BF16-target draft on a community-quantized target, or an NVFP4 draft on an oQ
+target) collapses acceptance to roughly one draft token per cycle and makes
+DFlash slower than plain decoding (issue #2398). The engine logs a warning at
+load time for recognizably mismatched pairs and shows it in the dashboard's
+Active Models card, together with per-session acceptance and tokens/cycle
+counters. Poolside also publishes INT4/FP8 drafters; their vLLM-format targets
+are not yet validated in oMLX. The adapter validates target
 depth, hidden size, and capture-layer IDs at load time. It implements Laguna's
 per-head/per-element softplus attention gating, partial RoPE,
 per-captured-layer RMS normalization, Poolside's fused `qkv_proj` checkpoint

--- a/docs/experimental/dflash_mlx_integration.md
+++ b/docs/experimental/dflash_mlx_integration.md
@@ -28,12 +28,12 @@ Key distinction from traditional speculative decoding: the draft model uses **bl
 ```
 API Request → server.py → engine_pool.py
                               │
-                              ├─ prompt < DFLASH_MAX_CTX (4096)
+                              ├─ dflash_max_ctx unset, or prompt below limit
                               │     └─ DFlashEngine
                               │           └─ stream_dflash_generate()  [dflash-mlx]
                               │                 └─ draft/verify loop (internal)
                               │
-                              └─ prompt >= DFLASH_MAX_CTX
+                              └─ configured limit reached
                                     └─ fallback engine (BatchedEngine / VLMBatchedEngine)
                                           └─ BatchGenerator + paged cache + SSD cache
 ```
@@ -42,7 +42,8 @@ DFlashEngine is a `BaseEngine` implementation that:
 - Loads target + draft models via `dflash_mlx.runtime.load_target_bundle()` / `load_draft_bundle()`
 - Consumes structured events from `stream_dflash_generate()` (prefill, token, summary)
 - Bridges sync generation to async streaming via `asyncio.Queue`
-- Holds an internal fallback engine for long-context requests
+- Lazily replaces DFlash with a fallback engine when a configured context
+  limit is reached
 
 ---
 
@@ -66,7 +67,7 @@ DFlashEngine is a `BaseEngine` implementation that:
 
 ### Dependency
 
-- `dflash-mlx` pinned to `bstnxbt/dflash-mlx@9ca0028` (v0.1.10)
+- `dflash-mlx` pinned to `jundot/dflash-mlx@474f8e1` (v0.1.10+omlx.3)
 - Listed as required dependency in `pyproject.toml` and `packaging/venvstacks.toml`
 
 ### Supported models
@@ -89,23 +90,23 @@ DFlash upstream registers `QwenGdnTargetOps` and `Gemma4TargetOps`. oMLX also re
 | google/gemma-4-31b-it | z-lab/gemma-4-31B-it-DFlash |
 | google/gemma-4-26b-a4b-it | z-lab/gemma-4-26B-A4B-it-DFlash |
 | poolside/Laguna-XS-2.1 | poolside/Laguna-XS-2.1-DFlash |
-| poolside/Laguna-XS-2.1-NVFP4(-mlx) | poolside/Laguna-XS-2.1-DFlash-NVFP4 |
+| poolside/Laguna-XS-2.1-NVFP4-mlx | poolside/Laguna-XS-2.1-DFlash-NVFP4 |
 | poolside/Laguna-S-2.1 | poolside/Laguna-S-2.1-DFlash |
-| poolside/Laguna-S-2.1-NVFP4(-mlx) | poolside/Laguna-S-2.1-DFlash-NVFP4 |
+| poolside/Laguna-S-2.1-NVFP4-mlx | poolside/Laguna-S-2.1-DFlash-NVFP4 |
 
 Other model families (Llama, Gemma3, etc.) are not supported — they require both a trained DFlash draft checkpoint and a compatible target adapter in dflash-mlx.
 
 Laguna target and draft checkpoints must be from the same size family and should
 use Poolside's quantization-matched draft when one is published (for example,
-`Laguna-S-2.1-DFlash-NVFP4` with the NVFP4 target). DFlash drafts predict from
-hidden states captured inside the target, so a precision-mismatched pair (a
-BF16-target draft on a community-quantized target, or an NVFP4 draft on an oQ
-target) collapses acceptance to roughly one draft token per cycle and makes
-DFlash slower than plain decoding (issue #2398). The engine logs a warning at
-load time for recognizably mismatched pairs and shows it in the dashboard's
-Active Models card, together with per-session acceptance and tokens/cycle
-counters. Poolside also publishes INT4/FP8 drafters; their vLLM-format targets
-are not yet validated in oMLX. The adapter validates target
+`Laguna-S-2.1-DFlash-NVFP4` with the NVFP4 target). A checkpoint that explicitly
+declares a different precision from the target may reduce acceptance; issue
+#2398 motivates checking this, but does not isolate pairing as the sole cause.
+The engine warns only when both target and draft expose contradictory precision
+metadata, and shows the warning in the dashboard together with acceptance and
+separate accepted-draft/output tokens-per-cycle counters. A generic `-DFlash`
+suffix is not treated as proof of a BF16-only draft. Poolside also publishes
+INT4/FP8 drafters; their vLLM-format
+targets are not yet validated in oMLX. The adapter validates target
 depth, hidden size, and capture-layer IDs at load time. It implements Laguna's
 per-head/per-element softplus attention gating, partial RoPE,
 per-captured-layer RMS normalization, Poolside's fused `qkv_proj` checkpoint
@@ -127,6 +128,9 @@ Note: the `-DFlash` suffix is specific to DFlash draft checkpoints. Gemma4 also 
 | `dflash_draft_quant_weight_bits` | int | Draft model quantization weight bits |
 | `dflash_draft_quant_activation_bits` | int | Draft model quantization activation bits |
 | `dflash_draft_quant_group_size` | int | Draft model quantization group size |
+| `dflash_max_ctx` | int or null | Optional prompt-token threshold for batched fallback (`null` = unlimited) |
+| `dflash_in_memory_cache` | bool | Enable DFlash L1 prefix snapshots |
+| `dflash_ssd_cache` | bool | Enable DFlash L2 snapshot spill |
 
 Configured via web admin UI → Model Settings → Experimental Features → DFlash.
 
@@ -134,7 +138,7 @@ Configured via web admin UI → Model Settings → Experimental Features → DFl
 
 ## Generation flow
 
-### Short context (< DFLASH_MAX_CTX)
+### DFlash path
 
 1. `DFlashEngine.stream_generate()` tokenizes prompt
 2. Submits to MLX executor thread via `_run_generate_streaming()`
@@ -150,11 +154,11 @@ Configured via web admin UI → Model Settings → Experimental Features → DFl
    - `"event": "summary"` → log metrics (tok/s, acceptance ratio, cycles)
 6. EOS tokens filtered from output
 
-### Long context (>= DFLASH_MAX_CTX)
+### Configured context fallback
 
 1. `DFlashEngine.stream_generate()` detects prompt length exceeds threshold
 2. Delegates entire request to `_fallback_engine.stream_generate()`
-3. Fallback engine is BatchedEngine or VLMBatchedEngine (started during `DFlashEngine.start()`)
+3. DFlash weights are evicted and BatchedEngine or VLMBatchedEngine starts lazily
 4. Full omlx features available: paged cache, SSD cache, prefix cache, continuous batching
 
 ### Non-streaming
@@ -196,15 +200,16 @@ The DFlash paper (arXiv:2602.06036) evaluates both temperature=0 (4.9x speedup) 
 
 DFlashEngine processes one request at a time. No continuous batching — the entire GPU is dedicated to a single draft/verify loop. For concurrent users, requests are serialized on the MLX executor thread.
 
-**Mitigation**: for Apple Silicon personal use (1-2 concurrent users), single-request 3-4x speed improvement outweighs batching benefits.
+**Trade-off**: on Apple Silicon with low concurrency, speculation can outweigh
+batching when acceptance is high; measure the actual target/draft pair and
+workload rather than assuming a fixed speedup.
 
 ### 2. Context length limit
 
 DFlash effectiveness degrades with long contexts:
-- Draft model trained on max sequence length 3072-4096 tokens
 - Verify pass attention cost grows with KV cache size
-- Default `DFLASH_MAX_CTX = 4096` (configurable via environment variable)
-- Beyond threshold, automatic fallback to BatchedEngine/VLMBatchedEngine
+- `dflash_max_ctx` defaults to unlimited
+- Setting a threshold enables automatic fallback to BatchedEngine/VLMBatchedEngine
 
 ### 3. Model support
 
@@ -217,13 +222,15 @@ Qwen, Gemma4, and Laguna have compatible target adapters and published draft che
 DFlashEngine loads both target and draft models simultaneously:
 - Draft model: typically ~1B parameters (small relative to target)
 - Draft int4 quantization available to reduce footprint
-- Fallback engine also loaded (for long-context requests) — shares the same model weights via mlx-lm if model path matches
+- The fallback engine is loaded only after DFlash weights are evicted
 
-### 5. No paged/SSD cache
+### 5. Separate prefix cache
 
-DFlashEngine does not use omlx's paged KV cache or SSD cache system. Cache is managed entirely within dflash-mlx's generation loop. Each request does full prefill from scratch (no prefix cache reuse across requests).
+DFlashEngine does not use omlx's paged KV block cache. It has a separate
+dflash-mlx snapshot cache: optional L1 memory entries and L2 SSD spill.
 
-**Mitigation**: long-context requests (where prefix caching matters most) fall back to BatchedEngine which has full paged + SSD cache support.
+When context fallback is configured, the batched engine provides oMLX's paged
+and SSD block cache after the switch.
 
 ### 6. No batch benchmark
 
@@ -240,14 +247,13 @@ When temperature > 0, acceptance rate drops because draft and target independent
 ```
 DFlashEngine.start()
   ├── load target model (dflash-mlx)
-  ├── load draft model (dflash-mlx)
-  └── start fallback engine
-        ├── VLMBatchedEngine (if model detected as VLM)
-        └── BatchedEngine (otherwise)
+  └── load draft model (dflash-mlx)
 
 Request arrives:
-  ├── len(prompt_tokens) < DFLASH_MAX_CTX → DFlash path
-  └── len(prompt_tokens) >= DFLASH_MAX_CTX → fallback engine path
+  ├── no configured limit, or prompt below it → DFlash path
+  └── configured limit reached
+        ├── evict DFlash target + draft
+        └── lazily start VLMBatchedEngine or BatchedEngine
 
 DFlashEngine.start() fails:
   └── engine_pool catches exception → creates VLMBatchedEngine or BatchedEngine directly
@@ -265,7 +271,6 @@ DFlash check runs **before** engine type routing in `_load_engine()`. If `dflash
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DFLASH_MAX_CTX` | 4096 | Max prompt tokens before fallback to AR |
 | `DFLASH_VERIFY_LEN` | block_size | Cap on verify block length |
 | `DFLASH_DRAFT_SINK` | 64 | Draft KV cache sink size |
 | `DFLASH_DRAFT_WINDOW` | 1024 | Draft KV cache window size |
@@ -290,7 +295,7 @@ DFlash generation complete: 502 tokens, 45.3 tok/s, acceptance=87.2%, cycles=38
 
 Context fallback is logged:
 ```
-DFlash context fallback: 5120 >= 4096, using vlm engine
+DFlash context fallback: 5120 >= 4096, evicting dflash models and switching to vlm engine
 ```
 
 ---
@@ -310,7 +315,7 @@ DFlash context fallback: 5120 >= 4096, using vlm engine
 2. Set the matching draft model path (for example, `poolside/Laguna-S-2.1-DFlash-NVFP4` for an NVFP4 Laguna S target)
 3. Reload model
 4. Send short prompt → verify DFlash logs (acceptance ratio, tok/s)
-5. Send long prompt (>4K tokens) → verify fallback to BatchedEngine logs
+5. Configure `dflash_max_ctx`, then send a prompt at or above it → verify fallback logs
 
 ---
 
@@ -318,5 +323,5 @@ DFlash context fallback: 5120 >= 4096, using vlm engine
 
 - **Upstream sync**: merge temperature patch to bstnxbt/dflash-mlx, update pin
 - **Broader model support**: as dflash-mlx adds new model families, omlx gets support automatically
-- **Prefix caching**: explore chunked prefill with block-level KV save/restore for multi-turn conversation acceleration (requires dflash-mlx exposing cache manipulation APIs)
-- **Benchmark integration**: add DFlash-specific benchmark metrics (acceptance ratio, draft/verify timing breakdown) to admin panel
+- **Adaptive fallback**: evaluate switching to plain decoding when measured speculation is consistently unprofitable
+- **Performance coverage**: add real Laguna matched-pair tests across short and long contexts

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -4681,6 +4681,24 @@ def _build_active_models_data() -> dict:
         if is_loaded and effective_ttl is not None and idle_seconds is not None:
             ttl_remaining_seconds = max(0.0, effective_ttl - idle_seconds)
 
+        # DFlash observability (issue #2398): session speculation counters and
+        # the load-time precision pairing warning. None on non-DFlash engines.
+        dflash_info = None
+        if entry is not None and entry.engine is not None:
+            pairing = getattr(entry.engine, "pairing_warning", None)
+            speculation = None
+            get_speculation = getattr(entry.engine, "get_speculation_stats", None)
+            if callable(get_speculation):
+                try:
+                    speculation = get_speculation()
+                except Exception:
+                    logger.debug("get_speculation_stats failed", exc_info=True)
+            if speculation is not None or pairing:
+                dflash_info = {
+                    "speculation": speculation,
+                    "pairing_warning": pairing,
+                }
+
         models.append(
             {
                 "id": model_id,
@@ -4707,6 +4725,7 @@ def _build_active_models_data() -> dict:
                 "generating": generating,
                 "idle_seconds": idle_seconds,
                 "ttl_remaining_seconds": ttl_remaining_seconds,
+                "dflash": dflash_info,
             }
         )
 

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -321,12 +321,18 @@
                                             <template x-if="m.dflash.speculation && m.dflash.speculation.last">
                                                 <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px] text-neutral-400">
                                                     <span class="font-medium text-neutral-500">DFlash</span>
-                                                    <span x-text="'acceptance ' + Math.round((m.dflash.speculation.last.acceptance_ratio || 0) * 100) + '%'"></span>
-                                                    <span x-show="m.dflash.speculation.last.tokens_per_cycle != null"
-                                                          x-text="(m.dflash.speculation.last.tokens_per_cycle || 0).toFixed(2) + ' tok/cycle'"></span>
-                                                    <span x-text="formatTokenCount(m.dflash.speculation.last.accepted_draft_tokens || 0) + ' draft tok (last req)'"></span>
-                                                    <span x-show="m.dflash.speculation.totals && m.dflash.speculation.totals.requests > 1"
-                                                          x-text="'session: ' + Math.round((m.dflash.speculation.totals.acceptance_ratio || 0) * 100) + '% · ' + (m.dflash.speculation.totals.tokens_per_cycle || 0).toFixed(2) + ' tok/cycle · ' + m.dflash.speculation.totals.requests + ' req'"></span>
+                                                    <span x-show="m.dflash.speculation.last.fallback_ar"
+                                                          x-text="'fallback AR' + (m.dflash.speculation.last.fallback_reason ? ' · ' + m.dflash.speculation.last.fallback_reason : '')"></span>
+                                                    <span x-show="!m.dflash.speculation.last.fallback_ar"
+                                                          x-text="'draft share ' + Math.round((m.dflash.speculation.last.acceptance_ratio || 0) * 100) + '%'"></span>
+                                                    <span x-show="!m.dflash.speculation.last.fallback_ar && m.dflash.speculation.last.accepted_draft_tokens_per_cycle != null"
+                                                          x-text="(m.dflash.speculation.last.accepted_draft_tokens_per_cycle || 0).toFixed(2) + ' accepted draft/cycle'"></span>
+                                                    <span x-show="!m.dflash.speculation.last.fallback_ar && m.dflash.speculation.last.tokens_per_cycle != null"
+                                                          x-text="(m.dflash.speculation.last.tokens_per_cycle || 0).toFixed(2) + ' output/cycle'"></span>
+                                                    <span x-show="!m.dflash.speculation.last.fallback_ar"
+                                                          x-text="formatTokenCount(m.dflash.speculation.last.accepted_draft_tokens || 0) + ' draft tok (last req)'"></span>
+                                                    <span x-show="m.dflash.speculation.totals && m.dflash.speculation.totals.speculative_requests > 1"
+                                                          x-text="'session: ' + Math.round((m.dflash.speculation.totals.acceptance_ratio || 0) * 100) + '% draft share · ' + (m.dflash.speculation.totals.accepted_draft_tokens_per_cycle || 0).toFixed(2) + ' accepted draft/cycle · ' + (m.dflash.speculation.totals.tokens_per_cycle || 0).toFixed(2) + ' output/cycle · ' + m.dflash.speculation.totals.speculative_requests + ' req'"></span>
                                                 </div>
                                             </template>
                                             <template x-if="m.dflash.pairing_warning">

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -315,6 +315,28 @@
                                             </template>
                                         </div>
                                     </template>
+                                    <!-- DFlash speculation sub-row (issue #2398) -->
+                                    <template x-if="m.dflash && (m.dflash.speculation || m.dflash.pairing_warning)">
+                                        <div class="mt-1.5 ml-5 space-y-1">
+                                            <template x-if="m.dflash.speculation && m.dflash.speculation.last">
+                                                <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px] text-neutral-400">
+                                                    <span class="font-medium text-neutral-500">DFlash</span>
+                                                    <span x-text="'acceptance ' + Math.round((m.dflash.speculation.last.acceptance_ratio || 0) * 100) + '%'"></span>
+                                                    <span x-show="m.dflash.speculation.last.tokens_per_cycle != null"
+                                                          x-text="(m.dflash.speculation.last.tokens_per_cycle || 0).toFixed(2) + ' tok/cycle'"></span>
+                                                    <span x-text="formatTokenCount(m.dflash.speculation.last.accepted_draft_tokens || 0) + ' draft tok (last req)'"></span>
+                                                    <span x-show="m.dflash.speculation.totals && m.dflash.speculation.totals.requests > 1"
+                                                          x-text="'session: ' + Math.round((m.dflash.speculation.totals.acceptance_ratio || 0) * 100) + '% · ' + (m.dflash.speculation.totals.tokens_per_cycle || 0).toFixed(2) + ' tok/cycle · ' + m.dflash.speculation.totals.requests + ' req'"></span>
+                                                </div>
+                                            </template>
+                                            <template x-if="m.dflash.pairing_warning">
+                                                <div class="flex items-center gap-1.5 text-[10px] text-amber-600">
+                                                    <i data-lucide="alert-triangle" class="w-3 h-3 flex-shrink-0"></i>
+                                                    <span class="min-w-0" x-text="m.dflash.pairing_warning"></span>
+                                                </div>
+                                            </template>
+                                        </div>
+                                    </template>
                                     <!-- Waiting sub-rows -->
                                     <template x-if="m.waiting && m.waiting.length > 0">
                                         <div class="mt-1.5 ml-5 space-y-1.5">

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -14,6 +14,7 @@ import copy
 import gc
 import json
 import logging
+import re
 import threading
 import time
 from collections.abc import AsyncIterator
@@ -112,6 +113,70 @@ def _format_phase_timings(phase_timings_us: object) -> str:
         f" replay={_ms('replay')}ms"
         f" commit={_ms('commit')}ms]"
     )
+
+
+# Precision suffixes Poolside uses for drafts trained against a quantized
+# target ("Laguna-S-2.1-DFlash-NVFP4" etc.). Anything else after "-DFlash-"
+# (e.g. z-lab's "-b16" block-size suffix) makes no precision claim.
+_DRAFT_PRECISION_TAGS = frozenset({"NVFP4", "INT4", "INT8", "FP8", "FP4", "MXFP4"})
+
+
+def check_draft_target_precision_pairing(
+    target_name: str,
+    target_config: dict | None,
+    draft_path: str,
+    model_type: str | None = None,
+) -> str | None:
+    """Heuristic precision-pairing check between a DFlash draft and its target.
+
+    DFlash drafts predict from hidden states captured inside the target, so a
+    draft trained against one target precision loses acceptance against
+    another (issue #2398: ~1 accepted draft token per cycle pairing BF16-target
+    Laguna drafts with community-quantized targets). Draft checkpoints do not
+    record their training target, so this keys off the published naming
+    convention (``*-DFlash`` = BF16 target, ``*-DFlash-<PRECISION>`` = the
+    matching quantized target) and the target's own quantization config.
+
+    Returns a warning message, or None when the pair looks matched or the
+    names carry no precision claim. The BF16-draft-on-quantized-target rule is
+    applied to Laguna only: the supported-pairs table explicitly endorses
+    quantized Qwen/Gemma4 targets with their generic drafts.
+    """
+    draft_base = Path(str(draft_path).rstrip("/")).name
+    match = re.search(r"-DFlash(?:-([A-Za-z0-9]+))?$", draft_base, re.IGNORECASE)
+    if match is None:
+        return None
+    suffix = (match.group(1) or "").upper()
+    draft_tag = suffix if suffix in _DRAFT_PRECISION_TAGS else ""
+
+    quant_section = None
+    if isinstance(target_config, dict):
+        quant_section = target_config.get("quantization") or target_config.get(
+            "quantization_config"
+        )
+    target_quantized = bool(quant_section)
+
+    advice = (
+        "Precision-mismatched pairs collapse draft acceptance and can make "
+        "DFlash slower than plain decoding (see issue #2398). Use the draft "
+        "published for this exact target precision."
+    )
+    if draft_tag:
+        if draft_tag.lower() in str(target_name).lower():
+            return None
+        return (
+            f"DFlash draft '{draft_base}' is published for a {draft_tag} "
+            f"target, but the loaded target is '{target_name}'"
+            f"{' (quantized)' if target_quantized else ' (not quantized)'}. "
+            f"{advice}"
+        )
+    if target_quantized and (model_type or "").lower() == "laguna":
+        return (
+            f"DFlash draft '{draft_base}' follows the BF16-target naming "
+            f"convention, but the loaded Laguna target '{target_name}' is "
+            f"quantized. {advice}"
+        )
+    return None
 
 
 class _DFlashPrefillGuard:
@@ -250,6 +315,18 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         # Session-scope hit/eviction rates for the admin cache observability
         # panel, fed from the dflash-mlx runtime cache manager counters.
         self._cache_rate_tracker = CacheRateTracker()
+        # Draft/target precision pairing warning (set in start(), surfaced in
+        # the dashboard) and per-session speculation counters fed from each
+        # request's SummaryEvent.
+        self._pairing_warning: str | None = None
+        self._spec_stats_lock = threading.Lock()
+        self._spec_last: dict[str, Any] | None = None
+        self._spec_totals = {
+            "requests": 0,
+            "generation_tokens": 0,
+            "accepted_draft_tokens": 0,
+            "cycles": 0,
+        }
 
         self._max_dflash_ctx = (
             getattr(model_settings, "dflash_max_ctx", None) if model_settings else None
@@ -497,6 +574,15 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             self._model_type_str = config.get("model_type")
         elif hasattr(config, "model_type"):
             self._model_type_str = config.model_type
+
+        self._pairing_warning = check_draft_target_precision_pairing(
+            self._model_name,
+            config if isinstance(config, dict) else None,
+            self._draft_model_path,
+            model_type=self._model_type_str,
+        )
+        if self._pairing_warning:
+            logger.warning(self._pairing_warning)
 
         suppress_ref = (
             getattr(self._executor_tokenizer, "name_or_path", None) or self._model_name
@@ -1127,6 +1213,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                     )
 
                 elif isinstance(event, SummaryEvent):
+                    self._record_speculation_summary(event)
                     # Flush any buffered tail from the parser (e.g. close an
                     # unterminated <think> block) before the metrics chunk so
                     # the client sees a well-formed final delta.
@@ -1312,6 +1399,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                                 parsed_visible_parts.append(result.visible_text)
                     elif isinstance(event, SummaryEvent):
                         summary = event
+                        self._record_speculation_summary(event)
                 if parser_session is not None:
                     final = parser_session.finalize()
                     if final.visible_text:
@@ -1753,7 +1841,64 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             "loaded": self._loaded,
             "in_memory_cache": self._in_memory_cache_enabled,
             "ssd_cache": self._resolve_dflash_l2_dir() is not None,
+            "pairing_warning": self._pairing_warning,
+            "speculation": self.get_speculation_stats(),
         }
+
+    @property
+    def pairing_warning(self) -> str | None:
+        """Draft/target precision pairing warning from load time, if any."""
+        return self._pairing_warning
+
+    def _record_speculation_summary(self, summary: Any) -> None:
+        """Fold one request's SummaryEvent into the session speculation stats.
+
+        Called from the MLX executor thread in both generate paths, hence the
+        lock. Best-effort: a malformed event is dropped, never raised.
+        """
+        try:
+            gen_tokens = int(summary.generation_tokens)
+            cycles = int(summary.cycles_completed)
+            ratio = float(summary.acceptance_ratio)
+        except (AttributeError, TypeError, ValueError):
+            return
+        if gen_tokens <= 0 and cycles <= 0:
+            return
+        accepted = int(round(gen_tokens * ratio))
+        last = {
+            "generation_tokens": gen_tokens,
+            "cycles": cycles,
+            "acceptance_ratio": ratio,
+            "accepted_draft_tokens": accepted,
+            "tokens_per_cycle": (gen_tokens / cycles) if cycles > 0 else None,
+            "fallback_ar": bool(getattr(summary, "fallback_ar", False)),
+        }
+        with self._spec_stats_lock:
+            self._spec_last = last
+            self._spec_totals["requests"] += 1
+            self._spec_totals["generation_tokens"] += gen_tokens
+            self._spec_totals["accepted_draft_tokens"] += accepted
+            self._spec_totals["cycles"] += cycles
+
+    def get_speculation_stats(self) -> dict[str, Any] | None:
+        """Session speculation counters for the admin dashboard.
+
+        The logged acceptance ratio is the share of output tokens supplied by
+        the draft (issue #2398); tokens_per_cycle is the number users need to
+        judge whether speculation is actually winning.
+        """
+        with self._spec_stats_lock:
+            if self._spec_totals["requests"] == 0:
+                return None
+            totals = dict(self._spec_totals)
+            last = dict(self._spec_last) if self._spec_last else None
+        gen_tokens = totals["generation_tokens"]
+        cycles = totals["cycles"]
+        totals["acceptance_ratio"] = (
+            totals["accepted_draft_tokens"] / gen_tokens if gen_tokens > 0 else None
+        )
+        totals["tokens_per_cycle"] = gen_tokens / cycles if cycles > 0 else None
+        return {"last": last, "totals": totals}
 
     def get_cache_stats(self) -> dict[str, Any] | None:
         if self._fallback_engine is not None:

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -14,6 +14,7 @@ import copy
 import gc
 import json
 import logging
+import math
 import re
 import threading
 import time
@@ -118,29 +119,71 @@ def _format_phase_timings(phase_timings_us: object) -> str:
 # Precision suffixes Poolside uses for drafts trained against a quantized
 # target ("Laguna-S-2.1-DFlash-NVFP4" etc.). Anything else after "-DFlash-"
 # (e.g. z-lab's "-b16" block-size suffix) makes no precision claim.
-_DRAFT_PRECISION_TAGS = frozenset({"NVFP4", "INT4", "INT8", "FP8", "FP4", "MXFP4"})
+_DRAFT_PRECISION_TAGS = frozenset(
+    {"NVFP4", "INT4", "INT8", "FP8", "FP4", "MXFP4"}
+)
+
+
+def _canonical_precision_tag(value: object) -> str | None:
+    """Normalize an explicit precision label from a name or config value."""
+    text = str(value or "").upper().replace("_", "-")
+    for tag in ("NVFP4", "MXFP4", "INT4", "INT8", "FP8", "FP4"):
+        if tag in text.replace("-", ""):
+            return tag
+    if re.search(r"(?:^|[-/])OQ\d", text):
+        return "OQ"
+    if "BFLOAT16" in text or "BF16" in text:
+        return "BF16"
+    if "FLOAT16" in text or re.search(r"(?:^|[-/])FP16(?:$|[-/])", text):
+        return "FP16"
+    return None
+
+
+def _target_precision_tag(
+    target_name: str,
+    target_config: dict | None,
+) -> str | None:
+    """Best-effort target precision, preferring checkpoint metadata to paths."""
+    if isinstance(target_config, dict):
+        for section_name in ("quantization", "quantization_config"):
+            section = target_config.get(section_name)
+            if not isinstance(section, dict):
+                continue
+            for key in ("mode", "format", "quant_method", "method"):
+                tag = _canonical_precision_tag(section.get(key))
+                if tag is not None:
+                    return tag
+
+        # An explicit floating dtype plus no quantization metadata is a useful
+        # signal for base checkpoints. Do not infer INT4 from `bits: 4` alone:
+        # oQ4, NVFP4, and several other formats share that width.
+        if not target_config.get("quantization") and not target_config.get(
+            "quantization_config"
+        ):
+            tag = _canonical_precision_tag(target_config.get("torch_dtype"))
+            if tag is not None:
+                return tag
+
+    # Local model directories normally retain their Hub basename, but this is
+    # deliberately only a fallback because users can rename them.
+    return _canonical_precision_tag(Path(str(target_name).rstrip("/")).name)
 
 
 def check_draft_target_precision_pairing(
     target_name: str,
     target_config: dict | None,
     draft_path: str,
-    model_type: str | None = None,
 ) -> str | None:
     """Heuristic precision-pairing check between a DFlash draft and its target.
 
-    DFlash drafts predict from hidden states captured inside the target, so a
-    draft trained against one target precision loses acceptance against
-    another (issue #2398: ~1 accepted draft token per cycle pairing BF16-target
-    Laguna drafts with community-quantized targets). Draft checkpoints do not
-    record their training target, so this keys off the published naming
-    convention (``*-DFlash`` = BF16 target, ``*-DFlash-<PRECISION>`` = the
-    matching quantized target) and the target's own quantization config.
+    Some Poolside drafts declare a target precision in their suffix, for
+    example ``*-DFlash-NVFP4``. Draft checkpoints do not otherwise record the
+    target they were trained against, so only warn when both sides make an
+    explicit, contradictory precision claim. A generic ``*-DFlash`` name is
+    intentionally treated as unknown rather than assumed to be BF16-only.
 
-    Returns a warning message, or None when the pair looks matched or the
-    names carry no precision claim. The BF16-draft-on-quantized-target rule is
-    applied to Laguna only: the supported-pairs table explicitly endorses
-    quantized Qwen/Gemma4 targets with their generic drafts.
+    Returns a warning message, or None when the pair looks matched or either
+    side carries no reliable precision claim.
     """
     draft_base = Path(str(draft_path).rstrip("/")).name
     match = re.search(r"-DFlash(?:-([A-Za-z0-9]+))?$", draft_base, re.IGNORECASE)
@@ -149,34 +192,20 @@ def check_draft_target_precision_pairing(
     suffix = (match.group(1) or "").upper()
     draft_tag = suffix if suffix in _DRAFT_PRECISION_TAGS else ""
 
-    quant_section = None
-    if isinstance(target_config, dict):
-        quant_section = target_config.get("quantization") or target_config.get(
-            "quantization_config"
-        )
-    target_quantized = bool(quant_section)
+    if not draft_tag:
+        return None
 
-    advice = (
-        "Precision-mismatched pairs collapse draft acceptance and can make "
-        "DFlash slower than plain decoding (see issue #2398). Use the draft "
-        "published for this exact target precision."
+    target_tag = _target_precision_tag(target_name, target_config)
+    if target_tag is None or target_tag == draft_tag:
+        return None
+
+    target_base = Path(str(target_name).rstrip("/")).name
+    return (
+        f"Possible DFlash precision mismatch: draft '{draft_base}' declares "
+        f"{draft_tag}, while target '{target_base}' appears to be {target_tag}. "
+        "This may reduce acceptance and make speculative decoding slower. "
+        "Use a target/draft pair recommended by the checkpoint's model card."
     )
-    if draft_tag:
-        if draft_tag.lower() in str(target_name).lower():
-            return None
-        return (
-            f"DFlash draft '{draft_base}' is published for a {draft_tag} "
-            f"target, but the loaded target is '{target_name}'"
-            f"{' (quantized)' if target_quantized else ' (not quantized)'}. "
-            f"{advice}"
-        )
-    if target_quantized and (model_type or "").lower() == "laguna":
-        return (
-            f"DFlash draft '{draft_base}' follows the BF16-target naming "
-            f"convention, but the loaded Laguna target '{target_name}' is "
-            f"quantized. {advice}"
-        )
-    return None
 
 
 class _DFlashPrefillGuard:
@@ -323,6 +352,8 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         self._spec_last: dict[str, Any] | None = None
         self._spec_totals = {
             "requests": 0,
+            "speculative_requests": 0,
+            "fallback_requests": 0,
             "generation_tokens": 0,
             "accepted_draft_tokens": 0,
             "cycles": 0,
@@ -579,7 +610,6 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             self._model_name,
             config if isinstance(config, dict) else None,
             self._draft_model_path,
-            model_type=self._model_type_str,
         )
         if self._pairing_warning:
             logger.warning(self._pairing_warning)
@@ -1860,22 +1890,45 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             gen_tokens = int(summary.generation_tokens)
             cycles = int(summary.cycles_completed)
             ratio = float(summary.acceptance_ratio)
-        except (AttributeError, TypeError, ValueError):
+            accepted = int(summary.accepted_from_draft)
+            tokens_per_cycle = float(summary.tokens_per_cycle)
+        except (AttributeError, OverflowError, TypeError, ValueError):
             return
-        if gen_tokens <= 0 and cycles <= 0:
+        fallback_ar = bool(getattr(summary, "fallback_ar", False))
+        if (
+            gen_tokens <= 0
+            or cycles < 0
+            or accepted < 0
+            or accepted > gen_tokens
+            or not math.isfinite(ratio)
+            or not 0.0 <= ratio <= 1.0
+            or not math.isfinite(tokens_per_cycle)
+            or tokens_per_cycle < 0.0
+        ):
             return
-        accepted = int(round(gen_tokens * ratio))
         last = {
             "generation_tokens": gen_tokens,
             "cycles": cycles,
             "acceptance_ratio": ratio,
             "accepted_draft_tokens": accepted,
-            "tokens_per_cycle": (gen_tokens / cycles) if cycles > 0 else None,
-            "fallback_ar": bool(getattr(summary, "fallback_ar", False)),
+            "tokens_per_cycle": tokens_per_cycle if cycles > 0 else None,
+            "accepted_draft_tokens_per_cycle": (
+                accepted / cycles if cycles > 0 else None
+            ),
+            "fallback_ar": fallback_ar,
+            "fallback_reason": getattr(summary, "fallback_reason", None),
         }
         with self._spec_stats_lock:
             self._spec_last = last
             self._spec_totals["requests"] += 1
+            if fallback_ar:
+                self._spec_totals["fallback_requests"] += 1
+                return
+            if cycles <= 0:
+                # A non-fallback summary without speculative cycles is not a
+                # valid contribution to acceptance/tokens-per-cycle totals.
+                return
+            self._spec_totals["speculative_requests"] += 1
             self._spec_totals["generation_tokens"] += gen_tokens
             self._spec_totals["accepted_draft_tokens"] += accepted
             self._spec_totals["cycles"] += cycles
@@ -1883,9 +1936,10 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
     def get_speculation_stats(self) -> dict[str, Any] | None:
         """Session speculation counters for the admin dashboard.
 
-        The logged acceptance ratio is the share of output tokens supplied by
-        the draft (issue #2398); tokens_per_cycle is the number users need to
-        judge whether speculation is actually winning.
+        The runtime's acceptance ratio is the share of output tokens supplied
+        by the draft, while tokens_per_cycle includes the target-owned token.
+        Expose accepted_draft_tokens_per_cycle separately so the dashboard does
+        not conflate those two quantities (issue #2398).
         """
         with self._spec_stats_lock:
             if self._spec_totals["requests"] == 0:
@@ -1898,6 +1952,9 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             totals["accepted_draft_tokens"] / gen_tokens if gen_tokens > 0 else None
         )
         totals["tokens_per_cycle"] = gen_tokens / cycles if cycles > 0 else None
+        totals["accepted_draft_tokens_per_cycle"] = (
+            totals["accepted_draft_tokens"] / cycles if cycles > 0 else None
+        )
         return {"last": last, "totals": totals}
 
     def get_cache_stats(self) -> dict[str, Any] | None:

--- a/tests/test_active_models_visibility.py
+++ b/tests/test_active_models_visibility.py
@@ -539,3 +539,48 @@ def test_active_models_resolves_scheduler_property_without_async_core():
     assert model["active_requests"] == 1
     assert model["generating"][0]["request_id"] == "gen-1"
     assert model["activities"] == []
+
+
+def test_active_models_surfaces_dflash_guardrail_stats():
+    """DFlash warning and exact speculation counters reach the dashboard API."""
+
+    speculation = {
+        "last": {
+            "generation_tokens": 768,
+            "cycles": 377,
+            "acceptance_ratio": 391 / 768,
+            "accepted_draft_tokens": 391,
+            "tokens_per_cycle": 768 / 377,
+            "accepted_draft_tokens_per_cycle": 391 / 377,
+            "fallback_ar": False,
+            "fallback_reason": None,
+        },
+        "totals": {
+            "requests": 1,
+            "speculative_requests": 1,
+            "fallback_requests": 0,
+            "generation_tokens": 768,
+            "accepted_draft_tokens": 391,
+            "cycles": 377,
+            "acceptance_ratio": 391 / 768,
+            "tokens_per_cycle": 768 / 377,
+            "accepted_draft_tokens_per_cycle": 391 / 377,
+        },
+    }
+
+    class Engine:
+        scheduler = None
+        pairing_warning = "Possible DFlash precision mismatch"
+
+        def get_activity_snapshot(self):
+            return {"active_requests": 0, "activities": []}
+
+        def get_speculation_stats(self):
+            return speculation
+
+    data = _build_with_pool(FakeDFlashPool(Engine()))
+
+    assert data["models"][0]["dflash"] == {
+        "speculation": speculation,
+        "pairing_warning": "Possible DFlash precision mismatch",
+    }

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -1460,3 +1460,169 @@ class TestFormatPhaseTimings:
         out = _format_phase_timings({"verify": 1000.0})
         assert "verify=1.0ms" in out
         assert "prefill=0.0ms" in out
+
+
+class TestDraftTargetPrecisionPairing:
+    """check_draft_target_precision_pairing heuristics (issue #2398)."""
+
+    QUANT_CFG = {"model_type": "laguna", "quantization": {"bits": 4, "group_size": 64}}
+    BF16_CFG = {"model_type": "laguna"}
+
+    def _check(self, target, config, draft, model_type):
+        from omlx.engine.dflash import check_draft_target_precision_pairing
+
+        return check_draft_target_precision_pairing(
+            target, config, draft, model_type=model_type
+        )
+
+    def test_laguna_bf16_draft_on_quantized_target_warns(self):
+        msg = self._check(
+            "mlx-community/Laguna-S-2.1-oQ3e-fast",
+            self.QUANT_CFG,
+            "/models/poolside/Laguna-S-2.1-DFlash",
+            "laguna",
+        )
+        assert msg is not None
+        assert "#2398" in msg
+
+    def test_laguna_bf16_draft_on_bf16_target_is_silent(self):
+        msg = self._check(
+            "poolside/Laguna-S-2.1",
+            self.BF16_CFG,
+            "/models/poolside/Laguna-S-2.1-DFlash",
+            "laguna",
+        )
+        assert msg is None
+
+    def test_nvfp4_draft_on_nvfp4_target_is_silent(self):
+        msg = self._check(
+            "poolside/Laguna-XS-2.1-NVFP4-mlx",
+            self.QUANT_CFG,
+            "/models/poolside/Laguna-XS-2.1-DFlash-NVFP4",
+            "laguna",
+        )
+        assert msg is None
+
+    def test_nvfp4_draft_on_oq4e_target_warns(self):
+        msg = self._check(
+            "mlx-community/Laguna-S-2.1-oQ4e-fast",
+            self.QUANT_CFG,
+            "/models/poolside/Laguna-S-2.1-DFlash-NVFP4",
+            "laguna",
+        )
+        assert msg is not None
+        assert "NVFP4" in msg
+
+    def test_nvfp4_draft_on_unquantized_target_warns(self):
+        msg = self._check(
+            "poolside/Laguna-S-2.1",
+            self.BF16_CFG,
+            "/models/poolside/Laguna-S-2.1-DFlash-NVFP4",
+            "laguna",
+        )
+        assert msg is not None
+
+    def test_qwen_generic_draft_on_quantized_target_is_silent(self):
+        """The supported-pairs table endorses quantized Qwen targets with the
+        generic z-lab drafts — no warning there."""
+        msg = self._check(
+            "mlx-community/Qwen3.5-27B-8bit",
+            {"model_type": "qwen3_5", "quantization": {"bits": 8}},
+            "/models/z-lab/Qwen3.5-27B-DFlash",
+            "qwen3_5",
+        )
+        assert msg is None
+
+    def test_b16_suffix_is_not_a_precision_tag(self):
+        """z-lab's -b16 suffix is a block-size marker, not a precision claim."""
+        msg = self._check(
+            "Qwen/Qwen3-4B",
+            {"model_type": "qwen3"},
+            "/models/z-lab/Qwen3-4B-DFlash-b16",
+            "qwen3",
+        )
+        assert msg is None
+
+    def test_unrecognized_draft_name_is_silent(self):
+        msg = self._check(
+            "mlx-community/Laguna-S-2.1-oQ3e-fast",
+            self.QUANT_CFG,
+            "/models/some/custom-draft",
+            "laguna",
+        )
+        assert msg is None
+
+
+class TestSpeculationStats:
+    """Session speculation counters exposed for the dashboard (issue #2398)."""
+
+    def _engine(self):
+        from omlx.engine.dflash import DFlashEngine
+
+        return DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+        )
+
+    def test_empty_stats_are_none(self):
+        engine = self._engine()
+        assert engine.get_speculation_stats() is None
+        assert engine.get_stats()["speculation"] is None
+        assert engine.get_stats()["pairing_warning"] is None
+
+    def test_records_issue_2398_shape(self):
+        """The S run from issue #2398: 768 tokens, 377 cycles, acceptance 50.9%."""
+        engine = self._engine()
+        engine._record_speculation_summary(
+            SimpleNamespace(
+                generation_tokens=768,
+                cycles_completed=377,
+                acceptance_ratio=0.509,
+                fallback_ar=False,
+            )
+        )
+        stats = engine.get_speculation_stats()
+        assert stats is not None
+        last = stats["last"]
+        assert last["accepted_draft_tokens"] == 391
+        assert last["cycles"] == 377
+        assert abs(last["tokens_per_cycle"] - 768 / 377) < 1e-9
+        assert last["fallback_ar"] is False
+
+    def test_totals_accumulate_across_requests(self):
+        engine = self._engine()
+        for gen, cycles, ratio in ((768, 377, 0.509), (1371, 666, 0.514)):
+            engine._record_speculation_summary(
+                SimpleNamespace(
+                    generation_tokens=gen,
+                    cycles_completed=cycles,
+                    acceptance_ratio=ratio,
+                    fallback_ar=False,
+                )
+            )
+        totals = engine.get_speculation_stats()["totals"]
+        assert totals["requests"] == 2
+        assert totals["generation_tokens"] == 768 + 1371
+        assert totals["accepted_draft_tokens"] == 391 + 705
+        assert totals["cycles"] == 377 + 666
+        assert 0.0 < totals["acceptance_ratio"] < 1.0
+        assert totals["tokens_per_cycle"] == (768 + 1371) / (377 + 666)
+
+    def test_malformed_summary_is_dropped(self):
+        engine = self._engine()
+        engine._record_speculation_summary(SimpleNamespace())
+        engine._record_speculation_summary(
+            SimpleNamespace(
+                generation_tokens="nope", cycles_completed=1, acceptance_ratio=0.5
+            )
+        )
+        assert engine.get_speculation_stats() is None
+
+    def test_empty_generation_is_dropped(self):
+        engine = self._engine()
+        engine._record_speculation_summary(
+            SimpleNamespace(
+                generation_tokens=0, cycles_completed=0, acceptance_ratio=0.0
+            )
+        )
+        assert engine.get_speculation_stats() is None

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -1465,60 +1465,62 @@ class TestFormatPhaseTimings:
 class TestDraftTargetPrecisionPairing:
     """check_draft_target_precision_pairing heuristics (issue #2398)."""
 
-    QUANT_CFG = {"model_type": "laguna", "quantization": {"bits": 4, "group_size": 64}}
-    BF16_CFG = {"model_type": "laguna"}
+    OQ_CFG = {
+        "model_type": "laguna",
+        "quantization": {"bits": 4, "group_size": 64, "mode": "oQ4e"},
+    }
+    NVFP4_CFG = {
+        "model_type": "laguna",
+        "quantization": {"bits": 4, "group_size": 16, "mode": "nvfp4"},
+    }
+    BF16_CFG = {"model_type": "laguna", "torch_dtype": "bfloat16"}
 
-    def _check(self, target, config, draft, model_type):
+    def _check(self, target, config, draft):
         from omlx.engine.dflash import check_draft_target_precision_pairing
 
-        return check_draft_target_precision_pairing(
-            target, config, draft, model_type=model_type
-        )
+        return check_draft_target_precision_pairing(target, config, draft)
 
-    def test_laguna_bf16_draft_on_quantized_target_warns(self):
+    def test_generic_draft_on_quantized_target_is_unknown_not_mismatch(self):
+        """A generic suffix does not prove BF16-only compatibility."""
         msg = self._check(
             "mlx-community/Laguna-S-2.1-oQ3e-fast",
-            self.QUANT_CFG,
+            self.OQ_CFG,
             "/models/poolside/Laguna-S-2.1-DFlash",
-            "laguna",
         )
-        assert msg is not None
-        assert "#2398" in msg
+        assert msg is None
 
     def test_laguna_bf16_draft_on_bf16_target_is_silent(self):
         msg = self._check(
             "poolside/Laguna-S-2.1",
             self.BF16_CFG,
             "/models/poolside/Laguna-S-2.1-DFlash",
-            "laguna",
         )
         assert msg is None
 
-    def test_nvfp4_draft_on_nvfp4_target_is_silent(self):
+    def test_nvfp4_config_matches_even_if_local_target_was_renamed(self):
         msg = self._check(
-            "poolside/Laguna-XS-2.1-NVFP4-mlx",
-            self.QUANT_CFG,
+            "/models/renamed-laguna-xs",
+            self.NVFP4_CFG,
             "/models/poolside/Laguna-XS-2.1-DFlash-NVFP4",
-            "laguna",
         )
         assert msg is None
 
-    def test_nvfp4_draft_on_oq4e_target_warns(self):
+    def test_nvfp4_draft_on_oq_config_warns_even_if_target_was_renamed(self):
         msg = self._check(
-            "mlx-community/Laguna-S-2.1-oQ4e-fast",
-            self.QUANT_CFG,
+            "/models/renamed-laguna-s",
+            self.OQ_CFG,
             "/models/poolside/Laguna-S-2.1-DFlash-NVFP4",
-            "laguna",
         )
         assert msg is not None
         assert "NVFP4" in msg
+        assert "appears to be OQ" in msg
+        assert "may reduce acceptance" in msg
 
     def test_nvfp4_draft_on_unquantized_target_warns(self):
         msg = self._check(
             "poolside/Laguna-S-2.1",
             self.BF16_CFG,
             "/models/poolside/Laguna-S-2.1-DFlash-NVFP4",
-            "laguna",
         )
         assert msg is not None
 
@@ -1529,7 +1531,6 @@ class TestDraftTargetPrecisionPairing:
             "mlx-community/Qwen3.5-27B-8bit",
             {"model_type": "qwen3_5", "quantization": {"bits": 8}},
             "/models/z-lab/Qwen3.5-27B-DFlash",
-            "qwen3_5",
         )
         assert msg is None
 
@@ -1539,16 +1540,22 @@ class TestDraftTargetPrecisionPairing:
             "Qwen/Qwen3-4B",
             {"model_type": "qwen3"},
             "/models/z-lab/Qwen3-4B-DFlash-b16",
-            "qwen3",
         )
         assert msg is None
 
     def test_unrecognized_draft_name_is_silent(self):
         msg = self._check(
             "mlx-community/Laguna-S-2.1-oQ3e-fast",
-            self.QUANT_CFG,
+            self.OQ_CFG,
             "/models/some/custom-draft",
-            "laguna",
+        )
+        assert msg is None
+
+    def test_explicit_draft_is_silent_when_target_precision_is_unknown(self):
+        msg = self._check(
+            "/models/renamed-target",
+            {"model_type": "laguna", "quantization": {"bits": 4}},
+            "/models/poolside/Laguna-S-2.1-DFlash-NVFP4",
         )
         assert msg is None
 
@@ -1578,6 +1585,8 @@ class TestSpeculationStats:
                 generation_tokens=768,
                 cycles_completed=377,
                 acceptance_ratio=0.509,
+                accepted_from_draft=391,
+                tokens_per_cycle=768 / 377,
                 fallback_ar=False,
             )
         )
@@ -1587,7 +1596,10 @@ class TestSpeculationStats:
         assert last["accepted_draft_tokens"] == 391
         assert last["cycles"] == 377
         assert abs(last["tokens_per_cycle"] - 768 / 377) < 1e-9
+        assert abs(last["accepted_draft_tokens_per_cycle"] - 391 / 377) < 1e-9
         assert last["fallback_ar"] is False
+        assert stats["totals"]["speculative_requests"] == 1
+        assert stats["totals"]["fallback_requests"] == 0
 
     def test_totals_accumulate_across_requests(self):
         engine = self._engine()
@@ -1597,6 +1609,8 @@ class TestSpeculationStats:
                     generation_tokens=gen,
                     cycles_completed=cycles,
                     acceptance_ratio=ratio,
+                    accepted_from_draft=round(gen * ratio),
+                    tokens_per_cycle=gen / cycles,
                     fallback_ar=False,
                 )
             )
@@ -1605,8 +1619,52 @@ class TestSpeculationStats:
         assert totals["generation_tokens"] == 768 + 1371
         assert totals["accepted_draft_tokens"] == 391 + 705
         assert totals["cycles"] == 377 + 666
+        assert totals["speculative_requests"] == 2
         assert 0.0 < totals["acceptance_ratio"] < 1.0
         assert totals["tokens_per_cycle"] == (768 + 1371) / (377 + 666)
+        assert totals["accepted_draft_tokens_per_cycle"] == (391 + 705) / (
+            377 + 666
+        )
+
+    def test_uses_runtime_exact_counters_not_reconstructed_values(self):
+        engine = self._engine()
+        engine._record_speculation_summary(
+            SimpleNamespace(
+                generation_tokens=10,
+                cycles_completed=4,
+                acceptance_ratio=0.61,
+                accepted_from_draft=6,
+                tokens_per_cycle=2.5,
+                fallback_ar=False,
+            )
+        )
+        last = engine.get_speculation_stats()["last"]
+        assert last["accepted_draft_tokens"] == 6
+        assert last["tokens_per_cycle"] == 2.5
+        assert last["accepted_draft_tokens_per_cycle"] == 1.5
+
+    def test_fallback_is_visible_but_excluded_from_speculative_totals(self):
+        engine = self._engine()
+        engine._record_speculation_summary(
+            SimpleNamespace(
+                generation_tokens=32,
+                cycles_completed=0,
+                acceptance_ratio=0.0,
+                accepted_from_draft=0,
+                tokens_per_cycle=0.0,
+                fallback_ar=True,
+                fallback_reason="adaptive guard",
+            )
+        )
+        stats = engine.get_speculation_stats()
+        assert stats["last"]["fallback_ar"] is True
+        assert stats["last"]["fallback_reason"] == "adaptive guard"
+        assert stats["totals"]["requests"] == 1
+        assert stats["totals"]["fallback_requests"] == 1
+        assert stats["totals"]["speculative_requests"] == 0
+        assert stats["totals"]["generation_tokens"] == 0
+        assert stats["totals"]["acceptance_ratio"] is None
+        assert stats["totals"]["accepted_draft_tokens_per_cycle"] is None
 
     def test_malformed_summary_is_dropped(self):
         engine = self._engine()
@@ -1618,11 +1676,31 @@ class TestSpeculationStats:
         )
         assert engine.get_speculation_stats() is None
 
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), -0.1, 1.1])
+    def test_invalid_acceptance_ratio_is_dropped(self, value):
+        engine = self._engine()
+        engine._record_speculation_summary(
+            SimpleNamespace(
+                generation_tokens=10,
+                cycles_completed=4,
+                acceptance_ratio=value,
+                accepted_from_draft=5,
+                tokens_per_cycle=2.5,
+                fallback_ar=False,
+            )
+        )
+        assert engine.get_speculation_stats() is None
+
     def test_empty_generation_is_dropped(self):
         engine = self._engine()
         engine._record_speculation_summary(
             SimpleNamespace(
-                generation_tokens=0, cycles_completed=0, acceptance_ratio=0.0
+                generation_tokens=0,
+                cycles_completed=0,
+                acceptance_ratio=0.0,
+                accepted_from_draft=0,
+                tokens_per_cycle=0.0,
+                fallback_ar=False,
             )
         )
         assert engine.get_speculation_stats() is None


### PR DESCRIPTION
Follow-up to https://github.com/jundot/omlx/issues/2398: with 51k-token prompts, the Laguna DFlash pairings reported there produced only ~1 accepted draft token per cycle, so DFlash was slower than plain decoding — and nothing surfaced that. This PR adds the first two defensive pieces promised in the issue.

## What's included

- **Load-time pairing warning** — warn when draft and target both make an explicit, contradictory precision claim (e.g. a `-DFlash-NVFP4` draft on an oQ4e target). A generic `-DFlash` name is treated as unknown rather than BF16-only, so the documented quantized Qwen/Gemma4 pairs stay silent. The warning is logged and shown in the dashboard.
- **Speculation metrics in the dashboard** — per-session counters folded from each request's `SummaryEvent` (both generate paths): draft share of output, accepted draft tokens/cycle, output tokens/cycle, and fallback-AR requests with their reason, rendered in the Active Models card. Draft share and per-cycle numbers are deliberately separate: the ~51% "acceptance" logged in #2398 reads healthy while the engine is actually losing.
- **Docs** — the pairing table gains the missing `Laguna-XS-2.1-NVFP4-mlx` row and the mismatch failure mode is documented.

## Not in this PR

Tracked as remaining follow-ups from #2398: porting the batched-engine prefill patches to the DFlash path (with parity coverage), automatic fallback to plain decode when speculation is losing, and INT4/FP8 (vLLM-format) checkpoint validation.

## Testing

148 tests passed across `test_dflash_engine.py`, `test_active_models_visibility.py`, `test_dflash_laguna.py`, `test_dflash_lifecycle.py`, `test_dflash_draft_config.py` — including the exact #2398 pairings and the counter accounting from that issue's log (768 tok / 377 cycles). Dashboard row verified visually against the compiled Tailwind stylesheet.
