### PR TITLE
feat(vlm_mtp): enforce thinking budget inside MTP speculative decoding

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -714,11 +714,9 @@ private struct AdvancedTab: View {
                 Row(label: String(localized: "settings.advanced.thinking_budget.label",
                                   defaultValue: "Thinking Budget",
                                   comment: "Row label for the thinking budget field"),
-                    sublabel: vm.vlmMtpEnabled
-                        ? vm.vlmMtpProcessorLockedReason
-                        : String(localized: "settings.advanced.thinking_budget.sub",
-                                 defaultValue: "Limit thinking tokens for reasoning models. Forces end of thinking when exceeded.",
-                                 comment: "Sublabel for the thinking budget field")) {
+                    sublabel: String(localized: "settings.advanced.thinking_budget.sub",
+                                     defaultValue: "Limit thinking tokens for reasoning models. Forces end of thinking when exceeded.",
+                                     comment: "Sublabel for the thinking budget field")) {
                     HStack(spacing: 8) {
                         if vm.thinkingBudgetEnabled {
                             TextInput(text: vm.bindProfile($vm.thinkingBudgetTokens),
@@ -727,8 +725,6 @@ private struct AdvancedTab: View {
                         Toggle("", isOn: vm.bindProfile($vm.thinkingBudgetEnabled))
                             .labelsHidden().toggleStyle(.switch)
                     }
-                    .disabled(vm.vlmMtpEnabled)
-                    .help(vm.vlmMtpEnabled ? vm.vlmMtpProcessorLockedReason : "")
                 }
                 Row(label: String(localized: "settings.advanced.tool_result_limit.label",
                                   defaultValue: "Limit Tool Result Tokens",

--- a/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
@@ -786,8 +786,8 @@ final class ModelSettingsScreenVM {
         }
         if vlmMtpProcessorConflict {
             return String(localized: "settings.vlm_mtp.conflict.processors",
-                          defaultValue: "Unset repetition / presence penalty and thinking budget before enabling VLM MTP.",
-                          comment: "Tooltip / sublabel shown when VLM MTP can't be enabled because penalty or thinking-budget settings are set")
+                          defaultValue: "Unset repetition / presence penalty before enabling VLM MTP.",
+                          comment: "Tooltip / sublabel shown when VLM MTP can't be enabled because penalty settings are set")
         }
         return nil
     }
@@ -795,11 +795,13 @@ final class ModelSettingsScreenVM {
     /// Settings that materialize as per-request logits processors, which the
     /// vlm_mtp decode path cannot apply (#2399). Mirrors
     /// vlm_mtp_processor_conflicts() in model_settings.py; neutral values
-    /// (repetition 1.0, presence 0.0) do not conflict.
+    /// (repetition 1.0, presence 0.0) do not conflict. Thinking budget is
+    /// exempt: it is applied on the vlm_mtp path at verify time
+    /// (MTPProcessingSampler).
     var vlmMtpProcessorConflict: Bool {
         if let rep = Double(repetitionPenalty), rep != 1.0 { return true }
         if let pres = Double(presencePenalty), pres != 0.0 { return true }
-        return thinkingBudgetEnabled
+        return false
     }
 
     /// Sublabel / tooltip for the sampling rows locked while VLM MTP is on.

--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -548,7 +548,7 @@
   "modal.model_settings.vlm_mtp": "VLM MTP",
   "modal.model_settings.vlm_mtp_hint": "Speculative decoding via an external MTP drafter model (Gemma 4 assistant or Qwen MTP). ~1.3–1.6× single-request speedup; concurrent eligible requests fall back to standard batching.",
   "modal.model_settings.vlm_mtp_conflict": "Disable DFlash / SpecPrefill / MTP / TurboQuant KV first — VLM MTP owns the speculative decode path.",
-  "modal.model_settings.vlm_mtp_processor_conflict": "Unset repetition / presence penalty, thinking budget and guided grammar first — VLM MTP cannot apply per-request logits processors.",
+  "modal.model_settings.vlm_mtp_processor_conflict": "Unset repetition / presence penalty and guided grammar first — VLM MTP cannot apply these per-request logits processors. Thinking budget is supported.",
   "modal.model_settings.vlm_mtp_processor_locked": "Locked while VLM MTP is enabled — this setting needs per-request logits processors, which VLM MTP cannot apply.",
   "modal.model_settings.vlm_mtp_draft_model": "Drafter model",
   "modal.model_settings.vlm_mtp_draft_model_placeholder": "Select an assistant or MTP drafter…",

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1437,6 +1437,8 @@
             // which the VLM MTP decode path cannot apply (#2399). Mirrors
             // vlm_mtp_processor_conflicts() in model_settings.py; neutral
             // values (repetition 1.0, presence 0.0) do not conflict.
+            // Thinking budget is exempt: it is applied on the vlm_mtp path
+            // at verify time (MTPProcessingSampler).
             vlmMtpProcessorConflict() {
                 const ms = this.modelSettings;
                 if (!ms) return false;
@@ -1445,7 +1447,6 @@
                 const pres = num(ms.presence_penalty);
                 return (rep !== null && rep !== 1.0)
                     || (pres !== null && pres !== 0.0)
-                    || !!ms.enableThinkingBudget
                     || !!ms.guided_grammar_enabled;
             },
 

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -458,15 +458,9 @@
                                     <div class="min-w-0">
                                         <span class="text-sm font-medium text-neutral-700">{{ t('modal.model_settings.thinking_budget') }}</span>
                                         <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.thinking_budget_hint') }}</p>
-                                        <p x-show="modelSettings.vlm_mtp_enabled"
-                                           class="text-xs text-amber-600 mt-1">{{ t('modal.model_settings.vlm_mtp_processor_locked') }}</p>
                                     </div>
-                                    <button type="button" @click="if (!modelSettings.vlm_mtp_enabled) { modelSettings.enableThinkingBudget = !modelSettings.enableThinkingBudget; if (!modelSettings.enableThinkingBudget) modelSettings.thinking_budget_tokens = null; }"
-                                            :disabled="modelSettings.vlm_mtp_enabled"
-                                            :class="[
-                                                modelSettings.enableThinkingBudget ? 'bg-black' : 'bg-neutral-200',
-                                                modelSettings.vlm_mtp_enabled ? 'opacity-40 cursor-not-allowed' : ''
-                                            ]"
+                                    <button type="button" @click="modelSettings.enableThinkingBudget = !modelSettings.enableThinkingBudget; if (!modelSettings.enableThinkingBudget) modelSettings.thinking_budget_tokens = null;"
+                                            :class="modelSettings.enableThinkingBudget ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                                         <span :class="modelSettings.enableThinkingBudget ? 'translate-x-5' : 'translate-x-0'"
                                               class="block w-5 h-5 bg-white rounded-full shadow-sm transform transition-transform duration-300 absolute top-0.5 left-0.5"></span>

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -556,3 +556,52 @@ class ThinkingBudgetProcessor:
         forced = mx.full(logits.shape, float("-inf"))
         forced[..., target_id] = 0.0
         return forced
+
+    # -- Speculative-decoding (vlm_mtp) support -----------------------------
+    #
+    # The vlm_mtp decode path applies this processor inside mlx-vlm's
+    # speculative verify walk, where positions past the first draft
+    # rejection are discarded and re-sampled on the next round.
+    # ``snapshot_state()`` / ``restore_state()`` let the caller checkpoint
+    # the processor after each position and rewind it when a draft suffix
+    # is rejected, keeping the one-call-per-emitted-token contract intact.
+    # See ``omlx/speculative/processing_sampler.py``.
+
+    _SNAPSHOT_ATTRS = (
+        "_thinking_tokens",
+        "_in_thinking",
+        "_forcing",
+        "_waiting_utf8",
+        "_force_idx",
+        "_done",
+        "_first_call",
+        "_recent_tokens",
+        "_last_token_utf8_complete",
+        "_pending_utf8",
+        "_accepted_up_to",
+    )
+
+    def snapshot_state(self) -> dict:
+        """Checkpoint mutable state for position-keyed rewind (vlm_mtp)."""
+        state: dict = {}
+        for name in self._SNAPSHOT_ATTRS:
+            if not hasattr(self, name):
+                continue
+            value = getattr(self, name)
+            if isinstance(value, list):
+                value = list(value)
+            state[name] = value
+        return state
+
+    def restore_state(self, state: dict) -> None:
+        """Restore a checkpoint produced by :meth:`snapshot_state`."""
+        for name in self._SNAPSHOT_ATTRS:
+            if name in state:
+                value = state[name]
+                if isinstance(value, list):
+                    value = list(value)
+                setattr(self, name, value)
+            elif name == "_accepted_up_to" and hasattr(self, name):
+                # Lazily-created attr absent from the snapshot: drop it so
+                # the next __call__ re-baselines from the history it sees.
+                delattr(self, name)

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -38,6 +38,12 @@ def vlm_mtp_processor_conflicts(data: dict) -> list:
     back to BatchGenerator and the toggle would never engage (#2399).
     Neutral values (repetition 1.0, presence 0.0) build no processor and do
     not conflict.
+
+    ``thinking_budget_enabled`` is intentionally absent: the vlm_mtp path
+    applies ``ThinkingBudgetProcessor`` at verify time via
+    ``MTPProcessingSampler`` (see omlx/speculative/processing_sampler.py),
+    so a thinking-budget default no longer forces the BatchGenerator
+    fallback.
     """
     conflicts = []
     rep = data.get("repetition_penalty")
@@ -46,8 +52,6 @@ def vlm_mtp_processor_conflicts(data: dict) -> list:
     pres = data.get("presence_penalty")
     if pres is not None and pres != 0.0:
         conflicts.append("presence_penalty")
-    if data.get("thinking_budget_enabled"):
-        conflicts.append("thinking_budget_enabled")
     if data.get("guided_grammar_enabled"):
         conflicts.append("guided_grammar_enabled")
     return conflicts
@@ -303,12 +307,13 @@ class ModelSettings:
                         f"vlm_mtp_enabled and {name} cannot both be True; "
                         "choose one speculative path per model"
                     )
-            # Grammar / thinking budget / penalty defaults materialize as
-            # per-request logits processors, which the vlm_mtp decode path
-            # cannot apply — every request would fall back to
-            # BatchGenerator and the toggle would silently never engage
-            # (#2399). Reject the combo at construction time like the
-            # speculative-path conflicts above.
+            # Grammar / penalty defaults materialize as per-request logits
+            # processors, which the vlm_mtp decode path cannot apply —
+            # every request would fall back to BatchGenerator and the
+            # toggle would silently never engage (#2399). Reject the combo
+            # at construction time like the speculative-path conflicts
+            # above. Thinking budget is exempt: it is applied at verify
+            # time via MTPProcessingSampler.
             processor_conflicts = vlm_mtp_processor_conflicts(self.to_dict())
             if processor_conflicts:
                 raise ValueError(

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -63,7 +63,11 @@ from .speculative.processing_sampler import (
     MTPProcessingSampler,
     supports_vlm_mtp_processing,
 )
-from .speculative.vlm_mtp import VLMMTPDrafter, run_vlm_mtp_decode
+from .speculative.vlm_mtp import (
+    VLMMTPDrafter,
+    run_vlm_mtp_decode,
+    vlm_mtp_positioned_sampling_available,
+)
 from .utils.fatal import FATAL_TEARDOWN_TIMEOUT_S, fatal_exit
 from .utils.generation_config import load_generation_config_token_ids
 from .utils.hardware import format_bytes
@@ -7368,18 +7372,25 @@ class Scheduler:
             )
             return None
 
-        if mtp_processors and not hasattr(lm, "speculative_logits_from_hidden"):
-            # Without this hook, mlx-vlm's verify step samples target tokens
-            # from raw logits in one vectorized call and never consults the
+        if mtp_processors and not vlm_mtp_positioned_sampling_available(self.model):
+            # Without speculative_logits_from_hidden visible to the round
+            # loop, mlx-vlm's verify step samples target tokens from raw
+            # logits in one vectorized call and never consults the
             # positioned ``sample_target`` hook — processors would be
-            # silently dropped again (#2399). Decline instead.
+            # silently dropped again (#2399). The check must look at what
+            # the round loop will actually see: for mRoPE adapters (Qwen
+            # VLMs) _VLMAdapterMTPProxy hides the inner model's
+            # speculative_* fast paths, so probing the inner model
+            # directly would pass the gate and then silently skip the
+            # budget. Decline instead.
             logger.info(
                 "vlm_mtp routing skipped for %s: request carries logits "
-                "processors but %s lacks speculative_logits_from_hidden "
-                "(positioned verify sampling unavailable); falling back to "
-                "BatchGenerator",
+                "processors but positioned verify sampling is unavailable "
+                "on %s (speculative_logits_from_hidden hidden or missing "
+                "on the round-loop view, e.g. mRoPE adapters); falling "
+                "back to BatchGenerator",
                 request.request_id,
-                type(lm).__name__,
+                type(self.model).__name__,
             )
             return None
         target_model = self.model

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -59,6 +59,10 @@ from .patches.sdpa256_attention import set_unfused_headroom_provider
 from .prefill_progress import get_prefill_tracker
 from .prefill_transient_tracker import PrefillTransientTracker
 from .request import Request, RequestOutput, RequestStatus, SamplingParams
+from .speculative.processing_sampler import (
+    MTPProcessingSampler,
+    supports_vlm_mtp_processing,
+)
 from .speculative.vlm_mtp import VLMMTPDrafter, run_vlm_mtp_decode
 from .utils.fatal import FATAL_TEARDOWN_TIMEOUT_S, fatal_exit
 from .utils.generation_config import load_generation_config_token_ids
@@ -7297,25 +7301,35 @@ class Scheduler:
         if drafter is None:
             return None
 
-        # Per-request logits processors (grammar constraints, thinking
-        # budget, repetition/presence/frequency penalties) have no
-        # application point on this path: run_vlm_mtp_decode threads only a
-        # sampler into mlx-vlm's _mtp_rounds, and a sampler sees logits
-        # without the token history processors need. Model-level suppress
-        # tokens are the one exception, reproduced below via
-        # _make_suppressing_sampler. Same convention as Lightning MTP,
-        # which declines activation when grammar processors are present:
-        # fall back to BatchGenerator so every processor is enforced
-        # (#2399).
-        if logits_processors and any(
-            not getattr(proc, "_omlx_suppress_processor", False)
-            for proc in logits_processors
-        ):
+        # Per-request logits processors that implement the snapshot/restore
+        # protocol (today: ThinkingBudgetProcessor) ARE applied on this
+        # path: MTPProcessingSampler threads them into mlx-vlm's verify
+        # walk through the positioned ``sample_target`` hook, with
+        # position-keyed state checkpoints so draft rejections rewind them
+        # correctly (see omlx/speculative/processing_sampler.py). Model
+        # level suppress tokens are reproduced via _make_suppressing_sampler.
+        # Everything else (grammar constraints, repetition/presence/
+        # frequency penalties) still has no application point here — same
+        # convention as Lightning MTP: fall back to BatchGenerator so every
+        # processor stays enforced (#2399).
+        mtp_processors: list[Any] = []
+        unsupported_processors: list[Any] = []
+        for proc in logits_processors or []:
+            if getattr(proc, "_omlx_suppress_processor", False):
+                continue
+            if supports_vlm_mtp_processing(proc):
+                mtp_processors.append(proc)
+            else:
+                unsupported_processors.append(proc)
+        if unsupported_processors:
             logger.info(
                 "vlm_mtp routing skipped for %s: request carries per-request "
-                "logits processors (grammar / thinking budget / penalties); "
-                "falling back to BatchGenerator",
+                "logits processors without vlm_mtp support (%s); falling "
+                "back to BatchGenerator",
                 request.request_id,
+                ", ".join(
+                    type(proc).__name__ for proc in unsupported_processors
+                ),
             )
             return None
 
@@ -7353,6 +7367,21 @@ class Scheduler:
                 request.request_id,
             )
             return None
+
+        if mtp_processors and not hasattr(lm, "speculative_logits_from_hidden"):
+            # Without this hook, mlx-vlm's verify step samples target tokens
+            # from raw logits in one vectorized call and never consults the
+            # positioned ``sample_target`` hook — processors would be
+            # silently dropped again (#2399). Decline instead.
+            logger.info(
+                "vlm_mtp routing skipped for %s: request carries logits "
+                "processors but %s lacks speculative_logits_from_hidden "
+                "(positioned verify sampling unavailable); falling back to "
+                "BatchGenerator",
+                request.request_id,
+                type(lm).__name__,
+            )
+            return None
         target_model = self.model
 
         if not last_tokens:
@@ -7363,6 +7392,14 @@ class Scheduler:
             return None
 
         mtp_sampler = _make_suppressing_sampler(sampler, self._model_suppress_tokens)
+        proc_sampler: MTPProcessingSampler | None = None
+        if mtp_processors:
+            proc_sampler = MTPProcessingSampler(
+                mtp_sampler,
+                mtp_processors,
+                request.prompt_token_ids or [],
+            )
+            mtp_sampler = proc_sampler
         last_arr = mx.array(last_tokens)[None]  # (1, len_last)
         try:
             with mx.stream(self._stream):
@@ -7394,8 +7431,15 @@ class Scheduler:
             logits = out.logits[:, -1, :]
             hidden_raw = out.hidden_states
 
+        if proc_sampler is not None:
+            # Apply processors to the post-prefill logits (history=prompt)
+            # so the first bonus honours them too, then checkpoint the
+            # round loop's starting position (mlx-vlm bakes in emitted=1).
+            logits = proc_sampler.process_first_logits(logits)
         first_bonus_arr = mtp_sampler(logits)  # mx.array shape [1]
         mx.eval(first_bonus_arr)
+        if proc_sampler is not None:
+            proc_sampler.note_first_bonus(int(first_bonus_arr.item()))
 
         if isinstance(hidden_raw, list):
             hidden = hidden_raw[-1]
@@ -7436,6 +7480,10 @@ class Scheduler:
                 e,
                 request.request_id,
             )
+            if proc_sampler is not None:
+                # The BatchGenerator fallback reuses these processors —
+                # rewind the state mutated by process_first_logits above.
+                proc_sampler.reset_processors()
             return None
 
         uid = self._vlm_mtp_next_uid

--- a/omlx/speculative/processing_sampler.py
+++ b/omlx/speculative/processing_sampler.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-request logits processors on the vlm_mtp decode path.
+
+Why this exists
+===============
+
+The vlm_mtp decode path (#2399) used to drop per-request logits processors
+because ``run_vlm_mtp_decode`` threads only a *sampler* into mlx-vlm's
+``_mtp_rounds``, and a bare sampler sees logits without the token history
+processors need. The interim fix routed any request carrying processors
+back to BatchGenerator, making e.g. ``thinking_budget`` and vlm_mtp
+mutually exclusive.
+
+mlx-vlm's verify walk, however, already exposes the application point we
+need: when the sampler object provides ``sample_target(logprobs, row_ids,
+positions)``, ``_positioned_target_tokens`` / the deferred-greedy walk call
+it with the **absolute position of every candidate token**. Two properties
+of the MTP round loop make processor application at that hook exact:
+
+1. Every *emitted* token equals the target-side sample at its position —
+   an accepted draft token is, by definition of the acceptance walk, equal
+   to the target's sample, and a rejected slot emits the target's sample
+   directly (``_speculative_walk``). So sampling from processor-modified
+   logits at each position reproduces BatchGenerator semantics exactly.
+2. Verify logits at slot ``i`` are conditioned on the draft prefix
+   ``d[0:i]``; slot ``i``'s sample is only ever *used* when that prefix was
+   accepted, in which case the wrapper's own sampled prefix equals
+   ``d[0:i]``. Building each slot's history from the wrapper's own samples
+   is therefore correct in every case where the slot's token survives.
+
+Statefulness is the remaining hazard: positions past the first rejection
+are discarded and re-sampled next round, so a stateful processor must be
+rewound. The wrapper checkpoints processor state after every position
+(``snapshot_state`` / ``restore_state`` on the processor) and restores the
+checkpoint matching ``positions[0]`` at the start of every call. Rounds
+only re-sample a *suffix* — committed positions are never revisited — so
+the checkpoint for a call's base position always exists.
+
+Cost: token values must be concrete before the next slot's processor call,
+so the walk pays one small ``.item()`` sync per candidate slot (block_size
++ 1 per round, on tiny arrays). Draft-side sampling is unaffected — with a
+positioned sampler present, mlx-vlm switches eligible drafters to greedy
+argmax and never calls the sampler for drafts; any plain ``sampler(...)``
+call falls through to the base sampler.
+
+Scope: processors must expose ``snapshot_state()`` / ``restore_state()``
+(today: ``ThinkingBudgetProcessor``). Grammar constraints stay on the
+BatchGenerator fallback — beyond statefulness, a grammar mask makes the
+unconstrained drafter's proposals systematically rejectable, so the
+speculative path would buy nothing there anyway.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, List, Optional, Sequence
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+
+def supports_vlm_mtp_processing(processor: Any) -> bool:
+    """True when a logits processor can be applied on the vlm_mtp path."""
+    return callable(getattr(processor, "snapshot_state", None)) and callable(
+        getattr(processor, "restore_state", None)
+    )
+
+
+class MTPProcessingSampler:
+    """Sampler wrapper that applies logits processors at MTP verify time.
+
+    Positions follow mlx-vlm's convention: the first bonus token (sampled
+    from the post-prefill logits before the round loop starts) occupies
+    position 0, and ``_mtp_rounds`` starts its verify walks at
+    ``base_position = 1``.
+
+    Call sequence:
+
+    1. ``process_first_logits(logits)`` — apply processors to the
+       post-prefill logits with ``history = prompt``.
+    2. ``__call__(logits)`` (plain) — sample the first bonus from them.
+    3. ``note_first_bonus(token)`` — append it; checkpoint position 1.
+    4. mlx-vlm then calls ``sample_target`` once per verify walk.
+    """
+
+    def __init__(
+        self,
+        base_sampler: Callable[[Any], Any],
+        logits_processors: Sequence[Any],
+        prompt_token_ids: Sequence[int],
+    ) -> None:
+        self._base = base_sampler
+        self._processors: List[Any] = list(logits_processors)
+        self._history: List[int] = [int(t) for t in prompt_token_ids]
+        self._prompt_len = len(self._history)
+        self._snapshots: dict[int, List[dict]] = {}
+        self._initial_snapshot = self._snap()
+        self._degraded = False
+
+    # -- plain sampler interface (drafter and non-verify call sites) --------
+
+    def __call__(self, logits: Any) -> Any:
+        return self._base(logits)
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def process_first_logits(self, logits: Any) -> Any:
+        """Apply processors to the post-prefill logits (history = prompt)."""
+        processed = logits
+        for proc in self._processors:
+            processed = proc(self._history, processed)
+        return processed
+
+    def note_first_bonus(self, token: int, position: int = 1) -> None:
+        """Record the emitted first-bonus token and checkpoint ``position``."""
+        self._history.append(int(token))
+        self._snapshots[int(position)] = self._snap()
+
+    def reset_processors(self) -> None:
+        """Rewind processors to their pre-routing state.
+
+        Called when vlm_mtp routing fails *after* ``process_first_logits``
+        already ran, so the BatchGenerator fallback sees fresh processors.
+        """
+        self._restore(self._initial_snapshot)
+        del self._history[self._prompt_len :]
+        self._snapshots.clear()
+
+    # -- mlx-vlm positioned verify hook -------------------------------------
+
+    def sample_target(
+        self,
+        logprobs: Any,
+        row_ids: Optional[Sequence[int]] = None,
+        positions: Optional[Sequence[int]] = None,
+    ) -> Any:
+        """Process-then-sample every candidate slot of a verify walk.
+
+        ``logprobs`` is ``[n_slots, vocab]`` (or ``[vocab]`` for a single
+        slot); ``positions`` carries each slot's absolute emitted-token
+        position. Slots are processed in order, each with the token history
+        reconstructed for its position; processor state is checkpointed
+        after every slot so a later call can rewind to any re-sampled
+        position.
+        """
+        if self._degraded or not self._processors:
+            return self._base(logprobs)
+        if not positions:
+            # Positioned contract violated — never sample unprocessed
+            # silently (#2399); degrade loudly.
+            self._degrade("sample_target called without positions")
+            return self._base(logprobs)
+
+        if logprobs.ndim == 1:
+            logprobs = logprobs[None, :]
+        n_slots = int(logprobs.shape[0])
+        if n_slots != len(positions):
+            self._degrade(
+                f"row/position mismatch (rows={n_slots}, "
+                f"positions={len(positions)})"
+            )
+            return self._base(logprobs)
+
+        base_pos = int(positions[0])
+        snapshot = self._snapshots.get(base_pos)
+        if snapshot is None:
+            self._degrade(f"no checkpoint for base position {base_pos}")
+            return self._base(logprobs)
+
+        # Rewind: restore state at base_pos and drop the re-sampled suffix.
+        self._restore(snapshot)
+        del self._history[self._prompt_len + base_pos :]
+        for key in [k for k in self._snapshots if k > base_pos]:
+            del self._snapshots[key]
+
+        mx.eval(logprobs)
+        sampled: List[int] = []
+        for i in range(n_slots):
+            pos = int(positions[i])
+            if pos != base_pos + i:
+                self._degrade(
+                    f"non-contiguous positions ({positions!r})"
+                )
+                # Finish this call unprocessed for the remaining slots.
+                rest = self._base(logprobs[i:])
+                rest_list = [int(t) for t in mx.reshape(rest, (-1,)).tolist()]
+                return mx.array(sampled + rest_list, dtype=mx.int32)
+            processed = logprobs[i][None, :]
+            for proc in self._processors:
+                processed = proc(self._history, processed)
+            token_arr = self._base(processed)
+            token = int(mx.reshape(token_arr, (-1,))[0].item())
+            sampled.append(token)
+            self._history.append(token)
+            self._snapshots[pos + 1] = self._snap()
+        return mx.array(sampled, dtype=mx.int32)
+
+    # -- internals ----------------------------------------------------------
+
+    def _snap(self) -> List[dict]:
+        return [proc.snapshot_state() for proc in self._processors]
+
+    def _restore(self, snapshot: List[dict]) -> None:
+        for proc, state in zip(self._processors, snapshot):
+            proc.restore_state(state)
+
+    def _degrade(self, reason: str) -> None:
+        self._degraded = True
+        logger.warning(
+            "MTPProcessingSampler degraded to plain sampling (%s) — "
+            "per-request logits processors are NOT enforced for the rest "
+            "of this request. This indicates an mlx-vlm contract change; "
+            "please report it.",
+            reason,
+        )

--- a/omlx/speculative/vlm_mtp.py
+++ b/omlx/speculative/vlm_mtp.py
@@ -255,6 +255,43 @@ class _MTPResetBindingProxy:
         return self._drafter.reset(target_model, *args, **kwargs)
 
 
+def vlm_mtp_positioned_sampling_available(target_language_model: Any) -> bool:
+    """True when mlx-vlm's round loop will see ``speculative_logits_from_hidden``.
+
+    The positioned ``sample_target`` verify path — the application point for
+    per-request logits processors on the vlm_mtp path — is only consulted
+    when the object mlx-vlm resolves as ``lm`` exposes
+    ``speculative_logits_from_hidden``. That object is not the inner
+    language model: ``run_vlm_mtp_decode`` wraps adapters in
+    ``_VLMAdapterMTPProxy``, which for mRoPE adapters (Qwen VLMs)
+    intentionally hides the inner model's ``speculative_*`` fast paths so
+    verify keeps mRoPE position handling. Checking the inner model
+    directly would report the hook as available while the round loop
+    falls back to plain vectorized sampling — silently dropping the
+    processors (#2399).
+
+    This helper mirrors the proxy's visibility rules exactly; the
+    equivalence is pinned by tests against the real proxy resolution.
+    """
+    adapter_lm = getattr(target_language_model, "_language_model", None)
+    if adapter_lm is None:
+        # No adapter: the model itself is handed to the round loop, and
+        # mlx-vlm resolves ``lm = model.language_model`` when present.
+        inner = getattr(target_language_model, "language_model", None)
+        lm = inner if inner is not None else target_language_model
+        return hasattr(lm, "speculative_logits_from_hidden")
+    # Adapter case: rounds receive _VLMAdapterMTPProxy, which hides
+    # ``language_model`` outside drafter reset, so mlx-vlm uses the proxy
+    # itself as ``lm``. Attribute lookup tries the adapter first, then
+    # falls through to the inner model — unless the adapter uses mRoPE,
+    # in which case ``speculative_*`` names are blocked at the proxy.
+    if hasattr(target_language_model, "speculative_logits_from_hidden"):
+        return True
+    if bool(getattr(target_language_model, "_uses_mrope", False)):
+        return False
+    return hasattr(adapter_lm, "speculative_logits_from_hidden")
+
+
 def load_vlm_mtp_drafter(path: str) -> Optional[VLMMTPDrafter]:
     """Load an MTP drafter (gemma4_assistant or qwen3_5_mtp); return None
     and log if the artifact is the wrong kind. Soft-fails so a misconfigured

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -683,13 +683,22 @@ class TestVlmMtpProcessorExclusivity:
         [
             ("repetition_penalty", 1.2),
             ("presence_penalty", 0.5),
-            ("thinking_budget_enabled", True),
             ("guided_grammar_enabled", True),
         ],
     )
     def test_conflicting_setting_raises(self, field, value):
         with pytest.raises(ValueError, match="vlm_mtp_enabled cannot be combined"):
             ModelSettings(vlm_mtp_enabled=True, **{field: value})
+
+    def test_thinking_budget_no_longer_conflicts(self):
+        """Thinking budget is applied on the vlm_mtp path at verify time
+        (MTPProcessingSampler), so the combo is allowed."""
+        settings = ModelSettings(
+            vlm_mtp_enabled=True,
+            thinking_budget_enabled=True,
+        )
+        assert settings.vlm_mtp_enabled is True
+        assert settings.thinking_budget_enabled is True
 
     def test_conflicts_ignored_when_vlm_mtp_off(self):
         settings = ModelSettings(

--- a/tests/test_vlm_mtp_thinking_budget.py
+++ b/tests/test_vlm_mtp_thinking_budget.py
@@ -30,6 +30,10 @@ from omlx.speculative.processing_sampler import (
     MTPProcessingSampler,
     supports_vlm_mtp_processing,
 )
+from omlx.speculative.vlm_mtp import (
+    _VLMAdapterMTPProxy,
+    vlm_mtp_positioned_sampling_available,
+)
 
 VOCAB = 32
 THINK = 7  # the model's preferred "thinking filler" token
@@ -472,3 +476,130 @@ class TestRouteGate:
         assert 1 in sampler._snapshots
         assert sampler._history == PROMPT + [THINK]
         assert sched._vlm_mtp_active[uid].sampler is sampler
+
+
+# ---------------------------------------------------------------------------
+# 5. Positioned-hook visibility through _VLMAdapterMTPProxy (mRoPE gate)
+# ---------------------------------------------------------------------------
+
+
+def _hook(hidden):
+    return hidden
+
+
+def _make_adapter(*, mrope: bool, adapter_hook: bool, lm_hook: bool):
+    """Build a fake VLM adapter + inner language model pair."""
+    lm_attrs = {"rollback_speculative_cache": lambda *a, **k: None}
+    if lm_hook:
+        lm_attrs["speculative_logits_from_hidden"] = _hook
+    lm = SimpleNamespace(**lm_attrs)
+    adapter_attrs = {"_language_model": lm, "_uses_mrope": mrope}
+    if adapter_hook:
+        adapter_attrs["speculative_logits_from_hidden"] = _hook
+    return SimpleNamespace(**adapter_attrs), lm
+
+
+class TestPositionedHookVisibility:
+    """The routing gate must probe what mlx-vlm's round loop will actually
+    see. For mRoPE adapters (Qwen VLMs) _VLMAdapterMTPProxy hides the inner
+    language model's ``speculative_*`` fast paths, so a check against the
+    inner model passes while the loop silently falls back to plain
+    vectorized sampling and drops the processors (#2399)."""
+
+    @pytest.mark.parametrize("mrope", [False, True])
+    @pytest.mark.parametrize("adapter_hook", [False, True])
+    @pytest.mark.parametrize("lm_hook", [False, True])
+    def test_helper_matches_real_proxy_resolution(
+        self, mrope, adapter_hook, lm_hook
+    ):
+        """vlm_mtp_positioned_sampling_available == what the round loop
+        resolves through the real proxy, for every combination."""
+        adapter, lm = _make_adapter(
+            mrope=mrope, adapter_hook=adapter_hook, lm_hook=lm_hook
+        )
+        proxy = _VLMAdapterMTPProxy(adapter, lm)
+        # mlx-vlm's resolution (mtp.py): lm = model.language_model if
+        # present else model; positioned path gated on the hook's presence.
+        loop_lm = (
+            proxy.language_model
+            if hasattr(proxy, "language_model")
+            else proxy
+        )
+        loop_sees_hook = hasattr(loop_lm, "speculative_logits_from_hidden")
+        assert (
+            vlm_mtp_positioned_sampling_available(adapter) == loop_sees_hook
+        )
+
+    def test_mrope_hides_inner_hook(self):
+        """The maintainer-reported case: inner LM has the hook, adapter is
+        mRoPE — the proxy hides it, so availability must be False."""
+        adapter, lm = _make_adapter(
+            mrope=True, adapter_hook=False, lm_hook=True
+        )
+        assert hasattr(lm, "speculative_logits_from_hidden")  # naive check
+        assert not vlm_mtp_positioned_sampling_available(adapter)
+
+    def test_adapter_level_hook_survives_mrope(self):
+        """An mRoPE-safe hook implemented on the adapter itself is visible
+        to the loop and keeps the vlm_mtp route open."""
+        adapter, _ = _make_adapter(
+            mrope=True, adapter_hook=True, lm_hook=False
+        )
+        assert vlm_mtp_positioned_sampling_available(adapter)
+
+    def test_no_adapter_falls_back_to_model_probe(self):
+        bare = SimpleNamespace(speculative_logits_from_hidden=_hook)
+        assert vlm_mtp_positioned_sampling_available(bare)
+        assert not vlm_mtp_positioned_sampling_available(SimpleNamespace())
+
+    def test_route_gate_declines_mrope_adapter(self, caplog):
+        """Regression for the silent-drop report on Qwen VLM targets: the
+        gate must decline (falling back to BatchGenerator) even though the
+        inner language model carries the hook."""
+        adapter, _ = _make_adapter(
+            mrope=True, adapter_hook=False, lm_hook=True
+        )
+        sched = SimpleNamespace(
+            _vlm_mtp_drafter=object(),
+            _vlm_mtp_active={},
+            model=adapter,
+        )
+        with caplog.at_level(logging.INFO, logger="omlx.scheduler"):
+            uid = Scheduler._route_to_vlm_mtp(
+                sched,
+                _make_route_request(),
+                [object()],
+                [42],
+                _argmax_sampler,
+                object(),
+                logits_processors=[_make_budget_processor(4)],
+            )
+        assert uid is None
+        assert "positioned verify sampling is unavailable" in caplog.text
+
+    def test_route_gate_passes_non_mrope_adapter(self, caplog):
+        """Same shape, mRoPE off: the hook is visible through the proxy, so
+        the gate passes; routing then declines on the empty last_tokens —
+        the check immediately after the positioned gate — proving the
+        positioned gate itself let the request through."""
+        adapter, _ = _make_adapter(
+            mrope=False, adapter_hook=False, lm_hook=True
+        )
+        sched = SimpleNamespace(
+            _vlm_mtp_drafter=object(),
+            _vlm_mtp_active={},
+            model=adapter,
+        )
+        with caplog.at_level(logging.INFO, logger="omlx.scheduler"):
+            uid = Scheduler._route_to_vlm_mtp(
+                sched,
+                _make_route_request(),
+                [object()],
+                [],
+                _argmax_sampler,
+                object(),
+                logits_processors=[_make_budget_processor(4)],
+            )
+        assert uid is None
+        assert "positioned verify sampling is unavailable" not in caplog.text
+        assert "last_tokens empty" in caplog.text

--- a/tests/test_vlm_mtp_thinking_budget.py
+++ b/tests/test_vlm_mtp_thinking_budget.py
@@ -1,0 +1,474 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Thinking budget enforcement on the vlm_mtp decode path.
+
+Covers the three layers of the fix for #2399 (thinking-budget half):
+
+1. ``ThinkingBudgetProcessor.snapshot_state`` / ``restore_state`` —
+   position-keyed rewind support.
+2. ``MTPProcessingSampler`` — processor application through mlx-vlm's
+   positioned ``sample_target`` hook, including draft-rejection rewinds.
+3. ``Scheduler._route_to_vlm_mtp`` gate — budget processors route through
+   vlm_mtp; unsupported processors still fall back to BatchGenerator.
+
+The end-to-end tests drive mlx-vlm's *real* ``_mtp_rounds`` loop with fake
+target/drafter modules, so the full contract (verify walk, acceptance,
+rollback, positioned sampling) is exercised without model weights.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+import omlx.scheduler as scheduler_mod
+from omlx.api.thinking import ThinkingBudgetProcessor
+from omlx.scheduler import Scheduler
+from omlx.speculative.processing_sampler import (
+    MTPProcessingSampler,
+    supports_vlm_mtp_processing,
+)
+
+VOCAB = 32
+THINK = 7  # the model's preferred "thinking filler" token
+LEAD, END, TRAIL = 20, 21, 22  # forced close sequence \n </think> \n\n
+PROMPT = [1, 2, 3]
+
+
+def _argmax_sampler(logits):
+    return mx.argmax(logits, axis=-1)
+
+
+def _favor(token_id: int) -> mx.array:
+    logits = mx.zeros((1, VOCAB))
+    logits[0, token_id] = 10.0
+    return logits
+
+
+def _make_budget_processor(budget: int) -> ThinkingBudgetProcessor:
+    return ThinkingBudgetProcessor(
+        think_end_token_ids=[END],
+        budget=budget,
+        think_start_token_id=None,
+        leading_token_ids=[LEAD],
+        trailing_token_ids=[TRAIL],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Processor snapshot / restore
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotRestore:
+    def test_supports_protocol(self):
+        assert supports_vlm_mtp_processing(_make_budget_processor(4))
+        assert not supports_vlm_mtp_processing(lambda toks, logits: logits)
+
+    def test_restore_rewinds_forcing(self):
+        proc = _make_budget_processor(2)
+        history = list(PROMPT)
+
+        proc(history, _favor(THINK))  # baseline call: count=1
+        snap = proc.snapshot_state()
+
+        history.append(THINK)
+        out = proc(history, _favor(THINK))  # count=2 >= budget -> forces LEAD
+        assert int(mx.argmax(out, axis=-1).item()) == LEAD
+        assert proc._forcing
+
+        proc.restore_state(snap)
+        assert not proc._forcing
+        assert proc._thinking_tokens == 1
+
+        # Replaying the same continuation reproduces the same decision.
+        out = proc(history, _favor(THINK))
+        assert int(mx.argmax(out, axis=-1).item()) == LEAD
+
+    def test_restore_drops_lazy_baseline_attr(self):
+        proc = _make_budget_processor(4)
+        snap = proc.snapshot_state()  # before any call: no _accepted_up_to
+        proc(list(PROMPT), _favor(THINK))
+        assert hasattr(proc, "_accepted_up_to")
+        proc.restore_state(snap)
+        assert not hasattr(proc, "_accepted_up_to")
+
+
+# ---------------------------------------------------------------------------
+# 2. MTPProcessingSampler unit behaviour
+# ---------------------------------------------------------------------------
+
+
+def _positioned_logprobs(n_slots: int, favored: int = THINK) -> mx.array:
+    logits = mx.zeros((n_slots, VOCAB))
+    for i in range(n_slots):
+        logits[i, favored] = 10.0
+    return logits
+
+
+class TestMTPProcessingSampler:
+    def _fresh(self, budget: int):
+        proc = _make_budget_processor(budget)
+        sampler = MTPProcessingSampler(_argmax_sampler, [proc], PROMPT)
+        logits = sampler.process_first_logits(_favor(THINK))
+        bonus = int(mx.argmax(logits, axis=-1).item())
+        sampler.note_first_bonus(bonus)
+        return proc, sampler, bonus
+
+    def test_forces_close_at_budget(self):
+        proc, sampler, bonus = self._fresh(budget=4)
+        assert bonus == THINK  # bonus counted as thinking token 1
+
+        out = sampler.sample_target(
+            _positioned_logprobs(4), row_ids=[0] * 4, positions=[1, 2, 3, 4]
+        )
+        # counts 2,3 free; count 4 hits the budget -> LEAD, then END.
+        assert [int(t) for t in out.tolist()] == [THINK, THINK, LEAD, END]
+        assert not sampler._degraded
+
+    def test_rejection_rewind_replays_forcing_decision(self):
+        proc, sampler, _ = self._fresh(budget=4)
+
+        out_a = sampler.sample_target(
+            _positioned_logprobs(3), row_ids=[0] * 3, positions=[1, 2, 3]
+        )
+        assert [int(t) for t in out_a.tolist()] == [THINK, THINK, LEAD]
+
+        # Simulate the walk rejecting the draft at slot 2: only position 1
+        # committed; mlx-vlm re-samples from position 2.
+        out_b = sampler.sample_target(
+            _positioned_logprobs(3), row_ids=[0] * 3, positions=[2, 3, 4]
+        )
+        assert [int(t) for t in out_b.tolist()] == [THINK, LEAD, END]
+
+        # All three committed; forcing continues exactly where it left off.
+        out_c = sampler.sample_target(
+            _positioned_logprobs(1), row_ids=[0], positions=[5]
+        )
+        assert [int(t) for t in out_c.tolist()] == [TRAIL]
+
+        out_d = sampler.sample_target(
+            _positioned_logprobs(1), row_ids=[0], positions=[6]
+        )
+        assert [int(t) for t in out_d.tolist()] == [THINK]  # budget done
+        assert proc._done
+        assert not sampler._degraded
+
+    def test_natural_close_disables_forcing(self):
+        proc, sampler, _ = self._fresh(budget=10)
+        logits = mx.zeros((3, VOCAB))
+        logits[0, THINK] = 10.0
+        logits[1, END] = 10.0  # model closes thinking naturally
+        logits[2, THINK] = 10.0
+        out = sampler.sample_target(logits, row_ids=[0] * 3, positions=[1, 2, 3])
+        assert [int(t) for t in out.tolist()] == [THINK, END, THINK]
+        assert proc._done
+        assert not proc._forcing
+
+    def test_reset_processors_restores_pristine_state(self):
+        proc, sampler, _ = self._fresh(budget=4)
+        assert proc._thinking_tokens == 1
+        sampler.reset_processors()
+        assert proc._thinking_tokens == 0
+        assert not hasattr(proc, "_accepted_up_to")
+        assert sampler._history == PROMPT
+
+    def test_missing_positions_degrades_loudly(self, caplog):
+        _, sampler, _ = self._fresh(budget=4)
+        with caplog.at_level(
+            logging.WARNING, logger="omlx.speculative.processing_sampler"
+        ):
+            out = sampler.sample_target(_positioned_logprobs(2))
+        assert sampler._degraded
+        assert "NOT enforced" in caplog.text
+        assert [int(t) for t in out.tolist()] == [THINK, THINK]
+
+
+# ---------------------------------------------------------------------------
+# 3. End-to-end through mlx-vlm's real _mtp_rounds
+# ---------------------------------------------------------------------------
+
+
+class _FakeTargetLM:
+    """Target language model driving mlx-vlm's verify path.
+
+    Encodes the absolute generated-token position of every verify slot in
+    ``hidden[..., 0]`` so ``speculative_logits_from_hidden`` can pick a
+    deterministic favored token per position. Tracks a fake KV length with
+    correct rollback semantics.
+    """
+
+    def __init__(self, favored_by_pos=None):
+        self.gen_tokens = 0  # generated tokens currently in the fake cache
+        self.rollbacks = []
+        self._favored_by_pos = favored_by_pos or {}
+
+    def speculative_verify_hidden(self, verify_input, prompt_cache):
+        n = int(verify_input.shape[1])
+        hidden = mx.zeros((1, n, 4))
+        for i in range(n):
+            # slot i predicts generated position gen_tokens + i + 1
+            hidden[0, i, 0] = float(self.gen_tokens + i + 1)
+        self.gen_tokens += n
+        kv = mx.zeros((1, 1, self.gen_tokens, 2))
+        return hidden, {"full": (kv, kv)}
+
+    def speculative_logits_from_hidden(self, hidden):
+        n = int(hidden.shape[1])
+        logits = mx.zeros((1, n, VOCAB))
+        for i in range(n):
+            pos = int(hidden[0, i, 0].item())
+            favored = self._favored_by_pos.get(pos, THINK)
+            logits[0, i, favored] = 10.0
+        return logits
+
+    def rollback_speculative_cache(self, prompt_cache, gdn_states, accepted, bs):
+        trimmed = bs - accepted - 1
+        self.gen_tokens -= trimmed
+        self.rollbacks.append((accepted, bs))
+
+
+class _FakeDrafter:
+    """Drafter proposing a fixed pattern (default: always THINK)."""
+
+    supports_greedy_draft_argmax = False
+
+    def __init__(self, pattern=None):
+        self.config = SimpleNamespace(block_size=4)
+        self.accept_lens = []
+        self.pattern = pattern or [THINK]
+
+    def reset(self, model):
+        pass
+
+    def set_shared_kv(self, states, kv_offset, position=None, kv_valid_len=None):
+        pass
+
+    def draft_block(self, b, hidden, x, bs, sampler, dtype):
+        row = [self.pattern[i % len(self.pattern)] for i in range(bs - 1)]
+        return mx.array([row], dtype=dtype)
+
+
+def _run_rounds(sampler, lm=None, drafter=None, max_tokens=16, first_bonus=THINK):
+    from mlx_vlm.speculative.mtp import _mtp_rounds
+
+    lm = lm or _FakeTargetLM()
+    drafter = drafter or _FakeDrafter()
+    prompt_cache = [SimpleNamespace(offset=len(PROMPT))]
+    hidden = mx.zeros((1, 1, 4))
+
+    tokens = [first_bonus]
+    for tok, _ in _mtp_rounds(
+        lm,
+        drafter,
+        prompt_cache,
+        hidden,
+        {},
+        first_bonus=first_bonus,
+        max_tokens=max_tokens,
+        sampler=sampler,
+        draft_block_size=4,
+        token_dtype=mx.int32,
+    ):
+        tokens.append(int(tok))
+    return tokens, lm, drafter
+
+
+def _wrapped_sampler(budget: int):
+    proc = _make_budget_processor(budget)
+    sampler = MTPProcessingSampler(_argmax_sampler, [proc], PROMPT)
+    logits = sampler.process_first_logits(_favor(THINK))
+    bonus = int(mx.argmax(logits, axis=-1).item())
+    sampler.note_first_bonus(bonus)
+    return proc, sampler, bonus
+
+
+class TestEndToEndMtpRounds:
+    def test_budget_forces_close_inside_speculation(self):
+        proc, sampler, bonus = _wrapped_sampler(budget=5)
+        tokens, lm, drafter = _run_rounds(sampler, first_bonus=bonus, max_tokens=12)
+
+        # bonus + 3 free thinking tokens, then the forced close sequence,
+        # then ordinary (fake) content until max_tokens.
+        assert tokens[:4] == [THINK] * 4
+        assert tokens[4:7] == [LEAD, END, TRAIL]
+        assert all(t == THINK for t in tokens[7:])
+        assert len(tokens) == 12
+        assert proc._done
+        assert not sampler._degraded
+        # The forced tokens mismatch the drafter's proposals, so at least
+        # one rejection/rollback must have occurred.
+        assert lm.rollbacks
+
+    def test_budget_holds_under_frequent_draft_rejection(self):
+        # Drafter proposes a wrong token in slot 2 of every block, forcing
+        # a rejection (and wrapper rewind) each round.
+        proc, sampler, bonus = _wrapped_sampler(budget=5)
+        drafter = _FakeDrafter(pattern=[THINK, 9, THINK])
+        tokens, lm, _ = _run_rounds(
+            sampler, drafter=drafter, first_bonus=bonus, max_tokens=12
+        )
+        assert tokens[:4] == [THINK] * 4
+        assert tokens[4:7] == [LEAD, END, TRAIL]
+        assert all(t == THINK for t in tokens[7:])
+        assert proc._done
+        assert not sampler._degraded
+
+    def test_natural_close_before_budget_is_respected(self):
+        proc, sampler, bonus = _wrapped_sampler(budget=10)
+        lm = _FakeTargetLM(favored_by_pos={3: END})
+        tokens, _, _ = _run_rounds(sampler, lm=lm, first_bonus=bonus, max_tokens=10)
+
+        assert tokens[3] == END
+        assert LEAD not in tokens
+        assert TRAIL not in tokens
+        assert proc._done
+        assert not proc._forcing
+        assert not sampler._degraded
+
+    def test_without_wrapper_budget_is_dropped(self):
+        # Control: a bare sampler (pre-fix behaviour) never closes thinking.
+        tokens, _, _ = _run_rounds(_argmax_sampler, max_tokens=12)
+        assert all(t == THINK for t in tokens)
+
+
+# ---------------------------------------------------------------------------
+# 4. _route_to_vlm_mtp gate
+# ---------------------------------------------------------------------------
+
+
+def _make_route_request():
+    return SimpleNamespace(
+        request_id="req-budget",
+        sampling_params=SimpleNamespace(max_tokens=64, stop_token_ids=None),
+        rope_deltas=0.0,
+        prompt_token_ids=list(PROMPT),
+    )
+
+
+class TestRouteGate:
+    def test_budget_processor_passes_gate(self, caplog):
+        """A snapshot-capable processor must not trigger the fallback; the
+        fake model lacks _language_model, so passing the gate surfaces as
+        the later rollback-hook decline."""
+        sched = SimpleNamespace(
+            _vlm_mtp_drafter=object(),
+            _vlm_mtp_active={},
+            model=SimpleNamespace(),
+        )
+        with caplog.at_level(logging.INFO, logger="omlx.scheduler"):
+            uid = Scheduler._route_to_vlm_mtp(
+                sched,
+                _make_route_request(),
+                [object()],
+                [42],
+                lambda x: x,
+                object(),
+                logits_processors=[_make_budget_processor(4)],
+            )
+        assert uid is None
+        assert "logits processors" not in caplog.text
+        assert "rollback_speculative_cache" in caplog.text
+
+    def test_unsupported_processor_still_declines(self, caplog):
+        sched = SimpleNamespace(_vlm_mtp_drafter=object())
+        with caplog.at_level(logging.INFO, logger="omlx.scheduler"):
+            uid = Scheduler._route_to_vlm_mtp(
+                sched,
+                _make_route_request(),
+                [object()],
+                [42],
+                lambda x: x,
+                object(),
+                logits_processors=[lambda toks, logits: logits],
+            )
+        assert uid is None
+        assert "without vlm_mtp support" in caplog.text
+
+    def test_budget_requires_positioned_verify_hook(self, caplog):
+        """When the language model lacks speculative_logits_from_hidden,
+        mlx-vlm would sample verify tokens without consulting the wrapper —
+        routing must decline instead of silently dropping the budget."""
+        lm = SimpleNamespace(rollback_speculative_cache=lambda *a, **k: None)
+        sched = SimpleNamespace(
+            _vlm_mtp_drafter=object(),
+            _vlm_mtp_active={},
+            model=SimpleNamespace(_language_model=lm),
+        )
+        with caplog.at_level(logging.INFO, logger="omlx.scheduler"):
+            uid = Scheduler._route_to_vlm_mtp(
+                sched,
+                _make_route_request(),
+                [object()],
+                [42],
+                lambda x: x,
+                object(),
+                logits_processors=[_make_budget_processor(4)],
+            )
+        assert uid is None
+        assert "speculative_logits_from_hidden" in caplog.text
+
+    def test_happy_path_builds_processing_sampler(self, monkeypatch):
+        """Routing with a budget processor must hand run_vlm_mtp_decode an
+        MTPProcessingSampler whose first-bonus state is initialized."""
+        captured = {}
+
+        def fake_decode(**kwargs):
+            captured.update(kwargs)
+
+            def gen():
+                yield kwargs["first_bonus"]
+
+            return gen()
+
+        monkeypatch.setattr(scheduler_mod, "run_vlm_mtp_decode", fake_decode)
+
+        class FakeVLM:
+            _language_model = SimpleNamespace(
+                rollback_speculative_cache=lambda *a, **k: None,
+                speculative_logits_from_hidden=lambda h: h,
+            )
+
+            def __call__(self, tokens, cache=None, **kwargs):
+                logits = mx.zeros((1, 1, VOCAB))
+                logits[0, 0, THINK] = 10.0
+                return SimpleNamespace(
+                    logits=logits,
+                    hidden_states=mx.zeros((1, 1, 4)),
+                    shared_kv_states={},
+                )
+
+        sched = SimpleNamespace(
+            _vlm_mtp_drafter=SimpleNamespace(model=object()),
+            _vlm_mtp_active={},
+            _vlm_mtp_next_uid=-1,
+            _vlm_mtp_draft_block_size=None,
+            _model_suppress_tokens=set(),
+            _stream=mx.default_device(),
+            model=FakeVLM(),
+            _get_stop_tokens=lambda: set(),
+        )
+        proc = _make_budget_processor(4)
+
+        uid = Scheduler._route_to_vlm_mtp(
+            sched,
+            _make_route_request(),
+            [SimpleNamespace(state=mx.zeros(1), offset=3)],
+            [42],
+            _argmax_sampler,
+            object(),
+            logits_processors=[proc],
+        )
+
+        assert uid is not None
+        sampler = captured["sampler"]
+        assert isinstance(sampler, MTPProcessingSampler)
+        # First bonus was processed and recorded: THINK counted, position 1
+        # checkpointed, history extended past the prompt.
+        assert captured["first_bonus"] == THINK
+        assert proc._thinking_tokens == 1
+        assert 1 in sampler._snapshots
+        assert sampler._history == PROMPT + [THINK]
+        assert sched._vlm_mtp_active[uid].sampler is sampler


### PR DESCRIPTION
> [!NOTE]
> **Disclaimer:** This PR was authored with Claude Code (Fable 5, ultracode mode) and **functionally confirmed working** on real hardware: Apple Silicon (32 GB), `gemma-4-12B-it-8bit` + `gemma-4-12B-it-qat-assistant-bf16` VLM MTP drafter. Measured results below under "Functional validation".

Closes #2455 (also relates to #2399).

## What

`thinking_budget` now works *with* `vlm_mtp_enabled` instead of forcing a BatchGenerator fallback (0.5.4rc1) or being silently dropped (≤0.5.3). The budget is enforced inside mlx-vlm's MTP round loop with BatchGenerator-identical semantics, keeping the speculative speedup — including during the thinking phase, which is exactly where reasoning models benefit from it most.

## How

mlx-vlm's verify walk consults `sampler.sample_target(logprobs, row_ids, positions)` when present, passing the absolute position of every candidate slot. The new `omlx/speculative/processing_sampler.py::MTPProcessingSampler` implements that hook: for each slot, in order, it applies the request's logits processors with the token history reconstructed for that position, samples with the base sampler, and checkpoints processor state. Two properties make this exact rather than approximate:

1. Every emitted token equals the target-side sample at its position (accepted draft ⇒ equal by definition of `_speculative_walk`; rejected slot ⇒ the target's sample is emitted). Sampling from processor-modified logits per position therefore reproduces BatchGenerator behavior token-for-token.
2. Slot *i*'s logits are conditioned on draft prefix `d[0:i]`, and its sample is only used when that prefix was fully accepted — in which case the wrapper's own sampled prefix equals `d[0:i]`, so histories built from the wrapper's own samples are correct whenever they matter.

Statefulness (the concern in #2399) is handled with position-keyed rewind: `ThinkingBudgetProcessor` gains `snapshot_state()`/`restore_state()`, and the wrapper restores the checkpoint for `positions[0]` at the start of every call. Rounds only re-sample a suffix, so the checkpoint always exists.

Budget forcing composes with speculation naturally: the forced close token mismatches the drafter's proposal, is emitted via the normal rejection path, and the next round continues from it — ~1 token/round for only the 3–4 forced close tokens. Until the boundary the processor is a no-op on logits, so acceptance rates are untouched.

## What still falls back

The routing gate is now capability-based: processors exposing `snapshot_state`/`restore_state` ride along; anything else (grammar, repetition/presence/frequency penalties) still declines vlm_mtp exactly as today. Grammar stays out deliberately — a grammar mask makes the unconstrained drafter's proposals systematically rejectable, so there is nothing to win. Routing also declines when `speculative_logits_from_hidden` is not visible to the round loop — checked via `vlm_mtp_positioned_sampling_available()`, which mirrors `_VLMAdapterMTPProxy`'s visibility rules. In particular, mRoPE adapters (Qwen VLMs) hide the inner model's `speculative_*` fast paths, so those targets fall back to BatchGenerator loudly instead of silently dropping the budget; an adapter that grows an mRoPE-safe positioned hook re-opens the route automatically.

## Changes

- `omlx/speculative/processing_sampler.py` (new): the wrapper + `supports_vlm_mtp_processing()`.
- `omlx/api/thinking.py`: `snapshot_state`/`restore_state` on `ThinkingBudgetProcessor` (pure addition; BatchGenerator path unchanged).
- `omlx/scheduler.py` `_route_to_vlm_mtp`: capability-based gate, positioned-hook eligibility check, wrapper construction, first-bonus processing (history = prompt), processor reset on setup-failure fallback.
- `omlx/model_settings.py`: `thinking_budget_enabled` removed from `vlm_mtp_processor_conflicts` (validation + load-time migration + request-time merge follow automatically).
- Admin UI (`dashboard.js`, `_modal_model_settings.html`, `en.json`) and macOS app (`ModelSettingsScreenVM.swift`, `ModelSettingsScreen.swift`): thinking-budget rows un-gated from VLM MTP; penalties/grammar gating unchanged. Note: non-English i18n strings for `vlm_mtp_processor_conflict` still mention thinking budget — left for a follow-up translation pass.

## Tests

- `tests/test_vlm_mtp_thinking_budget.py` (new, 16 tests): snapshot/restore; wrapper positioned semantics incl. draft-rejection rewind; **end-to-end through the real mlx-vlm `_mtp_rounds`** with fake target/drafter modules (budget forces close inside speculation; holds under per-round rejection; natural close respected; control shows a bare sampler drops the budget); routing-gate cases; happy-path wrapper construction.
- `tests/test_model_settings.py`: exclusivity test updated (budget combo now allowed; penalties/grammar still raise).
- Positioned-hook visibility (mRoPE) regression tests: an equivalence sweep pins the gate helper against the real `_VLMAdapterMTPProxy` attribute resolution for every (mrope, adapter-hook, lm-hook) combination, plus the reported Qwen case (inner LM has the hook, proxy hides it → decline).
- 299 tests across the touched files and the thinking/vlm_mtp/settings neighborhoods pass on Apple Silicon (Metal), after rebasing onto v0.5.4. The one failure in that sweep, `test_inkling_vlm_mtp.py::test_verify_rollback_matches_sequential_decode`, is pre-existing — it fails identically on clean `main` at c59b4cb without this patch.

## Functional validation

Apple Silicon (32 GB), `gemma-4-12B-it-8bit` + `gemma-4-12B-it-qat-assistant-bf16` drafter (VLM MTP, block_size=4), request `thinking_budget=100`, `max_tokens=200`, thinking enabled:

- **Before** (≤0.5.3 behavior, reproduced with `vlm_mtp_enabled` and no budget enforcement): thinking consumes all 200 completion tokens, `content` is empty (measured: 197 reasoning tokens, 0 content tokens).
- **After, vlm_mtp on + patch**: log shows `vlm_mtp decode started` (no `routing skipped` line) and `vlm_mtp stats: … rounds=73 accepted=127/219 (58.0%) tokens_per_round=2.74 emitted=200`; thinking stops at the budget with the forced close (96 reasoning tokens by tokenizer count) and the answer is present (100 content tokens, `finish_reason=length`).
- **Parity, vlm_mtp off (BatchGenerator baseline)**: same request → 94 reasoning tokens / 100 content tokens — within 2 tokens of the speculative path, i.e. identical `ThinkingBudgetProcessor` semantics on both paths.
- **Speedup retained**: 200 tokens in 11.5 s generation time with MTP vs 25.8 s on BatchGenerator for the same budgeted request (~2.2× on this pairing).

Happy to split the settings/UI relaxation from the core scheduler change if you'd prefer them separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


