### PR TITLE
feat(deepseek-v4): support official 0731 DSpark decoding

### DIFF
--- a/apps/omlx-mac/Scripts/build.sh
+++ b/apps/omlx-mac/Scripts/build.sh
@@ -110,6 +110,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$PROJECT_DIR/../.." && pwd)"
 PACKAGING_DIR="$REPO_ROOT/packaging"
 CUSTOM_KERNEL_DIRS=(
+    "$REPO_ROOT/omlx/custom_kernels/bonsai"
     "$REPO_ROOT/omlx/custom_kernels/glm_moe_dsa"
     "$REPO_ROOT/omlx/custom_kernels/minimax_m3"
     "$REPO_ROOT/omlx/custom_kernels/qwen35_prefill"
@@ -229,6 +230,7 @@ _custom_kernel_pythonpath() {
 
 _clean_custom_kernel_build_artifacts() {
     local dir
+    local kernel_name
     for dir in "${CUSTOM_KERNEL_DIRS[@]}"; do
         [ -d "$dir" ] || continue
         find "$dir" -maxdepth 1 -type f \( \
@@ -239,16 +241,23 @@ _clean_custom_kernel_build_artifacts() {
     done
 
     if [ -d "$REPO_ROOT/build" ]; then
-        for ext_name in \
-            "omlx.custom_kernels.glm_moe_dsa._ext" \
-            "omlx.custom_kernels.minimax_m3._ext" \
-            "omlx.custom_kernels.qwen35_prefill._ext"; do
+        for dir in "${CUSTOM_KERNEL_DIRS[@]}"; do
+            kernel_name="$(basename "$dir")"
             find "$REPO_ROOT/build" \
                 -type d \
-                -name "$ext_name" \
+                -name "omlx.custom_kernels.${kernel_name}._ext" \
                 -prune \
                 -exec rm -rf {} +
         done
+        # setuptools' build/lib tree can retain extensions from a previous
+        # Python ABI even after the CMake target directories are removed.
+        # build_ext --inplace copies every retained artifact into the source
+        # package, so remove those native outputs before rebuilding.
+        find "$REPO_ROOT/build" \
+            -type f \
+            -path "*/omlx/custom_kernels/*" \
+            \( -name "*.so" -o -name "*.dylib" -o -name "*.metallib" \) \
+            -delete
     fi
 }
 

--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -1007,6 +1007,8 @@ def detect_output_parser(
                 model_path=session_model_path,
             ),
             stop_token_ids=set(),
+            thinking_start_text="<think>",
+            thinking_end_text="</think>",
             protocol_marker_texts=(
                 _DEEPSEEK_V4_TOOL_CALL_START,
                 _DEEPSEEK_V4_TOOL_CALL_END,

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -402,6 +402,36 @@ def _block_cachelist_subtypes(
     return subtypes or None
 
 
+def _normalize_cachelist_storage_payloads(
+    cache_data: list[Any],
+    layer_cache_types: list[str] | None,
+) -> list[Any]:
+    """Canonicalize loaded CacheList payloads before writing them again.
+
+    ``load_block_with_metadata`` intentionally exposes a CacheList layer as
+    a bare list of sub-cache states for compatibility with prefix-cache
+    callers.  The writer's canonical representation is the
+    ``("__cache_list__", sub_states)`` marker.  A load/rewrite/save path
+    (notably superseded rotating-tip stripping) therefore needs this small
+    boundary normalization; otherwise the bare list is serialized as one
+    generic N-state and loses both its sub-cache wire layout and its
+    ``cachelist_subtypes`` compatibility signature.
+    """
+    if not cache_data or not layer_cache_types:
+        return cache_data
+
+    normalized: list[Any] | None = None
+    for i, cache_type in enumerate(layer_cache_types):
+        if i >= len(cache_data):
+            break
+        if cache_type != "CacheList" or not isinstance(cache_data[i], list):
+            continue
+        if normalized is None:
+            normalized = list(cache_data)
+        normalized[i] = ("__cache_list__", cache_data[i])
+    return normalized if normalized is not None else cache_data
+
+
 def cachelist_subtypes_from_cache_list(
     cache_list: list[Any] | tuple[Any, ...] | None,
 ) -> dict[str, list[str]] | None:
@@ -2167,6 +2197,9 @@ class PagedSSDCacheManager(CacheManager):
             return False
 
         layer_cache_types = _storage_layer_cache_types(layer_cache_types)
+        cache_data = _normalize_cachelist_storage_payloads(
+            cache_data, layer_cache_types
+        )
 
         # First save call after a model load is the canonical source for
         # the live layer-cache signature (post-TurboQuant / post-MTP). If

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -239,10 +239,11 @@ class ModelSettings:
     # with dflash.
     mtp_enabled: bool = False
     # Maximum chained MTP draft tokens per verify cycle (speculative depth).
-    # None = default (3). Effective for Qwen3.5/3.6 native MTP only;
-    # DeepSeek-V4 native MTP always runs depth 1. An adaptive controller
-    # picks 1..max per sequence from rolling acceptance/latency estimates;
-    # set to 1 for a fixed depth-1 cycle.
+    # None = default (3). Qwen3.5/3.6 and preview DeepSeek-V4 use this as
+    # their chain/controller ceiling. DeepSeek-V4-Flash-0731 instead uses
+    # the checkpoint's fixed DSpark block size (5): its rows are trained and
+    # computed together, so truncating the architecture at load time would
+    # save no work.
     mtp_num_draft_tokens: Optional[int] = None
 
     # VLM MTP speculative decoding via external MTP drafter (mlx-vlm f96138e+).

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -3842,7 +3842,10 @@ def _is_mtp_protected_tensor(name: str) -> bool:
     Qwen3.5-27B accepted 0/157 cycles). PR 990 protects ``mtp.fc`` for
     Qwen3.5/3.6; PR 15's DeepSeek-V4 ``MTPBlock`` exposes the same
     semantics under different names (``e_proj`` + ``h_proj`` for the
-    embedding/hidden fusion; ``hc_head.*`` for the final projection);
+    preview model, ``main_proj`` for 0731 DSpark, and ``hc_head.*`` for
+    the final projection). DSpark's low-rank Markov head supplies a
+    vocabulary-wide bias at every draft position and is equally
+    acceptance-sensitive;
     GLM-5.2's ``GlmMTPBlock`` calls it ``eh_proj``. All of these stay in
     full precision; the MTP block's internal decoder block (attn/ffn)
     gets the same quantization as the backbone's other layers.
@@ -3853,7 +3856,16 @@ def _is_mtp_protected_tensor(name: str) -> bool:
     if name.endswith("mtp.fc.weight") or ".mtp.fc.weight" in name:
         return True
     # DeepSeek-V4 / GLM-5.2 MTP block fusion projections
-    if name.endswith((".e_proj.weight", ".h_proj.weight", ".eh_proj.weight")):
+    if name.endswith(
+        (
+            ".e_proj.weight",
+            ".h_proj.weight",
+            ".eh_proj.weight",
+            ".main_proj.weight",
+        )
+    ):
+        return True
+    if ".markov_head." in name:
         return True
     # DeepSeek-V4 HyperHead final projection (sanitized form has the dot;
     # the raw-HF form arrives as ``hc_head_<param>`` and we cover both).

--- a/omlx/patches/deepseek_v4/chat_template_v4_dspark.py
+++ b/omlx/patches/deepseek_v4/chat_template_v4_dspark.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MIT
+"""mlx-lm adapter for the official DeepSeek V4 DSpark/0731 encoder."""
+
+from __future__ import annotations
+
+import copy
+
+from .vendor.encoding_dsv4 import (
+    ASSISTANT_SP_TOKEN,
+    encode_messages,
+    eos_token,
+    thinking_end_token,
+    thinking_start_token,
+)
+
+
+def apply_chat_template(
+    messages,
+    continue_final_message: bool = False,
+    add_generation_prompt: bool = False,
+    **kwargs,
+):
+    """Adapt the official DSpark/0731 encoder to mlx-lm's template API."""
+    if continue_final_message and add_generation_prompt:
+        raise ValueError(
+            "Only one of continue_final_message or add_generation_prompt can be True"
+        )
+
+    if "enable_thinking" in kwargs and "thinking_mode" not in kwargs:
+        kwargs["thinking_mode"] = (
+            "thinking" if kwargs.pop("enable_thinking") else "chat"
+        )
+    else:
+        kwargs.pop("enable_thinking", None)
+    kwargs.setdefault("thinking_mode", "thinking")
+
+    # DeepSeek's reference API stores tools on the system/developer message,
+    # while mlx-lm supplies them as a top-level template kwarg.
+    tools = kwargs.pop("tools", None)
+    messages = copy.deepcopy(messages)
+    if tools:
+        for message in messages:
+            if message.get("role") in ("system", "developer"):
+                message["tools"] = tools
+                break
+        else:
+            messages.insert(0, {"role": "system", "content": "", "tools": tools})
+
+    accepted = {
+        "thinking_mode",
+        "context",
+        "drop_thinking",
+        "add_default_bos_token",
+        "reasoning_effort",
+    }
+    encode_kwargs = {key: value for key, value in kwargs.items() if key in accepted}
+    out = encode_messages(messages, **encode_kwargs)
+
+    last_role = messages[-1].get("role") if messages else None
+    if not add_generation_prompt and last_role in ("user", "developer", "tool"):
+        thinking_suffix = (
+            thinking_start_token
+            if encode_kwargs["thinking_mode"] == "thinking"
+            else thinking_end_token
+        )
+        out = out.removesuffix(ASSISTANT_SP_TOKEN + thinking_suffix)
+    if continue_final_message and last_role == "assistant":
+        out = out.removesuffix(eos_token)
+    return out

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -1,6 +1,7 @@
 # Copyright © 2026 Apple Inc.
 
 import math
+import os
 from dataclasses import dataclass, field
 from functools import partial
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -10,15 +11,38 @@ import mlx.nn as nn
 from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 from mlx.utils import tree_flatten
 
+from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
+
 from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
 from .cache import CacheList, PoolingCache, RotatingKVCache
 from .hyper_connection import HyperConnection, HyperHead, hc_expand
 from .mla import MultiLinear
 from .pipeline import PipelineMixin
-from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
 
 _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = False
 _DEEPSEEK_V4_INDEXER_NATIVE_DISABLED = False
+_DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DEFAULT_MIN_L = 128
+
+
+def _parse_sparse_attention_native_min_l(value: str | None) -> int:
+    """Resolve the portable work-shape threshold for the native kernel."""
+    if value is None:
+        return _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DEFAULT_MIN_L
+    try:
+        return max(2, int(value))
+    except ValueError:
+        return _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DEFAULT_MIN_L
+
+
+# The native kernel dispatches one threadgroup per query token.  Short
+# speculative-verification windows (DSpark normally uses L=2..6) therefore
+# leave Apple GPUs badly under-occupied and are slower than MLX's fallback.
+# This is deliberately a workload threshold rather than a chip-name check.
+# Benchmarking a future kernel/device can override it before server launch:
+# OMLX_DEEPSEEK_V4_NATIVE_SPARSE_ATTENTION_MIN_L=<query rows>.
+_DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_MIN_L = _parse_sparse_attention_native_min_l(
+    os.environ.get("OMLX_DEEPSEEK_V4_NATIVE_SPARSE_ATTENTION_MIN_L")
+)
 
 
 def _materialize_cache_arrays(cache: Optional[Any]) -> None:
@@ -394,7 +418,7 @@ def _sparse_pooled_attention(
         and topk.dtype == mx.uint32
         and B >= 1
         and H == 64
-        and L > 1
+        and L >= _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_MIN_L
         and D == 512
         and local_kv.ndim == 4
         and local_kv.shape[1] == 1

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -82,6 +82,14 @@ class ModelArgs(BaseModelArgs):
     index_head_dim: int = 128
     index_topk: int = 512
     num_nextn_predict_layers: int = 1
+    # DeepSeek-V4-Flash-0731's DSpark speculative module.  The official
+    # checkpoint keeps the three DSpark stages under ``mtp.*`` but
+    # ``num_nextn_predict_layers`` remains 1 for compatibility with the
+    # preview model, so these fields are the authoritative discriminator.
+    dspark_block_size: int = 0
+    dspark_noise_token_id: int = 0
+    dspark_target_layer_ids: List[int] = field(default_factory=list)
+    dspark_markov_rank: int = 0
     tie_word_embeddings: bool = False
     topk_method: str = "noaux_tc"
 
@@ -126,7 +134,12 @@ def make_quantization_config(model):
     mtp_projs = {
         k: mxfp8
         for k, _ in flat_modules
-        if k.startswith("mtp.") and (k.endswith(".e_proj") or k.endswith(".h_proj"))
+        if k.startswith("mtp.")
+        and (
+            k.endswith(".e_proj")
+            or k.endswith(".h_proj")
+            or k.endswith(".main_proj")
+        )
     }
 
     return {

--- a/omlx/patches/deepseek_v4/switch_layers.py
+++ b/omlx/patches/deepseek_v4/switch_layers.py
@@ -21,6 +21,17 @@ _DEEPSEEK_MXFP4_SMALL_BLOCK_VARIANT = 1
 _DEEPSEEK_MXFP4_LARGE_BLOCK_BM = 32
 _DEEPSEEK_MXFP4_LARGE_BLOCK_VARIANT = 2
 _DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES = 8192
+# Expert sorting and the native block-list kernels are prefill
+# optimizations.  Dispatching them from ``indices.size`` alone makes the
+# arithmetic depend on how many unrelated requests happen to share a decode
+# batch: a single DeepSeek-V4 token has 24 routes, so B=1/B=2 used stock
+# gather_qmm while B=4/B=8 crossed the old 64-route threshold.  DSpark's
+# 2--6-token target verification window crossed it as well.
+#
+# Keep short decode/speculative windows on the same unsorted stock path and
+# decide from each sequence's own length, not total batch width.  Normal
+# prompt chunks still take the native prefill path.
+_DEEPSEEK_MOE_NATIVE_MIN_SEQUENCE_LENGTH = 16
 
 # On NAX GPUs (M5 family) mx.gather_qmm dispatches to the tensor-unit
 # gather_qmm_rhs_nax kernels, which beat the pre-NAX block-list kernels for
@@ -57,6 +68,27 @@ def _scatter_unsort(x, inv_order, shape=None):
     if shape is not None:
         x = mx.unflatten(x, 0, shape)
     return x
+
+
+def _should_sort_experts(x: mx.array, indices: mx.array) -> bool:
+    """Whether this per-sequence shape is large enough for prefill kernels.
+
+    ``x`` is normally ``[B, L, H, D]`` for DeepSeek-V4's Hyper-Connection
+    stream, and can be ``[B, L, D]`` for compatible callers.  In both cases
+    dimension 1 is the per-request sequence length.  Batch size must not
+    select a different numerical path for the same request.
+    """
+
+    if x.ndim >= 3:
+        sequence_length = int(x.shape[1])
+    elif x.ndim == 2:
+        sequence_length = int(x.shape[0])
+    else:
+        sequence_length = 1
+    return (
+        sequence_length >= _DEEPSEEK_MOE_NATIVE_MIN_SEQUENCE_LENGTH
+        and indices.size >= 64
+    )
 
 
 @lru_cache(maxsize=None)
@@ -390,10 +422,10 @@ class SwitchGLU(nn.Module):
         self.activation = activation
 
     def __call__(self, x, indices, scores=None) -> mx.array:
+        do_sort = _should_sort_experts(x, indices)
         x = mx.expand_dims(x, (-2, -3))
         original_dtype = x.dtype
 
-        do_sort = indices.size >= 64
         idx = indices
         inv_order = None
         if do_sort:
@@ -403,20 +435,24 @@ class SwitchGLU(nn.Module):
 
         block_plan = None
         native_kinds = None
-        use_f16_moe = False
+        use_f16_affine_moe = False
         projections = (self.up_proj, self.gate_proj, self.down_proj)
         if do_sort and all(isinstance(p, QuantizedSwitchLinear) for p in projections):
             native_kinds = tuple(p._native_block_kind(x, do_sort) for p in projections)
-            if x.dtype == mx.bfloat16:
+            # MXFP4 has native BF16 instantiations and must retain the
+            # request's decode dtype.  Legacy affine 2/3-bit checkpoints can
+            # carry FP16 scales/biases; keep their prefill-only compatibility
+            # path without letting batch width trigger it during decode.
+            if x.dtype == mx.bfloat16 and all(
+                kind is None for kind in native_kinds
+            ):
                 f16_native_kinds = tuple(
                     p._native_block_kind(x, do_sort, dtype=mx.float16)
                     for p in projections
                 )
-                if all(kind == "mxfp4" for kind in f16_native_kinds) or all(
-                    kind == "affine" for kind in f16_native_kinds
-                ):
+                if all(kind == "affine" for kind in f16_native_kinds):
                     native_kinds = f16_native_kinds
-                    use_f16_moe = True
+                    use_f16_affine_moe = True
             if all(kind is not None for kind in native_kinds):
                 block_bm, block_variant = _mxfp4_block_config(idx.size)
                 block_meta, block_count = _build_mxfp4_blocks(
@@ -426,7 +462,7 @@ class SwitchGLU(nn.Module):
                 )
                 block_plan = (block_meta, block_count, block_variant)
 
-        if use_f16_moe:
+        if use_f16_affine_moe:
             x = x.astype(mx.float16)
 
         use_pair_proj = (
@@ -527,7 +563,7 @@ class SwitchGLU(nn.Module):
             x = _scatter_unsort(x, inv_order, indices.shape)
 
         x = x.squeeze(-2)
-        if use_f16_moe:
+        if use_f16_affine_moe:
             x = x.astype(original_dtype)
         return x
 
@@ -548,9 +584,9 @@ class SwitchMLP(nn.Module):
         self.activation = activation
 
     def __call__(self, x, indices) -> mx.array:
+        do_sort = _should_sort_experts(x, indices)
         x = mx.expand_dims(x, (-2, -3))
 
-        do_sort = indices.size >= 64
         idx = indices
         inv_order = None
         if do_sort:

--- a/omlx/patches/deepseek_v4/tokenizer_patch.py
+++ b/omlx/patches/deepseek_v4/tokenizer_patch.py
@@ -162,20 +162,37 @@ def _register_chat_template_and_parser_modules() -> None:
         sys.modules["mlx_lm.tool_parsers.deepseek_v4"] = _tp
 
 
-def _is_deepseek_v4_model(model_path) -> bool:
-    """Return True if ``model_path/config.json`` declares deepseek_v4*."""
+def _deepseek_v4_config(model_path) -> dict | None:
+    """Return a DeepSeek V4 config dict, or ``None`` for another family."""
     import json
     from pathlib import Path
 
     p = Path(model_path) / "config.json"
     if not p.exists():
-        return False
+        return None
     try:
-        return str(json.loads(p.read_text()).get("model_type", "")).startswith(
-            "deepseek_v4"
-        )
+        config = json.loads(p.read_text())
     except Exception:
+        return None
+    if not str(config.get("model_type", "")).startswith("deepseek_v4"):
+        return None
+    return config
+
+
+def _is_deepseek_v4_model(model_path) -> bool:
+    """Return True if ``model_path/config.json`` declares deepseek_v4*."""
+    return _deepseek_v4_config(model_path) is not None
+
+
+def _uses_dspark_protocol(config: dict | None) -> bool:
+    """Identify the official DSpark/0731 prompt and speculative format."""
+    if not config:
         return False
+    return bool(
+        int(config.get("dspark_block_size", 0) or 0) > 0
+        and config.get("dspark_target_layer_ids")
+        and int(config.get("dspark_markov_rank", 0) or 0) > 0
+    )
 
 
 def apply_load_patch() -> bool:
@@ -207,10 +224,14 @@ def apply_load_patch() -> bool:
             eos_token_ids=eos_token_ids,
         )
 
-        if not _is_deepseek_v4_model(model_path):
+        config = _deepseek_v4_config(model_path)
+        if config is None:
             return wrapper
 
-        from . import chat_template_v4 as _ct
+        if _uses_dspark_protocol(config):
+            from . import chat_template_v4_dspark as _ct
+        else:
+            from . import chat_template_v4 as _ct
         from . import tool_parser_v4 as _tp
 
         # Skip if the published tokenizer_config already wired up V4 by

--- a/omlx/patches/deepseek_v4/vendor/encoding_dsv4.py
+++ b/omlx/patches/deepseek_v4/vendor/encoding_dsv4.py
@@ -1,0 +1,765 @@
+# Copyright © 2026 DeepSeek-AI
+# SPDX-License-Identifier: MIT
+"""
+DeepSeek-V4 Encoding
+
+A self-contained implementation for encoding/decoding DeepSeek-V4 chat messages
+with tool calling, thinking mode, and quick instruction task support.
+
+Vendored from deepseek-ai/DeepSeek-V4-Flash-0731 at revision
+9e165c30e2704aec5d9d593cce3eebd58bbef1cb.
+"""
+
+from typing import Any, Dict, List, Union, Optional, Tuple
+import copy
+import json
+import re
+
+# ============================================================
+# Special Tokens
+# ============================================================
+
+bos_token: str = "<｜begin▁of▁sentence｜>"
+eos_token: str = "<｜end▁of▁sentence｜>"
+thinking_start_token: str = "<think>"
+thinking_end_token: str = "</think>"
+dsml_token: str = "｜DSML｜"
+
+USER_SP_TOKEN = "<｜User｜>"
+ASSISTANT_SP_TOKEN = "<｜Assistant｜>"
+LATEST_REMINDER_SP_TOKEN = "<｜latest_reminder｜>"
+
+# Task special tokens for internal classification tasks
+DS_TASK_SP_TOKENS = {
+    "action": "<｜action｜>",
+    "query": "<｜query｜>",
+    "authority": "<｜authority｜>",
+    "domain": "<｜domain｜>",
+    "title": "<｜title｜>",
+    "read_url": "<｜read_url｜>",
+}
+VALID_TASKS = set(DS_TASK_SP_TOKENS.keys())
+
+# ============================================================
+# Templates
+# ============================================================
+
+system_msg_template: str = "{content}"
+user_msg_template: str = "{content}"
+latest_reminder_msg_template: str = "{content}"
+assistant_msg_template: str = "{reasoning}{content}{tool_calls}" + eos_token
+assistant_msg_wo_eos_template: str = "{reasoning}{content}{tool_calls}"
+thinking_template: str = "{reasoning_content}"
+
+response_format_template: str = (
+    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}"
+)
+tool_call_template: str = (
+    "<{dsml_token}invoke name=\"{name}\">\n{arguments}\n</{dsml_token}invoke>"
+)
+tool_calls_template = (
+    "<{dsml_token}{tc_block_name}>\n{tool_calls}\n</{dsml_token}{tc_block_name}>"
+)
+tool_calls_block_name: str = "tool_calls"
+
+tool_output_template: str = (
+    "<tool_result>{content}</tool_result>"
+)
+
+# Reasoning effort levels. In thinking mode, the prompt for the selected level is
+# prepended at the very beginning of the conversation. `low` is the default and
+# adds nothing.
+REASONING_EFFORT_PROMPTS: Dict[str, str] = {
+    "low": "",
+    "high": (
+        "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+        "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
+        "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+    ),
+    "max": (
+        "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n"
+        "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n"
+        "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n"
+    ),
+}
+DEFAULT_REASONING_EFFORT = "low"
+
+TOOLS_TEMPLATE = """## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml_token}tool_calls>" block like the following:
+
+<{dsml_token}tool_calls>
+<{dsml_token}invoke name="$TOOL_NAME">
+<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
+...
+</{dsml_token}invoke>
+<{dsml_token}invoke name="$TOOL_NAME2">
+...
+</{dsml_token}invoke>
+</{dsml_token}tool_calls>
+
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+
+If thinking_mode is enabled (triggered by {thinking_start_token}), you MUST output your complete reasoning inside {thinking_start_token}...{thinking_end_token} BEFORE any tool calls or final response.
+
+Otherwise, output directly after {thinking_end_token} with tool calls or final response.
+
+### Available Tool Schemas
+
+{tool_schemas}
+
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+"""
+
+# ============================================================
+# Utility Functions
+# ============================================================
+
+def to_json(value: Any) -> str:
+    """Serialize a value to JSON string."""
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except:
+        return json.dumps(value, ensure_ascii=True)
+
+
+def tools_from_openai_format(tools):
+    """Extract function definitions from OpenAI-format tool list."""
+    return [tool["function"] for tool in tools]
+
+
+def tool_calls_from_openai_format(tool_calls):
+    """Convert OpenAI-format tool calls to internal format."""
+    return [
+        {
+            "name": tool_call["function"]["name"],
+            "arguments": tool_call["function"]["arguments"],
+        }
+        for tool_call in tool_calls
+    ]
+
+
+def tool_calls_to_openai_format(tool_calls):
+    """Convert internal tool calls to OpenAI format."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool_call["name"],
+                "arguments": tool_call["arguments"],
+            }
+        }
+        for tool_call in tool_calls
+    ]
+
+
+def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
+    """
+    Encode tool call arguments into DSML parameter format.
+
+    Args:
+        tool_call: Dict with "name" and "arguments" (JSON string) keys.
+
+    Returns:
+        DSML-formatted parameter string.
+    """
+    p_dsml_template = '<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>'
+    P_dsml_strs = []
+
+    try:
+        arguments = json.loads(tool_call["arguments"])
+    except Exception as err:
+        arguments = {"arguments": tool_call["arguments"]}
+
+    for k, v in arguments.items():
+        p_dsml_str = p_dsml_template.format(
+            dsml_token=dsml_token,
+            key=k,
+            is_str="true" if isinstance(v, str) else "false",
+            value=v if isinstance(v, str) else to_json(v),
+        )
+        P_dsml_strs.append(p_dsml_str)
+
+    return "\n".join(P_dsml_strs)
+
+
+def decode_dsml_to_arguments(tool_name: str, tool_args: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
+    """
+    Decode DSML parameters back to a tool call dict.
+
+    Args:
+        tool_name: Name of the tool.
+        tool_args: Dict mapping param_name -> (value, is_string_flag).
+
+    Returns:
+        Dict with "name" and "arguments" (JSON string) keys.
+    """
+    def _decode_value(key: str, value: str, string: str):
+        if string == "true":
+            value = to_json(value)
+        return f"{to_json(key)}: {value}"
+
+    tool_args_json = "{" + ", ".join([_decode_value(k, v, string=is_str) for k, (v, is_str) in tool_args.items()]) + "}"
+    return dict(name=tool_name, arguments=tool_args_json)
+
+
+def render_tools(tools: List[Dict[str, Union[str, Dict[str, Any]]]]) -> str:
+    """
+    Render tool schemas into the system prompt format.
+
+    Args:
+        tools: List of tool schema dicts (each with name, description, parameters).
+
+    Returns:
+        Formatted tools section string.
+    """
+    tools_json = [to_json(t) for t in tools]
+
+    return TOOLS_TEMPLATE.format(
+        tool_schemas="\n".join(tools_json),
+        dsml_token=dsml_token,
+        thinking_start_token=thinking_start_token,
+        thinking_end_token=thinking_end_token,
+    )
+
+
+def find_last_user_index(messages: List[Dict[str, Any]]) -> int:
+    """Find the index of the last user/developer message."""
+    last_user_index = -1
+    for idx in range(len(messages) - 1, -1, -1):
+        if messages[idx].get("role") in ["user", "developer"]:
+            last_user_index = idx
+            break
+    return last_user_index
+
+
+# ============================================================
+# Message Rendering
+# ============================================================
+
+def render_message(index: int, messages: List[Dict[str, Any]], thinking_mode: str, drop_thinking: bool = True, reasoning_effort: Optional[str] = None) -> str:
+    """
+    Render a single message at the given index into its encoded string form.
+
+    This is the core function that converts each message in the conversation
+    into the DeepSeek-V4 format.
+
+    Args:
+        index: Index of the message to render.
+        messages: Full list of messages in the conversation.
+        thinking_mode: Either "chat" or "thinking".
+        drop_thinking: Whether to drop reasoning content from earlier turns.
+        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
+            None is treated as "low".
+
+    Returns:
+        Encoded string for this message.
+    """
+    assert 0 <= index < len(messages)
+    assert thinking_mode in ["chat", "thinking"], f"Invalid thinking_mode `{thinking_mode}`"
+
+    prompt = ""
+    msg = messages[index]
+    last_user_idx = find_last_user_index(messages)
+
+    role = msg.get("role")
+    content = msg.get("content")
+    tools = msg.get("tools")
+    response_format = msg.get("response_format")
+    tool_calls = msg.get("tool_calls")
+    reasoning_content = msg.get("reasoning_content")
+    wo_eos = msg.get("wo_eos", False)
+
+    if tools:
+        tools = tools_from_openai_format(tools)
+    if tool_calls:
+        tool_calls = tool_calls_from_openai_format(tool_calls)
+
+    # Reasoning effort prefix (only at index 0 in thinking mode; "low" adds nothing)
+    reasoning_effort = reasoning_effort or DEFAULT_REASONING_EFFORT
+    assert reasoning_effort in REASONING_EFFORT_PROMPTS, \
+        f"Invalid reasoning effort: {reasoning_effort}, expected one of {list(REASONING_EFFORT_PROMPTS)}"
+    if index == 0 and thinking_mode == "thinking":
+        prompt += REASONING_EFFORT_PROMPTS[reasoning_effort]
+
+    if role == "system":
+        prompt += system_msg_template.format(content=content or "")
+        if tools:
+            prompt += "\n\n" + render_tools(tools)
+        if response_format:
+            prompt += "\n\n" + response_format_template.format(schema=to_json(response_format))
+
+    elif role == "developer":
+        assert content, f"Invalid message for role `{role}`: {msg}"
+
+        content_developer = USER_SP_TOKEN
+        content_developer += content
+
+        if tools:
+            content_developer += "\n\n" + render_tools(tools)
+        if response_format:
+            content_developer += "\n\n" + response_format_template.format(schema=to_json(response_format))
+
+        prompt += user_msg_template.format(content=content_developer)
+
+    elif role == "user":
+        prompt += USER_SP_TOKEN
+
+        # Handle content blocks (tool results mixed with text)
+        content_blocks = msg.get("content_blocks")
+        if content_blocks:
+            parts = []
+            for block in content_blocks:
+                block_type = block.get("type")
+                if block_type == "text":
+                    parts.append(block.get("text", ""))
+                elif block_type == "tool_result":
+                    tool_content = block.get("content", "")
+                    if isinstance(tool_content, list):
+                        text_parts = []
+                        for b in tool_content:
+                            if b.get("type") == "text":
+                                text_parts.append(b.get("text", ""))
+                            else:
+                                text_parts.append(f"[Unsupported {b.get('type')}]")
+                        tool_content = "\n\n".join(text_parts)
+                    parts.append(tool_output_template.format(content=tool_content))
+                else:
+                    parts.append(f"[Unsupported {block_type}]")
+            prompt += "\n\n".join(parts)
+        else:
+            prompt += content or ""
+
+    elif role == "latest_reminder":
+        prompt += LATEST_REMINDER_SP_TOKEN + latest_reminder_msg_template.format(content=content)
+
+    elif role == "tool":
+        raise NotImplementedError("deepseek_v4 merges tool messages into user; please preprocess with merge_tool_messages()")
+
+    elif role == "assistant":
+        thinking_part = ""
+        tc_content = ""
+
+        if tool_calls:
+            tc_list = [
+                tool_call_template.format(
+                    dsml_token=dsml_token,
+                    name=tc.get("name"),
+                    arguments=encode_arguments_to_dsml(tc)
+                )
+                for tc in tool_calls
+            ]
+            tc_content += '\n\n' + tool_calls_template.format(
+                dsml_token=dsml_token,
+                tool_calls="\n".join(tc_list),
+                tc_block_name=tool_calls_block_name,
+            )
+
+        summary_content = content or ""
+        rc = reasoning_content or ""
+
+        # Check if previous message has a task - if so, this is a task output (no thinking)
+        prev_has_task = index - 1 >= 0 and messages[index - 1].get("task") is not None
+
+        if thinking_mode == "thinking" and not prev_has_task:
+            if not drop_thinking or index > last_user_idx:
+                thinking_part = thinking_template.format(reasoning_content=rc) + thinking_end_token
+            else:
+                thinking_part = ""
+
+        if wo_eos:
+            prompt += assistant_msg_wo_eos_template.format(
+                reasoning=thinking_part,
+                content=summary_content,
+                tool_calls=tc_content,
+            )
+        else:
+            prompt += assistant_msg_template.format(
+                reasoning=thinking_part,
+                content=summary_content,
+                tool_calls=tc_content,
+            )
+    else:
+        raise NotImplementedError(f"Unknown role: {role}")
+
+    # Append transition tokens based on what follows
+    if index + 1 < len(messages) and messages[index + 1].get("role") not in ["assistant", "latest_reminder"]:
+        return prompt
+
+    task = messages[index].get("task")
+    if task is not None:
+        # Task special token for internal classification tasks
+        assert task in VALID_TASKS, f"Invalid task: '{task}'. Valid tasks are: {list(VALID_TASKS)}"
+        task_sp_token = DS_TASK_SP_TOKENS[task]
+
+        if task != "action":
+            # Non-action tasks: append task sp token directly after the message
+            prompt += task_sp_token
+        else:
+            # Action task: append Assistant + thinking token + action sp token
+            prompt += ASSISTANT_SP_TOKEN
+            prompt += thinking_end_token if thinking_mode != "thinking" else thinking_start_token
+            prompt += task_sp_token
+
+    elif messages[index].get("role") in ["user", "developer"]:
+        # Normal generation: append Assistant + thinking token
+        prompt += ASSISTANT_SP_TOKEN
+        if not drop_thinking and thinking_mode == "thinking":
+            prompt += thinking_start_token
+        elif drop_thinking and thinking_mode == "thinking" and index >= last_user_idx:
+            prompt += thinking_start_token
+        else:
+            prompt += thinking_end_token
+
+    return prompt
+
+
+# ============================================================
+# Preprocessing
+# ============================================================
+
+def merge_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Merge tool messages into the preceding user message using content_blocks format.
+
+    DeepSeek-V4 does not have a standalone "tool" role; instead, tool results
+    are encoded as <tool_result> blocks within user messages.
+
+    This function converts a standard OpenAI-format conversation (with separate
+    "tool" role messages) into V4 format where tool results are merged into
+    user messages.
+
+    Args:
+        messages: List of message dicts in OpenAI format.
+
+    Returns:
+        Processed message list with tool messages merged into user messages.
+    """
+    merged: List[Dict[str, Any]] = []
+
+    for msg in messages:
+        msg = copy.deepcopy(msg)
+        role = msg.get("role")
+
+        if role == "tool":
+            # Convert tool message to a user message with tool_result block
+            tool_block = {
+                "type": "tool_result",
+                "tool_use_id": msg.get("tool_call_id", ""),
+                "content": msg.get("content", ""),
+            }
+            # Merge into previous message if it's already a user (merged tool)
+            if merged and merged[-1].get("role") == "user" and "content_blocks" in merged[-1]:
+                merged[-1]["content_blocks"].append(tool_block)
+            else:
+                merged.append({
+                    "role": "user",
+                    "content_blocks": [tool_block],
+                })
+        elif role == "user":
+            text_block = {"type": "text", "text": msg.get("content", "")}
+            if merged and merged[-1].get("role") == "user" and "content_blocks" in merged[-1] and merged[-1].get("task") is None:
+                merged[-1]["content_blocks"].append(text_block)
+            else:
+                new_msg = {
+                    "role": "user",
+                    "content": msg.get("content", ""),
+                    "content_blocks": [text_block],
+                }
+                # Preserve extra fields (task, wo_eos, mask, etc.)
+                for key in ("task", "wo_eos", "mask"):
+                    if key in msg:
+                        new_msg[key] = msg[key]
+                merged.append(new_msg)
+        else:
+            merged.append(msg)
+
+    return merged
+
+
+def sort_tool_results_by_call_order(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Sort tool_result blocks within user messages by the order of tool_calls
+    in the preceding assistant message.
+
+    Args:
+        messages: Preprocessed message list (after merge_tool_messages).
+
+    Returns:
+        Message list with sorted tool result blocks.
+    """
+    last_tool_call_order: Dict[str, int] = {}
+
+    for msg in messages:
+        role = msg.get("role")
+        if role == "assistant" and msg.get("tool_calls"):
+            last_tool_call_order = {}
+            for idx, tc in enumerate(msg["tool_calls"]):
+                tc_id = tc.get("id") or tc.get("function", {}).get("id", "")
+                if tc_id:
+                    last_tool_call_order[tc_id] = idx
+
+        elif role == "user" and msg.get("content_blocks"):
+            tool_blocks = [b for b in msg["content_blocks"] if b.get("type") == "tool_result"]
+            if len(tool_blocks) > 1 and last_tool_call_order:
+                sorted_blocks = sorted(
+                    tool_blocks,
+                    key=lambda b: last_tool_call_order.get(b.get("tool_use_id", ""), 0)
+                )
+                sorted_idx = 0
+                new_blocks = []
+                for block in msg["content_blocks"]:
+                    if block.get("type") == "tool_result":
+                        new_blocks.append(sorted_blocks[sorted_idx])
+                        sorted_idx += 1
+                    else:
+                        new_blocks.append(block)
+                msg["content_blocks"] = new_blocks
+
+    return messages
+
+
+# ============================================================
+# Main Encoding Function
+# ============================================================
+
+def encode_messages(
+    messages: List[Dict[str, Any]],
+    thinking_mode: str,
+    context: Optional[List[Dict[str, Any]]] = None,
+    drop_thinking: bool = True,
+    add_default_bos_token: bool = True,
+    reasoning_effort: Optional[str] = None,
+) -> str:
+    """
+    Encode a list of messages into the DeepSeek-V4 prompt format.
+
+    This is the main entry point for encoding conversations. It handles:
+    - BOS token insertion
+    - Thinking mode with optional reasoning content dropping
+    - Tool message merging into user messages
+    - Multi-turn conversation context
+
+    Args:
+        messages: List of message dicts to encode.
+        thinking_mode: Either "chat" or "thinking".
+        context: Optional preceding context messages (already encoded prefix).
+        drop_thinking: If True, drop reasoning_content from earlier assistant turns
+                      (only keep reasoning for messages after the last user message).
+        add_default_bos_token: Whether to prepend BOS token at conversation start.
+        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
+            Only takes effect in thinking mode. None is treated as "low".
+
+    Returns:
+        The encoded prompt string.
+    """
+    context = context if context else []
+
+    # Preprocess: merge tool messages and sort tool results
+    messages = merge_tool_messages(messages)
+    messages = sort_tool_results_by_call_order(context + messages)[len(context):]
+    if context:
+        context = merge_tool_messages(context)
+        context = sort_tool_results_by_call_order(context)
+
+    full_messages = context + messages
+
+    prompt = bos_token if add_default_bos_token and len(context) == 0 else ""
+
+    # Resolve drop_thinking: if any message has tools defined, don't drop thinking
+    effective_drop_thinking = drop_thinking
+    if any(m.get("tools") for m in full_messages):
+        effective_drop_thinking = False
+
+    if thinking_mode == "thinking" and effective_drop_thinking:
+        full_messages = _drop_thinking_messages(full_messages)
+        # After dropping, recalculate how many messages to render
+        # (context may have shrunk too)
+        num_to_render = len(full_messages) - len(_drop_thinking_messages(context))
+        context_len = len(full_messages) - num_to_render
+    else:
+        num_to_render = len(messages)
+        context_len = len(context)
+
+    for idx in range(num_to_render):
+        prompt += render_message(
+            idx + context_len,
+            full_messages,
+            thinking_mode=thinking_mode,
+            drop_thinking=effective_drop_thinking,
+            reasoning_effort=reasoning_effort,
+        )
+
+    return prompt
+
+
+def _drop_thinking_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Drop reasoning_content and non-essential messages before the last user message.
+
+    Behavior:
+    - Messages with role in ["user", "system", "tool", "latest_reminder"] are always kept.
+    - Messages at or after the last user index are always kept.
+    - Assistant messages before the last user get reasoning_content removed.
+    - Developer messages before the last user are dropped entirely.
+    """
+    last_user_idx = find_last_user_index(messages)
+    result = []
+    keep_roles = {"user", "system", "tool", "latest_reminder", "direct_search_results"}
+
+    for idx, msg in enumerate(messages):
+        role = msg.get("role")
+        if role in keep_roles or idx >= last_user_idx:
+            result.append(msg)
+        elif role == "assistant":
+            msg = copy.copy(msg)
+            msg.pop("reasoning_content", None)
+            result.append(msg)
+        # developer and other roles before last_user_idx are dropped
+
+    return result
+
+
+# ============================================================
+# Parsing (Decoding model output)
+# ============================================================
+
+def _read_until_stop(index: int, text: str, stop: List[str]) -> Tuple[int, str, Optional[str]]:
+    """
+    Read text from index until one of the stop strings is found.
+
+    Returns:
+        Tuple of (new_index, content_before_stop, matched_stop_string_or_None).
+    """
+    min_pos = len(text)
+    matched_stop = None
+
+    for s in stop:
+        pos = text.find(s, index)
+        if pos != -1 and pos < min_pos:
+            min_pos = pos
+            matched_stop = s
+
+    if matched_stop:
+        content = text[index:min_pos]
+        return min_pos + len(matched_stop), content, matched_stop
+    else:
+        content = text[index:]
+        return len(text), content, None
+
+
+def parse_tool_calls(index: int, text: str) -> Tuple[int, Optional[str], List[Dict[str, str]]]:
+    """
+    Parse DSML tool calls from text starting at the given index.
+
+    Args:
+        index: Starting position in text.
+        text: The full text to parse.
+
+    Returns:
+        Tuple of (new_index, last_stop_token, list_of_tool_call_dicts).
+        Each tool call dict has "name" and "arguments" keys.
+    """
+    tool_calls: List[Dict[str, Any]] = []
+    stop_token = None
+    tool_calls_end_token = f"</{dsml_token}{tool_calls_block_name}>"
+
+    while index < len(text):
+        index, _, stop_token = _read_until_stop(index, text, [f"<{dsml_token}invoke", tool_calls_end_token])
+        if _ != ">\n":
+            raise ValueError(f"Tool call format error: expected '>\\n' but got '{_}'")
+
+        if stop_token == tool_calls_end_token:
+            break
+
+        if stop_token is None:
+            raise ValueError("Missing special token in tool calls")
+
+        index, tool_name_content, stop_token = _read_until_stop(index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"])
+
+        p_tool_name = re.findall(r'^\s*name="(.*?)">\n$', tool_name_content, flags=re.DOTALL)
+        if len(p_tool_name) != 1:
+            raise ValueError(f"Tool name format error: '{tool_name_content}'")
+        tool_name = p_tool_name[0]
+
+        tool_args: Dict[str, Tuple[str, str]] = {}
+        while stop_token == f"<{dsml_token}parameter":
+            index, param_content, stop_token = _read_until_stop(index, text, [f"/{dsml_token}parameter"])
+
+            param_kv = re.findall(r'^ name="(.*?)" string="(true|false)">(.*?)<$', param_content, flags=re.DOTALL)
+            if len(param_kv) != 1:
+                raise ValueError(f"Parameter format error: '{param_content}'")
+            param_name, string, param_value = param_kv[0]
+
+            if param_name in tool_args:
+                raise ValueError(f"Duplicate parameter name: '{param_name}'")
+            tool_args[param_name] = (param_value, string)
+
+            index, content, stop_token = _read_until_stop(index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"])
+            if content != ">\n":
+                raise ValueError(f"Parameter format error: expected '>\\n' but got '{content}'")
+
+        tool_call = decode_dsml_to_arguments(tool_name=tool_name, tool_args=tool_args)
+        tool_calls.append(tool_call)
+
+    return index, stop_token, tool_calls
+
+
+def parse_message_from_completion_text(text: str, thinking_mode: str) -> Dict[str, Any]:
+    """
+    Parse a model completion text into a structured assistant message.
+
+    This function takes the raw text output from the model (a single assistant turn)
+    and extracts:
+    - reasoning_content (thinking block)
+    - content (summary/response)
+    - tool_calls (if any)
+
+    NOTE: This function is designed to parse only correctly formatted strings and
+    will raise ValueError for malformed output.
+
+    Args:
+        text: The raw completion text (including EOS token).
+        thinking_mode: Either "chat" or "thinking".
+
+    Returns:
+        Dict with keys: "role", "content", "reasoning_content", "tool_calls".
+        tool_calls are in OpenAI format.
+    """
+    summary_content, reasoning_content, tool_calls = "", "", []
+    index, stop_token = 0, None
+    tool_calls_start_token = f"\n\n<{dsml_token}{tool_calls_block_name}"
+
+    is_thinking = thinking_mode == "thinking"
+    is_tool_calling = False
+
+    if is_thinking:
+        index, content_delta, stop_token = _read_until_stop(index, text, [thinking_end_token, tool_calls_start_token])
+        reasoning_content = content_delta
+        assert stop_token == thinking_end_token, "Invalid thinking format: missing </think>"
+
+    index, content_delta, stop_token = _read_until_stop(index, text, [eos_token, tool_calls_start_token])
+    summary_content = content_delta
+    if stop_token == tool_calls_start_token:
+        is_tool_calling = True
+    else:
+        assert stop_token == eos_token, "Invalid format: missing EOS token"
+
+    if is_tool_calling:
+        index, stop_token, tool_calls = parse_tool_calls(index, text)
+
+        index, tool_ends_text, stop_token = _read_until_stop(index, text, [eos_token])
+        assert not tool_ends_text, "Unexpected content after tool calls"
+
+    assert len(text) == index and stop_token in [eos_token, None], "Unexpected content at end"
+
+    for sp_token in [bos_token, eos_token, thinking_start_token, thinking_end_token, dsml_token]:
+        assert sp_token not in summary_content and sp_token not in reasoning_content, \
+            f"Unexpected special token '{sp_token}' in content"
+
+    return {
+        "role": "assistant",
+        "content": summary_content,
+        "reasoning_content": reasoning_content,
+        "tool_calls": tool_calls_to_openai_format(tool_calls)
+    }

--- a/omlx/patches/deepseek_v4/vendor/encoding_dsv4.py
+++ b/omlx/patches/deepseek_v4/vendor/encoding_dsv4.py
@@ -153,12 +153,14 @@ def tool_calls_to_openai_format(tool_calls):
     ]
 
 
-def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
+def encode_arguments_to_dsml(tool_call: Dict[str, Any]) -> str:
     """
     Encode tool call arguments into DSML parameter format.
 
     Args:
-        tool_call: Dict with "name" and "arguments" (JSON string) keys.
+        tool_call: Dict with "name" and "arguments" keys. OpenAI history
+            commonly carries arguments as a JSON string, while oMLX's
+            normalized message path carries the already-decoded dict.
 
     Returns:
         DSML-formatted parameter string.
@@ -166,10 +168,22 @@ def encode_arguments_to_dsml(tool_call: Dict[str, str]) -> str:
     p_dsml_template = '<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>'
     P_dsml_strs = []
 
-    try:
-        arguments = json.loads(tool_call["arguments"])
-    except Exception as err:
-        arguments = {"arguments": tool_call["arguments"]}
+    raw_arguments = tool_call["arguments"]
+    if isinstance(raw_arguments, str):
+        try:
+            arguments = json.loads(raw_arguments)
+        except (json.JSONDecodeError, TypeError):
+            # Preserve the official encoder's tolerance for malformed
+            # string payloads without treating a valid decoded dict as an
+            # error and wrapping it once per history replay.
+            arguments = {"arguments": raw_arguments}
+    elif isinstance(raw_arguments, dict):
+        arguments = raw_arguments
+    else:
+        raise TypeError(
+            "Tool call arguments must be a JSON string or object, "
+            f"got {type(raw_arguments).__name__}"
+        )
 
     for k, v in arguments.items():
         p_dsml_str = p_dsml_template.format(

--- a/omlx/patches/mlx_lm_mtp/__init__.py
+++ b/omlx/patches/mlx_lm_mtp/__init__.py
@@ -4,7 +4,8 @@
 This package adapts two upstream PRs into runtime monkey-patches:
 
 - ml-explore/mlx-lm#990 — Qwen3.5 / Qwen3.6 native MTP heads (dense + MoE)
-- Blaizzy/mlx-lm#15    — DeepSeek-V4-Flash native MTP heads
+- Blaizzy/mlx-lm#15    — preview DeepSeek-V4-Flash native MTP heads
+- DeepSeek-V4-Flash-0731 — official three-stage, five-token DSpark module
 
 Both PRs follow the same shape: a model gains an extra ``mtp`` module + a
 ``mtp_forward`` method and an enhanced ``__call__`` that returns hidden
@@ -64,7 +65,8 @@ def is_mtp_active() -> bool:
 # patched ``TextModel.__init__`` copies it onto the instance
 # (``_omlx_mtp_depth``) so decode never reads the global. Depth > 1 only
 # engages on models whose patch marks ``_omlx_mtp_chain`` (Qwen3.5/3.6);
-# DeepSeek-V4 stays on the depth-1 legacy cycle.
+# DeepSeek-V4 preview uses this controller; the 0731 DSpark path takes its
+# fixed five-token block size directly from the checkpoint config.
 _MTP_DEPTH = 1
 
 

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -1953,6 +1953,15 @@ def _chain_next_drafts(
     procs = _proc_list(gen_batch)
 
     depth = state.controller.cur if state.controller is not None else state.depth
+    if getattr(model, "_omlx_dspark", False):
+        return _dspark_next_drafts(
+            gen_batch,
+            state,
+            hidden_rows,
+            committed,
+            prev_buf,
+            depth,
+        )
     if depth == 0 and not state.mtp_cache:
         # Depth-0 with a stateless head (no cache to keep warm, e.g. the
         # gemma4 assistant): skip the fold entirely — on fast backbones its
@@ -2038,6 +2047,74 @@ def _chain_next_drafts(
         state.drafts = mx.zeros((0,), dtype=mx.uint32)
     state.draft_lps = draft_lps
     state.draft_accept_lps = draft_accept_lps
+
+
+def _dspark_next_drafts(
+    gen_batch: Any,
+    state: _MtpState,
+    hidden_rows: Any,
+    committed: Any,
+    prev_buf: Optional[Any],
+    depth: int,
+) -> None:
+    """Produce DSpark's parallel block and apply its sequential Markov bias.
+
+    The three-stage DSpark backbone computes all query rows in one pass.
+    Sampling is sequential only because row ``j`` receives a low-rank
+    vocabulary bias derived from token ``j-1``.  Keeping that loop here
+    preserves oMLX's logits processors and records the exact filtered draft
+    distributions consumed by Leviathan/Chen acceptance.
+    """
+    import mlx.core as mx
+
+    model = gen_batch.model
+    sampler = _resolve_draft_sampler(gen_batch, state)
+    procs = _proc_list(gen_batch)
+
+    if depth <= 0:
+        state.drafts = mx.zeros((0,), dtype=mx.uint32)
+        state.draft_lps = []
+        state.draft_accept_lps = []
+        return
+
+    n = int(committed.shape[0])
+    base_logits = model.dspark_logits(
+        hidden_rows,
+        committed.reshape(1, n),
+        state.mtp_cache,
+    )
+    state.hist_offset += n
+    depth = min(depth, int(base_logits.shape[1]))
+
+    draft_toks: List[Any] = []
+    draft_lps: List[Any] = []
+    draft_accept_lps: List[Any] = []
+    previous = committed[-1:].reshape(1)
+    chain_prefix = committed[-1:]
+
+    for j in range(depth):
+        logits_2d = base_logits[:, j, :] + model.dspark_markov_logits(previous)
+        if procs is not None and prev_buf is not None:
+            prev = mx.concatenate(
+                [prev_buf.astype(mx.int32), chain_prefix.astype(mx.int32)]
+                + [tok.reshape(1).astype(mx.int32) for tok in draft_toks]
+            )
+            logits_2d = _apply_processors(procs, prev, logits_2d)
+        lp_2d = _logprobs(logits_2d)
+        tok = _ensure_uint32(sampler(lp_2d))
+        draft_toks.append(tok)
+        draft_lps.append(lp_2d.squeeze(0))
+        draft_accept_lps.append(_accept_lp_for(sampler, lp_2d).squeeze(0))
+        previous = tok.reshape(1)
+
+    state.drafts = (
+        mx.concatenate(draft_toks)
+        if draft_toks
+        else mx.zeros((0,), dtype=mx.uint32)
+    )
+    state.draft_lps = draft_lps
+    state.draft_accept_lps = draft_accept_lps
+    mx.async_eval(state.drafts)
 
 
 # ---------------------------------------------------------------------------

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -1949,7 +1949,11 @@ def _chain_next_drafts(
     import mlx.core as mx
 
     model = gen_batch.model
-    sampler = _resolve_draft_sampler(gen_batch, state)
+    # DSpark is trained as a full proposal distribution and the reference
+    # runtime samples it with the request's temperature.  Unlike the shallow
+    # legacy MTP head, it should not use oMLX's deliberately sharpened
+    # fallback drafter sampler.
+    sampler = _resolve_sampler(gen_batch)
     procs = _proc_list(gen_batch)
 
     depth = state.controller.cur if state.controller is not None else state.depth

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -160,6 +160,15 @@ def apply() -> bool:
                         return _mtp_next(self, state)
                 except _MtpStepFallback as exc:
                     logger.debug("MTP next() fallback to standard step: %s", exc)
+                    # A failed verify may already have advanced the backbone
+                    # cache through speculative rows.  Dropping the state
+                    # directly leaves `_next_tokens` stale against that
+                    # advanced cache and corrupts every following token.
+                    # Re-prefill the emitted timeline before handing control
+                    # back to mlx-lm's standard decoder.
+                    active = getattr(self, "_omlx_mtp_state", None)
+                    if active is not None:
+                        _reconcile_mtp_to_standard(self, active)
                     _drop_mtp_state(self, "step-fallback")
             else:
                 _drop_mtp_state(self, "non-singleton-or-ineligible")
@@ -1949,11 +1958,6 @@ def _chain_next_drafts(
     import mlx.core as mx
 
     model = gen_batch.model
-    # DSpark is trained as a full proposal distribution and the reference
-    # runtime samples it with the request's temperature.  Unlike the shallow
-    # legacy MTP head, it should not use oMLX's deliberately sharpened
-    # fallback drafter sampler.
-    sampler = _resolve_sampler(gen_batch)
     procs = _proc_list(gen_batch)
 
     depth = state.controller.cur if state.controller is not None else state.depth
@@ -1966,6 +1970,7 @@ def _chain_next_drafts(
             prev_buf,
             depth,
         )
+    sampler = _resolve_draft_sampler(gen_batch, state)
     if depth == 0 and not state.mtp_cache:
         # Depth-0 with a stateless head (no cache to keep warm, e.g. the
         # gemma4 assistant): skip the fold entirely — on fast backbones its
@@ -2072,7 +2077,10 @@ def _dspark_next_drafts(
     import mlx.core as mx
 
     model = gen_batch.model
-    sampler = _resolve_draft_sampler(gen_batch, state)
+    # DSpark is trained as a full proposal distribution and the reference
+    # runtime samples it with the request's temperature. Unlike the shallow
+    # legacy MTP head, it should not use oMLX's sharpened fallback drafter.
+    sampler = _resolve_sampler(gen_batch)
     procs = _proc_list(gen_batch)
 
     if depth <= 0:
@@ -2546,6 +2554,14 @@ def _run_verify_cycle_chain(gen_batch: Any, state: _MtpState) -> None:
     # Adaptive depth: the chain may have drafted fewer than state.depth
     # tokens this cycle — the verify window follows the actual drafts.
     k = int(state.drafts.shape[0])
+    safe_depth = getattr(gen_batch.model, "mtp_safe_draft_depth", None)
+    if callable(safe_depth):
+        safe_k = max(0, min(k, int(safe_depth(gen_batch.prompt_cache, k))))
+        if safe_k < k:
+            state.drafts = state.drafts[:safe_k]
+            state.draft_lps = state.draft_lps[:safe_k]
+            state.draft_accept_lps = state.draft_accept_lps[:safe_k]
+            k = safe_k
     cycle_t0 = time.perf_counter()
 
     inputs = mx.concatenate([state.next_main, state.drafts])  # (k+1,)

--- a/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
+++ b/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
@@ -401,8 +401,12 @@ def _patch_deepseek_v4_model_call(dsv4: Any) -> None:
         if pipeline_rank < pipeline_size - 1:
             h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
-        dspark_targets = set(
-            tuple(getattr(self.args, "dspark_target_layer_ids", ()) or ())
+        # Avoid even the three HC-mean reductions when DSpark hidden output
+        # was not requested (notably an MTP-disabled 0731 model).
+        dspark_targets = (
+            set(tuple(getattr(self.args, "dspark_target_layer_ids", ()) or ()))
+            if return_raw_hidden
+            else set()
         )
         dspark_hiddens = []
         for layer, layer_cache in zip(self.pipeline_layers, cache):

--- a/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
+++ b/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
@@ -714,7 +714,18 @@ def _patch_model(dsv4: Any) -> None:
             if n <= rem_min:
                 return True
             can_undo = getattr(c, "_can_undo", None)
-            return bool(can_undo and can_undo(n))
+            allowed = bool(can_undo and can_undo(n))
+            if not allowed:
+                logger.debug(
+                    "DSpark rollback blocked by %s: n=%d remainder=%r ratio=%r "
+                    "undo=%s",
+                    type(c).__name__,
+                    n,
+                    remainder,
+                    getattr(c, "ratio", None),
+                    getattr(c, "_undo", None) is not None,
+                )
+            return allowed
         is_trimmable = getattr(c, "is_trimmable", None)
         if callable(is_trimmable) and is_trimmable():
             return True
@@ -723,6 +734,14 @@ def _patch_model(dsv4: Any) -> None:
         undo = getattr(c, "_mtp_undo", None)
         if undo is not None:
             return undo[1].shape[2] >= n
+        logger.debug(
+            "DSpark rollback blocked by %s: n=%d offset=%r idx=%r max_size=%r",
+            type(c).__name__,
+            n,
+            getattr(c, "offset", None),
+            getattr(c, "_idx", None),
+            getattr(c, "max_size", None),
+        )
         return False
 
     def mtp_clamp_accept(self, cache, accepted: int, num_drafts: int) -> int:
@@ -739,6 +758,37 @@ def _patch_model(dsv4: Any) -> None:
             if n <= 0 or all(_cache_can_trim(c, n) for c in cache):
                 return m
         return 0
+
+    def mtp_safe_draft_depth(self, cache, desired: int) -> int:
+        """Clamp a verify block before it crosses an unreplayable pool seam.
+
+        PoolingCache can undo one multi-token update only while replaying the
+        confirmed prefix does not itself complete another compression window.
+        A rejection after ``m`` accepted drafts keeps ``m + 1`` rows (the
+        confirmed main token plus those drafts), so a depth ``k`` is safe for
+        every possible reject position iff ``remainder + k < ratio``.
+        """
+
+        safe = max(0, int(desired))
+        pending = list(cache or ())
+        while pending and safe:
+            entry = pending.pop()
+            subs = getattr(entry, "caches", None)
+            if subs is not None:
+                pending.extend(subs)
+                continue
+            remainder = getattr(entry, "remainder", None)
+            ratio = getattr(entry, "ratio", None)
+            if remainder is None or not ratio:
+                continue
+            values = (
+                [int(remainder)]
+                if isinstance(remainder, int)
+                else [int(v) for v in remainder]
+            )
+            for rem in values:
+                safe = min(safe, max(0, int(ratio) - rem - 1))
+        return safe
 
     def mtp_partial_rollback(self, cache, accepted: int, num_drafts: int) -> bool:
         """Trim the verify window back to ``accepted`` drafts on every layer."""
@@ -959,5 +1009,6 @@ def _patch_model(dsv4: Any) -> None:
     cls.dspark_markov_logits = dspark_markov_logits
     cls.make_mtp_cache = make_mtp_cache
     cls.mtp_clamp_accept = mtp_clamp_accept
+    cls.mtp_safe_draft_depth = mtp_safe_draft_depth
     cls.mtp_partial_rollback = mtp_partial_rollback
     cls.sanitize = sanitize

--- a/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
+++ b/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
@@ -13,11 +13,11 @@ adds the MTP head + ``mtp_forward`` / ``make_mtp_cache``. Apply order:
 caller (``patches/mlx_lm_mtp/__init__.py``) runs ``apply()`` after the
 base DeepSeek-V4 patch has registered the module.
 
-The DeepSeek-V4 backbone has 4D hidden states (``B, S, hc_mult, hidden``)
-because of the Hyper-head broadcasting. Both the patched ``__call__``
-(with ``return_hidden=True``) and ``mtp_forward`` accept / produce 4D
-tensors; the ``BatchGenerator`` MTP dispatch handles the dimension
-difference via a small adapter (see ``batch_generator._slice_hidden``).
+The preview DeepSeek-V4 backbone has 4D hidden states
+(``B, S, hc_mult, hidden``) because of Hyper-Connections.  The 0731
+checkpoint instead returns the concatenated, HC-mean hidden states from
+the target backbone layers requested by DSpark.  Both variants share the
+same public speculative-generation hooks.
 """
 
 from __future__ import annotations
@@ -29,6 +29,25 @@ from typing import Any, Dict, List, Optional
 from . import prompt_priming
 
 logger = logging.getLogger(__name__)
+
+
+def _is_dspark_config(config: Any) -> bool:
+    """Return whether ``config`` describes the official DSpark module."""
+    return bool(
+        int(getattr(config, "dspark_block_size", 0) or 0) > 0
+        and tuple(getattr(config, "dspark_target_layer_ids", ()) or ())
+        and int(getattr(config, "dspark_markov_rank", 0) or 0) > 0
+    )
+
+
+def _mtp_stage_count(config: Any) -> int:
+    """Physical checkpoint stages (DSpark's config compatibility field lies)."""
+    if _is_dspark_config(config):
+        # The official 0731 checkpoint has one DSpark stage per target
+        # backbone hidden (40, 41, 42).  Unlike the preview checkpoint,
+        # num_nextn_predict_layers is not the physical stage count.
+        return len(tuple(config.dspark_target_layer_ids))
+    return int(getattr(config, "num_nextn_predict_layers", 0) or 0)
 
 
 def _is_our_method(cls: Any, attr: str, marker: str) -> bool:
@@ -59,6 +78,7 @@ def apply() -> bool:
 
     _patch_model_args(dsv4)
     _register_mtp_block(dsv4)
+    _register_dspark_block(dsv4)
     _patch_deepseek_v4_model_call(dsv4)
     _patch_model(dsv4)
 
@@ -95,7 +115,17 @@ def _patch_model_args(dsv4: Any) -> None:
         # ``DeepseekV4Block(..., layer_idx=n_main+i)`` lookup succeeds.
         args = original_from_dict(cls, params)
         n_main = int(getattr(args, "num_hidden_layers", 0) or 0)
-        n_mtp = int(getattr(args, "num_nextn_predict_layers", 0) or 0)
+        # Older mlx-lm ModelArgs did not declare the new DSpark fields.  Set
+        # them explicitly so this patch also works on the oMLX release
+        # candidate's pinned mlx-lm version.
+        for name, default in (
+            ("dspark_block_size", 0),
+            ("dspark_noise_token_id", 0),
+            ("dspark_target_layer_ids", ()),
+            ("dspark_markov_rank", 0),
+        ):
+            setattr(args, name, params.get(name, getattr(args, name, default)))
+        n_mtp = _mtp_stage_count(args)
         if n_mtp > 0 and hasattr(args, "compress_ratios"):
             ratios = list(args.compress_ratios)
             if len(ratios) < n_main + n_mtp:
@@ -164,6 +194,163 @@ def _register_mtp_block(dsv4: Any) -> None:
     dsv4.MTPBlock = MTPBlock
 
 
+def _register_dspark_block(dsv4: Any) -> None:
+    """Register the official 0731 DSpark attention and stage modules.
+
+    DSpark's persistent cache contains only K/V projected from the target
+    backbone hidden states.  The five query slots (anchor + four noise
+    tokens) attend to that sliding window and to one another non-causally,
+    but are deliberately not written to the persistent cache.
+    """
+    if hasattr(dsv4, "DSparkBlock"):
+        return
+
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    LocalAttention = dsv4.LocalAttention
+    DeepseekV4Block = dsv4.DeepseekV4Block
+    HyperHead = dsv4.HyperHead
+    hc_expand = dsv4.hc_expand
+    scaled_dot_product_attention = dsv4.scaled_dot_product_attention
+
+    class DSparkAttention(LocalAttention):
+        """Local attention with a backbone-derived persistent K/V window."""
+
+        def _project_kv(self, x, offset):
+            batch, length, _ = x.shape
+            kv = self.kv_norm(self.wkv(x)).reshape(
+                batch, 1, length, self.head_dim
+            )
+            return self.rope(kv, offset)
+
+        def prefill(self, main_x, cache):
+            if cache is None or main_x is None or main_x.shape[1] == 0:
+                return None
+            offset = cache.offset
+            main_kv = self._project_kv(main_x, offset)
+            values = mx.zeros((*main_kv.shape[:-1], 0), dtype=main_kv.dtype)
+            kv, _ = cache.update_and_fetch(main_kv, values)
+            return kv
+
+        def __call__(self, x, mask=None, cache=None, main_x=None):
+            del mask  # DSpark query slots are intentionally non-causal.
+            batch, length, _ = x.shape
+
+            context_kv = self.prefill(main_x, cache)
+            query_offset = cache.offset if cache is not None else 0
+
+            q = self.wq_b(self.q_norm(self.wq_a(x)))
+            q = q.reshape(batch, length, self.n_heads, self.head_dim)
+            q = mx.fast.rms_norm(q, None, self.config.rms_norm_eps)
+            q = q.transpose(0, 2, 1, 3)
+            q = self.rope(q, query_offset)
+
+            query_kv = self._project_kv(x, query_offset)
+            if context_kv is None:
+                full_kv = query_kv
+            else:
+                full_kv = mx.concatenate([context_kv, query_kv], axis=2)
+
+            out = scaled_dot_product_attention(
+                q,
+                full_kv,
+                full_kv,
+                cache=None,
+                scale=self.scale,
+                mask=None,
+                sinks=self.attn_sink.astype(q.dtype),
+            )
+            out = self.rope(out, query_offset, inverse=True)
+
+            out = out.reshape(
+                batch, self.o_groups, -1, length, self.head_dim
+            )
+            out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
+            out = self.wo_a(out)
+            out = out.transpose(0, 2, 1, 3).flatten(-2)
+            out = self.wo_b(out)
+
+            if self.sharding_group is not None:
+                out = mx.distributed.all_sum(out, group=self.sharding_group)
+            return out
+
+    class DSparkMarkovHead(nn.Module):
+        def __init__(self, config):
+            rank = int(config.dspark_markov_rank)
+            self.markov_w1 = nn.Embedding(config.vocab_size, rank)
+            self.markov_w2 = nn.Linear(rank, config.vocab_size, bias=False)
+
+        def __call__(self, token_ids):
+            embed = self.markov_w1(token_ids)
+            return self.markov_w2(embed), embed
+
+    class DSparkConfidenceHead(nn.Module):
+        def __init__(self, config):
+            self.proj = nn.Linear(
+                config.hidden_size + int(config.dspark_markov_rank),
+                1,
+                bias=False,
+            )
+
+        def __call__(self, hidden, markov_embed):
+            return self.proj(
+                mx.concatenate([hidden, markov_embed], axis=-1).astype(mx.float32)
+            ).squeeze(-1)
+
+    class DSparkBlock(nn.Module):
+        """One of the three full decoder stages stored under ``mtp.<i>``."""
+
+        def __init__(self, config, layer_idx: int, stage_idx: int, n_stages: int):
+            self.block = DeepseekV4Block(config, layer_idx)
+            self.block.attn = DSparkAttention(config, layer_idx)
+            self.stage_idx = stage_idx
+            self.block_size = int(config.dspark_block_size)
+            self.noise_token_id = int(config.dspark_noise_token_id)
+
+            if stage_idx == 0:
+                targets = tuple(config.dspark_target_layer_ids)
+                self.main_proj = nn.Linear(
+                    config.hidden_size * len(targets),
+                    config.hidden_size,
+                    bias=False,
+                )
+                self.main_norm = nn.RMSNorm(
+                    config.hidden_size, eps=config.rms_norm_eps
+                )
+
+            if stage_idx == n_stages - 1:
+                self.norm = nn.RMSNorm(
+                    config.hidden_size, eps=config.rms_norm_eps
+                )
+                self.hc_head = HyperHead(config)
+                self.markov_head = DSparkMarkovHead(config)
+                # Kept load-compatible even though confidence-guided dynamic
+                # depth is not yet used by oMLX (nor by vLLM today).
+                self.confidence_head = DSparkConfidenceHead(config)
+
+        def prefill(self, main_x, cache):
+            return self.block.attn.prefill(main_x, cache)
+
+        def __call__(self, h, main_x, input_ids, cache):
+            residual = h
+            x, post, comb = self.block.attn_hc(h)
+            x = self.block.attn(
+                self.block.attn_norm(x),
+                cache=cache,
+                main_x=main_x,
+            )
+            h = hc_expand(x, residual, post, comb)
+
+            residual = h
+            x, post, comb = self.block.ffn_hc(h)
+            x = self.block.ffn(self.block.ffn_norm(x), input_ids)
+            return hc_expand(x, residual, post, comb)
+
+    dsv4.DSparkAttention = DSparkAttention
+    dsv4.DSparkBlock = DSparkBlock
+
+
 # ---------------------------------------------------------------------------
 # DeepseekV4Model — return_raw_hidden support.
 # ---------------------------------------------------------------------------
@@ -214,8 +401,15 @@ def _patch_deepseek_v4_model_call(dsv4: Any) -> None:
         if pipeline_rank < pipeline_size - 1:
             h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
+        dspark_targets = set(
+            tuple(getattr(self.args, "dspark_target_layer_ids", ()) or ())
+        )
+        dspark_hiddens = []
         for layer, layer_cache in zip(self.pipeline_layers, cache):
             h = layer(h, mask, layer_cache, inputs)
+            layer_idx = getattr(getattr(layer, "attn", None), "layer_idx", None)
+            if layer_idx in dspark_targets:
+                dspark_hiddens.append(h.mean(axis=2))
 
         materialize_cache_arrays(cache)
 
@@ -232,6 +426,14 @@ def _patch_deepseek_v4_model_call(dsv4: Any) -> None:
 
         out = self.norm(self.hc_head(h))
         if return_raw_hidden:
+            if dspark_targets:
+                if len(dspark_hiddens) != len(dspark_targets):
+                    raise RuntimeError(
+                        "DSpark requires all target backbone hidden states on "
+                        "one pipeline rank; distributed pipeline execution is "
+                        "not supported yet"
+                    )
+                return out, mx.concatenate(dspark_hiddens, axis=-1)
             return out, h
         return out
 
@@ -270,7 +472,8 @@ def _patch_model(dsv4: Any) -> None:
 
     def __init__(self, config):
         original_init(self, config)
-        n_mtp = int(getattr(config, "num_nextn_predict_layers", 0) or 0)
+        n_mtp = _mtp_stage_count(config)
+        is_dspark = _is_dspark_config(config)
         # See qwen35_model._patch_model: gated on the MTP active-flag so
         # mtp_enabled=False produces a model indistinguishable from stock.
         from . import is_mtp_active
@@ -279,7 +482,15 @@ def _patch_model(dsv4: Any) -> None:
         self._omlx_mtp_decode_enabled = mtp_decode_enabled
         if mtp_decode_enabled:
             n_main = config.num_hidden_layers
-            self.mtp = [dsv4.MTPBlock(config, n_main + i) for i in range(n_mtp)]
+            if is_dspark:
+                self.mtp = [
+                    dsv4.DSparkBlock(config, n_main + i, i, n_mtp)
+                    for i in range(n_mtp)
+                ]
+            else:
+                self.mtp = [
+                    dsv4.MTPBlock(config, n_main + i) for i in range(n_mtp)
+                ]
             # Depth-k chained drafting is available: mtp_forward supports
             # return_hidden below, backbone rollback goes through
             # mtp_partial_rollback, and the head cache is a RotatingKVCache
@@ -288,8 +499,17 @@ def _patch_model(dsv4: Any) -> None:
             from . import get_mtp_depth
 
             self._omlx_mtp_chain = True
-            self._omlx_mtp_depth = get_mtp_depth()
-            self._omlx_mtp_head_clone = True
+            self._omlx_dspark = is_dspark
+            if is_dspark:
+                self._omlx_mtp_depth = int(config.dspark_block_size)
+                self._omlx_mtp_head_clone = False
+                # The returned hidden is a concatenation of target-layer
+                # activations, not the final trunk hidden accepted by
+                # model.norm.
+                self._omlx_mtp_head_prenorm = True
+            else:
+                self._omlx_mtp_depth = get_mtp_depth()
+                self._omlx_mtp_head_clone = True
 
     def __call__(
         self,
@@ -383,6 +603,22 @@ def _patch_model(dsv4: Any) -> None:
         if cache is None:
             cache = [None] * len(self.mtp)
 
+        if getattr(self, "_omlx_dspark", False):
+            # Prompt priming calls this public hook with every confirmed
+            # target hidden.  DSpark uses those rows only to build the
+            # backbone-derived K/V window; proposal queries are produced by
+            # dspark_logits below.
+            main_x = self.mtp[0].main_norm(self.mtp[0].main_proj(h))
+            for stage, layer_cache in zip(self.mtp, cache):
+                stage.prefill(main_x, layer_cache)
+            materialize_cache_arrays(cache)
+            empty = mx.zeros(
+                (h.shape[0], 0, self.args.vocab_size), dtype=h.dtype
+            )
+            if return_hidden:
+                return empty, h
+            return empty
+
         first_cache = cache[0]
         mask_cache = (
             first_cache[0] if isinstance(first_cache, CacheList) else first_cache
@@ -410,6 +646,51 @@ def _patch_model(dsv4: Any) -> None:
         logits = self.lm_head(out)
         if return_hidden:
             return logits, h
+        return logits
+
+    def dspark_logits(self, h, input_ids, cache=None):
+        """Return the five parallel DSpark base-logit rows.
+
+        Markov biasing and sequential sampling stay in BatchGenerator so
+        oMLX's sampler, logits processors, and exact acceptance math are
+        applied consistently with every other model.
+        """
+        if not getattr(self, "_omlx_dspark", False):
+            raise RuntimeError("dspark_logits called on a non-DSpark model")
+        if cache is None:
+            cache = self.make_mtp_cache()
+
+        first = self.mtp[0]
+        main_x = first.main_norm(first.main_proj(h))
+        anchor = input_ids[:, -1:].astype(mx.uint32)
+        noise = mx.full(
+            (anchor.shape[0], int(self.args.dspark_block_size) - 1),
+            int(self.args.dspark_noise_token_id),
+            dtype=anchor.dtype,
+        )
+        query_ids = mx.concatenate([anchor, noise], axis=1)
+        x = self.model.embed_tokens(query_ids)
+        x = mx.broadcast_to(
+            x[:, :, None, :],
+            (x.shape[0], x.shape[1], self.args.hc_mult, x.shape[2]),
+        )
+        x = mx.contiguous(x)
+        for stage, layer_cache in zip(self.mtp, cache):
+            x = stage(x, main_x, query_ids, layer_cache)
+
+        last = self.mtp[-1]
+        out = last.norm(last.hc_head(x))
+        logits = self.lm_head(out)
+        materialize_cache_arrays(cache)
+        return logits
+
+    def dspark_markov_logits(self, token_ids):
+        """Vocabulary bias conditioned on the previous sampled draft token."""
+        if not getattr(self, "_omlx_dspark", False):
+            raise RuntimeError(
+                "dspark_markov_logits called on a non-DSpark model"
+            )
+        logits, _ = self.mtp[-1].markov_head(token_ids)
         return logits
 
     def _cache_can_trim(c, n: int) -> bool:
@@ -481,6 +762,7 @@ def _patch_model(dsv4: Any) -> None:
         layers.
         """
         n_layers = self.args.num_hidden_layers
+        n_mtp_layers = _mtp_stage_count(self.args)
         has_mtp = hasattr(self, "mtp")
         has_mtp_weights = any(k.startswith("mtp.") for k in weights)
         # Disable MTP module if weights are absent (e.g. quantized checkpoints
@@ -633,7 +915,7 @@ def _patch_model(dsv4: Any) -> None:
         # ndim==2 gate keeps this idempotent for checkpoints that already
         # store the 3D MultiLinear layout (e.g. oQ output).
         if has_mtp:
-            for mtp_idx in range(self.args.num_nextn_predict_layers):
+            for mtp_idx in range(n_mtp_layers):
                 prefix = f"mtp.{mtp_idx}.block.attn.wo_a"
                 for key in (f"{prefix}.weight", f"{prefix}.scales", f"{prefix}.biases"):
                     if key in weights and weights[key].ndim == 2:
@@ -643,7 +925,7 @@ def _patch_model(dsv4: Any) -> None:
 
         # Stack routed expert weights for MTP layers (PR 15).
         if has_mtp:
-            for mtp_idx in range(self.args.num_nextn_predict_layers):
+            for mtp_idx in range(n_mtp_layers):
                 prefix = f"mtp.{mtp_idx}.block.ffn.experts"
                 for src, dst in (
                     ("w1", "gate_proj"),
@@ -669,6 +951,8 @@ def _patch_model(dsv4: Any) -> None:
     __call__._omlx_mtp_call_marker = True
     cls.__call__ = __call__
     cls.mtp_forward = mtp_forward
+    cls.dspark_logits = dspark_logits
+    cls.dspark_markov_logits = dspark_markov_logits
     cls.make_mtp_cache = make_mtp_cache
     cls.mtp_clamp_accept = mtp_clamp_accept
     cls.mtp_partial_rollback = mtp_partial_rollback

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6755,8 +6755,6 @@ class Scheduler:
             return None
 
         prompt = request.prompt_token_ids or []
-        if len(prompt) < self._CACHE_FRESHNESS_WAIT_MIN_PROMPT_TOKENS:
-            return None
 
         best_rid: str | None = None
         best_future: concurrent.futures.Future | None = None
@@ -6776,6 +6774,20 @@ class Scheduler:
 
         if best_future is None or best_rid is None:
             return None
+        if len(prompt) < self._CACHE_FRESHNESS_WAIT_MIN_PROMPT_TOKENS:
+            # A prompt just below the normal threshold can still contain a
+            # complete threshold-sized conversation prefix once its partial
+            # tail is excluded.  Let that request wait only when the pending
+            # store covers every cacheable full block; arbitrary short prompts
+            # retain the no-wait fast path.
+            block_size = max(1, self.config.paged_cache_block_size)
+            near_threshold = len(prompt) >= max(
+                block_size,
+                self._CACHE_FRESHNESS_WAIT_MIN_PROMPT_TOKENS - block_size,
+            )
+            full_cacheable_prefix = len(prompt) // block_size * block_size
+            if not near_threshold or best_common < full_cacheable_prefix:
+                return None
         if not (
             best_common >= self._CACHE_FRESHNESS_WAIT_MIN_COMMON_TOKENS
             or best_common / len(prompt) >= self._CACHE_FRESHNESS_WAIT_MIN_PROMPT_RATIO

--- a/packaging/build.py
+++ b/packaging/build.py
@@ -12,6 +12,8 @@ Usage:
     python build.py --print-fingerprint
 """
 
+from __future__ import annotations
+
 import argparse
 import os
 import re

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -643,6 +643,50 @@ class TestChatTemplateV4DSpark:
         assert "<function_results>" not in prompt
         assert prompt.endswith("<｜Assistant｜><think>")
 
+    def test_replayed_dict_tool_arguments_are_not_nested(self, applied_patch):
+        """oMLX normalizes OpenAI JSON arguments to a dict before replay.
+
+        The DSpark encoder must render that dict exactly like the original
+        JSON string; wrapping it as an ``arguments`` parameter adds one
+        nesting level on every agent retry.
+        """
+        from omlx.patches.deepseek_v4 import chat_template_v4_dspark as ct
+
+        def render(arguments):
+            return ct.apply_chat_template(
+                [
+                    {"role": "user", "content": "Run the command."},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "run_command",
+                                    "arguments": arguments,
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_1",
+                        "content": "ok",
+                    },
+                ],
+                add_generation_prompt=True,
+                enable_thinking=True,
+            )
+
+        as_json = render('{"command":"echo ok"}')
+        as_dict = render({"command": "echo ok"})
+
+        assert as_dict == as_json
+        assert 'parameter name="command" string="true">echo ok<' in as_dict
+        assert 'parameter name="arguments"' not in as_dict
+
     def test_top_level_tools_are_injected_into_official_system_message(
         self, applied_patch
     ):

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -1072,6 +1072,145 @@ class TestDeepSeekV4SparseAttentionNativeDispatch:
 class TestDeepseekV4SwitchGLU:
     """DeepSeek-V4 SwitchGLU execution guards."""
 
+    def test_short_decode_dispatch_is_per_sequence_not_batch(self):
+        mx = pytest.importorskip("mlx.core")
+        from omlx.patches.deepseek_v4 import switch_layers
+
+        # DeepSeek-V4 has four Hyper-Connection streams and six routed
+        # experts, hence 24 routes per generated token.  The old global
+        # ``indices.size >= 64`` decision flipped B=1 to B=8 onto a
+        # different precision/kernel path.
+        for batch in (1, 2, 4, 8):
+            x = mx.zeros((batch, 1, 4, 32), dtype=mx.bfloat16)
+            indices = mx.zeros((batch, 1, 4, 6), dtype=mx.int32)
+            assert not switch_layers._should_sort_experts(x, indices)
+
+        # DSpark verifies at most six target tokens per cycle.  Keep that
+        # short block on the same row-stable path too, while preserving the
+        # optimized path for real prompt chunks.
+        short_x = mx.zeros((8, 6, 4, 32), dtype=mx.bfloat16)
+        short_indices = mx.zeros((8, 6, 4, 6), dtype=mx.int32)
+        assert not switch_layers._should_sort_experts(short_x, short_indices)
+
+        prefill_x = mx.zeros((1, 16, 4, 32), dtype=mx.bfloat16)
+        prefill_indices = mx.zeros((1, 16, 4, 6), dtype=mx.int32)
+        assert switch_layers._should_sort_experts(prefill_x, prefill_indices)
+
+    def test_short_mxfp4_block_matches_serial_m1(self, monkeypatch):
+        mx = pytest.importorskip("mlx.core")
+        from omlx.patches.deepseek_v4 import switch_layers
+
+        mx.random.seed(23)
+        model = switch_layers.SwitchGLU(32, 32, 8, bias=False)
+        for name in ("gate_proj", "up_proj", "down_proj"):
+            setattr(
+                model,
+                name,
+                getattr(model, name).to_quantized(
+                    group_size=32,
+                    bits=4,
+                    mode="mxfp4",
+                ),
+            )
+
+        # Pretend every native symbol is installed.  Short decode/verify must
+        # still avoid it; if the dispatch regresses these sentinels fail.
+        monkeypatch.setattr(
+            switch_layers.glm_fast,
+            "has_symbol",
+            lambda name: True,
+        )
+
+        def fail_native(*args, **kwargs):
+            raise AssertionError("short decode entered a native prefill kernel")
+
+        for name in (
+            "deepseek_mxfp4_gather_qmm_blocks",
+            "deepseek_mxfp4_gather_qmm_pair_blocks",
+            "deepseek_mxfp4_gather_qmm_pair_concat_blocks",
+        ):
+            monkeypatch.setattr(
+                switch_layers.glm_fast,
+                name,
+                fail_native,
+                raising=False,
+            )
+
+        x = mx.random.normal((1, 6, 4, 32), dtype=mx.bfloat16)
+        indices = mx.random.randint(0, 8, (1, 6, 4, 6)).astype(mx.int32)
+        block = model(x, indices)
+        serial = mx.concatenate(
+            [model(x[:, i : i + 1], indices[:, i : i + 1]) for i in range(6)],
+            axis=1,
+        )
+        mx.eval(block, serial)
+
+        assert mx.array_equal(block, serial).item()
+
+    def test_mxfp4_prefill_native_keeps_bfloat16(self, monkeypatch):
+        mx = pytest.importorskip("mlx.core")
+        from omlx.patches.deepseek_v4 import switch_layers
+
+        mx.random.seed(29)
+        model = switch_layers.SwitchGLU(32, 32, 8, bias=False)
+        for name in ("gate_proj", "up_proj", "down_proj"):
+            setattr(
+                model,
+                name,
+                getattr(model, name).to_quantized(
+                    group_size=32,
+                    bits=4,
+                    mode="mxfp4",
+                ),
+            )
+
+        monkeypatch.setattr(
+            switch_layers.glm_fast,
+            "has_symbol",
+            lambda name: True,
+        )
+        monkeypatch.setattr(
+            switch_layers,
+            "_build_mxfp4_blocks",
+            lambda indices, experts, bm: (
+                mx.zeros((1, 3), dtype=mx.int32),
+                mx.ones((1,), dtype=mx.int32),
+            ),
+        )
+        seen = []
+
+        def fake_pair(x, w0, s0, w1, s1, *args, **kwargs):
+            seen.append(x.dtype)
+            return mx.zeros(
+                x.shape[:-1] + (w0.shape[1] + w1.shape[1],),
+                dtype=x.dtype,
+            )
+
+        def fake_single(x, w, scales, *args, **kwargs):
+            seen.append(x.dtype)
+            return mx.zeros(x.shape[:-1] + (w.shape[1],), dtype=x.dtype)
+
+        monkeypatch.setattr(
+            switch_layers.glm_fast,
+            "deepseek_mxfp4_gather_qmm_pair_concat_blocks",
+            fake_pair,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            switch_layers.glm_fast,
+            "deepseek_mxfp4_gather_qmm_blocks",
+            fake_single,
+            raising=False,
+        )
+
+        x = mx.zeros((1, 16, 4, 32), dtype=mx.bfloat16)
+        indices = mx.zeros((1, 16, 4, 6), dtype=mx.int32)
+        y = model(x, indices)
+        mx.eval(y)
+
+        assert seen == [mx.bfloat16, mx.bfloat16]
+        assert y.dtype == mx.bfloat16
+
     def test_shared_expert_uses_configured_swiglu_limit(self, applied_patch):
         dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
 

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -558,6 +558,134 @@ class TestChatTemplateV4:
         assert "sunny, 22C" in prompt
 
 
+class TestChatTemplateV4DSpark:
+    """Official DSpark/0731 message encoding and reasoning-effort controls."""
+
+    def test_basic_thinking_prompt_matches_official_reference(self, applied_patch):
+        from omlx.patches.deepseek_v4 import chat_template_v4_dspark as ct
+
+        prompt = ct.apply_chat_template(
+            [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "What is 2+2?"},
+            ],
+            add_generation_prompt=True,
+            enable_thinking=True,
+        )
+        assert prompt == (
+            "<｜begin▁of▁sentence｜>You are a helpful assistant."
+            "<｜User｜>What is 2+2?<｜Assistant｜><think>"
+        )
+
+    def test_reasoning_effort_levels_are_distinct(self, applied_patch):
+        from omlx.patches.deepseek_v4 import chat_template_v4_dspark as ct
+
+        messages = [{"role": "user", "content": "Diagnose this."}]
+        low = ct.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            enable_thinking=True,
+            reasoning_effort="low",
+        )
+        high = ct.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            enable_thinking=True,
+            reasoning_effort="high",
+        )
+        maximum = ct.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            enable_thinking=True,
+            reasoning_effort="max",
+        )
+
+        assert low.startswith("<｜begin▁of▁sentence｜><｜User｜>")
+        assert high.startswith(
+            "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum"
+        )
+        assert maximum.startswith(
+            "<｜begin▁of▁sentence｜>Reasoning Effort: Beyond maximum"
+        )
+        assert high != maximum
+
+    def test_tool_results_use_official_user_block_format(self, applied_patch):
+        from omlx.patches.deepseek_v4 import chat_template_v4_dspark as ct
+
+        messages = [
+            {"role": "user", "content": "Weather in Seoul?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location":"Seoul"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "sunny, 22C",
+            },
+        ]
+        prompt = ct.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            enable_thinking=True,
+        )
+        assert "<｜User｜><tool_result>sunny, 22C</tool_result>" in prompt
+        assert "<function_results>" not in prompt
+        assert prompt.endswith("<｜Assistant｜><think>")
+
+    def test_top_level_tools_are_injected_into_official_system_message(
+        self, applied_patch
+    ):
+        from omlx.patches.deepseek_v4 import chat_template_v4_dspark as ct
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        prompt = ct.apply_chat_template(
+            [{"role": "user", "content": "Weather?"}],
+            tools=tools,
+            add_generation_prompt=True,
+        )
+        assert "### Available Tool Schemas" in prompt
+        assert "get_weather" in prompt
+        assert prompt.count("### Available Tool Schemas") == 1
+
+    def test_dspark_config_selects_official_protocol(self, applied_patch):
+        from omlx.patches.deepseek_v4 import tokenizer_patch
+
+        assert tokenizer_patch._uses_dspark_protocol(
+            {
+                "model_type": "deepseek_v4",
+                "dspark_block_size": 5,
+                "dspark_target_layer_ids": [40, 41, 42],
+                "dspark_markov_rank": 256,
+            }
+        )
+        assert not tokenizer_patch._uses_dspark_protocol(
+            {"model_type": "deepseek_v4", "num_nextn_predict_layers": 1}
+        )
+
+
 class TestChatTemplateModuleRegistration:
     """sys.modules registration so mlx-lm's importlib path picks up our types."""
 

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -957,6 +957,118 @@ class TestCacheMaterialization:
         assert loop_pos < materialize_pos < pipeline_send_pos
 
 
+class TestDeepSeekV4SparseAttentionNativeDispatch:
+    """The prefill-shaped native kernel must not handle short verify windows."""
+
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [
+            (None, 128),
+            ("256", 256),
+            ("1", 2),
+            ("invalid", 128),
+        ],
+    )
+    def test_portable_min_length_policy(self, applied_patch, configured, expected):
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+
+        assert dsv4._parse_sparse_attention_native_min_l(configured) == expected
+
+    @staticmethod
+    def _inputs(mx, query_length):
+        q = mx.zeros((1, 64, query_length, 512), dtype=mx.float16)
+        local_kv = mx.zeros((1, 1, 1, 512), dtype=mx.float16)
+        pooled = mx.zeros((1, 1, 512), dtype=mx.float16)
+        topk = mx.zeros((1, query_length, 1), dtype=mx.uint32)
+        sinks = mx.zeros((64,), dtype=mx.float16)
+        return q, local_kv, pooled, topk, sinks
+
+    @pytest.mark.parametrize("query_length", [2, 3, 4, 5, 6, 64])
+    def test_short_lengths_fall_back(self, applied_patch, monkeypatch, query_length):
+        import mlx.core as mx
+
+        from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        monkeypatch.setattr(
+            dsv4, "_DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED", False
+        )
+        monkeypatch.setattr(glm_fast, "has_symbol", lambda _name: True)
+
+        def fail_native(*_args, **_kwargs):
+            raise AssertionError(
+                f"native sparse attention must not run for L={query_length}"
+            )
+
+        monkeypatch.setattr(
+            glm_fast,
+            "deepseek_v4_sparse_attention",
+            fail_native,
+        )
+
+        q, local_kv, pooled, topk, sinks = self._inputs(mx, query_length)
+        out = dsv4._sparse_pooled_attention(
+            q,
+            local_kv,
+            pooled,
+            topk,
+            None,
+            None,
+            1.0,
+            sinks,
+            q_offset=0,
+            compress_ratio=4,
+            local_window=128,
+        )
+
+        assert out.shape == q.shape
+
+    def test_threshold_length_can_use_native(self, applied_patch, monkeypatch):
+        import mlx.core as mx
+
+        from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        monkeypatch.setattr(
+            dsv4, "_DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED", False
+        )
+        monkeypatch.setattr(
+            glm_fast,
+            "has_symbol",
+            lambda name: name == "deepseek_v4_sparse_attention",
+        )
+        native_calls = []
+
+        def fake_native(q, *_args, **_kwargs):
+            native_calls.append(q.shape)
+            return mx.zeros_like(q)
+
+        monkeypatch.setattr(
+            glm_fast,
+            "deepseek_v4_sparse_attention",
+            fake_native,
+        )
+
+        query_length = dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_MIN_L
+        q, local_kv, pooled, topk, sinks = self._inputs(mx, query_length)
+        out = dsv4._sparse_pooled_attention(
+            q,
+            local_kv,
+            pooled,
+            topk,
+            None,
+            None,
+            1.0,
+            sinks,
+            q_offset=0,
+            compress_ratio=4,
+            local_window=128,
+        )
+
+        assert native_calls == [q.shape]
+        assert out.shape == q.shape
+
+
 class TestDeepseekV4SwitchGLU:
     """DeepSeek-V4 SwitchGLU execution guards."""
 

--- a/tests/test_macos_custom_kernel_build_cleanup.py
+++ b/tests/test_macos_custom_kernel_build_cleanup.py
@@ -1,0 +1,109 @@
+"""Regression tests for native-kernel cleanup in the macOS app build."""
+
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+from pathlib import Path
+
+
+BUILD_SCRIPT = Path("apps/omlx-mac/Scripts/build.sh")
+SETUP_PY = Path("setup.py")
+
+
+def _kernel_names_from_setup() -> set[str]:
+    return set(
+        re.findall(
+            r'CMakeExtension\(\s*"omlx\.custom_kernels\.([^."]+)\._ext"',
+            SETUP_PY.read_text(),
+        )
+    )
+
+
+def _kernel_names_from_build_script(script: str) -> set[str]:
+    match = re.search(r"CUSTOM_KERNEL_DIRS=\((.*?)\n\)", script, re.DOTALL)
+    assert match is not None
+    return set(re.findall(r"custom_kernels/([a-z0-9_]+)\"", match.group(1)))
+
+
+def _cleanup_function(script: str) -> str:
+    match = re.search(
+        r"(_clean_custom_kernel_build_artifacts\(\) \{.*?\n\})"
+        r"\n\n_sdk_supports_nax\(\)",
+        script,
+        re.DOTALL,
+    )
+    assert match is not None
+    return match.group(1)
+
+
+def test_build_cleanup_tracks_every_cmake_extension():
+    script = BUILD_SCRIPT.read_text()
+    assert _kernel_names_from_build_script(script) == _kernel_names_from_setup()
+
+
+def test_build_cleanup_removes_stale_abi_outputs(tmp_path):
+    script = BUILD_SCRIPT.read_text()
+    kernel_names = sorted(_kernel_names_from_setup())
+    source_dirs = []
+
+    for name in kernel_names:
+        source_dir = tmp_path / "omlx" / "custom_kernels" / name
+        source_dir.mkdir(parents=True)
+        source_dirs.append(source_dir)
+        (source_dir / "_ext.cpython-39-darwin.so").touch()
+        (source_dir / "_ext.cpython-311-darwin.so").touch()
+        (source_dir / "libomlx_test.dylib").touch()
+        (source_dir / "omlx_test_kernels.metallib").touch()
+        (source_dir / "keep.py").write_text("# source sentinel\n")
+
+        cmake_dir = (
+            tmp_path
+            / "build"
+            / "temp.macosx-arm64-cpython-311"
+            / f"omlx.custom_kernels.{name}._ext"
+        )
+        cmake_dir.mkdir(parents=True)
+        (cmake_dir / "CMakeCache.txt").touch()
+
+        build_lib_dir = (
+            tmp_path
+            / "build"
+            / "lib.macosx-arm64-cpython-311"
+            / "omlx"
+            / "custom_kernels"
+            / name
+        )
+        build_lib_dir.mkdir(parents=True)
+        (build_lib_dir / "_ext.cpython-39-darwin.so").touch()
+        (build_lib_dir / "_ext.cpython-311-darwin.so").touch()
+        (build_lib_dir / "libomlx_test.dylib").touch()
+        (build_lib_dir / "omlx_test_kernels.metallib").touch()
+
+    build_sentinel = tmp_path / "build" / "keep.txt"
+    build_sentinel.write_text("build sentinel\n")
+
+    shell = "\n".join(
+        [
+            f"REPO_ROOT={shlex.quote(str(tmp_path))}",
+            "CUSTOM_KERNEL_DIRS=(",
+            *(f"  {shlex.quote(str(path))}" for path in source_dirs),
+            ")",
+            _cleanup_function(script),
+            "_clean_custom_kernel_build_artifacts",
+        ]
+    )
+    subprocess.run(["bash", "-c", shell], check=True)
+
+    for source_dir in source_dirs:
+        assert (source_dir / "keep.py").exists()
+        assert not list(source_dir.glob("*.so"))
+        assert not list(source_dir.glob("*.dylib"))
+        assert not list(source_dir.glob("*.metallib"))
+
+    assert build_sentinel.exists()
+    assert not list(tmp_path.glob("build/**/omlx.custom_kernels.*._ext"))
+    assert not list(tmp_path.glob("build/**/omlx/custom_kernels/**/*.so"))
+    assert not list(tmp_path.glob("build/**/omlx/custom_kernels/**/*.dylib"))
+    assert not list(tmp_path.glob("build/**/omlx/custom_kernels/**/*.metallib"))

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -564,6 +564,154 @@ class TestDeepseekV4Model:
         assert "materialize_cache_arrays(cache)" in call_source
         assert "materialize_cache_arrays(cache)" in model_source
 
+    def test_dspark_config_uses_physical_stage_count(self):
+        """0731 advertises one next-token layer but stores three DSpark stages."""
+        from omlx.patches.deepseek_v4 import apply_deepseek_v4_patch
+        from omlx.patches.mlx_lm_mtp import deepseek_v4_model
+
+        apply_deepseek_v4_patch()
+        assert deepseek_v4_model.apply()
+
+        import mlx_lm.models.deepseek_v4 as dsv4
+
+        args = dsv4.ModelArgs.from_dict(
+            {
+                "num_hidden_layers": 43,
+                "compress_ratios": [0] * 43,
+                "num_nextn_predict_layers": 1,
+                "dspark_block_size": 5,
+                "dspark_noise_token_id": 128799,
+                "dspark_target_layer_ids": [40, 41, 42],
+                "dspark_markov_rank": 256,
+            }
+        )
+        assert deepseek_v4_model._is_dspark_config(args)
+        assert deepseek_v4_model._mtp_stage_count(args) == 3
+        assert len(args.compress_ratios) == 46
+        assert hasattr(dsv4, "DSparkAttention")
+        assert hasattr(dsv4, "DSparkBlock")
+
+    def test_dspark_tiny_model_shapes_and_cache(self, monkeypatch):
+        """A tiny DSpark graph captures three hiddens and drafts five rows."""
+        import mlx.core as mx
+
+        from omlx.patches.deepseek_v4 import apply_deepseek_v4_patch
+        import omlx.patches.mlx_lm_mtp as mtp_runtime
+        from omlx.patches.mlx_lm_mtp import deepseek_v4_model
+
+        apply_deepseek_v4_patch()
+        assert deepseek_v4_model.apply()
+        monkeypatch.setattr(mtp_runtime, "_MTP_ACTIVE", True)
+
+        import mlx_lm.models.deepseek_v4 as dsv4
+
+        args = dsv4.ModelArgs.from_dict(
+            {
+                "vocab_size": 32,
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "moe_intermediate_size": 8,
+                "num_hidden_layers": 3,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "n_shared_experts": 1,
+                "n_routed_experts": 4,
+                "num_experts_per_tok": 2,
+                "q_lora_rank": 8,
+                "qk_rope_head_dim": 2,
+                "head_dim": 8,
+                "o_groups": 2,
+                "o_lora_rank": 8,
+                "index_n_heads": 2,
+                "index_head_dim": 4,
+                "index_topk": 4,
+                "hc_mult": 4,
+                "compress_ratios": [0, 0, 0],
+                "num_nextn_predict_layers": 1,
+                "dspark_block_size": 5,
+                "dspark_noise_token_id": 31,
+                "dspark_target_layer_ids": [0, 1, 2],
+                "dspark_markov_rank": 4,
+            }
+        )
+        model = dsv4.Model(args)
+        backbone_cache = model.make_cache()
+        dspark_cache = model.make_mtp_cache()
+
+        logits, hidden = model(
+            mx.array([[1, 2]], dtype=mx.uint32),
+            cache=backbone_cache,
+            return_hidden=True,
+        )
+        base = model.dspark_logits(
+            hidden[:, -1:],
+            mx.array([[3]], dtype=mx.uint32),
+            dspark_cache,
+        )
+        bias = model.dspark_markov_logits(mx.array([3], dtype=mx.uint32))
+        mx.eval(logits, hidden, base, bias)
+
+        assert logits.shape == (1, 2, 32)
+        assert hidden.shape == (1, 2, 48)
+        assert base.shape == (1, 5, 32)
+        assert bias.shape == (1, 32)
+        assert [cache.offset for cache in dspark_cache] == [1, 1, 1]
+
+    def test_dspark_batch_drafter_applies_markov_rows_sequentially(
+        self, monkeypatch
+    ):
+        """The parallel backbone rows must condition on each prior draft."""
+        import mlx.core as mx
+
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        seen_markov = []
+
+        class FakeDSpark:
+            _omlx_dspark = True
+
+            def dspark_logits(self, hidden, committed, cache):
+                assert hidden.shape == (1, 1, 6)
+                assert committed.tolist() == [[7]]
+                rows = mx.full((1, 5, 12), -10.0)
+                # Base argmaxes are 1..5.
+                for row in range(5):
+                    rows[:, row, row + 1] = 10.0
+                return rows
+
+            def dspark_markov_logits(self, previous):
+                seen_markov.append(int(previous.item()))
+                return mx.zeros((1, 12))
+
+        def greedy(logprobs):
+            return mx.argmax(logprobs, axis=-1).astype(mx.uint32)
+
+        monkeypatch.setattr(
+            batch_generator,
+            "_resolve_draft_sampler",
+            lambda *_: greedy,
+        )
+        monkeypatch.setattr(batch_generator, "_proc_list", lambda *_: None)
+
+        state = batch_generator._MtpState(uid=1)
+        state.mtp_cache = [object()]
+        batch = SimpleNamespace(model=FakeDSpark())
+        batch_generator._dspark_next_drafts(
+            batch,
+            state,
+            mx.zeros((1, 1, 6)),
+            mx.array([7], dtype=mx.uint32),
+            None,
+            5,
+        )
+        mx.eval(state.drafts)
+
+        assert state.drafts.tolist() == [1, 2, 3, 4, 5]
+        assert seen_markov == [7, 1, 2, 3, 4]
+        assert state.hist_offset == 1
+        assert len(state.draft_lps) == 5
+        assert len(state.draft_accept_lps) == 5
+
 
 class TestBatchGeneratorDispatch:
     @pytest.fixture(autouse=True)

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -712,6 +712,69 @@ class TestDeepseekV4Model:
         assert len(state.draft_lps) == 5
         assert len(state.draft_accept_lps) == 5
 
+    def test_dspark_sanitize_keeps_all_three_stage_names(self, monkeypatch):
+        """Official mtp.0/1/2 names map onto the nested MLX modules."""
+        import mlx.core as mx
+
+        import omlx.patches.mlx_lm_mtp as mtp_runtime
+        from omlx.patches.deepseek_v4 import apply_deepseek_v4_patch
+        from omlx.patches.mlx_lm_mtp import deepseek_v4_model
+
+        apply_deepseek_v4_patch()
+        assert deepseek_v4_model.apply()
+        monkeypatch.setattr(mtp_runtime, "_MTP_ACTIVE", True)
+
+        import mlx_lm.models.deepseek_v4 as dsv4
+
+        args = dsv4.ModelArgs.from_dict(
+            {
+                "vocab_size": 32,
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "moe_intermediate_size": 8,
+                "num_hidden_layers": 3,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 1,
+                "n_shared_experts": 1,
+                "n_routed_experts": 4,
+                "num_experts_per_tok": 2,
+                "q_lora_rank": 8,
+                "qk_rope_head_dim": 2,
+                "head_dim": 8,
+                "o_groups": 2,
+                "o_lora_rank": 8,
+                "index_n_heads": 2,
+                "index_head_dim": 4,
+                "index_topk": 4,
+                "hc_mult": 4,
+                "compress_ratios": [0, 0, 0],
+                "num_nextn_predict_layers": 1,
+                "dspark_block_size": 5,
+                "dspark_noise_token_id": 31,
+                "dspark_target_layer_ids": [0, 1, 2],
+                "dspark_markov_rank": 4,
+            }
+        )
+        model = dsv4.Model(args)
+        one = mx.ones((1,))
+        mapped = model.sanitize(
+            {
+                "mtp.0.main_proj.weight": one,
+                "mtp.0.attn.wq_a.weight": one,
+                "mtp.1.ffn.gate.weight": one,
+                "mtp.2.markov_head.markov_w1.weight": one,
+                "mtp.2.confidence_head.proj.weight": one,
+                "mtp.2.hc_head_fn": one,
+            }
+        )
+
+        assert "mtp.0.main_proj.weight" in mapped
+        assert "mtp.0.block.attn.wq_a.weight" in mapped
+        assert "mtp.1.block.ffn.gate.weight" in mapped
+        assert "mtp.2.markov_head.markov_w1.weight" in mapped
+        assert "mtp.2.confidence_head.proj.weight" in mapped
+        assert "mtp.2.hc_head.fn" in mapped
+
 
 class TestBatchGeneratorDispatch:
     @pytest.fixture(autouse=True)

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -657,6 +657,16 @@ class TestDeepseekV4Model:
         assert bias.shape == (1, 32)
         assert [cache.offset for cache in dspark_cache] == [1, 1, 1]
 
+        pool = SimpleNamespace(remainder=[0], ratio=4)
+        container = SimpleNamespace(caches=[pool])
+        assert model.mtp_safe_draft_depth([container], 5) == 3
+        pool.remainder = [1]
+        assert model.mtp_safe_draft_depth([container], 5) == 2
+        pool.remainder = [2]
+        assert model.mtp_safe_draft_depth([container], 5) == 1
+        pool.remainder = [3]
+        assert model.mtp_safe_draft_depth([container], 5) == 0
+
     def test_dspark_batch_drafter_applies_markov_rows_sequentially(
         self, monkeypatch
     ):

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -688,7 +688,7 @@ class TestDeepseekV4Model:
 
         monkeypatch.setattr(
             batch_generator,
-            "_resolve_draft_sampler",
+            "_resolve_sampler",
             lambda *_: greedy,
         )
         monkeypatch.setattr(batch_generator, "_proc_list", lambda *_: None)

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -726,6 +726,22 @@ class TestMtpFcFullPrecision:
         bits, _, _ = _get_predicate_bits("mtp.0.h_proj.weight", {}, 4, 64)
         assert bits is None
 
+    def test_dspark_main_proj_protected(self):
+        from omlx.oq import _get_predicate_bits
+
+        bits, _, _ = _get_predicate_bits("mtp.0.main_proj.weight", {}, 4, 64)
+        assert bits is None
+
+    def test_dspark_markov_head_protected(self):
+        from omlx.oq import _get_predicate_bits
+
+        for key in (
+            "mtp.2.markov_head.markov_w1.weight",
+            "mtp.2.markov_head.markov_w2.weight",
+        ):
+            bits, _, _ = _get_predicate_bits(key, {}, 4, 64)
+            assert bits is None
+
     def test_deepseek_hc_head_sanitized_protected(self):
         from omlx.oq import _get_predicate_bits
 

--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -502,6 +502,8 @@ class TestOutputParserFactory:
 
         assert factory is not None
         assert factory.kind == "deepseek_v4"
+        assert factory.thinking_start_text == "<think>"
+        assert factory.thinking_end_text == "</think>"
 
     def test_deepseek_v4_stops_at_first_dsml_tool_block(self):
         tokenizer = DeepSeekV4Tokenizer(

--- a/tests/test_prefix_cache_cachelist_mixed.py
+++ b/tests/test_prefix_cache_cachelist_mixed.py
@@ -267,6 +267,45 @@ def test_live_subtypes_descriptor_matches_block_stamp():
     )
 
 
+def test_loaded_cachelist_payload_resaves_in_canonical_format(tmp_path):
+    """A load/rewrite/save cycle must retain CacheList's wire layout.
+
+    ``load_block_with_metadata`` returns the legacy bare-list shape.  The
+    save boundary must re-wrap it before serializing, or rotating-tip
+    rewrites lose both ``sub_count`` metadata and the sub-composition cache
+    signature, causing every later prefix restore to truncate.
+    """
+    from omlx.cache.paged_ssd_cache import _signature_cachelist_subtypes
+
+    cache, ssd = _make_cache(tmp_path)
+    table = _store_blocks(cache, num_blocks=1, request_id="req-resave-source")
+    assert table is not None
+    source = cache.paged_cache.allocated_blocks[table.block_ids[0]]
+
+    loaded, metadata = ssd.load_block_with_metadata(source.block_hash)
+    assert loaded is not None and metadata is not None
+    assert isinstance(loaded[0], list)
+
+    rewritten_hash = b"cachelist-resave-regression-0001"
+    assert len(rewritten_hash) == 32
+    assert ssd.save_block(
+        rewritten_hash,
+        loaded,
+        token_count=BLOCK_SIZE,
+        model_name="test-model",
+        layer_cache_types=metadata["layer_cache_types"],
+        layer_meta_states=metadata["layer_meta_states"],
+    )
+
+    rewritten, rewritten_meta = ssd.load_block_with_metadata(rewritten_hash)
+    assert rewritten is not None and rewritten_meta is not None
+    assert isinstance(rewritten[0], list)
+    assert len(rewritten[0]) == 2
+    assert _signature_cachelist_subtypes(
+        rewritten_meta["cache_signature"]
+    ) == {"0": ["KVCache", "ArraysCache:4"]}
+
+
 def test_stale_sub_composition_swept(tmp_path):
     """A stored block whose ArraysCache slot count disagrees with the live
     model expectation must be swept, not restored into an IndexError."""

--- a/tests/test_prefix_cache_rotating_tip_strip.py
+++ b/tests/test_prefix_cache_rotating_tip_strip.py
@@ -115,6 +115,39 @@ def _hybrid_cache_data(seq_len, rotating_type="RotatingKVCache"):
     ]
 
 
+def _deepseek_cachelist_data(seq_len):
+    """DeepSeek-V4 shape: a rotating layer plus mixed CacheList layer."""
+    rotating_state = (
+        mx.ones((1, 2, WINDOW, 8)),
+        mx.ones((1, 2, WINDOW, 8)),
+    )
+    pooling_state = (
+        mx.ones((1, WINDOW, 8)),
+        mx.ones((1, WINDOW, 8)),
+        mx.ones((1, seq_len, 8)),
+    )
+    return [
+        {
+            "state": rotating_state,
+            "cache_type": "RotatingKVCache",
+            "class_name": "RotatingKVCache",
+            "meta_state": ("0", str(WINDOW), str(seq_len), str(WINDOW)),
+        },
+        {
+            "state": [rotating_state, pooling_state],
+            "cache_type": "CacheList",
+            "class_name": "CacheList",
+            "meta_state": (
+                ["RotatingKVCache", "PoolingCache"],
+                [
+                    ("0", str(WINDOW), str(seq_len), str(WINDOW)),
+                    (str(WINDOW),),
+                ],
+            ),
+        },
+    ]
+
+
 def _kvcache_only_data(seq_len):
     return [
         {
@@ -227,6 +260,39 @@ def test_stripped_block_keeps_sliceable_layers(tmp_path):
         if CacheTypeRegistry.is_rotating_family(t)
     )
     assert cache._is_placeholder_state(data[rotating_idx])
+
+
+def test_stripped_deepseek_tip_keeps_cachelist_signature(tmp_path):
+    """A DeepSeek load/rewrite/save must preserve CacheList composition."""
+    from omlx.cache.paged_ssd_cache import _signature_cachelist_subtypes
+
+    cache, ssd = _make_cache(tmp_path)
+    expected_subtypes = {"1": ["RotatingKVCache", "PoolingCache"]}
+    ssd.set_expected_layer_signature(
+        ["RotatingKVCache", "CacheList"],
+        cachelist_subtypes=expected_subtypes,
+    )
+
+    t1 = _store_turn(cache, 1, num_blocks=2, data_fn=_deepseek_cachelist_data)
+    tip1 = _block_hash(cache, t1, -1)
+    _, before_meta = ssd.load_block_with_metadata(tip1)
+    assert before_meta is not None
+    assert _signature_cachelist_subtypes(
+        before_meta["cache_signature"]
+    ) == expected_subtypes
+
+    _store_turn(cache, 2, num_blocks=3, data_fn=_deepseek_cachelist_data)
+    _store_turn(cache, 3, num_blocks=4, data_fn=_deepseek_cachelist_data)
+
+    rewritten, after_meta = ssd.load_block_with_metadata(tip1)
+    assert rewritten is not None and after_meta is not None
+    assert _rotating_layer_shape(ssd, tip1) == PLACEHOLDER_SHAPE
+    assert isinstance(rewritten[1], list)
+    assert len(rewritten[1]) == 2
+    assert _signature_cachelist_subtypes(
+        after_meta["cache_signature"]
+    ) == expected_subtypes
+    assert ssd.is_signature_compatible(after_meta["cache_signature"])
 
 
 def test_hot_cache_byte_counter_consistent(tmp_path):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -764,10 +764,40 @@ class TestSchedulerAddRequest:
         assert scheduler._should_defer_for_cache_freshness(request) is False
         assert request.request_id not in scheduler._cache_freshness_waits
 
-    def test_admission_does_not_defer_for_short_prompt_even_with_high_ratio(
+    def test_admission_defers_just_below_threshold_for_complete_block_prefix(
         self, mock_model, mock_tokenizer
     ):
-        """Prompts below the freshness minimum should never wait on store_cache."""
+        """A full cacheable prefix should bridge one block of threshold slack."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler.config.paged_cache_block_size = 512
+        prompt = list(range(8175))
+
+        future = MagicMock()
+        future.done.return_value = False
+        future.result.return_value = None
+        scheduler._inflight_store_futures["req-prev"] = future
+        scheduler._inflight_store_info["req-prev"] = (
+            scheduler_module._InflightStoreInfo(tokens=list(range(7680)))
+        )
+
+        request = Request(
+            request_id="req-next",
+            prompt=prompt,
+            sampling_params=SamplingParams(max_tokens=16),
+        )
+
+        scheduler.add_request(request)
+
+        future.result.assert_not_called()
+        scheduler.block_aware_cache.fetch_cache.assert_not_called()
+        assert scheduler._should_defer_for_cache_freshness(request) is True
+        assert request.request_id in scheduler._cache_freshness_waits
+
+    def test_admission_does_not_defer_well_below_threshold_even_with_high_ratio(
+        self, mock_model, mock_tokenizer
+    ):
+        """Short prompts retain the no-wait path even with a high overlap ratio."""
         scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
         scheduler.block_aware_cache = MagicMock()
         prompt = list(range(7000))
@@ -778,6 +808,36 @@ class TestSchedulerAddRequest:
         scheduler._inflight_store_futures["req-prev"] = future
         scheduler._inflight_store_info["req-prev"] = (
             scheduler_module._InflightStoreInfo(tokens=list(range(6000)))
+        )
+
+        request = Request(
+            request_id="req-next",
+            prompt=prompt,
+            sampling_params=SamplingParams(max_tokens=16),
+        )
+
+        scheduler.add_request(request)
+
+        future.result.assert_not_called()
+        scheduler.block_aware_cache.fetch_cache.assert_not_called()
+        assert scheduler._should_defer_for_cache_freshness(request) is False
+        assert request.request_id not in scheduler._cache_freshness_waits
+
+    def test_admission_does_not_defer_near_threshold_for_incomplete_block_prefix(
+        self, mock_model, mock_tokenizer
+    ):
+        """Threshold slack applies only when every full prompt block is pending."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+        scheduler.config.paged_cache_block_size = 512
+        prompt = list(range(8175))
+
+        future = MagicMock()
+        future.done.return_value = False
+        future.result.return_value = None
+        scheduler._inflight_store_futures["req-prev"] = future
+        scheduler._inflight_store_info["req-prev"] = (
+            scheduler_module._InflightStoreInfo(tokens=list(range(7679)))
         )
 
         request = Request(


### PR DESCRIPTION
## Current status

This remains a draft. The official checkpoint and 0731 protocol load and run,
but DSpark is **not yet merge-ready**: target-only and DSpark greedy generation
can produce different token streams. Production validation therefore keeps
`mtp_enabled=false` until OFF/ON exact-token parity passes on the real
checkpoint.

The earlier throughput figures in this PR came from the experimental DSpark
path and must not be treated as a correctness-safe performance claim.

## What changed

Adds support for the official `deepseek-ai/DeepSeek-V4-Flash-0731` checkpoint
and its dedicated message protocol, plus an experimental implementation of its
integrated DSpark module.

- recognizes the 0731 DSpark configuration and checkpoint weight layout
- implements the three-stage DSpark attention path, Markov head, and confidence
  head
- adds DSpark block proposals to the existing batched MTP generator
- uses the request sampler for proposals so sampling semantics remain aligned
- vendors DeepSeek's dedicated 0731 message encoder and wires it into oMLX's
  tokenizer/output protocol
- preserves already-parsed tool arguments during replay instead of nesting
  another `arguments` object on each retry
- makes speculative rollback safe around DeepSeek V4's ratio-4
  `BatchPoolingCache` compression boundaries
- reconciles the backbone cache before falling back from speculative to
  standard decoding
- teaches oQ discovery about the official DSpark projection names
- preserves `CacheList` subtype signatures when rotating prefix-cache tips are
  rewritten
- makes custom-kernel packaging reject and purge stale Python ABIs

## Why

The 0731 release is not the older single-head DeepSeek V4 MTP layout. It ships
an integrated DSpark module with multiple target layers and a dedicated
non-Jinja message protocol. Treating it as legacy MTP either leaves the extra
weights unmapped or enters a speculative path whose cache cannot always be
rolled back after a rejected draft crosses a pooling boundary.

This addresses the native DSpark request in #2046. It is also related to the
broader DeepSeek V4 MTP report in #1133, although this PR is specifically
validated against the official 0731 checkpoint.

## User impact

With speculative decoding disabled, `DeepSeek-V4-Flash-0731` now:

- strict-loads directly from the official 48-shard checkpoint
- exposes its native 1,048,576-token context
- supports thinking mode and `reasoning_effort`
- serves through the normal OpenAI-compatible oMLX API
- preserves prefix-cache signatures across follow-up turns
- replays tool calls without recursively nesting their arguments

The integrated DSpark path requires no separate draft model, but it remains
experimental pending exact-token parity.

## Validation

Unit and packaging validation:

- 176 focused DeepSeek, parser, thinking-budget, cache, and packaging tests
  passed
- 199 scheduler tests passed after the cache-freshness threshold fix
- 818 cache/prefix tests passed in an independent broad run
- critical Ruff checks and `git diff --check` passed
- native macOS app built with Xcode 26.6, passed strict codesign verification,
  and loaded all four custom-kernel modules with the bundled Python 3.11 ABI

Real-checkpoint validation:

- model: `deepseek-ai/DeepSeek-V4-Flash-0731` (official 48-shard, 163.2 GB
  checkpoint)
- hardware: Mac Studio, M3 Ultra, 256 GB unified memory
- target-only production profile: 1,048,576 context, 8,192 max output,
  low reasoning with a 2,048-token thinking budget
- three consecutive tool-call replays retained flat JSON arguments
- five-turn growing-prefix test completed without a cache-signature mismatch
- DSpark OFF/ON greedy A/B **failed** exact response equality; MTP remains
  disabled while the target-verification numerics are investigated

## Provenance

The dedicated message encoder under `omlx/patches/deepseek_v4/vendor/` is
derived from the encoder distributed with the official DeepSeek 0731 model,
kept isolated so its protocol can be reviewed and updated independently.
