### PR TITLE
fix(reranker): support Jina v3.5 reranker projector key naming

### DIFF
--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -573,37 +573,51 @@ class MLXRerankerModel:
         # raises "TypeError: data type 'bfloat16' not understood".
         weights = mx.load(str(projector_path))
 
-        required_keys = ("linear1.weight", "linear2.weight")
-        missing_keys = [key for key in required_keys if key not in weights]
-        if missing_keys:
+        # v3 ships two named nn.Linear submodules ("linear1"/"linear2").
+        # v3.5 exports the same fc1 -> ReLU -> fc2 stack from an nn.Sequential
+        # container, so the keys are auto-named by list index instead
+        # ("projector.0"/"projector.2", index 1 is ReLU). Confirmed against
+        # upstream's own remap in _load_projector:
+        # https://huggingface.co/jinaai/jina-reranker-v3.5-mlx/blob/3dd4ac901ccdcac85abe3815df0a0aaaf44e4a21/modeling.py
+        key_schemes = (
+            ("linear1.weight", "linear2.weight"),
+            ("projector.0.weight", "projector.2.weight"),
+        )
+        first_key = second_key = None
+        for scheme in key_schemes:
+            if all(key in weights for key in scheme):
+                first_key, second_key = scheme
+                break
+
+        if first_key is None:
             raise ValueError(
-                f"Jina projector is malformed: missing keys {missing_keys} in "
-                f"{projector_path}. "
+                "Jina projector is malformed: none of the expected key schemes "
+                f"{key_schemes} were fully present in {projector_path}. "
                 f"Available keys: {sorted(weights.keys())}"
             )
 
-        linear1_weight = weights["linear1.weight"]
-        linear2_weight = weights["linear2.weight"]
+        linear1_weight = weights[first_key]
+        linear2_weight = weights[second_key]
 
         if len(linear1_weight.shape) != 2 or len(linear2_weight.shape) != 2:
             raise ValueError(
                 "Jina projector weights must be 2D matrices: "
-                f"linear1.weight={linear1_weight.shape}, "
-                f"linear2.weight={linear2_weight.shape}."
+                f"{first_key}={linear1_weight.shape}, "
+                f"{second_key}={linear2_weight.shape}."
             )
 
         if linear1_weight.shape != (512, 1024) or linear2_weight.shape != (512, 512):
             raise ValueError(
                 "Unexpected Jina projector shapes. Expected "
-                "linear1.weight=(512, 1024) and linear2.weight=(512, 512), "
-                f"got linear1.weight={linear1_weight.shape}, "
-                f"linear2.weight={linear2_weight.shape}."
+                f"{first_key}=(512, 1024) and {second_key}=(512, 512), "
+                f"got {first_key}={linear1_weight.shape}, "
+                f"{second_key}={linear2_weight.shape}."
             )
 
         def _project(x):
             if x.shape[-1] != linear1_weight.shape[1]:
                 raise ValueError(
-                    "Jina projector input dim mismatch for linear1: "
+                    "Jina projector input dim mismatch for first layer: "
                     f"input={x.shape[-1]}, expected={linear1_weight.shape[1]}."
                 )
             hidden = x @ mx.transpose(linear1_weight)

--- a/tests/test_reranker_causal_lm.py
+++ b/tests/test_reranker_causal_lm.py
@@ -575,6 +575,65 @@ class TestJinaReranker:
         assert np.allclose(actual, expected, atol=1e-6)
 
     @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_load_jina_projector_v35_sequential_keys(self, tmp_path):
