### PR TITLE
fix: do not recover truncated thinking as content on the streaming paths

### DIFF
--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -323,7 +323,7 @@ class ThinkingParser:
             self._content_emitted = True
         return (thinking_delta, content_delta)
 
-    def finish(self) -> Tuple[str, str]:
+    def finish(self, truncated: bool = False) -> Tuple[str, str]:
         """Flush any remaining buffered content.
 
         Should be called when the stream is complete to emit any
@@ -332,6 +332,13 @@ class ThinkingParser:
         emitted ``</think>`` and no content was ever produced, returns
         the accumulated thinking text as content so the client surfaces
         a non-empty answer body.
+
+        Args:
+            truncated: True when generation was cut short by ``max_tokens``
+                (``finish_reason == "length"``). The recovery below is skipped
+                in that case: the close tag is missing because the model was
+                stopped mid-thought, not because it finished without one, so
+                the accumulated text is reasoning and not an answer.
 
         Returns:
             Tuple of (thinking_text, content_text) from remaining buffer
@@ -348,7 +355,8 @@ class ThinkingParser:
         # the same text twice — once in the thinking panel, once as the
         # answer. UX trade-off documented in the chat template plan.
         if (
-            self._in_thinking
+            not truncated
+            and self._in_thinking
             and not self._close_seen
             and not self._content_emitted
             and self._thinking_accumulated

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -273,6 +273,16 @@ class ServerState:
 _server_state: ServerState = ServerState()
 
 
+def _hit_token_limit(last_output) -> bool:
+    """True when generation stopped because it ran out of ``max_tokens``.
+
+    Used to tell ``ThinkingParser.finish()`` that a missing ``</think>`` is our
+    doing rather than the model's, so it does not recover the reasoning text
+    into ``content``.
+    """
+    return last_output is not None and last_output.finish_reason == "length"
+
+
 def get_server_state() -> ServerState:
     """Get the global server state."""
     return _server_state
@@ -4445,7 +4455,9 @@ async def stream_chat_completion(
 
     # Flush remaining buffered content from thinking/tool-call parsers
     if stream_content:
-        thinking_delta, content_delta = thinking_parser.finish()
+        thinking_delta, content_delta = thinking_parser.finish(
+            truncated=_hit_token_limit(last_output)
+        )
         if thinking_delta:
             if thinking_filter:
                 thinking_delta = thinking_filter.feed(thinking_delta)
@@ -4925,7 +4937,9 @@ async def stream_anthropic_messages(
         return
 
     # Flush remaining buffered content from thinking parser
-    thinking_delta, content_delta = thinking_parser.finish()
+    thinking_delta, content_delta = thinking_parser.finish(
+        truncated=_hit_token_limit(last_output)
+    )
     if thinking_delta:
         if thinking_filter:
             thinking_delta = thinking_filter.feed(thinking_delta)
@@ -6372,7 +6386,9 @@ async def stream_responses_api(
 
     # Flush remaining content from parsers
     if stream_content:
-        thinking_delta, content_delta = thinking_parser.finish()
+        thinking_delta, content_delta = thinking_parser.finish(
+            truncated=_hit_token_limit(last_output)
+        )
         if thinking_delta:
             if thinking_filter:
                 thinking_delta = thinking_filter.feed(thinking_delta)

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -383,6 +383,34 @@ class TestThinkingParser:
         assert t == ""
         assert c == "open but never closed"
 
+    def test_truncated_does_not_recover_thinking_as_content(self):
+        """max_tokens cut the model off mid-thought (finish_reason=length).
+        The close tag is missing because we stopped it, not because it
+        finished without one, so the accumulated text is reasoning and must
+        not be re-emitted as the answer."""
+        parser = ThinkingParser(start_in_thinking=True)
+        parser.feed("Let me work through the problem. ")
+        parser.feed("Step one is to recall the definition")
+        t, c = parser.finish(truncated=True)
+        assert t == ""
+        assert c == ""
+
+    def test_truncated_flag_does_not_disturb_a_normal_close(self):
+        """The flag only gates the recovery branch; a stream that closed its
+        block behaves the same either way."""
+        for truncated in (False, True):
+            parser = ThinkingParser(start_in_thinking=True)
+            t, c = parser.feed("reasoning</think>the answer")
+            assert t == "reasoning"
+            assert c == "the answer"
+            assert parser.finish(truncated=truncated) == ("", "")
+
+    def test_truncated_default_is_false(self):
+        """Callers that do not pass the flag keep the old recovery."""
+        parser = ThinkingParser(start_in_thinking=True)
+        parser.feed("never closed")
+        assert parser.finish() == ("", "never closed")
+
 
 class TestCleanSpecialTokens:
     """Tests for clean_special_tokens (preserves think tags)."""


### PR DESCRIPTION
Fixes #2457.

## The symptom

Ask Qwen3.6 for three bullets with `max_tokens: 400` and thinking on, and the
answer that comes back is 1815 characters of "The user is asking about Kalman
filters, let me recall...". The whole chain of thought, served as the reply. The
client already had that same text as `reasoning_content`, so it shows up twice.

Raise `max_tokens` to 2000, same prompt, and it splits properly. Streaming
`/v1/chat/completions` on 0.5.1, `Qwen3.6-35B-A3B-4bit`,
`chat_template_kwargs: {"enable_thinking": true}`:

| max_tokens | finish_reason | reasoning_content deltas | content deltas | content chars |
|---|---|---|---|---|
| 400 | `length` | 33 | 1 | 1815 |
| 2000 | `stop` | 61 | 14 | 884 |

One content delta in the truncated run, carrying the reasoning verbatim.

## Why this doesn't just delete the recovery

`ThinkingParser.finish()` re-emits unclosed thinking as content on purpose, and
for the case it was written for it's the right call. The model stopped on its own
without closing the tag, so what it produced is all the answer there is; returning
nothing would leave the client staring at an empty body. That's #903.

Truncation is a different animal. We know exactly why the close tag never showed
up, because we're the ones who stopped the model. There's no answer hiding behind
that text yet, it's reasoning and nothing else, and handing it over as a reply is
worse than sending nothing: the user can't tell it apart from a real one.

So the recovery stays, gated.

## What changed

`finish()` takes a `truncated` flag and skips the recovery branch when it's set.
Default `False`, so any caller that ignores it keeps today's behaviour.

The three streaming call sites (chat completions, Anthropic messages, responses
API) already track `last_output` for their own final chunk, so each one passes
`finish_reason == "length"` through a small `_hit_token_limit` helper. Nothing
else moves. A normal close behaves as before, and a model that stops without
closing still gets its content recovered.

## Tests

Three in `tests/test_thinking.py`: truncated emits no content, the flag leaves a
normal close alone, and the default keeps the old recovery. 71 pass across
`test_thinking.py`, `test_thinking_toggle.py` and
`test_chat_stream_thinking_static.py`.

I couldn't run `test_thinking_budget.py` here (no `openai_harmony` in my
environment). It doesn't touch this path, but CI should confirm.

## On #82

That PR says streaming already handles this "via the scheduler's
`needs_think_prefix` mechanism and `ThinkingParser.finish()`" and fixed only the
non-streaming side. On 0.5.1 that's not what the wire shows for the truncated
case. Whether it regressed afterwards or was never covered I honestly don't know,
so read the numbers above as a report, not a regression claim.

And if you'd rather keep the recovery unconditional and let clients key off
`finish_reason` themselves, say so and I'll close this.