+        """v3.5 exports the projector from an nn.Sequential container, so keys
+        are index-named ("projector.0"/"projector.2") instead of v3's
+        "linear1"/"linear2". Same architecture, same math -- should load
+        identically. Regression test for jundot/omlx#2422."""
+        model_dir = self._make_jina_model_dir(tmp_path, name="jina-reranker-v3.5-mlx")
+        model = MLXRerankerModel(str(model_dir))
+
+        w1 = np.zeros((512, 1024), dtype=np.float32)
+        w2 = np.zeros((512, 512), dtype=np.float32)
+
+        w1[0, 0] = 1.5
+        w1[1, 1] = -2.0
+        w1[2, 2] = 0.5
+
+        w2[0, 0] = 1.0
+        w2[1, 1] = -3.0
+        w2[3, 2] = 2.0
+
+        save_file(
+            {
+                "projector.0.weight": w1,
+                "projector.2.weight": w2,
+            },
+            str(model_dir / "projector.safetensors"),
+        )
+
+        projector = model._load_jina_projector(model_dir)
+
+        x = np.zeros((2, 1024), dtype=np.float32)
+        x[0, 0] = 2.0
+        x[0, 1] = 1.0
+        x[0, 2] = 4.0
+        x[1, 0] = -3.0
+        x[1, 1] = 5.0
+        x[1, 2] = -2.0
+
+        projected = projector(mx.array(x))
+        mx.eval(projected)
+
+        expected = np.maximum(x @ w1.T, 0.0) @ w2.T
+        actual = np.array(projected.tolist(), dtype=np.float32)
+        assert np.allclose(actual, expected, atol=1e-6)
+
+    def test_load_jina_projector_unrecognized_keys_raises_clear_error(self, tmp_path):
+        """Neither v3 nor v3.5 key scheme present should raise a clear error
+        listing both expected schemes and the actual available keys."""
+        model_dir = self._make_jina_model_dir(tmp_path)
+        model = MLXRerankerModel(str(model_dir))
+
+        save_file(
+            {"some.other.weight": np.zeros((512, 1024), dtype=np.float32)},
+            str(model_dir / "projector.safetensors"),
+        )
+
+        with pytest.raises(ValueError, match="none of the expected key schemes"):
+            model._load_jina_projector(model_dir)
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
     def test_rerank_jina_returns_scores_and_sorted_indices(self, tmp_path):
         """_rerank_jina should produce per-doc scores and descending indices."""
         model_dir = self._make_jina_model_dir(tmp_path)


### PR DESCRIPTION
## Summary
- `jinaai/jina-reranker-v3.5-mlx` fails to load with "Jina projector is
  malformed: missing keys ['linear1.weight', 'linear2.weight']" because
  oMLX's `_load_jina_projector` only recognized v3's key names.
- v3.5 exports the identical Linear -> ReLU -> Linear projector from an
  `nn.Sequential` container, so PyTorch/MLX auto-name the weight keys by
  list index (`projector.0.weight`, `projector.2.weight`) instead of the
  named `linear1`/`linear2` submodules v3 used. Confirmed against Jina's
  reference implementation, which performs this same remap itself:
  https://huggingface.co/jinaai/jina-reranker-v3.5-mlx/blob/3dd4ac901ccdcac85abe3815df0a0aaaf44e4a21/modeling.py
  (`Projector.__init__` defines `fc1`/`fc2`; `_load_projector` maps
  `projector.0.weight` -> `projector.fc1.weight` and `projector.2.weight`
  -> `projector.fc2.weight`). Shapes ((512,1024)/(512,512), no bias) are
  unchanged between versions. Also reported at
  https://huggingface.co/jinaai/jina-reranker-v3.5-mlx/discussions/1.
- `_load_jina_projector` now tries both key schemes in order before
  raising, with error messages that name whichever scheme(s) were
  checked.

## Test plan
- Added `test_load_jina_projector_v35_sequential_keys`, mirroring the
  existing v3 test but with v3.5's key names, asserting identical
  projector output.
- Added `test_load_jina_projector_unrecognized_keys_raises_clear_error`
  for the neither-scheme-matches failure path.
- Reproduced the original error locally against a synthetic
  `projector.safetensors` matching the issue's reported keys/shapes,
  confirmed it's fixed after the change.
- Not yet validated against the actual downloaded v3.5 weights — @T1T4N
  (reporter, and the one who filed the matching HF discussion above),
  if you get a chance to try this branch against your real model
  directory, that'd be great confirmation before merge.

Fixes #2422